### PR TITLE
Fix explorer suggestion streaming fallback

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
@@ -274,8 +274,9 @@ async def _generate_suggestions_stream(
     yield {"type": "meta", "num_examples_used": sample_size}
 
     try:
-        token_stream = await model.a_generate(
-            prompt=prompt_text, schema=response_model, stream=True
+        token_stream = model.generate_stream(
+            prompt=prompt_text,
+            schema=response_model,
         )
     except Exception as e:
         logger.error("LLM streaming generation failed: %s", e, exc_info=True)


### PR DESCRIPTION
## Purpose
Prevent explorer suggestion streaming from crashing when the configured model does not implement native `a_generate(..., stream=True)` support.

## What Changed
- Switched explorer suggestion streaming to call `generate_stream()` instead of `a_generate(..., stream=True)`
- Preserved compatibility with providers that only support the base-class single-chunk streaming fallback
- Kept the change scoped to the explorer service callsite

## Additional Context
- This fixes the explorer pipeline failure seen with Polyphemus, where the provider returned a structured object instead of an async iterator for `a_generate(..., stream=True)`.
- No SDK API changes were included in this PR.

## Testing
- Ran `uv run python -m py_compile src/rhesis/backend/app/services/explorer/suggestions.py` from `apps/backend`
- Did not run a focused automated explorer suggestion test because no matching test coverage was present