### PR TITLE
Fix blocking telemetry operations causing backend congestion

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -3381,36 +3381,28 @@ def create_trace_spans(
     Raises:
         Exception: If database operation fails
     """
+    from uuid import UUID as _UUID
+
+    def _safe_uuid(value: str | None, field_name: str) -> _UUID | None:
+        if not value:
+            return None
+        try:
+            return _UUID(value)
+        except (ValueError, TypeError):
+            logger.warning(f"Invalid UUID in test context {field_name}: {value}")
+            return None
+
     trace_models = []
 
     for span in spans:
-        # Calculate duration
         duration_ms = (span.end_time - span.start_time).total_seconds() * 1000
 
-        # Extract test execution context from span attributes
         test_run_id = span.attributes.get("rhesis.test.run_id")
         test_result_id = span.attributes.get("rhesis.test.result_id")
         test_id = span.attributes.get("rhesis.test.id")
 
-        # Convert to UUID if present, otherwise None
-        # Handle each UUID independently to preserve valid values
-        from uuid import UUID
-
-        def safe_uuid_convert(value: str | None, field_name: str) -> UUID | None:
-            """Convert string to UUID, handling errors independently."""
-            if not value:
-                return None
-            try:
-                return UUID(value)
-            except (ValueError, TypeError):
-                logger.warning(f"Invalid UUID in test context {field_name}: {value}")
-                return None
-
-        test_run_id_uuid = safe_uuid_convert(test_run_id, "test_run_id")
-        test_result_id_uuid = safe_uuid_convert(test_result_id, "test_result_id")
-        test_id_uuid = safe_uuid_convert(test_id, "test_id")
-
         trace_model = models.Trace(
+            id=uuid.uuid4(),
             trace_id=span.trace_id,
             span_id=span.span_id,
             parent_span_id=span.parent_span_id,
@@ -3429,20 +3421,17 @@ def create_trace_spans(
             events=[event.model_dump(mode="json") for event in span.events],
             links=[link.model_dump(mode="json") for link in span.links],
             resource=span.resource,
-            # Test execution context
-            test_run_id=test_run_id_uuid,
-            test_result_id=test_result_id_uuid,
-            test_id=test_id_uuid,
+            test_run_id=_safe_uuid(test_run_id, "test_run_id"),
+            test_result_id=_safe_uuid(test_result_id, "test_result_id"),
+            test_id=_safe_uuid(test_id, "test_id"),
         )
 
         db.add(trace_model)
         trace_models.append(trace_model)
 
-    # Bulk insert with single commit
     try:
+        db.expire_on_commit = False
         db.commit()
-        for trace_model in trace_models:
-            db.refresh(trace_model)
         return trace_models
     except Exception as e:
         db.rollback()

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 
 @router.post("/traces", response_model=TraceResponse)
-async def ingest_trace(
+def ingest_trace(
     trace_batch: OTELTraceBatch,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
@@ -98,13 +98,8 @@ async def ingest_trace(
     )
 
     # Pre-storage: inject any parked mapped output into span attributes.
-    # The SDK tracer sets rhesis.conversation.input per-span but cannot
-    # set rhesis.conversation.output (it only has the raw function
-    # return value).  The backend parks the response-mapped output after
-    # invocation and injects it here — before the span is stored.
+    # Must happen before storage because it mutates span attributes in-place.
     from rhesis.backend.app.services.telemetry.conversation_linking import (
-        apply_pending_conversation_links,
-        apply_pending_files,
         inject_pending_output,
     )
 
@@ -118,70 +113,81 @@ async def ingest_trace(
         logger.warning(f"Failed to inject pending output for trace_id={trace_id}: {inject_error}")
         logger.debug("Pending output injection traceback:", exc_info=True)
 
-    # Store spans and trigger enrichment
+    # Store spans, then enqueue linking + enrichment as a background task.
     try:
-        enrichment_service = EnrichmentService(db)
-        stored_spans, async_count, sync_count = enrichment_service.create_and_enrich_spans(
-            spans=trace_batch.spans,
-            organization_id=organization_id,
-            project_id=project_id,
-        )
+        stored_spans = crud.create_trace_spans(db, trace_batch.spans, organization_id)
 
-        unique_trace_count = len(set(s.trace_id for s in stored_spans))
+        if not stored_spans:
+            logger.warning(f"No spans were stored for trace_id={trace_id}")
+            return TraceResponse(status="received", span_count=0, trace_id=trace_id)
+
+        unique_trace_ids = list({s.trace_id for s in stored_spans})
+        stored_span_ids = [str(s.id) for s in stored_spans]
+
         logger.info(
             f"Ingested {len(stored_spans)} spans from "
-            f"{unique_trace_count} traces "
-            f"(async: {async_count}, sync: {sync_count})"
+            f"{len(unique_trace_ids)} trace(s) for trace_id={trace_id}"
         )
 
-        # Post-storage linking: apply deferred links now that spans
-        # are committed.  Each linking step is independent and must
-        # not fail the overall ingestion.
-        if stored_spans:
-            # 1. Test-result linking (traces <-> test results)
+        # Enqueue post-ingestion work (linking + enrichment) as a background task.
+        from rhesis.backend.app.services.telemetry.enrichment import (
+            are_workers_recently_available,
+        )
+
+        if are_workers_recently_available():
+            from rhesis.backend.tasks.telemetry.post_ingest import post_ingest_link
+
+            first_span = stored_spans[0]
+            post_ingest_link.delay(
+                stored_span_ids=stored_span_ids,
+                unique_trace_ids=unique_trace_ids,
+                organization_id=organization_id,
+                project_id=str(project_id),
+                test_run_id=str(first_span.test_run_id) if first_span.test_run_id else None,
+                test_id=str(first_span.test_id) if first_span.test_id else None,
+                test_configuration_id=first_span.attributes.get(
+                    "rhesis.test.test_configuration_id"
+                ),
+            )
+        else:
+            # Sync fallback: run linking in-request, enrichment via service
+            from rhesis.backend.app.services.telemetry.conversation_linking import (
+                apply_pending_conversation_links,
+                apply_pending_files,
+            )
             from rhesis.backend.app.services.telemetry.linking_service import (
                 TraceLinkingService,
             )
 
             linking_service = TraceLinkingService(db)
             try:
-                linked_count = linking_service.link_traces_for_incoming_batch(
+                linking_service.link_traces_for_incoming_batch(
                     spans=stored_spans,
                     organization_id=organization_id,
                 )
-                if linked_count > 0:
-                    logger.info(
-                        f"Linked {linked_count} traces to test result for trace_id={trace_id}"
-                    )
             except Exception as link_error:
                 logger.warning(f"Failed to link traces for trace_id={trace_id}: {link_error}")
-                logger.debug("Trace linking traceback:", exc_info=True)
 
-            # 2. Conversation-id linking (first-turn patching)
             try:
-                conversation_linked = apply_pending_conversation_links(db, stored_spans)
-                if conversation_linked > 0:
-                    logger.info(
-                        f"Applied {conversation_linked} pending "
-                        f"conversation links for trace_id={trace_id}"
-                    )
-            except Exception as conversation_error:
+                apply_pending_conversation_links(db, stored_spans)
+            except Exception as conv_error:
                 logger.warning(
-                    f"Failed to apply conversation links for "
-                    f"trace_id={trace_id}: {conversation_error}"
+                    f"Failed to apply conversation links for trace_id={trace_id}: {conv_error}"
                 )
-                logger.debug("Conversation linking traceback:", exc_info=True)
 
-            # 3. Input file linking (SDK turns with file attachments)
             try:
-                files_created = apply_pending_files(db, stored_spans)
-                if files_created > 0:
-                    logger.info(f"Created {files_created} pending file(s) for trace_id={trace_id}")
+                apply_pending_files(db, stored_spans)
             except Exception as file_error:
                 logger.warning(
                     f"Failed to apply pending files for trace_id={trace_id}: {file_error}"
                 )
-                logger.debug("File linking traceback:", exc_info=True)
+
+            enrichment_service = EnrichmentService(db)
+            enrichment_service.enrich_traces(
+                set(unique_trace_ids),
+                str(project_id),
+                organization_id,
+            )
 
         return TraceResponse(
             status="received",
@@ -190,7 +196,7 @@ async def ingest_trace(
         )
 
     except Exception as e:
-        logger.error(f"❌ Failed to store trace {trace_id}: {e}", exc_info=True)
+        logger.error(f"Failed to store trace {trace_id}: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to store trace spans",
@@ -198,7 +204,7 @@ async def ingest_trace(
 
 
 @router.get("/traces", response_model=TraceListResponse)
-async def list_traces(
+def list_traces(
     project_id: Optional[str] = Query(
         None, description="Project ID (optional - shows all projects if not specified)"
     ),
@@ -430,7 +436,7 @@ def lookup_span(
 
 
 @router.get("/traces/{trace_id}", response_model=TraceDetailResponse)
-async def get_trace(
+def get_trace(
     trace_id: str,
     project_id: str = Query(..., description="Project ID"),
     db: Session = Depends(get_tenant_db_session),
@@ -640,7 +646,7 @@ def list_span_files(
 
 
 @router.get("/metrics", response_model=TraceMetricsResponse)
-async def get_metrics(
+def get_metrics(
     project_id: str = Query(..., description="Project ID"),
     environment: Optional[str] = Query(None, description="Environment filter"),
     start_time_after: Optional[datetime] = Query(None, description="Start time >= (ISO 8601)"),

--- a/apps/backend/src/rhesis/backend/app/services/exchange_rate.py
+++ b/apps/backend/src/rhesis/backend/app/services/exchange_rate.py
@@ -83,7 +83,7 @@ class ExchangeRateService:
             response = httpx.get(
                 self._api_url,
                 params={"from": "USD", "to": "EUR"},
-                timeout=5.0,
+                timeout=2.0,
             )
             response.raise_for_status()
 

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/__init__.py
@@ -9,7 +9,11 @@ from rhesis.backend.app.services.telemetry.enrichment.core import (
     extract_metadata,
 )
 from rhesis.backend.app.services.telemetry.enrichment.processor import TraceEnricher
-from rhesis.backend.app.services.telemetry.enrichment.service import EnrichmentService
+from rhesis.backend.app.services.telemetry.enrichment.service import (
+    EnrichmentService,
+    are_workers_recently_available,
+    build_enrichment_chain,
+)
 
 __all__ = [
     # core
@@ -20,4 +24,6 @@ __all__ = [
     "TraceEnricher",
     # service
     "EnrichmentService",
+    "are_workers_recently_available",
+    "build_enrichment_chain",
 ]

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/service.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/service.py
@@ -24,6 +24,13 @@ _worker_cache: dict = {"available": None, "checked_at": 0.0}
 _WORKER_CACHE_TTL = 300.0  # seconds
 
 
+def are_workers_recently_available() -> bool:
+    """Return True if a recent worker-availability check was positive (cache-only, no ping)."""
+    now = time.monotonic()
+    age = now - _worker_cache["checked_at"]
+    return _worker_cache["available"] is True and age < _WORKER_CACHE_TTL
+
+
 class EnrichmentService:
     """Service for orchestrating trace enrichment with async/sync fallback."""
 
@@ -51,10 +58,9 @@ class EnrichmentService:
         try:
             from rhesis.backend.worker import app as celery_app
 
-            # Use ping with 3 second timeout - more reliable for solo pool workers
-            # Solo pool workers process tasks sequentially, so stats() may timeout
-            # while ping() is faster and gets prioritized
-            inspect = celery_app.control.inspect(timeout=3.0)
+            # Use ping with 1 second timeout. The result is cached for 300s,
+            # so the cost is only paid once per TTL window.
+            inspect = celery_app.control.inspect(timeout=1.0)
 
             # Ping is faster and works better with solo pool
             ping_result = inspect.ping()
@@ -109,22 +115,11 @@ class EnrichmentService:
 
         if workers_available:
             try:
-                from celery import chain
-
-                from rhesis.backend.tasks.telemetry.enrich import enrich_trace_async
-                from rhesis.backend.tasks.telemetry.evaluate import evaluate_turn_trace_metrics
-
-                # Orchestrate the pipeline using a Celery chain.
-                # .si() creates immutable signatures so the result of enrich isn't passed
-                # as the first argument to evaluate (since both just need the IDs).
-                workflow = chain(
-                    enrich_trace_async.si(trace_id, project_id, organization_id),
-                    evaluate_turn_trace_metrics.si(trace_id, project_id, organization_id),
-                )
-
+                workflow = build_enrichment_chain(trace_id, project_id, organization_id)
                 result = workflow.apply_async()
                 logger.debug(
-                    f"Enqueued async pipeline (enrich -> evaluate) for trace {trace_id} (task: {result.id})"
+                    f"Enqueued async pipeline (enrich -> evaluate) "
+                    f"for trace {trace_id} (task: {result.id})"
                 )
                 return True
 
@@ -135,29 +130,18 @@ class EnrichmentService:
         else:
             logger.info(f"No Celery workers available, using sync enrichment for trace {trace_id}")
 
-        # Fall back to synchronous enrichment
+        # Fall back to synchronous enrichment (cost calculation, anomaly
+        # detection).  Metric evaluation (LLM calls) is skipped -- it
+        # requires Celery workers and should never run in-process.
         try:
             enricher = TraceEnricher(self.db)
             enriched_data = enricher.enrich_trace(trace_id, project_id, organization_id)
             if enriched_data:
                 logger.info(f"Completed sync enrichment for trace {trace_id}")
-
-                # Trigger turn-level trace metrics evaluation (sync fallback)
-                try:
-                    from rhesis.backend.tasks.telemetry.evaluate import (
-                        evaluate_turn_trace_metrics,
-                    )
-
-                    # Call it synchronously via apply
-                    result = evaluate_turn_trace_metrics.apply(
-                        args=[trace_id, project_id, organization_id]
-                    )
-                    if result.failed():
-                        logger.error(f"Sync trace metrics evaluation failed: {result.traceback}")
-                except Exception as eval_err:
-                    logger.warning(
-                        f"Failed to run sync trace metrics evaluation for {trace_id}: {eval_err}"
-                    )
+                logger.warning(
+                    f"Trace metrics evaluation skipped for {trace_id} "
+                    f"(requires Celery workers for async processing)"
+                )
             else:
                 logger.warning(f"Sync enrichment returned no data for trace {trace_id}")
             return False
@@ -206,6 +190,10 @@ class EnrichmentService:
         """
         Create trace spans and automatically trigger enrichment.
 
+        Used by the endpoint invocation path (``services/invokers/tracing.py``),
+        **not** by the main telemetry ingestion router which handles storage and
+        enrichment dispatch separately.
+
         This helper consolidates the pattern of:
         1. Creating spans in database
         2. Extracting unique trace IDs
@@ -240,3 +228,16 @@ class EnrichmentService:
         )
 
         return stored_spans, async_count, sync_count
