### PR TITLE
Fix chatbot Docker build for SDK and rhesis paths

### DIFF
--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -32,21 +32,21 @@ ENV UV_NO_MANAGED_PYTHON=1
 # call python from the command line.
 ENV PATH="/app/.venv/bin:$PATH"
 
-# Copy the SDK directory (required dependency)
+# SDK and rhesis meta-package (SDK depends on rhesis[telemetry]) — same layout as backend
 COPY sdk /app/sdk/
+COPY packages/rhesis /app/packages/rhesis/
 
-# Fix the SDK source path (pyproject.toml and uv.lock reference ../../sdk locally,
-# but in Docker the SDK lives at /app/sdk). Patch both files then sync with the
-# frozen lock to avoid a full re-resolution (which fails due to extras conflicts).
-RUN sed -i 's|../../sdk|/app/sdk|g' pyproject.toml uv.lock && \
-    uv sync --frozen --no-dev
+# Fix paths in pyproject.toml to point to the correct locations in Docker (see apps/backend/Dockerfile)
+RUN sed -i 's|path = "../../sdk"|path = "/app/sdk"|g' pyproject.toml && \
+    sed -i 's|path = "../packages/rhesis"|path = "/app/packages/rhesis"|g' /app/sdk/pyproject.toml && \
+    uv sync --no-dev
 
 # Now copy the rest of your source (scripts, modules, etc.)
 COPY apps/chatbot /app/
 
-# Re-apply the SDK path patch: the COPY above overwrites pyproject.toml and uv.lock
-# with their original repo versions (containing ../../sdk), so we patch them again.
-RUN sed -i 's|../../sdk|/app/sdk|g' pyproject.toml uv.lock
+# Re-apply path patch: COPY restores repo pyproject.toml (../../sdk).
+RUN sed -i 's|path = "../../sdk"|path = "/app/sdk"|g' pyproject.toml && \
+    sed -i 's|path = "../packages/rhesis"|path = "/app/packages/rhesis"|g' /app/sdk/pyproject.toml
 
 # Remove build dependencies after installing Python packages
 RUN apt-get purge -y build-essential \


### PR DESCRIPTION
## Purpose
The chatbot image failed `uv sync` because the SDK depends on the local `rhesis[telemetry]` package under `packages/rhesis`, while only the SDK was copied into the image. Path rewriting also diverged from the working backend Docker pattern.

## What Changed
- Copy `packages/rhesis` into the image alongside `sdk`, matching `apps/backend/Dockerfile`.
- Rewrite path dependencies with the same `sed` patterns as the backend (`path = "../../sdk"` on the chatbot project, `path = "../packages/rhesis"` on `sdk/pyproject.toml`).
- Run `uv sync --no-dev` without `--frozen`, consistent with the backend builder (no `uv.lock` mass-replace).

## Additional Context
- Resolves normalization errors such as paths escaping `/app` when `rhesis` was missing or only lockfile paths were patched.

## Testing
- `docker build -t rhesis-chatbot -f apps/chatbot/Dockerfile .` from the repository root (requires Docker).