### PR TITLE
Fix: External Dns Controller

### DIFF
--- a/kubernetes/base/external-dns/external-dns-application.yaml
+++ b/kubernetes/base/external-dns/external-dns-application.yaml
@@ -22,8 +22,8 @@ spec:
                 name: cloudflare-api-token
                 key: cf-api-token
         domainFilters:
-          - example.com # need to change to the actual domain
-        policy: upsert-only
+          - rhesis.ai
+        policy: sync # sync or upsert
         txtOwnerId: PLACEHOLDER
         sources:
           - service

--- a/kubernetes/base/internal-dns/internal-dns-application.yaml
+++ b/kubernetes/base/internal-dns/internal-dns-application.yaml
@@ -34,7 +34,7 @@ spec:
                 key: tsig-secret
         domainFilters:
           - PLACEHOLDER
-        policy: upsert-only
+        policy: sync
         txtOwnerId: PLACEHOLDER
         sources:
           - service

--- a/kubernetes/clusters/dev/argocd/argocd-ingress.yaml
+++ b/kubernetes/clusters/dev/argocd/argocd-ingress.yaml
@@ -1,4 +1,4 @@
-# Exposes the ArgoCD dashboard UI. TLS is terminated at the ingress; ArgoCD server runs HTTP (server.insecure).
+# Exposes the ArgoCD dashboard UI over the internal ingress. ArgoCD server runs HTTP (server.insecure).
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -6,15 +6,10 @@ metadata:
   namespace: argocd
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
   ingressClassName: internal
-  tls:
-    - hosts:
-        - argocd.dev.rhesis.ai
-      secretName: argocd-tls
   rules:
-    - host: argocd.dev.rhesis.ai
+    - host: argocd.dev.rhesis.internal
       http:
         paths:
           - path: /

--- a/kubernetes/clusters/dev/external-dns/kustomization.yaml
+++ b/kubernetes/clusters/dev/external-dns/kustomization.yaml
@@ -8,8 +8,8 @@ configMapGenerator:
   - name: external-dns-config
     literals:
       - cloudflare-api-token-gcp-secret=cloudflare-api-token-dev
-      - domain-filter=example.com # need to change to the actual domain
-      - txt-owner-id=dev-external-dns # need to change to the actual owner id
+      - domain-filter=rhesis.ai
+      - txt-owner-id=dev-external-dns
     options:
       annotations:
         config.kubernetes.io/local-config: "true"

--- a/kubernetes/clusters/prd/argocd/argocd-ingress.yaml
+++ b/kubernetes/clusters/prd/argocd/argocd-ingress.yaml
@@ -1,4 +1,4 @@
-# Exposes the ArgoCD dashboard UI. TLS is terminated at the ingress; ArgoCD server runs HTTP (server.insecure).
+# Exposes the ArgoCD dashboard UI over the internal ingress. ArgoCD server runs HTTP (server.insecure).
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -6,15 +6,10 @@ metadata:
   namespace: argocd
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
   ingressClassName: internal
-  tls:
-    - hosts:
-        - argocd.prd.rhesis.ai
-      secretName: argocd-tls
   rules:
-    - host: argocd.prd.rhesis.ai
+    - host: argocd.prd.rhesis.internal
       http:
         paths:
           - path: /

--- a/kubernetes/clusters/prd/external-dns/kustomization.yaml
+++ b/kubernetes/clusters/prd/external-dns/kustomization.yaml
@@ -8,7 +8,7 @@ configMapGenerator:
   - name: external-dns-config
     literals:
       - cloudflare-api-token-gcp-secret=cloudflare-api-token-prd
-      - domain-filter=PLACEHOLDER_DOMAIN
+      - domain-filter=rhesis.ai
       - txt-owner-id=prd-external-dns
     options:
       annotations:

--- a/kubernetes/clusters/stg/argocd/argocd-ingress.yaml
+++ b/kubernetes/clusters/stg/argocd/argocd-ingress.yaml
@@ -1,4 +1,4 @@
-# Exposes the ArgoCD dashboard UI. TLS is terminated at the ingress; ArgoCD server runs HTTP (server.insecure).
+# Exposes the ArgoCD dashboard UI over the internal ingress. ArgoCD server runs HTTP (server.insecure).
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -6,15 +6,10 @@ metadata:
   namespace: argocd
   annotations:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
-    cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
   ingressClassName: internal
-  tls:
-    - hosts:
-        - argocd.stg.rhesis.ai
-      secretName: argocd-tls
   rules:
-    - host: argocd.stg.rhesis.ai
+    - host: argocd.stg.rhesis.internal
       http:
         paths:
           - path: /

--- a/kubernetes/clusters/stg/external-dns/kustomization.yaml
+++ b/kubernetes/clusters/stg/external-dns/kustomization.yaml
@@ -8,7 +8,7 @@ configMapGenerator:
   - name: external-dns-config
     literals:
       - cloudflare-api-token-gcp-secret=cloudflare-api-token-stg
-      - domain-filter=PLACEHOLDER_DOMAIN
+      - domain-filter=rhesis.ai
       - txt-owner-id=stg-external-dns
     options:
       annotations:

--- a/terraform/infrastructure/scripts/verify-dev-cluster.sh
+++ b/terraform/infrastructure/scripts/verify-dev-cluster.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 PROJECT_ID="${PROJECT_ID:-rhesis-dev-sandbox}"
 REGION="${REGION:-europe-west4}"
 CLUSTER_NAME="${CLUSTER_NAME:-gke-dev}"
-ARGOCD_HOST="${ARGOCD_HOST:-argocd.dev.rhesis.ai}"
+ARGOCD_HOST="${ARGOCD_HOST:-argocd.dev.rhesis.internal}"
 SKIP_VPN=false
 
 for arg in "$@"; do


### PR DESCRIPTION
This PR introduces changes from the `fix/external-dns-controller` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->


## 📁 Files Changed (       9 files)

```
kubernetes/base/external-dns/external-dns-application.yaml
kubernetes/base/internal-dns/internal-dns-application.yaml
kubernetes/clusters/dev/argocd/argocd-ingress.yaml
kubernetes/clusters/dev/external-dns/kustomization.yaml
kubernetes/clusters/prd/argocd/argocd-ingress.yaml
kubernetes/clusters/prd/external-dns/kustomization.yaml
kubernetes/clusters/stg/argocd/argocd-ingress.yaml
kubernetes/clusters/stg/external-dns/kustomization.yaml
terraform/infrastructure/scripts/verify-dev-cluster.sh
```

## 📋 Commit Details

```
40cd91a70 - fix: - - The external-dns controller is configured to domain-filter=internal-example.com, which should be rhesis.ai instead - The argocd ingress is configured to argocd.dev.rhesis.ai, which is not a valid domain for the internal dns controller (domain-filter=rhesis.internal) - Both dns controllers have policy=upsert-only. That is indeed the default, but that means they don’t clean up after themselves. Both have owner-ids set, so it should be safe to set the policy to „sync“ - The argocd ingress is configured to use TLS. That should be disabled and the cluster-issuer annotation removed (Md Asaduzzaman Miah, 2026-04-02 17:11)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->