### PR TITLE
fix(docs): correct broken footer links

### DIFF
--- a/docs/src/components/Footer.jsx
+++ b/docs/src/components/Footer.jsx
@@ -27,14 +27,14 @@ const footerData = {
     title: 'Product',
     links: [
       { name: 'Platform', href: 'https://app.rhesis.ai', external: true },
-      { name: 'SDK', href: '/development/sdk' },
+      { name: 'SDK', href: '/sdk' },
       { name: 'Repository', href: 'https://github.com/rhesis-ai/rhesis', external: true },
     ],
   },
   docs: {
     title: 'Docs',
     links: [
-      { name: 'Getting started', href: '/getting-started' },
+      { name: 'Getting started', href: '/getting-started/self-hosting' },
       { name: 'Test Generation', href: '/platform/tests-generation' },
       { name: 'Metrics', href: '/platform/metrics' },
     ],
@@ -54,7 +54,7 @@ const legalLinks = [
   { name: 'Privacy', href: 'https://www.rhesis.ai/privacy-policy', external: true },
   {
     name: 'Terms',
-    href: 'https://www.rhesis.ai/https://www.rhesis.ai/terms-conditions',
+    href: 'https://www.rhesis.ai/terms-conditions',
     external: true,
   },
 ]


### PR DESCRIPTION
## Summary
- Fixed duplicate URL prefix in Terms link that resulted in malformed URL
- Updated SDK link to point to correct documentation path
- Updated Getting Started link to point to self-hosting quick start guide

## Changes
- **Terms link**: Fixed `https://www.rhesis.ai/https://www.rhesis.ai/terms-conditions` → `https://www.rhesis.ai/terms-conditions`
- **SDK link**: Updated `/development/sdk` → `/sdk` (correct path)
- **Getting Started link**: Updated `/getting-started` → `/getting-started/self-hosting` (points to quick start guide)

## Test plan
- [ ] Verify Terms link navigates to correct page
- [ ] Verify SDK link points to SDK documentation
- [ ] Verify Getting Started link points to self-hosting guide
- [ ] Test all footer links in both light and dark mode