### PR TITLE
Restructure endpoint documentation into focused sub-pages

### DIFF
--- a/docs/content/platform/endpoints/_meta.tsx
+++ b/docs/content/platform/endpoints/_meta.tsx
@@ -2,6 +2,10 @@ import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {
   index: "Overview",
+  "single-turn": "Single-Turn Endpoints",
+  "multi-turn-conversations": "Multi-Turn Conversations",
+  "sdk-endpoints": "SDK Endpoints",
+  "mapping-examples": "Mapping Examples",
   "default-chatbot": "Default Insurance Chatbot",
 };
 

--- a/docs/content/platform/endpoints/index.mdx
+++ b/docs/content/platform/endpoints/index.mdx
@@ -32,6 +32,69 @@ An endpoint in Rhesis is a complete configuration for calling an external API. W
 
 Think of endpoints as the bridge between your tests and the AI system you're evaluating.
 
+## Platform-Managed Variables
+
+Rhesis uses a set of platform-managed variables to standardize communication between your tests and your API. You map these variables to the fields your endpoint expects (in request templates) and the fields your endpoint returns (in response mappings). This abstraction lets Rhesis work with any API regardless of its specific field names.
+
+### Request Variables
+
+These variables are available in your request body templates using Jinja2 syntax (`\{\{ variable \}\}`). Rhesis populates them automatically when running tests.
+
+| Variable | Required | Description |
+|---|---|---|
+| `input` | Yes | The user query or test prompt. This is the primary text sent to your AI endpoint. |
+| `conversation_id` | No | Conversation tracking identifier for multi-turn stateful endpoints. Rhesis passes this back on subsequent turns. |
+| `messages` | No | Full conversation history as an array of message objects. Used for stateless endpoints that require the entire history with every request. |
+| `system_prompt` | No | System prompt text. Rhesis prepends it to the `messages` array and strips it from the final request body before sending. |
+
+### Response Variables
+
+These variables are extracted from your API response using JSONPath or Jinja2 expressions in the response mapping. Rhesis uses them for evaluation, display, and conversation tracking.
+
+| Variable | Required | Description |
+|---|---|---|
+| `output` | Yes | The main response text from your API. This is what Rhesis evaluates against your metrics. |
+| `context` | No | Additional context or reasoning provided by the response (e.g., retrieved documents, sources). |
+| `metadata` | No | Arbitrary metadata about the response (e.g., model version, token counts). Stored but not actively evaluated. |
+| `tool_calls` | No | Tool or function call results returned by the API. |
+| Conversation ID fields | No | Any of the recognized conversation identifiers: `conversation_id`, `session_id`, `thread_id`, `chat_id`, `dialog_id`, `dialogue_id`, `context_id`, `interaction_id`. Rhesis auto-detects these for multi-turn tracking. |
+
+<Callout type="info">
+  You can include additional custom fields in both request templates and response
+  mappings. Custom fields are passed through and stored, but Rhesis does not
+  actively use them for evaluation or conversation management.
+</Callout>
+
+### How Mapping Works
+
+Request and response mappings tell Rhesis how to translate between its standard variables and your API's specific field names.
+
+**Request mapping** uses Jinja2 templates to place platform variables into your API's expected request body structure:
+
+<CodeBlock filename="request-mapping-example.json" language="json">
+  {`{
+  "model": "gpt-4",
+  "messages": [
+    {
+      "role": "user",
+      "content": "{{ input }}"
+    }
+  ],
+  "temperature": 0.7
+}`}
+</CodeBlock>
+
+**Response mapping** uses JSONPath expressions to extract values from your API's response into platform variables:
+
+<CodeBlock filename="response-mapping-example.json" language="json">
+  {`{
+  "output": "$.choices[0].message.content",
+  "metadata": "$.usage"
+}`}
+</CodeBlock>
+
+For full details on template syntax, filters, and advanced mapping techniques, see [Single-Turn Endpoints](/platform/endpoints/single-turn).
+
 ## Creating an Endpoint
 
 ### Manual Configuration
@@ -46,183 +109,36 @@ Define authentication and other required headers in JSON format:
 
 <CodeBlock filename="headers.json" language="json">
   {`{
-  "Authorization": "Bearer {API_KEY}",
+  "Authorization": "Bearer {{ auth_token }}",
   "Content-Type": "application/json"
 }`}
 </CodeBlock>
 
-**Request Body Template**
+The `auth_token` variable is a platform-managed placeholder that Rhesis
+automatically replaces with the authentication token you configure in the
+endpoint settings UI. You can reference it using Jinja2 syntax
+(`\{\{ auth_token \}\}`) or the legacy `\{API_KEY\}` / `\{auth_token\}`
+placeholders with single braces.
 
-Templates use Jinja2 syntax for dynamic values. Use the `tojson` filter for proper JSON formatting:
+If you configure an authentication token in the UI but do not include an
+`Authorization` header explicitly, Rhesis automatically adds
+`Authorization: Bearer <token>` to the request headers.
 
-<CodeBlock filename="request-body.json" language="json">
-  {`{
-  "model": "gpt-4",
-  "messages": [
-    {
-      "role": "user",
-      "content": "{{ input }}"
-    }
-  ],
-  "temperature": 0.7,
-  "conversation_id": {{ conversation_id | tojson }}
-}`}
-</CodeBlock>
+**Request and Response Mappings**
 
-The `tojson` filter ensures values are properly formatted as JSON (e.g., `null` instead of `None`, properly quoted strings).
+Configure your request body template and response mappings to bridge platform variables with your API's fields. Rhesis supports two endpoint patterns depending on how your API handles conversations:
 
-**Response Mappings**
+- **[Single-Turn Endpoints](/platform/endpoints/single-turn)**: Standard request/response mapping with Jinja2 templates and JSONPath. Covers most use cases including simple query-response APIs.
+- **[Multi-Turn Conversations](/platform/endpoints/multi-turn-conversations)**: Conversation tracking for stateful endpoints (your API manages session state) and message history for stateless endpoints (Rhesis manages conversation state).
+- **[Mapping Examples](/platform/endpoints/mapping-examples)**: Practical examples for OpenAI, Anthropic, Google Gemini, RAG pipelines, WebSocket endpoints, and more.
 
-Extract values using JSONPath or Jinja2 templates with conditional logic:
+### SDK Endpoints
 
