### PR TITLE
Fix backend Docker layout for monorepo uv paths

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -200,8 +200,7 @@ COPY --chown=rhesis-user:rhesis-user --chmod=755 apps/backend/start.sh ./start.s
 
 USER rhesis-user
 
-ENV RHESIS_BACKEND_CONTAINER=1 \
-    PYTHONPATH=/app/apps/backend/src \
+ENV PYTHONPATH=/app/apps/backend/src \
     PATH="/usr/local/bin:/app/apps/backend/.venv/bin:$PATH"
 
 CMD ["./start.sh"]

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -42,51 +42,43 @@ COPY packages/rhesis /app/packages/rhesis/
 # =============================================================================
 FROM base-build AS build-core
 
+# Match monorepo layout so [tool.uv.sources] path deps resolve without rewriting.
+WORKDIR /app/apps/backend
+
 COPY apps/backend/pyproject.toml apps/backend/uv.lock apps/backend/README.md ./
 
-RUN mkdir -p /app/src/rhesis/backend
-COPY apps/backend/src/rhesis/__init__.py /app/src/rhesis/__init__.py
-COPY apps/backend/src/rhesis/backend/__init__.py /app/src/rhesis/backend/__init__.py
+RUN mkdir -p src/rhesis/backend
+COPY apps/backend/src/rhesis/__init__.py src/rhesis/__init__.py
+COPY apps/backend/src/rhesis/backend/__init__.py src/rhesis/backend/__init__.py
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_NO_MANAGED_PYTHON=1 \
     UV_LINK_MODE=copy \
     UV_NO_DEV=1
 
-# Rewrite all [tool.uv.sources] paths so uv can resolve them. We don't install
-# rhesis-sdk / rhesis-penelope here (they're behind the [all] extra), but uv still
-# parses every source entry up front, so the paths must point somewhere valid.
-RUN sed -i 's|path = "../../sdk"|path = "/app/sdk"|g' /app/pyproject.toml && \
-    sed -i 's|path = "../../penelope"|path = "/app/penelope"|g' /app/pyproject.toml && \
-    sed -i 's|path = "../../packages/rhesis"|path = "/app/packages/rhesis"|g' /app/pyproject.toml && \
-    sed -i 's|path = "../packages/rhesis"|path = "/app/packages/rhesis"|g' /app/sdk/pyproject.toml
-
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cargo/registry \
     uv sync
 
-COPY apps/backend/src /app/src
+COPY apps/backend/src ./src
 
 # =============================================================================
 # build-backend: full backend venv (API + worker)
 # =============================================================================
 FROM base-build AS build-backend
 
+WORKDIR /app/apps/backend
+
 COPY apps/backend/pyproject.toml apps/backend/uv.lock apps/backend/README.md ./
 
-RUN mkdir -p /app/src/rhesis/backend
-COPY apps/backend/src/rhesis/__init__.py /app/src/rhesis/__init__.py
-COPY apps/backend/src/rhesis/backend/__init__.py /app/src/rhesis/backend/__init__.py
+RUN mkdir -p src/rhesis/backend
+COPY apps/backend/src/rhesis/__init__.py src/rhesis/__init__.py
+COPY apps/backend/src/rhesis/backend/__init__.py src/rhesis/backend/__init__.py
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_NO_MANAGED_PYTHON=1 \
     UV_LINK_MODE=copy \
     UV_NO_DEV=1
-
-RUN sed -i 's|path = "../../sdk"|path = "/app/sdk"|g' /app/pyproject.toml && \
-    sed -i 's|path = "../../penelope"|path = "/app/penelope"|g' /app/pyproject.toml && \
-    sed -i 's|path = "../../packages/rhesis"|path = "/app/packages/rhesis"|g' /app/pyproject.toml && \
-    sed -i 's|path = "../packages/rhesis"|path = "/app/packages/rhesis"|g' /app/sdk/pyproject.toml
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cargo/registry \
@@ -94,7 +86,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 RUN uv pip uninstall torch
 
-COPY apps/backend/src /app/src
+COPY apps/backend/src ./src
 
 # =============================================================================
 # base-runtime: shared slim runtime + uv + rhesis-user + full backend payload
@@ -102,7 +94,7 @@ COPY apps/backend/src /app/src
 FROM mirror.gcr.io/library/python:3.12.8-slim AS base-runtime
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-WORKDIR /app
+WORKDIR /app/apps/backend
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -121,12 +113,12 @@ ENV PYTHONUNBUFFERED=1 \
 RUN adduser --disabled-password --gecos '' rhesis-user && \
     chown rhesis-user:rhesis-user /app
 
-COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/.venv /app/.venv
-COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/src /app/src
+COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/apps/backend/.venv .venv
+COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/apps/backend/src src
 COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/sdk /app/sdk
 COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/penelope /app/penelope
 COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/packages/rhesis /app/packages/rhesis
-COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/pyproject.toml /app/pyproject.toml
+COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/apps/backend/pyproject.toml pyproject.toml
 
 RUN find /app -name ".env" -type f -delete
 
@@ -138,7 +130,7 @@ EXPOSE 8080
 FROM mirror.gcr.io/library/python:3.12.8-slim AS migrate
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-WORKDIR /app
+WORKDIR /app/apps/backend
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -157,21 +149,21 @@ ENV PYTHONUNBUFFERED=1 \
 RUN adduser --disabled-password --gecos '' rhesis-user && \
     chown rhesis-user:rhesis-user /app
 
-COPY --from=build-core --chown=rhesis-user:rhesis-user /app/.venv /app/.venv
-COPY --from=build-core --chown=rhesis-user:rhesis-user /app/src /app/src
+COPY --from=build-core --chown=rhesis-user:rhesis-user /app/apps/backend/.venv .venv
+COPY --from=build-core --chown=rhesis-user:rhesis-user /app/apps/backend/src src
 COPY --from=build-core --chown=rhesis-user:rhesis-user /app/packages/rhesis /app/packages/rhesis
-COPY --from=build-core --chown=rhesis-user:rhesis-user /app/pyproject.toml /app/pyproject.toml
+COPY --from=build-core --chown=rhesis-user:rhesis-user /app/apps/backend/pyproject.toml pyproject.toml
 
 RUN find /app -name ".env" -type f -delete
 
-COPY --chown=rhesis-user:rhesis-user --chmod=755 apps/backend/migrate.sh /app/migrate.sh
+COPY --chown=rhesis-user:rhesis-user --chmod=755 apps/backend/migrate.sh ./migrate.sh
 
 USER rhesis-user
 
-ENV PYTHONPATH=/app \
-    PATH="/app/.venv/bin:$PATH"
+ENV PYTHONPATH=/app/apps/backend/src \
+    PATH="/app/apps/backend/.venv/bin:$PATH"
 
-CMD ["/app/migrate.sh"]
+CMD ["./migrate.sh"]
 
 # =============================================================================
 # backend: Bun/npx, postgresql-client, FastAPI entrypoint
@@ -203,15 +195,16 @@ RUN apt-get update && \
     postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --chown=rhesis-user:rhesis-user --chmod=755 apps/backend/migrate.sh /app/migrate.sh
-COPY --chown=rhesis-user:rhesis-user --chmod=755 apps/backend/start.sh /app/start.sh
+COPY --chown=rhesis-user:rhesis-user --chmod=755 apps/backend/migrate.sh ./migrate.sh
+COPY --chown=rhesis-user:rhesis-user --chmod=755 apps/backend/start.sh ./start.sh
 
 USER rhesis-user
 
-ENV PYTHONPATH=/app \
-    PATH="/usr/local/bin:/app/.venv/bin:$PATH"
+ENV RHESIS_BACKEND_CONTAINER=1 \
+    PYTHONPATH=/app/apps/backend/src \
+    PATH="/usr/local/bin:/app/apps/backend/.venv/bin:$PATH"
 
-CMD ["/app/start.sh"]
+CMD ["./start.sh"]
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
     CMD curl -f http://localhost:8080/health || exit 1
@@ -244,8 +237,8 @@ ENV PYTHONHASHSEED=0 \
     MALLOC_TRIM_THRESHOLD_=100000 \
     MALLOC_MMAP_THRESHOLD_=131072 \
     MALLOC_TOP_PAD_=131072 \
-    PATH="/app/.venv/bin:$PATH" \
-    PYTHONPATH=/app \
+    PATH="/app/apps/backend/.venv/bin:$PATH" \
+    PYTHONPATH=/app/apps/backend/src \
     CELERY_OPTIMIZATION=fair \
     CELERY_DISABLE_RATE_LIMITS=True \
     CELERY_TASK_ALWAYS_EAGER=False \

--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -113,7 +113,6 @@ USER rhesis-user
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    RHESIS_BACKEND_CONTAINER=1 \
     PYTHONPATH=/app/apps/backend/src \
     PATH="/usr/local/bin:/app/apps/backend/.venv/bin:$PATH"
 

