### PR TITLE
Fix dashboard breadcrumbs showing external navigation links

### DIFF
--- a/apps/frontend/src/components/navigation/NavigationProvider.tsx
+++ b/apps/frontend/src/components/navigation/NavigationProvider.tsx
@@ -19,7 +19,7 @@ function transformNavigationItems(items: NavigationItem[]): any[] {
       // Transform link to a page item with metadata for rendering
       return {
         kind: 'page',
-        segment: '', // Empty segment since external links don't need routes
+        segment: '__external__', // Non-matching segment to prevent inclusion in breadcrumbs
         title: item.title,
         icon: item.icon,
         requireSuperuser: item.requireSuperuser,


### PR DESCRIPTION
## Purpose
Fixes an issue where external navigation links (SDK Reference, Documentation, Star Rhesis) were incorrectly appearing in the breadcrumbs hierarchy on the dashboard and other pages.

## What Changed
- Updated NavigationProvider.tsx to use '__external__' segment instead of empty string for external links
- This prevents external links from being matched/included in breadcrumb path generation
- External links in sidebar continue to work correctly

## Root Cause
External navigation links were being transformed to page items with empty segments (`segment: ''`), which caused Toolpad Core's breadcrumb generation to incorrectly include them in the hierarchy.

## Testing
- ✅ Dashboard breadcrumbs now show only "Dashboard" (no SDK Reference above it)
- ✅ All external links in sidebar work correctly (Star Rhesis, Documentation, SDK Reference)
- ✅ No linter errors introduced

## Screenshots
Before: Breadcrumbs showed "SDK Reference > Dashboard"
After: Breadcrumbs show only "Dashboard"