### PR TITLE
Fix backend default uvicorn start for docker/integration tests

### DIFF
--- a/apps/backend/start.sh
+++ b/apps/backend/start.sh
@@ -181,6 +181,14 @@ start_server() {
             --port "$port" \
             --log-level debug \
             --reload
+    else
+        # Default: no ENVIRONMENT/BACKEND_ENV (e.g. docker-compose for integration tests)
+        log "${BLUE}🛠️  Starting server with Uvicorn (default)...${NC}"
+        exec ${CMD_PREFIX}uvicorn \
+            rhesis.backend.app.main:app \
+            --host "$host" \
+            --port "$port" \
+            --log-level debug
     fi
 }
 


### PR DESCRIPTION
## Purpose
Ensure the backend start script has an explicit default path when neither `ENVIRONMENT` nor `BACKEND_ENV` is set (e.g. in docker-compose for integration tests), so the server starts with uvicorn without `--reload`.

## What Changed
- Added `else` branch in `start_server()` in `apps/backend/start.sh` to start uvicorn with debug log level when no env is set
- Prevents relying on implicit behavior and makes docker/integration test runs consistent

## Additional Context
- Cherry-picked from feat/adaptive-testing

## Testing
- Run backend via docker-compose or integration test setup without `ENVIRONMENT`/`BACKEND_ENV`; server should start with uvicorn (no reload).

Made with [Cursor](https://cursor.com)