### PR TITLE
fix(backend): add Rust build dependencies to Dockerfile.dev

### DIFF
--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -16,12 +16,17 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-# Install build dependencies
+# Install build dependencies including Rust (needed for base2048 via garak)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     libpq-dev \
     git \
+    curl \
+    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && rm -rf /var/lib/apt/lists/*
+
+# Add Rust to PATH for the build
+ENV PATH="/root/.cargo/bin:$PATH"
 
 ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \


### PR DESCRIPTION
## Purpose
Fix integration test builds that fail due to missing Rust compiler.

## What Changed
- Add Rust toolchain to builder stage (needed for base2048 via garak)