### PR TITLE
fix(hooks): resolve infinite loop in useFormChangeDetection

### DIFF
--- a/apps/frontend/src/hooks/useFormChangeDetection.ts
+++ b/apps/frontend/src/hooks/useFormChangeDetection.ts
@@ -51,7 +51,7 @@ export function useFormChangeDetection<
 
   useEffect(() => {
     setTrackedInitialData(initialData);
-  }, [initialDataString, initialData]);
+  }, [initialDataString]);
 
   const hasChanges = compareFormData(currentData, trackedInitialData);
 


### PR DESCRIPTION
Fix infinite re-renders in useFormChangeDetection

This PR fixes a regression introduced in #1235.

The useEffect inside useFormChangeDetection had redundant dependencies (initialData and initialDataString), causing unnecessary executions and in some cases infinite re-renders when initialData was recreated by reference.