### PR TITLE
Fix failing SDK Vertex AI stream credentials test

### DIFF
--- a/tests/sdk/models/providers/test_vertex_ai.py
+++ b/tests/sdk/models/providers/test_vertex_ai.py
@@ -664,8 +664,9 @@ class TestVertexAIGenerateStream:
             clear=True,
         ):
             llm = VertexAILLM(credentials=encoded_creds, location="europe-west3")
-            # load_model() sets the env var to the decoded temp file path;
-            # capture that value, then overwrite with an external path.
+            # load_model() already overwrote the env var with the decoded
+            # temp file path; set a known external value so we can verify
+            # generate_stream leaves it untouched.
             original_value = "/path/to/original/credentials.json"
             os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = original_value
 

--- a/tests/sdk/models/providers/test_vertex_ai.py
+++ b/tests/sdk/models/providers/test_vertex_ai.py
@@ -644,8 +644,8 @@ class TestVertexAIGenerateStream:
             assert call_kwargs["stream"] is True
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
-    def test_generate_stream_restores_credentials_env_var(self, mock_acompletion):
-        """Test that generate_stream restores GOOGLE_APPLICATION_CREDENTIALS."""
+    def test_generate_stream_preserves_credentials_env_var(self, mock_acompletion):
+        """Test that generate_stream does not alter GOOGLE_APPLICATION_CREDENTIALS."""
         mock_creds = {
             "type": "service_account",
             "project_id": "test-project",
@@ -658,14 +658,16 @@ class TestVertexAIGenerateStream:
 
         mock_acompletion.return_value = mock_stream()
 
-        original_value = "/path/to/original/credentials.json"
         with patch.dict(
             os.environ,
             {"GOOGLE_APPLICATION_CREDENTIALS": encoded_creds, "VERTEX_AI_LOCATION": "europe-west3"},
             clear=True,
         ):
-            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = original_value
             llm = VertexAILLM(credentials=encoded_creds, location="europe-west3")
+            # load_model() sets the env var to the decoded temp file path;
+            # capture that value, then overwrite with an external path.
+            original_value = "/path/to/original/credentials.json"
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = original_value
 
             async def run():
                 async for _ in llm.generate_stream("Test"):


### PR DESCRIPTION
## Purpose

Fix the failing `test_generate_stream_restores_credentials_env_var` test in the SDK CI pipeline ([run #1681](https://github.com/rhesis-ai/rhesis/actions/runs/26074421140/job/76662398199)).

## What Changed

- Fixed env var assertion order in `TestVertexAIGenerateStream`: the test was setting `GOOGLE_APPLICATION_CREDENTIALS` to a custom value *before* creating the `VertexAILLM` instance, but `load_model()` permanently overwrites it with the decoded temp file path during `__init__`. Moved the assignment to *after* init so the test properly verifies that `generate_stream` does not alter the env var.
- Renamed the test from `test_generate_stream_restores_credentials_env_var` to `test_generate_stream_preserves_credentials_env_var` to better reflect what it checks.

## Testing

```bash
cd sdk
uv run pytest ../tests/sdk/models/providers/test_vertex_ai.py -v
```

All 33 tests pass.