### PR TITLE
Run uv sync before ./rh dev backend

### DIFF
--- a/rh
+++ b/rh
@@ -723,6 +723,12 @@ start_backend() {
         exit 1
     }
 
+    check_uv
+    echo -e "${BLUE}Installing backend packages (uv sync)...${NC}"
+    uv sync || {
+        echo -e "${RED}❌ Error: uv sync failed${NC}"
+        exit 1
+    }
 
     source .venv/bin/activate || {
         echo -e "${RED}❌ Error: Failed to activate virtual environment${NC}"


### PR DESCRIPTION
## Purpose
Ensure the backend virtual environment matches `pyproject.toml` whenever developers start the local backend, so dependency drift does not cause confusing import or version errors.

## What Changed
- `./rh dev backend` now runs `check_uv`, prints a short status line, and runs `uv sync` in `apps/backend` before activating `.venv` and invoking `start.sh`.
- `uv sync` failures surface a clear error and exit before the server starts.

## Additional Context
- None.

## Testing
- Run `./rh dev backend` from the repo root and confirm the "Installing backend packages (uv sync)..." message appears and the backend starts as before.