### PR TITLE
fix(test-sets): disable execute button when test set has 0 tests

### DIFF
--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetDetailsSection.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetDetailsSection.tsx
@@ -201,19 +201,30 @@ export default function TestSetDetailsSection({
   const categories = testSet.attributes?.metadata?.categories || [];
   const topics = testSet.attributes?.metadata?.topics || [];
   const sources = testSet.attributes?.metadata?.sources || [];
+  const totalTests = testSet.attributes?.metadata?.total_tests || 0;
 
   return (
     <>
       {/* Action Buttons */}
       <Box sx={{ display: 'flex', gap: 2, mb: 3 }} suppressHydrationWarning>
-        <Button
-          variant="contained"
-          color="primary"
-          startIcon={<PlayArrowIcon />}
-          onClick={() => setTestRunDrawerOpen(true)}
+        <Tooltip
+          title={
+            totalTests === 0 ? 'Cannot execute a test set with 0 tests' : ''
+          }
+          arrow
         >
-          Execute Test Set
-        </Button>
+          <span>
+            <Button
+              variant="contained"
+              color="primary"
+              startIcon={<PlayArrowIcon />}
+              onClick={() => setTestRunDrawerOpen(true)}
+              disabled={totalTests === 0}
+            >
+              Execute Test Set
+            </Button>
+          </span>
+        </Tooltip>
         <Button
           variant="outlined"
           startIcon={<DownloadIcon />}


### PR DESCRIPTION
## Description

This PR fixes issue #592 by disabling the 'Execute Test Set' button when a test set contains 0 tests.

## Changes
- Added check for `total_tests` in test set metadata
- Disabled 'Execute Test Set' button when `totalTests === 0`
- Added tooltip explaining why button is disabled when hovering over disabled button

## Related Issue
Fixes #592

## Testing
- [x] Button is disabled when test set has 0 tests
- [x] Tooltip shows explanation when hovering over disabled button
- [x] Button is enabled when test set has 1 or more tests

## Notes
This is the frontend implementation. Backend validation should be added separately.