### PR TITLE
Restrict commit scope to allowed list in commits rule

### DIFF
--- a/.cursor/rules/commits.mdc
+++ b/.cursor/rules/commits.mdc
@@ -115,6 +115,8 @@ Always follow the Conventional Commits specification for all commit messages.
 
 
 ### Scope
+**Use only one of these scopes.** Do not invent other scopes (e.g. no `adaptive-testing`, `api`, `auth`).
+
 - **backend**: Changes to the backend code (apps/backend/)
 - **frontend**: Changes to the frontend code (apps/frontend/)
 - **sdk**: Changes to the SDK code (sdk/)


### PR DESCRIPTION
## Purpose
Clarify in the commits rule that only the defined scopes (backend, frontend, sdk, tests, dev) may be used, so agents and contributors do not invent scopes like `adaptive-testing` or `api`.

## What Changed
- Added explicit note under Scope: **Use only one of these scopes.**
- Added examples of disallowed scopes: no `adaptive-testing`, `api`, `auth`

## Additional Context
- Aligns with conventional commits and existing scope definitions in the same rule.
- No code or tests changed; documentation/rule only.

## Testing
N/A – cursor rule documentation only.