### PR TITLE
Add Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -327,3 +327,6 @@ infrastructure/k8s/manifests/configmaps/*
 *test_results*.json
 *TEST_ANALYSIS*.md
 sdk_test_analysis.md
+
+# Claude Code
+.claude/settings.local.json


### PR DESCRIPTION
## Purpose
Add Claude Code configuration to the repository for team-wide settings.

## What Changed
- Add `.claude/settings.json` with attribution settings
- Add `.claude/settings.local.json` to `.gitignore` to exclude personal permissions

## Additional Context
- `settings.json` contains team-wide Claude Code settings (attribution config)
- `settings.local.json` is excluded as it contains personal permission settings