### PR TITLE
fix: redis backend stability and infra secrets refactor

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          echo "REGION=${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}" >> $GITHUB_ENV
+          echo "REGION=${{ secrets.REGION || 'us-central1' }}" >> $GITHUB_ENV
 
       - name: Setup service environment
         id: setup_service_env
@@ -270,7 +270,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          echo "REGION=${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}" >> $GITHUB_ENV
+          echo "REGION=${{ secrets.REGION || 'us-central1' }}" >> $GITHUB_ENV
 
       - name: Setup service environment
         uses: ./.github/actions/setup-service-env
@@ -363,7 +363,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          REGION="${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}"
+          REGION="${{ secrets.REGION || 'us-central1' }}"
           echo "REGION=$REGION" >> $GITHUB_ENV
 
       - name: Setup service environment
@@ -470,7 +470,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          REGION="${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}"
+          REGION="${{ secrets.REGION || 'us-central1' }}"
           echo "REGION=$REGION" >> $GITHUB_ENV
 
       - name: Setup service environment

--- a/.github/workflows/chatbot.yml
+++ b/.github/workflows/chatbot.yml
@@ -90,7 +90,7 @@ jobs:
         id: set_env
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          echo "REGION=${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}" >> $GITHUB_ENV
+          echo "REGION=${{ secrets.REGION || 'us-central1' }}" >> $GITHUB_ENV
 
       - name: Setup service environment
         uses: ./.github/actions/setup-service-env
@@ -152,7 +152,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          REGION="${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}"
+          REGION="${{ secrets.REGION || 'us-central1' }}"
           echo "REGION=$REGION" >> $GITHUB_ENV
 
       - name: Setup service environment

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -134,7 +134,7 @@ jobs:
         id: set_env
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          echo "REGION=${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}" >> $GITHUB_ENV
+          echo "REGION=${{ secrets.REGION || 'us-central1' }}" >> $GITHUB_ENV
 
           # Get commit SHA (short version for URLs)
           COMMIT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
@@ -243,7 +243,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          echo "REGION=${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}" >> $GITHUB_ENV
+          echo "REGION=${{ secrets.REGION || 'us-central1' }}" >> $GITHUB_ENV
           if [ "${{ env.ENVIRONMENT }}" = "dev" ]; then
             echo "ROBOTS_NOINDEX=true" >> $GITHUB_ENV
           fi

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -131,7 +131,7 @@ jobs:
         id: set_env
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          echo "REGION=${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}" >> $GITHUB_ENV
+          echo "REGION=${{ secrets.REGION || 'us-central1' }}" >> $GITHUB_ENV
 
           # Get commit SHA (short version for URLs)
           COMMIT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
@@ -259,7 +259,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          echo "REGION=${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}" >> $GITHUB_ENV
+          echo "REGION=${{ secrets.REGION || 'us-central1' }}" >> $GITHUB_ENV
 
       - name: Setup service environment
         uses: ./.github/actions/setup-service-env

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -140,7 +140,7 @@ jobs:
         id: region
         run: |
           # Default to europe-west4 if not specified in secrets
-          REGION="${{ secrets.TF_VAR_REGION }}"
+          REGION="${{ secrets.REGION }}"
           REGION="${REGION:-europe-west4}"
           echo "region=$REGION" >> $GITHUB_OUTPUT
           echo "Region: $REGION"
@@ -244,11 +244,11 @@ jobs:
         run: |
           chmod +x infrastructure/scripts/check-images.sh
           # Export the image variables so the script can access them
