### PR TITLE
Add contributing page to documentation

### DIFF
--- a/docs/content/_meta.tsx
+++ b/docs/content/_meta.tsx
@@ -11,6 +11,7 @@ export default {
   },
   guides: "Guides",
   glossary: "Glossary",
+  contributing: "Contributing",
   sdk_reference: {
     title: "SDK Reference",
     href: "https://rhesis-sdk.readthedocs.io/en/latest/",

--- a/docs/content/contributing.mdx
+++ b/docs/content/contributing.mdx
@@ -1,0 +1,17 @@
+# Contributing to Rhesis
+
+We welcome contributions of all kinds — code, ideas, documentation, and bug reports. Here's how you can get involved:
+
+## Ways to Contribute
+
+- ⭐ **Star the repo** — show your support by [starring us on GitHub](https://github.com/rhesis-ai/rhesis).
+- **Suggest features** — have an idea? [Create a feature request](https://github.com/rhesis-ai/rhesis/issues/new?template=feature_request.md).
+- **Submit code** — check out our [open issues](https://github.com/rhesis-ai/rhesis/issues) and [contribution guide](/development/contributing) to get started.
+- **Report issues** — found a bug? [Open a GitHub issue](https://github.com/rhesis-ai/rhesis/issues/new?template=bug_report.md) to let us know.
+- **Improve documentation** — help us make the docs better by submitting a PR.
+- **Join the community** — connect with us on [Discord](https://discord.rhesis.ai) and [LinkedIn](https://www.linkedin.com/company/rhesis-ai/).
+- **Spread the word** — share your experience with Rhesis on social media and help others discover the project.
+
+---
+
+Thanks for being part of the Rhesis community!


### PR DESCRIPTION
## Purpose

Add a top-level contributing page to make it easy for community members to find ways to get involved with Rhesis.

## What Changed

- Added `docs/content/contributing.mdx` with ways to contribute
- Updated `docs/content/_meta.tsx` to add navigation link between Glossary and SDK Reference

## Contributing Options Listed

- Star the repo on GitHub
- Suggest features via GitHub issues
- Submit code (links to open issues and contribution guide)
- Report bugs via GitHub issues
- Improve documentation
- Join the community on Discord and LinkedIn
- Spread the word on social media

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a dedicated page to guide community contributions and surfaces it in the docs navigation.
> 
> - Adds `docs/content/contributing.mdx` outlining ways to contribute (issues, PRs, docs, community links)
> - Updates `docs/content/_meta.tsx` to add `contributing` to the sidebar between `glossary` and `sdk_reference`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7366926fc9fff5f624ef5014c37ab3da6621cbcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->