### PR TITLE
Hotfix: Disable Import From Notion

### DIFF
--- a/apps/frontend/src/app/(protected)/knowledge/components/UploadSourceDialog.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/UploadSourceDialog.tsx
@@ -14,7 +14,6 @@ import {
   LinearProgress,
   IconButton,
   Chip,
-  Tooltip,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import UploadIcon from '@mui/icons-material/Upload';
@@ -217,31 +216,27 @@ export default function UploadSourceDialog({
 
               {/* Import from Notion Button */}
               <Box sx={{ mt: 2, display: 'flex', justifyContent: 'center' }}>
-                <Tooltip title="User authentication for Notion is not yet available">
-                  <span style={{ width: '100%' }}>
-                    <Button
-                      variant="outlined"
-                      startIcon={<CloudIcon />}
-                      disabled
-                      fullWidth
-                      sx={{
-                        justifyContent: 'space-between',
-                        textTransform: 'none',
-                      }}
-                    >
-                      <span>Import from Notion</span>
-                      <Chip
-                        label="Coming Soon"
-                        size="small"
-                        sx={{
-                          height: '20px',
-                          fontSize: '0.7rem',
-                          backgroundColor: 'rgba(0, 0, 0, 0.08)',
-                        }}
-                      />
-                    </Button>
-                  </span>
-                </Tooltip>
+                <Button
+                  variant="outlined"
+                  startIcon={<CloudIcon />}
+                  disabled
+                  fullWidth
+                  sx={{
+                    justifyContent: 'space-between',
+                    textTransform: 'none',
+                  }}
+                >
+                  <span>Import from Notion</span>
+                  <Chip
+                    label="Coming Soon"
+                    size="small"
+                    sx={{
+                      height: '20px',
+                      fontSize: theme => theme.typography.caption.fontSize,
+                      backgroundColor: 'rgba(0, 0, 0, 0.08)',
+                    }}
+                  />
+                </Button>
               </Box>
             </Box>
 


### PR DESCRIPTION
This PR introduces changes from the `hotfix/disable-import-from-notion` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->


## 📁 Files Changed (       1 files)

```
apps/frontend/src/app/(protected)/knowledge/components/UploadSourceDialog.tsx
```

## 📋 Commit Details

```
d2a3e283 - feat(knowledge): disable import from notion button (Emanuele De Rossi, 2025-11-13 15:37)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->