### PR TITLE
Update Penelope README documentation links

### DIFF
--- a/penelope/README.md
+++ b/penelope/README.md
@@ -97,12 +97,11 @@ uv sync
 
 📚 **Full documentation is available at [docs.rhesis.ai/penelope](https://docs.rhesis.ai/penelope)**
 
-- [Installation Guide](https://docs.rhesis.ai/penelope/installation) - Detailed setup instructions
-- [Quick Start](https://docs.rhesis.ai/penelope/quick-start) - Get running in minutes
-- [Use Cases](https://docs.rhesis.ai/penelope/use-cases) - Real-world testing scenarios
+- [Getting Started](https://docs.rhesis.ai/penelope/getting-started) - Installation & quick start guide
+- [Examples & Use Cases](https://docs.rhesis.ai/penelope/examples) - Real-world testing scenarios
 - [Configuration](https://docs.rhesis.ai/penelope/configuration) - Advanced options
-- [Architecture](https://docs.rhesis.ai/penelope/architecture) - System design
-- [Custom Tools](https://docs.rhesis.ai/penelope/custom-tools) - Extend Penelope
+- [Execution Trace](https://docs.rhesis.ai/penelope/execution-trace) - Understanding test results
+- [Extending Penelope](https://docs.rhesis.ai/penelope/extending) - Custom tools & targets
 
 ## What Makes Penelope Unique?
 


### PR DESCRIPTION
## Purpose
Update the documentation links in Penelope's README to match the current documentation structure at docs.rhesis.ai/penelope.

## What Changed
- Consolidated Installation Guide and Quick Start into a single "Getting Started" link
- Renamed "Use Cases" to "Examples & Use Cases" with updated URL
- Removed outdated "Architecture" link
- Added new "Execution Trace" documentation link
- Renamed "Custom Tools" to "Extending Penelope" with updated URL

## Additional Context
- Documentation structure has been reorganized for better user experience
- All links point to the updated docs.rhesis.ai/penelope documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `penelope/README.md` docs section to match the new site structure.
> 
> - Consolidates installation and quick start into `Getting Started`
> - Renames `Use Cases` to `Examples & Use Cases`
> - Adds links for `Execution Trace` and `Extending Penelope`
> - Removes outdated `Architecture` and `Custom Tools` links; keeps `Configuration`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0493a35488f9317687d33d484d23920b69d3211b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->