+
+
+def build_enrichment_chain(trace_id: str, project_id: str, organization_id: str):
+    """Build the Celery chain for trace enrichment followed by metric evaluation."""
+    from celery import chain
+
+    from rhesis.backend.tasks.telemetry.enrich import enrich_trace_async
+    from rhesis.backend.tasks.telemetry.evaluate import evaluate_turn_trace_metrics
+
+    return chain(
+        enrich_trace_async.si(trace_id, project_id, organization_id),
+        evaluate_turn_trace_metrics.si(trace_id, project_id, organization_id),
+    )

--- a/apps/backend/src/rhesis/backend/tasks/telemetry/__init__.py
+++ b/apps/backend/src/rhesis/backend/tasks/telemetry/__init__.py
@@ -5,9 +5,11 @@ from rhesis.backend.tasks.telemetry.evaluate import (
     evaluate_conversation_trace_metrics,
     evaluate_turn_trace_metrics,
 )
+from rhesis.backend.tasks.telemetry.post_ingest import post_ingest_link
 
 __all__ = [
     "enrich_trace_async",
     "evaluate_turn_trace_metrics",
     "evaluate_conversation_trace_metrics",
+    "post_ingest_link",
 ]

--- a/apps/backend/src/rhesis/backend/tasks/telemetry/post_ingest.py
+++ b/apps/backend/src/rhesis/backend/tasks/telemetry/post_ingest.py
@@ -1,0 +1,147 @@
+"""Celery task for post-ingestion linking and enrichment dispatch.
+
+Runs after spans are stored in the database. Handles:
+1. Test-result linking (traces <-> test results)
+2. Conversation-id linking (first-turn patching)
+3. Input file linking (SDK turns with file attachments)
+4. Enrichment pipeline dispatch (enrich -> evaluate chain per trace)
+"""
+
+import logging
+from typing import List, Optional
+
+from celery import shared_task
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.database import SessionLocal, set_session_variables
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=30)
+def post_ingest_link(
+    self,
+    stored_span_ids: List[str],
+    unique_trace_ids: List[str],
+    organization_id: str,
+    project_id: str,
+    test_run_id: Optional[str] = None,
+    test_id: Optional[str] = None,
+    test_configuration_id: Optional[str] = None,
+) -> dict:
+    """Link ingested spans and dispatch enrichment.
+
+    Args:
+        stored_span_ids: Database primary keys of the stored spans.
+        unique_trace_ids: Unique OTEL trace IDs in this batch.
+        organization_id: Organization UUID string.
+        project_id: Project UUID string.
+        test_run_id: Test run UUID (if test execution trace).
+        test_id: Test UUID (if test execution trace).
+        test_configuration_id: Test configuration UUID (if test execution trace).
+    """
+    db: Session = SessionLocal()
+
+    try:
+        set_session_variables(db, organization_id, "")
+
+        stored_spans = db.query(models.Trace).filter(models.Trace.id.in_(stored_span_ids)).all()
+
+        if not stored_spans:
+            logger.warning(
+                f"post_ingest_link: no spans found for ids (count={len(stored_span_ids)})"
+            )
+            return {"status": "no_spans", "trace_ids": unique_trace_ids}
+
+        linked_count = 0
+        conversation_linked = 0
+        files_created = 0
+
+        # 1. Test-result linking
+        from rhesis.backend.app.services.telemetry.linking_service import (
+            TraceLinkingService,
+        )
+
+        linking_service = TraceLinkingService(db)
+        try:
+            linked_count = linking_service.link_traces_for_incoming_batch(
+                spans=stored_spans,
+                organization_id=organization_id,
+            )
+            if linked_count > 0:
+                logger.info(
+                    f"Linked {linked_count} traces to test result (traces={unique_trace_ids})"
+                )
+        except Exception as link_error:
+            logger.warning(f"Failed to link traces (traces={unique_trace_ids}): {link_error}")
+            logger.debug("Trace linking traceback:", exc_info=True)
+
+        # 2. Conversation-id linking
+        from rhesis.backend.app.services.telemetry.conversation_linking import (
+            apply_pending_conversation_links,
+            apply_pending_files,
+        )
+
+        try:
+            conversation_linked = apply_pending_conversation_links(db, stored_spans)
+            if conversation_linked > 0:
+                logger.info(
+                    f"Applied {conversation_linked} pending conversation "
+                    f"links (traces={unique_trace_ids})"
+                )
+        except Exception as conversation_error:
+            logger.warning(
+                f"Failed to apply conversation links "
+                f"(traces={unique_trace_ids}): {conversation_error}"
+            )
+            logger.debug("Conversation linking traceback:", exc_info=True)
+
+        # 3. Input file linking
+        try:
+            files_created = apply_pending_files(db, stored_spans)
+            if files_created > 0:
+                logger.info(f"Created {files_created} pending file(s) (traces={unique_trace_ids})")
+        except Exception as file_error:
+            logger.warning(
+                f"Failed to apply pending files (traces={unique_trace_ids}): {file_error}"
+            )
+            logger.debug("File linking traceback:", exc_info=True)
+
+        # 4. Dispatch enrichment pipeline per unique trace
+        from rhesis.backend.app.services.telemetry.enrichment import (
+            build_enrichment_chain,
+        )
+
+        for trace_id in unique_trace_ids:
+            try:
+                workflow = build_enrichment_chain(trace_id, project_id, organization_id)
+                workflow.apply_async()
+            except Exception as enrich_error:
+                logger.warning(f"Failed to enqueue enrichment for trace {trace_id}: {enrich_error}")
+
+        return {
+            "status": "success",
+            "trace_ids": unique_trace_ids,
+            "linked": linked_count,
+            "conversation_linked": conversation_linked,
+            "files_created": files_created,
+        }
+
+    except Exception as e:
+        logger.error(
+            f"post_ingest_link failed (traces={unique_trace_ids}): {e}",
+            exc_info=True,
+        )
+        try:
+            raise self.retry(exc=e)
+        except self.MaxRetriesExceededError:
+            logger.error(f"Max retries exceeded for post_ingest_link (traces={unique_trace_ids})")
+            return {
+                "status": "error",
+                "trace_ids": unique_trace_ids,
+                "message": str(e),
+            }
+
+    finally:
+        db.close()

