### PR TITLE
Add project_id field and ConnectionType enum to SDK Endpoint

### DIFF
--- a/sdk/src/rhesis/sdk/entities/endpoint.py
+++ b/sdk/src/rhesis/sdk/entities/endpoint.py
@@ -1,9 +1,19 @@
+from enum import Enum
 from typing import Any, ClassVar, Dict, Optional
 
 from rhesis.sdk.client import Client, Endpoints, Methods
 from rhesis.sdk.entities.base_entity import BaseEntity, handle_http_errors
 
 ENDPOINT = Endpoints.ENDPOINTS
+
+
+class ConnectionType(str, Enum):
+    """Connection type enum matching backend EndpointConnectionType."""
+
+    REST = "REST"
+    WEBSOCKET = "WebSocket"
+    GRPC = "GRPC"
+    SDK = "SDK"
 
 
 class Endpoint(BaseEntity):
@@ -32,8 +42,10 @@ class Endpoint(BaseEntity):
     endpoint: ClassVar[Endpoints] = ENDPOINT
     name: Optional[str] = None
     description: Optional[str] = None
-    connection_type: Optional[str] = None
+    # Required field - must be one of: "REST", "WebSocket", "GRPC", "SDK"
+    connection_type: Optional[ConnectionType] = None
     url: Optional[str] = None
+    project_id: Optional[str] = None
     id: Optional[str] = None
 
     @handle_http_errors

--- a/tests/sdk/integration/test_entities.py
+++ b/tests/sdk/integration/test_entities.py
@@ -241,6 +241,7 @@ def test_endpoint(db_cleanup):
         description="Test Endpoint Description",
         connection_type="REST",
         url="https://api.example.com/test",
+        project_id="12340000-0000-4000-8000-000000001234",
     )
 
     result = endpoint.push()
@@ -258,6 +259,7 @@ def test_endpoint_push_pull(db_cleanup):
         description="Test push pull endpoint description",
         connection_type="REST",
         url="https://api.example.com/push-pull",
+        project_id="12340000-0000-4000-8000-000000001234",
     )
     endpoint.push()
 
@@ -275,6 +277,7 @@ def test_endpoint_delete(db_cleanup):
         description="Test endpoint to delete description",
         connection_type="REST",
         url="https://api.example.com/delete",
+        project_id="12340000-0000-4000-8000-000000001234",
     )
 
     endpoint.push()
@@ -296,6 +299,7 @@ def test_test_run(db_cleanup):
         description="Test Endpoint Description",
         connection_type="REST",
         url="https://example.com/api",
+        project_id="12340000-0000-4000-8000-000000001234",
     )
     endpoint.push()
 
@@ -325,6 +329,7 @@ def test_test_run_push_pull(db_cleanup):
         description="Test Endpoint Description",
         connection_type="REST",
         url="https://example.com/api",
+        project_id="12340000-0000-4000-8000-000000001234",
     )
     endpoint.push()
 
@@ -354,6 +359,7 @@ def test_test_run_delete(db_cleanup):
         description="Test Endpoint Description",
         connection_type="REST",
         url="https://example.com/api",
+        project_id="12340000-0000-4000-8000-000000001234",
     )
     endpoint.push()
 


### PR DESCRIPTION
## Purpose
Add required `project_id` field to the SDK Endpoint entity, aligning with the backend migration that made `project_id` non-nullable on endpoints.

## What Changed
- Added `ConnectionType` enum to `endpoint.py` with options: REST, WebSocket, GRPC, SDK
- Added `project_id` field to the `Endpoint` entity (now required by backend)
- Updated integration test fixtures in `conftest.py` to create a test project with a known UUID
- Updated all endpoint-related tests to include the required `project_id` field

## Additional Context
- This change supports the backend migration `7b998a6fe52d_make_project_id_non_nullable_in_endpoint.py`
- All endpoints must now be associated with a project

## Testing
Run SDK integration tests:
```bash
cd sdk
make test-integration
```