### PR TITLE
Fix React error when testing endpoints with object responses

### DIFF
--- a/apps/frontend/src/app/(protected)/tests/components/TrialDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TrialDrawer.tsx
@@ -792,7 +792,19 @@ export default function TrialDrawer({
                   minHeight: '100px',
                 }}
               >
-                {trialResponse.output || 'No response received'}
+                {(() => {
+                  if (!trialResponse.output) {
+                    return 'No response received';
+                  }
+
+                  // If output is an object, stringify it
+                  if (typeof trialResponse.output === 'object') {
+                    return JSON.stringify(trialResponse.output, null, 2);
+                  }
+
+                  // Otherwise render as-is (string, number, boolean)
+                  return String(trialResponse.output);
+                })()}
               </Typography>
             )}
           </Box>


### PR DESCRIPTION
## Purpose
Fixes React minified error #31 that occurs when running tests on POST/GET endpoints that return object responses. The error prevented users from successfully testing their endpoints in the TrialDrawer component.

## What Changed
- Updated TrialDrawer component to safely handle object responses
- Added type checking before rendering response output
- Objects are now automatically stringified with JSON.stringify() for display
- Handles all response types: strings, numbers, booleans, objects, arrays, null/undefined
- Multi-turn test execution remains unaffected

## Additional Context
- Closes #1150
- The fix is minimal (13 lines added) and focused on the single-turn response rendering path
- All response types verified: strings, objects, nested objects, arrays, primitives, null/undefined
- No new linting errors introduced

## Testing
Verified the fix handles:
1. Simple string responses - renders correctly
2. Object responses (the bug scenario) - now stringified and displayed
3. Nested object responses - properly formatted JSON
4. Null/undefined responses - shows fallback message
5. Number/boolean responses - converted to strings
6. Array responses - stringified as JSON
7. Multi-turn test execution - unaffected, works as before