### PR TITLE
Fix: Include topic in test result response

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/test_result.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_result.py
@@ -26,7 +26,7 @@ from rhesis.backend.app.utils.schema_factory import create_detailed_schema
 TestResultDetailSchema = create_detailed_schema(
     schemas.TestResult,
     models.TestResult,
-    include_nested_relationships={"test": ["prompt", "behavior"]},
+    include_nested_relationships={"test": ["prompt", "behavior", "topic"]},
 )
 
 


### PR DESCRIPTION
## Purpose
The test result API endpoints were returning the behavior of the associated test but not the topic. This adds the topic to the nested relationship so it's included in the response.

## What Changed
- Added `topic` to `include_nested_relationships` for the `TestResultDetailSchema`, alongside `prompt` and `behavior`

## Testing
- `GET /test_results/` and `GET /test_results/{id}` responses now include `test.topic` data