### PR TITLE
Add org-scoped connector metric dispatch for metrics-only SDK

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/routers/__init__.py
@@ -1,5 +1,4 @@
 # Import existing routers
-from .explorer import router as explorer_router
 from .architect import router as architect_router
 from .auth import router as auth_router
 from .behavior import router as behavior_router
@@ -9,6 +8,7 @@ from .connector import router as connector_router
 from .demographic import router as demographic_router
 from .dimension import router as dimension_router
 from .endpoint import router as endpoint_router
+from .explorer import router as explorer_router
 from .feedback import router as feedback_router
 from .file import router as file_router
 from .file_import import router as file_import_router

--- a/apps/backend/src/rhesis/backend/app/services/connector/manager.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/manager.py
@@ -63,6 +63,11 @@ class ConnectionManager:
         # Store metric registries: {project_id:environment: [MetricMetadata]}
         self._metric_registries: Dict[str, List[MetricMetadata]] = {}
 
+        # Org-scoped metric routing: connection_id -> set of (org_id, metric_name).
+        # Mirrors what is written under ``ws:metric:{org}:{name}`` in Redis so
+        # the heartbeat loop and disconnect cleanup can keep those keys in sync.
+        self._connection_metric_keys: Dict[str, set] = {}
+
         # --- Result layer ---
         self._test_results: Dict[str, Dict[str, Any]] = {}
         self._metric_results: Dict[str, Dict[str, Any]] = {}
@@ -198,14 +203,20 @@ class ConnectionManager:
     async def _cleanup_redis_for_connection(self, connection_id: str, project_keys: set) -> None:
         """Remove all Redis keys for a disconnected connection.
 
-        Deletes the connection-level key and all project routing keys.
+        Deletes the connection-level key, all project routing keys, and any
+        org-scoped metric routing keys (``ws:metric:{org}:{name}``) that were
+        registered through this connection.
         """
+        metric_keys = self._connection_metric_keys.pop(connection_id, set())
         try:
             await redis_manager.client.delete(f"ws:conn:{connection_id}")
             for pk in project_keys:
                 await redis_manager.client.delete(f"ws:routing:{pk}")
+            for org_id, metric_name in metric_keys:
+                await redis_manager.client.delete(f"ws:metric:{org_id}:{metric_name}")
             logger.debug(
-                f"Cleaned Redis for connection {connection_id} ({len(project_keys)} project key(s))"
+                f"Cleaned Redis for connection {connection_id} "
+                f"({len(project_keys)} project key(s), {len(metric_keys)} metric key(s))"
             )
         except Exception as e:
             logger.warning(f"Failed to clean Redis for {connection_id}: {e}")
@@ -238,6 +249,14 @@ class ConnectionManager:
                             f"ws:routing:{pk}",
                             30,
                             self.worker_id,
+                        )
+                    for org_id, metric_name in self._connection_metric_keys.get(
+                        connection_id, set()
+                    ):
+                        await redis_manager.client.setex(
+                            f"ws:metric:{org_id}:{metric_name}",
+                            30,
+                            connection_id,
                         )
                     logger.debug(f"Heartbeat refreshed for {connection_id}")
                 except Exception as e:
@@ -277,6 +296,60 @@ class ConnectionManager:
         key = self.get_connection_key(project_id, environment)
         self._metric_registries[key] = metrics
         logger.info(f"Registered {len(metrics)} metric(s) for {key}")
+
+    async def _register_metric_routing(
+        self,
+        connection_id: str,
+        organization_id: Optional[str],
+        metrics: List[Any],
+    ) -> None:
+        """Write ``ws:metric:{org}:{name}`` routing keys for a connection.
+
+        Each key maps a (organization, metric_name) pair to the
+        ``connection_id`` that currently hosts the metric. The Celery
+        worker uses this lookup for org-scoped metric dispatch when no
+        ``project_id`` is configured on the SDK side.
+
+        The key value is ``connection_id`` (not ``worker_id``) so the
+        existing connection-scoped RPC path (``ws:conn:{connection_id}``)
+        handles cross-instance routing.
+
+        Args:
+            connection_id: WebSocket connection identifier.
+            organization_id: Organization owning the connection (from the
+                immutable auth context).
+            metrics: List of metric metadata objects (each with a ``name``).
+        """
+        if not metrics or not organization_id:
+            return
+
+        tracked = self._connection_metric_keys.setdefault(connection_id, set())
+        for m in metrics:
+            metric_name = getattr(m, "name", None) or (
+                m.get("name") if isinstance(m, dict) else None
+            )
+            if not metric_name:
+                continue
+            tracked.add((organization_id, metric_name))
+
+        if not redis_manager.is_available:
+            return
+
+        try:
+            for org_id, metric_name in tracked:
+                await redis_manager.client.setex(
+                    f"ws:metric:{org_id}:{metric_name}",
+                    30,
+                    connection_id,
+                )
+            logger.info(
+                f"Registered {len(tracked)} org-scoped metric route(s) "
+                f"for connection {connection_id} (org={organization_id})"
+            )
+        except Exception as e:
+            logger.warning(
+                f"Failed to set ws:metric:* keys for connection {connection_id}: {e}"
+            )
 
     def has_local_route(self, project_id: str, environment: str) -> bool:
         """Check whether this instance has a local route for a project:env."""
