### PR TITLE
Pin trivy-action to immutable SHA for supply chain security

### DIFF
--- a/.github/workflows/security-trivy.yml
+++ b/.github/workflows/security-trivy.yml
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scan-ref: ${{ matrix.path }}
@@ -123,7 +123,7 @@ jobs:
           version: v0.69.2
 
       - name: Run Trivy (SARIF upload)
-        uses: aquasecurity/trivy-action@v0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scan-ref: ${{ matrix.path }}


### PR DESCRIPTION
## Purpose
Pin `aquasecurity/trivy-action` to an immutable commit SHA instead of a mutable tag to protect against supply chain attacks — following the [recent incident](https://github.com/aquasecurity/trivy-action/releases/tag/v0.35.0) that compromised older tags.

## What Changed
- Replaced `aquasecurity/trivy-action@v0.35.0` with `aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1` (the commit SHA for `v0.35.0`)
- Added `# v0.35.0` comment for readability

## Additional Context
- Mutable tags can be force-pushed to point at malicious commits; pinning to a SHA makes the reference immutable
- The `v0.35.0` tag was re-created as a verified, non-compromised release after the supply chain attack on `aquasecurity/trivy-action`