### PR TITLE
docs: clarify ./rh start uses prebuilt GHCR images by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ test_set = synthesizer.generate(num_tests=10)
 git clone https://github.com/rhesis-ai/rhesis.git && cd rhesis && ./rh start
 ```
 
+`./rh start` pulls prebuilt images from GHCR. To build images from the repo instead, use `./rh start --build` (and `./rh restart --build` after local Dockerfile changes).
+
 **Access:** Frontend at `localhost:3000`, API at `localhost:8080/docs`
 
 **Commands:** `./rh logs` · `./rh stop` · `./rh restart` · `./rh delete`

--- a/docs/content/contribute/development-setup/index.mdx
+++ b/docs/content/contribute/development-setup/index.mdx
@@ -53,10 +53,11 @@ Run `./rh help` or `./rh dev` for the full command list (`./rh dev worker`, `./r
 ## Path 2: Full stack with Docker
 
 <CodeBlock filename="Terminal" language="bash" isTerminal={true}>
-{`./rh start`}
+{`./rh start              # pull prebuilt images (GHCR), then up
+./rh start --build        # optional: build images from local Dockerfiles`}
 </CodeBlock>
 
-Typical URLs: frontend [http://localhost:3000](http://localhost:3000), API [http://localhost:8080/docs](http://localhost:8080/docs). Use `./rh logs`, `./rh stop`, `./rh restart`, and `./rh delete` to manage the stack.
+Typical URLs: frontend [http://localhost:3000](http://localhost:3000), API [http://localhost:8080/docs](http://localhost:8080/docs). Use `./rh logs`, `./rh stop`, `./rh restart` (add `--build` to rebuild locally), and `./rh delete` to manage the stack.
 
 This mode is aimed at local testing (including convenient sign-in behavior). For production-style deployment, see the deployment documentation on this site.
 

--- a/docs/content/contribute/index.mdx
+++ b/docs/content/contribute/index.mdx
@@ -17,7 +17,7 @@ We welcome contributions of all kinds: code, ideas, documentation, and bug repor
 
 Run `./rh help` for all commands.
 
-**Full stack with Docker:** `./rh start` — frontend and API URLs match [development setup](/contribute/development-setup); use `./rh logs`, `stop`, `restart`, `delete` to manage containers.
+**Full stack with Docker:** `./rh start` (pulls prebuilt GHCR images by default; use `./rh start --build` to build locally) — frontend and API URLs match [development setup](/contribute/development-setup); use `./rh logs`, `stop`, `restart`, `delete` to manage containers.
 
 ## Repository layout
 

--- a/docs/content/docs/deployment/running-locally.mdx
+++ b/docs/content/docs/deployment/running-locally.mdx
@@ -37,8 +37,11 @@ Get Rhesis running in under 5 minutes:
 git clone https://github.com/rhesis-ai/rhesis.git
 cd rhesis
 
-# 2. Start all services with one command
+# 2. Start all services with one command (pulls prebuilt images from GHCR)
 ./rh start
+
+# To build backend, worker, and frontend images locally instead:
+# ./rh start --build
 
 # That's it! The platform will automatically:
 # - Generate database encryption key
@@ -57,12 +60,14 @@ cd rhesis
 # Edit .env.docker.local and update RHESIS_API_KEY=your-actual-key`}
 </CodeBlock>
 
+By default, `./rh start` uses **prebuilt container images** from GitHub Container Registry (GHCR), then starts the stack. Use `./rh start --build` when you need images built from the local Dockerfiles (for example, testing unreleased changes). `./rh restart --build` applies the same idea on restart.
+
 The `./rh start` command automatically:
 - Checks if Docker is running
 - Generates a secure database encryption key
 - Creates `.env.docker.local` with all required configuration
 - Enables local authentication bypass (auto-login)
-- Starts all services
+- Pulls (default) or builds (`--build`) images, then starts all services
 - Creates the database and runs migrations
 - Creates the default admin user (`Local Admin`)
 - Loads example test data
@@ -85,6 +90,11 @@ The zero-configuration setup uses these files:
       name: 'docker-compose.yml',
       type: 'file',
       description: 'Docker Compose configuration with sensible defaults'
+    },
+    {
+      name: 'docker-compose.ghcr.yml',
+      type: 'file',
+      description: 'Compose override: GHCR images for ./rh start (default)'
     },
     {
       name: 'rh',
@@ -210,7 +220,10 @@ Use the `./rh` CLI for easy service management:
 
 <CodeBlock filename="Terminal" language="bash">
 {`# Restart all services
-./rh restart`}
+./rh restart
+
+# Rebuild from local Dockerfiles and restart (same as ./rh start --build)
+./rh restart --build`}
 </CodeBlock>
 
 **Delete everything (fresh start):**
@@ -300,7 +313,7 @@ echo "NEXT_PUBLIC_QUICK_START=true" >> .env.docker.local
 ./rh restart`}
 </CodeBlock>
 
-**Note:** The `./rh start` command automatically sets both variables. If you're manually configuring, ensure both `QUICK_START=true` (for backend) and `NEXT_PUBLIC_QUICK_START=true` (for frontend) are set in your `.env.docker.local` file. If you add these variables after the frontend container was already built, you may need to rebuild it: `docker compose --env-file .env.docker.local build frontend && ./rh restart`
+**Note:** The `./rh start` command automatically sets both variables. If you're manually configuring, ensure both `QUICK_START=true` (for backend) and `NEXT_PUBLIC_QUICK_START=true` (for frontend) are set in your `.env.docker.local` file. If you add or change these after containers already exist, recreate the frontend with a local image build: `./rh restart --build` (or `./rh start --build` after `./rh delete`).
 
 ## Next Steps
 

--- a/docs/content/docs/getting-started/setup-environment.mdx
+++ b/docs/content/docs/getting-started/setup-environment.mdx
@@ -27,6 +27,8 @@ cd rhesis
 ./rh start`}
 </CodeBlock>
 
+This uses prebuilt images from GHCR by default. To build containers locally from the repo, run `./rh start --build` instead.
+
 Once the containers are running:
 1. Visit [http://localhost:3000](http://localhost:3000)
 2. You will be automatically logged in as a local user

--- a/docs/content/guides/quick-start-guide.mdx
+++ b/docs/content/guides/quick-start-guide.mdx
@@ -27,21 +27,26 @@ Testing LLM and agentic apps is challenging: outputs are non-deterministic, edge
 git clone https://github.com/rhesis-ai/rhesis.git
 cd rhesis
 
-# Start all services with one command
-./rh start`}
+# Start all services with one command (prebuilt GHCR images)
+./rh start
+
+# Optional: build images from this repo instead of pulling
+# ./rh start --build`}
 </CodeBlock>
