### PR TITLE
Add configurable Celery queues and optional dedicated worker pools

### DIFF
--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -127,7 +127,8 @@ ENV PYTHONUNBUFFERED=1 \
     CELERY_TASK_EAGER_PROPAGATES=False
 
 # Default Celery configuration (can be overridden at runtime)
-ENV CELERY_WORKER_CONCURRENCY=2 \
+ENV CELERY_WORKER_QUEUES=celery,execution,telemetry \
+    CELERY_WORKER_CONCURRENCY=2 \
     CELERY_WORKER_PREFETCH_MULTIPLIER=1 \
     CELERY_WORKER_LOGLEVEL=WARNING \
     CELERY_WORKER_OPTS="--without-gossip --without-mingle --without-heartbeat"

--- a/apps/worker/k8s/deployment-worker-celery.yaml
+++ b/apps/worker/k8s/deployment-worker-celery.yaml
@@ -1,20 +1,21 @@
+# Optional dedicated pool (default celery queue only). Not applied by kustomization.yaml by default.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: rhesis-worker
+  name: rhesis-worker-celery
   namespace: rhesis-worker-dev
   labels:
-    app: rhesis-worker
+    app: rhesis-worker-celery
     component: worker
 spec:
-  replicas: 4
+  replicas: 2
   selector:
     matchLabels:
-      app: rhesis-worker
+      app: rhesis-worker-celery
   template:
     metadata:
       labels:
-        app: rhesis-worker
+        app: rhesis-worker-celery
         component: worker
       annotations:
         # Always restart pods on every deployment
@@ -259,11 +260,7 @@ spec:
               name: rhesis-worker-secrets
               key: DEFAULT_POLYPHEMUS_URL
         - name: CELERY_WORKER_QUEUES
-          valueFrom:
-            secretKeyRef:
-              name: rhesis-worker-secrets
-              key: CELERY_WORKER_QUEUES
-              optional: true
+          value: "celery"
         - name: GIT_BRANCH
           value: "GIT_BRANCH_PLACEHOLDER"
         - name: GIT_COMMIT

--- a/apps/worker/k8s/deployment-worker-execution.yaml
+++ b/apps/worker/k8s/deployment-worker-execution.yaml
@@ -1,20 +1,22 @@
+# Optional dedicated pool (execution queue only). Not applied by kustomization.yaml by default.
+# Prefer scaling rhesis-worker to 0 when using split deployments, or keep a single monolith.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: rhesis-worker
+  name: rhesis-worker-execution
   namespace: rhesis-worker-dev
   labels:
-    app: rhesis-worker
+    app: rhesis-worker-execution
     component: worker
 spec:
   replicas: 4
   selector:
     matchLabels:
-      app: rhesis-worker
+      app: rhesis-worker-execution
   template:
     metadata:
       labels:
-        app: rhesis-worker
+        app: rhesis-worker-execution
         component: worker
       annotations:
         # Always restart pods on every deployment
@@ -259,11 +261,7 @@ spec:
               name: rhesis-worker-secrets
               key: DEFAULT_POLYPHEMUS_URL
         - name: CELERY_WORKER_QUEUES
-          valueFrom:
-            secretKeyRef:
-              name: rhesis-worker-secrets
-              key: CELERY_WORKER_QUEUES
-              optional: true
+          value: "execution"
         - name: GIT_BRANCH
           value: "GIT_BRANCH_PLACEHOLDER"
         - name: GIT_COMMIT

--- a/apps/worker/k8s/deployment-worker-telemetry.yaml
+++ b/apps/worker/k8s/deployment-worker-telemetry.yaml
@@ -1,20 +1,21 @@
+# Optional dedicated pool (telemetry queue only). Not applied by kustomization.yaml by default.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: rhesis-worker
+  name: rhesis-worker-telemetry
   namespace: rhesis-worker-dev
   labels:
-    app: rhesis-worker
+    app: rhesis-worker-telemetry
     component: worker
 spec:
-  replicas: 4
+  replicas: 2
   selector:
     matchLabels:
-      app: rhesis-worker
+      app: rhesis-worker-telemetry
   template:
     metadata:
       labels:
-        app: rhesis-worker
+        app: rhesis-worker-telemetry
         component: worker
       annotations:
         # Always restart pods on every deployment
@@ -259,11 +260,7 @@ spec:
               name: rhesis-worker-secrets
               key: DEFAULT_POLYPHEMUS_URL
         - name: CELERY_WORKER_QUEUES
-          valueFrom:
-            secretKeyRef:
-              name: rhesis-worker-secrets
-              key: CELERY_WORKER_QUEUES
-              optional: true
+          value: "telemetry"
         - name: GIT_BRANCH
           value: "GIT_BRANCH_PLACEHOLDER"
         - name: GIT_COMMIT

