### PR TITLE
Fix Frankfurter API URL and fallback exchange rate caching

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/exchange_rate.py
+++ b/apps/backend/src/rhesis/backend/app/services/exchange_rate.py
@@ -22,7 +22,8 @@ class ExchangeRateService:
         self._usd_to_eur_rate: Optional[float] = None
         self._last_fetch: Optional[datetime] = None
         self._cache_duration = timedelta(hours=24)
-        self._api_url = "https://api.frankfurter.app/latest"
+        # Frankfurter moved from api.frankfurter.app (301) to api.frankfurter.dev
+        self._api_url = "https://api.frankfurter.dev/v1/latest"
 
     def get_usd_to_eur_rate(self) -> float:
         """
@@ -55,12 +56,15 @@ class ExchangeRateService:
             logger.info(f"Using stale cached rate due to API failure: {self._usd_to_eur_rate}")
             return self._usd_to_eur_rate
 
-        # Final fallback to env var or default
+        # Final fallback to env var or default — cache it so we do not retry
+        # the API on every call when the network or endpoint is unavailable.
         fallback_rate = float(os.getenv("USD_TO_EUR_RATE", "0.92"))
         logger.warning(
             f"No cached rate available, using fallback: {fallback_rate} "
             "(from USD_TO_EUR_RATE env var or default)"
         )
+        self._usd_to_eur_rate = fallback_rate
+        self._last_fetch = datetime.utcnow()
         return fallback_rate
 
     def _is_cache_valid(self) -> bool:
@@ -84,6 +88,7 @@ class ExchangeRateService:
                 self._api_url,
                 params={"from": "USD", "to": "EUR"},
                 timeout=2.0,
+                follow_redirects=True,
             )
             response.raise_for_status()
 
@@ -112,7 +117,7 @@ class ExchangeRateService:
         """
         try:
             # Use async client for non-blocking HTTP request
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(follow_redirects=True) as client:
                 response = await client.get(
                     self._api_url,
                     params={"from": "USD", "to": "EUR"},
@@ -169,12 +174,14 @@ class ExchangeRateService:
             logger.info(f"Using stale cached rate due to API failure: {self._usd_to_eur_rate}")
             return self._usd_to_eur_rate
 
-        # Final fallback to env var or default
+        # Final fallback to env var or default — cache it (see sync method).
         fallback_rate = float(os.getenv("USD_TO_EUR_RATE", "0.92"))
         logger.warning(
             f"No cached rate available, using fallback: {fallback_rate} "
             "(from USD_TO_EUR_RATE env var or default)"
         )
+        self._usd_to_eur_rate = fallback_rate
+        self._last_fetch = datetime.utcnow()
         return fallback_rate
 
     def refresh_rate(self) -> None:

--- a/tests/backend/services/test_exchange_rate.py
+++ b/tests/backend/services/test_exchange_rate.py
@@ -124,8 +124,10 @@ class TestExchangeRateService:
 
         rate = service.get_usd_to_eur_rate()
 
-        # Should use env var fallback
+        # Should use env var fallback and cache it (avoids repeated API calls)
         assert rate == 0.88
+        assert service._usd_to_eur_rate == 0.88
+        assert service._last_fetch is not None
 
     def test_refresh_rate(self, mocker):
         """Test manual refresh."""
@@ -256,5 +258,7 @@ class TestExchangeRateService:
 
         rate = await service.get_usd_to_eur_rate_async()
 
-        # Should use env var fallback
+        # Should use env var fallback and cache it
         assert rate == 0.88
+        assert service._usd_to_eur_rate == 0.88
+        assert service._last_fetch is not None


### PR DESCRIPTION
## Purpose
Frankfurter redirects away from `api.frankfurter.app`; the exchange rate client should use the current endpoint. When the API is unreachable, repeated calls should not hammer the network without benefit.

## What Changed
- Pointed the exchange rate client at `api.frankfurter.dev` instead of the deprecated host.
- Cached the fallback exchange rate so offline or error paths reuse the last good fallback instead of retrying on every request.
- Extended backend tests to cover fallback caching behavior.

## Additional Context
- Aligns with Frankfurter’s documented/current API base URL.

## Testing
- `cd apps/backend && uv run pytest ../../tests/backend/services/test_exchange_rate.py -v`