### PR TITLE
Fix metric creation confirmation screen layout and styling

### DIFF
--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/page.tsx
@@ -758,10 +758,10 @@ export default function MetricDetailPage() {
                     <Typography>
                       {models.length > 0
                         ? models.find(model => model.id === metric.model_id)
-                            ?.name || '-'
+                            ?.name || 'Using default model'
                         : metric.model_id
                           ? 'Loading model...'
-                          : '-'}
+                          : 'Using default model'}
                     </Typography>
                     {models.length > 0 && metric.model_id && (
                       <Typography variant="body2" color="text.secondary">
@@ -956,7 +956,8 @@ export default function MetricDetailPage() {
                         px: 1.5,
                         py: 0.5,
                         borderRadius: theme => theme.shape.borderRadius * 0.25,
-                        fontSize: theme.typography.caption.fontSize,
+                        fontSize:
+                          theme?.typography?.caption?.fontSize || '0.75rem',
                         fontWeight: 'medium',
                       }}
                     >
@@ -1029,8 +1030,7 @@ export default function MetricDetailPage() {
                             borderRadius: theme =>
                               theme.shape.borderRadius * 0.25,
                             fontSize:
-                              theme?.typography?.helperText?.fontSize ||
-                              '0.75rem',
+                              theme?.typography?.caption?.fontSize || '0.75rem',
                             fontWeight: 'medium',
                           }}
                         >
@@ -1038,7 +1038,7 @@ export default function MetricDetailPage() {
                         </Typography>
                       ))
                     ) : (
-                      <Typography variant="body2" color="text.secondary">
+                      <Typography variant="body1" color="text.secondary">
                         No scope defined
                       </Typography>
                     )}
@@ -1066,7 +1066,7 @@ export default function MetricDetailPage() {
                           placeholder="Enter minimum score"
                         />
                       ) : (
-                        <Typography variant="h6" color="text.secondary">
+                        <Typography variant="body1" color="text.primary">
                           {metric.min_score}
                         </Typography>
                       )}
@@ -1088,7 +1088,7 @@ export default function MetricDetailPage() {
                           placeholder="Enter maximum score"
                         />
                       ) : (
-                        <Typography variant="h6" color="text.secondary">
+                        <Typography variant="body1" color="text.primary">
                           {metric.max_score}
                         </Typography>
                       )}
