### PR TITLE
Fix LiteLLM proxy strict JSON schema for structured output

### DIFF
--- a/sdk/src/rhesis/sdk/models/providers/litellm_proxy.py
+++ b/sdk/src/rhesis/sdk/models/providers/litellm_proxy.py
@@ -5,6 +5,7 @@ import os
 from typing import Any, Dict, List, Optional, Type, Union
 
 import requests
+from litellm.llms.base_llm.base_utils import type_to_response_format_param
 from pydantic import BaseModel
 
 from rhesis.sdk.errors import NO_MODEL_NAME_PROVIDED
@@ -101,14 +102,12 @@ class LiteLLMProxy(BaseLLM):
 
         if schema:
             if isinstance(schema, type) and issubclass(schema, BaseModel):
-                payload["response_format"] = {
-                    "type": "json_schema",
-                    "json_schema": {
-                        "name": schema.__name__,
-                        "schema": schema.model_json_schema(),
-                        "strict": True,
-                    },
-                }
+                # Use LiteLLM's helper so the emitted JSON schema satisfies
+                # OpenAI/Azure strict mode (e.g. additionalProperties: false on
+                # every object node, including nested $defs).
+                payload["response_format"] = type_to_response_format_param(
+                    response_format=schema
+                )
             elif isinstance(schema, dict):
                 payload["response_format"] = schema
 

--- a/sdk/src/rhesis/sdk/models/providers/litellm_proxy.py
+++ b/sdk/src/rhesis/sdk/models/providers/litellm_proxy.py
@@ -105,9 +105,7 @@ class LiteLLMProxy(BaseLLM):
                 # Use LiteLLM's helper so the emitted JSON schema satisfies
                 # OpenAI/Azure strict mode (e.g. additionalProperties: false on
                 # every object node, including nested $defs).
-                payload["response_format"] = type_to_response_format_param(
-                    response_format=schema
-                )
+                payload["response_format"] = type_to_response_format_param(response_format=schema)
             elif isinstance(schema, dict):
                 payload["response_format"] = schema
 

--- a/tests/sdk/models/providers/test_litellm_proxy.py
+++ b/tests/sdk/models/providers/test_litellm_proxy.py
@@ -137,6 +137,39 @@ class TestLiteLLMProxyGenerate:
         assert payload["response_format"]["json_schema"]["name"] == "PersonInfo"
 
     @patch("rhesis.sdk.models.providers.litellm_proxy.requests.post")
+    def test_generate_with_pydantic_schema_is_azure_strict_compatible(self, mock_post):
+        """Regression for issue #1657.
+
+        Azure OpenAI's strict mode rejects schemas that don't set
+        ``additionalProperties: false`` on every object node (including nested
+        ``$defs``). The provider must emit a strict-compliant schema so that
+        test set generation works when Azure is fronted by a LiteLLM Proxy.
+        """
+
+        class Inner(BaseModel):
+            name: str
+
+        class Outer(BaseModel):
+            inner: Inner
+            label: str
+
+        mock_post.return_value = _mock_openai_response(
+            '{"inner": {"name": "x"}, "label": "y"}'
+        )
+
+        llm = LiteLLMProxy(model_name="gemini")
+        llm.generate("hi", schema=Outer)
+
+        response_format = mock_post.call_args[1]["json"]["response_format"]
+        assert response_format["type"] == "json_schema"
+        json_schema = response_format["json_schema"]
+        assert json_schema["strict"] is True
+
+        schema = json_schema["schema"]
+        assert schema["additionalProperties"] is False
+        assert schema["$defs"]["Inner"]["additionalProperties"] is False
+
+    @patch("rhesis.sdk.models.providers.litellm_proxy.requests.post")
     def test_generate_with_dict_schema(self, mock_post):
         dict_schema = {
             "type": "json_schema",


### PR DESCRIPTION
## Purpose
Azure and OpenAI strict structured output require JSON schemas where every object node sets `additionalProperties: false`. Building `response_format` manually did not match LiteLLM’s normalization, which could break proxy calls when using Pydantic-backed schemas.

## What Changed
- `LiteLLMProxy` now builds `response_format` using LiteLLM’s `type_to_response_format_param` helper so nested Pydantic models get the same strict schema shape as the rest of the stack.
- Added a regression test covering nested Pydantic models and asserting `additionalProperties: false` on object nodes in the serialized schema.

## Additional Context
- Closes #1657

## Testing
- `pytest tests/sdk/models/providers/test_litellm_proxy.py -k strict_schema --no-header -q` (or run the full `test_litellm_proxy.py` module locally).