### PR TITLE
Fix: redact credentials from worker and RPC logs

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/connector/rpc_client.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/rpc_client.py
@@ -27,7 +27,7 @@ class SDKRpcClient:
         """
         try:
             redis_url = os.getenv("BROKER_URL", "redis://localhost:6379/0")
-            logger.info(f"🔌 Initializing RPC client with Redis URL: {redis_url}")
+            logger.info("🔌 Initializing RPC client with Redis")
             self._redis = await redis.from_url(redis_url, decode_responses=True)
             logger.info("✅ RPC client connected to Redis successfully")
             # Test the connection

--- a/apps/worker/start.sh
+++ b/apps/worker/start.sh
@@ -86,13 +86,11 @@ except Exception as e:
 # Override database URL for TCP connection if needed
 if [ "${USE_TCP_DATABASE:-false}" = "true" ]; then
     echo "🔧 Overriding database URL for TCP connection..."
-    echo "Original SQLALCHEMY_DATABASE_URL: ${SQLALCHEMY_DATABASE_URL}"
-    
+
     # Construct TCP database URL from components
     export SQLALCHEMY_DATABASE_URL="postgresql://${SQLALCHEMY_DB_USER:-}:${SQLALCHEMY_DB_PASS:-}@${SQLALCHEMY_DB_HOST:-127.0.0.1}:${SQLALCHEMY_DB_PORT:-5432}/${SQLALCHEMY_DB_NAME:-}"
-    echo "TCP SQLALCHEMY_DATABASE_URL: ${SQLALCHEMY_DATABASE_URL}"
-    
-    # Also set individual components for consistency
+
+    # Log connection details with credentials redacted
     echo "Database host: ${SQLALCHEMY_DB_HOST}"
     echo "Database port: ${SQLALCHEMY_DB_PORT}"
     echo "Database name: ${SQLALCHEMY_DB_NAME}"
@@ -140,7 +138,9 @@ try:
     
     # Test database connection
     db_url = os.getenv('SQLALCHEMY_DATABASE_URL')
-    print(f'Testing database connection: {db_url.replace(os.getenv(\"SQLALCHEMY_DB_PASS\", \"\"), \"***\")}')
+    db_pass = os.getenv('SQLALCHEMY_DB_PASS', '')
+    redacted_url = db_url.replace(db_pass, '***') if db_pass else db_url
+    print(f'Testing database connection: {redacted_url}')
     
     engine = create_engine(db_url, pool_pre_ping=True)
     with engine.connect() as conn:


### PR DESCRIPTION
## Summary
- Remove plaintext `SQLALCHEMY_DATABASE_URL` logging from worker startup script (`start.sh`)
- Stop logging the full Redis broker URL in `rpc_client.py`
- Fix fragile password redaction in database connection test that broke when `SQLALCHEMY_DB_PASS` was unset

## What Changed
- **`apps/worker/start.sh`**: Removed two `echo` lines that printed the full database URL (including password). Kept non-sensitive metadata (host, port, db name, user). Fixed the inline Python redaction to handle missing `SQLALCHEMY_DB_PASS` gracefully.
- **`apps/backend/.../rpc_client.py`**: Removed Redis URL from the `logger.info` call.

## Testing
- Deploy worker and verify startup logs no longer contain database passwords
- Verify RPC client logs no longer contain Redis URL