### PR TITLE
Add send Button to the comments text box

### DIFF
--- a/apps/frontend/src/components/comments/CommentItem.tsx
+++ b/apps/frontend/src/components/comments/CommentItem.tsx
@@ -252,8 +252,8 @@ export function CommentItem({
                             display: 'flex',
                             alignItems: 'center',
                             gap: 0.5,
-                            bgcolor: theme.palette.mode === 'dark' ? 'background.default' : '#f5f5f5',
-                            color: theme.palette.mode === 'dark' ? '#ffffff' : '#666666',
+                            bgcolor: 'background.default',
+                            color: 'text.primary',
                             border: '1px solid',
                             borderColor: hasReacted ? 'primary.main' : 'divider',
                             borderRadius: '16px',
@@ -262,14 +262,14 @@ export function CommentItem({
                             cursor: 'pointer',
                             '&:hover': {
                               bgcolor: 'action.hover',
-                              color: theme.palette.mode === 'dark' ? '#ffffff' : '#333333',
+                              color: 'text.primary',
                               borderColor: hasReacted ? 'primary.main' : 'text.primary'
                             }
                           }}
                         >
                           <Typography variant="body2" sx={{ fontSize: '1rem' }}>{emoji}</Typography>
                           <Typography variant="body2" fontWeight={600} sx={{ 
-                            color: theme.palette.mode === 'dark' ? '#ffffff' : '#333333'
+                            color: 'text.primary'
                           }}>
                             {reactionCount}
                           </Typography>

--- a/apps/frontend/src/components/comments/CommentsSection.tsx
+++ b/apps/frontend/src/components/comments/CommentsSection.tsx
@@ -9,7 +9,9 @@ import {
   CircularProgress,
   Divider,
   Paper,
+  IconButton,
 } from '@mui/material';
+import { Send as SendIcon } from '@mui/icons-material';
 import { Comment, EntityType } from '@/types/comments';
 import { CommentItem } from './CommentItem';
 import { UserAvatar } from '@/components/common/UserAvatar';
@@ -144,36 +146,61 @@ export function CommentsSection({
             size={40}
           />
 
-                      {/* Comment Input */}
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              <TextField
-                value={newComment}
-                onChange={(e) => setNewComment(e.target.value)}
-                placeholder="Add comment ..."
-                multiline
-                rows={3}
-                fullWidth
-                variant="outlined"
-                size="small"
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
-                    e.preventDefault();
-                    handleSubmit(e);
-                  }
-                }}
-              />
-              
-              {/* Error Message */}
-              {error && (
-                <Typography 
-                  variant="caption" 
-                  color="error" 
-                  sx={{ mt: 1, display: 'block' }}
-                >
-                  {error}
-                </Typography>
-              )}
-            </Box>
+          {/* Comment Input */}
+          <Box sx={{ flex: 1, minWidth: 0, position: 'relative' }}>
+            <TextField
+              value={newComment}
+              onChange={(e) => setNewComment(e.target.value)}
+              placeholder="Add comment ..."
+              multiline
+              rows={3}
+              fullWidth
+              variant="outlined"
+              size="small"
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSubmit(e);
+                }
+              }}
+              InputProps={{
+                endAdornment: newComment.trim().length > 0 ? (
+                  <IconButton
+                    type="submit"
+                    disabled={isSubmitting || !newComment.trim()}
+                    size="small"
+                    sx={{ 
+                      mr: 0.5,
+                      color: 'text.secondary',
+                      '&:hover': {
+                        color: 'primary.main',
+                      },
+                      '&:disabled': {
+                        color: 'action.disabled',
+                      }
+                    }}
+                  >
+                    {isSubmitting ? (
+                      <CircularProgress size={16} color="inherit" />
+                    ) : (
+                      <SendIcon fontSize="small" />
+                    )}
+                  </IconButton>
+                ) : null
+              }}
+            />
+            
+            {/* Error Message */}
+            {error && (
+              <Typography 
+                variant="caption" 
+                color="error" 
+                sx={{ mt: 1, display: 'block' }}
+              >
+                {error}
+              </Typography>
+            )}
+          </Box>
         </Box>
       </Box>
     </Paper>

--- a/apps/frontend/src/hooks/useComments.ts
+++ b/apps/frontend/src/hooks/useComments.ts
@@ -36,14 +36,10 @@ export function useComments({ entityType, entityId, sessionToken, currentUserId,
     } catch (err) {
       setError('Failed to fetch comments');
       console.error('Error fetching comments:', err);
-      notifications.show('Failed to fetch comments', { 
-        severity: 'error',
-        autoHideDuration: 3000
-      });
     } finally {
       setIsLoading(false);
     }
-  }, [entityType, entityId, sessionToken, notifications]);
+  }, [entityType, entityId, sessionToken]);
 
   const createComment = useCallback(async (text: string) => {
     if (!sessionToken) {


### PR DESCRIPTION
This PR introduces changes from the `feature/add_send_btn_comments` branch.

## 📝 Summary

- Added send button to comment text box.
- Fixed default theme colors for the emojis.
- Fixed redundant error notification which was causing re-render twice unnecessarily. 


## 📁 Files Changed (       3 files)

```
apps/frontend/src/components/comments/CommentItem.tsx
apps/frontend/src/components/comments/CommentsSection.tsx
apps/frontend/src/hooks/useComments.ts
```

## 📋 Commit Details

```
07777bf - Add send button to the comment text box and fix minor issues (jahanzaibsuleman07, 2025-09-12 12:08)
```

## ✅ Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of code has been performed
- [x] Code is commented, particularly in hard-to-understand areas
- [x] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->