### PR TITLE
fix(frontend): correct exec command syntax in start.sh

### DIFF
--- a/apps/frontend/start.sh
+++ b/apps/frontend/start.sh
@@ -74,7 +74,7 @@ start_server() {
         echo ""
         
         # Start the production server
-        exec NODE_ENV=production npm run start -- --hostname 0.0.0.0
+        NODE_ENV=production exec npm run start -- --hostname 0.0.0.0
     else
         log "${BLUE}🛠️  Starting development server...${NC}"
         log "${YELLOW}📦 Framework:${NC} ${GREEN}Next.js${NC}"
@@ -87,7 +87,7 @@ start_server() {
         echo ""
         
         # Start the development server
-        exec NODE_ENV=development npm run dev --host
+        NODE_ENV=development exec npm run dev --host
     fi
 }
 


### PR DESCRIPTION
- Move NODE_ENV assignment before exec command
- Fixes 'exec: NODE_ENV=development: not found' error
- Applied to both production and development server startup