### PR TITLE
fix(email): update sender name format for SendGrid SMTP

### DIFF
--- a/apps/backend/src/rhesis/backend/notifications/email/README.md
+++ b/apps/backend/src/rhesis/backend/notifications/email/README.md
@@ -22,7 +22,7 @@ success = email_service.send_email(
     subject="Your Task Completed Successfully",
     template_variables={
         'recipient_name': "John Doe",
-        'task_name': "API Test Suite", 
+        'task_name': "API Test Suite",
         'task_id': "task_12345",
         'status': "success",
         'execution_time': "2 minutes 30 seconds"
@@ -41,7 +41,7 @@ For general task completion notifications.
 - `recipient_name`, `task_name`, `task_id`, `status`, `completed_at`
 - `execution_time`, `error_message`, `test_run_id`, `frontend_url`
 
-### EmailTemplate.TEST_EXECUTION_SUMMARY  
+### EmailTemplate.TEST_EXECUTION_SUMMARY
 For test execution summary notifications.
 
 **Required Variables:**
@@ -91,14 +91,17 @@ Email service requires these environment variables:
 - `SMTP_PORT`: SMTP server port (465 for SSL, 587 for TLS)
 - `SMTP_USER`: SMTP username
 - `SMTP_PASSWORD`: SMTP password
-- `FROM_EMAIL`: Sender email address
+- `FROM_EMAIL`: Sender email address (defaults to `"Harry from Rhesis AI" <engineering@rhesis.ai>`)
+- `WELCOME_FROM_EMAIL`: Optional sender for welcome emails (e.g., `"Nicolai from Rhesis AI" <hello@rhesis.ai>`)
+
+**Note**: When including a sender name with spaces, wrap it in quotes: `"Sender Name" <email@domain.com>`
 
 ## Architecture
 
 ```
 notifications/email/
 ├── service.py              # EmailService - main orchestrator
-├── smtp.py                 # SMTPService - SMTP handling  
+├── smtp.py                 # SMTPService - SMTP handling
 ├── template_service.py     # TemplateService - Jinja2 rendering
 └── templates/
     ├── task_completion.html.jinja2
@@ -111,4 +114,4 @@ notifications/email/
 - **Maintainable**: Single method for all email types
 - **Robust**: Automatic handling of missing variables
 - **Developer Friendly**: Template discovery and clear error messages
-- **Future Proof**: Centralized system ready for any email template 
+- **Future Proof**: Centralized system ready for any email template

--- a/apps/backend/src/rhesis/backend/notifications/email/service.py
+++ b/apps/backend/src/rhesis/backend/notifications/email/service.py
@@ -210,7 +210,7 @@ class EmailService:
 
         # Get welcome-specific from email (defaults to hello@rhesis.ai for founder emails)
         welcome_from_email = os.getenv(
-            "WELCOME_FROM_EMAIL", "Nicolai from Rhesis AI <hello@rhesis.ai>"
+            "WELCOME_FROM_EMAIL", '"Nicolai from Rhesis AI" <hello@rhesis.ai>'
         )
 
         subject = "Welcome to Rhesis AI!"

--- a/apps/backend/src/rhesis/backend/notifications/email/smtp.py
+++ b/apps/backend/src/rhesis/backend/notifications/email/smtp.py
@@ -18,7 +18,7 @@ class SMTPService:
         self.smtp_port = int(os.getenv("SMTP_PORT", "587"))
         self.smtp_user = os.getenv("SMTP_USER")
         self.smtp_password = os.getenv("SMTP_PASSWORD")
-        self.from_email = os.getenv("FROM_EMAIL", "engineering@rhesis.ai")
+        self.from_email = os.getenv("FROM_EMAIL", '"Harry from Rhesis AI" <engineering@rhesis.ai>')
 
         # Check if all required SMTP configurations are present
         self.is_configured = all([self.smtp_host, self.smtp_user, self.smtp_password])


### PR DESCRIPTION
## Changes

- Wrap sender names in quotes per SendGrid SMTP requirements
- Update FROM_EMAIL default to "Harry from Rhesis AI" <engineering@rhesis.ai>
- Update WELCOME_FROM_EMAIL default to "Nicolai from Rhesis AI" <hello@rhesis.ai>
- Fix trailing whitespace and end-of-file formatting in README
- Add documentation about proper sender name format

## Why

According to SendGrid's SMTP documentation, sender names with spaces must be wrapped in quotes:

```
From: "<SenderName>" <<SenderEmail>>
```

This ensures that email clients properly display the sender name instead of just showing the email address.

## Testing

- [ ] Welcome emails show "Nicolai from Rhesis AI" as sender
- [ ] General emails show "Harry from Rhesis AI" as sender
- [ ] Email addresses are verified in SendGrid