### PR TITLE
Add file exclusions to VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,13 @@
 
 
     "files.exclude": {
-        "**/.venv": true,
+        "**/.venv": true, 
+        "**/.pytest_cache": true,
+        "**/_pycache_": true,
+        "**/__pycache__": true,
+        "**/.ruff_cache": true,
+        "**/.deepeval": true,
+
     },
     "python.testing.pytestArgs": [
         "."


### PR DESCRIPTION
## Summary
Add file exclusions to .vscode/settings.json to hide unnecessary files from VS Code search and file explorer.

## Changes
- Hide cache directories (__pycache__, .pytest_cache, .ruff_cache)
- Hide build artifacts and temporary files
- Reduce clutter in file explorer and search results

## Benefits
- Cleaner file explorer view
- Faster search results
- Better developer experience

Closes #304