### PR TITLE
fix(readthedocs): use pip instead of uv for better RTD compatibility

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,15 +5,11 @@ build:
   tools:
     python: "3.10"
   jobs:
-    post_create_environment:
-      # Install uv package manager
-      - pip install uv
     post_install:
-      # Install the SDK package and its dependencies from the sdk directory
-      # First, install the package itself
-      - cd sdk && uv pip install --system -e .
-      # Then install the dev dependencies which include Sphinx and related tools
-      - uv pip install --system sphinx>=8.1.3 sphinx-autodoc-typehints>=3.0.1 sphinx-rtd-theme>=3.0.2 myst-parser>=4.0.0
+      # Install Sphinx and documentation dependencies
+      - pip install sphinx>=8.1.3 sphinx-autodoc-typehints>=3.0.1 sphinx-rtd-theme>=3.0.2 myst-parser>=4.0.0
+      # Install the SDK package from the sdk directory
+      - pip install -e ./sdk
 
 sphinx:
   configuration: docs/sdk/source/conf.py


### PR DESCRIPTION
- Replace uv with standard pip (better RTD support)
- Use relative path ./sdk for package installation
- Simplify build jobs for more reliable execution
- Install Sphinx dependencies explicitly before SDK package