### PR TITLE
Fix SDK integration test backend startup failure

### DIFF
--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -25,6 +25,7 @@ x-sdk-redis-config: &sdk-redis-config
   CELERY_RESULT_BACKEND: redis://:rhesis-redis-pass@sdk-test-redis:6379/1
 
 x-sdk-backend-config: &sdk-backend-config
+  ENVIRONMENT: test
   JWT_SECRET_KEY: your-jwt-secret-key
   SESSION_SECRET_KEY: test-session-secret-key
   LOG_LEVEL: DEBUG


### PR DESCRIPTION
## Summary
- Set `ENVIRONMENT=test` for the SDK integration test backend in `tests/docker-compose.test.yml`
- EE bootstrap now requires `AUDIT_HASH_KEY` outside dev/test environments; without `ENVIRONMENT` set, the test backend crashed on startup and CI failed waiting for the health check

## Test plan
- [x] `docker compose -f tests/docker-compose.test.yml --profile sdk up -d --wait` — backend becomes healthy
- [x] `cd sdk && make test-integration` — 2161 passed, 10 skipped