### PR TITLE
fix: Unique Index Constraint

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/533ebb47f308_add_unique_active_chunk_index.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/533ebb47f308_add_unique_active_chunk_index.py
@@ -1,0 +1,24 @@
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "533ebb47f308"
+down_revision: Union[str, None] = "d22819b0aa66"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_unique_active_chunk_index",
+        "chunk",
+        ["source_id", "chunk_index"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_unique_active_chunk_index", table_name="chunk")

--- a/apps/backend/src/rhesis/backend/app/models/chunk.py
+++ b/apps/backend/src/rhesis/backend/app/models/chunk.py
@@ -18,7 +18,7 @@ class Chunk(
     content = Column(Text, nullable=False)
     chunk_index = Column(Integer, nullable=False)
     token_count = Column(Integer, nullable=False)
-    chunk_metadata = Column(JSONB, default=dict, server_default=text("'{}'::jsonb"))
+    chunk_metadata = Column(JSONB, default=dict)
     status_id = Column(GUID(), ForeignKey("status.id"))
 
     # Relationships


### PR DESCRIPTION
## Fix Unique Index Constraint for Active Chunks

This PR addresses database integrity issues with the Chunk model by adding a proper unique constraint and fixing metadata column defaults.

### Key Changes

**Database Constraint Fix:**
- Add unique index `ix_unique_active_chunk_index` on `(source_id, chunk_index)` for active chunks only (where `deleted_at IS NULL`)
- This prevents duplicate chunk indices within the same source while allowing soft-deleted chunks to coexist

**Model Fix:**
- Remove problematic `server_default=text("'{}'::jsonb")` from `chunk_metadata` column in Chunk model
- Keep Python `default=dict` for application-level defaults