### PR TITLE
Add segmented progress bar for adaptive testing suggestions pipeline

### DIFF
--- a/apps/frontend/src/app/(protected)/adaptive-testing/[identifier]/components/SuggestionsDialog.tsx
+++ b/apps/frontend/src/app/(protected)/adaptive-testing/[identifier]/components/SuggestionsDialog.tsx
@@ -84,7 +84,7 @@ function SegmentedProgressBar({
               position: 'relative',
               flex: 1,
               height: '100%',
-              borderRadius: 999,
+              borderRadius: theme.spacing(1),
               overflow: 'hidden',
               backgroundColor: theme.palette.action.disabledBackground,
               // Inset ring so focus/active state is not clipped by DialogContent overflow


### PR DESCRIPTION
## Purpose
Replace the coarse "Step 1/3" text in the suggestions dialog with a clearer, three-phase progress indicator for test generation, output generation, and metric evaluation.

## What Changed
- Added a three-segment progress bar in `SuggestionsDialog` driven by existing pipeline steps and NDJSON stream `item` events for outputs and evaluation.
- Phase 1 fills when suggestion generation completes; phases 2 and 3 fill proportionally as streamed rows complete.
- Used an inset highlight for the active segment and small top padding so the bar is not clipped by `DialogContent` overflow.

## Additional Context
- Frontend-only change; no API or backend changes.

## Testing
- Open adaptive testing, open **Suggested Tests** (suggestions dialog), and run generate/regenerate. Confirm the bar advances through the three segments and completes without the top being visually clipped.
