### PR TITLE
Fix: pin litellm to <=1.82.3 due to compromised newer versions

### DIFF
--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "tenacity>=8.2.3",
     "pyyaml>=6.0",
     "pydantic>=2.0.0",
-    "litellm>=1.76.0",
+    "litellm>=1.76.0,<=1.82.3",
     "deepteam>=0.2.5",
     "langchain-google-genai>=2.1.12",
     "ragas>=0.3.7",


### PR DESCRIPTION
## Purpose
Versions of litellm after 1.82.3 were found to be compromised (supply chain attack). This pins the SDK dependency to the last known safe version to protect users.

## What Changed
- Pinned `litellm` upper bound to `<=1.82.3` in `sdk/pyproject.toml`

## Additional Context
- This is a security fix and should be merged promptly
- Once litellm publishes verified safe versions, the upper bound can be relaxed