### PR TITLE
refactor: centralize test and test set type validation

### DIFF
--- a/apps/backend/src/rhesis/backend/app/constants.py
+++ b/apps/backend/src/rhesis/backend/app/constants.py
@@ -31,8 +31,38 @@ class EntityType(Enum):
         return entity_type
 
 
+# TestType Enum - DB-level test classification aligned with initial_data.json type_lookup
+class TestType(str, Enum):
+    """
+    Enum for test types.
+
+    These are reserved test type values in the TypeLookup table:
+    - SINGLE_TURN: Traditional single request-response tests
+    - MULTI_TURN: Agentic multi-turn conversation tests using Penelope
+    """
+    SINGLE_TURN = "Single-Turn"
+    MULTI_TURN = "Multi-Turn"
+
+    @classmethod
+    def get_value(cls, test_type):
+        """Get the string value of a test type"""
+        if isinstance(test_type, cls):
+            return test_type.value
+        return test_type
+
+    @classmethod
+    def from_string(cls, value: str):
+        """Get enum from string value (case-insensitive, accepts snake_case and hyphenated)."""
+        if not value:
+            return None
+        normalized = value.lower().replace("_", "-")
+        for test_type in cls:
+            if test_type.value.lower() == normalized:
+                return test_type
+        return None
+
 # TestSetType Enum - DB-level test set classification aligned with initial_data.json type_lookup
-class TestSetType(Enum):
+class TestSetType(str, Enum):
     SINGLE_TURN = "Single-Turn"
     MULTI_TURN = "Multi-Turn"
 

--- a/apps/backend/src/rhesis/backend/app/constants.py
+++ b/apps/backend/src/rhesis/backend/app/constants.py
@@ -53,12 +53,11 @@ class TestType(str, Enum):
 
     @classmethod
     def from_string(cls, value: str):
-        """Get enum from string value (case-insensitive, accepts snake_case and hyphenated)."""
+        """Get enum from string value (case-sensitive, accepts only allowed values)."""
         if not value:
             return None
-        normalized = value.lower().replace("_", "-")
         for test_type in cls:
-            if test_type.value.lower() == normalized:
+            if test_type.value == value:
                 return test_type
         return None
 
@@ -77,17 +76,11 @@ class TestSetType(str, Enum):
 
     @classmethod
     def from_string(cls, value: str):
-        """Get enum from string value (case-insensitive, accepts snake_case and hyphenated).
-
-        Maps both 'single_turn' and 'Single-Turn' to TestSetType.SINGLE_TURN, so API
-        clients that use snake_case conventions are handled transparently.
-        """
+        """Get enum from string value (case-sensitive, accepts only allowed values)."""
         if not value:
             return None
-        # Normalize underscores to hyphens so snake_case aliases work (single_turn → single-turn)
-        normalized = value.lower().replace("_", "-")
         for test_set_type in cls:
-            if test_set_type.value.lower() == normalized:
+            if test_set_type.value == value:
                 return test_set_type
         return None
 
@@ -183,17 +176,6 @@ REVIEW_TARGET_TRACE = ReviewTarget.TRACE
 REVIEW_TARGET_TURN = ReviewTarget.TURN
 REVIEW_TARGET_METRIC = ReviewTarget.METRIC
 VALID_TARGET_TYPES = tuple(ReviewTarget)
-
-
-class TestType(str, Enum):
-    """Reserved test type values in the TypeLookup table.
-
-    - SINGLE_TURN: Traditional single request-response tests
-    - MULTI_TURN: Agentic multi-turn conversation tests using Penelope
-    """
-
-    SINGLE_TURN = "Single-Turn"
-    MULTI_TURN = "Multi-Turn"
 
 
 class OverallTestResult(str, Enum):

