### PR TITLE
Fix test run status showing failed when tests succeed

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/invokers/tracing.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/tracing.py
@@ -228,7 +228,7 @@ async def create_invocation_trace(
         if result and hasattr(result, "model_dump"):
             result = result.model_dump(exclude_none=True)
 
-        if result:
+        if result and isinstance(result, dict):
             attributes[EndpointAttributes.RESPONSE_STATUS] = result.get("status", "unknown")
             attributes[EndpointAttributes.RESPONSE_HAS_OUTPUT] = result.get("output") is not None
 


### PR DESCRIPTION
## Purpose
Fix a bug where test runs were reported as failed even though all individual tests completed successfully.

## What Changed
- Added `isinstance(result, dict)` guard before calling `.get()` on the invocation result in `create_invocation_trace`

## Additional Context
The `create_invocation_trace` context manager in `tracing.py` assumed `result` would always be a dict or Pydantic model when reaching the attribute-mapping block. However, some invokers return a plain string. A non-empty string is truthy, so the `if result:` guard passed, and `result.get("status", "unknown")` raised `AttributeError: 'str' object has no attribute 'get'`. This exception was raised in the `finally` block — after the actual test invocation succeeded — causing the test run status to be recorded as failed.

The fix mirrors the existing `isinstance(result, dict)` checks already present earlier in the same `finally` block (lines 225 and 247).

## Testing
Reproduce by invoking an endpoint whose invoker returns a plain string response and verify the test run status is no longer marked as failed.