### PR TITLE
Fix invite email field losing focus on keystroke

### DIFF
--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteForm.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteForm.tsx
@@ -388,10 +388,8 @@ export default function TeamInviteForm({
       {/* Form Fields */}
       <Stack spacing={2} sx={{ mb: 3 }}>
         {formData.invites.map((invite, index) => {
-          // Create stable key from email or index
-          const inviteKey = invite.email || `invite-${index}`;
           return (
-            <Box key={inviteKey} display="flex" alignItems="flex-start" gap={2}>
+            <Box key={index} display="flex" alignItems="flex-start" gap={2}>
               <TextField
                 fullWidth
                 label="Email Address"


### PR DESCRIPTION
## Purpose
Fix the team invite email field losing focus every time a character is typed.

## What Changed
- Replaced unstable React `key` (derived from email value) with stable index-based key in `TeamInviteForm.tsx`

## Additional Context
The `key` was set to `invite.email || \`invite-${index}\``, which changed on every keystroke, causing React to unmount and remount the `TextField` component and lose focus.

## Testing
1. Navigate to Organizations > Team
2. Click in the email field and type an email address
3. Verify the field retains focus throughout typing