### PR TITLE
Fix: use stable unique id for invite row keys

### DIFF
--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteForm.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteForm.tsx
@@ -17,13 +17,22 @@ import { useNotifications } from '@/components/common/NotificationContext';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { UUID } from 'crypto';
 
+interface InviteItem {
+  id: string;
+  email: string;
+}
+
 interface FormData {
-  invites: { email: string }[];
+  invites: InviteItem[];
 }
 
 interface TeamInviteFormProps {
   onInvitesSent?: (emails: string[]) => void;
   disableDuringTour?: boolean;
+}
+
+function createInvite(email = ''): InviteItem {
+  return { id: crypto.randomUUID(), email };
 }
 
 export default function TeamInviteForm({
@@ -34,11 +43,11 @@ export default function TeamInviteForm({
   const notifications = useNotifications();
 
   const [formData, setFormData] = useState<FormData>({
-    invites: [{ email: '' }],
+    invites: [createInvite()],
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errors, setErrors] = useState<{
-    [key: number]: { hasError: boolean; message: string };
+    [key: string]: { hasError: boolean; message: string };
   }>({});
 
   // Email validation regex
@@ -48,8 +57,9 @@ export default function TeamInviteForm({
   const MAX_TEAM_MEMBERS = 10;
 
   const validateForm = () => {
-    const newErrors: { [key: number]: { hasError: boolean; message: string } } =
-      {};
+    const newErrors: {
+      [key: string]: { hasError: boolean; message: string };
+    } = {};
     let hasError = false;
 
     // Check maximum team size
@@ -66,9 +76,9 @@ export default function TeamInviteForm({
 
     // Get all non-empty emails for duplicate checking
     const emailsToCheck = formData.invites
-      .map((invite, index) => ({
+      .map(invite => ({
         email: invite.email.trim().toLowerCase(),
-        index,
+        id: invite.id,
       }))
       .filter(item => item.email);
 
@@ -76,7 +86,7 @@ export default function TeamInviteForm({
     const seenEmails = new Set<string>();
     const duplicateEmails = new Set<string>();
 
-    emailsToCheck.forEach(({ email, index: _index }) => {
+    emailsToCheck.forEach(({ email }) => {
       if (seenEmails.has(email)) {
         duplicateEmails.add(email);
       } else {
@@ -85,13 +95,13 @@ export default function TeamInviteForm({
     });
 
     // Validate each email
-    formData.invites.forEach((invite, index) => {
+    formData.invites.forEach(invite => {
       const trimmedEmail = invite.email.trim();
 
       if (trimmedEmail) {
         // Check email format
         if (!emailRegex.test(trimmedEmail)) {
-          newErrors[index] = {
+          newErrors[invite.id] = {
             hasError: true,
             message: 'Please enter a valid email address',
           };
@@ -99,7 +109,7 @@ export default function TeamInviteForm({
         }
         // Check for duplicates
         else if (duplicateEmails.has(trimmedEmail.toLowerCase())) {
-          newErrors[index] = {
+          newErrors[invite.id] = {
             hasError: true,
             message: 'This email address is already added',
           };
@@ -174,7 +184,9 @@ export default function TeamInviteForm({
             if (error.message.includes('API error:')) {
               // Extract the status code and message
               const statusMatch = error.message.match(/API error: (\d+)/);
-              const statusCode = statusMatch ? parseInt(statusMatch[1]) : null;
+              const statusCode = statusMatch
+                ? parseInt(statusMatch[1])
+                : null;
 
               // 400, 409, 422, 429 are expected client/validation errors
               isExpectedError = statusCode
@@ -187,7 +199,8 @@ export default function TeamInviteForm({
                 try {
                   // Try to parse as JSON first
                   const parsed = JSON.parse(match[1]);
-                  errorMessage = parsed.detail || parsed.message || match[1];
+                  errorMessage =
+                    parsed.detail || parsed.message || match[1];
                 } catch {
                   // If not JSON, use the raw message
                   errorMessage = match[1];
@@ -312,7 +325,7 @@ export default function TeamInviteForm({
 
       // Reset form only if some invitations succeeded
       if (successCount > 0) {
-        setFormData({ invites: [{ email: '' }] });
+        setFormData({ invites: [createInvite()] });
         setErrors({});
 
         // Notify parent component
@@ -332,15 +345,17 @@ export default function TeamInviteForm({
     }
   };
 
-  const handleEmailChange = (index: number, value: string) => {
-    const updatedInvites = [...formData.invites];
-    updatedInvites[index] = { email: value };
-    setFormData({ invites: updatedInvites });
+  const handleEmailChange = (invite: InviteItem, value: string) => {
+    setFormData(prev => ({
+      invites: prev.invites.map(i =>
+        i.id === invite.id ? { ...i, email: value } : i
+      ),
+    }));
 
     // Clear error when user types
-    if (errors[index]) {
+    if (errors[invite.id]) {
       const newErrors = { ...errors };
-      delete newErrors[index];
+      delete newErrors[invite.id];
       setErrors(newErrors);
     }
   };
@@ -355,19 +370,19 @@ export default function TeamInviteForm({
     }
 
     setFormData({
-      invites: [...formData.invites, { email: '' }],
+      invites: [...formData.invites, createInvite()],
     });
   };
 
-  const removeEmailField = (index: number) => {
-    const updatedInvites = [...formData.invites];
-    updatedInvites.splice(index, 1);
-    setFormData({ invites: updatedInvites });
+  const removeEmailField = (invite: InviteItem) => {
+    setFormData(prev => ({
+      invites: prev.invites.filter(i => i.id !== invite.id),
+    }));
 
     // Remove error for this field if it exists
-    if (errors[index]) {
+    if (errors[invite.id]) {
       const newErrors = { ...errors };
-      delete newErrors[index];
+      delete newErrors[invite.id];
       setErrors(newErrors);
     }
   };
@@ -389,14 +404,19 @@ export default function TeamInviteForm({
       <Stack spacing={2} sx={{ mb: 3 }}>
         {formData.invites.map((invite, index) => {
           return (
-            <Box key={index} display="flex" alignItems="flex-start" gap={2}>
+            <Box
+              key={invite.id}
+              display="flex"
+              alignItems="flex-start"
+              gap={2}
+            >
               <TextField
                 fullWidth
                 label="Email Address"
                 value={invite.email}
-                onChange={e => handleEmailChange(index, e.target.value)}
-                error={Boolean(errors[index]?.hasError)}
-                helperText={errors[index]?.message || ''}
+                onChange={e => handleEmailChange(invite, e.target.value)}
+                error={Boolean(errors[invite.id]?.hasError)}
+                helperText={errors[invite.id]?.message || ''}
                 placeholder="colleague@company.com"
                 variant="outlined"
                 size="small"
@@ -404,7 +424,7 @@ export default function TeamInviteForm({
               />
               {formData.invites.length > 1 && (
                 <IconButton
-                  onClick={() => removeEmailField(index)}
+                  onClick={() => removeEmailField(invite)}
                   color="error"
                   size="small"
                 >


### PR DESCRIPTION
## Purpose
Addresses review feedback from #1413. Index-based React keys can mis-associate rows when users delete an invite in the middle of the list, causing wrong email/error state to stick to the wrong row.

## What Changed
- Added `InviteItem` interface with a stable `id` field (via `crypto.randomUUID()`)
- Changed React `key` from `index` to `invite.id`
- Keyed validation errors by invite ID instead of array index
- Updated `handleEmailChange` and `removeEmailField` to operate by invite ID

## Testing
1. Open team invite form
2. Add 3+ email rows, type emails in each
3. Delete a row in the middle — remaining rows should keep their correct values and focus
4. Add validation errors, delete a row — errors should stay on the correct fields