### PR TITLE
498 Endpoint Model Encryption

### DIFF
--- a/apps/backend/src/rhesis/backend/app/models/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/models/endpoint.py
@@ -10,6 +10,7 @@ from .enums import (
 )
 from .guid import GUID
 from .mixins import TagsMixin
+from rhesis.backend.app.utils.encryption import EncryptedString
 
 
 class Endpoint(Base, TagsMixin):
@@ -62,12 +63,12 @@ class Endpoint(Base, TagsMixin):
 
     # Authentication fields
     auth_type = Column(String, nullable=True)
-    auth_token = Column(Text, nullable=True)
+    auth_token = Column(EncryptedString(), nullable=True)  # Encrypted for security
     client_id = Column(Text, nullable=True)
-    client_secret = Column(Text, nullable=True)
+    client_secret = Column(EncryptedString(), nullable=True)  # Encrypted for security
     token_url = Column(Text, nullable=True)
     scopes = Column(ARRAY(Text), nullable=True)
     audience = Column(Text, nullable=True)
     extra_payload = Column(JSON, nullable=True)
-    last_token = Column(Text, nullable=True)
+    last_token = Column(EncryptedString(), nullable=True)  # Encrypted for security
     last_token_expires_at = Column(DateTime, nullable=True)

--- a/apps/backend/src/rhesis/backend/app/models/model.py
+++ b/apps/backend/src/rhesis/backend/app/models/model.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import relationship
 from .base import Base
 from .guid import GUID
 from .mixins import CommentsMixin, CountsMixin, OrganizationAndUserMixin, TagsMixin, TasksMixin
+from rhesis.backend.app.utils.encryption import EncryptedString
 
 
 class Model(Base, OrganizationAndUserMixin, TagsMixin, CommentsMixin, TasksMixin, CountsMixin):
