### PR TITLE
Fix missing DEFAULT_POLYPHEMUS_URL in worker k8s deployment

### DIFF
--- a/apps/worker/k8s/deployment.yaml
+++ b/apps/worker/k8s/deployment.yaml
@@ -223,6 +223,16 @@ spec:
             secretKeyRef:
               name: rhesis-worker-secrets
               key: LOCAL_STORAGE_PATH
+        - name: RHESIS_CONNECTOR_DISABLED
+          valueFrom:
+            secretKeyRef:
+              name: rhesis-worker-secrets
+              key: RHESIS_CONNECTOR_DISABLED
+        - name: DEFAULT_POLYPHEMUS_URL
+          valueFrom:
+            secretKeyRef:
+              name: rhesis-worker-secrets
+              key: DEFAULT_POLYPHEMUS_URL
         ports:
         - containerPort: 8080
           name: health


### PR DESCRIPTION
## Purpose
Worker pods don't have `DEFAULT_POLYPHEMUS_URL` available as an environment variable. The value is created in the k8s secret (`worker.yml` line 309) but never mounted into the container via the deployment manifest.

## What Changed
- Added `DEFAULT_POLYPHEMUS_URL` env var to `apps/worker/k8s/deployment.yaml`, referencing the existing k8s secret
- Also added `RHESIS_CONNECTOR_DISABLED` which had the same gap (created in secret but not mounted)

## Testing
- Deploy worker to dev and verify `DEFAULT_POLYPHEMUS_URL` is available in the pod environment