### PR TITLE
Improve Dockerfile.dev layer caching and dependency installation

### DIFF
--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -27,19 +27,25 @@ ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
     UV_NO_MANAGED_PYTHON=1
 
-# Copy only the dependency files for backend and install backend dependencies
+# Copy only the dependency files for backend, sdk, and penelope and install all dependencies
 COPY apps/backend/uv.lock apps/backend/pyproject.toml apps/backend/README.md ./
-RUN uv remove rhesis-sdk --frozen && uv remove rhesis-penelope --frozen && uv sync --no-install-project
+COPY sdk/uv.lock sdk/pyproject.toml sdk/
+COPY penelope/uv.lock penelope/pyproject.toml penelope/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv remove rhesis-sdk --frozen && \
+    uv remove rhesis-penelope --frozen && \
+    cd penelope && uv remove rhesis-sdk --frozen && cd .. && \
+    uv add ./sdk --frozen --editable --no-workspace && \
+    uv add ./penelope --frozen --editable --no-workspace && \
+    uv sync --no-install-project --no-install-local
 
 # Install the project
 COPY sdk /app/sdk/
 COPY penelope /app/penelope/
 COPY apps/backend/src /app/src/
-RUN uv add ./sdk --frozen && uv add ./penelope --frozen && cd penelope && uv remove rhesis-sdk --frozen
 
-# # Install dependencies
+# Install the project (backend, sdk, and penelope)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=apps/backend/src,target=src \
     uv sync
 
 


### PR DESCRIPTION
## Purpose
Optimize the development Dockerfile for better layer caching and more efficient dependency installation.

## What Changed
- Added uv cache mount for faster dependency installation
- Copied SDK and Penelope dependency files earlier in the build process for better layer caching
- Installed SDK and Penelope as editable packages with `--no-workspace` flag
- Removed redundant bind mount for source files
- Aligned dependency installation approach with production Dockerfile

## Additional Context
- This change improves Docker build times during development by leveraging layer caching more effectively
- The changes mirror the optimizations already present in the production Dockerfile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Docker build performance and dependency handling in `apps/backend/Dockerfile.dev`.
> 
> - Pre-copies `sdk` and `penelope` `uv.lock`/`pyproject.toml` to leverage layer caching during `uv` resolution
> - Uses `--mount=type=cache,target=/root/.cache/uv` to speed up `uv` operations
> - Installs `sdk` and `penelope` as editable with `uv add ./sdk` and `uv add ./penelope` using `--frozen --editable --no-workspace`; runs `uv sync --no-install-project --no-install-local`
> - Removes redundant bind mount in `uv sync` and aligns flow with production Dockerfile
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2915a8999ef4b8d94b896f0d744a5563dcf9bff5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->