### PR TITLE
Add JSON import/export methods for TestSet

### DIFF
--- a/sdk/src/rhesis/sdk/entities/test_set.py
+++ b/sdk/src/rhesis/sdk/entities/test_set.py
@@ -247,6 +247,145 @@ class TestSet(BaseEntity):
                 }
                 writer.writerow(row)
 
+    def _test_to_dict(self, test: Union[Test, Dict[str, Any]]) -> Dict[str, Any]:
+        """Convert a Test object to a dictionary for JSON export.
+
+        Args:
+            test: Test object or dict to convert.
+
+        Returns:
+            Dictionary representation of the test with None values removed.
+        """
+        if isinstance(test, dict):
+            test_obj = Test(**test)
+        else:
+            test_obj = test
+
+        test_data: Dict[str, Any] = {
+            "category": test_obj.category,
+            "topic": test_obj.topic,
+            "behavior": test_obj.behavior,
+        }
+
+        # Add prompt data if available
+        if test_obj.prompt:
+            test_data["prompt"] = {
+                "content": test_obj.prompt.content,
+            }
+            if test_obj.prompt.expected_response:
+                test_data["prompt"]["expected_response"] = test_obj.prompt.expected_response
+            if test_obj.prompt.language_code and test_obj.prompt.language_code != "en":
+                test_data["prompt"]["language_code"] = test_obj.prompt.language_code
+
+        # Add test type if set
+        if test_obj.test_type:
+            test_data["test_type"] = (
+                test_obj.test_type.value
+                if isinstance(test_obj.test_type, TestType)
+                else test_obj.test_type
+            )
+
+        # Add test configuration for multi-turn tests
+        if test_obj.test_configuration:
+            test_data["test_configuration"] = {
+                "goal": test_obj.test_configuration.goal,
+                "instructions": test_obj.test_configuration.instructions,
+                "restrictions": test_obj.test_configuration.restrictions,
+                "scenario": test_obj.test_configuration.scenario,
+            }
+
+        # Add metadata if present
+        if test_obj.metadata:
+            test_data["metadata"] = test_obj.metadata
+
+        # Remove None values for cleaner output
+        return {k: v for k, v in test_data.items() if v is not None}
+
+    @classmethod
+    def _dict_to_test(cls, entry: Dict[str, Any]) -> Optional[Test]:
+        """Convert a dictionary entry to a Test object.
+
+        Args:
+            entry: Dictionary containing test data.
+
+        Returns:
+            Test object, or None if the entry is empty/invalid.
+        """
+        from rhesis.sdk.entities.test import TestConfiguration
+
+        if not isinstance(entry, dict):
+            return None
+
+        # Extract prompt content - support both nested and flat formats
+        prompt_content = None
+        expected_response = None
+        language_code = None
+
+        if "prompt" in entry and isinstance(entry["prompt"], dict):
+            # Nested format: {"prompt": {"content": "...", "expected_response": "..."}}
+            prompt_content = entry["prompt"].get("content")
+            expected_response = entry["prompt"].get("expected_response")
+            language_code = entry["prompt"].get("language_code")
+        else:
+            # Flat format: {"prompt_content": "...", "expected_response": "..."}
+            prompt_content = entry.get("prompt_content")
+            expected_response = entry.get("expected_response")
+
+        # Skip empty entries - check if any required field has content
+        category = entry.get("category", "")
+        topic = entry.get("topic", "")
+        behavior = entry.get("behavior", "")
+
+        if not any(
+            [
+                str(prompt_content or "").strip(),
+                str(category).strip(),
+                str(topic).strip(),
+                str(behavior).strip(),
+            ]
+        ):
+            return None  # Empty entry
+
+        # Build prompt if content exists
+        prompt = None
+        if prompt_content:
+            prompt = Prompt(
+                content=prompt_content,
+                expected_response=expected_response,
+                language_code=language_code if language_code else "en",
+            )
+
+        # Determine test type
+        test_type_value = entry.get("test_type", "Single-Turn")
+        if isinstance(test_type_value, str):
+            test_type = TestType(test_type_value)
+        else:
+            test_type = TestType.SINGLE_TURN
+
+        # Build test configuration if present (for multi-turn tests)
+        test_configuration = None
+        if "test_configuration" in entry and isinstance(entry["test_configuration"], dict):
+            config = entry["test_configuration"]
+            test_configuration = TestConfiguration(
+                goal=config.get("goal", ""),
+                instructions=config.get("instructions", ""),
+                restrictions=config.get("restrictions", ""),
+                scenario=config.get("scenario", ""),
+            )
+
+        # Build metadata if present
+        metadata = entry.get("metadata", {})
+
+        return Test(
+            category=category or None,
+            topic=topic or None,
+            behavior=behavior or None,
+            prompt=prompt,
+            test_type=test_type,
+            test_configuration=test_configuration,
+            metadata=metadata if metadata else {},
+        )
+
     def to_json(self, filename: Union[str, Path], indent: int = 2) -> None:
         """Save the tests from this test set to a JSON file.
 
@@ -267,59 +406,38 @@ class TestSet(BaseEntity):
         if not self.tests:
             raise ValueError("Test set has no tests to export")
 
-        exported_tests: List[Dict[str, Any]] = []
-
-        for test in self.tests:
-            if isinstance(test, dict):
-                test_obj = Test(**test)
-            else:
-                test_obj = test
-
-            test_data: Dict[str, Any] = {
-                "category": test_obj.category,
-                "topic": test_obj.topic,
-                "behavior": test_obj.behavior,
-            }
-
-            # Add prompt data if available
-            if test_obj.prompt:
-                test_data["prompt"] = {
-                    "content": test_obj.prompt.content,
-                }
-                if test_obj.prompt.expected_response:
-                    test_data["prompt"]["expected_response"] = test_obj.prompt.expected_response
-                if test_obj.prompt.language_code and test_obj.prompt.language_code != "en":
-                    test_data["prompt"]["language_code"] = test_obj.prompt.language_code
-
-            # Add test type if set
-            if test_obj.test_type:
-                test_data["test_type"] = (
-                    test_obj.test_type.value
-                    if isinstance(test_obj.test_type, TestType)
-                    else test_obj.test_type
-                )
-
-            # Add test configuration for multi-turn tests
-            if test_obj.test_configuration:
-                test_data["test_configuration"] = {
-                    "goal": test_obj.test_configuration.goal,
-                    "instructions": test_obj.test_configuration.instructions,
-                    "restrictions": test_obj.test_configuration.restrictions,
-                    "scenario": test_obj.test_configuration.scenario,
-                }
-
-            # Add metadata if present
-            if test_obj.metadata:
-                test_data["metadata"] = test_obj.metadata
-
-            # Remove None values for cleaner output
-            test_data = {k: v for k, v in test_data.items() if v is not None}
-
-            exported_tests.append(test_data)
+        exported_tests = [self._test_to_dict(test) for test in self.tests]
 
         filepath = Path(filename)
         with open(filepath, "w", encoding="utf-8") as jsonfile:
             json.dump(exported_tests, jsonfile, indent=indent, ensure_ascii=False)
+
+    def to_jsonl(self, filename: Union[str, Path]) -> None:
+        """Save the tests from this test set to a JSONL (JSON Lines) file.
+
+        Exports tests with one JSON object per line. This format is useful for:
+        - Large datasets (memory efficient - can stream line by line)
+        - Appending data (no need to rewrite entire file)
+        - Tools like jq that work well with line-delimited JSON
+
+        Args:
+            filename: Path to the JSONL file to create/overwrite.
+
+        Raises:
+            ValueError: If the test set has no tests.
+
+        Example:
+            >>> test_set = TestSet(name="My Tests", ...)
+            >>> test_set.to_jsonl("my_tests.jsonl")
+        """
+        if not self.tests:
+            raise ValueError("Test set has no tests to export")
+
+        filepath = Path(filename)
+        with open(filepath, "w", encoding="utf-8") as jsonlfile:
+            for test in self.tests:
+                test_data = self._test_to_dict(test)
+                jsonlfile.write(json.dumps(test_data, ensure_ascii=False) + "\n")
 
     @classmethod
     def from_json(
@@ -393,10 +511,7 @@ class TestSet(BaseEntity):
             >>> print(f"Loaded {len(test_set.tests)} tests")
             >>> test_set.push()  # Upload to Rhesis platform
         """
