### PR TITLE
fix(alembic): missing dimension column

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/554e3e207a3f_add_default_rhesis_embedding_model.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/554e3e207a3f_add_default_rhesis_embedding_model.py
@@ -115,7 +115,7 @@ def upgrade() -> None:
 
             # Check if a protected Rhesis embedding model already exists
             existing_model = (
-                session.query(models.Model)
+                session.query(models.Model.id)  # Only select ID instead of full model
                 .join(models.TypeLookup, models.Model.provider_type_id == models.TypeLookup.id)
                 .filter(
                     models.Model.organization_id == org.id,


### PR DESCRIPTION
## Fix: Migration Order Issue with Embedding Model

**Problem:**
Migration `554e3e207a3f_add_default_rhesis_embedding_model` fails with "column model.dimension does not exist" because it tries to query the full Model object before the dimension column is added in a later migration.

**Solution:**
Changed the query to only select `models.Model.id` instead of the full model. 
This avoids loading columns that don't exist yet while still checking if  the model exists.

**Changes:**
- Modified the `existing_model` query to use `.query(models.Model.id)`  instead of `.query(models.Model)`

This is a minimal fix that allows the migration to complete without reordering migrations (which would break production).


