### PR TITLE
fix: resolve duplicate key error in Run Test Drawer with same project names

### DIFF
--- a/apps/frontend/next-env.d.ts
+++ b/apps/frontend/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
@@ -377,6 +377,15 @@ export default function TestRunDrawer({
               value={project}
               onChange={(_, newValue) => setProject(newValue)}
               getOptionLabel={option => option.name}
+              isOptionEqualToValue={(option, value) => option.id === value.id}
+              renderOption={(props, option) => {
+                const { key, ...otherProps } = props;
+                return (
+                  <Box component="li" key={option.id} {...otherProps}>
+                    {option.name}
+                  </Box>
+                );
+              }}
               fullWidth
               renderInput={params => (
                 <TextField {...params} label="Application" required />

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/ExecuteTestSetDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/ExecuteTestSetDrawer.tsx
@@ -240,6 +240,14 @@ export default function ExecuteTestSetDrawer({
                 setSelectedEndpoint(null);
               }}
               getOptionLabel={option => option.name}
+              renderOption={(props, option) => {
+                const { key, ...otherProps } = props;
+                return (
+                  <Box component="li" key={option.id} {...otherProps}>
+                    {option.name}
+                  </Box>
+                );
+              }}
               renderInput={params => (
                 <TextField
                   {...params}

--- a/apps/frontend/src/app/(protected)/tests/components/TrialDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TrialDrawer.tsx
@@ -270,6 +270,14 @@ export default function TrialDrawer({
               setSelectedEndpoint(null);
             }}
             getOptionLabel={option => option.name}
+            renderOption={(props, option) => {
+              const { key, ...otherProps } = props;
+              return (
+                <Box component="li" key={option.id} {...otherProps}>
+                  {option.name}
+                </Box>
+              );
+            }}
             renderInput={params => (
               <TextField
                 {...params}

--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/GenerateTestsStepper.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/GenerateTestsStepper.tsx
@@ -269,6 +269,14 @@ const ConfigureGeneration = ({
             onChange={(_, value) => updateField('project', value)}
             getOptionLabel={option => option.name}
             isOptionEqualToValue={(option, value) => option.id === value.id}
+            renderOption={(props, option) => {
+              const { key, ...otherProps } = props;
+              return (
+                <Box component="li" key={option.id} {...otherProps}>
+                  {option.name}
+                </Box>
+              );
+            }}
             renderInput={params => (
               <TextField
                 {...params}


### PR DESCRIPTION
## Summary

Fixes the issue where the Run Test Drawer throws an error when there are multiple projects with the same name.

## Root Cause

The issue was caused by Material-UI's Autocomplete components missing the `renderOption` prop. When this prop is not provided, Material-UI defaults to using the option's string representation (the project name) as the React key, which causes duplicate key errors when multiple projects have the same name.

## Changes Made

Added missing `renderOption` prop to Autocomplete components in:
- `TrialDrawer.tsx` - The main Run Test Drawer component
- `GenerateTestsStepper.tsx` - Test generation component  
- `TestRunDrawer.tsx` - Test run management component
- `ExecuteTestSetDrawer.tsx` - Test set execution component

Each `renderOption` implementation now uses `option.id` as the React key instead of the project name:

```tsx
renderOption={(props, option) => {
  const { key, ...otherProps } = props;
  return (
    <Box component="li" key={option.id} {...otherProps}>
      {option.name}
    </Box>
  );
}}
```

## Expected Behavior After Fix

- ✅ Tests can run successfully even when multiple projects share the same name
- ✅ No duplicate key errors will be thrown
- ✅ Project selection works correctly in all affected components
- ✅ The UI continues to display project names to users while using unique IDs internally

## Testing

- [x] Linting passes with no new errors
- [x] TypeScript compilation successful
- [x] No breaking changes to existing functionality

Resolves #442