### PR TITLE
Fix test_type generation for single and multi-turn tests

### DIFF
--- a/sdk/src/rhesis/sdk/synthesizers/multi_turn/base.py
+++ b/sdk/src/rhesis/sdk/synthesizers/multi_turn/base.py
@@ -30,7 +30,8 @@ class Test(BaseModel):
     behavior: str
     category: str
     topic: str
-    test_type: str = TestType.MULTI_TURN.value
+    # Note: test_type is NOT included in the schema sent to the LLM
+    # It will be added programmatically after generation
 
 
 class Tests(BaseModel):
@@ -75,6 +76,9 @@ class MultiTurnSynthesizer:
                 test_dict["test_configuration"], BaseModel
             ):
                 test_dict["test_configuration"] = test_dict["test_configuration"].model_dump()
+
+            # Always set test_type to Multi-Turn (don't rely on LLM generation)
+            test_dict["test_type"] = TestType.MULTI_TURN.value
 
             multi_turn_tests.append(test_dict)
 


### PR DESCRIPTION
## Purpose
This PR fixes incorrect test_type values being generated during test synthesis. Multi-turn tests were generating invalid values like 'Adversarial', 'Non-adversarial', and 'Robustness' instead of 'Multi-Turn'. Single-turn tests had no test_type field at all.

## What Changed
- **SDK Base Synthesizer**: Added programmatic assignment of test_type='Single-Turn' for all tests generated by ConfigSynthesizer
- **SDK Multi-Turn Synthesizer**: Removed test_type from LLM schema and added programmatic assignment of test_type='Multi-Turn' 
- **Schema Updates**: Added comments explaining that test_type is set programmatically, not by LLM
- **Safety Checks**: Added test_type validation in source-based generation to ensure field is always present

## Root Cause
The multi-turn prompt template uses terms like 'Adversarial' and 'Non-adversarial' to describe testing strategies and goal types. The LLM was incorrectly using these terms to populate the test_type field instead of using 'Multi-Turn'. By removing test_type from the schema sent to the LLM and setting it programmatically, we ensure consistency.

## Testing
All generated tests now correctly have:
- Single-turn tests: `test_type: 'Single-Turn'`
- Multi-turn tests: `test_type: 'Multi-Turn'`

## Additional Context
- Related to previous fix in apps/backend schema (already merged)
- Ensures backend validation passes for /services/generate/multiturn-tests endpoint
- Part of multi-turn test generation feature stabilization