### PR TITLE
Refresh integrations and tracing documentation

### DIFF
--- a/docs/content/contribute/sdk/_meta.tsx
+++ b/docs/content/contribute/sdk/_meta.tsx
@@ -2,6 +2,7 @@ import type { MetaRecord } from 'nextra'
 
 const meta: MetaRecord = {
   'architect-agent': 'Architect Agent',
+  integrations: 'Integrations',
 }
 
 export default meta

--- a/docs/content/contribute/sdk/integrations.mdx
+++ b/docs/content/contribute/sdk/integrations.mdx
@@ -1,0 +1,63 @@
+import { CodeBlock } from '@/components/CodeBlock'
+
+# Framework telemetry integrations (SDK)
+
+The Rhesis Python SDK wires **automatic** tracing for some AI frameworks through small integration classes under `sdk/src/rhesis/sdk/telemetry/integrations/`. Each integration subclasses `BaseIntegration` and is registered in `get_all_integrations()` so [`auto_instrument()`](/docs/tracing/auto-instrumentation) can discover it.
+
+This page is for contributors who want to add or extend an integration the same way LangChain and LangGraph do today.
+
+## `BaseIntegration` contract
+
+Defined in `sdk/src/rhesis/sdk/telemetry/integrations/base.py`:
+
+| Piece | Role |
+| --- | --- |
+| `framework_name` | Stable string key (for example `"langchain"`) used in `auto_instrument("…")`. |
+| `is_installed()` | Return `True` when optional deps for that framework are importable. |
+| `_create_callback()` | Build the framework-specific callback, patch handle, or `None` if not applicable. |
+| `enable()` / `disable()` | Turn observation on or off; `enable()` should return `False` if the framework is not installed or setup fails. |
+| `callback()` | Return the live handler; the base implementation can call `enable()` if needed. |
+| `enabled` | Whether this integration is currently active. |
+
+**Reference implementations:**
+
+- **LangChain** — `sdk/src/rhesis/sdk/telemetry/integrations/langchain/integration.py`: singleton, `set_default_callback_manager`, optional fallback registration, `BaseTool.invoke` / `ainvoke` patching via `ToolPatchState` and `ensure_callback_in_config`.
+- **LangGraph** — `sdk/src/rhesis/sdk/telemetry/integrations/langgraph.py`: enables the **same** LangChain singleton callback, then patches compiled graph methods and sets `tracing_v2_callback_var` when available (`GraphPatchState` guards idempotent patching).
+
+## Public registration
+
+1. Implement a `get_integration()` factory that returns a **module-level singleton** (see existing modules).
+2. Add the integration to `get_all_integrations()` in `sdk/src/rhesis/sdk/telemetry/integrations/__init__.py`.
+3. Export any helpers (for example `get_callback`) from the framework package if users need manual wiring.
+4. Add an optional dependency group in `sdk/pyproject.toml` if the integration needs extra packages.
+5. Add tests under `tests/sdk/telemetry/integrations/` (patch state resets, enable/disable, and at least one smoke path through the framework API).
+
+## Checklist for a new framework
+
+- [ ] Subclass `BaseIntegration` with a clear `framework_name`.
+- [ ] Implement `is_installed()` with a narrow `import` check.
+- [ ] Implement `_create_callback()` (or override `enable()` if patching must happen before/after, like LangGraph).
+- [ ] Register in `get_all_integrations()`.
+- [ ] Document user-facing behavior in [Auto-Instrumentation](/docs/tracing/auto-instrumentation) when the feature is ready for end users.
+- [ ] Avoid advertising `auto_instrument("…")` for placeholders that still return `None` from `_create_callback()` — prefer `@observe` in docs until the hook is real.
+
+## Manual callback pattern
+
+LangChain exposes `get_callback()` for advanced injection when auto-patching does not run (custom wrappers). New integrations can follow the same idea: a small module-level helper that returns the active handler **after** `enable()` has succeeded.
+
+<CodeBlock filename="pattern.py" language="python">
+{`# Illustrative — see langchain/integration.py for the real API
+
+from rhesis.sdk.telemetry.integrations.myframework import get_integration
+
+def get_handler():
+    integration = get_integration()
+    if integration.enabled:
+        return integration.callback()
+    return None`}
+</CodeBlock>
+
+## Related code paths
+
+- Global orchestration: `sdk/src/rhesis/sdk/telemetry/observer.py` (`auto_instrument`, `disable_auto_instrument`).
+- LangChain callback and agent/heuristic logic: `sdk/src/rhesis/sdk/telemetry/integrations/langchain/callback.py`, `extractors.py`.

