### PR TITLE
Fix test assertion using wrong organization_id

### DIFF
--- a/tests/backend/services/test_test_set.py
+++ b/tests/backend/services/test_test_set.py
@@ -279,14 +279,15 @@ class TestTestSetExecution:
             assert result["task_id"] == "task_id_123"
 
             # Verify all mocks were called
+            # The function uses current_user.organization_id, not the passed-in test_org_id
             mock_resolve_test_set.assert_called_once_with(
-                str(test_set.id), test_db, organization_id=test_org_id
+                str(test_set.id), test_db, organization_id=str(user.organization_id)
             )
             mock_get_endpoint.assert_called_once_with(
                 test_db,
                 endpoint_id=endpoint.id,
-                organization_id=test_org_id,
-                user_id=authenticated_user_id,
+                organization_id=str(user.organization_id),
+                user_id=str(user.id),
             )
             mock_validate_access.assert_called_once_with(user, test_set, endpoint)
             mock_create_config.assert_called_once_with(


### PR DESCRIPTION
## Summary
- Fix `test_execute_test_set_on_endpoint_success` assertion that used `test_org_id` (from API key session fixture) instead of `user.organization_id` (from the User model record)
- The function under test (`execute_test_set_on_endpoint`) uses `current_user.organization_id`, which can differ from the fixture's `test_org_id`

## Test plan
- [x] `test_execute_test_set_on_endpoint_success` passes locally
- [x] All 10 tests in `test_test_set.py` pass