### PR TITLE
Fix: Metrics Text Field Rerenders

### DIFF
--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/page.tsx
@@ -113,7 +113,7 @@ export default function MetricDetailPage() {
     };
 
     fetchData();
-  }, [identifier, session?.session_token]); // Remove notifications dependency
+  }, [identifier, session?.session_token, notifications]);
 
   // Helper function to collect current field values without triggering re-renders
   const collectFieldValues = React.useCallback((): Partial<EditData> => {

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -275,7 +275,7 @@ export default function MetricsClientComponent({ sessionToken, organizationId }:
     };
 
     fetchData();
-  }, [sessionToken, refreshKey]); // Depend on sessionToken and refreshKey for manual refresh
+  }, [sessionToken, refreshKey, notifications]);
   
   // Debug log for useEffect triggers
   React.useEffect(() => {

--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/GenerateTestsStepper.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/GenerateTestsStepper.tsx
@@ -1162,7 +1162,7 @@ export default function GenerateTestsStepper({ sessionToken }: GenerateTestsStep
       default:
         return null;
     }
-  }, [activeStep, sessionToken, handleConfigSubmit, handleConfigChange, documents, samples, configData, isGenerating]);
+  }, [activeStep, sessionToken, handleConfigSubmit, handleConfigChange, documents, samples, configData, isGenerating, behaviors]);
 
   return (
     <Container maxWidth="lg" sx={{ mt: 4 }}>


### PR DESCRIPTION
This PR introduces changes from the `fix/metrics-text-field-rerenders` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->


## 📁 Files Changed (       3 files)

```
apps/frontend/src/app/(protected)/metrics/[identifier]/page.tsx
apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
apps/frontend/src/app/(protected)/tests/new-generated/components/GenerateTestsStepper.tsx
```

## 📋 Commit Details

```
a87cd22 - fix: eliminate text field re-renders in metrics detail page (Rhesis Engineering, 2025-09-03 17:34)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->