### PR TITLE
Fix: Prevent Env Loading In Vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,9 +160,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-# VS Code
-#  This ignores the .vscode/ folder which is used by Visual Studio Code to store its settings.
-.vscode/
 
 # Report JSON
 #  This ignores the json report file being created

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.envFile": "",
+}


### PR DESCRIPTION
This PR introduces changes from the `fix/prevent-env-loading-in-vscode` branch.

## 📝 Summary


Solves the problem of inconsistent parsing of variables stored in `.env` file. The inconsistency is caused by the difference in the way `dotenv` and VS Code parse the strings. To avoid this and other unexpected problems, it was decided to disable loading of environment variables from `.env` file in VS Code.

## 🔄 Changes

- chore: remove VS Code settings from .gitignore, prevent loading environment variables by VS Code (c222ddd)

## 📁 Files Changed (       2 files)

```
.gitignore
.vscode/settings.json
```

## 📋 Commit Details

```
c222ddd - chore: remove VS Code settings from .gitignore, prevent loading environment variables by VS Code (Arkadiusz Kwasigroch, 6 minutes ago)
```


## 🔗 Related Issues

Fixes #107 