### PR TITLE
Keep Created column next to Type in test and test-set tables

### DIFF
--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -200,6 +200,20 @@ export default function TestSetsGrid({
       ),
     },
     {
+      field: 'created_at',
+      headerName: 'Created',
+      flex: 0.8,
+      minWidth: 120,
+      filterable: false,
+      renderCell: params => {
+        return (
+          <Typography variant="body2" color="text.secondary">
+            {formatDate(params.row.created_at)}
+          </Typography>
+        );
+      },
+    },
+    {
       field: 'totalTests',
       headerName: 'Tests',
       flex: 0.5,
@@ -338,20 +352,6 @@ export default function TestSetsGrid({
               />
             )}
           </Box>
-        );
-      },
-    },
-    {
-      field: 'created_at',
-      headerName: 'Created',
-      flex: 0.8,
-      minWidth: 120,
-      filterable: false,
-      renderCell: params => {
-        return (
-          <Typography variant="body2" color="text.secondary">
-            {formatDate(params.row.created_at)}
-          </Typography>
         );
       },
     },

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -198,6 +198,20 @@ export default function TestsTable({
         },
       },
       {
+        field: 'created_at',
+        headerName: 'Created',
+        flex: 0.8,
+        minWidth: 120,
+        filterable: false,
+        renderCell: params => {
+          return (
+            <Typography variant="body2" color="text.secondary">
+              {formatDate(params.row.created_at)}
+            </Typography>
+          );
+        },
+      },
+      {
         field: 'counts.comments',
         headerName: 'Comments',
         width: 100,
@@ -301,20 +315,6 @@ export default function TestsTable({
                 />
               )}
             </Box>
-          );
-        },
-      },
-      {
-        field: 'created_at',
-        headerName: 'Created',
-        flex: 0.8,
-        minWidth: 120,
-        filterable: false,
-        renderCell: params => {
-          return (
-            <Typography variant="body2" color="text.secondary">
-              {formatDate(params.row.created_at)}
-            </Typography>
           );
         },
       },


### PR DESCRIPTION
## Purpose
Improve table layout by placing the Created column immediately after the Type column in both the tests table and test sets table, so creation date is easier to find.

## What Changed
- **TestsGrid**: Moved Created column from end of columns to right after Test Type column
- **TestSetsGrid**: Moved Created column from end of columns to right after Type column

## Additional Context
- Follows up on Display creation dates for tests and test sets (#1250) and the later refactor that removed Created from table views; Created is restored in table views with the requested column order.