--- a/apps/backend/src/rhesis/backend/worker.py
+++ b/apps/backend/src/rhesis/backend/worker.py
@@ -110,6 +110,7 @@ app.conf.update(
         "rhesis.backend.tasks.execution.test",
         "rhesis.backend.tasks.telemetry.enrich",
         "rhesis.backend.tasks.telemetry.evaluate",
+        "rhesis.backend.tasks.telemetry.post_ingest",
     ],
 )
 
@@ -126,6 +127,15 @@ from rhesis.backend.app.services.telemetry.trace_metrics_cache import (
 
 init_conv_cache()
 init_metrics_cache()
+
+# Pre-warm the exchange rate cache so the first enrichment task
+# does not block on an HTTP call to the exchange rate API.
+try:
+    from rhesis.backend.app.services.exchange_rate import get_usd_to_eur_rate
+
+    get_usd_to_eur_rate()
+except Exception:
+    pass
 
 # Configure logging to reduce verbosity
 # Suppress verbose Celery task result logging

--- a/tests/backend/services/telemetry/test_enrichment_service.py
+++ b/tests/backend/services/telemetry/test_enrichment_service.py
@@ -52,7 +52,7 @@ class TestEnrichmentService:
         result = enrichment_service._check_workers_available()
 
         assert result is True
-        mock_celery_app.control.inspect.assert_called_once_with(timeout=3.0)
+        mock_celery_app.control.inspect.assert_called_once_with(timeout=1.0)
         mock_inspect.ping.assert_called_once()
 
     @patch("rhesis.backend.worker.app")
@@ -133,11 +133,14 @@ class TestEnrichmentService:
         "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
     )
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.TraceEnricher")
-    @patch("rhesis.backend.tasks.telemetry.evaluate.evaluate_turn_trace_metrics")
     def test_enrich_traces_sync_fallback(
-        self, mock_eval_task, mock_enricher_class, mock_check_workers, enrichment_service
+        self, mock_enricher_class, mock_check_workers, enrichment_service
     ):
