### PR TITLE
Fix missing JWT secrets in worker k8s deployment

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -275,6 +275,9 @@ jobs:
             --from-literal=SQLALCHEMY_DB_HOST="${{ secrets.SQLALCHEMY_DB_HOST || '127.0.0.1' }}" \
             --from-literal=SQLALCHEMY_DB_NAME="${{ secrets.SQLALCHEMY_DB_NAME }}" \
             --from-literal=DB_ENCRYPTION_KEY="${{ secrets.DB_ENCRYPTION_KEY }}" \
+            --from-literal=JWT_SECRET_KEY="${{ secrets.JWT_SECRET_KEY }}" \
+            --from-literal=JWT_ALGORITHM="${{ secrets.JWT_ALGORITHM }}" \
+            --from-literal=JWT_ACCESS_TOKEN_EXPIRE_MINUTES="${{ secrets.JWT_ACCESS_TOKEN_EXPIRE_MINUTES }}" \
             --from-literal=LOG_LEVEL="${{ secrets.LOG_LEVEL }}" \
             --from-literal=CELERY_WORKER_LOGLEVEL="${{ secrets.LOG_LEVEL || 'INFO' }}" \
             --from-literal=CELERY_WORKER_CONCURRENCY="${{ secrets.CELERY_WORKER_CONCURRENCY || '2' }}" \

--- a/apps/worker/k8s/deployment.yaml
+++ b/apps/worker/k8s/deployment.yaml
@@ -175,6 +175,21 @@ spec:
             secretKeyRef:
               name: rhesis-worker-secrets
               key: DB_ENCRYPTION_KEY
+        - name: JWT_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: rhesis-worker-secrets
+              key: JWT_SECRET_KEY
+        - name: JWT_ALGORITHM
+          valueFrom:
+            secretKeyRef:
+              name: rhesis-worker-secrets
+              key: JWT_ALGORITHM
+        - name: JWT_ACCESS_TOKEN_EXPIRE_MINUTES
+          valueFrom:
+            secretKeyRef:
+              name: rhesis-worker-secrets
+              key: JWT_ACCESS_TOKEN_EXPIRE_MINUTES
         # Memory optimization settings
         - name: PYTHONMALLOC
           value: "malloc"


### PR DESCRIPTION
## Purpose
Worker pipeline fails because JWT_SECRET_KEY is not defined in the k8s secret or deployment manifest, even though it is required by the backend auth modules shared by the worker.

## What Changed
- Added `JWT_SECRET_KEY`, `JWT_ALGORITHM`, and `JWT_ACCESS_TOKEN_EXPIRE_MINUTES` to the `kubectl create secret` command in `.github/workflows/worker.yml`
- Added the corresponding env var entries in `apps/worker/k8s/deployment.yaml` to mount them from the k8s secret into the container

These three variables are already present in `backend.yml` and `polyphemus.yml` workflows, and listed as required in `infrastructure/config/service-secrets-create.sh`.

## Testing
- Deploy worker to dev and verify pods start without JWT_SECRET_KEY errors
- Confirm the GitHub environment secrets `JWT_SECRET_KEY`, `JWT_ALGORITHM`, and `JWT_ACCESS_TOKEN_EXPIRE_MINUTES` are set for the target environment