### PR TITLE
Streamline CONTRIBUTING.md for faster contributor onboarding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,662 +1,121 @@
-# 🚀 Contributing to Rhesis
+# Contributing to Rhesis
 
-Thank you for your interest in contributing to Rhesis! This document provides **general guidelines and instructions** for contributing to our main repository.
+Thank you for your interest in contributing to Rhesis! This guide will help you get started quickly.
 
-## 📋 Table of Contents
+## Quick Start
 
-- 📖 [Component-Specific Contributing Guides](#component-specific-contributing-guides)
-- 📁 [Project Structure](#project-structure)
-- 🐧 [Tools Installation on Linux](#tools-installation-on-linux)
-- 🐍 [Python Environment Setup](#python-environment-setup)
-- 🧹 [Coding Standards, Linting and Formatting](#coding-standards-linting-and-formatting)
-- 📚 [Documentation](#documentation)
-- 🧪 [Testing](#testing)
-- 🔄 [Development Workflow](#development-workflow)
-- 📝 [Commit Guidelines](#commit-guidelines)
-- 🔀 [Pull Request Process](#pull-request-process)
-- 🤖 [GitHub Automation Tools](#github-automation-tools)
-- 🏷️ [Versioning and Release Process](#versioning-and-release-process)
-- ❓ [Questions or Need Help?](#questions-or-need-help)
-- ⚖️ [Legal Notice](#legal-notice)
-
-<a id="component-specific-contributing-guides"></a>
-## 📖 Component-Specific Contributing Guides
-
-This is the **general contributing guide** for the Rhesis monorepo. Each component has its own detailed contributing guide:
-
-- 📦 **[SDK Contributing Guide](sdk/CONTRIBUTING.md)**
-- 🔙 **[Backend Contributing Guide](apps/backend/CONTRIBUTING.md)**
-- 🎨 **[Frontend Contributing Guide](apps/frontend/CONTRIBUTING.md)**
-
-**Please read this general guide first, then read the specific guide for the component you're contributing to.**
-
-
-
-
-
-<a id="project-structure"></a>
-## 📁 Project Structure
-
-The Rhesis repository is organized as a monorepo containing multiple applications and packages:
-
-```
-rhesis/
-├── apps/
-│   ├── backend/       # FastAPI backend service
-│   ├── frontend/      # React frontend application
-│   ├── worker/        # Celery worker service
-│   ├── chatbot/       # Chatbot application
-│   └── polyphemus/    # Monitoring service
-├── sdk/               # Python SDK for Rhesis
-├── infrastructure/    # Infrastructure as code
-├── scripts/           # Utility scripts
-└── docs/              # Documentation
-```
-
-<a id="tools-installation-on-linux"></a>
-## 🐧 Tools Installation on Linux
-
-These are the following tools that are required for development:
+1. **Fork and clone the repository:**
 ```bash
-# Install build dependencies (Ubuntu/Debian)
-sudo apt update && sudo apt install -y make build-essential libssl-dev zlib1g-dev \
-libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev \
-libncursesw5-dev xz-utils tk-dev libffi-dev liblzma-dev python-openssl
-
+git clone https://github.com/YOUR_USERNAME/rhesis.git
+cd rhesis
 ```
 
-
-<a id="python-environment-setup"></a>
-## 🐍 Python Environment Setup
-
-Both backend and SDK use Python as the primary language. We utilize the `uv` tool for Python version and package management. UV is a fast Python package installer and resolver that handles dependency management and virtual environments efficiently.
-
-UV is our recommended solution for all development tasks. While it differs from traditional package managers, it offers superior performance and ease of use. For comprehensive information, refer to the [uv documentation](https://docs.astral.sh/uv/).
-
-
-### 🍎 macOS UV Installation
-**Prerequisites**: Ensure you have [Homebrew](https://brew.sh/) and Xcode Command Line Tools installed. Install Xcode Command Line Tools using `xcode-select --install`
+2. **Set up local development environment:**
 ```bash
-# Install UV via Homebrew (recommended)
-brew install uv
-
-# Alternative installation via curl
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Verify installation
-uv --version
+./rh dev init         # Initialize env files (one-time setup)
+./rh dev up           # Start dev infrastructure (postgres + redis)
+./rh dev backend      # Start backend server (auto-login enabled)
+./rh dev frontend     # Start frontend server
 ```
 
-### 🐧 Linux UV Installation
+3. **Access the application** at http://localhost:3000
 
-```bash
-# Install UV via curl (recommended)
-curl -LsSf https://astral.sh/uv/install.sh | sh
+Run `./rh help` to see all available commands.
 
-# Add UV to your PATH (usually handled automatically by the installer)
-# If manual configuration is needed, add this line to your ~/.bashrc or ~/.zshrc:
-# export PATH="$HOME/.local/bin:$PATH"
+## Component Guides
 
-# Reload your shell configuration
-source ~/.bashrc  # or ~/.zshrc
+Each component has its own detailed contributing guide:
 
-# Verify installation
-uv --version
-```
+- [SDK Contributing Guide](sdk/CONTRIBUTING.md)
+- [Backend Contributing Guide](apps/backend/CONTRIBUTING.md)
+- [Frontend Contributing Guide](apps/frontend/CONTRIBUTING.md)
 
+## Development Workflow
 
-<!-- to do: add instructions for frontend -->
-
-<a id="coding-standards-linting-and-formatting"></a>
-## 🎨 Coding Standards, Linting and Formatting
-
-**Key principles:**
-- 💬 Write meaningful comments and comprehensive documentation
-- 📏 Maintain focused, single-responsibility functions
-- 🏷️ Use descriptive variable and function names
-
-**Follow language-specific style guides:**
-- 🐍 **Python**: We adhere to PEP 8 standards and utilize [Ruff](https://docs.astral.sh/ruff/) for both
-formatting and linting.
-- 🟨 **JavaScript/TypeScript**: We use ESLint for linting
-
-**Our code quality toolchain includes:**
-- 🖥️ VS Code / Cursor Configuration
-- 🛠️ Makefile: Linting & Formatting with Ruff
-- 📝 Pre-commit hooks
-
-**Note:** All tools utilize identical Ruff settings and configuration for consistency.
-
-### 🖥️ VS Code / Cursor Configuration
-
-The repository includes a `.vscode/settings.json` file that automatically configures your editor with the Ruff formatter and linter. Installation of the **[Ruff](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)** extension is required.
-
-The extension automatically executes Ruff formatting and linting on file save.
-
-### 🛠️ Makefile: Linting & Formatting with Ruff
-
-We use a `Makefile` to streamline common development tasks such as linting, formatting, type checking, and testing.
-
-The SDK and backend employ different Makefile configurations but share identical targets:
-
-Available targets include:
-- `make format` &mdash; Formats **all** Python files using Ruff
-- `make format_diff` &mdash; Formats only **modified files** using Ruff
-- `make lint` &mdash; Lints **all** Python files using Ruff
-- `make lint_diff` &mdash; Lints only **modified files** using Ruff
-- `make test` &mdash; Executes the test suite
-- `make all` &mdash; Runs all checks (format_diff, lint_diff, test)
-
-
-> **ℹ️ Note:**
-> You must execute all `make` commands from within either the `apps/backend/` or `sdk/` directories.
-> Running `make` from the repository root directory is **not supported** and will not work as expected.
-
-
-### 📝 Pre-commit Hooks
-We implement pre-commit hooks to automatically execute formatting and linting scripts before each commit.
-It also checks for secrets in the code using TruffleHog.
-
-Before installing the pre-commit hooks, you need to install TruffleHog:
-```bash
-# Install TruffleHog on macOS
-brew install trufflehog
-# Install TruffleHog on Linux
-curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
-```
-
-
-Installation requires the following command:
-```bash
-uvx pre-commit install
-```
-
-On every commit, pre-commit hooks automatically run Ruff formatting and linting on modified files.
-When issues are detected, the system attempts automatic resolution. Unresolved issues appear in the commit message and require manual attention. To proceed with the commit, resolve all issues and stage the modified files using the `git add` command. You can then retry the commit or manually execute checks using `make format` and `make lint` commands.
-
-
-If you want to disable pre-commit hooks for a specific commit, you can use the following command:
-```bash
-git commit --no-verify
-```
-
-To remove pre-commit hooks, execute:
-```bash
-uvx pre-commit uninstall
-```
-
-
-
-
-<a id="documentation"></a>
-## 📚 Documentation
-
-- 📝 Update documentation for any modified functionality
-- 💬 Include comprehensive docstrings for new functions and classes
-- 🔄 Maintain README.md currency with user-facing changes
-
-<a id="testing"></a>
-## 🧪 Testing
-
-- ✍️ Write unit tests for all new features and bug fixes
-- ✅ Ensure all tests pass before submitting a PR
-- 🔗 Include integration tests where appropriate
-
-<a id="development-workflow"></a>
-## 🔄 Development Workflow
-
-
-1. 🌿 **Create a feature branch**:
+1. **Create a feature branch:**
 ```bash
 git checkout -b feature/your-feature-name
 ```
 
-2. 🪝 **Enable pre-commit hooks**:
+2. **Enable pre-commit hooks:**
 ```bash
 uvx pre-commit install
 ```
 
-3. ✍️ **Implement changes and verify all checks pass using the Makefile**:
+3. **Make your changes** and run checks:
 ```bash
-make format      # Format code with Ruff
-make format_diff # Show formatting differences without applying
-make lint        # Lint code with Ruff
-make lint_diff   # Lint only modified files with Ruff
-make test        # Execute tests
+make format && make lint && make test
+```
+> Run `make` commands from `apps/backend/` or `sdk/` directories.
+
+4. **Commit your changes:**
+```bash
+git commit -m "feat: your descriptive commit message"
 ```
 
-Alternatively, run all checks simultaneously:
-```bash
-make all
-```
-
-
-4. 📝 **Commit your changes** (with recommended DCO sign-off):
-```bash
-git add .
-git commit -s -m "feat: your descriptive commit message"
-```
-> **Tip:** The `-s` flag adds a `Signed-off-by` line for the [Developer Certificate of Origin](#legal-notice). We recommend using it for all contributions.
-
-5. 📤 **Push changes and create a Pull Request**:
+5. **Push and create a Pull Request:**
 ```bash
 git push origin feature/your-feature-name
-```
-
-6. **Generate a Pull Request** using our automated PR tool:
-```bash
-# Navigate to the repository root first
-cd <repo_root>
-
-# Then create the PR
 .github/pr
 ```
 
+## Commit Guidelines
 
-<a id="commit-guidelines"></a>
-## 📝 Commit Guidelines
-
-We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```
 <type>[optional scope]: <description>
-
-[optional body]
-
-[optional footer(s)]
 ```
 
-Types include:
-- ✨ `feat`: A new feature
-- 🐛 `fix`: A bug fix
-- 📚 `docs`: Documentation only changes
-- 🎨 `style`: Changes that do not affect the meaning of the code
-- ♻️ `refactor`: A code change that neither fixes a bug nor adds a feature
-- ⚡ `perf`: A code change that improves performance
-- 🧪 `test`: Adding missing tests or correcting existing tests
-- 🔨 `build`: Changes that affect the build system or external dependencies
-- 👷 `ci`: Changes to our CI configuration files and scripts
+**Types:** `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`
 
+## Pull Request Checklist
 
-<a id="pull-request-process"></a>
-## 📨 Pull Request Process
+- [ ] Code follows our coding standards
+- [ ] Tests added/updated for changes
+- [ ] Documentation updated if needed
+- [ ] All CI checks pass
 
-1. ✅ Ensure code adherence to our coding standards
-2. 📚 Update documentation as necessary
-3. 🧪 Include tests that verify your changes
-4. 📝 Update the CHANGELOG.md file with change details
-5. 👥 Obtain approval from at least one maintainer
-6. 🔄 Maintainers will merge approved PRs
+## Learn More
 
-**Additional requirements:**
-- ✅ Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification for commit messages
-- 🧪 Include tests for new features
-- 📚 Update documentation as needed
-- ✔️ Ensure all checks pass before requesting review
+- [Development Setup](https://docs.rhesis.ai/development/contributing/development-setup) — Full environment setup guide
+- [Coding Standards](https://docs.rhesis.ai/development/contributing/coding-standards) — Python and TypeScript standards
+- [Release Process](RELEASING.md) — Versioning and release workflow
 
-<a id="github-automation-tools"></a>
-## 🤖 GitHub Automation Tools
+## Questions or Need Help?
 
-This repository includes automation scripts and tools for GitHub workflows and repository management located in the `.github/` directory.
-
-To utilize these tools, you must install and authenticate the GitHub CLI tool:
-
-1. 🛠️ **Install GitHub CLI** (required for automated PR creation):
-```bash
-# 🐧 Ubuntu/Debian
-sudo apt update && sudo apt install gh
-
-# 🍎 macOS
-brew install gh
-
-# Or download from: https://cli.github.com/
-```
-
-2. 🔐 **Authenticate with GitHub**:
-```bash
-gh auth login
-```
-
-
-
-
-### 🚀 PR Creation Script
-
-#### 📝 `create-pr.sh`
-
-An intelligent script that automates the creation of pull requests by analyzing your current branch and generating meaningful titles and descriptions.
-
-**🔍 Enhanced Features**
-The script now includes smart detection and update capabilities:
-- **Push Detection**: Automatically detects if your branch or changes aren't pushed
-- **Interactive Prompting**: Offers clear options to push content before PR creation
-- **PR Update**: Updates existing PRs instead of failing when a PR already exists
-- **Force Mode**: Skip detection with the `--force` flag for advanced users
-
-#### Usage
-
-```bash
-# Basic usage (compares current branch to main)
-./.github/create-pr.sh
-
-# Compare to a different base branch
-./.github/create-pr.sh develop
-
-# Skip push detection (for advanced users)
-./.github/create-pr.sh --force
-
-# Get help and see all options
-./.github/create-pr.sh --help
-
-# Short alias (supports all options)
-./.github/pr
-./.github/pr --force
-./.github/pr develop --force
-```
-
-#### Prerequisites
-
-- [GitHub CLI (gh)](https://cli.github.com/) must be installed and authenticated
-- Must be run from within a git repository
-- Current branch must have commits that differ from the base branch
-
-#### What it does
-
-1. **Validates environment**: Checks for gh CLI and git repository
-2. **🔍 Detects unpushed content**: Checks if branch/changes exist on remote (unless `--force` is used)
-3. **🤝 Interactive resolution**: Prompts to push content if needed, with options to push now or exit
-4. **Analyzes changes**: Gets commit history and file changes between branches
-5. **Generates content**: Creates intelligent PR title and comprehensive description
-6. **Creates PR**: Uses gh CLI to create the pull request
-7. **Provides summary**: Shows PR details and optionally opens in browser
-
-#### 🚨 Push Detection Scenarios
-
-The script will detect and handle these common scenarios:
-
-**Scenario 1: Branch doesn't exist on remote**
-```
-⚠️  [WARNING] The branch 'feature/new-functionality' doesn't exist on the remote repository.
-   This means the entire branch needs to be pushed before creating a PR.
-
-Options:
-  1) Push now and continue with PR creation
-  2) Exit and push manually later
-
-What would you like to do? (1/2):
-```
-
-**Scenario 2: Branch exists but has unpushed commits**
-```
-⚠️  [WARNING] There are unpushed commits on branch 'feature/new-functionality'.
-   You have local commits that haven't been pushed to the remote repository.
-
-Options:
-  1) Push now and continue with PR creation
-  2) Exit and push manually later
-
-What would you like to do? (1/2):
-```
-
-**Scenario 3: Everything is up to date**
-```
-ℹ️  [PR-Creator] Branch and all changes are already pushed to remote.
-ℹ️  [PR-Creator] Generated PR title: New Functionality
-```
-
-**Scenario 4: PR already exists**
-```
-ℹ️  [PR-Creator] Found existing PR for branch 'feature/new-functionality'
-ℹ️  [PR-Creator] Updating existing PR...
-✅  [SUCCESS] Pull request updated successfully!
-```
-
-#### Branch Naming Conventions
-
-The script intelligently handles different branch naming patterns and properly capitalizes common abbreviations:
-
-- `feature/websocket-endpoint` → "Websocket Endpoint"
-- `feature/api-dev-environment` → "API DEV Environment"
-- `feature/ui-ux-improvements` → "UI UX Improvements"
-- `fix/authentication-bug` → "Fix: authentication bug"
-- `fix/auth-jwt-bug` → "Fix: AUTH JWT Bug"
-- `hotfix/critical-security` → "Hotfix: critical security"
-- `hotfix/prod-db-issue` → "Hotfix: PROD DB Issue"
-- `custom-branch-name` → "Custom Branch Name"
-
-**Supported Abbreviations:**
-- **Infrastructure**: DEV, STG, STAGING, PROD, PRD, PRODUCTION, AWS, GCP, AZURE, K8S, DOCKER
-- **APIs & Protocols**: API, REST, HTTP, HTTPS, URL, URI, GRPC, TCP, UDP, SSH, FTP, SMTP
-- **Frontend**: UI, UX, CSS, HTML, JS, TS, JSX, TSX
-- **Backend**: DB, SQL, JWT, AUTH, OAUTH, SSO, LDAP
-- **Data**: JSON, XML, YAML, YML, CSV, PDF
-- **DevOps**: CI, CD, QA, QC, PR
-- **Tools**: SDK, CLI, GUI, IDE, VM, VPC, DNS
-- **Business**: CRM, ERP, SAAS, PAAS, IAAS
-- **Tech**: ML, AI, NLP, OCR, IOT, AR, VR
-
-#### Generated PR Template
-
-The script creates a comprehensive PR description including:
-
-- 📝 Summary section for manual description
-- 🔄 List of commits with hashes
-- 📁 Files changed with count
-- 📋 Detailed commit information
-- ✅ Standard checklist for reviews
-- 🧪 Testing section placeholder
-- 📸 Screenshots section for UI changes
-- 🔗 Related issues section
-
-#### Example Output
-
-```
-[PR-Creator] Current branch: feature/websocket-endpoint
-[PR-Creator] Base branch: main
-[PR-Creator] Found 4 commit(s) to include in PR
-[PR-Creator] Generated PR title: Websocket Endpoint
-[PR-Creator] Creating PR...
-[SUCCESS] Pull request created successfully!
-[SUCCESS] URL: https://github.com/rhesis-ai/rhesis/pull/36
-```
-
-
-### 🏷️ Release Management Script
-> **📋 For comprehensive release information, see [RELEASING.md](RELEASING.md)**
-
-#### 🔄 `release`
-
-A comprehensive release automation tool that manages version bumping, changelog generation, and tagging for individual components and platform-wide releases.
-
-For detailed information about the release process, see **[RELEASING.md](RELEASING.md)**.
-
-#### Quick Examples
-
-```bash
-# The release script automatically creates appropriate release branches
-
-# Individual component release (updates versions and changelogs only)
-./.github/release backend --minor
-# → Creates branch: release/backend-v0.2.0
-
-# Multiple components
-./.github/release backend --minor frontend --patch
-# → Creates branch: release/backend-v0.2.0-frontend-v0.1.1 (or release/multi-a1b2c3)
-
-# All components + platform
-./.github/release backend --minor frontend --minor worker --minor chatbot --minor polyphemus --minor sdk --minor platform --minor
-# → Creates branch: release/v0.2.0
-
-# Always test first (shows what branch would be created)
-./.github/release --dry-run backend --minor
-# → Would create release branch: release/backend-v0.2.0
-```
-
-### 📁 Automation Directory Structure
-
-```
-.github/
-├── create-pr.sh        # Main PR automation script
-├── pr                  # Short alias for create-pr.sh
-├── release             # Main release management script
-├── workflows/          # GitHub Actions workflows
-└── actions/            # Custom GitHub Actions
-```
-
-### 🛠️ Adding New Automation Tools
-
-When contributing new automation tools to the `.github/` directory:
-
-1. 📝 Document the tool in this CONTRIBUTING.md section
-2. 💡 Include usage examples and prerequisites
-3. 🛡️ Add comprehensive error handling and validation
-4. 🎨 Use consistent styling and output formatting
-5. 🧪 Test thoroughly before committing
-6. 📋 Follow the existing script patterns for consistency
-
-
-
-
-<a id="versioning-and-release-process"></a>
-## 🏷️ Versioning and Release Process
-
-### 📊 Versioning Strategy
-
-We follow [Semantic Versioning](https://semver.org/) (SemVer) for all components in the monorepo:
-
-- 🔴 **Major version (X.0.0)**: Incompatible API changes
-- 🟡 **Minor version (0.X.0)**: New functionality in a backward-compatible manner
-- 🟢 **Patch version (0.0.X)**: Backward-compatible bug fixes
-
-Each component (backend, frontend, SDK, etc.) maintains its own version number.
-
-### 🏷️ Tagging Strategy
-
-Since we use a monorepo structure, we employ a component-specific tagging strategy to distinguish between releases of different components:
-
-#### 🎯 Component-Specific Tags
-
-We use prefixed tags to identify which component a version belongs to:
-- 🔙 `backend-v1.0.0` - For backend releases
-- 🎨 `frontend-v2.3.1` - For frontend releases
-- 📦 `sdk-v0.5.2` - For SDK releases
-- ⚙️ `worker-v1.1.0` - For worker service releases
-- 🤖 `chatbot-v0.9.0` - For chatbot application releases
-- 👁️ `polyphemus-v0.3.2` - For monitoring service releases
-
-#### 🌐 Platform-Wide Versioning
-
-For the entire platform, we use a combination approach:
-
-1. 🔧 Use component-specific tags for regular development (`backend-v1.2.0`, `frontend-v1.1.0`, `sdk-v0.2.5`)
-2. 🎯 Periodically create platform-wide version tags (`v1.0.0`, `v2.0.0`) for major milestones
-
-This gives us the flexibility of independent component development while still providing stable, well-documented platform releases for users who want a known-good configuration.
-
-#### 🔧 Implementation
-
-When releasing a component:
-
-1. 📝 Update the component's version in its respective configuration file (e.g., `pyproject.toml`, `package.json`)
-2. 📋 Update the component's CHANGELOG.md
-3. 🏷️ Create a tag with the component prefix and version:
-   ```
-   git tag <component>-v<version>
-   git push origin <component>-v<version>
-   ```
-
-4. 🔗 Reference these tags in your changelogs:
-   ```
-   [0.1.0]: https://github.com/rhesis-ai/rhesis/releases/tag/backend-v0.1.0
-   ```
-
-When creating a platform-wide release:
-
-1. 📝 Update the main CHANGELOG.md with details of all component versions included
-2. 🏷️ Create a platform-wide tag:
-   ```
-   git tag v<version>
-   git push origin v<version>
-   ```
-
-3. 📋 Document the specific component versions included in this platform release
-
-#### 🔄 Advanced Patterns
-
-For more complex scenarios:
-
-- 🌐 **Platform-wide releases**: These are significant milestones where all components have reached a stable, compatible state. They represent "known good" configurations of the entire platform:
-  - Use simple version tags without component prefixes (e.g., `v1.0.0`, `v2.0.0`)
-  - Document in the main CHANGELOG.md which specific component versions are included
-  - Create these less frequently than component-specific releases
-  - Example: `v1.0.0` might include `backend-v1.2.0`, `frontend-v1.1.5`, and `sdk-v0.2.3`
-  - These releases are particularly useful for users who want a vetted, stable configuration
-
-- 🔗 **Coordinated component releases**: When multiple components need to be released together due to interdependencies:
-  - Create individual component tags for each component being released
-  - Document the interdependencies in each component's CHANGELOG.md
-  - Consider creating a platform-wide tag if the changes are significant enough
-
-- 🚨 **Hotfixes**: For urgent fixes, use the format `<component>-v<version>-hotfix.<number>` (e.g., `backend-v1.0.0-hotfix.1`)
-
-
-
-<a id="questions-or-need-help"></a>
-## ❓ Questions or Need Help?
-
-If you have questions or need help with the contribution process:
-- Contact us at support@rhesis.ai
-- Create an issue in the repository
 - Check our [documentation](https://docs.rhesis.ai)
+- Join our [Discord](https://discord.rhesis.ai)
+- Create an [issue](https://github.com/rhesis-ai/rhesis/issues)
+- Email us at support@rhesis.ai
 
-Thank you for contributing to Rhesis! 🎉
+---
 
-<a id="legal-notice"></a>
-## ⚖️ Legal Notice
+## Legal Notice
 
-By contributing to this project, you confirm that you have authored the content, that you have the necessary rights to the content, and that the content you contribute may be provided under the project's [MIT License](LICENSE).
+By contributing to this project, you confirm that you have authored the content, have the necessary rights, and that your contribution may be provided under the project's [MIT License](LICENSE).
 
 ### Developer Certificate of Origin (DCO)
 
-We encourage contributors to sign off on their commits to certify they have the right to submit their contributions under the project's open source license. We follow the same [Developer Certificate of Origin (DCO)](https://developercertificate.org/) as the Linux Foundation.
+We encourage contributors to sign off on their commits to certify they have the right to submit their contributions under the project's open source license. We follow the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) used by the Linux Foundation.
 
-By making a contribution to this project, I certify that:
-
-> (a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
->
-> (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
->
-> (c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
->
-> (d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
-
-### How to Sign Your Commits
-
-Add a `Signed-off-by` line to your commit messages using the `-s` flag:
+**Sign your commits** using the `-s` flag:
 
 ```bash
 git commit -s -m "feat: add new feature"
 ```
 
-This will automatically add a line like:
+This adds a `Signed-off-by` line to your commit:
 ```
 Signed-off-by: Your Name <your.email@example.com>
 ```
 
-Make sure your Git configuration matches:
+Ensure your Git config matches:
 ```bash
 git config user.name "Your Name"
 git config user.email "your.email@example.com"
 ```
 
-### Signing Past Commits
+---
 
-If you need to sign off on commits that have already been made, you can amend the most recent commit:
-```bash
-git commit --amend -s
-```
-
-Or rebase multiple commits:
-```bash
-git rebase --signoff HEAD~n  # where n is the number of commits
-```
+Thank you for contributing to Rhesis!

--- a/docs/content/contributing.mdx
+++ b/docs/content/contributing.mdx
@@ -1,16 +1,39 @@
 # Contributing to Rhesis
 
-We welcome contributions of all kinds — code, ideas, documentation, and bug reports. Here's how you can get involved:
+We welcome contributions of all kinds — code, ideas, documentation, and bug reports.
 
 ## Ways to Contribute
 
-- ⭐ **Star the repo** — show your support by [starring us on GitHub](https://github.com/rhesis-ai/rhesis).
-- **Suggest features** — have an idea? [Create a feature request](https://github.com/rhesis-ai/rhesis/issues/new?template=feature_request.md).
-- **Submit code** — check out our [open issues](https://github.com/rhesis-ai/rhesis/issues) and [contribution guide](/development/contributing) to get started.
-- **Report issues** — found a bug? [Open a GitHub issue](https://github.com/rhesis-ai/rhesis/issues/new?template=bug_report.md) to let us know.
-- **Improve documentation** — help us make the docs better by submitting a PR.
-- **Join the community** — connect with us on [Discord](https://discord.rhesis.ai) and [LinkedIn](https://www.linkedin.com/company/rhesis-ai/).
-- **Spread the word** — share your experience with Rhesis on social media and help others discover the project.
+- **Star the repo** — show your support by [starring us on GitHub](https://github.com/rhesis-ai/rhesis)
+- **Submit code** — check out our [open issues](https://github.com/rhesis-ai/rhesis/issues) and [contribution guide](https://github.com/rhesis-ai/rhesis/blob/main/CONTRIBUTING.md) to get started
+- **Suggest features** — have an idea? [Create a feature request](https://github.com/rhesis-ai/rhesis/issues/new?template=feature_request.md)
+- **Report issues** — found a bug? [Open a GitHub issue](https://github.com/rhesis-ai/rhesis/issues/new?template=bug_report.md)
+- **Improve documentation** — help us make the docs better by submitting a PR
+- **Join the community** — connect with us on [Discord](https://discord.rhesis.ai) and [LinkedIn](https://www.linkedin.com/company/rhesis-ai/)
+
+## Getting Started
+
+The fastest way to start contributing:
+
+```bash
+git clone https://github.com/rhesis-ai/rhesis.git && cd rhesis
+./rh dev init         # Initialize env files (one-time)
+./rh dev up           # Start postgres + redis
+./rh dev backend      # Start backend
+./rh dev frontend     # Start frontend
+```
+
+For detailed guides, see:
+
+- [Development Setup](/development/contributing/development-setup) — Full environment setup
+- [Coding Standards](/development/contributing/coding-standards) — Python and TypeScript standards
+- [CONTRIBUTING.md](https://github.com/rhesis-ai/rhesis/blob/main/CONTRIBUTING.md) — Quick start and workflow
+
+## Legal Information
+
+- [Developer Certificate of Origin (DCO)](https://github.com/rhesis-ai/rhesis/blob/main/CONTRIBUTING.md#legal-notice) — Sign off your commits with `git commit -s`
+- [MIT License](https://github.com/rhesis-ai/rhesis/blob/main/LICENSE) — Project license
+- [NOTICE](https://github.com/rhesis-ai/rhesis/blob/main/NOTICE) — Third-party attributions
 
 ## Legal Information
 


### PR DESCRIPTION
## Purpose

Reduce CONTRIBUTING.md from 663 lines to 121 lines (82% reduction) to make it easier for new contributors to get started quickly. The guide was bloated with content that already exists in the docs site.

## What Changed

- **Added Quick Start section** using `./rh dev` commands (init/up/backend/frontend)
- **Condensed** development workflow, commit guidelines, and PR process
- **Linked to docs** for detailed setup, coding standards, and release process
- **Removed** GitHub automation tools documentation (scripts have `--help`)
- **Removed** versioning/release details (already in RELEASING.md)
- **Preserved** Legal Notice / DCO section (required for OSS compliance)

Also updated `docs/content/contributing.mdx` to include quick start commands.

## Before/After

| File | Before | After | Reduction |
|------|--------|-------|-----------|
| CONTRIBUTING.md | 663 lines | 121 lines | 82% |
| contributing.mdx | 18 lines | 41 lines | (expanded with quick start) |

## Additional Context

- Designed to work with PR #1217 which adds `./rh dev` commands for local development
- All detailed content is still available in docs at https://docs.rhesis.ai/development/contributing/