-        """Test sync fallback when no workers available"""
+        """Test sync fallback when no workers available.
+
+        Metric evaluation is intentionally skipped in the sync fallback
+        (it requires Celery workers for LLM calls).
+        """
         # Mock no workers available
         mock_check_workers.return_value = False
 
@@ -145,11 +148,6 @@ class TestEnrichmentService:
         mock_enricher = Mock()
         mock_enricher.enrich_trace.return_value = {"costs": {"total_cost_usd": 0.01}}
         mock_enricher_class.return_value = mock_enricher
-
-        # Mock eval task apply
-        mock_eval_result = Mock()
-        mock_eval_result.failed.return_value = False
-        mock_eval_task.apply.return_value = mock_eval_result
 
         trace_ids = {"trace1", "trace2"}
         project_id = "project-123"
@@ -162,18 +160,19 @@ class TestEnrichmentService:
         assert async_count == 0
         assert sync_count == 2
         assert mock_enricher.enrich_trace.call_count == 2
-        assert mock_eval_task.apply.call_count == 2
 
     @patch(
         "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
     )
     @patch("celery.chain")
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.TraceEnricher")
-    @patch("rhesis.backend.tasks.telemetry.evaluate.evaluate_turn_trace_metrics")
     def test_enrich_traces_async_fallback_to_sync(
-        self, mock_eval_task, mock_enricher_class, mock_chain, mock_check_workers, enrichment_service
+        self, mock_enricher_class, mock_chain, mock_check_workers, enrichment_service
     ):
