### PR TITLE
Fix SDK integration tests: add missing SESSION_SECRET_KEY

### DIFF
--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -26,6 +26,7 @@ x-sdk-redis-config: &sdk-redis-config
 
 x-sdk-backend-config: &sdk-backend-config
   JWT_SECRET_KEY: your-jwt-secret-key
+  SESSION_SECRET_KEY: test-session-secret-key
   LOG_LEVEL: DEBUG
   RHESIS_CONNECTOR_DISABLED: true
 


### PR DESCRIPTION
## Purpose

Fix SDK integration tests that have been failing on `main` since March 18th. The backend container crashes on startup because `SESSION_SECRET_KEY` is missing from the test docker-compose environment.

## What Changed

- Added `SESSION_SECRET_KEY` to the SDK test backend configuration in `tests/docker-compose.test.yml`

## Additional Context

- The backend's `main.py` raises `ValueError("CRITICAL: SESSION_SECRET_KEY must be set in production environments")` when the key is absent and `is_running_locally()` returns `False`
- The test docker-compose had no local-detection signals (`QUICK_START`, `RHESIS_BASE_URL`, or `ENVIRONMENT=local`), so the backend treated it as a production environment
- This has been breaking the `[Test] SDK` (full) workflow on every push to `main` and every nightly schedule since March 18th
- Verified locally: backend now starts successfully and passes health checks

## Testing

- Rebuilt test containers locally with the fix and confirmed the backend starts and serves `GET /health` 200 responses