--- a/apps/worker/k8s/networkpolicy.yaml
+++ b/apps/worker/k8s/networkpolicy.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: rhesis-worker
+      component: worker
   policyTypes:
   - Egress
   egress:
@@ -18,4 +18,4 @@ spec:
   - to: []
     ports:
     - protocol: UDP
-      port: 53 
+      port: 53

--- a/apps/worker/start.sh
+++ b/apps/worker/start.sh
@@ -12,6 +12,7 @@ echo "Worker environment: ${WORKER_ENV:-not_set}"
 echo "Git branch: ${GIT_BRANCH:-unknown}"
 echo "Git commit: ${GIT_COMMIT:-unknown}"
 echo "Celery worker concurrency: ${CELERY_WORKER_CONCURRENCY:-2}"
+echo "Celery worker queues: ${CELERY_WORKER_QUEUES:-celery,execution,telemetry}"
 echo "Celery worker pool: threads"
 
 # Set log level based on worker environment
@@ -116,7 +117,7 @@ import os
 try:
     from rhesis.backend.worker import app
     print(f'Broker URL type: {\"TLS\" if os.getenv(\"BROKER_URL\", \"\").startswith(\"rediss://\") else \"standard\"}')
-    
+
     # Test basic broker connection (lighter than worker ping)
     with app.connection() as conn:
         conn.connect()
@@ -137,13 +138,13 @@ import sys
 try:
     from sqlalchemy import create_engine, text
     import os
-    
+
     # Test database connection
     db_url = os.getenv('SQLALCHEMY_DATABASE_URL')
     db_pass = os.getenv('SQLALCHEMY_DB_PASS', '')
     redacted_url = db_url.replace(db_pass, '***') if db_pass else db_url
     print(f'Testing database connection: {redacted_url}')
-    
+
     engine = create_engine(db_url, pool_pre_ping=True)
     with engine.connect() as conn:
         result = conn.execute(text('SELECT 1'))
@@ -174,18 +175,18 @@ for i in {1..10}; do
         ps aux | grep health_server.py | grep -v grep || echo "No health server processes found"
         break
     fi
-    
+
     # Test basic endpoint
     if curl -f -s http://localhost:8080/health/basic > /dev/null 2>&1; then
         echo "✅ Health server is responding to /health/basic"
-        
+
         # Also test the ping endpoint
         if curl -f -s http://localhost:8080/ping > /dev/null 2>&1; then
             echo "✅ Health server is responding to /ping"
         else
             echo "⚠️ Health server not responding to /ping"
         fi
-        
+
         # Test debug endpoint availability
         if curl -f -s http://localhost:8080/debug > /dev/null 2>&1; then
             echo "✅ Debug endpoints are available"
@@ -194,7 +195,7 @@ for i in {1..10}; do
         fi
         break
     fi
-    
+
     echo "Waiting for health server... attempt $i/10"
     sleep 1
 done
@@ -222,23 +223,23 @@ fi
 # Function to forward signals to children
 forward_signal() {
     echo "Received shutdown signal, stopping processes..."
-    
+
     if [ ! -z "$HEALTH_SERVER_PID" ] && kill -0 $HEALTH_SERVER_PID 2>/dev/null; then
         echo "Stopping health check server (PID: $HEALTH_SERVER_PID)..."
         kill -TERM $HEALTH_SERVER_PID || true
     fi
-    
+
     if [ ! -z "$FLOWER_PID" ] && kill -0 $FLOWER_PID 2>/dev/null; then
         echo "Stopping Flower (PID: $FLOWER_PID)..."
         kill -TERM $FLOWER_PID || true
     fi
-    
+
     if [ ! -z "$CELERY_PID" ] && kill -0 $CELERY_PID 2>/dev/null; then
         echo "Stopping Celery worker (PID: $CELERY_PID)..."
         kill -TERM $CELERY_PID || true
         wait $CELERY_PID
     fi
-    
+
     exit 0
 }
 
@@ -258,14 +259,18 @@ WORKER_UUID=$(python3 -c "import uuid; print(str(uuid.uuid4())[:8])")
 export CELERY_WORKER_NAME="worker@$(hostname)-${WORKER_UUID}"
 echo "Worker context identifier: $CELERY_WORKER_NAME"
 
+# Comma-separated Celery queue names (no spaces). Default: all app queues.
+# Override per deployment to dedicate workers (e.g. execution-only pools).
+CELERY_WORKER_QUEUES="${CELERY_WORKER_QUEUES:-celery,execution,telemetry}"
+
 # Build the Celery worker command.
 # Uses the threads pool: no fork(), so no fork-safety issues with native
 # libraries (SSL, gRPC, Kerberos/CoreFoundation). Works well for I/O-bound
 # work (LLM API calls, DB queries). -E enables events for Flower/monitoring.
