### PR TITLE
Use actions/checkout v6 across GitHub Actions

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
@@ -103,7 +103,7 @@ jobs:
       build_tag: ${{ steps.set_build_tag.outputs.build_tag }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key
@@ -235,7 +235,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key
@@ -342,7 +342,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key

--- a/.github/workflows/chatbot.yml
+++ b/.github/workflows/chatbot.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
@@ -62,7 +62,7 @@ jobs:
       environment: ${{ env.ENVIRONMENT }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key
@@ -125,7 +125,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key

--- a/.github/workflows/check-hardcoded-styles.yml
+++ b/.github/workflows/check-hardcoded-styles.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch more commits for git diff to work properly
           fetch-depth: 2

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -30,7 +30,7 @@ jobs:
           private-key: ${{ secrets.RHEO_APP_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
@@ -106,7 +106,7 @@ jobs:
       is_preview: ${{ steps.set_env.outputs.is_preview }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key
@@ -216,7 +216,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
@@ -103,7 +103,7 @@ jobs:
       is_preview: ${{ steps.set_env.outputs.is_preview }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key
@@ -232,7 +232,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -57,7 +57,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v2
@@ -169,7 +169,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Download setup artifacts
         uses: actions/download-artifact@v4
@@ -338,7 +338,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Download setup artifacts
         uses: actions/download-artifact@v4
@@ -461,7 +461,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Download setup artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Needed for paths-filter
 

--- a/.github/workflows/otel-collector.yml
+++ b/.github/workflows/otel-collector.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
@@ -85,7 +85,7 @@ jobs:
       commit_sha: ${{ steps.set_env.outputs.commit_sha }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key

--- a/.github/workflows/penelope-test.yml
+++ b/.github/workflows/penelope-test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Needed for git diff
 

--- a/.github/workflows/polyphemus-vertex-ai.yml
+++ b/.github/workflows/polyphemus-vertex-ai.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/polyphemus.yml
+++ b/.github/workflows/polyphemus.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
@@ -94,7 +94,7 @@ jobs:
       is_preview: ${{ steps.set_env.outputs.is_preview }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key
@@ -212,7 +212,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Python build environment
       uses: ./.github/actions/setup-python-build
@@ -48,7 +48,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Python build environment
       uses: ./.github/actions/setup-python-build

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -40,7 +40,7 @@ jobs:
           private-key: ${{ secrets.RHEO_APP_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0  # Needed for git diff
 

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Secret Scanning

--- a/.github/workflows/security-trivy.yml
+++ b/.github/workflows/security-trivy.yml
@@ -18,7 +18,7 @@ jobs:
       has_changes: ${{ steps.set-matrix.outputs.has_changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect changed paths
         if: github.event_name == 'pull_request'
@@ -109,7 +109,7 @@ jobs:
     name: Trivy - ${{ matrix.name }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0

--- a/.github/workflows/set-up-release.yml
+++ b/.github/workflows/set-up-release.yml
@@ -63,7 +63,7 @@ jobs:
           private-key: ${{ secrets.RHEO_APP_PRIVATE_KEY }}
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.generate-token.outputs.token }}
 

--- a/.github/workflows/telemetry-processor.yml
+++ b/.github/workflows/telemetry-processor.yml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
@@ -85,7 +85,7 @@ jobs:
       commit_sha: ${{ steps.set_env.outputs.commit_sha }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -72,7 +72,7 @@ jobs:
       git_branch: ${{ steps.set_env.outputs.git_branch }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key
@@ -160,7 +160,7 @@ jobs:
       ENVIRONMENT: ${{ needs.build.outputs.environment || inputs.environment || github.event.inputs.environment || 'dev' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create and validate service account key file
         id: sa_key

--- a/docs/content/contribute/frontend/testing.mdx
+++ b/docs/content/contribute/frontend/testing.mdx
@@ -505,7 +505,7 @@ test:
   runs-on: ubuntu-latest
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Node.js
       uses: actions/setup-node@v4

--- a/examples/ci-cd/rhesis-tests.yml
+++ b/examples/ci-cd/rhesis-tests.yml
@@ -13,7 +13,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/scripts/check_organization_filtering.py
+++ b/scripts/check_organization_filtering.py
@@ -344,7 +344,7 @@ jobs:
   check-organization-filtering:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
## Purpose
GitHub Actions is deprecating the Node.js 20 runtime used by older action versions. Upgrading `actions/checkout` to v6 aligns workflows with the Node.js 24 action runtime and clears related validation warnings.

## What Changed
- Replaced `actions/checkout@v4` with `actions/checkout@v6` in all affected workflow files under `.github/workflows/`
- Updated the same reference in `examples/ci-cd/rhesis-tests.yml`, `docs/content/contribute/frontend/testing.mdx`, and `scripts/check_organization_filtering.py` for consistency

## Additional Context
- See GitHub changelog: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
- Self-hosted runners may need to be on a recent enough version for v6; see [actions/checkout releases](https://github.com/actions/checkout/releases) if container jobs rely on persisted credentials.

## Testing
- Rely on CI after merge; no application code changes.