### PR TITLE
Add video walkthrough to Agent Skill docs

### DIFF
--- a/docs/content/docs/agent-skill/index.mdx
+++ b/docs/content/docs/agent-skill/index.mdx
@@ -8,6 +8,8 @@ The Rhesis Agent Skill packages the platform's domain knowledge into a portable 
   **This is different from Rhesis's inbound MCP connector** (where the platform imports content from Notion, GitHub, or Jira). Here, an external AI agent calls *into* Rhesis to drive the testing workflow.
 </Callout>
 
+<YouTubeEmbed videoId="_YYj98Lu5rU" />
+
 ## Prerequisites
 
 - A Rhesis account at [app.rhesis.ai](https://app.rhesis.ai) (or a self-hosted backend)


### PR DESCRIPTION
## Purpose
Embed the Rhesis v0.7.0 Agent Skill launch video directly in the documentation page so readers can see a live demo before working through the installation steps.

## What Changed
- Added `<YouTubeEmbed videoId="_YYj98Lu5rU" />` to `docs/content/docs/agent-skill/index.mdx`, placed after the intro callout and before the Prerequisites section

## Additional Context
- The video (2:05) walks through connecting the MCP server in Cursor, discovering endpoints, generating a test set, running it, and reviewing results — the full discover-plan-review-execute loop
- Uses the existing globally-registered `YouTubeEmbed` component (no new components or imports needed)
- Placement follows the same pattern used in `test-execution` and `conversation-tracing` docs pages

## Testing
- Verify the video renders correctly on the Agent Skill docs page
- Confirm layout is responsive (the component uses a 16:9 aspect ratio container)