--- a/apps/backend/src/rhesis/backend/app/constants.py
+++ b/apps/backend/src/rhesis/backend/app/constants.py
@@ -40,6 +40,7 @@ class TestType(str, Enum):
     - SINGLE_TURN: Traditional single request-response tests
     - MULTI_TURN: Agentic multi-turn conversation tests using Penelope
     """
+
     SINGLE_TURN = "Single-Turn"
     MULTI_TURN = "Multi-Turn"
 
@@ -60,6 +61,7 @@ class TestType(str, Enum):
             if test_type.value.lower() == normalized:
                 return test_type
         return None
+
 
 # TestSetType Enum - DB-level test set classification aligned with initial_data.json type_lookup
 class TestSetType(str, Enum):

--- a/apps/backend/src/rhesis/backend/app/schemas/test.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test.py
@@ -116,12 +116,14 @@ class TestCreate(TestBase):
     @classmethod
     def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
         from rhesis.backend.app.schemas.validators import format_test_type
+
         return format_test_type(v)
 
     @field_validator("test_configuration")
     @classmethod
     def validate_test_configuration(cls, v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         from rhesis.backend.app.schemas.validators import validate_test_config_content
+
         return validate_test_config_content(v)
 
 
@@ -137,12 +139,14 @@ class TestUpdate(TestBase):
     @classmethod
     def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
         from rhesis.backend.app.schemas.validators import format_test_type
+
         return format_test_type(v)
 
     @field_validator("test_configuration")
     @classmethod
     def validate_test_configuration(cls, v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         from rhesis.backend.app.schemas.validators import validate_test_config_content
+
         return validate_test_config_content(v)
 
 
@@ -188,6 +192,7 @@ class TestBulkCreate(BaseModel):
     @classmethod
     def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
         from rhesis.backend.app.schemas.validators import format_test_type
+
         return format_test_type(v)
 
     @field_validator("assignee_id", "owner_id")
@@ -228,6 +233,7 @@ class TestBulkCreate(BaseModel):
             )
 
         from rhesis.backend.app.schemas.validators import validate_test_config_content
+
         return validate_test_config_content(v)
 
 
@@ -298,6 +304,7 @@ class TestExecuteRequest(BaseModel):
     @classmethod
     def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
         from rhesis.backend.app.schemas.validators import format_test_type
+
         return format_test_type(v)
 
     @field_validator("test_configuration")
@@ -305,6 +312,7 @@ class TestExecuteRequest(BaseModel):
     def validate_test_configuration(cls, v, info):
         """Validate multi-turn test configuration if provided."""
         from rhesis.backend.app.schemas.validators import validate_test_config_content
+
         return validate_test_config_content(v)
 
     def model_post_init(self, __context):
@@ -375,6 +383,7 @@ class ConversationToTestRequest(BaseModel):
     @classmethod
     def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
         from rhesis.backend.app.schemas.validators import format_test_type
+
         return format_test_type(v)
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/test.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test.py
@@ -1,10 +1,9 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import UUID4, BaseModel, ConfigDict, ValidationError, field_validator
+from pydantic import UUID4, BaseModel, ConfigDict, field_validator
 
 from rhesis.backend.app.schemas import Base
-from rhesis.backend.app.schemas.multi_turn_test_config import validate_multi_turn_config
 from rhesis.backend.app.schemas.user import UserReference
 
 
@@ -113,36 +112,17 @@ class TestCreate(TestBase):
     prompt: Optional[TestPromptCreate] = None
     test_type: Optional[str] = None
 
+    @field_validator("test_type")
+    @classmethod
+    def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
+        from rhesis.backend.app.schemas.validators import format_test_type
+        return format_test_type(v)
+
     @field_validator("test_configuration")
     @classmethod
     def validate_test_configuration(cls, v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-        """
