### PR TITLE
docs: add connector documentation with architecture overview

### DIFF
--- a/docs/content/development/_meta.tsx
+++ b/docs/content/development/_meta.tsx
@@ -3,6 +3,7 @@ export default {
   changelog: "Changelog",
   frontend: "Frontend (Platform)",
   backend: "Backend",
+  connector: "Connector",
   worker: "Worker",
   "environment-setup": "Environment Setup",
   contributing: "Contributing",

--- a/docs/content/development/connector.mdx
+++ b/docs/content/development/connector.mdx
@@ -1,0 +1,223 @@
+import { CodeBlock } from '@/components/CodeBlock'
+
+# Connector
+
+The connector enables bidirectional communication between your application (via the Rhesis SDK), the Rhesis backend, and worker processes. It allows remote function execution and automatic endpoint registration without manual configuration.
+
+## System Architecture
+
+The connector connects three main components: your target application (via the SDK), the Rhesis backend, and worker processes.
+
+```mermaid
+graph LR
+    TargetApp["Target Application<br/><small>Python SDK<br/>@collaborate decorator</small>"]
+    Backend["Rhesis Backend<br/><small>ConnectionManager<br/>WebSocket</small>"]
+    Workers["Workers<br/><small>Celery<br/>Test Execution</small>"]
+    Redis["Redis<br/><small>Pub/Sub RPC<br/>Message Broker</small>"]
+    PostgreSQL["PostgreSQL<br/><small>Endpoint Records<br/>Configuration</small>"]
+
+    TargetApp <-->|WebSocket<br/>Registration & Execution| Backend
+    Backend <-->|Pub/Sub RPC| Redis
+    Workers <-->|Pub/Sub RPC| Redis
+    Backend -->|Store Endpoints| PostgreSQL
+    Workers -->|Read Config| PostgreSQL
+
+    style TargetApp fill:#e3f2fd,stroke:#1976d2,stroke-width:2px
+    style Backend fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+    style Workers fill:#fce4ec,stroke:#c2185b,stroke-width:2px
+    style Redis fill:#fff3e0,stroke:#f57c00,stroke-width:2px
+    style PostgreSQL fill:#e8f5e9,stroke:#388e3c,stroke-width:2px
+```
+
+**Target Application (SDK)**:
+- Decorates functions with `@collaborate`
+- Maintains WebSocket connection to backend
+- Executes functions when requested
+- Sends results back via WebSocket
+
+**Rhesis Backend**:
+- Manages WebSocket connections from SDK clients
+- Receives function registrations
+- Creates/updates endpoint records in database
+- Forwards test execution requests to SDK
+- Publishes responses to Redis for workers
+
+**Workers**:
+- Execute tests asynchronously via Celery
+- Use Redis RPC to invoke SDK functions
+- Cannot directly access backend's in-memory WebSocket connections
+- Subscribe to Redis channels for SDK responses
+
+### Connection Flow
+
+**Initial Connection**:
+1. Target app starts → SDK initializes `RhesisClient` with `project_id` and `environment`
+2. SDK establishes WebSocket connection to backend (`/ws/connector`)
+3. SDK sends registration message with function metadata
+4. Backend stores connection and creates endpoint records
+
+**Test Execution Flow**:
+1. Worker receives test execution task
+2. Worker publishes RPC request to Redis (`ws:rpc:requests`)
+3. Backend subscribes to Redis and forwards request to SDK via WebSocket
+4. SDK executes function in target app
+5. SDK sends result back via WebSocket
+6. Backend publishes result to Redis (`ws:rpc:response:{test_run_id}`)
+7. Worker subscribes and receives result
+
+## Backend Components
+
+### Connection Manager
+
+Manages WebSocket connections and RPC routing:
+
+<CodeBlock filename="connection-manager.py" language="python">
+{`from rhesis.backend.app.services.connector.manager import ConnectionManager
+
+# Store connections (in-memory + Redis)
+await connection_manager.connect(project_id, environment, websocket)
+
+# Check connection status
+is_connected = await connection_manager.is_connected(project_id, environment)
+
+# Listen for RPC requests from workers
+asyncio.create_task(connection_manager._listen_for_rpc_requests())`}
+</CodeBlock>
+
+### Message Handlers
+
+- **`registration.py`**: Processes SDK function registration, syncs endpoints
+- **`test_result.py`**: Handles test execution results, triggers validation
+- **`pong.py`**: Keepalive message handling
+
+### Mapping System
+
+4-tier priority for request/response mapping:
+
+1. **SDK Manual**: Explicit mappings from `@collaborate` decorator
+2. **Existing DB**: Preserved manual edits from UI
+3. **Auto-Mapping**: Pattern-based heuristics (confidence >= 0.7)
+4. **LLM Fallback**: GPT-4 generates mappings (confidence < 0.7)
+
+<CodeBlock filename="mapping-service.py" language="python">
+{`from rhesis.backend.app.services.connector.mapping import MappingService
+
+mapping_service = MappingService()
+result = mapping_service.generate_or_use_existing(
+    function_data=function_data,
+    existing_mappings=endpoint.mappings
+)`}
+</CodeBlock>
+
+## RPC Architecture
+
+### Problem
+
+Workers run in separate processes and cannot access backend's in-memory connection dictionary.
+
+### Solution: Redis Pub/Sub RPC
+
+**Flow**:
+1. Worker publishes request to Redis channel
+2. Backend subscribes and forwards to WebSocket
+3. SDK executes function and returns result
+4. Backend publishes response to Redis
+5. Worker subscribes and receives result
+
+<CodeBlock filename="rpc-usage.py" language="python">
+{`from rhesis.backend.app.services.connector.rpc_client import SDKRpcClient
+
+# Initialize in worker
+rpc_client = SDKRpcClient()
+await rpc_client.initialize()
+
+# Check connection
+if await rpc_client.is_connected(project_id, environment):
+    # Invoke function
+    result = await rpc_client.send_and_await_result(
+        project_id=project_id,
+        environment=environment,
+        test_run_id=test_run_id,
+        function_name="chat",
+        inputs={"input": "Hello"},
+        timeout=30.0
+    )`}
+</CodeBlock>
+
+## WebSocket Protocol
+
+### Message Types
+
+- **`register`**: SDK registers functions with metadata
+- **`execute_test`**: Backend requests function execution
+- **`test_result`**: SDK returns execution result
+- **`pong`**: Keepalive response
+
+### Registration Message
+
+<CodeBlock filename="registration-message.json" language="json">
+{`{
+  "type": "register",
+  "project_id": "project_123",
+  "environment": "development",
+  "sdk_version": "1.0.0",
+  "functions": [
+    {
+      "name": "chat",
+      "parameters": {
+        "input": {
+          "type": "str"
+        }
+      },
+      "return_type": "dict",
+      "metadata": {
+        "description": "Chat handler"
+      }
+    }
+  ]
+}`}
+</CodeBlock>
+
+## Endpoint Synchronization
+
+When SDK registers functions, backend automatically:
+
+1. Creates/updates endpoint records
+2. Generates or applies mappings
+3. Validates mappings via test execution
+4. Updates endpoint status (Active/Error/Inactive)
+
+<CodeBlock filename="endpoint-sync.py" language="python">
+{`from rhesis.backend.app.services.endpoint.sdk_sync import sync_sdk_endpoints
+
+stats = await sync_sdk_endpoints(
+    db=db,
+    project_id=project_id,
+    environment=environment,
+    functions_data=functions_data,
+    organization_id=org_id,
+    user_id=user_id
+)
+# Returns: {"created": 2, "updated": 1, "marked_inactive": 0}`}
+</CodeBlock>
+
+## Key Files
+
+**Backend** (`apps/backend/src/rhesis/backend/app/`):
+- `services/connector/manager.py` - Connection management
+- `services/connector/handlers/` - Message handlers
+- `services/connector/mapping/` - Mapping logic
+- `services/connector/rpc_client.py` - Worker RPC client
+- `services/connector/redis_client.py` - Redis connection
+- `routers/connector.py` - WebSocket and REST endpoints
+
+**SDK** (`sdk/src/rhesis/sdk/`):
+- `connector/manager.py` - SDK connector manager
+- `connector/connection.py` - WebSocket connection
+- `decorators.py` - `@collaborate` decorator
+
+---
+
+<Callout type="default">
+  **Related Documentation** - [Backend](./backend) - [Worker](./worker) - [SDK Connector](/sdk/connector)
+</Callout>

--- a/docs/content/sdk/_meta.tsx
+++ b/docs/content/sdk/_meta.tsx
@@ -4,6 +4,7 @@ const meta: MetaRecord = {
   installation: "Installation & Setup",
   models: "Models",
   metrics: "Metrics",
+  connector: "Connector",
 };
 
 export default meta;

--- a/docs/content/sdk/connector.mdx
+++ b/docs/content/sdk/connector.mdx
@@ -1,0 +1,243 @@
+import { CodeBlock } from '@/components/CodeBlock'
+
+# Connector
+
+Register Python functions as testable endpoints in Rhesis using the SDK connector. This code-first approach automatically creates and manages endpoints, providing an alternative to [manual endpoint configuration](/platform/endpoints/index).
+
+<Callout type="info">
+  **How it works**: Decorate functions with `@collaborate` and they automatically become endpoints
+  in Rhesis. The SDK connects via WebSocket, registers function metadata, and keeps endpoints in
+  sync with your code.
+</Callout>
+
+## Quick Start
+
+<Steps>
+### 1. Initialize the Client
+
+<CodeBlock filename="setup.py" language="python">
+{`from rhesis.sdk import RhesisClient
+
+client = RhesisClient(
+api_key="your-api-key",
+project_id="your-project-id",
+environment="development" # Required: "development", "staging", or "production"
+)`}
+
+</CodeBlock>
+
+### 2. Decorate Functions
+
+<CodeBlock filename="app.py" language="python">
+{`from rhesis.sdk import collaborate
+
+@collaborate()
+def chat(input: str, session_id: str = None) -> dict:
+"""Handle chat messages."""
+return {
+"output": process_message(input),
+"session_id": session_id or generate_session_id()
+}`}
+
+</CodeBlock>
+
+### 3. Automatic Registration
+
+When your app starts, functions are automatically registered as endpoints. View them in **Projects** → **Your Project** → **Endpoints**.
+
+</Steps>
+
+## Environment
+
+The `environment` parameter is **required** and must be one of:
+
+- **`development`**: Local iteration and testing
+- **`staging`**: Pre-production validation
+- **`production`**: Live systems
+
+<Callout type="warning">
+  **Production**: Changes take effect immediately. Test in development/staging first.
+</Callout>
+
+<CodeBlock filename="config.py" language="python">
+{`import os
+
+client = RhesisClient(
+api_key=os.getenv("RHESIS_API_KEY"),
+project_id=os.getenv("RHESIS_PROJECT_ID"),
+environment=os.getenv("RHESIS_ENVIRONMENT", "development")
+)`}
+
+</CodeBlock>
+
+## Mapping
+
+### Auto-Mapping (Recommended)
+
+Use standard field names for automatic detection:
+
+<CodeBlock filename="auto_mapping.py" language="python">
+  {`@collaborate()
+def chat(input: str, session_id: str = None) -> dict:
+    """Standard names auto-detect."""
+    return {
+        "output": process_message(input),
+        "session_id": session_id
+    }`}
+</CodeBlock>
+
+**Standard fields**:
+
+- Request: `input`, `session_id`, `context`, `metadata`, `tool_calls`
+- Response: `output`, `context`, `metadata`, `tool_calls`, `session_id`
+
+### Manual Mapping
+
+For custom parameter names or complex structures, provide explicit mappings:
+
+<CodeBlock filename="manual_mapping.py" language="python">
+  {`@collaborate(
+    request_mapping={
+        "user_query": "{{ input }}",
+        "conv_id": "{{ session_id }}"
+    },
+    response_mapping={
+        "output": "$.result.text",
+        "session_id": "$.conv_id"
+    }
+)
+def chat(user_query: str, conv_id: str = None) -> dict:
+    """Custom names require manual mapping."""
+    return {"result": {"text": "..."}, "conv_id": conv_id}`}
+</CodeBlock>
+
+**Request Mapping** (Jinja2 Templates):
+
+- Use Jinja2 template syntax: `{{ variable_name }}`
+- Maps standard Rhesis request fields (`input`, `session_id`, `context`) to your function parameters
+- Custom fields from the request are passed through automatically
+- Example: `"user_message": "{{ input }}"` maps the Rhesis `input` field to your function's `user_message` parameter
+
+**Response Mapping** (JSONPath or Jinja2):
+
+- **JSONPath syntax** (starting with `$`): Use for direct field extraction
+  - Example: `"output": "$.choices[0].message.content"` extracts a nested field
+  - Example: `"session_id": "$.conv_id"` extracts a top-level field
+- **Jinja2 templates**: Use with `jsonpath()` function for conditional logic or complex extraction
+  - Example: `"output": "{{ jsonpath('$.text_response') or jsonpath('$.result.content') }}"` tries the first path, falls back to second if empty
+  - Pure JSONPath expressions (starting with `$`) work directly without Jinja2
+
+For conditional logic or fallback values, use Jinja2 templates with `jsonpath()`:
+
+<CodeBlock filename="advanced_mapping.py" language="python">
+  {`@collaborate(
+    response_mapping={
+        "output": "{{ jsonpath('$.text_response') or jsonpath('$.result.content') }}",
+        "conversation_id": "$.conv_id"
+    }
+)
+def chat(input: str) -> dict:
+    """Extract output from multiple possible locations."""
+    # Function may return different structures
+    return {"text_response": "...", "conv_id": "abc123"}`}
+</CodeBlock>
+
+## Examples
+
+### Multiple Functions
+
+<CodeBlock filename="multi_function.py" language="python">
+{`from rhesis.sdk import RhesisClient, collaborate
+
+client = RhesisClient(
+api_key="your-api-key",
+project_id="your-project-id",
+environment="development"
+)
+
+@collaborate()
+def handle_chat(input: str, session_id: str = None) -> dict:
+"""Process chat messages."""
+return {"output": generate_response(input), "session_id": session_id}
+
+@collaborate()
+def search_documents(input: str, context: list = None) -> dict:
+"""Search documents."""
+results = perform_search(input, context or [])
+return {"output": format_results(results), "context": results}`}
+
+</CodeBlock>
+
+### Custom Fields
+
+<CodeBlock filename="custom_fields.py" language="python">
+  {`@collaborate(
+    request_mapping={
+        "question": "{{ input }}",
+        "policy_id": "{{ policy_number }}"
+    },
+    response_mapping={"output": "$.answer"}
+)
+def insurance_query(question: str, policy_id: str) -> dict:
+    """Query insurance policy."""
+    return {"answer": lookup_policy(question, policy_id)}`}
+</CodeBlock>
+
+## Platform Integration
+
+### Viewing Endpoints
+
+Registered endpoints appear in the Rhesis dashboard:
+
+- **Location**: Projects → Your Project → Endpoints
+- **Connection Type**: `SDK`
+- **Status**: `Active` (connected) or `Inactive` (disconnected)
+- **Naming**: `{Project Name} ({function_name})`
+
+### Connection Management
+
+- **Reconnection**: SDK automatically reconnects with exponential backoff if connection is lost
+- **Re-registration**: Functions are automatically re-registered on reconnect
+- **Function changes**: Adding/modifying functions updates endpoints automatically; removing functions marks endpoints as Inactive
+
+## Best Practices
+
+- **Use connectors when**: Functions are in your codebase, using standard patterns, want code-first definition
+- **Use manual config when**: Testing external APIs, need complex transformations, services outside codebase
+- **Function naming**: Use descriptive names (avoid `function1`, `handler`)
+- **Type hints**: Always include type hints for better auto-detection
+- **Error handling**: Return structured error responses: `{"output": None, "status": "error", "error": str(e)}`
+
+## Troubleshooting
+
+**Functions not appearing**:
+
+- Verify `RhesisClient` initialized with `api_key`, `project_id`, and `environment`
+- Check functions use `@collaborate()` decorator
+- Check logs for "Connector initialized" and "Sent registration" messages
+
+**Connection issues**:
+
+- Verify API key and project ID are correct
+- Ensure Rhesis backend is accessible
+- Check firewall/network settings for WebSocket connections
+
+**Mapping problems**:
+
+- **Auto-mapping**: Use standard field names (`input`, `session_id`, `output`)
+- **Manual mapping**: Verify Jinja2/JSONPath syntax
+- **Custom fields**: Ensure custom request fields are included in API requests
+
+**Common errors**:
+
+- `"RhesisClient not initialized"`: Create `RhesisClient` instance before using `@collaborate`
+- `"@collaborate requires project_id"`: Provide `project_id` or set `RHESIS_PROJECT_ID` env var
+- `"Functions not appearing as Active"`: Restart app to trigger re-registration
+
+---
+
+<Callout type="default">
+  **Next Steps** - Learn about [Models](./models) to use LLMs in your functions - Explore
+  [Metrics](./metrics) to evaluate responses - See [Platform Endpoints](/platform/endpoints/index)
+  for manual configuration
+</Callout>

--- a/docs/src/components/Footer.jsx
+++ b/docs/src/components/Footer.jsx
@@ -197,7 +197,7 @@ export const Footer = ({
                   <h3 style={styles.sectionTitle}>{section.title}</h3>
                   <ul style={styles.linkList}>
                     {section.links.map((link, linkIndex) => (
-                      <li key={linkIndex}>
+                      <li key={`${section.title}-link-${linkIndex}`}>
                         <a
                           href={link.href}
                           target={link.external ? '_blank' : '_self'}
@@ -213,7 +213,7 @@ export const Footer = ({
                     {additionalLinks
                       .filter(link => link.section === section.title.toLowerCase())
                       .map((link, linkIndex) => (
-                        <li key={`additional-${linkIndex}`}>
+                        <li key={`${section.title}-additional-${linkIndex}`}>
                           <a
                             href={link.href}
                             target={link.external ? '_blank' : '_self'}
@@ -242,7 +242,7 @@ export const Footer = ({
             <div style={styles.legalLinks}>
               {legalLinks.map((link, index) => (
                 <a
-                  key={index}
+                  key={`legal-default-${index}`}
                   href={link.href}
                   target={link.external ? '_blank' : '_self'}
                   rel={link.external ? 'noopener noreferrer' : undefined}
@@ -257,7 +257,7 @@ export const Footer = ({
                 .filter(link => link.section === 'legal')
                 .map((link, index) => (
                   <a
-                    key={`legal-${index}`}
+                    key={`legal-additional-${index}`}
                     href={link.href}
                     target={link.external ? '_blank' : '_self'}
                     rel={link.external ? 'noopener noreferrer' : undefined}


### PR DESCRIPTION
## Purpose
Add comprehensive connector documentation for both SDK users and developers, explaining how the target application, Rhesis backend, and workers are connected.

## What Changed
- Added SDK connector documentation page (`/sdk/connector`) with usage guide, mapping examples, and best practices
- Created developer connector documentation at development level (`/development/connector`) explaining the three-component architecture
- Moved connector docs from backend subfolder to development level for better organization
- Added Mermaid architecture diagram matching the style used in guides section
- Updated navigation metadata to include connector at appropriate levels
- Fixed React key prop warnings in Footer component

## Additional Context
- Connector documentation explains the WebSocket-based communication between SDK, backend, and workers
- Architecture diagram shows Target App (SDK), Rhesis Backend, Workers, Redis, and PostgreSQL connections
- Documentation includes both user-facing (SDK) and developer-facing (architecture) perspectives