### PR TITLE
fix: remove litellm ssl transport error filter

### DIFF
--- a/sdk/src/rhesis/sdk/models/providers/litellm.py
+++ b/sdk/src/rhesis/sdk/models/providers/litellm.py
@@ -1,6 +1,4 @@
-import atexit
 import json
-import logging
 from typing import List, Optional, Type, Union
 
 import litellm
@@ -12,39 +10,6 @@ from rhesis.sdk.models.base import BaseEmbedder, BaseLLM, Embedding
 from rhesis.sdk.models.utils import validate_llm_response
 
 litellm.suppress_debug_info = True
-
-
-class _LiteLLMTransportErrorFilter(logging.Filter):
-    """Filter out SSL transport errors caused by litellm's LoggingWorker.
-
-    litellm's LoggingWorker._flush_on_exit() creates a temporary event loop
-    to flush queued logging coroutines at process exit.  When that loop
-    closes, the SSL transports on the HTTP connections used during the flush
-    attempt a close_notify on an already-closed socket — harmless but noisy.
-
-    The resulting "Fatal error on SSL transport" is logged by asyncio's
-    default exception handler through the 'asyncio' logger.  This filter
-    suppresses only those specific messages.
-    """
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        msg = record.getMessage()
-        if "Fatal error on SSL transport" in msg:
-            return False
-        if "Event loop is closed" in msg:
-            return False
-        return True
-
-
-def _install_litellm_transport_error_filter():
-    logging.getLogger("asyncio").addFilter(_LiteLLMTransportErrorFilter())
-
-
-# Registered AFTER litellm's LoggingWorker atexit handler (which was
-# registered at import time above).  atexit is LIFO, so this runs FIRST —
-# the filter is in place before the LoggingWorker flushes its queue.
-# During normal operation no filter is active on the asyncio logger.
-atexit.register(_install_litellm_transport_error_filter)
 
 
 class LiteLLM(BaseLLM):

--- a/sdk/uv.lock
+++ b/sdk/uv.lock
@@ -2264,7 +2264,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.80.0"
+version = "1.82.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2280,9 +2280,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/8c/48d533affdbc6d485b7ad4221cd3b40b8c12f9f5568edfe0be0b11e7b945/litellm-1.80.0.tar.gz", hash = "sha256:eeac733eb6b226f9e5fb020f72fe13a32b3354b001dc62bcf1bc4d9b526d6231", size = 11591976, upload-time = "2025-11-16T00:03:51.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/00/13993312e6d2fb29cd6d5ffceb293455ef747fe5675eaa9aa49b09184656/litellm-1.82.3.tar.gz", hash = "sha256:7215b95e7cc38a52b5ae778d67e8829dec86594c8b05d8431294e95c7d59937c", size = 17368754, upload-time = "2026-03-16T21:51:30.356Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/53/aa31e4d057b3746b3c323ca993003d6cf15ef987e7fe7ceb53681695ae87/litellm-1.80.0-py3-none-any.whl", hash = "sha256:fd0009758f4772257048d74bf79bb64318859adb4ea49a8b66fdbc718cd80b6e", size = 10492975, upload-time = "2025-11-16T00:03:49.182Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/3a/590d58dee65a238f7f3d5c37f8f9f9021ecaf27fe379a393b4259324b56e/litellm-1.82.3-py3-none-any.whl", hash = "sha256:609901f6c5a5cf8c24386e4e3f50738bb8a9db719709fd76b208c8ee6d00f7a7", size = 15551034, upload-time = "2026-03-16T21:51:26.747Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose
Removes the `_LiteLLMTransportErrorFilter` workaround that was previously added to suppress SSL transport errors on process exit. The problem was naturally solved because we upgraded to Python 3.12, which resolves the underlying asyncio issue.

## What Changed
- Removed `_LiteLLMTransportErrorFilter` and its registration from `sdk/src/rhesis/sdk/models/providers/litellm.py`.

## Additional Context
- Refers to previous PR: #1471 ("Make SDK model generation async-first") where this filter was initially added.

## Testing
- Ensure that LiteLLM chat generation commands and playground scripts execute and complete cleanly without spewing "Fatal error on SSL transport" exceptions.