### PR TITLE
Hide Polyphemus from model provider list

### DIFF
--- a/apps/frontend/src/app/(protected)/models/components/ProviderSelectionDialog.tsx
+++ b/apps/frontend/src/app/(protected)/models/components/ProviderSelectionDialog.tsx
@@ -38,10 +38,15 @@ export function ProviderSelectionDialog({
   providers,
   modelType = 'language',
 }: ProviderSelectionDialogProps) {
-  // Filter out system-managed providers (like 'rhesis') that users cannot create
+  // Filter out providers users cannot create from this UI.
   // and filter by model type (embedding providers for embedding models)
   const userSelectableProviders = providers.filter(provider => {
-    if (provider.type_value === 'rhesis') return false;
+    if (
+      provider.type_value === 'rhesis' ||
+      provider.type_value === 'polyphemus'
+    ) {
+      return false;
+    }
 
     // For embedding models, only show providers that support embeddings
     if (modelType === 'embedding') {


### PR DESCRIPTION
## Summary
- remove `polyphemus` from the user-selectable providers in the Models provider selection dialog
- keep provider filtering behavior for embedding and other language model providers unchanged
- update inline filter comment to reflect non-creatable providers

## Test plan
- [x] verify `polyphemus` no longer appears in the Models provider selection dialog
- [x] confirm other providers still render and sort as before
- [ ] run full frontend lint/typecheck (`npm run lint`, `npx tsc --noEmit`) if needed