### PR TITLE
Document Support Generate Tests

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -215,12 +215,12 @@ async def upload_document(document: UploadFile = File(...)):
         document: The document to upload (multipart/form-data)
 
     Returns:
-        DocumentUploadResponse: Contains the temporary filename identifier
+        DocumentUploadResponse: Contains the full path to the uploaded document
     
     Note: 
         The document will be saved in the temporary directory and should be cleaned up after use.
-        Use the returned filename to reference this document in other endpoints.
+        Use the returned path to reference this document in other endpoints.
     """
     handler = DocumentHandler()
-    filename = await handler.save_document(document)
-    return {"filename": filename}
+    path = await handler.save_document(document)
+    return {"path": path}

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -215,12 +215,12 @@ async def upload_document(document: UploadFile = File(...)):
         document: The document to upload (multipart/form-data)
 
     Returns:
-        DocumentUploadResponse: Contains the temporary path identifier
+        DocumentUploadResponse: Contains the temporary filename identifier
     
     Note: 
         The document will be saved in the temporary directory and should be cleaned up after use.
-        Use the returned path to reference this document in other endpoints.
+        Use the returned filename to reference this document in other endpoints.
     """
     handler = DocumentHandler()
-    path = await handler.save_document(document)
-    return {"path": path}
+    filename = await handler.save_document(document)
+    return {"filename": filename}

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -204,23 +204,23 @@ async def generate_text(prompt_request: PromptRequest):
 
 
 @router.post("/documents/upload", response_model=DocumentUploadResponse)
-async def upload_document(file: UploadFile = File(...)):
+async def upload_document(document: UploadFile = File(...)):
     """
     Upload a document to temporary storage.
 
-    The file will be saved in a temporary directory with a UUID prefix to avoid naming conflicts.
-    Maximum file size is 5MB.
+    The document will be saved in a temporary directory with a UUID prefix to avoid naming conflicts.
+    Maximum document size is 5MB.
 
     Args:
-        file: The file to upload (multipart/form-data)
+        document: The document to upload (multipart/form-data)
 
     Returns:
         DocumentUploadResponse: Contains the temporary path identifier
     
     Note: 
-        The file will be saved in the temporary directory and should be cleaned up after use.
-        Use the returned path to reference this file in other endpoints.
+        The document will be saved in the temporary directory and should be cleaned up after use.
+        Use the returned path to reference this document in other endpoints.
     """
     handler = DocumentHandler()
-    path = await handler.save_file(file)
+    path = await handler.save_document(document)
     return {"path": path}

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -12,7 +12,8 @@ from rhesis.backend.app.schemas.services import (
     GenerateTestsRequest, 
     GenerateTestsResponse,
     PromptRequest,
-    TextResponse
+    TextResponse,
+    DocumentUploadResponse
 )
 from rhesis.backend.app.services.github import read_repo_contents
 from rhesis.backend.app.services.generation import generate_tests
