### PR TITLE
docs: add v0.7.0 changelog entry and slim v0.6.12

### DIFF
--- a/docs/content/changelog.mdx
+++ b/docs/content/changelog.mdx
@@ -8,6 +8,38 @@ This is the aggregated changelog for the entire Rhesis repository. For detailed 
 - [Frontend Changelog](https://github.com/rhesis-ai/rhesis/blob/main/apps/frontend/CHANGELOG.md)
 - [Polyphemus Changelog](https://github.com/rhesis-ai/rhesis/blob/main/apps/polyphemus/CHANGELOG.md)
 
+## [0.7.0] - 2026-04-23
+
+### Platform Release
+
+This release includes the following component versions:
+- **Backend 0.7.0**
+- **Frontend 0.7.0**
+- **SDK 0.7.0**
+
+### Summary
+
+This release introduces the **Rhesis Architect** — a conversational AI agent for test-suite design and execution — alongside **metric synthesis and improvement**, **OData `$select` support** for list endpoints, and adaptive testing upgrades including diversity-aware suggestions and async embedding generation.
+
+### Backend Highlights
+- Added Architect chat backend with session/message models, WebSocket handlers, and Celery task orchestration
+- Added MCP server package exposing backend API routes as agent-accessible tools with server-managed pagination and confirmation metadata
+- Added `POST /metrics/{metric_id}/improve` endpoint for in-place metric refinement from natural-language instructions
+- Added OData `$select` support across all list endpoints for efficient field retrieval
+- Added local tool provider path with delegation-token authentication for in-process tool calls
+
+### Frontend Highlights
+- Added Architect chat page under Testing navigation with streaming tool activity, plan display, and session history sidebar
+- Added confirmation action controls for mutating operations with auto-approve toggle
+- Added `@mention` support for entity references in Architect chat input
+- Improved chat streaming UX with token-by-token display, tool reasoning, and session state management
+
+### SDK Highlights
+- Added `agents` framework with `BaseAgent`, `BaseTool`, `MCPTool`, and `ArchitectAgent` for conversational agent workflows
+- Added `MetricSynthesizer` for generating and improving metrics from natural-language instructions
+- Added `ExploreEndpointTool` for structured multi-turn endpoint exploration with strategy support
+- Added adaptive testing embedding generation and diversity-aware suggestion strategies
+
 ## [0.6.12] - 2026-04-09
 
 ### Platform Release
@@ -20,68 +52,26 @@ This release includes the following component versions:
 
 ### Summary
 
-This release introduces **test run cancellation**, **adaptive testing settings and export workflows**, and
-an **async batch execution engine** replacing chord fan-out for test execution. It also adds a built-in
-`echo` chatbot use case and extends Polyphemus deployment controls with serving-container log-level
-configuration.
-
-### Featured Capabilities
-
-**Test Run Cancellation**
-
-Queued and in-progress test runs can now be cancelled from the API and UI:
-
-- **New endpoint**: `POST /test_runs/{id}/cancel`
-- **Immediate status transition**: run status is set to `Cancelled` immediately
-- **Cooperative stop behavior**: running async batch work is cancelled via revoke checks and watchdog cancellation
-- **Grid action support**: test runs list supports bulk cancel for selected queued/progress runs
-
-**Adaptive Testing Settings + Export**
-
-Adaptive testing now supports persistent configuration and cleaner handoff workflows:
-
-- **Adaptive settings endpoints**: `GET/PUT /adaptive_testing/{id}/settings`
-- **Default endpoint + metric assignments**: adaptive sets can store default execution/evaluation settings
-- **Export endpoint**: `POST /adaptive_testing/export/\{source_test_set_identifier\}` creates a regular test set
-- **Suggestion UX updates**: streaming progress, user feedback guidance, and batch accept in the suggestions flow
-- **Topic management improvement**: adaptive tree now includes a "Tests without topic" filter
-
-**Async Batch Execution Engine**
-
-Parallel execution now uses a single-task async batch architecture:
-
-- **Orchestration change**: replaced Celery chord fan-out with internal asyncio task fan-out
-- **Concurrency controls**: semaphore-limited execution via configurable batch concurrency
-- **Recovery pass**: retries transient failures after the main pass
-- **Per-test timeout default**: increased to `1800` seconds (`30` minutes)
-- **Worker compatibility**: thread-pool execution path avoids fork-related instability
-
-**Chatbot Echo Use Case**
-
-The default chatbot service includes a built-in `echo` path:
-
-- **No LLM invocation**: returns input verbatim
-- **Rate-limit exemption**: `echo` requests bypass chatbot usage limits
-- **Practical use**: lightweight connectivity and request-mapping checks
+This release introduces **test run cancellation**, **adaptive testing settings and export workflows**, and **faster parallel test execution** with improved reliability. It also adds a built-in `echo` chatbot use case and extends Polyphemus deployment controls with serving-container log-level configuration.
 
 ### Backend Highlights
-- Added run cancellation endpoint and cancellation state handling for queued/progress runs
-- Added adaptive settings read/update endpoints and export-from-adaptive endpoint
-- Added suggestion-generation user feedback support and streaming evaluation/output paths
-- Added file-import turn config alias support (`Turn Config`, `turns`, `num_turns`) with range parsing
-- Replaced chord fan-out path with async batch engine and cancellation watchdog
+- Added test run cancellation endpoint (`POST /test_runs/{id}/cancel`) with immediate status transition for queued and in-progress runs
+- Added adaptive testing settings endpoints (`GET/PUT /adaptive_testing/{id}/settings`) and export-to-test-set endpoint
+- Added user feedback support and streaming output paths for suggestion generation
+- Added file-import support for turn configuration aliases (`Turn Config`, `turns`, `num_turns`) with range parsing
+- Replaced parallel execution engine with async batch architecture for improved performance and reliability
 
 ### Frontend Highlights
-- Added cancel test run actions in test runs grid for queued/progress statuses
-- Added adaptive settings dialog for default endpoint/metric assignment
-- Added adaptive export action to create regular test sets from adaptive sets
-- Added suggestions progress segmentation, per-metric detail tooltip, and accept-all flow
-- Added "Tests without topic" adaptive tree filter
+- Added cancel action for queued and in-progress test runs in the test runs grid
+- Added adaptive testing settings dialog for default endpoint and metric assignment
+- Added export action to create a regular test set from an adaptive testing set
+- Added segmented progress bar, per-metric detail tooltips, and batch accept for suggestions
+- Added "Tests without topic" filter to the adaptive testing tree
 
 ### SDK Highlights
-- Added support for run cancellation endpoint usage in client flows
-- Improved execution reliability with async batch behavior and retry/recovery path support
-- Included echo use-case support for chatbot interactions
+- Added test run cancellation support in client workflows
+- Improved execution reliability with retry and recovery support for transient failures
+- Added echo use case for chatbot interactions that returns input verbatim
 
 ### Polyphemus Highlights
 - Added `VLLM_LOGGING_LEVEL` deployment variable support for Vertex serving container logs


### PR DESCRIPTION
## Purpose

The docs changelog (`docs/content/changelog.mdx`) had two issues:
1. The latest entry was `[0.6.12]`, missing the `[0.7.0] - 2026-04-23` release entirely.
2. The `[0.6.12]` entry was the heaviest in the 0.6.x range — a `### Featured Capabilities` block duplicated the Highlights content with engineering-flavoured sub-bullets.

## What Changed

- Added a lean `[0.7.0]` entry (Summary + Backend/Frontend/SDK Highlights, no Featured Capabilities subsections) covering Rhesis Architect, MetricSynthesizer, OData `$select`, and adaptive testing upgrades
- Removed the `### Featured Capabilities` block from `[0.6.12]` and rewrote the component Highlights in plain, user-facing language
- Removed backslash-escaped curly braces from inline code in the updated entry (not needed inside backticks per MDX rules)

## Additional Context

- `[0.6.11]` and all earlier entries are unchanged
- No edits to per-component `CHANGELOG.md` files or other docs pages

## Testing

Verify the docs changelog renders correctly and both `[0.7.0]` and `[0.6.12]` entries display as expected.