### PR TITLE
fix: resolve project owner field not being saved in edit drawer

### DIFF
--- a/apps/frontend/src/app/(protected)/projects/[identifier]/edit-drawer.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/edit-drawer.tsx
@@ -142,7 +142,7 @@ export default function EditDrawer({
   const [formData, setFormData] = React.useState({
     name: project.name,
     description: project.description || '',
-    owner_id: project.owner?.id,
+    owner_id: project.owner?.id || project.owner_id, // Fallback to owner_id field
     is_active: project.is_active,
     icon: project.icon || 'SmartToy',
   });
@@ -153,7 +153,7 @@ export default function EditDrawer({
       setFormData({
         name: project.name,
         description: project.description || '',
-        owner_id: project.owner?.id,
+        owner_id: project.owner?.id || project.owner_id, // Fallback to owner_id field
         is_active: project.is_active,
         icon: project.icon || 'SmartToy',
       });
@@ -260,7 +260,7 @@ export default function EditDrawer({
       newErrors.description = 'Description must be less than 500 characters';
     }
 
-    if (!formData.owner_id) {
+    if (!formData.owner_id || formData.owner_id.trim() === '') {
       newErrors.owner_id = 'Owner is required';
     }
 
@@ -290,7 +290,7 @@ export default function EditDrawer({
         projectUpdate.description = formData.description;
       }
 
-      if (formData.owner_id) {
+      if (formData.owner_id !== undefined) {
         projectUpdate.owner_id = formData.owner_id;
       }
 

--- a/apps/frontend/src/app/(protected)/projects/components/ProjectEditDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/ProjectEditDrawer.tsx
@@ -193,7 +193,39 @@ export default function ProjectEditDrawer({
   const handleSaveWrapper = async () => {
     setLoading(true);
     try {
-      await onSave(formData);
+      // Create a clean update object with only the fields we want to update
+      const projectUpdate: Partial<Project> = {};
+
+      if (formData.name) {
+        projectUpdate.name = formData.name;
+      }
+
+      if (formData.description !== undefined) {
+        projectUpdate.description = formData.description;
+      }
+
+      // Always include owner_id if it's set (even if empty string to clear owner)
+      if (formData.owner_id !== undefined) {
+        projectUpdate.owner_id = formData.owner_id;
+      }
+
+      if (formData.environment) {
+        projectUpdate.environment = formData.environment;
+      }
+
+      if (formData.useCase) {
+        projectUpdate.useCase = formData.useCase;
+      }
+
+      if (formData.icon) {
+        projectUpdate.icon = formData.icon;
+      }
+
+      if (formData.tags) {
+        projectUpdate.tags = formData.tags;
+      }
+
+      await onSave(projectUpdate);
       onClose();
     } catch (error) {
       console.error('Failed to save project:', error);


### PR DESCRIPTION
## Problem

When opening a project from the projects list page and then opening the edit drawer, the owner field appears empty even though the owner is displayed on the project card.

## Root Cause

The issue was caused by different API endpoints returning different data structures:

- **Projects list API**  returns projects with full  objects containing user details
- **Single project API** returns projects with only the field, without the nested owner object

The EditDrawer component was only checking , which would be  when the owner object wasn't present.

## Solution

Updated the EditDrawer component to use a fallback pattern:

```typescript
// Before (only checked project.owner?.id)
owner_id: project.owner?.id,

// After (checks both possible locations)
owner_id: project.owner?.id || project.owner_id,
```

This change was made in two places:
1. Initial form data setup
2. Form data reset when project changes

Also improved the validation logic to handle string values properly:

```typescript
if (!formData.owner_id || formData.owner_id.trim() === '') {
  newErrors.owner_id = 'Owner is required';
}
```

## Testing

✅ Owner field now populates correctly in edit drawer  
✅ Can change owner and save successfully  
✅ Handles both API response formats gracefully  
✅ Works from both projects list and individual project pages  

## Files Changed

- `apps/frontend/src/app/(protected)/projects/[identifier]/edit-drawer.tsx`
- `apps/frontend/src/app/(protected)/projects/components/ProjectEditDrawer.tsx`

Fixes #482