@@ -202,7 +203,7 @@ async def generate_text(prompt_request: PromptRequest):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.post("/documents/upload")
+@router.post("/documents/upload", response_model=DocumentUploadResponse)
 async def upload_document(file: UploadFile = File(...)):
     """
     Upload a document to temporary storage.
@@ -214,16 +215,9 @@ async def upload_document(file: UploadFile = File(...)):
         file: The file to upload (multipart/form-data)
 
     Returns:
-        dict: Contains the temporary path identifier:
-            {
-                "path": str  # UUID-prefixed filename (e.g. "123e4567-e89b-12d3-a456-426614174000.txt")
-            }
-
-    Raises:
-        HTTPException (400): If file is empty, too large, or has no filename
-        HTTPException (500): For unexpected server errors
-
-    Note:
+        DocumentUploadResponse: Contains the temporary path identifier
+    
+    Note: 
         The file will be saved in the temporary directory and should be cleaned up after use.
         Use the returned path to reference this file in other endpoints.
     """

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -140,6 +140,12 @@ async def generate_tests_endpoint(
 
     Args:
         request: The request containing the prompt, number of tests, and optional documents
+            - Each document may contain:
+                - `name` (str): Identifier for the document.
+                - `description` (str): Short description of its purpose.
+                - `path` (str): Path to the uploaded document file.
+                - `content` (str, optional): Raw content of the document.
+                ⚠️ If both `path` and `content` are provided in a document, `content` will override `path`: the file at `path` will not be read or used.
         db: Database session
         current_user: Current authenticated user
 
@@ -170,6 +176,7 @@ async def generate_tests_endpoint(
             for doc in documents_dict:
                 if doc.get('path'):
                     await handler.cleanup(doc['path'])
+
 
 @router.post("/generate/text", response_model=TextResponse)
 async def generate_text(prompt_request: PromptRequest):

--- a/apps/backend/src/rhesis/backend/app/schemas/services.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/services.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Optional, Dict, Any
 
 from pydantic import BaseModel, model_validator
@@ -30,10 +31,17 @@ class Document(BaseModel):
     content: Optional[str] = None
 
     @model_validator(mode='after')
-    def require_path_or_content(self):
+    def validate_document(self):
+        # Check that either path or content is provided
         if not self.path and not self.content:
             raise ValueError('Either path or content must be provided')
+        
+        # If path is provided, check that file exists
+        if self.path and not os.path.exists(self.path):
+            raise ValueError(f"Document not found at path: {self.path}. Note: Documents are automatically cleaned up after processing, you may need to re-upload.")
+            
         return self
+
 
 class GenerateTestsRequest(BaseModel):
     prompt: str

--- a/apps/backend/src/rhesis/backend/app/schemas/services.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/services.py
@@ -48,3 +48,7 @@ class Test(BaseModel):
 
 class GenerateTestsResponse(BaseModel):
     tests: List[Test]
+
+
+class DocumentUploadResponse(BaseModel):
+    path: str

--- a/apps/backend/src/rhesis/backend/app/schemas/services.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/services.py
@@ -51,4 +51,5 @@ class GenerateTestsResponse(BaseModel):
 
 
 class DocumentUploadResponse(BaseModel):
-    filename: str
+    """Response model for document upload endpoint. Returns the full path where the document is stored."""
+    path: str

--- a/apps/backend/src/rhesis/backend/app/schemas/services.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/services.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Dict, Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, model_validator
 
 
 class PromptRequest(BaseModel):
@@ -29,16 +29,11 @@ class Document(BaseModel):
     path: Optional[str] = None
     content: Optional[str] = None
 
-    @field_validator("path", "content", mode="after")
-    def require_path_or_content(cls, v, values, field):
-        # Only run this check once, for one of the fields
-        if field.name == "content":
-            path = values.get("path")
-            content = v
-            if not path and not content:
-                raise ValueError("Either 'path' or 'content' must be provided.")
-        return v
-
+    @model_validator(mode='after')
+    def require_path_or_content(self):
+        if not self.path and not self.content:
+            raise ValueError('Either path or content must be provided')
+        return self
 
 class GenerateTestsRequest(BaseModel):
     prompt: str

--- a/apps/backend/src/rhesis/backend/app/schemas/services.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/services.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Dict, Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class PromptRequest(BaseModel):
@@ -23,10 +23,27 @@ class ChatRequest(BaseModel):
     stream: bool = False
 
 
+class Document(BaseModel):
+    name: str
+    description: str
+    path: Optional[str] = None
+    content: Optional[str] = None
+
+    @field_validator("path", "content", mode="after")
+    def require_path_or_content(cls, v, values, field):
+        # Only run this check once, for one of the fields
+        if field.name == "content":
+            path = values.get("path")
+            content = v
+            if not path and not content:
+                raise ValueError("Either 'path' or 'content' must be provided.")
+        return v
+
+
 class GenerateTestsRequest(BaseModel):
     prompt: str
     num_tests: int = 5
-
+    documents: Optional[List[Document]] = None
 
 class TestPrompt(BaseModel):
     content: str

--- a/apps/backend/src/rhesis/backend/app/schemas/services.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/services.py
@@ -51,4 +51,4 @@ class GenerateTestsResponse(BaseModel):
 
 
 class DocumentUploadResponse(BaseModel):
-    path: str
+    filename: str

--- a/apps/backend/src/rhesis/backend/app/services/document_handler.py
+++ b/apps/backend/src/rhesis/backend/app/services/document_handler.py
@@ -29,7 +29,7 @@ class DocumentHandler:
             document: FastAPI UploadFile object
             
         Returns:
-            str: Temporary filename (e.g. 'uuid_filename.ext')
+            str: Full path to the saved document (e.g. '/tmp/temp/uuid_filename.ext')
             
         Raises:
             ValueError: If document size exceeds limit or is empty
@@ -56,36 +56,16 @@ class DocumentHandler:
         with open(full_path, "wb") as f:
             f.write(content)
             
-        return filename
-
-    def get_path(self, filename: str) -> str:
-        """
-        Get full path for a temporary document.
-        
-        Args:
-            filename: The temporary filename returned by save_document
-            
-        Returns:
-            str: Full path to the temporary document
-            
-        Raises:
-            FileNotFoundError: If document doesn't exist
-        """
-        full_path = os.path.join(self.temp_dir, filename)
-        if not os.path.exists(full_path):
-            raise FileNotFoundError(f"Document {filename} not found")
-            
         return full_path
 
-    async def cleanup(self, filename: str) -> None:
+    async def cleanup(self, path: str) -> None:
         """
-        Remove specified document.
+        Remove document at the specified path.
         
         Args:
-            filename: Document filename to cleanup.
+            path: Full path to the document to cleanup.
         """
-        full_path = os.path.join(self.temp_dir, filename)
         try:
-            os.remove(full_path)
+            os.remove(path)
         except OSError:
             pass  # File already gone or permission error

--- a/apps/backend/src/rhesis/backend/app/services/document_handler.py
+++ b/apps/backend/src/rhesis/backend/app/services/document_handler.py
@@ -1,0 +1,100 @@
+import os
+import uuid
+from pathlib import Path
+from typing import Optional
+from fastapi import UploadFile
+
+class DocumentHandler:
+    """Handles temporary document storage with automatic cleanup using async context manager."""
+    
+    def __init__(self, temp_dir: Optional[str] = None, max_file_size: int = 5 * 1024 * 1024):  # 5MB default
+        """
+        Initialize DocumentHandler with configurable temp directory and max file size.
+        
+        Args:
+            temp_dir: Optional custom temp directory path. If None, uses system temp dir
+            max_file_size: Maximum allowed file size in bytes (default 5MB)
+        """
+        self.temp_dir = temp_dir or os.path.join(os.path.dirname(__file__), "temp")
+        self.max_file_size = max_file_size
+        self._saved_files = set()
+        
+        # Ensure temp directory exists
+        os.makedirs(self.temp_dir, exist_ok=True)
+
+    async def __aenter__(self):
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Cleanup saved files on context exit."""
+        await self.cleanup()
+
+    async def save_file(self, file: UploadFile) -> str:
+        """
+        Save uploaded file to temporary location with UUID prefix.
+        
+        Args:
+            file: FastAPI UploadFile object
+            
+        Returns:
+            str: Temporary path (e.g. 'uuid_filename.ext')
+            
+        Raises:
+            ValueError: If file size exceeds limit or file is empty
+        """
+        if not file.filename:
+            raise ValueError("File has no name")
+            
+        # Read file content to check size
+        content = await file.read()
+        if len(content) > self.max_file_size:
+            raise ValueError(f"File size exceeds limit of {self.max_file_size} bytes")
+        if len(content) == 0:
+            raise ValueError("File is empty")
+            
+        # Reset file position after reading
+        await file.seek(0)
+        
+        # Generate unique filename
+        ext = Path(file.filename).suffix
+        temp_filename = f"{uuid.uuid4().hex}{ext}"
+        temp_path = os.path.join(self.temp_dir, temp_filename)
+        
+        # Save file
+        with open(temp_path, "wb") as f:
+            f.write(content)
+            
+        self._saved_files.add(temp_filename)
+        return temp_filename
+
+    def get_path(self, filename: str) -> str:
+        """
+        Get full path for a temporary file.
+        
+        Args:
+            filename: The temporary filename returned by save_file
+            
+        Returns:
+            str: Full path to the temporary file
+            
+        Raises:
+            FileNotFoundError: If file doesn't exist or wasn't created by this handler
+        """
+        if filename not in self._saved_files:
+            raise FileNotFoundError(f"File {filename} not found or not created by this handler")
+            
+        full_path = os.path.join(self.temp_dir, filename)
+        if not os.path.exists(full_path):
+            raise FileNotFoundError(f"File {filename} no longer exists")
+            
+        return full_path
+
+    async def cleanup(self) -> None:
+        """Remove all files created by this handler instance."""
+        for filename in self._saved_files:
+            try:
+                os.remove(os.path.join(self.temp_dir, filename))
+            except OSError:
+                pass  # Ignore errors during cleanup
+        self._saved_files.clear()

--- a/apps/backend/src/rhesis/backend/app/services/generation.py
+++ b/apps/backend/src/rhesis/backend/app/services/generation.py
@@ -14,7 +14,13 @@ from rhesis.backend.app.crud import get_user_tokens
 from rhesis.backend.app.models.user import User
 
 
-async def generate_tests(db: Session, user: User, prompt: str, num_tests: int = 5) -> Dict:
+async def generate_tests(
+    db: Session, 
+    user: User, 
+    prompt: str, 
+    num_tests: int = 5,
+    documents: Optional[List[Dict]] = None
+) -> Dict:
     """
     Generate tests using the prompt synthesizer.
 
@@ -23,6 +29,11 @@ async def generate_tests(db: Session, user: User, prompt: str, num_tests: int = 
         user: Current user
         prompt: The generation prompt to use
         num_tests: Number of test cases to generate (default: 5)
+        documents: Optional list of document objects. Each document should contain:
+            - name (str): Unique identifier or label for the document
+            - description (str): Short description of the document's purpose or content
+            - path (str): Local file path from upload endpoint
+            - content (str): Pre-provided document content (optional)
 
     Returns:
         Dict: The generated test set as a dictionary
@@ -44,7 +55,7 @@ async def generate_tests(db: Session, user: User, prompt: str, num_tests: int = 
 
     print("This is configured in Rhesis Base URL: ", rhesis.sdk.base_url)
     
-    synthesizer = PromptSynthesizer(prompt=prompt)
+    synthesizer = PromptSynthesizer(prompt=prompt, documents=documents)
 
     # Run the potentially blocking operation in a separate thread
     # to avoid blocking the event loop

--- a/apps/backend/src/rhesis/backend/app/services/generation.py
+++ b/apps/backend/src/rhesis/backend/app/services/generation.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict
+from typing import Dict, List, Optional
 import asyncio
 from functools import partial
 


### PR DESCRIPTION
This PR introduces changes from the `feature/document-support-generate-tests-163` branch.

**Note:**
This PR is based on the branch from PR #160 and includes all of its changes. Please review and merge PR #160 first.
Once that PR is merged, this PR will only contain the new changes specific to this feature. I will then update this description afterward to better reflect the final changes, as it was generated automatically.

## 📝 Summary

<!-- Add a brief summary of the changes here -->

## 🔄 Changes

- docs: clarify that content overrides path if both are provided (22a1934)
- feat: improve Document validation error message (1923178)
- fix: add missing imports and migrate Document validator to Pydantic v2 (1df009c)
- feat: add optional argument documents to generate_tests (3798731)
- feat: add document support to /generate/tests endpoint (1b5df96)
- refactor: return full paths from DocumentHandler instead of filenames (58fe431)
- refactor: rename document_id to filename and remove registry system (02bac71)
- refactor: improve terminology consistency in document handling (5bb5ab6)
- feat: add response model and improve docs for /documents/upload (378fee9)
- feat: add /documents/upload endpoint (25b748b)
- fix: remove auto-cleanup from DocumentHandler (129f7f6)
- feat: add DocumentHandler for temporary file storage (62a4840)

## 📁 Files Changed (       7 files)

```
.gitignore
.vscode/settings.json
apps/backend/src/rhesis/backend/app/routers/services.py
apps/backend/src/rhesis/backend/app/schemas/services.py
apps/backend/src/rhesis/backend/app/services/document_handler.py
apps/backend/src/rhesis/backend/app/services/generation.py
sdk/src/rhesis/sdk/config.py
```

## 📋 Commit Details

```
22a1934 - docs: clarify that content overrides path if both are provided (Emanuele De Rossi, 18 minutes ago)
1923178 - feat: improve Document validation error message (Emanuele De Rossi, 17 hours ago)
1df009c - fix: add missing imports and migrate Document validator to Pydantic v2 (Emanuele De Rossi, 18 hours ago)
3798731 - feat: add optional argument documents to generate_tests (Emanuele De Rossi, 18 hours ago)
1b5df96 - feat: add document support to /generate/tests endpoint (Emanuele De Rossi, 18 hours ago)
58fe431 - refactor: return full paths from DocumentHandler instead of filenames (Emanuele De Rossi, 19 hours ago)
02bac71 - refactor: rename document_id to filename and remove registry system (Emanuele De Rossi, 23 hours ago)
5bb5ab6 - refactor: improve terminology consistency in document handling (Emanuele De Rossi, 25 hours ago)
378fee9 - feat: add response model and improve docs for /documents/upload (Emanuele De Rossi, 2 days ago)
25b748b - feat: add /documents/upload endpoint (Emanuele De Rossi, 2 days ago)
129f7f6 - fix: remove auto-cleanup from DocumentHandler (Emanuele De Rossi, 2 days ago)
62a4840 - feat: add DocumentHandler for temporary file storage (Emanuele De Rossi, 2 days ago)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->