### PR TITLE
Include all glossary terms in docs sitemap

### DIFF
--- a/docs/src/app/sitemap.js
+++ b/docs/src/app/sitemap.js
@@ -93,15 +93,18 @@ function getGlossaryTermIds(possibleContentDirs) {
     try {
       if (fs.existsSync(fullPath)) {
         const raw = fs.readFileSync(fullPath, 'utf8')
-        return raw
-          .trim()
-          .split('\n')
-          .filter(Boolean)
-          .map(line => {
+        const ids = []
+        for (const line of raw.trim().split('\n')) {
+          if (!line.trim()) continue
+          try {
             const row = JSON.parse(line)
-            return row?.id
-          })
-          .filter(Boolean)
+            if (row?.id) ids.push(row.id)
+          } catch {
+            // eslint-disable-next-line no-console
+            console.warn('[sitemap] Skipping malformed glossary-terms.jsonl line')
+          }
+        }
+        return ids
       }
     } catch {
       // Continue to next directory


### PR DESCRIPTION
## Purpose
The docs sitemap was only listing a subset of glossary term pages (e.g. ~30 instead of 58). The sitemap is built by scanning the content directory for MDX files; in some cases (e.g. build context or deployment) not all generated glossary term pages are present on disk when the sitemap runs.

## What Changed
- Sitemap now loads glossary term IDs from `content/glossary/glossary-terms.jsonl` and adds an entry for each term URL.
- Entries are deduplicated so existing MDX-derived URLs are not duplicated.
- Comments updated to describe the safety net (Cloud Run / Docker) rather than serverless.

## Additional Context
- Glossary term pages are generated at build time (prebuild) by `generate-glossary-pages.js` into `content/glossary/<id>/index.mdx`. Using the JSONL as a second source ensures the sitemap stays complete even if the content tree is partial.
- Deployed via Cloud Run (Docker); the supplement does not change behavior when content is complete.

## Testing
- Run docs build locally and request `/sitemap.xml`; all `/glossary/<term>` URLs from `glossary-terms.jsonl` should appear.