### PR TITLE
[2] feat(metrics): introduce MetricResultBuilder for standardized metric evaluation results

### DIFF
--- a/apps/backend/src/rhesis/backend/metrics/evaluator.py
+++ b/apps/backend/src/rhesis/backend/metrics/evaluator.py
@@ -14,6 +14,7 @@ from tenacity import (
 )
 
 from rhesis.backend.app.models.metric import Metric as MetricModel
+from rhesis.backend.metrics.result_builder import MetricResultBuilder
 from rhesis.backend.metrics.score_evaluator import ScoreEvaluator
 from rhesis.backend.metrics.utils import diagnose_invalid_metric
 from rhesis.sdk.metrics import BaseMetric, MetricConfig, MetricResult
@@ -217,41 +218,32 @@ class MetricEvaluator:
                 if error_reason and error_reason != "unknown validation error":
                     # Create error result for invalid metric
                     invalid_key = f"InvalidMetric_{i}"
-                    invalid_metric_results[invalid_key] = {
-                        "score": 0.0,
-                        "reason": f"Invalid metric configuration: {error_reason}",
-                        "is_successful": False,
-                        "threshold": 0.0,
-                        "backend": config.get("backend", "unknown")
-                        if isinstance(config, dict)
-                        else getattr(config, "backend", "unknown"),
-                        "name": config.get("name", invalid_key)
-                        if isinstance(config, dict)
-                        else getattr(config, "name", invalid_key),
-                        "class_name": config.get("class_name", "Unknown")
-                        if isinstance(config, dict)
-                        else getattr(config, "class_name", "Unknown"),
-                        "description": f"Failed to load metric: {error_reason}",
-                        "error": error_reason,
-                    }
+                    invalid_metric_results[invalid_key] = MetricResultBuilder.error(
+                        reason=f"Invalid metric configuration: {error_reason}",
+                        backend=self._get_config_value(config, "backend", "unknown"),
+                        name=self._get_config_value(config, "name", invalid_key),
+                        class_name=self._get_config_value(config, "class_name", "Unknown"),
+                        description=f"Failed to load metric: {error_reason}",
+                        error=error_reason,
+                        threshold=0.0,
+                    )
                     logger.warning(f"Invalid metric configuration {i}: {error_reason}")
                 else:
                     metric_configs.append(config)
             else:
                 # Invalid config type
                 invalid_key = f"InvalidMetric_{i}"
-                invalid_metric_results[invalid_key] = {
-                    "score": 0.0,
-                    "reason": f"Invalid config type: {type(config).__name__}",
-                    "is_successful": False,
-                    "threshold": 0.0,
-                    "backend": "unknown",
-                    "name": invalid_key,
-                    "class_name": "Unknown",
-                    "description": f"Invalid config type: {type(config).__name__}",
-                    "error": f"Invalid config type: {type(config).__name__}",
-                }
-                logger.warning(f"Invalid config type for metric {i}: {type(config).__name__}")
+                type_name = type(config).__name__
+                invalid_metric_results[invalid_key] = MetricResultBuilder.error(
+                    reason=f"Invalid config type: {type_name}",
+                    backend="unknown",
+                    name=invalid_key,
+                    class_name="Unknown",
+                    description=f"Invalid config type: {type_name}",
+                    error=f"Invalid config type: {type_name}",
+                    threshold=0.0,
+                )
+                logger.warning(f"Invalid config type for metric {i}: {type_name}")
 
         # Log summary
         if invalid_metric_results:
