### PR TITLE
Reduce toolbar height for more compact header

### DIFF
--- a/apps/frontend/src/app/(protected)/layout.tsx
+++ b/apps/frontend/src/app/(protected)/layout.tsx
@@ -137,9 +137,10 @@ export default function ProtectedLayout({
           },
           // Make header more compact
           '& .MuiToolbar-root': {
-            minHeight: '56px',
-            paddingTop: (theme: Theme) => theme.spacing(1),
-            paddingBottom: (theme: Theme) => theme.spacing(1),
+            minHeight: '48px !important',
+            height: '48px',
+            paddingTop: (theme: Theme) => theme.spacing(0.25),
+            paddingBottom: (theme: Theme) => theme.spacing(0.25),
           },
         }
       : {


### PR DESCRIPTION
## Purpose
Make the header toolbar more compact by reducing its height and padding.

## What Changed
- Reduced toolbar minHeight from 56px to 48px
- Added explicit height: 48px to override default MUI styles
- Reduced padding from theme.spacing(1) (8px) to theme.spacing(0.25) (2px)

## Additional Context
- Style improvement for better space utilization
- Changes applied to protected layout toolbar styling