### PR TITLE
fix(frontend): update Dockerfile to reference eslint.config.mjs

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -22,7 +22,7 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 
 # Copy only necessary files for the build
-COPY tsconfig.json next.config.mjs .eslintrc.json package.json package-lock.json ./
+COPY tsconfig.json next.config.mjs eslint.config.mjs package.json package-lock.json ./
 COPY public ./public
 COPY src ./src
 COPY scripts ./scripts
@@ -98,7 +98,7 @@ COPY --from=builder  /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-# Do NOT copy src, tsconfig.json, .eslintrc.json or any .env files to production image
+# Do NOT copy src, tsconfig.json, eslint.config.mjs or any .env files to production image
 # Install dependencies and handle environment-specific setup
 RUN if [ "$FRONTEND_ENV" = "production" ] || [ "$FRONTEND_ENV" = "staging" ] || [ "$FRONTEND_ENV" = "development" ] || [ "$FRONTEND_ENV" = "local" ]; then \
         echo "Production mode detected"; \


### PR DESCRIPTION
## Problem

The Dockerfile build is failing with:
```
ERROR: "/.eslintrc.json": not found
```

This was introduced when ESLint was migrated from v8 to v9 with flat config in #986 (commit f1069cb0). The migration changed `.eslintrc.json` to `eslint.config.mjs`, but the Dockerfile was not updated to reflect this change.

## Changes

- Line 25: Updated COPY command to reference `eslint.config.mjs` instead of `.eslintrc.json`
- Line 101: Updated comment to reflect the new config file name

## Testing

- [ ] Docker build completes successfully
- [ ] Frontend container starts without errors

## Related

- Fixes the build error encountered after merging #706 (dashboard modernization)
- Related to #986 (ESLint migration)