@@ -335,15 +327,13 @@ class MetricEvaluator:
         if not self._sdk_metric_sender:
             logger.warning("Cannot evaluate SDK metrics: no sdk_metric_sender configured")
             return {
-                self._get_config_value(c, "name", f"SDKMetric_{i}"): {
-                    "score": 0.0,
-                    "reason": "SDK metric sender not configured",
-                    "is_successful": False,
-                    "backend": "sdk",
-                    "name": self._get_config_value(c, "name", f"SDKMetric_{i}"),
-                    "class_name": self._get_config_value(c, "class_name", "Unknown"),
-                    "error": "sdk_metric_sender not configured",
-                }
+                self._get_config_value(c, "name", f"SDKMetric_{i}"): MetricResultBuilder.error(
+                    reason="SDK metric sender not configured",
+                    backend="sdk",
+                    name=self._get_config_value(c, "name", f"SDKMetric_{i}"),
+                    class_name=self._get_config_value(c, "class_name", "Unknown"),
+                    error="sdk_metric_sender not configured",
+                )
                 for i, c in enumerate(sdk_configs)
             }
 
@@ -383,32 +373,26 @@ class MetricEvaluator:
                     sdk_result = asyncio.run(coro)
 
                 if "error" in sdk_result and "status" not in sdk_result:
-                    results[metric_name or class_name] = {
-                        "score": 0.0,
-                        "reason": sdk_result.get(
-                            "details", sdk_result.get("error", "Unknown error")
-                        ),
-                        "is_successful": False,
-                        "backend": "sdk",
-                        "name": metric_name,
-                        "class_name": class_name,
-                        "description": description,
-                        "error": sdk_result.get("error"),
-                        "threshold": threshold,
-                    }
+                    results[metric_name or class_name] = MetricResultBuilder.error(
+                        reason=sdk_result.get("details", sdk_result.get("error", "Unknown error")),
+                        backend="sdk",
+                        name=metric_name,
+                        class_name=class_name,
+                        description=description,
+                        error=sdk_result.get("error"),
+                        threshold=threshold,
+                    )
                 elif sdk_result.get("status") == "error":
-                    results[metric_name or class_name] = {
-                        "score": 0.0,
-                        "reason": sdk_result.get("error", "SDK metric error"),
-                        "is_successful": False,
-                        "backend": "sdk",
-                        "name": metric_name,
-                        "class_name": class_name,
-                        "description": description,
-                        "error": sdk_result.get("error"),
-                        "threshold": threshold,
-                        "duration_ms": sdk_result.get("duration_ms"),
-                    }
+                    results[metric_name or class_name] = MetricResultBuilder.error(
+                        reason=sdk_result.get("error", "SDK metric error"),
+                        backend="sdk",
+                        name=metric_name,
+                        class_name=class_name,
+                        description=description,
+                        error=sdk_result.get("error"),
+                        threshold=threshold,
+                        duration_ms=sdk_result.get("duration_ms"),
+                    )
                 else:
                     score = sdk_result.get("score", 0.0)
                     details = sdk_result.get("details", {})
@@ -419,34 +403,33 @@ class MetricEvaluator:
                         threshold_operator=threshold_op,
                     )
 
-                    results[metric_name or class_name] = {
-                        "score": score,
-                        "reason": details.get("reason", f"SDK metric score: {score}"),
-                        "is_successful": is_successful,
-                        "backend": "sdk",
-                        "name": metric_name,
-                        "class_name": class_name,
-                        "description": description,
-                        "threshold": threshold,
-                        "duration_ms": sdk_result.get("duration_ms"),
-                    }
+                    results[metric_name or class_name] = MetricResultBuilder.success(
+                        score=score,
+                        reason=details.get("reason", f"SDK metric score: {score}"),
+                        is_successful=is_successful,
+                        backend="sdk",
+                        name=metric_name,
+                        class_name=class_name,
+                        description=description,
+                        threshold=threshold,
+                        duration_ms=sdk_result.get("duration_ms"),
+                    )
 
             except Exception as e:
                 logger.error(
                     f"Error evaluating SDK metric '{class_name}': {e}",
                     exc_info=True,
                 )
