### PR TITLE
fix: Add --legacy-peer-deps to Dockerfile npm ci commands

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -91,12 +91,12 @@ RUN if [ "$FRONTEND_ENV" = "production" ] || [ "$FRONTEND_ENV" = "staging" ] || 
         echo "Production mode detected"; \
         rm -rf ./src ./tsconfig.json ./.eslintrc.json && \
         echo "Source files removed for production mode"; \
-        npm ci --only=production && \
+        npm ci --only=production --legacy-peer-deps && \
         npm cache clean --force; \
     else \
         echo "Development mode detected"; \
         echo "Source files kept for development mode"; \
-        npm ci && npm cache clean --force; \
+        npm ci --legacy-peer-deps && npm cache clean --force; \
     fi
 
 # Create a non-root user and switch to it


### PR DESCRIPTION
- Add --legacy-peer-deps to production dependency installation
- Add --legacy-peer-deps to development dependency installation
- Ensures Docker builds work with React 19 compatibility issues