### PR TITLE
Fix: add SESSION_SECRET_KEY to worker deployment and k8s manifest

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -286,6 +286,7 @@ jobs:
             --from-literal=SQLALCHEMY_DB_NAME="${{ secrets.SQLALCHEMY_DB_NAME }}" \
             --from-literal=DB_ENCRYPTION_KEY="${{ secrets.DB_ENCRYPTION_KEY }}" \
             --from-literal=JWT_SECRET_KEY="${{ secrets.JWT_SECRET_KEY }}" \
+            --from-literal=SESSION_SECRET_KEY="${{ secrets.SESSION_SECRET_KEY }}" \
             --from-literal=JWT_ALGORITHM="${{ secrets.JWT_ALGORITHM }}" \
             --from-literal=JWT_ACCESS_TOKEN_EXPIRE_MINUTES="${{ secrets.JWT_ACCESS_TOKEN_EXPIRE_MINUTES }}" \
             --from-literal=LOG_LEVEL="${{ secrets.LOG_LEVEL }}" \

--- a/apps/worker/k8s/deployment.yaml
+++ b/apps/worker/k8s/deployment.yaml
@@ -210,6 +210,11 @@ spec:
             secretKeyRef:
               name: rhesis-worker-secrets
               key: JWT_SECRET_KEY
+        - name: SESSION_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: rhesis-worker-secrets
+              key: SESSION_SECRET_KEY
         - name: JWT_ALGORITHM
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Purpose
Fix architect failing in staging with `CRITICAL: SESSION_SECRET_KEY must be set in production environments`.

## What Changed
- Added `SESSION_SECRET_KEY` to `.github/workflows/worker.yml` secret injection
- Added `SESSION_SECRET_KEY` to `apps/worker/k8s/deployment.yaml` env vars

## Root Cause
The architect Celery task imports `rhesis.backend.app.main` to instantiate `LocalToolProvider`. This triggers a module-level validation that requires `SESSION_SECRET_KEY` to be set in non-local environments. The backend deployment already passes this secret, but the worker deployment (both Cloud Run workflow and k8s manifest) was missing it.

The secret value is already defined in `infrastructure/config/service-secrets-config.sh` for all environments and should already exist as a GitHub Actions secret (used by the backend workflow). No new secret values need to be generated — just ensure `SESSION_SECRET_KEY` is available in the GitHub Actions secrets for the environments being deployed.

## Testing
Deploy the worker and send any message to the Architect in staging — it should no longer return the `SESSION_SECRET_KEY` error.