-                results[metric_name or class_name] = {
-                    "score": 0.0,
-                    "reason": f"SDK metric evaluation failed: {e}",
-                    "is_successful": False,
-                    "backend": "sdk",
-                    "name": metric_name,
-                    "class_name": class_name,
-                    "description": description,
-                    "error": str(e),
-                    "threshold": threshold,
-                }
+                results[metric_name or class_name] = MetricResultBuilder.error(
+                    reason=f"SDK metric evaluation failed: {e}",
+                    backend="sdk",
+                    name=metric_name,
+                    class_name=class_name,
+                    description=description,
+                    error=str(e),
+                    error_type=type(e).__name__,
+                    threshold=threshold,
+                )
 
         return results
 
@@ -915,20 +898,18 @@ class MetricEvaluator:
         Returns:
             Dictionary with error result
         """
-        return {
-            "score": 0.0,
-            "reason": f"Evaluation failed: {str(exception)}",
-            "is_successful": False,
-            "backend": backend,
-            "name": self._get_config_value(metric_config, "name", class_name),
-            "class_name": class_name,
-            "description": self._get_config_value(
+        return MetricResultBuilder.error(
+            reason=f"Evaluation failed: {str(exception)}",
+            backend=backend,
+            name=self._get_config_value(metric_config, "name", class_name),
+            class_name=class_name,
+            description=self._get_config_value(
                 metric_config, "description", f"{class_name} evaluation metric"
             ),
-            "error": str(exception),
-            "error_type": type(exception).__name__,
-            "threshold": self._get_config_value(metric_config, "threshold", 0.0),
-        }
+            error=str(exception),
+            error_type=type(exception).__name__,
+            threshold=self._get_config_value(metric_config, "threshold", 0.0),
+        )
 
     def _create_timeout_result(
         self,
@@ -947,20 +928,16 @@ class MetricEvaluator:
         Returns:
             Dictionary with timeout result
         """
-        return {
-            "score": 0.0,
-            "reason": f"Metric evaluation timed out after {METRIC_OVERALL_TIMEOUT}s",
-            "is_successful": False,
-            "backend": backend,
-            "name": self._get_config_value(metric_config, "name", class_name),
-            "class_name": class_name,
-            "description": self._get_config_value(
+        return MetricResultBuilder.timeout(
+            backend=backend,
+            name=self._get_config_value(metric_config, "name", class_name),
+            class_name=class_name,
+            description=self._get_config_value(
                 metric_config, "description", f"{class_name} evaluation metric"
             ),
-            "error": "Timeout",
-            "error_type": "TimeoutError",
-            "threshold": self._get_config_value(metric_config, "threshold", 0.0),
-        }
+            threshold=self._get_config_value(metric_config, "threshold", 0.0),
+            timeout_seconds=METRIC_OVERALL_TIMEOUT,
+        )
 
     # ============================================================================
     # MAIN ORCHESTRATION METHOD
@@ -1163,29 +1140,20 @@ class MetricEvaluator:
                     f"{is_successful}"
                 )
 
-            # Store results - structure depends on metric type
-            processed_result = {
-                "score": result.score,
-                "reason": result.details.get("reason", f"Score: {result.score}"),
-                "is_successful": is_successful,
-                "backend": backend,
-                "name": self._get_config_value(metric_config, "name"),
-                "class_name": class_name,  # Include class_name for identification
-                "description": description,
-            }
-
-            # Add threshold or reference_score based on metric type
             threshold = self._get_config_value(metric_config, "threshold")
             reference_score = self._get_config_value(metric_config, "reference_score")
-            if threshold is not None:
-                # Numeric metric - include threshold
-                processed_result["threshold"] = threshold
-            elif reference_score is not None:
-                # Binary/categorical metric - include reference_score
-                processed_result["reference_score"] = reference_score
-
             logger.debug(f"Completed metric '{class_name}' with score {result.score}")
