### PR TITLE
Fix incorrect section name in source selector message

### DIFF
--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/shared/SourceSelector.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/shared/SourceSelector.tsx
@@ -148,7 +148,7 @@ export default function SourceSelector({
   if (sources.length === 0) {
     return (
       <Alert severity="info" sx={{ mb: 2 }}>
-        No sources available. Please upload sources in the Sources section
+        No sources available. Please upload sources in the Knowledge section
         first.
       </Alert>
     );


### PR DESCRIPTION
## Purpose
Fix incorrect section name reference in the source selector component. The alert message was referring to "Sources section" when it should reference "Knowledge section" to match the actual UI.

## What Changed
- Updated alert message in SourceSelector component to reference "Knowledge section" instead of "Sources section"

## Additional Context
- This is a simple text correction to improve user experience and accuracy