### PR TITLE
Fix: Adaptive Testing Delete

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -215,6 +215,11 @@ def delete_explorer_test_set(
         raise ValueError("Test set not found with provided identifier")
     if not _is_explorer_test_set(db_test_set):
         raise ValueError("Test set is not configured for Explorer (Adaptive Testing behavior)")
+
+    # Build the response payload before deleting to avoid response serialization
+    # touching an expired/deleted SQLAlchemy instance after commit.
+    payload = schemas.TestSet.model_validate(db_test_set)
+
     deleted = crud.delete_test_set(
         db,
         test_set_id=db_test_set.id,
@@ -223,7 +228,7 @@ def delete_explorer_test_set(
     )
     if deleted is None:
         raise ValueError("Test set not found with provided identifier")
-    return deleted
+    return payload
 
 
 def _unique_explorer_import_name(db: Session, organization_id: str, base_name: str) -> str:


### PR DESCRIPTION
This PR introduces changes from the `fix/adaptive-testing-delete` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->


## 📁 Files Changed (       1 files)

```
apps/backend/src/rhesis/backend/app/services/explorer/tests.py
```

## 📋 Commit Details

```
9e876d7d - fix(explorer): return response payload after deleting test set (Arkadiusz Kwasigroch, 2026-05-07 09:02)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->