### PR TITLE
feat(frontend): resolve QUICK_START at runtime instead of build time

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -41,15 +41,14 @@ ENV GIT_COMMIT=${GIT_COMMIT}
 ENV NEXT_PUBLIC_GIT_BRANCH=${GIT_BRANCH}
 ENV NEXT_PUBLIC_GIT_COMMIT=${GIT_COMMIT}
 
-# NEXT_PUBLIC_API_BASE_URL is a fixed placeholder; replace-runtime-env.sh substitutes
-# the real URL at container start from API_BASE_URL / BACKEND_URL.
-ARG NEXT_PUBLIC_QUICK_START=false
+# NEXT_PUBLIC_API_BASE_URL and NEXT_PUBLIC_QUICK_START are fixed placeholders;
+# replace-runtime-env.sh substitutes the real values at container start.
 
 # Create a temporary .env file using build arguments for NEXT_PUBLIC_ and direct placeholders for the rest
 RUN echo "NEXTAUTH_SECRET=temporary-build-secret-not-for-production" > .env && \
     echo "NEXT_PUBLIC_API_BASE_URL=__NEXT_PUBLIC_API_BASE_URL__" >> .env && \
     echo "BACKEND_URL=${BACKEND_URL}" >> .env && \
-    echo "NEXT_PUBLIC_QUICK_START=${NEXT_PUBLIC_QUICK_START}" >> .env && \
+    echo "NEXT_PUBLIC_QUICK_START=__NEXT_PUBLIC_QUICK_START__" >> .env && \
     echo "GOOGLE_CLIENT_ID=placeholder-client-id" >> .env && \
     echo "GOOGLE_CLIENT_SECRET=placeholder-client-secret" >> .env && \
     echo "AUTH_SECRET=placeholder-auth-secret" >> .env

--- a/apps/frontend/scripts/replace-runtime-env.sh
+++ b/apps/frontend/scripts/replace-runtime-env.sh
@@ -1,46 +1,46 @@
 #!/bin/sh
-# Replace the build-time placeholder in the Next.js bundle with the runtime
-# public API URL before starting the standalone server.
+# Replace build-time placeholders in the Next.js bundle with runtime values
+# before starting the standalone server.
 #
-# Resolution: API_BASE_URL (browser-facing) -> BACKEND_URL -> localhost default.
-# The image is built with NEXT_PUBLIC_API_BASE_URL=__NEXT_PUBLIC_API_BASE_URL__
-# inlined into the client bundle; this script rewrites that placeholder in
-# compiled JS/HTML, then exports NEXT_PUBLIC_API_BASE_URL for the Node process
-# (e.g. api-client/config.ts validation) without changing application source.
+# Placeholders baked into the bundle at build time:
+#   __NEXT_PUBLIC_API_BASE_URL__  -> API_BASE_URL | BACKEND_URL | localhost:8080
+#   __NEXT_PUBLIC_QUICK_START__   -> QUICK_START | false
+#
+# This allows a single Docker image to be used for all deployment modes.
 
 set -eu
 
