### PR TITLE
Fix: Improve Linting Github Action

### DIFF
--- a/.github/workflows/lint-manual.yml
+++ b/.github/workflows/lint-manual.yml
@@ -19,24 +19,15 @@ jobs:
         fetch-depth: 0  # Needed for git diff
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.10"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v1
+      uses: astral-sh/setup-uv@v6
       with:
         version: latest
-
-    - name: Install SDK dependencies
-      run: |
-        cd sdk
-        uv sync --dev
-
-    - name: Install Backend dependencies
-      run: |
-        cd apps/backend
-        uv sync --dev
+        enable-cache: true
 
     - name: Run SDK linting
       run: |

--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -8,18 +8,18 @@ DIFF_FILES := $(shell git diff --relative=apps/backend --name-only --diff-filter
 
 
 lint:
-	uv run --all-groups ruff check $(ALL_FILES)
-	uv run --all-groups ruff format $(ALL_FILES) --diff
+	uvx ruff check $(ALL_FILES)
+	uvx ruff format $(ALL_FILES) --diff
 
 format:
-	uv run --all-groups ruff format $(ALL_FILES)
-	uv run --all-groups ruff check --fix $(ALL_FILES)
+	uvx ruff format $(ALL_FILES)
+	uvx ruff check --fix $(ALL_FILES)
 
 
 lint_diff:
 	@if [ -n "$(DIFF_FILES)" ]; then \
-		uv run --all-groups ruff check $(DIFF_FILES); \
-		uv run --all-groups ruff format $(DIFF_FILES) --diff; \
+		uvx ruff check $(DIFF_FILES); \
+		uvx ruff format $(DIFF_FILES) --diff; \
 	else \
 		echo "No Python file changes detected in git diff with the main branch."; \
 	fi
@@ -27,8 +27,8 @@ lint_diff:
 
 format_diff:
 	@if [ -n "$(DIFF_FILES)" ]; then \
-		uv run --all-groups ruff format $(DIFF_FILES); \
-		uv run --all-groups ruff check --fix $(DIFF_FILES); \
+		uvx ruff format $(DIFF_FILES); \
+		uvx ruff check --fix $(DIFF_FILES); \
 	else \
 		echo "No Python file changes detected in git diff with the main branch."; \
 	fi

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -8,18 +8,18 @@ DIFF_FILES := $(shell git diff --relative=sdk --name-only --diff-filter=d main |
 
 
 lint:
-	uv run --all-groups ruff check $(ALL_FILES)
-	uv run --all-groups ruff format $(ALL_FILES) --diff
+	uvx ruff check $(ALL_FILES)
+	uvx ruff format $(ALL_FILES) --diff
 
 format:
-	uv run --all-groups ruff format $(ALL_FILES)
-	uv run --all-groups ruff check --fix $(ALL_FILES)
+	uvx ruff format $(ALL_FILES)
+	uvx ruff check --fix $(ALL_FILES)
 
 
 lint_diff:
 	@if [ -n "$(DIFF_FILES)" ]; then \
-		uv run --all-groups ruff check $(DIFF_FILES); \
-		uv run --all-groups ruff format $(DIFF_FILES) --diff; \
+		uvx ruff check $(DIFF_FILES); \
+		uvx ruff format $(DIFF_FILES) --diff; \
 	else \
 		echo "No Python file changes detected in git diff with the main branch."; \
 	fi
@@ -27,8 +27,8 @@ lint_diff:
 
 format_diff:
 	@if [ -n "$(DIFF_FILES)" ]; then \
-		uv run --all-groups ruff format $(DIFF_FILES); \
-		uv run --all-groups ruff check --fix $(DIFF_FILES); \
+		uvx ruff format $(DIFF_FILES); \
+		uvx ruff check --fix $(DIFF_FILES); \
 	else \
 		echo "No Python file changes detected in git diff with the main branch."; \
 	fi


### PR DESCRIPTION
# Improve Linting GitHub Action and Makefile Commands

## Summary
Optimizes the linting workflow by transitioning from `uv run —all-groups` to `uvx` for enhanced execution and updates GitHub Actions dependencies. The `uvx` command installation process is limited to installing only `ruff`, whereas `uv run` installs all the dependencies specified in both the backend and frontend. This approach is inefficient, as we only require `ruff` and not all the other dependencies.

## Changes Made
- **GitHub Actions**: Updated Python setup from v4 to v5, uv setup from v1 to v6, and enabled caching
- **Makefiles**: Replaced `uv run --all-groups` with `uvx` in both `apps/backend/` and `sdk/` Makefiles
- **Performance**: Removed manual dependency installation steps in favor of uv's built-in caching

## Benefits
- Use `uvx` instead of `uv run —all-groups` to speed up linting execution. `uv run` requires the installation of the entire backend and SDK environment, which takes time and necessitates downloading packages.
- Improved GitHub Actions performance with dependency caching
- Updated to latest stable versions of setup actions
- Cleaner, more efficient Makefile commands


## 📁 Files Changed (       3 files)

```
.github/workflows/lint-manual.yml
apps/backend/Makefile
sdk/Makefile
```

## 📋 Commit Details

```
94d752b - Use uvx instead of uv run for linting (Arkadiusz Kwasigroch, 2025-08-23 09:24)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->