### PR TITLE
Migrate Docker images to mirror.gcr.io for restricted environments

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -117,7 +117,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: mirror.gcr.io/library/postgres:15
         env:
           POSTGRES_DB: postgres
           POSTGRES_USER: postgres
@@ -132,7 +132,7 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis:7
+        image: mirror.gcr.io/library/redis:7
         ports:
           - 6379:6379
         options: >-

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-alpine AS base
+FROM mirror.gcr.io/library/node:22-alpine AS base
 
 ########################################################
 # First stage: Install dependencies

--- a/apps/nocodb/Dockerfile
+++ b/apps/nocodb/Dockerfile
@@ -1,4 +1,4 @@
-FROM nocodb/nocodb:latest
+FROM mirror.gcr.io/nocodb/nocodb:latest
 
 COPY knex.json /knex.json
 

--- a/apps/nocodb/Dockerfile.template
+++ b/apps/nocodb/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM nocodb/nocodb:latest
+FROM mirror.gcr.io/nocodb/nocodb:latest
 
 # Install gettext to get envsubst
 RUN apk add --no-cache gettext

--- a/apps/otel-collector/Dockerfile
+++ b/apps/otel-collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM otel/opentelemetry-collector-contrib:0.97.0
+FROM mirror.gcr.io/otel/opentelemetry-collector-contrib:0.97.0
 
 # Copy custom configuration
 COPY otel-collector-config.yaml /etc/otelcol-contrib/config.yaml

--- a/apps/telemetry-processor/Dockerfile
+++ b/apps/telemetry-processor/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM mirror.gcr.io/library/python:3.11-slim
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ x-nextjs-frontend: &nextjs-frontend
 services:
   # PostgreSQL Database
   postgres:
-    image: postgres:16-alpine
+    image: mirror.gcr.io/library/postgres:16-alpine
     container_name: rhesis-postgres
     environment:
       POSTGRES_DB: ${SQLALCHEMY_DB_NAME:-rhesis-db}
@@ -91,7 +91,7 @@ services:
 
    # Redis for Celery
   redis:
-    image: redis:7-alpine
+    image: mirror.gcr.io/library/redis:7-alpine
     container_name: rhesis-redis
     command: redis-server --requirepass ${REDIS_PASSWORD:-rhesis-redis-pass}
     ports:

--- a/docs/content/development/index.mdx
+++ b/docs/content/development/index.mdx
@@ -127,7 +127,7 @@ print(f"Expected: {test.expected_behavior}")`}
 
 services:
 postgres:
-image: postgres:15
+image: mirror.gcr.io/library/postgres:15
 environment:
 POSTGRES_DB: your_database
 POSTGRES_USER: your_username
@@ -135,7 +135,7 @@ POSTGRES_PASSWORD: your_password
 ports: - "5432:5432"
 
 redis:
-image: redis:7-alpine
+image: mirror.gcr.io/library/redis:7-alpine
 ports: - "6379:6379"
 
 backend:

--- a/docs/src/Dockerfile
+++ b/docs/src/Dockerfile
@@ -1,5 +1,5 @@
 # First stage: Build the application
-FROM node:22-alpine AS base
+FROM mirror.gcr.io/library/node:22-alpine AS base
 
 ########################################################
 # First stage: Install dependencies

--- a/infrastructure/k8s/charts/rhesis/deploy-local.sh
+++ b/infrastructure/k8s/charts/rhesis/deploy-local.sh
@@ -42,14 +42,14 @@ load_images() {
     fi
     
     # List of required images
-    local images=("rhesis-frontend:latest" "rhesis-backend:latest" "rhesis-worker:latest" "postgres:16-alpine" "redis:7-alpine")
+    local images=("rhesis-frontend:latest" "rhesis-backend:latest" "rhesis-worker:latest" "mirror.gcr.io/library/postgres:16-alpine" "mirror.gcr.io/library/redis:7-alpine")
     
     for image in "${images[@]}"; do
         echo "  - Checking image: $image"
         
         # Check if image exists locally
         if ! docker images --format "table {{.Repository}}:{{.Tag}}" | grep -q "^$image$"; then
-            echo "    📥 Image $image not found locally, pulling from Docker Hub..."
+            echo "    📥 Image $image not found locally, pulling..."
             if docker pull "$image"; then
                 echo "    ✅ Image $image pulled successfully"
             else

--- a/infrastructure/k8s/charts/rhesis/values-local.yaml
+++ b/infrastructure/k8s/charts/rhesis/values-local.yaml
@@ -34,9 +34,9 @@ database:
   enabled: true
   type: "postgresql"
   postgresql:
-    # Image configuration - pull from cloud registry
+    # Image configuration - pull from mirror.gcr.io (avoids Docker Hub for restricted networks)
     image:
-      repository: postgres  # or use cloud registry like gcr.io/google-containers/postgres
+      repository: mirror.gcr.io/library/postgres
       tag: "16-alpine"
       pullPolicy: "IfNotPresent"  # Changed from "Never" to pull from cloud
     persistence:

--- a/infrastructure/k8s/charts/rhesis/values.yaml
+++ b/infrastructure/k8s/charts/rhesis/values.yaml
@@ -37,7 +37,7 @@ database:
   postgresql:
     disableSecurityContext: true  # Temporarily disable for PostgreSQL due to permission issues
     image:
-      repository: postgres
+      repository: mirror.gcr.io/library/postgres
       tag: "16-alpine"
     persistence:
       enabled: true
@@ -62,7 +62,7 @@ redis:
   enabled: true
   type: "redis"  # redis, external
   image:
-    repository: redis
+    repository: mirror.gcr.io/library/redis
     tag: "7-alpine"
   persistence:
     enabled: true

--- a/rh
+++ b/rh
@@ -104,7 +104,7 @@ check_node() {
 
 # Function to generate encryption key using Docker
 generate_encryption_key() {
-    docker run --rm python:3.10.17-slim sh -c \
+    docker run --rm mirror.gcr.io/library/python:3.10.17-slim sh -c \
         "pip install --quiet --no-cache-dir cryptography > /dev/null 2>&1 && \
          python3 -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'" 2>/dev/null
 }
@@ -331,13 +331,13 @@ dev_up() {
         -e POSTGRES_USER=rhesis-user \
         -e POSTGRES_PASSWORD=rhesis-password \
         -p ${DEV_POSTGRES_PORT}:5432 \
-        postgres:16-alpine
+        mirror.gcr.io/library/postgres:16-alpine
 
     docker start rhesis-dev-redis 2>/dev/null || \
     docker run -d \
         --name rhesis-dev-redis \
         -p ${DEV_REDIS_PORT}:6379 \
-        redis:7-alpine \
+        mirror.gcr.io/library/redis:7-alpine \
         redis-server --requirepass rhesis-redis-pass
 
     # Wait for postgres to be ready

--- a/tests/README.md
+++ b/tests/README.md
@@ -808,7 +808,7 @@ Consistent, isolated test environments are crucial for reliable testing.
 version: '3.8'
 services:
   test-db:
-    image: postgres:15
+    image: mirror.gcr.io/library/postgres:15
     environment:
       POSTGRES_DB: rhesis_test
       POSTGRES_USER: test
@@ -817,7 +817,7 @@ services:
       - "5433:5432"
   
   redis-test:
-    image: redis:7
+    image: mirror.gcr.io/library/redis:7
     ports:
       - "6380:6379"
 ```