@@ -1119,13 +1119,12 @@ export default function MetricDetailPage() {
                           sx={{
                             bgcolor: 'success.main',
                             color: 'success.contrastText',
-                            px: 2,
+                            px: 1.5,
                             py: 0.5,
                             borderRadius: theme =>
                               theme.shape.borderRadius * 0.25,
                             fontSize:
-                              theme?.typography?.helperText?.fontSize ||
-                              '0.75rem',
+                              theme?.typography?.caption?.fontSize || '0.75rem',
                             fontWeight: 'medium',
                           }}
                         >

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricCard.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricCard.tsx
@@ -25,6 +25,8 @@ import {
 import TurnedInIcon from '@mui/icons-material/TurnedIn';
 import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
 import MessageIcon from '@mui/icons-material/Message';
+import HandymanIcon from '@mui/icons-material/Handyman';
+import FaceIcon from '@mui/icons-material/Face';
 
 // Custom Rhesis AI icon component using inline SVG
 const RhesisAIIcon = ({
@@ -78,9 +80,11 @@ const getMetricIcon = (type: string) => {
 const getBackendIcon = (backend: string) => {
   switch (backend.toLowerCase()) {
     case 'custom':
-      return <StorageIcon fontSize="small" />;
+      return <FaceIcon fontSize="small" />;
     case 'deepeval':
-      return <ApiIcon fontSize="small" />;
+      return <HandymanIcon fontSize="small" />;
+    case 'ragas':
+      return <HandymanIcon fontSize="small" />;
     case 'rhesis ai':
     case 'rhesis':
       return <RhesisAIIcon fontSize="small" />;
@@ -204,13 +208,14 @@ export default function MetricCard({
         }}
       >
         <Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
+          <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 1.5 }}>
             <Box
               sx={{
                 mr: 1.5,
                 color: 'primary.main',
                 display: 'flex',
                 alignItems: 'center',
+                mt: 0.25,
               }}
             >
               {getMetricIcon(type || '')}
@@ -221,6 +226,9 @@ export default function MetricCard({
               sx={{
                 fontWeight: 500,
                 lineHeight: 1.2,
+                maxWidth: '30ch', // Reverted to 30ch
+                wordWrap: 'break-word',
+                overflowWrap: 'break-word',
               }}
             >
               {title}
@@ -266,15 +274,6 @@ export default function MetricCard({
               <Chip
                 icon={getBackendIcon(backend || '')}
                 label={capitalizedBackend}
-                size="small"
-                variant="outlined"
-              />
-            )}
-            {(metricType ||
-              getMetricTypeDisplay(metricType || '') !== 'Unknown') && (
-              <Chip
-                icon={getMetricTypeIcon(metricType || '')}
-                label={getMetricTypeDisplay(metricType || '')}
                 size="small"
                 variant="outlined"
               />

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -79,8 +79,8 @@ const initialFilterOptions: FilterOptions = {
   backend: [],
   type: [],
   scoreType: [
-    { value: 'binary', label: 'Binary (Pass/Fail)' },
     { value: 'numeric', label: 'Numeric' },
+    { value: 'categorical', label: 'Categorical' },
   ],
   metricScope: [
     { value: 'Single-Turn', label: 'Single-Turn' },

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
@@ -676,26 +676,11 @@ export default function MetricsDirectoryTab({
                 </MenuItem>
                 {filterOptions.type.map(option => (
                   <MenuItem key={option.type_value} value={option.type_value}>
-                    <Box>
-                      <Typography>
-                        {option.type_value
-                          .replace(/-/g, ' ')
-                          .split(' ')
-                          .map(
-                            word => word.charAt(0).toUpperCase() + word.slice(1)
-                          )
-                          .join(' ')}
-                      </Typography>
-                      {option.description && (
-                        <Typography
-                          variant="caption"
-                          color="text.secondary"
-                          display="block"
-                        >
-                          {option.description}
-                        </Typography>
-                      )}
-                    </Box>
+                    {option.type_value
+                      .replace(/-/g, ' ')
+                      .split(' ')
+                      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+                      .join(' ')}
                   </MenuItem>
                 ))}
               </Select>
@@ -810,113 +795,119 @@ export default function MetricsDirectoryTab({
 
       {/* Metrics Stack */}
       <Box sx={{ p: 3, flex: 1, overflow: 'auto' }}>
-        <Stack
-          spacing={3}
+        <Box
           sx={{
-            '& > *': {
-              display: 'flex',
-              flexDirection: 'row',
-              flexWrap: 'wrap',
-              gap: 3,
-              '& > *': {
-                flex: {
-                  xs: '1 1 100%',
-                  sm: '1 1 calc(50% - 12px)',
-                  md: '1 1 calc(33.333% - 16px)',
-                },
-                minWidth: {
-                  xs: '100%',
-                  sm: theme => theme.spacing(37.5),
-                  md: theme => theme.spacing(40),
-                },
-                maxWidth: {
-                  xs: '100%',
-                  sm: 'calc(50% - 12px)',
-                  md: 'calc(33.333% - 16px)',
-                },
-              },
+            display: 'grid',
+            gridTemplateColumns: {
+              xs: '1fr',
+              sm: 'repeat(2, 1fr)',
+              md: 'repeat(3, 1fr)',
             },
+            gap: 3,
           }}
         >
-          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 3 }}>
-            {filteredMetrics.map(metric => {
-              const assignedBehaviors = activeBehaviors.filter(b => {
-                if (!Array.isArray(metric.behaviors)) return false;
-                // Check if behaviors is an array of strings (UUIDs) or BehaviorReference objects
-                const behaviorIds = metric.behaviors.map(behavior =>
-                  typeof behavior === 'string' ? behavior : behavior.id
-                );
-                return behaviorIds.includes(b.id as string);
-              });
-              const behaviorNames = assignedBehaviors.map(
-                b => b.name || 'Unnamed Behavior'
+          {filteredMetrics.map(metric => {
+            const assignedBehaviors = activeBehaviors.filter(b => {
+              if (!Array.isArray(metric.behaviors)) return false;
+              // Check if behaviors is an array of strings (UUIDs) or BehaviorReference objects
+              const behaviorIds = metric.behaviors.map(behavior =>
+                typeof behavior === 'string' ? behavior : behavior.id
               );
+              return behaviorIds.includes(b.id as string);
+            });
+            const behaviorNames = assignedBehaviors.map(
+              b => b.name || 'Unnamed Behavior'
+            );
 
-              return (
+            return (
+              <Box
+                key={metric.id}
+                sx={{
+                  position: 'relative',
+                  ...(assignMode && {
+                    cursor: 'pointer',
+                    transition: theme.transitions.create(
+                      ['transform', 'box-shadow'],
+                      {
+                        duration: theme.transitions.duration.short,
+                      }
+                    ),
+                    '&:hover': {
+                      transform: `translateY(-${theme.spacing(0.5)})`,
+                    },
+                    '&:active': {
+                      transform: `translateY(-${theme.spacing(0.25)})`,
+                    },
+                  }),
+                }}
+                onClick={
+                  assignMode
+                    ? () => {
+                        setSelectedMetric(metric);
+                        setAssignDialogOpen(true);
+                      }
+                    : undefined
+                }
+              >
                 <Box
-                  key={metric.id}
                   sx={{
-                    position: 'relative',
-                    flex: {
-                      xs: '1 1 100%',
-                      sm: '1 1 calc(50% - 12px)',
-                      md: '1 1 calc(33.333% - 16px)',
-                    },
-                    minWidth: {
-                      xs: '100%',
-                      sm: theme => theme.spacing(37.5),
-                      md: theme => theme.spacing(40),
-                    },
-                    maxWidth: {
-                      xs: '100%',
-                      sm: 'calc(50% - 12px)',
-                      md: 'calc(33.333% - 16px)',
-                    },
-                    ...(assignMode && {
-                      cursor: 'pointer',
-                      transition: theme.transitions.create(
-                        ['transform', 'box-shadow'],
-                        {
-                          duration: theme.transitions.duration.short,
-                        }
-                      ),
-                      '&:hover': {
-                        transform: `translateY(-${theme.spacing(0.5)})`,
-                      },
-                      '&:active': {
-                        transform: `translateY(-${theme.spacing(0.25)})`,
-                      },
-                    }),
+                    position: 'absolute',
+                    top: 8,
+                    right: 8,
+                    display: 'flex',
+                    gap: 1,
+                    zIndex: 1,
                   }}
-                  onClick={
-                    assignMode
-                      ? () => {
-                          setSelectedMetric(metric);
-                          setAssignDialogOpen(true);
-                        }
-                      : undefined
-                  }
                 >
-                  <Box
+                  {/* Only show detail button for rhesis and custom metrics */}
+                  {(metric.backend_type?.type_value?.toLowerCase() ===
+                    'rhesis' ||
+                    metric.backend_type?.type_value?.toLowerCase() ===
+                      'custom') && (
+                    <IconButton
+                      size="small"
+                      onClick={e => {
+                        if (assignMode) e.stopPropagation();
+                        handleMetricDetail(metric.id);
+                      }}
+                      sx={{
+                        padding: theme.spacing(0.25),
+                        '& .MuiSvgIcon-root': {
+                          fontSize:
+                            theme?.typography?.helperText?.fontSize ||
+                            '0.75rem',
+                        },
+                      }}
+                    >
+                      <OpenInNewIcon fontSize="inherit" />
+                    </IconButton>
+                  )}
+                  <IconButton
+                    size="small"
+                    onClick={e => {
+                      if (assignMode) e.stopPropagation();
+                      setSelectedMetric(metric);
+                      setAssignDialogOpen(true);
+                    }}
                     sx={{
-                      position: 'absolute',
-                      top: 8,
-                      right: 8,
-                      display: 'flex',
-                      gap: 1,
-                      zIndex: 1,
+                      padding: theme => theme.spacing(0.25),
+                      '& .MuiSvgIcon-root': {
+                        fontSize:
+                          theme?.typography?.helperText?.fontSize || '0.75rem',
+                      },
                     }}
                   >
-                    {/* Only show detail button for rhesis and custom metrics */}
-                    {(metric.backend_type?.type_value?.toLowerCase() ===
-                      'rhesis' ||
-                      metric.backend_type?.type_value?.toLowerCase() ===
-                        'custom') && (
+                    <AddIcon fontSize="inherit" />
+                  </IconButton>
+                  {/* Only show delete button for unassigned custom metrics */}
+                  {assignedBehaviors.length === 0 &&
+                    metric.backend_type?.type_value?.toLowerCase() ===
+                      'custom' && (
                       <IconButton
                         size="small"
                         onClick={e => {
-                          if (assignMode) e.stopPropagation();
-                          handleMetricDetail(metric.id);
+                          e.stopPropagation();
+                          handleDeleteMetric(metric.id, metric.name);
                         }}
                         sx={{
                           padding: theme.spacing(0.25),
@@ -927,70 +918,29 @@ export default function MetricsDirectoryTab({
                           },
                         }}
                       >
-                        <OpenInNewIcon fontSize="inherit" />
+                        <DeleteIcon fontSize="inherit" />
                       </IconButton>
                     )}
-                    <IconButton
-                      size="small"
-                      onClick={e => {
-                        if (assignMode) e.stopPropagation();
-                        setSelectedMetric(metric);
-                        setAssignDialogOpen(true);
-                      }}
-                      sx={{
-                        padding: theme => theme.spacing(0.25),
-                        '& .MuiSvgIcon-root': {
-                          fontSize:
-                            theme?.typography?.helperText?.fontSize ||
-                            '0.75rem',
-                        },
-                      }}
-                    >
-                      <AddIcon fontSize="inherit" />
-                    </IconButton>
-                    {/* Only show delete button for unassigned custom metrics */}
-                    {assignedBehaviors.length === 0 &&
-                      metric.backend_type?.type_value?.toLowerCase() ===
-                        'custom' && (
-                        <IconButton
-                          size="small"
-                          onClick={e => {
-                            e.stopPropagation();
-                            handleDeleteMetric(metric.id, metric.name);
-                          }}
-                          sx={{
-                            padding: theme.spacing(0.25),
-                            '& .MuiSvgIcon-root': {
-                              fontSize:
-                                theme?.typography?.helperText?.fontSize ||
-                                '0.75rem',
-                            },
-                          }}
-                        >
-                          <DeleteIcon fontSize="inherit" />
-                        </IconButton>
-                      )}
-                  </Box>
-                  <MetricCard
-                    type={
-                      isValidMetricType(metric.metric_type?.type_value)
-                        ? metric.metric_type.type_value
-                        : undefined
-                    }
-                    title={metric.name}
-                    description={metric.description}
-                    backend={metric.backend_type?.type_value}
-                    metricType={metric.metric_type?.type_value}
-                    scoreType={metric.score_type}
-                    metricScope={metric.metric_scope}
-                    usedIn={behaviorNames}
-                    showUsage={true}
-                  />
                 </Box>
-              );
-            })}
-          </Box>
-        </Stack>
+                <MetricCard
+                  type={
+                    isValidMetricType(metric.metric_type?.type_value)
+                      ? metric.metric_type.type_value
+                      : undefined
+                  }
+                  title={metric.name}
+                  description={metric.description}
+                  backend={metric.backend_type?.type_value}
+                  metricType={metric.metric_type?.type_value}
+                  scoreType={metric.score_type}
+                  metricScope={metric.metric_scope}
+                  usedIn={behaviorNames}
+                  showUsage={true}
+                />
+              </Box>
+            );
+          })}
+        </Box>
       </Box>
 
       {/* Dialogs */}


### PR DESCRIPTION
## Changes

### Fixed Confirmation Screen (Step 2) Layout Issues
- **Removed double elevation**: Eliminated nested Paper components causing awkward shadow stacking
- **Removed unnecessary border boxes**: Aligned with Step 1's clean layout (section headers + direct content)
- **Fixed content organization**: Moved Evaluation Steps to be directly after Evaluation Process for logical flow

### Fixed Button Positioning
- Changed button layout to use `justifyContent: 'space-between'`
- Back/Cancel button now on the left, Create/Next button on the right

### Fixed Chip Consistency
- **Size**: Removed `size='small'` from all Step 2 chips to match Step 1's default size
- **Variant**: All chips in Step 2 now use `variant='filled'` to match selected chips from Step 1
- Consistent styling across: Tags, Score Type, and Metric Scope chips

### Minor Improvements
- Changed evaluation step numbers from primary blue to text.secondary (gray) for better visual hierarchy
- Improved spacing and margins for cleaner presentation
- Maintained consistent `mb: 5` spacing between sections like Step 1

## Result
The confirmation screen now has a clean, consistent layout that matches Step 1's design pattern, with no double elevations, proper button positioning, and uniform chip styling.