### PR TITLE
Enable ralph-loop Claude Code plugin

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,8 @@
   "attribution": {
     "commit": "",
     "pr": ""
+  },
+  "enabledPlugins": {
+    "ralph-loop@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Purpose
Enable the ralph-loop plugin for Claude Code.

## What Changed
- Added `enabledPlugins` configuration to `.claude/settings.json`
- Enabled `ralph-loop@claude-plugins-official` plugin