### PR TITLE
fix(e2e): resolve traces test failure and navigation flakiness

### DIFF
--- a/apps/frontend/tests/e2e/pages/DashboardPage.ts
+++ b/apps/frontend/tests/e2e/pages/DashboardPage.ts
@@ -36,11 +36,14 @@ export class DashboardPage extends BasePage {
   /**
    * Click a navigation item in the sidebar by its visible text.
    * Works for top-level sidebar items rendered by Toolpad's DashboardLayout.
+   * Scrolls the item into view first to handle long sidebars.
    */
   async navigateTo(itemText: string) {
     const navItem = this.page
       .locator('nav')
       .getByRole('link', { name: itemText });
+    await navItem.waitFor({ state: 'visible', timeout: 10_000 });
+    await navItem.scrollIntoViewIfNeeded();
     await navItem.click();
   }
 

--- a/apps/frontend/tests/e2e/tests/traces.spec.ts
+++ b/apps/frontend/tests/e2e/tests/traces.spec.ts
@@ -36,11 +36,9 @@ test.describe('Traces @sanity', () => {
     const traceTable = page.locator('table, [role="grid"]');
     const authRequired = page.getByText(/authentication required/i);
 
-    const hasEmptyState = await emptyState.isVisible().catch(() => false);
-    const hasTable = await traceTable.isVisible().catch(() => false);
-    const hasAuthMsg = await authRequired.isVisible().catch(() => false);
-
-    expect(hasEmptyState || hasTable || hasAuthMsg).toBeTruthy();
+    await expect(emptyState.or(traceTable).or(authRequired)).toBeVisible({
+      timeout: 10_000,
+    });
   });
 
   test('traces page has a valid page title', async ({ page }) => {


### PR DESCRIPTION
## Purpose
Fix CI failures on the release PR (#1673) caused by two e2e test issues.

## What Changed
- **`traces.spec.ts`**: Replace bare `isVisible()` with `toBeVisible({ timeout: 10_000 })` using Playwright's `.or()` locator combinator. The old pattern could catch the page in a transient loading state after `networkidle` (when `TracesClient` briefly shows a spinner between its initial render and the API response). The new pattern properly waits up to 10s for any of the expected states.
- **`DashboardPage.ts`**: Add `waitFor({ state: 'visible' })` and `scrollIntoViewIfNeeded()` before clicking nav items. The "Test Sets" navigation became flaky after the Adaptive Testing nav item was enabled for all environments, making the sidebar longer and occasionally pushing items below the fold on Firefox.

## Testing
- Targets `release/v0.7.0` branch — fixes shard 3 failure in the [e2e CI run](https://github.com/rhesis-ai/rhesis/actions/runs/24838808682/job/72706555138?pr=1673)
- No logic changes, test robustness only