### PR TITLE
Add backend GHCR smoke build

### DIFF
--- a/.github/workflows/backend-ghcr.yml
+++ b/.github/workflows/backend-ghcr.yml
@@ -24,6 +24,20 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
 
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v5
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -34,21 +48,12 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create tiny GHCR smoke Dockerfile
-        run: |
-          {
-            echo "FROM alpine:3.20"
-            echo 'LABEL org.opencontainers.image.source="${{ github.server_url }}/${{ github.repository }}"'
-            echo 'CMD ["sh", "-c", "echo GHCR smoke image works"]'
-          } > "${RUNNER_TEMP}/Dockerfile.ghcr-smoke"
-
-      - name: Build and push tiny GHCR smoke image
+      - name: Build and push backend image
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: ${{ runner.temp }}/Dockerfile.ghcr-smoke
-          platforms: linux/amd64
+          file: ./apps/backend/Dockerfile
+          target: backend
+          platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ghcr.io/rhesis-ai/backend:ghcr-smoke
-            ghcr.io/rhesis-ai/backend:ghcr-smoke-${{ github.run_id }}
+          tags: ghcr.io/rhesis-ai/backend:latest

--- a/.github/workflows/backend-ghcr.yml
+++ b/.github/workflows/backend-ghcr.yml
@@ -31,8 +31,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
-          username: rheo-app[bot]
-          password: ${{ steps.generate-token.outputs.token }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create tiny GHCR smoke Dockerfile
         run: |

--- a/.github/workflows/backend-ghcr.yml
+++ b/.github/workflows/backend-ghcr.yml
@@ -12,17 +12,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Generate bot token
-        id: generate-token
-        uses: actions/create-github-app-token@v2
-        with:
-          app-id: ${{ vars.RHEO_APP_ID }}
-          private-key: ${{ secrets.RHEO_APP_PRIVATE_KEY }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set up Docker
         uses: docker/setup-docker-action@v5

--- a/.github/workflows/backend-ghcr.yml
+++ b/.github/workflows/backend-ghcr.yml
@@ -57,3 +57,13 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/rhesis-ai/backend:latest
+
+      - name: Build and push worker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/backend/Dockerfile
+          target: worker
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/rhesis-ai/worker:latest

--- a/.github/workflows/backend-ghcr.yml
+++ b/.github/workflows/backend-ghcr.yml
@@ -24,20 +24,6 @@ jobs:
         with:
           token: ${{ steps.generate-token.outputs.token }}
 
-      - name: Set up Docker
-        uses: docker/setup-docker-action@v5
-        with:
-          daemon-config: |
-            {
-              "debug": true,
-              "features": {
-                "containerd-snapshotter": true
-              }
-            }
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -48,12 +34,21 @@ jobs:
           username: rheo-app[bot]
           password: ${{ steps.generate-token.outputs.token }}
 
-      - name: Build and push backend image
+      - name: Create tiny GHCR smoke Dockerfile
+        run: |
+          {
+            echo "FROM alpine:3.20"
+            echo 'LABEL org.opencontainers.image.source="${{ github.server_url }}/${{ github.repository }}"'
+            echo 'CMD ["sh", "-c", "echo GHCR smoke image works"]'
+          } > "${RUNNER_TEMP}/Dockerfile.ghcr-smoke"
+
+      - name: Build and push tiny GHCR smoke image
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: ./apps/backend/Dockerfile
-          target: backend
-          platforms: linux/amd64,linux/arm64
+          file: ${{ runner.temp }}/Dockerfile.ghcr-smoke
+          platforms: linux/amd64
           push: true
-          tags: ghcr.io/rhesis-ai/backend:latest
+          tags: |
+            ghcr.io/rhesis-ai/backend:ghcr-smoke
+            ghcr.io/rhesis-ai/backend:ghcr-smoke-${{ github.run_id }}


### PR DESCRIPTION
## Purpose
Temporarily replace the expensive backend GHCR image build with a tiny smoke image so we can isolate GHCR authentication and package push issues quickly.

## What Changed
- Builds a tiny Alpine image from an inline Dockerfile during the manual backend GHCR workflow.
- Pushes smoke tags instead of the full backend `latest` image.
- Removes QEMU/custom Docker setup that is not needed for a single-platform smoke build.

## Additional Context
- This is intended to verify whether the failure is in GHCR auth/permissions before restoring the full backend image build.

## Testing
- Ran `git diff --check` for the workflow change.
- Cursor reported no linter diagnostics for `.github/workflows/backend-ghcr.yml`.