### PR TITLE
Add placeholder for local-style backend test workflow

### DIFF
--- a/.github/workflows/backend-test-local.yml
+++ b/.github/workflows/backend-test-local.yml
@@ -1,0 +1,15 @@
+name: "[Test] Backend Local-Style"
+
+# Placeholder workflow to register the workflow in GitHub Actions.
+# Full implementation will be added in a follow-up PR.
+
+on:
+  workflow_dispatch:
+
+jobs:
+  placeholder:
+    name: 🚧 Placeholder
+    runs-on: ubuntu-latest
+    steps:
+      - name: Info
+        run: echo "This workflow will mirror the local backend testing workflow (make docker-up && make test)"


### PR DESCRIPTION
## Purpose
Register the backend-test-local workflow file in GitHub Actions so it appears in the Actions tab for manual triggering.

## What Changed
- Added `.github/workflows/backend-test-local.yml` with a placeholder implementation
- The workflow currently just prints an informational message
- Full implementation will follow in a separate PR once this is merged

## Additional Context
- This is a prerequisite for the full implementation in branch `feat/backend-test-localy`
- The full workflow will mirror local development testing: `make docker-up && make test`

## Testing
After merging, the workflow should appear in the Actions tab and can be triggered manually.