### PR TITLE
refactor(ci): optimize Cloud Run migration job by removing VPC connector

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -277,18 +277,20 @@ jobs:
           MIGRATION_JOB_NAME="${SERVICE_NAME}-migrate"
           echo "Deploying/updating Cloud Run Job: $MIGRATION_JOB_NAME"
 
+          # No VPC: migration only needs Cloud SQL via /cloudsql/... socket
+          # (attached by --set-cloudsql-instances). Dropping the VPC connector
+          # cuts a large chunk of cold-start overhead.
           gcloud run jobs deploy "$MIGRATION_JOB_NAME" \
             --image=${{ env.IMAGE_NAME }}:$IMAGE_TAG \
             --project=${{ env.PROJECT_ID }} \
             --region=${{ env.REGION }} \
-            --vpc-connector=${{ secrets.VPC_CONNECTOR_NAME }} \
-            --vpc-egress=private-ranges-only \
             --max-retries=0 \
             --task-timeout=10m \
             --memory=1Gi \
             --cpu=1 \
             --set-cloudsql-instances=${{ env.PROJECT_ID }}:${{ env.REGION }}:${{ env.CLOUDSQL_INSTANCE }} \
             --set-env-vars="SQLALCHEMY_DB_DRIVER=${{ secrets.SQLALCHEMY_DB_DRIVER }},SQLALCHEMY_DB_USER=${{ secrets.SQLALCHEMY_DB_USER }},SQLALCHEMY_DB_PASS=${{ secrets.SQLALCHEMY_DB_PASS }},SQLALCHEMY_DB_HOST=${{ secrets.SQLALCHEMY_DB_HOST }},SQLALCHEMY_DB_NAME=${{ secrets.SQLALCHEMY_DB_NAME }}" \
+            --clear-vpc-connector \
             --args=bash,-c,./migrate.sh
 
           echo "✅ Migration job definition updated"

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -273,29 +273,21 @@ jobs:
 
           echo "Using image: ${{ env.IMAGE_NAME }}:$IMAGE_TAG"
 
-          # Cloud Run Jobs cold-start in us-central1 was measured at ~1m 40s
-          # steady-state (and ~2m 18s first-execution). The same workload in
-          # us-east1 starts in ~11s. We therefore run the migration job in
-          # us-east1 while Cloud SQL + all other services stay in env.REGION
-          # (us-central1). Cross-region DB access adds ~1-2s to Alembic DDL,
-          # a tiny cost vs. the ~90s platform cold-start saving.
-          MIGRATE_REGION="us-east1"
-
           # Stable job name per environment (create-or-update via deploy)
           MIGRATION_JOB_NAME="${SERVICE_NAME}-migrate"
-          echo "Deploying/updating Cloud Run Job: $MIGRATION_JOB_NAME in $MIGRATE_REGION"
+          echo "Deploying/updating Cloud Run Job: $MIGRATION_JOB_NAME"
 
-          # No VPC on the migrate job: Cloud SQL is reached via the
-          # /cloudsql/... socket attached by --set-cloudsql-instances, which
-          # works cross-region because sqladmin.googleapis.com is a global API.
+          # No VPC: migration only needs Cloud SQL via /cloudsql/... socket
+          # (attached by --set-cloudsql-instances). Dropping the VPC connector
+          # cuts a large chunk of cold-start overhead.
           gcloud run jobs deploy "$MIGRATION_JOB_NAME" \
             --image=${{ env.IMAGE_NAME }}:$IMAGE_TAG \
             --project=${{ env.PROJECT_ID }} \
-            --region=$MIGRATE_REGION \
+            --region=${{ env.REGION }} \
             --max-retries=0 \
             --task-timeout=10m \
             --memory=1Gi \
-            --cpu=2 \
+            --cpu=1 \
             --set-cloudsql-instances=${{ env.PROJECT_ID }}:${{ env.REGION }}:${{ env.CLOUDSQL_INSTANCE }} \
             --set-env-vars="SQLALCHEMY_DB_DRIVER=${{ secrets.SQLALCHEMY_DB_DRIVER }},SQLALCHEMY_DB_USER=${{ secrets.SQLALCHEMY_DB_USER }},SQLALCHEMY_DB_PASS=${{ secrets.SQLALCHEMY_DB_PASS }},SQLALCHEMY_DB_HOST=${{ secrets.SQLALCHEMY_DB_HOST }},SQLALCHEMY_DB_NAME=${{ secrets.SQLALCHEMY_DB_NAME }}" \
             --args=bash,-c,./migrate.sh