-          export TF_VAR_BACKEND_IMAGE="${{ secrets.TF_VAR_BACKEND_IMAGE }}"
-          export TF_VAR_FRONTEND_IMAGE="${{ secrets.TF_VAR_FRONTEND_IMAGE }}"
-          export TF_VAR_WORKER_IMAGE="${{ secrets.TF_VAR_WORKER_IMAGE }}"
-          export TF_VAR_POLYPHEMUS_IMAGE="${{ secrets.TF_VAR_POLYPHEMUS_IMAGE }}"
-          export TF_VAR_CHATBOT_IMAGE="${{ secrets.TF_VAR_CHATBOT_IMAGE }}"
+          export BACKEND_IMAGE="${{ secrets.BACKEND_IMAGE }}"
+          export FRONTEND_IMAGE="${{ secrets.FRONTEND_IMAGE }}"
+          export WORKER_IMAGE="${{ secrets.WORKER_IMAGE }}"
+          export POLYPHEMUS_IMAGE="${{ secrets.POLYPHEMUS_IMAGE }}"
+          export CHATBOT_IMAGE="${{ secrets.CHATBOT_IMAGE }}"
           
           # Default region if not set
           REGION="${{ needs.setup.outputs.region }}"
@@ -265,47 +265,47 @@ jobs:
             --environment ${{ github.event.inputs.environment }} \
             --region "$REGION"
           
-          # Print all the TF_VAR_ environment variables set by the script
+          # Print all the environment variables set by the script
           echo "Environment variables set for Terraform:"
-          grep -E "^TF_VAR_.*_IMAGE=" $GITHUB_ENV || echo "No image variables were set"
+          grep -E ".*_IMAGE=" $GITHUB_ENV || echo "No image variables were set"
       
       - name: Debug Environment Variables
         run: |
-          echo "Current GITHUB_ENV file contents (TF_VAR_ only):"
-          grep -E "^TF_VAR_" $GITHUB_ENV || echo "No TF_VAR_ variables found"
+          echo "Current GITHUB_ENV file contents:"
+          cat $GITHUB_ENV || echo "No variables found"
       
       - name: Generate Terraform Plan
         env:
           # Environment-specific variables are automatically available from the environment
-          TF_VAR_DATABASE_PASSWORD: ${{ secrets.TF_VAR_DATABASE_PASSWORD }}
+          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
           
           # Explicitly set image variables from GitHub ENV file
           # These will be empty for non-existent images causing Terraform to use defaults
-          TF_VAR_BACKEND_IMAGE: ${{ env.TF_VAR_BACKEND_IMAGE }}
-          TF_VAR_FRONTEND_IMAGE: ${{ env.TF_VAR_FRONTEND_IMAGE }}
-          TF_VAR_WORKER_IMAGE: ${{ env.TF_VAR_WORKER_IMAGE }}
-          TF_VAR_POLYPHEMUS_IMAGE: ${{ env.TF_VAR_POLYPHEMUS_IMAGE }}
-          TF_VAR_CHATBOT_IMAGE: ${{ env.TF_VAR_CHATBOT_IMAGE }}
+          BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          FRONTEND_IMAGE: ${{ env.FRONTEND_IMAGE }}
+          WORKER_IMAGE: ${{ env.WORKER_IMAGE }}
+          POLYPHEMUS_IMAGE: ${{ env.POLYPHEMUS_IMAGE }}
+          CHATBOT_IMAGE: ${{ env.CHATBOT_IMAGE }}
           
-          TF_VAR_ENABLE_LOAD_BALANCERS: ${{ secrets.TF_VAR_ENABLE_LOAD_BALANCERS }}
-          TF_VAR_BACKEND_DOMAIN: ${{ secrets.TF_VAR_BACKEND_DOMAIN }}
-          TF_VAR_FRONTEND_DOMAIN: ${{ secrets.TF_VAR_FRONTEND_DOMAIN }}
-          TF_VAR_WORKER_DOMAIN: ${{ secrets.TF_VAR_WORKER_DOMAIN }}
-          TF_VAR_POLYPHEMUS_DOMAIN: ${{ secrets.TF_VAR_POLYPHEMUS_DOMAIN }}
-          TF_VAR_CHATBOT_DOMAIN: ${{ secrets.TF_VAR_CHATBOT_DOMAIN }}
+          ENABLE_LOAD_BALANCERS: ${{ secrets.ENABLE_LOAD_BALANCERS }}
+          BACKEND_DOMAIN: ${{ secrets.BACKEND_DOMAIN }}
+          FRONTEND_DOMAIN: ${{ secrets.FRONTEND_DOMAIN }}
+          WORKER_DOMAIN: ${{ secrets.WORKER_DOMAIN }}
+          POLYPHEMUS_DOMAIN: ${{ secrets.POLYPHEMUS_DOMAIN }}
+          CHATBOT_DOMAIN: ${{ secrets.CHATBOT_DOMAIN }}
           
           # Common variables from repo secrets
