### PR TITLE
fix: remove step prefix from evaluation steps edit fields

### DIFF
--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/page.tsx
@@ -177,10 +177,14 @@ export default function MetricDetailPage() {
 
         // Populate step refs
         const steps = currentMetric.evaluation_steps?.split('\n---\n') || [''];
-        const stepsWithIds = steps.map((step, index) => ({
-          id: `step-${Date.now()}-${index}`,
-          content: step,
-        }));
+        const stepsWithIds = steps.map((step, index) => {
+          // Remove the "Step X:" prefix if it exists
+          const cleanedStep = step.replace(/^Step \d+:\n?/, '').trim();
+          return {
+            id: `step-${Date.now()}-${index}`,
+            content: cleanedStep,
+          };
+        });
         setStepsWithIds(stepsWithIds);
 
         // Populate step refs after a brief delay to ensure DOM elements exist
@@ -320,8 +324,9 @@ export default function MetricDetailPage() {
 
       // Handle evaluation steps
       if (Array.isArray(dataToSend.evaluation_steps)) {
-        dataToSend.evaluation_steps =
-          dataToSend.evaluation_steps.join('\n---\n');
+        dataToSend.evaluation_steps = dataToSend.evaluation_steps
+          .map((step: string, index: number) => `Step ${index + 1}:\n${step}`)
+          .join('\n---\n');
       }
 
       // Remove tags from the update data as they're handled separately
@@ -848,7 +853,7 @@ export default function MetricDetailPage() {
                               {index + 1}
                             </Typography>
                             <Typography sx={{ whiteSpace: 'pre-wrap' }}>
-                              {step.replace(/^Step \d+:\n/, '')}
+                              {step.replace(/^Step \d+:\n?/, '').trim()}
                             </Typography>
                           </Paper>
                         ))


### PR DESCRIPTION
## Description
Fixes #262 

This PR fixes the issue where evaluation steps were displaying the 'Step X:' prefix inside the editable text fields when editing metrics.

## Changes
- Remove 'Step X:' prefix from editable text fields when editing evaluation steps
- Add prefix back when saving to maintain backend storage format consistency  
- Update read-only display to also remove prefix for consistency
- Fix TypeScript type annotations for map function parameters

## Result
- Step numbers now appear as visual labels rather than editable content
- Improved user experience while maintaining data format compatibility
- Clean separation between step numbering and step content

## Testing
- [x] Edit evaluation steps and verify no 'Step X:' prefix appears in text fields
- [x] Save changes and verify backend format is maintained
- [x] View read-only steps and verify consistent display