--- a/tests/sdk/integration/docker-compose.yml
+++ b/tests/sdk/integration/docker-compose.yml
@@ -23,7 +23,7 @@ x-backend-config: &backend-config
 services:
   # PostgreSQL Database
   postgres:
-    image: postgres:16-alpine
+    image: mirror.gcr.io/library/postgres:16-alpine
     container_name: rhesis-postgres-test
     environment:
       POSTGRES_DB: rhesis-db
@@ -42,7 +42,7 @@ services:
 
   # Redis for Celery
   redis:
-    image: redis:7-alpine
+    image: mirror.gcr.io/library/redis:7-alpine
     container_name: rhesis-redis-test
     command: redis-server --requirepass rhesis-redis-pass
     ports:


### PR DESCRIPTION
## Purpose

Migrate all Docker Hub image references to `mirror.gcr.io` to support deployments in environments where Docker Hub is blocked, such as financial institutions and enterprises with strict network policies.

## What Changed

**Base Images Migrated:**
- `postgres:16-alpine` → `mirror.gcr.io/library/postgres:16-alpine`
- `postgres:15` → `mirror.gcr.io/library/postgres:15`
- `redis:7-alpine` → `mirror.gcr.io/library/redis:7-alpine`
- `redis:7` → `mirror.gcr.io/library/redis:7`
- `node:22-alpine` → `mirror.gcr.io/library/node:22-alpine`
- `python:3.10.17-slim` → `mirror.gcr.io/library/python:3.10.17-slim`
- `python:3.11-slim` → `mirror.gcr.io/library/python:3.11-slim`

**Third-party Images Migrated:**
- `otel/opentelemetry-collector-contrib:0.97.0` → `mirror.gcr.io/otel/opentelemetry-collector-contrib:0.97.0`
- `nocodb/nocodb:latest` → `mirror.gcr.io/nocodb/nocodb:latest`

**Files Updated (15 total):**
- Production: `docker-compose.yml`, `rh` script
- Dockerfiles: frontend, docs, telemetry-processor, otel-collector, nocodb (×2)
- Testing: `tests/sdk/integration/docker-compose.yml`, `.github/workflows/backend-test.yml`
- Infrastructure: Helm chart values (`values.yaml`, `values-local.yaml`, `deploy-local.sh`)
- Documentation: `docs/content/development/index.mdx`, `tests/README.md`

## Additional Context

**Why mirror.gcr.io?**
- Google's official cache for Docker Hub images
- Automatically mirrors images on first pull
- No API rate limits
- Works in restricted network environments where Docker Hub is blocked

**No Changes to:**
- `ghcr.io/astral-sh/uv` - GitHub Container Registry (different registry)
- `gcr.io/*` images - Already on Google Container Registry

## Testing

**Local testing:**
```bash
# Test dev infrastructure
./rh dev up

# Test full stack
./rh start

# Test SDK integration tests
cd sdk && make test-integration
```

**Verify image pulls:**
```bash
docker pull mirror.gcr.io/library/postgres:16-alpine
docker pull mirror.gcr.io/library/redis:7-alpine
```

All images should pull successfully from mirror.gcr.io without authentication.