### PR TITLE
feat: add editable test set title functionality

### DIFF
--- a/apps/frontend/next-env.d.ts
+++ b/apps/frontend/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetDetailsSection.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetDetailsSection.tsx
@@ -230,9 +230,9 @@ export default function TestSetDetailsSection({
           Test Set Details
         </Typography>
 
-        {/* Title Field */}
+        {/* Name Field */}
         <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'medium' }}>
-          Title
+          Name
         </Typography>
         {isEditingTitle ? (
           <TextField

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetDetailsSection.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetDetailsSection.tsx
@@ -155,7 +155,7 @@ export default function TestSetDetailsSection({
       // Update the testSet object to reflect the new title
       testSet.name = editedTitle;
       setIsEditingTitle(false);
-      
+
       // Refresh the page to update breadcrumbs and title
       window.location.reload();
     } catch (error) {
@@ -229,7 +229,7 @@ export default function TestSetDetailsSection({
         <Typography variant="h6" sx={{ mb: 2 }}>
           Test Set Details
         </Typography>
-        
+
         {/* Title Field */}
         <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'medium' }}>
           Title
@@ -295,7 +295,9 @@ export default function TestSetDetailsSection({
 
         {/* Title Edit Actions */}
         {isEditingTitle && (
-          <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mb: 3 }}>
+          <Box
+            sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1, mb: 3 }}
+          >
             <Button
               variant="outlined"
               color="error"

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTags.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTags.tsx
@@ -27,7 +27,7 @@ export default function TestSetTags({
   }, [testSet.tags]);
 
   return (
-    <Box sx={{ width: '100%' }}>
+    <Box sx={{ width: '100%' }} suppressHydrationWarning>
       <BaseTag
         value={tagNames}
         onChange={setTagNames}

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/page.tsx
@@ -1,16 +1,12 @@
 import TestSetDetailCharts from './components/TestSetDetailCharts';
 import TestSetTestsGrid from './components/TestSetTestsGrid';
 import TestSetDetailsSection from './components/TestSetDetailsSection';
-import CommentsWrapper from '@/components/comments/CommentsWrapper'; // Added import
 import { TasksAndCommentsWrapper } from '@/components/tasks/TasksAndCommentsWrapper';
 import { auth } from '@/auth';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { Box, Grid, Paper, Typography, Button, TextField } from '@mui/material';
+import { Box, Grid, Paper } from '@mui/material';
 import { Metadata } from 'next';
 import { PageContainer } from '@toolpad/core/PageContainer';
-import PlayArrowIcon from '@mui/icons-material/PlayArrowOutlined';
-import DownloadIcon from '@mui/icons-material/Download';
-import BaseFreesoloAutocomplete from '@/components/common/BaseFreesoloAutocomplete';
 import { PaginationParams } from '@/utils/api-client/interfaces/pagination';
 
 interface TestSetsQueryParams extends Partial<PaginationParams> {

--- a/apps/frontend/src/components/tasks/TasksAndCommentsWrapper.tsx
+++ b/apps/frontend/src/components/tasks/TasksAndCommentsWrapper.tsx
@@ -82,7 +82,7 @@ export function TasksAndCommentsWrapper({
   }, [router, entityType, entityId]);
 
   return (
-    <Paper sx={{ p: 3 }}>
+    <Paper sx={{ p: 3 }} suppressHydrationWarning>
       {/* Tasks Section */}
       <TasksSection
         entityType={entityType}


### PR DESCRIPTION
## Summary

This PR adds the ability to edit test set titles directly from the test set detail page.

## Changes Made

- ✅ **Editable Title Field**: Added title editing field above description in test set details
- ✅ **Inline Editing**: Implemented edit/cancel/confirm buttons with consistent UI/UX
- ✅ **Enter Key Support**: Added Enter key submission for quick title updates
- ✅ **Proper Height Sizing**: Adjusted field height to accommodate longer titles
- ✅ **Breadcrumb Updates**: Title changes update breadcrumbs via page reload
- ✅ **Hydration Fixes**: Added suppressHydrationWarning to resolve console errors
- ✅ **API Integration**: Uses existing updateTestSet endpoint with name field

## Technical Details

- Follows the same UX pattern as description editing
- Maintains server component architecture for better performance
- Includes proper error handling and loading states
- Auto-focuses on edit field when activated
- Validates and formats code according to project standards

## Testing

- ✅ All validation checks pass (formatting, TypeScript, linting, tests, build)
- ✅ Manual testing confirms functionality works as expected
- ✅ No breaking changes to existing functionality

Closes #502