### PR TITLE
chore(sdk): bump version to 0.6.8.post1

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rhesis-sdk"
-version = "0.6.8"
+version = "0.6.8.post1"
 description = "SDK for testing and validating LLM applications"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Purpose
Interim PyPI release for the `explanation` field added to `MetricConfig` (merged in #1448).

## What Changed
- `sdk/pyproject.toml`: version `0.6.8` → `0.6.8.post1`

## Additional Context
- PEP 440 post-release so next automated patch bump correctly produces `0.6.9`
- Tag `sdk-v0.6.8.post1` will be created on main after merge to trigger `publish-pypi.yml`