### PR TITLE
Add GitHub CLI guidance to local development rules

### DIFF
--- a/.cursor/rules/local-development.mdc
+++ b/.cursor/rules/local-development.mdc
@@ -27,3 +27,8 @@ Just add the code and do not check the linter. Do not comment it in the chat.
 ```bash
 docker compose --env-file <project_root>/.env.docker up -d postgres
 ```
+
+
+# Github CLI
+
+1. Use Github CLI whenever possible. If the link from github is pasted in the chat, use Github CLI to open it.


### PR DESCRIPTION
## Purpose
Add guidance for using GitHub CLI in local development workflow.

## What Changed
- Added new "Github CLI" section to local development rules
- Recommends using `gh` CLI when possible for GitHub interactions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds guidance to local development rules.
> 
> - **New section:** `Github CLI` recommending use of `gh` for GitHub interactions and opening links via CLI
> - *Minor fix:* closes a code block properly by adding missing newline
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0837c0217134845b9d5712d0f8fdd37c48a0ebbd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->