### PR TITLE
Fix Garak import: remove metric prefix and improve UX

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/5d7e4f2a3b1c_add_garak_metrics_to_existing_orgs.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/5d7e4f2a3b1c_add_garak_metrics_to_existing_orgs.py
@@ -8,18 +8,18 @@ The Garak metrics use the new 'garak' backend type and 'GarakDetectorMetric' cla
 to integrate with Garak's vulnerability detection framework.
 
 Added metrics:
-- Garak: Mitigation Bypass
-- Garak: Continuation Detection
-- Garak: Misleading Claims
-- Garak: LMRC Risk
-- Garak: Toxicity Detection
-- Garak: Malware Generation
-- Garak: Package Hallucination
-- Garak: Known Bad Signatures
-- Garak: XSS Detection
-- Garak: Snowball Detection
-- Garak: Do Not Answer Detection
-- Garak: Leak Replay Detection
+- Mitigation Bypass
+- Continuation Detection
+- Misleading Claims
+- LMRC Risk
+- Toxicity Detection
+- Malware Generation
+- Package Hallucination
+- Known Bad Signatures
+- XSS Detection
+- Snowball Detection
+- Do Not Answer Detection
+- Leak Replay Detection
 
 Revision ID: 5d7e4f2a3b1c
 Revises: 3f8a2b9c1d4e
@@ -45,18 +45,18 @@ depends_on: Union[str, Sequence[str], None] = None
 
 # List of Garak metric names added in this migration
 GARAK_METRIC_NAMES = [
-    "Garak: Mitigation Bypass",
-    "Garak: Continuation Detection",
-    "Garak: Misleading Claims",
-    "Garak: LMRC Risk",
-    "Garak: Toxicity Detection",
-    "Garak: Malware Generation",
-    "Garak: Package Hallucination",
-    "Garak: Known Bad Signatures",
-    "Garak: XSS Detection",
-    "Garak: Snowball Detection",
-    "Garak: Do Not Answer Detection",
-    "Garak: Leak Replay Detection",
+    "Mitigation Bypass",
+    "Continuation Detection",
+    "Misleading Claims",
+    "LMRC Risk",
+    "Toxicity Detection",
+    "Malware Generation",
+    "Package Hallucination",
+    "Known Bad Signatures",
+    "XSS Detection",
+    "Snowball Detection",
+    "Do Not Answer Detection",
+    "Leak Replay Detection",
 ]
 
 

--- a/apps/backend/src/rhesis/backend/app/services/garak/importer.py
+++ b/apps/backend/src/rhesis/backend/app/services/garak/importer.py
@@ -272,7 +272,7 @@ class GarakImporter:
 
         # Check if this specific detector metric already exists
         # Use naming convention to identify Garak metrics
