### PR TITLE
Fix documentation footer styling and 404 error page UI

### DIFF
--- a/docs/src/app/not-found.js
+++ b/docs/src/app/not-found.js
@@ -1,6 +1,6 @@
 export default function NotFound() {
   return (
-    <div style={{ padding: '2rem', textAlign: 'center' }}>
+    <div className="not-found-container" style={{ padding: '2rem', textAlign: 'center' }}>
       <h1>404 - Page Not Found</h1>
       <p>The requested page could not be found.</p>
       <a href="/" style={{ color: '#2AA1CE', textDecoration: 'underline' }}>

--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -114,6 +114,22 @@
   font-display: swap;
 }
 
+/* Sticky footer support */
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* Center 404 page content */
+.not-found-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+}
+
 /* Apply brand fonts and colors to Nextra */
 
 /* Typography - apply to all text elements */


### PR DESCRIPTION
Problem:
The documentation page footer is not sticking to the bottom of the page, which negatively impacts the UI. Additionally, when tried to make footer page to the bottom, the error page content is not centered, making the layout look unbalanced.

Solution:
Fixed the documentation page footer so it stays at the bottom of the screen. Also centered the error page content to improve overall UI consistency and user experience.

Before: 
<img width="1440" height="818" alt="Screenshot 2026-01-20 at 10 16 59 AM" src="https://github.com/user-attachments/assets/bca07fb3-782c-4dd6-94f7-f959d7ba8ab1" />

After:

<img width="1440" height="818" alt="Screenshot 2026-01-20 at 10 15 51 AM" src="https://github.com/user-attachments/assets/202590af-fa66-4a10-a26d-901c3ba57dd6" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves documentation layout consistency.
> 
> - Adds sticky footer layout by making `body` a flex column with `min-height: 100vh` in `globals.css`
> - Centers 404 content by introducing `.not-found-container` styles and applying the class in `app/not-found.js`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45ddd75ef7ab177b826d939ae9240bcb635f6765. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->