### PR TITLE
Fix model connection endpoint passthrough

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/model.py
+++ b/apps/backend/src/rhesis/backend/app/routers/model.py
@@ -238,6 +238,7 @@ async def test_model_connection(
             provider=provider,
             model_name=model_name,
             api_key=api_key,
+            endpoint=db_model.endpoint,
             model_type=model_type,
         )
 

--- a/apps/backend/src/rhesis/backend/app/services/model_connection.py
+++ b/apps/backend/src/rhesis/backend/app/services/model_connection.py
@@ -135,7 +135,7 @@ class ModelConnectionService:
             # Build extra params for providers that need them
             extra_params = {}
             if endpoint:
-                extra_params["base_url"] = endpoint
+                extra_params["api_base"] = endpoint
 
             # Create model config
             config = ModelConfig(
@@ -204,7 +204,7 @@ class ModelConnectionService:
             # Build extra params for providers that need them
             extra_params = {}
             if endpoint:
-                extra_params["base_url"] = endpoint
+                extra_params["api_base"] = endpoint
 
             # Create embedder config
             config = EmbeddingModelConfig(

--- a/sdk/src/rhesis/sdk/models/factory.py
+++ b/sdk/src/rhesis/sdk/models/factory.py
@@ -387,6 +387,8 @@ def get_model(
         api_key = api_key or config.api_key
         if isinstance(config, EmbeddingModelConfig):
             dimensions = dimensions or config.dimensions
+        if config.extra_params:
+            kwargs = {**config.extra_params, **kwargs}
 
     # Parse shorthand notation (e.g., "openai/gpt-4o")
     if provider and "/" in provider and model_name is None:


### PR DESCRIPTION
## Purpose

Custom endpoints (e.g. Azure OpenAI base URLs) were not being passed through correctly when testing model connections or creating models via the SDK, causing connection failures for non-default provider endpoints.

## What Changed

- **Backend router**: Forward the `endpoint` field from the DB model when calling `test_model_connection`
- **Backend service**: Rename `base_url` to `api_base` in `extra_params` to match the LiteLLM provider SDK expectations (both for chat and embedding models)
- **SDK factory**: Merge `extra_params` from `ModelConfig` into `kwargs` in `get_model`, so custom endpoint URLs and other provider-specific settings are passed through to the underlying LLM client

## Testing

- Test model connection from the UI with a model that has a custom endpoint configured
- Verify both chat and embedding model types work with custom endpoints