### PR TITLE
fix(worker): add Rust build dependencies to Dockerfile

### DIFF
--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -15,13 +15,18 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-# Install build dependencies
+# Install build dependencies including Rust (needed for base2048 via garak)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libpq-dev \
     python3-dev \
     git \
+    curl \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && rm -rf /var/lib/apt/lists/*
+
+# Add Rust to PATH for the build
+ENV PATH="/root/.cargo/bin:$PATH"
 
 # Copy Celery worker requirements
 COPY apps/worker/pyproject.toml /app/pyproject.toml


### PR DESCRIPTION
## Purpose

Add Rust toolchain to the worker Dockerfile to enable building packages that require Rust compilation during the Docker build process.

## What Changed

- Added `curl` to build dependencies for downloading rustup
- Added rustup installation to set up the Rust toolchain
- Added Rust's cargo bin directory to PATH for the build process

## Additional Context

- Required for the `base2048` package which is a dependency of garak (added in #1190)
- The `base2048` package does not provide pre-built wheels for ARM64 architecture (e.g., Apple Silicon Macs, ARM-based cloud instances), so it must be compiled from source
- Rust is required at build time to compile the native extensions when no compatible wheel is available
- This ensures the worker image builds successfully on both AMD64 and ARM64 architectures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds required Rust toolchain to build Rust-backed Python deps and optimizes CI disk usage.
> 
> - Dockerfile (builder stage): installs `curl` and Rust via `rustup`, adds Cargo to `PATH` to compile deps (e.g., `base2048` via garak)
> - GitHub Actions `worker.yml`: new "Free disk space" step removes large preinstalled SDKs/tools and prunes Docker before building
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c173588cc526df3433656126499c613360e6211f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->