### PR TITLE
Fix Redis backend stability: break autoscaler feedback loop on trace ingestion

### DIFF
--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -135,6 +135,12 @@ async def lifespan(app: FastAPI):
     """
     set_logger()
 
+    # Apply fail-fast Celery broker settings for the web process.
+    # Must happen before any Celery task is published from an HTTP handler.
+    from rhesis.backend.celery.core import apply_web_context_overrides
+
+    apply_web_context_overrides()
+
     # Set anyio threadpool size for async-to-thread offloading.
     # Default is 40; 100 is a reasonable production value for 2 vCPU + concurrency 80.
     try:

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -26,7 +26,6 @@ from rhesis.backend.app.schemas.telemetry import (
     TraceType,
 )
 from rhesis.backend.app.services.async_service import BROKER_ERRORS
-from rhesis.backend.app.services.telemetry.enrichment import EnrichmentService
 from rhesis.backend.app.services.trace_review_override import (
     apply_review_override as trace_apply_review_override,
 )
@@ -135,26 +134,15 @@ def ingest_trace(
             unique_trace_ids=unique_trace_ids,
             organization_id=organization_id,
             project_id=str(project_id),
-            test_run_id=(
-                str(first_span.test_run_id) if first_span.test_run_id else None
-            ),
+            test_run_id=(str(first_span.test_run_id) if first_span.test_run_id else None),
             test_id=str(first_span.test_id) if first_span.test_id else None,
-            test_configuration_id=first_span.attributes.get(
-                "rhesis.test.test_configuration_id"
-            ),
+            test_configuration_id=first_span.attributes.get("rhesis.test.test_configuration_id"),
         )
 
         logger.info(
             f"Ingested {stored_count} spans from "
             f"{len(unique_trace_ids)} trace(s) for trace_id={trace_id}"
         )
-
-        _stage = "worker_check"
-        _workers_available = EnrichmentService._worker_cache.get("available")
-        if _workers_available is None:
-            enrichment_service = EnrichmentService(db)
-            _workers_available = enrichment_service._check_workers_available()
-        logger.info(f"Worker availability for trace_id={trace_id}: {_workers_available}")
 
         # Commit and release the DB connection BEFORE dispatching to Celery.
         # If delay() blocks (Redis contention), this prevents holding a
@@ -163,103 +151,30 @@ def ingest_trace(
         db.commit()
         db.close()
 
-        _dispatched_async = False
-        if _workers_available:
-            from rhesis.backend.tasks.telemetry.post_ingest import post_ingest_link
+        # Fire-and-forget: dispatch async post-processing.
+        # Spans are already persisted — enrichment is eventual-consistency.
+        # If the broker is unreachable, we log a warning and return success.
+        from rhesis.backend.tasks.telemetry.post_ingest import post_ingest_link
 
-            _stage = "async_dispatch"
-            try:
-                post_ingest_link.delay(**dispatch_kwargs)
-                _dispatched_async = True
-                logger.info(f"Dispatched post_ingest_link for trace_id={trace_id}")
-            except BROKER_ERRORS as broker_err:
-                logger.warning(
-                    f"Broker unavailable for trace_id={trace_id} | "
-                    f"error_type={type(broker_err).__name__} | "
-                    f"error={broker_err} | "
-                    f"falling back to synchronous processing",
-                )
-            except Exception as broker_err:
-                logger.warning(
-                    f"Failed to dispatch post_ingest_link for trace_id={trace_id} | "
-                    f"error_type={type(broker_err).__name__} | "
-                    f"error={broker_err} | "
-                    f"falling back to synchronous processing",
-                    exc_info=True,
-                )
-
-        if not _dispatched_async:
-            _stage = "sync_fallback"
+        _stage = "async_dispatch"
+        try:
+            post_ingest_link.delay(**dispatch_kwargs)
+            logger.info(f"Dispatched post_ingest_link for trace_id={trace_id}")
+        except BROKER_ERRORS as broker_err:
             logger.warning(
-                f"Running synchronous post-ingestion fallback for trace_id={trace_id} | "
-                f"workers_available={_workers_available}"
+                f"Broker unavailable for trace_id={trace_id}, "
+                f"post-processing deferred | "
+                f"error_type={type(broker_err).__name__} | "
+                f"error={broker_err}"
             )
-
-            # Re-open a DB session for sync fallback work
-            from rhesis.backend.app.database import get_db_with_tenant_variables
-
-            with get_db_with_tenant_variables(
-                organization_id, tenant_context[1]
-            ) as fallback_db:
-                # Re-fetch the stored spans in the new session
-                from rhesis.backend.app.models.trace import Trace
-                from rhesis.backend.app.services.telemetry.conversation_linking import (
-                    apply_pending_conversation_links,
-                    apply_pending_files,
-                )
-                from rhesis.backend.app.services.telemetry.linking_service import (
-                    TraceLinkingService,
-                )
-
-                fallback_spans = (
-                    fallback_db.query(Trace)
-                    .filter(Trace.id.in_(stored_span_ids))
-                    .all()
-                )
-
-                linking_service = TraceLinkingService(fallback_db)
-                try:
-                    linking_service.link_traces_for_incoming_batch(
-                        spans=fallback_spans,
-                        organization_id=organization_id,
-                    )
-                except Exception as link_error:
-                    logger.warning(
-                        f"Failed to link traces for trace_id={trace_id}: {link_error}",
-                        exc_info=True,
-                    )
-
-                try:
-                    apply_pending_conversation_links(fallback_db, fallback_spans)
-                except Exception as conv_error:
-                    logger.warning(
-                        f"Failed to apply conversation links for "
-                        f"trace_id={trace_id}: {conv_error}",
-                        exc_info=True,
-                    )
-
-                try:
-                    apply_pending_files(fallback_db, fallback_spans)
-                except Exception as file_error:
-                    logger.warning(
-                        f"Failed to apply pending files for "
-                        f"trace_id={trace_id}: {file_error}",
-                        exc_info=True,
-                    )
-
-                try:
-                    enrichment_service = EnrichmentService(fallback_db)
-                    enrichment_service.enrich_traces(
-                        set(unique_trace_ids),
-                        str(project_id),
-                        organization_id,
-                        workers_available=_workers_available,
-                    )
-                except Exception as enrich_error:
-                    logger.warning(
-                        f"Failed to enrich traces for trace_id={trace_id}: {enrich_error}",
-                        exc_info=True,
-                    )
+        except Exception as broker_err:
+            logger.warning(
+                f"Failed to dispatch post_ingest_link for "
+                f"trace_id={trace_id}, post-processing deferred | "
+                f"error_type={type(broker_err).__name__} | "
+                f"error={broker_err}",
+                exc_info=True,
+            )
 
         return TraceResponse(
             status="received",

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -25,6 +25,7 @@ from rhesis.backend.app.schemas.telemetry import (
     TraceSummary,
     TraceType,
 )
+from rhesis.backend.app.services.async_service import BROKER_ERRORS
 from rhesis.backend.app.services.telemetry.enrichment import EnrichmentService
 from rhesis.backend.app.services.trace_review_override import (
     apply_review_override as trace_apply_review_override,
@@ -124,39 +125,60 @@ def ingest_trace(
 
         unique_trace_ids = list({s.trace_id for s in stored_spans})
         stored_span_ids = [str(s.id) for s in stored_spans]
+        stored_count = len(stored_spans)
+
+        # Extract all data needed for async dispatch before releasing the DB
+        # connection.  ORM objects remain usable because expire_on_commit=False.
+        first_span = stored_spans[0]
+        dispatch_kwargs = dict(
+            stored_span_ids=stored_span_ids,
+            unique_trace_ids=unique_trace_ids,
+            organization_id=organization_id,
+            project_id=str(project_id),
+            test_run_id=(
+                str(first_span.test_run_id) if first_span.test_run_id else None
+            ),
+            test_id=str(first_span.test_id) if first_span.test_id else None,
+            test_configuration_id=first_span.attributes.get(
+                "rhesis.test.test_configuration_id"
+            ),
+        )
 
         logger.info(
-            f"Ingested {len(stored_spans)} spans from "
+            f"Ingested {stored_count} spans from "
             f"{len(unique_trace_ids)} trace(s) for trace_id={trace_id}"
         )
 
-        # Enqueue post-ingestion work (linking + enrichment) as a background task.
-        enrichment_service = EnrichmentService(db)
-
         _stage = "worker_check"
-        _workers_available = enrichment_service._check_workers_available()
+        _workers_available = EnrichmentService._worker_cache.get("available")
+        if _workers_available is None:
+            enrichment_service = EnrichmentService(db)
+            _workers_available = enrichment_service._check_workers_available()
         logger.info(f"Worker availability for trace_id={trace_id}: {_workers_available}")
+
+        # Commit and release the DB connection BEFORE dispatching to Celery.
+        # If delay() blocks (Redis contention), this prevents holding a
+        # database connection hostage and starving other endpoints.
+        _stage = "db_release"
+        db.commit()
+        db.close()
 
         _dispatched_async = False
         if _workers_available:
             from rhesis.backend.tasks.telemetry.post_ingest import post_ingest_link
 
-            first_span = stored_spans[0]
             _stage = "async_dispatch"
             try:
-                post_ingest_link.delay(
-                    stored_span_ids=stored_span_ids,
-                    unique_trace_ids=unique_trace_ids,
-                    organization_id=organization_id,
-                    project_id=str(project_id),
-                    test_run_id=str(first_span.test_run_id) if first_span.test_run_id else None,
-                    test_id=str(first_span.test_id) if first_span.test_id else None,
-                    test_configuration_id=first_span.attributes.get(
-                        "rhesis.test.test_configuration_id"
-                    ),
-                )
+                post_ingest_link.delay(**dispatch_kwargs)
                 _dispatched_async = True
                 logger.info(f"Dispatched post_ingest_link for trace_id={trace_id}")
+            except BROKER_ERRORS as broker_err:
+                logger.warning(
+                    f"Broker unavailable for trace_id={trace_id} | "
+                    f"error_type={type(broker_err).__name__} | "
+                    f"error={broker_err} | "
+                    f"falling back to synchronous processing",
+                )
             except Exception as broker_err:
                 logger.warning(
                     f"Failed to dispatch post_ingest_link for trace_id={trace_id} | "
@@ -173,59 +195,75 @@ def ingest_trace(
                 f"workers_available={_workers_available}"
             )
 
-            # Sync fallback: run linking in-request, enrichment via service
-            from rhesis.backend.app.services.telemetry.conversation_linking import (
-                apply_pending_conversation_links,
-                apply_pending_files,
-            )
-            from rhesis.backend.app.services.telemetry.linking_service import (
-                TraceLinkingService,
-            )
+            # Re-open a DB session for sync fallback work
+            from rhesis.backend.app.database import get_db_with_tenant_variables
 
-            linking_service = TraceLinkingService(db)
-            try:
-                linking_service.link_traces_for_incoming_batch(
-                    spans=stored_spans,
-                    organization_id=organization_id,
+            with get_db_with_tenant_variables(
+                organization_id, tenant_context[1]
+            ) as fallback_db:
+                # Re-fetch the stored spans in the new session
+                from rhesis.backend.app.models.trace import Trace
+                from rhesis.backend.app.services.telemetry.conversation_linking import (
+                    apply_pending_conversation_links,
+                    apply_pending_files,
                 )
-            except Exception as link_error:
-                logger.warning(
-                    f"Failed to link traces for trace_id={trace_id}: {link_error}",
-                    exc_info=True,
+                from rhesis.backend.app.services.telemetry.linking_service import (
+                    TraceLinkingService,
                 )
 
-            try:
-                apply_pending_conversation_links(db, stored_spans)
-            except Exception as conv_error:
-                logger.warning(
-                    f"Failed to apply conversation links for trace_id={trace_id}: {conv_error}",
-                    exc_info=True,
+                fallback_spans = (
+                    fallback_db.query(Trace)
+                    .filter(Trace.id.in_(stored_span_ids))
+                    .all()
                 )
 
-            try:
-                apply_pending_files(db, stored_spans)
-            except Exception as file_error:
-                logger.warning(
-                    f"Failed to apply pending files for trace_id={trace_id}: {file_error}",
-                    exc_info=True,
-                )
+                linking_service = TraceLinkingService(fallback_db)
+                try:
+                    linking_service.link_traces_for_incoming_batch(
+                        spans=fallback_spans,
+                        organization_id=organization_id,
+                    )
+                except Exception as link_error:
+                    logger.warning(
+                        f"Failed to link traces for trace_id={trace_id}: {link_error}",
+                        exc_info=True,
+                    )
 
-            try:
-                enrichment_service.enrich_traces(
-                    set(unique_trace_ids),
-                    str(project_id),
-                    organization_id,
-                    workers_available=_workers_available,
-                )
-            except Exception as enrich_error:
-                logger.warning(
-                    f"Failed to enrich traces for trace_id={trace_id}: {enrich_error}",
-                    exc_info=True,
-                )
+                try:
+                    apply_pending_conversation_links(fallback_db, fallback_spans)
+                except Exception as conv_error:
+                    logger.warning(
+                        f"Failed to apply conversation links for "
+                        f"trace_id={trace_id}: {conv_error}",
+                        exc_info=True,
+                    )
+
+                try:
+                    apply_pending_files(fallback_db, fallback_spans)
+                except Exception as file_error:
+                    logger.warning(
+                        f"Failed to apply pending files for "
+                        f"trace_id={trace_id}: {file_error}",
+                        exc_info=True,
+                    )
+
+                try:
+                    enrichment_service = EnrichmentService(fallback_db)
+                    enrichment_service.enrich_traces(
+                        set(unique_trace_ids),
+                        str(project_id),
+                        organization_id,
+                        workers_available=_workers_available,
+                    )
+                except Exception as enrich_error:
+                    logger.warning(
+                        f"Failed to enrich traces for trace_id={trace_id}: {enrich_error}",
+                        exc_info=True,
+                    )
 
         return TraceResponse(
             status="received",
-            span_count=len(stored_spans),
+            span_count=stored_count,
             trace_id=trace_id,
         )
 

--- a/apps/backend/src/rhesis/backend/app/services/async_service.py
+++ b/apps/backend/src/rhesis/backend/app/services/async_service.py
@@ -2,12 +2,11 @@
 
 This module provides a reusable base class for services that need to:
 - Execute tasks asynchronously via Celery when workers are available
-- Fallback to synchronous execution in development environments
+- Fallback to synchronous execution when the broker is unreachable
 - Batch process multiple tasks efficiently
 """
 
 import logging