-          TF_VAR_REGION: ${{ secrets.TF_VAR_REGION }}
-          TF_VAR_BILLING_ACCOUNT: ${{ secrets.TF_VAR_BILLING_ACCOUNT }}
-          TF_VAR_ORG_ID: ${{ secrets.TF_VAR_ORG_ID }}
+          REGION: ${{ secrets.REGION }}
+          BILLING_ACCOUNT: ${{ secrets.BILLING_ACCOUNT }}
+          ORG_ID: ${{ secrets.ORG_ID }}
         run: |
           # Print the image variables being used by Terraform
           echo "Image variables being used by Terraform:"
-          echo "BACKEND_IMAGE: $TF_VAR_BACKEND_IMAGE"
-          echo "FRONTEND_IMAGE: $TF_VAR_FRONTEND_IMAGE"
-          echo "WORKER_IMAGE: $TF_VAR_WORKER_IMAGE"
-          echo "POLYPHEMUS_IMAGE: $TF_VAR_POLYPHEMUS_IMAGE"
-          echo "CHATBOT_IMAGE: $TF_VAR_CHATBOT_IMAGE"
+          echo "BACKEND_IMAGE: $BACKEND_IMAGE"
+          echo "FRONTEND_IMAGE: $FRONTEND_IMAGE"
+          echo "WORKER_IMAGE: $WORKER_IMAGE"
+          echo "POLYPHEMUS_IMAGE: $POLYPHEMUS_IMAGE"
+          echo "CHATBOT_IMAGE: $CHATBOT_IMAGE"
           
           # Run the deploy script with plan-only option
           # Pass the deployment stage parameter if specified
@@ -511,12 +511,12 @@ jobs:
       - name: Apply Services
         env:
           # Environment-specific variables are automatically available from the environment
-          TF_VAR_DATABASE_PASSWORD: ${{ secrets.TF_VAR_DATABASE_PASSWORD }}
-          TF_VAR_BACKEND_IMAGE: ${{ env.TF_VAR_BACKEND_IMAGE }}
-          TF_VAR_FRONTEND_IMAGE: ${{ env.TF_VAR_FRONTEND_IMAGE }}
-          TF_VAR_WORKER_IMAGE: ${{ env.TF_VAR_WORKER_IMAGE }}
-          TF_VAR_POLYPHEMUS_IMAGE: ${{ env.TF_VAR_POLYPHEMUS_IMAGE }}
-          TF_VAR_CHATBOT_IMAGE: ${{ env.TF_VAR_CHATBOT_IMAGE }}
+          DATABASE_PASSWORD: ${{ secrets.DATABASE_PASSWORD }}
+          BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          FRONTEND_IMAGE: ${{ env.FRONTEND_IMAGE }}
+          WORKER_IMAGE: ${{ env.WORKER_IMAGE }}
+          POLYPHEMUS_IMAGE: ${{ env.POLYPHEMUS_IMAGE }}
+          CHATBOT_IMAGE: ${{ env.CHATBOT_IMAGE }}
         run: |
           cd infrastructure/environments/${{ github.event.inputs.environment }}
           

--- a/.github/workflows/otel-collector.yml
+++ b/.github/workflows/otel-collector.yml
@@ -113,7 +113,7 @@ jobs:
         id: set_env
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          echo "REGION=${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}" >> $GITHUB_ENV
+          echo "REGION=${{ secrets.REGION || 'us-central1' }}" >> $GITHUB_ENV
 
           # Get commit SHA (short version for URLs)
           COMMIT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
@@ -184,7 +184,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          REGION="${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}"
+          REGION="${{ secrets.REGION || 'us-central1' }}"
           echo "REGION=$REGION" >> $GITHUB_ENV
 
       - name: Setup service environment

--- a/.github/workflows/polyphemus-vertex-ai.yml
+++ b/.github/workflows/polyphemus-vertex-ai.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
           echo "GCP_PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          echo "GCP_REGION=${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}" >> $GITHUB_ENV
