### PR TITLE
Fix worker CreateContainerConfigError for missing Azure secrets

### DIFF
--- a/apps/worker/k8s/deployment.yaml
+++ b/apps/worker/k8s/deployment.yaml
@@ -134,26 +134,6 @@ spec:
             secretKeyRef:
               name: rhesis-worker-secrets
               key: VERTEX_AI_PROJECT
-        - name: AZURE_OPENAI_ENDPOINT
-          valueFrom:
-            secretKeyRef:
-              name: rhesis-worker-secrets
-              key: AZURE_OPENAI_ENDPOINT
-        - name: AZURE_OPENAI_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: rhesis-worker-secrets
-              key: AZURE_OPENAI_API_KEY
-        - name: AZURE_OPENAI_DEPLOYMENT_NAME
-          valueFrom:
-            secretKeyRef:
-              name: rhesis-worker-secrets
-              key: AZURE_OPENAI_DEPLOYMENT_NAME
-        - name: AZURE_OPENAI_API_VERSION
-          valueFrom:
-            secretKeyRef:
-              name: rhesis-worker-secrets
-              key: AZURE_OPENAI_API_VERSION
         - name: PERSPECTIVE_API_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Purpose
Fix the worker deployment failing with `CreateContainerConfigError` because it references Azure OpenAI secret keys that no longer exist in `rhesis-worker-secrets`.

## What Changed
- Removed 4 Azure OpenAI environment variable references from the worker K8s deployment manifest (`AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_DEPLOYMENT_NAME`, `AZURE_OPENAI_API_VERSION`)
- These secrets were never populated by the worker workflow's `kubectl create secret` step, so the container failed to start when the keys were absent

## Testing
- Deploy the worker to dev and verify the pod starts without `CreateContainerConfigError`
- Confirm worker health endpoint responds successfully