### PR TITLE
fix(frontend): duplicate breadcrumb routes

### DIFF
--- a/apps/frontend/src/app/(protected)/behaviors/page.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/page.tsx
@@ -25,10 +25,7 @@ export default function BehaviorsPage() {
   // Handle loading state
   if (status === 'loading') {
     return (
-      <PageContainer
-        title="Behaviors"
-        breadcrumbs={[{ title: 'Behaviors', path: '/behaviors' }]}
-      >
+      <PageContainer title="Behaviors" breadcrumbs={[]}>
         <Box
           sx={{
             p: 3,
@@ -50,10 +47,7 @@ export default function BehaviorsPage() {
   // Handle no session state
   if (!sessionToken) {
     return (
-      <PageContainer
-        title="Behaviors"
-        breadcrumbs={[{ title: 'Behaviors', path: '/behaviors' }]}
-      >
+      <PageContainer title="Behaviors" breadcrumbs={[]}>
         <Box sx={{ p: 3 }}>
           <Typography color="error">
             Authentication required. Please log in.
@@ -64,10 +58,7 @@ export default function BehaviorsPage() {
   }
 
   return (
-    <PageContainer
-      title="Behaviors"
-      breadcrumbs={[{ title: 'Behaviors', path: '/behaviors' }]}
-    >
+    <PageContainer title="Behaviors" breadcrumbs={[]}>
       <BehaviorsClient
         sessionToken={sessionToken}
         organizationId={organizationId}

--- a/apps/frontend/src/app/(protected)/dashboard/page.tsx
+++ b/apps/frontend/src/app/(protected)/dashboard/page.tsx
@@ -38,7 +38,7 @@ export default function DashboardPage() {
   }, [session?.session_token, forceSyncToDatabase]);
 
   return (
-    <PageContainer>
+    <PageContainer breadcrumbs={[]}>
       {!allLoaded && (
         <Box
           sx={{

--- a/apps/frontend/src/app/(protected)/endpoints/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/page.tsx
@@ -71,7 +71,7 @@ export default function EndpointsPage() {
   }
 
   return (
-    <PageContainer title="Endpoints" breadcrumbs={[{ title: 'Endpoints' }]}>
+    <PageContainer title="Endpoints" breadcrumbs={[]}>
       <Box sx={{ mb: 3 }}>
         <Typography color="text.secondary">
           Connect the Rhesis platform to your application under test via

--- a/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
@@ -67,10 +67,7 @@ export default function KnowledgeClientWrapper({
   // Show error state if no session token
   if (!sessionToken) {
     return (
-      <PageContainer
-        title="Knowledge"
-        breadcrumbs={[{ title: 'Knowledge', path: '/knowledge' }]}
-      >
+      <PageContainer title="Knowledge" breadcrumbs={[]}>
         <Alert severity="error" className={styles.marginBottom3}>
           Session expired. Please refresh the page or log in again.
         </Alert>
@@ -83,10 +80,7 @@ export default function KnowledgeClientWrapper({
   }
 
   return (
-    <PageContainer
-      title="Knowledge"
-      breadcrumbs={[{ title: 'Knowledge', path: '/knowledge' }]}
-    >
+    <PageContainer title="Knowledge" breadcrumbs={[]}>
       <Box sx={{ mb: 3 }}>
         <Typography color="text.secondary">
           Upload knowledge sources to use as context for test generation and

--- a/apps/frontend/src/app/(protected)/mcp/page.tsx
+++ b/apps/frontend/src/app/(protected)/mcp/page.tsx
@@ -191,7 +191,7 @@ export default function MCPSPage() {
   };
 
   return (
-    <PageContainer title="MCP" breadcrumbs={[{ title: 'MCP', path: '/mcp' }]}>
+    <PageContainer title="MCP" breadcrumbs={[]}>
       <Box sx={{ mb: 3 }}>
         <Typography color="text.secondary">
           Connect to Model Context Protocol (MCP) providers to import knowledge

--- a/apps/frontend/src/app/(protected)/metrics/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/page.tsx
@@ -25,10 +25,7 @@ export default function MetricsPage() {
   // Handle loading state
   if (status === 'loading') {
     return (
-      <PageContainer
-        title="Metrics"
-        breadcrumbs={[{ title: 'Metrics', path: '/metrics' }]}
-      >
+      <PageContainer title="Metrics" breadcrumbs={[]}>
         <Box
           sx={{
             p: 3,
@@ -50,10 +47,7 @@ export default function MetricsPage() {
   // Handle no session state
   if (!sessionToken) {
     return (
-      <PageContainer
-        title="Metrics"
-        breadcrumbs={[{ title: 'Metrics', path: '/metrics' }]}
-      >
+      <PageContainer title="Metrics" breadcrumbs={[]}>
         <Box sx={{ p: 3 }}>
           <Typography color="error">
             Authentication required. Please log in.
@@ -64,10 +58,7 @@ export default function MetricsPage() {
   }
 
   return (
-    <PageContainer
-      title="Metrics"
-      breadcrumbs={[{ title: 'Metrics', path: '/metrics' }]}
-    >
+    <PageContainer title="Metrics" breadcrumbs={[]}>
       <MetricsClientComponent
         sessionToken={sessionToken}
         organizationId={organizationId}

--- a/apps/frontend/src/app/(protected)/models/page.tsx
+++ b/apps/frontend/src/app/(protected)/models/page.tsx
@@ -170,10 +170,7 @@ export default function ModelsPage() {
   };
 
   return (
-    <PageContainer
-      title="Models"
-      breadcrumbs={[{ title: 'Models', path: '/models' }]}
-    >
+    <PageContainer title="Models" breadcrumbs={[]}>
       <Box sx={{ mb: 3 }}>
         <Typography color="text.secondary">
           Connect to leading AI model providers to power your evaluation and

--- a/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
@@ -90,10 +90,7 @@ export default function ProjectsClientWrapper({
   // Show error state if no session token
   if (!sessionToken) {
     return (
-      <PageContainer
-        title="Projects"
-        breadcrumbs={[{ title: 'Projects', path: '/projects' }]}
-      >
+      <PageContainer title="Projects" breadcrumbs={[]}>
         <Alert severity="error" sx={{ mb: 3 }}>
           Session expired. Please refresh the page or log in again.
         </Alert>
@@ -106,10 +103,7 @@ export default function ProjectsClientWrapper({
   }
 
   return (
-    <PageContainer
-      title="Projects"
-      breadcrumbs={[{ title: 'Projects', path: '/projects' }]}
-    >
+    <PageContainer title="Projects" breadcrumbs={[]}>
       {/* Header with actions */}
       <Box
         sx={{

--- a/apps/frontend/src/app/(protected)/tasks/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/page.tsx
@@ -24,10 +24,7 @@ export default function TasksPage() {
   // Handle loading state
   if (status === 'loading') {
     return (
-      <PageContainer
-        title="Tasks"
-        breadcrumbs={[{ title: 'Tasks', path: '/tasks' }]}
-      >
+      <PageContainer title="Tasks" breadcrumbs={[]}>
         <Box sx={{ p: 3 }}>
           <Typography>Loading...</Typography>
         </Box>
@@ -38,10 +35,7 @@ export default function TasksPage() {
   // Handle no session state
   if (!session?.session_token) {
     return (
-      <PageContainer
-        title="Tasks"
-        breadcrumbs={[{ title: 'Tasks', path: '/tasks' }]}
-      >
+      <PageContainer title="Tasks" breadcrumbs={[]}>
         <Box sx={{ p: 3 }}>
           <Typography color="error">No session token available</Typography>
         </Box>
@@ -50,10 +44,7 @@ export default function TasksPage() {
   }
 
   return (
-    <PageContainer
-      title="Tasks"
-      breadcrumbs={[{ title: 'Tasks', path: '/tasks' }]}
-    >
+    <PageContainer title="Tasks" breadcrumbs={[]}>
       {/* Charts Section */}
       <TasksCharts
         sessionToken={session.session_token}

--- a/apps/frontend/src/app/(protected)/test-results/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-results/page.tsx
@@ -15,10 +15,7 @@ export default async function TestResultsPage() {
     }
 
     return (
-      <PageContainer
-        title="Test Results"
-        breadcrumbs={[{ title: 'Test Results', path: '/test-results' }]}
-      >
+      <PageContainer title="Test Results" breadcrumbs={[]}>
         <Box sx={{ mb: 3 }}>
           <Typography variant="body1" color="text.secondary">
             Track and analyze test performance over time. Filter by time range,
@@ -31,7 +28,7 @@ export default async function TestResultsPage() {
   } catch (error) {
     const errorMessage = (error as Error).message;
     return (
-      <PageContainer title="Test Results">
+      <PageContainer title="Test Results" breadcrumbs={[]}>
         <Paper elevation={2} sx={{ p: 3 }}>
           <Typography color="error" variant="h6" gutterBottom>
             Error Loading Test Results

--- a/apps/frontend/src/app/(protected)/test-runs/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/page.tsx
@@ -29,10 +29,7 @@ export default function TestRunsPage() {
   // Handle loading state
   if (status === 'loading') {
     return (
-      <PageContainer
-        title="Test Runs"
-        breadcrumbs={[{ title: 'Test Runs', path: '/test-runs' }]}
-      >
+      <PageContainer title="Test Runs" breadcrumbs={[]}>
         <Box sx={{ p: 3 }}>
           <Typography>Loading...</Typography>
         </Box>
@@ -43,10 +40,7 @@ export default function TestRunsPage() {
   // Handle no session state
   if (!session?.session_token) {
     return (
-      <PageContainer
-        title="Test Runs"
-        breadcrumbs={[{ title: 'Test Runs', path: '/test-runs' }]}
-      >
+      <PageContainer title="Test Runs" breadcrumbs={[]}>
         <Box sx={{ p: 3 }}>
           <Typography color="error">No session token available</Typography>
         </Box>
@@ -55,10 +49,7 @@ export default function TestRunsPage() {
   }
 
   return (
-    <PageContainer
-      title="Test Runs"
-      breadcrumbs={[{ title: 'Test Runs', path: '/test-runs' }]}
-    >
+    <PageContainer title="Test Runs" breadcrumbs={[]}>
       {/* Charts Section */}
       <TestRunCharts
         sessionToken={session.session_token}

--- a/apps/frontend/src/app/(protected)/test-sets/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/page.tsx
@@ -67,10 +67,7 @@ export default async function TestSetsPage() {
     );
 
     return (
-      <PageContainer
-        title="Test Sets"
-        breadcrumbs={[{ title: 'Test Sets', path: '/test-sets' }]}
-      >
+      <PageContainer title="Test Sets" breadcrumbs={[]}>
         {/* Charts Section - Client Component */}
         <TestSetsCharts />
 

--- a/apps/frontend/src/app/(protected)/tests/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/page.tsx
@@ -171,10 +171,7 @@ export default function TestsPage() {
   // Handle loading state
   if (status === 'loading') {
     return (
-      <PageContainer
-        title="Tests"
-        breadcrumbs={[{ title: 'Tests', path: '/tests' }]}
-      >
+      <PageContainer title="Tests" breadcrumbs={[]}>
         <Box sx={{ p: 3 }}>
           <Typography>Loading...</Typography>
         </Box>
@@ -185,10 +182,7 @@ export default function TestsPage() {
   // Handle no session state
   if (!session?.session_token) {
     return (
-      <PageContainer
-        title="Tests"
-        breadcrumbs={[{ title: 'Tests', path: '/tests' }]}
-      >
+      <PageContainer title="Tests" breadcrumbs={[]}>
         <Box sx={{ p: 3 }}>
           <Typography color="error">No session token available</Typography>
         </Box>
@@ -198,10 +192,7 @@ export default function TestsPage() {
 
   return (
     <>
-      <PageContainer
-        title="Tests"
-        breadcrumbs={[{ title: 'Tests', path: '/tests' }]}
-      >
+      <PageContainer title="Tests" breadcrumbs={[]}>
         {/* Charts Section */}
         <TestCharts
           sessionToken={session.session_token}

--- a/apps/frontend/src/app/(protected)/tokens/page.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/page.tsx
@@ -15,10 +15,7 @@ export default async function TokensPage() {
   }
 
   return (
-    <PageContainer
-      title="API Tokens"
-      breadcrumbs={[{ title: 'API Tokens', path: '/tokens' }]}
-    >
+    <PageContainer title="API Tokens" breadcrumbs={[]}>
       <Box sx={{ mb: 3 }}>
         <Typography color="text.secondary">
           Create API tokens to authenticate with the Rhesis SDK and

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClientWrapper.tsx
@@ -88,10 +88,7 @@ export default function TracesClientWrapper({
   // Show error state if no session token
   if (!sessionToken) {
     return (
-      <PageContainer
-        title="Traces"
-        breadcrumbs={[{ title: 'Traces', path: '/traces' }]}
-      >
+      <PageContainer title="Traces" breadcrumbs={[]}>
         <Alert severity="error" sx={{ mb: 3 }}>
           Session expired. Please refresh the page or log in again.
         </Alert>
@@ -104,10 +101,7 @@ export default function TracesClientWrapper({
   }
 
   return (
-    <PageContainer
-      title="Traces"
-      breadcrumbs={[{ title: 'Traces', path: '/traces' }]}
-    >
+    <PageContainer title="Traces" breadcrumbs={[]}>
       <Box sx={{ mb: 3 }}>
         <Typography color="text.secondary">
           View and analyze OpenTelemetry traces from test executions and


### PR DESCRIPTION
Before - 
<img width="1344" height="705" alt="Screenshot 2026-01-30 at 7 08 20 PM" src="https://github.com/user-attachments/assets/7e95e67b-353b-486f-a133-5779c2965823" />

After - 
<img width="671" height="258" alt="Screenshot 2026-01-30 at 7 17 16 PM" src="https://github.com/user-attachments/assets/b8d5d726-e604-4696-a254-05c5795b7c5e" />

<img width="671" height="258" alt="Screenshot 2026-01-30 at 7 17 06 PM" src="https://github.com/user-attachments/assets/8bc4e445-2aba-4e46-b169-26a7b8adc616" />
