### PR TITLE
Fix failing tests for chat handler and auto_mapper

### DIFF
--- a/tests/backend/services/connector/mapping/test_auto_mapper.py
+++ b/tests/backend/services/connector/mapping/test_auto_mapper.py
@@ -30,8 +30,9 @@ class TestAutoMapper:
         assert len(result["missing_fields"]) == 0  # All REQUEST fields matched
 
         # Check request template (only REQUEST fields)
+        # Keys are original parameter names, values are standard template variables
         assert result["request_mapping"]["input"] == "{{ input }}"
-        assert result["request_mapping"]["conversation_id"] == "{{ conversation_id }}"
+        assert result["request_mapping"]["session_id"] == "{{ conversation_id }}"
         assert "context" not in result["request_mapping"]  # RESPONSE field
 
         # Check response mappings exist

--- a/tests/backend/services/websocket/test_chat_handler.py
+++ b/tests/backend/services/websocket/test_chat_handler.py
@@ -133,7 +133,9 @@ class TestChatMessageHandler:
             mock_service = MockEndpointService.return_value
             mock_service.invoke_endpoint = AsyncMock(return_value=mock_result)
 
-            with patch("rhesis.backend.app.services.websocket.handlers.chat.get_db") as mock_get_db:
+            with patch(
+                "rhesis.backend.app.services.websocket.handlers.chat.get_db_with_tenant_variables"
+            ) as mock_get_db:
                 # Mock the context manager
                 mock_db = MagicMock()
                 mock_get_db.return_value.__enter__ = MagicMock(return_value=mock_db)
@@ -174,7 +176,9 @@ class TestChatMessageHandler:
             mock_service = MockEndpointService.return_value
             mock_service.invoke_endpoint = AsyncMock(side_effect=Exception("Endpoint not found"))
 
-            with patch("rhesis.backend.app.services.websocket.handlers.chat.get_db") as mock_get_db:
+            with patch(
+                "rhesis.backend.app.services.websocket.handlers.chat.get_db_with_tenant_variables"
+            ) as mock_get_db:
                 mock_db = MagicMock()
                 mock_get_db.return_value.__enter__ = MagicMock(return_value=mock_db)
                 mock_get_db.return_value.__exit__ = MagicMock(return_value=False)
@@ -219,7 +223,9 @@ class TestChatMessageHandler:
             mock_service = MockEndpointService.return_value
             mock_service.invoke_endpoint = AsyncMock(return_value=error_response)
 
-            with patch("rhesis.backend.app.services.websocket.handlers.chat.get_db") as mock_get_db:
+            with patch(
+                "rhesis.backend.app.services.websocket.handlers.chat.get_db_with_tenant_variables"
+            ) as mock_get_db:
                 mock_db = MagicMock()
                 mock_get_db.return_value.__enter__ = MagicMock(return_value=mock_db)
                 mock_get_db.return_value.__exit__ = MagicMock(return_value=False)
@@ -263,7 +269,9 @@ class TestChatMessageHandler:
             mock_service = MockEndpointService.return_value
             mock_service.invoke_endpoint = AsyncMock(return_value=mock_result)
 
-            with patch("rhesis.backend.app.services.websocket.handlers.chat.get_db") as mock_get_db:
+            with patch(
+                "rhesis.backend.app.services.websocket.handlers.chat.get_db_with_tenant_variables"
+            ) as mock_get_db:
                 mock_db = MagicMock()
                 mock_get_db.return_value.__enter__ = MagicMock(return_value=mock_db)
                 mock_get_db.return_value.__exit__ = MagicMock(return_value=False)
@@ -305,7 +313,9 @@ class TestChatMessageHandler:
             mock_service = MockEndpointService.return_value
             mock_service.invoke_endpoint = AsyncMock(return_value=mock_result)
 
-            with patch("rhesis.backend.app.services.websocket.handlers.chat.get_db") as mock_get_db:
+            with patch(
+                "rhesis.backend.app.services.websocket.handlers.chat.get_db_with_tenant_variables"
+            ) as mock_get_db:
                 mock_db = MagicMock()
                 mock_get_db.return_value.__enter__ = MagicMock(return_value=mock_db)
                 mock_get_db.return_value.__exit__ = MagicMock(return_value=False)
@@ -341,7 +351,9 @@ class TestChatMessageHandler:
             mock_service = MockEndpointService.return_value
             mock_service.invoke_endpoint = AsyncMock(return_value=mock_result)
 
-            with patch("rhesis.backend.app.services.websocket.handlers.chat.get_db") as mock_get_db:
+            with patch(
+                "rhesis.backend.app.services.websocket.handlers.chat.get_db_with_tenant_variables"
+            ) as mock_get_db:
                 mock_db = MagicMock()
                 mock_get_db.return_value.__enter__ = MagicMock(return_value=mock_db)
                 mock_get_db.return_value.__exit__ = MagicMock(return_value=False)


### PR DESCRIPTION
## Purpose

Fix test failures caused by the session context changes in #1337.

## What Changed

- **Chat handler tests** (`test_chat_handler.py`): Updated all mock targets from `get_db` to `get_db_with_tenant_variables` to match the import change in the chat handler
- **Auto mapper test** (`test_auto_mapper.py`): Fixed `test_standard_naming_high_confidence` to use the original parameter name (`session_id`) as the `request_mapping` key instead of the mapped field name (`conversation_id`), matching the actual auto mapper behavior

## Testing

All 13 tests pass locally:
- `tests/backend/services/websocket/test_chat_handler.py` (12 tests)
- `tests/backend/services/connector/mapping/test_auto_mapper.py::TestAutoMapper::test_standard_naming_high_confidence` (1 test)