@@ -761,6 +834,13 @@ class ConnectionManager:
             # their metric handlers on this connection.
             if reg_project_id and reg_environment:
                 await self.handle_registration(reg_project_id, reg_environment, message)
+                await self._register_metric_routing(
+                    connection_id=connection_id,
+                    organization_id=organization_id,
+                    metrics=self._metric_registries.get(
+                        self.get_connection_key(reg_project_id, reg_environment), []
+                    ),
+                )
                 return await message_handler.handle_register_message(
                     project_id=reg_project_id,
                     environment=reg_environment,
@@ -772,6 +852,15 @@ class ConnectionManager:
 
             # Metrics-only registration (no project binding)
             logger.info(f"Metrics-only registration for connection {connection_id}")
+            try:
+                reg_msg = RegisterMessage(**message)
+                await self._register_metric_routing(
+                    connection_id=connection_id,
+                    organization_id=organization_id,
+                    metrics=reg_msg.metrics,
+                )
+            except Exception as e:
+                logger.error(f"Failed to register org-scoped metric routing: {e}")
             response = await message_handler.handle_register_message(
                 project_id="",
                 environment="",

--- a/apps/backend/src/rhesis/backend/app/services/connector/manager.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/manager.py
@@ -347,9 +347,7 @@ class ConnectionManager:
                 f"for connection {connection_id} (org={organization_id})"
             )
         except Exception as e:
-            logger.warning(
-                f"Failed to set ws:metric:* keys for connection {connection_id}: {e}"
-            )
+            logger.warning(f"Failed to set ws:metric:* keys for connection {connection_id}: {e}")
 
     def has_local_route(self, project_id: str, environment: str) -> bool:
         """Check whether this instance has a local route for a project:env."""

--- a/apps/backend/src/rhesis/backend/app/services/connector/rpc_client.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/rpc_client.py
@@ -245,8 +245,7 @@ class SDKRpcClient:
             return {
                 "error": "sdk_disconnected",
                 "details": (
-                    f"No SDK registered metric '{metric_name}' "
-                    f"for organization {organization_id}"
+                    f"No SDK registered metric '{metric_name}' for organization {organization_id}"
                 ),
             }
 

--- a/apps/backend/src/rhesis/backend/app/services/connector/rpc_client.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/rpc_client.py
@@ -128,6 +128,7 @@ class SDKRpcClient:
             "inputs": inputs,
         }
         dispatch_context = f"({function_name})"
+        logger.debug(f"Sending RPC request to {request}")
         return await self._send_and_await(
             routing_key=routing_key,
             request=request,
@@ -162,6 +163,8 @@ class SDKRpcClient:
             "metric_name": metric_name,
             "inputs": inputs,
         }
