### PR TITLE
Fix circular import between worker and embedding task

### DIFF
--- a/apps/backend/src/rhesis/backend/tasks/embedding/generate.py
+++ b/apps/backend/src/rhesis/backend/tasks/embedding/generate.py
@@ -6,7 +6,7 @@ This task generates embeddings for entities in a background worker.
 import logging
 
 from rhesis.backend.tasks.base import SilentTask
-from rhesis.backend.worker import app
+from rhesis.backend.celery.core import app
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Problem
Worker pod was crashing on startup (`CrashLoopBackOff`) due to a circular import:

`worker.py` → `celery/signals.py` → `tasks/__init__.py` → `tasks/embedding/generate.py` → `worker.py`

## Fix
In `tasks/embedding/generate.py`, changed import source from `rhesis.backend.worker`  to `rhesis.backend.celery.core` where `app` is originally defined, breaking the cycle.