### PR TITLE
Fix GHCR builds and quickstart compose mode

### DIFF
--- a/.github/workflows/backend-ghcr.yml
+++ b/.github/workflows/backend-ghcr.yml
@@ -47,6 +47,7 @@ jobs:
           target: backend
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: ghcr.io/rhesis-ai/backend:latest
 
       - name: Build and push worker image
@@ -57,4 +58,5 @@ jobs:
           target: worker
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: ghcr.io/rhesis-ai/worker:latest

--- a/.github/workflows/backend-ghcr.yml
+++ b/.github/workflows/backend-ghcr.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
 
       - name: Set up Docker
         uses: docker/setup-docker-action@v5

--- a/.github/workflows/backend-ghcr.yml
+++ b/.github/workflows/backend-ghcr.yml
@@ -60,3 +60,55 @@ jobs:
           push: true
           provenance: false
           tags: ghcr.io/rhesis-ai/worker:latest
+
+  frontend:
+    runs-on: ubuntu-latest
+
+    env:
+      FRONTEND_ENV: local
+      NEXT_PUBLIC_API_BASE_URL: http://localhost:8080
+      NEXT_PUBLIC_QUICK_START: "true"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v5
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./apps/frontend
+          file: ./apps/frontend/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            FRONTEND_ENV=${{ env.FRONTEND_ENV }}
+            NEXT_PUBLIC_API_BASE_URL=${{ env.NEXT_PUBLIC_API_BASE_URL }}
+            NEXT_PUBLIC_QUICK_START=${{ env.NEXT_PUBLIC_QUICK_START }}
+            GIT_BRANCH=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.sha }}
+          push: true
+          provenance: false
+          tags: ghcr.io/rhesis-ai/frontend:latest

--- a/.github/workflows/backend-ghcr.yml
+++ b/.github/workflows/backend-ghcr.yml
@@ -1,4 +1,4 @@
-name: "[Build] Backend GHCR"
+name: "[Build] Docker GitHub Container Registry"
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ permissions:
   packages: write
 
 jobs:
-  docker:
+  backend:
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,8 @@ tests/airtable.toml
 
 #  RHESIS cli
 .rhesis_cli_history
