### PR TITLE
Free disk space and clean uv cache in SDK test workflow

### DIFF
--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -45,6 +45,9 @@ jobs:
         make test
       continue-on-error: false
 
+    - name: Clean uv cache
+      run: uv cache clean --force
+
     - name: Test SDK (full)
       if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
       run: |


### PR DESCRIPTION
## Purpose
Prevent No space left on device errors during SDK integration tests in CI.

## What Changed
- Added jlumbroso/free-disk-space step to reclaim runner disk space before tests
- Added uv cache clean --force step between fast and full test runs to free cached packages

## Additional Context
The full SDK test run builds Docker images and runs integration tests, which can exhaust disk space on GitHub Actions runners. These two steps ensure sufficient disk space is available.