### PR TITLE
Remove Rust from Polyphemus Docker image

### DIFF
--- a/apps/polyphemus/Dockerfile
+++ b/apps/polyphemus/Dockerfile
@@ -19,17 +19,12 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-# Install build dependencies including Rust (needed for base2048/maturin)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
     git \
     curl \
-    && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
     && rm -rf /var/lib/apt/lists/*
-
-# Add Rust to PATH
-ENV PATH="/root/.cargo/bin:${PATH}"
 
 # Copy only the dependency files for polyphemus
 COPY apps/polyphemus/pyproject.toml apps/polyphemus/uv.lock ./


### PR DESCRIPTION
## Purpose
Polyphemus no longer needs a Rust toolchain in the image for Python dependency builds, so the Dockerfile can stay smaller and faster to build.

## What Changed
- Dropped `rustup` install and `PATH` tweak from `apps/polyphemus/Dockerfile`
- Removed the related comment about base2048/maturin

## Additional Context
- None

## Testing
- CI should exercise the Polyphemus Docker build on this branch