+
+By default, images are **pulled from GHCR**. Use `./rh start --build` if you need a fully local Docker build.
 
 The `./rh start` command automatically:
 - Checks if Docker is running
 - Generates a secure database encryption key
 - Creates `.env.docker.local` with all required configuration
 - Enables local authentication bypass (auto-login)
-- Starts all services (backend, frontend, database, worker)
+- Pulls or builds images, then starts all services (backend, frontend, database, worker)
 - Creates the database and runs migrations
 - Creates the default admin user (`Local Admin`)
 - Loads example test data
 
-Wait approximately 5-7 minutes for all services to start. You'll see containers starting up in your terminal.
+Wait while images download or build and services start (often a few minutes on first run). You'll see progress in your terminal.
 
 ## Step 2: Access the Platform (1 minute)
 
@@ -276,6 +281,9 @@ graph LR
 
 # Restart services
 ./rh restart
+
+# Restart and rebuild images from local Dockerfiles
+# ./rh restart --build
 
 # Delete everything (fresh start)
 ./rh delete`}


### PR DESCRIPTION
## Purpose

Clarify the behavior of `./rh start` across docs and the README so contributors know it pulls prebuilt images from GHCR by default, and document `./rh start --build` / `./rh restart --build` as the local-build alternative.

## What Changed

- `README.md`: note that `./rh start` pulls prebuilt GHCR images and how to build locally with `--build`.
- `docs/content/contribute/development-setup/index.mdx`: show both `./rh start` and `./rh start --build`; mention `./rh restart --build`.
- `docs/content/contribute/index.mdx`: clarify default GHCR behavior in the contribute landing page.
- `docs/content/docs/deployment/running-locally.mdx`: describe default GHCR pull vs `--build`, document `docker-compose.ghcr.yml`, and update restart/quick-start notes to use `./rh restart --build` instead of ad-hoc `docker compose build` commands.
- `docs/content/docs/getting-started/setup-environment.mdx`: mention prebuilt GHCR images and `--build` flag.
- `docs/content/guides/quick-start-guide.mdx`: update the quick-start steps to reflect prebuilt images by default and add `./rh restart --build`; soften the fixed "5-7 minutes" wording.

## Additional Context

Documentation-only change. Aligns guidance with the current `./rh` CLI behavior introduced by the GHCR-based quickstart compose mode.

## Testing

No code changes; verify the docs render correctly in the docs site (Nextra) and the README displays as expected on GitHub.