### PR TITLE
Add Ollama

### DIFF
--- a/sdk/src/rhesis/sdk/models/factory.py
+++ b/sdk/src/rhesis/sdk/models/factory.py
@@ -104,7 +104,6 @@ def get_model(
         cfg = config
     else:
         cfg = ModelConfig()
-
     # Case: shorthand string like "provider/model"
     if provider and "/" in provider and model_name is None:
         # split only first "/" so that names like "rhesis/rhesis-default" still work
@@ -126,7 +125,7 @@ def get_model(
     elif config.provider == "gemini":
         from rhesis.sdk.models.providers.gemini import GeminiLLM
 
-        return GeminiLLM(model_name=config.model_name)
+        return GeminiLLM(model_name=config.model_name, api_key=api_key)
 
     elif config.provider == "ollama":
         from rhesis.sdk.models.providers.ollama import OllamaLLM
@@ -136,7 +135,7 @@ def get_model(
     elif config.provider == "openai":
         from rhesis.sdk.models.providers.openai import OpenAILLM
 
-        return OpenAILLM(model_name=config.model_name, api_key=config.api_key)
+        return OpenAILLM(model_name=config.model_name, api_key=api_key)
 
     else:
         raise ValueError(f"Provider {config.provider} not supported")

--- a/sdk/src/rhesis/sdk/models/factory.py
+++ b/sdk/src/rhesis/sdk/models/factory.py
@@ -15,8 +15,9 @@ from rhesis.sdk.models.base import BaseLLM
 DEFAULT_PROVIDER = "rhesis"
 DEFAULT_MODELS = {
     "rhesis": "rhesis-default",
-    "rhesis_premium": "rhesis-premium-default",
     "gemini": "gemini-2.0-flash-lite-preview-02-05",
+    "ollama": "llama3.1",
+    "openai": "gpt-4o",
 }
 
 
@@ -25,7 +26,7 @@ class ModelConfig:
     """Configuration for a model instance.
 
     Args:
-        provider: The provider name (e.g., "rhesis", "rhesis_premium")
+        provider: The provider name (e.g., "rhesis", "gemini", "ollama")
         model_name: Specific model name (E.g gpt-4o, gemini-2.0-flash, etc)
         api_key: The API key to use for the model.
         extra_params: Extra parameters to pass to the model.
@@ -55,7 +56,7 @@ def get_model(
     5. **Full config**: `get_model(config=ModelConfig(...))`
 
     Args:
-        provider: Provider name (e.g., "rhesis", "rhesis_premium")
+        provider: Provider name (e.g., "rhesis", "gemini", "ollama")
         model_name: Specific model name
         api_key: API key for authentication
         config: Complete configuration object
@@ -103,11 +104,13 @@ def get_model(
         cfg = config
     else:
         cfg = ModelConfig()
+
     # Case: shorthand string like "provider/model"
     if provider and "/" in provider and model_name is None:
         # split only first "/" so that names like "rhesis/rhesis-default" still work
         prov, model = provider.split("/", 1)
         provider, model_name = prov, model
+
     provider = provider or cfg.provider or DEFAULT_PROVIDER
     if provider not in DEFAULT_MODELS.keys():
         raise ValueError(f"Provider {provider} not supported")
@@ -119,9 +122,21 @@ def get_model(
         from rhesis.sdk.models.providers.native import RhesisLLM
 
         return RhesisLLM(model_name=config.model_name, api_key=config.api_key)
+
     elif config.provider == "gemini":
         from rhesis.sdk.models.providers.gemini import GeminiLLM
 
         return GeminiLLM(model_name=config.model_name)
+
+    elif config.provider == "ollama":
+        from rhesis.sdk.models.providers.ollama import OllamaLLM
+
+        return OllamaLLM(model_name=config.model_name)
+
+    elif config.provider == "openai":
+        from rhesis.sdk.models.providers.openai import OpenAILLM
+
+        return OpenAILLM(model_name=config.model_name, api_key=config.api_key)
+
     else:
         raise ValueError(f"Provider {config.provider} not supported")

--- a/sdk/src/rhesis/sdk/models/factory.py
+++ b/sdk/src/rhesis/sdk/models/factory.py
@@ -120,7 +120,10 @@ def get_model(
     if config.provider == "rhesis":
         from rhesis.sdk.models.providers.native import RhesisLLM
 
-        return RhesisLLM(model_name=config.model_name, api_key=config.api_key)
+        if api_key is None:
+            api_key = config.api_key
+
+        return RhesisLLM(model_name=config.model_name, api_key=api_key)
 
     elif config.provider == "gemini":
         from rhesis.sdk.models.providers.gemini import GeminiLLM

--- a/sdk/src/rhesis/sdk/models/providers/ollama.py
+++ b/sdk/src/rhesis/sdk/models/providers/ollama.py
@@ -1,0 +1,40 @@
+"""
+Available models:
+https://ollama.com/library
+"""
+
+from rhesis.sdk.models.providers.litellm import LiteLLM
+
+PROVIDER = "ollama"
+DEFAULT_MODEL_NAME = "llama3.1"
+
+
+class OllamaLLM(LiteLLM):
+    def __init__(self, model_name: str = DEFAULT_MODEL_NAME, **kwargs):
+        """
+        OllamaLLM: Ollama LLM Provider
+
+        This class provides an interface to the Ollama family of large language models via LiteLLM.
+
+        In order to use this class, you need to have Ollama installed and running.
+        See https://ollama.com/download for more information.
+
+        Each model before the use should be downloaded using the following command:
+        >> ollama pull <model_name>
+
+        Args:
+            model_name (str): The name of the Ollama model to use (default: "llama3.1").
+            **kwargs: Additional parameters passed to the underlying LiteLLM completion call.
+
+        Usage:
+            >>> llm = OllamaLLM(model_name="llama3.1")
+            >>> result = llm.generate("Tell me a joke.")
+            >>> print(result)
+
+        If a Pydantic schema is provided to `generate`, the response will be validated and returned
+        as a dict.
+
+        Raises:
+            ValueError: If the API key is not set.
+        """
+        super().__init__(PROVIDER + "/" + model_name)

--- a/tests/sdk/models/test_model_factory.py
+++ b/tests/sdk/models/test_model_factory.py
@@ -157,7 +157,9 @@ class TestGetModel:
 
         result = get_model("gemini", "gemini-model")
 
-        mock_gemini_class.assert_called_once_with(model_name="gemini-model")
+        mock_gemini_class.assert_called_once_with(
+            model_name="gemini-model", api_key=None
+        )
         assert result == mock_instance
 
     @patch("rhesis.sdk.models.providers.gemini.GeminiLLM")
@@ -168,7 +170,9 @@ class TestGetModel:
 
         result = get_model("gemini")
 
-        mock_gemini_class.assert_called_once_with(model_name=DEFAULT_MODELS["gemini"])
+        mock_gemini_class.assert_called_once_with(
+            model_name=DEFAULT_MODELS["gemini"], api_key=None
+        )
         assert result == mock_instance
 
     def test_get_model_unsupported_provider(self):


### PR DESCRIPTION
This PR adds support for Ollama as a new LLM provider in the Rhesis SDK.

## Summary

- **New Ollama Provider**: Created `OllamaLLM` class that extends `LiteLLM` to support Ollama models
- **Factory Integration**: Updated the model factory to support Ollama provider with default model "llama3.1"
- **Provider Registration**: Added Ollama to the supported providers list alongside existing providers
- **Documentation**: Added comprehensive docstring with usage examples and setup instructions

## Files Changed

- `sdk/src/rhesis/sdk/models/factory.py` - Added Ollama provider support
- `sdk/src/rhesis/sdk/models/providers/ollama.py` - New Ollama provider implementation

## Testing

To test the Ollama integration:
1. Install Ollama: https://ollama.com/download
2. Pull a model: `ollama pull llama3.1`
3. Start Ollama service: `ollama serve`
4. Use the SDK: `OllamaLLM(model_name="llama3.1")`