### PR TITLE
Fix Garak dynamic import dialog auto-closing on completion

### DIFF
--- a/apps/frontend/src/app/(protected)/test-sets/components/GarakImportDialog.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/GarakImportDialog.tsx
@@ -739,7 +739,7 @@ export default function GarakImportDialog({
                 bgcolor: alpha(theme.palette.primary.main, 0.08),
                 border: 1,
                 borderColor: alpha(theme.palette.primary.main, 0.24),
-                borderRadius: 2,
+                borderRadius: `${theme.shape.borderRadius}px`,
               })}
             >
               <Stack spacing={2}>


### PR DESCRIPTION
## Purpose

When importing dynamic probes from Garak, a background generation job is started. Previously the completion modal auto-closed after 1 second, giving users no time to see which probes were submitted for generation.

## What Changed

- Dialog no longer auto-closes when dynamic probes were part of the import
- Cancel button becomes a "Close" button when the dynamic import completes
- Preview and Import buttons are hidden in the completion view, leaving only Close
- Completion summary now lists individual probe names (both static and dynamic)
- Import Preview now lists dynamic probe names alongside static test set info
- State cleanup deferred to dialog exit transition (`TransitionProps.onExited`) to prevent content flickering during fade-out
- Replaced hardcoded border styles with MUI theme-based values

## Testing

1. Open the Garak import dialog
2. Select at least one dynamic probe (marked with "Dynamic" chip)
3. Click Import/Generate
4. Verify the completion dialog stays open and shows probe names
5. Click "Close" to dismiss — verify no flickering
6. Repeat with only static probes — verify auto-close still works after 1 second