### PR TITLE
fix(ci): address trivy workflow review feedback

### DIFF
--- a/.github/workflows/security-trivy.yml
+++ b/.github/workflows/security-trivy.yml
@@ -8,7 +8,7 @@ on:
 permissions:
   contents: read
   security-events: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   detect-changes:
@@ -40,7 +40,7 @@ jobs:
               - 'apps/chatbot/**'
             polyphemus:
               - 'apps/polyphemus/**'
-            telemetry-processor:
+            telemetry_processor:
               - 'apps/telemetry-processor/**'
 
       - name: Build scan matrix
@@ -85,7 +85,7 @@ jobs:
             if [ "${{ steps.filter.outputs.polyphemus }}" == "true" ]; then
               add_entry "Polyphemus" "polyphemus" "apps/polyphemus"
             fi
-            if [ "${{ steps.filter.outputs.telemetry-processor }}" == "true" ]; then
+            if [ "${{ steps.filter.outputs.telemetry_processor }}" == "true" ]; then
               add_entry "Telemetry Processor" "telemetry-processor" "apps/telemetry-processor"
             fi
           fi


### PR DESCRIPTION
## Purpose
Address review feedback from #1388 to fix a workflow-breaking issue and tighten permissions.

## What Changed
- Renamed `telemetry-processor` paths-filter key to `telemetry_processor` — GitHub Actions expressions interpret hyphens in dot notation as subtraction, so `steps.filter.outputs.telemetry-processor` silently fails
- Scoped `pull-requests` permission from `write` to `read` (least privilege)

## Additional Context
- Fixes issues raised by peqy in #1388

## Testing
- Workflow triggers on PRs to `main`