### PR TITLE
Add backend embedding 2D scatter graph for test sets

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -73,6 +73,8 @@ ee = ["rhesis-backend-ee"]
 # `migrate` image and out of Polyphemus.
 all = [
     "rhesis-sdk",
+    "umap-learn>=0.5.7",
+    "hdbscan>=0.8.39",
     "rhesis-penelope",
     "garak>=0.14.0",
     "mirascope==1.24.0",

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -945,7 +945,8 @@ def get_active_embeddings_for_entities(
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.Embedding]:
-    from rhesis.backend.app.models.status import EmbeddingStatus, Status
+    from rhesis.backend.app.models.enums import EmbeddingStatus
+    from rhesis.backend.app.models.status import Status
 
     return (
         QueryBuilder(db, models.Embedding)

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -938,6 +938,27 @@ def get_embeddings(
     )
 
 
+def get_embeddings_for_entities(
+    db: Session,
+    entity_ids: List[UUID],
+    entity_type: str,
+    organization_id: str = None,
+    user_id: str = None,
+) -> List[models.Embedding]:
+    from rhesis.backend.app.models.status import Status
+    return (
+        QueryBuilder(db, models.Embedding)
+        .with_organization_filter(organization_id)
+        .with_custom_filter(
+            lambda q: q.filter(
+                models.Embedding.entity_id.in_(entity_ids),
+                models.Embedding.entity_type == entity_type,
+            )
+        )
+        .all()
+    ) # TODO: you might want to add a status filter here
+
+
 def create_embedding(
     db: Session,
     embedding: schemas.EmbeddingCreate,

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -938,14 +938,15 @@ def get_embeddings(
     )
 
 
-def get_embeddings_for_entities(
+def get_active_embeddings_for_entities(
     db: Session,
     entity_ids: List[UUID],
     entity_type: str,
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.Embedding]:
-    from rhesis.backend.app.models.status import Status
+    from rhesis.backend.app.models.status import EmbeddingStatus, Status
+
     return (
         QueryBuilder(db, models.Embedding)
         .with_organization_filter(organization_id)
@@ -953,10 +954,11 @@ def get_embeddings_for_entities(
             lambda q: q.filter(
                 models.Embedding.entity_id.in_(entity_ids),
                 models.Embedding.entity_type == entity_type,
+                models.Embedding.status.has(Status.name == EmbeddingStatus.ACTIVE.value),
             )
         )
         .all()
-    ) # TODO: you might want to add a status filter here
+    )
 
 
 def create_embedding(

--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -374,6 +374,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[
         "http://localhost:3000",
+        "http://127.0.0.1:3000",
+        "http://0.0.0.0:3000",
         "http://frontend:3000",
         "https://app.rhesis.ai",
         "https://dev-app.rhesis.ai",

--- a/apps/backend/src/rhesis/backend/app/models/mixins.py
+++ b/apps/backend/src/rhesis/backend/app/models/mixins.py
@@ -351,9 +351,11 @@ class EmbeddableMixin:
         return relationship(
             "Embedding",
             primaryjoin=(
+                # foreign() wraps entity_id, the referencing side, not the parent id. Works anyways
                 f"and_(Embedding.entity_id == foreign({cls.__name__}.id), "
                 f"Embedding.entity_type == '{cls.__name__}')"
             ),
+            # this likely overrides the foreign() above
             foreign_keys="[Embedding.entity_id]",
             viewonly=True,
             uselist=True,

--- a/apps/backend/src/rhesis/backend/app/routers/source.py
+++ b/apps/backend/src/rhesis/backend/app/routers/source.py
@@ -13,6 +13,13 @@ from rhesis.backend.app.dependencies import (
     get_tenant_db_session,
 )
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.schemas.embedding import (
+    EmbeddingGraphComputeResponse,
+    EmbeddingGraphGetResponse,
+    EmbeddingGraphPendingResponse,
+    EmbeddingGraphReadyResponse,
+    Scatter2DGraph,
+)
 from rhesis.backend.app.services.source import (
     extract_source_content,
     get_source_file_content,
@@ -24,6 +31,7 @@ from rhesis.backend.app.services.source import (
 from rhesis.backend.app.utils.database_exceptions import handle_database_exceptions
 from rhesis.backend.app.utils.decorators import with_count_header
 from rhesis.backend.app.utils.odata import apply_select
+from rhesis.backend.tasks.embedding.graph import compute_source_graph_task
 
 router = APIRouter(
     prefix="/sources",
@@ -271,6 +279,47 @@ def read_source_with_content(
     if db_source is None:
         raise HTTPException(status_code=404, detail="Source not found")
     return db_source
+
+
+@router.post(
+    "/{source_id}/embeddings/compute-graph",
+    response_model=EmbeddingGraphComputeResponse,
+)
+def compute_source_embedding_graph(
+    source_id: uuid.UUID,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Queue background computation of a 2D embedding graph over this source's chunks."""
+    organization_id, user_id = tenant_context
+    db_source = crud.get_source(db, source_id, organization_id=organization_id, user_id=user_id)
+    if db_source is None:
+        raise HTTPException(status_code=404, detail="Source not found")
+    task = compute_source_graph_task.delay(str(source_id), user_id)
+    return EmbeddingGraphComputeResponse(status="pending", task_id=str(task.id))
+
+
+@router.get(
+    "/{source_id}/embeddings/graph",
+    response_model=EmbeddingGraphGetResponse,
+)
+def get_source_embedding_graph(
+    source_id: uuid.UUID,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Return the persisted embedding graph from ``source_metadata`` when available."""
+    organization_id, user_id = tenant_context
+    db_source = crud.get_source(db, source_id, organization_id=organization_id, user_id=user_id)
+    if db_source is None:
+        raise HTTPException(status_code=404, detail="Source not found")
+    meta = db_source.source_metadata or {}
+    graph = meta.get("graph")
+    if not graph:
+        return EmbeddingGraphPendingResponse(status="pending")
+    return EmbeddingGraphReadyResponse(status="ready", graph=Scatter2DGraph.model_validate(graph))
 
 
 @router.get("/{source_id}/file")

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -49,7 +49,7 @@ from rhesis.backend.app.utils.execution_validation import (
 from rhesis.backend.app.utils.odata import apply_select
 from rhesis.backend.app.utils.schema_factory import create_detailed_schema
 from rhesis.backend.tasks import task_launcher
-from rhesis.backend.tasks.embedding.graph import compute_graph_task
+from rhesis.backend.tasks.embedding.graph import compute_test_set_graph_task
 from rhesis.backend.tasks.test_set import generate_and_save_test_set
 
 logger = logging.getLogger(__name__)
@@ -841,28 +841,6 @@ def remove_metric_from_test_set(
         raise HTTPException(status_code=404, detail=str(e))
 
 
-def _test_entity_ids_for_embedding_graph(db: Session, test_set_id: uuid.UUID) -> list[uuid.UUID]:
-    """Paginate through all tests linked to a test set."""
-    entity_ids: list[uuid.UUID] = []
-    skip = 0
-    page_size = 100
-    while True:
-        items, _count = crud.get_test_set_tests(
-            db=db,
-            test_set_id=test_set_id,
-            skip=skip,
-            limit=page_size,
-            sort_by="created_at",
-            sort_order="desc",
-            filter=None,
-        )
-        entity_ids.extend(t.id for t in items)
-        if len(items) < page_size:
-            break
-        skip += page_size
-    return entity_ids
-
-
 @router.post(
     "/{test_set_identifier}/embeddings/compute-graph",
     response_model=EmbeddingGraphComputeResponse,
@@ -878,9 +856,7 @@ def compute_test_set_embedding_graph(
     db_test_set = resolve_test_set_or_raise(
         test_set_identifier, db, str(current_user.organization_id)
     )
-    entity_ids = _test_entity_ids_for_embedding_graph(db, db_test_set.id)
-    entity_id_strs = [str(eid) for eid in entity_ids]
-    task = compute_graph_task.delay(entity_id_strs, str(db_test_set.id), str(current_user.id))
+    task = compute_test_set_graph_task.delay(str(db_test_set.id), str(current_user.id))
     return EmbeddingGraphComputeResponse(status="pending", task_id=str(task.id))
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -20,6 +20,13 @@ from rhesis.backend.app.dependencies import (
 from rhesis.backend.app.models.test_set import TestSet
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.schemas import services as services_schemas
+from rhesis.backend.app.schemas.embedding import (
+    EmbeddingGraphComputeResponse,
+    EmbeddingGraphGetResponse,
+    EmbeddingGraphPendingResponse,
+    EmbeddingGraphReadyResponse,
+    Scatter2DGraph,
+)
 from rhesis.backend.app.services.prompt import get_prompts_for_test_set, prompts_to_csv
 from rhesis.backend.app.services.test import (
     create_test_set_associations,
@@ -42,6 +49,7 @@ from rhesis.backend.app.utils.execution_validation import (
 from rhesis.backend.app.utils.odata import apply_select
 from rhesis.backend.app.utils.schema_factory import create_detailed_schema
 from rhesis.backend.tasks import task_launcher
+from rhesis.backend.tasks.embedding.graph import compute_graph_task
 from rhesis.backend.tasks.test_set import generate_and_save_test_set
 
 logger = logging.getLogger(__name__)
@@ -831,3 +839,70 @@ def remove_metric_from_test_set(
         return db_test_set.metrics or []
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
+
+
+def _test_entity_ids_for_embedding_graph(db: Session, test_set_id: uuid.UUID) -> list[uuid.UUID]:
+    """Paginate through all tests linked to a test set."""
+    entity_ids: list[uuid.UUID] = []
+    skip = 0
+    page_size = 100
+    while True:
+        items, _count = crud.get_test_set_tests(
+            db=db,
+            test_set_id=test_set_id,
+            skip=skip,
+            limit=page_size,
+            sort_by="created_at",
+            sort_order="desc",
+            filter=None,
+        )
+        entity_ids.extend(t.id for t in items)
+        if len(items) < page_size:
+            break
+        skip += page_size
+    return entity_ids
+
+
+@router.post(
+    "/{test_set_identifier}/embeddings/compute-graph",
+    response_model=EmbeddingGraphComputeResponse,
+)
+def compute_test_set_embedding_graph(
+    test_set_identifier: str,
+    db: Session = Depends(get_tenant_db_session),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """
+    Compute a embedding graph for a test set.
+    """
+    db_test_set = resolve_test_set_or_raise(
+        test_set_identifier, db, str(current_user.organization_id)
+    )
+    entity_ids = _test_entity_ids_for_embedding_graph(db, db_test_set.id)
+    entity_id_strs = [str(eid) for eid in entity_ids]
+    task = compute_graph_task.delay(entity_id_strs, str(db_test_set.id), str(current_user.id))
+    return EmbeddingGraphComputeResponse(status="pending", task_id=str(task.id))
+
+
+# for pooling until task is ready
+@router.get(
+    "/{test_set_identifier}/embeddings/graph",
+    response_model=EmbeddingGraphGetResponse,
+)
+def get_test_set_embedding_graph(
+    test_set_identifier: str,
+    db: Session = Depends(get_tenant_db_session),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """
+    Get the embedding graph for a test set.
+    """
+    db_test_set = resolve_test_set_or_raise(
+        test_set_identifier, db, str(current_user.organization_id)
+    )
+    attrs = db_test_set.attributes or {}
+    graph = attrs.get("graph")
+    if not graph:
+        return EmbeddingGraphPendingResponse(status="pending")
+
+    return EmbeddingGraphReadyResponse(status="ready", graph=Scatter2DGraph.model_validate(graph))

--- a/apps/backend/src/rhesis/backend/app/schemas/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/__init__.py
@@ -13,7 +13,16 @@ from .chunk import Chunk, ChunkBase, ChunkCreate, ChunkUpdate
 from .comment import Comment, CommentBase, CommentCreate, CommentUpdate
 from .demographic import Demographic, DemographicBase, DemographicCreate, DemographicUpdate
 from .dimension import Dimension, DimensionBase, DimensionCreate, DimensionUpdate
-from .embedding import Embedding, EmbeddingBase, EmbeddingCreate, EmbeddingUpdate
+from .embedding import (
+    Embedding,
+    EmbeddingBase,
+    EmbeddingCreate,
+    EmbeddingGraphComputeResponse,
+    EmbeddingGraphGetResponse,
+    EmbeddingGraphPendingResponse,
+    EmbeddingGraphReadyResponse,
+    EmbeddingUpdate,
+)
 from .emoji_reaction import CommentEmojis, EmojiReaction
 from .endpoint import (
     Endpoint,
@@ -267,6 +276,10 @@ __all__ = [
     "Embedding",
     "EmbeddingBase",
     "EmbeddingCreate",
+    "EmbeddingGraphComputeResponse",
+    "EmbeddingGraphGetResponse",
+    "EmbeddingGraphPendingResponse",
+    "EmbeddingGraphReadyResponse",
     "EmbeddingUpdate",
     "TypeLookup",
     "TypeLookupBase",

--- a/apps/backend/src/rhesis/backend/app/schemas/embedding.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/embedding.py
@@ -49,13 +49,14 @@ class Point(Base):
 
 
 class ScatterPoint2D(Point):
-    cluster_id: str
+    cluster_index: int  # HDBSCAN cluster id, or -1 for noise
+    searchable_text: str
     x: float  # 2D UMAP coordinates for visualization
     y: float
 
 
 class Cluster(Base):
-    id: str  # "cluster_1", "cluster_2", etc.
+    cluster_index: int
     label: str  # A descriptive, LLM-generated label
     size: int  # number of entities in the cluster
 

--- a/apps/backend/src/rhesis/backend/app/schemas/embedding.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/embedding.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Any, Dict, List, Optional
 
 from pydantic import UUID4
@@ -39,3 +40,22 @@ class EmbeddingUpdate(EmbeddingBase):
 
 class Embedding(EmbeddingBase):
     embedding: Optional[List[float]] = None
+
+class Point(Base):
+    entity_id: UUID4
+    entity_type: str
+
+class ScatterPoint2D(Point):
+    cluster_id: str
+    x: float
+    y: float
+
+class Cluster(Base):
+    id: str # "cluster_1", "cluster_2", etc.
+    label: str # A descriptive, LLM-generated label
+    size: int # number of entities in the cluster
+
+class Scatter2DGraph(Base):
+    computed_at: datetime.datetime
+    clusters: List[Cluster]
+    points: List[ScatterPoint2D]

--- a/apps/backend/src/rhesis/backend/app/schemas/embedding.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/embedding.py
@@ -41,19 +41,23 @@ class EmbeddingUpdate(EmbeddingBase):
 class Embedding(EmbeddingBase):
     embedding: Optional[List[float]] = None
 
+
 class Point(Base):
     entity_id: UUID4
     entity_type: str
+
 
 class ScatterPoint2D(Point):
     cluster_id: str
     x: float
     y: float
 
+
 class Cluster(Base):
-    id: str # "cluster_1", "cluster_2", etc.
-    label: str # A descriptive, LLM-generated label
-    size: int # number of entities in the cluster
+    id: str  # "cluster_1", "cluster_2", etc.
+    label: str  # A descriptive, LLM-generated label
+    size: int  # number of entities in the cluster
+
 
 class Scatter2DGraph(Base):
     computed_at: datetime.datetime

--- a/apps/backend/src/rhesis/backend/app/schemas/embedding.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/embedding.py
@@ -1,7 +1,7 @@
 import datetime
-from typing import Any, Dict, List, Optional
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
-from pydantic import UUID4
+from pydantic import UUID4, Field
 
 from rhesis.backend.app.schemas.base import Base
 
@@ -43,13 +43,14 @@ class Embedding(EmbeddingBase):
 
 
 class Point(Base):
+    embedding_id: UUID4
     entity_id: UUID4
     entity_type: str
 
 
 class ScatterPoint2D(Point):
     cluster_id: str
-    x: float
+    x: float  # 2D UMAP coordinates for visualization
     y: float
 
 
@@ -63,3 +64,29 @@ class Scatter2DGraph(Base):
     computed_at: datetime.datetime
     clusters: List[Cluster]
     points: List[ScatterPoint2D]
+
+
+class EmbeddingGraphComputeResponse(Base):
+    """Response when a background task to compute the embedding graph has been queued."""
+
+    status: Literal["pending"] = "pending"
+    task_id: str
+
+
+class EmbeddingGraphPendingResponse(Base):
+    """Graph is not computed yet or has not been persisted on the test set."""
+
+    status: Literal["pending"] = "pending"
+
+
+class EmbeddingGraphReadyResponse(Base):
+    """Computed 2D embedding graph is available."""
+
+    status: Literal["ready"] = "ready"
+    graph: Scatter2DGraph
+
+
+EmbeddingGraphGetResponse = Annotated[
+    Union[EmbeddingGraphPendingResponse, EmbeddingGraphReadyResponse],
+    Field(discriminator="status"),
+]

--- a/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
@@ -134,7 +134,7 @@ def _generate_cluster_labels(
             continue
 
         combined_text = "\n".join(sample_text)
-        prompt = "Summarize these items in 1-2 words: " + combined_text
+        prompt = "Create a very short label for these items (1-2-3 words max): " + combined_text
 
         try:
             label = _model.generate(prompt)

--- a/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
@@ -1,0 +1,273 @@
+"""Build graph structures from stored embeddings (UMAP, clustering, etc.)."""
+
+import logging
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from uuid import UUID
+
+import numpy as np
+from hdbscan import HDBSCAN
+from sqlalchemy.orm import Session
+from umap import UMAP
+
+from rhesis.backend.app import crud, models
+from rhesis.backend.app.models.test import Test
+from rhesis.backend.app.models.user import User
+from rhesis.backend.app.schemas.embedding import Cluster, Scatter2DGraph, ScatterPoint2D
+from rhesis.backend.app.utils.user_model_utils import get_user_generation_model
+from rhesis.sdk.models.factory import get_model
+
+logger = logging.getLogger(__name__)
+
+def _embedding_entity_type_key(model_or_name: type | str) -> str:
+    return model_or_name if isinstance(model_or_name, str) else model_or_name.__name__
+
+
+def fetch_embeddings(
+    db: Session,
+    entity_ids: Sequence[UUID],
+    embedded_entity: type | str = Test,
+    organization_id: str = None,
+    user_id: str = None,
+) -> list[models.Embedding]:
+    """Load embeddings for one entity type and a set of IDs."""
+    if not entity_ids:
+        return []
+    return crud.get_active_embeddings_for_entities(
+        db,
+        entity_ids=list(entity_ids),
+        entity_type=_embedding_entity_type_key(embedded_entity),
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+
+def _reduce_dimensions(X: np.ndarray, purpose: str) -> np.ndarray:
+    """Reduce the dimensions of the embeddings (requires n_samples >= 3)."""
+    n_samples = X.shape[0]
+
+    max_neighbors = max(1, n_samples - 1)
+
+    if purpose == "clustering":
+        n_components = max(2, min(50, n_samples - 1))
+        n_neighbors = max(3, min(15, int(0.08 * n_samples)))
+        n_neighbors = min(n_neighbors, max_neighbors)
+        n_neighbors = max(2, n_neighbors)
+    elif purpose == "visualization":
+        n_components = 2
+        n_neighbors = max(2, min(10, int(0.05 * n_samples)))
+        n_neighbors = min(n_neighbors, max_neighbors)
+        n_neighbors = max(1, n_neighbors)
+
+    umap = UMAP(n_components=n_components, n_neighbors=n_neighbors, random_state=42)
+    return umap.fit_transform(X)
+
+def _cluster_with_hdbscan(X: np.ndarray) -> tuple[np.ndarray, dict[int, np.ndarray]]:
+    """Cluster the embeddings with HDBSCAN."""
+    n_samples = X.shape[0]
+
+    # 5-10% of dataset, min 3, max 20, never exceeding n_samples
+    min_cluster_size = max(3, min(20, int(0.08 * n_samples)))
+    min_cluster_size = min(min_cluster_size, n_samples)
+    min_cluster_size = max(2, min_cluster_size)
+
+    # min_samples: typically smaller than min_cluster_size
+    min_samples = max(2, min_cluster_size // 2)
+    min_samples = min(min_samples, n_samples)
+
+    clusterer = HDBSCAN(
+        min_cluster_size=min_cluster_size,
+        min_samples=min_samples,
+        metric="euclidean",
+        cluster_selection_epsilon=0.5,
+    )
+    cluster_ids = clusterer.fit_predict(X)
+
+    centroids = {}
+    for cluster_id in np.unique(cluster_ids):
+        if cluster_id == -1:  # Skip noise points
+            continue
+        mask = cluster_ids == cluster_id
+        centroids[int(cluster_id)] = X[mask].mean(axis=0)
+
+    return cluster_ids, centroids
+
+def _generate_cluster_labels(
+    embeddings: list[models.Embedding],
+    cluster_ids: np.ndarray,
+    umap_50d: np.ndarray,
+    centroids: dict[int, np.ndarray],
+    db: Session,
+    user: User,
+) -> dict[int, str]:
+    _model = get_user_generation_model(db, user)
+    if isinstance(_model, str):
+        _model = get_model(_model)
+
+    labels = {}
+    for cluster_id, centroid in centroids.items():
+        logger.info(f"Generating label for cluster {cluster_id}")
+
+        # Get all embeddings in this cluster
+        mask = cluster_ids == cluster_id
+        cluster_embeddings = [e for e, m in zip(embeddings, mask) if m]
+        cluster_coords = umap_50d[mask]
+
+        # Find closest to centroid
+        distances = np.linalg.norm(cluster_coords - centroid, axis=1)
+        closest_indices = np.argsort(distances)[:3]
+
+        # Get text from closest
+        sample_text = [
+            cluster_embeddings[i].searchable_text
+            for i in closest_indices
+            if cluster_embeddings[i].searchable_text
+        ]
+
+        if not sample_text:
+            labels[cluster_id] = "Unlabeled"
+            continue
+
+        combined_text = "\n".join(sample_text)
+        prompt = "Summarize these items in 1-2 words: " + combined_text
+
+        try:
+            label = _model.generate(prompt)
+            labels[cluster_id] = label.strip()
+        except Exception as e:
+            logger.error(f"Error generating cluster label: {e}", exc_info=True)
+            labels[cluster_id] = "Unlabeled"
+            continue
+
+    return labels
+
+def _trivial_single_point_graph(embedding: models.Embedding, now_utc: datetime) -> Scatter2DGraph:
+    """One sample: pin at origin, no clusters (noise only). Used when UMAP is ill-defined."""
+    return Scatter2DGraph(
+        computed_at=now_utc,
+        clusters=[],
+        points=[
+            ScatterPoint2D(
+                embedding_id=embedding.id,
+                entity_id=embedding.entity_id,
+                entity_type=embedding.entity_type,
+                cluster_id="-1",
+                x=0.0,
+                y=0.0,
+            )
+        ],
+    )
+
+
+def _trivial_two_point_graph(
+    embeddings_two: list[models.Embedding],
+    now_utc: datetime,
+) -> Scatter2DGraph:
+    """Two samples: fixed symmetric layout without UMAP."""
+    left, right = embeddings_two
+    return Scatter2DGraph(
+        computed_at=now_utc,
+        clusters=[],
+        points=[
+            ScatterPoint2D(
+                embedding_id=left.id,
+                entity_id=left.entity_id,
+                entity_type=left.entity_type,
+                cluster_id="-1",
+                x=-0.5,
+                y=0.0,
+            ),
+            ScatterPoint2D(
+                embedding_id=right.id,
+                entity_id=right.entity_id,
+                entity_type=right.entity_type,
+                cluster_id="-1",
+                x=0.5,
+                y=0.0,
+            ),
+        ],
+    )
+
+
+def build_2d_graph(db: Session, entity_ids: Sequence[UUID], user: User) -> Scatter2DGraph:
+    """Build a graph from embeddings for visualization and clustering."""
+
+    requested_count = len(entity_ids)
+
+    embeddings = fetch_embeddings(
+        db,
+        entity_ids,
+        organization_id=user.organization_id,
+        user_id=user.id,
+    )
+
+    logger.info(
+        "Building embedding graph: requested_entity_ids=%s active_embeddings_loaded=%s",
+        requested_count,
+        len(embeddings),
+    )
+
+    if requested_count > 0 and not embeddings:
+        logger.warning(
+            "Embedding graph has no active embeddings for requested tests: "
+            "requested_entity_ids=%s",
+            requested_count,
+        )
+
+    if not embeddings:
+        return Scatter2DGraph(computed_at=datetime.now(timezone.utc), clusters=[], points=[])
+
+    now_utc = datetime.now(timezone.utc)
+    n_samples = len(embeddings)
+
+    if n_samples == 1:
+        return _trivial_single_point_graph(embeddings[0], now_utc)
+    if n_samples == 2:
+        return _trivial_two_point_graph(embeddings, now_utc)
+
+    X = np.array([e.embedding for e in embeddings])
+
+    umap_50d = _reduce_dimensions(X, purpose="clustering")
+    umap_2d = _reduce_dimensions(X, purpose="visualization")
+
+    cluster_ids, centroids = _cluster_with_hdbscan(umap_50d)
+
+    cluster_labels = _generate_cluster_labels(
+        embeddings, cluster_ids, umap_50d, centroids, db, user
+    )
+
+    # Build scatter points
+    points = []
+    for embedding, cluster_id, coords_2d in zip(embeddings, cluster_ids, umap_2d):
+        points.append(
+            ScatterPoint2D(
+                embedding_id=embedding.id,
+                entity_id=embedding.entity_id,
+                entity_type=embedding.entity_type,
+                cluster_id=str(cluster_id),
+                x=float(coords_2d[0]),
+                y=float(coords_2d[1]),
+            )
+        )
+
+    # Build clusters
+    cluster_counts = {}
+    for cluster_id in cluster_ids:
+        cluster_id = int(cluster_id)
+        if cluster_id == -1:
+            continue
+        cluster_counts[cluster_id] = cluster_counts.get(cluster_id, 0) + 1
+
+    clusters = [
+        Cluster(
+            id=f"cluster_{cluster_id}",
+            label=cluster_labels.get(cluster_id, "Unlabeled"),
+            size=cluster_counts[cluster_id],
+        )
+        for cluster_id in sorted(cluster_counts.keys())
+    ]
+
+    return Scatter2DGraph(
+        computed_at=now_utc,
+        clusters=clusters,
+        points=points,
+    )

--- a/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
@@ -28,8 +28,8 @@ def fetch_embeddings(
     db: Session,
     entity_ids: Sequence[UUID],
     embedded_entity: type | str = Test,
-    organization_id: str = None,
-    user_id: str = None,
+    organization_id: str | None = None,
+    user_id: str | None = None,
 ) -> list[models.Embedding]:
     """Load embeddings for one entity type and a set of IDs."""
     if not entity_ids:
@@ -193,7 +193,13 @@ def _trivial_two_point_graph(
     )
 
 
-def build_2d_graph(db: Session, entity_ids: Sequence[UUID], user: User) -> Scatter2DGraph:
+def build_2d_graph(
+    db: Session,
+    entity_ids: Sequence[UUID],
+    user: User,
+    *,
+    embedded_entity: type | str = Test,
+) -> Scatter2DGraph:
     """Build a graph from embeddings for visualization and clustering."""
 
     requested_count = len(entity_ids)
@@ -201,19 +207,25 @@ def build_2d_graph(db: Session, entity_ids: Sequence[UUID], user: User) -> Scatt
     embeddings = fetch_embeddings(
         db,
         entity_ids,
+        embedded_entity=embedded_entity,
         organization_id=user.organization_id,
         user_id=user.id,
     )
 
+    entity_type_key = _embedding_entity_type_key(embedded_entity)
     logger.info(
-        "Building embedding graph: requested_entity_ids=%s active_embeddings_loaded=%s",
+        "Building embedding graph: entity_type=%s requested_entity_ids=%s "
+        "active_embeddings_loaded=%s",
+        entity_type_key,
         requested_count,
         len(embeddings),
     )
 
     if requested_count > 0 and not embeddings:
         logger.warning(
-            "Embedding graph has no active embeddings for requested tests: requested_entity_ids=%s",
+            "Embedding graph has no active embeddings for requested entities: "
+            "entity_type=%s requested_entity_ids=%s",
+            entity_type_key,
             requested_count,
         )
 

--- a/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
@@ -19,6 +19,7 @@ from rhesis.sdk.models.factory import get_model
 
 logger = logging.getLogger(__name__)
 
+
 def _embedding_entity_type_key(model_or_name: type | str) -> str:
     return model_or_name if isinstance(model_or_name, str) else model_or_name.__name__
 
@@ -41,6 +42,7 @@ def fetch_embeddings(
         user_id=user_id,
     )
 
+
 def _reduce_dimensions(X: np.ndarray, purpose: str) -> np.ndarray:
     """Reduce the dimensions of the embeddings (requires n_samples >= 3)."""
     n_samples = X.shape[0]
@@ -60,6 +62,7 @@ def _reduce_dimensions(X: np.ndarray, purpose: str) -> np.ndarray:
 
     umap = UMAP(n_components=n_components, n_neighbors=n_neighbors, random_state=42)
     return umap.fit_transform(X)
+
 
 def _cluster_with_hdbscan(X: np.ndarray) -> tuple[np.ndarray, dict[int, np.ndarray]]:
     """Cluster the embeddings with HDBSCAN."""
@@ -90,6 +93,7 @@ def _cluster_with_hdbscan(X: np.ndarray) -> tuple[np.ndarray, dict[int, np.ndarr
         centroids[int(cluster_id)] = X[mask].mean(axis=0)
 
     return cluster_ids, centroids
+
 
 def _generate_cluster_labels(
     embeddings: list[models.Embedding],
@@ -139,6 +143,7 @@ def _generate_cluster_labels(
             continue
 
     return labels
+
 
 def _trivial_single_point_graph(embedding: models.Embedding, now_utc: datetime) -> Scatter2DGraph:
     """One sample: pin at origin, no clusters (noise only). Used when UMAP is ill-defined."""
@@ -208,8 +213,7 @@ def build_2d_graph(db: Session, entity_ids: Sequence[UUID], user: User) -> Scatt
 
     if requested_count > 0 and not embeddings:
         logger.warning(
-            "Embedding graph has no active embeddings for requested tests: "
-            "requested_entity_ids=%s",
+            "Embedding graph has no active embeddings for requested tests: requested_entity_ids=%s",
             requested_count,
         )
 

--- a/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
@@ -105,9 +105,20 @@ def _generate_cluster_labels(
     db: Session,
     user: User,
 ) -> dict[int, str]:
-    _model = get_user_generation_model(db, user)
-    if isinstance(_model, str):
-        _model = get_model(_model)
+    if not centroids:
+        return {}
+
+    try:
+        _model = get_user_generation_model(db, user)
+        if isinstance(_model, str):
+            _model = get_model(_model)
+    except Exception as e:
+        logger.warning(
+            "Skipping cluster labels: generation model unavailable (%s)",
+            e,
+            exc_info=True,
+        )
+        return {}
 
     labels = {}
     for cluster_id, centroid in centroids.items():

--- a/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
@@ -59,6 +59,8 @@ def _reduce_dimensions(X: np.ndarray, purpose: str) -> np.ndarray:
         n_neighbors = max(2, min(10, int(0.05 * n_samples)))
         n_neighbors = min(n_neighbors, max_neighbors)
         n_neighbors = max(1, n_neighbors)
+    else:
+        raise ValueError(f"Invalid purpose: {purpose}")
 
     umap = UMAP(n_components=n_components, n_neighbors=n_neighbors, random_state=42)
     return umap.fit_transform(X)
@@ -234,7 +236,10 @@ def build_2d_graph(
     if n_samples == 2:
         return _trivial_two_point_graph(embeddings, now_utc)
 
-    X = np.array([e.embedding for e in embeddings])
+    dims = {len(e.embedding) for e in embeddings}
+    if len(dims) > 1:
+        raise ValueError(f"Mixed embedding dimensions: {sorted(dims)}")
+    X = np.array([e.embedding for e in embeddings], dtype=np.float64)
 
     umap_50d = _reduce_dimensions(X, purpose="clustering")
     umap_2d = _reduce_dimensions(X, purpose="visualization")

--- a/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
@@ -228,6 +228,25 @@ def build_2d_graph(
     if not embeddings:
         return Scatter2DGraph(computed_at=datetime.now(timezone.utc), clusters=[], points=[])
 
+    config_hashes = {e.config_hash for e in embeddings}
+    seen_entity_ids: set[UUID] = set()
+    duplicate_entity = False
+    for e in embeddings:
+        if e.entity_id in seen_entity_ids:
+            duplicate_entity = True
+            break
+        seen_entity_ids.add(e.entity_id)
+
+    if len(config_hashes) > 1 or duplicate_entity:
+        logger.warning(
+            "Skipping embedding graph: ambiguous active embeddings "
+            "(entity_type=%s mixed_config=%s duplicate_entity=%s)",
+            entity_type_key,
+            len(config_hashes) > 1,
+            duplicate_entity,
+        )
+        return Scatter2DGraph(computed_at=datetime.now(timezone.utc), clusters=[], points=[])
+
     now_utc = datetime.now(timezone.utc)
     n_samples = len(embeddings)
 
@@ -236,9 +255,6 @@ def build_2d_graph(
     if n_samples == 2:
         return _trivial_two_point_graph(embeddings, now_utc)
 
-    dims = {len(e.embedding) for e in embeddings}
-    if len(dims) > 1:
-        raise ValueError(f"Mixed embedding dimensions: {sorted(dims)}")
     X = np.array([e.embedding for e in embeddings], dtype=np.float64)
 
     umap_50d = _reduce_dimensions(X, purpose="clustering")

--- a/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
@@ -145,21 +145,29 @@ def _generate_cluster_labels(
     return labels
 
 
+def _scatter_point(
+    embedding: models.Embedding,
+    cluster_index: int,
+    x: float,
+    y: float,
+) -> ScatterPoint2D:
+    return ScatterPoint2D(
+        embedding_id=embedding.id,
+        entity_id=embedding.entity_id,
+        entity_type=embedding.entity_type,
+        cluster_index=cluster_index,
+        searchable_text=embedding.searchable_text or "",
+        x=x,
+        y=y,
+    )
+
+
 def _trivial_single_point_graph(embedding: models.Embedding, now_utc: datetime) -> Scatter2DGraph:
     """One sample: pin at origin, no clusters (noise only). Used when UMAP is ill-defined."""
     return Scatter2DGraph(
         computed_at=now_utc,
         clusters=[],
-        points=[
-            ScatterPoint2D(
-                embedding_id=embedding.id,
-                entity_id=embedding.entity_id,
-                entity_type=embedding.entity_type,
-                cluster_id="-1",
-                x=0.0,
-                y=0.0,
-            )
-        ],
+        points=[_scatter_point(embedding, -1, 0.0, 0.0)],
     )
 
 
@@ -173,22 +181,8 @@ def _trivial_two_point_graph(
         computed_at=now_utc,
         clusters=[],
         points=[
-            ScatterPoint2D(
-                embedding_id=left.id,
-                entity_id=left.entity_id,
-                entity_type=left.entity_type,
-                cluster_id="-1",
-                x=-0.5,
-                y=0.0,
-            ),
-            ScatterPoint2D(
-                embedding_id=right.id,
-                entity_id=right.entity_id,
-                entity_type=right.entity_type,
-                cluster_id="-1",
-                x=0.5,
-                y=0.0,
-            ),
+            _scatter_point(left, -1, -0.5, 0.0),
+            _scatter_point(right, -1, 0.5, 0.0),
         ],
     )
 
@@ -255,13 +249,11 @@ def build_2d_graph(
     points = []
     for embedding, cluster_id, coords_2d in zip(embeddings, cluster_ids, umap_2d):
         points.append(
-            ScatterPoint2D(
-                embedding_id=embedding.id,
-                entity_id=embedding.entity_id,
-                entity_type=embedding.entity_type,
-                cluster_id=str(cluster_id),
-                x=float(coords_2d[0]),
-                y=float(coords_2d[1]),
+            _scatter_point(
+                embedding,
+                int(cluster_id),
+                float(coords_2d[0]),
+                float(coords_2d[1]),
             )
         )
 
@@ -275,7 +267,7 @@ def build_2d_graph(
 
     clusters = [
         Cluster(
-            id=f"cluster_{cluster_id}",
+            cluster_index=cluster_id,
             label=cluster_labels.get(cluster_id, "Unlabeled"),
             size=cluster_counts[cluster_id],
         )

--- a/apps/backend/src/rhesis/backend/celery/config.py
+++ b/apps/backend/src/rhesis/backend/celery/config.py
@@ -83,6 +83,7 @@ CELERY_CONFIG = {
     "include": [
         "rhesis.backend.tasks.test_configuration",
         "rhesis.backend.tasks.embedding.generate",
+        "rhesis.backend.tasks.embedding.graph",
         "rhesis.backend.tasks.example_task",
         "rhesis.backend.tasks.test_set",
         "rhesis.backend.tasks.execution.results",

--- a/apps/backend/src/rhesis/backend/tasks/__init__.py
+++ b/apps/backend/src/rhesis/backend/tasks/__init__.py
@@ -23,7 +23,7 @@ from rhesis.backend.tasks.base import (
     SilentTask,
     email_notification,
 )
-from rhesis.backend.tasks.embedding import generate_embedding_task
+from rhesis.backend.tasks.embedding import compute_graph_task, generate_embedding_task
 from rhesis.backend.tasks.enums import (
     DEFAULT_METRIC_WORKERS,
     DEFAULT_RESULT_STATUS,
@@ -69,6 +69,7 @@ __all__ = [
     # Tasks
     "echo",
     "generate_embedding_task",
+    "compute_graph_task",
     "count_test_sets",
     "execute_test_configuration",
     "collect_results",

--- a/apps/backend/src/rhesis/backend/tasks/__init__.py
+++ b/apps/backend/src/rhesis/backend/tasks/__init__.py
@@ -23,7 +23,11 @@ from rhesis.backend.tasks.base import (
     SilentTask,
     email_notification,
 )
-from rhesis.backend.tasks.embedding import compute_graph_task, generate_embedding_task
+from rhesis.backend.tasks.embedding import (
+    compute_source_graph_task,
+    compute_test_set_graph_task,
+    generate_embedding_task,
+)
 from rhesis.backend.tasks.enums import (
     DEFAULT_METRIC_WORKERS,
     DEFAULT_RESULT_STATUS,
@@ -69,7 +73,8 @@ __all__ = [
     # Tasks
     "echo",
     "generate_embedding_task",
-    "compute_graph_task",
+    "compute_test_set_graph_task",
+    "compute_source_graph_task",
     "count_test_sets",
     "execute_test_configuration",
     "collect_results",

--- a/apps/backend/src/rhesis/backend/tasks/embedding/__init__.py
+++ b/apps/backend/src/rhesis/backend/tasks/embedding/__init__.py
@@ -1,6 +1,10 @@
 """Embedding generation tasks."""
 
 from .generate import generate_embedding_task
-from .graph import compute_graph_task
+from .graph import compute_source_graph_task, compute_test_set_graph_task
 
-__all__ = ["compute_graph_task", "generate_embedding_task"]
+__all__ = [
+    "compute_source_graph_task",
+    "compute_test_set_graph_task",
+    "generate_embedding_task",
+]

--- a/apps/backend/src/rhesis/backend/tasks/embedding/__init__.py
+++ b/apps/backend/src/rhesis/backend/tasks/embedding/__init__.py
@@ -1,5 +1,6 @@
 """Embedding generation tasks."""
 
 from .generate import generate_embedding_task
+from .graph import compute_graph_task
 
-__all__ = ["generate_embedding_task"]
+__all__ = ["compute_graph_task", "generate_embedding_task"]

--- a/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
+++ b/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
@@ -1,0 +1,51 @@
+"""Celery task for computing a graph.
+
+This task computes a embedding graph for entities in a background worker.
+"""
+
+import logging
+from uuid import UUID
+
+from rhesis.backend.celery.core import app
+from rhesis.backend.tasks.base import SilentTask
+
+logger = logging.getLogger(__name__)
+
+
+@app.task(
+    base=SilentTask,
+    name="rhesis.backend.tasks.embedding.compute_graph",
+    bind=True,
+    display_name="Embedding Graph Computation",
+)
+def compute_graph_task(self, entity_ids: list[str], test_set_id: str, user_id: str):
+    """
+    Compute an embedding graph for the given entity IDs and persist it on the test set.
+
+    The HTTP layer resolves which entities belong to the test set and passes their IDs here.
+    """
+    from rhesis.backend.app import crud
+    from rhesis.backend.app.services.embedding.graph_builder import build_2d_graph
+
+    with self.get_db_session() as db:
+        user = crud.get_user_by_id(db, user_id)
+        if user is None:
+            logger.warning("Skipping graph computation: user not found", extra={"user_id": user_id})
+            return
+
+        test_set = crud.get_test_set(db, UUID(test_set_id), str(user.organization_id), str(user.id))
+        if test_set is None:
+            logger.warning(
+                "Skipping graph computation: test set not found",
+                extra={"test_set_id": test_set_id},
+            )
+            return
+
+        ids = [UUID(eid) for eid in entity_ids]
+        graph = build_2d_graph(db, ids, user)
+
+        attrs = dict(test_set.attributes or {})
+        attrs["graph"] = graph.model_dump(mode="json")
+        test_set.attributes = attrs
+        db.add(test_set)
+        db.commit()

--- a/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
+++ b/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
@@ -1,9 +1,8 @@
-"""Celery task for computing a graph.
-
-This task computes a embedding graph for entities in a background worker.
-"""
+"""Celery tasks for computing embedding graphs (2D scatter + clusters)."""
 
 import logging
+from collections.abc import Callable
+from typing import Any
 from uuid import UUID
 
 from rhesis.backend.celery.core import app
@@ -11,41 +10,173 @@ from rhesis.backend.tasks.base import SilentTask
 
 logger = logging.getLogger(__name__)
 
+_GRAPH_KEY = "graph"
+_PAGE_SIZE = 100
 
-@app.task(
-    base=SilentTask,
-    name="rhesis.backend.tasks.embedding.compute_graph",
-    bind=True,
-    display_name="Embedding Graph Computation",
-)
-def compute_graph_task(self, entity_ids: list[str], test_set_id: str, user_id: str):
-    """
-    Compute an embedding graph for the given entity IDs and persist it on the test set.
 
-    The HTTP layer resolves which entities belong to the test set and passes their IDs here.
-    """
+def _collect_test_set_entity_ids(db, test_set_id: UUID) -> list[UUID]:
+    """Paginate through all tests linked to a test set."""
+    from rhesis.backend.app import crud
+
+    entity_ids: list[UUID] = []
+    skip = 0
+    while True:
+        items, _count = crud.get_test_set_tests(
+            db=db,
+            test_set_id=test_set_id,
+            skip=skip,
+            limit=_PAGE_SIZE,
+            sort_by="created_at",
+            sort_order="desc",
+            filter=None,
+        )
+        entity_ids.extend(t.id for t in items)
+        if len(items) < _PAGE_SIZE:
+            break
+        skip += _PAGE_SIZE
+    return entity_ids
+
+
+def _collect_source_chunk_entity_ids(db, source_id: UUID, organization_id: str) -> list[UUID]:
+    """Paginate non-deleted chunk IDs for a source in ``chunk_index`` order."""
+    from rhesis.backend.app import models
+    from rhesis.backend.app.utils.query_utils import QueryBuilder
+
+    entity_ids: list[UUID] = []
+    skip = 0
+    while True:
+        chunks = (
+            QueryBuilder(db, models.Chunk)
+            .with_organization_filter(organization_id)
+            .with_visibility_filter()
+            .with_custom_filter(lambda q: q.filter(models.Chunk.source_id == source_id))
+            .with_sorting(sort_by="chunk_index", sort_order="asc")
+            .with_pagination(skip=skip, limit=_PAGE_SIZE)
+            .all()
+        )
+        entity_ids.extend(c.id for c in chunks)
+        if len(chunks) < _PAGE_SIZE:
+            break
+        skip += _PAGE_SIZE
+    return entity_ids
+
+
+def _run_embedding_graph(
+    db,
+    *,
+    user_id: str,
+    resolve_entity_ids: Callable[[Any, Any, Any], list[UUID]],
+    embedded_entity: type,
+    load_parent: Callable[[Any, Any], Any | None],
+    persist_graph: Callable[[Any, Any], None],
+    parent_not_found_log: str,
+    parent_not_found_extra: dict[str, str],
+) -> None:
     from rhesis.backend.app import crud
     from rhesis.backend.app.services.embedding.graph_builder import build_2d_graph
 
-    with self.get_db_session() as db:
-        user = crud.get_user_by_id(db, user_id)
-        if user is None:
-            logger.warning("Skipping graph computation: user not found", extra={"user_id": user_id})
-            return
+    user = crud.get_user_by_id(db, user_id)
+    if user is None:
+        logger.warning("Skipping graph computation: user not found", extra={"user_id": user_id})
+        return
 
-        test_set = crud.get_test_set(db, UUID(test_set_id), str(user.organization_id), str(user.id))
-        if test_set is None:
-            logger.warning(
-                "Skipping graph computation: test set not found",
-                extra={"test_set_id": test_set_id},
-            )
-            return
+    parent = load_parent(db, user)
+    if parent is None:
+        logger.warning(parent_not_found_log, extra=parent_not_found_extra)
+        return
 
-        ids = [UUID(eid) for eid in entity_ids]
-        graph = build_2d_graph(db, ids, user)
+    entity_ids = resolve_entity_ids(db, user, parent)
+    graph = build_2d_graph(db, entity_ids, user, embedded_entity=embedded_entity)
+    persist_graph(parent, graph)
+    db.add(parent)
+    db.commit()
 
+
+def _run_test_set_embedding_graph(db, *, test_set_id: str, user_id: str) -> None:
+    from rhesis.backend.app import crud, models
+
+    test_set_uuid = UUID(test_set_id)
+
+    def load_parent(db_session, user):
+        return crud.get_test_set(
+            db_session,
+            test_set_uuid,
+            str(user.organization_id),
+            str(user.id),
+        )
+
+    def resolve_entity_ids(db_session, _user, _test_set):
+        return _collect_test_set_entity_ids(db_session, test_set_uuid)
+
+    def persist_graph(test_set, graph):
         attrs = dict(test_set.attributes or {})
-        attrs["graph"] = graph.model_dump(mode="json")
+        attrs[_GRAPH_KEY] = graph.model_dump(mode="json")
         test_set.attributes = attrs
-        db.add(test_set)
-        db.commit()
+
+    _run_embedding_graph(
+        db,
+        user_id=user_id,
+        resolve_entity_ids=resolve_entity_ids,
+        embedded_entity=models.Test,
+        load_parent=load_parent,
+        persist_graph=persist_graph,
+        parent_not_found_log="Skipping graph computation: test set not found",
+        parent_not_found_extra={"test_set_id": test_set_id},
+    )
+
+
+def _run_source_embedding_graph(db, *, source_id: str, user_id: str) -> None:
+    from rhesis.backend.app import crud, models
+
+    source_uuid = UUID(source_id)
+
+    def load_parent(db_session, user):
+        return crud.get_source(
+            db_session,
+            source_uuid,
+            str(user.organization_id),
+            str(user.id),
+        )
+
+    def resolve_entity_ids(db_session, user, _db_source):
+        return _collect_source_chunk_entity_ids(db_session, source_uuid, str(user.organization_id))
+
+    def persist_graph(db_source, graph):
+        meta = dict(db_source.source_metadata or {})
+        meta[_GRAPH_KEY] = graph.model_dump(mode="json")
+        db_source.source_metadata = meta
+
+    _run_embedding_graph(
+        db,
+        user_id=user_id,
+        resolve_entity_ids=resolve_entity_ids,
+        embedded_entity=models.Chunk,
+        load_parent=load_parent,
+        persist_graph=persist_graph,
+        parent_not_found_log="Skipping graph computation: source not found",
+        parent_not_found_extra={"source_id": source_id},
+    )
+
+
+@app.task(
+    base=SilentTask,
+    name="rhesis.backend.tasks.embedding.compute_graph_test_set",
+    bind=True,
+    display_name="Embedding Graph Computation (test set)",
+)
+def compute_test_set_graph_task(self, test_set_id: str, user_id: str):
+    """Compute embedding graph for a test set and store on ``attributes`` JSON."""
+    with self.get_db_session() as db:
+        _run_test_set_embedding_graph(db, test_set_id=test_set_id, user_id=user_id)
+
+
+@app.task(
+    base=SilentTask,
+    name="rhesis.backend.tasks.embedding.compute_graph_source",
+    bind=True,
+    display_name="Embedding Graph Computation (source chunks)",
+)
+def compute_source_graph_task(self, source_id: str, user_id: str):
+    """Compute embedding graph for a source and store under ``source_metadata`` JSON."""
+    with self.get_db_session() as db:
+        _run_source_embedding_graph(db, source_id=source_id, user_id=user_id)

--- a/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
+++ b/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
@@ -15,26 +15,15 @@ _PAGE_SIZE = 100
 
 
 def _collect_test_set_entity_ids(db, test_set_id: UUID) -> list[UUID]:
-    """Paginate through all tests linked to a test set."""
-    from rhesis.backend.app import crud
+    """Return all test IDs linked to a test set via the association table."""
+    from rhesis.backend.app.models.test import test_test_set_association
 
-    entity_ids: list[UUID] = []
-    skip = 0
-    while True:
-        items, _count = crud.get_test_set_tests(
-            db=db,
-            test_set_id=test_set_id,
-            skip=skip,
-            limit=_PAGE_SIZE,
-            sort_by="created_at",
-            sort_order="desc",
-            filter=None,
+    rows = db.execute(
+        test_test_set_association.select().where(
+            test_test_set_association.c.test_set_id == test_set_id
         )
-        entity_ids.extend(t.id for t in items)
-        if len(items) < _PAGE_SIZE:
-            break
-        skip += _PAGE_SIZE
-    return entity_ids
+    ).fetchall()
+    return [row.test_id for row in rows]
 
 
 def _collect_source_chunk_entity_ids(db, source_id: UUID, organization_id: str) -> list[UUID]:

--- a/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
+++ b/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
@@ -69,8 +69,7 @@ def _run_embedding_graph(
     embedded_entity: type,
     load_parent: Callable[[Any, Any], Any | None],
     persist_graph: Callable[[Any, Any], None],
-    parent_not_found_log: str,
-    parent_not_found_extra: dict[str, str],
+    parent_name: str,
 ) -> None:
     from rhesis.backend.app import crud
     from rhesis.backend.app.services.embedding.graph_builder import build_2d_graph
@@ -82,7 +81,7 @@ def _run_embedding_graph(
 
     parent = load_parent(db, user)
     if parent is None:
-        logger.warning(parent_not_found_log, extra=parent_not_found_extra)
+        logger.warning(f"Skipping graph computation: {parent_name} not found")
         return
 
     entity_ids = resolve_entity_ids(db, user, parent)
@@ -120,8 +119,7 @@ def _run_test_set_embedding_graph(db, *, test_set_id: str, user_id: str) -> None
         embedded_entity=models.Test,
         load_parent=load_parent,
         persist_graph=persist_graph,
-        parent_not_found_log="Skipping graph computation: test set not found",
-        parent_not_found_extra={"test_set_id": test_set_id},
+        parent_name="test set",
     )
 
 
@@ -153,8 +151,7 @@ def _run_source_embedding_graph(db, *, source_id: str, user_id: str) -> None:
         embedded_entity=models.Chunk,
         load_parent=load_parent,
         persist_graph=persist_graph,
-        parent_not_found_log="Skipping graph computation: source not found",
-        parent_not_found_extra={"source_id": source_id},
+        parent_name="source",
     )
 
 

--- a/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
+++ b/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
@@ -15,15 +15,25 @@ _PAGE_SIZE = 100
 
 
 def _collect_test_set_entity_ids(db, test_set_id: UUID) -> list[UUID]:
-    """Return all test IDs linked to a test set via the association table."""
-    from rhesis.backend.app.models.test import test_test_set_association
+    """Return visible test IDs for a test set (excludes soft-deleted tests)."""
+    from rhesis.backend.app import crud
 
-    rows = db.execute(
-        test_test_set_association.select().where(
-            test_test_set_association.c.test_set_id == test_set_id
+    entity_ids: list[UUID] = []
+    skip = 0
+    while True:
+        items, _count = crud.get_test_set_tests(
+            db=db,
+            test_set_id=test_set_id,
+            skip=skip,
+            limit=_PAGE_SIZE,
+            sort_by="created_at",
+            sort_order="desc",
         )
-    ).fetchall()
-    return [row.test_id for row in rows]
+        entity_ids.extend(test.id for test in items)
+        if len(items) < _PAGE_SIZE:
+            break
+        skip += _PAGE_SIZE
+    return entity_ids
 
 
 def _collect_source_chunk_entity_ids(db, source_id: UUID, organization_id: str) -> list[UUID]:

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -39,7 +39,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-05-05T20:04:52.692132Z"
+exclude-newer = "2026-05-06T13:53:31.087507Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -2441,6 +2441,26 @@ wheels = [
 ]
 
 [[package]]
+name = "hdbscan"
+version = "0.8.42"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/e1/f0d795e4b015f9e210d1e75a0fc538722a68152044b919d26ff30479aff4/hdbscan-0.8.42.tar.gz", hash = "sha256:3bd749a3df39c7e965bd8b2173c3804cdb11ad73d524a5df1201360814293614", size = 7089885, upload-time = "2026-03-27T19:17:04.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/25/6a24f09f857593b8f3bcb9af523fa45fd072e27e015f83f172f380981cb7/hdbscan-0.8.42-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:31541afa4ce2d42ad828ffd5da1bf40d8212fa8318cc28e58c65ffe719e9083b", size = 1390158, upload-time = "2026-03-27T19:20:45.349Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b4/6592160ec00d660ef3e3754644a98503d865947480e2f6f1c1fb6f284a64/hdbscan-0.8.42-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f0cc0f279f0f83203277fb5b09422cbfab577fe269e3f71d0082354f65d71cf3", size = 4551160, upload-time = "2026-03-27T19:17:06.171Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/95/fbe79ed618e869c9bd9f70429e04c69ce7dabd24d42cb3d5ce8fb44c5268/hdbscan-0.8.42-cp312-cp312-win_amd64.whl", hash = "sha256:fd9f0d5f65a5aa4437b8f69ff8cb4ae6d42723e543254dca49c62f02192c2791", size = 670598, upload-time = "2026-03-27T19:20:21.832Z" },
+    { url = "https://files.pythonhosted.org/packages/86/80/82a3b7f17dafe38d5bd0d59add7318149898c657837ceba6815bfa3214dc/hdbscan-0.8.42-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7e0f160ee0d5e61d9a2411c44fa41c12849e814899851cab8e17e924487018e1", size = 1383016, upload-time = "2026-03-27T19:18:09.929Z" },
+    { url = "https://files.pythonhosted.org/packages/de/81/4c36b1d3363d9f7c831994a8cae073941798915f86e80c8863cbbe161df0/hdbscan-0.8.42-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e14d7309c91e1a59f592936555fe4282e66061719225d9cb2d7bf18040bb8b54", size = 4535332, upload-time = "2026-03-27T19:17:01.775Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f7/5f91bf58a8519cf91ddfc815f560ae6fa507a12902ee9fb6b54c72ac6bcd/hdbscan-0.8.42-cp313-cp313-win_amd64.whl", hash = "sha256:990b9f9ce14f290eb8bd9343048cb50b890560de99ced4fb31c486cb0c9f0f74", size = 670554, upload-time = "2026-03-27T19:19:59.603Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3546,6 +3566,30 @@ wheels = [
 ]
 
 [[package]]
+name = "llvmlite"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/88/a8952b6d5c21e74cbf158515b779666f692846502623e9e3c39d8e8ba25f/llvmlite-0.47.0.tar.gz", hash = "sha256:62031ce968ec74e95092184d4b0e857e444f8fdff0b8f9213707699570c33ccc", size = 193614, upload-time = "2026-03-31T18:29:53.497Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/48/4b7fe0e34c169fa2f12532916133e0b219d2823b540733651b34fdac509a/llvmlite-0.47.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:306a265f408c259067257a732c8e159284334018b4083a9e35f67d19792b164f", size = 37232769, upload-time = "2026-03-31T18:28:43.735Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/4b/e3f2cd17822cf772a4a51a0a8080b0032e6d37b2dbe8cfb724eac4e31c52/llvmlite-0.47.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5853bf26160857c0c2573415ff4efe01c4c651e59e2c55c2a088740acfee51cd", size = 56275178, upload-time = "2026-03-31T18:28:48.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a3b4a543185305a9bdf3d9759d53646ed96e55e7dfd43f53e7a421b8fbae/llvmlite-0.47.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:003bcf7fa579e14db59c1a1e113f93ab8a06b56a4be31c7f08264d1d4072d077", size = 55128632, upload-time = "2026-03-31T18:28:52.901Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/f5/d281ae0f79378a5a91f308ea9fdb9f9cc068fddd09629edc0725a5a8fde1/llvmlite-0.47.0-cp312-cp312-win_amd64.whl", hash = "sha256:f3079f25bdc24cd9d27c4b2b5e68f5f60c4fdb7e8ad5ee2b9b006007558f9df7", size = 38138692, upload-time = "2026-03-31T18:28:57.147Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6f/4615353e016799f80fa52ccb270a843c413b22361fadda2589b2922fb9b0/llvmlite-0.47.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a3c6a735d4e1041808434f9d440faa3d78d9b4af2ee64d05a66f351883b6ceec", size = 37232771, upload-time = "2026-03-31T18:29:01.324Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b8/69f5565f1a280d032525878a86511eebed0645818492feeb169dfb20ae8e/llvmlite-0.47.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2699a74321189e812d476a43d6d7f652f51811e7b5aad9d9bba842a1c7927acb", size = 56275178, upload-time = "2026-03-31T18:29:05.748Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/da/b32cafcb926fb0ce2aa25553bf32cb8764af31438f40e2481df08884c947/llvmlite-0.47.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c6951e2b29930227963e53ee152441f0e14be92e9d4231852102d986c761e40", size = 55128632, upload-time = "2026-03-31T18:29:11.235Z" },
+    { url = "https://files.pythonhosted.org/packages/46/9f/4898b44e4042c60fafcb1162dfb7014f6f15b1ec19bf29cfea6bf26df90d/llvmlite-0.47.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2e9adf8698d813a9a5efb2d4370caf344dbc1e145019851fee6a6f319ba760e", size = 38138695, upload-time = "2026-03-31T18:29:15.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d4/33c8af00f0bf6f552d74f3a054f648af2c5bc6bece97972f3bfadce4f5ec/llvmlite-0.47.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:de966c626c35c9dff5ae7bf12db25637738d0df83fc370cf793bc94d43d92d14", size = 37232773, upload-time = "2026-03-31T18:29:19.453Z" },
+    { url = "https://files.pythonhosted.org/packages/64/1d/a760e993e0c0ba6db38d46b9f48f6c7dceb8ac838824997fb9e25f97bc04/llvmlite-0.47.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ddbccff2aeaff8670368340a158abefc032fe9b3ccf7d9c496639263d00151aa", size = 56275176, upload-time = "2026-03-31T18:29:24.149Z" },
+    { url = "https://files.pythonhosted.org/packages/84/3b/e679bc3b29127182a7f4aa2d2e9e5bea42adb93fb840484147d59c236299/llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca", size = 55128631, upload-time = "2026-03-31T18:29:29.536Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f7/19e2a09c62809c9e63bbd14ce71fb92c6ff7b7b3045741bb00c781efc3c9/llvmlite-0.47.0-cp314-cp314-win_amd64.whl", hash = "sha256:694e3c2cdc472ed2bd8bd4555ca002eec4310961dd58ef791d508f57b5cc4c94", size = 39153826, upload-time = "2026-03-31T18:29:33.681Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a1/581a8c707b5e80efdbbe1dd94527404d33fe50bceb71f39d5a7e11bd57b7/llvmlite-0.47.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:92ec8a169a20b473c1c54d4695e371bde36489fc1efa3688e11e99beba0abf9c", size = 37232772, upload-time = "2026-03-31T18:29:37.952Z" },
+    { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/79/d3bbab197e86e0ff4f9c07122895b66a3e0d024247fcff7f12c473cb36d9/llvmlite-0.47.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6842cf6f707ec4be3d985a385ad03f72b2d724439e118fcbe99b2929964f0453", size = 39153839, upload-time = "2026-03-31T18:29:51.004Z" },
+]
+
+[[package]]
 name = "lorem"
 version = "0.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4338,6 +4382,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
+]
+
+[[package]]
+name = "numba"
+version = "0.65.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "llvmlite" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/c5/db2ac3685833d626c0dcae6bd2330cd68433e1fd248d15f70998160d3ad7/numba-0.65.1.tar.gz", hash = "sha256:19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23", size = 2765600, upload-time = "2026-04-24T02:02:56.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/bc/76f8f8c5cf9adee47fdb7bbb03be8900f76f902d451d7477cf12b845e1de/numba-0.65.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:ac3f1e77c352dd0ea9712732c2d8f9ca507717435eec5b5013bf138ac33c4a08", size = 2681371, upload-time = "2026-04-24T02:02:26.105Z" },
+    { url = "https://files.pythonhosted.org/packages/69/47/a415af0283e4db0398104c6d1c11c9861a98dc67a7aa442a7769ed5d6196/numba-0.65.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:52bc6f3ceb8fcaff9b2ae26b4c6b1e9fee39db8d355534c0fe4f39a901246b84", size = 3802467, upload-time = "2026-04-24T02:02:27.712Z" },
+    { url = "https://files.pythonhosted.org/packages/46/36/246f73ec99cfeab2f2cb2ce7d4218766cc36a2da418901223f4f4da9c813/numba-0.65.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90ca10b3463bae0bd70589726fe3c77d01d6b5fc86bee54bcdf9fb6b47c28977", size = 3502628, upload-time = "2026-04-24T02:02:29.763Z" },
+    { url = "https://files.pythonhosted.org/packages/db/9e/3c679b2ee078425b9e99a91e44f8d132a6830d8ccce5227bc5e9181aeed8/numba-0.65.1-cp312-cp312-win_amd64.whl", hash = "sha256:5971c632be2a2351500431f46213821dba8d02b18a9f7d02fd36bd2743e41a6a", size = 2750611, upload-time = "2026-04-24T02:02:31.477Z" },
+    { url = "https://files.pythonhosted.org/packages/79/37/14a4579049c1eb673afd0de0cb4842982acd55b9ce2643e763db858bcea0/numba-0.65.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:1735c15c1134a5108b4d6a5c77fc0947924ea066a738dc09a52008c13df9cad3", size = 2681344, upload-time = "2026-04-24T02:02:33.65Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/22/b8d873f6466b20aa563fc9b33acd48dec89a07803ddaa2f1c8ca1cd33126/numba-0.65.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c09f49117ef255e1f1c6dad0c7a1ed39868243862a73be5706793241a3755f1b", size = 3810619, upload-time = "2026-04-24T02:02:36.041Z" },
+    { url = "https://files.pythonhosted.org/packages/62/08/e16a8b5d9a018962ebb5c66be662317cde32b9f5dab08441f90bed5522fb/numba-0.65.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:594a8680b3fadac99e97e489b1fd89007177e5336713745c3b769528c635a464", size = 3509783, upload-time = "2026-04-24T02:02:38.245Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/a5/03c970d57f4c1741354837353ce39fb5206952ae1dba8922d29c86f64805/numba-0.65.1-cp313-cp313-win_amd64.whl", hash = "sha256:85be74c0d036842699a30058f82fb88fc5ffdc59f7615cab5792ea92914c9b62", size = 2750534, upload-time = "2026-04-24T02:02:39.903Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/2e/8aed9b726d9ba5f11ad287645fd479e88278db3060a25cb1225d730eb2b7/numba-0.65.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:33f5eb68eb1c843511615d14663ce60258525d6a4c65ab040e2c2b0c4cf17450", size = 2681554, upload-time = "2026-04-24T02:02:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/87/96/f3eb235fafa82a34e2ab5dd7dc9ffff998ebf5f0bbc23fa56a96aeb44da6/numba-0.65.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:71e73029bf53a62cc6afcf96be4bd942290d8b4c55f0a454fb536158115790f7", size = 3779602, upload-time = "2026-04-24T02:02:43.726Z" },
+    { url = "https://files.pythonhosted.org/packages/09/90/b0f09b48752d23640b8284f22aa597737e8adaddc7fbfacc4708b7f73a4c/numba-0.65.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a07635e0be926b9bdbffb09137c230fb13f6ec0e564914ba937cee12ce3eb35", size = 3479532, upload-time = "2026-04-24T02:02:45.427Z" },
+    { url = "https://files.pythonhosted.org/packages/56/46/3f7fc04fb853559e74b210e0b62c19974ec844cefec611f9e535f4da3761/numba-0.65.1-cp314-cp314-win_amd64.whl", hash = "sha256:2a20fcdabdefbdacf88d85caf70c3b18c4bcb7ebb8f82e6a19486383dd26ab63", size = 2752637, upload-time = "2026-04-24T02:02:47.664Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7b/c1a341a9067367778f4152a5f01061cf281fb09582c92c510ec4918cabf6/numba-0.65.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:548dd4b3a4508d5062768d1514b2cd7b015f9a25ec7af651c50dee243965e652", size = 2684600, upload-time = "2026-04-24T02:02:49.653Z" },
+    { url = "https://files.pythonhosted.org/packages/03/36/98ddbcf3e4f04a6dd07e1c67249955920579ba4af6bb6868e3088f4ed282/numba-0.65.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:78abc28feff2c2ff8307fff3975b6438352759c9acb797ecd6b1fb6e7e39e31d", size = 3817198, upload-time = "2026-04-24T02:02:51.266Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/83/0dad21057ece5a835599f5d24099b091703995e23dbbf894f259e91c010b/numba-0.65.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee7676cb389555805f9b9a1840cbcd1ea6c8bd5376ab6918e3a29c5ea1dbda20", size = 3533862, upload-time = "2026-04-24T02:02:52.987Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/8be7118ffd4c8440881046eac3d0982cc5ab42909508cf5d67024d62a2e4/numba-0.65.1-cp314-cp314t-win_amd64.whl", hash = "sha256:20609346e3bd75204950dcbbfe383a8d7dbf4902f442aedbf00f97fef4aa8f38", size = 2758237, upload-time = "2026-04-24T02:02:54.612Z" },
 ]
 
 [[package]]
@@ -5717,6 +5789,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pynndescent"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "llvmlite" },
+    { name = "numba" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4a/fb/7f58c397fb31666756457ee2ac4c0289ef2daad57f4ae4be8dec12f80b03/pynndescent-0.6.0.tar.gz", hash = "sha256:7ffde0fb5b400741e055a9f7d377e3702e02250616834231f6c209e39aac24f5", size = 2992987, upload-time = "2026-01-08T21:29:58.943Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/e6/94145d714402fd5ade00b5661f2d0ab981219e07f7db9bfa16786cdb9c04/pynndescent-0.6.0-py3-none-any.whl", hash = "sha256:dc8c74844e4c7f5cbd1e0cd6909da86fdc789e6ff4997336e344779c3d5538ef", size = 73511, upload-time = "2026-01-08T21:29:57.306Z" },
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -6468,12 +6556,14 @@ all = [
     { name = "garak" },
     { name = "gcsfs" },
     { name = "google-genai" },
+    { name = "hdbscan" },
     { name = "huggingface-hub" },
     { name = "mcp-atlassian" },
     { name = "mirascope" },
     { name = "rhesis-penelope" },
     { name = "rhesis-sdk" },
     { name = "sendgrid" },
+    { name = "umap-learn" },
 ]
 cpu = [
     { name = "torch", version = "2.10.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'darwin' and extra == 'extra-14-rhesis-backend-cpu') or (extra == 'extra-14-rhesis-backend-cpu' and extra == 'extra-14-rhesis-backend-gpu')" },
@@ -6521,6 +6611,7 @@ requires-dist = [
     { name = "google-cloud-storage", specifier = ">=3.8.0" },
     { name = "google-genai", marker = "extra == 'all'", specifier = ">=1.13.0" },
     { name = "gunicorn", specifier = ">=21.2.0" },
+    { name = "hdbscan", marker = "extra == 'all'", specifier = ">=0.8.39" },
     { name = "httpx" },
     { name = "huggingface-hub", marker = "extra == 'all'" },
     { name = "itsdangerous" },
@@ -6566,6 +6657,7 @@ requires-dist = [
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'gpu') or (sys_platform == 'win32' and extra == 'gpu')", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "rhesis-backend", extra = "gpu" } },
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'gpu'", specifier = ">=2.0" },
     { name = "torch", marker = "extra == 'cpu'", specifier = ">=2.0", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "rhesis-backend", extra = "cpu" } },
+    { name = "umap-learn", marker = "extra == 'all'", specifier = ">=0.5.7" },
     { name = "uvicorn" },
     { name = "websockets", specifier = "==15.0.1" },
     { name = "yaspin", specifier = "==3.1.0" },
@@ -8094,6 +8186,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
+name = "umap-learn"
+version = "0.5.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "pynndescent" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/ee/af4171241117f85c74b5ca6448ea1033cc28d599c13651d67289bacd4083/umap_learn-0.5.12.tar.gz", hash = "sha256:6aff02ecac5f2aad9f3c65ee518d7ae93e1a985ae38721fdcffceee4232c33c7", size = 96672, upload-time = "2026-04-08T20:03:54.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/98/f63318ccbe75c810011fe9233884c5d348d94d90005de1b79e5f93bef9c0/umap_learn-0.5.12-py3-none-any.whl", hash = "sha256:f2a85d2a2adcb52b541bed9b27a23ca169b56bb1b23283abeebfb8dfb8a42fe5", size = 91849, upload-time = "2026-04-08T20:03:52.561Z" },
 ]
 
 [[package]]

--- a/tests/backend/routes/test_embedding_graph.py
+++ b/tests/backend/routes/test_embedding_graph.py
@@ -1,0 +1,154 @@
+"""Route tests for embedding 2D scatter graph APIs (test sets and sources)."""
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import status
+
+from rhesis.backend.app import models
+from rhesis.backend.app.models.type_lookup import TypeLookup
+
+
+@pytest.mark.unit
+class TestTestSetEmbeddingGraphRoutes:
+    def test_get_graph_pending_without_attributes(self, authenticated_client, db_test_set):
+        response = authenticated_client.get(f"/test_sets/{db_test_set.id}/embeddings/graph")
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body.get("status") == "pending"
+        assert body.get("graph") is None
+
+    def test_get_graph_ready_when_attributes_contain_graph(
+        self, authenticated_client, test_db, db_test_set
+    ):
+        point_id = uuid.uuid4()
+        entity_id = uuid.uuid4()
+        now = datetime.now(timezone.utc)
+        db_test_set.attributes = {
+            "graph": {
+                "computed_at": now.isoformat(),
+                "clusters": [
+                    {"cluster_index": 0, "label": "L", "size": 1},
+                ],
+                "points": [
+                    {
+                        "embedding_id": str(point_id),
+                        "entity_id": str(entity_id),
+                        "entity_type": "Test",
+                        "cluster_index": 0,
+                        "searchable_text": "hello",
+                        "x": 0.1,
+                        "y": -0.2,
+                    }
+                ],
+            }
+        }
+        test_db.add(db_test_set)
+        test_db.commit()
+
+        response = authenticated_client.get(f"/test_sets/{db_test_set.id}/embeddings/graph")
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["status"] == "ready"
+        assert body["graph"]["clusters"][0]["label"] == "L"
+        assert len(body["graph"]["points"]) == 1
+        assert body["graph"]["points"][0]["searchable_text"] == "hello"
+
+    @patch("rhesis.backend.app.routers.test_set.compute_test_set_graph_task")
+    def test_compute_graph_queues_celery_task(self, mock_task, authenticated_client, db_test_set):
+        async_result = MagicMock()
+        async_result.id = "celery-task-id"
+        mock_task.delay.return_value = async_result
+
+        response = authenticated_client.post(
+            f"/test_sets/{db_test_set.id}/embeddings/compute-graph"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body.get("status") == "pending"
+        assert body.get("task_id") == "celery-task-id"
+        mock_task.delay.assert_called_once()
+
+
+@pytest.mark.unit
+class TestSourceEmbeddingGraphRoutes:
+    def _create_source(self, test_db, test_organization, db_user, db_status) -> models.Source:
+        st = TypeLookup(
+            type_name="SourceType",
+            type_value="document",
+            organization_id=test_organization.id,
+            user_id=db_user.id,
+        )
+        test_db.add(st)
+        test_db.flush()
+        src = models.Source(
+            title="Embedding graph source",
+            source_type_id=st.id,
+            status_id=db_status.id,
+            organization_id=test_organization.id,
+            user_id=db_user.id,
+        )
+        test_db.add(src)
+        test_db.commit()
+        test_db.refresh(src)
+        return src
+
+    def test_get_source_graph_pending(
+        self, authenticated_client, test_db, test_organization, db_user, db_status
+    ):
+        src = self._create_source(test_db, test_organization, db_user, db_status)
+        response = authenticated_client.get(f"/sources/{src.id}/embeddings/graph")
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body.get("status") == "pending"
+        assert body.get("graph") is None
+
+    def test_get_source_graph_ready_from_metadata(
+        self, authenticated_client, test_db, test_organization, db_user, db_status
+    ):
+        src = self._create_source(test_db, test_organization, db_user, db_status)
+        point_id = uuid.uuid4()
+        entity_id = uuid.uuid4()
+        now = datetime.now(timezone.utc)
+        src.source_metadata = {
+            "graph": {
+                "computed_at": now.isoformat(),
+                "clusters": [],
+                "points": [
+                    {
+                        "embedding_id": str(point_id),
+                        "entity_id": str(entity_id),
+                        "entity_type": "Chunk",
+                        "cluster_index": -1,
+                        "searchable_text": "chunk text",
+                        "x": 0.0,
+                        "y": 0.0,
+                    },
+                ],
+            }
+        }
+        test_db.add(src)
+        test_db.commit()
+
+        response = authenticated_client.get(f"/sources/{src.id}/embeddings/graph")
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["status"] == "ready"
+        assert body["graph"]["points"][0]["entity_type"] == "Chunk"
+
+    @patch("rhesis.backend.app.routers.source.compute_source_graph_task")
+    def test_compute_source_graph_queues_task(
+        self, mock_task, authenticated_client, test_db, test_organization, db_user, db_status
+    ):
+        src = self._create_source(test_db, test_organization, db_user, db_status)
+        async_result = MagicMock()
+        async_result.id = "src-task-id"
+        mock_task.delay.return_value = async_result
+
+        response = authenticated_client.post(f"/sources/{src.id}/embeddings/compute-graph")
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body.get("status") == "pending"
+        assert body.get("task_id") == "src-task-id"

--- a/tests/backend/services/embedding/test_graph_builder.py
+++ b/tests/backend/services/embedding/test_graph_builder.py
@@ -1,0 +1,157 @@
+"""Tests for embedding 2D graph builder (UMAP + HDBSCAN pipeline)."""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from rhesis.backend.app.models.test import Test
+from rhesis.backend.app.services.embedding import graph_builder
+from rhesis.backend.app.services.embedding.graph_builder import (
+    _reduce_dimensions,
+    build_2d_graph,
+)
+
+
+def _mock_user(org_id: str, user_id: str) -> MagicMock:
+    user = MagicMock()
+    user.organization_id = org_id
+    user.id = user_id
+    return user
+
+
+def _mock_embedding(
+    *,
+    entity_id: uuid.UUID | None = None,
+    config_hash: str = "cfg-a",
+    vector: list[float] | None = None,
+    searchable_text: str = "sample",
+) -> MagicMock:
+    e = MagicMock()
+    e.id = uuid.uuid4()
+    e.entity_id = entity_id or uuid.uuid4()
+    e.entity_type = "Test"
+    e.config_hash = config_hash
+    e.embedding = vector if vector is not None else [0.0, 0.0, 0.0]
+    e.searchable_text = searchable_text
+    return e
+
+
+@pytest.mark.unit
+class TestReduceDimensions:
+    def test_invalid_purpose_raises(self):
+        X = np.array([[0.0, 1.0], [1.0, 0.0], [0.5, 0.5]])
+        with pytest.raises(ValueError, match="Invalid purpose"):
+            _reduce_dimensions(X, purpose="other")
+
+
+@pytest.mark.unit
+class TestBuild2DGraph:
+    def test_empty_entity_list_returns_empty_graph(self, test_db, test_org_id, authenticated_user_id):
+        user = _mock_user(test_org_id, authenticated_user_id)
+        graph = build_2d_graph(test_db, [], user)
+        assert graph.points == []
+        assert graph.clusters == []
+
+    def test_no_embeddings_fetched_returns_empty_graph(
+        self, test_db, test_org_id, authenticated_user_id
+    ):
+        user = _mock_user(test_org_id, authenticated_user_id)
+        eid = uuid.uuid4()
+        with patch.object(graph_builder, "fetch_embeddings", return_value=[]):
+            graph = build_2d_graph(test_db, [eid], user)
+        assert graph.points == []
+
+    def test_mixed_config_hash_returns_empty_graph(
+        self, test_db, test_org_id, authenticated_user_id
+    ):
+        user = _mock_user(test_org_id, authenticated_user_id)
+        a = _mock_embedding(config_hash="h1")
+        b = _mock_embedding(config_hash="h2")
+        eids = [a.entity_id, b.entity_id]
+        with patch.object(graph_builder, "fetch_embeddings", return_value=[a, b]):
+            graph = build_2d_graph(test_db, eids, user, embedded_entity=Test)
+        assert graph.points == []
+
+    def test_duplicate_entity_in_fetched_embeddings_returns_empty_graph(
+        self, test_db, test_org_id, authenticated_user_id
+    ):
+        user = _mock_user(test_org_id, authenticated_user_id)
+        shared = uuid.uuid4()
+        a = _mock_embedding(entity_id=shared)
+        b = _mock_embedding(entity_id=shared)
+        with patch.object(graph_builder, "fetch_embeddings", return_value=[a, b]):
+            graph = build_2d_graph(test_db, [shared], user)
+        assert graph.points == []
+
+    def test_single_point_trivial_layout(self, test_db, test_org_id, authenticated_user_id):
+        user = _mock_user(test_org_id, authenticated_user_id)
+        emb = _mock_embedding(vector=[0.1, 0.2])
+        with patch.object(graph_builder, "fetch_embeddings", return_value=[emb]):
+            graph = build_2d_graph(test_db, [emb.entity_id], user)
+        assert len(graph.points) == 1
+        assert graph.points[0].x == pytest.approx(0.0)
+        assert graph.points[0].y == pytest.approx(0.0)
+        assert graph.points[0].cluster_index == -1
+        assert graph.points[0].embedding_id == emb.id
+        assert graph.clusters == []
+
+    def test_two_points_trivial_layout(self, test_db, test_org_id, authenticated_user_id):
+        user = _mock_user(test_org_id, authenticated_user_id)
+        left = _mock_embedding(vector=[0.0, 0.0])
+        right = _mock_embedding(vector=[1.0, 1.0])
+        with patch.object(graph_builder, "fetch_embeddings", return_value=[left, right]):
+            graph = build_2d_graph(test_db, [left.entity_id, right.entity_id], user)
+        assert len(graph.points) == 2
+        xs = sorted(p.x for p in graph.points)
+        assert xs[0] == pytest.approx(-0.5)
+        assert xs[1] == pytest.approx(0.5)
+        assert all(p.cluster_index == -1 for p in graph.points)
+
+    @patch.object(graph_builder, "_generate_cluster_labels")
+    @patch.object(graph_builder, "_cluster_with_hdbscan")
+    @patch.object(graph_builder, "_reduce_dimensions")
+    def test_three_plus_points_pipeline(
+        self,
+        mock_reduce,
+        mock_cluster,
+        mock_labels,
+        test_db,
+        test_org_id,
+        authenticated_user_id,
+    ):
+        user = _mock_user(test_org_id, authenticated_user_id)
+        uids = [uuid.uuid4() for _ in range(3)]
+        embs = [
+            _mock_embedding(entity_id=uids[0], vector=[0.0] * 8, searchable_text="a"),
+            _mock_embedding(entity_id=uids[1], vector=[1.0] * 8, searchable_text="b"),
+            _mock_embedding(entity_id=uids[2], vector=[0.5] * 8, searchable_text="c"),
+        ]
+        umap_50 = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]], dtype=np.float64)
+        umap_2 = np.array([[0.0, 0.0], [2.0, 0.0], [1.0, 3.0]], dtype=np.float64)
+        mock_reduce.side_effect = [umap_50, umap_2]
+        mock_cluster.return_value = (
+            np.array([0, 0, -1]),
+            {0: np.array([0.33, 0.33])},
+        )
+        mock_labels.return_value = {0: "Alpha"}
+
+        with patch.object(graph_builder, "fetch_embeddings", return_value=embs):
+            graph = build_2d_graph(test_db, uids, user)
+
+        assert mock_reduce.call_count == 2
+        mock_cluster.assert_called_once()
+        mock_labels.assert_called_once()
+
+        assert len(graph.points) == 3
+        assert {p.searchable_text for p in graph.points} == {"a", "b", "c"}
+        by_text = {p.searchable_text: p for p in graph.points}
+        assert by_text["a"].cluster_index == 0
+        assert by_text["b"].cluster_index == 0
+        assert by_text["c"].cluster_index == -1
+
+        assert len(graph.clusters) == 1
+        assert graph.clusters[0].cluster_index == 0
+        assert graph.clusters[0].label == "Alpha"
+        assert graph.clusters[0].size == 2

--- a/tests/backend/services/embedding/test_graph_builder.py
+++ b/tests/backend/services/embedding/test_graph_builder.py
@@ -9,9 +9,11 @@ import pytest
 from rhesis.backend.app.models.test import Test
 from rhesis.backend.app.services.embedding import graph_builder
 from rhesis.backend.app.services.embedding.graph_builder import (
+    _generate_cluster_labels,
     _reduce_dimensions,
     build_2d_graph,
 )
+from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 
 
 def _mock_user(org_id: str, user_id: str) -> MagicMock:
@@ -39,6 +41,38 @@ def _mock_embedding(
 
 
 @pytest.mark.unit
+class TestGenerateClusterLabels:
+    @patch.object(graph_builder, "get_model")
+    @patch.object(graph_builder, "get_user_generation_model")
+    def test_empty_centroids_skips_model_resolution(
+        self, mock_get_user_model, mock_get_model, test_db
+    ):
+        user = MagicMock()
+        embeddings = [_mock_embedding(), _mock_embedding()]
+        cluster_ids = np.array([-1, -1])
+        umap_50d = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float64)
+
+        result = _generate_cluster_labels(embeddings, cluster_ids, umap_50d, {}, test_db, user)
+
+        assert result == {}
+        mock_get_user_model.assert_not_called()
+        mock_get_model.assert_not_called()
+
+    @patch.object(graph_builder, "get_user_generation_model")
+    def test_model_resolution_failure_returns_empty(self, mock_get_user_model, test_db):
+        mock_get_user_model.side_effect = ModelConfigurationError("misconfigured")
+        user = MagicMock()
+        emb = _mock_embedding(searchable_text="hello")
+        cluster_ids = np.array([0])
+        umap_50d = np.array([[0.0, 0.0]], dtype=np.float64)
+        centroids = {0: np.array([0.0, 0.0])}
+
+        result = _generate_cluster_labels([emb], cluster_ids, umap_50d, centroids, test_db, user)
+
+        assert result == {}
+
+
+@pytest.mark.unit
 class TestReduceDimensions:
     def test_invalid_purpose_raises(self):
         X = np.array([[0.0, 1.0], [1.0, 0.0], [0.5, 0.5]])
@@ -48,7 +82,9 @@ class TestReduceDimensions:
 
 @pytest.mark.unit
 class TestBuild2DGraph:
-    def test_empty_entity_list_returns_empty_graph(self, test_db, test_org_id, authenticated_user_id):
+    def test_empty_entity_list_returns_empty_graph(
+        self, test_db, test_org_id, authenticated_user_id
+    ):
         user = _mock_user(test_org_id, authenticated_user_id)
         graph = build_2d_graph(test_db, [], user)
         assert graph.points == []
@@ -154,4 +190,40 @@ class TestBuild2DGraph:
         assert len(graph.clusters) == 1
         assert graph.clusters[0].cluster_index == 0
         assert graph.clusters[0].label == "Alpha"
+        assert graph.clusters[0].size == 2
+
+    @patch.object(graph_builder, "get_user_generation_model")
+    @patch.object(graph_builder, "_cluster_with_hdbscan")
+    @patch.object(graph_builder, "_reduce_dimensions")
+    def test_graph_uses_unlabeled_when_label_model_unavailable(
+        self,
+        mock_reduce,
+        mock_cluster,
+        mock_get_user_model,
+        test_db,
+        test_org_id,
+        authenticated_user_id,
+    ):
+        mock_get_user_model.side_effect = ModelConfigurationError("misconfigured")
+        user = _mock_user(test_org_id, authenticated_user_id)
+        uids = [uuid.uuid4() for _ in range(3)]
+        embs = [
+            _mock_embedding(entity_id=uids[0], vector=[0.0] * 8),
+            _mock_embedding(entity_id=uids[1], vector=[1.0] * 8),
+            _mock_embedding(entity_id=uids[2], vector=[0.5] * 8),
+        ]
+        umap_50 = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]], dtype=np.float64)
+        umap_2 = np.array([[0.0, 0.0], [2.0, 0.0], [1.0, 3.0]], dtype=np.float64)
+        mock_reduce.side_effect = [umap_50, umap_2]
+        mock_cluster.return_value = (
+            np.array([0, 0, -1]),
+            {0: np.array([0.33, 0.33])},
+        )
+
+        with patch.object(graph_builder, "fetch_embeddings", return_value=embs):
+            graph = build_2d_graph(test_db, uids, user)
+
+        assert len(graph.points) == 3
+        assert len(graph.clusters) == 1
+        assert graph.clusters[0].label == "Unlabeled"
         assert graph.clusters[0].size == 2


### PR DESCRIPTION
## Purpose

Expose a 2D embedding scatter visualization by building UMAP-reduced coordinates, optional HDBSCAN clustering, and LLM-generated cluster labels. Results are persisted and served through the API, with Celery-backed refresh for **test sets** (member tests) and **sources** (chunk embeddings).

## What changed

- Pydantic schemas for 2D graphs: scatter points (including `cluster_index`, `searchable_text`), clusters, and API responses (`pending` vs `ready`).
- CRUD: `get_active_embeddings_for_entities` loads only **active** embeddings for given entity IDs and entity type.
- Optional dependencies: `umap-learn`, `hdbscan` (declared on the backend package).
- `graph_builder` service: UMAP + HDBSCAN, trivial layouts for 1–2 points, **empty graph** when there are no embeddings or when active embeddings are **ambiguous** (mixed `config_hash` or duplicate `entity_id` in the loaded set).
- Celery tasks split for test-set vs source graph builds; registered in Celery config and task exports.
- REST: `POST/GET .../embeddings/compute-graph` and `.../embeddings/graph` on **test sets** (`attributes.graph`) and **sources** (`source_metadata.graph`).
- Docs/comments on `EmbeddableMixin`; Ruff formatting on touched files.

## Additional context

- Branch history includes rebase/lockfile conflict resolution and follow-up fixes (import paths, graph hardening, ambiguous-embedding handling, shorter cluster label prompt).

## Testing

From `apps/backend`:

```bash
uv run pytest ../../tests/backend/services/embedding/test_graph_builder.py ../../tests/backend/routes/test_embedding_graph.py -v
```

Broader backend suite:

```bash
uv run pytest ../../tests/backend/ -v
```

Manual: queue `compute-graph` for a test set or source with consistent active embeddings, poll `get .../embeddings/graph` until `ready`, and confirm scatter payload shape.