### PR TITLE
fix: clean up __init__.py imports after PR merge

### DIFF
--- a/sdk/src/rhesis/sdk/synthesizers/__init__.py
+++ b/sdk/src/rhesis/sdk/synthesizers/__init__.py
@@ -1,9 +1,4 @@
 from rhesis.sdk.synthesizers.base import TestSetSynthesizer
-from rhesis.sdk.synthesizers.context_synthesizer import (
-    ContextConfig,
-    ContextSynthesizer,
-    DocumentChunk,
-)
 from rhesis.sdk.synthesizers.factory import SynthesizerFactory, SynthesizerType
 from rhesis.sdk.synthesizers.paraphrasing_synthesizer import ParaphrasingSynthesizer
 from rhesis.sdk.synthesizers.prompt_synthesizer import PromptSynthesizer
@@ -12,9 +7,6 @@ __all__ = [
     "TestSetSynthesizer",
     "PromptSynthesizer",
     "ParaphrasingSynthesizer",
-    "ContextSynthesizer",
-    "DocumentChunk",
-    "ContextConfig",
     "SynthesizerFactory",
     "SynthesizerType",
 ]


### PR DESCRIPTION
Remove references to deleted ContextSynthesizer and DocumentSynthesizer classes.