### PR TITLE
feat: Send project_id to test config generation endpoint

### DIFF
--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationFlow.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationFlow.tsx
@@ -116,6 +116,7 @@ export default function TestGenerationFlow({
             const configResponse = await servicesClient.generateTestConfig({
               prompt: template.prompt,
               sample_size: 5,
+              project_id: selectedProjectId || undefined,
             });
 
             // Create chips from API response and template values
@@ -268,6 +269,7 @@ export default function TestGenerationFlow({
         const configResponse = await servicesClient.generateTestConfig({
           prompt: desc,
           sample_size: 10,
+          project_id: projectId || undefined,
         });
 
         console.log('Config response:', configResponse);
@@ -713,6 +715,7 @@ export default function TestGenerationFlow({
         const configResponse = await servicesClient.generateTestConfig({
           prompt: description, // Keep original prompt separate
           sample_size: 10,
+          project_id: selectedProjectId || undefined,
           rated_samples: ratedSamples,
           previous_messages: [
             ...previousMessages,

--- a/apps/frontend/src/utils/api-client/services-client.ts
+++ b/apps/frontend/src/utils/api-client/services-client.ts
@@ -66,6 +66,7 @@ interface IterationMessage {
 interface GenerateTestConfigRequest {
   prompt: string;
   sample_size: number;
+  project_id?: string;
   // Iteration context
   chip_states?: ChipState[];
   rated_samples?: RatedSample[];


### PR DESCRIPTION
## Summary

This PR enables the frontend to send the selected project_id to the test configuration generation endpoint, allowing the backend to use project context for more relevant test generation.

## Changes

- **API Interface**: Added `project_id` parameter to `GenerateTestConfigRequest` interface
- **Test Generation Flow**: Updated all three `generateTestConfig` calls to include the selected project_id:
  - Template initialization
  - Initial configuration from input screen
  - Chat message refinement

## Benefits

- When users select a project in TestInputScreen, the AI will receive project context
- More relevant and accurate test configurations based on project details
- Backward compatible (project_id is optional)

## Testing

- No linter errors
- All existing functionality remains intact
- Project selection flows through to the API correctly