### PR TITLE
Add rule: run backend tests from apps/backend

### DIFF
--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -25,5 +25,22 @@ docker logs rhesis-backend-test
 For example:
 ```bash
 cd sdk
-uv run pytest tests/sdk/integration/test_entities.py::test_endpoint
+uv run pytest ../tests/sdk/integration/test_entities.py::test_endpoint
 ```
+
+## Backend Tests
+
+Backend tests must be run from the backend app directory (`apps/backend`). The backend's `pyproject.toml` configures pytest with `testpaths = ["../../tests/backend"]` and `pythonpath = ["src"]`, so `uv run pytest` must be executed from `apps/backend` for paths and imports to resolve correctly.
+
+1. Tests are stored in <project_root>/tests/backend.
+2. Always run pytest from the backend directory:
+```bash
+cd apps/backend
+uv run pytest ../../tests/backend/ -v
+```
+3. Run a specific test file or test class:
+```bash
+cd apps/backend
+uv run pytest ../../tests/backend/services/test_adaptive_testing.py::TestCreateAdaptiveTestSet -v
+```
+4. Do not run backend tests from the project root (e.g. `uv run pytest tests/backend/...` from repo root); pytest will not be found or paths will be wrong.


### PR DESCRIPTION
## Purpose
Backend tests require running pytest from `apps/backend` because the backend's `pyproject.toml` sets `testpaths` and `pythonpath` relative to that directory. Running `uv run pytest` from the repo root fails (pytest not found). This PR documents that in the testing rule so developers and AI always run backend tests from the correct directory.

## What Changed
- Added **Backend Tests** section to `.cursor/rules/testing.mdc`
- Document that tests live in `tests/backend` and must be run via `cd apps/backend && uv run pytest ../../tests/backend/ ...`
- Added examples for running all backend tests and a specific test class
- Corrected SDK single-test example path to `../tests/sdk/...` for consistency

## Additional Context
- Fixes the error: `error: Failed to spawn: pytest` when running `uv run pytest tests/backend/...` from repo root
- Backend `pyproject.toml` has `testpaths = ["../../tests/backend"]` and `pythonpath = ["src"]`

## Testing
- Read the updated `.cursor/rules/testing.mdc` and run backend tests from `apps/backend` as documented.