-        Validate test_configuration JSON based on content.
-
-        For multi-turn tests (when goal is present), validates against MultiTurnTestConfig schema.
-        """
-        if v is None:
-            return None
-
-        # If 'goal' is present, this is a multi-turn test configuration
-        if "goal" in v:
-            try:
-                # Validate using multi-turn config schema
-                validated_config = validate_multi_turn_config(v)
-                # Return as dict for storage
-                return validated_config.model_dump(exclude_none=True)
-            except ValidationError as e:
-                # Re-raise with more context
-                error_messages = []
-                for error in e.errors():
-                    field = " -> ".join(str(loc) for loc in error["loc"])
-                    error_messages.append(f"{field}: {error['msg']}")
-                raise ValueError(
-                    f"Invalid multi-turn test configuration: {'; '.join(error_messages)}"
-                )
-
-        # For other configurations, allow any valid JSON
-        return v
+        from rhesis.backend.app.schemas.validators import validate_test_config_content
+        return validate_test_config_content(v)
 
 
 class TestUpdate(TestBase):
@@ -153,36 +133,17 @@ class TestUpdate(TestBase):
     prompt: Optional[TestPromptCreate] = None
     test_type: Optional[str] = None
 
+    @field_validator("test_type")
+    @classmethod
+    def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
+        from rhesis.backend.app.schemas.validators import format_test_type
+        return format_test_type(v)
+
     @field_validator("test_configuration")
     @classmethod
     def validate_test_configuration(cls, v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
-        """
-        Validate test_configuration JSON based on content.
-
-        For multi-turn tests (when goal is present), validates against MultiTurnTestConfig schema.
-        """
-        if v is None:
-            return None
-
-        # If 'goal' is present, this is a multi-turn test configuration
-        if "goal" in v:
-            try:
-                # Validate using multi-turn config schema
-                validated_config = validate_multi_turn_config(v)
-                # Return as dict for storage
-                return validated_config.model_dump(exclude_none=True)
-            except ValidationError as e:
-                # Re-raise with more context
-                error_messages = []
-                for error in e.errors():
-                    field = " -> ".join(str(loc) for loc in error["loc"])
-                    error_messages.append(f"{field}: {error['msg']}")
-                raise ValueError(
-                    f"Invalid multi-turn test configuration: {'; '.join(error_messages)}"
-                )
-
-        # For other configurations, allow any valid JSON
-        return v
+        from rhesis.backend.app.schemas.validators import validate_test_config_content
+        return validate_test_config_content(v)
 
 
 class Test(TestBase):
@@ -221,6 +182,13 @@ class TestBulkCreate(BaseModel):
     owner_id: Optional[UUID4] = None
     status: Optional[str] = None
     priority: Optional[int] = None
+    test_type: Optional[str] = None
+
+    @field_validator("test_type")
+    @classmethod
+    def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
+        from rhesis.backend.app.schemas.validators import format_test_type
+        return format_test_type(v)
 
     @field_validator("assignee_id", "owner_id")
     @classmethod
@@ -259,21 +227,8 @@ class TestBulkCreate(BaseModel):
                 "or 'test_configuration' with 'goal' must be provided (for multi-turn tests)"
             )
 
-        # If 'goal' is present, validate as multi-turn config
-        if "goal" in v:
-            try:
-                validated_config = validate_multi_turn_config(v)
-                return validated_config.model_dump(exclude_none=True)
-            except ValidationError as e:
-                error_messages = []
-                for error in e.errors():
-                    field = " -> ".join(str(loc) for loc in error["loc"])
-                    error_messages.append(f"{field}: {error['msg']}")
-                raise ValueError(
-                    f"Invalid multi-turn test configuration: {'; '.join(error_messages)}"
-                )
-
-        return v
+        from rhesis.backend.app.schemas.validators import validate_test_config_content
+        return validate_test_config_content(v)
 
 
 class TestBulkCreateRequest(BaseModel):
@@ -339,23 +294,18 @@ class TestExecuteRequest(BaseModel):
     # Optional: Explicitly specify test type (otherwise auto-detected)
     test_type: Optional[str] = None  # "Single-Turn" or "Multi-Turn"
 
+    @field_validator("test_type")
+    @classmethod
+    def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
+        from rhesis.backend.app.schemas.validators import format_test_type
+        return format_test_type(v)
+
     @field_validator("test_configuration")
     @classmethod
     def validate_test_configuration(cls, v, info):
         """Validate multi-turn test configuration if provided."""
-        if v and "goal" in v:
-            try:
-                validated_config = validate_multi_turn_config(v)
-                return validated_config.model_dump(exclude_none=True)
-            except ValidationError as e:
-                error_messages = []
-                for error in e.errors():
-                    field = " -> ".join(str(loc) for loc in error["loc"])
-                    error_messages.append(f"{field}: {error['msg']}")
-                raise ValueError(
-                    f"Invalid multi-turn test configuration: {'; '.join(error_messages)}"
-                )
-        return v
+        from rhesis.backend.app.schemas.validators import validate_test_config_content
+        return validate_test_config_content(v)
 
     def model_post_init(self, __context):
         """Validate that either test_id or test definition is provided."""
@@ -420,6 +370,12 @@ class ConversationToTestRequest(BaseModel):
     messages: List[ConversationMessage]
     endpoint_id: Optional[UUID4] = None
     test_type: Optional[str] = "Multi-Turn"  # "Single-Turn" or "Multi-Turn"
+
+    @field_validator("test_type")
+    @classmethod
+    def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
+        from rhesis.backend.app.schemas.validators import format_test_type
+        return format_test_type(v)
 
 
 class SingleTurnTestExtraction(BaseModel):

--- a/apps/backend/src/rhesis/backend/app/schemas/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_set.py
@@ -85,6 +85,7 @@ class TestData(BaseModel):
     @classmethod
     def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
         from rhesis.backend.app.schemas.validators import format_test_type
+
         return format_test_type(v)
 
     @field_validator("assignee_id", "owner_id")
@@ -112,7 +113,6 @@ class TestData(BaseModel):
         - test_configuration with goal is provided (multi-turn test)
         """
 
