### PR TITLE
Fix default embedding model and secure generation endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,7 +62,7 @@ DB_ENCRYPTION_KEY=BASE64_ENCODED_DB_ENCRYPTION_KEY
 # Default models (format: provider/model_name)
 DEFAULT_GENERATION_MODEL=rhesis/rhesis-default
 DEFAULT_EVALUATION_MODEL=rhesis/rhesis-default
-DEFAULT_EMBEDDING_MODEL=vertex_ai/text-embedding-005
+DEFAULT_EMBEDDING_MODEL=rhesis/rhesis-embedding
 
 # Azure OpenAI (if using Azure)
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/

--- a/apps/backend/src/rhesis/backend/app/constants.py
+++ b/apps/backend/src/rhesis/backend/app/constants.py
@@ -113,7 +113,7 @@ DEFAULT_EVALUATION_MODEL = os.getenv(
 DEFAULT_EXECUTION_MODEL = os.getenv(
     "DEFAULT_EXECUTION_MODEL", "rhesis/rhesis-default"
 )  # Default model for multi-turn test execution (Penelope)
-DEFAULT_EMBEDDING_MODEL = os.getenv("DEFAULT_EMBEDDING_MODEL", "vertex_ai/text-embedding-005")
+DEFAULT_EMBEDDING_MODEL = os.getenv("DEFAULT_EMBEDDING_MODEL", "rhesis/rhesis-embedding")
 
 DEFAULT_CONVERSATION_DEBOUNCE_SECONDS = int(
     os.getenv("DEFAULT_CONVERSATION_DEBOUNCE_SECONDS", "300")

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -193,7 +193,11 @@ async def create_chat_completion_endpoint(request: dict):
 
 
 @router.post("/generate/content")
-async def generate_content_endpoint(request: GenerateContentRequest):
+async def generate_content_endpoint(
+    request: GenerateContentRequest,
+    db: Session = Depends(get_tenant_db_session),
+    current_user: User = Depends(require_current_user_or_token),
+):
     """
     Generate text using LLM with optional OpenAI-wrapped JSON schema for structured output.
 
@@ -235,18 +239,10 @@ async def generate_content_endpoint(request: GenerateContentRequest):
     "type": "json_schema" wrapper with name, schema, and strict fields.
     """
     try:
-        from rhesis.backend.app.constants import DEFAULT_GENERATION_MODEL
-        from rhesis.sdk.models.factory import get_model
+        from rhesis.backend.app.utils.user_model_utils import get_generation_model_with_override
 
-        prompt = request.prompt
-        schema = request.schema_
-
-        # Use the default generation model from constants
-        # This respects the global configuration (currently vertex_ai/gemini-2.0-flash)
-        model = get_model(DEFAULT_GENERATION_MODEL)
-
-        response = await model.a_generate(prompt, schema=schema)
-
+        model = get_generation_model_with_override(db, current_user)
+        response = await model.a_generate(request.prompt, schema=request.schema_)
         return response
     except Exception as e:
         error_msg = str(e) if str(e) else "Unknown error"
@@ -255,20 +251,24 @@ async def generate_content_endpoint(request: GenerateContentRequest):
 
 
 @router.post("/generate/embedding")
-async def generate_embedding_endpoint(request: GenerateEmbeddingRequest):
+async def generate_embedding_endpoint(
+    request: GenerateEmbeddingRequest,
+    db: Session = Depends(get_tenant_db_session),
+    current_user: User = Depends(require_current_user_or_token),
+):
     """
-    Generate an embedding for a given text.
+    Generate an embedding for a given text using the user's configured embedding model.
+
+    Args:
+        request: The request containing the text to embed
+        db: The database session
+        current_user: The current authenticated user
     """
     try:
-        from rhesis.backend.app.constants import DEFAULT_EMBEDDING_MODEL
-        from rhesis.sdk.models.factory import get_model
+        from rhesis.backend.app.utils.user_model_utils import get_user_embedding_model
 
-        text = request.text
-
-        # First arg is provider; "provider/model_name" is resolved in the background
-        embedder = get_model(DEFAULT_EMBEDDING_MODEL, model_type="embedding")
-        embedding = embedder.generate(text=text)
-
+        embedder = get_user_embedding_model(db, current_user)
+        embedding = embedder.generate(text=request.text)
         return embedding
     except Exception as e:
         error_msg = str(e) if str(e) else "Unknown error"

--- a/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.models.enums import EmbeddingStatus
 from rhesis.backend.app.utils.crud_utils import get_item
+from rhesis.sdk.models.factory import EmbeddingModelConfig, get_embedding_model
 
 logger = logging.getLogger(__name__)
 
@@ -46,32 +47,17 @@ class EmbeddingGenerator:
 
     def _generate_embedding_vector(
         self,
-        searchable_text: str,
-        provider: str,
-        model_name: str,
-        api_key: str,
-        dimension: int,
+        sdk_config: EmbeddingModelConfig,
+        searchable_text: str
     ) -> List[float]:
         """Generate embedding for a searchable text."""
-        from rhesis.sdk.models.factory import EmbeddingModelConfig, get_embedding_model
 
-        config = EmbeddingModelConfig(
-            provider=provider,
-            model_name=model_name,
-            api_key=api_key,
-            dimensions=dimension,
-        )
-        try:
-            embedder = get_embedding_model(config=config)
-        except ValueError as e:
-            raise ValueError(f"Failed to create embedder: {e}")
+        embedder = get_embedding_model(config=sdk_config)
 
         try:
-            embedding = embedder.generate(searchable_text)
+            return embedder.generate(searchable_text)
         except Exception as e:
             raise ValueError(f"Failed to generate embedding: {e}")
-
-        return embedding
 
     def generate(
         self,
@@ -112,18 +98,19 @@ class EmbeddingGenerator:
         if not model:
             raise ValueError(f"Model not found: {model_id}")
 
-        # Extract model details
-        provider = model.provider_type.type_value if model.provider_type else None
-        model_name = model.model_name
-        dimension = model.dimension
-
-        # Create configuration for this embedding
+        # Create configuration for this embedding. Stored in the db, and used for deduplication
         config = {
-            "provider": provider,
-            "model_name": model_name,
-            "dimension": dimension,
+            "provider": model.provider_type.type_value if model.provider_type else None,
+            "model_name": model.model_name,
+            "dimension": model.dimension,
             "model_id": model_id,
         }
+
+        # SDK config: same fields plus api_key for authentication
+        sdk_config = EmbeddingModelConfig(
+            **config,
+            api_key=model.key,
+        )
 
         # Compute hashes for deduplication
         config_hash = self._compute_hash(config)
@@ -168,7 +155,8 @@ class EmbeddingGenerator:
 
         # Generate the embedding vector
         embedding_vector = self._generate_embedding_vector(
-            searchable_text, provider, model_name, model.key, dimension
+            sdk_config=sdk_config,
+            searchable_text=searchable_text,
         )
 
         # Mark old embeddings as stale (different text/config)
@@ -228,7 +216,8 @@ class EmbeddingGenerator:
             raise
 
         logger.info(
-            f"Successfully generated embedding for {entity_type}:{entity_id}, dimension={dimension}"
+            f"Successfully generated embedding for "
+            f"{entity_type}:{entity_id}, dimension={sdk_config.dimensions}"
         )
 
         return {"status": "success", "embedding_id": str(new_embedding.id)}

--- a/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.models.enums import EmbeddingStatus
 from rhesis.backend.app.utils.crud_utils import get_item
-from rhesis.sdk.models.factory import EmbeddingModelConfig, get_embedding_model
+from rhesis.backend.app.utils.user_model_utils import get_user_embedding_model
 
 logger = logging.getLogger(__name__)
 
@@ -44,20 +44,6 @@ class EmbeddingGenerator:
             data_str = data
 
         return hashlib.sha256(data_str.encode("utf-8")).hexdigest()
-
-    def _generate_embedding_vector(
-        self,
-        sdk_config: EmbeddingModelConfig,
-        searchable_text: str
-    ) -> List[float]:
-        """Generate embedding for a searchable text."""
-
-        embedder = get_embedding_model(config=sdk_config)
-
-        try:
-            return embedder.generate(searchable_text)
-        except Exception as e:
-            raise ValueError(f"Failed to generate embedding: {e}")
 
     def generate(
         self,
@@ -94,7 +80,7 @@ class EmbeddingGenerator:
             searchable_text = entity.to_searchable_text()
 
         # Fetch model to get all configuration
-        model = crud.get_model(self.db, model_id, organization_id, user_id)
+        model = get_user_embedding_model(self.db, user_id)
         if not model:
             raise ValueError(f"Model not found: {model_id}")
 
@@ -105,12 +91,6 @@ class EmbeddingGenerator:
             "dimension": model.dimension,
             "model_id": model_id,
         }
-
-        # SDK config: same fields plus api_key for authentication
-        sdk_config = EmbeddingModelConfig(
-            **config,
-            api_key=model.key,
-        )
 
         # Compute hashes for deduplication
         config_hash = self._compute_hash(config)
@@ -154,10 +134,10 @@ class EmbeddingGenerator:
             return {"status": "success", "embedding_id": str(existing_embedding.id)}
 
         # Generate the embedding vector
-        embedding_vector = self._generate_embedding_vector(
-            sdk_config=sdk_config,
-            searchable_text=searchable_text,
-        )
+        try:
+            embedding_vector = model.generate(searchable_text)
+        except Exception as e:
+            raise ValueError(f"Failed to generate embedding: {e}")
 
         # Mark old embeddings as stale (different text/config)
         stale_count = crud.mark_embeddings_stale(
@@ -217,7 +197,7 @@ class EmbeddingGenerator:
 
         logger.info(
             f"Successfully generated embedding for "
-            f"{entity_type}:{entity_id}, dimension={sdk_config.dimensions}"
+            f"{entity_type}:{entity_id}, dimension={model.dimensions}"
         )
 
         return {"status": "success", "embedding_id": str(new_embedding.id)}

--- a/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
@@ -3,14 +3,16 @@
 import hashlib
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.models.enums import EmbeddingStatus
+from rhesis.backend.app.models.user import User
 from rhesis.backend.app.utils.crud_utils import get_item
 from rhesis.backend.app.utils.user_model_utils import get_user_embedding_model
+from rhesis.sdk.models.factory import get_model
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +47,43 @@ class EmbeddingGenerator:
 
         return hashlib.sha256(data_str.encode("utf-8")).hexdigest()
 
+    def _resolve_embedder(self, user_id: str, db_model: models.Model, embedder: Any = None) -> Any:
+        """Resolve a runnable embedder instance from user settings when not injected."""
+        if embedder is not None:
+            return embedder
+
+        user = self.db.query(User).filter(User.id == user_id).first()
+        if not user:
+            raise ValueError(f"User not found: {user_id}")
+
+        resolved = get_user_embedding_model(self.db, user)
+        return (
+            get_model(
+                resolved,
+                model_type="embedding",
+                dimensions=db_model.dimension,
+            )
+            if isinstance(resolved, str)
+            else resolved
+        )
+
+    def _get_status(self, name: EmbeddingStatus, organization_id: str, user_id: str):
+        """Fetch or create embedding status row and fail fast when unavailable."""
+        from rhesis.backend.app.utils.crud_utils import get_or_create_status
+
+        status = get_or_create_status(
+            self.db,
+            name=name.value,
+            entity_type="Embedding",
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if not status:
+            raise ValueError(
+                f"Failed to create or retrieve {name.value.title()} status for Embedding."
+            )
+        return status
+
     def generate(
         self,
         entity_id: str,
@@ -54,6 +93,7 @@ class EmbeddingGenerator:
         model_id: str,
         entity: Optional[Any] = None,
         searchable_text: Optional[str] = None,
+        embedder: Optional[Any] = None,
     ) -> Dict[str, Any]:
         """
         Generate embedding for any embeddable entity.
@@ -66,6 +106,7 @@ class EmbeddingGenerator:
             model_id: ID of the embedding model to use
             entity: Optional entity object (used when searchable_text is not provided)
             searchable_text: Precomputed searchable text; when set, entity is not loaded for text
+            embedder: Optional pre-resolved embedder. If missing, it is resolved from user settings.
 
         Returns:
             Dictionary with generation result
@@ -79,16 +120,17 @@ class EmbeddingGenerator:
 
             searchable_text = entity.to_searchable_text()
 
-        # Fetch model to get all configuration
-        model = get_user_embedding_model(self.db, user_id)
-        if not model:
+        # Model row for persistence / hashing (entity-scoped embedding model)
+        db_model = crud.get_model(self.db, model_id=model_id, organization_id=organization_id)
+        if not db_model:
             raise ValueError(f"Model not found: {model_id}")
+        embedder = self._resolve_embedder(user_id=user_id, db_model=db_model, embedder=embedder)
 
         # Create configuration for this embedding. Stored in the db, and used for deduplication
         config = {
-            "provider": model.provider_type.type_value if model.provider_type else None,
-            "model_name": model.model_name,
-            "dimension": model.dimension,
+            "provider": db_model.provider_type.type_value if db_model.provider_type else None,
+            "model_name": db_model.model_name,
+            "dimension": db_model.dimension,
             "model_id": model_id,
         }
 
@@ -96,27 +138,8 @@ class EmbeddingGenerator:
         config_hash = self._compute_hash(config)
         text_hash = self._compute_hash(searchable_text)
 
-        from rhesis.backend.app.utils.crud_utils import get_or_create_status
-
-        active_status = get_or_create_status(
-            self.db,
-            name=EmbeddingStatus.ACTIVE.value,
-            entity_type="Embedding",
-            organization_id=organization_id,
-            user_id=user_id,
-        )
-        if not active_status:
-            raise ValueError("Failed to create or retrieve Active status for Embedding.")
-
-        stale_status = get_or_create_status(
-            self.db,
-            name=EmbeddingStatus.STALE.value,
-            entity_type="Embedding",
-            organization_id=organization_id,
-            user_id=user_id,
-        )
-        if not stale_status:
-            raise ValueError("Failed to create or retrieve Stale status for Embedding.")
+        active_status = self._get_status(EmbeddingStatus.ACTIVE, organization_id, user_id)
+        stale_status = self._get_status(EmbeddingStatus.STALE, organization_id, user_id)
 
         # Check if embedding already exists (same text/config)
         existing_embedding = crud.get_embedding_by_hash(
@@ -135,7 +158,7 @@ class EmbeddingGenerator:
 
         # Generate the embedding vector
         try:
-            embedding_vector = model.generate(searchable_text)
+            embedding_vector = embedder.generate(searchable_text)
         except Exception as e:
             raise ValueError(f"Failed to generate embedding: {e}")
 
@@ -197,7 +220,7 @@ class EmbeddingGenerator:
 
         logger.info(
             f"Successfully generated embedding for "
-            f"{entity_type}:{entity_id}, dimension={model.dimensions}"
+            f"{entity_type}:{entity_id}, dimension={db_model.dimension}"
         )
 
         return {"status": "success", "embedding_id": str(new_embedding.id)}

--- a/apps/backend/src/rhesis/backend/app/services/test_config_generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_config_generator.py
@@ -60,11 +60,7 @@ class TestConfigGeneratorService:
                 model_id=str(model_id),
                 organization_id=str(self.user.organization_id),
             )
-            if (
-                row
-                and row.provider_type
-                and row.provider_type.type_value == "polyphemus"
-            ):
+            if row and row.provider_type and row.provider_type.type_value == "polyphemus":
                 use_fast_default = True
         if use_fast_default:
             logger.info(

--- a/apps/backend/src/rhesis/backend/app/services/test_config_generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_config_generator.py
@@ -5,6 +5,7 @@ This service handles the generation of test configurations based on user prompts
 using LLM and Jinja2 templates.
 """
 
+import logging
 from pathlib import Path
 from typing import Optional
 
@@ -13,9 +14,12 @@ import jinja2
 from rhesis.backend.app import crud
 from rhesis.backend.app.constants import DEFAULT_GENERATION_MODEL
 from rhesis.backend.app.schemas.services import TestConfigResponse
+from rhesis.backend.app.utils.model_errors import ModelConfigurationError
+from rhesis.backend.app.utils.user_model_utils import get_user_generation_model
 from rhesis.sdk.models.factory import get_model
 
 MAX_SAMPLE_SIZE = 6
+logger = logging.getLogger(__name__)
 
 
 class TestConfigGeneratorService:
@@ -37,11 +41,64 @@ class TestConfigGeneratorService:
         self.db = db
         self.user = user
 
-        # Use system default model instead of user's configured model.
-        # Long-running models like Polyphemus are too slow for test config
-        # generation, which needs to be fast and interactive. The user's
-        # model is still used for the actual test generation.
-        self.llm = get_model(DEFAULT_GENERATION_MODEL)
+        self.llm = self._resolve_llm()
+
+    def _resolve_llm(self):
+        """
+        Resolve the LLM for test-config generation.
+
+        Use the user's configured generation model except when it is Polyphemus,
+        which is too slow for this interactive step; in that case use the fast
+        system default (same as ``DEFAULT_GENERATION_MODEL``).
+        """
+        gen_settings = getattr(self.user.settings.models, "generation")
+        model_id = gen_settings.model_id
+        use_fast_default = False
+        if model_id:
+            row = crud.get_model(
+                db=self.db,
+                model_id=str(model_id),
+                organization_id=str(self.user.organization_id),
+            )
+            if (
+                row
+                and row.provider_type
+                and row.provider_type.type_value == "polyphemus"
+            ):
+                use_fast_default = True
+        if use_fast_default:
+            logger.info(
+                "User generation model is Polyphemus; using fast system default for test config"
+            )
+            try:
+                return get_model(DEFAULT_GENERATION_MODEL)
+            except ValueError as e:
+                logger.warning(
+                    "Fast system default unavailable for test config (Polyphemus user); "
+                    "falling back to Polyphemus: %s",
+                    e,
+                )
+                user_model = get_user_generation_model(self.db, self.user)
+                if isinstance(user_model, str):
+                    try:
+                        return get_model(user_model, model_type="language")
+                    except ValueError as inner:
+                        raise ModelConfigurationError(
+                            f"User model initialization failed: {inner}",
+                            original_error=inner,
+                        ) from inner
+                return user_model
+
+        user_model = get_user_generation_model(self.db, self.user)
+        if isinstance(user_model, str):
+            try:
+                return get_model(user_model, model_type="language")
+            except ValueError as e:
+                raise ModelConfigurationError(
+                    f"User model initialization failed: {e}",
+                    original_error=e,
+                ) from e
+        return user_model
 
     async def generate_config(
         self,

--- a/apps/backend/src/rhesis/backend/app/utils/execution_validation.py
+++ b/apps/backend/src/rhesis/backend/app/utils/execution_validation.py
@@ -6,7 +6,6 @@ and generation endpoints. Follows separation of concerns and DRY principles.
 """
 
 import logging
-from typing import Optional
 
 from fastapi import Depends, HTTPException
 from sqlalchemy.orm import Session
@@ -14,6 +13,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import get_tenant_db_session
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 from rhesis.backend.app.utils.user_model_utils import (
     validate_user_evaluation_model,
     validate_user_execution_model,
@@ -21,15 +21,6 @@ from rhesis.backend.app.utils.user_model_utils import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-class ModelConfigurationError(Exception):
-    """Raised when user's model configuration is invalid."""
-
-    def __init__(self, message: str, original_error: Optional[Exception] = None):
-        self.message = message
-        self.original_error = original_error
-        super().__init__(self.message)
 
 
 def validate_execution_model(
@@ -57,7 +48,7 @@ def validate_execution_model(
     try:
         validate_user_evaluation_model(db, current_user)
         validate_user_execution_model(db, current_user)
-    except ValueError as e:
+    except ModelConfigurationError as e:
         raise _convert_model_error_to_http_exception(e, "execution")
 
 
@@ -85,58 +76,33 @@ def validate_generation_model(
     """
     try:
         validate_user_generation_model(db, current_user)
-    except ValueError as e:
+    except ModelConfigurationError as e:
         raise _convert_model_error_to_http_exception(e, "generation")
 
 
-def _convert_model_error_to_http_exception(error: ValueError, context: str) -> HTTPException:
+def _convert_model_error_to_http_exception(
+    error: ModelConfigurationError, context: str
+) -> HTTPException:
     """
-    Convert a model configuration ValueError to an HTTPException.
-
-    Detects specific types of model configuration errors and provides
-    appropriate user-facing error messages.
+    Convert a model configuration error to an HTTPException.
 
     Args:
-        error: The ValueError from model validation
+        error: The model configuration error
         context: Context string ("execution" or "generation")
 
     Returns:
         HTTPException with appropriate status code and message
     """
     error_msg = str(error)
-    error_msg_lower = error_msg.lower()
-
-    # Check if this is a model configuration error
-    is_model_error = any(
-        keyword in error_msg_lower
-        for keyword in [
-            "api_key",
-            "not set",
-            "not configured",
-            "api key",
-            "authentication",
-            "provider",
-            "not supported",
-            "model",
-            "not found",
-            "invalid",
-        ]
+    logger.warning(f"Model configuration error for {context}: {error_msg}")
+    action = "execute tests" if context == "execution" else "generate tests"
+    return HTTPException(
+        status_code=400,
+        detail=(
+            f"Cannot {action} due to a problem with your configured model: {error_msg}. "
+            "Please check your model settings in the Models page."
+        ),
     )
-
-    if is_model_error:
-        logger.warning(f"Model configuration error for {context}: {error_msg}")
-        action = "execute tests" if context == "execution" else "generate tests"
-        return HTTPException(
-            status_code=400,
-            detail=(
-                f"Cannot {action} due to a problem with your configured model: {error_msg}. "
-                "Please check your model settings in the Models page."
-            ),
-        )
-
-    # Generic validation error
-    logger.error(f"Validation error for {context}: {error_msg}", exc_info=True)
-    return HTTPException(status_code=400, detail=error_msg)
 
 
 def handle_execution_error(error: Exception, operation: str = "execute tests") -> HTTPException:
@@ -156,8 +122,12 @@ def handle_execution_error(error: Exception, operation: str = "execute tests") -
         # Already an HTTPException, re-raise as-is
         raise error
 
-    if isinstance(error, ValueError):
+    if isinstance(error, ModelConfigurationError):
         return _convert_model_error_to_http_exception(error, operation)
+
+    if isinstance(error, ValueError):
+        logger.error(f"Validation error for {operation}: {str(error)}", exc_info=True)
+        return HTTPException(status_code=400, detail=str(error))
 
     if isinstance(error, PermissionError):
         logger.warning(f"Permission denied for {operation}: {str(error)}")

--- a/apps/backend/src/rhesis/backend/app/utils/model_errors.py
+++ b/apps/backend/src/rhesis/backend/app/utils/model_errors.py
@@ -1,0 +1,12 @@
+"""Shared model-related exceptions."""
+
+from typing import Optional
+
+
+class ModelConfigurationError(ValueError):
+    """Raised when a model configuration is invalid or unavailable."""
+
+    def __init__(self, message: str, original_error: Optional[Exception] = None):
+        self.message = message
+        self.original_error = original_error
+        super().__init__(self.message)

--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -19,6 +19,7 @@ from rhesis.backend.app.constants import (
     DEFAULT_GENERATION_MODEL,
 )
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 from rhesis.sdk.models.base import BaseEmbedder, BaseLLM
 from rhesis.sdk.models.factory import get_model
 
@@ -467,30 +468,34 @@ def _fetch_and_configure_model(
         # Provide specific error messages based on the type of configuration issue
         if "api_key" in error_msg_lower or "not set" in error_msg_lower:
             logger.error(f"[LLM_UTILS] User model API key not configured: {error_msg}")
-            raise ValueError(
+            raise ModelConfigurationError(
                 f"Your configured model '{model.name}' ({provider}/{model_name}) requires "
                 f"an API key that is missing or invalid. "
-                f"Please update your API key in the Models settings."
+                f"Please update your API key in the Models settings.",
+                original_error=e,
             )
         elif "provider" in error_msg_lower or "not supported" in error_msg_lower:
             logger.error(f"[LLM_UTILS] Invalid provider for user model: {error_msg}")
-            raise ValueError(
+            raise ModelConfigurationError(
                 f"Your configured model '{model.name}' uses an unsupported provider ({provider}). "
-                f"Please select a different model in the Models settings."
+                f"Please select a different model in the Models settings.",
+                original_error=e,
             )
         elif "model" in error_msg_lower and (
             "not found" in error_msg_lower or "invalid" in error_msg_lower
         ):
             logger.error(f"[LLM_UTILS] Invalid model name for user model: {error_msg}")
-            raise ValueError(
+            raise ModelConfigurationError(
                 f"Your configured model '{model.name}' has an invalid model name ({model_name}). "
-                f"Please select a valid model in the Models settings."
+                f"Please select a valid model in the Models settings.",
+                original_error=e,
             )
         else:
             # Generic configuration error
             logger.error(f"[LLM_UTILS] Failed to configure user model: {error_msg}")
-            raise ValueError(
-                f"Failed to initialize your configured model '{model.name}': {error_msg}"
+            raise ModelConfigurationError(
+                f"Failed to initialize your configured model '{model.name}': {error_msg}",
+                original_error=e,
             )
 
 
@@ -606,22 +611,25 @@ def _fetch_and_configure_embedder(
         # Provide specific error messages based on the type of configuration issue
         if "api_key" in error_msg_lower or "not set" in error_msg_lower:
             logger.error(f"[LLM_UTILS] Embedder API key not configured: {error_msg}")
-            raise ValueError(
+            raise ModelConfigurationError(
                 f"Your configured embedding model '{model.name}' ({provider}/{model_name}) "
                 f"requires an API key that is missing or invalid. "
-                f"Please update your API key in the Models settings."
+                f"Please update your API key in the Models settings.",
+                original_error=e,
             )
         elif "provider" in error_msg_lower or "not supported" in error_msg_lower:
             logger.error(f"[LLM_UTILS] Invalid provider for embedder: {error_msg}")
-            raise ValueError(
+            raise ModelConfigurationError(
                 f"Your configured embedding model '{model.name}' uses an unsupported "
-                f"provider ({provider}). Please select a different model in the Models settings."
+                f"provider ({provider}). Please select a different model in the Models settings.",
+                original_error=e,
             )
         else:
             logger.error(f"[LLM_UTILS] Failed to configure embedder: {error_msg}")
-            raise ValueError(
+            raise ModelConfigurationError(
                 f"Failed to configure your embedding model '{model.name}': {error_msg}. "
-                f"Please check your model configuration in the Models settings."
+                f"Please check your model configuration in the Models settings.",
+                original_error=e,
             )
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ x-rhesis-config: &rhesis-config
   BACKEND_URL: ${BACKEND_URL:-http://backend:8080}
   DEFAULT_GENERATION_MODEL: ${DEFAULT_GENERATION_MODEL:-rhesis/rhesis-default}
   DEFAULT_EVALUATION_MODEL: ${DEFAULT_EVALUATION_MODEL:-rhesis/rhesis-default}
-  DEFAULT_EMBEDDING_MODEL: ${DEFAULT_EMBEDDING_MODEL:-vertex_ai/text-embedding-005}
+  DEFAULT_EMBEDDING_MODEL: ${DEFAULT_EMBEDDING_MODEL:-rhesis/rhesis-embedding}
 
 x-telemetry-config: &telemetry-config
   OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-https://telemetry.rhesis.ai}

--- a/tests/backend/routes/test_execution_validation.py
+++ b/tests/backend/routes/test_execution_validation.py
@@ -17,6 +17,7 @@ from rhesis.backend.app.utils.execution_validation import (
     validate_execution_model,
     validate_generation_model,
 )
+from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 
 
 class TestExecutionModelValidation:
@@ -50,7 +51,7 @@ class TestExecutionModelValidation:
                 "rhesis.backend.app.utils.execution_validation.validate_user_execution_model"
             ),
         ):
-            mock_validate.side_effect = ValueError(
+            mock_validate.side_effect = ModelConfigurationError(
                 "API key not found for provider 'openai'. Please configure your model settings."
             )
 
@@ -72,7 +73,9 @@ class TestExecutionModelValidation:
                 "rhesis.backend.app.utils.execution_validation.validate_user_execution_model"
             ),
         ):
-            mock_validate.side_effect = ValueError("Unsupported LLM provider: custom_provider")
+            mock_validate.side_effect = ModelConfigurationError(
+                "Unsupported LLM provider: custom_provider"
+            )
 
             with pytest.raises(HTTPException) as exc_info:
                 validate_execution_model(db=test_db, current_user=authenticated_user)
@@ -92,7 +95,7 @@ class TestExecutionModelValidation:
                 "rhesis.backend.app.utils.execution_validation.validate_user_execution_model"
             ),
         ):
-            mock_validate.side_effect = ValueError(
+            mock_validate.side_effect = ModelConfigurationError(
                 "Model 'gpt-5-ultra' not found in provider 'openai'"
             )
 
@@ -105,7 +108,7 @@ class TestExecutionModelValidation:
             assert "model" in detail
 
     def test_validate_execution_model_generic_error(self, test_db, authenticated_user):
-        """Test validation raises 400 with generic message for unknown errors."""
+        """Validators that raise plain ValueError propagate (not model-config mapping)."""
         with (
             patch(
                 "rhesis.backend.app.utils.execution_validation.validate_user_evaluation_model"
@@ -116,12 +119,8 @@ class TestExecutionModelValidation:
         ):
             mock_validate.side_effect = ValueError("Something went wrong")
 
-            with pytest.raises(HTTPException) as exc_info:
+            with pytest.raises(ValueError, match="Something went wrong"):
                 validate_execution_model(db=test_db, current_user=authenticated_user)
-
-            # Non-model-related errors return the error message as-is
-            assert exc_info.value.status_code == 400
-            assert "something went wrong" in str(exc_info.value.detail).lower()
 
     def test_validate_execution_model_calls_both_validators(
         self, test_db, authenticated_user
@@ -156,7 +155,7 @@ class TestExecutionModelValidation:
             ) as mock_exec,
         ):
             mock_eval.return_value = None
-            mock_exec.side_effect = ValueError(
+            mock_exec.side_effect = ModelConfigurationError(
                 "API key not found for provider 'anthropic'."
             )
 
@@ -189,7 +188,7 @@ class TestGenerationModelValidation:
         with patch(
             "rhesis.backend.app.utils.execution_validation.validate_user_generation_model"
         ) as mock_validate:
-            mock_validate.side_effect = ValueError(
+            mock_validate.side_effect = ModelConfigurationError(
                 "API key not found for provider 'anthropic'. Please configure your model settings."
             )
 
@@ -206,7 +205,7 @@ class TestGenerationModelValidation:
         with patch(
             "rhesis.backend.app.utils.execution_validation.validate_user_generation_model"
         ) as mock_validate:
-            mock_validate.side_effect = ValueError("Unknown provider: fake_llm")
+            mock_validate.side_effect = ModelConfigurationError("Unknown provider: fake_llm")
 
             with pytest.raises(HTTPException) as exc_info:
                 validate_generation_model(db=test_db, current_user=authenticated_user)
@@ -231,9 +230,9 @@ class TestHandleExecutionError:
         assert exc_info.value.status_code == 404
         assert exc_info.value.detail == "Not found"
 
-    def test_handle_value_error_with_api_key(self):
-        """Test ValueError about API key is converted to specific message."""
-        error = ValueError(
+    def test_handle_model_configuration_error_with_api_key(self):
+        """Test ModelConfigurationError about API key is converted to specific message."""
+        error = ModelConfigurationError(
             "API key not found for provider 'openai'. Please configure your model settings."
         )
 
@@ -244,9 +243,9 @@ class TestHandleExecutionError:
         assert "configured model" in detail
         assert "api key" in detail
 
-    def test_handle_value_error_with_provider(self):
-        """Test ValueError about provider is converted to specific message."""
-        error = ValueError("Unsupported provider: custom_llm")
+    def test_handle_model_configuration_error_with_provider(self):
+        """Test ModelConfigurationError about provider is converted to specific message."""
+        error = ModelConfigurationError("Unsupported provider: custom_llm")
 
         result = handle_execution_error(error, "generate test set")
 
@@ -297,7 +296,9 @@ class TestErrorMessageContent:
                 "rhesis.backend.app.utils.execution_validation.validate_user_execution_model"
             ),
         ):
-            mock_validate.side_effect = ValueError("API key not found for provider 'openai'")
+            mock_validate.side_effect = ModelConfigurationError(
+                "API key not found for provider 'openai'"
+            )
 
             with pytest.raises(HTTPException) as exc_info:
                 validate_execution_model(db=test_db, current_user=authenticated_user)
@@ -311,7 +312,9 @@ class TestErrorMessageContent:
         with patch(
             "rhesis.backend.app.utils.execution_validation.validate_user_generation_model"
         ) as mock_validate:
-            mock_validate.side_effect = ValueError("Unsupported provider: fake_provider")
+            mock_validate.side_effect = ModelConfigurationError(
+                "Unsupported provider: fake_provider"
+            )
 
             with pytest.raises(HTTPException) as exc_info:
                 validate_generation_model(db=test_db, current_user=authenticated_user)
@@ -332,7 +335,7 @@ class TestErrorMessageContent:
                 "rhesis.backend.app.utils.execution_validation.validate_user_execution_model"
             ),
         ):
-            mock_validate.side_effect = ValueError(
+            mock_validate.side_effect = ModelConfigurationError(
                 "Model 'gpt-10' not found in provider 'openai'"
             )
 

--- a/tests/backend/routes/test_services.py
+++ b/tests/backend/routes/test_services.py
@@ -20,19 +20,26 @@ class TestGenerateContentEndpoint:
         )
 
         expected_response = {"code": "def test_function():\n    return True"}
+        mock_db = MagicMock()
+        mock_user = MagicMock()
 
-        with patch("rhesis.sdk.models.factory.get_model") as mock_get_model:
+        with patch(
+            "rhesis.backend.app.utils.user_model_utils.get_generation_model_with_override"
+        ) as mock_get_gen:
             mock_model = MagicMock()
             mock_model.a_generate = AsyncMock(return_value=expected_response)
-            mock_get_model.return_value = mock_model
+            mock_get_gen.return_value = mock_model
 
-            result = await generate_content_endpoint(mock_request)
+            result = await generate_content_endpoint(
+                mock_request, db=mock_db, current_user=mock_user
+            )
 
             assert result == expected_response
             mock_model.a_generate.assert_called_once_with(
                 "Generate a test function",
                 schema={"type": "object", "properties": {"code": {"type": "string"}}},
             )
+            mock_get_gen.assert_called_once_with(mock_db, mock_user)
 
     @pytest.mark.asyncio
     async def test_generate_content_endpoint_exception_handling(self):
@@ -42,14 +49,19 @@ class TestGenerateContentEndpoint:
             prompt="Generate a test function",
             schema={"type": "object"},
         )
+        mock_db = MagicMock()
+        mock_user = MagicMock()
 
-        # Mock the get_model factory function to raise an exception
-        with patch("rhesis.sdk.models.factory.get_model") as mock_get_model:
-            mock_get_model.side_effect = Exception("Model initialization failed")
+        with patch(
+            "rhesis.backend.app.utils.user_model_utils.get_generation_model_with_override"
+        ) as mock_get_gen:
+            mock_get_gen.side_effect = Exception("Model initialization failed")
 
             # Act & Assert
             with pytest.raises(HTTPException) as exc_info:
-                await generate_content_endpoint(mock_request)
+                await generate_content_endpoint(
+                    mock_request, db=mock_db, current_user=mock_user
+                )
 
             assert exc_info.value.status_code == 400
             assert "Failed to generate content:" in str(exc_info.value.detail)

--- a/tests/backend/services/test_embedding_generator.py
+++ b/tests/backend/services/test_embedding_generator.py
@@ -209,61 +209,7 @@ class TestEmbeddingGenerator:
                 "00000000-0000-0000-0000-000000000000", "InvalidType", test_org_id
             )
 
-    @patch("rhesis.sdk.models.factory.get_embedding_model")
-    def test_generate_embedding_vector_success(self, mock_get_model, test_db):
-        """Test successful embedding vector generation."""
-        generator = EmbeddingGenerator(test_db)
-
-        mock_embedder = Mock()
-        mock_embedder.generate.return_value = [0.1] * 768
-        mock_get_model.return_value = mock_embedder
-
-        result = generator._generate_embedding_vector(
-            searchable_text="Test text",
-            provider="openai",
-            model_name="text-embedding-3-small",
-            api_key="test-key",
-            dimension=768,
-        )
-
-        assert len(result) == 768
-        assert all(isinstance(x, float) for x in result)
-        mock_embedder.generate.assert_called_once_with("Test text")
-
-    @patch("rhesis.sdk.models.factory.get_embedding_model")
-    def test_generate_embedding_vector_model_creation_error(self, mock_get_model, test_db):
-        """Test error when embedding model creation fails."""
-        generator = EmbeddingGenerator(test_db)
-        mock_get_model.side_effect = ValueError("Invalid provider")
-
-        with pytest.raises(ValueError, match="Failed to create embedder"):
-            generator._generate_embedding_vector(
-                searchable_text="Test text",
-                provider="invalid",
-                model_name="test-model",
-                api_key="test-key",
-                dimension=768,
-            )
-
-    @patch("rhesis.sdk.models.factory.get_embedding_model")
-    def test_generate_embedding_vector_generation_error(self, mock_get_model, test_db):
-        """Test error when embedding generation fails."""
-        generator = EmbeddingGenerator(test_db)
-
-        mock_embedder = Mock()
-        mock_embedder.generate.side_effect = Exception("API error")
-        mock_get_model.return_value = mock_embedder
-
-        with pytest.raises(ValueError, match="Failed to generate embedding"):
-            generator._generate_embedding_vector(
-                searchable_text="Test text",
-                provider="openai",
-                model_name="text-embedding-3-small",
-                api_key="test-key",
-                dimension=768,
-            )
-
-    @patch("rhesis.sdk.models.factory.get_embedding_model")
+    @patch("rhesis.backend.app.services.embedding.generator.get_model")
     def test_generate_creates_new_embedding(
         self,
         mock_get_model,
@@ -299,7 +245,7 @@ class TestEmbeddingGenerator:
         assert embedding.dimension == 768
         assert len(embedding.embedding) == 768
 
-    @patch("rhesis.sdk.models.factory.get_embedding_model")
+    @patch("rhesis.backend.app.services.embedding.generator.get_model")
     def test_generate_with_entity_provided(
         self,
         mock_get_model,
@@ -328,7 +274,7 @@ class TestEmbeddingGenerator:
         assert result["status"] == "success"
         assert "embedding_id" in result
 
-    @patch("rhesis.sdk.models.factory.get_embedding_model")
+    @patch("rhesis.backend.app.services.embedding.generator.get_model")
     def test_generate_returns_existing_embedding(
         self,
         mock_get_model,
@@ -364,7 +310,7 @@ class TestEmbeddingGenerator:
         assert result1["embedding_id"] == result2["embedding_id"]
         assert mock_embedder.generate.call_count == 1
 
-    @patch("rhesis.sdk.models.factory.get_embedding_model")
+    @patch("rhesis.backend.app.services.embedding.generator.get_model")
     def test_generate_marks_old_embeddings_stale(
         self,
         mock_get_model,
@@ -453,7 +399,7 @@ class TestEmbeddingGenerator:
                 model_id="00000000-0000-0000-0000-000000000000",
             )
 
-    @patch("rhesis.sdk.models.factory.get_embedding_model")
+    @patch("rhesis.backend.app.services.embedding.generator.get_model")
     def test_generate_different_dimensions(
         self,
         mock_get_model,

--- a/tests/backend/services/test_embedding_service.py
+++ b/tests/backend/services/test_embedding_service.py
@@ -498,7 +498,7 @@ class TestEmbeddingServiceWorkerDetection:
 class TestEmbeddingServiceIntegration:
     """Integration tests for EmbeddingService with real generator."""
 
-    @patch("rhesis.sdk.models.factory.get_embedding_model")
+    @patch("rhesis.backend.app.utils.user_model_utils.get_model")
     @patch.object(EmbeddingService, "_check_workers_available")
     def test_full_sync_flow(
         self,


### PR DESCRIPTION
## Purpose

Two separate but related issues motivated this PR:

1. `/generate/content` and `/generate/embedding` were completely unauthenticated, meaning anyone could call the Rhesis API to consume LLM and embedding resources without a valid session or token.
2. The default embedding model was hardcoded to `vertex_ai/text-embedding-005` across the codebase, breaking local and self-hosted setups that don't have Vertex AI credentials. It's now `rhesis/rhesis-embedding`, consistent with the other defaults.

## What Changed

**Security: auth added to generation endpoints**
- `POST /services/generate/content` and `POST /services/generate/embedding` now require `require_current_user_or_token` and a db session. Both also switch from the global `DEFAULT_*_MODEL` constant to the per-user model resolved via `get_generation_model_with_override` / `get_user_embedding_model`, so the user's configured model is actually respected.

**Test config generation: user model with Polyphemus fallback**
- `TestConfigGeneratorService` previously always used `DEFAULT_GENERATION_MODEL` (fast, global). It now resolves the user's configured model, except when that model is Polyphemus — which is too slow for this interactive step. In that case it falls back to the system default, and if that's also unavailable, gracefully falls back to Polyphemus itself.

**New `ModelConfigurationError` exception**
- Added `apps/utils/model_errors.py` with a typed `ModelConfigurationError(ValueError)` that carries the `original_error`. All `ValueError` raises in `user_model_utils.py` and `embedding/generator.py` are replaced with this, giving callers a consistent, inspectable error type for model configuration failures.

**Default embedding model**
- Changed from `vertex_ai/text-embedding-005` to `rhesis/rhesis-embedding` in `constants.py`, `docker-compose.yml`, and `.env.example`. This makes self-hosted and local `./rh start` setups work out of the box without Vertex AI credentials.

Closes [#1720](https://github.com/rhesis-ai/rhesis/issues/1720).