### PR TITLE
chore(sdk): bump version to 0.3.1.post1 for PyPI README update

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhesis-sdk"
-version = "0.3.1"
+version = "0.3.1.post1"
 description = "SDK for testing and validating LLM applications"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bumps SDK version to 0.3.1.post1 to allow republishing to PyPI with updated README and LICENSE files.