### PR TITLE
Fix missing PERSPECTIVE_API_KEY in worker deployment

### DIFF
--- a/apps/worker/k8s/deployment.yaml
+++ b/apps/worker/k8s/deployment.yaml
@@ -154,6 +154,11 @@ spec:
             secretKeyRef:
               name: rhesis-worker-secrets
               key: AZURE_OPENAI_API_VERSION
+        - name: PERSPECTIVE_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: rhesis-worker-secrets
+              key: PERSPECTIVE_API_KEY
         # SMTP configuration for email notifications
         - name: SMTP_HOST
           valueFrom:


### PR DESCRIPTION
## Purpose
Fix the worker GKE deployment to inject the `PERSPECTIVE_API_KEY` environment variable into the container.

## What Changed
- Added `PERSPECTIVE_API_KEY` environment variable reference to the worker deployment manifest

## Additional Context
The secret was already being created in the GitHub Actions workflow (`worker.yml` line 293), but the deployment manifest was missing the `secretKeyRef` to mount it as an environment variable in the worker container.