@@ -305,7 +297,7 @@ jobs:
           echo "🚀 Executing migration job..."
           gcloud run jobs execute "$MIGRATION_JOB_NAME" \
             --project=${{ env.PROJECT_ID }} \
-            --region=$MIGRATE_REGION \
+            --region=${{ env.REGION }} \
             --wait
 
           MIGRATION_EXIT_CODE=$?

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -207,42 +207,6 @@ jobs:
             echo "Pushed regular images: ${{ env.IMAGE_NAME }}:${{ env.BUILD_TAG }} and :latest"
           fi
 
-      # Experiment: mirror the freshly-built image to a regional Artifact
-      # Registry repo in us-east1 so the migrate Cloud Run Job (which runs in
-      # us-east1) can pull the bytes from the same region. The deploy job
-      # continues to use the gcr.io image unchanged.
-      - name: Mirror image to us-east1 Artifact Registry (migrate experiment)
-        run: |
-          AR_LOCATION="us-east1"
-          AR_REPO="rhesis-migrate"
-          AR_HOST="${AR_LOCATION}-docker.pkg.dev"
-          IMAGE_BASENAME="$(basename "${{ env.IMAGE_NAME }}")"
-          AR_IMAGE="${AR_HOST}/${{ secrets.PROJECT_ID }}/${AR_REPO}/${IMAGE_BASENAME}"
-
-          echo "📦 Preparing AR mirror: $AR_IMAGE"
-
-          # Idempotent repo creation — cheap describe first, create only if missing.
-          if ! gcloud artifacts repositories describe "$AR_REPO" \
-                --location="$AR_LOCATION" \
-                --project="${{ secrets.PROJECT_ID }}" >/dev/null 2>&1; then
-            echo "  Repo does not exist — creating..."
-            gcloud artifacts repositories create "$AR_REPO" \
-              --repository-format=docker \
-              --location="$AR_LOCATION" \
-              --project="${{ secrets.PROJECT_ID }}" \
-              --description="Regional mirror of backend images for fast migrate-job cold starts"
-          else
-            echo "  Repo already exists in $AR_LOCATION"
-          fi
-
-          # Configure docker for this AR host (gcr.io is already configured above).
-          gcloud auth configure-docker "$AR_HOST" --quiet
-
-          # Re-tag the locally built image (no re-build — layers already in place).
-          docker tag "${{ env.IMAGE_NAME }}:${{ env.BUILD_TAG }}" "${AR_IMAGE}:${{ env.BUILD_TAG }}"
-          docker push "${AR_IMAGE}:${{ env.BUILD_TAG }}"
-          echo "✅ Mirrored to ${AR_IMAGE}:${{ env.BUILD_TAG }}"
-
   migrate:
     needs: [validate-inputs, build]
     runs-on: ubuntu-latest
@@ -307,6 +271,8 @@ jobs:
           # Use the unique BUILD_TAG to ensure we get the freshly built image
           IMAGE_TAG="${{ env.BUILD_TAG }}"
 
+          echo "Using image: ${{ env.IMAGE_NAME }}:$IMAGE_TAG"
+
           # Cloud Run Jobs cold-start in us-central1 was measured at ~1m 40s
           # steady-state (and ~2m 18s first-execution). The same workload in
           # us-east1 starts in ~11s. We therefore run the migration job in
@@ -314,18 +280,6 @@ jobs:
           # (us-central1). Cross-region DB access adds ~1-2s to Alembic DDL,
           # a tiny cost vs. the ~90s platform cold-start saving.
           MIGRATE_REGION="us-east1"
-
-          # Experiment: pull the migrate image from a regional Artifact
-          # Registry repo in the same region as the job. The image was
-          # mirrored there by the build job. The deploy job (service) still
-          # uses the gcr.io image, unchanged.
-          AR_LOCATION="$MIGRATE_REGION"
-          AR_REPO="rhesis-migrate"
-          AR_HOST="${AR_LOCATION}-docker.pkg.dev"
-          IMAGE_BASENAME="$(basename "${{ env.IMAGE_NAME }}")"
-          MIGRATE_IMAGE="${AR_HOST}/${{ env.PROJECT_ID }}/${AR_REPO}/${IMAGE_BASENAME}"
-
-          echo "Using migrate image: ${MIGRATE_IMAGE}:$IMAGE_TAG"
 
           # Stable job name per environment (create-or-update via deploy)
           MIGRATION_JOB_NAME="${SERVICE_NAME}-migrate"