-import time
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
@@ -31,132 +30,53 @@ class AsyncService(ABC, Generic[T]):
     """
     Abstract base service for orchestrating async/sync task execution.
 
-    Provides common patterns for:
-    - Checking Celery worker availability (shared TTL cache across subclasses)
-    - Enqueuing async tasks with fallback to sync
-    - Batch processing with a single worker check per batch (or caller-supplied flag)
+    Always attempts async dispatch first. Falls back to sync only when
+    the broker is unreachable (BROKER_ERRORS). No pre-flight worker
+    availability checks — those add latency on the hot path and trigger
+    autoscaler cascades when Redis is slow.
 
     Subclasses must implement:
     - _execute_sync(): Synchronous fallback implementation
     - _enqueue_async(): Async task enqueuing logic
     """
 
-    _worker_cache: dict = {"available": None, "checked_at": 0.0}
-    _worker_cache_ttl: float = 300.0  # 5 minutes TTL
-
     def __init__(self):
         """Initialize the async service."""
         pass
 
-    def _check_workers_available(self) -> bool:
-        """
-        Check if Celery workers are available, with shared TTL caching.
-
-        Uses monotonic time (immune to clock adjustments) and a 1-second ping
-        timeout (faster than the default 3s, avoids blocking request handling).
-
-        Returns:
-            True if workers are available, False otherwise
-        """
-        now = time.monotonic()
-        cache = self.__class__._worker_cache
-
-        if cache["available"] is not None and now - cache["checked_at"] < self._worker_cache_ttl:
-            return cache["available"]
-
-        is_available = False
-        try:
-            from rhesis.backend.worker import app as celery_app
-
-            inspect = celery_app.control.inspect(timeout=1.0)
-            ping_result = inspect.ping()
-
-            if ping_result:
-                logger.debug(
-                    f"Found {len(ping_result)} available worker(s): {list(ping_result.keys())}"
-                )
-                is_available = True
-
-        except Exception as e:
-            logger.debug(f"Worker availability check failed: {e}")
-
-        cache["available"] = is_available
-        cache["checked_at"] = time.monotonic()
-
-        return is_available
-
     @abstractmethod
     def _execute_sync(self, *args, **kwargs) -> T:
-        """
-        Execute task synchronously (development fallback).
-
-        Must be implemented by subclasses.
-
-        Returns:
-            Result of synchronous execution
-        """
+        """Execute task synchronously (fallback when broker is unreachable)."""
         pass
 
     @abstractmethod
     def _enqueue_async(self, *args, **kwargs) -> Any:
-        """
-        Enqueue async Celery task.
-
-        Must be implemented by subclasses.
-
-        Returns:
-            Celery AsyncResult or task ID
-        """
+        """Enqueue async Celery task."""
         pass
 
     def execute_with_fallback(
         self,
         *args,
-        workers_available: bool | None = None,
         swallow_exceptions: bool = False,
         **kwargs,
     ) -> tuple[bool, T | None]:
         """
-        Execute task with async/sync fallback strategy.
-
-        This implements a robust fallback:
-        1. Check if workers are available (or use cached result)
-        2. If yes, try async execution (optimal for production)
-        3. If no workers or async fails, fall back to sync (development-friendly)
-
-        Args:
-            *args: Positional arguments for task
-            workers_available: Optional cached worker availability.
-                             If None, will check on this call.
-            **kwargs: Keyword arguments for task
-            swallow_exceptions: If True, will swallow exceptions and return None
+        Execute task: try async first, fall back to sync on broker errors.
 
         Returns:
             Tuple of (was_async, result)
             - was_async: True if async task was enqueued, False if sync fallback
             - result: Result from sync execution, or None if async
         """
-        # Check worker availability (use cached if provided)
-        if workers_available is None:
-            workers_available = self._check_workers_available()
+        try:
+            task_result = self._enqueue_async(*args, **kwargs)
+            logger.debug(f"Enqueued async task: {task_result}")
+            return True, None
+        except BROKER_ERRORS as e:
+            logger.warning(f"Broker unavailable ({type(e).__name__}), falling back to sync: {e}")
+        except Exception as e:
+            logger.warning(f"Async task failed, using sync fallback: {e}")
 