+
+        logger.debug(f"Sending RPC request to {request}")
         return await self._send_and_await(
             routing_key=routing_key,
             request=request,
@@ -202,6 +205,57 @@ class SDKRpcClient:
             timeout=timeout,
             disconnected_details=f"No worker for connection {connection_id}",
             dispatch_log_context=dispatch_context,
+        )
+
+    async def send_and_await_metric_by_org(
+        self,
+        organization_id: str,
+        metric_run_id: str,
+        metric_name: str,
+        inputs: Dict[str, Any],
+        timeout: float = 30.0,
+    ) -> Dict[str, Any]:
+        """Org-scoped metric dispatch.
+
+        Resolves ``ws:metric:{organization_id}:{metric_name}`` -> ``connection_id``
+        in Redis, then forwards through :meth:`send_and_await_metric_by_connection`
+        which handles the worker lookup and direct dispatch.
+
+        Used when the SDK is connected without a ``project_id``
+        (metrics-only registration). The Redis key is written by the
+        backend at registration time and refreshed by the connection's
+        heartbeat loop.
+
+        Returns:
+            Result dictionary or error dict.
+        """
+        if not self._redis:
+            logger.error("Redis not initialized for RPC call")
+            return {"error": "send_failed", "details": "Redis not initialized"}
+
+        metric_key = f"ws:metric:{organization_id}:{metric_name}"
+        try:
+            connection_id = await self._redis.get(metric_key)
+        except Exception as e:
+            logger.error(f"Failed to check routing for {metric_key}: {e}")
+            return {"error": "send_failed", "details": f"Failed to check routing: {e}"}
+
+        if not connection_id:
+            logger.error(f"SDK connection unavailable for {metric_key}")
+            return {
+                "error": "sdk_disconnected",
+                "details": (
+                    f"No SDK registered metric '{metric_name}' "
+                    f"for organization {organization_id}"
+                ),
+            }
+
+        return await self.send_and_await_metric_by_connection(
+            connection_id=connection_id,
+            metric_run_id=metric_run_id,
+            metric_name=metric_name,
+            inputs=inputs,
+            timeout=timeout,
         )
 
     async def _send_and_await(

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
@@ -220,7 +220,9 @@ def prefetch_execution_context(
 
         project_id = str(endpoint.project_id) if endpoint.project_id else None
         environment = endpoint.environment
-        connector_metric_sender = _build_connector_metric_sender(project_id, environment)
+        connector_metric_sender = _build_connector_metric_sender(
+            project_id, environment, organization_id
+        )
     except Exception as e:
         logger.warning(f"Failed to build connector metric sender: {e}")
 

--- a/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
@@ -200,7 +200,9 @@ def evaluate_multi_turn_metrics(
         model=model,
         db=db,
         organization_id=organization_id,
-        connector_metric_sender=_build_connector_metric_sender(project_id, environment),
+        connector_metric_sender=_build_connector_metric_sender(
+            project_id, environment, organization_id
+        ),
     )
 
     conversation_summary = stored_output.get(CONVERSATION_SUMMARY_KEY, [])

--- a/apps/backend/src/rhesis/backend/tasks/execution/executors/runners.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/executors/runners.py
@@ -50,22 +50,49 @@ def _get_endpoint_routing(
 def _build_connector_metric_sender(
     project_id: Optional[str],
     environment: Optional[str],
+    organization_id: Optional[str] = None,
 ):
     """Build an async callable that dispatches connector metrics via WebSocket RPC.
 
-    Returns None when project/environment are unavailable, which tells
-    the evaluator to skip connector metrics.
+    Routing priority per metric call:
+
+    1. **Project-scoped** (``ws:routing:{project_id}:{environment}``) when both
+       ``project_id`` and ``environment`` are available.  Falls back to (2) on
+       ``sdk_disconnected`` (e.g. SDK connected metrics-only without a project).
+    2. **Org-scoped** (``ws:metric:{organization_id}:{metric_name}``) when an
+       ``organization_id`` is available.  Used by SDKs that register
+       ``@metric``-decorated functions without ``RHESIS_PROJECT_ID``.
+
+    Returns ``None`` when neither routing path is available, telling the
+    evaluator to skip connector metrics.
     """
-    if not project_id or not environment:
+    if not (project_id and environment) and not organization_id:
         return None
 
     async def _send(metric_run_id, metric_name, inputs):
         from rhesis.backend.app.services.connector.rpc_client import get_rpc_client
 
         rpc = await get_rpc_client()
-        return await rpc.send_and_await_metric_result(
-            project_id=project_id,
-            environment=environment,
+
+        if project_id and environment:
+            result = await rpc.send_and_await_metric_result(
+                project_id=project_id,
+                environment=environment,
+                metric_run_id=metric_run_id,
+                metric_name=metric_name,
+                inputs=inputs,
+                timeout=30.0,
+            )
+            if result.get("error") != "sdk_disconnected" or not organization_id:
+                return result
+            logger.info(
+                f"No project route for {project_id}:{environment}; "
+                f"falling back to org-scoped dispatch for metric '{metric_name}'"
+            )
+
+        assert organization_id is not None
+        return await rpc.send_and_await_metric_by_org(
+            organization_id=organization_id,
             metric_run_id=metric_run_id,
             metric_name=metric_name,
             inputs=inputs,
@@ -211,7 +238,7 @@ class SingleTurnRunner(BaseRunner):
                 db=db,
                 organization_id=organization_id,
                 connector_metric_sender=_build_connector_metric_sender(
-                    ep_project_id, ep_environment
+                    ep_project_id, ep_environment, organization_id
                 ),
             )
 


### PR DESCRIPTION
## Purpose
SDKs can register connector metrics without a project ID (metrics-only registration). Evaluation tasks still need to invoke those metrics over the WebSocket RPC path. This change adds organization-scoped Redis routing so Celery can resolve the correct connection when project-scoped routing is missing or the SDK is not bound to a project.

## What Changed
- Connection manager: track `ws:metric:{org}:{name}` keys per connection, set them on registration, refresh on heartbeat, and delete them on disconnect cleanup.
- `SDKRpcClient`: add `send_and_await_metric_by_org` to resolve org-scoped Redis keys and dispatch by `connection_id`; add debug logging for outbound RPC payloads.
- Execution pipeline: `_build_connector_metric_sender` accepts `organization_id`, tries project routing first, then falls back to org-scoped dispatch on `sdk_disconnected` or when project/env are absent; batch context and evaluation callers pass `organization_id`.

## Additional Context
- None.

## Testing
- Not run in this session. Recommend from `apps/backend`: `uv run pytest ../../tests/backend/ -v` (or targeted connector/task tests if present).