### PR TITLE
fix(frontend): chown standalone tree so runtime sed can write

### DIFF
--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -115,11 +115,18 @@ RUN addgroup --system --gid 1001 nodejs && \
 # The standalone output mirrors the repo-root structure because
 # outputFileTracingRoot is set to the repo root in next.config.mjs.
 # standalone/ contains apps/frontend/server.js (and ee/frontend/ if traced).
-COPY --from=builder /app/apps/frontend/.next/standalone ./
+#
+# --chown=nextjs:nodejs is required: the entrypoint script (replace-runtime-env.sh)
+# runs as the nextjs user and uses `sed -i` to inject runtime values into
+# .next/server/chunks/*.js. sed -i creates a temp file in the same directory
+# as the target, which fails with "Permission denied" if the standalone tree
+# is root-owned. Same applies to public/, which sed never touches today but
+# Next.js needs to read regardless.
+COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/.next/standalone ./
 
 # Static assets and public must sit alongside server.js so Next.js serves them.
 COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/.next/static ./apps/frontend/.next/static
-COPY --from=builder /app/apps/frontend/public ./apps/frontend/public
+COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/public ./apps/frontend/public
 COPY --from=builder --chown=nextjs:nodejs /app/apps/frontend/scripts/replace-runtime-env.sh ./apps/frontend/scripts/replace-runtime-env.sh
 RUN chmod +x /app/apps/frontend/scripts/replace-runtime-env.sh
 


### PR DESCRIPTION
## Purpose

Cloud Run \`rhesis-frontend-dev\` was crash-looping on startup after the
runtime-env injection change (#1759 / #1760) landed on main. The
entrypoint script can't rewrite the Next.js chunks because they're root-owned.

## Symptom

\`\`\`
[entrypoint] replacing __NEXT_PUBLIC_API_BASE_URL__ in
  /app/apps/frontend/.next/server/chunks/6623.js
sed: can't create temp file
  '/app/apps/frontend/.next/server/chunks/6623.jsXXXXXX':
  Permission denied
Container called exit(1).
Default STARTUP TCP probe failed 1 time consecutively for container
  "rhesis-frontend-dev-1" on port 3000.
\`\`\`

…repeating on every restart attempt.

## Root cause

\`apps/frontend/Dockerfile\` runner stage:

1. \`chown -R nextjs:nodejs /app\` runs while \`/app\` is essentially empty.
2. \`COPY --from=builder /app/apps/frontend/.next/standalone ./\` (no \`--chown\`)
   then drops the standalone tree in as **root-owned**. Same for \`public/\`.
3. \`USER nextjs\` switches to the unprivileged user.
4. \`ENTRYPOINT\` runs \`replace-runtime-env.sh\`, which uses \`sed -i\` to inject
   the resolved \`NEXT_PUBLIC_API_BASE_URL\` / \`NEXT_PUBLIC_QUICK_START\` into
   every chunk that still contains the build-time placeholder.
5. \`sed -i\` creates a sibling temp file (the \`XXXXXX\` suffix) in the chunks
   directory — which the \`nextjs\` user cannot write to, so it dies and the
   container exits 1.

## What Changed

- \`apps/frontend/Dockerfile\` — add \`--chown=nextjs:nodejs\` to the
  \`standalone\` and \`public\` COPY lines so the runtime user owns the tree
  it needs to mutate at startup.
- Inline comment explaining why this is required, so the next person
  doesn't drop the chown when refactoring.

The chunk JS files themselves are still effectively immutable after the
one-shot startup substitution — \`sed -i\` only runs once per cold start.

## Testing

- Local Docker build of \`apps/frontend\` succeeds and the container starts
  without the \"Permission denied\" error.
- After redeploying to Cloud Run dev, the startup TCP probe should pass
  and the service should serve \`200\` on \`/\` instead of crash-looping.
- No code or runtime behaviour change beyond file ownership.