### PR TITLE
Fix: Double Elevation Clean

### DIFF
--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -60,7 +60,7 @@ export default function TasksGrid({ sessionToken, onRefresh }: TasksGridProps) {
       
       // Debug logging for search functionality
       if (oDataFilter) {
-        console.log('🔍 Task search/filter OData:', oDataFilter);
+        console.log('Task search/filter OData:', oDataFilter);
       }
       
       const response = await tasksClient.getTasks({

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetDetailsSection.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetDetailsSection.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Box, Paper, Button, TextField, Typography, Tooltip, Chip, useTheme } from '@mui/material';
+import { Box, Button, TextField, Typography, Tooltip, Chip, useTheme } from '@mui/material';
 import PlayArrowIcon from '@mui/icons-material/PlayArrowOutlined';
 import DownloadIcon from '@mui/icons-material/Download';
+import DocumentIcon from '@mui/icons-material/InsertDriveFileOutlined';
 import { TestSet } from '@/utils/api-client/interfaces/test-set';
 import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
@@ -148,7 +149,7 @@ export default function TestSetDetailsSection({ testSet, sessionToken }: TestSet
   const sources = testSet.attributes?.metadata?.sources || [];
 
   return (
-    <Paper sx={{ p: 3, mb: 3 }}>
+    <>
       {/* Action Buttons */}
       <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
         <Button
@@ -277,8 +278,9 @@ export default function TestSetDetailsSection({ testSet, sessionToken }: TestSet
                   backgroundColor: 'background.paper'
                 }}
               >
-                <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1 }}>
-                  📄 {source.name || source.document || 'Unknown Document'}
+                <Typography variant="subtitle1" sx={{ fontWeight: 'bold', mb: 1, display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <DocumentIcon sx={{ fontSize: 'inherit' }} />
+                  {source.name || source.document || 'Unknown Document'}
                 </Typography>
                 {source.description && (
                   <Typography variant="body2" color="text.secondary">
@@ -308,6 +310,6 @@ export default function TestSetDetailsSection({ testSet, sessionToken }: TestSet
         testSetId={testSet.id}
         sessionToken={sessionToken}
       />
-    </Paper>
+    </>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
@@ -117,7 +117,7 @@ export default function TestSetTestsGrid({ sessionToken, testSetId, onRefresh }:
             label={behaviorName}
             variant="outlined"
             size="small"
-            color="primary"
+            color="default"
           />
         );
       }
@@ -135,7 +135,7 @@ export default function TestSetTestsGrid({ sessionToken, testSetId, onRefresh }:
             label={topicName}
             variant="outlined"
             size="small"
-            color="secondary"
+            color="default"
           />
         );
       }
@@ -245,6 +245,7 @@ export default function TestSetTestsGrid({ sessionToken, testSetId, onRefresh }:
         serverSidePagination={true}
         totalRows={totalCount}
         pageSizeOptions={[10, 25, 50]}
+        disablePaperWrapper={true}
       />
     </>
   );

--- a/scripts/check-hardcoded-styles.js
+++ b/scripts/check-hardcoded-styles.js
@@ -86,7 +86,10 @@ const PATTERNS = {
   boxShadows: /boxShadow:\s*['"`]([^'"`]+)['"`]/g,
   
   // Border radius values
-  borderRadius: /borderRadius:\s*['"`]?(\d+(?:\.\d+)?(?:px|rem|em)?)['"`]?/g
+  borderRadius: /borderRadius:\s*['"`]?(\d+(?:\.\d+)?(?:px|rem|em)?)['"`]?/g,
+  
+  // Emoji characters (Unicode emoji ranges)
+  emojis: /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/gu
 };
 
 // Files to exclude from checking
@@ -211,6 +214,9 @@ class StyleChecker {
         }
         return `Consider using consistent borderRadius values from theme`;
       
+      case 'emoji':
+        return `Use MUI icons instead of emoji characters for better accessibility and theme consistency`;
+      
       default:
         return `Consider using theme values instead of hardcoded ${type}`;
     }
@@ -320,6 +326,20 @@ class StyleChecker {
           });
         }
 
+        // Check for emoji characters
+        PATTERNS.emojis.lastIndex = 0;
+        while ((match = PATTERNS.emojis.exec(line)) !== null) {
+          this.violations.push({
+            file: filePath,
+            line: lineNumber,
+            column: match.index + 1,
+            type: 'emoji',
+            value: match[0],
+            message: this.suggestThemeAlternative('emoji', match[0]),
+            context: line.trim()
+          });
+        }
+
         // Reset regex lastIndex to avoid issues
         Object.values(PATTERNS).forEach(pattern => {
           if (pattern.global) pattern.lastIndex = 0;
@@ -422,6 +442,7 @@ class StyleChecker {
     console.log('  • Font sizes: Use Typography variants (h1, h2, body1, etc.) or theme.typography.*');
     console.log('  • Spacing: Use theme.spacing(1), theme.spacing(2), or theme.customSpacing.*');
     console.log('  • Elevations: Use theme.elevation.standard, theme.elevation.prominent, etc.');
+    console.log('  • Emojis: Use MUI icons from @mui/icons-material instead of emoji characters');
     console.log('  • See apps/frontend/src/styles/rhesis-theme-usage.md for detailed examples');
   }
 


### PR DESCRIPTION
This PR introduces changes from the `fix/double-elevation-clean` branch.

## 📝 Summary

🎯 Primary Objective
Resolve double elevation UI issues and improve theme compliance across the application, particularly in test set components.
📋 Key Changes

1. Double Elevation Fixes (97f68f1)
TestSetDetailsSection: Removed inner Paper wrapper to eliminate double elevation effect
TestSetTestsGrid: Added disablePaperWrapper prop to BaseDataGrid to prevent nested Paper components
Result: Cleaner, flatter UI design following Material Design principles

2. Theme & Accessibility Improvements (97f68f1)
Icon Replacement: Replaced emoji icon with MUI DocumentIcon for better accessibility
Chip Colors: Updated chip colors to use theme-appropriate 'default' color instead of CTA colors
Theme Consistency: Improved overall visual consistency across components

3. Linting & Code Quality
Emoji Removal (041c2ae): Removed 🔍 emoji from console.log in TasksGrid component
Style Checker Enhancement (97f68f1): Added emoji detection to hardcoded styles checker script

## 📁 Files Changed (3 files)

```
apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetDetailsSection.tsx
apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
scripts/check-hardcoded-styles.js
```

## 📋 Commit Details

```
97f68f1 - fix(ui): resolve double elevation and improve theme compliance (Nicolai Bohn, 2025-09-23 19:26)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->