### PR TITLE
Add Agent Skill cross-references and fix video spacing

### DIFF
--- a/docs/content/docs/getting-started/index.mdx
+++ b/docs/content/docs/getting-started/index.mdx
@@ -65,6 +65,13 @@ Pick a path that matches your goal — each card links to deeper docs.
     link="/docs/conversation-simulation"
     linkText="Conversation simulation →"
   />
+  <NextStepCard
+    emoji="🖥️"
+    title="Test from your IDE"
+    description="Run the full test workflow from Cursor or Claude Code."
+    link="/docs/agent-skill"
+    linkText="Agent Skill →"
+  />
 </NextStepCardGrid>
 
 <Callout type="default">

--- a/docs/content/docs/getting-started/run-evaluations.mdx
+++ b/docs/content/docs/getting-started/run-evaluations.mdx
@@ -66,6 +66,10 @@ Rhesis will orchestrate the execution, sending each test case to your applicatio
 
 For detailed information on configuring execution behavior, concurrency, and handling retries, see the [Test Execution Guide](/docs/test-execution).
 
+<Callout type="info">
+  **Prefer working from your IDE?** The [Agent Skill](/docs/agent-skill) lets you run the full discover-plan-execute workflow from Cursor, Claude Code, or any compatible AI interface — no browser tab required.
+</Callout>
+
 <Callout type="success">
 **Congratulations!** You've completed the Getting Started guide. To dive deeper, explore the [Product Tour](/docs/product-tour) or read up on our [Core Concepts](/docs/concepts).
 </Callout>

--- a/docs/content/docs/mcp/index.mdx
+++ b/docs/content/docs/mcp/index.mdx
@@ -3,6 +3,10 @@
 MCP (Model Context Protocol) servers allow you to export sources from external tools into your Rhesis Knowledge base.
 These sources can then be used in test generation and other workflows.
 
+<Callout type="info">
+  This page covers importing knowledge into Rhesis from tools like Notion, GitHub, and Jira. If you want to call Rhesis from Cursor or Claude Code to explore endpoints and run tests, see [Agent Skill](/docs/agent-skill) instead.
+</Callout>
+
 ![MCP Page](/screenshots/rhesis-ai-mcp.png)
 ## Setting Up an MCP Connection
 

--- a/docs/src/components/YouTubeEmbed.jsx
+++ b/docs/src/components/YouTubeEmbed.jsx
@@ -8,6 +8,7 @@ const styles = {
     paddingBottom: '56.25%',
     height: 0,
     overflow: 'hidden',
+    marginTop: '2rem',
     marginBottom: '2rem',
   },
   iframe: {


### PR DESCRIPTION
## Purpose
Make the Agent Skill discoverable from the pages users actually land on, and fix the video spacing that was too tight against the callout box.

## What Changed
- **`docs/src/components/YouTubeEmbed.jsx`** — added `marginTop: '2rem'` so the video always has breathing room above it (was missing, causing it to visually merge with callout boxes)
- **`docs/content/docs/getting-started/run-evaluations.mdx`** — added an info callout after "Running the Test Set" pointing users to Agent Skill for IDE-based workflows
- **`docs/content/docs/mcp/index.mdx`** — added a disambiguation callout at the top clarifying this page covers inbound knowledge sources, and pointing readers who want to call Rhesis from Cursor/Claude Code to Agent Skill
- **`docs/content/docs/getting-started/index.mdx`** — added a "Test from your IDE" `NextStepCard` alongside the existing CI/CD, conversation testing, and adversarial testing cards

## Additional Context
- The Architect page (`docs/content/docs/architect/index.mdx`) already links to Agent Skill in its "Related pages" section — no change needed there
- The `marginTop` fix applies globally to all `YouTubeEmbed` uses, which is the right behavior

## Testing
- Verify video spacing on the Agent Skill page looks correct
- Check that the Agent Skill callout renders on `run-evaluations` and `mcp` pages
- Confirm the new NextStepCard appears on the Getting Started overview