-
         prompt = info.data.get("prompt")
 
         # If prompt is provided, it's a single-turn test - OK
@@ -127,6 +127,7 @@ class TestData(BaseModel):
             )
 
         from rhesis.backend.app.schemas.validators import validate_test_config_content
+
         return validate_test_config_content(v)
 
 
@@ -146,6 +147,7 @@ class TestSetBulkCreate(BaseModel):
     @classmethod
     def validate_test_set_type(cls, v: str) -> str:
         from rhesis.backend.app.schemas.validators import format_test_set_type
+
         return format_test_set_type(v)
 
     @field_validator("owner_id", "assignee_id")

--- a/apps/backend/src/rhesis/backend/app/schemas/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_set.py
@@ -81,6 +81,12 @@ class TestData(BaseModel):
     priority: Optional[int] = None
     metadata: Optional[Dict[str, Any]] = {}
 
+    @field_validator("test_type")
+    @classmethod
+    def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
+        from rhesis.backend.app.schemas.validators import format_test_type
+        return format_test_type(v)
+
     @field_validator("assignee_id", "owner_id")
     @classmethod
     def validate_uuid(cls, v):
@@ -105,9 +111,7 @@ class TestData(BaseModel):
         - prompt is provided (single-turn test), OR
         - test_configuration with goal is provided (multi-turn test)
         """
-        from pydantic import ValidationError
 
-        from rhesis.backend.app.schemas.multi_turn_test_config import validate_multi_turn_config
 
         prompt = info.data.get("prompt")
 
@@ -122,21 +126,8 @@ class TestData(BaseModel):
                 "or 'test_configuration' with 'goal' must be provided (for multi-turn tests)"
             )
 
-        # If 'goal' is present, validate as multi-turn config
-        if "goal" in v:
-            try:
-                validated_config = validate_multi_turn_config(v)
-                return validated_config.model_dump(exclude_none=True)
-            except ValidationError as e:
-                error_messages = []
-                for error in e.errors():
-                    field = " -> ".join(str(loc) for loc in error["loc"])
-                    error_messages.append(f"{field}: {error['msg']}")
-                raise ValueError(
-                    f"Invalid multi-turn test configuration: {'; '.join(error_messages)}"
-                )
-
-        return v
+        from rhesis.backend.app.schemas.validators import validate_test_config_content
+        return validate_test_config_content(v)
 
 
 class TestSetBulkCreate(BaseModel):
@@ -150,6 +141,12 @@ class TestSetBulkCreate(BaseModel):
     project_id: Optional[UUID4] = None
     tests: List[TestData]
     metadata: Optional[Dict[str, Any]] = None
+
+    @field_validator("test_set_type")
+    @classmethod
+    def validate_test_set_type(cls, v: str) -> str:
+        from rhesis.backend.app.schemas.validators import format_test_set_type
+        return format_test_set_type(v)
 
     @field_validator("owner_id", "assignee_id")
     @classmethod

--- a/apps/backend/src/rhesis/backend/app/schemas/validators.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/validators.py
@@ -1,0 +1,65 @@
+from typing import Any, Dict, Optional
+
+from pydantic import ValidationError
+
+from rhesis.backend.app.constants import TestSetType, TestType
+from rhesis.backend.app.schemas.multi_turn_test_config import validate_multi_turn_config
+
+
+def format_test_type(v: Optional[str]) -> Optional[str]:
+    """Format test type to title case and validate against allowed types."""
+    if v is None:
+        return None
+        
+    formatted = v.title()
+    allowed_types = [t.value for t in TestType]
+    
+    if formatted not in allowed_types:
+        raise ValueError(
+            f"Invalid test type '{v}'. Allowed values are: {', '.join(allowed_types)}"
+        )
+        
+    return formatted
+
+def format_test_set_type(v: Optional[str]) -> Optional[str]:
+    """Format test set type to title case and validate against allowed types."""
+    if v is None:
+        return None
+        
+    formatted = v.title()
+    allowed_types = [t.value for t in TestSetType]
+    
+    if formatted not in allowed_types:
+        raise ValueError(
+            f"Invalid test set type '{v}'. Allowed values are: {', '.join(allowed_types)}"
+        )
+        
+    return formatted
+
+
+def validate_test_config_content(v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """
+    Validate test_configuration JSON based on content.
+
+    For multi-turn tests (when goal is present), validates against MultiTurnTestConfig schema.
+    """
+    if v is None:
+        return None
+
+    # If 'goal' is present, this is a multi-turn test configuration
+    if "goal" in v:
+        try:
+            # Validate using multi-turn config schema
+            validated_config = validate_multi_turn_config(v)
+            # Return as dict for storage
+            return validated_config.model_dump(exclude_none=True)
+        except ValidationError as e:
+            # Re-raise with more context
+            error_messages = []
+            for error in e.errors():
+                field = " -> ".join(str(loc) for loc in error["loc"])
+                error_messages.append(f"{field}: {error['msg']}")
+            raise ValueError(f"Invalid multi-turn test configuration: {'; '.join(error_messages)}")
+
+    # For other configurations, allow any valid JSON
+    return v

--- a/apps/backend/src/rhesis/backend/app/schemas/validators.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/validators.py
@@ -10,30 +10,29 @@ def format_test_type(v: Optional[str]) -> Optional[str]:
     """Format test type to title case and validate against allowed types."""
     if v is None:
         return None
-        
+
     formatted = v.title()
     allowed_types = [t.value for t in TestType]
-    
+
     if formatted not in allowed_types:
-        raise ValueError(
-            f"Invalid test type '{v}'. Allowed values are: {', '.join(allowed_types)}"
-        )
-        
+        raise ValueError(f"Invalid test type '{v}'. Allowed values are: {', '.join(allowed_types)}")
+
     return formatted
+
 
 def format_test_set_type(v: Optional[str]) -> Optional[str]:
     """Format test set type to title case and validate against allowed types."""
     if v is None:
         return None
-        
+
     formatted = v.title()
     allowed_types = [t.value for t in TestSetType]
-    
+
     if formatted not in allowed_types:
         raise ValueError(
             f"Invalid test set type '{v}'. Allowed values are: {', '.join(allowed_types)}"
         )
-        
+
     return formatted
 
 

--- a/apps/backend/src/rhesis/backend/app/services/test_execution.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_execution.py
@@ -61,14 +61,16 @@ async def execute_test_in_place(
 
     evaluation_model = get_evaluation_model(db, user_id)
     execution_model = get_execution_model(db, user_id)
-    logger.info(
-        f"[InPlaceExecution] Using evaluation model for user {user_id}: "
-        f"{type(evaluation_model).__name__ if not isinstance(evaluation_model, str) else evaluation_model}"
+    eval_model_name = (
+        type(evaluation_model).__name__
+        if not isinstance(evaluation_model, str)
+        else evaluation_model
     )
-    logger.info(
-        f"[InPlaceExecution] Using execution model for user {user_id}: "
-        f"{type(execution_model).__name__ if not isinstance(execution_model, str) else execution_model}"
+    logger.info(f"[InPlaceExecution] Using evaluation model for user {user_id}: {eval_model_name}")
+    exec_model_name = (
+        type(execution_model).__name__ if not isinstance(execution_model, str) else execution_model
     )
+    logger.info(f"[InPlaceExecution] Using execution model for user {user_id}: {exec_model_name}")
 
     # Determine if using existing test or creating temporary one
     test_id = request_data.get("test_id")

--- a/apps/backend/src/rhesis/backend/tasks/__init__.py
+++ b/apps/backend/src/rhesis/backend/tasks/__init__.py
@@ -34,7 +34,6 @@ from rhesis.backend.tasks.enums import (
     DEFAULT_RUN_STATUS_COMPLETED,
     DEFAULT_RUN_STATUS_FAILED,
     DEFAULT_RUN_STATUS_PROGRESS,
-    TestType,
 )
 
 # Import task functions after BaseTask is defined to avoid circular imports

--- a/apps/backend/src/rhesis/backend/tasks/execution/executors/data.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/executors/data.py
@@ -33,7 +33,7 @@ def get_test_and_prompt(
         ValueError: If test is not found or validation fails
     """
     # Import here to avoid circular dependency
