### PR TITLE
Fix incorrect columns in test set download

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/prompt.py
+++ b/apps/backend/src/rhesis/backend/app/services/prompt.py
@@ -43,8 +43,6 @@ def get_prompts_for_test_set(
     results = (
         results_query.options(
             # Load Prompt relationships
-            joinedload(Prompt.demographic),
-            joinedload(Prompt.attack_category),
             # joinedload(Prompt.source),  # Temporarily disabled due to entity_type column issue
             joinedload(Prompt.status),
             # Load Test relationships for category, topic, behavior
@@ -66,11 +64,7 @@ def get_prompts_for_test_set(
             prompts_data.append(
                 {
                     "content": prompt.content,
-                    "demographic": prompt.demographic.name if prompt.demographic else None,
                     "category": test.category.name if test.category else None,  # From Test
-                    "attack_category": prompt.attack_category.name
-                    if prompt.attack_category
-                    else None,
                     "topic": test.topic.name if test.topic else None,  # From Test
                     "language_code": prompt.language_code,
                     "behavior": test.behavior.name if test.behavior else None,  # From Test


### PR DESCRIPTION
## Purpose
Remove demographic and attack_category columns from test set exports. These columns were incorrectly included in the downloaded test sets and should not be part of the export data.

## What Changed
- Removed `demographic` relationship loading from query
- Removed `attack_category` relationship loading from query  
- Removed `demographic` field from exported data dictionary
- Removed `attack_category` field from exported data dictionary

## Additional Context
- This ensures test set downloads only contain the correct columns
- Aligns with the expected test set schema