### PR TITLE
Fix: Allow users to execute test configurations from other users

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/test_configuration.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_configuration.py
@@ -199,12 +199,6 @@ def execute_test_configuration_endpoint(
     if db_test_configuration is None:
         raise HTTPException(status_code=404, detail="Test configuration not found")
 
-    # Check if the user has permission to execute this test configuration
-    if db_test_configuration.user_id != current_user.id and not current_user.is_superuser:
-        raise HTTPException(
-            status_code=403, detail="Not authorized to execute this test configuration"
-        )
-
     # Submit the celery task with the task_launcher which automatically adds context
     task = task_launcher(
         execute_test_configuration, str(test_configuration_id), current_user=current_user


### PR DESCRIPTION
## Purpose
Allow users to re-run test configurations created by other users within the same organization.

## What Changed
- Removed user-level authorization check in the test configuration execute endpoint that was blocking users from executing test configurations created by other users
- Organization-level tenant isolation remains in place to ensure users can only access test configurations within their organization

## Additional Context
Previously, users would receive a 403 "Not authorized to execute this test configuration" error when trying to re-run a test run created by a different user. This was overly restrictive since users within the same organization should be able to collaborate and re-run each other's test configurations.