### PR TITLE
feat(docs): improve SEO across docs site

### DIFF
--- a/docs/content/docs/concepts.mdx
+++ b/docs/content/docs/concepts.mdx
@@ -1,3 +1,9 @@
+---
+title: Core Concepts – Rhesis
+description: Understand the core concepts behind Rhesis — test sets, behaviors, metrics, endpoints, and the end-to-end AI testing workflow.
+keywords: [AI testing concepts, test sets, LLM behaviors, AI metrics, test workflow]
+---
+
 # Core Concepts
 
 This guide walks you through the core concepts of Rhesis.

--- a/docs/content/docs/endpoints/index.mdx
+++ b/docs/content/docs/endpoints/index.mdx
@@ -1,3 +1,9 @@
+---
+title: Endpoints – Rhesis
+description: Configure and manage API endpoints that Rhesis tests execute against. Connect single-turn and multi-turn LLM applications for automated evaluation.
+keywords: [AI endpoint configuration, LLM API endpoint, test endpoint, AI application testing]
+---
+
 import { CodeBlock } from "@/components/CodeBlock";
 
 # Endpoints

--- a/docs/content/docs/getting-started/connecting-application.mdx
+++ b/docs/content/docs/getting-started/connecting-application.mdx
@@ -1,3 +1,9 @@
+---
+title: Connect Your Application – Rhesis
+description: Connect your Generative AI application to Rhesis via REST endpoints or the Python SDK. Rhesis orchestrates test prompts and records responses for evaluation.
+keywords: [connect AI application, Rhesis integration, LLM API integration, Python SDK integration]
+---
+
 import { CodeBlock } from '@/components/CodeBlock'
 
 # Connect Application

--- a/docs/content/docs/getting-started/index.mdx
+++ b/docs/content/docs/getting-started/index.mdx
@@ -1,3 +1,9 @@
+---
+title: Getting Started with Rhesis
+description: Set up your Rhesis environment, connect your Gen AI application, and run your first automated evaluations in minutes.
+keywords: [getting started, AI testing setup, LLM evaluation quickstart, connect AI application]
+---
+
 import { NextStepCard, NextStepCardGrid } from '@/components/NextStepCard'
 
 # Getting Started

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -1,3 +1,9 @@
+---
+title: Rhesis Documentation
+description: The AI testing platform for Gen AI teams. Connect your LLM apps, generate test sets, simulate adversarial conversations, and trace every failure to its root cause.
+keywords: [AI testing platform, LLM testing, Gen AI evaluation, AI quality assurance]
+---
+
 import { ButtonGroup } from '@/components/ButtonGroup'
 import { CommunitySupport } from '@/components/CommunitySupport'
 

--- a/docs/content/docs/test-execution/index.mdx
+++ b/docs/content/docs/test-execution/index.mdx
@@ -1,3 +1,9 @@
+---
+title: Test Execution – Rhesis
+description: Execute test sets against your AI endpoints to evaluate model performance, safety, and reliability. Configure execution options and analyse results.
+keywords: [test execution, AI test runner, LLM evaluation, model safety testing, automated AI testing]
+---
+
 import { YouTubeEmbed } from "@/components/YouTubeEmbed";
 
 # Test Execution

--- a/docs/content/docs/tracing/index.mdx
+++ b/docs/content/docs/tracing/index.mdx
@@ -1,3 +1,9 @@
+---
+title: Tracing – Rhesis
+description: OpenTelemetry-based observability for AI applications. Trace LLM calls, agent steps, and tool use to debug failures and understand model behaviour.
+keywords: [AI tracing, OpenTelemetry LLM, AI observability, LLM tracing, agent tracing]
+---
+
 import { CodeBlock } from "@/components/CodeBlock";
 
 # Tracing

--- a/docs/content/guides/index.mdx
+++ b/docs/content/guides/index.mdx
@@ -1,3 +1,9 @@
+---
+title: Guides – Rhesis
+description: Step-by-step guides for testing AI applications with Rhesis — from a 10-minute quickstart to building custom metrics and CI/CD integration.
+keywords: [AI testing guides, LLM testing tutorial, custom metrics, CI/CD AI testing]
+---
+
 import { NextStepCard, NextStepCardGrid } from '@/components/NextStepCard'
 
 # Guides

--- a/docs/content/sdk/client.mdx
+++ b/docs/content/sdk/client.mdx
@@ -1,3 +1,9 @@
+---
+title: RhesisClient – Rhesis Python SDK
+description: The RhesisClient is the central entry point for the Rhesis SDK. Initialize telemetry, manage connectors for remote testing, and access the Rhesis API.
+keywords: [RhesisClient, Rhesis Python SDK, SDK API client, AI testing client]
+---
+
 import { CodeBlock } from "@/components/CodeBlock";
 
 # RhesisClient

--- a/docs/content/sdk/installation.mdx
+++ b/docs/content/sdk/installation.mdx
@@ -1,3 +1,9 @@
+---
+title: SDK Installation & Setup – Rhesis
+description: Install the Rhesis Python SDK, configure authentication, and learn the core concepts — models, synthesizers, and metrics — to start testing your AI applications.
+keywords: [Rhesis SDK, Python SDK install, AI testing SDK, SDK setup, pip install rhesis]
+---
+
 import { CodeBlock } from '@/components/CodeBlock'
 
 # Installation & Setup

--- a/docs/src/app/sitemap.js
+++ b/docs/src/app/sitemap.js
@@ -5,6 +5,8 @@
  * the sitemap stays in sync with llms.txt and llms-full.txt automatically.
  */
 
