### PR TITLE
feat(test-runs): add tags support for test runs

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -522,11 +522,6 @@ export default function TestRunMainView({
             canRerun={!!testRun.test_configuration_id}
           />
 
-          {/* Test Run Tags */}
-          <Box sx={{ mb: 3 }}>
-            <TestRunTags sessionToken={sessionToken} testRun={testRun} />
-          </Box>
-
           {/* Conditional Layout based on viewMode */}
           {viewMode === 'split' ? (
             <Paper
@@ -638,6 +633,11 @@ export default function TestRunMainView({
               projectName={testRun.test_configuration?.endpoint?.project?.name}
             />
           )}
+
+          {/* Test Run Tags - moved to bottom */}
+          <Box sx={{ mt: 3 }}>
+            <TestRunTags sessionToken={sessionToken} testRun={testRun} />
+          </Box>
         </>
       ) : (
         <ComparisonView

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -635,9 +635,9 @@ export default function TestRunMainView({
           )}
 
           {/* Test Run Tags - moved to bottom */}
-          <Box sx={{ mt: 3 }}>
+          <Paper elevation={2} sx={{ mt: 3, p: 2 }}>
             <TestRunTags sessionToken={sessionToken} testRun={testRun} />
-          </Box>
+          </Paper>
         </>
       ) : (
         <ComparisonView

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -9,6 +9,7 @@ import TestDetailPanel from './TestDetailPanel';
 import TestsTableView from './TestsTableView';
 import ComparisonView from './ComparisonView';
 import TestRunHeader from './TestRunHeader';
+import TestRunTags from './TestRunTags';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 import { useNotifications } from '@/components/common/NotificationContext';
@@ -520,6 +521,11 @@ export default function TestRunMainView({
             isRerunning={isRerunning}
             canRerun={!!testRun.test_configuration_id}
           />
+
+          {/* Test Run Tags */}
+          <Box sx={{ mb: 3 }}>
+            <TestRunTags sessionToken={sessionToken} testRun={testRun} />
+          </Box>
 
           {/* Conditional Layout based on viewMode */}
           {viewMode === 'split' ? (

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsTableView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsTableView.tsx
@@ -987,20 +987,22 @@ export default function TestsTableView({
       </TableContainer>
 
       {/* Pagination */}
-      <TablePagination
-        rowsPerPageOptions={[10, 25, 50, 100]}
-        component="div"
-        count={mergedTests.length}
-        rowsPerPage={rowsPerPage}
-        page={page}
-        onPageChange={handleChangePage}
-        onRowsPerPageChange={handleChangeRowsPerPage}
-        sx={{
-          borderTop: 1,
-          borderColor: 'divider',
-          backgroundColor: theme.palette.background.paper,
-        }}
-      />
+      <Paper elevation={2}>
+        <TablePagination
+          rowsPerPageOptions={[10, 25, 50, 100]}
+          component="div"
+          count={mergedTests.length}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
+          sx={{
+            borderTop: 1,
+            borderColor: 'divider',
+            backgroundColor: theme.palette.background.paper,
+          }}
+        />
+      </Paper>
 
       {/* Test Result Drawer */}
       <TestResultDrawer

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
@@ -478,8 +478,16 @@ export default function TestRunDrawer({
           chipColor="default"
           addOnBlur
           delimiters={[',', 'Enter']}
-          size="small"
+          size="medium"
           fullWidth
+          sx={{
+            '& .MuiInputBase-root': {
+              minHeight: '56px',
+              alignItems: 'flex-start',
+              paddingTop: 1,
+              paddingBottom: 1,
+            },
+          }}
         />
       </Stack>
     </BaseDrawer>

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
@@ -107,7 +107,10 @@ export default function TestRunDrawer({
           ]);
 
           // Ensure we always set arrays, never undefined
-          setUsers(Array.isArray(fetchedUsers?.data) ? fetchedUsers.data : []);
+          const usersArray = Array.isArray(fetchedUsers?.data)
+            ? fetchedUsers.data
+            : [];
+          setUsers(usersArray);
           setTestSets(
             Array.isArray(fetchedTestSets?.data) ? fetchedTestSets.data : []
           );
@@ -131,13 +134,13 @@ export default function TestRunDrawer({
           // Set initial values if editing
           if (testRun) {
             if (testRun.assignee_id) {
-              const currentAssignee = fetchedUsers.data.find(
+              const currentAssignee = usersArray.find(
                 u => u.id === testRun.assignee_id
               );
               setAssignee(currentAssignee || null);
             }
             if (testRun.owner_id) {
-              const currentOwner = fetchedUsers.data.find(
+              const currentOwner = usersArray.find(
                 u => u.id === testRun.owner_id
               );
               setOwner(currentOwner || null);
@@ -152,9 +155,7 @@ export default function TestRunDrawer({
           } else {
             // Set default owner as current user for new test runs
             if (currentUserId) {
-              const currentUser = fetchedUsers.data.find(
-                u => u.id === currentUserId
-              );
+              const currentUser = usersArray.find(u => u.id === currentUserId);
               setOwner(currentUser || null);
             }
             // Reset tags for new test runs

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
@@ -469,26 +469,19 @@ export default function TestRunDrawer({
         <Divider />
 
         {/* Tags Section */}
-        <Stack spacing={1}>
-          <Typography variant="subtitle2" color="text.secondary">
-            Test Run Tags
-          </Typography>
-          <Box sx={{ width: '100%' }}>
-            <BaseTag
-              value={tags}
-              onChange={setTags}
-              label="Tags"
-              placeholder="Add tags (press Enter or comma to add)"
-              helperText="These tags help categorize and find this test run"
-              chipColor="default"
-              addOnBlur
-              delimiters={[',', 'Enter']}
-              size="small"
-              margin="normal"
-              fullWidth
-            />
-          </Box>
-        </Stack>
+        <BaseTag
+          value={tags}
+          onChange={setTags}
+          label="Tags"
+          placeholder="Add tags (press Enter or comma to add)"
+          helperText="These tags help categorize and find this test run"
+          chipColor="default"
+          addOnBlur
+          delimiters={[',', 'Enter']}
+          size="small"
+          margin="normal"
+          fullWidth
+        />
       </Stack>
     </BaseDrawer>
   );

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
@@ -21,6 +21,11 @@ import { TestConfigurationCreate } from '@/utils/api-client/interfaces/test-conf
 import PersonIcon from '@mui/icons-material/Person';
 import { UUID } from 'crypto';
 import { useNotifications } from '@/components/common/NotificationContext';
+import BaseTag from '@/components/common/BaseTag';
+import { EntityType, TagCreate } from '@/utils/api-client/interfaces/tag';
+import { TagsClient } from '@/utils/api-client/tags-client';
+import { AVATAR_SIZES } from '@/constants/avatar-sizes';
+import { pollForTestRun } from '@/utils/test-run-utils';
 
 interface TestRunDrawerProps {
   open: boolean;
@@ -53,6 +58,7 @@ export default function TestRunDrawer({
   const [filteredEndpoints, setFilteredEndpoints] = React.useState<Endpoint[]>(
     []
   );
+  const [tags, setTags] = React.useState<string[]>([]);
 
   const getCurrentUserId = useCallback(() => {
     try {
@@ -101,7 +107,7 @@ export default function TestRunDrawer({
           ]);
 
           // Ensure we always set arrays, never undefined
-          setUsers(Array.isArray(fetchedUsers) ? fetchedUsers : []);
+          setUsers(Array.isArray(fetchedUsers?.data) ? fetchedUsers.data : []);
           setTestSets(
             Array.isArray(fetchedTestSets?.data) ? fetchedTestSets.data : []
           );
@@ -136,6 +142,12 @@ export default function TestRunDrawer({
               );
               setOwner(currentOwner || null);
             }
+            // Set tags if available
+            if (testRun.tags && testRun.tags.length > 0) {
+              setTags(testRun.tags.map(tag => tag.name));
+            } else {
+              setTags([]);
+            }
             // Add test set, project and endpoint initialization if available in testRun
           } else {
             // Set default owner as current user for new test runs
@@ -145,6 +157,8 @@ export default function TestRunDrawer({
               );
               setOwner(currentUser || null);
             }
+            // Reset tags for new test runs
+            setTags([]);
           }
         } catch (fetchError) {
           setError('Failed to load required data');
@@ -217,6 +231,45 @@ export default function TestRunDrawer({
         testConfiguration.id
       );
 
+      // Get the created test run and assign tags if any
+      if (tags.length > 0) {
+        try {
+          const testRunsClient = clientFactory.getTestRunsClient();
+          const testRun = await pollForTestRun(
+            testRunsClient,
+            testConfiguration.id
+          );
+
+          if (testRun) {
+            const tagsClient = new TagsClient(sessionToken);
+            const organizationId = endpoint.organization_id as UUID;
+            const userId = owner?.id as UUID;
+
+            // Assign each tag to the test run
+            for (const tagName of tags) {
+              const tagPayload: TagCreate = {
+                name: tagName,
+                ...(organizationId && { organization_id: organizationId }),
+                ...(userId && { user_id: userId }),
+              };
+
+              await tagsClient.assignTagToEntity(
+                EntityType.TEST_RUN,
+                testRun.id,
+                tagPayload
+              );
+            }
+          } else {
+            console.warn(
+              'Test run not found after polling, tags will not be assigned'
+            );
+          }
+        } catch (tagError) {
+          // Log error but don't fail the whole operation
+          console.error('Failed to assign tags to test run:', tagError);
+        }
+      }
+
       // Show success notification
       notifications.show('Test execution started successfully', {
         severity: 'success',
@@ -247,7 +300,10 @@ export default function TestRunDrawer({
     return (
       <Box component="li" key={key} {...otherProps}>
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-          <Avatar src={option.picture} sx={{ width: 24, height: 24 }}>
+          <Avatar
+            src={option.picture}
+            sx={{ width: AVATAR_SIZES.SMALL, height: AVATAR_SIZES.SMALL }}
+          >
             <PersonIcon />
           </Avatar>
           {getUserDisplayName(option)}
@@ -290,7 +346,11 @@ export default function TestRunDrawer({
                     startAdornment: assignee && (
                       <Avatar
                         src={assignee.picture}
-                        sx={{ width: 24, height: 24, mr: 1 }}
+                        sx={{
+                          width: AVATAR_SIZES.SMALL,
+                          height: AVATAR_SIZES.SMALL,
+                          mr: 1,
+                        }}
                       >
                         <PersonIcon />
                       </Avatar>
@@ -317,7 +377,11 @@ export default function TestRunDrawer({
                     startAdornment: owner && (
                       <Avatar
                         src={owner.picture}
-                        sx={{ width: 24, height: 24, mr: 1 }}
+                        sx={{
+                          width: AVATAR_SIZES.SMALL,
+                          height: AVATAR_SIZES.SMALL,
+                          mr: 1,
+                        }}
                       >
                         <PersonIcon />
                       </Avatar>
@@ -374,7 +438,7 @@ export default function TestRunDrawer({
               }}
               fullWidth
               renderInput={params => (
-                <TextField {...params} label="Application" required />
+                <TextField {...params} label="Project" required />
               )}
             />
 
@@ -394,13 +458,35 @@ export default function TestRunDrawer({
                   {...params}
                   label="Endpoint"
                   required
-                  helperText={
-                    !project ? 'Select an application first' : undefined
-                  }
+                  helperText={!project ? 'Select a project first' : undefined}
                 />
               )}
             />
           </Stack>
+        </Stack>
+
+        <Divider />
+
+        {/* Tags Section */}
+        <Stack spacing={1}>
+          <Typography variant="subtitle2" color="text.secondary">
+            Test Run Tags
+          </Typography>
+          <Box sx={{ width: '100%' }}>
+            <BaseTag
+              value={tags}
+              onChange={setTags}
+              label="Tags"
+              placeholder="Add tags (press Enter or comma to add)"
+              helperText="These tags help categorize and find this test run"
+              chipColor="default"
+              addOnBlur
+              delimiters={[',', 'Enter']}
+              size="small"
+              margin="normal"
+              fullWidth
+            />
+          </Box>
         </Stack>
       </Stack>
     </BaseDrawer>

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
@@ -479,7 +479,6 @@ export default function TestRunDrawer({
           addOnBlur
           delimiters={[',', 'Enter']}
           size="small"
-          margin="normal"
           fullWidth
         />
       </Stack>

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -320,6 +320,17 @@ function TestRunsTable({
         flex: 1.5,
         minWidth: 140,
         sortable: false,
+        filterable: true,
+        valueGetter: (_, row) => {
+          if (!row.tags || !Array.isArray(row.tags)) {
+            return '';
+          }
+          // Return comma-separated tag names for filtering
+          return row.tags
+            .filter((tag: Tag) => tag && tag.name)
+            .map((tag: Tag) => tag.name)
+            .join(', ');
+        },
         renderCell: params => {
           const testRun = params.row as TestRunDetail;
           if (!testRun.tags || testRun.tags.length === 0) {

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -315,61 +315,6 @@ function TestRunsTable({
         },
       },
       {
-        field: 'tags',
-        headerName: 'Tags',
-        flex: 1.5,
-        minWidth: 140,
-        sortable: false,
-        filterable: true,
-        valueGetter: (_, row) => {
-          if (!row.tags || !Array.isArray(row.tags)) {
-            return '';
-          }
-          // Return comma-separated tag names for filtering
-          return row.tags
-            .filter((tag: Tag) => tag && tag.name)
-            .map((tag: Tag) => tag.name)
-            .join(', ');
-        },
-        renderCell: params => {
-          const testRun = params.row as TestRunDetail;
-          if (!testRun.tags || testRun.tags.length === 0) {
-            return null;
-          }
-
-          return (
-            <Box
-              sx={{
-                display: 'flex',
-                gap: 0.5,
-                flexWrap: 'nowrap',
-                overflow: 'hidden',
-              }}
-            >
-              {testRun.tags
-                .filter((tag: Tag) => tag && tag.id && tag.name)
-                .slice(0, 2)
-                .map((tag: Tag) => (
-                  <Chip
-                    key={tag.id}
-                    label={tag.name}
-                    size="small"
-                    variant="outlined"
-                  />
-                ))}
-              {testRun.tags.filter((tag: Tag) => tag && tag.id && tag.name)
-                .length > 2 && (
-                <Chip
-                  label={`+${testRun.tags.filter((tag: Tag) => tag && tag.id && tag.name).length - 2}`}
-                  size="small"
-                  variant="outlined"
-                />
-              )}
-            </Box>
-          );
-        },
-      },
-      {
         field: 'user.name',
         headerName: 'Executor',
         flex: 1,
@@ -432,6 +377,61 @@ function TestRunsTable({
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
               <DescriptionIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
               <Typography variant="body2">{count}</Typography>
+            </Box>
+          );
+        },
+      },
+      {
+        field: 'tags',
+        headerName: 'Tags',
+        flex: 1.5,
+        minWidth: 140,
+        sortable: false,
+        filterable: true,
+        valueGetter: (_, row) => {
+          if (!row.tags || !Array.isArray(row.tags)) {
+            return '';
+          }
+          // Return comma-separated tag names for filtering
+          return row.tags
+            .filter((tag: Tag) => tag && tag.name)
+            .map((tag: Tag) => tag.name)
+            .join(', ');
+        },
+        renderCell: params => {
+          const testRun = params.row as TestRunDetail;
+          if (!testRun.tags || testRun.tags.length === 0) {
+            return null;
+          }
+
+          return (
+            <Box
+              sx={{
+                display: 'flex',
+                gap: 0.5,
+                flexWrap: 'nowrap',
+                overflow: 'hidden',
+              }}
+            >
+              {testRun.tags
+                .filter((tag: Tag) => tag && tag.id && tag.name)
+                .slice(0, 2)
+                .map((tag: Tag) => (
+                  <Chip
+                    key={tag.id}
+                    label={tag.name}
+                    size="small"
+                    variant="outlined"
+                  />
+                ))}
+              {testRun.tags.filter((tag: Tag) => tag && tag.id && tag.name)
+                .length > 2 && (
+                <Chip
+                  label={`+${testRun.tags.filter((tag: Tag) => tag && tag.id && tag.name).length - 2}`}
+                  size="small"
+                  variant="outlined"
+                />
+              )}
             </Box>
           );
         },

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -37,6 +37,7 @@ import PersonIcon from '@mui/icons-material/Person';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 import { TestSet } from '@/utils/api-client/interfaces/test-set';
+import { Tag } from '@/utils/api-client/interfaces/tag';
 import TestRunDrawer from './TestRunDrawer';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import { combineTestRunFiltersToOData } from '@/utils/odata-filter';
@@ -310,6 +311,50 @@ function TestRunsTable({
               {...(icon && { icon })}
               sx={{ fontWeight: 500 }}
             />
+          );
+        },
+      },
+      {
+        field: 'tags',
+        headerName: 'Tags',
+        flex: 1.5,
+        minWidth: 140,
+        sortable: false,
+        renderCell: params => {
+          const testRun = params.row as TestRunDetail;
+          if (!testRun.tags || testRun.tags.length === 0) {
+            return null;
+          }
+
+          return (
+            <Box
+              sx={{
+                display: 'flex',
+                gap: 0.5,
+                flexWrap: 'nowrap',
+                overflow: 'hidden',
+              }}
+            >
+              {testRun.tags
+                .filter((tag: Tag) => tag && tag.id && tag.name)
+                .slice(0, 2)
+                .map((tag: Tag) => (
+                  <Chip
+                    key={tag.id}
+                    label={tag.name}
+                    size="small"
+                    variant="outlined"
+                  />
+                ))}
+              {testRun.tags.filter((tag: Tag) => tag && tag.id && tag.name)
+                .length > 2 && (
+                <Chip
+                  label={`+${testRun.tags.filter((tag: Tag) => tag && tag.id && tag.name).length - 2}`}
+                  size="small"
+                  variant="outlined"
+                />
+              )}
+            </Box>
           );
         },
       },

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/ExecuteTestSetDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/ExecuteTestSetDrawer.tsx
@@ -431,7 +431,6 @@ export default function ExecuteTestSetDrawer({
               addOnBlur
               delimiters={[',', 'Enter']}
               size="small"
-              margin="normal"
               fullWidth
             />
           </Stack>

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/ExecuteTestSetDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/ExecuteTestSetDrawer.tsx
@@ -421,21 +421,19 @@ export default function ExecuteTestSetDrawer({
             <Typography variant="subtitle2" color="text.secondary">
               Test Run Tags
             </Typography>
-            <Box sx={{ width: '100%' }}>
-              <BaseTag
-                value={tags}
-                onChange={setTags}
-                label="Tags"
-                placeholder="Add tags (press Enter or comma to add)"
-                helperText="These tags help categorize and find this test run"
-                chipColor="default"
-                addOnBlur
-                delimiters={[',', 'Enter']}
-                size="small"
-                margin="normal"
-                fullWidth
-              />
-            </Box>
+            <BaseTag
+              value={tags}
+              onChange={setTags}
+              label="Tags"
+              placeholder="Add tags (press Enter or comma to add)"
+              helperText="These tags help categorize and find this test run"
+              chipColor="default"
+              addOnBlur
+              delimiters={[',', 'Enter']}
+              size="small"
+              margin="normal"
+              fullWidth
+            />
           </Stack>
         </Stack>
       )}

--- a/apps/frontend/src/app/(protected)/test-sets/components/CreateTestRun.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/CreateTestRun.tsx
@@ -421,21 +421,19 @@ export default function CreateTestRun({
             <Typography variant="subtitle2" color="text.secondary">
               Test Run Tags
             </Typography>
-            <Box sx={{ width: '100%' }}>
-              <BaseTag
-                value={tags}
-                onChange={setTags}
-                label="Tags"
-                placeholder="Add tags (press Enter or comma to add)"
-                helperText="These tags help categorize and find this test run"
-                chipColor="default"
-                addOnBlur
-                delimiters={[',', 'Enter']}
-                size="small"
-                margin="normal"
-                fullWidth
-              />
-            </Box>
+            <BaseTag
+              value={tags}
+              onChange={setTags}
+              label="Tags"
+              placeholder="Add tags (press Enter or comma to add)"
+              helperText="These tags help categorize and find this test run"
+              chipColor="default"
+              addOnBlur
+              delimiters={[',', 'Enter']}
+              size="small"
+              margin="normal"
+              fullWidth
+            />
           </Stack>
         </Stack>
       )}

--- a/apps/frontend/src/app/(protected)/test-sets/components/CreateTestRun.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/CreateTestRun.tsx
@@ -17,8 +17,11 @@ import {
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { Project } from '@/utils/api-client/interfaces/project';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
-import { EntityType } from '@/utils/api-client/interfaces/tag';
+import { EntityType, TagCreate } from '@/utils/api-client/interfaces/tag';
 import { UUID } from 'crypto';
+import BaseTag from '@/components/common/BaseTag';
+import { TagsClient } from '@/utils/api-client/tags-client';
+import { pollForTestRun } from '@/utils/test-run-utils';
 
 interface ProjectOption {
   id: UUID;
@@ -62,6 +65,7 @@ export default function CreateTestRun({
   const [selectedProject, setSelectedProject] = useState<UUID | null>(null);
   const [selectedEndpoint, setSelectedEndpoint] = useState<UUID | null>(null);
   const [executionMode, setExecutionMode] = useState<string>('Parallel');
+  const [tags, setTags] = useState<string[]>([]);
 
   // Fetch projects and endpoints when drawer opens
   useEffect(() => {
@@ -137,6 +141,7 @@ export default function CreateTestRun({
       // Reset selections when drawer opens
       setSelectedProject(null);
       setSelectedEndpoint(null);
+      setTags([]);
     }
   }, [sessionToken, onError, selectedTestSetIds, open]);
 
@@ -176,6 +181,9 @@ export default function CreateTestRun({
     try {
       const clientFactory = new ApiClientFactory(sessionToken);
       const testSetsClient = clientFactory.getTestSetsClient();
+      const testConfigurationsClient =
+        clientFactory.getTestConfigurationsClient();
+      const tagsClient = new TagsClient(sessionToken);
 
       // Prepare test configuration attributes
       const testConfigurationAttributes = {
@@ -183,15 +191,65 @@ export default function CreateTestRun({
       };
 
       // Execute each test set individually with test configuration attributes
-      const promises = selectedTestSetIds.map(testSetId =>
-        testSetsClient.executeTestSet(
-          testSetId,
-          selectedEndpoint,
-          testConfigurationAttributes
+      const results = await Promise.all(
+        selectedTestSetIds.map(testSetId =>
+          testSetsClient.executeTestSet(
+            testSetId,
+            selectedEndpoint,
+            testConfigurationAttributes
+          )
         )
       );
 
-      await Promise.all(promises);
+      // Get the test configuration IDs from results and assign tags if any
+      if (tags.length > 0) {
+        try {
+          // Get endpoint to retrieve organization_id
+          const endpointsClient = clientFactory.getEndpointsClient();
+          const endpoint = await endpointsClient.getEndpoint(selectedEndpoint);
+
+          const organizationId = endpoint.organization_id as UUID;
+          const testRunsClient = clientFactory.getTestRunsClient();
+          const tagsClient = new TagsClient(sessionToken);
+
+          // Assign tags to each created test run
+          for (const result of results) {
+            // The result should contain test_configuration_id
+            // We need to get the test run from the test configuration
+            if ((result as any).test_configuration_id) {
+              const testConfigurationId = (result as any).test_configuration_id;
+
+              const testRun = await pollForTestRun(
+                testRunsClient,
+                testConfigurationId
+              );
+
+              if (testRun) {
+                // Assign each tag to the test run
+                for (const tagName of tags) {
+                  const tagPayload: TagCreate = {
+                    name: tagName,
+                    ...(organizationId && { organization_id: organizationId }),
+                  };
+
+                  await tagsClient.assignTagToEntity(
+                    EntityType.TEST_RUN,
+                    testRun.id,
+                    tagPayload
+                  );
+                }
+              } else {
+                console.warn(
+                  `Test run not found for configuration ${testConfigurationId}, tags will not be assigned`
+                );
+              }
+            }
+          }
+        } catch (tagError) {
+          // Log error but don't fail the whole operation
+          console.error('Failed to assign tags to test runs:', tagError);
+        }
+      }
 
       onSuccess?.();
     } catch (error) {
@@ -355,6 +413,30 @@ export default function CreateTestRun({
               </MenuItem>
             </Select>
           </FormControl>
+
+          <Divider />
+
+          {/* Tags Section */}
+          <Stack spacing={1}>
+            <Typography variant="subtitle2" color="text.secondary">
+              Test Run Tags
+            </Typography>
+            <Box sx={{ width: '100%' }}>
+              <BaseTag
+                value={tags}
+                onChange={setTags}
+                label="Tags"
+                placeholder="Add tags (press Enter or comma to add)"
+                helperText="These tags help categorize and find this test run"
+                chipColor="default"
+                addOnBlur
+                delimiters={[',', 'Enter']}
+                size="small"
+                margin="normal"
+                fullWidth
+              />
+            </Box>
+          </Stack>
         </Stack>
       )}
     </>

--- a/apps/frontend/src/app/(protected)/test-sets/components/CreateTestRun.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/CreateTestRun.tsx
@@ -431,7 +431,6 @@ export default function CreateTestRun({
               addOnBlur
               delimiters={[',', 'Enter']}
               size="small"
-              margin="normal"
               fullWidth
             />
           </Stack>

--- a/apps/frontend/src/utils/test-run-utils.ts
+++ b/apps/frontend/src/utils/test-run-utils.ts
@@ -1,0 +1,69 @@
+import { TestRunsClient } from '@/utils/api-client/test-runs-client';
+import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
+
+interface PollForTestRunOptions {
+  /** Maximum number of polling attempts (default: 10) */
+  maxAttempts?: number;
+  /** Initial delay in milliseconds before first attempt (default: 500) */
+  initialDelay?: number;
+  /** Whether to enable exponential backoff (default: true) */
+  exponentialBackoff?: boolean;
+}
+
+/**
+ * Polls for a test run created by a test configuration execution.
+ * Uses exponential backoff to handle the delay between test configuration
+ * execution and test run creation by the worker.
+ *
+ * @param testRunsClient - The TestRunsClient instance to use for API calls
+ * @param testConfigurationId - The ID of the test configuration
+ * @param options - Optional polling configuration
+ * @returns The test run if found, or null if not found after all attempts
+ */
+export async function pollForTestRun(
+  testRunsClient: TestRunsClient,
+  testConfigurationId: string,
+  options: PollForTestRunOptions = {}
+): Promise<TestRunDetail | null> {
+  const {
+    maxAttempts = 10,
+    initialDelay = 500,
+    exponentialBackoff = true,
+  } = options;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    // Calculate delay with exponential backoff: 500ms, 1s, 2s, 4s, etc.
+    const delay = exponentialBackoff
+      ? initialDelay * Math.pow(2, attempt)
+      : initialDelay;
+
+    // Wait before attempting (skip delay on first attempt)
+    if (attempt > 0) {
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+
+    try {
+      const testRunsResponse =
+        await testRunsClient.getTestRunsByTestConfiguration(
+          testConfigurationId,
+          { limit: 1, sort_by: 'created_at', sort_order: 'desc' }
+        );
+
+      if (testRunsResponse.data && testRunsResponse.data.length > 0) {
+        return testRunsResponse.data[0];
+      }
+    } catch (error) {
+      // Log warning but continue retrying (except on last attempt)
+      if (attempt === maxAttempts - 1) {
+        console.warn(
+          `Failed to fetch test run after ${maxAttempts} attempts:`,
+          error
+        );
+      }
+      // Continue to next attempt
+    }
+  }
+
+  // Test run not found after all attempts
+  return null;
+}


### PR DESCRIPTION
## Purpose
This PR adds comprehensive tags support for test runs, allowing users to categorize and filter test runs by tags. This improves organization and discoverability of test runs.

## What Changed
- Added tags support to test run creation (TestRunDrawer)
- Added tags display in test runs list (TestRunsGrid) with filterable column
- Fixed tags filtering by using correct OData relationship path (`_tags_relationship/tag/name`)
- Added tags display and management on test run detail page (below filter bar)
- Updated OData filter utilities to handle tags filtering with proper `any()` syntax
- Added tags to quick filter searchable fields

## Additional Context
- Tags use the existing TagsMixin pattern consistent with other entities
- Backend already supports tags for test runs through TagsMixin
- Filter uses `_tags_relationship` SQLAlchemy relationship path instead of Python property `tags`
- All changes follow existing patterns in the codebase for tag management

## Testing
- Test tag creation when creating new test runs
- Test filtering test runs by tags using column filter
- Test searching test runs by tags using quick filter
- Test viewing and editing tags on test run detail page
- Verify tags persist correctly after creation and updates