### PR TITLE
fix/uuid conversion

### DIFF
--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -5,7 +5,6 @@ Utility functions for CRUD operations with improved readability and maintainabil
 import logging
 import uuid
 from typing import Any, Dict, List, Optional, Type, TypeVar, Union
-from uuid import UUID
 
 from pydantic import BaseModel
 from sqlalchemy import inspect
@@ -17,6 +16,7 @@ from rhesis.backend.app.constants import EntityType
 from rhesis.backend.app.models import Behavior, Category, Model, Status, Topic, TypeLookup
 from rhesis.backend.app.utils.database_exceptions import ItemDeletedException, ItemNotFoundException
 from rhesis.backend.app.utils.query_utils import QueryBuilder
+from rhesis.backend.app.utils.uuid_utils import to_uuid
 
 logger = logging.getLogger(__name__)
 
@@ -119,15 +119,9 @@ def _auto_populate_tenant_fields(
             or not isinstance(organization_id, str)
         )
     ):
-        try:
-            # Handle both UUID objects and string IDs
-            if isinstance(organization_id, uuid.UUID):
-                org_uuid = organization_id
-            else:
-                org_uuid = UUID(organization_id)
+        org_uuid = to_uuid(organization_id)
+        if org_uuid:
             populated_data["organization_id"] = org_uuid
