### PR TITLE
docs(changelog): add launch week Day 1-5 videos

### DIFF
--- a/docs/content/changelog.mdx
+++ b/docs/content/changelog.mdx
@@ -8,31 +8,7 @@ This is the aggregated changelog for the entire Rhesis repository. For detailed 
 - [Frontend Changelog](https://github.com/rhesis-ai/rhesis/blob/main/apps/frontend/CHANGELOG.md)
 - [Polyphemus Changelog](https://github.com/rhesis-ai/rhesis/blob/main/apps/polyphemus/CHANGELOG.md)
 
-## [0.8.0] - Unreleased
-
-### Storage migration: file bytes move out of Postgres
-
-This release migrates all file content from Postgres `bytea` columns to object storage (GCS/S3/local-FS via `STORAGE_SERVICE_URI`). The change eliminates Cloud Run memory crashes caused by multi-MB file buffers and brings consistent streaming upload/download semantics across all execution paths.
-
-**Breaking changes:**
-
-- `GET /files/{id}/content` now returns HTTP 302 to a presigned URL instead of streaming bytes directly. HTTP clients that follow redirects (including the SDK and all browsers) are unaffected.
-- `FileCreate` schema no longer accepts a `content` field. Upload bytes are streamed to object storage; only metadata is stored in Postgres.
-- `File.extracted_text` is now pre-computed at upload time rather than per-invocation. A brief soak window applies while the Celery extraction queue drains after deployment.
-
-**New features:**
-
-- `GET /files/{id}/thumbnail?size=N` — server-side WebP thumbnail (sizes: 72, 144, 288 px).
-- `STORAGE_SERVICE_URI=file:///path` — first-class local-FS mode for dev/CI (previously only `gs://` was supported).
-- `FileReference` type in the SDK connector for passing file metadata through the execution pipeline without embedding bytes.
-- `extraction_status` field on `FileResponse` (`pending | done | failed | not_applicable`).
-- ETag / If-None-Match support on `/content` and `/thumbnail` for browser-level caching.
-
-**Deployment:** Apply Alembic revision `9b25f353e9c8` (adds storage columns), deploy the new code, then apply revision `f1e2d3c4b5a6` to drop the legacy `content` column.
-
-**IAM prerequisite:** The backend Cloud Run service account needs `roles/storage.objectAdmin` on the storage bucket (previously `roles/storage.objectViewer` was sufficient).
-
-
+## [0.7.1] - 2026-05-07
 
 ### Platform Release
 
@@ -109,6 +85,19 @@ This release introduces the **Rhesis Architect** workflow for conversational tes
 
 **Rhesis Architect (Backend + Frontend + SDK)**
 
+Architect (Telemachus) turns the testing workflow into a single chat: describe a goal, approve a plan, watch it execute.
+
+<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '800px', margin: '20px 0', borderRadius: '8px', boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)' }}>
+  <iframe
+    style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+    src="https://www.youtube.com/embed/M-x-Bjbgl2g"
+    title="Day 2: Architect (Telemachus) - Release 0.7.0"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  />
+</div>
+
 Architect is now available as a full product workflow:
 
 - **Conversational planning and execution**: multi-phase agent flow for discovery, planning, creation, and execution
@@ -117,6 +106,19 @@ Architect is now available as a full product workflow:
 - **Safety controls**: explicit confirmation flow for mutating operations and scoped write-guards
 
 **Agent Tooling via MCP**
+
+The Rhesis Agent Skill brings the full testing workflow into Claude Code, Cursor, and 40+ other AI tools with a single install.
+
+<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '800px', margin: '20px 0', borderRadius: '8px', boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)' }}>
+  <iframe
+    style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+    src="https://www.youtube.com/embed/_YYj98Lu5rU"
+    title="Day 1: Rhesis Agent Skill - Release 0.7.0"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  />
+</div>
 
 Agent tools are now delivered through a dedicated MCP architecture:
 
@@ -413,6 +415,19 @@ This release introduces **file attachments across tests, traces, and playground 
 
 **File Attachments Across Test Workflows**
 
+Multi-file Testing lets you attach up to 10 images, PDFs, or audio files to a test; in multi-turn flows, Penelope picks when each file enters the conversation.
+
+<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '800px', margin: '20px 0', borderRadius: '8px', boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)' }}>
+  <iframe
+    style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+    src="https://www.youtube.com/embed/odq3GW5qspY"
+    title="Day 5: Multi-file Testing - Release 0.6.8"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  />
+</div>
+
 File support is now available end-to-end across execution and debugging flows:
 
 - **Test and Test Result Attachments**: Upload, list, download, and remove files linked to tests and test results
@@ -548,6 +563,19 @@ This release introduces **Polyphemus access control with delegation tokens**, **
 
 **Polyphemus Access Control**
 
+Polyphemus is an uncensored language model for adversarial test generation — prompt injection, jailbreaks, hate speech, and scenarios safety-aligned models will not generate.
+
+<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '800px', margin: '20px 0', borderRadius: '8px', boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)' }}>
+  <iframe
+    style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+    src="https://www.youtube.com/embed/gjLV7lnDjKw"
+    title="Day 3: Polyphemus - Release 0.6.6"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  />
+</div>
+
 Secure, governed access to Polyphemus models:
 
 - **Request/Grant Workflow**: Users can request access to Polyphemus, admins can grant or revoke it
@@ -632,6 +660,19 @@ Comprehensive metric evaluation in live multi-turn execution:
 - **Pass/Fail Determination**: All evaluated metrics contribute to overall pass/fail outcomes
 
 **Adaptive Testing**
+
+Test Explorer is an interactive workspace for discovering new tests: seed a few, score them, and let Explorer rank diverse suggestions.
+
+<div style={{ position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '800px', margin: '20px 0', borderRadius: '8px', boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)' }}>
+  <iframe
+    style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+    src="https://www.youtube.com/embed/4E1vD7UiHqU"
+    title="Day 4: Test Explorer - Release 0.6.5"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  />
+</div>
 
 New tools for building and managing adaptive test suites:
 


### PR DESCRIPTION
## Purpose

Embed the five Day 1-5 launch week videos into the docs changelog, each placed next to the release section where its feature was first introduced. Also fixes the changelog to show 0.7.1 as a proper released entry.

## What Changed

- Day 1 (Agent Skill, `_YYj98Lu5rU`) → [0.7.0] under **Agent Tooling via MCP**
- Day 2 (Architect / Telemachus, `M-x-Bjbgl2g`) → [0.7.0] under **Rhesis Architect**
- Day 3 (Polyphemus, `gjLV7lnDjKw`) → [0.6.6] under **Polyphemus Access Control**
- Day 4 (Test Explorer, `4E1vD7UiHqU`) → [0.6.5] under **Adaptive Testing**
- Day 5 (Multi-file Testing, `odq3GW5qspY`) → [0.6.8] under **File Attachments Across Test Workflows**
- Removed `[0.8.0] - Unreleased` section (genuinely unreleased storage migration content stripped)
- Added `[0.7.1] - 2026-05-07` as a proper released entry with its Architect UX / Explorer / Agent Skill content

## Additional Context

Each video uses the existing responsive 16:9 iframe wrapper pattern already used throughout the changelog, with a one-sentence lead-in above the embed.

## Testing

Review the rendered changelog at docs.rhesis.ai/changelog after deploy.