### PR TITLE
Fix trace status card display and refresh grid after review

### DIFF
--- a/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
@@ -52,6 +52,7 @@ interface TraceDrawerProps {
   currentUserId?: string;
   currentUserName?: string;
   currentUserPicture?: string;
+  onTraceUpdated?: () => void;
 }
 
 export default function TraceDrawer({
@@ -64,6 +65,7 @@ export default function TraceDrawer({
   currentUserId = '',
   currentUserName = '',
   currentUserPicture,
+  onTraceUpdated,
 }: TraceDrawerProps) {
   const [trace, setTrace] = useState<TraceDetailResponse | null>(null);
   const [loading, setLoading] = useState(false);
@@ -270,7 +272,8 @@ export default function TraceDrawer({
 
   const handleReviewSave = useCallback(async () => {
     await refreshTrace();
-  }, [refreshTrace]);
+    onTraceUpdated?.();
+  }, [refreshTrace, onTraceUpdated]);
 
   useEffect(() => {
     if (open && traceId && projectId) {

--- a/apps/frontend/src/app/(protected)/traces/components/TraceMetricsTab.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceMetricsTab.tsx
@@ -27,6 +27,7 @@ import {
   SpanNode,
   TraceMetricsStatus,
   TraceReview,
+  TRACE_METRICS_STATUS,
   TRACE_REVIEW_TARGET_TYPES,
 } from '@/utils/api-client/interfaces/telemetry';
 import StatusChip from '@/components/common/StatusChip';
@@ -451,19 +452,32 @@ export default function TraceMetricsTab({
                     '&:last-child': { pb: theme.spacing(2) },
                   }}
                 >
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    gutterBottom
+                  >
+                    Trace Status
+                  </Typography>
                   <Box
                     sx={{
                       display: 'flex',
                       alignItems: 'center',
-                      justifyContent: 'space-between',
+                      gap: 1,
                     }}
                   >
                     <Typography
-                      variant="body2"
-                      color="text.secondary"
-                      gutterBottom
+                      variant="h5"
+                      fontWeight={600}
+                      color={
+                        traceMetricsStatus === TRACE_METRICS_STATUS.PASS
+                          ? 'success.main'
+                          : traceMetricsStatus === TRACE_METRICS_STATUS.FAIL
+                            ? 'error.main'
+                            : 'warning.main'
+                      }
                     >
-                      Trace Status
+                      {traceMetricsStatus}
                     </Typography>
                     {onReviewTrace && (
                       <Tooltip title="Review overall trace">
@@ -488,12 +502,6 @@ export default function TraceMetricsTab({
                       </Tooltip>
                     )}
                   </Box>
-                  <StatusChip
-                    status={traceMetricsStatus}
-                    label={traceMetricsStatus}
-                    size="small"
-                    variant="filled"
-                  />
                   <Typography variant="caption" color="text.secondary">
                     {summary.passed}/{summary.total} metrics passed
                   </Typography>

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
@@ -161,6 +161,7 @@ export default function TracesClient({
         currentUserId={currentUserId}
         currentUserName={currentUserName}
         currentUserPicture={currentUserPicture}
+        onTraceUpdated={handleRefresh}
       />
     </>
   );


### PR DESCRIPTION
## Purpose
Improve the trace metrics overview card UX and fix a stale-data issue where the traces grid did not reflect review changes until a page reload.

## What Changed
- Replaced the `StatusChip` pill in the Trace Status card with plain text styled consistently with the other overview cards, and moved the review icon inline next to the status
- Used `TRACE_METRICS_STATUS` constants instead of hardcoded string literals for status-to-color mapping
- Added an `onTraceUpdated` callback to `TraceDrawer` so that saving a review now refreshes the underlying traces grid immediately

## Testing
- Open a trace, submit a review on the overall trace status
- Verify the traces grid updates without a page refresh
- Verify the Trace Status card shows plain text (Pass/Fail) with the review icon next to it