### PR TITLE
Fix quick start runtime placeholder and consolidate QUICK_START

### DIFF
--- a/.github/workflows/backend-ghcr.yml
+++ b/.github/workflows/backend-ghcr.yml
@@ -67,7 +67,6 @@ jobs:
     env:
       FRONTEND_ENV: local
       NEXT_PUBLIC_API_BASE_URL: http://localhost:8080
-      NEXT_PUBLIC_QUICK_START: "true"
 
     steps:
       - name: Check out repository
@@ -106,7 +105,6 @@ jobs:
           build-args: |
             FRONTEND_ENV=${{ env.FRONTEND_ENV }}
             NEXT_PUBLIC_API_BASE_URL=${{ env.NEXT_PUBLIC_API_BASE_URL }}
-            NEXT_PUBLIC_QUICK_START=${{ env.NEXT_PUBLIC_QUICK_START }}
             GIT_BRANCH=${{ github.ref_name }}
             GIT_COMMIT=${{ github.sha }}
           push: true

--- a/apps/frontend/src/utils/__tests__/quick_start.test.ts
+++ b/apps/frontend/src/utils/__tests__/quick_start.test.ts
@@ -30,7 +30,6 @@ describe('quick_start', () => {
     describe('Environment variable validation', () => {
       it('should return false when NEXT_PUBLIC_QUICK_START is not set', () => {
         delete process.env.NEXT_PUBLIC_QUICK_START;
-        delete process.env.QUICK_START;
 
         const result = isQuickStartEnabled();
 
@@ -61,9 +60,16 @@ describe('quick_start', () => {
         expect(result).toBe(true);
       });
 
-      it('should accept QUICK_START as fallback', () => {
-        delete process.env.NEXT_PUBLIC_QUICK_START;
-        process.env.QUICK_START = 'true';
+      it('should accept value with surrounding whitespace', () => {
+        process.env.NEXT_PUBLIC_QUICK_START = '  true  ';
+
+        const result = isQuickStartEnabled('localhost');
+
+        expect(result).toBe(true);
+      });
+
+      it('should be case-insensitive for the env value', () => {
+        process.env.NEXT_PUBLIC_QUICK_START = 'TRUE';
 
         const result = isQuickStartEnabled('localhost');
 

--- a/apps/frontend/src/utils/quick_start.ts
+++ b/apps/frontend/src/utils/quick_start.ts
@@ -26,11 +26,15 @@
  * ```
  */
 export function isQuickStartEnabled(hostname?: string): boolean {
-  // 1. Check QUICK_START environment variable (default: false for safety)
-  // In Next.js, check both NEXT_PUBLIC_QUICK_START (build-time) and QUICK_START (runtime)
-  const quickStartEnv =
-    process.env.NEXT_PUBLIC_QUICK_START === 'true' ||
-    process.env.QUICK_START === 'true';
+  // 1. Check QUICK_START environment variable (default: false for safety).
+  //
+  // The value is captured into a string variable before comparison so the
+  // build-time placeholder (`__NEXT_PUBLIC_QUICK_START__`) survives SWC
+  // constant folding and can be substituted at container start by
+  // scripts/replace-runtime-env.sh. Direct `=== 'true'` comparison gets
+  // folded to a static `false` and removes the placeholder from the bundle.
+  const raw = process.env.NEXT_PUBLIC_QUICK_START ?? '';
+  const quickStartEnv = String(raw).trim().toLowerCase() === 'true';
 
   if (!quickStartEnv) {
     return false;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ x-common-environment: &common-environment
   FRONTEND_ENV: ${FRONTEND_ENV:-local}
   WORKER_ENV: ${WORKER_ENV:-local}
   LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
+  QUICK_START: ${QUICK_START:-false}
 
 x-rhesis-config: &rhesis-config
   RHESIS_BASE_URL: ${RHESIS_BASE_URL:-https://api.rhesis.ai}
@@ -128,7 +129,6 @@ services:
     environment:
       <<: [*common-database, *common-redis, *common-auth, *common-auth0, *common-smtp, *common-jwt, *common-environment, *rhesis-config, *telemetry-config]
       LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
-      QUICK_START: ${QUICK_START:-false}
     ports:
       - "8080:8080"
     extra_hosts:

--- a/docs/content/docs/deployment/running-locally.mdx
+++ b/docs/content/docs/deployment/running-locally.mdx
@@ -110,9 +110,8 @@ When you run `./rh start`, the `.env.docker.local` file is automatically created
 
 **Auto-Generated Keys:**
 - Database encryption key (using Python cryptography.fernet)
-- Local authentication bypass flags:
-  - `QUICK_START=true` (enables backend auto-login endpoint)
-  - `NEXT_PUBLIC_QUICK_START=true` (enables frontend auto-login detection)
+- Local authentication bypass flag:
+  - `QUICK_START=true` (single source of truth — enables backend auto-login and is propagated to the frontend at container start)
 
 **You can add (optional):**
 - Rhesis API key (for test generation)
@@ -298,22 +297,20 @@ pip install cryptography
 ### Auto-login not working
 
 <CodeBlock filename="Terminal" language="bash">
-{`# Check if Quick Start variables are set correctly
+{`# Check if Quick Start is set correctly
 cat .env.docker.local | grep QUICK_START
 
 # Should show:
 # QUICK_START=true
-# NEXT_PUBLIC_QUICK_START=true
 
-# If missing, add them:
+# If missing, add it:
 echo "QUICK_START=true" >> .env.docker.local
-echo "NEXT_PUBLIC_QUICK_START=true" >> .env.docker.local
 
 # Then restart:
 ./rh restart`}
 </CodeBlock>
 
-**Note:** The `./rh start` command automatically sets both variables. If you're manually configuring, ensure both `QUICK_START=true` (for backend) and `NEXT_PUBLIC_QUICK_START=true` (for frontend) are set in your `.env.docker.local` file. If you add or change these after containers already exist, recreate the frontend with a local image build: `./rh restart --build` (or `./rh start --build` after `./rh delete`).
+**Note:** The `./rh start` command automatically sets `QUICK_START=true`, which is the single source of truth — the frontend container picks up the same value at startup. If you change this after containers already exist, recreate the frontend with a local image build: `./rh restart --build` (or `./rh start --build` after `./rh delete`).
 
 ## Next Steps
 

--- a/infrastructure/k8s/k8s-deploy.sh
+++ b/infrastructure/k8s/k8s-deploy.sh
@@ -186,7 +186,6 @@ build_service_image() {
             cd "$PROJECT_ROOT/apps/frontend" || exit 1
             docker build -t rhesis-frontend:latest . \
                 --build-arg FRONTEND_ENV=local \
-                --build-arg NEXT_PUBLIC_QUICK_START=false \
                 --build-arg NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
             ;;
         backend)

--- a/rh
+++ b/rh
@@ -594,7 +594,6 @@ start_all() {
             echo "" >> .env.docker.local
             echo "# Local Authentication Bypass" >> .env.docker.local
             echo "QUICK_START=true" >> .env.docker.local
-            echo "NEXT_PUBLIC_QUICK_START=true" >> .env.docker.local
             echo -e "${GREEN}✅ Created .env.docker.local with local configuration${NC}"
         else
             # Update existing file
@@ -614,11 +613,6 @@ start_all() {
             # Add QUICK_START if missing
             if ! grep -q "^QUICK_START=" .env.docker.local 2>/dev/null; then
                 echo "QUICK_START=true" >> .env.docker.local
-            fi
-
-            # Add NEXT_PUBLIC_QUICK_START if missing
-            if ! grep -q "^NEXT_PUBLIC_QUICK_START=" .env.docker.local 2>/dev/null; then
-                echo "NEXT_PUBLIC_QUICK_START=true" >> .env.docker.local
             fi
 
             echo -e "${GREEN}✅ Local configuration updated in .env.docker.local${NC}"


### PR DESCRIPTION
## Purpose
Quick start mode must work when the frontend Docker image substitutes `__NEXT_PUBLIC_QUICK_START__` at container start. A direct `process.env.NEXT_PUBLIC_QUICK_START === 'true'` check was susceptible to SWC constant folding, which could strip the placeholder from the bundle. Local and CI configuration also duplicated quick start flags (`NEXT_PUBLIC_QUICK_START` vs `QUICK_START`).

## What Changed
- **Frontend:** Read `NEXT_PUBLIC_QUICK_START` via an intermediate string and compare with trim/case-insensitivity so the build-time placeholder survives substitution and behaves predictably.
- **Tests:** Cover whitespace and case; drop the removed server `QUICK_START` fallback in client checks.
- **Docker Compose:** Move `QUICK_START` into shared environment so the frontend container receives the same value the entrypoint script uses.
- **`rh` + docs:** Treat `QUICK_START=true` as the single source of truth for local `.env.docker.local`; stop writing `NEXT_PUBLIC_QUICK_START` there.
- **CI / k8s:** Stop passing `NEXT_PUBLIC_QUICK_START` as a frontend Docker build arg where runtime replacement is used instead.

## Additional Context
- Builds on runtime env replacement in `apps/frontend/scripts/replace-runtime-env.sh` (QUICK_START → bundle placeholder).
- Related prior change: frontend resolves quick start at runtime (#1759).

## Testing
- `cd apps/frontend && npm test -- --testPathPattern=quick_start` (or project’s usual frontend test command for this file).
- Local Docker: `./rh start` with quick start; confirm auto-login after frontend container starts with `QUICK_START` propagated from compose.