### PR TITLE
Task/Run Docker In Prod Mode

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -55,7 +55,7 @@ RUN echo "🔍 FRONTEND_ENV value is: '${FRONTEND_ENV}'"
 
 # Build the Next.js application
 #RUN npm run build
-RUN if [ "$FRONTEND_ENV" = "production" ] || [ "$FRONTEND_ENV" = "staging" ] || [ "$FRONTEND_ENV" = "development" ]; then \
+RUN if [ "$FRONTEND_ENV" = "production" ] || [ "$FRONTEND_ENV" = "staging" ] || [ "$FRONTEND_ENV" = "development" ] || [ "$FRONTEND_ENV" = "local" ]; then \
         npm run build; \
     else \
         echo "Skipping build for non-production environment"; \
@@ -98,7 +98,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/.eslintrc.json ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
 # Do NOT copy src, tsconfig.json, .eslintrc.json or any .env files to production image
 # Install dependencies and handle environment-specific setup
-RUN if [ "$FRONTEND_ENV" = "production" ] || [ "$FRONTEND_ENV" = "staging" ] || [ "$FRONTEND_ENV" = "development" ]; then \
+RUN if [ "$FRONTEND_ENV" = "production" ] || [ "$FRONTEND_ENV" = "staging" ] || [ "$FRONTEND_ENV" = "development" ] || [ "$FRONTEND_ENV" = "local" ]; then \
         echo "Production mode detected"; \
         rm -rf ./src ./tsconfig.json ./.eslintrc.json && \
         echo "Source files removed for production mode"; \
@@ -120,4 +120,4 @@ HEALTHCHECK --interval=30s --timeout=10s --retries=3 \
   CMD curl -f http://localhost:${PORT:-3000}/ || exit 1
 
 # Start the appropriate server based on FRONTEND_ENV
-CMD ["sh", "-c", "export PORT=${PORT:-3000} && if [ \"$FRONTEND_ENV\" = \"production\" ] || [ \"$FRONTEND_ENV\" = \"staging\" ] || [ \"$FRONTEND_ENV\" = \"development\" ]; then npm start; else npm run dev; fi"]
+CMD ["sh", "-c", "export PORT=${PORT:-3000} && if [ \"$FRONTEND_ENV\" = \"production\" ] || [ \"$FRONTEND_ENV\" = \"staging\" ] || [ \"$FRONTEND_ENV\" = \"development\" ] || [ \"$FRONTEND_ENV\" = \"local\" ]; then npm start; else npm run dev; fi"]


### PR DESCRIPTION
This PR introduces changes from the `task/run-docker-in-prod-mode` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->


## 📁 Files Changed (       1 files)

```
apps/frontend/Dockerfile
```

## 📋 Commit Details

```
14e18ce9 - fix: update Dockerfile to include 'local' environment in build and start conditions (Md Asaduzzaman Miah, 2025-11-14 14:46)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treats FRONTEND_ENV=local like prod/staging/dev in the frontend Dockerfile for build, install, and start behavior.
> 
> - **Dockerfile (`apps/frontend/Dockerfile`)**:
>   - Build: include `local` in condition to run `npm run build`.
>   - Install: include `local` in production-mode branch (`npm ci --only=production` and remove source files).
>   - Start: include `local` to use `npm start` instead of `npm run dev`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14e18ce9266f5eeb07a16e9e966c73bb9f347bc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->