### PR TITLE
Use pgvector postgres image for dev

### DIFF
--- a/rh
+++ b/rh
@@ -331,7 +331,7 @@ dev_up() {
         -e POSTGRES_USER=rhesis-user \
         -e POSTGRES_PASSWORD=rhesis-password \
         -p ${DEV_POSTGRES_PORT}:5432 \
-        mirror.gcr.io/library/postgres:16-alpine
+        mirror.gcr.io/pgvector/pgvector:pg16
 
     docker start rhesis-dev-redis 2>/dev/null || \
     docker run -d \


### PR DESCRIPTION
## Purpose
Use the pgvector-enabled Postgres image for local development so dev environment matches backend requirements (e.g. adaptive testing).

## What Changed
- In `rh` script, `dev_up()` now uses `mirror.gcr.io/pgvector/pgvector:pg16` instead of `mirror.gcr.io/library/postgres:16-alpine`

## Additional Context
- Cherry-picked from feat/adaptive-testing to keep this change in a small, separate PR.