+          echo "GCP_REGION=${{ secrets.REGION || 'us-central1' }}" >> $GITHUB_ENV
           echo "GCP_SERVICE_ACCOUNT=${{ secrets.GCP_SERVICE_ACCOUNT }}" >> $GITHUB_ENV 
           
           # Model path and default model (existing GitHub secrets)

--- a/.github/workflows/polyphemus.yml
+++ b/.github/workflows/polyphemus.yml
@@ -122,7 +122,7 @@ jobs:
         id: set_env
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          echo "REGION=${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}" >> $GITHUB_ENV
+          echo "REGION=${{ secrets.REGION || 'us-central1' }}" >> $GITHUB_ENV
 
           # Get commit SHA (short version for URLs)
           COMMIT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
@@ -239,7 +239,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          REGION="${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}"
+          REGION="${{ secrets.REGION || 'us-central1' }}"
           echo "REGION=$REGION" >> $GITHUB_ENV
           
           # Get commit SHA (short version) - use build output if available, otherwise compute from github.sha

--- a/.github/workflows/telemetry-processor.yml
+++ b/.github/workflows/telemetry-processor.yml
@@ -113,7 +113,7 @@ jobs:
         id: set_env
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          echo "REGION=${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}" >> $GITHUB_ENV
+          echo "REGION=${{ secrets.REGION || 'us-central1' }}" >> $GITHUB_ENV
 
           # Get commit SHA (short version for URLs)
           COMMIT_SHA=$(echo "${{ github.sha }}" | cut -c1-8)
@@ -189,7 +189,7 @@ jobs:
       - name: Set environment variables
         run: |
           echo "PROJECT_ID=${{ secrets.PROJECT_ID }}" >> $GITHUB_ENV
-          REGION="${{ secrets.REGION || secrets.TF_VAR_REGION || 'us-central1' }}"
+          REGION="${{ secrets.REGION || 'us-central1' }}"
           echo "REGION=$REGION" >> $GITHUB_ENV
 
       - name: Setup service environment

--- a/docs/content/contribute/polyphemus/index.mdx
+++ b/docs/content/contribute/polyphemus/index.mdx
@@ -43,7 +43,7 @@ Region configuration uses two separate variables depending on context:
 
 | Context | Variable | Source | Where it is consumed |
 |---|---|---|---|
-| GitHub Actions CI/CD workflow | `REGION` | `secrets.REGION` (falls back to `secrets.TF_VAR_REGION`, then `us-central1`) | `.github/workflows/polyphemus.yml` |
+| GitHub Actions CI/CD workflow | `REGION` | `secrets.REGION` (falls back to `us-central1`) | `.github/workflows/polyphemus.yml` |
 | Running Polyphemus service | `POLYPHEMUS_LOCATION` | Set to `$REGION` by the CI workflow | `apps/polyphemus/src/rhesis/polyphemus/routers/services.py` |
 | Vertex model deployment script | `GCP_REGION` | Set directly in the local environment (not mapped from `REGION`) | `apps/polyphemus/model_deployment/config.py` |
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -101,7 +101,7 @@ This repository includes a GitHub Actions workflow for automated deployments. Se
 ### Variable Management
 
 The deployment process uses a standardized approach to map GitHub secrets to Terraform variables:
-1. GitHub secrets follow the naming convention `TF_VAR_VARIABLE_NAME` (uppercase)
+1. GitHub secrets follow the naming convention `VARIABLE_NAME` (uppercase)
 2. Terraform variables use snake_case in the .tf files
 3. The deployment script automatically converts between these formats
 4. Variables are organized by environment using GitHub Environments feature

