### PR TITLE
Prevent submission of whitespace-only token names

### DIFF
--- a/apps/frontend/src/app/(protected)/tokens/components/CreateTokenModal.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/CreateTokenModal.tsx
@@ -54,7 +54,7 @@ export default function CreateTokenModal({
     e.preventDefault();
     const trimmedName = name.trim();
     if (!trimmedName) return;
-    
+
     try {
       let expiresInDays: number | null = null;
 

--- a/apps/frontend/src/app/(protected)/tokens/components/CreateTokenModal.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/CreateTokenModal.tsx
@@ -52,6 +52,9 @@ export default function CreateTokenModal({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const trimmedName = name.trim();
+    if (!trimmedName) return;
+    
     try {
       let expiresInDays: number | null = null;
 
@@ -62,7 +65,7 @@ export default function CreateTokenModal({
         expiresInDays = parseInt(expiryOption);
       }
 
-      await onCreateToken(name, expiresInDays);
+      await onCreateToken(trimmedName, expiresInDays);
       handleClose();
     } catch (_error) {}
   };
@@ -124,7 +127,7 @@ export default function CreateTokenModal({
         </DialogContent>
         <DialogActions>
           <Button onClick={handleClose}>Cancel</Button>
-          <Button type="submit" variant="contained">
+          <Button type="submit" variant="contained" disabled={!name.trim()}>
             Create
           </Button>
         </DialogActions>


### PR DESCRIPTION
Prevents creation of tokens with names that contain only whitespace.

## Changes
- Trim token name before submitting
- Block submission if trimmed name is empty
- Disable "Create" button when input is only whitespace