### PR TITLE
fix: use List[str] instead of list[str] in GenerationConfig dataclass

### DIFF
--- a/sdk/src/rhesis/sdk/synthesizers/config_synthesizer.py
+++ b/sdk/src/rhesis/sdk/synthesizers/config_synthesizer.py
@@ -25,9 +25,9 @@ class GenerationConfig:
     """Dataclass representing generation config information."""
 
     project_context: str  # Select project
-    behaviors: list[str]  # Behaviors
-    topics: list[str]  # Topics
-    categories: list[str]  # Categories
+    behaviors: List[str]  # Behaviors
+    topics: List[str]  # Topics
+    categories: List[str]  # Categories
     specific_requirements: str  # Describe what you want to test
     test_type: str
     output_format: str  # Generate prompts only

--- a/sdk/src/rhesis/sdk/synthesizers_v2/config_synthesizer.py
+++ b/sdk/src/rhesis/sdk/synthesizers_v2/config_synthesizer.py
@@ -25,9 +25,9 @@ class GenerationConfig:
     """Dataclass representing generation config information."""
 
     project_context: str  # Select project
-    behaviors: list[str]  # Behaviors
-    topics: list[str]  # Topics
-    categories: list[str]  # Categories
+    behaviors: List[str]  # Behaviors
+    topics: List[str]  # Topics
+    categories: List[str]  # Categories
     specific_requirements: str  # Describe what you want to test
     test_type: str
     output_format: str  # Generate prompts only


### PR DESCRIPTION
## Problem
The `GenerationConfig` dataclass was using `list[str]` (Python 3.9+ syntax) which caused a runtime error when creating the dataclass:
```
GenerationConfig.__init__() got an unexpected keyword argument 'behaviors'
```

## Solution
Changed type annotations to use `List[str]` from the `typing` module for:
- `behaviors` field
- `topics` field
- `categories` field

## Impact
- ✅ Fixes the runtime error in test generation flow
- ✅ Ensures Python 3.8+ compatibility
- ✅ No breaking changes - only type annotation fixes

## Files Changed
- `sdk/src/rhesis/sdk/synthesizers/config_synthesizer.py`
- `sdk/src/rhesis/sdk/synthesizers_v2/config_synthesizer.py`

## Testing
The fix resolves the error when calling the test generation API with a prompt containing `behaviors`, `topics`, and `categories` parameters.