### PR TITLE
docs(contributing): fix npm install paths and python version

### DIFF
--- a/docs/content/development/contributing/development-setup/index.mdx
+++ b/docs/content/development/contributing/development-setup/index.mdx
@@ -16,7 +16,7 @@ Before you begin, ensure you have the following installed on your system:
 
 <Callout type="default">
   **System Requirements** - **Operating System**: macOS, Linux, or Windows (WSL
-  recommended) - **Python 3.8+**: For backend development - **Node.js 18+**: For
+  recommended) - **Python 3.10+**: For backend development - **Node.js 18+**: For
   frontend development - **Git**: For version control - **Docker**: For
   containerized development (optional) - **PostgreSQL**: For database
   development - **Redis**: For background task processing
@@ -109,8 +109,11 @@ uv sync
 cd apps/frontend
 npm install
 
+# Return to root
+cd ../..
+
 # Install documentation dependencies
-cd ../docs
+cd docs/src
 npm install
 
 # Return to root
@@ -198,7 +201,7 @@ cd apps/frontend
 npm run dev
 
 # Documentation (Nextra)
-cd apps/documentation
+cd docs/src
 npm run dev
 
 # Worker (Celery)

--- a/docs/content/development/contributing/index.mdx
+++ b/docs/content/development/contributing/index.mdx
@@ -17,7 +17,7 @@ Thank you for your interest in contributing to Rhesis! This guide will help you 
 Before contributing, make sure you have:
 
 <Callout type="default">
-  **Development Requirements** - **Python 3.8+** with
+  **Development Requirements** - **Python 3.10+** with
   [uv](https://docs.astral.sh/uv/) package manager - **Node.js 18+** and npm -
   **Git** for version control - **Docker** (optional, for containerized
   development) - **PostgreSQL** (for backend development) - **Redis** (for
@@ -40,8 +40,8 @@ cd rhesis`}
 uv sync
 
 # Install Node.js dependencies
-cd apps/frontend && npm install
-cd ../docs && npm install`}
+cd apps/frontend && npm install && cd ../..
+cd docs/src && npm install && cd ../..`}
 </CodeBlock>
 
 3. **Configure environment:**
@@ -80,7 +80,7 @@ Understanding the project structure will help you navigate the codebase:
   <div>
     <h3>Documentation</h3>
     <p>
-      Nextra-based documentation in `apps/documentation/` with comprehensive
+      Nextra-based documentation in `docs/` with comprehensive
       guides.
     </p>
   </div>


### PR DESCRIPTION
Fixes incorrect setup instructions in contributing documentation that would cause new contributors to fail during setup.

## Changes

1. **Fixed npm install paths** - Changed `cd ../docs` to `cd docs/src` (correct path from apps/frontend)
2. **Updated Python version** - Changed from 3.8+ to 3.10+ (matches backend/pyproject.toml requirement)
3. **Fixed docs location** - Changed `apps/documentation/` to `docs/` in project structure

## Type of Change

- [x] Documentation update

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 093cf4974c9f55b8a5373d144e2cd9600209daf6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->