### PR TITLE
Add development environment with hot reload support

### DIFF
--- a/apps/backend/start.sh
+++ b/apps/backend/start.sh
@@ -29,6 +29,11 @@ is_production() {
 is_local() {
     [ "${ENVIRONMENT}" = "local" ] || [ "${BACKEND_ENV}" = "local" ]
 }
+
+is_development() {
+    [ "${ENVIRONMENT}" = "development" ] || [ "${BACKEND_ENV}" = "development" ]
+}
+
 # Function to display banner
 show_banner() {
     echo -e "${CYAN}"
@@ -167,10 +172,9 @@ start_server() {
         exec ${CMD_PREFIX}uvicorn \
             rhesis.backend.app.main:app \
             --host "$host" \
-            --port "$port" \
-
-    else
-        log "${BLUE}🛠️  Starting development server with Uvicorn...${NC}"
+            --port "$port"
+    elif is_development; then
+        log "${BLUE}🛠️  Starting development server with Uvicorn (hot reload)...${NC}"
         exec ${CMD_PREFIX}uvicorn \
             rhesis.backend.app.main:app \
             --host "$host" \

--- a/rh
+++ b/rh
@@ -176,8 +176,8 @@ BROKER_URL=redis://:rhesis-redis-pass@localhost:${DEV_REDIS_PORT}/0
 CELERY_RESULT_BACKEND=redis://:rhesis-redis-pass@localhost:${DEV_REDIS_PORT}/1
 
 # Environment
-ENVIRONMENT=local
-BACKEND_ENV=local
+ENVIRONMENT=development
+BACKEND_ENV=development
 LOG_LEVEL=DEBUG
 
 # URLs


### PR DESCRIPTION
## Purpose

Enable hot reload for local development by adding explicit `development` environment support in the backend startup script.

## What Changed

- Added `is_development()` function to `apps/backend/start.sh`
- Changed `else` to `elif is_development` with uvicorn `--reload` flag
- Updated `rh` CLI to generate `.env` with `ENVIRONMENT=development` instead of `local`

## Additional Context

Previously, `./rh dev backend` would start uvicorn without hot reload because `ENVIRONMENT=local` fell into the `is_local` branch which didn't have `--reload`. Now with `ENVIRONMENT=development`, the backend starts with hot reload enabled for faster development iteration.

## Testing

1. Run `./rh dev init` to regenerate `.env` files (or manually set `ENVIRONMENT=development`)
2. Run `./rh dev backend`
3. Verify uvicorn starts with `--reload` flag and code changes trigger automatic restarts