### PR TITLE
Add Claude skills.local to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,3 +336,4 @@ sdk_test_analysis.md
 
 # Claude Code
 .claude/settings.local.json
+.claude/skills.local


### PR DESCRIPTION
## Purpose
Ignore the `.claude/skills.local` directory which contains local-only Claude agent skills that should not be tracked in the repository.

## What Changed
- Updated `.gitignore` to ignore `.claude/skills.local` directory

## Additional Context
- The previous entry `.claude/skills.local/*` only ignored the contents, not the directory itself