### PR TITLE
Fix: Go to TestResult link for single-turn test runs

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
@@ -459,6 +459,7 @@ export default function TestResultDrawer({
               currentUserPicture={currentUserPicture}
               elevation={0}
               onCountsChange={handleCountsChange}
+              additionalMetadata={{ test_run_id: testRunId }}
             />
           </TabPanel>
         </Box>


### PR DESCRIPTION
## Purpose
Fix the \"Go to TestResult\" link that appears on tasks created from single-turn test results. The link was navigating to a non-existent route (`/test-results/{id}`), causing a 404.

## What Changed
- Added `additionalMetadata={{ test_run_id: testRunId }}` to the `TasksAndCommentsWrapper` inside `TestResultDrawer.tsx`

This ensures that when a task is created from the table/drawer view (used for single-turn tests), the `test_run_id` is stored in `task_metadata`. The task page uses this field to build the correct URL: `/test-runs/{test_run_id}?selectedresult={entity_id}`.

## Additional Context
- The same `additionalMetadata` prop was already correctly set in `TestDetailPanel.tsx` (used for multi-turn / split view) — this fix brings `TestResultDrawer.tsx` in line with that behaviour.
- Root cause: without `test_run_id` in `task_metadata`, the task page fell back to a generic entity URL map which resolved `TestResult` → `/test-results/{id}`, a route that does not exist.

## Testing
1. Open a test run with a single-turn test
2. Open the Tasks & Comments tab on a test result
3. Create a task
4. Navigate to the created task
5. Click \"Go to TestResult\" — it should navigate to the test run page with the result selected, rather than returning a 404