### PR TITLE
Fix: Optimize Backend Dockerfile

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -39,6 +39,9 @@ ENV UV_COMPILE_BYTECODE=1
 # the size of the image.
 ENV UV_NO_MANAGED_PYTHON=1
 
+# Skip the installation of the dev dependencies
+ENV UV_NO_DEV=1
+
 # Copy the SDK directory
 COPY sdk /app/sdk/
 

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "chardet",
     "jsonpath-ng==1.7.0",
     "websockets==15.0.1",
-    "pandas==2.2.2",
     "tenacity==8.2.3",
     "psutil==5.9.5",
     "celery[redis]==5.5.2",

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -4244,7 +4244,6 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-sdk" },
-    { name = "pandas" },
     { name = "pathspec" },
     { name = "portalocker" },
     { name = "proto-plus" },
@@ -4311,7 +4310,6 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.32.1" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.45b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.32.1" },
-    { name = "pandas", specifier = "==2.2.2" },
     { name = "pathspec", specifier = "==0.12.1" },
     { name = "portalocker", specifier = "==3.1.1" },
     { name = "proto-plus", specifier = ">=1.26.1" },


### PR DESCRIPTION
This PR introduces changes from the `fix/optimize-backend-dockerfile` branch.

Done:
- introduced two stage build to minimize the size of the image
- remove chown layer, that caused additional 1.6gb in the final docker image


Before:
- 5.1 GB - 2 min 50 s - build job
After:
- 1.8 GB  - 2 min - build job

## 📝 Summary

<!-- Add a brief summary of the changes here -->


## 📁 Files Changed (       4 files)

```
apps/backend/Dockerfile
apps/backend/pyproject.toml
apps/backend/uv.lock
docker-compose.yml
```

## 📋 Commit Details

```
d2397469 - ci: no dev install (Arkadiusz Kwasigroch, 2025-10-30 16:51)
5dbc1ad2 - fix: two stage build and chown bug (Arkadiusz Kwasigroch, 2025-10-30 16:18)
4a319e0e - fix: opentelemetry default var (Arkadiusz Kwasigroch, 2025-10-30 16:18)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

#344 