### PR TITLE
Chore/Get Entity Fields Names

### DIFF
--- a/sdk/src/rhesis/sdk/entities/base_entity.py
+++ b/sdk/src/rhesis/sdk/entities/base_entity.py
@@ -257,7 +257,7 @@ class BaseEntity:
             "Content-Type": "application/json",
         }
         
-        # Get OpenAPI schema
+        # Get OpenAPI schema 
         url = f"{client.base_url}/openapi.json"
         logger.debug(f"GET request to {url} for schema discovery")
         

--- a/sdk/src/rhesis/sdk/entities/base_entity.py
+++ b/sdk/src/rhesis/sdk/entities/base_entity.py
@@ -237,7 +237,7 @@ class BaseEntity:
 
     @classmethod
     @handle_http_errors
-    def get_fields_names(cls) -> Optional[list[str]]:
+    def get_fields_with_types(cls) -> Optional[Dict[str, Any]]:
         """Get field names for this entity type using the OpenAPI schema.
         
         This method retrieves the OpenAPI schema from the API and extracts
@@ -245,11 +245,11 @@ class BaseEntity:
         and complete field information including types and descriptions.
         
         Returns:
-            Optional[list[str]]: List of field names if successful, None if failed.
+            Optional[Dict[str, Any]]: Dictionary of field names and their types if successful, None if failed.
             
         Example:
-            >>> field_names = Behavior.get_fields_names()
-            >>> print(field_names)  # ['id', 'name', 'description', 'status_id', ...]
+            >>> field_names_with_types = Behavior.get_fields_with_types()
+            >>> print(field_names_with_types)  # {'id': ['string'], 'name': ['string'], 'description': ['string'], 'status_id': ['string'], ...}
         """
         client = Client()
         headers = {

--- a/sdk/src/rhesis/sdk/entities/base_entity.py
+++ b/sdk/src/rhesis/sdk/entities/base_entity.py
@@ -235,6 +235,70 @@ class BaseEntity:
             )
         return dict(entity_dict)
 
