### PR TITLE
Reuse Cloud Run job for backend database migrations

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -273,13 +273,11 @@ jobs:
 
           echo "Using image: ${{ env.IMAGE_NAME }}:$IMAGE_TAG"
 
-          # Create a unique job name for this migration run
-          MIGRATION_JOB_NAME="backend-migrate-$(date +%s)"
+          # Stable job name per environment (create-or-update via deploy)
+          MIGRATION_JOB_NAME="${SERVICE_NAME}-migrate"
+          echo "Deploying/updating Cloud Run Job: $MIGRATION_JOB_NAME"
 
-          echo "Creating Cloud Run Job: $MIGRATION_JOB_NAME"
-
-          # Create a Cloud Run Job to run migrations (executes once)
-          gcloud run jobs create $MIGRATION_JOB_NAME \
+          gcloud run jobs deploy "$MIGRATION_JOB_NAME" \
             --image=${{ env.IMAGE_NAME }}:$IMAGE_TAG \
             --project=${{ env.PROJECT_ID }} \
             --region=${{ env.REGION }} \
@@ -293,23 +291,15 @@ jobs:
             --set-env-vars="SQLALCHEMY_DB_DRIVER=${{ secrets.SQLALCHEMY_DB_DRIVER }},SQLALCHEMY_DB_USER=${{ secrets.SQLALCHEMY_DB_USER }},SQLALCHEMY_DB_PASS=${{ secrets.SQLALCHEMY_DB_PASS }},SQLALCHEMY_DB_HOST=${{ secrets.SQLALCHEMY_DB_HOST }},SQLALCHEMY_DB_NAME=${{ secrets.SQLALCHEMY_DB_NAME }}" \
             --args=bash,-c,./migrate.sh
 
-          echo "✅ Migration job created"
+          echo "✅ Migration job definition updated"
 
-          # Execute the migration job
           echo "🚀 Executing migration job..."
-          gcloud run jobs execute $MIGRATION_JOB_NAME \
+          gcloud run jobs execute "$MIGRATION_JOB_NAME" \
             --project=${{ env.PROJECT_ID }} \
             --region=${{ env.REGION }} \
             --wait
 
           MIGRATION_EXIT_CODE=$?
-
-          # Clean up the job after execution
-          echo "🧹 Cleaning up migration job..."
-          gcloud run jobs delete $MIGRATION_JOB_NAME \
-            --project=${{ env.PROJECT_ID }} \
-            --region=${{ env.REGION }} \
-            --quiet
 
           if [ $MIGRATION_EXIT_CODE -ne 0 ]; then
             echo "❌ Migration failed with exit code $MIGRATION_EXIT_CODE"


### PR DESCRIPTION
## Purpose
Each deploy created a new Cloud Run Job with a timestamped name, ran migrations, then deleted the job. That added API overhead and prevented reuse of job-level caching for the same workload.

## What Changed
- Replaced `gcloud run jobs create` / `jobs delete` with idempotent `gcloud run jobs deploy` using a stable name: `${SERVICE_NAME}-migrate` (e.g. `rhesis-backend-migrate-dev`).
- Kept the same image tag, VPC connector, Cloud SQL attachment, resource limits, env vars, and `bash -c ./migrate.sh` invocation as before.
- Still fail the workflow when `jobs execute --wait` returns a non-zero exit code.

## Additional Context
- Does not change the migration image size; only job lifecycle and naming.

## Testing
- Merge and run the `[Deploy] Backend` workflow against dev; confirm `gcloud run jobs list` shows one job per env named `*-migrate` and that repeat deploys update the same job instead of creating ephemeral names.