--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -38,27 +38,26 @@ ENV UV_LINK_MODE=copy \
     UV_COMPILE_BYTECODE=1 \
     UV_NO_MANAGED_PYTHON=1
 
-# Layer 1: dependency manifests only (invalidates on lock / pyproject changes)
-COPY apps/backend/uv.lock apps/backend/pyproject.toml apps/backend/README.md ./
-COPY sdk/uv.lock sdk/pyproject.toml sdk/
-COPY penelope/uv.lock penelope/pyproject.toml penelope/
-COPY packages/rhesis/pyproject.toml packages/rhesis/README.md packages/rhesis/
+# Layer 1: dependency manifests only (invalidates on lock / pyproject changes).
+# Layout matches the monorepo so [tool.uv.sources] paths need no rewriting.
+COPY sdk/uv.lock sdk/pyproject.toml /app/sdk/
+COPY penelope/uv.lock penelope/pyproject.toml /app/penelope/
+COPY packages/rhesis/pyproject.toml packages/rhesis/README.md /app/packages/rhesis/
 
-# Fix paths in pyproject.toml for Docker layout (/app), same as production Dockerfile
-RUN sed -i 's|path = "../../sdk"|path = "/app/sdk"|g' /app/pyproject.toml && \
-    sed -i 's|path = "../../penelope"|path = "/app/penelope"|g' /app/pyproject.toml && \
-    sed -i 's|path = "../../packages/rhesis"|path = "/app/packages/rhesis"|g' /app/pyproject.toml && \
-    sed -i 's|path = "../packages/rhesis"|path = "/app/packages/rhesis"|g' /app/sdk/pyproject.toml
+WORKDIR /app/apps/backend
+COPY apps/backend/uv.lock apps/backend/pyproject.toml apps/backend/README.md ./
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --no-install-project --no-install-local --extra all --extra cpu
 
 # Layer 2: full sources, then install local packages
+WORKDIR /app
 COPY sdk /app/sdk/
 COPY penelope /app/penelope/
 COPY packages/rhesis /app/packages/rhesis/
-COPY apps/backend/src /app/src/
+COPY apps/backend/src /app/apps/backend/src/
 
+WORKDIR /app/apps/backend
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --extra all --extra cpu
 
@@ -74,7 +73,7 @@ COPY --from=oven/bun:latest /usr/local/bin/bunx /usr/local/bin/bunx
 # Create npx alias to bunx for compatibility (users can write npx, Docker will use bunx)
 RUN ln -s /usr/local/bin/bunx /usr/local/bin/npx
 
-WORKDIR /app
+WORKDIR /app/apps/backend
 
 # Install only runtime dependencies (no build tools)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -95,15 +94,15 @@ RUN adduser --disabled-password --gecos '' rhesis-user && \
     chown rhesis-user:rhesis-user /app
 
 # Copy the virtual environment from builder
-COPY --from=builder --chown=rhesis-user:rhesis-user /app/.venv /app/.venv
+COPY --from=builder --chown=rhesis-user:rhesis-user /app/apps/backend/.venv .venv
 
 # Copy source code and scripts with proper ownership and permissions
-COPY --from=builder --chown=rhesis-user:rhesis-user /app/src /app/src
+COPY --from=builder --chown=rhesis-user:rhesis-user /app/apps/backend/src src
 COPY --from=builder --chown=rhesis-user:rhesis-user /app/sdk /app/sdk
 COPY --from=builder --chown=rhesis-user:rhesis-user /app/penelope /app/penelope
 COPY --from=builder --chown=rhesis-user:rhesis-user /app/packages/rhesis /app/packages/rhesis
-COPY --chown=rhesis-user:rhesis-user --chmod=755 apps/backend/migrate.sh /app/migrate.sh
-COPY --chown=rhesis-user:rhesis-user --chmod=755 apps/backend/start.sh /app/start.sh
+COPY --chown=rhesis-user:rhesis-user --chmod=755 apps/backend/migrate.sh ./migrate.sh
+COPY --chown=rhesis-user:rhesis-user --chmod=755 apps/backend/start.sh ./start.sh
 
 # Remove .env files
 RUN find /app -name ".env" -type f -delete
@@ -114,14 +113,15 @@ USER rhesis-user
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONPATH=/app \
-    PATH="/usr/local/bin:/app/.venv/bin:$PATH"
+    RHESIS_BACKEND_CONTAINER=1 \
+    PYTHONPATH=/app/apps/backend/src \
+    PATH="/usr/local/bin:/app/apps/backend/.venv/bin:$PATH"
 
 # Expose port
 EXPOSE 8080
 
 # Use the improved startup script
