### PR TITLE
fix(docs): remove problematic body flexbox while preserving 404 styles

### DIFF
--- a/docs/src/styles/globals.css
+++ b/docs/src/styles/globals.css
@@ -114,20 +114,6 @@
   font-display: swap;
 }
 
-/* Sticky footer layout - ensures footer sticks to bottom on short pages */
-body {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-}
-
-/* Nextra's main wrapper should grow to push footer down */
-body > div {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-}
-
 /* Center 404 page content */
 .not-found-container {
   display: flex;


### PR DESCRIPTION
## Purpose

Fix documentation layout issues on dev-docs.rhesis.ai caused by flexbox CSS that was breaking Nextra's layout system.

## What Changed

- Removed problematic `body` flexbox CSS that was causing:
  - Main content to overflow its boundaries
  - Table of contents navigation to move from left to right
  - Disruption of Nextra's default layout system
- Removed `body > div` flexbox that interfered with Nextra's internal structure
- Preserved 404 page (`.not-found-container`) styles which don't interfere with layout

## Additional Context

- Related to commit 71643161b which introduced the problematic CSS
- The body-level flexbox changes conflicted with Nextra's layout architecture
- 404 page styles use flexbox only on the container itself, not on body elements, so they're safe to keep

## Testing

After deployment to dev-docs.rhesis.ai, verify:
1. Main content stays within proper boundaries
2. Table of contents is on the left side (not right)
3. Page layout matches Nextra's default structure
4. 404 page still displays correctly with proper styling