### PR TITLE
Add interactive RHESIS_API_KEY setup to rh start

### DIFF
--- a/rh
+++ b/rh
@@ -578,6 +578,34 @@ start_all() {
         fi
     fi
 
+    # Check if RHESIS_API_KEY is missing or still the placeholder
+    CURRENT_API_KEY=$(grep "^RHESIS_API_KEY=" .env.docker.local 2>/dev/null | cut -d'=' -f2-)
+    if [ -z "$CURRENT_API_KEY" ] || [ "$CURRENT_API_KEY" = "your-rhesis-api-key" ]; then
+        echo ""
+        echo -e "${YELLOW}🔑 Rhesis API Key${NC}"
+        echo -e "${WHITE}   Test generation requires a Rhesis API key to call the generation service.${NC}"
+        echo -e "${WHITE}   Get your key at: ${CYAN}https://app.rhesis.ai/tokens${NC}"
+        echo ""
+        read -p "$(echo -e ${YELLOW}Enter your RHESIS_API_KEY \(or press Enter to skip\): ${NC})" -r USER_API_KEY
+        if [ -n "$USER_API_KEY" ]; then
+            if grep -q "^RHESIS_API_KEY=" .env.docker.local 2>/dev/null; then
+                if [[ "$OSTYPE" == "darwin"* ]]; then
+                    sed -i '' "s|^RHESIS_API_KEY=.*|RHESIS_API_KEY=$USER_API_KEY|" .env.docker.local
+                else
+                    sed -i "s|^RHESIS_API_KEY=.*|RHESIS_API_KEY=$USER_API_KEY|" .env.docker.local
+                fi
+            else
+                echo "" >> .env.docker.local
+                echo "# Rhesis API Key (required for test generation)" >> .env.docker.local
+                echo "RHESIS_API_KEY=$USER_API_KEY" >> .env.docker.local
+            fi
+            echo -e "${GREEN}✅ RHESIS_API_KEY saved to .env.docker.local${NC}"
+        else
+            echo -e "${YELLOW}⚠️  Skipping — test generation will not work without a valid API key${NC}"
+            echo -e "${YELLOW}   Add it later: ${WHITE}RHESIS_API_KEY=<your-key>${YELLOW} in .env.docker.local, then ${GREEN}./rh restart${NC}"
+        fi
+    fi
+
     echo ""
     echo -e "${YELLOW}Starting services ...${NC}"
 

--- a/rh
+++ b/rh
@@ -589,7 +589,9 @@ if ! grep -q "^RHESIS_API_KEY=" .env.docker.local 2>/dev/null; then
     if [ -t 0 ]; then
         read -r -p "$(echo -e ${YELLOW}Enter your RHESIS_API_KEY \(or press Enter to skip\): ${NC})" USER_API_KEY
         echo
-    else
+    fi
+
+    if [ -z "$USER_API_KEY" ]; then
         echo -e "${YELLOW}⚠️  Skipping — test generation will not work without a valid API key${NC}"
         echo -e "${YELLOW}   Add it later: ${WHITE}RHESIS_API_KEY=<your-key>${YELLOW} in .env.docker.local${NC}"
     fi

--- a/rh
+++ b/rh
@@ -578,33 +578,30 @@ start_all() {
         fi
     fi
 
-    # Check if RHESIS_API_KEY is missing or still the placeholder
-    CURRENT_API_KEY=$(grep "^RHESIS_API_KEY=" .env.docker.local 2>/dev/null | cut -d'=' -f2-)
-    if [ -z "$CURRENT_API_KEY" ] || [ "$CURRENT_API_KEY" = "your-rhesis-api-key" ]; then
-        echo ""
-        echo -e "${YELLOW}🔑 Rhesis API Key${NC}"
-        echo -e "${WHITE}   Test generation requires a Rhesis API key to call the generation service.${NC}"
-        echo -e "${WHITE}   Get your key at: ${CYAN}https://app.rhesis.ai/tokens${NC}"
-        echo ""
-        read -p "$(echo -e ${YELLOW}Enter your RHESIS_API_KEY \(or press Enter to skip\): ${NC})" -r USER_API_KEY
-        if [ -n "$USER_API_KEY" ]; then
-            if grep -q "^RHESIS_API_KEY=" .env.docker.local 2>/dev/null; then
-                if [[ "$OSTYPE" == "darwin"* ]]; then
-                    sed -i '' "s|^RHESIS_API_KEY=.*|RHESIS_API_KEY=$USER_API_KEY|" .env.docker.local
-                else
-                    sed -i "s|^RHESIS_API_KEY=.*|RHESIS_API_KEY=$USER_API_KEY|" .env.docker.local
-                fi
-            else
-                echo "" >> .env.docker.local
-                echo "# Rhesis API Key (required for test generation)" >> .env.docker.local
-                echo "RHESIS_API_KEY=$USER_API_KEY" >> .env.docker.local
-            fi
-            echo -e "${GREEN}✅ RHESIS_API_KEY saved to .env.docker.local${NC}"
-        else
-            echo -e "${YELLOW}⚠️  Skipping — test generation will not work without a valid API key${NC}"
-            echo -e "${YELLOW}   Add it later: ${WHITE}RHESIS_API_KEY=<your-key>${YELLOW} in .env.docker.local, then ${GREEN}./rh restart${NC}"
-        fi
+# Check if RHESIS_API_KEY is set in .env.docker.local
+if ! grep -q "^RHESIS_API_KEY=" .env.docker.local 2>/dev/null; then
+    echo ""
+    echo -e "${YELLOW}🔑 Rhesis API Key${NC}"
+    echo -e "${WHITE}   Test generation requires a Rhesis API key to call the generation service.${NC}"
+    echo -e "${WHITE}   Get your key at: ${CYAN}https://app.rhesis.ai/tokens${NC}"
+    echo ""
+
+    if [ -t 0 ]; then
+        read -r -p "$(echo -e ${YELLOW}Enter your RHESIS_API_KEY \(or press Enter to skip\): ${NC})" USER_API_KEY
+        echo
+    else
+        echo -e "${YELLOW}⚠️  Skipping — test generation will not work without a valid API key${NC}"
+        echo -e "${YELLOW}   Add it later: ${WHITE}RHESIS_API_KEY=<your-key>${YELLOW} in .env.docker.local${NC}"
     fi
+
+    if [ -n "$USER_API_KEY" ]; then
+        echo "" >> .env.docker.local
+        echo "# Rhesis API Key (required for test generation)" >> .env.docker.local
+        echo "RHESIS_API_KEY=$USER_API_KEY" >> .env.docker.local
+        chmod 600 .env.docker.local
+        echo -e "${GREEN}✅ RHESIS_API_KEY saved to .env.docker.local${NC}"
+    fi
+fi
 
     echo ""
     echo -e "${YELLOW}Starting services ...${NC}"


### PR DESCRIPTION
During ./rh start, if RHESIS_API_KEY is missing from .env.docker.local, interactively prompt the user to enter it. Saves the key to .env.docker.local if provided, or skips with a warning if not.

