### PR TITLE
Fix: remove redundant staging deploy from release step 2

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,3 +1,6 @@
+# This workflow creates the release branch, bumps versions, generates changelogs, and opens a PR.
+# Staging deployment is handled by release.yml, which triggers on push to release/* branches.
+# This ensures the build uses the release branch (with bumped versions), not main.
 name: "[Release] 2. Create and deploy (stg)"
 
 on:
@@ -128,27 +131,3 @@ jobs:
             --head $BRANCH_NAME
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-
-  backend-deploy:
-    needs: release
-    uses: ./.github/workflows/backend.yml
-    with:
-      environment: stg
-      reason: "Release deployment to staging"
-    secrets: inherit
-
-  frontend-deploy:
-    needs: release
-    uses: ./.github/workflows/frontend.yml
-    with:
-      environment: stg
-      reason: "Release deployment to staging"
-    secrets: inherit
-
-  worker-deploy:
-    needs: release
-    uses: ./.github/workflows/worker.yml
-    with:
-      environment: stg
-      reason: "Release deployment to dev"
-    secrets: inherit


### PR DESCRIPTION
## Purpose

Fix the release workflow deploying the old (pre-bump) version to staging. The deployment jobs in `create-release.yml` (step 2) ran in the context of `main`, so `actions/checkout` checked out the pre-bump code. This caused a race condition with `release.yml` which correctly deploys from the release branch.

## What Changed

- Removed `backend-deploy`, `frontend-deploy`, and `worker-deploy` jobs from `create-release.yml`
- Added a comment explaining that staging deployment is handled by `release.yml` on push to `release/*`

## Additional Context

Staging deployment is already handled by `release.yml`, which triggers on push to `release/*` branches. Since that workflow runs in the context of the release branch, `actions/checkout` picks up the bumped versions correctly. The removed jobs were redundant and could overwrite the correct deployment with the old version.