-        # Try async execution
-        if workers_available:
-            try:
-                task_result = self._enqueue_async(*args, **kwargs)
-                logger.debug(f"Enqueued async task: {task_result}")
-                return True, None
-            except BROKER_ERRORS as e:
-                logger.warning(
-                    f"Broker unavailable ({type(e).__name__}), "
-                    f"falling back to sync: {e}"
-                )
-            except Exception as e:
-                logger.warning(f"Async task failed, using sync fallback: {e}")
-        else:
-            logger.info("No Celery workers available, using sync execution")
-
-        # Fall back to sync execution
         try:
             result = self._execute_sync(*args, **kwargs)
             logger.info("Completed sync execution")
@@ -171,19 +91,9 @@ class AsyncService(ABC, Generic[T]):
         self,
         items: list[tuple[tuple, dict]],
         swallow_exceptions: bool = False,
-        workers_available: bool | None = None,
     ) -> tuple[int, int]:
         """
-        Execute multiple tasks using async/sync fallback strategy.
-
-        Checks worker availability once before the loop (unless ``workers_available``
-        is provided) to avoid N×ping cost when workers are unavailable.
-
-        Args:
-            items: List of (args_tuple, kwargs_dict) for each task
-            swallow_exceptions: If True, sync failures return (False, None) per item
-            workers_available: If set, skip an extra ping; use for callers that
-                already resolved availability (e.g. telemetry ingest orchestration).
+        Execute multiple tasks: try async first, fall back to sync per-item.
 
         Returns:
             Tuple of (async_count, sync_count)
@@ -191,13 +101,9 @@ class AsyncService(ABC, Generic[T]):
         async_count = 0
         sync_count = 0
 
-        if workers_available is None:
-            workers_available = self._check_workers_available()
-
         for args, kwargs in items:
             was_async, _ = self.execute_with_fallback(
                 *args,
-                workers_available=workers_available,
                 swallow_exceptions=swallow_exceptions,
                 **kwargs,
             )
@@ -205,6 +111,5 @@ class AsyncService(ABC, Generic[T]):
                 async_count += 1
             else:
                 sync_count += 1
-                workers_available = False
 
         return async_count, sync_count

--- a/apps/backend/src/rhesis/backend/app/services/async_service.py
+++ b/apps/backend/src/rhesis/backend/app/services/async_service.py
@@ -11,7 +11,18 @@ import time
 from abc import ABC, abstractmethod
 from typing import Any, Generic, TypeVar
 
+import kombu.exceptions
+import redis.exceptions
+
 logger = logging.getLogger(__name__)
+
+BROKER_ERRORS = (
+    redis.exceptions.RedisError,
+    kombu.exceptions.OperationalError,
+    ConnectionError,
+    TimeoutError,
+    OSError,
+)
 
 T = TypeVar("T")  # For return types
 
@@ -135,6 +146,11 @@ class AsyncService(ABC, Generic[T]):
                 task_result = self._enqueue_async(*args, **kwargs)
                 logger.debug(f"Enqueued async task: {task_result}")
                 return True, None
+            except BROKER_ERRORS as e:
+                logger.warning(
+                    f"Broker unavailable ({type(e).__name__}), "
+                    f"falling back to sync: {e}"
+                )
             except Exception as e:
                 logger.warning(f"Async task failed, using sync fallback: {e}")
         else:

--- a/apps/backend/src/rhesis/backend/app/services/cache.py
+++ b/apps/backend/src/rhesis/backend/app/services/cache.py
@@ -55,6 +55,7 @@ class RedisBackedCache:
                 cache_url,
                 decode_responses=True,
                 encoding="utf-8",
+                max_connections=3,
                 socket_connect_timeout=5,
                 socket_timeout=5,
             )

--- a/apps/backend/src/rhesis/backend/app/services/connector/redis_client.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/redis_client.py
@@ -29,7 +29,12 @@ class RedisConnectionManager:
 
         try:
             redis_url = os.getenv("BROKER_URL", "redis://localhost:6379/0")
-            self._client = await redis.from_url(redis_url, decode_responses=True, encoding="utf-8")
+            self._client = await redis.from_url(
+                redis_url,
+                decode_responses=True,
+                encoding="utf-8",
+                max_connections=3,
+            )
             # Actually test the connection - from_url() doesn't connect until first use
             await self._client.ping()
             self._initialized = True

--- a/apps/backend/src/rhesis/backend/app/services/garak/cache.py
+++ b/apps/backend/src/rhesis/backend/app/services/garak/cache.py
@@ -71,6 +71,7 @@ class GarakProbeCache:
                 cache_url,
                 decode_responses=True,
                 encoding="utf-8",
+                max_connections=3,
                 socket_connect_timeout=5,  # Don't hang forever on connect
                 socket_timeout=5,  # Don't hang forever on operations
             )

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/service.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/service.py
@@ -97,27 +97,10 @@ class EnrichmentService(AsyncService[dict | None]):
         trace_id: str,
         project_id: str,
         organization_id: str,
-        workers_available: bool | None = None,
         root_span_id: str | None = None,
     ) -> bool:
         """
-        Try to enqueue async enrichment. Fall back to sync if workers unavailable.
-
-        This function implements a robust fallback strategy:
-        1. Check if workers are available (or use cached result)
-        2. If yes, try async enrichment (optimal for production)
-        3. If no workers or async fails, fall back to sync (development-friendly)
-
-        Args:
-            trace_id: Trace ID to enrich
-            project_id: Project ID for access control
-            organization_id: Organization ID for multi-tenant security
-            workers_available: Optional cached worker availability check result.
-                             If None, will check on this call.
-            root_span_id: DB primary key of the root span that triggered
-                this enrichment.  Passed through to
-                ``evaluate_turn_trace_metrics`` so it evaluates the
-                correct span in multi-turn conversations.
+        Enqueue enrichment: try async, fall back to sync on broker errors.
 
         Returns:
             True if async task was enqueued, False if sync fallback was used
@@ -127,12 +110,10 @@ class EnrichmentService(AsyncService[dict | None]):
                 trace_id,
                 project_id,
                 organization_id,
-                workers_available=workers_available,
                 root_span_id=root_span_id,
             )
             return was_async
         except Exception as e:
-            # Log but don't fail the ingestion
             logger.error(f"Enrichment failed for trace {trace_id}: {e}", exc_info=True)
             return False
 
@@ -141,21 +122,9 @@ class EnrichmentService(AsyncService[dict | None]):
         trace_ids: Set[str],
         project_id: str,
         organization_id: str,