--- a/docs/content/docs/frameworks.mdx
+++ b/docs/content/docs/frameworks.mdx
@@ -1,8 +1,10 @@
 import { CodeBlock } from '@/components/CodeBlock'
 
-# Supported Frameworks
+# Evaluation Frameworks
 
-Rhesis supports a growing ecosystem of evaluation, testing, and red teaming frameworks natively. These tools define structured methodologies for AI red teaming, evaluation, and risk assessment. Rhesis seamlessly integrates with these tools to provide instant access to robust evaluation metrics and adversarial probes.
+In addition to Rhesis-native metrics, you can use metrics from DeepEval and Ragas, and import Garak probes as test sets for adversarial scanning. Each framework defines a structured methodology for evaluation, testing, or red teaming, and Rhesis exposes it directly inside your test suites — no separate CLI or wiring required.
+
+For the broader integration map (LLM providers, tracing, connector, REST API), see [Integrations](/docs/integrations).
 
 ---
 

--- a/docs/content/docs/integrations.mdx
+++ b/docs/content/docs/integrations.mdx
@@ -2,44 +2,74 @@ import { ObservabilitySection, TestsSection, McpSection, ModelProvidersSection }
 
 # Integrations
 
-<div className="not-prose framework-integrations-showcase" style={{ margin: '1.5rem 0 0' }}>
-  <div
-    style={{
-      margin: '0 0 1.75rem 0',
-      fontSize: '0.975rem',
-      color: 'var(--integration-showcase-lede)',
-      maxWidth: '44rem',
-      lineHeight: 1.6,
-    }}
-  >
-    Plug Rhesis into your environment: observability and remote test runs, evaluation-framework
-    integrations, MCP servers, and LLM providers.
-  </div>
-</div>
+Rhesis plugs into your LLM stack across four layers, each addressing a different concern. This page is the single map: pick the layer you care about and follow the link into the matching guide.
 
