### PR TITLE
fix: skip embedding job when searchable text is unchanged

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/c2e4f8a91b0d_set_rhesis_default_embedding_model_dimension.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/c2e4f8a91b0d_set_rhesis_default_embedding_model_dimension.py
@@ -28,7 +28,7 @@ def upgrade() -> None:
     session = Session(bind=bind)
     dim = 768  # Default dimension of vertex text-embedding-005
     try:
-        result = session.execute(
+        session.execute(
             sa.text(
                 """
                 UPDATE model
@@ -44,7 +44,6 @@ def upgrade() -> None:
             {"dim": dim},
         )
         session.commit()
-        print(f"✓ Set dimension={dim} on {result.rowcount} Rhesis Default Embedding model(s)")
     except Exception:
         session.rollback()
         raise
@@ -58,7 +57,7 @@ def downgrade() -> None:
     session = Session(bind=bind)
     dim = 768  # Default dimension of vertex text-embedding-005
     try:
-        result = session.execute(
+        session.execute(
             sa.text(
                 """
                 UPDATE model
@@ -75,7 +74,6 @@ def downgrade() -> None:
             {"dim": dim},
         )
         session.commit()
-        print(f"✓ Cleared dimension on {result.rowcount} Rhesis Default Embedding model(s)")
     except Exception:
         session.rollback()
         raise

--- a/apps/backend/src/rhesis/backend/app/models/mixins.py
+++ b/apps/backend/src/rhesis/backend/app/models/mixins.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, declared_attr, object_session, relationship
 from sqlalchemy.orm.exc import DetachedInstanceError
 
+from .enums import EmbeddingStatus
 from .guid import GUID
 
 logger = logging.getLogger(__name__)
@@ -366,7 +367,7 @@ class EmbeddableMixin:
         """
         Return True if embeddings should be (re)generated for this entity.
         - No rows in embedding yet -> True.
-        - At least one row has text_hash matching current searchable text -> False.
+        - At least one ACTIVE row has text_hash matching current searchable text -> False.
         - Otherwise -> True.
         """
         searchable_text = self.to_searchable_text()
@@ -379,6 +380,19 @@ class EmbeddableMixin:
                 WHERE entity_id = :entity_id
                   AND entity_type = :entity_type
                   AND text_hash = :text_hash
+                  AND status_id = (
+                      SELECT s.id
+                      FROM status s
+                      JOIN type_lookup tl ON tl.id = s.entity_type_id
+                      WHERE s.name = :active_status
+                        AND (
+                            s.organization_id = :organization_id
+                            OR (s.organization_id IS NULL AND :organization_id IS NULL)
+                        )
+                        AND tl.type_name = 'EntityType'
+                        AND tl.type_value = 'Embedding'
+                      LIMIT 1
+                  )
             )
         """)
         has_match = bool(
@@ -388,6 +402,8 @@ class EmbeddableMixin:
                     "entity_id": self.id,
                     "entity_type": self.__class__.__name__,
                     "text_hash": current_hash,
+                    "active_status": EmbeddingStatus.ACTIVE.value,
+                    "organization_id": self.organization_id,
                 },
             ).scalar_one()
         )

--- a/apps/backend/src/rhesis/backend/app/models/mixins.py
+++ b/apps/backend/src/rhesis/backend/app/models/mixins.py
@@ -2,7 +2,7 @@ import functools
 import hashlib
 import logging
 
-from sqlalchemy import Column, ForeignKey, and_, event
+from sqlalchemy import Column, Connection, ForeignKey, and_, event, text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, declared_attr, object_session, relationship
 from sqlalchemy.orm.exc import DetachedInstanceError
@@ -362,24 +362,36 @@ class EmbeddableMixin:
             uselist=True,
         )
 
-    def searchable_text_changed(self) -> bool:
+    def searchable_text_changed(self, connection: Connection) -> bool:
         """
         Return True if embeddings should be (re)generated for this entity.
-
-        - No rows in ``embedding`` yet → True (first-time embed).
-        - At least one row has ``text_hash`` matching the current searchable text → False.
-        - Otherwise (text changed vs. stored hashes) → True.
-
-        Multiple embedding rows (e.g. different models) are handled by checking whether
-        *any* row already matches the current content hash; the generator still decides
-        per-model work and deduplication.
+        - No rows in embedding yet -> True.
+        - At least one row has text_hash matching current searchable text -> False.
+        - Otherwise -> True.
         """
-        text = self.to_searchable_text()
-        current_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()
-        existing = self.embeddings
-        if not existing:
-            return True
-        return not any(e.text_hash == current_hash for e in existing)
+        searchable_text = self.to_searchable_text()
+        current_hash = hashlib.sha256(searchable_text.encode("utf-8")).hexdigest()
+
+        stmt = text("""
+            SELECT EXISTS (
+                SELECT 1
+                FROM embedding
+                WHERE entity_id = :entity_id
+                  AND entity_type = :entity_type
+                  AND text_hash = :text_hash
+            )
+        """)
+        has_match = bool(
+            connection.execute(
+                stmt,
+                {
+                    "entity_id": self.id,
+                    "entity_type": self.__class__.__name__,
+                    "text_hash": current_hash,
+                },
+            ).scalar_one()
+        )
+        return not has_match
 
     def to_searchable_text(self) -> str:
         """
@@ -486,7 +498,7 @@ def on_entity_update(mapper, connection, target):
         return
 
     try:
-        if not target.searchable_text_changed():
+        if not target.searchable_text_changed(connection):
             return
         _queue_embedding_after_commit(target)
     except Exception as e:

--- a/apps/backend/src/rhesis/backend/app/models/mixins.py
+++ b/apps/backend/src/rhesis/backend/app/models/mixins.py
@@ -486,6 +486,8 @@ def on_entity_update(mapper, connection, target):
         return
 
     try:
+        if not target.searchable_text_changed():
+            return
         _queue_embedding_after_commit(target)
     except Exception as e:
         logger.error(f"Error enqueuing embedding for {target.__class__.__name__} {target.id}: {e}")


### PR DESCRIPTION
## Purpose
EmbeddableMixin was queueing an embedding job on every after_update, even when the searchable text was unchanged. Generator-side hash dedup limited wasted work, but we still paid post-commit cost (new session, service, enqueue).
## What changed
- In on_entity_update, call searchable_text_changed() and return early when it is False (text hash already matches an existing embedding row). after_insert is unchanged.