-        *,
-        workers_available: bool | None = None,
     ) -> tuple[int, int]:
         """
-        Enrich multiple traces using async/sync fallback strategy.
-
-        Resolves worker availability once for the whole batch (TTL-cached).
-        Pass ``workers_available`` to skip a redundant ping when the caller
-        already checked (e.g. the telemetry ingest router).
-
-        Args:
-            trace_ids: Set of trace IDs to enrich
-            project_id: Project ID for access control
-            organization_id: Organization ID for multi-tenant security
-            workers_available: Optional precomputed flag to skip an extra ping.
+        Enrich multiple traces: try async, fall back to sync per-item.
 
         Returns:
             Tuple of (async_count, sync_count)
@@ -167,7 +136,6 @@ class EnrichmentService(AsyncService[dict | None]):
         return self.batch_execute(
             items,
             swallow_exceptions=True,
-            workers_available=workers_available,
         )
 
     def create_and_enrich_spans(
@@ -204,7 +172,6 @@ class EnrichmentService(AsyncService[dict | None]):
             logger.warning("No spans were stored")
             return [], 0, 0
 
-        workers_available = self._check_workers_available()
         async_count = 0
         sync_count = 0
         dispatched_traces: Set[str] = set()
@@ -215,7 +182,6 @@ class EnrichmentService(AsyncService[dict | None]):
                 root_span.trace_id,
                 project_id,
                 organization_id,
-                workers_available=workers_available,
                 root_span_id=str(root_span.id),
             ):
                 async_count += 1
@@ -225,7 +191,7 @@ class EnrichmentService(AsyncService[dict | None]):
 
         child_only_traces = {s.trace_id for s in stored_spans} - dispatched_traces
         for trace_id in child_only_traces:
-            if self.enqueue_enrichment(trace_id, project_id, organization_id, workers_available):
+            if self.enqueue_enrichment(trace_id, project_id, organization_id):
                 async_count += 1
             else:
                 sync_count += 1

--- a/apps/backend/src/rhesis/backend/celery/config.py
+++ b/apps/backend/src/rhesis/backend/celery/config.py
@@ -1,5 +1,6 @@
 import os
 
+# Worker-context config: retry aggressively to ensure task delivery
 CELERY_CONFIG = {
     # Redis configuration
     "broker_url": os.getenv("BROKER_URL", "redis://localhost:6379/0"),
@@ -18,10 +19,15 @@ CELERY_CONFIG = {
     "broker_connection_retry_on_startup": True,
     "broker_connection_retry": True,
     "broker_connection_max_retries": 10,
-    # Simplified Redis transport options
+    # Cap the kombu broker connection pool (default is 10, making explicit)
+    "broker_pool_limit": 10,
+    # Redis transport options with explicit connection pool caps.
+    # max_connections limits the underlying redis-py ConnectionPool so that
+    # slow operations under Redis contention don't cause unbounded growth.
     "broker_transport_options": {
         "retry_on_timeout": True,
         "connection_pool_kwargs": {
+            "max_connections": 10,
             "retry_on_timeout": True,
             "socket_connect_timeout": 30,
             "socket_timeout": 30,
@@ -30,6 +36,7 @@ CELERY_CONFIG = {
     "result_backend_transport_options": {
         "retry_on_timeout": True,
         "connection_pool_kwargs": {
+            "max_connections": 5,
             "retry_on_timeout": True,
             "socket_connect_timeout": 30,
             "socket_timeout": 30,
@@ -91,4 +98,37 @@ CELERY_CONFIG = {
         "rhesis.backend.tasks.telemetry.evaluate",
         "rhesis.backend.tasks.telemetry.post_ingest",
     ],
+}
+
+# Web-context overrides: fail fast instead of blocking HTTP request threads.
+# Applied by apply_web_context_overrides() during FastAPI startup.
+# Worst case changes from 10 retries x 30s = 300s to a single 2s attempt.
+WEB_CELERY_OVERRIDES = {
+    "broker_connection_max_retries": 0,
+    # Web processes only publish tasks — they need fewer connections than workers.
+    "broker_pool_limit": 5,
+    "broker_transport_options": {
+        "retry_on_timeout": False,
+        "connection_pool_kwargs": {
+            "max_connections": 5,
+            "retry_on_timeout": False,
+            "socket_connect_timeout": 2,
+            "socket_timeout": 2,
+        },
+    },
+    "result_backend_transport_options": {
+        "retry_on_timeout": False,
+        "connection_pool_kwargs": {
+            "max_connections": 3,
+            "retry_on_timeout": False,
+            "socket_connect_timeout": 2,
+            "socket_timeout": 2,
+        },
+    },
+    "task_publish_retry_policy": {
+        "max_retries": 1,
+        "interval_start": 0.1,
+        "interval_step": 0.1,
+        "interval_max": 0.5,
+    },
 }

--- a/apps/backend/src/rhesis/backend/celery/core.py
+++ b/apps/backend/src/rhesis/backend/celery/core.py
@@ -1,6 +1,10 @@
+import logging
+
 from celery import Celery
 
 from rhesis.backend.celery.config import CELERY_CONFIG
+
+logger = logging.getLogger(__name__)
 
 # Create the Celery app
 app = Celery("rhesis")
@@ -10,3 +14,23 @@ app.conf.update(CELERY_CONFIG)
 
 # Auto-discover tasks
 app.autodiscover_tasks(["rhesis.backend.tasks"], force=True)
+
+_web_overrides_applied = False
+
+
+def apply_web_context_overrides():
+    """Apply fail-fast broker settings for the FastAPI web process.
+
+    Workers keep the default aggressive retry config (30s timeouts,
+    10 retries). The web process should never block an HTTP thread
+    for more than a couple of seconds waiting on Redis.
+    """
+    global _web_overrides_applied
+    if _web_overrides_applied:
+        return
+
+    from rhesis.backend.celery.config import WEB_CELERY_OVERRIDES
+
+    app.conf.update(WEB_CELERY_OVERRIDES)
+    _web_overrides_applied = True
+    logger.info("Celery broker configured for web context (fail-fast timeouts)")

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -230,9 +230,7 @@ def disable_enrichment(request, monkeypatch):
         yield
         return
 
-    def mock_enqueue_enrichment(
-        self, trace_id, project_id, organization_id, workers_available=None, root_span_id=None
-    ):
+    def mock_enqueue_enrichment(self, trace_id, project_id, organization_id, root_span_id=None):
         return False
 
     monkeypatch.setattr(

--- a/tests/backend/routes/test_telemetry_query.py
+++ b/tests/backend/routes/test_telemetry_query.py
@@ -10,7 +10,6 @@ This module tests the telemetry query endpoints including:
 """
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import patch
 
 import pytest
 from fastapi import status
@@ -1029,24 +1028,19 @@ class TestQueryEdgeCases:
         trace_batch = {"spans": [span_data]}
         authenticated_client.post("/telemetry/traces", json=trace_batch)
 
-        # Mock enrichment to add cost data
-        with patch(
-            "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available",
-            return_value=False,
-        ):
-            # This will trigger sync enrichment
-            response = authenticated_client.get(
-                f"/telemetry/traces?project_id={db_project.id}&limit=1"
-            )
+        # Query traces
+        response = authenticated_client.get(
+            f"/telemetry/traces?project_id={db_project.id}&limit=1"
+        )
 
-            assert response.status_code == status.HTTP_200_OK
-            data = response.json()
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
 
-            if data["traces"]:
-                trace = data["traces"][0]
-                # Cost fields should be present (may be null if no enrichment occurred)
-                assert "total_cost_usd" in trace
-                assert "total_tokens" in trace
+        if data["traces"]:
+            trace = data["traces"][0]
+            # Cost fields should be present (may be null if no enrichment occurred)
+            assert "total_cost_usd" in trace
+            assert "total_tokens" in trace
 
 
 @pytest.mark.unit

--- a/tests/backend/routes/test_trace_linking_timing.py
+++ b/tests/backend/routes/test_trace_linking_timing.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 
 import pytest
 from faker import Faker
+from rhesis.telemetry.schemas import SpanKind, StatusCode
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
@@ -21,7 +22,6 @@ from rhesis.backend.app.constants import TestExecutionContext
 from rhesis.backend.app.schemas.telemetry import OTELSpanCreate
 from rhesis.backend.app.services.telemetry.enrichment import EnrichmentService
 from rhesis.backend.app.services.telemetry.linking_service import TraceLinkingService
-from rhesis.telemetry.schemas import SpanKind, StatusCode
 
 fake = Faker()
 
@@ -282,10 +282,14 @@ class TestTraceLinkingTiming:
         ]
 
         # Use EnrichmentService (simulates telemetry endpoint flow)
+        # Force sync fallback by making async dispatch fail with a broker error
         enrichment_service = EnrichmentService(test_db)
 
-        # Mock worker check to force sync enrichment
-        with patch.object(enrichment_service, "_check_workers_available", return_value=False):
+        with patch.object(
+            enrichment_service,
+            "_enqueue_async",
+            side_effect=ConnectionError("Broker unavailable"),
+        ):
             stored_spans, async_count, sync_count = enrichment_service.create_and_enrich_spans(
                 spans=spans,
                 organization_id=str(test_organization.id),
@@ -293,7 +297,7 @@ class TestTraceLinkingTiming:
             )
 
         assert len(stored_spans) == 5
-        assert sync_count == 5  # One sync enrichment per root span
+        assert sync_count == 5
 
         # Link traces
         linking_service = TraceLinkingService(test_db)

--- a/tests/backend/services/telemetry/test_enrichment_service.py
+++ b/tests/backend/services/telemetry/test_enrichment_service.py
@@ -2,7 +2,6 @@
 Tests for telemetry enrichment service
 
 This module tests the EnrichmentService class including:
-- Worker availability checking
 - Async/sync enrichment fallback logic
 - Error handling and edge cases
 """
@@ -34,81 +33,9 @@ class TestEnrichmentService:
         service = EnrichmentService(mock_db)
         assert service.db == mock_db
 
-    @patch("rhesis.backend.worker.app")
-    def test_check_workers_available_success(self, mock_celery_app, enrichment_service):
-        """Test worker availability check when workers are available"""
-        # Reset the class-level cache so the mock ping is triggered (not a stale cached value)
-        EnrichmentService._worker_cache["available"] = None
-        EnrichmentService._worker_cache["checked_at"] = 0.0
-
-        # Mock successful worker inspection
-        mock_inspect = Mock()
-        mock_inspect.ping.return_value = {
-            "worker1": "pong"
-        }  # Non-empty dict means workers available
-        mock_celery_app.control.inspect.return_value = mock_inspect
-
-        result = enrichment_service._check_workers_available()
-
-        assert result is True
-        mock_celery_app.control.inspect.assert_called_once_with(timeout=1.0)
-        mock_inspect.ping.assert_called_once()
-
-    @patch("rhesis.backend.worker.app")
-    def test_check_workers_available_no_active_workers(self, mock_celery_app, enrichment_service):
-        """Test worker availability check when no active workers"""
-        EnrichmentService._worker_cache["available"] = None
-        EnrichmentService._worker_cache["checked_at"] = 0.0
-
-        # Mock no workers responding to ping
-        mock_inspect = Mock()
-        mock_inspect.ping.return_value = None
-        mock_celery_app.control.inspect.return_value = mock_inspect
-
-        result = enrichment_service._check_workers_available()
-
-        assert result is False
-
-    @patch("rhesis.backend.worker.app")
-    def test_check_workers_available_empty_response(self, mock_celery_app, enrichment_service):
-        """Test worker availability check when ping returns empty dict"""
-        EnrichmentService._worker_cache["available"] = None
-        EnrichmentService._worker_cache["checked_at"] = 0.0
-
-        # Mock empty response (no workers)
-        mock_inspect = Mock()
-        mock_inspect.ping.return_value = {}
-        mock_celery_app.control.inspect.return_value = mock_inspect
-
-        result = enrichment_service._check_workers_available()
-
-        assert result is False
-
-    @patch("rhesis.backend.worker.app")
-    def test_check_workers_available_exception(self, mock_celery_app, enrichment_service):
-        """Test worker availability check when exception occurs"""
-        EnrichmentService._worker_cache["available"] = None
-        EnrichmentService._worker_cache["checked_at"] = 0.0
-
-        # Mock exception during inspection
-        mock_celery_app.control.inspect.side_effect = Exception("Connection error")
-
-        result = enrichment_service._check_workers_available()
-
-        assert result is False
-
-    @patch(
-        "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
-    )
     @patch("celery.chain")
-    def test_enrich_traces_async_success(
-        self, mock_chain, mock_check_workers, enrichment_service
-    ):
+    def test_enrich_traces_async_success(self, mock_chain, enrichment_service):
         """Test successful async enrichment"""
-        # Mock workers available
-        mock_check_workers.return_value = True
-
-        # Mock successful async task
         mock_workflow = Mock()
         mock_result = Mock()
         mock_result.id = "task-123"
@@ -128,22 +55,20 @@ class TestEnrichmentService:
         assert mock_chain.call_count == 2
         assert mock_workflow.apply_async.call_count == 2
 
-    @patch(
-        "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
-    )
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.TraceEnricher")
-    def test_enrich_traces_sync_fallback(
-        self, mock_enricher_class, mock_check_workers, enrichment_service
+    @patch("celery.chain")
+    def test_enrich_traces_sync_fallback_on_broker_error(
+        self, mock_chain, mock_enricher_class, enrichment_service
     ):
-        """Test sync fallback when no workers available.
+        """Test sync fallback when broker is unreachable.
 
         Metric evaluation is intentionally skipped in the sync fallback
         (it requires Celery workers for LLM calls).
         """
