### PR TITLE
Extract frontend E2E docker setup into dedicated compose file

### DIFF
--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -25,69 +25,26 @@ jobs:
           cache-dependency-path: apps/frontend/package-lock.json
 
       - name: Install dependencies
-        run: |
-          cd apps/frontend
-          npm ci --legacy-peer-deps
+        run: make install
+        working-directory: apps/frontend
 
       - name: Install Playwright browsers
-        run: |
-          cd apps/frontend
-          npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: apps/frontend
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Create .env file for Docker Compose
-        run: |
-          cat > .env << EOF
-          SQLALCHEMY_DB_USER=rhesis-user
-          SQLALCHEMY_DB_PASS=rhesis-password
-          SQLALCHEMY_DB_HOST=postgres
-          SQLALCHEMY_DB_NAME=rhesis-db
-          DB_ENCRYPTION_KEY=test-encryption-key-32-bytes-long
-          REDIS_PASSWORD=rhesis-redis-pass
-          JWT_SECRET_KEY=test-jwt-secret-key-for-e2e-tests
-          JWT_ALGORITHM=HS256
-          JWT_ACCESS_TOKEN_EXPIRE_MINUTES=10080
-          SESSION_SECRET_KEY=test-session-secret-key-for-e2e
-          LOG_LEVEL=INFO
-          ENVIRONMENT=test
-          BACKEND_ENV=test
-          QUICK_START=true
-          RHESIS_CONNECTOR_DISABLED=true
-          EOF
+      - name: Run E2E tests
+        run: make test-e2e
+        working-directory: apps/frontend
 
-      - name: Start backend services
-        run: |
-          docker compose up -d postgres redis
-          echo "Waiting for services to be healthy..."
-          timeout 60 bash -c 'until docker compose ps | grep -q "postgres.*healthy"; do sleep 2; done'
-          timeout 60 bash -c 'until docker compose ps | grep -q "redis.*healthy"; do sleep 2; done'
-          echo "Services are healthy"
-
-      - name: Build and start backend
-        run: |
-          docker compose up -d backend
-          echo "Waiting for backend to be healthy..."
-          timeout 120 bash -c 'until curl -f http://localhost:8080/health > /dev/null 2>&1; do sleep 2; done'
-          echo "Backend is ready"
-
-      - name: Run Playwright E2E tests
-        run: |
-          cd apps/frontend
-          npx playwright test --grep "@sanity"
-        env:
-          NEXT_PUBLIC_QUICK_START: 'true'
-          NEXT_PUBLIC_API_BASE_URL: 'http://localhost:8080'
-          BACKEND_URL: 'http://localhost:8080'
-          NEXTAUTH_SECRET: 'test-secret-for-e2e-tests-only'
-          NEXTAUTH_URL: 'http://localhost:3000'
-
-      - name: Stop backend services
+      - name: Stop Docker services
         if: always()
         run: |
-          docker compose logs backend
-          docker compose down -v
+          docker compose -f ../../tests/docker-compose.frontend.yml logs frontend-test-backend
+          make docker-down
+        working-directory: apps/frontend
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/apps/frontend/Makefile
+++ b/apps/frontend/Makefile
@@ -1,7 +1,7 @@
 # Frontend Makefile
 # Mimics the validation script behavior with focus on errors only
 
-.PHONY: help lint lint-fast clean format format-check type-check eslint test test-coverage build install
+.PHONY: help lint lint-fast clean format format-check type-check eslint test test-coverage build install docker-up docker-down docker-clean test-e2e
 
 # Default target
 help:
@@ -88,3 +88,24 @@ build:
 install:
 	@echo "📦 Installing dependencies..."
 	@npm ci --legacy-peer-deps
+
+# Docker management for E2E tests
+BACKEND_E2E_PORT := 14003
+
+docker-up:
+	docker compose -f ../../tests/docker-compose.frontend.yml up -d --build --wait
+
+docker-down:
+	docker compose -f ../../tests/docker-compose.frontend.yml down
+
+docker-clean:
+	docker compose -f ../../tests/docker-compose.frontend.yml down -v
+
+# E2E tests (starts docker automatically)
+test-e2e: docker-up
+	NEXT_PUBLIC_QUICK_START=true \
+	NEXT_PUBLIC_API_BASE_URL=http://localhost:$(BACKEND_E2E_PORT) \
+	BACKEND_URL=http://localhost:$(BACKEND_E2E_PORT) \
+	NEXTAUTH_SECRET=test-secret-for-e2e-tests-only \
+	NEXTAUTH_URL=http://localhost:3000 \
+	npx playwright test --grep "@sanity"

