### PR TITLE
Fix trace metrics test mocks for idempotency guard

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/processor.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/processor.py
@@ -64,11 +64,28 @@ class TraceEnricher:
             logger.warning(f"No spans found for trace {trace_id}")
             return None
 
-        # Check if already enriched (cache hit)
-        if spans[0].enriched_data:
-            logger.debug(f"Using cached enrichment for trace {trace_id}")
-            # Convert cached dict back to Pydantic model for type safety
-            return EnrichedTraceData(**spans[0].enriched_data)
+        # Smart cache: return cached enrichment only when no new spans have
+        # arrived since the last enrichment pass.  This allows progressive
+        # re-enrichment as child spans (LLM calls, costs, etc.) arrive after
+        # the root span, while avoiding redundant work once everything is
+        # processed.
+        #
+        # `processed_at` is set on every span row by mark_trace_processed.
+        # Newly stored spans default to processed_at=None, so any span with
+        # processed_at=None means new data has arrived that warrants a re-run.
+        root_span = spans[0]  # ordered by start_time asc, so this is the root
+        if root_span.enriched_data and root_span.processed_at:
+            unprocessed = [s for s in spans if s.processed_at is None]
+            if not unprocessed:
+                logger.debug(
+                    f"Using cached enrichment for trace {trace_id} "
+                    f"(all {len(spans)} spans processed)"
+                )
+                return EnrichedTraceData(**root_span.enriched_data)
+            logger.debug(
+                f"Re-enriching trace {trace_id}: "
+                f"{len(unprocessed)} new span(s) since last enrichment"
+            )
 
         # Calculate enrichment (returns Pydantic model)
         logger.debug(f"Enriching trace {trace_id}")

--- a/apps/backend/src/rhesis/backend/tasks/telemetry/evaluate.py
+++ b/apps/backend/src/rhesis/backend/tasks/telemetry/evaluate.py
@@ -257,6 +257,19 @@ def evaluate_turn_trace_metrics(
             logger.warning(f"No root span found for trace {trace_id}")
             return {"status": "no_root_span", "trace_id": trace_id}
 
+        # Skip if turn metrics were already evaluated for this specific span.
+        # We use trace_metrics_processed_at as the guard (only set after a real
+        # evaluation, not after a no_io/skipped result) so that spans whose
+        # input/output attributes hadn't arrived yet still get a second chance.
+        if root_span.trace_metrics_processed_at and (root_span.trace_metrics or {}).get(
+            "turn_metrics"
+        ):
+            logger.debug(
+                f"Turn metrics already evaluated for span {root_span.id} "
+                f"(trace {trace_id}), skipping"
+            )
+            return {"status": "already_evaluated", "trace_id": trace_id}
+
         input_text = (root_span.attributes or {}).get(CONVERSATION_INPUT_KEY, "")
         output_text = (root_span.attributes or {}).get(CONVERSATION_OUTPUT_KEY, "")
         if not input_text and not output_text:

--- a/tests/backend/tasks/test_trace_metrics_evaluation.py
+++ b/tests/backend/tasks/test_trace_metrics_evaluation.py
@@ -42,6 +42,8 @@ def _mock_root_span(
     conversation_id=None,
     attributes: dict | None = None,
     span_db_id: str = SPAN_DB_ID,
+    trace_metrics: dict | None = None,
+    trace_metrics_processed_at=None,
 ) -> MagicMock:
     span = MagicMock(spec=models.Trace)
     span.id = span_db_id
@@ -53,6 +55,8 @@ def _mock_root_span(
         CONVERSATION_INPUT_KEY: "user says hi",
         CONVERSATION_OUTPUT_KEY: "assistant replies",
     }
+    span.trace_metrics = trace_metrics or {}
+    span.trace_metrics_processed_at = trace_metrics_processed_at
     return span
 
 


### PR DESCRIPTION
## Purpose
The `perf(telemetry): skip redundant turn evaluation and enrichment re-runs` commit added an idempotency guard to `evaluate_turn_trace_metrics` that checks `trace_metrics_processed_at` and `turn_metrics` on root spans. The test mocks use `MagicMock(spec=models.Trace)`, which auto-creates these attributes as truthy objects, causing the guard to always trigger and return `already_evaluated` — failing 10 tests.

## What Changed
- Added explicit `trace_metrics_processed_at=None` and `trace_metrics={}` defaults to `_mock_root_span()` in `test_trace_metrics_evaluation.py`

## Testing
```bash
cd apps/backend
RHESIS_SKIP_MIGRATIONS=1 .venv/bin/python -m pytest ../../tests/backend/tasks/test_trace_metrics_evaluation.py -v
```
All 25 tests pass.