### PR TITLE
Fix chatbot Docker build: update base image to Python 3.12

### DIFF
--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -3,7 +3,7 @@
 
 # Single stage build for simplicity
 # IMPORTANT: The python version must match the version in the .python-version file.
-FROM mirror.gcr.io/library/python:3.10.17-slim
+FROM mirror.gcr.io/library/python:3.12-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Purpose
Fix Docker build failure caused by a Python version mismatch between the base image and the SDK requirement.

## What Changed
- Updated chatbot Dockerfile base image from `python:3.10.17-slim` to `python:3.12-slim`

## Additional Context
- The SDK (`rhesis-sdk`) requires `python>=3.12`
- The chatbot itself also requires `python>=3.12`
- With `UV_NO_MANAGED_PYTHON=1` set, uv cannot download a newer Python, causing the build to fail when trying to install the SDK on a Python 3.10 system interpreter

## Testing
Docker build should complete without the `No interpreter found for Python >=3.12` error.