### PR TITLE
Refactor SDK: Extract low-level API client

### DIFF
--- a/sdk/src/rhesis/sdk/client.py
+++ b/sdk/src/rhesis/sdk/client.py
@@ -55,6 +55,87 @@ class Methods(Enum):
     DELETE = "DELETE"
 
 
+class _APIClient:
+    """
+    Low-level API client responsible only for HTTP communication with the Rhesis API.
+
+    This class handles authentication headers, URL construction, and HTTP requests.
+    It is used internally by SDK components that need to communicate with the API.
+
+    For most use cases, use the higher-level `Client` class instead.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+    ):
+        """
+        Initialize the API client.
+
+        Args:
+            api_key: Optional API key. If not provided, will try to get it from
+                    module level variable or environment variable.
+            base_url: Optional base URL. If not provided, will try to get it from
+                     module level variable or environment variable.
+        """
+        self.api_key = api_key if api_key is not None else get_api_key()
+        self._base_url = base_url if base_url is not None else get_base_url()
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    @property
+    def base_url(self) -> str:
+        """Get the base URL with trailing slash removed."""
+        return self._base_url.rstrip("/")
+
+    def get_url(self, endpoint: str) -> str:
+        """
+        Construct a URL by combining base_url and endpoint.
+
+        Args:
+            endpoint: The API endpoint path.
+
+        Returns:
+            str: The complete URL with proper formatting.
+        """
+        # Remove leading slash from endpoint if present
+        endpoint = endpoint.lstrip("/")
+        return f"{self.base_url}/{endpoint}"
+
+    def send_request(
+        self,
+        endpoint: Endpoints,
+        method: Methods,
+        data: Optional[dict] = None,
+        params: Optional[dict] = None,
+        url_params: Optional[str] = None,
+    ) -> dict:
+        """
+        Send a request to the API.
+
+        Args:
+            endpoint: The API endpoint path.
+            method: The HTTP method to use.
+            data: The data to send in the request body.
+            params: Query parameters for the request.
+            url_params: Additional URL path parameters.
+
+        Returns:
+            dict: The JSON response from the API.
+        """
+        url = self.get_url(endpoint.value)
+        if url_params is not None:
+            url = f"{url}/{url_params}"
+        response = requests.request(
+            method=method.value, url=url, headers=self.headers, json=data, params=params
+        )
+        response.raise_for_status()
+        return response.json()
+
+
 class DisabledClient:
     """
     No-op client implementation used when RHESIS_CONNECTOR_DISABLE is enabled.

--- a/sdk/src/rhesis/sdk/entities/base_collection.py
+++ b/sdk/src/rhesis/sdk/entities/base_collection.py
@@ -2,7 +2,7 @@ from typing import Any, Generic, Optional, Type, TypeVar
 
 from requests.exceptions import HTTPError
 
-from rhesis.sdk.client import Client, Endpoints, HTTPStatus, Methods
+from rhesis.sdk.client import Endpoints, HTTPStatus, Methods, _APIClient
 from rhesis.sdk.entities.base_entity import BaseEntity, handle_http_errors
 
 T = TypeVar("T", bound=BaseEntity)
@@ -29,7 +29,7 @@ class BaseCollection(Generic[T]):
         Returns:
             List of records matching the filter, or all records if no filter is provided
         """
-        client = Client()
+        client = _APIClient()
 
         params = {"$filter": filter} if filter else None
         response = client.send_request(
@@ -50,7 +50,7 @@ class BaseCollection(Generic[T]):
         Returns:
             The first record, or None if no records found
         """
