### PR TITLE
fix(docker): add git package to worker and chatbot containers

### DIFF
--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     curl \
+    git \
     && pip install --no-cache-dir uv \
     && rm -rf /var/lib/apt/lists/*
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get install -y \
     gcc \
     g++ \
     procps \
+    git \
     && pip install --no-cache-dir uv \
     && rm -rf /var/lib/apt/lists/*
 
@@ -81,6 +82,7 @@ RUN uv sync
 #Add environment variable for the path. This way the Python environment is activated.
 
 # Remove build dependencies after installing Python packages
+# Keep git as it's needed by ragas package at runtime
 RUN apt-get purge -y gcc \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Problem

The worker and chatbot services fail to start with the following error:

```
ImportError: Failed to initialize: Bad git executable.
The git executable must be specified in one of the following ways:
- be included in your $PATH
- be set via $GIT_PYTHON_GIT_EXECUTABLE
- explicitly set via git.refresh(<full-path-to-git-executable>)
```

This happens because both services import ragas metrics (via the SDK), and ragas depends on GitPython which requires git to be installed.

## Solution

Added `git` package to both worker and chatbot Dockerfiles:
- Added git to the apt-get install command
- Added comment to prevent it from being removed in cleanup

## Related

This is the same fix that was applied to the backend service in PR #726.

## Testing

- ✅ Git package added to worker Dockerfile
- ✅ Git package added to chatbot Dockerfile  
- ✅ Git kept in container after build dependencies cleanup

## Impact

- Fixes worker container startup failures
- Fixes chatbot container startup failures
- Allows ragas metrics to function properly in both services