-<CodeBlock filename="response-mappings.json" language="json">
-  {`{
-  "output": "$.choices[0].message.content",
-  "model_used": "$.model",
-  "tokens": "$.usage.total_tokens"
-}`}
-</CodeBlock>
-
-For conditional logic or nested fields, use Jinja2 templates with the `jsonpath()` function:
-
-<CodeBlock filename="response-mappings-advanced.json" language="json">
-  {`{
-  "output": "{{ jsonpath('$.text_response') or jsonpath('$.result.content') }}",
-  "conversation_id": "$.conversation_id"
-}`}
-</CodeBlock>
-
-The first value evaluates as a Jinja2 template (returns first non-empty field), while pure JSONPath expressions (starting with `$`) work as before.
-
-<Callout type="info">
-  **Platform-Managed Fields**: Rhesis actively uses certain mapped fields:
-  - `output`: The main response text from your API (required)
-  - `context`: Additional context or reasoning from the response
-  - Conversation tracking fields (see below) for multi-turn conversations
-
-  Other fields like `model_used` or `tokens` are stored but not actively used by the platform.
-</Callout>
-
-**Conversation Tracking for Multi-Turn Conversations**
-
-Rhesis automatically tracks conversation state across multiple turns when you include a conversation identifier in your response mappings. This enables testing of conversational AI systems that maintain context across interactions.
-
-To enable conversation tracking, simply map the conversation field from your API response:
-
-<CodeBlock filename="response-mappings-with-conversation.json" language="json">
-  {`{
-  "output": "$.choices[0].message.content",
-  "conversation_id": "$.conversation_id"
-}`}
-</CodeBlock>
-
-Rhesis automatically detects and handles the following conversation field names:
-
-**Most Common (Tier 1)**:
-- `conversation_id`
-- `session_id`
-- `thread_id`
-- `chat_id`
-
-**Common Variants (Tier 2)**:
-- `dialog_id`
-- `dialogue_id`
-- `context_id`
-- `interaction_id`
-
-When a conversation field is mapped, Rhesis will:
-1. Extract the conversation ID from each API response
-2. Automatically include it in subsequent requests for the same conversation
-3. Maintain conversation context across multiple test turns
-
-This works for both REST and WebSocket endpoints without any additional configuration.
-
-<CodeBlock filename="multi-turn-example.json" language="json">
-  {`// First request - no conversation_id
-{
-  "query": "What is the capital of France?"
-}
-
-// API returns: { "output": "Paris", "conversation_id": "abc-123" }
-
-// Second request - conversation_id automatically included
-{
-  "query": "What is its population?",
-  "conversation_id": "abc-123"
-}
-
-// API maintains context and responds about Paris`}
-</CodeBlock>
-
-![Request Settings](/screenshots/rhesis-ai-endpoint-request-settings.png)
-
-**Stateless Endpoints (Message History)**
-
-Some AI endpoints are stateless: they do not maintain conversation context on
-the server side. Instead, the caller must send the entire conversation history
-with every request. Rhesis supports this pattern natively.
-
-To configure a stateless endpoint, use the `messages` template variable in your
-request body template. Rhesis detects this and manages the conversation history
-internally:
-
-<CodeBlock filename="stateless-request-body.json" language="json">
-  {`{
-  "messages": "{{ messages }}",
-  "model": "my-model",
-  "temperature": 0.7,
-  "system_prompt": "You are a helpful assistant."
-}`}
-</CodeBlock>
-
-How it works:
-
-- **Automatic detection**: Rhesis identifies a stateless endpoint when the
-  request body template contains `\{\{ messages \}\}`.
-- **History management**: During multi-turn test execution, Rhesis accumulates
-  the full conversation history (user messages and assistant responses) and sends
-  it as the `messages` array with each request.
-- **System prompt**: If you include a `system_prompt` field in the request body
-  template, Rhesis prepends it to the messages array as the first entry with the
-  `system` role. The `system_prompt` field itself is stripped from the final
-  request before sending.
-- **Single-turn auto-population**: For single test runs (outside multi-turn
-  conversations), Rhesis automatically builds the messages array from the test
-  input and system prompt so you do not need to provide it manually.
-
-The messages array follows the standard chat completion format used by most LLM
-providers:
-
-<CodeBlock filename="messages-format.json" language="json">
-  {`[
-  { "role": "system", "content": "You are a helpful assistant." },
-  { "role": "user", "content": "What is the capital of France?" },
-  { "role": "assistant", "content": "The capital of France is Paris." },
-  { "role": "user", "content": "What is its population?" }
-]`}
-</CodeBlock>
-
-The response mapping for stateless endpoints works the same way as for any other
-endpoint. Map the `output` field to the response path where the assistant's reply
-is returned:
-
-<CodeBlock filename="stateless-response-mapping.json" language="json">
-  {`{
-  "output": "$.choices[0].message.content"
-}`}
-</CodeBlock>
-
-<Callout type="info">
-  **Stateless vs. Stateful**: Use stateless configuration when your endpoint
-  expects the full conversation history in every request. Use stateful
-  configuration (with conversation tracking fields like `conversation_id`) when
-  your endpoint maintains server-side session state. Rhesis detects which mode to
-  use based on your request body template.
-</Callout>
-
-### Importing from Swagger/OpenAPI
-
-Click **Import Swagger**, enter your Swagger/OpenAPI specification URL, and click **Import**. This automatically populates request templates and response structures from your API documentation. You'll still need to fill in authentication details and select which operations to configure.
+If your AI logic lives in Python functions, you can register them as endpoints
+directly from code using the Rhesis SDK. Decorate your functions with `@endpoint`
+and the SDK handles registration and mapping automatically. See
+[SDK Endpoints](/platform/endpoints/sdk-endpoints) for details, or the full
+[SDK Connector reference](/sdk/connector) for advanced patterns.
 
 ## Testing Your Endpoint
 
@@ -239,6 +155,10 @@ The Endpoints page displays all your configured endpoints organized by project. 
 ### Editing Endpoints
 
 Open the endpoint details page, click **Edit**, modify any configuration fields, and click **Save**. Changes take effect immediately for new test runs.
+
+### Duplicating Endpoints
+
+To create a copy of an existing endpoint, open the endpoint details page and click **Duplicate**. Rhesis creates a new endpoint with the same configuration and appends "(Copy)" to the name. You can also select multiple endpoints from the grid and duplicate them in bulk.
 
 ### Deleting Endpoints
 
@@ -275,9 +195,15 @@ Environment tags help you quickly identify which endpoints are production-critic
 ---
 
 <Callout type="default">
