### PR TITLE
fix(scripts): symlink claude code settings in worktrees

### DIFF
--- a/scripts/create-worktree.sh
+++ b/scripts/create-worktree.sh
@@ -225,6 +225,24 @@ worktree_create() {
     if [ "$env_count" -eq 0 ]; then
         echo -e "  ${BLUE}No .env files found in source, skipping${NC}"
     fi
+    echo ""
+
+    # Symlink Claude Code settings.local.json
+    echo -e "${YELLOW}Symlinking Claude Code settings...${NC}"
+    if [ -f "$SOURCE_DIR/.claude/settings.local.json" ]; then
+        mkdir -p "$worktree_dir/.claude"
+        if [ -f "$worktree_dir/.claude/settings.local.json" ] && [ ! -L "$worktree_dir/.claude/settings.local.json" ]; then
+            rm "$worktree_dir/.claude/settings.local.json"
+        fi
+        if ln -sf "$SOURCE_DIR/.claude/settings.local.json" "$worktree_dir/.claude/settings.local.json" 2>/dev/null; then
+            symlink_count=$((symlink_count + 1))
+            echo -e "  ${GREEN}.claude/settings.local.json${NC}"
+        else
+            echo -e "  ${YELLOW}.claude/settings.local.json (failed to create symlink, skipping)${NC}"
+        fi
+    else
+        echo -e "  ${BLUE}.claude/settings.local.json not found in source, skipping${NC}"
+    fi
 
     # Summary
     echo ""


### PR DESCRIPTION
## Summary
- Symlink `.claude/settings.local.json` into worktrees during creation so Claude Code permission settings are shared
- Handles existing non-symlink files by replacing them
- Skips gracefully if no settings file exists in the source repo

## Test plan
- [ ] Create a new worktree and verify `.claude/settings.local.json` is a symlink
- [ ] Verify Claude Code permissions work in the new worktree without prompting