### PR TITLE
test(risk): ensure long name generates 100+ chars

### DIFF
--- a/tests/backend/routes/fixtures/data_factories.py
+++ b/tests/backend/routes/fixtures/data_factories.py
@@ -1202,8 +1202,16 @@ class RiskDataFactory(BaseDataFactory):
     def edge_case_data(cls, case_type: str) -> Dict[str, Any]:
         """Generate risk edge case data"""
         if case_type == "long_name":
+            # Generate text that's guaranteed to be longer than 100 chars
+            long_text = fake.text(max_nb_chars=200).replace('\n', ' ')
+            # Ensure it's at least 101 characters long
+            while len(long_text) < 101:
+                long_text += " " + fake.sentence()
+            # Trim if it exceeds 200 characters
+            if len(long_text) > 200:
+                long_text = long_text[:200].rsplit(' ', 1)[0]  # Cut at last word boundary
             return {
-                "name": fake.text(max_nb_chars=200).replace('\n', ' '),
+                "name": long_text,
                 "description": fake.paragraph(nb_sentences=5)
             }
         elif case_type == "security_risk":


### PR DESCRIPTION
## Summary

Fixes the failing test `test_create_risk_with_long_name` by ensuring the RiskDataFactory always generates names longer than 100 characters.

## Problem

The test was failing because `fake.text(max_nb_chars=200)` doesn't guarantee a minimum length, and in some cases it was generating only 70 characters when the test expected 100+.

## Solution

Updated `RiskDataFactory.edge_case_data("long_name")` to:
- Generate initial text with max 200 characters
- Add sentences if the text is shorter than 101 characters
- Trim at word boundaries if it exceeds 200 characters

## Test Results

✅ All 1660 backend tests now pass (88 skipped)