-  **Next Steps** - Test your endpoint configuration using the Test Connection
-  tab - Generate [Tests](/platform/tests-generation) with AI to create
-  comprehensive coverage - Create multiple endpoints to compare models or
-  environments - Define [Metrics](/platform/metrics) to evaluate response
-  quality
+  **Next Steps**
+  - Learn about [Single-Turn Endpoints](/platform/endpoints/single-turn) for
+    request/response mapping details
+  - Configure [Multi-Turn Conversations](/platform/endpoints/multi-turn-conversations)
+    for conversational AI testing
+  - Register Python functions with [SDK Endpoints](/platform/endpoints/sdk-endpoints)
+  - Browse [Mapping Examples](/platform/endpoints/mapping-examples) for
+    real-world configuration patterns
+  - Generate [Tests](/platform/tests-generation) with AI to create
+    comprehensive coverage
+  - Define [Metrics](/platform/metrics) to evaluate response quality
 </Callout>

--- a/docs/content/platform/endpoints/mapping-examples.mdx
+++ b/docs/content/platform/endpoints/mapping-examples.mdx
@@ -1,0 +1,388 @@
+import { CodeBlock } from "@/components/CodeBlock";
+
+# Mapping Examples
+
+Practical examples showing how to configure request and response mappings for
+different API patterns. Each example includes the request body template, response
+mapping, and a description of how Rhesis translates between
+[platform-managed variables](/platform/endpoints#platform-managed-variables) and
+your API.
+
+## Simple Query-Response API
+
+The most basic pattern: a single input field and a top-level output field.
+
+**API contract**: Your API expects `\{"prompt": "..."\}` and returns `\{"text": "..."\}`.
+
+**Request body template**:
+
+<CodeBlock filename="simple-request.json" language="json">
+  {`{
+  "prompt": "{{ input }}"
+}`}
+</CodeBlock>
+
+**Response mapping**:
+
+<CodeBlock filename="simple-response.json" language="json">
+  {`{
+  "output": "$.text"
+}`}
+</CodeBlock>
+
+Rhesis maps its `input` variable to your API's `prompt` field, and extracts
+your API's `text` field into the platform's `output` variable.
+
+## OpenAI-Compatible API
+
+For APIs that follow the OpenAI chat completions format.
+
+**Request body template**:
+
+<CodeBlock filename="openai-request.json" language="json">
+  {`{
+  "model": "gpt-4",
+  "messages": [
+    {
+      "role": "user",
+      "content": "{{ input }}"
+    }
+  ],
+  "temperature": 0.7,
+  "max_tokens": 1024
+}`}
+</CodeBlock>
+
+**Response mapping**:
+
+<CodeBlock filename="openai-response.json" language="json">
+  {`{
+  "output": "$.choices[0].message.content",
+  "metadata": "$.usage"
+}`}
+</CodeBlock>
+
+The response text is nested inside `choices[0].message.content`. The `metadata`
+field captures token usage statistics for reference.
+
+<Callout type="info">
+  **Multi-turn conversations**: This example sends a single user message. Since
+  OpenAI-compatible APIs are stateless, you can use `"messages": "{{ messages }}"`
+  instead to let Rhesis manage the full conversation history automatically. The
+  response mapping stays the same. See the
+  [Stateless Endpoint example](#stateless-conversation-endpoint) below or
+  [Multi-Turn Conversations](/platform/endpoints/multi-turn-conversations#stateless-endpoints-message-history)
+  for details.
+</Callout>
+
+## Anthropic Claude API
+
+For APIs following Anthropic's message format.
+
+**Request body template**:
+
+<CodeBlock filename="anthropic-request.json" language="json">
+  {`{
+  "model": "claude-3-sonnet-20240229",
+  "max_tokens": 1024,
+  "system": "You are a helpful assistant.",
+  "messages": [
+    {
+      "role": "user",
+      "content": "{{ input }}"
+    }
+  ]
+}`}
+</CodeBlock>
+
+**Response mapping**:
+
+<CodeBlock filename="anthropic-response.json" language="json">
+  {`{
+  "output": "$.content[0].text",
+  "metadata": "$.usage"
+}`}
+</CodeBlock>
+
+Anthropic returns the response in `content[0].text` rather than
+`choices[0].message.content`.
+
+<Callout type="info">
+  **Multi-turn conversations**: Like OpenAI, the Anthropic API is stateless.
+  Replace the hardcoded `messages` array with `"messages": "{{ messages }}"` to
+  let Rhesis manage conversation history across multiple turns. See
+  [Multi-Turn Conversations](/platform/endpoints/multi-turn-conversations#stateless-endpoints-message-history)
+  for details.
+</Callout>
+
+## Google Gemini API
+
+For the Google Gemini (Vertex AI) chat format.
+
+**Request body template**:
+
+<CodeBlock filename="gemini-request.json" language="json">
+  {`{
+  "contents": [
+    {
+      "role": "user",
+      "parts": [
+        {
+          "text": "{{ input }}"
+        }
+      ]
+    }
+  ],
+  "generationConfig": {
+    "temperature": 0.7,
+    "maxOutputTokens": 1024
+  }
+}`}
+</CodeBlock>
+
+**Response mapping**:
+
+<CodeBlock filename="gemini-response.json" language="json">
+  {`{
+  "output": "$.candidates[0].content.parts[0].text",
+  "metadata": "$.usageMetadata"
+}`}
+</CodeBlock>
+
+Gemini uses a deeply nested structure with `candidates`, `content`, and `parts`.
+
+<Callout type="info">
+  **Multi-turn conversations**: The Gemini API is also stateless. For
+  multi-turn testing, replace the hardcoded `contents` array with
+  `"contents": "{{ messages }}"` to let Rhesis manage the conversation
+  history. See
+  [Multi-Turn Conversations](/platform/endpoints/multi-turn-conversations#stateless-endpoints-message-history)
+  for details.
+</Callout>
+
+## RAG Endpoint with Context
+
+For retrieval-augmented generation APIs that return source documents alongside
+the answer.
+
+**API contract**: Your API expects a query and returns an answer with sources.
+
+**Request body template**:
+
+<CodeBlock filename="rag-request.json" language="json">
+  {`{
+  "query": "{{ input }}",
+  "num_sources": 5,
+  "include_metadata": true
+}`}
+</CodeBlock>
+
+**Response mapping**:
+
+<CodeBlock filename="rag-response.json" language="json">
+  {`{
+  "output": "$.answer",
+  "context": "$.sources",
+  "metadata": "$.metadata"
+}`}
+</CodeBlock>
+
+The `context` variable captures the retrieved sources, which Rhesis can use for
+context-dependent metrics like faithfulness and relevance.
+
+## Fallback Response Paths
+
+When your API might return the response in different locations depending on the
+request type, use Jinja2 templates with `jsonpath()` for fallback logic.
+
+**Response mapping**:
+
+<CodeBlock filename="fallback-response.json" language="json">
+  {`{
+  "output": "{{ jsonpath('$.result.text') or jsonpath('$.message') or jsonpath('$.output') }}",
+  "metadata": "$.debug_info"
+}`}
+</CodeBlock>
+
+Rhesis tries each JSONPath expression in order and uses the first non-empty
+result. This is useful for APIs that have different response shapes for different
+endpoints or error conditions.
+
+## Stateful Conversation Endpoint
+
+For APIs that manage their own session state and return a conversation
+identifier.
+
+**Request body template**:
+
+<CodeBlock filename="stateful-request.json" language="json">
+  {`{
+  "message": "{{ input }}",
+  "conversation_id": {{ conversation_id | tojson }}
+}`}
+</CodeBlock>
+
+**Response mapping**:
+
+<CodeBlock filename="stateful-response.json" language="json">
+  {`{
+  "output": "$.response",
+  "conversation_id": "$.conversation_id",
+  "context": "$.sources"
+}`}
+</CodeBlock>
+
+On the first turn, `conversation_id` renders as `null`. The API returns a new
+conversation ID, which Rhesis automatically includes in subsequent requests.
+See [Multi-Turn Conversations](/platform/endpoints/multi-turn-conversations)
+for details.
+
+## Stateless Conversation Endpoint
+
+For APIs that expect the full message history with every request (e.g., direct
+LLM provider APIs).
+
+**Request body template**:
+
+<CodeBlock filename="stateless-request.json" language="json">
+  {`{
+  "model": "gpt-4",
+  "messages": "{{ messages }}",
+  "temperature": 0.7,
+  "system_prompt": "You are a knowledgeable insurance advisor."
+}`}
+</CodeBlock>
+
+**Response mapping**:
+
+<CodeBlock filename="stateless-response.json" language="json">
+  {`{
+  "output": "$.choices[0].message.content"
+}`}
+</CodeBlock>
+
+Rhesis detects the `messages` variable and manages conversation history
+internally. The `system_prompt` is prepended to the messages array and removed
+from the request body before sending. See
+[Multi-Turn Conversations](/platform/endpoints/multi-turn-conversations) for
+details.
+
+## Custom Business Fields
+
+For APIs that require domain-specific fields beyond the standard platform
+variables. Custom fields are passed through from the test input.
+
+**Request body template**:
+
+<CodeBlock filename="custom-fields-request.json" language="json">
+  {`{
+  "question": "{{ input }}",
+  "policy_number": "{{ policy_number }}",
+  "customer_tier": "{{ tier | default('standard') }}",
+  "language": "{{ language | default('en') }}"
+}`}
+</CodeBlock>
+
+**Response mapping**:
+
+<CodeBlock filename="custom-fields-response.json" language="json">
+  {`{
+  "output": "$.answer",
+  "context": "$.relevant_clauses",
+  "metadata": "$.claim_info"
+}`}
+</CodeBlock>
+
+Custom fields like `policy_number` and `tier` must be included in the test input
+or API request body when invoking the endpoint. Use the `default` filter to
+provide fallback values for optional fields.
+
+## API with Authentication in the Body
+
+Some APIs require authentication tokens or API keys in the request body rather
+than in headers.
+
+**Request body template**:
+
+<CodeBlock filename="auth-body-request.json" language="json">
+  {`{
+  "api_key": "sk-your-api-key",
+  "input": {
+    "text": "{{ input }}",
+    "options": {
+      "temperature": 0.5,
+      "format": "text"
+    }
+  }
+}`}
+</CodeBlock>
+
+**Response mapping**:
+
+<CodeBlock filename="auth-body-response.json" language="json">
+  {`{
+  "output": "$.result.generated_text",
+  "metadata": "$.result.statistics"
+}`}
+</CodeBlock>
+
+Static values like `api_key` are included as-is in every request.
+
+## Deeply Nested Response
+
+For APIs with complex, deeply nested response structures.
+
+**Response mapping**:
+
+<CodeBlock filename="nested-response.json" language="json">
+  {`{
+  "output": "$.data.completion.choices[0].message.content",
+  "context": "$.data.retrieval.documents[*].text",
+  "metadata": "{{ {'model': jsonpath('$.data.model_info.name'), 'latency_ms': jsonpath('$.data.timing.total_ms')} }}"
+}`}
+</CodeBlock>
+
+The `metadata` field uses a Jinja2 template to construct a custom object from
+multiple response paths. This is useful when you want to aggregate data from
+different parts of the response.
+
+## WebSocket Endpoint
+
+WebSocket endpoints use the same mapping syntax. The request template defines the
+message format sent over the WebSocket connection.
+
+**Request body template**:
+
+<CodeBlock filename="websocket-request.json" language="json">
+  {`{
+  "type": "chat_message",
+  "payload": {
+    "text": "{{ input }}",
+    "session_id": {{ conversation_id | tojson }}
+  }
+}`}
+</CodeBlock>
+
+**Response mapping**:
+
+<CodeBlock filename="websocket-response.json" language="json">
+  {`{
+  "output": "$.payload.response",
+  "conversation_id": "$.payload.session_id",
+  "metadata": "$.payload.metadata"
+}`}
+</CodeBlock>
+
+The mapping works the same regardless of transport protocol (REST or WebSocket).
+
+---
+
+<Callout type="default">
+  **Next Steps**
+  - Learn about [Single-Turn Endpoints](/platform/endpoints/single-turn) for
+    template syntax details
+  - Configure [Multi-Turn Conversations](/platform/endpoints/multi-turn-conversations)
+    for conversational testing
+  - Explore [SDK Endpoints](/platform/endpoints/sdk-endpoints) for code-first
+    endpoint definition
+</Callout>

--- a/docs/content/platform/endpoints/multi-turn-conversations.mdx
+++ b/docs/content/platform/endpoints/multi-turn-conversations.mdx
@@ -1,0 +1,249 @@
+import { CodeBlock } from "@/components/CodeBlock";
+
+# Multi-Turn Conversations
+
+Test conversational AI systems that maintain context across multiple interactions.
+
+<Callout type="default">
+  **What are multi-turn conversations?** Many AI applications are conversational:
+  users ask follow-up questions, refer to previous answers, and expect the system
+  to remember context. Rhesis supports testing these interactions by managing
+  conversation state automatically, regardless of whether your API is stateful or
+  stateless.
+</Callout>
+
+## Stateful vs. Stateless Endpoints
+
+AI endpoints handle conversation context in one of two ways:
+
+- **Stateful endpoints** maintain session state on the server. Your API returns a
+  conversation identifier (e.g., `conversation_id` or `session_id`), and the
+  caller passes it back on subsequent requests. The API looks up the conversation
+  history internally.
+- **Stateless endpoints** do not maintain any server-side state. The caller must
+  send the entire conversation history (as a `messages` array) with every
+  request. This is the pattern used by most LLM provider APIs.
+
+Rhesis detects which mode to use based on your endpoint configuration and
+handles both patterns transparently.
+
+## Stateful Endpoints (Conversation Tracking)
+
+For endpoints that manage their own session state, Rhesis tracks the
+conversation identifier returned by your API and includes it in subsequent
+requests automatically.
+
+### Configuration
+
+Map the conversation field from your API response in the response mapping:
+
+<CodeBlock filename="stateful-response-mapping.json" language="json">
+  {`{
+  "output": "$.choices[0].message.content",
+  "conversation_id": "$.conversation_id"
+}`}
+</CodeBlock>
+
+Include the conversation variable in your request body template so Rhesis can
+pass it back on subsequent turns:
+
+<CodeBlock filename="stateful-request-template.json" language="json">
+  {`{
+  "query": "{{ input }}",
+  "conversation_id": {{ conversation_id | tojson }}
+}`}
+</CodeBlock>
+
+The `tojson` filter ensures the value is `null` on the first turn (when no
+conversation has been established) and a properly quoted string on subsequent
+turns.
+
+### Supported Conversation Field Names
+
+Rhesis automatically detects and handles the following conversation field names
+in your response mapping. You do not need any additional configuration beyond
+mapping the field.
+
+**Most common (Tier 1)**:
+- `conversation_id`
+- `session_id`
+- `thread_id`
+- `chat_id`
+
+**Common variants (Tier 2)**:
+- `dialog_id`
+- `dialogue_id`
+- `context_id`
+- `interaction_id`
+
+<Callout type="info">
+  Internally, Rhesis normalizes all conversation field names to
+  `conversation_id`. If your API uses `session_id` or `thread_id`, Rhesis
+  still maps it correctly in both directions.
+</Callout>
+
+### How It Works
+
+When a conversation field is mapped, Rhesis will:
+
+1. Send the first request without a conversation identifier (or with `null`)
+2. Extract the conversation ID from the API response
+3. Automatically include it in subsequent requests for the same conversation
+4. Maintain conversation context across all test turns
+
+This works for both REST and WebSocket endpoints without any additional
+configuration.
+
+### Example Flow
+
+<CodeBlock filename="stateful-flow-example.json" language="json">
+  {`// First request - no conversation_id
+{
+  "query": "What is the capital of France?"
+}
+
+// API returns: { "output": "Paris", "conversation_id": "abc-123" }
+
+// Second request - conversation_id automatically included
+{
+  "query": "What is its population?",
+  "conversation_id": "abc-123"
+}
+
+// API maintains context and responds about Paris`}
+</CodeBlock>
+
+![Request Settings](/screenshots/rhesis-ai-endpoint-request-settings.png)
+
+## Stateless Endpoints (Message History)
+
+Some AI endpoints are stateless: they do not maintain conversation context on
+the server side. Instead, the caller must send the entire conversation history
+with every request. Rhesis supports this pattern natively by managing the
+conversation history internally.
+
+### Configuration
+
+Use the `messages` template variable in your request body template. Rhesis
+detects this and switches to stateless conversation management:
+
+<CodeBlock filename="stateless-request-template.json" language="json">
+  {`{
+  "messages": "{{ messages }}",
+  "model": "my-model",
+  "temperature": 0.7,
+  "system_prompt": "You are a helpful assistant."
+}`}
+</CodeBlock>
+
+The response mapping works the same as any other endpoint. Map the `output`
+field to where the assistant's reply is returned:
+
+<CodeBlock filename="stateless-response-mapping.json" language="json">
+  {`{
+  "output": "$.choices[0].message.content"
+}`}
+</CodeBlock>
+
+### How It Works
+
+- **Automatic detection**: Rhesis identifies a stateless endpoint when the
+  request body template contains `\{\{ messages \}\}`.
+- **History management**: During multi-turn test execution, Rhesis accumulates
+  the full conversation history (user messages and assistant responses) and sends
+  it as the `messages` array with each request.
+- **System prompt**: If you include a `system_prompt` field in the request body
+  template, Rhesis prepends it to the messages array as the first entry with the
+  `system` role. The `system_prompt` field itself is stripped from the final
+  request before sending.
+- **Single-turn auto-population**: For single test runs (outside multi-turn
+  conversations), Rhesis automatically builds the messages array from the test
+  input and system prompt so you do not need to provide it manually.
+- **Conversation ID**: Even though your endpoint is stateless, Rhesis assigns an
+  internal `conversation_id` so the platform can track the conversation across
+  turns. This ID is returned in the API response but is not sent to your
+  endpoint.
+
+### Messages Format
+
+The messages array follows the standard chat completion format used by most LLM
+providers:
+
+<CodeBlock filename="messages-format.json" language="json">
+  {`[
+  { "role": "system", "content": "You are a helpful assistant." },
+  { "role": "user", "content": "What is the capital of France?" },
+  { "role": "assistant", "content": "The capital of France is Paris." },
+  { "role": "user", "content": "What is its population?" }
+]`}
+</CodeBlock>
+
+Each message has a `role` (`system`, `user`, or `assistant`) and `content` (the
+message text). Rhesis builds this array incrementally as the conversation
+progresses:
+
+1. **Turn 1**: `[system, user]` — system prompt plus the first user input
+2. **Turn 2**: `[system, user, assistant, user]` — previous history plus the new
+   user input
+3. **Turn N**: Full history up to the current turn
+
+### System Prompt Handling
+
+The `system_prompt` field in the request body template is a special
+platform-managed variable:
+
+- Rhesis extracts its value from the template
+- It is prepended to the `messages` array as the first entry with `role: "system"`
+- The `system_prompt` field itself is removed from the final request body before
+  sending to your API
+
+This means your API only receives the standard `messages` array with the system
+prompt already included as the first message.
+
+<CodeBlock filename="system-prompt-example.json" language="json">
+  {`// Your request template:
+{
+  "messages": "{{ messages }}",
+  "model": "gpt-4",
+  "system_prompt": "You are a helpful insurance expert."
+}
+
+// What Rhesis actually sends to your API:
+{
+  "messages": [
+    { "role": "system", "content": "You are a helpful insurance expert." },
+    { "role": "user", "content": "What is term life insurance?" }
+  ],
+  "model": "gpt-4"
+}`}
+</CodeBlock>
+
+## Choosing Between Stateful and Stateless
+
+<Callout type="info">
+  **Stateless vs. Stateful**: Use stateless configuration when your endpoint
+  expects the full conversation history in every request. Use stateful
+  configuration (with conversation tracking fields like `conversation_id`) when
+  your endpoint maintains server-side session state. Rhesis detects which mode to
+  use based on your request body template.
+</Callout>
+
+| Aspect | Stateful | Stateless |
+|---|---|---|
+| **Server manages context** | Yes | No |
+| **Request body includes** | `conversation_id` | `messages` array |
+| **Detected by** | Conversation field in response mapping | `\{\{ messages \}\}` in request template |
+| **Example providers** | Custom chatbots, managed services | OpenAI, Anthropic, Google AI |
+| **Rhesis manages** | Conversation ID tracking | Full message history |
+
+---
+
+<Callout type="default">
+  **Next Steps**
+  - Learn about [Single-Turn Endpoints](/platform/endpoints/single-turn) for
+    request/response mapping details
+  - Return to the [Endpoints Overview](/platform/endpoints) for general
+    endpoint management
+  - Explore the [Default Insurance Chatbot](/platform/endpoints/default-chatbot)
+    for a working multi-turn example
+</Callout>

--- a/docs/content/platform/endpoints/sdk-endpoints.mdx
+++ b/docs/content/platform/endpoints/sdk-endpoints.mdx
@@ -1,0 +1,213 @@
+import { CodeBlock } from "@/components/CodeBlock";
+
+# SDK Endpoints
+
+Register Python functions as testable endpoints using the Rhesis SDK. Instead of
+configuring endpoints manually in the dashboard, you decorate your functions and
+the SDK handles registration, mapping, and synchronization automatically.
+
+<Callout type="default">
+  **Code-first approach**: Decorate your functions with `@endpoint` and they
+  become testable endpoints in Rhesis. No manual URL configuration, request
+  templates, or response mappings needed.
+</Callout>
+
+<Callout type="info">
+  This page provides a summary of SDK endpoint capabilities. For the complete
+  reference including advanced patterns, parameter binding, serializers, and
+  working examples, see the [SDK Connector documentation](/sdk/connector).
+</Callout>
+
+## How It Works
+
+The SDK connector establishes a WebSocket connection to the Rhesis backend. When
+your application starts, the SDK:
+
+1. Discovers all functions decorated with `@endpoint`
+2. Registers them as endpoints in your Rhesis project
+3. Keeps the connection alive for remote invocation during tests
+
+When Rhesis runs tests against an SDK endpoint, it sends the test input over the
+WebSocket connection, the SDK calls your function locally, and returns the result
+to the platform for evaluation.
+
+## Quick Start
+
+<Steps>
+### Initialize the Client
+
+<CodeBlock filename="setup.py" language="python">
+{`from rhesis.sdk import RhesisClient
+
+client = RhesisClient(
+    api_key="your-api-key",
+    project_id="your-project-id",
+    environment="development"
+)`}
+</CodeBlock>
+
+### Decorate Your Function
+
+<CodeBlock filename="app.py" language="python">
+{`from rhesis.sdk import endpoint
+
+@endpoint()
+def chat(input: str, session_id: str = None) -> dict:
+    """Handle chat messages."""
+    response = generate_response(input)
+    return {
+        "output": response,
+        "session_id": session_id or generate_session_id(),
+    }`}
+</CodeBlock>
+
+### View in Dashboard
+
+Registered endpoints appear under **Projects** > **Your Project** > **Endpoints**
+with connection type `SDK` and status `Active`.
+
+</Steps>
+
+## Auto-Mapping
+
+When your function uses standard field names, the SDK automatically maps them
+to platform variables. No manual mapping configuration is needed.
+
+**Standard request fields**: `input`, `session_id` (or `conversation_id`),
+`context`, `metadata`, `tool_calls`
+
+**Standard response fields**: `output`, `context`, `metadata`, `tool_calls`,
+`session_id` (or `conversation_id`)
+
+<CodeBlock filename="auto_mapped.py" language="python">
+{`@endpoint()
+def chat(input: str, session_id: str = None) -> dict:
+    """Standard names are auto-detected."""
+    return {
+        "output": process_message(input),
+        "session_id": session_id,
+    }`}
+</CodeBlock>
+
+## Manual Mapping
+
+For functions with custom parameter names or complex structures, provide explicit
+mappings using the same Jinja2 and JSONPath syntax as
+[REST endpoint mappings](/platform/endpoints/single-turn):
+
+<CodeBlock filename="manual_mapped.py" language="python">
+{`@endpoint(
+    request_mapping={
+        "user_query": "{{ input }}",
+        "conv_id": "{{ conversation_id }}",
+    },
+    response_mapping={
+        "output": "$.result.text",
+        "conversation_id": "$.conv_id",
+    },
+)
+def chat(user_query: str, conv_id: str = None) -> dict:
+    """Custom names require manual mapping."""
+    return {
+        "result": {"text": process(user_query)},
+        "conv_id": conv_id,
+    }`}
+</CodeBlock>
+
+## Multiple Functions
+
+Register multiple endpoints from a single application. Each decorated function
+becomes its own endpoint:
+
+<CodeBlock filename="multi_function.py" language="python">
+{`@endpoint()
+def handle_chat(input: str, session_id: str = None) -> dict:
+    """Process chat messages."""
+    return {"output": generate_response(input), "session_id": session_id}
+
+@endpoint()
+def search_documents(input: str) -> dict:
+    """Search documents."""
+    results = perform_search(input)
+    return {"output": format_results(results), "context": results}
+
+@endpoint()
+def summarize(input: str) -> dict:
+    """Summarize text."""
+    return {"output": generate_summary(input)}`}
+</CodeBlock>
+
+## Parameter Binding
+
+Inject infrastructure dependencies (database connections, configuration, auth
+context) without exposing them in the remote function signature:
+
+<CodeBlock filename="bound_endpoint.py" language="python">
+{`@endpoint(
+    bind={
+        "db": lambda: get_db_session(),
+        "config": AppConfig(),
+    }
+)
+def query_data(db, config, input: str) -> dict:
+    """
+    db and config are injected automatically.
+    Remote signature: query_data(input: str)
+    """
+    results = db.query(config.table, input)
+    return {"output": format_results(results)}`}
+</CodeBlock>
+
+For full details on binding patterns, see
+[Parameter Binding](/sdk/connector/binding).
+
+## SDK vs. REST Endpoints
+
+| Aspect | SDK Endpoints | REST Endpoints |
+|---|---|---|
+| **Setup** | Decorate Python functions | Configure URL, headers, templates in dashboard |
+| **Connection** | WebSocket (bidirectional) | HTTP requests |
+| **Mapping** | Auto-detected or via decorator | Jinja2 templates and JSONPath |
+| **Best for** | Functions in your codebase | External APIs and third-party services |
+| **Dependencies** | Supports parameter binding | N/A (API manages its own state) |
+| **Requires** | Running application with SDK | Accessible API URL |
+
+<Callout type="info">
+  **When to use which?**
+  - Use **SDK endpoints** when your AI logic lives in Python functions you
+    control and you want a code-first testing workflow.
+  - Use **REST endpoints** when testing external APIs, third-party LLM
+    providers, or services deployed outside your codebase.
+  - You can use both in the same project.
+</Callout>
+
+## Connection Management
+
+- **Auto-reconnect**: The SDK reconnects automatically with exponential backoff
+  if the connection is lost.
+- **Re-registration**: Functions are re-registered on reconnect.
+- **Status sync**: Adding or modifying functions updates endpoints automatically.
+  Removing a function marks its endpoint as `Inactive`.
+
+## Disabling the Connector
+
+To disable all connector functionality (useful for CI/CD or testing), set the
+environment variable:
+
+<CodeBlock filename="terminal" language="bash">
+{`export RHESIS_CONNECTOR_DISABLED=true`}
+</CodeBlock>
+
+When disabled, `@endpoint` decorators return functions unmodified and no
+WebSocket connection is established.
+
+---
+
+<Callout type="default">
+  **Learn More**
+  - [SDK Connector](/sdk/connector) — Full reference with advanced patterns
+  - [Input/Output Mapping](/sdk/connector/mapping) — Detailed mapping guide
+  - [Parameter Binding](/sdk/connector/binding) — Dependency injection patterns
+  - [Advanced Mapping](/sdk/connector/serializers) — Complex type serialization
+  - [Examples](/sdk/connector/examples) — Complete working examples
+</Callout>

--- a/docs/content/platform/endpoints/single-turn.mdx
+++ b/docs/content/platform/endpoints/single-turn.mdx
@@ -1,0 +1,253 @@
+import { CodeBlock } from "@/components/CodeBlock";
+
+# Single-Turn Endpoints
+
+Configure request and response mappings for endpoints that handle one exchange at a time.
+
+<Callout type="default">
+  **Single-turn** endpoints process one request-response pair per invocation.
+  This is the most common pattern: you send a prompt, the API returns a
+  response, and Rhesis evaluates it. For conversational endpoints that maintain
+  context across multiple turns, see
+  [Multi-Turn Conversations](/platform/endpoints/multi-turn-conversations).
+</Callout>
+
+## Request Body Templates
+
+Request body templates define how Rhesis transforms its
+[platform-managed variables](/platform/endpoints#platform-managed-variables)
+into the JSON structure your API expects. Templates use Jinja2 syntax for
+dynamic values.
+
+### Basic Template
+
+Place the `input` variable wherever your API expects the user query:
+
+<CodeBlock filename="simple-request.json" language="json">
+  {`{
+  "prompt": "{{ input }}",
+  "max_tokens": 500
+}`}
+</CodeBlock>
+
+### Nested Structures
+
+For APIs that use nested message formats, embed `input` within the appropriate
+structure:
+
+<CodeBlock filename="openai-style-request.json" language="json">
+  {`{
+  "model": "gpt-4",
+  "messages": [
+    {
+      "role": "user",
+      "content": "{{ input }}"
+    }
+  ],
+  "temperature": 0.7
+}`}
+</CodeBlock>
+
+<Callout type="info">
+  **Note**: The example above hardcodes a single user message in the `messages`
+  array. If your endpoint is stateless and you need Rhesis to manage the full
+  conversation history across multiple turns, use `"messages": "{{ messages }}"`
+  instead. Rhesis detects this and automatically builds the messages array
+  with the complete conversation history. See
+  [Multi-Turn Conversations](/platform/endpoints/multi-turn-conversations#stateless-endpoints-message-history)
+  for details.
+</Callout>
+
+### The `tojson` Filter
+
+Use the `tojson` filter when a variable might be `null` or when you need proper
+JSON serialization. This is especially useful for optional fields:
+
+<CodeBlock filename="tojson-example.json" language="json">
+  {`{
+  "query": "{{ input }}",
+  "conversation_id": {{ conversation_id | tojson }},
+  "metadata": {{ metadata | tojson }}
+}`}
+</CodeBlock>
+
+The `tojson` filter ensures values are properly formatted as JSON:
+- Python `None` becomes JSON `null`
+- Strings are properly quoted
+- Objects and arrays are serialized correctly
+
+### Custom Static Fields
+
+You can include any static values alongside platform variables. These are sent
+as-is with every request:
+
+<CodeBlock filename="custom-fields-request.json" language="json">
+  {`{
+  "model": "claude-3-sonnet",
+  "prompt": "{{ input }}",
+  "temperature": 0.3,
+  "max_tokens": 1024,
+  "stream": false
+}`}
+</CodeBlock>
+
+## Response Mappings
+
+Response mappings tell Rhesis how to extract
+[platform-managed variables](/platform/endpoints#platform-managed-variables)
+from your API's response. You can use JSONPath expressions, Jinja2 templates,
+or a combination of both.
+
+### JSONPath Expressions
+
+JSONPath is the simplest approach. Expressions starting with `$` are evaluated
+as JSONPath against the response body:
+
+<CodeBlock filename="jsonpath-response.json" language="json">
+  {`{
+  "output": "$.choices[0].message.content",
+  "model_used": "$.model",
+  "tokens": "$.usage.total_tokens"
+}`}
+</CodeBlock>
+
+Common JSONPath patterns:
+
+| Pattern | Description |
+|---|---|
+| `$.field` | Top-level field |
+| `$.nested.field` | Nested field |
+| `$.array[0]` | First element of an array |
+| `$.array[0].field` | Field from the first array element |
+| `$.data[*].text` | `text` field from all array elements |
+
+### Jinja2 Templates with `jsonpath()`
+
+For conditional logic or fallback values, use Jinja2 templates with the
+`jsonpath()` function:
+
+<CodeBlock filename="jinja2-response.json" language="json">
+  {`{
+  "output": "{{ jsonpath('$.text_response') or jsonpath('$.result.content') }}",
+  "conversation_id": "$.conversation_id"
+}`}
+</CodeBlock>
+
+The first value evaluates as a Jinja2 template and returns the first non-empty
+field. Pure JSONPath expressions (starting with `$`) work without any wrapping.
+
+### Mixing Approaches
+
+You can mix JSONPath and Jinja2 in the same response mapping. Each field is
+evaluated independently:
+
+<CodeBlock filename="mixed-response.json" language="json">
+  {`{
+  "output": "$.response.text",
+  "context": "{{ jsonpath('$.sources') or jsonpath('$.references') }}",
+  "metadata": "$.usage"
+}`}
+</CodeBlock>
+
+## Platform-Managed Fields
+
+Rhesis actively uses certain mapped response fields for evaluation and
+tracking. Other fields are stored but not actively used by the platform.
+
+<Callout type="info">
+  **Required field**: The `output` field must always be mapped. Without it,
+  Rhesis cannot evaluate your endpoint's responses against metrics.
+</Callout>
+
+**Actively used fields**:
+- `output`: The main response text, used for metric evaluation
+- `context`: Additional context, used by context-dependent metrics
+- Conversation tracking fields (`conversation_id`, `session_id`, etc.): Used for
+  [multi-turn conversation](/platform/endpoints/multi-turn-conversations) management
+
+**Stored fields**:
+- `metadata`: Stored with the test result for reference
+- `tool_calls`: Stored with the test result for reference
+- Any custom fields you define in the response mapping
+
+## Testing Your Endpoint
+
+Before running full test suites, verify your endpoint configuration works
+correctly.
+
+1. Navigate to the **Test Connection** tab on the endpoint details page
+2. Enter sample input data in the text field
+3. Click **Test Endpoint**
+4. Review the response to ensure it returns expected data
+
+![Test Connection](/screenshots/rhesis-ai-endpoint-test-connection.png)
+
+The test connection sends a single request using your configured template and
+displays the raw API response alongside the mapped result. This helps you verify
+that your JSONPath expressions and Jinja2 templates extract the correct values.
+
+<Callout type="info">
+  **Stateless endpoints**: If your endpoint uses the `messages` template
+  variable, the test connection automatically builds a one-shot messages array
+  from your input and system prompt. You do not need to provide the messages
+  array manually.
+</Callout>
+
+## Example: Complete REST Endpoint
+
+Here is a complete configuration for a typical REST endpoint calling an
+LLM API.
+
+**Request headers**:
+
+<CodeBlock filename="example-headers.json" language="json">
+  {`{
+  "Authorization": "Bearer {{ auth_token }}",
+  "Content-Type": "application/json"
+}`}
+</CodeBlock>
+
+The `auth_token` placeholder is automatically replaced with the token configured
+in the endpoint settings. See the
+[Endpoints Overview](/platform/endpoints#creating-an-endpoint) for details.
+
+**Request body template**:
+
+<CodeBlock filename="example-request.json" language="json">
+  {`{
+  "model": "gpt-4",
+  "messages": [
+    {
+      "role": "user",
+      "content": "{{ input }}"
+    }
+  ],
+  "temperature": 0.7,
+  "max_tokens": 1024
+}`}
+</CodeBlock>
+
+**Response mapping**:
+
+<CodeBlock filename="example-response.json" language="json">
+  {`{
+  "output": "$.choices[0].message.content",
+  "metadata": "$.usage"
+}`}
+</CodeBlock>
+
+With this configuration, when Rhesis sends a test prompt like "What is machine
+learning?", it formats the request, sends it to your API, extracts the response
+text from `choices[0].message.content`, and evaluates it against your configured
+metrics.
+
+---
+
+<Callout type="default">
+  **Next Steps**
+  - Configure [Multi-Turn Conversations](/platform/endpoints/multi-turn-conversations)
+    for conversational AI testing
+  - Return to the [Endpoints Overview](/platform/endpoints) for general
+    endpoint management
+  - Generate [Tests](/platform/tests-generation) to validate your endpoint
+</Callout>


### PR DESCRIPTION
## Purpose

The endpoint documentation was a single monolithic page that covered everything from basic setup to multi-turn conversations to mapping examples. This made it hard to navigate and find specific information. This PR restructures it into focused, well-organized sub-pages.

## What Changed

- **Overview page** (`index.mdx`): Rewritten to focus on high-level concepts and a reference table of platform-managed variables (input, output, context, messages, conversation_id, auth_token, etc.)
- **Single-Turn Endpoints** (`single-turn.mdx`): New page covering request body templates, response mapping (JSONPath and Jinja2), and complete REST endpoint examples
- **Multi-Turn Conversations** (`multi-turn-conversations.mdx`): New page explaining both stateful (conversation tracking) and stateless (message history) endpoint patterns
- **SDK Endpoints** (`sdk-endpoints.mdx`): New page summarizing the `@endpoint` decorator approach with auto-mapping, manual mapping, and parameter binding
- **Mapping Examples** (`mapping-examples.mdx`): New page with 12 concrete examples covering OpenAI, Anthropic, Gemini, RAG, stateful/stateless conversations, and more
- **Navigation** (`_meta.tsx`): Updated to include the new pages in a logical order
- Removed unsupported "Importing from Swagger/OpenAPI" section
- Added auth_token placeholder documentation (auto-replacement and Authorization header injection)
- Added notes linking single-turn `messages` arrays to stateless multi-turn configuration

## Additional Context

- Related issue: #1348 (Gemini-style stateless multi-turn support)

## Testing

- Verify documentation pages render correctly at `/platform/endpoints` and sub-pages
- Check that navigation sidebar shows the new structure
- Confirm internal links between pages resolve properly