### PR TITLE
Shrink worker Docker image and build time

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,6 +37,7 @@ Thumbs.db
 # Logs
 *.log
 logs/
+**/logs/
 
 # Temporary files
 *.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ cover/
 
 # Django stuff:
 *.log
+logs/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -62,10 +62,14 @@ RUN sed -i 's|path = "../../sdk"|path = "/app/sdk"|g' /app/pyproject.toml && \
     sed -i 's|path = "../../penelope"|path = "/app/penelope"|g' /app/pyproject.toml && \
     sed -i 's|path = "../packages/rhesis"|path = "/app/packages/rhesis"|g' /app/sdk/pyproject.toml
 
-# Install dependencies
-
+# Install dependencies (CPU torch via extra, then remove torch — matches apps/backend)
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync
+    uv sync --extra cpu
+
+# Remove PyTorch to reduce image size (~780MB savings)
+# Garak declares torch as a dependency, but our usage doesn't require it at runtime.
+# See: apps/backend/Dockerfile and apps/backend/src/rhesis/backend/app/services/garak/taxonomy.py
+RUN uv pip uninstall torch
 
 # ============================================================================
 # STAGE 2: Runtime - Create minimal runtime image
@@ -88,6 +92,7 @@ RUN apt-get update && \
     jq \
     procps \
     git \
+    ncdu \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user and directories

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
     "sqlalchemy>=2.0.43",
     "tenacity==8.2.3",
     "tomli>=2.0.0",
-    "torch",  # Explicit dep to force CPU-only via [tool.uv.sources]
     "uvicorn>=0.35.0",
     "websockets==15.0.1",
     "yaspin==3.0.2",
@@ -55,11 +54,13 @@ dependencies = [
     "sendgrid",
 ]
 
+[project.optional-dependencies]
+# CPU-only PyTorch for Docker builds (`uv sync --extra cpu`); same pattern as apps/backend.
+cpu = ["torch>=2.0"]
+
 [tool.uv]
 exclude-newer = "1 week"
 exclude-newer-package = { torch = false }
-# Use CPU-only PyTorch to reduce image size (~200MB instead of ~3GB)
-# garak requires torch, but the worker doesn't need GPU support
 # Force minimum versions for transitive dependencies with security advisories
 constraint-dependencies = [
     "pyasn1>=0.6.3",
@@ -79,6 +80,6 @@ url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
 [tool.uv.sources]
-torch = { index = "pytorch-cpu" }
+torch = [{ index = "pytorch-cpu", extra = "cpu" }]
 rhesis-sdk = { path = "../../sdk", editable = true }
 rhesis-penelope = { path = "../../penelope", editable = true }

--- a/apps/worker/uv.lock
+++ b/apps/worker/uv.lock
@@ -14,7 +14,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-07T15:16:53.968779Z"
+exclude-newer = "2026-04-15T14:06:53.181491Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -5265,11 +5265,15 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tenacity" },
     { name = "tomli" },
-    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
     { name = "uvicorn" },
     { name = "websockets" },
     { name = "yaspin" },
+]
+
+[package.optional-dependencies]
+cpu = [
+    { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.10.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
 
 [package.metadata]
@@ -5318,11 +5322,12 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.43" },
     { name = "tenacity", specifier = "==8.2.3" },
     { name = "tomli", specifier = ">=2.0.0" },
-    { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", marker = "extra == 'cpu'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "rhesis-worker", extra = "cpu" } },
     { name = "uvicorn", specifier = ">=0.35.0" },
     { name = "websockets", specifier = "==15.0.1" },
     { name = "yaspin", specifier = "==3.0.2" },
 ]
+provides-extras = ["cpu"]
 
 [[package]]
 name = "rich"


### PR DESCRIPTION
## Purpose
The worker image was noticeably larger than the backend image because it installed and retained PyTorch while the backend uses the CPU extra and uninstalls torch. The worker Dockerfile also copied all of `apps/backend/`, so local `logs/` directories could inflate the build context and the image. This change aligns the worker with the backend dependency strategy and tightens ignore rules.

## What Changed
- Worker: `uv sync --extra cpu` and `uv pip uninstall torch` after sync (same approach as `apps/backend/Dockerfile`).
- Worker `pyproject.toml`: move torch to optional `[project.optional-dependencies] cpu`, and gate the PyTorch CPU index on that extra (mirrors backend pattern). Regenerated `apps/worker/uv.lock`.
- Root `.gitignore`: ignore `logs/` directories.
- Root `.dockerignore`: add `**/logs/` so nested log dirs (e.g. under `apps/backend/`) are excluded from the build context.

## Benchmarks (local `docker build --no-cache --pull`, `time`)
| Image | Wall time | Reported image size |
|-------|-----------|---------------------|
| Backend (before this PR) | 3 min 28 s | 3.18 GB |
| Worker (before) | 3 min 49 s | 4.76 GB |
| Worker after CPU torch + uninstall | 1 min 30 s | 3.96 GB |
| Worker after ignoring `logs/` in context | 1 min 24 s | 2.84 GB |

## Additional Context
- Local `uv sync` for the worker no longer installs torch by default; use `uv sync --extra cpu` when you need torch in a dev venv.
- `docs/builds.md` was used as the source for the table above and is not part of this branch.

## Testing
- `uv lock` in `apps/worker` after `pyproject.toml` changes.
- Recommend: `time docker build --no-cache --pull -t test-worker -f apps/worker/Dockerfile .` and confirm image size with `docker images`.