### PR TITLE
Add developer confirmation step before issue creation

### DIFF
--- a/.cursor/rules/issue.mdc
+++ b/.cursor/rules/issue.mdc
@@ -13,3 +13,4 @@ Use only the labels from the returned list.
 4. Select appropriate title for the issue
 5. The issuse should be short and to the point, avoid using too many words, you can remove sections
 from the template that are not relevant to the issue
+6. Before creating an issue, ask the user for confirmation.


### PR DESCRIPTION
## Add developer confirmation step before issue creation

This PR adds a simple rule to the issue creation workflow requiring developer confirmation before creating an issue.

**Changes:**
- Added confirmation step (#6) to `.cursor/rules/issue.mdc`
- Ensures developers are prompted before automatic issue creation

**Impact:** 
- Prevents accidental issue creation
- Gives developers control over when issues are generated

This is a minimal change that improves the developer experience by adding a confirmation step to the automated issue creation process.