### PR TITLE
docs: add walkthrough videos for Test Explorer, Polyphemus, and Architect

### DIFF
--- a/docs/content/docs/adversarial-testing/polyphemus.mdx
+++ b/docs/content/docs/adversarial-testing/polyphemus.mdx
@@ -4,6 +4,8 @@ import { CodeBlock } from '@/components/CodeBlock'
 
 Polyphemus is a Rhesis-managed language model built for adversarial test generation. It is designed to produce the kinds of prompts that commercial models routinely refuse: adversarial scenarios, sensitive edge cases, and inputs that probe policy boundaries.
 
+<YouTubeEmbed videoId="gjLV7lnDjKw" />
+
 ## What Makes Polyphemus Different
 
 Commercial models are optimized for safety and helpfulness. This makes them useful for many tasks, but it also means they will decline to generate prompts that violate their content policies—even when those prompts are needed specifically to test another system's behavior.

--- a/docs/content/docs/architect/index.mdx
+++ b/docs/content/docs/architect/index.mdx
@@ -2,7 +2,7 @@
 
 Architect (also known as Telemachus) is a conversational agent that designs, builds, and runs test suites for your AI endpoints. Describe what you want to test — it explores your endpoint, proposes a plan, waits for your approval, then creates everything on the platform.
 
-![Rhesis AI Architect chat](/screenshots/rhesis-ai-architect-chat.png)
+<YouTubeEmbed videoId="M-x-Bjbgl2g" />
 
 ## What you can do
 
@@ -14,6 +14,8 @@ Architect (also known as Telemachus) is a conversational agent that designs, bui
 - **Compare** two test runs to spot regressions and improvements
 - **Analyze** any existing test run with behavior and metric breakdowns
 - **Do direct operations** — update a metric, link a behavior, list test sets — without going through the full planning flow
+
+![Rhesis AI Architect chat](/screenshots/rhesis-ai-architect-chat.png)
 
 <Callout type="info">
   Architect refers to all entities by name. You never need to supply an ID.

--- a/docs/content/docs/explorer/index.mdx
+++ b/docs/content/docs/explorer/index.mdx
@@ -2,6 +2,8 @@
 
 Test Explorer is an interactive workspace for building a test set. Draft or import tests, invoke your endpoint, and see responses and metric scores in the same place — so you can iterate until you find the gaps you care about.
 
+<YouTubeEmbed videoId="4E1vD7UiHqU" />
+
 <div style={{ display: "flex", justifyContent: "center", margin: "24px 0" }}>
   <img
     src="/screenshots/rhesis-test-explorer.png"

--- a/docs/content/docs/explorer/index.mdx
+++ b/docs/content/docs/explorer/index.mdx
@@ -4,14 +4,6 @@ Test Explorer is an interactive workspace for building a test set. Draft or impo
 
 <YouTubeEmbed videoId="4E1vD7UiHqU" />
 
-<div style={{ display: "flex", justifyContent: "center", margin: "24px 0" }}>
-  <img
-    src="/screenshots/rhesis-test-explorer.png"
-    alt="Test Explorer"
-    className="screenshot"
-  />
-</div>
-
 ## Two benefits of Test Explorer
 
 Test Explorer surfaces two complementary capabilities:
@@ -25,6 +17,14 @@ Write a test, invoke the endpoint, see metric scores — all in the same view. N
 Given the tests you already have, Test Explorer samples up to **10** of them as examples and asks an LLM for **20** new inputs. Each suggestion is embedded; the batch is **re-ranked by diversity** so the prompts that differ most from the *other suggestions in the same run* appear first. The endpoint and your metrics run in parallel as results stream in. You read the ranked table, then **accept** only the rows that add real coverage or expose real failures.
 
 For the full pipeline (topic-scoped runs, generation guide, progress bar, accept flows), see [Building and Evaluating — Suggestions](/docs/explorer/building-and-evaluating#suggestions-explore-the-space-automatically) and [Workflow](/docs/explorer/workflow).
+
+<div style={{ display: "flex", justifyContent: "center", margin: "24px 0" }}>
+  <img
+    src="/screenshots/rhesis-test-explorer.png"
+    alt="Test Explorer"
+    className="screenshot"
+  />
+</div>
 
 ## What you can do
 


### PR DESCRIPTION
## Purpose

Embed the new YouTube walkthroughs for Rhesis v0.7.0 directly into the docs pages they describe, so readers can watch each feature in action without leaving the docs.

## What Changed

- Added Test Explorer walkthrough (`4E1vD7UiHqU`) to `docs/content/docs/explorer/index.mdx` under the intro paragraph; moved the existing screenshot down so it sits below the "Two benefits of Test Explorer" section.
- Added Polyphemus / adversarial testing walkthrough (`gjLV7lnDjKw`) to `docs/content/docs/adversarial-testing/polyphemus.mdx`, just below the intro paragraph.
- Added Architect walkthrough (`M-x-Bjbgl2g`) to `docs/content/docs/architect/index.mdx` under the intro paragraph; moved the existing `rhesis-ai-architect-chat.png` screenshot down to the end of the "What you can do" section so the video gets the top-of-page slot.

All three pages use the existing `YouTubeEmbed` component, which is globally registered via `docs/src/mdx-components.js` (matching the pattern used in `agent-skill`, `conversation-simulation`, `multimodal-testing`, etc.) — no MDX imports required.

## Testing

- Visual: open `/docs/explorer`, `/docs/adversarial-testing/polyphemus`, and `/docs/architect` locally and confirm each video renders in the responsive 16:9 wrapper, and that the screenshots appear in their new positions.