### PR TITLE
Temporarly disable default embedding model selection

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -32,6 +32,12 @@ from rhesis.backend.notifications import email_service
 
 logger = logging.getLogger(__name__)
 
+# Temporary product/API restriction (see PR: disable default embedding model changes):
+# Traces and some other embeddables have no user, so a per-user embedding default cannot
+# be resolved consistently everywhere. Until we model defaults for user-less entities,
+# block *changes* to models.embedding via PATCH /users/settings. Stored values and GET are
+# unchanged; org onboarding may still set embedding server-side—align separately if needed.
+
 
 def _settings_patch_forbids_embedding_update(settings_dict: dict) -> bool:
     """True if the client explicitly tried to update models.embedding (PATCH must reject)."""
@@ -226,6 +232,9 @@ def update_user_settings(
             "theme": "dark"
         }
     }
+
+    Embedding default: including ``models.embedding`` in the body is rejected (422).
+    This is temporary.
     """
     # Get the user from database
     db_user = db.query(models.User).filter(models.User.id == current_user.id).first()

--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
@@ -31,6 +31,13 @@ from rhesis.backend.app.utils.validation import validate_and_normalize_email
 from rhesis.backend.notifications import email_service
 
 logger = logging.getLogger(__name__)
+
+
+def _settings_patch_forbids_embedding_update(settings_dict: dict) -> bool:
+    """True if the client explicitly tried to update models.embedding (PATCH must reject)."""
+    models = settings_dict.get("models")
+    return isinstance(models, dict) and "embedding" in models
+
 
 router = APIRouter(
     prefix="/users",
@@ -231,6 +238,12 @@ def update_user_settings(
     # exclude_none=False (default): Keep fields that were explicitly set to null
     # (for clearing values)
     settings_dict = settings_update.model_dump(exclude_unset=True, mode="json")
+
+    if _settings_patch_forbids_embedding_update(settings_dict):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="The default embedding model cannot be changed via user settings.",
+        )
 
     # Get the settings manager instance (property creates new instance each time!)
     settings_manager = db_user.settings

--- a/apps/frontend/src/app/(protected)/models/components/ConnectionDialog.tsx
+++ b/apps/frontend/src/app/(protected)/models/components/ConnectionDialog.tsx
@@ -87,7 +87,6 @@ export function ConnectionDialog({
   const [defaultForGeneration, setDefaultForGeneration] = useState(false);
   const [defaultForEvaluation, setDefaultForEvaluation] = useState(false);
   const [defaultForExecution, setDefaultForExecution] = useState(false);
-  const [defaultForEmbedding, setDefaultForEmbedding] = useState(false);
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [loadingModels, setLoadingModels] = useState(false);
 
@@ -143,12 +142,9 @@ export function ConnectionDialog({
           userSettings?.models?.evaluation?.model_id === model.id;
         const isDefaultExecution =
           userSettings?.models?.execution?.model_id === model.id;
-        const isDefaultEmbedding =
-          userSettings?.models?.embedding?.model_id === model.id;
         setDefaultForGeneration(isDefaultGeneration || false);
         setDefaultForEvaluation(isDefaultEvaluation || false);
         setDefaultForExecution(isDefaultExecution || false);
-        setDefaultForEmbedding(isDefaultEmbedding || false);
       } else if (provider) {
         // Create mode: reset to defaults
         setName('');
@@ -170,7 +166,6 @@ export function ConnectionDialog({
         setDefaultForGeneration(false);
         setDefaultForEvaluation(false);
         setDefaultForExecution(false);
-        setDefaultForEmbedding(false);
         setLoading(false); // Reset loading state
       }
     }
@@ -257,14 +252,6 @@ export function ConnectionDialog({
         updates.models.execution = { model_id: modelId };
       } else if (userSettings?.models?.execution?.model_id === modelId) {
         updates.models.execution = { model_id: null };
-      }
-
-      // Update embedding default if toggle is on
-      if (defaultForEmbedding) {
-        updates.models.embedding = { model_id: modelId };
-      } else if (userSettings?.models?.embedding?.model_id === modelId) {
-        // If toggle is off and this model was previously the default, clear it by setting model_id to null
-        updates.models.embedding = { model_id: null };
       }
 
       // Only update if there are changes
@@ -926,27 +913,12 @@ export function ConnectionDialog({
                     />
                   </>
                 )}
-                {/* Show embedding toggle for embedding models */}
                 {modelType === 'embedding' && (
-                  <FormControlLabel
-                    control={
-                      <Switch
-                        checked={defaultForEmbedding}
-                        onChange={e => setDefaultForEmbedding(e.target.checked)}
-                      />
-                    }
-                    label={
-                      <Box>
-                        <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                          Default Embedding Model
-                        </Typography>
-                        <Typography variant="caption" color="text.secondary">
-                          Use this model for semantic search and similarity
-                          tasks
-                        </Typography>
-                      </Box>
-                    }
-                  />
+                  <Typography variant="caption" color="text.secondary">
+                    The default embedding model is managed by the platform and
+                    cannot be changed here. Connect embedding models so the
+                    platform can use them where needed.
+                  </Typography>
                 )}
               </Stack>
             </Box>

--- a/apps/frontend/src/app/(protected)/models/components/ModelCard.tsx
+++ b/apps/frontend/src/app/(protected)/models/components/ModelCard.tsx
@@ -225,10 +225,26 @@ export function ConnectedModelCard({
                   isGenerationDefault && 'Generation',
                   isEvaluationDefault && 'Evaluation',
                   isExecutionDefault && 'Execution',
-                  isEmbeddingDefault && 'Embedding',
+                  isEmbeddingDefault && (
+                    <Tooltip
+                      key="embedding-default"
+                      title="Platform-managed; cannot be changed in settings"
+                    >
+                      <Box component="span">Embedding</Box>
+                    </Tooltip>
+                  ),
                 ]
                   .filter(Boolean)
-                  .join(' & ')}
+                  .map((part, index) => (
+                    <React.Fragment
+                      key={
+                        typeof part === 'string' ? part : 'embedding-default'
+                      }
+                    >
+                      {index > 0 && ' & '}
+                      {part}
+                    </React.Fragment>
+                  ))}
               </Box>
             </Typography>
           )}

--- a/apps/frontend/src/app/(protected)/models/page.tsx
+++ b/apps/frontend/src/app/(protected)/models/page.tsx
@@ -368,8 +368,10 @@ export default function ModelsPage() {
       <Box sx={{ mb: 3 }}>
         <Typography color="text.secondary">
           Connect language models for test generation and
-          language-model-as-judge evaluation, and embedding models for semantic
-          search. Set your default models for each purpose.
+          language-model-as-judge evaluation, and embedding models for platform
+          use (including semantic search where applicable). Set your defaults
+          for generation, evaluation, and execution; the embedding default is
+          not user-configurable.
         </Typography>
         {error && (
           <Alert severity="error" sx={{ mt: 2 }}>

--- a/tests/backend/routes/test_user_settings.py
+++ b/tests/backend/routes/test_user_settings.py
@@ -166,6 +166,36 @@ class TestUserSettingsRoutes:
         assert data["ui"]["theme"] == sample_ui_settings["theme"]
         assert data["ui"]["default_page_size"] == sample_ui_settings["default_page_size"]
 
+    def test_patch_settings_rejects_models_embedding(
+        self, authenticated_client, settings_endpoint
+    ):
+        """❌ PATCH cannot change models.embedding via user settings"""
+        get_before = authenticated_client.get(settings_endpoint)
+        assert get_before.status_code == status.HTTP_200_OK
+        before_models = get_before.json().get("models") or {}
+
+        payload = {"models": {"embedding": {"model_id": str(uuid.uuid4())}}}
+        response = authenticated_client.patch(settings_endpoint, json=payload)
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert "embedding" in response.json().get("detail", "").lower()
+
+        get_after = authenticated_client.get(settings_endpoint)
+        assert get_after.status_code == status.HTTP_200_OK
+        assert (get_after.json().get("models") or {}) == before_models
+
+    def test_patch_settings_models_generation_only_still_ok(
+        self, authenticated_client, settings_endpoint
+    ):
+        """✅ PATCH only models.generation still succeeds (not blocked with embedding rule)"""
+        gen_id = str(uuid.uuid4())
+        response = authenticated_client.patch(
+            settings_endpoint,
+            json={"models": {"generation": {"model_id": gen_id}}},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["models"]["generation"]["model_id"] == gen_id
+
     def test_patch_settings_models_with_uuid(
         self, authenticated_client, settings_endpoint, sample_model_settings
     ):


### PR DESCRIPTION
## Purpose

Temporarily prevent users from changing their per-user default embedding model (`user_settings.models.embedding`) via the Models UI and `PATCH /users/settings`.

**Why:** Traces are embeddable, but traces do not have an associated user. User-default embedding therefore cannot be resolved consistently for those entities, which breaks or complicates embedding behavior that assumes a user-scoped default.

**Options we considered (deferred for now):**

- Attach users to traces — difficult when production traces have no user.
- Always use Rhesis’s global default for embedding — avoids the missing-user issue but diverges from how generation/evaluation defaults work (user-scoped).
- Organization-scoped embedding defaults — still misaligned with other model defaults that remain user-scoped.
- A richer model: user-scoped *and* org-scoped layers, with embedding org-only — coherent long-term but too much work right now.

**Decision:** Keep the existing architecture, and just do not allow *changing* the default embedding model from product/API until we have a proper model for defaults across user-less embeddables.

## What Changed

- **Backend:** Reject any `PATCH /users/settings` payload whose `models` object explicitly includes `embedding` (422 + clear message). Patches that omit `embedding` (e.g. only `generation`) continue to work.
- **Tests:** Assert embedding updates are rejected and generation-only patches still succeed.
- **Connection dialog:** Remove the “Default Embedding Model” switch and stop sending `models.embedding` on save; short copy explains the default is platform-managed.
- **Models page:** Intro copy no longer suggests users set an embedding default; legacy validation for stored `models.embedding.model_id` remains for misconfiguration warnings.
- **Model cards:** Optional tooltip on the embedding “default” line for legacy data: platform-managed; not configurable in settings.

## Additional Context

- **Read paths and stored values** are unchanged; existing embedding` in the DB stays until a separate migration/cleanup if needed.
- **Organization onboarding** may still set `models.embedding` server-side; align in a follow-up if new users should not get a per-user embedding default.
- **Embedding resolution for traces / user-less embeddables** is a separate follow-up; this PR only removes the user-facing and API surface for *changing* the default.

## Testing

- `cd apps/backend && uv run pytest ../../tests/backend/routes/test_user_settings.py -v`
- Manual: Models → add/edit embedding model → no default switch; save does not PATCH `models.embedding`.
