### PR TITLE
Use in-memory volumes for PostgreSQL and Redis in integration tests

### DIFF
--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -42,7 +42,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     cd penelope && uv remove rhesis-sdk --frozen && cd .. && \
     uv add ./sdk --frozen --editable --no-workspace && \
     uv add ./penelope --frozen --editable --no-workspace && \
-    uv sync --no-install-project --no-install-local
+    uv sync --no-install-project --no-install-local --extra cpu
 
 # Install the project
 COPY sdk /app/sdk/

--- a/tests/sdk/integration/docker-compose.yml
+++ b/tests/sdk/integration/docker-compose.yml
@@ -39,6 +39,8 @@ services:
     networks:
       - rhesis-network
     env_file: []
+    tmpfs:
+      - /var/lib/postgresql/data
 
   # Redis for Celery
   redis:
@@ -56,6 +58,8 @@ services:
       retries: 5
     networks:
       - rhesis-network
+    tmpfs:
+      - /data
 
   # Backend API
   backend:


### PR DESCRIPTION
## Purpose
Switch PostgreSQL and Redis services in integration tests to use in-memory tmpfs volumes instead of disk volumes for improved test performance and clean state between test runs.

## What Changed
- Added tmpfs mount for PostgreSQL data directory (/var/lib/postgresql/data)
- Added tmpfs mount for Redis data directory (/data)
- Updated Dockerfile.dev to include --extra cpu flag in uv sync command to prevent CUDA installation

## Additional Context
This change improves test performance by storing database and cache data in memory, and ensures a clean state for each test run since data is ephemeral and cleared when containers stop. The --extra cpu flag prevents unnecessary CUDA dependencies from being installed in the test environment.