### PR TITLE
fix(test-generation): resolve dataclass serialization error with documents

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -104,7 +104,7 @@ async def get_ai_chat_response(chat_request: ChatRequest):
         if chat_request.stream:
             return StreamingResponse(
                 get_chat_response(
-                    messages=[msg.dict() for msg in chat_request.messages],
+                    messages=[msg.model_dump() for msg in chat_request.messages],
                     response_format=chat_request.response_format,
                     stream=True,
                 ),
@@ -112,7 +112,7 @@ async def get_ai_chat_response(chat_request: ChatRequest):
             )
 
         return get_chat_response(
-            messages=[msg.dict() for msg in chat_request.messages],
+            messages=[msg.model_dump() for msg in chat_request.messages],
             response_format=chat_request.response_format,
         )
     except Exception as e:

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import asdict
 from enum import Enum
 from typing import List, Optional
 
@@ -308,7 +309,7 @@ async def generate_test_set(
             num_tests=test_count,
             batch_size=request.batch_size,
             prompt=generation_prompt,
-            documents=[doc.dict() for doc in documents_to_use] if documents_to_use else None,
+            documents=[asdict(doc) for doc in documents_to_use] if documents_to_use else None,
             source_ids=source_ids_list,  # Pass actual source_ids list
             source_ids_to_documents=source_ids_to_documents,  # Pass mapping for debugging
             name=request.name,  # Pass optional test set name


### PR DESCRIPTION
## Description
Fixes the AttributeError that occurred during test set generation with documents.

## Problem
When generating test sets with documents, the application threw an error:
`AttributeError: 'Document' object has no attribute 'dict'`

## Root Cause
The `Document` class in the SDK is a dataclass (not a Pydantic model), but the code was calling `.dict()` on it, which is a Pydantic method.

## Changes
- **test_set.py**: Replaced `doc.dict()` with `asdict(doc)` for proper dataclass serialization
- **services.py**: Updated Pydantic models to use `model_dump()` instead of `.dict()` for Pydantic v2 compatibility

## Testing
- ✅ Ruff linting passes
- ✅ Ruff formatting passes
- ✅ No linter errors

## Impact
- Fixes test set generation with documents
- Improves Pydantic v2 compatibility