### PR TITLE
fix: merge migration branches

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/e1cbd5f10580_merge_embedding_unique_and_cancelled_.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/e1cbd5f10580_merge_embedding_unique_and_cancelled_.py
@@ -1,0 +1,15 @@
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "e1cbd5f10580"
+down_revision: Union[str, None] = ("8993eecbb913", "a1b2c3d4e5f9")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
This PR merges two alembic migration branches:

- `8993eecbb913` — unique embedding index (`1010fc534974` → …)
- `a1b2c3d4e5f9` — cancelled test run status (`533ebb47f308` → …) 