-        """Test fallback to sync when async fails"""
+        """Test fallback to sync when async fails.
+
+        Metric evaluation is skipped in the sync fallback path.
+        """
         # Mock workers available initially
         mock_check_workers.return_value = True
 
@@ -184,11 +183,6 @@ class TestEnrichmentService:
         mock_enricher = Mock()
         mock_enricher.enrich_trace.return_value = {"costs": {"total_cost_usd": 0.01}}
         mock_enricher_class.return_value = mock_enricher
-
-        # Mock eval task apply
-        mock_eval_result = Mock()
-        mock_eval_result.failed.return_value = False
-        mock_eval_task.apply.return_value = mock_eval_result
 
         trace_ids = {"trace1"}
         project_id = "project-123"
@@ -201,7 +195,6 @@ class TestEnrichmentService:
         assert async_count == 0
         assert sync_count == 1
         mock_enricher.enrich_trace.assert_called_once_with("trace1", project_id, organization_id)
-        mock_eval_task.apply.assert_called_once()
 
     @patch(
         "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
@@ -276,11 +269,14 @@ class TestEnrichmentService:
     )
     @patch("celery.chain")
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.TraceEnricher")
-    @patch("rhesis.backend.tasks.telemetry.evaluate.evaluate_turn_trace_metrics")
     def test_enrich_traces_mixed_success_failure(
-        self, mock_eval_task, mock_enricher_class, mock_chain, mock_check_workers, enrichment_service
+        self, mock_enricher_class, mock_chain, mock_check_workers, enrichment_service
     ):
