### PR TITLE
Fix: Kubernetes Restart

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -253,6 +253,9 @@ jobs:
           sed -i "s|PROJECT_ID:REGION:CLOUDSQL_INSTANCE|${{ env.PROJECT_ID }}:${{ env.REGION }}:${{ secrets.CLOUDSQL_INSTANCE }}|g" deployment.yaml
           sed -i "s|GCP_SERVICE_ACCOUNT_EMAIL|${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}|g" serviceaccount.yaml
           
+          # Always force pod restart by updating timestamp annotation
+          sed -i "s|deployment-timestamp: \"placeholder\"|deployment-timestamp: \"$(date +%s)\"|g" deployment.yaml
+          
           # Update kustomization for environment
           cat > kustomization.yaml << EOF
           apiVersion: kustomize.config.k8s.io/v1beta1

--- a/apps/worker/k8s/deployment.yaml
+++ b/apps/worker/k8s/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         app: rhesis-worker
         component: worker
+      annotations:
+        # Always restart pods on every deployment
+        deployment-timestamp: "placeholder"
     spec:
       serviceAccountName: rhesis-worker-sa
       containers:


### PR DESCRIPTION
This PR introduces changes from the `fix/kubernetes-restart` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->

## 🔄 Changes

- Restarting Kubernetes pods by default (202f9c2)

## 📁 Files Changed (2 files)

```
.github/workflows/worker.yml
apps/worker/k8s/deployment.yaml
```

## 📋 Commit Details

```
202f9c2 - Restarting Kubernetes pods by default (Harry Cruz, 73 seconds ago)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->