-CELERY_CMD="celery -A rhesis.backend.worker.app worker --pool threads --queues=celery,execution,telemetry --loglevel=${CELERY_WORKER_LOGLEVEL:-WARNING} --concurrency=${CELERY_WORKER_CONCURRENCY:-2} --optimization=fair -E ${CELERY_WORKER_OPTS}"
+CELERY_CMD="celery -A rhesis.backend.worker.app worker --pool threads --queues=${CELERY_WORKER_QUEUES} --loglevel=${CELERY_WORKER_LOGLEVEL:-WARNING} --concurrency=${CELERY_WORKER_CONCURRENCY:-2} --optimization=fair -E ${CELERY_WORKER_OPTS}"
 
 echo "Command: $CELERY_CMD"
-echo "Queues: celery,execution,telemetry"
+echo "Queues: ${CELERY_WORKER_QUEUES}"
 echo "Pool: threads"
 echo "Concurrency: ${CELERY_WORKER_CONCURRENCY:-2}"
 echo "Log level: ${CELERY_WORKER_LOGLEVEL}"
@@ -287,7 +292,7 @@ for i in {1..10}; do
         wait $CELERY_PID
         EXIT_CODE=$?
         echo "Worker exit code: $EXIT_CODE"
-        
+
         # Try to get more information about the failure
         echo ""
         echo "=== Failure Analysis ==="
@@ -296,10 +301,10 @@ for i in {1..10}; do
         df -h 2>/dev/null || echo "Disk info not available"
         echo "Checking for core dumps..."
         ls -la core* 2>/dev/null || echo "No core dumps found"
-        
+
         exit $EXIT_CODE
     fi
-    
+
     echo "Worker running... check $i/10 (PID: $CELERY_PID)"
     sleep 1
 done
@@ -314,7 +319,7 @@ echo "Waiting for worker to fully initialize before connectivity test..."
 # Give the worker time to fully start up
 sleep 5
 