-        # Mock no workers available
-        mock_check_workers.return_value = False
+        import redis.exceptions
 
-        # Mock successful sync enrichment
+        mock_chain.side_effect = redis.exceptions.ConnectionError("Redis down")
+
         mock_enricher = Mock()
         mock_enricher.enrich_trace.return_value = {"costs": {"total_cost_usd": 0.01}}
         mock_enricher_class.return_value = mock_enricher
@@ -160,25 +85,17 @@ class TestEnrichmentService:
         assert sync_count == 2
         assert mock_enricher.enrich_trace.call_count == 2
 
-    @patch(
-        "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
-    )
     @patch("celery.chain")
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.TraceEnricher")
     def test_enrich_traces_async_fallback_to_sync(
-        self, mock_enricher_class, mock_chain, mock_check_workers, enrichment_service
+        self, mock_enricher_class, mock_chain, enrichment_service
     ):
-        """Test fallback to sync when async fails.
+        """Test fallback to sync when async fails with non-broker error.
 
         Metric evaluation is skipped in the sync fallback path.
         """
-        # Mock workers available initially
-        mock_check_workers.return_value = True
-
-        # Mock async task failure (chain building or applying fails)
         mock_chain.side_effect = Exception("Celery error")
 
-        # Mock successful sync enrichment
         mock_enricher = Mock()
         mock_enricher.enrich_trace.return_value = {"costs": {"total_cost_usd": 0.01}}
         mock_enricher_class.return_value = mock_enricher
@@ -195,18 +112,14 @@ class TestEnrichmentService:
         assert sync_count == 1
         mock_enricher.enrich_trace.assert_called_once_with("trace1", project_id, organization_id)
 
-    @patch(
-        "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
-    )
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.TraceEnricher")
-    def test_enrich_traces_sync_failure(
-        self, mock_enricher_class, mock_check_workers, enrichment_service
-    ):
+    @patch("celery.chain")
+    def test_enrich_traces_sync_failure(self, mock_chain, mock_enricher_class, enrichment_service):
         """Test handling of sync enrichment failure"""
-        # Mock no workers available
-        mock_check_workers.return_value = False
+        import redis.exceptions
 
-        # Mock sync enrichment failure
+        mock_chain.side_effect = redis.exceptions.ConnectionError("Redis down")
+
         mock_enricher = Mock()
         mock_enricher.enrich_trace.side_effect = Exception("Database error")
         mock_enricher_class.return_value = mock_enricher
@@ -219,22 +132,17 @@ class TestEnrichmentService:
             trace_ids, project_id, organization_id
         )
 
-        # Should still count as attempted sync enrichment
         assert async_count == 0
         assert sync_count == 1
 
-    @patch(
-        "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
-    )
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.TraceEnricher")
-    def test_enrich_traces_sync_no_data(
-        self, mock_enricher_class, mock_check_workers, enrichment_service
-    ):
+    @patch("celery.chain")
+    def test_enrich_traces_sync_no_data(self, mock_chain, mock_enricher_class, enrichment_service):
         """Test handling when sync enrichment returns no data"""
-        # Mock no workers available
-        mock_check_workers.return_value = False
+        import redis.exceptions
 
-        # Mock sync enrichment returning None
+        mock_chain.side_effect = redis.exceptions.ConnectionError("Redis down")
+
         mock_enricher = Mock()
         mock_enricher.enrich_trace.return_value = None
         mock_enricher_class.return_value = mock_enricher
@@ -263,30 +171,22 @@ class TestEnrichmentService:
         assert async_count == 0
         assert sync_count == 0
 
-    @patch(
-        "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
-    )
     @patch("celery.chain")
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.TraceEnricher")
     def test_enrich_traces_mixed_success_failure(
-        self, mock_enricher_class, mock_chain, mock_check_workers, enrichment_service
+        self, mock_enricher_class, mock_chain, enrichment_service
     ):
         """Test mixed async success and failure scenarios.
 
         When async fails for one trace, it falls back to sync enrichment
         (without metric evaluation).
         """
-        # Mock workers available
-        mock_check_workers.return_value = True
-
-        # Mock async task: first succeeds, second fails
         mock_workflow = Mock()
         mock_result = Mock()
         mock_result.id = "task-123"
         mock_workflow.apply_async.return_value = mock_result
         mock_chain.side_effect = [mock_workflow, Exception("Task error")]
 
-        # Mock successful sync enrichment for fallback
         mock_enricher = Mock()
         mock_enricher.enrich_trace.return_value = {"costs": {"total_cost_usd": 0.01}}
         mock_enricher_class.return_value = mock_enricher
@@ -299,23 +199,14 @@ class TestEnrichmentService:
             trace_ids, project_id, organization_id
         )
 
-        assert async_count == 1  # First trace succeeded async
-        assert sync_count == 1  # Second trace fell back to sync
+        assert async_count == 1
+        assert sync_count == 1
         mock_enricher.enrich_trace.assert_called_once()
 
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.logger")
-    @patch(
-        "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
-    )
     @patch("celery.chain")
-    def test_enrich_traces_logging(
-        self, mock_chain, mock_check_workers, mock_logger, enrichment_service
-    ):
+    def test_enrich_traces_logging(self, mock_chain, mock_logger, enrichment_service):
         """Test that appropriate logging occurs during enrichment"""
-        # Mock workers available
-        mock_check_workers.return_value = True
-
-        # Mock successful async task
         mock_workflow = Mock()
         mock_result = Mock()
         mock_result.id = "task-123"
@@ -328,24 +219,21 @@ class TestEnrichmentService:
 
         enrichment_service.enrich_traces(trace_ids, project_id, organization_id)
 
-        # Check that debug logging occurred
         mock_logger.debug.assert_called_with(
             "Enqueued async pipeline (enrich -> evaluate) for trace trace1 (task: task-123)"
         )
 
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.logger")
-    @patch(
-        "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
-    )
     @patch("rhesis.backend.app.services.telemetry.enrichment.service.TraceEnricher")
+    @patch("celery.chain")
     def test_enrich_traces_sync_logging(
-        self, mock_enricher_class, mock_check_workers, mock_logger, enrichment_service
+        self, mock_chain, mock_enricher_class, mock_logger, enrichment_service
     ):
         """Test logging during sync enrichment"""
-        # Mock no workers available
-        mock_check_workers.return_value = False
+        import redis.exceptions
 
-        # Mock successful sync enrichment
+        mock_chain.side_effect = redis.exceptions.ConnectionError("Redis down")
+
         mock_enricher = Mock()
         mock_enricher.enrich_trace.return_value = {"costs": {"total_cost_usd": 0.01}}
         mock_enricher_class.return_value = mock_enricher
@@ -356,48 +244,7 @@ class TestEnrichmentService:
 
         enrichment_service.enrich_traces(trace_ids, project_id, organization_id)
 
-        # Check that info logging occurred
         mock_logger.info.assert_any_call("Completed sync enrichment for trace trace1")
-
-    @patch("celery.chain")
-    @patch(
-        "rhesis.backend.app.services.telemetry.enrichment.EnrichmentService._check_workers_available"
-    )
-    def test_enrich_traces_checks_workers_once(
-        self, mock_check_workers, mock_chain, enrichment_service
-    ):
-        """
-        Test that worker availability is checked once per batch, not per trace.
-
-        This verifies the performance optimization that prevents N×3 second timeouts
-        when processing N traces without available workers.
-        """
-        # Mock workers available
-        mock_check_workers.return_value = True
-
-        # Mock successful async task
-        mock_workflow = Mock()
-        mock_result = Mock()
-        mock_result.id = "task-123"
-        mock_workflow.apply_async.return_value = mock_result
-        mock_chain.return_value = mock_workflow
-
-        # Process 10 traces
-        trace_ids = {f"trace{i}" for i in range(10)}
-        project_id = "project-123"
-        organization_id = "org-123"
-
-        async_count, sync_count = enrichment_service.enrich_traces(
-            trace_ids, project_id, organization_id
-        )
-
-        # Verify results
-        assert async_count == 10
-        assert sync_count == 0
-
-        # CRITICAL: Worker check should only be called once, not 10 times
-        # This prevents 10×3=30 seconds of timeout delays when workers are unavailable
-        assert mock_check_workers.call_count == 1
 
 
 @pytest.mark.unit
@@ -412,9 +259,8 @@ class TestBuildEnrichmentChainRootSpanId:
 
         build_enrichment_chain("t1", "p1", "o1", root_span_id="span-db-1")
 
-        # chain() is called with two .si() signatures
         args = mock_chain.call_args
-        evaluate_sig = args[0][1]  # second positional arg to chain()
+        evaluate_sig = args[0][1]
         assert evaluate_sig.kwargs.get("root_span_id") == "span-db-1"
 
     @patch("celery.chain")
@@ -460,17 +306,18 @@ class TestCreateAndEnrichSpansPerRootSpan:
 
     def test_dispatches_per_root_span(self, service):
         """Each root span dispatches its own chain with root_span_id."""
-        stored = self._mock_stored_spans([
-            ("T1", "root-1", None),
-            ("T1", "child-1", "root-1"),
-            ("T1", "root-2", None),
-        ])
+        stored = self._mock_stored_spans(
+            [
+                ("T1", "root-1", None),
+                ("T1", "child-1", "root-1"),
+                ("T1", "root-2", None),
+            ]
+        )
         mock_workflow = Mock()
         mock_result = Mock(id="task-x")
         mock_workflow.apply_async.return_value = mock_result
 
         with (
-            patch.object(service, "_check_workers_available", return_value=True),
             patch(
                 f"{self.MODULE}.build_enrichment_chain",
                 return_value=mock_workflow,
@@ -478,7 +325,9 @@ class TestCreateAndEnrichSpansPerRootSpan:
             patch("rhesis.backend.app.crud.create_trace_spans", return_value=stored),
         ):
             spans_out, async_c, sync_c = service.create_and_enrich_spans(
-                [], "org-1", "proj-1",
+                [],
+                "org-1",
+                "proj-1",
             )
 
         assert async_c == 2
@@ -489,16 +338,17 @@ class TestCreateAndEnrichSpansPerRootSpan:
 
     def test_child_only_traces_get_enrichment_without_root_span_id(self, service):
         """Trace IDs with only child spans still get enrichment (no root_span_id)."""
-        stored = self._mock_stored_spans([
-            ("T1", "root-1", None),
-            ("T2", "child-only", "some-parent"),
-        ])
+        stored = self._mock_stored_spans(
+            [
+                ("T1", "root-1", None),
+                ("T2", "child-only", "some-parent"),
+            ]
+        )
         mock_workflow = Mock()
         mock_result = Mock(id="task-x")
         mock_workflow.apply_async.return_value = mock_result
 
         with (
-            patch.object(service, "_check_workers_available", return_value=True),
             patch(
                 f"{self.MODULE}.build_enrichment_chain",
                 return_value=mock_workflow,
@@ -506,7 +356,9 @@ class TestCreateAndEnrichSpansPerRootSpan:
             patch("rhesis.backend.app.crud.create_trace_spans", return_value=stored),
         ):
             spans_out, async_c, sync_c = service.create_and_enrich_spans(
-                [], "org-1", "proj-1",
+                [],
+                "org-1",
+                "proj-1",
             )
 
         assert async_c == 2
@@ -520,14 +372,15 @@ class TestCreateAndEnrichSpansPerRootSpan:
     def test_empty_batch(self, service):
         """Empty batch returns early."""
         with (
-            patch.object(service, "_check_workers_available", return_value=True),
             patch(
                 f"{self.MODULE}.build_enrichment_chain",
             ) as mock_build,
             patch("rhesis.backend.app.crud.create_trace_spans", return_value=[]),
         ):
             spans_out, async_c, sync_c = service.create_and_enrich_spans(
-                [], "org-1", "proj-1",
+                [],
+                "org-1",
+                "proj-1",
             )
 
         assert spans_out == []
@@ -544,19 +397,3 @@ class TestEnrichmentServiceIntegration:
         """Test EnrichmentService with real database session"""
         service = EnrichmentService(test_db)
         assert service.db == test_db
-
-    @patch("rhesis.backend.worker.app")
-    def test_worker_check_integration(self, mock_celery_app, test_db):
-        """Test worker availability check with real service instance"""
-        EnrichmentService._worker_cache["available"] = None
-        EnrichmentService._worker_cache["checked_at"] = 0.0
-
-        service = EnrichmentService(test_db)
-
-        # Mock no workers available
-        mock_inspect = Mock()
-        mock_inspect.ping.return_value = None
-        mock_celery_app.control.inspect.return_value = mock_inspect
-
-        result = service._check_workers_available()
-        assert result is False

--- a/tests/backend/services/test_async_service.py
+++ b/tests/backend/services/test_async_service.py
@@ -2,10 +2,11 @@
 Tests for the AsyncService base class.
 """
 