--- a/infrastructure/config/infra-secrets-create.sh
+++ b/infrastructure/config/infra-secrets-create.sh
@@ -166,9 +166,9 @@ function set_repo_secret() {
 
 # Set common secrets at repository level
 echo -e "${BLUE}Setting common repository secrets...${NC}"
-set_repo_secret "TF_VAR_REGION" "$REGION"
-set_repo_secret "TF_VAR_BILLING_ACCOUNT" "$BILLING_ACCOUNT"
-set_repo_secret "TF_VAR_ORG_ID" "$ORG_ID"
+set_repo_secret "REGION" "$REGION"
+set_repo_secret "BILLING_ACCOUNT" "$BILLING_ACCOUNT"
+set_repo_secret "ORG_ID" "$ORG_ID"
 
 # Set GCP service account key as repository secret
 echo -e "${BLUE}Setting GCP service account key...${NC}"
@@ -182,7 +182,7 @@ for env in "${ENV_ARRAY[@]}"; do
   # Database password
   db_password_var="${env_upper}_DATABASE_PASSWORD"
   if [[ -n "${!db_password_var}" ]]; then
-    set_secret "$env" "TF_VAR_DATABASE_PASSWORD" "${!db_password_var}"
+    set_secret "$env" "DATABASE_PASSWORD" "${!db_password_var}"
   else
     echo -e "${YELLOW}Warning:${NC} $db_password_var environment variable is not set"
   fi
@@ -191,7 +191,7 @@ for env in "${ENV_ARRAY[@]}"; do
   for service in BACKEND FRONTEND WORKER POLYPHEMUS CHATBOT; do
     image_var="${env_upper}_${service}_IMAGE"
     if [[ -n "${!image_var}" ]]; then
-      set_secret "$env" "TF_VAR_${service}_IMAGE" "${!image_var}"
+      set_secret "$env" "${service}_IMAGE" "${!image_var}"
     else
       echo -e "${YELLOW}Warning:${NC} $image_var environment variable is not set"
     fi
@@ -200,10 +200,10 @@ for env in "${ENV_ARRAY[@]}"; do
   # Load balancer settings
   lb_var="${env_upper}_ENABLE_LOAD_BALANCERS"
   if [[ -n "${!lb_var}" ]]; then
-    set_secret "$env" "TF_VAR_ENABLE_LOAD_BALANCERS" "${!lb_var}"
+    set_secret "$env" "ENABLE_LOAD_BALANCERS" "${!lb_var}"
   else
     echo -e "${YELLOW}Warning:${NC} $lb_var environment variable is not set, using default: true"
-    set_secret "$env" "TF_VAR_ENABLE_LOAD_BALANCERS" "true"
+    set_secret "$env" "ENABLE_LOAD_BALANCERS" "true"
   fi
   
   # Domain settings
@@ -232,10 +232,10 @@ for env in "${ENV_ARRAY[@]}"; do
     domain_var="${env_upper}_${domain_key}"
     
     if [[ -n "${!domain_var}" ]]; then
-      set_secret "$env" "TF_VAR_${domain_key}" "${!domain_var}"
+      set_secret "$env" "${domain_key}" "${!domain_var}"
     elif [[ -n "$domain_default" ]]; then
       echo -e "${YELLOW}Warning:${NC} $domain_var environment variable is not set, using default: $domain_default"
-      set_secret "$env" "TF_VAR_${domain_key}" "$domain_default"
+      set_secret "$env" "${domain_key}" "$domain_default"
     fi
   done
 done

--- a/infrastructure/scripts/DEPLOYMENT.md
+++ b/infrastructure/scripts/DEPLOYMENT.md
@@ -118,30 +118,30 @@ The repository includes a GitHub Actions workflow file (`infrastructure.yml`) in
 
 2. Add Terraform variables as GitHub secrets with the following naming convention:
    - Common variables for all environments:
-     - `TF_VAR_REGION`: The GCP region (e.g., "europe-west4")
-     - `TF_VAR_BILLING_ACCOUNT`: Your GCP billing account ID
+     - `REGION`: The GCP region (e.g., "europe-west4")
+     - `BILLING_ACCOUNT`: Your GCP billing account ID
 
    - Environment-specific variables (replace ENV with DEV, STG, or PRD):
-     - `TF_VAR_ENV_DATABASE_PASSWORD`: Database password
-     - `TF_VAR_ENV_BACKEND_IMAGE`: Backend container image URL
-     - `TF_VAR_ENV_FRONTEND_IMAGE`: Frontend container image URL
-     - `TF_VAR_ENV_WORKER_IMAGE`: Worker container image URL
-     - `TF_VAR_ENV_POLYPHEMUS_IMAGE`: Polyphemus container image URL
-     - `TF_VAR_ENV_CHATBOT_IMAGE`: Chatbot container image URL
-     - `TF_VAR_ENV_ENABLE_LOAD_BALANCERS`: Whether to enable load balancers (true/false)
+     - `ENV_DATABASE_PASSWORD`: Database password
+     - `ENV_BACKEND_IMAGE`: Backend container image URL
+     - `ENV_FRONTEND_IMAGE`: Frontend container image URL
+     - `ENV_WORKER_IMAGE`: Worker container image URL
+     - `ENV_POLYPHEMUS_IMAGE`: Polyphemus container image URL
+     - `ENV_CHATBOT_IMAGE`: Chatbot container image URL
+     - `ENV_ENABLE_LOAD_BALANCERS`: Whether to enable load balancers (true/false)
      
    - Domain naming follows these conventions:
      - For development and staging: `env-service.rhesis.ai` (e.g., dev-api.rhesis.ai)
      - For production: `service.rhesis.ai` (e.g., api.rhesis.ai)
      
    - Domain variables:
-     - For dev/stg: `TF_VAR_ENV_SERVICE_DOMAIN` (e.g., TF_VAR_DEV_BACKEND_DOMAIN = "dev-api.rhesis.ai")
-     - For production: `TF_VAR_PRD_SERVICE_DOMAIN` (e.g., TF_VAR_PRD_BACKEND_DOMAIN = "api.rhesis.ai")
+     - For dev/stg: `ENV_SERVICE_DOMAIN` (e.g., DEV_BACKEND_DOMAIN = "dev-api.rhesis.ai")
+     - For production: `PRD_SERVICE_DOMAIN` (e.g., PRD_BACKEND_DOMAIN = "api.rhesis.ai")
 
    Example:
-   - `TF_VAR_DEV_DATABASE_PASSWORD`: Password for the development database
-   - `TF_VAR_DEV_FRONTEND_DOMAIN`: "dev-app.rhesis.ai"
-   - `TF_VAR_PRD_FRONTEND_DOMAIN`: "app.rhesis.ai"
+   - `DEV_DATABASE_PASSWORD`: Password for the development database
+   - `DEV_FRONTEND_DOMAIN`: "dev-app.rhesis.ai"
+   - `PRD_FRONTEND_DOMAIN`: "app.rhesis.ai"
 
 ### Container Image Validation
 
@@ -190,14 +190,14 @@ This approach ensures that Cloud Run services can be deployed even without custo
 The deployment process automatically maps GitHub secrets to Terraform variables using a standardized approach:
 
 1. **Naming Convention Alignment**:
-   - GitHub secrets use the `TF_VAR_` prefix followed by the variable name in uppercase
+   - GitHub secrets use the variable name in uppercase
    - Terraform variables use lowercase/snake_case in the .tf files
    - The deployment script automatically converts between these formats
 
 2. **Variable Mapping Process**:
    - The `deploy-terraform.sh` script reads the `terraform.tfvars.example` file to identify required variables
-   - For each variable, it looks for a corresponding GitHub secret with the `TF_VAR_` prefix
-   - The script converts Terraform's snake_case to GitHub's uppercase format (e.g., `database_password` → `TF_VAR_DATABASE_PASSWORD`)
+   - For each variable, it looks for a corresponding GitHub secret
+   - The script converts Terraform's snake_case to GitHub's uppercase format (e.g., `database_password` → `DATABASE_PASSWORD`)
    - When a matching secret is found, its value is written to the generated `terraform.tfvars` file
 
 3. **Example Mapping**:
@@ -209,7 +209,7 @@ The deployment process automatically maps GitHub secrets to Terraform variables 
    }
    
    # Corresponding GitHub secret