@@ -335,7 +289,7 @@ jobs:
           # /cloudsql/... socket attached by --set-cloudsql-instances, which
           # works cross-region because sqladmin.googleapis.com is a global API.
           gcloud run jobs deploy "$MIGRATION_JOB_NAME" \
-            --image=${MIGRATE_IMAGE}:$IMAGE_TAG \
+            --image=${{ env.IMAGE_NAME }}:$IMAGE_TAG \
             --project=${{ env.PROJECT_ID }} \
             --region=$MIGRATE_REGION \
             --max-retries=0 \

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -295,7 +295,7 @@ jobs:
             --max-retries=0 \
             --task-timeout=10m \
             --memory=1Gi \
-            --cpu=1 \
+            --cpu=2 \
             --set-cloudsql-instances=${{ env.PROJECT_ID }}:${{ env.REGION }}:${{ env.CLOUDSQL_INSTANCE }} \
             --set-env-vars="SQLALCHEMY_DB_DRIVER=${{ secrets.SQLALCHEMY_DB_DRIVER }},SQLALCHEMY_DB_USER=${{ secrets.SQLALCHEMY_DB_USER }},SQLALCHEMY_DB_PASS=${{ secrets.SQLALCHEMY_DB_PASS }},SQLALCHEMY_DB_HOST=${{ secrets.SQLALCHEMY_DB_HOST }},SQLALCHEMY_DB_NAME=${{ secrets.SQLALCHEMY_DB_NAME }}" \
             --args=bash,-c,./migrate.sh

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -273,17 +273,25 @@ jobs:
 
           echo "Using image: ${{ env.IMAGE_NAME }}:$IMAGE_TAG"
 
+          # Cloud Run Jobs cold-start in us-central1 was measured at ~1m 40s
+          # steady-state (and ~2m 18s first-execution). The same workload in
+          # us-east1 starts in ~11s. We therefore run the migration job in
+          # us-east1 while Cloud SQL + all other services stay in env.REGION
+          # (us-central1). Cross-region DB access adds ~1-2s to Alembic DDL,
+          # a tiny cost vs. the ~90s platform cold-start saving.
+          MIGRATE_REGION="us-east1"
+
           # Stable job name per environment (create-or-update via deploy)
           MIGRATION_JOB_NAME="${SERVICE_NAME}-migrate"
-          echo "Deploying/updating Cloud Run Job: $MIGRATION_JOB_NAME"
+          echo "Deploying/updating Cloud Run Job: $MIGRATION_JOB_NAME in $MIGRATE_REGION"
 
-          # No VPC: migration only needs Cloud SQL via /cloudsql/... socket
-          # (attached by --set-cloudsql-instances). Dropping the VPC connector
-          # cuts a large chunk of cold-start overhead.
+          # No VPC on the migrate job: Cloud SQL is reached via the
+          # /cloudsql/... socket attached by --set-cloudsql-instances, which
+          # works cross-region because sqladmin.googleapis.com is a global API.
           gcloud run jobs deploy "$MIGRATION_JOB_NAME" \
             --image=${{ env.IMAGE_NAME }}:$IMAGE_TAG \
             --project=${{ env.PROJECT_ID }} \
-            --region=${{ env.REGION }} \
+            --region=$MIGRATE_REGION \
             --max-retries=0 \
             --task-timeout=10m \
             --memory=1Gi \
@@ -297,7 +305,7 @@ jobs:
           echo "🚀 Executing migration job..."
           gcloud run jobs execute "$MIGRATION_JOB_NAME" \
             --project=${{ env.PROJECT_ID }} \
-            --region=${{ env.REGION }} \
+            --region=$MIGRATE_REGION \
             --wait
 
           MIGRATION_EXIT_CODE=$?

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -207,6 +207,42 @@ jobs:
             echo "Pushed regular images: ${{ env.IMAGE_NAME }}:${{ env.BUILD_TAG }} and :latest"
           fi
 
