### PR TITLE
feat: added lm-format-enforcer as a new provider

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/c9d8e7f6a5b4_add_lmformatenforcer_provider_type.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/c9d8e7f6a5b4_add_lmformatenforcer_provider_type.py
@@ -1,0 +1,43 @@
+"""add_lmformatenforcer_provider_type
+
+Adds 'lmformatenforcer' as a new ProviderType to support constrained decoding
+with guaranteed JSON schema compliance using LM Format Enforcer library.
+
+This provider uses the same underlying HuggingFace models but enforces JSON
+schema constraints during generation for 100% schema compliance.
+
+Revision ID: c9d8e7f6a5b4
+Revises: b18dc9a57319
+Create Date: 2026-01-29 13:09:50
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from rhesis.backend.alembic.utils.template_loader import (
+    load_cleanup_type_lookup_template,
+    load_type_lookup_template,
+)
+
+# revision identifiers, used by Alembic.
+revision: str = "c9d8e7f6a5b4"
+down_revision: Union[str, None] = "b18dc9a57319"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add 'lmformatenforcer' provider type for constrained decoding with HuggingFace models."""
+    provider_type_values = (
+        "('ProviderType', 'lmformatenforcer', "
+        "'LM Format Enforcer for guaranteed JSON schema compliance')"
+    )
+    op.execute(load_type_lookup_template(provider_type_values))
+
+
+def downgrade() -> None:
+    """Remove 'lmformatenforcer' provider type from all organizations."""
+    provider_type_value = "'lmformatenforcer'"
+    op.execute(load_cleanup_type_lookup_template("ProviderType", provider_type_value))

--- a/apps/frontend/src/config/model-providers.tsx
+++ b/apps/frontend/src/config/model-providers.tsx
@@ -37,13 +37,19 @@ export const SUPPORTED_PROVIDERS = [
   'together_ai',
   'cohere',
   'huggingface',
+  'lmformatenforcer',
   'meta_llama',
 ];
 
-export const LOCAL_PROVIDERS = ['huggingface', 'ollama'];
+export const LOCAL_PROVIDERS = ['huggingface', 'lmformatenforcer', 'ollama'];
 
 // Providers that require custom endpoint URLs (self-hosted or local)