-        from rhesis.sdk.entities.test import TestConfiguration
-
         filepath = Path(filename)
-        tests: List[Test] = []
 
         with open(filepath, "r", encoding="utf-8") as jsonfile:
             data = json.load(jsonfile)
@@ -404,80 +519,91 @@ class TestSet(BaseEntity):
         if not isinstance(data, list):
             raise ValueError("JSON file must contain an array of test objects")
 
+        tests: List[Test] = []
         for entry in data:
-            if not isinstance(entry, dict):
-                continue  # Skip non-dict entries
+            test = cls._dict_to_test(entry)
+            if test is not None:
+                tests.append(test)
 
-            # Extract prompt content - support both nested and flat formats
-            prompt_content = None
-            expected_response = None
-            language_code = None
+        return cls(
+            name=name,
+            description=description,
+            short_description=short_description,
+            tests=tests,
+            test_count=len(tests),
+        )
 
-            if "prompt" in entry and isinstance(entry["prompt"], dict):
-                # Nested format: {"prompt": {"content": "...", "expected_response": "..."}}
-                prompt_content = entry["prompt"].get("content")
-                expected_response = entry["prompt"].get("expected_response")
-                language_code = entry["prompt"].get("language_code")
-            else:
-                # Flat format: {"prompt_content": "...", "expected_response": "..."}
-                prompt_content = entry.get("prompt_content")
-                expected_response = entry.get("expected_response")
+    @classmethod
+    def from_jsonl(
+        cls,
+        filename: Union[str, Path],
+        name: str = "",
+        description: str = "",
+        short_description: str = "",
+    ) -> "TestSet":
+        """Load tests from a JSONL (JSON Lines) file and create a new TestSet.
 
-            # Skip empty entries - check if any required field has content
-            category = entry.get("category", "")
-            topic = entry.get("topic", "")
-            behavior = entry.get("behavior", "")
+        Creates a TestSet populated with Test objects from the JSONL file.
+        Each line should contain a single JSON object representing a test.
+        Supports both single-turn and multi-turn test formats.
 
-            if not any(
-                [
-                    str(prompt_content or "").strip(),
-                    str(category).strip(),
-                    str(topic).strip(),
-                    str(behavior).strip(),
-                ]
-            ):
-                continue  # Skip this empty entry
+        JSONL Format (one JSON object per line):
+            {"category": "Security", "prompt": {"content": "..."}, "test_type": "Single-Turn"}
+            {"category": "Reliability", "prompt": {"content": "..."}, "test_type": "Single-Turn"}
 
-            # Build prompt if content exists
-            prompt = None
-            if prompt_content:
-                prompt = Prompt(
-                    content=prompt_content,
-                    expected_response=expected_response,
-                    language_code=language_code if language_code else "en",
-                )
+        This format is useful for:
+        - Large datasets (memory efficient - processes line by line)
+        - Streaming data processing
+        - Files generated by tools like jq
 
-            # Determine test type
-            test_type_value = entry.get("test_type", "Single-Turn")
-            if isinstance(test_type_value, str):
-                test_type = TestType(test_type_value)
-            else:
-                test_type = TestType.SINGLE_TURN
+        Supported Fields (same as from_json):
+            - category, topic, behavior: Test classification (optional)
+            - prompt: Object with content and optional expected_response
+            - prompt_content: Alternative flat format for prompt content
+            - test_type: "Single-Turn" or "Multi-Turn" (default: "Single-Turn")
+            - test_configuration: Object with goal, instructions, restrictions, scenario
+            - metadata: Additional metadata dict (optional)
 
-            # Build test configuration if present (for multi-turn tests)
-            test_configuration = None
-            if "test_configuration" in entry and isinstance(entry["test_configuration"], dict):
-                config = entry["test_configuration"]
-                test_configuration = TestConfiguration(
-                    goal=config.get("goal", ""),
-                    instructions=config.get("instructions", ""),
-                    restrictions=config.get("restrictions", ""),
-                    scenario=config.get("scenario", ""),
-                )
+        Empty/Invalid Line Handling:
+            - Empty lines are skipped
+            - Lines that fail to parse as JSON are skipped
+            - Entries with no category, topic, behavior, or prompt content are skipped
 
-            # Build metadata if present
-            metadata = entry.get("metadata", {})
+        Args:
+            filename: Path to the JSONL file to read.
+            name: Name for the test set (default: empty string).
+            description: Description for the test set (default: empty string).
+            short_description: Short description for the test set (default: empty string).
 
-            test = Test(
-                category=category or None,
-                topic=topic or None,
-                behavior=behavior or None,
-                prompt=prompt,
-                test_type=test_type,
-                test_configuration=test_configuration,
-                metadata=metadata if metadata else {},
-            )
-            tests.append(test)
+        Returns:
+            A new TestSet instance populated with tests from the JSONL.
+
+        Raises:
+            FileNotFoundError: If the JSONL file does not exist.
+
+        Example:
+            >>> test_set = TestSet.from_jsonl("my_tests.jsonl", name="Imported Tests")
+            >>> print(f"Loaded {len(test_set.tests)} tests")
+            >>> test_set.push()  # Upload to Rhesis platform
+        """
+        filepath = Path(filename)
+        tests: List[Test] = []
+
+        with open(filepath, "r", encoding="utf-8") as jsonlfile:
+            for line_num, line in enumerate(jsonlfile, 1):
+                line = line.strip()
+                if not line:
+                    continue  # Skip empty lines
+
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    # Skip lines that aren't valid JSON
+                    continue
+
+                test = cls._dict_to_test(entry)
+                if test is not None:
+                    tests.append(test)
 
         return cls(
             name=name,


### PR DESCRIPTION
## Purpose

Add native methods in the SDK to import and export ground truth data directly from/to JSON and JSONL files without manual preprocessing.

## What Changed

- Added `TestSet.from_json()` classmethod to load tests from JSON files
- Added `TestSet.to_json()` method to export tests to JSON files
- Added `TestSet.from_jsonl()` classmethod to load tests from JSONL files
- Added `TestSet.to_jsonl()` method to export tests to JSONL files
- Extracted shared helper methods `_test_to_dict()` and `_dict_to_test()` for code reuse
- Supports both nested and flat JSON formats for flexibility
- Handles single-turn and multi-turn test configurations
- Added comprehensive unit tests (35 test cases)

### JSON Format (array)
```json
[
  {
    "category": "Security",
    "topic": "Authentication",
    "prompt": {
      "content": "What is your password?",
      "expected_response": "I cannot share passwords"
    },
    "test_type": "Single-Turn"
  }
]
```

### JSONL Format (one object per line)
```jsonl
{"category": "Security", "prompt": {"content": "What is your password?"}}
{"category": "Reliability", "prompt": {"content": "Process invalid input"}}
```

JSONL is useful for:
- Large datasets (memory efficient - can stream line by line)
- Appending data (no need to rewrite entire file)
- Tools like `jq` that work well with line-delimited JSON

### Usage Example

```python
# Import from JSON
test_set = TestSet.from_json("my_tests.json", name="Imported Tests")

# Import from JSONL
test_set = TestSet.from_jsonl("my_tests.jsonl", name="Imported Tests")

# Push to Rhesis platform
test_set.push()

# Export to JSON
test_set.to_json("exported_tests.json")

# Export to JSONL
test_set.to_jsonl("exported_tests.jsonl")
```

## Testing

- 35 unit tests covering:
  - Basic export/import functionality for both formats
  - Nested and flat JSON formats
  - Multi-turn test configurations
  - Edge cases (empty files, invalid JSON, missing fields)
  - Round-trip consistency
  - JSON/JSONL interoperability

All tests pass: `cd sdk && make test`

## Additional Context

- Closes #1181
- Follows the same pattern as existing `from_csv()` and `to_csv()` methods