-## Observability
+| Layer | What it covers | Where to start |
+|---|---|---|
+| **LLM providers** | The model that runs your test generation and LLM-as-Judge evaluation. | [Models](/docs/models) |
+| **Tracing** | Streaming OpenTelemetry spans from your application to Rhesis. | [Tracing](/docs/tracing) · [Auto-instrumentation](/docs/tracing/auto-instrumentation) |
+| **Test execution** | Letting Rhesis invoke entry points in your application remotely to run test cases. | [Connector](/sdk/connector) |
+| **REST API** | Programmatic access to test sets, runs, and platform resources. | [api.rhesis.ai/docs](https://api.rhesis.ai/docs) |
+
+Beyond those four layers, Rhesis also bundles **evaluation frameworks** (DeepEval, Ragas, Garak) and **MCP servers** as additional sources of metrics, tests, and tool context.
+
+## Tracing your application
+
+Your application emits spans through the Rhesis SDK; spans are batched and sent to Rhesis over HTTP using OpenTelemetry conventions. The integration mechanism depends on the framework:
+
+- **LangChain** and **LangGraph** are auto-instrumented end-to-end with a single `auto_instrument()` call — no per-function decorators required.
+- Other Python frameworks (CrewAI, OpenAI Agents SDK, LlamaIndex, AutoGen, …) are traced with the `@observe.*` decorators, applied to the functions, tools, or agents you want to capture.
+- Any OpenTelemetry-compatible exporter can target the Rhesis ingestion endpoint directly. See [Tracing setup](/docs/tracing/setup) for the exact endpoint and headers.
+
+See: [Tracing overview](/docs/tracing) · [Auto-instrumentation](/docs/tracing/auto-instrumentation) · [Decorators](/docs/tracing/decorators) · [Multi-agent tracing](/docs/tracing/multi-agent)
 
 <div className="not-prose framework-integrations-showcase">
   <ObservabilitySection />
 </div>
 
-## Frameworks
+## Test execution: the connector
+
+For Rhesis to run test cases against your application, it needs a way to call your code from outside your environment. The Rhesis SDK opens a **persistent outbound WebSocket connection** at startup; Rhesis can then invoke registered entry points whenever a test run fires. The connection is outbound from your app, so it works through firewalls and from local laptops without exposing a public URL.
+
+Register an entry point with the `@endpoint` decorator. When a test run starts, Rhesis sends each test case's input down the WebSocket; your application runs the function locally and sends the output back up the same connection. The same call path serves single-turn test cases and multi-turn conversations.
+
+See: [Connector](/sdk/connector) · [Parameter binding](/sdk/connector/binding) · [Connector examples](/sdk/connector/examples)
+
+## LLM providers
+
+Choose any provider for the LLMs that drive test synthesis and LLM-as-Judge evaluation. Provider routing is powered by [LiteLLM](https://github.com/BerriAI/litellm), giving you a single interface to 100+ models — cloud (OpenAI, Anthropic, Google Gemini, Mistral, Cohere, Groq, Together AI) or local/self-hosted (Ollama, vLLM, LiteLLM proxy).
+
+See: [Models](/docs/models) · [API tokens](/docs/api-tokens)
+
+<div className="not-prose framework-integrations-showcase">
+  <ModelProvidersSection />
+</div>
+
+## Evaluation frameworks
+
+In addition to Rhesis-native metrics, you can use metrics from DeepEval and Ragas, and import Garak probes as test sets for adversarial scanning.
+
+See: [Frameworks](/docs/frameworks) · [Metrics](/docs/metrics) · [Adversarial testing](/docs/adversarial-testing)
 
 <div className="not-prose framework-integrations-showcase">
   <TestsSection />
 </div>
 
-## MCPs
+## MCP servers
+
+Connect MCP servers so Rhesis can use external tools during workflows — for example pulling context from Notion, GitHub, Jira, or Confluence during test generation.
+
+See: [MCP](/docs/mcp)
 
 <div className="not-prose framework-integrations-showcase">
   <McpSection />
 </div>
 
-## Model providers
+## REST API
 
-<div className="not-prose framework-integrations-showcase">
-  <ModelProvidersSection />
-</div>
+Direct API access for custom integrations and CI/CD pipelines: manage test sets, trigger test runs, fetch results, and inspect traces programmatically. Language-agnostic — call from Python, TypeScript, Go, shell scripts, or anywhere else.
+
+See: [OpenAPI spec](https://api.rhesis.ai/docs) · [API tokens](/docs/api-tokens)
 
 <div className="not-prose" style={{ marginTop: '1rem' }}>
 

--- a/docs/content/docs/integrations.mdx
+++ b/docs/content/docs/integrations.mdx
@@ -29,7 +29,7 @@ See: [Tracing overview](/docs/tracing) · [Auto-instrumentation](/docs/tracing/a
 
 ## Test execution: the connector
 
-For Rhesis to run test cases against your application, it needs a way to call your code from outside your environment. The Rhesis SDK opens a **persistent outbound WebSocket connection** at startup; Rhesis can then invoke registered entry points whenever a test run fires. The connection is outbound from your app, so it works through firewalls and from local laptops without exposing a public URL.
+For Rhesis to run test cases against your application, it needs a way to call your code from outside your environment. The Rhesis SDK maintains a **persistent outbound WebSocket connection** to Rhesis once the connector is started — typically by calling `client.connect()` in sync scripts, or implicitly when the connector runs inside an existing event loop (for example, a web server or an async app). Rhesis can then invoke registered entry points whenever a test run fires. The connection is outbound from your app, so it works through firewalls and from local laptops without exposing a public URL.
 
 Register an entry point with the `@endpoint` decorator. When a test run starts, Rhesis sends each test case's input down the WebSocket; your application runs the function locally and sends the output back up the same connection. The same call path serves single-turn test cases and multi-turn conversations.
 

--- a/docs/content/docs/tracing/auto-instrumentation.mdx
+++ b/docs/content/docs/tracing/auto-instrumentation.mdx
@@ -15,6 +15,32 @@ Auto-instrumentation automatically traces all LLM calls, tool invocations, and c
     LC --> T["Automatic Traces"]
     LG --> T`} />
 
+## API at a glance
+
+The full auto-instrumentation surface lives in `rhesis.sdk.telemetry`:
+
+<CodeBlock filename="app.py" language="python">
+{`from rhesis.sdk.telemetry import auto_instrument, disable_auto_instrument
+
+auto_instrument()                              # auto-detect installed frameworks
+auto_instrument("langchain")                   # explicit single framework
+auto_instrument("langchain", "langgraph")      # explicit multiple frameworks
+disable_auto_instrument()                      # turn everything off`}
+</CodeBlock>
+
+| Call | Behavior |
+|---|---|
+| `auto_instrument()` | Tries every supported framework and enables the ones whose package is importable. |
+| `auto_instrument("langchain", ...)` | Enables only the named frameworks. Unknown names are logged as warnings but do not raise. |
+| `disable_auto_instrument()` | Disables every framework that was previously enabled in this process. |
+
+The function returns the list of frameworks it actually instrumented, so you can log it in your bootstrap:
+
+<CodeBlock filename="bootstrap.py" language="python">
+{`enabled = auto_instrument()
+print(f"Tracing enabled for: {enabled}")  # e.g. ['langchain', 'langgraph']`}
+</CodeBlock>
+
 ## LangChain
 
 ### Installation
@@ -82,6 +108,8 @@ def calculator(expression: str) -> str:
 result = calculator.invoke({"expression": "2 + 2 * 3"})`}
 </CodeBlock>
 
+Under the hood the integration registers a callback handler globally and patches `BaseTool.invoke` / `BaseTool.ainvoke`, so tool spans fire even when the framework's normal callback plumbing is bypassed by user code.
+
 ## LangGraph
 
 ### Installation
@@ -132,6 +160,14 @@ app = workflow.compile()
 result = app.invoke({"messages": ["What are the benefits of LangGraph?"]})`}
 </CodeBlock>
 
+### How LangChain and LangGraph share a callback
+
+LangGraph runs on top of LangChain's callback system. To avoid emitting duplicate spans when both are present, the LangGraph integration **reuses the singleton LangChain callback** instead of creating its own. That means:
+
+- `auto_instrument("langgraph")` already covers LangChain chains, LCEL pipelines, tools, and LLM calls invoked from inside graph nodes — you do not need to add `"langchain"` explicitly.
+- Calling `auto_instrument("langchain", "langgraph")` is safe and idempotent: the second integration finds the callback already registered and only adds the graph-method patches on top.
+- The integration also patches `CompiledStateGraph.invoke` / `ainvoke` / `stream` / `astream`, so every graph entry point injects the callback automatically — no need to thread it through `config={"callbacks": [...]}` yourself.
+
 ## Trace Output
 
 Each node in the graph produces spans following [semantic conventions](/tracing/semantic-conventions). In this example, `researcher` and `analyst` are not named with agent keywords, so their LLM calls are traced as `ai.llm.invoke` spans directly.
@@ -167,17 +203,52 @@ def chat_handler(input: str) -> dict:
     return {"output": chain.invoke({"message": input})}`}
 </CodeBlock>
 
+## Manual callback injection (advanced)
+
+In nearly all cases, `auto_instrument()` is enough — the SDK patches the framework entry points and traces fire transparently. For the rare situation where you build a custom wrapper around `CompiledStateGraph` that bypasses the patched methods, you can fetch the active callback and pass it through yourself:
+
+<CodeBlock filename="custom_runner.py" language="python">
+{`from rhesis.sdk.telemetry import auto_instrument
+from rhesis.sdk.telemetry.integrations.langchain import get_callback
+
+auto_instrument("langgraph")
+
+callback = get_callback()
+config = {"callbacks": [callback]} if callback else {}
+result = my_custom_invoke(graph, state, config=config)`}
+</CodeBlock>
+
+`get_callback()` returns `None` if LangChain instrumentation has not been enabled in this process.
+
+## Disabling
+
+To turn off every previously-enabled framework — for example before reconfiguring tracing in a test fixture — call `disable_auto_instrument()`:
+
+<CodeBlock filename="teardown.py" language="python">
+{`from rhesis.sdk.telemetry import disable_auto_instrument
+
+disable_auto_instrument()`}
+</CodeBlock>
+
 ## Supported Frameworks
 
-| Framework | Extra | Status |
-|-----------|-------|--------|
-| LangChain | `langchain` | Supported |
-| LangGraph | `langgraph` | Supported |
+| Framework | Mechanism | Extra | Status |
+|---|---|---|---|
+| LangChain | Auto-instrument (callback + tool patch) | `langchain` | Supported |
+| LangGraph | Auto-instrument (callback + graph patch) | `langgraph` | Supported |
+| Other Python frameworks (CrewAI, OpenAI Agents SDK, LlamaIndex, AutoGen, …) | `@observe.*` decorators | n/a | Use [Decorators](/tracing/decorators) |
+
+For frameworks not in the auto-instrument list, wrap the functions, tools, or agents you want to trace with `@observe.llm`, `@observe.tool`, `@observe.retrieval`, etc. Without decorators only top-level inputs and outputs are captured.
+
+To add a new framework to the auto-instrument list, see [Contributing: SDK Integrations](/contribute/sdk/integrations).
 
 ---
 
 <Callout type="info">
   **Related:**
   - [Setup](/tracing/setup) - Initial configuration
+  - [Decorators](/tracing/decorators) - `@observe` and `@endpoint`
+  - [Multi-Agent Tracing](/tracing/multi-agent) - Agent and handoff spans
+  - [Integrations](/docs/integrations) - The four integration layers at a glance
   - [Connector](/sdk/connector) - Register functions as endpoints
 </Callout>

--- a/docs/content/docs/tracing/multi-agent.mdx
+++ b/docs/content/docs/tracing/multi-agent.mdx
@@ -45,13 +45,28 @@ graph.invoke(state, config={"metadata": {"agent_name": "researcher"}})
 graph.invoke(state, config={"metadata": {"is_agent": True}})`}
 </CodeBlock>
 
+### Agent name resolution
+
+The agent name on each `ai.agent.invoke` span is resolved with this priority order. The first source that produces a value wins:
+
+1. `metadata.agent_name` — explicit override passed in the invocation config.
+2. `metadata.langgraph_node` — set automatically by LangGraph for each node.
+3. `serialized.name` — provided by the framework when available.
+4. Last segment of `serialized.id` — falls back to the class path (for example `ChatGoogleGenerativeAI`).
+5. `"unknown"` — when none of the above is set.
+
+### Handoff detection
+
 Handoffs are detected automatically in two ways:
-- **`transfer_to_*` tools** — any tool named `transfer_to_<agent>` creates an `ai.agent.handoff` span
-- **Sequential transitions** — when one agent ends and another starts, a handoff span is created between them
+
+- **`transfer_to_*` tools** — any tool whose name starts with `transfer_to_` creates an `ai.agent.handoff` span. Detection runs in the LangChain callback's tool path, so it works for any LangChain-based system (including LangGraph and the LangGraph prebuilt agents that emit these tools), not just LangGraph specifically.
+- **Sequential transitions** — when one agent ends and a different agent starts, a handoff span is created between them.
 
 ### More Frameworks
 
-LangGraph is the first framework with native `ai.agent.invoke` and `ai.agent.handoff` span support. LangChain is also supported for general tracing (LLM calls, tools, chains), but agent and handoff span detection currently requires LangGraph node naming conventions. Support for additional frameworks will be added over time. Use [manual decoration](#manual-decoration) for any framework not yet covered.
+LangGraph is currently the only framework with native `ai.agent.invoke` and `ai.agent.handoff` span support out of the box (it benefits from the agent-name keywords, `langgraph_node` metadata, and `transfer_to_*` tool detection described above). LangChain itself is auto-instrumented for general tracing — LLM calls, tools, chains — but agent and handoff spans only appear when one of the agent signals above is present.
+
+For every other framework (CrewAI, OpenAI Agents SDK, LlamaIndex, AutoGen, …), use [manual decoration](#manual-decoration) below: wrap the agent functions with `@observe(span_name=AIOperationType.AGENT_INVOKE, ...)` and they will produce the same span shape.
 
 ## Manual Decoration
 

--- a/docs/content/sdk/_meta.tsx
+++ b/docs/content/sdk/_meta.tsx
@@ -5,7 +5,6 @@ const meta: MetaRecord = {
   client: "Rhesis Client",
   agents: "Agents",
   entities: "Entities",
-  agents: "Agents",
   execution: "Test Execution",
   statistics: "Statistics",
   models: "Models",


### PR DESCRIPTION
## Summary
- Restructure `/docs/integrations` around the four-layer model (LLM providers, tracing, test execution, REST API) with a clearer hub table and reordered sections.
- Refresh `/docs/tracing/auto-instrumentation` and `/docs/tracing/multi-agent` against the real SDK surface in `sdk/src/rhesis/sdk/telemetry/` (`auto_instrument`, `disable_auto_instrument`, `get_callback`, `BaseTool` / `CompiledStateGraph` patching, 5-step agent-name resolution, `transfer_to_*` handoff detection in the LangChain callback).
- Add a contributor guide at `/contribute/sdk/integrations` documenting the `BaseIntegration` extension pattern, and register it in the `contribute/sdk` sidebar.
- Smaller fixes: rename `/docs/frameworks` top heading to "Evaluation Frameworks" to remove a collision with the auto-instrumentation "Supported frameworks" table (anchors `#deepeval`, `#ragas`, `#garak` unchanged); remove a duplicate `agents:` key in the SDK sidebar.

## What changed
| File | Change |
|---|---|
| `docs/content/docs/integrations.mdx` | Four-layer table + reordered sections |
| `docs/content/docs/tracing/auto-instrumentation.mdx` | API-at-a-glance, callback sharing, manual injection, disabling |
| `docs/content/docs/tracing/multi-agent.mdx` | Agent name resolution + handoff detection subsections |
| `docs/content/docs/frameworks.mdx` | Heading rename + lede rework (anchors preserved) |
| `docs/content/contribute/sdk/integrations.mdx` | New: `BaseIntegration` contributor guide |
| `docs/content/contribute/sdk/_meta.tsx` | Register Integrations in contribute sidebar |
| `docs/content/sdk/_meta.tsx` | Remove duplicate `agents:` key |

## Test plan
- [x] Verify the four-layer table on `/docs/integrations` and the surrounding sections render correctly.
- [x] Verify the "API at a glance" table, "How LangChain and LangGraph share a callback" bullets, "Manual callback injection (advanced)" example, and "Disabling" section on `/docs/tracing/auto-instrumentation`.
- [x] Verify the agent-name resolution list and handoff-detection subsections on `/docs/tracing/multi-agent`.
- [x] Click `/docs/frameworks#deepeval`, `#ragas`, `#garak` from the showcase chips on `/docs/integrations` to confirm anchors still resolve after the heading rename.
- [x] Confirm `/contribute/sdk/integrations` loads via the contribute sidebar.
- [x] Confirm the SDK sidebar shows `Agents` once (no duplicate).
- [x] Documentation-only change; no runtime code changes.