-        client = Client()
+        client = _APIClient()
 
         response = client.send_request(
             endpoint=cls.endpoint,
@@ -82,7 +82,7 @@ class BaseCollection(Generic[T]):
         if not id and not name:
             raise ValueError("Either id or name must be provided")
 
-        client = Client()
+        client = _APIClient()
 
         if id:
             response = client.send_request(
@@ -123,7 +123,7 @@ class BaseCollection(Generic[T]):
     @classmethod
     def exists(cls, id: str) -> bool:
         """Check if an entity exists."""
-        client = Client()
+        client = _APIClient()
         try:
             response = client.send_request(
                 endpoint=cls.endpoint,

--- a/sdk/src/rhesis/sdk/entities/base_entity.py
+++ b/sdk/src/rhesis/sdk/entities/base_entity.py
@@ -6,7 +6,7 @@ from typing import Any, Callable, ClassVar, Dict, Optional, TypeVar
 import requests
 from pydantic import BaseModel, ConfigDict
 
-from rhesis.sdk.client import Client, Endpoints, HTTPStatus, Methods
+from rhesis.sdk.client import Endpoints, HTTPStatus, Methods, _APIClient
 
 T = TypeVar("T")
 
@@ -64,7 +64,7 @@ class BaseEntity(BaseModel):
     @classmethod
     def _delete(cls, id: str) -> bool:
         """Delete the entity from the database."""
-        client = Client()
+        client = _APIClient()
         try:
             client.send_request(
                 endpoint=cls.endpoint,
@@ -81,7 +81,7 @@ class BaseEntity(BaseModel):
     @classmethod
     def _update(cls, id: str, data: Dict[str, Any]) -> Dict[str, Any]:
         """Push the entity to the database."""
-        client = Client()
+        client = _APIClient()
         response = client.send_request(
             endpoint=cls.endpoint,
             method=Methods.PUT,
@@ -92,7 +92,7 @@ class BaseEntity(BaseModel):
 
     @classmethod
     def _create(cls, data: Dict[str, Any]) -> Dict[str, Any]:
-        client = Client()
+        client = _APIClient()
         response = client.send_request(
             endpoint=cls.endpoint,
             method=Methods.POST,
@@ -103,7 +103,7 @@ class BaseEntity(BaseModel):
     @classmethod
     def _pull(cls, id: str) -> Dict[str, Any]:
         """Pull entity data from the database and validate against schema."""
-        client = Client()
+        client = _APIClient()
         response = client.send_request(
             endpoint=cls.endpoint,
             method=Methods.GET,

--- a/sdk/src/rhesis/sdk/entities/behavior.py
+++ b/sdk/src/rhesis/sdk/entities/behavior.py
@@ -1,6 +1,6 @@
 from typing import Any, ClassVar, Dict, Optional
 
-from rhesis.sdk.client import Client, Endpoints, Methods
+from rhesis.sdk.client import Endpoints, Methods, _APIClient
 from rhesis.sdk.entities.base_collection import BaseCollection
 from rhesis.sdk.entities.base_entity import BaseEntity
 
@@ -29,7 +29,7 @@ class Behavior(BaseEntity):
         if self.id is None:
             raise ValueError("Behavior ID is required")
 
-        client = Client()
+        client = _APIClient()
 
         response = client.send_request(
             endpoint=self.endpoint,
@@ -57,7 +57,7 @@ class Behavior(BaseEntity):
         if self.id is None:
             raise ValueError("Behavior ID is required")
 
-        client = Client()
+        client = _APIClient()
 
         response = client.send_request(
             endpoint=self.endpoint,
@@ -85,7 +85,7 @@ class Behavior(BaseEntity):
         if self.id is None:
             raise ValueError("Behavior ID is required")
 
-        client = Client()
+        client = _APIClient()
 
         response = client.send_request(
             endpoint=self.endpoint,

--- a/sdk/src/rhesis/sdk/entities/endpoint.py
+++ b/sdk/src/rhesis/sdk/entities/endpoint.py
@@ -1,8 +1,8 @@
 from enum import Enum
 from typing import Any, ClassVar, Dict, Optional
 
-from rhesis.sdk.client import Client, Methods
 from rhesis.sdk.client import Endpoints as ApiEndpoints
+from rhesis.sdk.client import Methods, _APIClient
 from rhesis.sdk.entities.base_collection import BaseCollection
 from rhesis.sdk.entities.base_entity import BaseEntity, handle_http_errors
 
@@ -100,7 +100,7 @@ class Endpoint(BaseEntity):
         if session_id is not None:
             input_data["session_id"] = session_id
 
-        client = Client()
+        client = _APIClient()
         return client.send_request(
             endpoint=self.endpoint,
             method=Methods.POST,

--- a/sdk/src/rhesis/sdk/entities/test.py
+++ b/sdk/src/rhesis/sdk/entities/test.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, Optional
 
 from pydantic import BaseModel
 
-from rhesis.sdk.client import Client, Endpoints, Methods
+from rhesis.sdk.client import Endpoints, Methods, _APIClient
 from rhesis.sdk.entities.base_collection import BaseCollection
 from rhesis.sdk.entities.base_entity import BaseEntity, handle_http_errors
 from rhesis.sdk.entities.endpoint import Endpoint
@@ -58,7 +58,7 @@ class Test(BaseEntity):
             "evaluate_metrics": True,
         }
 
-        client = Client()
+        client = _APIClient()
         return client.send_request(
             endpoint=self.endpoint,
             method=Methods.POST,

--- a/sdk/src/rhesis/sdk/entities/test_configuration.py
+++ b/sdk/src/rhesis/sdk/entities/test_configuration.py
@@ -1,6 +1,6 @@
 from typing import Any, ClassVar, Dict, Optional
 
-from rhesis.sdk.client import Client, Endpoints, Methods
+from rhesis.sdk.client import Endpoints, Methods, _APIClient
 from rhesis.sdk.entities.base_collection import BaseCollection
 from rhesis.sdk.entities.base_entity import BaseEntity
 
@@ -30,7 +30,7 @@ class TestConfiguration(BaseEntity):
         """
         if self.id is None:
             raise ValueError("Test configuration ID is required")
-        client = Client()
+        client = _APIClient()
 
         # Filter test runs by test_configuration_id using OData
         params = {"$filter": f"test_configuration_id eq '{self.id}'"}

--- a/sdk/src/rhesis/sdk/entities/test_run.py
+++ b/sdk/src/rhesis/sdk/entities/test_run.py
@@ -3,7 +3,7 @@ from typing import Any, ClassVar, Dict, Optional
 
 from pydantic import field_validator
 
-from rhesis.sdk.client import Client, Endpoints, Methods
+from rhesis.sdk.client import Endpoints, Methods, _APIClient
 from rhesis.sdk.entities.base_collection import BaseCollection
 from rhesis.sdk.entities.base_entity import BaseEntity
 
@@ -46,7 +46,7 @@ class TestRun(BaseEntity):
         """
         if self.id is None:
             raise ValueError("Test run ID is required")
-        client = Client()
+        client = _APIClient()
 
         # Filter test results by test_run_id using OData
         params = {"$filter": f"test_run_id eq '{self.id}'"}

--- a/sdk/src/rhesis/sdk/entities/test_set.py
+++ b/sdk/src/rhesis/sdk/entities/test_set.py
@@ -5,7 +5,7 @@ from typing import Any, ClassVar, Dict, List, Optional, Union
 from jinja2 import Template
 from pydantic import BaseModel, field_validator
 
-from rhesis.sdk.client import Client, Endpoints, Methods
+from rhesis.sdk.client import Endpoints, Methods, _APIClient
 from rhesis.sdk.entities import BaseEntity, Endpoint
 from rhesis.sdk.entities.base_collection import BaseCollection
 from rhesis.sdk.entities.base_entity import handle_http_errors
@@ -70,7 +70,7 @@ class TestSet(BaseEntity):
         if not self.id:
             raise ValueError("Test set ID must be set before executing")
 
-        client = Client()
+        client = _APIClient()
         response = client.send_request(
             endpoint=self.endpoint,
             method=Methods.POST,
@@ -149,7 +149,7 @@ class TestSet(BaseEntity):
         if not data.get("tests"):
             raise ValueError("Test set must have at least one test before creating")
 
-        client = Client()
+        client = _APIClient()
         response = client.send_request(
             endpoint=cls.endpoint,
             method=Methods.POST,

--- a/sdk/src/rhesis/sdk/metrics/providers/native/serialization.py
+++ b/sdk/src/rhesis/sdk/metrics/providers/native/serialization.py
@@ -12,7 +12,7 @@ import inspect
 from dataclasses import asdict
 from typing import Any, Dict, Optional, TypeVar
 
-from rhesis.sdk.client import Client, Endpoints, Methods
+from rhesis.sdk.client import Endpoints, Methods, _APIClient
 from rhesis.sdk.metrics.base import MetricConfig
 from rhesis.sdk.metrics.utils import backend_config_to_sdk_config, sdk_config_to_backend_config
 
@@ -102,7 +102,7 @@ class BackendSyncMixin:
         Raises:
             Exception: If push fails
         """
-        client = Client()
+        client = _APIClient()
         config = asdict(self.to_config())
         config = sdk_config_to_backend_config(config)
 
@@ -132,7 +132,7 @@ class BackendSyncMixin:
         if not name and not nano_id:
             raise ValueError("Either name or nano_id must be provided")
 
-        client = Client()
+        client = _APIClient()
 
         # Build filter based on provided parameter
         filter_field = "nano_id" if nano_id else "name"

--- a/tests/sdk/metrics/test_metric_scope.py
+++ b/tests/sdk/metrics/test_metric_scope.py
@@ -132,7 +132,7 @@ class TestMetricWithScope:
 class TestMetricScopePushPull:
     """Tests for push/pull operations with metric scope."""
 
-    @patch("rhesis.sdk.metrics.providers.native.serialization.Client")
+    @patch("rhesis.sdk.metrics.providers.native.serialization._APIClient")
     def test_push_metric_with_scope(self, mock_client_class):
         """Test pushing a metric with metric_scope."""
         mock_client = Mock()
@@ -162,7 +162,7 @@ class TestMetricScopePushPull:
             # Verify metric_scope was converted to strings
             assert sent_config["metric_scope"] == ["Single-Turn", "Multi-Turn"]
 
-    @patch("rhesis.sdk.metrics.providers.native.serialization.Client")
+    @patch("rhesis.sdk.metrics.providers.native.serialization._APIClient")
     def test_pull_metric_with_scope(self, mock_client_class):
         """Test pulling a metric with metric_scope."""
         mock_client = Mock()


### PR DESCRIPTION
## Purpose
Improve SDK architecture by separating concerns between user-facing client and internal HTTP operations.

## What Changed
- Added `_APIClient` class in `client.py` for low-level HTTP communication with the Rhesis API
- Updated all entity classes (`base_entity.py`, `base_collection.py`, `behavior.py`, `endpoint.py`, `test.py`, `test_configuration.py`, `test_run.py`, `test_set.py`) to use `_APIClient` for API calls
- Updated metrics serialization module to use `_APIClient`
- Updated tests to mock `_APIClient` instead of `Client`

## Additional Context
This refactoring separates the high-level `Client` class (user-facing, provides entity access) from the low-level `_APIClient` (internal, handles HTTP requests). The underscore prefix indicates `_APIClient` is for internal use only.

## Testing
- Existing SDK tests continue to pass
- Run `make test` in the `sdk/` directory to verify