### PR TITLE
Fix: Add Password Visibility Toggle

### DIFF
--- a/apps/frontend/src/app/auth/reset-password/page.tsx
+++ b/apps/frontend/src/app/auth/reset-password/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import {
   Box,
   Grid,
@@ -47,6 +47,34 @@ export default function ResetPasswordPage() {
   // Password visibility toggles
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const passwordInputRef = useRef<HTMLInputElement>(null);
+  const confirmPasswordInputRef = useRef<HTMLInputElement>(null);
+
+  const handleTogglePasswordVisibility = () => {
+    const input = passwordInputRef.current;
+    const cursorPosition = input?.selectionStart ?? 0;
+
+    setShowPassword(!showPassword);
+
+    setTimeout(() => {
+      if (input) {
+        input.setSelectionRange(cursorPosition, cursorPosition);
+      }
+    }, 0);
+  };
+
+  const handleToggleConfirmPasswordVisibility = () => {
+    const input = confirmPasswordInputRef.current;
+    const cursorPosition = input?.selectionStart ?? 0;
+
+    setShowConfirmPassword(!showConfirmPassword);
+
+    setTimeout(() => {
+      if (input) {
+        input.setSelectionRange(cursorPosition, cursorPosition);
+      }
+    }, 0);
+  };
 
   useEffect(() => {
     const fetchPolicy = async () => {
@@ -221,19 +249,15 @@ export default function ResetPasswordPage() {
                       size="small"
                       autoComplete="new-password"
                       helperText={`Minimum ${passwordPolicy?.min_length ?? 8} characters`}
+                      inputRef={passwordInputRef}
                       InputProps={{
                         endAdornment: (
                           <InputAdornment position="end">
                             <IconButton
                               aria-label="toggle password visibility"
-                              onClick={() => setShowPassword(!showPassword)}
-                              onMouseDown={e => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                              }}
+                              onClick={handleTogglePasswordVisibility}
                               edge="end"
                               size="small"
-                              tabIndex={-1}
                             >
                               {showPassword ? (
                                 <VisibilityOffIcon />
@@ -254,21 +278,15 @@ export default function ResetPasswordPage() {
                       fullWidth
                       size="small"
                       autoComplete="new-password"
+                      inputRef={confirmPasswordInputRef}
                       InputProps={{
                         endAdornment: (
                           <InputAdornment position="end">
                             <IconButton
                               aria-label="toggle confirm password visibility"
-                              onClick={() =>
-                                setShowConfirmPassword(!showConfirmPassword)
-                              }
-                              onMouseDown={e => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                              }}
+                              onClick={handleToggleConfirmPasswordVisibility}
                               edge="end"
                               size="small"
-                              tabIndex={-1}
                             >
                               {showConfirmPassword ? (
                                 <VisibilityOffIcon />

--- a/apps/frontend/src/components/auth/AuthForm.tsx
+++ b/apps/frontend/src/components/auth/AuthForm.tsx
@@ -22,7 +22,7 @@ import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import VisibilityIcon from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { signIn } from 'next-auth/react';
 import { getClientApiBaseUrl } from '../../utils/url-resolver';
 import {
@@ -78,6 +78,21 @@ export default function AuthForm({ isRegistration = false }: AuthFormProps) {
 
   // Password visibility toggle
   const [showPassword, setShowPassword] = useState(false);
+  const passwordInputRef = useRef<HTMLInputElement>(null);
+
+  const handleTogglePasswordVisibility = () => {
+    const input = passwordInputRef.current;
+    const cursorPosition = input?.selectionStart ?? 0;
+
+    setShowPassword(!showPassword);
+
+    // Restore cursor position after state update
+    setTimeout(() => {
+      if (input) {
+        input.setSelectionRange(cursorPosition, cursorPosition);
+      }
+    }, 0);
+  };
 
   // Check local storage for previous acceptance on component mount
   useEffect(() => {
@@ -380,19 +395,15 @@ export default function AuthForm({ isRegistration = false }: AuthFormProps) {
                     ? `Minimum ${passwordPolicy?.min_length ?? 8} characters`
                     : undefined
                 }
+                inputRef={passwordInputRef}
                 InputProps={{
                   endAdornment: (
                     <InputAdornment position="end">
                       <IconButton
                         aria-label="toggle password visibility"
-                        onClick={() => setShowPassword(!showPassword)}
-                        onMouseDown={e => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                        }}
+                        onClick={handleTogglePasswordVisibility}
                         edge="end"
                         size="small"
-                        tabIndex={-1}
                       >
                         {showPassword ? (
                           <VisibilityOffIcon />


### PR DESCRIPTION
This PR introduces changes from the `fix/add-password-visibility-toggle` branch.

## 📝 Summary

This PR fixes the issue where users did not have the option to see their password when logging in or registering.

## 📁 Files Changed (      21 files)

```
apps/frontend/src/app/auth/reset-password/page.tsx
apps/frontend/src/components/auth/AuthForm.tsx
```

## 📋 Commit Details

```
ce9058aa8 - feat(auth): add password visibility toggle to authentication forms (Emanuele De Rossi, 2026-02-12 13:04)
```
