### PR TITLE
Add Polyphemus adversarial test generation example notebook

### DIFF
--- a/examples/polyphemus.ipynb
+++ b/examples/polyphemus.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Polyphemus — Adversarial Test Generation\n",
+    "\n",
+    "**Polyphemus** is the LLM hosted by Rhesis, built specifically for adversarial testing.\n",
+    "\n",
+    "Commercial LLMs refuse up to 65% of critical test cases — jailbreaks, prompt injections, goal hijacking — because their safety filters treat adversarial prompts as harmful content. Polyphemus does not refuse. It is designed to generate exactly the adversarial scenarios you need to find vulnerabilities before your users do.\n",
+    "\n",
+    "Authentication uses your `RHESIS_API_KEY` — no separate API key needed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from rhesis.sdk.models import PolyphemusLLM\n",
+    "from rhesis.sdk.synthesizers import PromptSynthesizer\n",
+    "\n",
+    "os.environ[\"RHESIS_API_KEY\"] = \"replace-with-your-api-key\"  # Replace with your actual API key\n",
+    "\n",
+    "print(\"✓ Ready\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Use Polyphemus directly\n",
+    "\n",
+    "`PolyphemusLLM` exposes a simple `generate()` interface. You can call it on its own before wiring it into a synthesizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = PolyphemusLLM()\n",
+    "\n",
+    "response = model.generate(\n",
+    "    prompt=\"What are three common failure modes for a customer service chatbot?\",\n",
+    "    system_prompt=\"You are a QA engineer. Answer concisely.\",\n",
+    ")\n",
+    "\n",
+    "print(response)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate adversarial test cases with PromptSynthesizer\n",
+    "\n",
+    "Pass `PolyphemusLLM` as the `model` to generate structured adversarial test sets. Because Polyphemus does not apply commercial safety filters, it produces the full range of jailbreaks, injections, and edge cases your system needs to be tested against."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "synthesizer = PromptSynthesizer(\n",
+    "    prompt=\"Generate test cases for a customer service chatbot that handles refund requests\",\n",
+    "    batch_size=5,\n",
+    "    model=model,\n",
+    ")\n",
+    "\n",
+    "result = synthesizer.generate(num_tests=5)\n",
+    "\n",
+    "print(f\"Generated {len(result.tests)} tests\")\n",
+    "print(f\"Synthesizer : {result.metadata.get('synthesizer_name')}\")\n",
+    "print(f\"Model       : {model.model_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Inspect the results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i, test in enumerate(result.tests):\n",
+    "    print(f\"Test {i + 1}\")\n",
+    "    print(f\"  Prompt   : {test.prompt.content[:100]}...\")\n",
+    "    print(f\"  Behavior : {test.behavior}\")\n",
+    "    print(f\"  Category : {test.category}\")\n",
+    "    print(f\"  Topic    : {test.topic}\")\n",
+    "    print()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Purpose
Add an example notebook demonstrating how to use `PolyphemusLLM` with `PromptSynthesizer` for adversarial test generation.

## What Changed
- Added `examples/polyphemus.ipynb` showing:
  - How to use `PolyphemusLLM` directly via `generate()`
  - How to pass it as the model to `PromptSynthesizer`
  - Why Polyphemus is suited for adversarial testing (no commercial safety filter refusals)

## Additional Context
- Polyphemus is the Rhesis-hosted LLM — only `RHESIS_API_KEY` needed, no extra credentials
- Complements the existing `examples/config-synthesizer.ipynb`

## Testing
Open the notebook and run cells with a valid `RHESIS_API_KEY`.