### PR TITLE
Fix test runs failing due to profiling log permission error

### DIFF
--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/profiling.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/profiling.py
@@ -25,31 +25,38 @@ logger = logging.getLogger(__name__)
 
 _RSS_DIVISOR = 1024 * 1024 if sys.platform == "darwin" else 1024
 
-_PROFILING_LOG = os.environ.get("RHESIS_PROFILING_LOG", "profiling.log")
+_PROFILING_LOG = os.environ.get("RHESIS_PROFILING_LOG", "/tmp/profiling.log")
 
 _file_logger: logging.Logger | None = None
 _file_logger_lock = threading.Lock()
 
 
-def _get_file_logger() -> logging.Logger:
+def _get_file_logger() -> logging.Logger | None:
     """Lazily create a logger that appends to the dedicated profiling file.
 
     Thread-safe: double-checked locking prevents multiple handlers being added
     when concurrent Celery worker threads initialise the logger simultaneously.
+
+    Returns None if the log file cannot be opened (e.g. permission denied in
+    a read-only container filesystem) so callers can fall back gracefully
+    without crashing the task.
     """
     global _file_logger
     if _file_logger is None:
         with _file_logger_lock:
             if _file_logger is None:
-                logger_ = logging.getLogger("rhesis.profiling")
-                logger_.setLevel(logging.INFO)
-                logger_.propagate = False
-                handler = logging.FileHandler(_PROFILING_LOG, mode="a")
-                handler.setFormatter(
-                    logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
-                )
-                logger_.addHandler(handler)
-                _file_logger = logger_
+                try:
+                    logger_ = logging.getLogger("rhesis.profiling")
+                    logger_.setLevel(logging.INFO)
+                    logger_.propagate = False
+                    handler = logging.FileHandler(_PROFILING_LOG, mode="a")
+                    handler.setFormatter(
+                        logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+                    )
+                    logger_.addHandler(handler)
+                    _file_logger = logger_
+                except OSError as exc:
+                    logger.warning("Profiling file logger unavailable (%s): %s", _PROFILING_LOG, exc)
     return _file_logger
 
 
@@ -112,4 +119,6 @@ def log_batch_report(
     )
 
     logger.info(line)
-    _get_file_logger().info(line)
+    file_logger = _get_file_logger()
+    if file_logger is not None:
+        file_logger.info(line)

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/profiling.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/profiling.py
@@ -4,60 +4,20 @@ Lightweight process-level profiling for batch execution.
 Uses ``resource.getrusage(RUSAGE_SELF)`` — zero overhead, no dependencies,
 works on Linux (production) and macOS (development).
 
-Reports are written to a dedicated ``profiling.log`` file (in the working
-directory) so they don't get buried in normal worker output.  The same line
-is also emitted via the standard logger at INFO level.
-
 Note: ``ru_maxrss`` is a high-water mark that only grows within a process
 lifetime.  The *growth* between two snapshots still tells you how much a
 given batch contributed to peak memory.
 """
 
 import logging
-import os
 import resource
 import sys
-import threading
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
 logger = logging.getLogger(__name__)
 
 _RSS_DIVISOR = 1024 * 1024 if sys.platform == "darwin" else 1024
-
-_PROFILING_LOG = os.environ.get("RHESIS_PROFILING_LOG", "/tmp/profiling.log")
-
-_file_logger: logging.Logger | None = None
-_file_logger_lock = threading.Lock()
-
-
-def _get_file_logger() -> logging.Logger | None:
-    """Lazily create a logger that appends to the dedicated profiling file.
-
-    Thread-safe: double-checked locking prevents multiple handlers being added
-    when concurrent Celery worker threads initialise the logger simultaneously.
-
-    Returns None if the log file cannot be opened (e.g. permission denied in
-    a read-only container filesystem) so callers can fall back gracefully
-    without crashing the task.
-    """
-    global _file_logger
-    if _file_logger is None:
-        with _file_logger_lock:
-            if _file_logger is None:
-                try:
-                    logger_ = logging.getLogger("rhesis.profiling")
-                    logger_.setLevel(logging.INFO)
-                    logger_.propagate = False
-                    handler = logging.FileHandler(_PROFILING_LOG, mode="a")
-                    handler.setFormatter(
-                        logging.Formatter("%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
-                    )
-                    logger_.addHandler(handler)
-                    _file_logger = logger_
-                except OSError as exc:
-                    logger.warning("Profiling file logger unavailable (%s): %s", _PROFILING_LOG, exc)
-    return _file_logger
 
 
 @dataclass
@@ -92,7 +52,7 @@ def log_batch_report(
     concurrency: int,
     test_run_id: str = "",
 ) -> None:
-    """Write a structured report to profiling.log and the standard logger."""
+    """Emit a structured batch profiling report via the standard logger."""
     failed = sum(1 for r in results if isinstance(r, dict) and r.get("status") == "failed")
     skipped = sum(1 for r in results if isinstance(r, dict) and r.get("status") == "skipped")
     succeeded = total_tests - failed - skipped
@@ -108,17 +68,23 @@ def log_batch_report(
     wall_s = round(wall_time_ms / 1000, 1)
     cpu_pct = round(total_cpu / (wall_s or 1) * 100, 1)
 
-    line = (
-        f"[BATCH] run={test_run_id} "
-        f"tests={total_tests} (ok={succeeded} fail={failed} skip={skipped}) "
-        f"concurrency={concurrency} | "
-        f"wall={wall_s}s | "
-        f"cpu: user={user}s sys={sys_cpu}s total={total_cpu}s ({cpu_pct}%) | "
-        f"mem: peak_rss={rss_peak}MB growth={rss_growth}MB | "
-        f"ctx_sw: vol={vol_cs} invol={invol_cs}"
+    logger.info(
+        "[BATCH] run=%s tests=%d (ok=%d fail=%d skip=%d) concurrency=%d | "
+        "wall=%ss | cpu: user=%ss sys=%ss total=%ss (%s%%) | "
+        "mem: peak_rss=%sMB growth=%sMB | ctx_sw: vol=%d invol=%d",
+        test_run_id,
+        total_tests,
+        succeeded,
+        failed,
+        skipped,
+        concurrency,
+        wall_s,
+        user,
+        sys_cpu,
+        total_cpu,
+        cpu_pct,
+        rss_peak,
+        rss_growth,
+        vol_cs,
+        invol_cs,
     )
-
-    logger.info(line)
-    file_logger = _get_file_logger()
-    if file_logger is not None:
-        file_logger.info(line)


### PR DESCRIPTION
## Purpose
Test runs were being set to Failed because the profiling logger tried to write to `/app/apps/backend/profiling.log`, which is not writable in the container.

## What Changed
- Removed the dedicated `FileHandler`-based file logger entirely
- Profiling reports now go through the standard `logger.info()` call, picked up by the existing log infrastructure

## Additional Context
Profiling is observability — it should never be able to crash a test execution. The `PermissionError` was propagating all the way through `log_batch_report` → `execute_tests_as_batch` → the Celery task, which retried 3 times and then permanently set the `TestRun` status to `Failed` even when all tests had already completed successfully.

## Testing
Deploy and verify test runs complete with a status that reflects actual test results.