-    from rhesis.backend.tasks.enums import TestType
+    from rhesis.backend.app.constants import TestType
     from rhesis.backend.tasks.execution.modes import get_test_type
 
     # Get the test

--- a/apps/backend/src/rhesis/backend/tasks/execution/executors/factory.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/executors/factory.py
@@ -6,8 +6,8 @@ Uses the Strategy Pattern to select the correct executor based on test type.
 
 import logging
 
-from rhesis.backend.app.models.test import Test
 from rhesis.backend.app.constants import TestType
+from rhesis.backend.app.models.test import Test
 from rhesis.backend.tasks.execution.executors.base import BaseTestExecutor
 from rhesis.backend.tasks.execution.modes import get_test_type
 

--- a/apps/backend/src/rhesis/backend/tasks/execution/executors/factory.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/executors/factory.py
@@ -7,7 +7,7 @@ Uses the Strategy Pattern to select the correct executor based on test type.
 import logging
 
 from rhesis.backend.app.models.test import Test
-from rhesis.backend.tasks.enums import TestType
+from rhesis.backend.app.constants import TestType
 from rhesis.backend.tasks.execution.executors.base import BaseTestExecutor
 from rhesis.backend.tasks.execution.modes import get_test_type
 

--- a/docs/content/contribute/worker/test-types.mdx
+++ b/docs/content/contribute/worker/test-types.mdx
@@ -203,7 +203,7 @@ The system automatically routes tests to the appropriate executor:
 
 <CodeBlock language="python" filename="test_type_detection.py" isTerminal={false}>
 {`from rhesis.backend.tasks.execution.modes import get_test_type, is_multi_turn_test
-from rhesis.backend.tasks.enums import TestType
+from rhesis.backend.app.constants import TestType
 
 # Get test type
 test_type = get_test_type(test)

--- a/tests/backend/tasks/test_validation.py
+++ b/tests/backend/tasks/test_validation.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 
 import pytest
 
-from rhesis.backend.tasks.enums import TestType
+from rhesis.backend.app.constants import TestType
 from rhesis.backend.tasks.execution.executors.data import get_test_and_prompt
 
 


### PR DESCRIPTION
## Purpose
This PR centralizes the validation logic for `test_type`, `test_set_type`, and `test_configuration` to prevent pushing garbage types.

## What Changed
- Centralized `TestType` into `rhesis.backend.app.constants` alongside `TestSetType`.
- Created `format_test_type` and `format_test_set_type` validators in a new `validators.py` file to automatically format inputs using `v.title()` and check them against the allowed enum values.
- Replaced the duplicate schema field validation code in `test.py` and `test_set.py` models with the centralized methods.
- Updated all references and imports to the new `TestType` module location.