### PR TITLE
docs: remove empty Unreleased section from changelog

### DIFF
--- a/docs/content/development/changelog.mdx
+++ b/docs/content/development/changelog.mdx
@@ -8,8 +8,6 @@ This is the aggregated changelog for the entire Rhesis repository. For detailed 
 - [Frontend Changelog](https://github.com/rhesis-ai/rhesis/blob/main/apps/frontend/CHANGELOG.md)
 - [Polyphemus Changelog](https://github.com/rhesis-ai/rhesis/blob/main/apps/polyphemus/CHANGELOG.md)
 
-## [Unreleased]
-
 ## [0.4.2] - 2025-11-13
 
 ### Platform Release
@@ -358,6 +356,3 @@ First release of the Rhesis main repository, including all components. Note that
 - The SDK was previously developed and released (up to v0.1.8) in a separate repository
 - After this initial release, each component follows its own versioning lifecycle
 - Component-specific tags use the format: `<component>-vX.Y.Z`
-
-[Unreleased]: https://github.com/rhesis-ai/rhesis/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/rhesis-ai/rhesis/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

Remove the empty "Unreleased" section from the changelog since there are no unreleased changes to document.

## Changes

- Remove  header from the top of the changelog
- Remove the corresponding link definition at the bottom
- Clean up the changelog to show only actual releases (v0.4.2 through v0.1.0)

## Why

The "Unreleased" section was showing up as a link in the rendered documentation even though it was empty. This creates a cleaner user experience by removing the empty section.

## Before


## After


## Commit

- `33743589` docs: remove empty Unreleased section from changelog