-import time
 from unittest.mock import patch
 
+import kombu.exceptions
 import pytest
+import redis.exceptions
 
 from rhesis.backend.app.services.async_service import AsyncService
 
@@ -21,79 +22,15 @@ class ConcreteAsyncService(AsyncService[str]):
     def _enqueue_async(self, *args, **kwargs) -> str:
         if kwargs.get("fail_async"):
             raise ValueError("Async failed")
+        if kwargs.get("fail_broker"):
+            raise redis.exceptions.ConnectionError("Redis unavailable")
         return "async_task_id"
 
 
 @pytest.fixture
 def service():
-    """Create a service instance and reset the worker cache."""
-    AsyncService._worker_cache = {"available": None, "checked_at": 0.0}
+    """Create a service instance."""
     return ConcreteAsyncService()
-
-
-@pytest.mark.unit
-@pytest.mark.services
-class TestAsyncServiceWorkerCheck:
-    """Tests for the _check_workers_available method."""
-
-    @patch("rhesis.backend.worker.app.control.inspect")
-    def test_check_workers_available_success(self, mock_inspect, service):
-        """Test successful worker availability check."""
-        mock_inspect_instance = mock_inspect.return_value
-        mock_inspect_instance.ping.return_value = {"worker1@host": {"ok": "pong"}}
-
-        assert service._check_workers_available() is True
-        assert AsyncService._worker_cache["available"] is True
-        mock_inspect_instance.ping.assert_called_once()
-
-    @patch("rhesis.backend.worker.app.control.inspect")
-    def test_check_workers_available_none(self, mock_inspect, service):
-        """Test worker availability check when no workers are found."""
-        mock_inspect_instance = mock_inspect.return_value
-        mock_inspect_instance.ping.return_value = None
-
-        assert service._check_workers_available() is False
-        assert AsyncService._worker_cache["available"] is False
-
-    @patch("rhesis.backend.worker.app.control.inspect")
-    def test_check_workers_available_empty(self, mock_inspect, service):
-        """Test worker availability check when workers list is empty."""
-        mock_inspect_instance = mock_inspect.return_value
-        mock_inspect_instance.ping.return_value = {}
-
-        assert service._check_workers_available() is False
-        assert AsyncService._worker_cache["available"] is False
-
-    @patch("rhesis.backend.worker.app.control.inspect")
-    def test_check_workers_available_exception(self, mock_inspect, service):
-        """Test worker availability check when an exception occurs."""
-        mock_inspect_instance = mock_inspect.return_value
-        mock_inspect_instance.ping.side_effect = Exception("Connection error")
-
-        assert service._check_workers_available() is False
-        assert AsyncService._worker_cache["available"] is False
-
-    @patch("rhesis.backend.worker.app.control.inspect")
-    def test_check_workers_available_cache_hit(self, mock_inspect, service):
-        """Test worker availability check uses cache within TTL."""
-        AsyncService._worker_cache = {"available": True, "checked_at": time.monotonic()}
-
-        assert service._check_workers_available() is True
-        mock_inspect.assert_not_called()
-
-    @patch("rhesis.backend.worker.app.control.inspect")
-    def test_check_workers_available_cache_miss_ttl(self, mock_inspect, service):
-        """Test worker availability check ignores cache after TTL."""
-        mock_inspect_instance = mock_inspect.return_value
-        mock_inspect_instance.ping.return_value = {"worker1": "pong"}
-
-        AsyncService._worker_cache = {
-            "available": False,
-            "checked_at": time.monotonic() - AsyncService._worker_cache_ttl - 1,
-        }
-
-        assert service._check_workers_available() is True
-        mock_inspect_instance.ping.assert_called_once()
 
 
 @pytest.mark.unit
@@ -103,51 +40,62 @@ class TestAsyncServiceExecuteWithFallback:
 
     def test_execute_with_fallback_async_success(self, service):
         """Test successful async execution."""
