### PR TITLE
Fix Dockerfile build optimization and add UV link mode

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -39,6 +39,8 @@ ENV UV_COMPILE_BYTECODE=1
 # the size of the image.
 ENV UV_NO_MANAGED_PYTHON=1
 
+# Use copy mode for linking dependencies (required by the cache)
+ENV UV_LINK_MODE=copy 
 # Skip the installation of the dev dependencies
 ENV UV_NO_DEV=1
 
@@ -63,6 +65,9 @@ COPY apps/backend/src /app/src
 # STAGE 2: Runtime - Create minimal runtime image
 # ============================================================================
 FROM mirror.gcr.io/library/python:3.10.17-slim AS runtime
+# Copy Bun from official image (lighter than Node.js, required for bunx to run MCP servers)
+COPY --from=oven/bun:latest /usr/local/bin/bun /usr/local/bin/bun
+COPY --from=oven/bun:latest /usr/local/bin/bunx /usr/local/bin/bunx
 
 WORKDIR /app
 
@@ -74,9 +79,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Bun from official image (lighter than Node.js, required for bunx to run MCP servers)
-COPY --from=oven/bun:latest /usr/local/bin/bun /usr/local/bin/bun
-COPY --from=oven/bun:latest /usr/local/bin/bunx /usr/local/bin/bunx
 
 # Create non-root user first
 RUN adduser --disabled-password --gecos '' rhesis-user && \

--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -48,6 +48,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # ============================================================================
 FROM mirror.gcr.io/library/python:3.10.17-slim AS runtime
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Copy Bun from official image (lighter than Node.js, required for bunx to run MCP servers)
+COPY --from=oven/bun:latest /usr/local/bin/bun /usr/local/bin/bun
+COPY --from=oven/bun:latest /usr/local/bin/bunx /usr/local/bin/bunx
 
 WORKDIR /app
 
@@ -59,9 +62,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy Bun from official image (lighter than Node.js, required for bunx to run MCP servers)
-COPY --from=oven/bun:latest /usr/local/bin/bun /usr/local/bin/bun
-COPY --from=oven/bun:latest /usr/local/bin/bunx /usr/local/bin/bunx
 
 # Create non-root user first
 RUN adduser --disabled-password --gecos '' rhesis-user && \


### PR DESCRIPTION
## Purpose
Fix Docker build issues by adding the required UV_LINK_MODE environment variable and optimize layer caching by moving Bun binary copies earlier in the build stage.

## What Changed
- Added `UV_LINK_MODE=copy` environment variable in Dockerfile (required by the cache)
- Moved Bun binary COPY instructions earlier in the runtime stage for better layer caching
- Applied same Bun copy optimization to Dockerfile.dev

## Additional Context
- These changes improve Docker build reliability and caching efficiency
- The UV_LINK_MODE=copy setting is required when using uv with mounted cache volumes