### PR TITLE
fix: Remove redundant lambda in chatbot rate limiter decorators

### DIFF
--- a/apps/chatbot/client.py
+++ b/apps/chatbot/client.py
@@ -181,7 +181,7 @@ async def root(request: Request, auth: dict = Depends(verify_api_key)):
     }
 
 @app.post("/chat", response_model=ChatResponse)
-@limiter.limit(lambda request: get_rate_limit_for_request(request))
+@limiter.limit(get_rate_limit_for_request)
 async def chat(
     request: Request, 
     chat_request: ChatRequest,
@@ -232,14 +232,14 @@ async def chat(
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/sessions/{session_id}")
-@limiter.limit(lambda request: get_rate_limit_for_request(request))
+@limiter.limit(get_rate_limit_for_request)
 async def get_session(request: Request, session_id: str, auth: dict = Depends(verify_api_key)):
     if session_id not in sessions:
         raise HTTPException(status_code=404, detail="Session not found")
     return {"messages": sessions[session_id]}
 
 @app.delete("/sessions/{session_id}")
-@limiter.limit(lambda request: get_rate_limit_for_request(request))
+@limiter.limit(get_rate_limit_for_request)
 async def delete_session(request: Request, session_id: str, auth: dict = Depends(verify_api_key)):
     if session_id not in sessions:
         raise HTTPException(status_code=404, detail="Session not found")
@@ -247,7 +247,7 @@ async def delete_session(request: Request, session_id: str, auth: dict = Depends
     return {"message": "Session deleted"}
 
 @app.get("/use-cases")
-@limiter.limit(lambda request: get_rate_limit_for_request(request))
+@limiter.limit(get_rate_limit_for_request)
 async def list_use_cases(request: Request, auth: dict = Depends(verify_api_key)):
     """Get list of available use cases"""
     try:


### PR DESCRIPTION
## Summary
Fixes the  in the chatbot API endpoints caused by incorrect slowapi rate limiter decorator usage.

## Problem
The chatbot endpoints at  were returning  due to:
```
TypeError: <lambda>() missing 1 required positional argument: 'request'
```

This was occurring in the slowapi rate limiter when processing dynamic rate limits.

## Root Cause
The lambda wrapper around `get_rate_limit_for_request()` was redundant and caused a parameter mismatch. Slowapi expects either:
- A string rate limit (e.g., `"100/day"`)
- A callable that takes a request parameter and returns a string

We were passing: `lambda request: get_rate_limit_for_request(request)` which created an extra layer that broke slowapi's internal logic.

## Solution
Removed the lambda wrapper and passed the function directly:

**Before:**
```python
@limiter.limit(lambda request: get_rate_limit_for_request(request))
```

**After:**
```python
@limiter.limit(get_rate_limit_for_request)
```

## Changes
- Updated `/chat` endpoint
- Updated `/sessions/{session_id}` endpoint
- Updated `/use-cases` endpoint
- Updated session delete endpoint

## Testing
After deployment, the following should work:
```bash
# Test health check
curl https://dev-chatbot.rhesis.ai/health

# Test use cases
curl https://dev-chatbot.rhesis.ai/use-cases

# Test chat
curl -X POST https://dev-chatbot.rhesis.ai/chat \
  -H "Content-Type: application/json" \
  -d '{"message": "What is term life insurance?"}'
```

## Related Issues
- Part of #636 (Default Insurance Chatbot Endpoint for New User Onboarding)