-        with patch.object(service, "_check_workers_available", return_value=True):
-            was_async, result = service.execute_with_fallback()
+        was_async, result = service.execute_with_fallback()
 
         assert was_async is True
         assert result is None
 
-    def test_execute_with_fallback_no_workers_sync_success(self, service):
-        """Test sync fallback when no workers are available."""
-        with patch.object(service, "_check_workers_available", return_value=False):
-            was_async, result = service.execute_with_fallback()
+    def test_execute_with_fallback_broker_error_sync_fallback(self, service):
+        """Test sync fallback when broker is unreachable."""
+        was_async, result = service.execute_with_fallback(fail_broker=True)
 
         assert was_async is False
         assert result == "sync_result"
 
     def test_execute_with_fallback_async_fails_sync_success(self, service):
-        """Test sync fallback when async execution fails."""
-        with patch.object(service, "_check_workers_available", return_value=True):
-            was_async, result = service.execute_with_fallback(fail_async=True)
+        """Test sync fallback when async execution fails with non-broker error."""
+        was_async, result = service.execute_with_fallback(fail_async=True)
 
         assert was_async is False
         assert result == "sync_result"
 
     def test_execute_with_fallback_sync_fails_raises(self, service):
         """Test that sync failure raises an exception by default."""
-        with patch.object(service, "_check_workers_available", return_value=False):
-            with pytest.raises(ValueError, match="Sync failed"):
-                service.execute_with_fallback(fail_sync=True)
+        with pytest.raises(ValueError, match="Sync failed"):
+            service.execute_with_fallback(fail_broker=True, fail_sync=True)
 
     def test_execute_with_fallback_sync_fails_swallow(self, service):
         """Test that sync failure is swallowed when requested."""
-        with patch.object(service, "_check_workers_available", return_value=False):
-            was_async, result = service.execute_with_fallback(
-                fail_sync=True, swallow_exceptions=True
-            )
+        was_async, result = service.execute_with_fallback(
+            fail_broker=True, fail_sync=True, swallow_exceptions=True
+        )
 
         assert was_async is False
         assert result is None
 
-    def test_execute_with_fallback_provided_workers_available(self, service):
-        """Test using provided workers_available flag."""
-        with patch.object(service, "_check_workers_available") as mock_check:
-            was_async, result = service.execute_with_fallback(workers_available=True)
+    def test_execute_with_fallback_kombu_error(self, service):
+        """Test sync fallback on kombu OperationalError."""
+        with patch.object(
+            service,
+            "_enqueue_async",
+            side_effect=kombu.exceptions.OperationalError("Broker down"),
+        ):
+            was_async, result = service.execute_with_fallback()
 
-            assert was_async is True
-            mock_check.assert_not_called()
+        assert was_async is False
+        assert result == "sync_result"
+
+    def test_execute_with_fallback_timeout_error(self, service):
+        """Test sync fallback on TimeoutError."""
+        with patch.object(
+            service,
+            "_enqueue_async",
+            side_effect=TimeoutError("Connection timed out"),
+        ):
+            was_async, result = service.execute_with_fallback()
+
+        assert was_async is False
+        assert result == "sync_result"
 
 
 @pytest.mark.unit
@@ -158,51 +106,26 @@ class TestAsyncServiceBatchExecute:
     def test_batch_execute_all_async(self, service):
         """Test batch execution where all tasks are async."""
         items = [((), {}), ((), {})]
-        with patch.object(service, "_check_workers_available", return_value=True):
-            async_count, sync_count = service.batch_execute(items)
+        async_count, sync_count = service.batch_execute(items)
 
         assert async_count == 2
         assert sync_count == 0
 
     def test_batch_execute_all_sync(self, service):
-        """Test batch execution where all tasks are sync."""
-        items = [((), {}), ((), {})]
-        with patch.object(service, "_check_workers_available", return_value=False):
-            async_count, sync_count = service.batch_execute(items)
+        """Test batch execution where all tasks fall back to sync."""
+        items = [((), {"fail_broker": True}), ((), {"fail_broker": True})]
+        async_count, sync_count = service.batch_execute(items)
 
         assert async_count == 0
         assert sync_count == 2
 
-    def test_batch_execute_mixed_async_fallback(self, service):
-        """Test batch execution with mixed results due to async failure."""
-        # First task succeeds async, second fails async and falls back to sync
-        items = [((), {"fail_async": False}), ((), {"fail_async": True})]
-
-        with patch.object(service, "_check_workers_available", return_value=True):
-            async_count, sync_count = service.batch_execute(items)
+    def test_batch_execute_mixed(self, service):
+        """Test batch execution with mixed async and sync fallback."""
+        items = [((), {}), ((), {"fail_async": True})]
+        async_count, sync_count = service.batch_execute(items)
 
         assert async_count == 1
         assert sync_count == 1
-
-    def test_batch_execute_stops_async_after_first_fallback(self, service):
-        """Test that once a sync fallback occurs, subsequent tasks in batch also use sync."""
-        # First task fails async -> falls back to sync.
-        # This should set workers_available to False for subsequent tasks.
-        items = [((), {"fail_async": True}), ((), {"fail_async": False})]
-
-        with patch.object(service, "_check_workers_available", return_value=True):
-            # We patch execute_with_fallback to see what workers_available it gets
-            with patch.object(
-                service, "execute_with_fallback", wraps=service.execute_with_fallback
-            ) as mock_execute:
-                async_count, sync_count = service.batch_execute(items)
-
-        assert async_count == 0
-        assert sync_count == 2
-
-        # Check workers_available argument in both calls
-        assert mock_execute.call_args_list[0].kwargs["workers_available"] is True
-        assert mock_execute.call_args_list[1].kwargs["workers_available"] is False
 
 
 @pytest.mark.integration
@@ -210,44 +133,10 @@ class TestAsyncServiceBatchExecute:
 class TestAsyncServiceIntegration:
     """Integration tests for the AsyncService base class."""
 
-    def test_check_workers_available_real_broker(self):
-        """Test worker availability check against the real configured broker."""
-        # Reset cache to force a real check
-        AsyncService._worker_cache = {"available": None, "checked_at": 0.0}
-
+    def test_execute_with_fallback_attempts_async_first(self):
+        """Test that execute_with_fallback always attempts async first."""
         service = ConcreteAsyncService()
-
-        # Since no Celery workers are running in the backend test environment,
-        # this should successfully connect to Redis but return False
-        is_available = service._check_workers_available()
-
-        assert is_available is False
-        assert AsyncService._worker_cache["available"] is False
-
-    def test_execute_with_fallback_real_broker(self):
-        """Test execute_with_fallback using the real broker connection."""
-        # Reset cache
-        AsyncService._worker_cache = {"available": None, "checked_at": 0.0}
-
-        service = ConcreteAsyncService()
-
-        # Will check real broker, find no workers, and fallback to sync
         was_async, result = service.execute_with_fallback()
 
-        assert was_async is False
-        assert result == "sync_result"
-
-    def test_batch_execute_real_broker(self):
-        """Test batch_execute using the real broker connection."""
-        # Reset cache
-        AsyncService._worker_cache = {"available": None, "checked_at": 0.0}
-
-        service = ConcreteAsyncService()
-
-        items = [((), {}), ((), {})]
-
-        # Will check real broker once, find no workers, and execute all sync
-        async_count, sync_count = service.batch_execute(items)
-
-        assert async_count == 0
-        assert sync_count == 2
+        assert was_async is True
+        assert result is None