+    @classmethod
+    @handle_http_errors
+    def get_fields_names(cls) -> Optional[list[str]]:
+        """Get field names for this entity type using the OpenAPI schema.
+        
+        This method retrieves the OpenAPI schema from the API and extracts
+        the field names for this entity type. This provides the most accurate
+        and complete field information including types and descriptions.
+        
+        Returns:
+            Optional[list[str]]: List of field names if successful, None if failed.
+            
+        Example:
+            >>> field_names = Behavior.get_fields_names()
+            >>> print(field_names)  # ['id', 'name', 'description', 'status_id', ...]
+        """
+        client = Client()
+        headers = {
+            "Authorization": f"Bearer {client.api_key}",
+            "Content-Type": "application/json",
+        }
+        
+        # Get OpenAPI schema
+        url = f"{client.base_url}/openapi.json"
+        logger.debug(f"GET request to {url} for schema discovery")
+        
+        try:
+            response = requests.get(url, headers=headers)
+            response.raise_for_status()
+            
+            schema = response.json()
+            # Extract entity schema fields
+            # The entity name in OpenAPI schema is typically the class name
+            entity_schema = schema.get("components", {}).get("schemas", {}).get(cls.__name__, {})
+            properties = entity_schema.get("properties", {})
+            
+            if not properties:
+                logger.warning(f"No schema found for entity {cls.__name__}")
+                return []
+            
+            fields_with_types = {}
+            for field_name, field_type in properties.items():
+                type_list = []
+                # Handle anyOf (optional fields)
+                if 'anyOf' in field_type:
+                    for type_option in field_type['anyOf']:
+                        field_type = type_option.get('type')
+                        if field_type:
+                            type_list.append(field_type)
+                
+                else:
+                    # Direct type
+                    field_type = field_type.get('type')
+                    if field_type:
+                        type_list.append(field_type)
+                
+                if type_list:
+                    fields_with_types[field_name] = type_list
+            
+            return fields_with_types
+        except requests.exceptions.RequestException as e:
+            logger.error(f"Failed to get field names for {cls.__name__}: {e}")
+            return None
+
     def _validate_update(self) -> None:
         """Validate entity before update."""
         if not (


### PR DESCRIPTION
This PR introduces changes from the `chore/get-entity-fields-names` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->

## 🔄 Changes

- test (7af50cc)
- Merge remote-tracking branch 'origin/main' into chore/get-entity-fields-names (f857ec6)
- update the name and documentation (8a38321)
- add method to retrieve field names from OpenAPI schema in BaseEntity class. (3810134)
- Merge branch 'main' of github.com:rhesis-ai/rhesis into main (6740a25)
- Merge pull request #168 from rhesis-ai/fix/pr-script-behavior-unpushed (383f8fc)
- chore: Making sure all else is ignored by .gitigore except settings.json (4ac7d29)
- docs: Update contributing guides with PR update functionality (d311d54)
- feat: Add PR update functionality for existing pull requests (26df4ff)
- fix: Set upstream tracking when pushing branches (e272ae0)
- fix: Add PR to capitalization abbreviations list (865fbf6)
- docs: Update contributing guides with new PR creation features (e10c577)
- Implement Option 1: Detect and Prompt for unpushed branches/changes (ffa6332)
- fix: Making prepositions and conjunctions not capitalized (4017681)
- Merge pull request #167 from rhesis-ai/feature/test-results-data-and-statistics (ec3d20e)
- refactor: modularize test_result.py to eliminate repetition (b9db433)
- refactor: rename test_results.py to test_result.py for naming consistency (0e58730)
- Removed standalone stats module (98c896d)
- feat: Refactored stats module to accomodate specifics of test result (4dceea8)
- Adding new refactored version of stats module (4140d24)
- Adding router support for test result stats (59bfc58)
- Adding new schema definition for test result (500114c)
- docs: Adding documentation to backend on how to use the test results stats endpoint. (c9c0817)

## 📁 Files Changed (      18 files)

```
.github/create-pr.sh
.gitignore
CONTRIBUTING.md
apps/backend/CONTRIBUTING.md
apps/backend/src/rhesis/backend/app/routers/test_result.py
apps/backend/src/rhesis/backend/app/schemas/__init__.py
apps/backend/src/rhesis/backend/app/schemas/stats.py
apps/backend/src/rhesis/backend/app/services/stats/__init__.py
apps/backend/src/rhesis/backend/app/services/stats/calculator.py
apps/backend/src/rhesis/backend/app/services/stats/config.py
apps/backend/src/rhesis/backend/app/services/stats/test_result.py
apps/backend/src/rhesis/backend/app/services/stats/utils.py
apps/backend/src/rhesis/backend/app/services/test.py
apps/backend/src/rhesis/backend/app/services/test_set.py
apps/frontend/CONTRIBUTING.md
docs/backend/index.md
docs/backend/test-result-stats.md
sdk/src/rhesis/sdk/entities/base_entity.py
```

## 📋 Commit Details

```
7af50cc - test (Arkadiusz Kwasigroch, 38 seconds ago)
f857ec6 - Merge remote-tracking branch 'origin/main' into chore/get-entity-fields-names (Arkadiusz Kwasigroch, 3 minutes ago)
8a38321 - update the name and documentation (Arkadiusz Kwasigroch, 4 minutes ago)
3810134 - add method to retrieve field names from OpenAPI schema in BaseEntity class. (Arkadiusz Kwasigroch, 10 minutes ago)
6740a25 - Merge branch 'main' of github.com:rhesis-ai/rhesis into main (Harry Cruz, 19 hours ago)
383f8fc - Merge pull request #168 from rhesis-ai/fix/pr-script-behavior-unpushed (Harry Cruz, 20 hours ago)
4ac7d29 - chore: Making sure all else is ignored by .gitigore except settings.json (Harry Cruz, 20 hours ago)
d311d54 - docs: Update contributing guides with PR update functionality (Harry Cruz, 20 hours ago)
26df4ff - feat: Add PR update functionality for existing pull requests (Harry Cruz, 20 hours ago)
e272ae0 - fix: Set upstream tracking when pushing branches (Harry Cruz, 20 hours ago)
865fbf6 - fix: Add PR to capitalization abbreviations list (Harry Cruz, 20 hours ago)
e10c577 - docs: Update contributing guides with new PR creation features (Harry Cruz, 20 hours ago)
ffa6332 - Implement Option 1: Detect and Prompt for unpushed branches/changes (Harry Cruz, 20 hours ago)
4017681 - fix: Making prepositions and conjunctions not capitalized (Harry Cruz, 21 hours ago)
ec3d20e - Merge pull request #167 from rhesis-ai/feature/test-results-data-and-statistics (Harry Cruz, 21 hours ago)
b9db433 - refactor: modularize test_result.py to eliminate repetition (Harry Cruz, 21 hours ago)
0e58730 - refactor: rename test_results.py to test_result.py for naming consistency (Harry Cruz, 21 hours ago)
98c896d - Removed standalone stats module (Harry Cruz, 21 hours ago)
4dceea8 - feat: Refactored stats module to accomodate specifics of test result (Harry Cruz, 21 hours ago)
4140d24 - Adding new refactored version of stats module (Harry Cruz, 21 hours ago)
59bfc58 - Adding router support for test result stats (Harry Cruz, 2 days ago)
500114c - Adding new schema definition for test result (Harry Cruz, 2 days ago)
c9c0817 - docs: Adding documentation to backend on how to use the test results stats endpoint. (Harry Cruz, 2 days ago)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->