--- a/tests/docker-compose.frontend.yml
+++ b/tests/docker-compose.frontend.yml
@@ -1,0 +1,95 @@
+# Frontend E2E test infrastructure
+#
+# Usage:
+#   docker compose -f tests/docker-compose.frontend.yml up -d --build --wait
+#
+# Port allocation (xx001=postgres, xx002=redis, xx003=backend):
+#   PostgreSQL 14001, Redis 14002, Backend 14003
+
+# Backend environment configuration
+x-frontend-database-config: &frontend-database-config
+  SQLALCHEMY_DB_NAME: rhesis-db
+  SQLALCHEMY_DB_USER: rhesis-user
+  SQLALCHEMY_DB_PASS: rhesis-password # trufflehog:ignore
+  SQLALCHEMY_DB_PORT: 5432
+  SQLALCHEMY_DATABASE_URL: postgresql://rhesis-user:rhesis-password@frontend-test-postgres:5432/rhesis-db # trufflehog:ignore
+  SQLALCHEMY_DB_DRIVER: postgresql
+  SQLALCHEMY_DB_HOST: frontend-test-postgres
+  DB_ENCRYPTION_KEY: Zb21wZbPsUpb-c2JKj8uMugk767pWXHFTsjocd0Orac= # trufflehog:ignore
+x-frontend-redis-config: &frontend-redis-config
+  REDIS_URL: redis://:rhesis-redis-pass@frontend-test-redis:6379/0
+  BROKER_URL: redis://:rhesis-redis-pass@frontend-test-redis:6379/0
+  CELERY_RESULT_BACKEND: redis://:rhesis-redis-pass@frontend-test-redis:6379/1
+
+x-frontend-backend-config: &frontend-backend-config
+  JWT_SECRET_KEY: test-jwt-secret-key-for-e2e-tests
+  JWT_ALGORITHM: HS256
+  JWT_ACCESS_TOKEN_EXPIRE_MINUTES: 10080
+  SESSION_SECRET_KEY: test-session-secret-key-for-e2e
+  LOG_LEVEL: INFO
+  ENVIRONMENT: test
+  BACKEND_ENV: test
+  QUICK_START: true
+  RHESIS_CONNECTOR_DISABLED: true
+
+services:
+  frontend-test-postgres:
+    image: mirror.gcr.io/pgvector/pgvector:pg16
+    environment:
+      POSTGRES_DB: rhesis-db
+      POSTGRES_USER: rhesis-user
+      POSTGRES_PASSWORD: rhesis-password
+    ports:
+      - "14001:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U rhesis-user -d rhesis-db"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - frontend-test-network
+    tmpfs:
+      - /var/lib/postgresql/data
+
+  frontend-test-redis:
+    image: mirror.gcr.io/redis:7-alpine
+    command: redis-server --requirepass rhesis-redis-pass
+    ports:
+      - "14002:6379"
+    environment:
+      - REDIS_PASSWORD=rhesis-redis-pass
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "rhesis-redis-pass", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - frontend-test-network
+    tmpfs:
+      - /data
+
+  frontend-test-backend:
+    build:
+      context: ..
+      dockerfile: apps/backend/Dockerfile
+    environment:
+      <<: [*frontend-database-config, *frontend-redis-config, *frontend-backend-config]
+    ports:
+      - "14003:8080"
+    depends_on:
+      frontend-test-postgres:
+        condition: service_healthy
+      frontend-test-redis:
+        condition: service_healthy
+    networks:
+      - frontend-test-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+networks:
+  frontend-test-network:
+    driver: bridge


### PR DESCRIPTION
## Purpose

Move frontend E2E test infrastructure out of the GitHub workflow and into a dedicated Docker Compose file, following the same pattern established in PR #1334 for SDK and backend tests.

## What Changed

- Created `tests/docker-compose.frontend.yml` with dedicated services:
  - `frontend-test-postgres` (14001)
  - `frontend-test-redis` (14002)
  - `frontend-test-backend` (14003)
- Added `docker-up`/`docker-down`/`docker-clean`/`test-e2e` Make targets to `apps/frontend/Makefile`
- Simplified `.github/workflows/frontend-e2e-test.yml`:
  - Removed inline `.env` file creation
  - Removed manual `docker compose up/down` and health-check polling
  - Replaced with `make test-e2e` (which handles docker-up automatically)

## Port Allocation

Follows the `xx001=postgres, xx002=redis, xx003=backend` convention:

| Suite | PostgreSQL | Redis | Backend |
|-------|-----------|-------|---------|
| SDK | 10001 | 10002 | 10003 |
| Backend | 12001 | 12002 | -- |
| **Frontend E2E** | **14001** | **14002** | **14003** |

## Testing

```bash
cd apps/frontend
make docker-up       # starts postgres, redis, backend
make test-e2e        # runs docker-up + playwright tests
make docker-down     # stops containers
```