-PLACEHOLDER='__NEXT_PUBLIC_API_BASE_URL__'
-RUNTIME_VALUE="${API_BASE_URL:-${BACKEND_URL:-http://localhost:8080}}"
-if [ -z "$RUNTIME_VALUE" ] || [ "$RUNTIME_VALUE" = "$PLACEHOLDER" ]; then
-  RUNTIME_VALUE='http://localhost:8080'
-fi
+replace_placeholder() {
+  _placeholder=$1
+  _value=$2
+  _escaped=$(printf '%s' "$_value" | sed 's/[\\|&]/\\&/g')
 
-# Escape &, |, \ for sed replacement (delimiter |)
-ESCAPED=$(printf '%s' "$RUNTIME_VALUE" | sed 's/[\\|&]/\\&/g')
+  find /app/.next -type f \( -name '*.js' -o -name '*.html' \) 2>/dev/null | while IFS= read -r f; do
+    if test -f "$f" && grep -q "$_placeholder" "$f" 2>/dev/null; then
+      printf '[entrypoint] replacing %s in %s\n' "$_placeholder" "$f"
+      sed -i "s|${_placeholder}|${_escaped}|g" "$f"
+    fi
+  done
 
-replace_if_match() {
-  _f=$1
-  if ! test -f "$_f"; then
-    return 0
+  if test -f /app/server.js && grep -q "$_placeholder" /app/server.js 2>/dev/null; then
+    printf '[entrypoint] replacing %s in server.js\n' "$_placeholder"
+    sed -i "s|${_placeholder}|${_escaped}|g" /app/server.js
   fi
-  if ! grep -q "$PLACEHOLDER" "$_f" 2>/dev/null; then
-    return 0
-  fi
-  printf '[entrypoint] replacing placeholder in %s\n' "$_f"
-  sed -i "s|${PLACEHOLDER}|${ESCAPED}|g" "$_f"
 }
 
-find /app/.next -type f \( -name '*.js' -o -name '*.html' \) 2>/dev/null | while IFS= read -r f; do
-  replace_if_match "$f"
-done
-
-if test -f /app/server.js; then
-  replace_if_match /app/server.js
+# API base URL
+API_URL_VALUE="${API_BASE_URL:-${BACKEND_URL:-http://localhost:8080}}"
+if [ -z "$API_URL_VALUE" ] || [ "$API_URL_VALUE" = '__NEXT_PUBLIC_API_BASE_URL__' ]; then
+  API_URL_VALUE='http://localhost:8080'
 fi
+replace_placeholder '__NEXT_PUBLIC_API_BASE_URL__' "$API_URL_VALUE"
+printf '[entrypoint] using NEXT_PUBLIC_API_BASE_URL=%s (set at runtime)\n' "$API_URL_VALUE"
+export NEXT_PUBLIC_API_BASE_URL="$API_URL_VALUE"
 
-printf '[entrypoint] using NEXT_PUBLIC_API_BASE_URL=%s (set at runtime)\n' "$RUNTIME_VALUE"
-
-export NEXT_PUBLIC_API_BASE_URL="$RUNTIME_VALUE"
+# Quick Start mode - read from QUICK_START (single source of truth)
+QUICK_START_VALUE="${QUICK_START:-false}"
+replace_placeholder '__NEXT_PUBLIC_QUICK_START__' "$QUICK_START_VALUE"
+printf '[entrypoint] using NEXT_PUBLIC_QUICK_START=%s (set at runtime)\n' "$QUICK_START_VALUE"
+export NEXT_PUBLIC_QUICK_START="$QUICK_START_VALUE"
 
 exec "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,6 @@ x-nextjs-frontend: &nextjs-frontend
   NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:-your-nextauth-secret-change-in-production}
   NEXTAUTH_URL: ${NEXTAUTH_URL:-http://localhost:3000}
   API_BASE_URL: ${API_BASE_URL:-http://localhost:8080}
-  NEXT_PUBLIC_QUICK_START: ${NEXT_PUBLIC_QUICK_START:-false}
   NEXT_TELEMETRY_DISABLED: 1
 
 
@@ -190,7 +189,6 @@ services:
       dockerfile: Dockerfile
       args:
         FRONTEND_ENV: ${FRONTEND_ENV:-local}
-        NEXT_PUBLIC_QUICK_START: ${NEXT_PUBLIC_QUICK_START:-false}
     environment:
       <<: [*nextjs-frontend, *common-environment, *rhesis-config]
       PORT: ${FRONTEND_PORT:-3000}


### PR DESCRIPTION
## Purpose

`NEXT_PUBLIC_QUICK_START` was baked into the Docker image at build time via a `Dockerfile` `ARG`, so toggling Quick Start mode required a full rebuild. It also forced operators to manage two separate variables (`QUICK_START` for the backend, `NEXT_PUBLIC_QUICK_START` for the frontend) that always had to agree.

This PR extends the existing runtime-substitution pattern already used for `NEXT_PUBLIC_API_BASE_URL` so the same image can serve any mode, and `QUICK_START` becomes the single source of truth shared with the backend.

## What Changed

- **`apps/frontend/Dockerfile`**: dropped `ARG NEXT_PUBLIC_QUICK_START` and bake a `__NEXT_PUBLIC_QUICK_START__` placeholder into the bundle instead of the actual value.
- **`apps/frontend/scripts/replace-runtime-env.sh`**: refactored into a reusable `replace_placeholder()` helper and added substitution for the new placeholder, reading `QUICK_START` (default `false`) at container start.
- **`docker-compose.yml`**: removed the `NEXT_PUBLIC_QUICK_START` build arg and env from the frontend service; the backend `QUICK_START` variable now drives both services.

## Additional Context

- Mirrors the pattern introduced in #1707 ("Resolve frontend API base URL at runtime instead of build time").
- The frontend utility `apps/frontend/src/utils/quick_start.ts` already reads `process.env.NEXT_PUBLIC_QUICK_START` — no application code changes needed.
- Backend's `is_quick_start_enabled()` continues to be the security gate for `/auth/local-login`; this change only affects how the frontend learns about the mode.

## Testing

1. Build a single image with the default args:
   ```bash
   docker compose build frontend
   ```
2. Start with Quick Start **disabled** (default) and confirm the login page shows normal sign-in:
   ```bash
   docker compose up -d
   ```
3. Stop, then start again with `QUICK_START=true` (no rebuild) and confirm the frontend auto-logs in as `admin@local.dev`:
   ```bash
   QUICK_START=true docker compose up -d
   ```
4. Inspect the entrypoint logs to confirm the substitution ran:
   ```bash
   docker compose logs frontend | grep '\[entrypoint\]'
   ```