-   TF_VAR_DATABASE_PASSWORD = "secure-password-value"
+DATABASE_PASSWORD = "secure-password-value"
    
    # Generated entry in terraform.tfvars
    database_password = "secure-password-value"

--- a/infrastructure/scripts/check-images.sh
+++ b/infrastructure/scripts/check-images.sh
@@ -116,7 +116,7 @@ if [[ -z "$REGISTRY_EXISTS" ]]; then
   
   # Create empty environment variables for all services
   for SERVICE in "${SERVICES[@]}"; do
-    VAR_NAME="TF_VAR_$(echo "${SERVICE}_IMAGE" | tr '[:lower:]' '[:upper:]')"
+    VAR_NAME="$(echo "${SERVICE}_IMAGE" | tr '[:lower:]' '[:upper:]')"
     echo "$VAR_NAME=" >> $GITHUB_ENV
     echo "ℹ️ Set $VAR_NAME to empty (will use default image)"
   done
@@ -144,7 +144,7 @@ for SERVICE in "${SERVICES[@]}"; do
   echo "📦 Checking service: $SERVICE"
   
   # Get the original image from environment
-  ENV_VAR_NAME="TF_VAR_$(echo "${SERVICE}_IMAGE" | tr '[:lower:]' '[:upper:]')"
+  ENV_VAR_NAME="$(echo "${SERVICE}_IMAGE" | tr '[:lower:]' '[:upper:]')"
   ORIGINAL_IMAGE="${!ENV_VAR_NAME}"
   
   # Skip if not set

