### PR TITLE
refactor(frontend): simplify make test command to match SDK pattern

### DIFF
--- a/apps/frontend/Makefile
+++ b/apps/frontend/Makefile
@@ -70,8 +70,7 @@ eslint:
 
 # Run tests
 test:
-	@echo "🔍 Running tests..."
-	@npm test -- --passWithNoTests --watchAll=false || (echo "❌ Tests failed" && exit 1)
+	npm test -- --passWithNoTests --ci --watchAll=false
 
 # Build the application
 build:


### PR DESCRIPTION
## Purpose
Addresses feedback from PR #1298 to simplify the `make test` command in the frontend Makefile to match the SDK pattern.

## What Changed
- Removed decorative output (emoji and echo statements) from the `test` target
- Added `--ci` flag to match GitHub workflow behavior
- Simplified error handling by letting npm/jest handle exit codes naturally
- Aligned with SDK Makefile style for consistency

## Comparison

### Before
```makefile
test:
	@echo "🔍 Running tests..."
	@npm test -- --passWithNoTests --watchAll=false || (echo "❌ Tests failed" && exit 1)
```

### After
```makefile
test:
	npm test -- --passWithNoTests --ci --watchAll=false
```

## Testing
- Ran `make test` successfully - all 183 tests passed across 12 test suites
- Command now matches the GitHub workflow configuration exactly

## Related
- Addresses feedback in #1298