-        metric_name = f"Garak: {detector_class.split('.')[-1]}"
+        metric_name = detector_class.split(".")[-1]
 
         existing_metric = (
             self.db.query(Metric)
@@ -329,7 +329,7 @@ class GarakImporter:
         # - threshold=0.5 with operator "<" means passing when score < 0.5
         metric_data = schemas.MetricCreate(
             name=metric_name,
-            description=f"Garak detector: {detector_class}",
+            description=f"Garak detector for {metric_name}. {detector_class}",
             evaluation_prompt=detector_class,  # Store detector class in evaluation_prompt
             evaluation_steps="[garak]",
             reasoning="[garak]",

--- a/apps/backend/src/rhesis/backend/app/services/initial_data.json
+++ b/apps/backend/src/rhesis/backend/app/services/initial_data.json
@@ -1454,7 +1454,7 @@
             "metric_scope": ["Multi-Turn"]
         },
         {
-            "name": "Garak: Mitigation Bypass",
+            "name": "Mitigation Bypass",
             "description": "Garak detector for identifying successful jailbreak attempts and guardrail bypasses. Detects when an LLM complies with harmful requests despite safety mitigations.",
             "evaluation_prompt": "garak.detectors.mitigation.MitigationBypass",
             "evaluation_steps": "[garak]",
@@ -1475,7 +1475,7 @@
             "metric_scope": ["Single-Turn"]
         },
         {
-            "name": "Garak: Continuation Detection",
+            "name": "Continuation Detection",
             "description": "Garak detector for continuation-based elicitation attacks. Identifies when an LLM continues generating harmful content after being prompted with a partial unsafe statement.",
             "evaluation_prompt": "garak.detectors.continuation.Continuation",
             "evaluation_steps": "[garak]",
@@ -1496,7 +1496,7 @@
             "metric_scope": ["Single-Turn"]
         },
         {
-            "name": "Garak: Misleading Claims",
+            "name": "Misleading Claims",
             "description": "Garak detector for misleading and false claims. Identifies when an LLM generates misinformation or makes factually incorrect statements that could mislead users.",
             "evaluation_prompt": "garak.detectors.misleading.MisleadingClaim",
             "evaluation_steps": "[garak]",
@@ -1517,7 +1517,7 @@
             "metric_scope": ["Single-Turn"]
         },
         {
-            "name": "Garak: LMRC Risk",
+            "name": "LMRC Risk",
             "description": "Garak detector for Language Model Risk Cards (LMRC) categories. Evaluates model responses against known risk categories from the LMRC framework.",
             "evaluation_prompt": "garak.detectors.lmrc.Lmrc",
             "evaluation_steps": "[garak]",
@@ -1538,7 +1538,7 @@
             "metric_scope": ["Single-Turn"]
         },
         {
-            "name": "Garak: Toxicity Detection",
+            "name": "Toxicity Detection",
             "description": "Garak detector for toxic content in LLM outputs. Uses Google Perspective API to identify harmful, offensive, or inappropriate language in responses.",
             "evaluation_prompt": "garak.detectors.perspective.Toxicity",
             "evaluation_steps": "[garak]",
@@ -1559,7 +1559,7 @@
             "metric_scope": ["Single-Turn"]
         },
         {
-            "name": "Garak: Malware Generation",
+            "name": "Malware Generation",
             "description": "Garak detector for malware code generation. Identifies when an LLM generates functional malicious code, exploits, or malware components.",
             "evaluation_prompt": "garak.detectors.malwaregen.MalwareGenDetector",
             "evaluation_steps": "[garak]",
@@ -1580,7 +1580,7 @@
             "metric_scope": ["Single-Turn"]
         },
         {
-            "name": "Garak: Package Hallucination",
+            "name": "Package Hallucination",
             "description": "Garak detector for package and library hallucination. Identifies when an LLM recommends non-existent software packages, which could lead to supply chain attacks.",
             "evaluation_prompt": "garak.detectors.packagehallucination.PackageHallucination",
             "evaluation_steps": "[garak]",
@@ -1601,7 +1601,7 @@
             "metric_scope": ["Single-Turn"]
         },
         {
-            "name": "Garak: Known Bad Signatures",
+            "name": "Known Bad Signatures",
             "description": "Garak detector for known malicious content signatures. Identifies outputs containing EICAR test strings or other known malware signatures.",
             "evaluation_prompt": "garak.detectors.knownbadsignatures.EICAR",
             "evaluation_steps": "[garak]",
@@ -1622,7 +1622,7 @@
             "metric_scope": ["Single-Turn"]
         },
         {
-            "name": "Garak: XSS Detection",
+            "name": "XSS Detection",
             "description": "Garak detector for Cross-Site Scripting (XSS) payload generation. Identifies when an LLM generates JavaScript or HTML that could be used for XSS attacks.",
             "evaluation_prompt": "garak.detectors.xss.XSSDetector",
             "evaluation_steps": "[garak]",
@@ -1643,7 +1643,7 @@
             "metric_scope": ["Single-Turn"]
         },
         {
-            "name": "Garak: Snowball Detection",
+            "name": "Snowball Detection",
             "description": "Garak detector for snowball factual errors. Identifies when an LLM doubles down on incorrect information or propagates factual errors through conversation.",
             "evaluation_prompt": "garak.detectors.snowball.SnowballDetector",
             "evaluation_steps": "[garak]",
@@ -1664,7 +1664,7 @@
             "metric_scope": ["Single-Turn"]
         },
         {
-            "name": "Garak: Do Not Answer Detection",
+            "name": "Do Not Answer Detection",
             "description": "Garak detector for 'Do Not Answer' dataset evaluation. Identifies when an LLM fails to appropriately refuse harmful or sensitive requests.",
             "evaluation_prompt": "garak.detectors.donotanswer.DoNotAnswerDetector",
             "evaluation_steps": "[garak]",
@@ -1685,7 +1685,7 @@
             "metric_scope": ["Single-Turn"]
         },
         {
-            "name": "Garak: Leak Replay Detection",
+            "name": "Leak Replay Detection",
             "description": "Garak detector for training data leakage and replay. Identifies when an LLM reproduces memorized training data, potentially exposing private information.",
             "evaluation_prompt": "garak.detectors.leakreplay.LeakReplayDetector",
             "evaluation_steps": "[garak]",

--- a/sdk/src/rhesis/sdk/metrics/providers/garak/detector_metric.py
+++ b/sdk/src/rhesis/sdk/metrics/providers/garak/detector_metric.py
@@ -78,7 +78,7 @@ class GarakDetectorMetric(BaseMetric):
         config = MetricConfig(
             class_name="GarakDetectorMetric",
             backend=Backend.GARAK,
-            name=name or f"Garak: {detector_class.split('.')[-1]}",
+            name=name or detector_class.split(".")[-1],
             description=description or f"Garak detector: {detector_class}",
             score_type=ScoreType.NUMERIC,
             metric_type=MetricType.CUSTOM_CODE,

--- a/tests/backend/services/garak/test_importer.py
+++ b/tests/backend/services/garak/test_importer.py
@@ -347,18 +347,14 @@ class TestGarakImporterPreview:
 class TestGarakImporterMetricCreation:
     """Tests for metric creation/lookup."""
 
-    def test_get_or_create_garak_metric_naming(
-        self, test_db: Session, authenticated_user_id, test_org_id
-    ):
+    def test_get_or_create_garak_metric_naming(self):
         """Test _get_or_create_garak_metric generates correct metric name."""
-        importer = GarakImporter(test_db)
-
-        # Test the metric name generation logic by checking the query
-        # The method looks for metrics named "Garak: {detector_class_name}"
+        # Test the metric name generation logic
+        # The method looks for metrics named "{detector_class_name}" (no prefix)
         detector_class = "garak.detectors.mitigation.MitigationBypass"
-        expected_name = f"Garak: {detector_class.split('.')[-1]}"
+        expected_name = detector_class.split(".")[-1]
 
-        assert expected_name == "Garak: MitigationBypass"
+        assert expected_name == "MitigationBypass"
 
     def test_garak_metric_constants(self):
         """Test GarakImporter metric class constants."""

--- a/tests/sdk/metrics/providers/garak/test_detector_metric.py
+++ b/tests/sdk/metrics/providers/garak/test_detector_metric.py
@@ -17,7 +17,7 @@ class TestGarakDetectorMetricInitialization:
 
         assert metric.detector_class_path == "garak.detectors.mitigation.MitigationBypass"
         assert metric.threshold == GarakDetectorMetric.DEFAULT_THRESHOLD
-        assert metric.name == "Garak: MitigationBypass"
+        assert metric.name == "MitigationBypass"
         assert metric.score_type == ScoreType.NUMERIC
         assert metric.metric_type == MetricType.CUSTOM_CODE
         assert MetricScope.SINGLE_TURN in metric.metric_scope
@@ -27,7 +27,7 @@ class TestGarakDetectorMetricInitialization:
         metric = GarakDetectorMetric(detector_class="mitigation.MitigationBypass")
 
         assert metric.detector_class_path == "mitigation.MitigationBypass"
-        assert metric.name == "Garak: MitigationBypass"
+        assert metric.name == "MitigationBypass"
 
     def test_initialization_with_custom_name(self):
         """Test initialization with a custom metric name."""


### PR DESCRIPTION
## Purpose
Fix issues with Garak probe import functionality:
1. Remove redundant "Garak: " prefix from metric names
2. Improve import dialog UX with better loading states and progress tracking

## What Changed

### Backend & SDK
- Remove "Garak: " prefix from all 12 garak metric names in `initial_data.json`
- Update metric name generation in SDK `detector_metric.py` and backend `importer.py`
- Update migration file to use new metric names without prefix
- Update related tests

### Frontend (GarakImportDialog)
- Fix loading indicator to show on Import button instead of Preview button
- Gray out Cancel and Preview buttons during import process
- Change progress bar to track total tests instead of just probe count
- Cap simulated progress at 95% until import actually completes to prevent misleading "100% but still processing" state

## Testing
- All garak unit tests pass (SDK: 65 tests, Backend: 100 tests)
- Ruff linting and formatting verified for all Python files
- ESLint verified for frontend changes