### PR TITLE
fix: respecting environment variable for Polyphemus URL

### DIFF
--- a/sdk/src/rhesis/sdk/models/providers/polyphemus.py
+++ b/sdk/src/rhesis/sdk/models/providers/polyphemus.py
@@ -12,7 +12,7 @@ from rhesis.sdk.models.utils import validate_llm_response
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_POLYPHEMUS_URL = "https://polyphemus.rhesis.ai"
+DEFAULT_POLYPHEMUS_URL = os.getenv("DEFAULT_POLYPHEMUS_URL") or "https://polyphemus.rhesis.ai"
 
 
 class PolyphemusLLM(BaseLLM):


### PR DESCRIPTION
closing #1245 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small configuration change limited to the Polyphemus provider; behavior only differs when `DEFAULT_POLYPHEMUS_URL` is set.
> 
> **Overview**
> Updates the Polyphemus SDK provider to *respect an environment override* by setting `DEFAULT_POLYPHEMUS_URL` from `os.getenv("DEFAULT_POLYPHEMUS_URL")` and falling back to `https://polyphemus.rhesis.ai` when unset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cd78beefb0a5fcdf18a2eca0ae55841fe680f4e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->