### PR TITLE
Fix: log batch item failures in polyphemus service

### DIFF
--- a/apps/polyphemus/src/rhesis/polyphemus/services/services.py
+++ b/apps/polyphemus/src/rhesis/polyphemus/services/services.py
@@ -357,6 +357,7 @@ async def generate_text_batch_via_vertex_endpoint(
                     timeout_seconds=timeout_seconds,
                 )
             except Exception as exc:
+                logger.error("Batch item failed: %s", exc, exc_info=True)
                 return {"error": str(exc)}
 
     results = await asyncio.gather(


### PR DESCRIPTION
## Purpose
Batch item failures in the polyphemus service were returned as `{"error": ...}` to the caller but never appearing in logs, making partial batch failures invisible server-side.