### PR TITLE
Fix empty test searchable text breaking embedding API

### DIFF
--- a/apps/backend/src/rhesis/backend/app/models/mixins.py
+++ b/apps/backend/src/rhesis/backend/app/models/mixins.py
@@ -425,6 +425,14 @@ def _queue_embedding_after_commit(target) -> None:
         )
         return
 
+    if not (searchable_text or "").strip():
+        logger.info(
+            "Deferred embedding: skipping queue for %s id=%s (empty searchable text)",
+            target.__class__.__name__,
+            getattr(target, "id", None),
+        )
+        return
+
     job: dict[str, Any] = {
         "entity_type": target.__class__.__name__,
         "entity_id": str(target.id),

--- a/apps/backend/src/rhesis/backend/app/models/test.py
+++ b/apps/backend/src/rhesis/backend/app/models/test.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, ForeignKey, Integer, Table, and_, case, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import object_session, relationship
 
 from .base import Base
 from .guid import GUID
@@ -118,14 +118,33 @@ class Test(
         """
         from rhesis.backend.app.constants import TestType
         from rhesis.backend.tasks.execution.modes import get_test_type
+        from .behavior import Behavior
+        from .category import Category
+        from .prompt import Prompt
+        from .topic import Topic
 
         test_type = get_test_type(self)
 
+        sess = object_session(self)
+
+        def _fk_obj(related, fk_id, model_cls):
+            """Resolve FK when relationship not populated (e.g. during flush/mapper events)."""
+            if related is not None:
+                return related
+            if fk_id is None or sess is None:
+                return None
+            return sess.get(model_cls, fk_id)
+
+        topic = _fk_obj(self.topic, self.topic_id, Topic)
+        behavior = _fk_obj(self.behavior, self.behavior_id, Behavior)
+        category = _fk_obj(self.category, self.category_id, Category)
+        prompt = _fk_obj(self.prompt, self.prompt_id, Prompt)
+
         # Common metadata for both types
         metadata = [
-            self.topic.name if self.topic else None,
-            self.behavior.name if self.behavior else None,
-            self.category.name if self.category else None,
+            topic.name if topic else None,
+            behavior.name if behavior else None,
+            category.name if category else None,
         ]
 
         if test_type == TestType.MULTI_TURN:
@@ -141,8 +160,8 @@ class Test(
         else:  # SINGLE_TURN (default)
             # Single-turn: extract from prompt
             content = [
-                self.prompt.content if self.prompt else None,
-                self.prompt.expected_response if self.prompt else None,
+                prompt.content if prompt else None,
+                prompt.expected_response if prompt else None,
             ]
 
         return " ".join(filter(None, content + metadata))

--- a/apps/backend/src/rhesis/backend/app/models/test.py
+++ b/apps/backend/src/rhesis/backend/app/models/test.py
@@ -133,7 +133,9 @@ class Test(
                 return related
             if fk_id is None or sess is None:
                 return None
-            return sess.get(model_cls, fk_id)
+            # Avoid re-entrant flush: to_searchable_text runs from after_insert/after_update.
+            with sess.no_autoflush:
+                return sess.get(model_cls, fk_id)
 
         topic = _fk_obj(self.topic, self.topic_id, Topic)
         behavior = _fk_obj(self.behavior, self.behavior_id, Behavior)

--- a/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
@@ -159,6 +159,14 @@ class EmbeddingGenerator:
 
             searchable_text = entity.to_searchable_text()
 
+        if not (searchable_text or "").strip():
+            logger.info(
+                "Skipping embedding: empty searchable_text for %s:%s",
+                entity_type,
+                entity_id,
+            )
+            return {"status": "skipped_empty_text", "embedding_id": None}
+
         # Model row for persistence / hashing (entity-scoped embedding model)
         db_model = crud.get_model(self.db, model_id=model_id, organization_id=organization_id)
         if not db_model:

--- a/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
@@ -148,7 +148,15 @@ class EmbeddingGenerator:
             embedder: Optional pre-resolved embedder. If missing, it is resolved from user settings.
 
         Returns:
-            Dictionary with generation result
+            A dict with at least ``status`` and ``embedding_id`` keys:
+
+            - ``{"status": "success", "embedding_id": "<uuid>"}`` — new or reused
+              active embedding for the text/config.
+            - ``{"status": "skipped_empty_text", "embedding_id": None}`` —
+              ``searchable_text`` was missing or only whitespace; no API call and
+              no embedding row created.
+
+            Celery task ``generate_embedding_task`` returns this dict unchanged.
         """
         if searchable_text is None:
             if not entity:

--- a/apps/backend/src/rhesis/backend/tasks/embedding/generate.py
+++ b/apps/backend/src/rhesis/backend/tasks/embedding/generate.py
@@ -24,6 +24,11 @@ def generate_embedding_task(
     model_id: str | None = None,
     searchable_text: str | None = None,
 ):
+    """Run :meth:`~rhesis.backend.app.services.embedding.generator.EmbeddingGenerator.generate`.
+
+    Return value is that method's result dict (``status``, ``embedding_id``). See its
+    docstring for ``status`` values, including ``skipped_empty_text`` when text is empty.
+    """
     from rhesis.backend.app.services.embedding.generator import EmbeddingGenerator
 
     organization_id, user_id = self.get_tenant_context()
@@ -46,5 +51,10 @@ def generate_embedding_task(
             searchable_text=searchable_text,
         )
 
-    self.log_with_context("info", "Embedding generated successfully", status=result["status"])
+    self.log_with_context(
+        "info",
+        "Embedding task finished",
+        status=result["status"],
+        embedding_id=result.get("embedding_id"),
+    )
     return result

--- a/tests/backend/services/test_embedding_generator.py
+++ b/tests/backend/services/test_embedding_generator.py
@@ -399,6 +399,33 @@ class TestEmbeddingGenerator:
                 model_id="00000000-0000-0000-0000-000000000000",
             )
 
+    @pytest.mark.parametrize("empty_text", ["", "   ", "\n\t"])
+    @patch("rhesis.backend.app.services.embedding.generator.get_model")
+    def test_generate_skips_when_searchable_text_empty(
+        self,
+        mock_get_model,
+        test_db,
+        test_entity,
+        embedding_model,
+        test_org_id,
+        authenticated_user_id,
+        empty_text,
+    ):
+        """No embedder or model resolution when precomputed text is empty."""
+        generator = EmbeddingGenerator(test_db)
+
+        result = generator.generate(
+            entity_id=str(test_entity.id),
+            entity_type="Test",
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+            model_id=str(embedding_model.id),
+            searchable_text=empty_text,
+        )
+
+        assert result == {"status": "skipped_empty_text", "embedding_id": None}
+        mock_get_model.assert_not_called()
+
     @patch("rhesis.backend.app.services.embedding.generator.get_model")
     def test_generate_different_dimensions(
         self,


### PR DESCRIPTION
## Purpose
Deferred embedding jobs called `Test.to_searchable_text()` while the `prompt` relationship was often still unloaded (single-turn), so searchable text was empty, Celery posted empty `text` to the embedding service, and the worker saw HTTP 400 retries.

## What Changed
- Resolve `Prompt`, `Topic`, `Behavior`, and `Category` with `object_session(self).get(...)` when FKs are set but relationships are not loaded (e.g. mapper / flush timing).
- Skip queuing deferred embedding jobs when stripped searchable text is empty.
- Short-circuit `EmbeddingGenerator.generate` with `skipped_empty_text` when text is still empty, avoiding useless API calls.

## Additional Context
Root cause observed in debug logs: `prompt_id_set` true, `prompt` relationship not loaded, `result_len` 0; post-fix worker received non-zero `text_len`.

## Testing
- Reproduced bulk test create/update with worker: embeddings succeed, no repeated 400 from `services/generate/embedding`.
- `cd apps/backend && uv run pytest ../../tests/backend/services/test_embedding_generator.py ../../tests/backend/models/test_embedding.py::TestSearchableTextIntegration::test_test_to_searchable_text_single_turn -q`