+      # Experiment: mirror the freshly-built image to a regional Artifact
+      # Registry repo in us-east1 so the migrate Cloud Run Job (which runs in
+      # us-east1) can pull the bytes from the same region. The deploy job
+      # continues to use the gcr.io image unchanged.
+      - name: Mirror image to us-east1 Artifact Registry (migrate experiment)
+        run: |
+          AR_LOCATION="us-east1"
+          AR_REPO="rhesis-migrate"
+          AR_HOST="${AR_LOCATION}-docker.pkg.dev"
+          IMAGE_BASENAME="$(basename "${{ env.IMAGE_NAME }}")"
+          AR_IMAGE="${AR_HOST}/${{ secrets.PROJECT_ID }}/${AR_REPO}/${IMAGE_BASENAME}"
+
+          echo "📦 Preparing AR mirror: $AR_IMAGE"
+
+          # Idempotent repo creation — cheap describe first, create only if missing.
+          if ! gcloud artifacts repositories describe "$AR_REPO" \
+                --location="$AR_LOCATION" \
+                --project="${{ secrets.PROJECT_ID }}" >/dev/null 2>&1; then
+            echo "  Repo does not exist — creating..."
+            gcloud artifacts repositories create "$AR_REPO" \
+              --repository-format=docker \
+              --location="$AR_LOCATION" \
+              --project="${{ secrets.PROJECT_ID }}" \
+              --description="Regional mirror of backend images for fast migrate-job cold starts"
+          else
+            echo "  Repo already exists in $AR_LOCATION"
+          fi
+
+          # Configure docker for this AR host (gcr.io is already configured above).
+          gcloud auth configure-docker "$AR_HOST" --quiet
+
+          # Re-tag the locally built image (no re-build — layers already in place).
+          docker tag "${{ env.IMAGE_NAME }}:${{ env.BUILD_TAG }}" "${AR_IMAGE}:${{ env.BUILD_TAG }}"
+          docker push "${AR_IMAGE}:${{ env.BUILD_TAG }}"
+          echo "✅ Mirrored to ${AR_IMAGE}:${{ env.BUILD_TAG }}"
+
   migrate:
     needs: [validate-inputs, build]
     runs-on: ubuntu-latest
@@ -271,8 +307,6 @@ jobs:
           # Use the unique BUILD_TAG to ensure we get the freshly built image
           IMAGE_TAG="${{ env.BUILD_TAG }}"
 
-          echo "Using image: ${{ env.IMAGE_NAME }}:$IMAGE_TAG"
-
           # Cloud Run Jobs cold-start in us-central1 was measured at ~1m 40s
           # steady-state (and ~2m 18s first-execution). The same workload in
           # us-east1 starts in ~11s. We therefore run the migration job in
@@ -280,6 +314,18 @@ jobs:
           # (us-central1). Cross-region DB access adds ~1-2s to Alembic DDL,
           # a tiny cost vs. the ~90s platform cold-start saving.
           MIGRATE_REGION="us-east1"
+
+          # Experiment: pull the migrate image from a regional Artifact
+          # Registry repo in the same region as the job. The image was
+          # mirrored there by the build job. The deploy job (service) still
+          # uses the gcr.io image, unchanged.
+          AR_LOCATION="$MIGRATE_REGION"
+          AR_REPO="rhesis-migrate"
+          AR_HOST="${AR_LOCATION}-docker.pkg.dev"
+          IMAGE_BASENAME="$(basename "${{ env.IMAGE_NAME }}")"
+          MIGRATE_IMAGE="${AR_HOST}/${{ env.PROJECT_ID }}/${AR_REPO}/${IMAGE_BASENAME}"
+
+          echo "Using migrate image: ${MIGRATE_IMAGE}:$IMAGE_TAG"
 
           # Stable job name per environment (create-or-update via deploy)
           MIGRATION_JOB_NAME="${SERVICE_NAME}-migrate"
@@ -289,7 +335,7 @@ jobs:
           # /cloudsql/... socket attached by --set-cloudsql-instances, which
           # works cross-region because sqladmin.googleapis.com is a global API.
           gcloud run jobs deploy "$MIGRATION_JOB_NAME" \
