### PR TITLE
Fix: #531 Organisation Name Overlaps

### DIFF
--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { Metadata } from 'next';
-import Image from 'next/image';
-import { Box } from '@mui/material';
+import { Box, Tooltip } from '@mui/material';
 import ThemeAwareLogo from '../components/common/ThemeAwareLogo';
 import '../styles/fonts.css';
 import {
@@ -13,8 +12,6 @@ import {
   GroupIcon,
   PlayArrowIcon,
   AssessmentIcon,
-  DescriptionIcon,
-  AutoFixHighIcon,
   CategoryIcon,
   AutoGraphIcon,
   IntegrationInstructionsIcon,
@@ -80,7 +77,17 @@ async function getNavigationItems(
     {
       kind: 'page',
       segment: 'organizations',
-      title: organizationName,
+      title: (
+        <Tooltip
+          placement="top"
+          // sidebar is 240px, px to rem conversion => 240/16=15, so from 16 characters we display ellipsis+tooltip
+          title={organizationName.length < 15 ? '' : organizationName}
+        >
+          <Box sx={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {organizationName}
+          </Box>
+        </Tooltip>
+      ),
       icon: <BusinessIcon />,
       children: [
         {


### PR DESCRIPTION
This PR should fix the overlapping organisation name in the navigation mentioned in the issue #531 

It implements the tooltip on top of the organisation name when exeeding the width limit (15rem/240px) 

Side Note:
Having the server action for the protected navigation is not clean, since it is not related to #531 I left it as it was.
Also because of this I did not extracted the width to a flexible variable. (That would be imported here) 