### PR TITLE
Fix worktree name validation for leading dashes

### DIFF
--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -262,11 +262,9 @@ fi
 NAME="$1"
 ACTION="${2:-create}"
 
-# Validate name: reject path traversal and absolute paths
-if [[ "$NAME" == /* ]] || [[ "$NAME" == *..* ]]; then
-    echo -e "${RED}Error: Invalid worktree name '${WHITE}$NAME${RED}'${NC}"
-    echo -e "${YELLOW}Name must not contain '..' or start with '/'${NC}"
-    exit 1
+# Validate name: reject path traversal, absolute paths, and leading dashes
+if [[ "$NAME" == /* ]] || [[ "$NAME" == *..* ]] || [[ "$NAME" == -* ]]; then
+    show_usage "Invalid worktree name '$NAME'. Name must not contain '..', start with '/', or start with '-'"
 fi
 
 case "$ACTION" in


### PR DESCRIPTION
## Summary
- Reject worktree names starting with `-` so that typos like `./rh worktree --badflag` show a usage error instead of attempting to create a branch named `--badflag`
- Consolidated inline error handling to reuse `show_usage` for consistent output

## Test plan
- [ ] Run `./rh worktree --badflag` and verify it shows a usage error
- [ ] Run `./rh worktree feat/my-feature` and verify it still creates normally
- [ ] Run `./rh worktree /absolute` and `./rh worktree ../traversal` and verify they are still rejected