### PR TITLE
feat(docs): replace emojis with SVG icons in contribute sidebar

### DIFF
--- a/docs/content/contribute/_meta.tsx
+++ b/docs/content/contribute/_meta.tsx
@@ -1,5 +1,26 @@
 import type { MetaRecord } from 'nextra'
 
+const iconProps = {
+  xmlns: 'http://www.w3.org/2000/svg',
+  viewBox: '0 0 24 24',
+  fill: 'currentColor',
+  width: 18,
+  height: 18,
+  style: { verticalAlign: 'middle', marginRight: 6, flexShrink: 0 } as const,
+}
+
+const ArchitectureIcon = () => (
+  <svg {...iconProps}>
+    <path d="M3 3h8v8H3zm10 0h8v8h-8zM3 13h8v8H3zm14 0h-4v4h-4v4h8z" />
+  </svg>
+)
+
+const ReferenceIcon = () => (
+  <svg {...iconProps}>
+    <path d="M18 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m0 18H6V4h2v8l2.5-1.5L13 12V4h5z" />
+  </svg>
+)
+
 const meta: MetaRecord = {
   index: 'Overview',
   'development-setup': 'Development Setup',
@@ -8,7 +29,12 @@ const meta: MetaRecord = {
 
   '---architecture': {
     type: 'separator',
-    title: '🏗️ Architecture',
+    title: (
+      <span className="sidebar-icon-label">
+        <ArchitectureIcon />
+        Architecture
+      </span>
+    ),
   },
   frontend: 'Frontend',
   backend: 'Backend',
@@ -19,7 +45,12 @@ const meta: MetaRecord = {
 
   '---reference': {
     type: 'separator',
-    title: '📚 Reference',
+    title: (
+      <span className="sidebar-icon-label">
+        <ReferenceIcon />
+        Reference
+      </span>
+    ),
   },
   'environment-variables': 'Environment Variables',
   telemetry: 'Telemetry',


### PR DESCRIPTION
## Purpose
Replace emoji separators in the Contribute section sidebar with consistent SVG icons, matching the style used across the rest of the docs navigation.

## What Changed
- Replace 🏗️ with an architecture/grid SVG icon for the Architecture section
- Replace 📚 with a bookmark/book SVG icon for the Reference section