-        """Test mixed async success and failure scenarios"""
+        """Test mixed async success and failure scenarios.
+
+        When async fails for one trace, it falls back to sync enrichment
+        (without metric evaluation).
+        """
         # Mock workers available
         mock_check_workers.return_value = True
 
@@ -296,11 +292,6 @@ class TestEnrichmentService:
         mock_enricher.enrich_trace.return_value = {"costs": {"total_cost_usd": 0.01}}
         mock_enricher_class.return_value = mock_enricher
 
-        # Mock eval task apply
-        mock_eval_result = Mock()
-        mock_eval_result.failed.return_value = False
-        mock_eval_task.apply.return_value = mock_eval_result
-
         trace_ids = {"trace1", "trace2"}
         project_id = "project-123"
         organization_id = "org-123"
@@ -311,7 +302,7 @@ class TestEnrichmentService:
 
         assert async_count == 1  # First trace succeeded async
         assert sync_count == 1  # Second trace fell back to sync
-        mock_eval_task.apply.assert_called_once()
+        mock_enricher.enrich_trace.assert_called_once()
 
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.logger")
     @patch(
@@ -348,9 +339,8 @@ class TestEnrichmentService:
         "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
     )
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.TraceEnricher")
-    @patch("rhesis.backend.tasks.telemetry.evaluate.evaluate_turn_trace_metrics")
     def test_enrich_traces_sync_logging(
-        self, mock_eval_task, mock_enricher_class, mock_check_workers, mock_logger, enrichment_service
+        self, mock_enricher_class, mock_check_workers, mock_logger, enrichment_service
     ):
         """Test logging during sync enrichment"""
         # Mock no workers available
