### PR TITLE
Fix default endpoint URLs to use host.docker.internal

### DIFF
--- a/apps/frontend/src/app/(protected)/models/components/ConnectionDialog.tsx
+++ b/apps/frontend/src/app/(protected)/models/components/ConnectionDialog.tsx
@@ -648,9 +648,9 @@ export function ConnectionDialog({
                     placeholder={DEFAULT_ENDPOINTS[provider?.type_value || '']}
                     helperText={
                       provider?.type_value === 'ollama'
-                        ? 'The URL where Ollama is running (default: http://host.docker.internal:11434)'
+                        ? 'When Rhesis runs in Docker, use host.docker.internal instead of localhost to reach Ollama on your machine'
                         : provider?.type_value === 'litellm_proxy'
-                          ? 'The base URL of your LiteLLM Proxy server (default: http://0.0.0.0:4000)'
+                          ? 'When Rhesis runs in Docker, use host.docker.internal instead of localhost to reach LiteLLM on your machine'
                           : provider?.type_value === 'azure_ai'
                             ? 'Your Azure AI inference endpoint URL (e.g. https://your-deployment.inference.ai.azure.com/)'
                             : provider?.type_value === 'azure'

--- a/apps/frontend/src/config/model-providers.tsx
+++ b/apps/frontend/src/config/model-providers.tsx
@@ -66,8 +66,8 @@ export const PROVIDERS_REQUIRING_ENDPOINT = [
 // Default endpoints for providers that need them
 export const DEFAULT_ENDPOINTS: Record<string, string> = {
   ollama: 'http://host.docker.internal:11434',
-  vllm: 'http://localhost:8000',
-  litellm_proxy: 'http://0.0.0.0:4000',
+  vllm: 'http://host.docker.internal:8000',
+  litellm_proxy: 'http://host.docker.internal:4000',
 };
 
 // Providers where the API key is optional (proxy servers that may not require auth)


### PR DESCRIPTION
## Purpose

When Rhesis backend runs inside Docker, `localhost` and `0.0.0.0` in endpoint URLs refer to the container itself, not the host machine. Users running Ollama, LiteLLM, or vLLM on their host need `host.docker.internal` to reach those services from inside the container. The previous defaults were inconsistent — Ollama already used `host.docker.internal`, but vLLM used `localhost` and LiteLLM used `0.0.0.0`.

## What Changed

- **Default endpoints**: Updated vLLM (`localhost:8000` → `host.docker.internal:8000`) and LiteLLM proxy (`0.0.0.0:4000` → `host.docker.internal:4000`) to use `host.docker.internal`, matching Ollama
- **Helper text**: Replaced generic endpoint descriptions for Ollama and LiteLLM with a clear explanation: *"When Rhesis runs in Docker, use host.docker.internal instead of localhost to reach [service] on your machine"*

## Testing

- Open the model connection dialog for Ollama, LiteLLM proxy, and vLLM providers
- Verify the default endpoint URL pre-fills with `host.docker.internal`
- Verify the helper text explains the Docker networking context