-            return processed_result
+            return MetricResultBuilder.success(
+                score=result.score,
+                reason=result.details.get("reason", f"Score: {result.score}"),
+                is_successful=is_successful,
+                backend=backend,
+                name=self._get_config_value(metric_config, "name"),
+                class_name=class_name,
+                description=description,
+                threshold=threshold,
+                reference_score=reference_score,
+            )
 
         except Exception as exc:
             import traceback
@@ -1196,27 +1164,19 @@ class MetricEvaluator:
             logger.error(f"Exception type: {type(exc).__name__}")
             logger.error(f"Full traceback:\n{traceback.format_exc()}")
 
-            # Store error information in results
-            error_result = {
-                "score": 0.0,
-                "reason": f"Error: {str(exc)}",
-                "is_successful": False,
-                "backend": backend,
-                "name": self._get_config_value(metric_config, "name"),
-                "class_name": class_name,  # Include class_name for identification
-                "description": description
-                if "description" in locals()
-                else f"{class_name} evaluation metric",
-                "error": str(exc),
-                "exception_type": type(exc).__name__,
-            }
-
-            # Add threshold or reference_score for error results too
+            error_description = (
+                description if "description" in locals() else f"{class_name} evaluation metric"
+            )
             threshold = self._get_config_value(metric_config, "threshold")
             reference_score = self._get_config_value(metric_config, "reference_score")
-            if threshold is not None:
-                error_result["threshold"] = threshold
-            elif reference_score is not None:
-                error_result["reference_score"] = reference_score
-
-            return error_result
+            return MetricResultBuilder.error(
+                reason=f"Error: {str(exc)}",
+                backend=backend,
+                name=self._get_config_value(metric_config, "name"),
+                class_name=class_name,
+                description=error_description,
+                error=str(exc),
+                error_type=type(exc).__name__,
+                threshold=threshold,
+                reference_score=reference_score,
+            )

