### PR TITLE
Gemini Default Metrics

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -44,7 +44,9 @@ dependencies = [
     "gunicorn>=21.2.0",
     "tomli>=2.0.0",
     "google-genai==1.13.0",
-    "mirascope==1.24.0"
+    "mirascope==1.24.0",
+    "protobuf>=5.29.4",
+    "proto-plus>=1.26.1",
 ]
 
 [build-system]

--- a/apps/backend/src/rhesis/backend/metrics/__init__.py
+++ b/apps/backend/src/rhesis/backend/metrics/__init__.py
@@ -2,8 +2,11 @@
 
 from .base import BaseMetric, MetricConfig, MetricResult
 from .config.loader import MetricConfigLoader
-from .evaluator import MetricEvaluator as Evaluator, run_evaluation
+from .evaluator import MetricEvaluator as Evaluator
 from .factory import MetricFactory
+from .score_evaluator import ScoreEvaluator
+from .types import ScoreType, ThresholdOperator, OPERATOR_MAP, VALID_OPERATORS_BY_SCORE_TYPE
+from .utils import run_evaluation, diagnose_invalid_metric
 from .rhesis import (  # Re-export Rhesis metrics
     RhesisMetricBase,
     RhesisMetricFactory,
@@ -35,7 +38,15 @@ __all__ = [
     
     # Evaluation
     "Evaluator",
+    "ScoreEvaluator",
     "run_evaluation",
+    
+    # Types and utilities
+    "ScoreType",
+    "ThresholdOperator",
+    "OPERATOR_MAP",
+    "VALID_OPERATORS_BY_SCORE_TYPE",
+    "diagnose_invalid_metric",
     
     # Rhesis metrics
     "RhesisMetricBase",

--- a/apps/backend/src/rhesis/backend/metrics/evaluator.py
+++ b/apps/backend/src/rhesis/backend/metrics/evaluator.py
@@ -1,66 +1,23 @@
 import concurrent.futures
-import operator
-from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from rhesis.backend.logging.rhesis_logger import logger
 from rhesis.backend.metrics.base import BaseMetric, MetricConfig, MetricResult
+from rhesis.backend.metrics.score_evaluator import ScoreEvaluator
+from rhesis.backend.metrics.utils import diagnose_invalid_metric
 
 # Use inline factory creation to avoid circular imports
 # Implementation of the factory import will be delayed until needed
 
 
-class ScoreType(str, Enum):
-    BINARY = "binary"
-    NUMERIC = "numeric"
-    CATEGORICAL = "categorical"
-
-
-class ThresholdOperator(str, Enum):
-    EQUAL = "="
-    LESS_THAN = "<"
-    GREATER_THAN = ">"
-    LESS_THAN_OR_EQUAL = "<="
-    GREATER_THAN_OR_EQUAL = ">="
-    NOT_EQUAL = "!="
-
-
-# Mapping threshold operators to Python operator functions
-OPERATOR_MAP = {
-    ThresholdOperator.EQUAL: operator.eq,
-    ThresholdOperator.LESS_THAN: operator.lt,
-    ThresholdOperator.GREATER_THAN: operator.gt,
-    ThresholdOperator.LESS_THAN_OR_EQUAL: operator.le,
-    ThresholdOperator.GREATER_THAN_OR_EQUAL: operator.ge,
-    ThresholdOperator.NOT_EQUAL: operator.ne,
-}
-
-# Valid operators for different score types
-VALID_OPERATORS_BY_SCORE_TYPE = {
-    ScoreType.BINARY: {ThresholdOperator.EQUAL, ThresholdOperator.NOT_EQUAL},
-    ScoreType.CATEGORICAL: {ThresholdOperator.EQUAL, ThresholdOperator.NOT_EQUAL},
-    ScoreType.NUMERIC: set(ThresholdOperator),  # All operators are valid for numeric
-}
-
-# Legacy mapping for string operators (for backward compatibility)
-THRESHOLD_OPERATOR_MAP = {
-    "<": operator.lt,
-    "<=": operator.le,
-    ">": operator.gt,
-    ">=": operator.ge,
-    "=": operator.eq,
-    "==": operator.eq,
-    "!=": operator.ne,
-    "<>": operator.ne,
-}
-
 class MetricEvaluator:
     """Evaluator class that handles metric computation using configured backends."""
 
     def __init__(self):
-        """Initialize evaluator with factory."""
+        """Initialize evaluator with factory and score evaluator."""
         # Lazy load factory to avoid circular imports
         self.factory = None
+        self.score_evaluator = ScoreEvaluator()
 
     def _get_factory(self):
         """Lazy load the MetricFactory to avoid circular imports."""
@@ -68,85 +25,6 @@ class MetricEvaluator:
             from rhesis.backend.metrics.factory import MetricFactory
             self.factory = MetricFactory()
         return self.factory
-
-    def _sanitize_threshold_operator(self, threshold_operator: Union[ThresholdOperator, str, None]) -> Optional[ThresholdOperator]:
-        """
-        Sanitize and validate the threshold operator.
-        
-        Args:
-            threshold_operator: The threshold operator to sanitize
-            
-        Returns:
-            ThresholdOperator: Sanitized and validated threshold operator, or None if invalid
-            
-        Raises:
-            ValueError: If the operator is invalid
-        """
-        if threshold_operator is None:
-            return None
-            
-        # Trim whitespace if it's a string
-        if isinstance(threshold_operator, str):
-            threshold_operator = threshold_operator.strip()
-            
-        # Convert string to enum if needed
-        if isinstance(threshold_operator, str):
-            try:
-                threshold_operator = ThresholdOperator(threshold_operator)
-            except ValueError:
-                logger.warning(f"Invalid threshold operator: '{threshold_operator}'. "
-                             f"Valid operators are: {', '.join([op.value for op in ThresholdOperator])}")
-                return None
-        
-        # Validate that it's a valid ThresholdOperator
-        if not isinstance(threshold_operator, ThresholdOperator):
-            logger.warning(f"threshold_operator must be a ThresholdOperator enum or valid string, "
-                         f"got {type(threshold_operator)}")
-            return None
-            
-        return threshold_operator
-    
-    def _validate_operator_for_score_type(self, threshold_operator: ThresholdOperator, score_type: ScoreType) -> bool:
-        """
-        Validate that the threshold operator is appropriate for the score type.
-        
-        Args:
-            threshold_operator: The threshold operator to validate
-            score_type: The score type to validate against
-            
-        Returns:
-            bool: True if the operator is valid for the score type
-        """
-        valid_operators = VALID_OPERATORS_BY_SCORE_TYPE.get(score_type, set())
-        if threshold_operator not in valid_operators:
-            valid_ops_str = ', '.join([op.value for op in valid_operators])
-            logger.warning(f"Operator '{threshold_operator.value}' is not valid for score type '{score_type.value}'. "
-                         f"Valid operators for {score_type.value} are: {valid_ops_str}")
-            return False
-        return True
-
-    def _determine_score_type(self, score: Union[float, str, int], threshold_operator: Optional[str]) -> ScoreType:
-        """
-        Determine the score type based on the score value and threshold operator.
-        
-        Args:
-            score: The score value
-            threshold_operator: The threshold operator
-            
-        Returns:
-            ScoreType: The determined score type
-        """
-        # If it's a string score, determine if it's binary or categorical
-        if isinstance(score, str):
-            # Common binary values
-            binary_values = {"true", "false", "yes", "no", "pass", "fail", "success", "failure", "1", "0"}
-            if score.lower().strip() in binary_values:
-                return ScoreType.BINARY
-            else:
-                return ScoreType.CATEGORICAL
-        
-        # If it's numeric, it's numeric type
-        return ScoreType.NUMERIC
 
     def evaluate(
         self,
@@ -204,7 +82,7 @@ class MetricEvaluator:
                         metric_configs.append(parsed_config)
                     else:
                         # Create error result for invalid metric
-                        error_reason = self._diagnose_invalid_metric(config)
+                        error_reason = diagnose_invalid_metric(config)
                         invalid_key = f"InvalidMetric_{i}"
                         invalid_metric_results[invalid_key] = {
                             "score": 0.0,
@@ -452,8 +330,8 @@ class MetricEvaluator:
             # Get description from config or use a default
             description = metric_config.description or f"{class_name} evaluation metric"
             
-            # Calculate is_successful based on threshold operator from database
-            is_successful = self.evaluate_score(
+            # Calculate is_successful using the score evaluator
+            is_successful = self.score_evaluator.evaluate_score(
                 score=result.score,
                 threshold=metric_config.threshold,
                 threshold_operator=metric_config.threshold_operator,
@@ -463,7 +341,7 @@ class MetricEvaluator:
             # Store results
             processed_result = {
                 "score": result.score,
-                "reason": result.details["reason"],
+                "reason": result.details.get("reason", f"Score: {result.score}"),
                 "is_successful": is_successful,
                 "threshold": metric_config.threshold,
                 "backend": backend,
@@ -475,7 +353,13 @@ class MetricEvaluator:
             return processed_result
 
         except Exception as exc:
+            import traceback
             logger.error(f"Metric '{class_name}' generated an exception: {exc}", exc_info=True)
+            logger.error(f"Backend: {backend}")
+            logger.error(f"Metric config: {metric_config}")
+            logger.error(f"Exception type: {type(exc).__name__}")
+            logger.error(f"Full traceback:\n{traceback.format_exc()}")
+            
             # Store error information in results
             return {
                 "score": 0.0,
@@ -487,209 +371,5 @@ class MetricEvaluator:
                 "class_name": class_name,  # Include class_name for identification
                 "description": description if 'description' in locals() else f"{class_name} evaluation metric",
                 "error": str(exc),
+                "exception_type": type(exc).__name__,
             }
-
-    def evaluate_score(
-        self,
-        score: Union[float, str, int],
-        threshold: Optional[float],
-        threshold_operator: Optional[str],
-        reference_score: Optional[str] = None,
-        score_type: Optional[Union[ScoreType, str]] = None
-    ) -> bool:
-        """
-        Evaluate whether a metric score meets the success criteria based on threshold and operator.
-        This method incorporates all the functionality from metric_base.py for comprehensive score evaluation.
-        
-        Args:
-            score: The metric score (can be numeric or string)
-            threshold: The threshold value for numeric scores
-            threshold_operator: The comparison operator ('<', '>', '>=', '<=', '=', '!=')
-            reference_score: Reference score for binary/categorical metrics
-            score_type: Explicit score type, if not provided will be auto-determined
-            
-        Returns:
-            bool: True if the metric score meets the success criteria
-        """
-        # Determine score type if not provided
-        if score_type is None:
-            score_type = self._determine_score_type(score, threshold_operator)
-        elif isinstance(score_type, str):
-            try:
-                score_type = ScoreType(score_type)
-            except ValueError:
-                logger.warning(f"Invalid score type '{score_type}', auto-determining from score")
-                score_type = self._determine_score_type(score, threshold_operator)
-        
-        # Sanitize and validate threshold operator
-        sanitized_operator = self._sanitize_threshold_operator(threshold_operator)
-        
-        # Set default threshold operator based on score type if none provided or invalid
-        if sanitized_operator is None:
-            if score_type == ScoreType.NUMERIC:
-                sanitized_operator = ThresholdOperator.GREATER_THAN_OR_EQUAL
-            else:  # BINARY or CATEGORICAL
-                sanitized_operator = ThresholdOperator.EQUAL
-            logger.debug(f"Using default operator '{sanitized_operator.value}' for score type '{score_type.value}'")
-        
-        # Validate operator for score type
-        if not self._validate_operator_for_score_type(sanitized_operator, score_type):
-            # Fall back to appropriate default if validation fails
-            if score_type == ScoreType.NUMERIC:
-                sanitized_operator = ThresholdOperator.GREATER_THAN_OR_EQUAL
-            else:
-                sanitized_operator = ThresholdOperator.EQUAL
-            logger.debug(f"Falling back to operator '{sanitized_operator.value}' for score type '{score_type.value}'")
-        
-        # Handle different score types
-        if score_type == ScoreType.NUMERIC:
-            return self._evaluate_numeric_score(score, threshold, sanitized_operator)
-        else:  # BINARY or CATEGORICAL
-            return self._evaluate_categorical_score(score, reference_score, threshold, sanitized_operator)
-
-    def _evaluate_numeric_score(
-        self,
-        score: Union[float, int],
-        threshold: Optional[float],
-        threshold_operator: ThresholdOperator
-    ) -> bool:
-        """
-        Evaluate numeric scores against threshold using the specified operator.
-        
-        Args:
-            score: The numeric score
-            threshold: The threshold value
-            threshold_operator: The comparison operator
-            
-        Returns:
-            bool: True if the score meets the criteria
-        """
-        # Convert score to float if it's not already
-        try:
-            numeric_score = float(score)
-        except (ValueError, TypeError):
-            logger.warning(f"Could not convert score '{score}' to numeric value")
-            return False
-        
-        # Validate threshold is provided for numeric scores
-        if threshold is None:
-            logger.warning("Threshold is required for numeric score type but was not provided")
-            return False
-        
-        # Use operator module for comparison
-        op_func = OPERATOR_MAP.get(threshold_operator)
-        if op_func is None:
-            # Fallback to default behavior
-            logger.warning(f"Unknown operator '{threshold_operator}', defaulting to '>='")
-            return numeric_score >= threshold
-            
-        return op_func(numeric_score, threshold)
-
-    def _evaluate_categorical_score(
-        self,
-        score: Union[str, float, int],
-        reference_score: Optional[str],
-        threshold: Optional[float],
-        threshold_operator: ThresholdOperator
-    ) -> bool:
-        """
-        Evaluate binary/categorical scores against reference score using the specified operator.
-        
-        Args:
-            score: The score value
-            reference_score: The reference score to compare against
-            threshold: The threshold (used as reference if reference_score not provided)
-            threshold_operator: The comparison operator
-            
-        Returns:
-            bool: True if the score meets the criteria
-        """
-        # Determine reference value
-        if reference_score is None:
-            if threshold is not None:
-                reference_value = str(threshold)
-            else:
-                logger.warning("Reference score or threshold is required for binary/categorical score type but was not provided")
-                return False
-        else:
-            reference_value = reference_score
-        
-        # Convert score to string for comparison
-        score_str = str(score).lower().strip() if not isinstance(score, str) else score.lower().strip()
-        reference_str = reference_value.lower().strip()
-        
-        # Use operator module for comparison
-        op_func = OPERATOR_MAP.get(threshold_operator)
-        if op_func is None:
-            # Fallback to equality check
-            logger.warning(f"Unknown operator '{threshold_operator}', defaulting to equality")
-            return score_str == reference_str
-            
-        return op_func(score_str, reference_str)
-
-    def _diagnose_invalid_metric(self, config: Union[Dict[str, Any], MetricConfig]) -> str:
-        """
-        Diagnose the reason why a metric configuration is invalid.
-
-        Args:
-            config: The metric configuration
-
-        Returns:
-            A string describing the reason why the metric configuration is invalid
-        """
-        if config is None:
-            return "configuration is None"
-            
-        if isinstance(config, MetricConfig):
-            missing_fields = []
-            if not config.class_name or (isinstance(config.class_name, str) and not config.class_name.strip()):
-                missing_fields.append("class_name")
-            if not config.backend or (isinstance(config.backend, str) and not config.backend.strip()):
-                missing_fields.append("backend")
-            if missing_fields:
-                return f"missing or empty required fields: {', '.join(missing_fields)}"
-        elif isinstance(config, dict):
-            missing_fields = []
-            if "class_name" not in config or config["class_name"] is None or (isinstance(config["class_name"], str) and not config["class_name"].strip()):
-                missing_fields.append("class_name")
-            if "backend" not in config or config["backend"] is None or (isinstance(config["backend"], str) and not config["backend"].strip()):
-                missing_fields.append("backend")
-            if missing_fields:
-                return f"missing or empty required fields: {', '.join(missing_fields)}"
-        else:
-            return f"invalid configuration type: {type(config).__name__} (expected dict or MetricConfig)"
-            
-        return "unknown validation error"
-
-
-def run_evaluation(
-    input_text: str,
-    output_text: str,
-    expected_output: Optional[str],
-    context: List[str],
-    metrics: List[Union[Dict[str, Any], MetricConfig]],
-    max_workers: int = 5,
-) -> Dict[str, Any]:
-    """
-    Helper function to run the metric evaluation using MetricEvaluator.
-    
-    Args:
-        input_text: The input query or question
-        output_text: The actual output from the LLM
-        expected_output: The expected or reference output
-        context: List of context strings used for the response
-        metrics: List of metric configurations (MetricConfig objects or dictionaries)
-        max_workers: Maximum number of parallel workers
-        
-    Returns:
-        Dictionary of metric results
-    """
-    evaluator = MetricEvaluator()
-    return evaluator.evaluate(
-        input_text=input_text,
-        output_text=output_text,
-        expected_output=expected_output,
-        context=context,
-        metrics=metrics,
-        max_workers=max_workers,
-    )

--- a/apps/backend/src/rhesis/backend/metrics/rhesis/metric_base.py
+++ b/apps/backend/src/rhesis/backend/metrics/rhesis/metric_base.py
@@ -1,8 +1,9 @@
-from typing import List, Optional, Union
+from typing import Any, Dict, Optional, Union
 
+from rhesis.backend.logging.rhesis_logger import logger
 from rhesis.backend.metrics.base import BaseMetric, MetricResult, MetricType
-# Import the enums and evaluator from the centralized location
-from rhesis.backend.metrics.evaluator import ScoreType, ThresholdOperator, MetricEvaluator
+from rhesis.backend.metrics.types import ScoreType, ThresholdOperator
+from rhesis.backend.metrics.score_evaluator import ScoreEvaluator
 
 
 class RhesisMetricBase(BaseMetric):
@@ -12,7 +13,7 @@ class RhesisMetricBase(BaseMetric):
         super().__init__(name=name, metric_type=metric_type)
         self._threshold = threshold
         self._reference_score = reference_score
-        self._evaluator = MetricEvaluator()
+        self._score_evaluator = ScoreEvaluator()
 
     @property
     def threshold(self) -> Optional[float]:
@@ -41,7 +42,7 @@ class RhesisMetricBase(BaseMetric):
     ) -> bool:
         """
         Evaluate if a score meets the success criteria based on score type and threshold operator.
-        Delegates to the evaluator's comprehensive implementation.
+        Delegates to the score evaluator's comprehensive implementation.
         
         Args:
             score: The score to evaluate
@@ -59,8 +60,8 @@ class RhesisMetricBase(BaseMetric):
         if reference_score is None:
             reference_score = self.reference_score
             
-        # Delegate to the evaluator's comprehensive implementation
-        return self._evaluator.evaluate_score(
+        # Delegate to the score evaluator's comprehensive implementation
+        return self._score_evaluator.evaluate_score(
             score=score,
             threshold=threshold,
             threshold_operator=threshold_operator,

--- a/apps/backend/src/rhesis/backend/metrics/score_evaluator.py
+++ b/apps/backend/src/rhesis/backend/metrics/score_evaluator.py
@@ -1,0 +1,233 @@
+from typing import Optional, Union
+
+from rhesis.backend.logging.rhesis_logger import logger
+from rhesis.backend.metrics.types import (
+    ScoreType,
+    ThresholdOperator,
+    OPERATOR_MAP,
+    VALID_OPERATORS_BY_SCORE_TYPE,
+)
+
+
+class ScoreEvaluator:
+    """Class responsible for evaluating scores against thresholds and criteria."""
+
+    @staticmethod
+    def _sanitize_threshold_operator(threshold_operator: Union[ThresholdOperator, str, None]) -> Optional[ThresholdOperator]:
+        """
+        Sanitize and validate the threshold operator.
+        
+        Args:
+            threshold_operator: The threshold operator to sanitize
+            
+        Returns:
+            ThresholdOperator: Sanitized and validated threshold operator, or None if invalid
+            
+        Raises:
+            ValueError: If the operator is invalid
+        """
+        if threshold_operator is None:
+            return None
+            
+        # Trim whitespace if it's a string
+        if isinstance(threshold_operator, str):
+            threshold_operator = threshold_operator.strip()
+            
+        # Convert string to enum if needed
+        if isinstance(threshold_operator, str):
+            try:
+                threshold_operator = ThresholdOperator(threshold_operator)
+            except ValueError:
+                logger.warning(f"Invalid threshold operator: '{threshold_operator}'. "
+                             f"Valid operators are: {', '.join([op.value for op in ThresholdOperator])}")
+                return None
+        
+        # Validate that it's a valid ThresholdOperator
+        if not isinstance(threshold_operator, ThresholdOperator):
+            logger.warning(f"threshold_operator must be a ThresholdOperator enum or valid string, "
+                         f"got {type(threshold_operator)}")
+            return None
+            
+        return threshold_operator
+    
+    @staticmethod
+    def _validate_operator_for_score_type(threshold_operator: ThresholdOperator, score_type: ScoreType) -> bool:
+        """
+        Validate that the threshold operator is appropriate for the score type.
+        
+        Args:
+            threshold_operator: The threshold operator to validate
+            score_type: The score type to validate against
+            
+        Returns:
+            bool: True if the operator is valid for the score type
+        """
+        valid_operators = VALID_OPERATORS_BY_SCORE_TYPE.get(score_type, set())
+        if threshold_operator not in valid_operators:
+            valid_ops_str = ', '.join([op.value for op in valid_operators])
+            logger.warning(f"Operator '{threshold_operator.value}' is not valid for score type '{score_type.value}'. "
+                         f"Valid operators for {score_type.value} are: {valid_ops_str}")
+            return False
+        return True
+
+    @staticmethod
+    def _determine_score_type(score: Union[float, str, int], threshold_operator: Optional[str]) -> ScoreType:
+        """
+        Determine the score type based on the score value and threshold operator.
+        
+        Args:
+            score: The score value
+            threshold_operator: The threshold operator
+            
+        Returns:
+            ScoreType: The determined score type
+        """
+        # If it's a string score, determine if it's binary or categorical
+        if isinstance(score, str):
+            # Common binary values
+            binary_values = {"true", "false", "yes", "no", "pass", "fail", "success", "failure", "1", "0"}
+            if score.lower().strip() in binary_values:
+                return ScoreType.BINARY
+            else:
+                return ScoreType.CATEGORICAL
+        
+        # If it's numeric, it's numeric type
+        return ScoreType.NUMERIC
+
+    def evaluate_score(
+        self,
+        score: Union[float, str, int],
+        threshold: Optional[float],
+        threshold_operator: Optional[str],
+        reference_score: Optional[str] = None,
+        score_type: Optional[Union[ScoreType, str]] = None
+    ) -> bool:
+        """
+        Evaluate whether a metric score meets the success criteria based on threshold and operator.
+        This method incorporates all the functionality from metric_base.py for comprehensive score evaluation.
+        
+        Args:
+            score: The metric score (can be numeric or string)
+            threshold: The threshold value for numeric scores
+            threshold_operator: The comparison operator ('<', '>', '>=', '<=', '=', '!=')
+            reference_score: Reference score for binary/categorical metrics
+            score_type: Explicit score type, if not provided will be auto-determined
+            
+        Returns:
+            bool: True if the metric score meets the success criteria
+        """
+        # Determine score type if not provided
+        if score_type is None:
+            score_type = self._determine_score_type(score, threshold_operator)
+        elif isinstance(score_type, str):
+            try:
+                score_type = ScoreType(score_type)
+            except ValueError:
+                logger.warning(f"Invalid score type '{score_type}', auto-determining from score")
+                score_type = self._determine_score_type(score, threshold_operator)
+        
+        # Sanitize and validate threshold operator
+        sanitized_operator = self._sanitize_threshold_operator(threshold_operator)
+        
+        # Set default threshold operator based on score type if none provided or invalid
+        if sanitized_operator is None:
+            if score_type == ScoreType.NUMERIC:
+                sanitized_operator = ThresholdOperator.GREATER_THAN_OR_EQUAL
+            else:  # BINARY or CATEGORICAL
+                sanitized_operator = ThresholdOperator.EQUAL
+            logger.debug(f"Using default operator '{sanitized_operator.value}' for score type '{score_type.value}'")
+        
+        # Validate operator for score type
+        if not self._validate_operator_for_score_type(sanitized_operator, score_type):
+            # Fall back to appropriate default if validation fails
+            if score_type == ScoreType.NUMERIC:
+                sanitized_operator = ThresholdOperator.GREATER_THAN_OR_EQUAL
+            else:
+                sanitized_operator = ThresholdOperator.EQUAL
+            logger.debug(f"Falling back to operator '{sanitized_operator.value}' for score type '{score_type.value}'")
+        
+        # Handle different score types
+        if score_type == ScoreType.NUMERIC:
+            return self._evaluate_numeric_score(score, threshold, sanitized_operator)
+        else:  # BINARY or CATEGORICAL
+            return self._evaluate_categorical_score(score, reference_score, threshold, sanitized_operator)
+
+    def _evaluate_numeric_score(
+        self,
+        score: Union[float, int],
+        threshold: Optional[float],
+        threshold_operator: ThresholdOperator
+    ) -> bool:
+        """
+        Evaluate numeric scores against threshold using the specified operator.
+        
+        Args:
+            score: The numeric score
+            threshold: The threshold value
+            threshold_operator: The comparison operator
+            
+        Returns:
+            bool: True if the score meets the criteria
+        """
+        # Convert score to float if it's not already
+        try:
+            numeric_score = float(score)
+        except (ValueError, TypeError):
+            logger.warning(f"Could not convert score '{score}' to numeric value")
+            return False
+        
+        # Validate threshold is provided for numeric scores
+        if threshold is None:
+            logger.warning("Threshold is required for numeric score type but was not provided")
+            return False
+        
+        # Use operator module for comparison
+        op_func = OPERATOR_MAP.get(threshold_operator)
+        if op_func is None:
+            # Fallback to default behavior
+            logger.warning(f"Unknown operator '{threshold_operator}', defaulting to '>='")
+            return numeric_score >= threshold
+            
+        return op_func(numeric_score, threshold)
+
+    def _evaluate_categorical_score(
+        self,
+        score: Union[str, float, int],
+        reference_score: Optional[str],
+        threshold: Optional[float],
+        threshold_operator: ThresholdOperator
+    ) -> bool:
+        """
+        Evaluate binary/categorical scores against reference score using the specified operator.
+        
+        Args:
+            score: The score value
+            reference_score: The reference score to compare against
+            threshold: The threshold (used as reference if reference_score not provided)
+            threshold_operator: The comparison operator
+            
+        Returns:
+            bool: True if the score meets the criteria
+        """
+        # Determine reference value
+        if reference_score is None:
+            if threshold is not None:
+                reference_value = str(threshold)
+            else:
+                logger.warning("Reference score or threshold is required for binary/categorical score type but was not provided")
+                return False
+        else:
+            reference_value = reference_score
+        
+        # Convert score to string for comparison
+        score_str = str(score).lower().strip() if not isinstance(score, str) else score.lower().strip()
+        reference_str = reference_value.lower().strip()
+        
+        # Use operator module for comparison
+        op_func = OPERATOR_MAP.get(threshold_operator)
+        if op_func is None:
+            # Fallback to equality check
+            logger.warning(f"Unknown operator '{threshold_operator}', defaulting to equality")
+            return score_str == reference_str
+            
+        return op_func(score_str, reference_str) 

--- a/apps/backend/src/rhesis/backend/metrics/types.py
+++ b/apps/backend/src/rhesis/backend/metrics/types.py
@@ -1,0 +1,47 @@
+import operator
+from enum import Enum
+
+
+class ScoreType(str, Enum):
+    BINARY = "binary"
+    NUMERIC = "numeric"
+    CATEGORICAL = "categorical"
+
+
+class ThresholdOperator(str, Enum):
+    EQUAL = "="
+    LESS_THAN = "<"
+    GREATER_THAN = ">"
+    LESS_THAN_OR_EQUAL = "<="
+    GREATER_THAN_OR_EQUAL = ">="
+    NOT_EQUAL = "!="
+
+
+# Mapping threshold operators to Python operator functions
+OPERATOR_MAP = {
+    ThresholdOperator.EQUAL: operator.eq,
+    ThresholdOperator.LESS_THAN: operator.lt,
+    ThresholdOperator.GREATER_THAN: operator.gt,
+    ThresholdOperator.LESS_THAN_OR_EQUAL: operator.le,
+    ThresholdOperator.GREATER_THAN_OR_EQUAL: operator.ge,
+    ThresholdOperator.NOT_EQUAL: operator.ne,
+}
+
+# Valid operators for different score types
+VALID_OPERATORS_BY_SCORE_TYPE = {
+    ScoreType.BINARY: {ThresholdOperator.EQUAL, ThresholdOperator.NOT_EQUAL},
+    ScoreType.CATEGORICAL: {ThresholdOperator.EQUAL, ThresholdOperator.NOT_EQUAL},
+    ScoreType.NUMERIC: set(ThresholdOperator),  # All operators are valid for numeric
+}
+
+# Legacy mapping for string operators (for backward compatibility)
+THRESHOLD_OPERATOR_MAP = {
+    "<": operator.lt,
+    "<=": operator.le,
+    ">": operator.gt,
+    ">=": operator.ge,
+    "=": operator.eq,
+    "==": operator.eq,
+    "!=": operator.ne,
+    "<>": operator.ne,
+} 

--- a/apps/backend/src/rhesis/backend/metrics/utils.py
+++ b/apps/backend/src/rhesis/backend/metrics/utils.py
@@ -1,0 +1,74 @@
+from typing import Any, Dict, List, Optional, Union
+
+from rhesis.backend.metrics.base import MetricConfig
+
+
+def run_evaluation(
+    input_text: str,
+    output_text: str,
+    expected_output: Optional[str],
+    context: List[str],
+    metrics: List[Union[Dict[str, Any], MetricConfig]],
+    max_workers: int = 5,
+) -> Dict[str, Any]:
+    """
+    Helper function to run the metric evaluation using MetricEvaluator.
+    
+    Args:
+        input_text: The input query or question
+        output_text: The actual output from the LLM
+        expected_output: The expected or reference output
+        context: List of context strings used for the response
+        metrics: List of metric configurations (MetricConfig objects or dictionaries)
+        max_workers: Maximum number of parallel workers
+        
+    Returns:
+        Dictionary of metric results
+    """
+    # Lazy import to avoid circular dependencies
+    from rhesis.backend.metrics.evaluator import MetricEvaluator
+    
+    evaluator = MetricEvaluator()
+    return evaluator.evaluate(
+        input_text=input_text,
+        output_text=output_text,
+        expected_output=expected_output,
+        context=context,
+        metrics=metrics,
+        max_workers=max_workers,
+    )
+
+
+def diagnose_invalid_metric(config: Union[Dict[str, Any], MetricConfig]) -> str:
+    """
+    Diagnose the reason why a metric configuration is invalid.
+
+    Args:
+        config: The metric configuration
+
+    Returns:
+        A string describing the reason why the metric configuration is invalid
+    """
+    if config is None:
+        return "configuration is None"
+        
+    if isinstance(config, MetricConfig):
+        missing_fields = []
+        if not config.class_name or (isinstance(config.class_name, str) and not config.class_name.strip()):
+            missing_fields.append("class_name")
+        if not config.backend or (isinstance(config.backend, str) and not config.backend.strip()):
+            missing_fields.append("backend")
+        if missing_fields:
+            return f"missing or empty required fields: {', '.join(missing_fields)}"
+    elif isinstance(config, dict):
+        missing_fields = []
+        if "class_name" not in config or config["class_name"] is None or (isinstance(config["class_name"], str) and not config["class_name"].strip()):
+            missing_fields.append("class_name")
+        if "backend" not in config or config["backend"] is None or (isinstance(config["backend"], str) and not config["backend"].strip()):
+            missing_fields.append("backend")
+        if missing_fields:
+            return f"missing or empty required fields: {', '.join(missing_fields)}"
+    else:
+        return f"invalid configuration type: {type(config).__name__} (expected dict or MetricConfig)"
+        
+    return "unknown validation error" 

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1924,6 +1924,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.26.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/ac/87285f15f7cce6d4a008f33f1757fb5a13611ea8914eb58c3d0d26243468/proto_plus-1.26.1.tar.gz", hash = "sha256:21a515a4c4c0088a773899e23c7bbade3d18f9c66c73edd4c7ee3816bc96a012", size = 56142, upload-time = "2025-03-10T15:54:38.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/6d/280c4c2ce28b1593a19ad5239c8b826871fc6ec275c21afc8e1820108039/proto_plus-1.26.1-py3-none-any.whl", hash = "sha256:13285478c2dcf2abb829db158e1047e2f1e8d63a077d94263c2b88b043c75a66", size = 50163, upload-time = "2025-03-10T15:54:37.335Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "5.29.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2408,6 +2420,8 @@ dependencies = [
     { name = "pandas" },
     { name = "pathspec" },
     { name = "portalocker" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
     { name = "psutil" },
     { name = "psycopg2-binary" },
     { name = "pydantic" },
@@ -2452,6 +2466,8 @@ requires-dist = [
     { name = "pandas", specifier = "==2.2.2" },
     { name = "pathspec", specifier = "==0.12.1" },
     { name = "portalocker", specifier = "==3.1.1" },
+    { name = "proto-plus", specifier = ">=1.26.1" },
+    { name = "protobuf", specifier = ">=5.29.4" },
     { name = "psutil", specifier = "==5.9.5" },
     { name = "psycopg2-binary", specifier = "==2.9.9" },
     { name = "pydantic" },


### PR DESCRIPTION
This PR introduces changes from the `feature/gemini-default-metrics` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->

## 🔄 Changes

- Enabling Gemini as backend for Rhesis metrics (800a728)

## 📁 Files Changed (9 files)

```
apps/backend/pyproject.toml
apps/backend/src/rhesis/backend/metrics/__init__.py
apps/backend/src/rhesis/backend/metrics/evaluator.py
apps/backend/src/rhesis/backend/metrics/rhesis/metric_base.py
apps/backend/src/rhesis/backend/metrics/rhesis/prompt_metric.py
apps/backend/src/rhesis/backend/metrics/score_evaluator.py
apps/backend/src/rhesis/backend/metrics/types.py
apps/backend/src/rhesis/backend/metrics/utils.py
apps/backend/uv.lock
```

## 📋 Commit Details

```
800a728 - Enabling Gemini as backend for Rhesis metrics (Harry Cruz, 36 seconds ago)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->