--- a/tests/backend/services/test_embedding_service.py
+++ b/tests/backend/services/test_embedding_service.py
@@ -143,15 +143,9 @@ def test_entity(
 
 
 @pytest.fixture
-def user_with_embedding_model(
-    test_db: Session, db_user, embedding_model
-):
+def user_with_embedding_model(test_db: Session, db_user, embedding_model):
     """Create a user with embedding model configured in settings."""
-    db_user.settings.update({
-        "models": {
-            "embedding": {"model_id": str(embedding_model.id)}
-        }
-    })
+    db_user.settings.update({"models": {"embedding": {"model_id": str(embedding_model.id)}}})
     test_db.commit()
     test_db.refresh(db_user)
     return db_user
@@ -264,26 +258,23 @@ class TestEmbeddingService:
         with pytest.raises(ValueError, match="No embedding model found"):
             service._resolve_model_id("00000000-0000-0000-0000-000000000000", None)
 
-    @patch.object(EmbeddingService, "_check_workers_available")
     @patch.object(EmbeddingService, "_execute_sync")
     @patch.object(EmbeddingService, "_enqueue_async")
     def test_enqueue_embedding_sync_fallback(
         self,
         mock_enqueue,
         mock_execute,
-        mock_workers,
         test_db,
         test_entity,
         user_with_embedding_model,
     ):
-        """Test enqueue_embedding with sync fallback when no workers available."""
-        mock_workers.return_value = False
+        """Test enqueue_embedding with sync fallback when broker is unreachable."""
+        mock_enqueue.side_effect = ConnectionError("Broker unavailable")
         mock_execute.return_value = {"status": "success"}
 
         test_entity.user_id = user_with_embedding_model.id
         test_db.commit()
 
-        # Commit triggers EmbeddableMixin listeners; reset mocks to assert only this direct call:
         mock_execute.reset_mock()
         mock_enqueue.reset_mock()
 
@@ -298,23 +289,19 @@ class TestEmbeddingService:
 
         assert result is False
         mock_execute.assert_called_once()
-        mock_enqueue.assert_not_called()
+        mock_enqueue.assert_called_once()
 
-    @patch.object(EmbeddingService, "_check_workers_available")
     @patch.object(EmbeddingService, "_execute_sync")
     @patch.object(EmbeddingService, "_enqueue_async")
     def test_enqueue_embedding_async_success(
         self,
         mock_enqueue,
         mock_execute,
-        mock_workers,
         test_db,
         test_entity,
         user_with_embedding_model,
     ):
-        """Test enqueue_embedding with async execution when workers available."""
-        mock_workers.return_value = True
-
+        """Test enqueue_embedding with async execution (default path)."""
         test_entity.user_id = user_with_embedding_model.id
         test_db.commit()
 
@@ -334,20 +321,17 @@ class TestEmbeddingService:
         mock_enqueue.assert_called_once()
         mock_execute.assert_not_called()
 
-    @patch.object(EmbeddingService, "_check_workers_available")
     @patch.object(EmbeddingService, "_execute_sync")
     @patch.object(EmbeddingService, "_enqueue_async")
     def test_enqueue_embedding_async_fallback_to_sync(
         self,
         mock_enqueue,
         mock_execute,
-        mock_workers,
         test_db,
         test_entity,
         user_with_embedding_model,
     ):
         """Test enqueue_embedding falls back to sync when async fails."""
-        mock_workers.return_value = True
         mock_enqueue.side_effect = Exception("Celery error")
         mock_execute.return_value = {"status": "success"}
 
@@ -371,10 +355,8 @@ class TestEmbeddingService:
         mock_execute.assert_called_once()
 
     @patch.object(EmbeddingService, "_resolve_model_id")
-    @patch.object(EmbeddingService, "_check_workers_available")
     def test_enqueue_embedding_handles_exception(
         self,
-        mock_workers,
         mock_resolve,
         test_db,
         test_entity,
@@ -382,7 +364,6 @@ class TestEmbeddingService:
     ):
         """Test enqueue_embedding handles exceptions gracefully."""
         mock_resolve.side_effect = ValueError("No model found")
-        mock_workers.return_value = False
 
         service = EmbeddingService(test_db)
         result = service.enqueue_embedding(
@@ -395,20 +376,18 @@ class TestEmbeddingService:
 
         assert result is False
 
-    @patch.object(EmbeddingService, "_check_workers_available")
     @patch.object(EmbeddingService, "_execute_sync")
     @patch.object(EmbeddingService, "_enqueue_async")
     def test_enqueue_embedding_after_test_entity_has_user_id(
         self,
         mock_enqueue,
         mock_execute,
-        mock_workers,
         test_db,
         test_entity,
         user_with_embedding_model,
     ):
         """enqueue_embedding works when Test row has user_id set (listeners reset mocks)."""
-        mock_workers.return_value = False
+        mock_enqueue.side_effect = ConnectionError("Broker unavailable")
         mock_execute.return_value = {"status": "success"}
 
         test_entity.user_id = user_with_embedding_model.id
@@ -432,84 +411,21 @@ class TestEmbeddingService:
 
 @pytest.mark.unit
 @pytest.mark.service
-class TestEmbeddingServiceWorkerDetection:
-    """Test worker detection functionality in EmbeddingService."""
-
-    @patch("rhesis.backend.app.services.embedding.services.EmbeddingService._worker_cache_ttl", 0)
-    @patch("rhesis.backend.worker.app")
-    def test_check_workers_available_with_workers(self, mock_celery_app, test_db):
-        """Test worker detection when workers are available."""
-        mock_inspect = Mock()
-        mock_inspect.ping.return_value = {"worker1": {"ok": "pong"}}
-        mock_celery_app.control.inspect.return_value = mock_inspect
-
-        service = EmbeddingService(test_db)
-        result = service._check_workers_available()
-
-        assert result is True
-
-    @patch("rhesis.backend.app.services.embedding.services.EmbeddingService._worker_cache_ttl", 0)
-    @patch("rhesis.backend.worker.app")
-    def test_check_workers_available_no_workers(self, mock_celery_app, test_db):
-        """Test worker detection when no workers are available."""
-        mock_inspect = Mock()
-        mock_inspect.ping.return_value = None
-        mock_celery_app.control.inspect.return_value = mock_inspect
-
-        service = EmbeddingService(test_db)
-        result = service._check_workers_available()
-
-        assert result is False
-
-    @patch("rhesis.backend.app.services.embedding.services.EmbeddingService._worker_cache_ttl", 0)
-    @patch("rhesis.backend.worker.app")
-    def test_check_workers_available_exception(self, mock_celery_app, test_db):
-        """Test worker detection handles exceptions gracefully."""
-        mock_celery_app.control.inspect.side_effect = Exception("Connection error")
-
-        service = EmbeddingService(test_db)
-        result = service._check_workers_available()
-
-        assert result is False
-
-    @patch("rhesis.backend.worker.app")
-    def test_check_workers_available_caching(self, mock_celery_app, test_db):
-        """Test that worker availability is cached."""
-        mock_inspect = Mock()
-        mock_inspect.ping.return_value = {"worker1": {"ok": "pong"}}
-        mock_celery_app.control.inspect.return_value = mock_inspect
-
-        service = EmbeddingService(test_db)
-        # Clear cache before testing caching functionality
-        if "checked_at" in EmbeddingService._worker_cache:
-            EmbeddingService._worker_cache["checked_at"] = 0
-            EmbeddingService._worker_cache["available"] = None
-
-        result1 = service._check_workers_available()
-        result2 = service._check_workers_available()
-
-        assert result1 is True
-        assert result2 is True
-        assert mock_celery_app.control.inspect.call_count == 1
-
-
-@pytest.mark.unit
-@pytest.mark.service
 class TestEmbeddingServiceIntegration:
     """Integration tests for EmbeddingService with real generator."""
 
     @patch("rhesis.backend.app.utils.user_model_utils.get_model")
-    @patch.object(EmbeddingService, "_check_workers_available")
+    @patch.object(EmbeddingService, "_enqueue_async")
     def test_full_sync_flow(
         self,
-        mock_workers,
+        mock_enqueue,
         mock_get_model,
         test_db,
         test_entity,
         user_with_embedding_model,
     ):
         """Test complete sync flow with real generator."""
-        mock_workers.return_value = False
+        mock_enqueue.side_effect = ConnectionError("Broker unavailable")
 
         mock_embedder = Mock()
         mock_embedder.generate.return_value = [0.1] * 768


### PR DESCRIPTION
## Summary

- Cap Redis connection pools across all consumers with explicit `max_connections` limits to prevent unbounded connection growth under contention
- Apply fail-fast Celery broker overrides in the FastAPI web process (2s timeouts, zero retries) so a degraded Redis never blocks HTTP threads
- **Remove `_check_workers_available()` entirely** — it performed a 1s `inspect.ping()` Redis round-trip on every cache miss, triggering a feedback loop that caused Cloud Run to spin up 14+ instances at just 2-3 req/s
- Make telemetry trace ingestion **fire-and-forget**: store spans to DB, dispatch async, return success regardless of broker availability
- Release DB session before Celery `.delay()` to prevent slow broker dispatch from holding connections hostage

## Root cause

A feedback loop where slow Redis amplified request latency and caused autoscaler storms:

1. `_check_workers_available()` does `inspect.ping(timeout=1.0)` — a 1s synchronous Redis round-trip on every cache miss
2. When ping fails → sync fallback adds 500ms-2s of DB work in-request
3. Each request holds a concurrency slot 10-15x longer (130ms → 1.5s)
4. Cloud Run autoscaler overreacts: 0.4 concurrent slots needed at 130ms, 4.5 at 1.5s
5. New instances open more Redis connections, making Redis slower → repeat

One organization sending 192K trace requests/day (99.95% of traffic) made this visible.

## Changes

| File | Change |
|------|--------|
| `app/services/async_service.py` | Remove `_check_workers_available`, `_worker_cache`, `workers_available` param; always try async first, fall back to sync on broker errors |
| `app/routers/telemetry.py` | Fire-and-forget dispatch: remove sync fallback, log warning on broker failure, return success |
| `app/services/telemetry/enrichment/service.py` | Remove `workers_available` parameter from all methods |
| `celery/config.py` | Add `WEB_CELERY_OVERRIDES` (2s timeouts, 0 retries, pool limit 5) |
| `celery/core.py` | Add `apply_web_context_overrides()` for web process |
| `app/main.py` | Call overrides during FastAPI lifespan startup |
| `app/services/cache.py` | `max_connections=3` on sync Redis cache |
| `app/services/garak/cache.py` | `max_connections=3` on async Garak cache |
| `app/services/connector/redis_client.py` | `max_connections=3` on SDK RPC Redis |
| 6 test files | Update tests for simplified async-first interface (-576 lines net) |

## Test plan

- [ ] Verify backend tests pass
- [ ] Deploy and confirm trace ingestion works with workers available
- [ ] Confirm fire-and-forget behavior: `.delay()` fails fast with warning, response still succeeds
- [ ] Monitor Cloud Run instance count: should stay at 1-3 under 2-3 req/s (was spiking to 14+)
- [ ] Monitor P99 latency on POST /telemetry/traces: should stay under 200ms