### PR TITLE
Fix: Remove Assignee and Owner from Test Run Configuration

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
@@ -54,7 +54,7 @@ export default function TestRunDrawer({
   );
   const [tags, setTags] = React.useState<string[]>([]);
 
-  const getCurrentUserId = useCallback(() => {
+  const getCurrentUserId = useCallback((): UUID | undefined => {
     try {
       const [, payloadBase64] = sessionToken.split('.');
       const base64 = payloadBase64.replace(/-/g, '+').replace(/_/g, '/');
@@ -63,7 +63,7 @@ export default function TestRunDrawer({
 
       const payload = JSON.parse(
         Buffer.from(paddedBase64, 'base64').toString('utf-8')
-      );
+      ) as { user?: { id?: UUID } };
       return payload.user?.id;
     } catch (_err) {
       return undefined;
@@ -176,7 +176,7 @@ export default function TestRunDrawer({
       const testConfigurationsClient =
         clientFactory.getTestConfigurationsClient();
 
-      const currentUserId: UUID | undefined = getCurrentUserId();
+      const currentUserId = getCurrentUserId();
 
       // Create test configuration
       const testConfigurationData: TestConfigurationCreate = {

--- a/apps/frontend/src/utils/api-client/interfaces/test-configuration.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/test-configuration.ts
@@ -57,13 +57,18 @@ export interface TestConfigurationBase {
   prompt_id?: UUID;
   use_case_id?: UUID;
   test_set_id: UUID;
-  user_id?: UUID;
+  user_id: UUID;
   organization_id?: UUID;
   status_id?: UUID;
   attributes?: TestConfigurationAttributes;
 }
 
-export type TestConfigurationCreate = TestConfigurationBase;
+export interface TestConfigurationCreate extends Omit<
+  TestConfigurationBase,
+  'user_id'
+> {
+  user_id?: UUID;
+}
 
 export type TestConfigurationUpdate = Partial<TestConfigurationBase>;
 


### PR DESCRIPTION
## Purpose
The Assignee and Owner fields in the Test Run Configuration drawer are not needed to be set manually by the user. This fix removes them from the UI to simplify the configuration flow.

## What Changed
- Removed the **Assignee** and **Owner** Autocomplete fields from the Test Run Configuration drawer
- Removed the entire **Workflow** section (which only contained these two fields)
- Removed `users` state and the related API call to fetch users on drawer open
- Replaced `owner?.id` references in `handleSave` with `getCurrentUserId()` so the current user is automatically used as the owner
- Removed unused imports: `Avatar`, `PersonIcon`, `User`, `AVATAR_SIZES`
- Removed unused helper functions: `getUserDisplayName`, `renderUserOption`

## Additional Context
- Targets release branch `release/v0.6.9`
- No backend changes required

## Testing
1. Open the Test Run Configuration drawer
2. Verify that only **Test Set**, **Project**, **Endpoint**, and **Tags** fields are shown
3. Verify that executing a test run still works correctly with the current user as the owner