### PR TITLE
Fix: Enable trigger lint on every pull request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [ main ]
-    paths:
-      - 'sdk/**'
 
 jobs:
   lint:


### PR DESCRIPTION
Enable trigger lint on every pull request to ensure required checks are not blocking merges.