### PR TITLE
Fix dashboard recent activity display validation error

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -783,7 +783,7 @@ def get_recent_activities(
         organization_id, user_id = tenant_context
         service = RecentActivitiesService()
         result = service.get_recent_activities(db=db, organization_id=organization_id, limit=limit)
-        return result
+        return RecentActivitiesResponse(**result)
     except Exception as e:
         logger.error(f"Failed to get recent activities: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to retrieve recent activities")

--- a/apps/backend/src/rhesis/backend/app/schemas/services.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/services.py
@@ -378,5 +378,3 @@ class RecentActivitiesResponse(BaseModel):
 
     activities: List[ActivityItem]
     total: int  # Total number of activity groups (not individual activities)
-    is_authenticated: str  # "Yes" or "No"
-    message: str


### PR DESCRIPTION
## Purpose
Fix the validation error preventing recent activities from displaying in the dashboard. The backend response schema included required fields (is_authenticated and message) that were not being returned by the service, causing FastAPI response validation to fail.

## What Changed
- Removed unnecessary `is_authenticated` and `message` fields from `RecentActivitiesResponse` schema
- Updated endpoint to explicitly construct the response model for clarity
- Schema now matches the frontend interface expectations and service return values

## Additional Context
- The endpoint is already authenticated via `require_current_user_or_token` dependency, so these fields were redundant
- The service only returns `activities` and `total`, which matches the frontend interface
- This fix resolves the `ResponseValidationError` that was preventing the dashboard from loading recent activities