### PR TITLE
Add explanation field to SDK MetricConfig

### DIFF
--- a/sdk/src/rhesis/sdk/metrics/base.py
+++ b/sdk/src/rhesis/sdk/metrics/base.py
@@ -84,6 +84,7 @@ class MetricConfig:
         MetricType.CUSTOM_PROMPT
     )  # Default for SDK metrics
     metric_scope: Optional[List[Union[str, MetricScope]]] = None  # list of scopes
+    explanation: Optional[str] = None
     requires_ground_truth: Optional[bool] = False
     requires_context: Optional[bool] = False
     id: Optional[str] = None  # ID from backend when pulled

--- a/tests/sdk/metrics/test_base.py
+++ b/tests/sdk/metrics/test_base.py
@@ -38,6 +38,16 @@ def test_metric_config_with_metric_type():
     assert config.metric_type == "generation"
 
 
+def test_metric_config_with_explanation():
+    config = MetricConfig(explanation="This metric measures response quality")
+    assert config.explanation == "This metric measures response quality"
+
+
+def test_metric_config_explanation_defaults_to_none():
+    config = MetricConfig()
+    assert config.explanation is None
+
+
 def test_metric_config_with_invalid_backend():
     with pytest.raises(ValueError):
         MetricConfig(backend="invalid")


### PR DESCRIPTION
## Summary
- Adds the `explanation` field to `MetricConfig` in the SDK to match the backend metric schema
- Field propagates automatically to all judge config subclasses (`BaseJudgeConfig`, `NumericJudgeConfig`, `CategoricalJudgeConfig`, `ConversationalNumericConfig`)
- Adds unit tests for the new field

## Test plan
- [x] Existing metric tests pass (79/79)
- [x] Ruff checks pass
- [x] New tests verify field can be set and defaults to `None`