@@ -15,7 +16,7 @@ class Model(Base, OrganizationAndUserMixin, TagsMixin, CommentsMixin, TasksMixin
     icon = Column(String)
     model_name = Column(String, nullable=False)
     endpoint = Column(String, nullable=False)
-    key = Column(String, nullable=False)
+    key = Column(EncryptedString(), nullable=False)  # Encrypted for security (LLM provider API keys)
     request_headers = Column(JSON)
 
     # Provider type relationship

--- a/apps/backend/src/rhesis/backend/app/models/token.py
+++ b/apps/backend/src/rhesis/backend/app/models/token.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import relationship
 
 from .base import Base
 from .mixins import OrganizationMixin
+from rhesis.backend.app.utils.encryption import EncryptedString
 
 
 class Token(Base, OrganizationMixin):
@@ -13,7 +14,7 @@ class Token(Base, OrganizationMixin):
     name = Column(String)
 
     # Token-specific columns
-    token = Column(String, nullable=False)
+    token = Column(EncryptedString(), nullable=False)  # Encrypted for security (user-generated tokens)
     token_obfuscated = Column(String)
     token_type = Column(String, nullable=False)
     expires_at = Column(DateTime, nullable=True)

--- a/tests/backend/utils/test_endpoint_encryption.py
+++ b/tests/backend/utils/test_endpoint_encryption.py
@@ -1,0 +1,242 @@
+import pytest
+import os
+from cryptography.fernet import Fernet
+from sqlalchemy import text
+from faker import Faker
+
+from rhesis.backend.app.models.endpoint import Endpoint
+from rhesis.backend.app.utils.encryption import is_encrypted
+from tests.backend.routes.fixtures.data_factories import BaseDataFactory
+
+fake = Faker()
+
+
+class EndpointEncryptionDataFactory(BaseDataFactory):
+    """Factory for generating endpoint test data for encryption tests"""
+    
+    @classmethod
+    def minimal_data(cls) -> dict:
+        return {
+            "name": fake.company() + " API",
+            "protocol": "REST",
+            "url": fake.url()
+        }
+    
+    @classmethod
+    def sample_data(cls) -> dict:
+        data = cls.minimal_data()
+        data.update({
+            "auth_token": fake.sha256(),
+            "client_id": fake.uuid4(),
+            "client_secret": fake.sha256(),
+            "last_token": fake.sha256()
+        })
+        return data
+    
+    @classmethod
+    def update_data(cls) -> dict:
+        return {
+            "auth_token": fake.sha256(),
+            "client_secret": fake.sha256()
+        }
+    
+    @classmethod
+    def invalid_data(cls) -> dict:
+        return {}  # Missing required fields
+
+
+@pytest.fixture
+def encryption_key():
+    """Provide test encryption key"""
+    key = Fernet.generate_key().decode()
+    os.environ["DB_ENCRYPTION_KEY"] = key
+    yield key
+    if "DB_ENCRYPTION_KEY" in os.environ:
+        del os.environ["DB_ENCRYPTION_KEY"]
+
+
+class TestEndpointEncryption:
+    """Test encryption of Endpoint model authentication fields"""
+    
+    def test_auth_token_encrypted_in_db(self, test_db, encryption_key):
+        """Test that auth_token is encrypted when stored in database"""
+        # Create endpoint using factory
+        endpoint_data = EndpointEncryptionDataFactory.sample_data()
+        endpoint = Endpoint(**endpoint_data)
+        test_db.add(endpoint)
+        test_db.commit()
+        
+        # Read directly from DB (bypassing ORM)
+        result = test_db.execute(
+            text("SELECT auth_token FROM endpoint WHERE id = :id"),
+            {"id": str(endpoint.id)}
+        ).fetchone()
+        
+        # Verify encrypted in DB
+        assert result[0] is not None
+        assert result[0] != endpoint_data["auth_token"]
+        assert is_encrypted(result[0])
+        
+        # Verify ORM returns decrypted value
+        test_db.refresh(endpoint)
+        assert endpoint.auth_token == endpoint_data["auth_token"]
+    
+    def test_client_secret_encrypted_in_db(self, test_db, encryption_key):
+        """Test that client_secret is encrypted when stored"""
+        endpoint_data = EndpointEncryptionDataFactory.sample_data()
+        endpoint = Endpoint(**endpoint_data)
+        test_db.add(endpoint)
+        test_db.commit()
+        
+        # Check DB directly
+        result = test_db.execute(
+            text("SELECT client_secret FROM endpoint WHERE id = :id"),
+            {"id": str(endpoint.id)}
+        ).fetchone()
+        
+        assert is_encrypted(result[0])
+        test_db.refresh(endpoint)
+        assert endpoint.client_secret == endpoint_data["client_secret"]
+    
+    def test_last_token_encrypted_in_db(self, test_db, encryption_key):
+        """Test that last_token is encrypted when stored"""
+        endpoint_data = EndpointEncryptionDataFactory.sample_data()
+        endpoint = Endpoint(**endpoint_data)
+        test_db.add(endpoint)
+        test_db.commit()
+        
+        result = test_db.execute(
+            text("SELECT last_token FROM endpoint WHERE id = :id"),
+            {"id": str(endpoint.id)}
+        ).fetchone()
+        
+        assert is_encrypted(result[0])
+        test_db.refresh(endpoint)
+        assert endpoint.last_token == endpoint_data["last_token"]
+    
+    def test_none_values_handled(self, test_db, encryption_key):
+        """Test that None values work correctly"""
+        endpoint_data = EndpointEncryptionDataFactory.minimal_data()
+        endpoint = Endpoint(**endpoint_data)
+        test_db.add(endpoint)
+        test_db.commit()
+        
+        test_db.refresh(endpoint)
+        assert endpoint.auth_token is None
+        assert endpoint.client_secret is None
+        assert endpoint.last_token is None
+    
+    def test_update_encrypted_field(self, test_db, encryption_key):
+        """Test updating encrypted fields"""
+        endpoint_data = EndpointEncryptionDataFactory.sample_data()
+        endpoint = Endpoint(**endpoint_data)
+        test_db.add(endpoint)
+        test_db.commit()
+        
+        # Update token
+        new_token = fake.sha256()
+        endpoint.auth_token = new_token
+        test_db.commit()
+        
+        # Verify still encrypted
+        result = test_db.execute(
+            text("SELECT auth_token FROM endpoint WHERE id = :id"),
+            {"id": str(endpoint.id)}
+        ).fetchone()
+        
+        assert is_encrypted(result[0])
+        test_db.refresh(endpoint)
+        assert endpoint.auth_token == new_token
+    
+    def test_client_id_not_encrypted(self, test_db, encryption_key):
+        """Test that client_id is NOT encrypted (it's public)"""
+        endpoint_data = EndpointEncryptionDataFactory.sample_data()
+        endpoint = Endpoint(**endpoint_data)
+        test_db.add(endpoint)
+        test_db.commit()
+        
+        result = test_db.execute(
+            text("SELECT client_id FROM endpoint WHERE id = :id"),
+            {"id": str(endpoint.id)}
+        ).fetchone()
+        
+        assert result[0] == endpoint_data["client_id"]
+        assert not is_encrypted(result[0])
+    
+    def test_all_encrypted_fields_together(self, test_db, encryption_key):
+        """Test that all three encrypted fields work together"""
+        endpoint_data = EndpointEncryptionDataFactory.sample_data()
+        endpoint = Endpoint(**endpoint_data)
+        test_db.add(endpoint)
+        test_db.commit()
+        
+        # Query all encrypted fields at once
+        result = test_db.execute(
+            text("SELECT auth_token, client_secret, last_token FROM endpoint WHERE id = :id"),
+            {"id": str(endpoint.id)}
+        ).fetchone()
+        
+        # All should be encrypted in DB
+        assert is_encrypted(result[0])
+        assert is_encrypted(result[1])
+        assert is_encrypted(result[2])
+        
+        # All should decrypt correctly via ORM
+        test_db.refresh(endpoint)
+        assert endpoint.auth_token == endpoint_data["auth_token"]
+        assert endpoint.client_secret == endpoint_data["client_secret"]
+        assert endpoint.last_token == endpoint_data["last_token"]
+    
+    def test_empty_string_handled(self, test_db, encryption_key):
+        """Test that empty strings are handled correctly"""
+        endpoint_data = EndpointEncryptionDataFactory.minimal_data()
+        endpoint_data["auth_token"] = ""
+        endpoint = Endpoint(**endpoint_data)
+        test_db.add(endpoint)
+        test_db.commit()
+        
+        test_db.refresh(endpoint)
+        assert endpoint.auth_token == ""
+    
+    def test_update_from_none_to_value(self, test_db, encryption_key):
+        """Test updating a field from None to a value"""
+        endpoint_data = EndpointEncryptionDataFactory.minimal_data()
+        endpoint = Endpoint(**endpoint_data)
+        test_db.add(endpoint)
+        test_db.commit()
+        
+        # Initially None
+        assert endpoint.auth_token is None
+        
+        # Update to a value
+        new_token = fake.sha256()
+        endpoint.auth_token = new_token
+        test_db.commit()
+        
+        # Verify encrypted and retrievable
+        result = test_db.execute(
+            text("SELECT auth_token FROM endpoint WHERE id = :id"),
+            {"id": str(endpoint.id)}
+        ).fetchone()
+        
+        assert is_encrypted(result[0])
+        test_db.refresh(endpoint)
+        assert endpoint.auth_token == new_token
+    
+    def test_update_from_value_to_none(self, test_db, encryption_key):
+        """Test updating a field from a value to None"""
+        endpoint_data = EndpointEncryptionDataFactory.sample_data()
+        endpoint = Endpoint(**endpoint_data)
+        test_db.add(endpoint)
+        test_db.commit()
+        
+        # Initially has value
+        assert endpoint.auth_token is not None
+        
+        # Update to None
+        endpoint.auth_token = None
+        test_db.commit()
+        
+        test_db.refresh(endpoint)
+        assert endpoint.auth_token is None
+

--- a/tests/backend/utils/test_model_encryption.py
+++ b/tests/backend/utils/test_model_encryption.py
@@ -1,0 +1,208 @@
+import pytest
+import os
+from cryptography.fernet import Fernet
+from sqlalchemy import text
+
+from rhesis.backend.app.models.model import Model
+from rhesis.backend.app.utils.encryption import is_encrypted
+from tests.backend.routes.fixtures.data_factories import BaseDataFactory
+from faker import Faker
+
+fake = Faker()
+
+
+class ModelEncryptionDataFactory(BaseDataFactory):
+    """Factory for generating model test data for encryption tests"""
+    
+    @classmethod
+    def minimal_data(cls) -> dict:
+        return {
+            "name": fake.company() + " Model",
+            "model_name": fake.random_element(["gpt-4", "gpt-4-turbo", "claude-3-opus", "claude-3-sonnet", "gemini-pro"]),
+            "endpoint": fake.url(),
+            "key": "sk-" + fake.sha256()[:40]  # Simulate API key format
+        }
+    
+    @classmethod
+    def sample_data(cls) -> dict:
+        data = cls.minimal_data()
+        data.update({
+            "description": fake.text(max_nb_chars=200),
+            "icon": fake.random_element(["🤖", "🧠", "💡", "⚡"]),
+            "request_headers": {
+                "Content-Type": "application/json",
+                "User-Agent": "Rhesis/1.0"
+            }
+        })
+        return data
+    
+    @classmethod
+    def openai_key(cls) -> str:
+        """Generate OpenAI-style API key"""
+        return "sk-" + fake.sha256()[:48]
+    
+    @classmethod
+    def anthropic_key(cls) -> str:
+        """Generate Anthropic-style API key"""
+        return "sk-ant-" + fake.sha256()[:40]
+    
+    @classmethod
+    def google_key(cls) -> str:
+        """Generate Google-style API key"""
+        return "AIza" + fake.sha256()[:35]
+
+
+@pytest.fixture
+def encryption_key():
+    """Provide test encryption key"""
+    key = Fernet.generate_key().decode()
+    os.environ["DB_ENCRYPTION_KEY"] = key
+    yield key
+    if "DB_ENCRYPTION_KEY" in os.environ:
+        del os.environ["DB_ENCRYPTION_KEY"]
+
+
+class TestModelEncryption:
+    """Test encryption of Model API key field"""
+    
+    def test_api_key_encrypted_in_db(self, test_db, encryption_key):
+        """Test that API key is encrypted when stored in database"""
+        model_data = ModelEncryptionDataFactory.sample_data()
+        model = Model(**model_data)
+        test_db.add(model)
+        test_db.commit()
+        
+        # Read directly from DB (bypassing ORM)
+        result = test_db.execute(
+            text("SELECT key FROM model WHERE id = :id"),
+            {"id": str(model.id)}
+        ).fetchone()
+        
+        # Verify encrypted in DB
+        assert result[0] is not None
+        assert result[0] != model_data["key"]
+        assert is_encrypted(result[0])
+        
+        # Verify ORM returns decrypted value
+        test_db.refresh(model)
+        assert model.key == model_data["key"]
+    
+    def test_different_provider_keys(self, test_db, encryption_key):
+        """Test encryption works for different LLM provider key formats"""
+        provider_keys = [
+            ModelEncryptionDataFactory.openai_key(),
+            ModelEncryptionDataFactory.anthropic_key(),
+            ModelEncryptionDataFactory.google_key(),
+        ]
+        
+        for api_key in provider_keys:
+            model_data = ModelEncryptionDataFactory.minimal_data()
+            model_data["key"] = api_key
+            model = Model(**model_data)
+            test_db.add(model)
+            test_db.commit()
+            
+            # Check encryption
+            result = test_db.execute(
+                text("SELECT key FROM model WHERE id = :id"),
+                {"id": str(model.id)}
+            ).fetchone()
+            
+            assert is_encrypted(result[0])
+            test_db.refresh(model)
+            assert model.key == api_key
+    
+    def test_update_api_key(self, test_db, encryption_key):
+        """Test updating API key (key rotation scenario)"""
+        model_data = ModelEncryptionDataFactory.sample_data()
+        model = Model(**model_data)
+        test_db.add(model)
+        test_db.commit()
+        
+        # Rotate key
+        new_key = ModelEncryptionDataFactory.openai_key()
+        model.key = new_key
+        test_db.commit()
+        
+        # Verify new key is encrypted
+        result = test_db.execute(
+            text("SELECT key FROM model WHERE id = :id"),
+            {"id": str(model.id)}
+        ).fetchone()
+        
+        assert is_encrypted(result[0])
+        test_db.refresh(model)
+        assert model.key == new_key
+        assert model.key != model_data["key"]
+    
+    def test_model_name_not_encrypted(self, test_db, encryption_key):
+        """Test that model_name is NOT encrypted (it's public)"""
+        model_data = ModelEncryptionDataFactory.sample_data()
+        model = Model(**model_data)
+        test_db.add(model)
+        test_db.commit()
+        
+        result = test_db.execute(
+            text("SELECT model_name FROM model WHERE id = :id"),
+            {"id": str(model.id)}
+        ).fetchone()
+        
+        assert result[0] == model_data["model_name"]
+        assert not is_encrypted(result[0])
+    
+    def test_endpoint_not_encrypted(self, test_db, encryption_key):
+        """Test that endpoint URL is NOT encrypted (it's public)"""
+        model_data = ModelEncryptionDataFactory.sample_data()
+        model = Model(**model_data)
+        test_db.add(model)
+        test_db.commit()
+        
+        result = test_db.execute(
+            text("SELECT endpoint FROM model WHERE id = :id"),
+            {"id": str(model.id)}
+        ).fetchone()
+        
+        assert result[0] == model_data["endpoint"]
+        assert not is_encrypted(result[0])
+    
+    def test_multiple_models_with_different_keys(self, test_db, encryption_key):
+        """Test multiple models with different API keys"""
+        models_data = [
+            ModelEncryptionDataFactory.sample_data(),
+            ModelEncryptionDataFactory.sample_data(),
+            ModelEncryptionDataFactory.sample_data(),
+        ]
+        
+        created_models = []
+        for model_data in models_data:
+            model = Model(**model_data)
+            test_db.add(model)
+            test_db.commit()
+            created_models.append((model.id, model_data["key"]))
+        
+        # Verify each model's key is encrypted and decrypts correctly
+        for model_id, original_key in created_models:
+            result = test_db.execute(
+                text("SELECT key FROM model WHERE id = :id"),
+                {"id": str(model_id)}
+            ).fetchone()
+            
+            assert is_encrypted(result[0])
+            
+            model = test_db.query(Model).filter(Model.id == model_id).first()
+            assert model.key == original_key
+    
+    def test_empty_key_not_allowed(self, test_db, encryption_key):
+        """Test that empty key is not allowed (nullable=False)"""
+        model_data = ModelEncryptionDataFactory.minimal_data()
+        model_data["key"] = None
+        
+        model = Model(**model_data)
+        test_db.add(model)
+        
+        # Should raise IntegrityError due to nullable=False
+        with pytest.raises(Exception):
+            test_db.commit()
+        
+        test_db.rollback()
+

--- a/tests/backend/utils/test_token_encryption.py
+++ b/tests/backend/utils/test_token_encryption.py
@@ -1,0 +1,264 @@
+import pytest
+import os
+from cryptography.fernet import Fernet
+from sqlalchemy import text
+from datetime import datetime, timedelta, timezone
+
+from rhesis.backend.app.models.token import Token
+from rhesis.backend.app.utils.encryption import is_encrypted
+from tests.backend.routes.fixtures.data_factories import BaseDataFactory
+from faker import Faker
+
+fake = Faker()
+
+
+class TokenEncryptionDataFactory(BaseDataFactory):
+    """Factory for generating token test data for encryption tests"""
+    
+    @classmethod
+    def minimal_data(cls) -> dict:
+        return {
+            "name": fake.word() + " Token",
+            "token": cls.generate_token(),
+            "token_type": fake.random_element(["api_key", "access_token", "bearer"])
+        }
+    
+    @classmethod
+    def sample_data(cls) -> dict:
+        data = cls.minimal_data()
+        data.update({
+            "token_obfuscated": cls.obfuscate_token(data["token"]),
+            "expires_at": datetime.now(timezone.utc) + timedelta(days=30),
+            "last_used_at": datetime.now(timezone.utc),
+        })
+        return data
+    
+    @classmethod
+    def generate_token(cls) -> str:
+        """Generate a realistic token"""
+        return "rh_" + fake.sha256()[:48]
+    
+    @classmethod
+    def obfuscate_token(cls, token: str) -> str:
+        """Obfuscate token for display"""
+        if len(token) > 8:
+            return token[:4] + "..." + token[-4:]
+        return "***"
+    
+    @classmethod
+    def expired_token_data(cls) -> dict:
+        """Generate expired token data"""
+        data = cls.sample_data()
+        data["expires_at"] = datetime.now(timezone.utc) - timedelta(days=1)
+        return data
+
+
+@pytest.fixture
+def encryption_key():
+    """Provide test encryption key"""
+    key = Fernet.generate_key().decode()
+    os.environ["DB_ENCRYPTION_KEY"] = key
+    yield key
+    if "DB_ENCRYPTION_KEY" in os.environ:
+        del os.environ["DB_ENCRYPTION_KEY"]
+
+
+class TestTokenEncryption:
+    """Test encryption of Token field"""
+    
+    def test_token_encrypted_in_db(self, test_db, encryption_key, authenticated_user_id, test_org_id):
+        """Test that token is encrypted when stored in database"""
+        token_data = TokenEncryptionDataFactory.sample_data()
+        token_data["user_id"] = authenticated_user_id
+        token_data["organization_id"] = test_org_id
+        token = Token(**token_data)
+        test_db.add(token)
+        test_db.commit()
+        
+        # Read directly from DB (bypassing ORM)
+        result = test_db.execute(
+            text("SELECT token FROM token WHERE id = :id"),
+            {"id": str(token.id)}
+        ).fetchone()
+        
+        # Verify encrypted in DB
+        assert result[0] is not None
+        assert result[0] != token_data["token"]
+        assert is_encrypted(result[0])
+        
+        # Verify ORM returns decrypted value
+        test_db.refresh(token)
+        assert token.token == token_data["token"]
+    
+    def test_token_obfuscated_not_encrypted(self, test_db, encryption_key, authenticated_user_id, test_org_id):
+        """Test that token_obfuscated is NOT encrypted (it's for display)"""
+        token_data = TokenEncryptionDataFactory.sample_data()
+        token_data["user_id"] = authenticated_user_id
+        token_data["organization_id"] = test_org_id
+        token = Token(**token_data)
+        test_db.add(token)
+        test_db.commit()
+        
+        result = test_db.execute(
+            text("SELECT token_obfuscated FROM token WHERE id = :id"),
+            {"id": str(token.id)}
+        ).fetchone()
+        
+        # token_obfuscated should remain plaintext
+        assert result[0] == token_data["token_obfuscated"]
+        assert not is_encrypted(result[0])
+    
+    def test_update_token(self, test_db, encryption_key, authenticated_user_id, test_org_id):
+        """Test updating token (token refresh/rotation scenario)"""
+        token_data = TokenEncryptionDataFactory.sample_data()
+        token_data["user_id"] = authenticated_user_id
+        token_data["organization_id"] = test_org_id
+        token = Token(**token_data)
+        test_db.add(token)
+        test_db.commit()
+        
+        # Rotate token
+        new_token = TokenEncryptionDataFactory.generate_token()
+        token.token = new_token
+        token.last_refreshed_at = datetime.now(timezone.utc)
+        test_db.commit()
+        
+        # Verify new token is encrypted
+        result = test_db.execute(
+            text("SELECT token FROM token WHERE id = :id"),
+            {"id": str(token.id)}
+        ).fetchone()
+        
+        assert is_encrypted(result[0])
+        test_db.refresh(token)
+        assert token.token == new_token
+        assert token.token != token_data["token"]
+    
+    def test_different_token_types(self, test_db, encryption_key, authenticated_user_id, test_org_id):
+        """Test encryption works for different token types"""
+        token_types = ["api_key", "access_token", "bearer", "refresh_token"]
+        
+        for token_type in token_types:
+            token_data = TokenEncryptionDataFactory.minimal_data()
+            token_data["token_type"] = token_type
+            token_data["user_id"] = authenticated_user_id
+            token_data["organization_id"] = test_org_id
+            token = Token(**token_data)
+            test_db.add(token)
+            test_db.commit()
+            
+            # Check encryption
+            result = test_db.execute(
+                text("SELECT token FROM token WHERE id = :id"),
+                {"id": str(token.id)}
+            ).fetchone()
+            
+            assert is_encrypted(result[0])
+            test_db.refresh(token)
+            assert token.token == token_data["token"]
+    
+    def test_multiple_tokens_for_same_user(self, test_db, encryption_key, authenticated_user_id, test_org_id):
+        """Test multiple tokens with different values"""
+        tokens_data = [
+            TokenEncryptionDataFactory.sample_data(),
+            TokenEncryptionDataFactory.sample_data(),
+            TokenEncryptionDataFactory.sample_data(),
+        ]
+        
+        created_tokens = []
+        for token_data in tokens_data:
+            token_data["user_id"] = authenticated_user_id
+            token_data["organization_id"] = test_org_id
+            token = Token(**token_data)
+            test_db.add(token)
+            test_db.commit()
+            created_tokens.append((token.id, token_data["token"]))
+        
+        # Verify each token is encrypted and decrypts correctly
+        for token_id, original_token in created_tokens:
+            result = test_db.execute(
+                text("SELECT token FROM token WHERE id = :id"),
+                {"id": str(token_id)}
+            ).fetchone()
+            
+            assert is_encrypted(result[0])
+            
+            token = test_db.query(Token).filter(Token.id == token_id).first()
+            assert token.token == original_token
+    
+    def test_token_query(self, test_db, encryption_key, authenticated_user_id, test_org_id):
+        """Test that we can query tokens and access values transparently"""
+        token_data = TokenEncryptionDataFactory.sample_data()
+        token_data["user_id"] = authenticated_user_id
+        token_data["organization_id"] = test_org_id
+        token = Token(**token_data)
+        test_db.add(token)
+        test_db.commit()
+        
+        # Query via ORM
+        queried_token = test_db.query(Token).filter(Token.name == token_data["name"]).first()
+        assert queried_token is not None
+        assert queried_token.token == token_data["token"]  # Transparently decrypted
+    
+    def test_expired_token_still_encrypted(self, test_db, encryption_key, authenticated_user_id, test_org_id):
+        """Test that expired tokens are still encrypted"""
+        token_data = TokenEncryptionDataFactory.expired_token_data()
+        token_data["user_id"] = authenticated_user_id
+        token_data["organization_id"] = test_org_id
+        token = Token(**token_data)
+        test_db.add(token)
+        test_db.commit()
+        
+        # Even expired tokens should be encrypted
+        result = test_db.execute(
+            text("SELECT token FROM token WHERE id = :id"),
+            {"id": str(token.id)}
+        ).fetchone()
+        
+        assert is_encrypted(result[0])
+        
+        # Verify expired property works with encrypted token
+        test_db.refresh(token)
+        assert token.is_expired is True
+        assert token.token == token_data["token"]
+    
+    def test_token_last_used_tracking(self, test_db, encryption_key, authenticated_user_id, test_org_id):
+        """Test that token usage tracking works with encryption"""
+        token_data = TokenEncryptionDataFactory.sample_data()
+        token_data["user_id"] = authenticated_user_id
+        token_data["organization_id"] = test_org_id
+        token = Token(**token_data)
+        test_db.add(token)
+        test_db.commit()
+        
+        # Simulate token usage
+        token.last_used_at = datetime.now(timezone.utc)
+        test_db.commit()
+        
+        # Token should still be encrypted and accessible
+        result = test_db.execute(
+            text("SELECT token FROM token WHERE id = :id"),
+            {"id": str(token.id)}
+        ).fetchone()
+        
+        assert is_encrypted(result[0])
+        test_db.refresh(token)
+        assert token.token == token_data["token"]
+        assert token.last_used_at is not None
+    
+    def test_token_required_validation(self, test_db, encryption_key, authenticated_user_id, test_org_id):
+        """Test that token field is required (cannot be None)"""
+        token_data = TokenEncryptionDataFactory.minimal_data()
+        token_data["token"] = None
+        token_data["user_id"] = authenticated_user_id
+        token_data["organization_id"] = test_org_id
+        
+        token = Token(**token_data)
+        test_db.add(token)
+        
+        # Should raise IntegrityError due to nullable=False
+        with pytest.raises(Exception):
+            test_db.commit()
+        
+        test_db.rollback()
+


### PR DESCRIPTION
This PR introduces changes from the `feature/498-endpoint-model-encryption` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->


## 📁 Files Changed (       6 files)

```
apps/backend/src/rhesis/backend/app/models/endpoint.py
apps/backend/src/rhesis/backend/app/models/model.py
apps/backend/src/rhesis/backend/app/models/token.py
tests/backend/utils/test_endpoint_encryption.py
tests/backend/utils/test_model_encryption.py
tests/backend/utils/test_token_encryption.py
```

## 📋 Commit Details

```
4288c74b - feat: add encryption to Model and Token tables (#499, #498) (Harry Cruz, 2025-10-07 16:44)
5189d61c - feat: add encryption to Endpoint model authentication fields (#498) (Harry Cruz, 2025-10-07 16:25)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->