-export const PROVIDERS_REQUIRING_ENDPOINT = ['ollama', 'vllm', 'huggingface'];
+export const PROVIDERS_REQUIRING_ENDPOINT = [
+  'ollama',
+  'vllm',
+  'huggingface',
+  'lmformatenforcer',
+];
 
 // Default endpoints for providers that need them
 export const DEFAULT_ENDPOINTS: Record<string, string> = {
@@ -60,6 +66,7 @@ export const PROVIDER_ICONS: Record<string, React.ReactNode> = {
   gemini: <SiGoogle className="h-8 w-8" />,
   groq: <SmartToyIcon sx={{ fontSize: theme => theme.iconSizes.large }} />,
   huggingface: <SiHuggingface className="h-8 w-8" />,
+  lmformatenforcer: <SiHuggingface className="h-8 w-8" />,
   meta: <SmartToyIcon sx={{ fontSize: theme => theme.iconSizes.large }} />,
   mistral: <MistralIcon sx={{ fontSize: theme => theme.iconSizes.large }} />,
   ollama: <SiOllama className="h-8 w-8" />,

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -65,6 +65,7 @@ huggingface = [
     "transformers==4.57.1",
     "accelerate>=1.2.0",
     "bitsandbytes>=0.45.0",
+    "lm-format-enforcer>=0.10.0",
 ]
 
 # Garak LLM vulnerability scanner integration
@@ -100,6 +101,7 @@ all = [
     "transformers==4.57.1",
     "accelerate>=1.2.0",
     "bitsandbytes>=0.45.0",
+    "lm-format-enforcer>=0.10.0",
     "langchain>=0.1.0",
     "langchain-core>=1.2.5",
     "langgraph>=0.0.26",

--- a/sdk/src/rhesis/sdk/models/__init__.py
+++ b/sdk/src/rhesis/sdk/models/__init__.py
@@ -15,6 +15,13 @@ try:
 except ImportError:
     HUGGINGFACE_AVAILABLE = False
 
+try:
+    from rhesis.sdk.models.providers.lmformatenforcer import LMFormatEnforcerLLM
+
+    LMFORMATENFORCER_AVAILABLE = True
+except ImportError:
+    LMFORMATENFORCER_AVAILABLE = False
+
 __all__ = [
     "BaseEmbedder",
     "BaseLLM",
@@ -34,3 +41,6 @@ __all__ = [
 
 if HUGGINGFACE_AVAILABLE:
     __all__.append("HuggingFaceLLM")
+
+if LMFORMATENFORCER_AVAILABLE:
+    __all__.append("LMFormatEnforcerLLM")

--- a/sdk/src/rhesis/sdk/models/factory.py
+++ b/sdk/src/rhesis/sdk/models/factory.py
@@ -20,6 +20,7 @@ DEFAULT_MODELS = {
     "gemini": "gemini-2.0-flash",
     "groq": "llama3-8b-8192",
     "huggingface": "meta-llama/Llama-2-7b-chat-hf",
+    "lmformatenforcer": "meta-llama/Llama-2-7b-chat-hf",
     "meta_llama": "Llama-3.3-70B-Instruct",
     "mistral": "mistral-medium-latest",
     "ollama": "llama3.1",
@@ -110,6 +111,14 @@ def _create_huggingface_llm(model_name: str, api_key: Optional[str], **kwargs) -
     return HuggingFaceLLM(model_name=model_name, **kwargs)
 
 
+def _create_lmformatenforcer_llm(model_name: str, api_key: Optional[str], **kwargs) -> BaseLLM:
+    """Factory function for LMFormatEnforcerLLM."""
+    from rhesis.sdk.models.providers.lmformatenforcer import LMFormatEnforcerLLM
+
+    # Note: api_key is ignored for LMFormatEnforcer as it uses local models
+    return LMFormatEnforcerLLM(model_name=model_name, **kwargs)
+
+
 def _create_meta_llama_llm(model_name: str, api_key: Optional[str], **kwargs) -> BaseLLM:
     """Factory function for MetaLlamaLLM."""
     from rhesis.sdk.models.providers.meta_llama import MetaLlamaLLM
@@ -167,6 +176,7 @@ PROVIDER_REGISTRY: Dict[str, Callable[[str, Optional[str]], BaseLLM]] = {
     "gemini": _create_gemini_llm,
     "groq": _create_groq_llm,
     "huggingface": _create_huggingface_llm,
+    "lmformatenforcer": _create_lmformatenforcer_llm,
     "meta_llama": _create_meta_llama_llm,
     "mistral": _create_mistral_llm,
     "ollama": _create_ollama_llm,

--- a/sdk/src/rhesis/sdk/models/providers/lmformatenforcer.py
+++ b/sdk/src/rhesis/sdk/models/providers/lmformatenforcer.py
@@ -1,0 +1,410 @@
+import gc
+import json
+import time
+from typing import Any, List, Optional, Type
+
+try:
+    import torch
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+except ImportError:
+    raise ImportError(
+        "HuggingFace dependencies are not installed.\n"
+        "Please install them with:\n"
+        "  pip install rhesis-sdk[huggingface]\n"
+        "or:\n"
+        "  uv sync --extra huggingface"
+    )
+
+try:
+    from lmformatenforcer import JsonSchemaParser
+    from lmformatenforcer.integrations.transformers import (
+        build_transformers_prefix_allowed_tokens_fn,
+    )
+except ImportError:
+    raise ImportError(
+        "LM Format Enforcer is not installed.\n"
+        "Please install it with:\n"
+        "  pip install rhesis-sdk[huggingface]\n"
+        "or:\n"
+        "  uv sync --extra huggingface\n"
+        "Note: lmformatenforcer is included in the huggingface extras."
+    )
+
+from pydantic import BaseModel
+
+from rhesis.sdk.errors import (
+    HUGGINGFACE_MODEL_NOT_LOADED,
+    MODEL_RELOAD_WARNING,
+    NO_MODEL_NAME_PROVIDED,
+    WARNING_TOKENIZER_ALREADY_LOADED_RELOAD,
+)
+from rhesis.sdk.models.base import BaseLLM
+from rhesis.sdk.models.utils import validate_llm_response
+
+
+class LMFormatEnforcerLLM(BaseLLM):
+    """
+    LM Format Enforcer provider for guaranteed schema-compliant generation.
+
+    This provider uses the lmformatenforcer library to enforce JSON schema constraints
+    during generation, ensuring 100% schema compliance without relying on prompt engineering.
+
+    When a schema is provided, constrained decoding is used to guarantee valid JSON output.
+    When no schema is provided, behaves identically to HuggingFaceLLM.
+
+    Example usage:
+        >>> from rhesis.sdk.models.factory import get_model
+        >>> from pydantic import BaseModel
+        >>>
+        >>> class OutputSchema(BaseModel):
+        ...     answer: str
+        ...     confidence: float
+        >>>
+        >>> llm = get_model("lmformatenforcer", "meta-llama/Llama-2-7b-chat-hf")
+        >>> result = llm.generate(
+        ...     "What is 2+2?",
+        ...     schema=OutputSchema
+        ... )
+        >>> print(result)  # Guaranteed to match OutputSchema
+
+        >>> # Can also be used in synthesizers
+        >>> from rhesis.sdk.synthesizers import PromptSynthesizer
+        >>> synthesizer = PromptSynthesizer(
+        ...     prompt="Generate tests for a chatbot",
+        ...     model="lmformatenforcer/meta-llama/Llama-2-7b-chat-hf"
+        ... )
+    """
+
+    PROVIDER = "lmformatenforcer"
+
+    def __init__(
+        self,
+        model_name: str,
+        auto_loading: bool = True,
+        generate_kwargs: Optional[dict] = None,
+        gpu_only: bool = False,
+        load_kwargs: Optional[dict] = None,
+        custom_results_dir: Optional[str] = None,
+        model_path: Optional[str] = None,
+    ):
+        """
+        Initialize the LM Format Enforcer model.
+
+        Args:
+            model_name: The HuggingFace model ID or local path
+            auto_loading: Whether to automatically load the model on initialization.
+                If False, manual loading is needed via load_model().
+            generate_kwargs: Default kwargs to pass to generate()
+            gpu_only: If True, restrict model to GPU only (no CPU/disk offloading).
+                Will raise an error if model doesn't fit in available GPU memory.
+            load_kwargs: Additional kwargs to pass to AutoModelForCausalLM.from_pretrained()
+            custom_results_dir: Optional custom directory for results
+                (unused, kept for compatibility)
+            model_path: Optional local path to pre-downloaded model. If provided, loads from
+                this path instead of downloading from HuggingFace Hub.
+        """
+        if not model_name or not isinstance(model_name, str) or model_name.strip() == "":
+            raise ValueError(NO_MODEL_NAME_PROVIDED)
+
+        self.model_name = model_name
+        self.model_path = model_path
+        self.generate_kwargs = generate_kwargs
+        self.gpu_only = gpu_only
+        self.load_kwargs = load_kwargs or {}
+        self.custom_results_dir = custom_results_dir
+
+        self.model = None
+        self.tokenizer = None
+        self.device = None
+        self.last_generation_metadata = None
+
+        if auto_loading:
+            self.load_model()
+
+    def __del__(self):
+        """
+        Unload model and tokenizer to free up resources.
+        """
+        if self.model is not None or self.tokenizer is not None:
+            self.unload_model()
+
+    def load_model(self):
+        """
+        Load the model and tokenizer from the specified location.
+
+        If model_path is provided, loads from that local path.
+        Otherwise, downloads from HuggingFace Hub.
+
+        Returns
+        -------
+        self
+            Returns self for method chaining
+
+        Raises
+        ------
+        RuntimeError
+            If gpu_only=True but CUDA is not available or model doesn't fit on GPU
+        """
+        if self.model is not None:
+            print(MODEL_RELOAD_WARNING.format(self.model_name))
+        if self.tokenizer is not None:
+            print(WARNING_TOKENIZER_ALREADY_LOADED_RELOAD.format(self.model_name))
+
+        # Configure device_map based on gpu_only flag
+        if self.gpu_only:
+            if not torch.cuda.is_available():
+                raise RuntimeError(
+                    "gpu_only=True but CUDA is not available. Cannot load model without GPU."
+                )
+            device_map = "auto"
+            print("Loading model with gpu_only=True (device_map='auto', multi-GPU enabled)")
+        else:
+            device_map = "auto"
+
+        # Determine the source (local path or HuggingFace model ID)
+        model_source = self.model_path if self.model_path else self.model_name
+
+        if self.model_path:
+            print(f"Loading model from local path: {self.model_path}")
+        else:
+            print(f"Loading model from HuggingFace Hub: {self.model_name}")
+
+        # Configure kwargs based on whether we have a local path
+        load_kwargs = {**self.load_kwargs}
+
+        if self.model_path:
+            # Local path - need trust_remote_code for custom model architectures
+            load_kwargs["trust_remote_code"] = True
+
+        # Load model and tokenizer
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_source,
+            device_map=device_map,
+            **load_kwargs,
+        )
+
+        # Tokenizer loaded WITHOUT trust_remote_code to avoid config dict/object issues
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            model_source,
+        )
+
+        # Get the device for input tensors
+        if hasattr(self.model, "hf_device_map"):
+            # Model is split across devices - get the device of the first module
+            first_device = next(iter(self.model.hf_device_map.values()))
+            self.device = torch.device(first_device)
+
+            # If gpu_only, verify no layers were offloaded to CPU/disk
+            if self.gpu_only:
+                offloaded_devices = set(self.model.hf_device_map.values())
+                non_gpu_devices = [d for d in offloaded_devices if str(d) == "cpu"]
+                if non_gpu_devices:
+                    raise RuntimeError(
+                        f"gpu_only=True but model has layers offloaded to: {non_gpu_devices}. "
+                        f"The model is too large for available GPU memory."
+                    )
+        else:
+            # Model is on a single device
+            self.device = self.model.device
+
+        print(f"Model loaded successfully on device: {self.device}")
+        return self
+
+    def unload_model(self):
+        """
+        Aggressively unload the model and tokenizer to free up GPU/CPU memory.
+        """
+        try:
+            if self.model is not None:
+                try:
+                    self.model.cpu()
+                except Exception:
+                    pass
+                try:
+                    if hasattr(self.model, "state_dict"):
+                        sd = self.model.state_dict()
+                        for k in list(sd.keys()):
+                            sd.pop(k)
+                        del sd
+                except Exception:
+                    pass
+                del self.model
+                self.model = None
+        except Exception:
+            pass
+
+        try:
+            if self.tokenizer is not None:
+                try:
+                    if hasattr(self.tokenizer, "backend_tokenizer"):
+                        self.tokenizer.backend_tokenizer = None
+                except Exception:
+                    pass
+                del self.tokenizer
+                self.tokenizer = None
+        except Exception:
+            pass
+
+        # Force cleanup
+        torch.cuda.empty_cache()
+        gc.collect()
+        torch.cuda.empty_cache()
+
+    def _get_model_memory_gb(self) -> float:
+        """
+        Get the model's memory footprint in GB.
+        """
+        if self.model is None:
+            return 0.0
+
+        try:
+            param_size = sum(p.numel() * p.element_size() for p in self.model.parameters())
+            buffer_size = sum(b.numel() * b.element_size() for b in self.model.buffers())
+            total_bytes = param_size + buffer_size
+            return round(total_bytes / (1024**3), 3)
+        except Exception:
+            return 0.0
+
+    def generate(
+        self,
+        prompt: str,
+        system_prompt: Optional[str] = None,
+        schema: Optional[Type[BaseModel]] = None,
+        **kwargs,
+    ) -> str:
+        """
+        Generate a response from the model.
+
+        When a schema is provided, uses LM Format Enforcer to guarantee schema compliance
+        through constrained decoding. When no schema is provided, behaves like standard
+        HuggingFace generation.
+
+        Args:
+            prompt: The user prompt
+            system_prompt: Optional system prompt
+            schema: Optional Pydantic BaseModel for structured output with guaranteed compliance
+            **kwargs: Additional generation parameters (e.g., max_new_tokens, temperature)
+
+        Returns:
+            str if no schema provided, dict if schema provided (guaranteed to match schema)
+
+        Raises:
+            RuntimeError: If model or tokenizer is not loaded
+            json.JSONDecodeError: If schema is provided but output is not valid JSON
+        """
+        # Check model and tokenizer
+        if self.model is None or self.tokenizer is None:
+            raise RuntimeError(HUGGINGFACE_MODEL_NOT_LOADED)
+
+        # Merge generate_kwargs
+        if self.generate_kwargs:
+            kwargs = {**self.generate_kwargs, **kwargs}
+
+        # Build prefix function for constrained decoding if schema is provided
+        prefix_function = None
+        if schema:
+            json_schema = schema.model_json_schema()
+
+            # Create parser and build prefix function for constrained decoding
+            parser = JsonSchemaParser(json_schema)
+            prefix_function = build_transformers_prefix_allowed_tokens_fn(self.tokenizer, parser)
+
+            # Add schema instruction to prompt to help the model understand the task
+            schema_instruction = (
+                f"\n\nYou must respond with valid JSON matching this schema:\n"
+                f"```json\n{json.dumps(json_schema, indent=2)}\n```\n"
+                f"Only return the JSON object, nothing else."
+            )
+            prompt = prompt + schema_instruction
+
+        # Format input with chat template if available
+        if hasattr(self.tokenizer, "chat_template") and self.tokenizer.chat_template is not None:
+            messages = (
+                [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": prompt},
+                ]
+                if system_prompt
+                else [
+                    {"role": "user", "content": prompt},
+                ]
+            )
+            inputs = self.tokenizer.apply_chat_template(
+                messages, add_generation_prompt=True, return_dict=True, return_tensors="pt"
+            )
+        else:
+            # Fallback to simple concatenation
+            messages = f"{system_prompt}\n\n{prompt}" if system_prompt else prompt
+            inputs = self.tokenizer(messages, return_tensors="pt")
+
+        # Move inputs to the model's device
+        inputs = {k: v.to(self.device) for k, v in inputs.items()}
+
+        # Capture metrics
+        input_tokens = inputs["input_ids"].shape[1]
+        model_memory_gb = self._get_model_memory_gb()
+        start_time = time.time()
+
+        # Set default max_new_tokens
+        kwargs.setdefault("max_new_tokens", 2048)
+
+        # Generate response with optional constrained decoding
+        generation_kwargs = {
+            **inputs,
+            "pad_token_id": self.tokenizer.eos_token_id,
+            "eos_token_id": self.tokenizer.eos_token_id,
+            **kwargs,
+        }
+
+        if prefix_function is not None:
+            generation_kwargs["prefix_allowed_tokens_fn"] = prefix_function
+
+        output_ids = self.model.generate(**generation_kwargs)
+
+        end_time = time.time()
+        generation_time = end_time - start_time
+
+        # Decode only the newly generated content
+        completion = self.tokenizer.decode(
+            output_ids[0][inputs["input_ids"].shape[1] :],
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=True,
+        ).strip()
+
+        # Calculate output tokens
+        output_tokens = output_ids.shape[1] - input_tokens
+
+        # Store metrics
+        self.last_generation_metadata = {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "generation_time_seconds": round(generation_time, 3),
+            "model_memory_gb": model_memory_gb,
+            "constrained_decoding": schema is not None,
+        }
+
+        # If schema was provided, parse and validate the JSON response
+        if schema:
+            response_dict = json.loads(completion)
+            validate_llm_response(response_dict, schema)
+            return response_dict
+
+        return completion
+
+    def generate_batch(
+        self,
+        prompts: List[str],
+        system_prompt: Optional[str] = None,
+        schema: Optional[Type[BaseModel]] = None,
+        **kwargs: Any,
+    ) -> List[Any]:
+        """
+        Batch processing is not implemented for LMFormatEnforcerLLM.
+
+        Constrained decoding with LM Format Enforcer is currently designed for
+        single-sequence generation. Use generate() in a loop for multiple prompts.
+        """
+        raise NotImplementedError(
+            "generate_batch is not implemented for LMFormatEnforcerLLM. "
+            "Please use generate() in a loop for multiple prompts."
+        )

--- a/tests/sdk/models/providers/test_lmformatenforcer.py
+++ b/tests/sdk/models/providers/test_lmformatenforcer.py
@@ -1,0 +1,663 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("transformers")
+pytest.importorskip("lmformatenforcer")
+
+import torch
+from pydantic import BaseModel
+
+from rhesis.sdk.errors import (
+    HUGGINGFACE_MODEL_NOT_LOADED,
+    MODEL_RELOAD_WARNING,
+    NO_MODEL_NAME_PROVIDED,
+    WARNING_TOKENIZER_ALREADY_LOADED_RELOAD,
+)
+from rhesis.sdk.models import LMFormatEnforcerLLM
+
+
+class TestLMFormatEnforcerLLM:
+    def test_init_without_auto_loading_and_no_defaults(self):
+        """Should initialize without auto-loading and no defaults"""
+        model_name = "provider/model"
+        llm = LMFormatEnforcerLLM(model_name, auto_loading=False)
+
+        assert llm.model_name == model_name
+        assert llm.model is None
+        assert llm.tokenizer is None
+        assert llm.device is None
+        assert llm.generate_kwargs is None
+
+    def test_init_without_auto_loading_and_with_defaults(self):
+        """Should initialize without auto-loading and with defaults"""
+        model_name = "provider/model"
+        generate_kwargs = {"temperature": 0.7}
+
+        llm = LMFormatEnforcerLLM(model_name, auto_loading=False, generate_kwargs=generate_kwargs)
+
+        assert llm.model_name == model_name
+        assert llm.model is None
+        assert llm.tokenizer is None
+        assert llm.device is None
+        assert llm.generate_kwargs is generate_kwargs
+
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.torch.device")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoTokenizer")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoModelForCausalLM")
+    def test_init_with_auto_loading_and_no_defaults(
+        self, mock_auto_model, mock_auto_tokenizer, mock_torch_device
+    ):
+        """Should auto-load model when auto_loading=True and no defaults"""
+        mock_model = Mock(spec=["device", "generate", "parameters", "buffers"])
+        mock_model.device = torch.device("cpu")
+        mock_tokenizer = Mock()
+        mock_device = Mock()
+
+        mock_auto_model.from_pretrained.return_value = mock_model
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+        mock_torch_device.return_value = mock_device
+
+        model_name = "provider/model"
+        llm = LMFormatEnforcerLLM(model_name, auto_loading=True)
+
+        assert llm.model_name == model_name
+        assert llm.model is mock_model
+        assert llm.tokenizer is mock_tokenizer
+        assert llm.device == mock_model.device
+        assert llm.generate_kwargs is None
+        mock_auto_model.from_pretrained.assert_called_once_with(model_name, device_map="auto")
+        mock_auto_tokenizer.from_pretrained.assert_called_once_with(model_name)
+
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.torch.device")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoTokenizer")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoModelForCausalLM")
+    def test_init_with_auto_loading_and_with_defaults(
+        self, mock_auto_model, mock_auto_tokenizer, mock_torch_device
+    ):
+        """Should auto-load model when auto_loading=True and defaults provided"""
+        mock_model = Mock(spec=["device", "generate", "parameters", "buffers"])
+        mock_model.device = torch.device("cpu")
+        mock_tokenizer = Mock()
+        mock_device = Mock()
+
+        mock_auto_model.from_pretrained.return_value = mock_model
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+        mock_torch_device.return_value = mock_device
+
+        model_name = "provider/model"
+        generate_kwargs = {"temperature": 0.7}
+        llm = LMFormatEnforcerLLM(model_name, auto_loading=True, generate_kwargs=generate_kwargs)
+
+        assert llm.model_name == model_name
+        assert llm.model is mock_model
+        assert llm.tokenizer is mock_tokenizer
+        assert llm.device == mock_model.device
+        assert llm.generate_kwargs is generate_kwargs
+        mock_auto_model.from_pretrained.assert_called_once_with(model_name, device_map="auto")
+        mock_auto_tokenizer.from_pretrained.assert_called_once_with(model_name)
+
+    def test_init_raises_with_no_model_name(self):
+        """Should raise ValueError if model_name is None"""
+        with pytest.raises(ValueError) as excinfo:
+            LMFormatEnforcerLLM(None)
+        assert str(excinfo.value) == NO_MODEL_NAME_PROVIDED
+
+    def test_init_raises_with_empty_string(self):
+        """Should raise ValueError if model_name is empty string"""
+        with pytest.raises(ValueError) as excinfo:
+            LMFormatEnforcerLLM("")
+        assert str(excinfo.value) == NO_MODEL_NAME_PROVIDED
+
+    def setup_model_with_mocks(self, has_chat_template=True):
+        """Helper to create a LMFormatEnforcerLLM with mocked model + tokenizer"""
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        llm.device = torch.device("cpu")
+
+        # Mock tokenizer
+        mock_tokenizer = Mock()
+        mock_tokenizer.chat_template = "template" if has_chat_template else None
+        mock_tokenizer.eos_token_id = 42
+        mock_tokenizer.decode.return_value = "Generated response"
+
+        # Create actual dict with tensors
+        inputs = {
+            "input_ids": torch.tensor([[1, 995, 460, 10032, 13, 13, 22467, 528, 264, 13015]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]),
+        }
+
+        if has_chat_template:
+            mock_tokenizer.apply_chat_template.return_value = inputs
+        else:
+            mock_tokenizer.return_value = inputs
+
+        # Mock model
+        mock_model = Mock()
+        output_tensor = torch.tensor([[101, 102, 103, 104, 105]])
+        mock_model.generate.return_value = output_tensor
+
+        llm.tokenizer = mock_tokenizer
+        llm.model = mock_model
+
+        return llm, mock_model, mock_tokenizer
+
+    def test_generate_without_chat_template(self):
+        """Should generate when tokenizer has no chat_template"""
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks(has_chat_template=False)
+        result = llm.generate("Hello, world!")
+        assert result == "Generated response"
+        mock_tokenizer.assert_called_once_with("Hello, world!", return_tensors="pt")
+        mock_model.generate.assert_called_once()
+        mock_tokenizer.decode.assert_called_once()
+
+    def test_generate_with_chat_template_and_system_prompt(self):
+        """Should use apply_chat_template when chat_template is available and system_prompt given"""
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks(has_chat_template=True)
+        result = llm.generate("Hello?", system_prompt="You are a helpful assistant.")
+        assert result == "Generated response"
+        mock_tokenizer.apply_chat_template.assert_called_once()
+        mock_model.generate.assert_called_once()
+        mock_tokenizer.decode.assert_called_once()
+
+    def test_generate_with_chat_template_no_system_prompt(self):
+        """Should use apply_chat_template when chat_template is available and no system_prompt given"""
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks(has_chat_template=True)
+        result = llm.generate("Hello?")
+        assert result == "Generated response"
+        mock_tokenizer.apply_chat_template.assert_called_once()
+        mock_model.generate.assert_called_once()
+        mock_tokenizer.decode.assert_called_once()
+
+    def test_generate_with_system_prompt_no_chat_template(self):
+        """Should prepend system_prompt when chat_template is missing"""
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks(has_chat_template=False)
+        prompt = "Hello?"
+        system_prompt = "You are helpful."
+        result = llm.generate(prompt, system_prompt=system_prompt)
+        assert result == "Generated response"
+        expected_input = f"{system_prompt}\n\n{prompt}"
+        mock_tokenizer.assert_called_once_with(expected_input, return_tensors="pt")
+
+    def test_generate_merges_generate_kwargs(self):
+        """Should merge generate_kwargs with passed kwargs, allowing override"""
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks()
+        llm.generate_kwargs = {"temperature": 0.7, "max_new_tokens": 10}
+        result = llm.generate("Test prompt", max_new_tokens=20)
+        assert result == "Generated response"
+        _, kwargs = mock_model.generate.call_args
+        assert kwargs["temperature"] == 0.7
+        assert kwargs["max_new_tokens"] == 20
+
+    def test_generate_respects_only_generate_kwargs(self):
+        """Should pass only generate_kwargs if no kwargs given"""
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks()
+        llm.generate_kwargs = {"top_p": 0.9}
+        result = llm.generate("Test prompt")
+        assert result == "Generated response"
+        _, kwargs = mock_model.generate.call_args
+        assert kwargs["top_p"] == 0.9
+
+    def test_generate_without_generate_kwargs(self):
+        """Should work when generate_kwargs is None and no kwargs provided"""
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks()
+        llm.generate_kwargs = None
+        result = llm.generate("Just a plain test")
+        assert result == "Generated response"
+        mock_model.generate.assert_called_once()
+
+    def test_generate_returns_stripped_output(self):
+        """Should strip whitespace from decoded text"""
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks()
+        mock_tokenizer.decode.return_value = "   padded text   "
+        result = llm.generate("Strip test")
+        assert result == "padded text"
+
+    # Tests for model_path functionality
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoTokenizer")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoModelForCausalLM")
+    def test_load_model_with_model_path(self, mock_auto_model, mock_auto_tokenizer):
+        """Should load model from local path when model_path is provided"""
+        mock_model = Mock(spec=["device", "generate", "parameters", "buffers"])
+        mock_model.device = torch.device("cpu")
+        mock_tokenizer = Mock()
+
+        mock_auto_model.from_pretrained.return_value = mock_model
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+
+        llm = LMFormatEnforcerLLM(
+            "provider/model", auto_loading=False, model_path="/local/path/to/model"
+        )
+        llm.load_model()
+
+        # Should use model_path instead of model_name
+        mock_auto_model.from_pretrained.assert_called_once()
+        call_args = mock_auto_model.from_pretrained.call_args
+        assert call_args[0][0] == "/local/path/to/model"
+        assert call_args[1]["device_map"] == "auto"
+        assert call_args[1]["trust_remote_code"] is True
+
+        # Tokenizer should also use model_path
+        mock_auto_tokenizer.from_pretrained.assert_called_once_with("/local/path/to/model")
+
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoTokenizer")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoModelForCausalLM")
+    def test_load_model_without_model_path(self, mock_auto_model, mock_auto_tokenizer):
+        """Should load model from HuggingFace Hub when model_path is not provided"""
+        mock_model = Mock(spec=["device", "generate", "parameters", "buffers"])
+        mock_model.device = torch.device("cpu")
+        mock_tokenizer = Mock()
+
+        mock_auto_model.from_pretrained.return_value = mock_model
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        llm.load_model()
+
+        # Should use model_name
+        mock_auto_model.from_pretrained.assert_called_once()
+        call_args = mock_auto_model.from_pretrained.call_args
+        assert call_args[0][0] == "provider/model"
+        assert (
+            "trust_remote_code" not in call_args[1]
+            or call_args[1].get("trust_remote_code") is not True
+        )
+
+    # Tests for gpu_only functionality
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.torch.cuda.is_available")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoTokenizer")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoModelForCausalLM")
+    def test_load_model_gpu_only_without_cuda(
+        self, mock_auto_model, mock_auto_tokenizer, mock_cuda_available
+    ):
+        """Should raise RuntimeError when gpu_only=True but CUDA is not available"""
+        mock_cuda_available.return_value = False
+
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False, gpu_only=True)
+        with pytest.raises(RuntimeError, match="gpu_only=True but CUDA is not available"):
+            llm.load_model()
+
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.torch.cuda.is_available")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoTokenizer")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoModelForCausalLM")
+    def test_load_model_gpu_only_with_cuda(
+        self, mock_auto_model, mock_auto_tokenizer, mock_cuda_available
+    ):
+        """Should load model with gpu_only=True when CUDA is available"""
+        mock_cuda_available.return_value = True
+        mock_model = Mock(spec=["device", "generate", "parameters", "buffers", "hf_device_map"])
+        mock_model.device = torch.device("cuda:0")
+        mock_model.hf_device_map = {"layer1": "cuda:0", "layer2": "cuda:0"}
+        mock_tokenizer = Mock()
+
+        mock_auto_model.from_pretrained.return_value = mock_model
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False, gpu_only=True)
+        llm.load_model()
+
+        call_args = mock_auto_model.from_pretrained.call_args
+        assert call_args[1]["device_map"] == "auto"
+
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.torch.cuda.is_available")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoTokenizer")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoModelForCausalLM")
+    def test_load_model_gpu_only_with_cpu_offload(
+        self, mock_auto_model, mock_auto_tokenizer, mock_cuda_available
+    ):
+        """Should raise RuntimeError when gpu_only=True but model is offloaded to CPU"""
+        mock_cuda_available.return_value = True
+        mock_model = Mock(spec=["device", "generate", "parameters", "buffers", "hf_device_map"])
+        mock_model.device = torch.device("cuda:0")
+        # Simulate CPU offloading
+        mock_model.hf_device_map = {"layer1": "cuda:0", "layer2": "cpu"}
+        mock_tokenizer = Mock()
+
+        mock_auto_model.from_pretrained.return_value = mock_model
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False, gpu_only=True)
+        with pytest.raises(RuntimeError, match="gpu_only=True but model has layers offloaded to"):
+            llm.load_model()
+
+    # Tests for hf_device_map handling (multi-device models)
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.torch.device")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoTokenizer")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoModelForCausalLM")
+    def test_load_model_with_hf_device_map(
+        self, mock_auto_model, mock_auto_tokenizer, mock_torch_device
+    ):
+        """Should handle multi-device models with hf_device_map"""
+        mock_model = Mock(spec=["device", "generate", "parameters", "buffers", "hf_device_map"])
+        mock_model.device = torch.device("cuda:0")
+        mock_model.hf_device_map = {"layer1": "cuda:0", "layer2": "cuda:1"}
+        mock_tokenizer = Mock()
+        mock_device = torch.device("cuda:0")
+
+        mock_auto_model.from_pretrained.return_value = mock_model
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+        mock_torch_device.return_value = mock_device
+
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        llm.load_model()
+
+        # Should use device from first layer in hf_device_map
+        assert llm.device == mock_device
+
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.torch.device")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoTokenizer")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoModelForCausalLM")
+    def test_load_model_without_hf_device_map(
+        self, mock_auto_model, mock_auto_tokenizer, mock_torch_device
+    ):
+        """Should use model.device when hf_device_map is not present"""
+        mock_model = Mock(spec=["device", "generate", "parameters", "buffers"])
+        mock_model.device = torch.device("cpu")
+        mock_tokenizer = Mock()
+
+        mock_auto_model.from_pretrained.return_value = mock_model
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        llm.load_model()
+
+        # Should use model.device directly
+        assert llm.device == mock_model.device
+
+    # Tests for load_kwargs
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoTokenizer")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoModelForCausalLM")
+    def test_load_model_with_load_kwargs(self, mock_auto_model, mock_auto_tokenizer):
+        """Should pass load_kwargs to from_pretrained"""
+        mock_model = Mock(spec=["device", "generate", "parameters", "buffers"])
+        mock_model.device = torch.device("cpu")
+        mock_tokenizer = Mock()
+
+        mock_auto_model.from_pretrained.return_value = mock_model
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+
+        load_kwargs = {"torch_dtype": torch.float16, "low_cpu_mem_usage": True}
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False, load_kwargs=load_kwargs)
+        llm.load_model()
+
+        call_args = mock_auto_model.from_pretrained.call_args
+        assert call_args[1]["torch_dtype"] == torch.float16
+        assert call_args[1]["low_cpu_mem_usage"] is True
+        assert call_args[1]["device_map"] == "auto"
+
+    # Tests for reload warnings
+    @patch("builtins.print")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoTokenizer")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoModelForCausalLM")
+    def test_load_model_warns_on_model_reload(
+        self, mock_auto_model, mock_auto_tokenizer, mock_print
+    ):
+        """Should warn when reloading an already loaded model"""
+        mock_model = Mock(spec=["device", "generate", "parameters", "buffers"])
+        mock_model.device = torch.device("cpu")
+        mock_tokenizer = Mock()
+
+        mock_auto_model.from_pretrained.return_value = mock_model
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        llm.model = Mock()  # Simulate already loaded model
+        llm.load_model()
+
+        mock_print.assert_any_call(MODEL_RELOAD_WARNING.format("provider/model"))
+
+    @patch("builtins.print")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoTokenizer")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.AutoModelForCausalLM")
+    def test_load_model_warns_on_tokenizer_reload(
+        self, mock_auto_model, mock_auto_tokenizer, mock_print
+    ):
+        """Should warn when reloading an already loaded tokenizer"""
+        mock_model = Mock(spec=["device", "generate", "parameters", "buffers"])
+        mock_model.device = torch.device("cpu")
+        mock_tokenizer = Mock()
+
+        mock_auto_model.from_pretrained.return_value = mock_model
+        mock_auto_tokenizer.from_pretrained.return_value = mock_tokenizer
+
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        llm.tokenizer = Mock()  # Simulate already loaded tokenizer
+        llm.load_model()
+
+        mock_print.assert_any_call(WARNING_TOKENIZER_ALREADY_LOADED_RELOAD.format("provider/model"))
+
+    # Tests for memory calculation
+    def test_get_model_memory_gb_without_model(self):
+        """Should return 0.0 when model is not loaded"""
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        assert llm._get_model_memory_gb() == 0.0
+
+    def test_get_model_memory_gb_with_model(self):
+        """Should calculate memory footprint when model is loaded"""
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+
+        # Create tensors large enough to result in non-zero GB
+        num_elements = (10 * 1024 * 1024) // 4  # 10MB / 4 bytes per float32
+        param1 = torch.randn(num_elements // 2)  # ~5MB
+        param2 = torch.randn(num_elements // 2)  # ~5MB
+        buffer1 = torch.randn(1000)  # Small buffer
+
+        # Create a mock model that returns these tensors
+        mock_model = Mock()
+        mock_model.parameters.return_value = [param1, param2]
+        mock_model.buffers.return_value = [buffer1]
+
+        llm.model = mock_model
+
+        memory_gb = llm._get_model_memory_gb()
+        assert memory_gb > 0
+        assert isinstance(memory_gb, float)
+        assert memory_gb >= 0.010
+
+    def test_get_model_memory_gb_handles_exception(self):
+        """Should return 0.0 when memory calculation fails"""
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        mock_model = Mock()
+        mock_model.parameters.side_effect = Exception("Error calculating memory")
+        llm.model = mock_model
+
+        assert llm._get_model_memory_gb() == 0.0
+
+    # Tests for constrained schema support (LMFormatEnforcer-specific)
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.JsonSchemaParser")
+    @patch(
+        "rhesis.sdk.models.providers.lmformatenforcer.build_transformers_prefix_allowed_tokens_fn"
+    )
+    def test_generate_with_schema_uses_constrained_decoding(self, mock_build_fn, mock_json_parser):
+        """Should use constrained decoding when schema is provided"""
+
+        class TestSchema(BaseModel):
+            name: str
+            age: int
+
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks()
+        # Mock decode to return valid JSON matching schema
+        mock_tokenizer.decode.return_value = '{"name": "John", "age": 30}'
+
+        # Mock the constrained decoding components
+        mock_parser_instance = Mock()
+        mock_json_parser.return_value = mock_parser_instance
+        mock_prefix_fn = Mock()
+        mock_build_fn.return_value = mock_prefix_fn
+
+        result = llm.generate("Generate person data", schema=TestSchema)
+
+        assert isinstance(result, dict)
+        assert result["name"] == "John"
+        assert result["age"] == 30
+
+        # Verify JsonSchemaParser was created with the schema
+        mock_json_parser.assert_called_once()
+        # Verify constrained decoding function was built
+        mock_build_fn.assert_called_once()
+        # Verify prefix_allowed_tokens_fn was passed to generate
+        _, kwargs = mock_model.generate.call_args
+        assert "prefix_allowed_tokens_fn" in kwargs
+
+    def test_generate_with_schema_guarantees_valid_json(self):
+        """Should always return valid JSON matching the schema (guaranteed by library)"""
+
+        class TestSchema(BaseModel):
+            name: str
+            age: int
+
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks()
+        # The library guarantees valid JSON, so we mock that behavior
+        mock_tokenizer.decode.return_value = '{"name": "Alice", "age": 25}'
+
+        result = llm.generate("Generate person data", schema=TestSchema)
+
+        # Should successfully parse and validate
+        assert isinstance(result, dict)
+        assert "name" in result
+        assert "age" in result
+        assert isinstance(result["name"], str)
+        assert isinstance(result["age"], int)
+
+    def test_generate_without_schema_no_constrained_decoding(self):
+        """Should not use constrained decoding when no schema is provided"""
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks()
+
+        result = llm.generate("Generate text")
+
+        # Verify no constrained decoding was used
+        _, kwargs = mock_model.generate.call_args
+        assert "prefix_allowed_tokens_fn" not in kwargs
+        assert result == "Generated response"
+
+    # Tests for metadata tracking
+    def test_generate_stores_metadata(self):
+        """Should store generation metadata in last_generation_metadata"""
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks()
+
+        # Setup mocks to return predictable values
+        input_tensor = torch.tensor([[1, 2, 3, 4, 5]])
+        output_tensor = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]])  # 3 more tokens than input
+
+        mock_tokenizer.apply_chat_template.return_value = {
+            "input_ids": input_tensor,
+            "attention_mask": torch.tensor([[1, 1, 1, 1, 1]]),
+        }
+        mock_model.generate.return_value = output_tensor
+
+        llm.generate("Test prompt")
+
+        assert llm.last_generation_metadata is not None
+        assert "input_tokens" in llm.last_generation_metadata
+        assert "output_tokens" in llm.last_generation_metadata
+        assert "generation_time_seconds" in llm.last_generation_metadata
+        assert "model_memory_gb" in llm.last_generation_metadata
+        assert llm.last_generation_metadata["input_tokens"] == 5
+        assert llm.last_generation_metadata["output_tokens"] == 3
+
+    def test_generate_sets_default_max_new_tokens(self):
+        """Should set default max_new_tokens to 2048 if not provided"""
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks()
+        llm.generate("Test prompt")
+
+        call_args = mock_model.generate.call_args
+        assert call_args[1]["max_new_tokens"] == 2048
+
+    def test_generate_respects_custom_max_new_tokens(self):
+        """Should use custom max_new_tokens when provided"""
+        llm, mock_model, mock_tokenizer = self.setup_model_with_mocks()
+        llm.generate("Test prompt", max_new_tokens=100)
+
+        call_args = mock_model.generate.call_args
+        assert call_args[1]["max_new_tokens"] == 100
+
+    # Tests for error handling
+    def test_generate_raises_when_model_not_loaded(self):
+        """Should raise RuntimeError when model is not loaded"""
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            llm.generate("Test prompt")
+        assert str(exc_info.value) == HUGGINGFACE_MODEL_NOT_LOADED
+
+    def test_generate_raises_when_tokenizer_not_loaded(self):
+        """Should raise RuntimeError when tokenizer is not loaded"""
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        llm.model = Mock()  # Model loaded but tokenizer not
+
+        with pytest.raises(RuntimeError) as exc_info:
+            llm.generate("Test prompt")
+        assert str(exc_info.value) == HUGGINGFACE_MODEL_NOT_LOADED
+
+    # Tests for unload_model
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.torch.cuda.empty_cache")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.gc.collect")
+    def test_unload_model(self, mock_gc_collect, mock_empty_cache):
+        """Should unload model and tokenizer and free memory"""
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        llm.model = Mock()
+        llm.tokenizer = Mock()
+
+        initial_empty_cache_count = mock_empty_cache.call_count
+        initial_gc_count = mock_gc_collect.call_count
+
+        llm.unload_model()
+
+        assert llm.model is None
+        assert llm.tokenizer is None
+        # Should attempt to free GPU cache (even if no GPU) - called twice in unload_model
+        assert mock_empty_cache.call_count >= initial_empty_cache_count + 2
+        # Should call gc.collect at least once
+        assert mock_gc_collect.call_count >= initial_gc_count + 1
+
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.torch.cuda.empty_cache")
+    @patch("rhesis.sdk.models.providers.lmformatenforcer.gc.collect")
+    def test_unload_model_handles_exceptions(self, mock_gc_collect, mock_empty_cache):
+        """Should handle exceptions during unload gracefully"""
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        mock_model = Mock()
+        mock_model.cpu.side_effect = Exception("Error moving to CPU")
+        llm.model = mock_model
+        llm.tokenizer = Mock()
+
+        # Should not raise exception
+        llm.unload_model()
+
+        # Should still attempt cleanup
+        assert mock_empty_cache.call_count == 2
+        mock_gc_collect.assert_called_once()
+
+    def test_unload_model_with_state_dict(self):
+        """Should clear state_dict when unloading model"""
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        mock_model = Mock()
+        mock_state_dict = {"layer1": Mock(), "layer2": Mock()}
+        mock_model.state_dict.return_value = mock_state_dict
+        llm.model = mock_model
+
+        llm.unload_model()
+
+        assert llm.model is None
+        # Verify state_dict was accessed
+        mock_model.state_dict.assert_called_once()
+
+    # Tests for custom_results_dir
+    def test_init_with_custom_results_dir(self):
+        """Should store custom_results_dir when provided"""
+        llm = LMFormatEnforcerLLM(
+            "provider/model", auto_loading=False, custom_results_dir="/custom/path"
+        )
+        assert llm.custom_results_dir == "/custom/path"
+
+    def test_init_without_custom_results_dir(self):
+        """Should set custom_results_dir to None when not provided"""
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+        assert llm.custom_results_dir is None
+
+    # Tests for generate_batch (not implemented)
+    def test_generate_batch_raises_not_implemented(self):
+        """Should raise NotImplementedError for batch generation"""
+        llm = LMFormatEnforcerLLM("provider/model", auto_loading=False)
+
+        with pytest.raises(NotImplementedError):
+            llm.generate_batch(["prompt1", "prompt2"])


### PR DESCRIPTION
This helps us combat the problem of small local models not adhering to given JSON schemas by forcing generation inside the schema

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: introduces a new LLM provider (plus optional dependency) with custom generation constraints and adds a backend migration to extend provider types; issues would primarily impact model selection/SDK users and DB lookups.
> 
> **Overview**
> Adds a new `lmformatenforcer` model provider to support *schema-constrained decoding* (guaranteed JSON schema compliance) for local HuggingFace models.
> 
> This includes a backend Alembic migration adding `lmformatenforcer` to `ProviderType`, frontend provider config updates (supported/local providers, endpoint requirements, icon mapping), and SDK support: new `LMFormatEnforcerLLM` provider implementation, factory/exports wiring (defaults + registry), and `lm-format-enforcer` added to the `huggingface`/`all` extras.
> 
> Comprehensive tests cover initialization/loading options (`model_path`, `gpu_only`, `load_kwargs`), constrained decoding behavior when `schema` is provided, metadata capture, and unload/error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9731031a776363bd2867481b05f64c8470f55bd2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->