### PR TITLE
Fix: change default generation and evaluation models to rhesis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,8 +64,8 @@ DB_ENCRYPTION_KEY=BASE64_ENCODED_DB_ENCRYPTION_KEY
 # Choose one or more AI providers based on your needs
 
 # Default models (format: provider/model_name)
-DEFAULT_GENERATION_MODEL=vertex_ai/gemini-2.0-flash
-DEFAULT_EVALUATION_MODEL=vertex_ai/gemini-2.0-flash
+DEFAULT_GENERATION_MODEL=rhesis/rhesis-default
+DEFAULT_EVALUATION_MODEL=rhesis/rhesis-default
 DEFAULT_EMBEDDING_MODEL=vertex_ai/text-embedding-005
 
 # Azure OpenAI (if using Azure)

--- a/apps/backend/src/rhesis/backend/app/constants.py
+++ b/apps/backend/src/rhesis/backend/app/constants.py
@@ -72,12 +72,12 @@ DEFAULT_PRIORITY = 1
 
 # Model-related defaults
 # Can be overridden via environment variables for flexible deployment
-# Format: "provider/model_name" (e.g., "vertex_ai/gemini-2.0-flash")
+# Format: "provider/model_name" (e.g., "rhesis/rhesis-default")
 DEFAULT_GENERATION_MODEL = os.getenv(
-    "DEFAULT_GENERATION_MODEL", "vertex_ai/gemini-2.0-flash"
+    "DEFAULT_GENERATION_MODEL", "rhesis/rhesis-default"
 )  # Default model for test generation
 DEFAULT_EVALUATION_MODEL = os.getenv(
-    "DEFAULT_EVALUATION_MODEL", "vertex_ai/gemini-2.0-flash"
+    "DEFAULT_EVALUATION_MODEL", "rhesis/rhesis-default"
 )  # Default model for evaluation (language-model-as-a-judge)
 DEFAULT_EMBEDDING_MODEL = os.getenv(
     "DEFAULT_EMBEDDING_MODEL", "vertex_ai/text-embedding-005"

--- a/apps/chatbot/endpoint.py
+++ b/apps/chatbot/endpoint.py
@@ -35,7 +35,7 @@ INITIAL_RETRY_DELAY = 1  # seconds
 MAX_RETRY_DELAY = 10  # seconds
 
 # Model configuration - uses SDK providers approach
-DEFAULT_GENERATION_MODEL = os.getenv("DEFAULT_GENERATION_MODEL", "vertex_ai/gemini-2.0-flash")
+DEFAULT_GENERATION_MODEL = os.getenv("DEFAULT_GENERATION_MODEL", "rhesis/rhesis-default")
 
 # Split for @observe.llm decorator
 _provider, _model_name = (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,8 @@ x-rhesis-config: &rhesis-config
   RHESIS_CONNECTOR_DISABLED: ${RHESIS_CONNECTOR_DISABLED:-true}
   FRONTEND_URL: ${FRONTEND_URL:-http://localhost:3000}
   BACKEND_URL: ${BACKEND_URL:-http://backend:8080}
-  DEFAULT_GENERATION_MODEL: ${DEFAULT_GENERATION_MODEL:-vertex_ai/gemini-2.0-flash}
-  DEFAULT_EVALUATION_MODEL: ${DEFAULT_EVALUATION_MODEL:-vertex_ai/gemini-2.0-flash}
+  DEFAULT_GENERATION_MODEL: ${DEFAULT_GENERATION_MODEL:-rhesis/rhesis-default}
+  DEFAULT_EVALUATION_MODEL: ${DEFAULT_EVALUATION_MODEL:-rhesis/rhesis-default}
   DEFAULT_EMBEDDING_MODEL: ${DEFAULT_EMBEDDING_MODEL:-vertex_ai/text-embedding-005}
 
 x-telemetry-config: &telemetry-config


### PR DESCRIPTION
## Purpose
Align backend defaults with the SDK by using `rhesis/rhesis-default` instead of `vertex_ai/gemini-2.0-flash` for generation and evaluation models. This ensures users use the Rhesis API by default (requiring a `RHESIS_API_KEY`).

## What Changed
- `apps/backend/src/rhesis/backend/app/constants.py` — default generation and evaluation model fallbacks changed to `rhesis/rhesis-default`
- `apps/chatbot/endpoint.py` — default generation model fallback changed to `rhesis/rhesis-default`
- `docker-compose.yml` — both model env var fallbacks changed to `rhesis/rhesis-default`
- `.env.example` — both model example values changed to `rhesis/rhesis-default`

## Additional Context
- Deployments can still override via `DEFAULT_GENERATION_MODEL` / `DEFAULT_EVALUATION_MODEL` env vars
- Embedding model default (`vertex_ai/text-embedding-005`) is unchanged

## Testing
- Verify backend starts with `RHESIS_API_KEY` set and no explicit model env vars
- Verify env var overrides still work (e.g. `DEFAULT_GENERATION_MODEL=vertex_ai/gemini-2.0-flash`)