### PR TITLE
fix: remove escaped curly braces in changelog.mdx video embeds

### DIFF
--- a/docs/content/development/changelog.mdx
+++ b/docs/content/development/changelog.mdx
@@ -20,9 +20,9 @@ This release includes the following component versions:
 
 ### Video Overview
 
-<div style=\{\{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '800px', margin: '20px 0', borderRadius: '8px', boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)' \}\}>
+<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '800px', margin: '20px 0', borderRadius: '8px', boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)' }}>
   <iframe
-    style=\{\{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' \}\}
+    style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
     src="https://www.youtube.com/embed/vdbWfqhQpZs"
     title="Now live: Metrics per Run + Output re-runs | Rhesis AI"
     frameBorder="0"
@@ -31,9 +31,9 @@ This release includes the following component versions:
   />
 </div>
 
-<div style=\{\{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '800px', margin: '20px 0', borderRadius: '8px', boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)' \}\}>
+<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '800px', margin: '20px 0', borderRadius: '8px', boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)' }}>
   <iframe
-    style=\{\{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' \}\}
+    style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
     src="https://www.youtube.com/embed/OH7e_7q7_oU"
     title="Multi-Agent Workflow Testing & Observability | Rhesis AI v0.6.4"
     frameBorder="0"


### PR DESCRIPTION
## Summary

Fixes MDX build failures caused by escaped curly braces in JSX style attributes for video embeds in the changelog.

## Problem

The changelog.mdx file contains escaped curly braces (`\{\{`) in the style attributes of video embed divs and iframes. MDX requires unescaped curly braces (`{{`) for JSX expressions, and the escaped version causes build failures with:

```
Unexpected character `\` (U+005C) before attribute value
```

## Changes

- Changed `style=\{\{ ... \}\}` to `style={{ ... }}` in all video embed elements
- Affects two video embeds in the v0.6.4 section:
  - "Now live: Metrics per Run + Output re-runs" video
  - "Multi-Agent Workflow Testing & Observability" video

## Test Plan

- [x] Pre-commit hooks passed
- [ ] Verify docs build passes in CI
- [ ] Confirm videos display correctly in the documentation