### PR TITLE
fix(models): Set default Rhesis model name to 'default'

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/organization.py
+++ b/apps/backend/src/rhesis/backend/app/services/organization.py
@@ -590,15 +590,10 @@ def load_initial_data(db: Session, organization_id: str, user_id: str) -> None:
             commit=False,
         )
 
-        # Get the backend-configured model name (e.g., gemini-2.0-flash)
-        from rhesis.backend.app.constants import DEFAULT_MODEL_NAME
-
-        default_model_name = DEFAULT_MODEL_NAME
-
         # Create the default Rhesis model
         default_model_data = {
             "name": "Rhesis Default",
-            "model_name": default_model_name,
+            "model_name": "default",
             "description": "Default Rhesis-hosted model. No API key required.",
             "icon": "rhesis",  # Maps to PROVIDER_ICONS['rhesis'] in frontend
             "provider_type_id": rhesis_provider_type.id,


### PR DESCRIPTION
## Changes
- Changed the default Rhesis model's `model_name` from using the `DEFAULT_MODEL_NAME` constant (which was set to 'gemini-2.0-flash') to the literal string 'default'
- Removed the now-unused import and variable assignment

## Why
This standardizes the model identifier for the default Rhesis model to use a simple 'default' string instead of the backend's configured model name.

## Testing
- Verified that the code compiles without linter errors
- The change only affects the initial data loaded when creating new organizations