### PR TITLE
Fix test creation TypeError and association NoneType crash

### DIFF
--- a/apps/backend/src/rhesis/backend/app/schemas/test.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test.py
@@ -82,7 +82,6 @@ class TestTag(Base):
 # Test schemas
 class TestBase(Base):
     prompt_id: Optional[UUID4] = None  # Optional for Multi-Turn tests
-    test_set_id: Optional[UUID4] = None
     test_type_id: Optional[UUID4] = None
     priority: Optional[int] = None
     user_id: Optional[UUID4] = None

--- a/apps/backend/src/rhesis/backend/app/services/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_set.py
@@ -81,15 +81,15 @@ def generate_test_set_attributes(
     Returns:
         Dict containing the complete attributes structure
     """
-    # Get all unique IDs and names for each dimension
-    topics = list(set(str(test.topic_id) for test in test_set.tests))
-    behaviors = list(set(str(test.behavior_id) for test in test_set.tests))
-    categories = list(set(str(test.category_id) for test in test_set.tests))
+    # Get all unique IDs and names for each dimension (skip tests with None values)
+    topics = list(set(str(test.topic_id) for test in test_set.tests if test.topic_id))
+    behaviors = list(set(str(test.behavior_id) for test in test_set.tests if test.behavior_id))
+    categories = list(set(str(test.category_id) for test in test_set.tests if test.category_id))
 
-    # Get all unique names for metadata
-    topic_names = list(set(test.topic.name for test in test_set.tests))
-    behavior_names = list(set(test.behavior.name for test in test_set.tests))
-    category_names = list(set(test.category.name for test in test_set.tests))
+    # Get all unique names for metadata (skip tests with None relationships)
+    topic_names = list(set(test.topic.name for test in test_set.tests if test.topic))
+    behavior_names = list(set(test.behavior.name for test in test_set.tests if test.behavior))
+    category_names = list(set(test.category.name for test in test_set.tests if test.category))
 
     # Get a random prompt's content for the sample (now through tests)
     sample = None


### PR DESCRIPTION
## Purpose
Fix two related bugs preventing test creation and test set association via the API.

## What Changed
- **Removed `test_set_id` from `TestBase` schema** — this field has no corresponding column on the SQLAlchemy `Test` model (the relationship is many-to-many via `test_test_set_association`), causing a `TypeError: 'test_set_id' is an invalid keyword argument for Test` on creation. Bulk create already handles `test_set_id` separately via `TestBulkCreateRequest`.
- **Added None guards in `generate_test_set_attributes`** — when tests have optional `topic`, `behavior`, or `category` set to `None`, the attribute generation crashed with `'NoneType' object has no attribute 'name'`, causing the `/associate` endpoint to return 400 even though associations were successfully created.

## Testing
- All 3138 backend tests pass
- Verified with ruff linting