+import fs from 'fs'
+import path from 'path'
 import {
   findContentDir,
   getMdxFiles,
@@ -31,13 +33,13 @@ export default async function sitemap() {
   const urlSet = new Set()
   const entries = []
 
-  const addEntry = urlPath => {
+  const addEntry = (urlPath, lastModified = new Date()) => {
     const url = urlPath ? `${BASE_URL}/${urlPath}` : BASE_URL
     if (urlSet.has(url)) return
     urlSet.add(url)
     entries.push({
       url,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'weekly',
       priority: getPriority(urlPath),
     })
@@ -45,10 +47,21 @@ export default async function sitemap() {
 
   if (!contentDir) {
     // Minimal fallback when content dir is unavailable (e.g. partial build)
+    // eslint-disable-next-line no-console
+    console.warn(
+      'Content directory not found; sitemap will include base URL only'
+    )
     addEntry('')
   } else {
     for (const filePath of getMdxFiles(contentDir)) {
-      addEntry(filePathToUrl(filePath))
+      const urlPath = filePathToUrl(filePath)
+      let lastModified = new Date()
+      try {
+        lastModified = fs.statSync(path.join(contentDir, filePath)).mtime
+      } catch {
+        // use default lastModified
+      }
+      addEntry(urlPath, lastModified)
     }
 
     // Safety net: ensure glossary terms from the JSONL are always included

--- a/docs/src/app/sitemap.js
+++ b/docs/src/app/sitemap.js
@@ -48,9 +48,7 @@ export default async function sitemap() {
   if (!contentDir) {
     // Minimal fallback when content dir is unavailable (e.g. partial build)
     // eslint-disable-next-line no-console
-    console.warn(
-      'Content directory not found; sitemap will include base URL only'
-    )
+    console.warn('Content directory not found; sitemap will include base URL only')
     addEntry('')
   } else {
     for (const filePath of getMdxFiles(contentDir)) {

--- a/docs/src/lib/metadata.js
+++ b/docs/src/lib/metadata.js
@@ -90,13 +90,22 @@ export function generatePageMetadata(
     description = config.siteDescription
   }
 
+  // Merge page-level keywords (from frontmatter) with sitewide defaults
+  const pageKeywords = baseMetadata?.keywords
+  const keywords = pageKeywords
+    ? [...new Set([...(Array.isArray(pageKeywords) ? pageKeywords : [pageKeywords]), ...config.keywords])]
+    : config.keywords
+
   const canonicalUrl = getCanonicalUrl(urlPath, config)
   const imageUrl = getOpenGraphImage(urlPath, config.defaultImage)
+
+  // Respect ROBOTS_NOINDEX env var (e.g. staging deployments)
+  const noIndex = process.env.ROBOTS_NOINDEX === 'true'
 
   return {
     title,
     description,
-    keywords: config.keywords,
+    keywords,
     authors: [{ name: config.author.name, url: config.author.url }],
     creator: config.author.name,
     publisher: config.organization.name,
@@ -144,13 +153,13 @@ export function generatePageMetadata(
       images: [imageUrl],
     },
 
-    // Robots
+    // Robots — respect ROBOTS_NOINDEX for staging/preview environments
     robots: {
-      index: true,
-      follow: true,
+      index: !noIndex,
+      follow: !noIndex,
       googleBot: {
-        index: true,
-        follow: true,
+        index: !noIndex,
+        follow: !noIndex,
         'max-video-preview': -1,
         'max-image-preview': 'large',
         'max-snippet': -1,

--- a/docs/src/lib/metadata.js
+++ b/docs/src/lib/metadata.js
@@ -93,7 +93,12 @@ export function generatePageMetadata(
   // Merge page-level keywords (from frontmatter) with sitewide defaults
   const pageKeywords = baseMetadata?.keywords
   const keywords = pageKeywords
-    ? [...new Set([...(Array.isArray(pageKeywords) ? pageKeywords : [pageKeywords]), ...config.keywords])]
+    ? [
+        ...new Set([
+          ...(Array.isArray(pageKeywords) ? pageKeywords : [pageKeywords]),
+          ...config.keywords,
+        ]),
+      ]
     : config.keywords
 
   const canonicalUrl = getCanonicalUrl(urlPath, config)


### PR DESCRIPTION
## Purpose
Address SEO issues found during an audit of the docs site.

## What Changed

### Bug fixes
- **Robots conflict** — `generatePageMetadata` previously hardcoded `robots: { index: true }` on every MDX page, ignoring the `ROBOTS_NOINDEX` env var used by the root layout. Staging/preview deployments are now correctly noindexed.
- **Sitemap `lastModified`** — was always `new Date()` (today). Now uses real file `mtime` via `fs.statSync`, so crawlers only re-fetch pages that actually changed.

### Enhancements
- **Page-level keywords** — `generatePageMetadata` now reads `keywords` from MDX frontmatter and merges them with the sitewide defaults (deduplicated). Previously every page had identical keywords.
- **Explicit frontmatter on top 10 pages** — added `title`, `description`, and `keywords` to the highest-traffic pages so search snippets are controlled rather than auto-extracted:
  - `docs/index` (Welcome)
  - `docs/getting-started`
  - `docs/getting-started/connecting-application`
  - `docs/concepts`
  - `docs/tracing`
  - `docs/endpoints`
  - `docs/test-execution`
  - `guides/index`
  - `sdk/installation`
  - `sdk/client`

## Testing
- Build passes locally
- Visit any of the above pages and inspect `<head>` to verify correct `<title>`, `<meta name="description">`, and `<meta name="keywords">`