### PR TITLE
Fix onboarding button disable logic and step completion tracking

### DIFF
--- a/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
@@ -68,11 +68,14 @@ export default function ProjectsClientWrapper({
 }: ProjectsClientWrapperProps) {
   const [projects, setProjects] = useState<Project[]>(initialProjects || []);
   const notifications = useNotifications();
-  const { markStepComplete, progress, isComplete } = useOnboarding();
+  const { markStepComplete, progress, isComplete, activeTour } =
+    useOnboarding();
 
-  // Check if create project button should be disabled
-  const isProjectButtonDisabled =
-    !progress.projectCreated && !progress.dismissed && !isComplete;
+  // Check if user is currently on the project tour
+  const isOnProjectTour = activeTour === 'project';
+
+  // Disable button ONLY when user is actively on a tour OTHER than project
+  const isProjectButtonDisabled = activeTour !== null && !isOnProjectTour;
 
   // Enable tour for this page
   useOnboardingTour('project');

--- a/apps/frontend/src/app/(protected)/projects/endpoints/components/EndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/projects/endpoints/components/EndpointForm.tsx
@@ -61,6 +61,7 @@ import {
 } from '@/components/icons';
 import { useSession } from 'next-auth/react';
 import { useNotifications } from '@/components/common/NotificationContext';
+import { useOnboarding } from '@/contexts/OnboardingContext';
 
 // Map of icon names to components for easy lookup
 const ICON_MAP: Record<string, React.ComponentType> = {
@@ -177,6 +178,7 @@ export default function EndpointForm() {
   const [showAuthToken, setShowAuthToken] = useState(false);
   const { data: session } = useSession();
   const notifications = useNotifications();
+  const { markStepComplete } = useOnboarding();
 
   // Determine editor theme based on MUI theme
   const editorTheme = theme.palette.mode === 'dark' ? 'vs-dark' : 'light';
@@ -336,6 +338,9 @@ export default function EndpointForm() {
       // Ensure we're sending a single object, not an array
       const endpointData = transformedData as unknown as Omit<Endpoint, 'id'>;
       await createEndpoint(endpointData);
+
+      // Mark onboarding step as complete
+      markStepComplete('endpointSetup');
 
       // Show success notification
       notifications.show('Endpoint created successfully!', {

--- a/apps/frontend/src/app/(protected)/projects/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/projects/endpoints/components/EndpointsGrid.tsx
@@ -112,14 +112,14 @@ export default function EndpointGrid({
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const { data: session } = useSession();
-  const { progress, isComplete } = useOnboarding();
+  const { progress, isComplete, activeTour } = useOnboarding();
 
   // Check if user is currently on the endpoint tour
-  const isOnEndpointTour = searchParams.get('tour') === 'endpoint';
+  const isOnEndpointTour =
+    searchParams.get('tour') === 'endpoint' || activeTour === 'endpoint';
 
-  // Disable buttons when onboarding is active, UNLESS user is on the endpoint tour
-  const shouldDisableButtons =
-    !progress.dismissed && !isComplete && !isOnEndpointTour;
+  // Disable buttons ONLY when user is actively on a tour OTHER than endpoint
+  const shouldDisableButtons = activeTour !== null && !isOnEndpointTour;
 
   // Fetch projects when component mounts
   useEffect(() => {

--- a/apps/frontend/src/app/(protected)/projects/endpoints/components/SwaggerEndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/projects/endpoints/components/SwaggerEndpointForm.tsx
@@ -29,6 +29,8 @@ import { Project } from '@/utils/api-client/interfaces/project';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useSession } from 'next-auth/react';
 import { auth } from '@/auth';
+import { useOnboarding } from '@/contexts/OnboardingContext';
+import { useNotifications } from '@/components/common/NotificationContext';
 
 // Import icons for project icon rendering
 import SmartToyIcon from '@mui/icons-material/SmartToy';
@@ -100,6 +102,8 @@ export default function SwaggerEndpointForm() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loadingProjects, setLoadingProjects] = useState<boolean>(true);
   const { data: session } = useSession();
+  const { markStepComplete } = useOnboarding();
+  const notifications = useNotifications();
 
   const [formData, setFormData] = useState({
     name: '',
@@ -194,6 +198,15 @@ export default function SwaggerEndpointForm() {
 
     try {
       await createEndpoint(formData as unknown as Omit<Endpoint, 'id'>);
+
+      // Mark onboarding step as complete
+      markStepComplete('endpointSetup');
+
+      // Show success notification
+      notifications.show('Endpoint created successfully!', {
+        severity: 'success',
+      });
+
       router.push('/projects/endpoints');
     } catch (error) {
       setError((error as Error).message);

--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/SelectTestCreationMethod.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/SelectTestCreationMethod.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Box,
   Typography,
@@ -15,6 +15,7 @@ import EditNoteIcon from '@mui/icons-material/EditNote';
 import { TestTemplate, TestType } from './shared/types';
 import { TEMPLATES } from '@/config/test-templates';
 import SelectionModal, { SelectionCardConfig } from './shared/SelectionModal';
+import { useOnboarding } from '@/contexts/OnboardingContext';
 
 interface SelectTestCreationMethodProps {
   open: boolean;
@@ -41,6 +42,14 @@ export default function SelectTestCreationMethod({
 }: SelectTestCreationMethodProps) {
   const [showAllTemplates, setShowAllTemplates] = useState(false);
   const visibleTemplates = showAllTemplates ? TEMPLATES : TEMPLATES.slice(0, 4);
+  const { markStepComplete } = useOnboarding();
+
+  // Mark onboarding step complete when the modal opens
+  useEffect(() => {
+    if (open) {
+      markStepComplete('testCasesCreated');
+    }
+  }, [open, markStepComplete]);
 
   const testTypeLabel =
     testType === 'single_turn' ? 'Single-Turn' : 'Multi-Turn';

--- a/apps/frontend/src/app/(protected)/tests/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/page.tsx
@@ -37,9 +37,8 @@ export default function TestsPage() {
   const isOnTestCasesTour =
     tourParam === 'testCases' || activeTour === 'testCases';
 
-  // Disable "Add Tests" button when onboarding is active, UNLESS user is on the testCases tour
-  const shouldDisableAddButton =
-    !progress.dismissed && !isComplete && !isOnTestCasesTour;
+  // Disable "Add Tests" button ONLY when user is actively on a tour OTHER than testCases
+  const shouldDisableAddButton = activeTour !== null && !isOnTestCasesTour;
 
   // Start tour only after charts are loaded
   React.useEffect(() => {


### PR DESCRIPTION
## Purpose
Fix critical onboarding UX issues where:
1. Buttons were incorrectly disabled during onboarding tours
2. Onboarding steps were not being marked as complete when actions were performed outside the active tour flow

## What Changed
- **Button Disable Logic**: Updated logic to only disable buttons when user is on a *different* tour, not the current page's tour
  - Fixed in ProjectsClientWrapper.tsx (project creation button)
  - Fixed in EndpointsGrid.tsx (endpoint action buttons)
  - Fixed in tests/page.tsx (Add Tests button)

- **Endpoint Step Completion**: Added onboarding step tracking when creating endpoints
  - EndpointForm.tsx: Marks 'endpointSetup' complete after successful endpoint creation
  - SwaggerEndpointForm.tsx: Same fix for OpenAPI/Swagger endpoint creation

- **Test Step Completion**: Added onboarding step tracking for test creation
  - SelectTestCreationMethod.tsx: Marks 'testCasesCreated' complete when modal opens
  - Works even when user is not actively in onboarding tour

## Additional Context
- Fixes onboarding flow where users couldn't interact with UI elements during tours
- Ensures onboarding progress is tracked regardless of how users complete tasks
- Improves UX by allowing users to complete onboarding steps naturally
- Supersedes #910 (was created from wrong base branch)

## Testing
1. Start onboarding flow and navigate to Projects page
2. Create a project - button should be enabled during project tour
3. Navigate to a different page - verify previous page buttons were disabled during other tours
4. Create an endpoint outside onboarding flow - verify step is marked complete
5. Open test creation modal - verify test step is marked complete

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines onboarding to only disable actions during other tours and marks endpoint/test steps as complete upon creation, with success notifications.
> 
> - **Onboarding UI logic**
>   - Update button disabling to only occur when `activeTour` is set to a different tour
>     - `apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx`: enable Create Project when on project tour
>     - `apps/frontend/src/app/(protected)/projects/endpoints/components/EndpointsGrid.tsx`: enable endpoint actions when on endpoint tour (considers URL param and `activeTour`)
>     - `apps/frontend/src/app/(protected)/tests/page.tsx`: enable Add Tests when on testCases tour
> - **Onboarding progress tracking**
>   - Mark steps complete on user actions outside guided flow
>     - `EndpointForm.tsx` and `SwaggerEndpointForm.tsx`: call `markStepComplete('endpointSetup')` after successful create
>     - `SelectTestCreationMethod.tsx`: call `markStepComplete('testCasesCreated')` when modal opens
> - **UX improvements**
>   - Show success notifications after endpoint creation in `EndpointForm.tsx` and `SwaggerEndpointForm.tsx`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e33b06a9fdc2ed613e6c95d7b50bf9f49bf7550b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->