### PR TITLE
fix(frontend): prevent changing endpoint connection type during edit

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointDetail.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointDetail.tsx
@@ -68,9 +68,8 @@ import { useNotifications } from '@/components/common/NotificationContext';
 import Tooltip from '@mui/material/Tooltip';
 
 // Constants for select fields
-const CONNECTION_TYPES = ['REST', 'WEBSOCKET', 'GRPC', 'SDK'];
 const ENVIRONMENTS = ['production', 'staging', 'development', 'local'];
-const METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'];
+const METHODS = ['POST'];
 
 // Map of icon names to components for easy lookup
 const ICON_MAP: Record<string, React.ComponentType> = {
@@ -517,36 +516,15 @@ export default function EndpointDetail({
                     md: endpoint.connection_type === 'SDK' ? 12 : 3,
                   }}
                 >
-                  {isEditing ? (
-                    <FormControl fullWidth>
-                      <InputLabel>Connection Type</InputLabel>
-                      <Select
-                        value={editedValues.connection_type || ''}
-                        label="Connection Type"
-                        onChange={e =>
-                          handleChange('connection_type', e.target.value)
-                        }
-                      >
-                        {CONNECTION_TYPES.map(connectionType => (
-                          <MenuItem key={connectionType} value={connectionType}>
-                            {connectionType}
-                          </MenuItem>
-                        ))}
-                      </Select>
-                    </FormControl>
-                  ) : (
-                    <>
-                      <Typography variant="subtitle2" color="text.secondary">
-                        Connection Type
-                      </Typography>
-                      <Typography variant="body1">
-                        {endpoint.connection_type}
-                      </Typography>
-                    </>
-                  )}
+                  <Typography variant="subtitle2" color="text.secondary">
+                    Connection Type
+                  </Typography>
+                  <Typography variant="body1">
+                    {endpoint.connection_type}
+                  </Typography>
                 </Grid>
-                {/* Hide method field for SDK connection type */}
-                {endpoint.connection_type !== 'SDK' && (
+                {/* Only show method field for REST endpoints */}
+                {endpoint.connection_type === 'REST' && (
                   <Grid
                     size={{
                       xs: 12,


### PR DESCRIPTION
## Summary

Fixes #1151

This PR prevents users from changing the connection type of existing endpoints in the edit form, while still allowing them to edit all other appropriate fields based on the endpoint's type.

## Changes

- **Made connection type field read-only**: The connection type now displays as plain text in both view and edit modes, preventing users from changing it
- **Restricted HTTP methods to POST only**: For REST endpoints, only the POST method is available in the dropdown (matching the creation form)
- **Hide method field for non-REST endpoints**: The method field is now only shown for REST endpoints, hiding it for WebSocket, SDK, and GRPC endpoints
- **Removed unused constant**: Cleaned up the `CONNECTION_TYPES` constant that was no longer needed

## Behavior

### Before
- ❌ Users could change connection type from REST to WebSocket/GRPC/SDK (or vice versa)
- ❌ REST methods (GET, POST, PUT, DELETE, PATCH) were shown for non-REST connection types
- ❌ This created invalid configurations

### After
- ✅ **REST endpoints**: Connection type is read-only, method dropdown shows only "POST"
- ✅ **SDK endpoints**: Connection type is read-only, no URL or method fields shown
- ✅ **WebSocket/GRPC endpoints**: Connection type is read-only, URL shown but no method field
- ✅ **All endpoints**: Users cannot change the connection type

## Testing

- [ ] Verify REST endpoints can be edited but connection type cannot be changed
- [ ] Verify SDK endpoints display correctly with no URL/Method fields
- [ ] Verify WebSocket/GRPC endpoints display correctly with URL but no Method field
- [ ] Verify method dropdown only shows POST for REST endpoints
- [ ] Verify form validation still works correctly

## Screenshots

_Screenshots will be added during review_