### PR TITLE
fix: sync topic relationship after FK updates

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/adaptive_testing/topics.py
+++ b/apps/backend/src/rhesis/backend/app/services/adaptive_testing/topics.py
@@ -201,7 +201,7 @@ def update_topic_node(
             organization_id=organization_id,
             user_id=user_id,
         )
-        db_test.topic_id = new_db_topic.id
+        db_test.topic = new_db_topic
         db.add(db_test)
 
     db.flush()
@@ -283,7 +283,10 @@ def remove_topic_node(
         if is_marker:
             topic_marker_ids.append(db_test.id)
         else:
-            db_test.topic_id = parent_topic.id if parent_topic else None
+            if parent_topic:
+                db_test.topic = parent_topic
+            else:
+                db_test.topic = None
             db.add(db_test)
 
     for test_id in topic_marker_ids:


### PR DESCRIPTION
## Problem
When updating a topic's FK, only the `topic_id` was set, leaving the  in-memory `topic` relationship stale if it was eagerly loaded. This caused  `_db_test_to_node` to read the old topic name, leading to test failures  that only appeared under full-suite load (not in isolated tests).

## Solution
Set the `topic` relationship object directly instead of just the FK.  This keeps the in-memory object in sync with the database.

## Changes
- `update_topic_node`: Set `db_test.topic = new_db_topic`
- `remove_topic_node`: Set `db_test.topic = parent_topic` (or None)

