### PR TITLE
Fix: prevent duplicate form submissions

### DIFF
--- a/apps/frontend/src/app/(protected)/projects/endpoints/components/EndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/projects/endpoints/components/EndpointForm.tsx
@@ -176,6 +176,7 @@ export default function EndpointForm() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loadingProjects, setLoadingProjects] = useState<boolean>(true);
   const [showAuthToken, setShowAuthToken] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const { data: session } = useSession();
   const notifications = useNotifications();
   const { markStepComplete } = useOnboarding();
@@ -299,6 +300,7 @@ export default function EndpointForm() {
       return;
     }
 
+    setIsSubmitting(true);
     try {
       const transformedData = { ...formData } as Partial<typeof formData>;
 
@@ -349,6 +351,8 @@ export default function EndpointForm() {
       router.push('/projects/endpoints');
     } catch (error) {
       setError((error as Error).message);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -367,17 +371,19 @@ export default function EndpointForm() {
             <Button
               variant="outlined"
               onClick={() => router.push('/projects/endpoints')}
+              disabled={isSubmitting}
             >
               Cancel
             </Button>
-            <Button
+            <LoadingButton
               type="submit"
               variant="contained"
               color="primary"
+              loading={isSubmitting}
               disabled={(projects?.length || 0) === 0 && !loadingProjects}
             >
               Create Endpoint
-            </Button>
+            </LoadingButton>
           </Box>
         </Box>
 

--- a/apps/frontend/src/app/(protected)/projects/endpoints/components/SwaggerEndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/projects/endpoints/components/SwaggerEndpointForm.tsx
@@ -98,6 +98,7 @@ export default function SwaggerEndpointForm() {
   const projectIdFromUrl = params?.identifier || '';
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [swaggerUrl, setSwaggerUrl] = useState('');
   const [projects, setProjects] = useState<Project[]>([]);
   const [loadingProjects, setLoadingProjects] = useState<boolean>(true);
@@ -196,6 +197,7 @@ export default function SwaggerEndpointForm() {
       return;
     }
 
+    setIsSubmitting(true);
     try {
       await createEndpoint(formData as unknown as Omit<Endpoint, 'id'>);
 
@@ -210,6 +212,8 @@ export default function SwaggerEndpointForm() {
       router.push('/projects/endpoints');
     } catch (error) {
       setError((error as Error).message);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -228,17 +232,19 @@ export default function SwaggerEndpointForm() {
             <Button
               variant="outlined"
               onClick={() => router.push('/projects/endpoints')}
+              disabled={isSubmitting}
             >
               Cancel
             </Button>
-            <Button
+            <LoadingButton
               type="submit"
               variant="contained"
               color="primary"
+              loading={isSubmitting}
               disabled={projects.length === 0 && !loadingProjects}
             >
               Create Endpoint
-            </Button>
+            </LoadingButton>
           </Box>
         </Box>
 


### PR DESCRIPTION
Prevent duplicate form submissions by disabling buttons and showing loading states during async operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-32bbb004-2b8f-436e-b8c7-30ed400783e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-32bbb004-2b8f-436e-b8c7-30ed400783e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>