### PR TITLE
Feat/basic search capabilities for tests basedatagrid 119

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -80,12 +80,14 @@ export default function TestRunsTable({ sessionToken, onRefresh }: TestRunsTable
       const clientFactory = new ApiClientFactory(sessionToken);
       const testRunsClient = clientFactory.getTestRunsClient();
       
-      const response = await testRunsClient.getTestRuns({
+      const apiParams = {
         skip,
         limit,
         sort_by: 'created_at',
-        sort_order: 'desc'
-      });
+        sort_order: 'desc' as const,
+      };
+      
+      const response = await testRunsClient.getTestRuns(apiParams);
       
       if (isMounted.current) {
         setTestRuns(response.data);

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -147,12 +147,14 @@ export default function TestSetsGrid({
       const skip = paginationModel.page * paginationModel.pageSize;
       const limit = paginationModel.pageSize;
       
-      const response = await testSetsClient.getTestSets({ 
-                  skip, 
-          limit,
-          sort_by: 'created_at',
-          sort_order: 'desc'
-      });
+      const apiParams = {
+        skip, 
+        limit,
+        sort_by: 'created_at',
+        sort_order: 'desc' as const,
+      };
+      
+      const response = await testSetsClient.getTestSets(apiParams);
       
       setTestSets(response.data);
       setTotalCount(response.pagination.totalCount);
@@ -198,27 +200,32 @@ export default function TestSetsGrid({
       field: 'behaviors', 
       headerName: 'Behaviors', 
       flex: 1.0,
-      renderCell: (params) => <ChipContainer items={params.value || []} />
+      renderCell: (params) => <ChipContainer items={params.row.behaviors || []} />
     },
     { 
       field: 'categories', 
       headerName: 'Categories', 
       flex: 1.0,
-      renderCell: (params) => <ChipContainer items={params.value || []} />
+      renderCell: (params) => <ChipContainer items={params.row.categories || []} />
     },
-    { field: 'totalTests', headerName: 'Tests', flex: 0.5 },
+    { 
+      field: 'totalTests', 
+      headerName: 'Tests', 
+      flex: 0.5,
+      valueGetter: (_, row) => row.totalTests
+    },
     { 
       field: 'status', 
       headerName: 'Status', 
       flex: 0.5,
-      renderCell: (params) => <Chip label={params.value} size="small" variant="outlined" color="secondary" />
+      renderCell: (params) => <Chip label={params.row.status} size="small" variant="outlined" color="secondary" />
     },
     {
       field: 'assignee',
       headerName: 'Assignee',
       flex: 0.75,
       renderCell: (params) => {
-        const assignee = params.value;
+        const assignee = params.row.assignee;
         if (!assignee) return '-';
         
         const displayName = assignee.name || 

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -70,11 +70,11 @@ export default function TestsTable({ sessionToken, onRefresh }: TestsTableProps)
       // Convert filter model to OData filter string
       const filterString = convertGridFilterModelToOData(filterModel);
       
-      const apiParams = {
+      const apiParams: Parameters<typeof testsClient.getTests>[0] = {
         skip: paginationModel.page * paginationModel.pageSize,
         limit: paginationModel.pageSize,
         sort_by: 'created_at',
-        sort_order: 'desc' as const,
+        sort_order: 'desc',
         ...(filterString && { filter: filterString })
       };
       

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -69,8 +69,6 @@ export default function TestsTable({ sessionToken, onRefresh }: TestsTableProps)
       
       // Convert filter model to OData filter string
       const filterString = convertGridFilterModelToOData(filterModel);
-      console.log('Filter model:', filterModel);
-      console.log('Converted OData filter string:', filterString);
       
       const apiParams = {
         skip: paginationModel.page * paginationModel.pageSize,
@@ -79,8 +77,6 @@ export default function TestsTable({ sessionToken, onRefresh }: TestsTableProps)
         sort_order: 'desc' as const,
         ...(filterString && { filter: filterString })
       };
-      
-      console.log('API call parameters:', apiParams);
       
       const response = await testsClient.getTests(apiParams);
       
@@ -109,7 +105,6 @@ export default function TestsTable({ sessionToken, onRefresh }: TestsTableProps)
 
   // Handle filter change
   const handleFilterModelChange = useCallback((newModel: GridFilterModel) => {
-    console.log('Filter model changed:', newModel);
     setFilterModel(newModel);
     // Reset to first page when filters change
     setPaginationModel(prev => ({ ...prev, page: 0 }));

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -121,6 +121,8 @@ export default function TestsTable({ sessionToken, onRefresh }: TestsTableProps)
       field: 'prompt.content', 
       headerName: 'Content', 
       flex: 3,
+      filterable: true,
+      valueGetter: (value, row) => row.prompt?.content || '',
       renderCell: (params) => {
         const content = params.row.prompt?.content || params.row.content;
         if (!content) return null;
@@ -144,6 +146,8 @@ export default function TestsTable({ sessionToken, onRefresh }: TestsTableProps)
       field: 'behavior.name',
       headerName: 'Behavior', 
       flex: 1,
+      filterable: true,
+      valueGetter: (value, row) => row.behavior?.name || '',
       renderCell: (params) => {
         const behaviorName = params.row.behavior?.name;
         if (!behaviorName) return null;
@@ -162,6 +166,8 @@ export default function TestsTable({ sessionToken, onRefresh }: TestsTableProps)
       field: 'topic.name', 
       headerName: 'Topic', 
       flex: 1,
+      filterable: true,
+      valueGetter: (value, row) => row.topic?.name || '',
       renderCell: (params) => {
         const topicName = params.row.topic?.name;
         if (!topicName) return null;
@@ -180,6 +186,8 @@ export default function TestsTable({ sessionToken, onRefresh }: TestsTableProps)
       field: 'category.name', 
       headerName: 'Category', 
       flex: 1,
+      filterable: true,
+      valueGetter: (value, row) => row.category?.name || '',
       renderCell: (params) => {
         const categoryName = params.row.category?.name;
         if (!categoryName) return null;
@@ -198,6 +206,14 @@ export default function TestsTable({ sessionToken, onRefresh }: TestsTableProps)
       field: 'assignee.name', 
       headerName: 'Assignee', 
       flex: 1,
+      filterable: true,
+      valueGetter: (value, row) => {
+        const assignee = row.assignee;
+        if (!assignee) return '';
+        return assignee.name || 
+          `${assignee.given_name || ''} ${assignee.family_name || ''}`.trim() || 
+          assignee.email || '';
+      },
       renderCell: (params) => {
         const assignee = params.row.assignee;
         if (!assignee) return null;
@@ -377,6 +393,7 @@ export default function TestsTable({ sessionToken, onRefresh }: TestsTableProps)
         pageSizeOptions={[10, 25, 50]}
         serverSideFiltering={true}
         onFilterModelChange={handleFilterModelChange}
+        showToolbar={true}
       />
 
       {sessionToken && (

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -28,7 +28,8 @@ import {
   GridRowSelectionModel,
   GridToolbar,
   GridToolbarQuickFilter,
-  useGridApiRef
+  useGridApiRef,
+  GridFilterModel
 } from '@mui/x-data-grid';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -100,6 +101,9 @@ interface BaseDataGridProps {
   pageSizeOptions?: number[];
   // Quick filter props
   enableQuickFilter?: boolean;
+  // Server-side filtering props
+  serverSideFiltering?: boolean;
+  onFilterModelChange?: (model: GridFilterModel) => void;
 }
 
 // Create a styled version of DataGrid with bold headers
@@ -159,7 +163,9 @@ export default function BaseDataGrid({
   paginationModel,
   onPaginationModelChange,
   pageSizeOptions = [10, 25, 50],
-  enableQuickFilter = false
+  enableQuickFilter = false,
+  serverSideFiltering = false,
+  onFilterModelChange
 }: BaseDataGridProps) {
   const router = useRouter();
   const apiRef = useGridApiRef();
@@ -456,6 +462,10 @@ export default function BaseDataGrid({
           loading={loading}
           onRowClick={enableEditing ? undefined : (linkPath || onRowClick) ? handleRowClickWithLink : undefined}
           disableMultipleRowSelection={disableMultipleRowSelection}
+          {...(serverSideFiltering && {
+            filterMode: "server",
+            onFilterModelChange: onFilterModelChange
+          })}
           {...(enableQuickFilter && {
             slots: { toolbar: CustomToolbar }
           })}

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -308,6 +308,15 @@ export default function BaseDataGrid({
     );
   };
 
+  const CustomToolbarWithFilters = () => {
+    return (
+      <Box sx={{ p: 1, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <GridToolbar />
+        <GridToolbarQuickFilter debounceMs={300} />
+      </Box>
+    );
+  };
+
   if (!isInitialized) {
     return (
       <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center', p: 4 }}>
@@ -464,9 +473,10 @@ export default function BaseDataGrid({
           disableMultipleRowSelection={disableMultipleRowSelection}
           {...(serverSideFiltering && {
             filterMode: "server",
-            onFilterModelChange: onFilterModelChange
+            onFilterModelChange: onFilterModelChange,
+            slots: { toolbar: CustomToolbarWithFilters }
           })}
-          {...(enableQuickFilter && {
+          {...(enableQuickFilter && !serverSideFiltering && {
             slots: { toolbar: CustomToolbar }
           })}
           {...(enableEditing && {

--- a/apps/frontend/src/utils/api-client/tests-client.ts
+++ b/apps/frontend/src/utils/api-client/tests-client.ts
@@ -66,12 +66,16 @@ export class TestsClient extends BaseApiClient {
     return result;
   }
 
-  async getTests(params?: PaginationParams): Promise<PaginatedResponse<TestDetail>> {
-    const paginationParams = { ...DEFAULT_PAGINATION, ...params };
+  async getTests(params?: PaginationParams & { filter?: string }): Promise<PaginatedResponse<TestDetail>> {
+    const { filter, ...paginationParams } = params || {};
+    const finalParams = { ...DEFAULT_PAGINATION, ...paginationParams };
     
     const response = await this.fetchPaginated<TestDetail>(
       API_ENDPOINTS.tests,
-      paginationParams,
+      {
+        ...finalParams,
+        ...(filter && { $filter: filter })
+      },
       {
         cache: 'no-store'
       }

--- a/apps/frontend/src/utils/odata-filter.ts
+++ b/apps/frontend/src/utils/odata-filter.ts
@@ -127,26 +127,16 @@ export function convertGridFilterModelToOData(filterModel: GridFilterModel): str
     return '';
   }
 
-  console.log('Converting filter model to OData:', filterModel);
-
   const filterExpressions = filterModel.items
-    .map(item => {
-      const expression = convertFilterItemToOData(item);
-      console.log(`Filter item ${JSON.stringify(item)} -> "${expression}"`);
-      return expression;
-    })
+    .map(item => convertFilterItemToOData(item))
     .filter(expr => expr !== '');
 
   if (filterExpressions.length === 0) {
-    console.log('No valid filter expressions generated');
     return '';
   }
 
   // Join multiple filters with AND (MUI DataGrid typically uses AND by default)
   // Note: linkOperator might not be available in all versions, so we default to 'and'
   const linkOperator = (filterModel as any).linkOperator || 'and';
-  const result = filterExpressions.join(` ${linkOperator} `);
-  
-  console.log(`Final OData filter: "${result}"`);
-  return result;
+  return filterExpressions.join(` ${linkOperator} `);
 } 

--- a/apps/frontend/src/utils/odata-filter.ts
+++ b/apps/frontend/src/utils/odata-filter.ts
@@ -1,0 +1,132 @@
+import { GridFilterModel, GridFilterItem } from '@mui/x-data-grid';
+
+/**
+ * Creates a wildcard search filter that searches across all major text fields
+ * This simulates a $search functionality by using OR conditions across multiple fields
+ */
+export function createWildcardSearchFilter(searchTerm: string): string {
+  if (!searchTerm || searchTerm.trim() === '') {
+    return '';
+  }
+
+  const escapedTerm = escapeODataValue(searchTerm.trim());
+  
+  // Define all the searchable fields for tests
+  const searchableFields = [
+    'behavior/name',
+    'topic/name', 
+    'category/name',
+    'prompt/content',
+    'assignee/name',
+    'assignee/email',
+    'assignee/given_name',
+    'assignee/family_name',
+    'owner/name',
+    'owner/email',
+    'owner/given_name', 
+    'owner/family_name'
+  ];
+
+  // Create contains conditions for each field
+  const conditions = searchableFields.map(field => 
+    `contains(tolower(${field}), tolower('${escapedTerm}'))`
+  );
+
+  // Join all conditions with OR
+  return conditions.join(' or ');
+}
+
+/**
+ * Converts a MUI DataGrid filter item to an OData filter expression
+ */
+function convertFilterItemToOData(item: GridFilterItem): string {
+  const { field, operator, value } = item;
+  
+  if (!field || !operator || value === undefined || value === null || value === '') {
+    return '';
+  }
+
+  // Convert dot notation to OData relationship syntax
+  // e.g., 'behavior.name' becomes 'behavior/name'
+  const odataField = field.replace(/\./g, '/');
+
+  // Handle different operators
+  switch (operator) {
+    case 'contains':
+      return `contains(tolower(${odataField}), tolower('${escapeODataValue(value)}'))`;
+    
+    case 'startsWith':
+      return `startswith(tolower(${odataField}), tolower('${escapeODataValue(value)}'))`;
+    
+    case 'endsWith':
+      return `endswith(tolower(${odataField}), tolower('${escapeODataValue(value)}'))`;
+    
+    case 'equals':
+    case '=':
+      return `${odataField} eq '${escapeODataValue(value)}'`;
+    
+    case 'not':
+    case '!=':
+      return `${odataField} ne '${escapeODataValue(value)}'`;
+    
+    case 'greaterThan':
+    case '>':
+      return `${odataField} gt ${escapeODataValue(value)}`;
+    
+    case 'greaterThanOrEqual':
+    case '>=':
+      return `${odataField} ge ${escapeODataValue(value)}`;
+    
+    case 'lessThan':
+    case '<':
+      return `${odataField} lt ${escapeODataValue(value)}`;
+    
+    case 'lessThanOrEqual':
+    case '<=':
+      return `${odataField} le ${escapeODataValue(value)}`;
+    
+    case 'isEmpty':
+      return `${odataField} eq null`;
+    
+    case 'isNotEmpty':
+      return `${odataField} ne null`;
+    
+    default:
+      console.warn(`Unsupported operator: ${operator}`);
+      return '';
+  }
+}
+
+/**
+ * Escapes special characters in OData filter values
+ */
+function escapeODataValue(value: any): string {
+  if (typeof value !== 'string') {
+    return String(value);
+  }
+  
+  // Escape single quotes by doubling them
+  return value.replace(/'/g, "''");
+}
+
+/**
+ * Converts a MUI DataGrid filter model to an OData filter expression
+ */
+export function convertGridFilterModelToOData(filterModel: GridFilterModel): string {
+  if (!filterModel.items || filterModel.items.length === 0) {
+    return '';
+  }
+
+  const filterExpressions = filterModel.items
+    .map(item => convertFilterItemToOData(item))
+    .filter(expr => expr !== '');
+
+  if (filterExpressions.length === 0) {
+    return '';
+  }
+
+  // Join multiple filters with AND (MUI DataGrid typically uses AND by default)
+  // Note: linkOperator might not be available in all versions, so we default to 'and'
+  const linkOperator = (filterModel as any).linkOperator || 'and';
+  return filterExpressions.join(` ${linkOperator} `);
+} 

--- a/apps/frontend/src/utils/odata-filter.ts
+++ b/apps/frontend/src/utils/odata-filter.ts
@@ -64,6 +64,7 @@ function convertFilterItemToOData(item: GridFilterItem): string {
     
     case 'equals':
     case '=':
+    case 'is':
       // For string fields, use case-insensitive comparison
       if (typeof value === 'string') {
         return `tolower(${odataField}) eq tolower('${escapeODataValue(value)}')`;
@@ -95,14 +96,21 @@ function convertFilterItemToOData(item: GridFilterItem): string {
       return `${odataField} le ${escapeODataValue(value)}`;
     
     case 'isEmpty':
-      return `${odataField} eq null`;
+      return `${odataField} eq null or ${odataField} eq ''`;
     
     case 'isNotEmpty':
-      return `${odataField} ne null`;
+      return `${odataField} ne null and ${odataField} ne ''`;
+    
+    case 'isAnyOf':
+      if (Array.isArray(value) && value.length > 0) {
+        const conditions = value.map(v => `${odataField} eq '${escapeODataValue(v)}'`).join(' or ');
+        return `(${conditions})`;
+      }
+      return '';
     
     default:
-      console.warn(`Unsupported operator: ${operator}`);
-      return '';
+      // Fallback for unknown operators - treat as contains
+      return `contains(tolower(${odataField}), tolower('${escapeODataValue(value)}'))`;
   }
 }
 
@@ -123,20 +131,76 @@ function escapeODataValue(value: any): string {
  * Optimized for Tests filtering
  */
 export function convertGridFilterModelToOData(filterModel: GridFilterModel): string {
-  if (!filterModel.items || filterModel.items.length === 0) {
+  if (!filterModel || !filterModel.items || filterModel.items.length === 0) {
     return '';
   }
 
+  // Convert each filter item to OData expression
   const filterExpressions = filterModel.items
     .map(item => convertFilterItemToOData(item))
-    .filter(expr => expr !== '');
+    .filter(expr => expr !== ''); // Remove empty expressions
 
   if (filterExpressions.length === 0) {
     return '';
   }
 
-  // Join multiple filters with AND (MUI DataGrid typically uses AND by default)
-  // Note: linkOperator might not be available in all versions, so we default to 'and'
-  const linkOperator = (filterModel as any).linkOperator || 'and';
-  return filterExpressions.join(` ${linkOperator} `);
+  if (filterExpressions.length === 1) {
+    return filterExpressions[0];
+  }
+
+  // Join multiple filters with the logic operator
+  const logicOperator = filterModel.logicOperator === 'or' ? ' or ' : ' and ';
+  return `(${filterExpressions.join(logicOperator)})`;
+}
+
+/**
+ * Handles quick filter (global search) conversion to OData
+ */
+export function convertQuickFilterToOData(quickFilterValues: any[], searchFields: string[]): string {
+  if (!quickFilterValues || quickFilterValues.length === 0 || !searchFields || searchFields.length === 0) {
+    return '';
+  }
+
+  const quickFilterExpressions = quickFilterValues.map(value => {
+    if (!value || value === '') return '';
+    
+    // Create a contains condition for each search field
+    const fieldConditions = searchFields.map(field => 
+      `contains(tolower(${field}), tolower('${escapeODataValue(value)}'))`
+    );
+    
+    // Join field conditions with OR (search in any field)
+    return `(${fieldConditions.join(' or ')})`;
+  }).filter(expr => expr !== '');
+
+  if (quickFilterExpressions.length === 0) {
+    return '';
+  }
+
+  if (quickFilterExpressions.length === 1) {
+    return quickFilterExpressions[0];
+  }
+
+  // Join multiple quick filter values with AND (all values must match)
+  return `(${quickFilterExpressions.join(' and ')})`;
+}
+
+/**
+ * Combines regular filters and quick filters into a single OData expression
+ */
+export function combineFiltersToOData(
+  filterModel: GridFilterModel, 
+  quickFilterValues?: any[], 
+  searchFields?: string[]
+): string {
+  const regularFilter = convertGridFilterModelToOData(filterModel);
+  const quickFilter = quickFilterValues && searchFields 
+    ? convertQuickFilterToOData(quickFilterValues, searchFields) 
+    : '';
+
+  if (regularFilter && quickFilter) {
+    return `(${regularFilter}) and (${quickFilter})`;
+  }
+
+  return regularFilter || quickFilter || '';
 } 


### PR DESCRIPTION
# Fix Server-Side OData Filtering in MUI DataGrid

## Summary
This PR fixes the broken server-side filtering functionality in the Tests grid by implementing proper OData filter conversion and enabling column filters in the MUI DataGrid. The implementation follows OData best practices with case-insensitive searches and supports navigation properties for related entities.

## Problem
The server-side filtering with OData was not working because:
- Column filters were not enabled in the MUI DataGrid
- Missing proper OData conversion from MUI filter model to backend-compatible syntax
- No toolbar configuration to show column filter controls
- Missing `valueGetter` functions for nested properties

## Solution
Implemented comprehensive server-side filtering with proper OData syntax conversion, enabling users to filter tests by behavior, topic, category, assignee, and prompt content directly from the DataGrid column headers.

## Files Changed

### `apps/frontend/src/utils/odata-filter.ts`
**Why changed:** Core OData conversion logic was incomplete and missing best practices
- **Enhanced case-insensitive filtering:** Added `tolower()` functions for all string operations following OData documentation best practices
- **Improved equals/not-equals operators:** Made string comparisons case-insensitive by default for better user experience
- **Added comprehensive debugging:** Implemented step-by-step logging for filter conversion process (later removed for production)
- **Maintained security:** Proper SQL injection prevention with `escapeODataValue()`

### `apps/frontend/src/components/common/BaseDataGrid.tsx`
**Why changed:** DataGrid needed proper toolbar configuration to show column filters
- **Added `CustomToolbarWithFilters` component:** New toolbar that includes both column filters (`GridToolbar`) and quick search functionality
- **Enhanced server-side filtering configuration:** Updated DataGrid props to use the appropriate toolbar when `serverSideFiltering` is enabled
- **Improved conditional toolbar logic:** Ensures quick filter and column filters don't conflict

### `apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx`
**Why changed:** Column definitions needed filtering configuration and proper data access
- **Enabled column filtering:** Added `filterable: true` to all relevant columns
- **Added `valueGetter` functions:** Implemented proper data extraction for nested properties (e.g., `row.behavior?.name`) so DataGrid can filter on relationship data
- **Fixed TypeScript compatibility:** Updated valueGetter signature to use MUI DataGrid v6+ format: `(value, row) => ...`
- **Enabled toolbar:** Added `showToolbar={true}` to display the column filter controls
- **Removed debugging logs:** Cleaned up console.log statements for production readiness

## Key Features Implemented

### 🔍 **Comprehensive Filter Support**
- **String operations:** `contains`, `startsWith`, `endsWith` (all case-insensitive)
- **Comparison operators:** `equals`, `not equals`, `greater than`, `less than`, etc.
- **Null checks:** `isEmpty`, `isNotEmpty` for handling null values
- **Navigation properties:** Support for filtering on related entities (`behavior/name`, `topic/name`, etc.)

Solves #119 