### PR TITLE
Fix worktree review feedback from #1370

### DIFF
--- a/.claude/commands/worktree.md
+++ b/.claude/commands/worktree.md
@@ -6,5 +6,5 @@ Run the worktree command: `./rh worktree $ARGUMENTS`
 If the user did not provide arguments, ask which operation they want:
 - `./rh worktree <name>` — Create a new worktree with symlinked .env files and shared directories
 - `./rh worktree <name> --remove` — Remove a worktree and delete its branch
-- `./rh worktree <name> --load` — Show the path to an existing worktree
+- `./rh worktree <name> --load` — Launch shell in an existing worktree
 - `./rh worktree --list` — List all worktrees

--- a/rh
+++ b/rh
@@ -52,7 +52,7 @@ show_help() {
     echo -e "${YELLOW}Worktree:${NC}"
     echo -e "  ${GREEN}./rh worktree <name>${NC}            - Create a worktree with shared env/config"
     echo -e "  ${GREEN}./rh worktree <name> --remove${NC}   - Remove worktree and delete branch"
-    echo -e "  ${GREEN}./rh worktree <name> --load${NC}     - Show worktree path"
+    echo -e "  ${GREEN}./rh worktree <name> --load${NC}     - Launch shell in worktree"
     echo -e "  ${GREEN}./rh worktree --list${NC}            - List all worktrees"
     echo ""
     echo -e "${YELLOW}Other:${NC}"


### PR DESCRIPTION
## Summary
- Address review comments from peqy on #1370
- Fix help text mismatches, add input validation, and improve error messages

## What Changed
- **`scripts/create-worktree.sh`** — `show_usage()` accepts optional error message; validate name to reject path traversal (`..`, leading `/`); fix `--load` help/comments to say "Launch shell" instead of "Show/Print path"; export `RHESIS_WORKTREE_COLOR` for prompt theming in worktree shells
- **`rh`** — Fix `--load` help text
- **`.claude/commands/worktree.md`** — Fix `--load` description

## Test plan
- [ ] `./rh worktree ../escape` rejects with validation error
- [ ] `./rh worktree test --badflag` shows "Unknown option '--badflag'" (not "Missing worktree name")
- [ ] `./rh worktree test --load` launches shell with `RHESIS_WORKTREE_COLOR` set
- [ ] `./rh help` shows "Launch shell in worktree" for `--load`