-        except (ValueError, TypeError):
-            pass
 
     # Auto-populate user_id (direct - no DB queries, no session variables!)
     if (
@@ -136,15 +130,9 @@ def _auto_populate_tenant_fields(
         and user_id
         and (isinstance(user_id, str) and user_id.strip() or not isinstance(user_id, str))
     ):
-        try:
-            # Handle both UUID objects and string IDs
-            if isinstance(user_id, uuid.UUID):
-                user_uuid = user_id
-            else:
-                user_uuid = UUID(user_id)
+        user_uuid = to_uuid(user_id)
+        if user_uuid:
             populated_data["user_id"] = user_uuid
-        except (ValueError, TypeError):
-            pass
 
     return populated_data
 
@@ -570,32 +558,20 @@ def update_item(
     if organization_id is not None:
         columns = inspect(model).columns.keys()
         if "organization_id" in columns:
-            try:
-                # Handle both UUID objects and string IDs
-                if isinstance(organization_id, uuid.UUID):
-                    update_data["organization_id"] = organization_id
-                else:
-                    update_data["organization_id"] = UUID(organization_id)
+            org_uuid = to_uuid(organization_id)
+            if org_uuid:
+                update_data["organization_id"] = org_uuid
                 logger.debug(
                     f"update_item - Auto-populating organization_id: '{organization_id}' for update"
-                )
-            except (ValueError, TypeError) as e:
-                logger.debug(
-                    f"update_item - Invalid organization_id: {organization_id}, error: {e}"
                 )
 
     if user_id is not None:
         columns = inspect(model).columns.keys()
         if "user_id" in columns:
-            try:
-                # Handle both UUID objects and string IDs
-                if isinstance(user_id, uuid.UUID):
-                    update_data["user_id"] = user_id
-                else:
-                    update_data["user_id"] = UUID(user_id)
+            user_uuid = to_uuid(user_id)
+            if user_uuid:
+                update_data["user_id"] = user_uuid
                 logger.debug(f"update_item - Auto-populating user_id: '{user_id}' for update")
-            except (ValueError, TypeError) as e:
-                logger.debug(f"update_item - Invalid user_id: {user_id}, error: {e}")
 
     # Apply updates
     for key, value in update_data.items():
@@ -1207,8 +1183,8 @@ def create_default_rhesis_model(
         "key": "",
         "endpoint": None,
         "is_protected": True,
-        "user_id": uuid.UUID(user_id),
-        "owner_id": uuid.UUID(user_id),
+        "user_id": to_uuid(user_id),
+        "owner_id": to_uuid(user_id),
     }
 
     return get_or_create_entity(

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -1183,8 +1183,8 @@ def create_default_rhesis_model(
         "key": "",
         "endpoint": None,
         "is_protected": True,
-        "user_id": safe_uuid_convert(user_id),
-        "owner_id": safe_uuid_convert(user_id),
+        "user_id": uuid.UUID(str(user_id)),
+        "owner_id": uuid.UUID(str(user_id)),
     }
 
     return get_or_create_entity(

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -16,7 +16,7 @@ from rhesis.backend.app.constants import EntityType
 from rhesis.backend.app.models import Behavior, Category, Model, Status, Topic, TypeLookup
 from rhesis.backend.app.utils.database_exceptions import ItemDeletedException, ItemNotFoundException
 from rhesis.backend.app.utils.query_utils import QueryBuilder
-from rhesis.backend.app.utils.uuid_utils import to_uuid
+from rhesis.backend.app.utils.uuid_utils import safe_uuid_convert
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +119,7 @@ def _auto_populate_tenant_fields(
             or not isinstance(organization_id, str)
         )
     ):
-        org_uuid = to_uuid(organization_id)
+        org_uuid = safe_uuid_convert(organization_id)
         if org_uuid:
             populated_data["organization_id"] = org_uuid
 
@@ -130,7 +130,7 @@ def _auto_populate_tenant_fields(
         and user_id
         and (isinstance(user_id, str) and user_id.strip() or not isinstance(user_id, str))
     ):
-        user_uuid = to_uuid(user_id)
+        user_uuid = safe_uuid_convert(user_id)
         if user_uuid:
             populated_data["user_id"] = user_uuid
 
@@ -558,7 +558,7 @@ def update_item(
     if organization_id is not None:
         columns = inspect(model).columns.keys()
         if "organization_id" in columns:
-            org_uuid = to_uuid(organization_id)
+            org_uuid = safe_uuid_convert(organization_id)
             if org_uuid:
                 update_data["organization_id"] = org_uuid
                 logger.debug(
@@ -568,7 +568,7 @@ def update_item(
     if user_id is not None:
         columns = inspect(model).columns.keys()
         if "user_id" in columns:
-            user_uuid = to_uuid(user_id)
+            user_uuid = safe_uuid_convert(user_id)
             if user_uuid:
                 update_data["user_id"] = user_uuid
                 logger.debug(f"update_item - Auto-populating user_id: '{user_id}' for update")
@@ -1183,8 +1183,8 @@ def create_default_rhesis_model(
         "key": "",
         "endpoint": None,
         "is_protected": True,
-        "user_id": to_uuid(user_id),
-        "owner_id": to_uuid(user_id),
+        "user_id": safe_uuid_convert(user_id),
+        "owner_id": safe_uuid_convert(user_id),
     }
 
     return get_or_create_entity(

--- a/apps/backend/src/rhesis/backend/app/utils/status.py
+++ b/apps/backend/src/rhesis/backend/app/utils/status.py
@@ -25,9 +25,9 @@ def get_or_create_status(
     Returns:
         The Status object if found or created, None otherwise
     """
-    from uuid import UUID
 
     from rhesis.backend.app.models.type_lookup import TypeLookup
+    from rhesis.backend.app.utils.uuid_utils import to_uuid
 
     # First, get or create the TypeLookup for the entity type
     entity_type_query = session.query(TypeLookup).filter(
@@ -35,7 +35,7 @@ def get_or_create_status(
     )
     if organization_id:
         entity_type_query = entity_type_query.filter(
-            TypeLookup.organization_id == UUID(organization_id)
+            TypeLookup.organization_id == to_uuid(organization_id)
         )
 
     entity_type_lookup = entity_type_query.first()
@@ -43,9 +43,9 @@ def get_or_create_status(
         # Create the entity type lookup if it doesn't exist
         entity_type_data = {"type_name": "EntityType", "type_value": entity_type}
         if organization_id:
-            entity_type_data["organization_id"] = UUID(organization_id)
+            entity_type_data["organization_id"] = to_uuid(organization_id)
             if user_id:
-                entity_type_data["user_id"] = UUID(user_id)
+                entity_type_data["user_id"] = to_uuid(user_id)
 
         entity_type_lookup = TypeLookup(**entity_type_data)
         session.add(entity_type_lookup)
@@ -57,16 +57,16 @@ def get_or_create_status(
     )
 
     if organization_id:
-        query = query.filter(Status.organization_id == UUID(organization_id))
+        query = query.filter(Status.organization_id == to_uuid(organization_id))
 
     status = query.first()
     if not status:
         # Create new status with organization context
         status_data = {"name": status_name, "entity_type_id": entity_type_lookup.id}
         if organization_id:
-            status_data["organization_id"] = UUID(organization_id)
+            status_data["organization_id"] = to_uuid(organization_id)
             if user_id:
-                status_data["user_id"] = UUID(user_id)
+                status_data["user_id"] = to_uuid(user_id)
 
         status = Status(**status_data)
         session.add(status)

--- a/apps/backend/src/rhesis/backend/app/utils/status.py
+++ b/apps/backend/src/rhesis/backend/app/utils/status.py
@@ -27,7 +27,7 @@ def get_or_create_status(
     """
 
     from rhesis.backend.app.models.type_lookup import TypeLookup
-    from rhesis.backend.app.utils.uuid_utils import to_uuid
+    from rhesis.backend.app.utils.uuid_utils import safe_uuid_convert
 
     # First, get or create the TypeLookup for the entity type
     entity_type_query = session.query(TypeLookup).filter(
@@ -35,7 +35,7 @@ def get_or_create_status(
     )
     if organization_id:
         entity_type_query = entity_type_query.filter(
-            TypeLookup.organization_id == to_uuid(organization_id)
+            TypeLookup.organization_id == safe_uuid_convert(organization_id)
         )
 
     entity_type_lookup = entity_type_query.first()
@@ -43,9 +43,9 @@ def get_or_create_status(
         # Create the entity type lookup if it doesn't exist
         entity_type_data = {"type_name": "EntityType", "type_value": entity_type}
         if organization_id:
-            entity_type_data["organization_id"] = to_uuid(organization_id)
+            entity_type_data["organization_id"] = safe_uuid_convert(organization_id)
             if user_id:
-                entity_type_data["user_id"] = to_uuid(user_id)
+                entity_type_data["user_id"] = safe_uuid_convert(user_id)
 
         entity_type_lookup = TypeLookup(**entity_type_data)
         session.add(entity_type_lookup)
@@ -57,16 +57,16 @@ def get_or_create_status(
     )
 
     if organization_id:
-        query = query.filter(Status.organization_id == to_uuid(organization_id))
+        query = query.filter(Status.organization_id == safe_uuid_convert(organization_id))
 
     status = query.first()
     if not status:
         # Create new status with organization context
         status_data = {"name": status_name, "entity_type_id": entity_type_lookup.id}
         if organization_id:
-            status_data["organization_id"] = to_uuid(organization_id)
+            status_data["organization_id"] = safe_uuid_convert(organization_id)
             if user_id:
-                status_data["user_id"] = to_uuid(user_id)
+                status_data["user_id"] = safe_uuid_convert(user_id)
 
         status = Status(**status_data)
         session.add(status)

--- a/apps/backend/src/rhesis/backend/app/utils/uuid_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/uuid_utils.py
@@ -5,7 +5,7 @@ from uuid import UUID
 logger = logging.getLogger(__name__)
 
 
-def to_uuid(value: Any) -> Optional[UUID]:
+def safe_uuid_convert(value: Any) -> Optional[UUID]:
     """
     Safely convert a value to UUID object.
 

--- a/apps/backend/src/rhesis/backend/app/utils/uuid_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/uuid_utils.py
@@ -5,6 +5,28 @@ from uuid import UUID
 logger = logging.getLogger(__name__)
 
 
+def to_uuid(value: Any) -> Optional[UUID]:
+    """
+    Safely convert a value to UUID object.
+
+    Args:
+        value: Value to convert (string, UUID, or other)
+
+    Returns:
+        UUID object or None if conversion fails or input is None
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, UUID):
+        return value
+
+    try:
+        return UUID(str(value))
+    except (ValueError, TypeError):
+        return None
+
+
 def sanitize_uuid_field(value: Any) -> Optional[str]:
     """
     Sanitize UUID field values to handle empty strings and validate format.
@@ -13,7 +35,8 @@ def sanitize_uuid_field(value: Any) -> Optional[str]:
         value: The value to sanitize (could be None, empty string, or valid UUID string)
 
     Returns:
-        None if value is None, empty string, or invalid UUID format, otherwise returns the value as string
+        None if value is None, empty string, or invalid UUID format,
+        otherwise returns the value as string
     """
     logger.debug(f"sanitize_uuid_field - Input: value='{value}', type={type(value)}")
 

--- a/apps/backend/src/rhesis/backend/tasks/example_task.py
+++ b/apps/backend/src/rhesis/backend/tasks/example_task.py
@@ -257,9 +257,9 @@ def example_execution_mode_task(self, test_config_id: str) -> Dict[str, Any]:
 
     try:
         # Get test configuration
-        from rhesis.backend.app.utils.uuid_utils import to_uuid
+        from rhesis.backend.app.utils.uuid_utils import safe_uuid_convert
 
-        test_config_uuid = to_uuid(test_config_id)
+        test_config_uuid = safe_uuid_convert(test_config_id)
         if not test_config_uuid:
             raise ValueError(f"Invalid test configuration ID: {test_config_id}")
 

--- a/apps/backend/src/rhesis/backend/tasks/example_task.py
+++ b/apps/backend/src/rhesis/backend/tasks/example_task.py
@@ -257,9 +257,9 @@ def example_execution_mode_task(self, test_config_id: str) -> Dict[str, Any]:
 
     try:
         # Get test configuration
-        from rhesis.backend.tasks.utils import safe_uuid_convert
+        from rhesis.backend.app.utils.uuid_utils import to_uuid
 
-        test_config_uuid = safe_uuid_convert(test_config_id)
+        test_config_uuid = to_uuid(test_config_id)
         if not test_config_uuid:
             raise ValueError(f"Invalid test configuration ID: {test_config_id}")
 
@@ -342,7 +342,8 @@ def example_set_execution_mode(test_config_id: str, execution_mode: str) -> bool
 
             if success:
                 logger.info(
-                    f"Successfully set execution mode to {execution_mode} for test config {test_config_id}"
+                    f"Successfully set execution mode to {execution_mode} "
+                    f"for test config {test_config_id}"
                 )
                 return True
             else:

--- a/apps/backend/src/rhesis/backend/tasks/execution/modes.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/modes.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import crud
 from rhesis.backend.app.models.test import Test
 from rhesis.backend.app.models.test_configuration import TestConfiguration
-from rhesis.backend.app.utils.uuid_utils import to_uuid
+from rhesis.backend.app.utils.uuid_utils import safe_uuid_convert
 from rhesis.backend.tasks.enums import ExecutionMode, TestType
 
 logger = logging.getLogger(__name__)
@@ -68,7 +68,7 @@ def set_execution_mode(
     """
     try:
         # Get test configuration
-        test_config_uuid = to_uuid(test_config_id)
+        test_config_uuid = safe_uuid_convert(test_config_id)
         if not test_config_uuid:
             logger.error(f"Invalid test configuration ID: {test_config_id}")
             return False

--- a/apps/backend/src/rhesis/backend/tasks/execution/modes.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/modes.py
@@ -12,8 +12,8 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import crud
 from rhesis.backend.app.models.test import Test
 from rhesis.backend.app.models.test_configuration import TestConfiguration
+from rhesis.backend.app.utils.uuid_utils import to_uuid
 from rhesis.backend.tasks.enums import ExecutionMode, TestType
-from rhesis.backend.tasks.utils import safe_uuid_convert
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ def set_execution_mode(
     """
     try:
         # Get test configuration
-        test_config_uuid = safe_uuid_convert(test_config_id)
+        test_config_uuid = to_uuid(test_config_id)
         if not test_config_uuid:
             logger.error(f"Invalid test configuration ID: {test_config_id}")
             return False

--- a/apps/backend/src/rhesis/backend/tasks/utils.py
+++ b/apps/backend/src/rhesis/backend/tasks/utils.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, Optional, Tuple
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud
-from rhesis.backend.app.utils.uuid_utils import to_uuid
+from rhesis.backend.app.utils.uuid_utils import safe_uuid_convert
 from rhesis.backend.tasks.enums import RunStatus
 
 logger = logging.getLogger(__name__)
@@ -97,7 +97,7 @@ def increment_test_run_progress(
     """
     try:
         # Get the test run
-        test_run_uuid = to_uuid(test_run_id)
+        test_run_uuid = safe_uuid_convert(test_run_id)
         if not test_run_uuid:
             return False
 
@@ -231,7 +231,7 @@ def validate_task_parameters(**params) -> Tuple[bool, Optional[str]]:
 
             # Validate UUID format for ID parameters
             if param_name.endswith("_id"):
-                uuid_val = to_uuid(param_value)
+                uuid_val = safe_uuid_convert(param_value)
                 if uuid_val is None:
                     return False, f"Invalid UUID format for {param_name}: {param_value}"
 

--- a/apps/backend/src/rhesis/backend/tasks/utils.py
+++ b/apps/backend/src/rhesis/backend/tasks/utils.py
@@ -5,36 +5,14 @@ Utility functions for task operations and common patterns.
 import logging
 from datetime import datetime
 from typing import Any, Dict, Optional, Tuple
-from uuid import UUID
 
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud
+from rhesis.backend.app.utils.uuid_utils import to_uuid
 from rhesis.backend.tasks.enums import RunStatus
 
 logger = logging.getLogger(__name__)
-
-
-def safe_uuid_convert(value: Any) -> Optional[UUID]:
-    """
-    Safely convert a value to UUID, returning None if conversion fails.
-
-    Args:
-        value: Value to convert (string, UUID, or other)
-
-    Returns:
-        UUID object or None if conversion fails
-    """
-    if value is None:
-        return None
-
-    if isinstance(value, UUID):
-        return value
-
-    try:
-        return UUID(str(value))
-    except (ValueError, TypeError):
-        return None
 
 
 def get_test_run_by_config(
@@ -119,7 +97,7 @@ def increment_test_run_progress(
     """
     try:
         # Get the test run
-        test_run_uuid = safe_uuid_convert(test_run_id)
+        test_run_uuid = to_uuid(test_run_id)
         if not test_run_uuid:
             return False
 
@@ -253,7 +231,7 @@ def validate_task_parameters(**params) -> Tuple[bool, Optional[str]]:
 
             # Validate UUID format for ID parameters
             if param_name.endswith("_id"):
-                uuid_val = safe_uuid_convert(param_value)
+                uuid_val = to_uuid(param_value)
                 if uuid_val is None:
                     return False, f"Invalid UUID format for {param_name}: {param_value}"
 


### PR DESCRIPTION
## The bug

This PR fixes the `AttributeError: 'UUID' object has no attribute 'replace'`, which occured because the `organization_id` being passed to `get_or_create_status` was already a uuid.UUID object, but the code explicitly tried to wrap it in a UUID() constructor again.

Across the codebase a lot of times this was solved in-line, using a string conversion:

`uuid.UUID(str(organization_id))
`

instead of 

`uuid.UUID(organization_id)
`

Which would lead to the above mentioned error in case `organization_id` was _already_ a UUID. This PR does not touch those in-line, already working solutions.

## The fix

Use a helper function (`safe_uuid_convert()`) to handle the case where `organization_id` was already a UUID.

## The related refactor

Move the helper function (`safe_uuid_convert()`) which lived in `task/utils.py` to a more centralized `uuid_utils.py`.

As before, the helper handles None, existing UUID objects, and string values uniformly, returning None on failure rather than raising.