-            --image=${{ env.IMAGE_NAME }}:$IMAGE_TAG \
+            --image=${MIGRATE_IMAGE}:$IMAGE_TAG \
             --project=${{ env.PROJECT_ID }} \
             --region=$MIGRATE_REGION \
             --max-retries=0 \

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -290,7 +290,6 @@ jobs:
             --cpu=1 \
             --set-cloudsql-instances=${{ env.PROJECT_ID }}:${{ env.REGION }}:${{ env.CLOUDSQL_INSTANCE }} \
             --set-env-vars="SQLALCHEMY_DB_DRIVER=${{ secrets.SQLALCHEMY_DB_DRIVER }},SQLALCHEMY_DB_USER=${{ secrets.SQLALCHEMY_DB_USER }},SQLALCHEMY_DB_PASS=${{ secrets.SQLALCHEMY_DB_PASS }},SQLALCHEMY_DB_HOST=${{ secrets.SQLALCHEMY_DB_HOST }},SQLALCHEMY_DB_NAME=${{ secrets.SQLALCHEMY_DB_NAME }}" \
-            --clear-vpc-connector \
             --args=bash,-c,./migrate.sh
 
           echo "✅ Migration job definition updated"

--- a/apps/backend/migrate.sh
+++ b/apps/backend/migrate.sh
@@ -40,35 +40,36 @@ wait_for_database() {
 }
 
 # Function to run migrations
+#
+# We use `psql` (not `alembic current`) to read the revision before and after
+# the upgrade. Each `alembic` invocation costs ~5-6s of Python cold-start +
+# SDK/model imports inside the Cloud Run Job, so two diagnostic calls used to
+# add ~10-12s. A `psql` query on `alembic_version` returns in <100 ms and gives
+# us the same information. Verbose Alembic diagnostics still run, but only on
+# failure, where the extra latency does not matter.
 run_migrations() {
-    log "${YELLOW}🔍 Checking current migration status...${NC}"
-    
-    # Navigate to the backend directory
     cd /app/src/rhesis/backend || handle_error "Could not navigate to backend directory"
-    
-    # Check current revision
-    local current_revision
-    current_revision=$(alembic current 2>/dev/null | awk '{print $1}' || echo "None")
-    
-    log "${YELLOW}📦 Running database migrations...${NC}"
-    
-    # Run migrations with proper error handling
-    if alembic upgrade head; then
-        log "${GREEN}✅ Database migrations completed successfully!${NC}"
-        
-        # Show migration status
-        log "${BLUE}📊 Current Migration Status:${NC}"
-        alembic current || log "${YELLOW}⚠️  Could not retrieve current migration status${NC}"
-        
-        # Show tables created (limit output and handle errors)
-        log "${BLUE}📋 Database Tables:${NC}"
-        if PGPASSWORD="$DB_PASS" psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -c "\dt" 2>/dev/null | head -20; then
-            :  # Success, do nothing
-        else
-            log "${YELLOW}⚠️  Could not list database tables${NC}"
-        fi
-    else
+
+    local before after
+    before=$(PGPASSWORD="$DB_PASS" psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" \
+        -tAc "SELECT version_num FROM alembic_version;" 2>/dev/null | tr -d '[:space:]' || echo "")
+
+    log "${YELLOW}📦 Running migrations (from: ${before:-'fresh DB'})...${NC}"
+
+    if ! alembic upgrade head; then
+        log "${RED}❌ alembic upgrade head failed — gathering diagnostics:${NC}"
+        alembic current || true
+        alembic history --verbose | tail -30 || true
         handle_error "alembic upgrade head command failed"
+    fi
+
+    after=$(PGPASSWORD="$DB_PASS" psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" \
+        -tAc "SELECT version_num FROM alembic_version;" 2>/dev/null | tr -d '[:space:]' || echo "")
+
+    if [ "$before" = "$after" ]; then
+        log "${GREEN}ℹ️  Already at head: ${after:-'(unknown)'} (no migrations applied)${NC}"
+    else
+        log "${GREEN}✅ Migrations applied: ${before:-'(none)'} → ${after}${NC}"
     fi
 }
 


### PR DESCRIPTION
- Updated backend workflow to eliminate the VPC connector for the migration job, reducing cold-start overhead.
- Added comments to clarify the necessity of using Cloud SQL via socket without VPC.