-# Use same timeout logic as broker test  
+# Use same timeout logic as broker test
 if [[ "$BROKER_URL" == rediss://* ]]; then
     CONNECTIVITY_TIMEOUT=20
     echo "Using TLS timeout: ${CONNECTIVITY_TIMEOUT}s"
@@ -326,17 +331,17 @@ fi
 # Try multiple times with increasing delays
 for attempt in {1..3}; do
     echo "Connectivity test attempt $attempt/3..."
-    
+
     timeout $CONNECTIVITY_TIMEOUT python -c "
 import sys
 import time
 try:
     from rhesis.backend.worker import app
-    
+
     # Give a moment for workers to register
     time.sleep(2)
-    
-    # Test if we can connect to our own worker  
+
+    # Test if we can connect to our own worker
     result = app.control.inspect().ping()
     if result:
         print('✅ Worker is responding to ping')
@@ -383,4 +388,4 @@ if [ ! -z "$FLOWER_PID" ] && kill -0 $FLOWER_PID 2>/dev/null; then
     wait $FLOWER_PID 2>/dev/null || true
 fi
 
-exit $EXIT_CODE 
+exit $EXIT_CODE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,7 +150,7 @@ services:
       retries: 3
       start_period: 60s
 
-  # Celery Worker
+  # Celery Worker (monolith: all queues; set CELERY_WORKER_QUEUES to restrict)
   worker:
     build:
       context: .
@@ -158,6 +158,7 @@ services:
     environment:
       <<: [*common-database, *common-redis, *common-auth, *common-auth0, *common-smtp, *common-jwt, *common-environment, *rhesis-config]
       LOG_LEVEL: ${CELERY_WORKER_LOGLEVEL:-INFO}
+      CELERY_WORKER_QUEUES: ${CELERY_WORKER_QUEUES:-celery,execution,telemetry}
       CELERY_WORKER_CONCURRENCY: ${CELERY_WORKER_CONCURRENCY:-8}
       CELERY_WORKER_PREFETCH_MULTIPLIER: ${CELERY_WORKER_PREFETCH_MULTIPLIER:-4}
       CELERY_WORKER_LOGLEVEL: ${CELERY_WORKER_LOGLEVEL:-INFO}
@@ -177,6 +178,105 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8081/health/basic"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  # Optional: one worker pool per queue for priority via replicas/concurrency.
+  # Profile workers-split — enable with: docker compose --profile workers-split up -d
+  # Prefer either this profile or the monolith `worker` above to avoid redundant capacity.
+  worker-execution:
+    profiles:
+      - workers-split
+    build:
+      context: .
+      dockerfile: apps/worker/Dockerfile
+    environment:
+      <<: [*common-database, *common-redis, *common-auth, *common-auth0, *common-smtp, *common-jwt, *common-environment, *rhesis-config]
+      LOG_LEVEL: ${CELERY_WORKER_LOGLEVEL:-INFO}
+      CELERY_WORKER_QUEUES: execution
+      CELERY_WORKER_CONCURRENCY: ${CELERY_WORKER_EXECUTION_CONCURRENCY:-8}
+      CELERY_WORKER_PREFETCH_MULTIPLIER: ${CELERY_WORKER_PREFETCH_MULTIPLIER:-4}
+      CELERY_WORKER_LOGLEVEL: ${CELERY_WORKER_LOGLEVEL:-INFO}
+      USE_TCP_DATABASE: ${USE_TCP_DATABASE:-true}
+      ENABLE_FLOWER: ${ENABLE_FLOWER:-no}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - rhesis-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/basic"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  worker-telemetry:
+    profiles:
+      - workers-split
+    build:
+      context: .
+      dockerfile: apps/worker/Dockerfile
+    environment:
+      <<: [*common-database, *common-redis, *common-auth, *common-auth0, *common-smtp, *common-jwt, *common-environment, *rhesis-config]
+      LOG_LEVEL: ${CELERY_WORKER_LOGLEVEL:-INFO}
+      CELERY_WORKER_QUEUES: telemetry
+      CELERY_WORKER_CONCURRENCY: ${CELERY_WORKER_TELEMETRY_CONCURRENCY:-4}
+      CELERY_WORKER_PREFETCH_MULTIPLIER: ${CELERY_WORKER_PREFETCH_MULTIPLIER:-4}
+      CELERY_WORKER_LOGLEVEL: ${CELERY_WORKER_LOGLEVEL:-INFO}
+      USE_TCP_DATABASE: ${USE_TCP_DATABASE:-true}
+      ENABLE_FLOWER: ${ENABLE_FLOWER:-no}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - rhesis-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/basic"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+  worker-celery:
+    profiles:
+      - workers-split
+    build:
+      context: .
+      dockerfile: apps/worker/Dockerfile
+    environment:
+      <<: [*common-database, *common-redis, *common-auth, *common-auth0, *common-smtp, *common-jwt, *common-environment, *rhesis-config]
+      LOG_LEVEL: ${CELERY_WORKER_LOGLEVEL:-INFO}
+      CELERY_WORKER_QUEUES: celery
+      CELERY_WORKER_CONCURRENCY: ${CELERY_WORKER_CELERY_CONCURRENCY:-4}
+      CELERY_WORKER_PREFETCH_MULTIPLIER: ${CELERY_WORKER_PREFETCH_MULTIPLIER:-4}
+      CELERY_WORKER_LOGLEVEL: ${CELERY_WORKER_LOGLEVEL:-INFO}
+      USE_TCP_DATABASE: ${USE_TCP_DATABASE:-true}
+      ENABLE_FLOWER: ${ENABLE_FLOWER:-no}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - rhesis-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health/basic"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION

**Purpose**  
Workers previously consumed `celery`, `execution`, and `telemetry` in one process with fair scheduling, which does not let you allocate capacity by importance. This change makes the queue list environment-driven and adds an optional split layout so priority can be expressed through replicas and concurrency per queue.

**What changed**  
- `CELERY_WORKER_QUEUES` controls `--queues` in [`apps/worker/start.sh`](apps/worker/start.sh) (default unchanged: `celery,execution,telemetry`).  
- [`apps/worker/Dockerfile`](apps/worker/Dockerfile) documents/sets the same default.  
- [`docker-compose.yml`](docker-compose.yml): monolith worker passes the env var; Compose profile `workers-split` adds `worker-execution`, `worker-telemetry`, and `worker-celery` with separate concurrency env vars.  
- Kubernetes: optional `CELERY_WORKER_QUEUES` in [`apps/worker/k8s/deployment.yaml`](apps/worker/k8s/deployment.yaml) via secret (optional key); new [`apps/worker/k8s/deployment-worker-*.yaml`](apps/worker/k8s/) manifests for dedicated pools; [`apps/worker/k8s/networkpolicy.yaml`](apps/worker/k8s/networkpolicy.yaml) selects pods by `component: worker` so pool-specific `app` labels still match.

**Additional context**  
- Kustomize still only references the main deployment by default; dedicated manifests are opt-in. Running monolith and `workers-split` together is allowed but usually redundant—prefer one or the other for predictable capacity.

**Testing**  
- `bash -n apps/worker/start.sh`  
- Local: `docker compose up` (monolith); optional `docker compose --profile workers-split up -d` with monolith stopped/omitted as needed.  
- K8s: verify optional manifests apply and queues have consumers when using split pools.