+#  ./rh quickstart: ghcr vs build compose merge (written by rh start/restart)
+.rhesis-quickstart-compose.mode
 
 # Knowledge Base
 kb/*

--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -228,31 +228,44 @@ def set_logger():
         from pythonjsonlogger.json import JsonFormatter
 
         timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        Path(LOG_DIR).mkdir(parents=True, exist_ok=True)
+        log_dir_path = Path(LOG_DIR)
+        try:
+            log_dir_path.mkdir(parents=True, exist_ok=True)
+            probe = log_dir_path / ".rhesis_log_write_probe"
+            probe.write_text("", encoding="utf-8")
+            probe.unlink()
+        except OSError as exc:
+            # Typical in Docker: non-root user, cwd or LOG_DIR not writable (Permission denied).
+            root_logger.warning(
+                "Skipping file logging under LOG_DIR=%r (%s: %s). Console logging only.",
+                LOG_DIR,
+                type(exc).__name__,
+                exc,
+            )
+        else:
+            log_file_path = os.path.join(LOG_DIR, f"rhesis_{timestamp}.log")
+            file_handler = logging.FileHandler(log_file_path)
+            file_handler.setLevel(LOG_LEVEL)
+            file_handler.setFormatter(RedactingFormatter(_create_formatter(color=False)))
+            root_logger.addHandler(file_handler)
 
-        log_file_path = os.path.join(LOG_DIR, f"rhesis_{timestamp}.log")
-        file_handler = logging.FileHandler(log_file_path)
-        file_handler.setLevel(LOG_LEVEL)
-        file_handler.setFormatter(RedactingFormatter(_create_formatter(color=False)))
-        root_logger.addHandler(file_handler)
-
-        json_log_path = os.path.join(LOG_DIR, f"rhesis_{timestamp}.json.log")
-        json_handler = logging.FileHandler(json_log_path)
-        json_handler.setLevel(LOG_LEVEL)
-        json_handler.setFormatter(
-            RedactingFormatter(
-                JsonFormatter(
-                    fmt="%(asctime)s %(name)s %(levelname)s %(message)s",
-                    datefmt=LOG_DATE_FORMAT,
-                    rename_fields={
-                        "asctime": "timestamp",
-                        "levelname": "level",
-                        "name": "logger",
-                    },
+            json_log_path = os.path.join(LOG_DIR, f"rhesis_{timestamp}.json.log")
+            json_handler = logging.FileHandler(json_log_path)
+            json_handler.setLevel(LOG_LEVEL)
+            json_handler.setFormatter(
+                RedactingFormatter(
+                    JsonFormatter(
+                        fmt="%(asctime)s %(name)s %(levelname)s %(message)s",
+                        datefmt=LOG_DATE_FORMAT,
+                        rename_fields={
+                            "asctime": "timestamp",
+                            "levelname": "level",
+                            "name": "logger",
+                        },
+                    )
                 )
             )
-        )
-        root_logger.addHandler(json_handler)
+            root_logger.addHandler(json_handler)
 
     for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "websockets", "fastapi"):
         logger = logging.getLogger(name)

--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -228,44 +228,31 @@ def set_logger():
         from pythonjsonlogger.json import JsonFormatter
 
         timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        log_dir_path = Path(LOG_DIR)
-        try:
-            log_dir_path.mkdir(parents=True, exist_ok=True)
-            probe = log_dir_path / ".rhesis_log_write_probe"
-            probe.write_text("", encoding="utf-8")
-            probe.unlink()
-        except OSError as exc:
-            # Typical in Docker: non-root user, cwd or LOG_DIR not writable (Permission denied).
-            root_logger.warning(
-                "Skipping file logging under LOG_DIR=%r (%s: %s). Console logging only.",
-                LOG_DIR,
-                type(exc).__name__,
-                exc,
-            )
-        else:
-            log_file_path = os.path.join(LOG_DIR, f"rhesis_{timestamp}.log")
-            file_handler = logging.FileHandler(log_file_path)
-            file_handler.setLevel(LOG_LEVEL)
-            file_handler.setFormatter(RedactingFormatter(_create_formatter(color=False)))
-            root_logger.addHandler(file_handler)
+        Path(LOG_DIR).mkdir(parents=True, exist_ok=True)
 
-            json_log_path = os.path.join(LOG_DIR, f"rhesis_{timestamp}.json.log")
-            json_handler = logging.FileHandler(json_log_path)
-            json_handler.setLevel(LOG_LEVEL)
-            json_handler.setFormatter(
-                RedactingFormatter(
-                    JsonFormatter(
-                        fmt="%(asctime)s %(name)s %(levelname)s %(message)s",
-                        datefmt=LOG_DATE_FORMAT,
-                        rename_fields={
-                            "asctime": "timestamp",
-                            "levelname": "level",
-                            "name": "logger",
-                        },
-                    )
+        log_file_path = os.path.join(LOG_DIR, f"rhesis_{timestamp}.log")
+        file_handler = logging.FileHandler(log_file_path)
+        file_handler.setLevel(LOG_LEVEL)
+        file_handler.setFormatter(RedactingFormatter(_create_formatter(color=False)))
+        root_logger.addHandler(file_handler)
+
+        json_log_path = os.path.join(LOG_DIR, f"rhesis_{timestamp}.json.log")
+        json_handler = logging.FileHandler(json_log_path)
+        json_handler.setLevel(LOG_LEVEL)
+        json_handler.setFormatter(
+            RedactingFormatter(
+                JsonFormatter(
+                    fmt="%(asctime)s %(name)s %(levelname)s %(message)s",
+                    datefmt=LOG_DATE_FORMAT,
+                    rename_fields={
+                        "asctime": "timestamp",
+                        "levelname": "level",
+                        "name": "logger",
+                    },
                 )
             )
-            root_logger.addHandler(json_handler)
+        )
+        root_logger.addHandler(json_handler)
 
     for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "websockets", "fastapi"):
         logger = logging.getLogger(name)

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -1,0 +1,14 @@
+# Override for ./rh start (default): use prebuilt images from GHCR instead of local builds.
+# See .github/workflows/backend-ghcr.yml for publish workflow.
+services:
+  backend:
+    image: ghcr.io/rhesis-ai/backend:latest
+    build: !reset null
+
+  worker:
+    image: ghcr.io/rhesis-ai/worker:latest
+    build: !reset null
+
+  frontend:
+    image: ghcr.io/rhesis-ai/frontend:latest
+    build: !reset null

--- a/rh
+++ b/rh
@@ -27,9 +27,11 @@ show_help() {
     echo -e "${PURPLE}════════════════════════════════════════${NC}"
     echo ""
     echo -e "${YELLOW}Usage:${NC}"
-    echo -e "  ${GREEN}./rh start${NC}             - Start all services with Docker (zero-config)"
+    echo -e "  ${GREEN}./rh start${NC}             - Start all services (prebuilt GHCR images)"
+    echo -e "  ${GREEN}./rh start --build${NC}     - Start all services, building images locally"
     echo -e "  ${GREEN}./rh stop${NC}              - Stop all Docker services"
     echo -e "  ${GREEN}./rh restart${NC}           - Restart all Docker services"
+    echo -e "  ${GREEN}./rh restart --build${NC}   - Restart and rebuild images locally"
     echo -e "  ${GREEN}./rh logs${NC}              - View logs from all services"
     echo -e "  ${GREEN}./rh delete${NC}            - Delete all services, images, volumes, and data"
     echo ""
@@ -59,7 +61,8 @@ show_help() {
     echo -e "  ${GREEN}./rh help${NC}              - Show this help message"
     echo ""
     echo -e "${YELLOW}Examples:${NC}"
-    echo -e "  ${BLUE}./rh start${NC}               # Start all services with Docker"
+    echo -e "  ${BLUE}./rh start${NC}               # Start with prebuilt GHCR images"
+    echo -e "  ${BLUE}./rh start --build${NC}       # Build and start from local Dockerfiles"
     echo -e "  ${BLUE}./rh dev init${NC}            # Initialize environment files (first time)"
     echo -e "  ${BLUE}./rh dev up${NC}              # Bring up dev infrastructure"
     echo -e "  ${BLUE}./rh dev backend${NC}         # Start backend locally (without Docker)"
@@ -504,8 +507,38 @@ dev_status() {
 # from manually created containers. This prevents ./rh delete from removing
 # containers created outside of the rh script.
 PROJECT_NAME="rhesis-quickstart"
+# Written by ./rh start / ./rh restart so stop/logs/restart/delete use the same compose merge.
+QUICKSTART_COMPOSE_MODE_FILE="$SCRIPT_DIR/.rhesis-quickstart-compose.mode"
+
+# Returns ghcr or build (validated).
+quickstart_compose_mode_from_file() {
+    local mode="ghcr"
+    if [ -f "$QUICKSTART_COMPOSE_MODE_FILE" ]; then
+        mode=$(tr -d '[:space:]' < "$QUICKSTART_COMPOSE_MODE_FILE")
+    fi
+    if [ "$mode" = "build" ]; then
+        echo "build"
+    else
+        echo "ghcr"
+    fi
+}
+
+# Echoes docker compose -f ... flags for the given mode (ghcr = base + GHCR override).
+quickstart_compose_flags_for_mode() {
+    local mode="$1"
+    if [ "$mode" = "build" ]; then
+        echo "-f docker-compose.yml"
+    else
+        echo "-f docker-compose.yml -f docker-compose.ghcr.yml"
+    fi
+}
+
+quickstart_compose_flags_from_file() {
+    quickstart_compose_flags_for_mode "$(quickstart_compose_mode_from_file)"
+}
 
 # Function to start all services with Docker Compose
+# Optional: --build  Build from local Dockerfiles instead of pulling GHCR images.
 start_all() {
     echo -e "${GREEN}Starting all Rhesis services with Docker...${NC}"
     echo -e "${BLUE}Using zero-configuration local setup${NC}"
@@ -525,6 +558,20 @@ start_all() {
     }
 
     check_docker
+
+    local use_build=0
+    for arg in "$@"; do
+        if [ "$arg" = "--build" ]; then
+            use_build=1
+        fi
+    done
+
+    local quickstart_mode="ghcr"
+    if [ "$use_build" -eq 1 ]; then
+        quickstart_mode="build"
+    fi
+    local compose_flags
+    compose_flags=$(quickstart_compose_flags_for_mode "$quickstart_mode")
 
     # Check if .env.docker.local exists and has DB_ENCRYPTION_KEY
     if [ ! -f ".env.docker.local" ] || ! grep -q "^DB_ENCRYPTION_KEY=.\+" .env.docker.local 2>/dev/null; then
@@ -608,8 +655,21 @@ fi
     echo ""
     echo -e "${YELLOW}Starting services ...${NC}"
 
-    docker compose -p "$PROJECT_NAME" --env-file .env.docker.local up --build -d postgres redis backend worker frontend
-    if [ $? -eq 0 ]; then
+    local compose_rc=0
+    if [ "$use_build" -eq 1 ]; then
+        docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local up --build -d postgres redis backend worker frontend
+        compose_rc=$?
+    else
+        docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local pull postgres redis backend worker frontend
+        compose_rc=$?
+        if [ "$compose_rc" -eq 0 ]; then
+            docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local up -d postgres redis backend worker frontend
+            compose_rc=$?
+        fi
+    fi
+
+    if [ "$compose_rc" -eq 0 ]; then
+        echo "$quickstart_mode" > "$QUICKSTART_COMPOSE_MODE_FILE"
         echo ""
         echo -e "${GREEN}✅ All services started successfully!${NC}"
         echo ""
@@ -638,7 +698,9 @@ stop_all() {
         exit 1
     }
 
-    docker compose -p "$PROJECT_NAME" down
+    local compose_flags
+    compose_flags=$(quickstart_compose_flags_from_file)
+    docker compose $compose_flags -p "$PROJECT_NAME" down
 
     if [ $? -eq 0 ]; then
         echo -e "${GREEN}✅ All services stopped${NC}"
@@ -649,6 +711,7 @@ stop_all() {
 }
 
 # Function to restart all services (recreates containers so .env.docker.local changes apply)
+# Optional: --build  Rebuild from local Dockerfiles and switch quickstart mode to build.
 restart_all() {
     echo -e "${YELLOW}Restarting all Rhesis services...${NC}"
 
@@ -659,10 +722,33 @@ restart_all() {
 
     check_docker
 
-    # Recreate containers so updated .env.docker.local variables are applied
-    docker compose -p "$PROJECT_NAME" --env-file .env.docker.local up -d --force-recreate postgres redis backend worker frontend
+    local use_build=0
+    for arg in "$@"; do
+        if [ "$arg" = "--build" ]; then
+            use_build=1
+        fi
+    done
 
-    if [ $? -eq 0 ]; then
+    local quickstart_mode
+    if [ "$use_build" -eq 1 ]; then
+        quickstart_mode="build"
+    else
+        quickstart_mode=$(quickstart_compose_mode_from_file)
+    fi
+    local compose_flags
+    compose_flags=$(quickstart_compose_flags_for_mode "$quickstart_mode")
+
+    local compose_rc=0
+    if [ "$use_build" -eq 1 ]; then
+        docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local up -d --force-recreate --build postgres redis backend worker frontend
+        compose_rc=$?
+    else
+        docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local up -d --force-recreate postgres redis backend worker frontend
+        compose_rc=$?
+    fi
+
+    if [ "$compose_rc" -eq 0 ]; then
+        echo "$quickstart_mode" > "$QUICKSTART_COMPOSE_MODE_FILE"
         echo -e "${GREEN}✅ All services restarted with current .env.docker.local${NC}"
     else
         echo -e "${RED}❌ Error: Failed to restart services${NC}"
@@ -679,12 +765,15 @@ view_logs() {
         exit 1
     }
 
+    local compose_flags
+    compose_flags=$(quickstart_compose_flags_from_file)
+
     if [ -z "$1" ]; then
         # No service specified, show all logs
-        docker compose -p "$PROJECT_NAME" logs -f
+        docker compose $compose_flags -p "$PROJECT_NAME" logs -f
     else
         # Show logs for specific service
-        docker compose -p "$PROJECT_NAME" logs -f "$1"
+        docker compose $compose_flags -p "$PROJECT_NAME" logs -f "$1"
     fi
 }
 
@@ -720,14 +809,18 @@ delete_all() {
     # Use docker compose with explicit project name to ensure we only delete resources from THIS project
     # This prevents accidentally deleting containers with similar names from other projects
 
+    local compose_flags
+    compose_flags=$(quickstart_compose_flags_from_file)
+
     # Stop and remove containers, networks, and volumes managed by this compose file
-    docker compose -p "$PROJECT_NAME" down -v --rmi all 2>/dev/null || {
+    docker compose $compose_flags -p "$PROJECT_NAME" down -v --rmi all 2>/dev/null || {
         # Fallback: If project name doesn't match, try without -p flag
         echo -e "${YELLOW}⚠️  Project-specific deletion failed, trying default method...${NC}"
-        docker compose down -v --rmi all
+        docker compose $compose_flags down -v --rmi all
     }
 
     rm -f .env.docker.local
+    rm -f "$QUICKSTART_COMPOSE_MODE_FILE"
 
     if [ $? -eq 0 ]; then
         echo ""
@@ -1010,7 +1103,8 @@ test_frontend() {
 # Parse command line arguments
 case "$1" in
     "start")
-        start_all
+        shift
+        start_all "$@"
         ;;
     "dev")
         case "$2" in
@@ -1083,7 +1177,8 @@ case "$1" in
         stop_all
         ;;
     "restart")
-        restart_all
+        shift
+        restart_all "$@"
         ;;
     "logs")
         view_logs "$2"


### PR DESCRIPTION
## Purpose
Make `./rh start` work out of the box for new users by pulling prebuilt images from GHCR, and fix the GHCR publish workflow so those images actually get built (backend, worker, frontend). Also harden file logging so the backend container doesn't crash when `LOG_DIR` isn't writable.

## What Changed
- `.github/workflows/backend-ghcr.yml`
  - Added missing `actions/checkout@v6` step (the previous workflow had no checkout, so the build context was empty).
  - Added `provenance: false` to backend and worker builds to avoid GHCR multi-arch manifest issues.
  - Added a new `frontend` job that builds and pushes `ghcr.io/rhesis-ai/frontend:latest` (multi-arch, with the same `FRONTEND_ENV` / `NEXT_PUBLIC_*` build args used by the local Dockerfile).
- `docker-compose.ghcr.yml` (new)
  - Override file that points `backend`, `worker`, and `frontend` services at the GHCR `:latest` images and resets their `build:` blocks so compose pulls instead of building.
- `rh`
  - `./rh start` now defaults to GHCR images (pull + up). New `--build` flag preserves the old behavior of building locally from Dockerfiles.
  - `./rh restart` gains the same `--build` flag; without it, restart reuses whatever mode `start` used.
  - Selected mode is persisted to `.rhesis-quickstart-compose.mode` so `stop`, `logs`, `restart`, and `delete` all use a consistent `docker compose -f ...` flag set.
  - Help text updated to document the new defaults and `--build` flag.
- `apps/backend/src/rhesis/backend/logging/logging_config.py`
  - Wrap `LOG_DIR` creation + a write probe in a `try/except OSError`. If the directory isn't writable (typical in containers running as a non-root user), log a warning and fall back to console-only logging instead of crashing on handler setup.

## Additional Context
- Default quickstart UX is now: clone repo → `./rh start` → containers come up from prebuilt GHCR images, no local build required.
- Power users / contributors can still get the previous behavior with `./rh start --build`.
- `.rhesis-quickstart-compose.mode` is a local state file (gitignored via `?? ` status, not committed) that records the chosen mode per checkout.

## Testing
- `./rh start` (no flags) → pulls `ghcr.io/rhesis-ai/{backend,worker,frontend}:latest` and brings up postgres, redis, backend, worker, frontend.
- `./rh start --build` → builds all images locally from Dockerfiles as before.
- `./rh restart`, `./rh logs`, `./rh stop`, `./rh delete` → all use the same compose flags as the previous `start`/`restart`.
- Backend container with a read-only working directory → starts cleanly and emits the "Skipping file logging" warning instead of failing.
- Manually triggered `backend-ghcr.yml` → builds and pushes backend, worker, and frontend images to GHCR.