### PR TITLE
Fix metrics assignment by adding id field to MetricConfig

### DIFF
--- a/sdk/src/rhesis/sdk/metrics/base.py
+++ b/sdk/src/rhesis/sdk/metrics/base.py
@@ -86,6 +86,7 @@ class MetricConfig:
     metric_scope: Optional[List[Union[str, MetricScope]]] = None  # list of scopes
     requires_ground_truth: Optional[bool] = False
     requires_context: Optional[bool] = False
+    id: Optional[str] = None  # ID from backend when pulled
 
     def __post_init__(self):
         if isinstance(self.backend, str):
@@ -148,6 +149,7 @@ class BaseMetric(ABC):
         self.requires_context = config.requires_context
         self.class_name = config.class_name
         self.backend = config.backend
+        self.id = config.id  # ID from backend when pulled
 
         self.model = self.set_model(model)
 

--- a/sdk/src/rhesis/sdk/metrics/providers/native/numeric_judge.py
+++ b/sdk/src/rhesis/sdk/metrics/providers/native/numeric_judge.py
@@ -41,6 +41,7 @@ class NumericJudge(JudgeBase, NumericEvaluationMixin):
         metric_type: Optional[Union[str, MetricType]] = None,
         metric_scope: Optional[List[Union[str, MetricScope]]] = None,
         model: Optional[Union[str, BaseLLM]] = None,
+        id: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -92,6 +93,7 @@ class NumericJudge(JudgeBase, NumericEvaluationMixin):
             metric_scope=metric_scope,
             score_type=SCORE_TYPE,
             class_name=self.__class__.__name__,
+            id=id,
         )
         super().__init__(config=self.config, model=model)
 


### PR DESCRIPTION
## Purpose
Fix the metrics assignment workflow by adding an `id` field to `MetricConfig` that can store metric IDs when pulled from the backend.

## What Changed
- Added `id` field to `MetricConfig` dataclass in `base.py`
- Propagated `id` field to `BaseMetric` class initialization
- Added `id` parameter to `NumericJudge` constructor and config creation

## Testing
Run SDK unit tests:
```bash
cd sdk
make test
```