### PR TITLE
Hotfix: Tasks Organization Id

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -2199,7 +2199,7 @@ def create_task(
     return create_item(db, models.Task, task, organization_id=organization_id, user_id=user_id)
 
 
-def update_task(db: Session, task_id: uuid.UUID, task: schemas.TaskUpdate, organization_id: str = None) -> Optional[models.Task]:
+def update_task(db: Session, task_id: uuid.UUID, task: schemas.TaskUpdate, organization_id: str = None, user_id: str = None) -> Optional[models.Task]:
     """Update a task with organization filtering"""
     # Check if status is being changed to "Completed"
     if task.status_id is not None:
@@ -2221,7 +2221,7 @@ def update_task(db: Session, task_id: uuid.UUID, task: schemas.TaskUpdate, organ
                 # Set completed_at to current timestamp
                 task.completed_at = datetime.utcnow()
 
-    return update_item(db, models.Task, task_id, task)
+    return update_item(db, models.Task, task_id, task, organization_id=organization_id, user_id=user_id)
 
 
 def delete_task(db: Session, task_id: uuid.UUID, organization_id: str, user_id: str) -> bool:

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -1498,7 +1498,7 @@ def get_test_run_behaviors(db: Session, test_run_id: uuid.UUID, organization_id:
     )
 
 
-def create_test_run(db: Session, test_run: schemas.TestRunCreate) -> models.TestRun:
+def create_test_run(db: Session, test_run: schemas.TestRunCreate, organization_id: str = None, user_id: str = None) -> models.TestRun:
     """Create a new test run with automatic name generation if no name is provided"""
 
     # If no name is provided or it's empty, generate a memorable one
@@ -1536,7 +1536,7 @@ def create_test_run(db: Session, test_run: schemas.TestRunCreate) -> models.Test
         else:
             logger.warning("No organization_id available for test run name generation")
 
-    return create_item(db, models.TestRun, test_run)
+    return create_item(db, models.TestRun, test_run, organization_id=organization_id, user_id=user_id)
 
 
 def update_test_run(

--- a/apps/backend/src/rhesis/backend/app/routers/task_management.py
+++ b/apps/backend/src/rhesis/backend/app/routers/task_management.py
@@ -157,7 +157,7 @@ def update_task(
             task.assignee_id is not None and task.assignee_id != current_task.assignee_id
         )
 
-        updated_task = crud.update_task(db=db, task_id=task_id, task=task, organization_id=organization_id)
+        updated_task = crud.update_task(db=db, task_id=task_id, task=task, organization_id=organization_id, user_id=user_id)
         if updated_task is None:
             raise HTTPException(status_code=404, detail="Task not found")
 

--- a/apps/backend/src/rhesis/backend/app/routers/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_run.py
@@ -369,7 +369,7 @@ def delete_test_run(
     if db_test_run.user_id != current_user.id and not current_user.is_superuser:
         raise HTTPException(status_code=403, detail="Not authorized to delete this test run")
 
-    return crud.delete_test_run(db=db, test_run_id=test_run_id)
+    return crud.delete_test_run(db=db, test_run_id=test_run_id, organization_id=organization_id, user_id=user_id)
 
 
 @router.get("/{test_run_id}/download", response_class=StreamingResponse)


### PR DESCRIPTION
This PR introduces changes from the `hotfix/tasks-organization-id` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->


## 📁 Files Changed (       3 files)

```
apps/backend/src/rhesis/backend/app/crud.py
apps/backend/src/rhesis/backend/app/routers/task_management.py
apps/backend/src/rhesis/backend/app/routers/test_run.py
```

## 📋 Commit Details

```
dce88cf2 - fix: add missing organization_id and user_id to test_run CRUD operations (Harry Cruz, 2025-10-02 16:24)
492f8013 - fix: add missing user_id parameter to update_task CRUD function (Harry Cruz, 2025-10-02 16:21)
4938cef4 - fix: add organization_id and user_id to task endpoints (Harry Cruz, 2025-10-02 16:15)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->