--- a/apps/backend/src/rhesis/backend/metrics/result_builder.py
+++ b/apps/backend/src/rhesis/backend/metrics/result_builder.py
@@ -1,0 +1,123 @@
+"""
+Result builder for metric evaluation output.
+
+Provides a single schema and factory methods for success, error, and timeout
+results produced by MetricEvaluator, replacing ad-hoc dict construction.
+"""
+
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional, Union
+
+
+@dataclass
+class MetricResultBuilder:
+    """Standard shape for metric evaluation results.
+
+    Provides factory classmethods for success, error, and timeout
+    results. Call .to_dict() to get the plain dict for storage.
+    """
+
+    score: Union[float, str]
+    reason: str
+    is_successful: bool
+    backend: str
+    name: str
+    class_name: str
+    description: str = ""
+    threshold: Optional[float] = None
+    reference_score: Optional[Union[float, str]] = None
+    error_message: Optional[str] = None  # output key "error" for API
+    error_type: Optional[str] = None
+    duration_ms: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to plain dict, omitting None optional fields."""
+        d = {k: v for k, v in asdict(self).items() if v is not None}
+        if "error_message" in d:
+            d["error"] = d.pop("error_message")
+        return d
+
+    @classmethod
+    def success(
+        cls,
+        *,
+        score: Union[float, str],
+        reason: str,
+        is_successful: bool,
+        backend: str,
+        name: str,
+        class_name: str,
+        description: str = "",
+        threshold: Optional[float] = None,
+        reference_score: Optional[Union[float, str]] = None,
+        duration_ms: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Build a success result dict."""
+        return cls(
+            score=score,
+            reason=reason,
+            is_successful=is_successful,
+            backend=backend,
+            name=name,
+            class_name=class_name,
+            description=description,
+            threshold=threshold,
+            reference_score=reference_score,
+            duration_ms=duration_ms,
+        ).to_dict()
+
+    @classmethod
+    def error(
+        cls,
+        *,
+        reason: str,
+        backend: str,
+        name: str,
+        class_name: str,
+        description: str = "",
+        error: Optional[str] = None,
+        error_type: Optional[str] = None,
+        threshold: Optional[float] = None,
+        reference_score: Optional[Union[float, str]] = None,
+        duration_ms: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Build an error result dict (score=0.0, is_successful=False)."""
+        return cls(
+            score=0.0,
+            reason=reason,
+            is_successful=False,
+            backend=backend,
+            name=name,
+            class_name=class_name,
+            description=description,
+            threshold=threshold,
+            reference_score=reference_score,
+            error_message=error,
+            error_type=error_type,
+            duration_ms=duration_ms,
+        ).to_dict()
+
+    @classmethod
+    def timeout(
+        cls,
+        *,
+        backend: str,
+        name: str,
+        class_name: str,
+        description: str = "",
+        threshold: Optional[float] = None,
+        timeout_seconds: int = 600,
+    ) -> Dict[str, Any]:
+        """Build a timeout result dict."""
+        return cls(
+            score=0.0,
+            reason=f"Metric evaluation timed out after {timeout_seconds}s",
+            is_successful=False,
+            backend=backend,
+            name=name,
+            class_name=class_name,
+            description=description,
+            threshold=threshold,
+            error_message="Timeout",
+            error_type="TimeoutError",
+        ).to_dict()

--- a/tests/backend/metrics/test_result_builder.py
+++ b/tests/backend/metrics/test_result_builder.py
@@ -1,0 +1,161 @@
+"""
+Unit tests for MetricResultBuilder - success, error, and timeout result factories.
+"""
+
+from rhesis.backend.metrics.result_builder import MetricResultBuilder
+
+
+class TestMetricResultBuilderSuccess:
+    """Tests for MetricResultBuilder.success()."""
+
+    def test_success_returns_expected_dict(self):
+        """Success result includes required fields and strips None optionals."""
+        d = MetricResultBuilder.success(
+            score=0.85,
+            reason="Score: 0.85",
+            is_successful=True,
+            backend="rhesis",
+            name="MyMetric",
+            class_name="NumericJudge",
+        )
+        assert d["score"] == 0.85
+        assert d["reason"] == "Score: 0.85"
+        assert d["is_successful"] is True
+        assert d["backend"] == "rhesis"
+        assert d["name"] == "MyMetric"
+        assert d["class_name"] == "NumericJudge"
+        assert "error" not in d
+        assert "error_type" not in d
+
+    def test_success_with_threshold(self):
+        """Success result can include threshold."""
+        d = MetricResultBuilder.success(
+            score=0.9,
+            reason="Pass",
+            is_successful=True,
+            backend="deepeval",
+            name="Faithfulness",
+            class_name="DeepEvalFaithfulness",
+            threshold=0.7,
+        )
+        assert d["threshold"] == 0.7
+
+    def test_success_with_reference_score(self):
+        """Success result can include reference_score for categorical metrics."""
+        d = MetricResultBuilder.success(
+            score="True",
+            reason="Match",
+            is_successful=True,
+            backend="rhesis",
+            name="CatJudge",
+            class_name="CategoricalJudge",
+            reference_score="True",
+        )
+        assert d["reference_score"] == "True"
+        assert "threshold" not in d
+
+    def test_success_with_duration_ms(self):
+        """Success result can include duration_ms (e.g. from SDK)."""
+        d = MetricResultBuilder.success(
+            score=1.0,
+            reason="OK",
+            is_successful=True,
+            backend="sdk",
+            name="SDKMetric",
+            class_name="CustomMetric",
+            duration_ms=150.5,
+        )
+        assert d["duration_ms"] == 150.5
+
+
+class TestMetricResultBuilderError:
+    """Tests for MetricResultBuilder.error()."""
+
+    def test_error_returns_expected_dict(self):
+        """Error result has score=0, is_successful=False and error fields."""
+        d = MetricResultBuilder.error(
+            reason="Evaluation failed: connection error",
+            backend="rhesis",
+            name="MyMetric",
+            class_name="NumericJudge",
+            error="connection error",
+            error_type="ConnectionError",
+        )
+        assert d["score"] == 0.0
+        assert d["reason"] == "Evaluation failed: connection error"
+        assert d["is_successful"] is False
+        assert d["backend"] == "rhesis"
+        assert d["name"] == "MyMetric"
+        assert d["class_name"] == "NumericJudge"
+        assert d["error"] == "connection error"
+        assert d["error_type"] == "ConnectionError"
+
+    def test_error_with_duration_ms(self):
+        """Error result can include duration_ms (e.g. from SDK)."""
+        d = MetricResultBuilder.error(
+            reason="SDK metric error",
+            backend="sdk",
+            name="SDKMetric",
+            class_name="Unknown",
+            error="timeout",
+            duration_ms=60000.0,
+        )
+        assert d["duration_ms"] == 60000.0
+
+
+class TestMetricResultBuilderTimeout:
+    """Tests for MetricResultBuilder.timeout()."""
+
+    def test_timeout_returns_expected_dict(self):
+        """Timeout result has timeout reason and error_type TimeoutError."""
+        d = MetricResultBuilder.timeout(
+            backend="rhesis",
+            name="SlowMetric",
+            class_name="NumericJudge",
+            timeout_seconds=600,
+        )
+        assert d["score"] == 0.0
+        assert "Metric evaluation timed out after 600s" in d["reason"]
+        assert d["is_successful"] is False
+        assert d["backend"] == "rhesis"
+        assert d["name"] == "SlowMetric"
+        assert d["class_name"] == "NumericJudge"
+        assert d["error"] == "Timeout"
+        assert d["error_type"] == "TimeoutError"
+
+    def test_timeout_custom_seconds(self):
+        """Timeout message uses provided timeout_seconds."""
+        d = MetricResultBuilder.timeout(
+            backend="x",
+            name="n",
+            class_name="C",
+            timeout_seconds=120,
+        )
+        assert "120s" in d["reason"]
+
+
+class TestMetricResultBuilderToDict:
+    """Tests for to_dict() None-stripping."""
+
+    def test_to_dict_strips_none_fields(self):
+        """Optional None fields are omitted from the dict."""
+        b = MetricResultBuilder(
+            score=0.0,
+            reason="err",
+            is_successful=False,
+            backend="x",
+            name="n",
+            class_name="C",
+            description="",
+            threshold=None,
+            reference_score=None,
+            error_message="err",
+            error_type=None,
+            duration_ms=None,
+        )
+        d = b.to_dict()
+        assert "threshold" not in d
+        assert "reference_score" not in d
+        assert "error_type" not in d
+        assert "duration_ms" not in d
+        assert d["error"] == "err"


### PR DESCRIPTION
## Purpose
Introduce a dedicated `MetricResultBuilder` to standardize how metric evaluation results (success, error, timeout) are built. This removes ad-hoc dictionary construction from `MetricEvaluator` and centralizes result shape in one place.

**Important:** We no longer use manual dict construction for metric results. Using a builder with explicit factory methods reduces the risk of typos, missing keys, or inconsistent structure, making the code less prone to bugs.

## What Changed
- Added `MetricResultBuilder` class to encapsulate success, error, and timeout result structures, replacing ad-hoc dictionary constructions in `MetricEvaluator`.
- Refactored `MetricEvaluator` to use `MetricResultBuilder` for generating error results, improving code clarity and maintainability.
- Implemented unit tests for `MetricResultBuilder` to ensure correct behaviour of success, error, and timeout result factories.

## Additional Context
- Part of metrics/evaluator refactoring.

## Testing
- `uv run pytest` from `apps/backend` (backend tests).
- `MetricResultBuilder` unit tests in `tests/backend/metrics/test_result_builder.py`.