### PR TITLE
Fix test sets creator chart to display users instead of organizations

### DIFF
--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsCharts.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsCharts.tsx
@@ -176,14 +176,14 @@ export default function TestSetsCharts() {
       .slice(0, CHART_CONFIG.status.top);
   };
 
-  // Generate creator data using organization property
+  // Generate creator data using user property
   const generateCreatorData = () => {
-    if (!testSetStats?.stats.organization) {
+    if (!testSetStats?.stats.user) {
       return FALLBACK_DATA.noData;
     }
 
     const { stats } = testSetStats;
-    return Object.entries(stats.organization.breakdown)
+    return Object.entries(stats.user.breakdown)
       .map(([name, value]) => ({
         name: truncateName(name),
         value: value as number,


### PR DESCRIPTION
## Purpose
Update the 'Test Sets by Creator' chart to group by users instead of organizations, since Row Level Security (RLS) filtering ensures only one organization is active at a time.

## What Changed
- Updated `generateCreatorData()` function in `TestSetsCharts.tsx` to use `stats.user` instead of `stats.organization`
- Chart now displays individual users who created test sets rather than organizations

## Additional Context
- Refs #1006
- This change makes the chart more useful since all test sets shown are already filtered to a single organization due to RLS