### PR TITLE
Fix missing screenshots and broken documentation links

### DIFF
--- a/docs/content/platform/endpoints/index.mdx
+++ b/docs/content/platform/endpoints/index.mdx
@@ -154,7 +154,7 @@ This works for both REST and WebSocket endpoints without any additional configur
 // API maintains context and responds about Paris`}
 </CodeBlock>
 
-![Request Settings](/screenshots/rhesis-ai-request-settings.png)
+![Request Settings](/screenshots/rhesis-ai-endpoint-request-settings.png)
 
 ### Importing from Swagger/OpenAPI
 
@@ -164,7 +164,7 @@ Click **Import Swagger**, enter your Swagger/OpenAPI specification URL, and clic
 
 Before running full test suites, verify your endpoint configuration works correctly. Navigate to the **Test Connection** tab, enter sample input data, and click **Test Endpoint**. Review the response to ensure it returns expected data.
 
-![Test Connection](/screenshots/rhesis-ai-test-connection.png)
+![Test Connection](/screenshots/rhesis-ai-endpoint-test-connection.png)
 
 ## Managing Endpoints
 


### PR DESCRIPTION
## Purpose
Fix Docker build failure caused by missing screenshot references and improve documentation navigation by fixing broken internal links.

## What Changed
- **Fixed screenshot paths**: Corrected image references in endpoints documentation to match actual filenames
  - `rhesis-ai-request-settings.png` → `rhesis-ai-endpoint-request-settings.png`
  - `rhesis-ai-test-connection.png` → `rhesis-ai-endpoint-test-connection.png`
- **Added missing screenshots**: Added 10 new screenshots for platform documentation
  - Endpoints configuration screenshots
  - Projects overview and detail views
  - Team management interface
  - API tokens management
  - Metrics assignment
  - Model configuration
  - Test results views
- **Fixed broken internal links**: Updated 34 documentation files with correct relative paths for navigation
- **Cleaned up**: Removed redundant trailing content in some docs

## Additional Context
This PR resolves the Next.js build failure that was blocking documentation deployment:
```
Module not found: Can't resolve 'private-next-root-dir/public/screenshots/rhesis-ai-request-settings.png'
Module not found: Can't resolve 'private-next-root-dir/public/screenshots/rhesis-ai-test-connection.png'
```

The build now successfully compiles with all image references properly resolved.