@@ -360,11 +350,6 @@ class TestEnrichmentService:
         mock_enricher = Mock()
         mock_enricher.enrich_trace.return_value = {"costs": {"total_cost_usd": 0.01}}
         mock_enricher_class.return_value = mock_enricher
-
-        # Mock eval task apply
-        mock_eval_result = Mock()
-        mock_eval_result.failed.return_value = False
-        mock_eval_task.apply.return_value = mock_eval_result
 
         trace_ids = {"trace1"}
         project_id = "project-123"


### PR DESCRIPTION
## Purpose
Fix backend congestion under high test execution load caused by blocking telemetry operations running on the async event loop.

## What Changed
- Converted all telemetry router endpoints (`ingest_trace`, `list_traces`, `get_trace`, `get_metrics`) from `async def` to `def` so blocking DB/IO runs in FastAPI's threadpool
- Created `post_ingest_link` Celery task to offload trace linking and enrichment dispatch out of the request path
- Eliminated N+1 lazy-load SELECTs in `create_trace_spans` by disabling `expire_on_commit` around the commit
- Removed in-process LLM metric evaluation from the sync fallback path
- Extracted `build_enrichment_chain()` and `are_workers_recently_available()` helpers to reduce code duplication
- Reduced Celery ping timeout (3s to 1s) and external HTTP timeout (5s to 2s)
- Pre-warmed exchange rate cache at Celery worker startup

## Testing
All 3450 backend tests pass. No new test failures introduced.