### PR TITLE
fix(metrics): respect is_successful from external metric libraries

### DIFF
--- a/apps/backend/src/rhesis/backend/metrics/evaluator.py
+++ b/apps/backend/src/rhesis/backend/metrics/evaluator.py
@@ -946,15 +946,27 @@ class MetricEvaluator:
                 or f"{class_name} evaluation metric"
             )
 
-            # Calculate is_successful using the score evaluator
-            is_successful = self.score_evaluator.evaluate_score(
-                score=result.score,
-                threshold=self._get_config_value(metric_config, "threshold"),
-                threshold_operator=self._get_config_value(metric_config, "threshold_operator"),
-                reference_score=self._get_config_value(metric_config, "reference_score"),
-                categories=self._get_config_value(metric_config, "categories"),
-                passing_categories=self._get_config_value(metric_config, "passing_categories"),
-            )
+            # Determine is_successful value
+            # Priority: Use metric's own is_successful if provided, otherwise compute it
+            if "is_successful" in result.details and result.details["is_successful"] is not None:
+                # Trust the metric's own evaluation (e.g., DeepEval, Ragas)
+                is_successful = result.details["is_successful"]
+                logger.debug(
+                    f"Using metric's own is_successful value for '{class_name}': {is_successful}"
+                )
+            else:
+                # Compute is_successful using our score evaluator
+                is_successful = self.score_evaluator.evaluate_score(
+                    score=result.score,
+                    threshold=self._get_config_value(metric_config, "threshold"),
+                    threshold_operator=self._get_config_value(metric_config, "threshold_operator"),
+                    reference_score=self._get_config_value(metric_config, "reference_score"),
+                    categories=self._get_config_value(metric_config, "categories"),
+                    passing_categories=self._get_config_value(metric_config, "passing_categories"),
+                )
+                logger.debug(
+                    f"Computed is_successful for '{class_name}' using score evaluator: {is_successful}"
+                )
 
             # Store results - structure depends on metric type
             processed_result = {


### PR DESCRIPTION
## Problem

The `MetricEvaluator` was ignoring the `is_successful` value computed by external metric libraries (DeepEval, Ragas) and always recomputing it using our own `ScoreEvaluator`. This caused potential inconsistencies when external libraries had more sophisticated logic than simple threshold comparison.

## Example Issue

If DeepEval has complex internal logic like:
```python
def is_successful(self):
    if self.strict_mode:
        return self.score >= self.threshold and self.reasoning_quality > 0.8
    else:
        return self.score >= self.threshold
```

Our evaluator would ignore this and just do `score >= threshold`, losing the additional `reasoning_quality` check.

## Solution

The `MetricEvaluator._process_metric_result()` method now:
1. **First checks** if `result.details` contains `is_successful`
2. **If present**, uses it directly (trusts the external library)
3. **If not present**, computes it using `ScoreEvaluator` (backward compatible)
4. **Adds debug logging** to indicate which approach was used

## Benefits

✅ **DeepEval**: Internal threshold logic (strict mode, etc.) is now respected  
✅ **Ragas**: Computed `is_successful` values are preserved  
✅ **Native Judge**: Continue to work correctly (they include `is_successful`)  
✅ **Backward Compatible**: Metrics not providing `is_successful` are computed as before

## Testing

- [x] Code compiles without linter errors
- [ ] Verify external metrics (DeepEval, Ragas) respect their own `is_successful` logic
- [ ] Verify Native Judge metrics still work correctly

## Note on Ragas

**Ragas metrics hardcode `is_successful = score >= threshold`** - they don't respect `threshold_operator`. This is a separate issue that could be addressed in a future PR if needed. For now, this fix ensures we at least respect what Ragas computes.