### PR TITLE
Replace hardcoded API key with auth_token variable in mapping examples

### DIFF
--- a/docs/content/platform/endpoints/mapping-examples.mdx
+++ b/docs/content/platform/endpoints/mapping-examples.mdx
@@ -306,7 +306,7 @@ than in headers.
 
 <CodeBlock filename="auth-body-request.json" language="json">
   {`{
-  "api_key": "sk-your-api-key",
+  "api_key": "{{ auth_token }}",
   "input": {
     "text": "{{ input }}",
     "options": {
@@ -326,7 +326,10 @@ than in headers.
 }`}
 </CodeBlock>
 
-Static values like `api_key` are included as-is in every request.
+The `auth_token` variable is automatically populated from the authentication
+token configured in your endpoint settings. See
+[Platform-Managed Variables](/platform/endpoints#platform-managed-variables)
+for details.
 
 ## Deeply Nested Response
 


### PR DESCRIPTION
## Purpose
The "API with Authentication in the Body" example in the endpoint mapping docs hardcoded a fake API key (`"sk-your-api-key"`), which could encourage users to copy secrets into templates. This replaces it with the platform-managed `{{ auth_token }}` variable and clarifies that the value is populated from endpoint settings.

## What Changed
- Replaced `"api_key": "sk-your-api-key"` with `"api_key": "{{ auth_token }}"` in the request body template
- Updated the explanation text to describe how `auth_token` is automatically populated from endpoint settings, with a link to the Platform-Managed Variables reference

## Additional Context
Single-file documentation fix in `docs/content/platform/endpoints/mapping-examples.mdx`.