### PR TITLE
Add 0.6.6 release notes to changelog

### DIFF
--- a/docs/content/development/changelog.mdx
+++ b/docs/content/development/changelog.mdx
@@ -55,13 +55,12 @@ Stricter type safety across test sets:
 - Updated vulnerable dependencies (cryptography, pillow, fastmcp, redis, langgraph-checkpoint, marshmallow, virtualenv, mammoth, langchain-core)
 - Added Polyphemus integration with service delegation tokens and access control request/grant workflow
 - Implemented conversation-based tracing across SDK, backend, and frontend with `trace_id` linking
-- Added UI improvements for conversation traces: turn navigation, edge labels, and resizable trace detail drawer
 - Enforced `test_set_type` requirement on test set creation and type-matching when assigning tests
 
 ### Frontend Highlights
 - Added Polyphemus access request modal, model card UI states, and Polyphemus provider icon/logo
 - Improved trace UI with conversation tracing support: conversation icon, type filter buttons, Conversation View tab, and turn navigation
-- Enhanced trace graph view with turn labels on edges, progressive agent invocation count, and improved edge routing
+- Enhanced trace graph view with turn labels on edges, progressive agent invocation count, improved edge routing, and resizable trace detail drawer
 - Fixed security vulnerabilities in frontend transitive dependencies
 
 ### SDK Highlights
@@ -84,6 +83,7 @@ This release includes the following component versions:
 - **Backend 0.6.4**
 - **Frontend 0.6.5**
 - **SDK 0.6.5**
+- **Polyphemus 0.2.5** (no changes in this release)
 
 ### Summary
 


### PR DESCRIPTION
## Purpose
Add the 0.6.6 platform release notes to the documentation changelog, covering the Polyphemus access control, conversation-based tracing, and test set type enforcement features.

## What Changed
- Added `## [0.6.6] - 2026-02-26` section to `docs/content/development/changelog.mdx`
- Includes Platform Release component versions, Summary, Featured Capabilities, and per-component highlights

## Additional Context
- Follows the same style and structure as previous release entries (0.6.3, 0.6.4)

## Testing
Review the rendered changelog page in the docs to verify formatting.