-CMD ["/app/start.sh"]
+CMD ["./start.sh"]
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:8080/health || exit 1

--- a/apps/backend/migrate.sh
+++ b/apps/backend/migrate.sh
@@ -48,7 +48,9 @@ wait_for_database() {
 # us the same information. Verbose Alembic diagnostics still run, but only on
 # failure, where the extra latency does not matter.
 run_migrations() {
-    cd /app/src/rhesis/backend || handle_error "Could not navigate to backend directory"
+    local backend_root
+    backend_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    cd "$backend_root/src/rhesis/backend" || handle_error "Could not navigate to backend directory"
 
     local before after
     before=$(PGPASSWORD="$DB_PASS" psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" \

--- a/apps/backend/start.sh
+++ b/apps/backend/start.sh
@@ -60,10 +60,10 @@ run_migrations() {
         CMD_PREFIX="uv run "
     fi
 
-    # Docker: use migrate.sh, Local: run alembic directly
-    if [ -d "/app/src/rhesis/backend" ]; then
-        # Docker environment - use migrate.sh
-        log "${BLUE}📍 Running migrations via migrate.sh (Docker)${NC}"
+    # Container image (see RHESIS_BACKEND_CONTAINER in Dockerfile): migrate.sh with
+    # DB wait + psql revision hints. Local dev: alembic directly (no pg_isready requirement).
+    if [ "${RHESIS_BACKEND_CONTAINER:-}" = "1" ]; then
+        log "${BLUE}📍 Running migrations via migrate.sh (container)${NC}"
         if ./migrate.sh; then
             log "${GREEN}✅ Database migrations completed successfully${NC}"
         else

--- a/apps/backend/start.sh
+++ b/apps/backend/start.sh
@@ -60,10 +60,10 @@ run_migrations() {
         CMD_PREFIX="uv run "
     fi
 
-    # Container image (see RHESIS_BACKEND_CONTAINER in Dockerfile): migrate.sh with
-    # DB wait + psql revision hints. Local dev: alembic directly (no pg_isready requirement).
-    if [ "${RHESIS_BACKEND_CONTAINER:-}" = "1" ]; then
-        log "${BLUE}📍 Running migrations via migrate.sh (container)${NC}"
+    # Docker image layout: migrate.sh with DB wait + psql revision hints. Local dev:
+    # alembic directly (no pg_isready requirement).
+    if [ -d "/app/apps/backend/src/rhesis/backend" ]; then
+        log "${BLUE}📍 Running migrations via migrate.sh (Docker)${NC}"
         if ./migrate.sh; then
             log "${GREEN}✅ Database migrations completed successfully${NC}"
         else

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -97,10 +97,11 @@ services:
       retries: 3
       start_period: 60s
     env_file: []
-    command: ["/app/start.sh"]
+    command: ["./start.sh"]
+    working_dir: /app/apps/backend
     volumes:
-      - ../apps/backend/src:/app/src
-      - ../apps/backend/start.sh:/app/start.sh
+      - ../apps/backend/src:/app/apps/backend/src
+      - ../apps/backend/start.sh:/app/apps/backend/start.sh
 
   # ==========================================================================
   # Backend Integration Tests (--profile backend)


### PR DESCRIPTION
## Purpose
Backend images previously rewrote `pyproject.toml` path dependencies with `sed` and used `/app` as the app root. Aligning the container filesystem with the monorepo layout (`/app/apps/backend`, etc.) lets `uv` resolve `[tool.uv.sources]` without rewriting and keeps paths consistent across prod, dev, and test compose.

## What Changed
- Production `Dockerfile`: `WORKDIR` under `apps/backend`, relative `COPY` for `src` and venv, removed `sed` path hacks; runtime `PYTHONPATH` points at backend `src`; worker stage PATH/PYTHONPATH updated.
- `Dockerfile.dev`: same monorepo-aligned layout and env vars; scripts invoked as `./start.sh` from backend workdir.
- `migrate.sh`: `cd` to Alembic dir using script location instead of hardcoded `/app/src/...`.
- `start.sh`: detect Docker vs local by checking for `/app/apps/backend/src/rhesis/backend` (container layout); use `migrate.sh` in Docker and `alembic` locally.
- `tests/docker-compose.test.yml`: `working_dir`, command, and volume mounts updated for the new paths.

## Additional Context
- Untracked `tests/sdk/agents/__pycache__/*.pyc` were not committed.

## Testing
- Build backend image locally: `docker build -f apps/backend/Dockerfile .` from repo root (or rely on CI).
- Run integration stack that uses `tests/docker-compose.test.yml` if applicable.