--- a/infrastructure/scripts/deploy-terraform.sh
+++ b/infrastructure/scripts/deploy-terraform.sh
@@ -283,9 +283,9 @@ else
   echo "# Auto-generated terraform.tfvars from environment variables" > "terraform.tfvars"
 
   # Look for common variables in GitHub Actions environment
-  REGION=${TF_VAR_REGION:-}
-  BILLING_ACCOUNT=${TF_VAR_BILLING_ACCOUNT:-}
-  ORG_ID=${TF_VAR_ORG_ID:-}
+  REGION=${REGION:-}
+  BILLING_ACCOUNT=${BILLING_ACCOUNT:-}
+  ORG_ID=${ORG_ID:-}
 
   # Add common settings if they exist in environment variables
   if [[ -n "$REGION" ]]; then
@@ -331,7 +331,7 @@ else
     fi
     
     # Convert variable name to environment variable format
-    ENV_VAR_NAME="TF_VAR_$(echo "$VAR" | tr '[:lower:]' '[:upper:]')"
+    ENV_VAR_NAME="$(echo "$VAR" | tr '[:lower:]' '[:upper:]')"
     
     # Special logging for image variables
     if [[ "$VAR" == *"_image" ]]; then


### PR DESCRIPTION
## Purpose
Address Redis backend stability issues in Celery workers and API routers, and clean up the `TF_VAR_` prefix from our infrastructure configuration and CI/CD pipelines.

## What Changed
- **Backend Redis Stability**:
  - Implemented connection pool limits (`max_connections`) and `WEB_CELERY_OVERRIDES` to ensure the API fails-fast and falls back gracefully when Redis is slow/unavailable.
  - Released SQLAlchemy sessions earlier in the telemetry router before calling Celery async tasks, preventing slow broker operations from exhausting the DB pool.
  - Added specific error trapping for `BROKER_ERRORS` to better handle redis disconnections without crashing the API requests.
- **Infrastructure Config Refactor**:
  - Completely removed the `TF_VAR_` prefix from GitHub Secrets, `.github/workflows/*.yml`, and our deployment shell scripts. Environment variables and secrets are now natively mapped without prefix gymnastics (e.g. `REGION` instead of `TF_VAR_REGION`).
  - Standardized all secrets provisioning (`infra-secrets-create.sh`) and deployment (`deploy-terraform.sh`, `check-images.sh`) to adhere to this cleaner setup.

## Additional Context
- The backend changes should massively reduce HTTP 500s during sudden spikes or transient network issues with the MemoryStore (Redis) instance.
- The infra secret change streamlines developer onboarding and manual secret management via the GitHub UI.

## Testing
- Ensure CI passes.
- To test the backend changes, simulate high load or a transient Redis outage in a local/staging environment, verifying that `async_dispatch` falls back to `sync` processing gracefully.