### PR TITLE
fixed tags not showing up without refresh on source page

### DIFF
--- a/apps/frontend/src/app/(protected)/knowledge/[identifier]/components/SourcePreviewClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/[identifier]/components/SourcePreviewClientWrapper.tsx
@@ -169,19 +169,13 @@ export default function SourcePreviewClientWrapper({
 
   // fetch updated source after tag update and refresh local state
   const handleTagsUpdate = async () => {
-    setTimeout(async () => {
-      try {
-        const clientFactory = new ApiClientFactory(sessionToken);
-        const sourcesClient = clientFactory.getSourcesClient();
-        const updatedSource = await sourcesClient.getSourceWithContent(
-          localSource.id
-        );
+    const clientFactory = new ApiClientFactory(sessionToken);
+    const sourcesClient = clientFactory.getSourcesClient();
+    const updatedSource = await sourcesClient.getSourceWithContent(
+      localSource.id
+    );
 
-        setLocalSource(updatedSource);
-      } catch (error) {
-        console.error('Failed to refresh source after tag update', error);
-      }
-    }, 500);
+    setLocalSource(updatedSource);
   };
 
   const handleUpdateFromMCP = async () => {

--- a/apps/frontend/src/app/(protected)/knowledge/[identifier]/components/SourceTags.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/[identifier]/components/SourceTags.tsx
@@ -28,18 +28,12 @@ export default function SourceTags({
     }
   }, [source.tags]);
 
-  const handleTagsChange = (newTagNames: string[]) => {
-    setTagNames(newTagNames);
-    if (onUpdate) {
-      onUpdate();
-    }
-  };
-
   return (
     <Box sx={{ width: '100%' }}>
       <BaseTag
         value={tagNames}
-        onChange={handleTagsChange}
+        onChange={setTagNames}
+        onTagUpdate={onUpdate}
         placeholder="Add tags..."
         chipColor="primary"
         disableEdition={disableEdition}

--- a/apps/frontend/src/components/common/BaseTag.tsx
+++ b/apps/frontend/src/components/common/BaseTag.tsx
@@ -82,6 +82,7 @@ export interface BaseTagProps extends Omit<
   entity?: TaggableEntity;
   /** Custom className for chip styling */
   chipClassName?: string;
+  onTagUpdate?: () => void;
 }
 
 // Tag validation utilities
@@ -116,6 +117,7 @@ export default function BaseTag({
   InputProps: customInputProps,
   InputLabelProps: customInputLabelProps,
   id,
+  onTagUpdate,
   ...textFieldProps
 }: BaseTagProps) {
   const [inputValue, setInputValue] = useState<string>('');
@@ -210,6 +212,10 @@ export default function BaseTag({
         severity: 'success',
         autoHideDuration: 4000,
       });
+
+      if (onTagUpdate) {
+        onTagUpdate();
+      }
     } catch (error) {
       notifications?.show(
         error instanceof Error ? error.message : 'Failed to update tags',


### PR DESCRIPTION
This PR fixes the tags not showing up without refresh issue on source page.

## Changes
Updated the source state on `SourcePreviewClientWrapper` using the same method as in `TestResultTags`


## Testing
✅ Tested creation of new tags
✅ Tested deletion of new tags
✅ Tested deletion of existing tags

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes tag UI to reflect changes immediately without a page reload.
> 
> - Adds `handleTagsUpdate` in `SourcePreviewClientWrapper` to refetch the source and refresh local state after tag edits
> - Wires an `onUpdate`/`onTagUpdate` callback from `SourcePreviewClientWrapper` → `SourceTags` → `BaseTag`, triggering after successful tag mutations
> - Ensures tags section stays in sync with server data during add/remove actions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62df3399c2214ddea01e839d1536a1efea3c2eb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->