### PR TITLE
Fix Vertex AI credentials and Turbopack CPU bug

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "rhesis-app",
   "version": "0.7.1",
   "scripts": {
-    "dev": "next dev --turbo -H 0.0.0.0 -p 3000",
+    "dev": "next dev --webpack -H 0.0.0.0 -p 3000",
     "build": "npm run clean && next build --webpack",
     "postinstall": "patch-package",
     "start": "next start -p ${PORT}",

--- a/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
+++ b/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
@@ -13,15 +13,11 @@ Regional availability:
 For detailed usage and configuration options, see VertexAILLM class documentation.
 """
 
-import atexit
 import base64
-import hashlib
 import json
 import logging
 import os
-import tempfile
-from pathlib import Path
-from typing import List, Optional, Set, Type, Union
+from typing import List, Optional, Type, Union
 
 from pydantic import BaseModel
 
@@ -35,29 +31,9 @@ from rhesis.sdk.models.providers.litellm import LiteLLM, LiteLLMEmbedder
 
 logger = logging.getLogger(__name__)
 
-# Track temp files created by this process for cleanup
-_temp_credential_files: Set[str] = set()
-
 DEFAULT_MODEL = DEFAULT_LANGUAGE_MODELS["vertex_ai"]
 DEFAULT_MODEL_NAME = model_name_from_id(DEFAULT_MODEL)
 DEFAULT_EMBEDDING_MODEL = model_name_from_id(DEFAULT_EMBEDDING_MODELS["vertex_ai"])
-
-
-def _cleanup_temp_credentials():
-    """
-    Clean up temporary credential files created by this process.
-    Called automatically at process exit via atexit.
-    """
-    for temp_file in _temp_credential_files:
-        try:
-            if os.path.exists(temp_file):
-                os.unlink(temp_file)
-        except Exception:
-            pass  # Ignore cleanup errors
-
-
-# Register cleanup function to run at process exit
-atexit.register(_cleanup_temp_credentials)
 
 
 class VertexAICredentialsMixin:
@@ -93,17 +69,16 @@ class VertexAICredentialsMixin:
 
     def _load_credentials_from_base64(self, credentials: str) -> dict:
         """
-        Attempt to load credentials from base64-encoded string.
+        Decode base64-encoded service account credentials and return as
+        a JSON string suitable for LiteLLM's ``vertex_credentials`` parameter.
 
-        Uses a deterministic temp file path based on credentials hash to ensure
-        multiple instances can share the same file without race conditions.
-        Files are tracked and cleaned up at process exit.
+        No temporary files are created; the credentials stay in memory.
 
         Args:
             credentials: Base64-encoded service account JSON
 
         Returns:
-            dict: Config with credentials_path and project
+            dict: Config with vertex_credentials (JSON string) and project
 
         Raises:
             Exception: If not valid base64 or JSON
@@ -111,43 +86,23 @@ class VertexAICredentialsMixin:
         decoded_credentials = base64.b64decode(credentials, validate=True)
         credentials_json = json.loads(decoded_credentials)
 
-        # Create a deterministic temp file path based on credentials hash
-        # This ensures all instances with the same credentials use the same file
-        creds_hash = hashlib.sha256(credentials.encode()).hexdigest()[:16]
-        temp_dir = Path(tempfile.gettempdir())
-        temp_file_path = temp_dir / f"vertex_ai_creds_{creds_hash}.json"
-
-        # Write credentials to the persistent temp file with restricted permissions
-        # (0o600 = owner read/write only). Use os.open so the mode is set atomically
-        # at creation time rather than relying on a post-creation chmod.
-        try:
-            fd = os.open(
-                str(temp_file_path),
-                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                0o600,
-            )
-            with os.fdopen(fd, "w") as f:
-                json.dump(credentials_json, f)
-
-            # Track this file for cleanup at process exit
-            _temp_credential_files.add(str(temp_file_path))
-        except (OSError, PermissionError) as e:
-            raise ValueError(f"Failed to create temporary credentials file: {e}")
-
         return {
-            "credentials_path": str(temp_file_path),
+            "vertex_credentials": json.dumps(credentials_json),
+            "credentials_source": "base64",
             "project": credentials_json.get("project_id"),
         }
 
     def _load_credentials_from_file(self, credentials: str) -> dict:
         """
-        Load credentials from file path.
+        Load credentials from a file path.  LiteLLM accepts file paths
+        directly via ``vertex_credentials``, so we just validate and
+        extract the project_id without writing anything.
 
         Args:
             credentials: Path to service account JSON file
 
         Returns:
-            dict: Config with credentials_path and project
+            dict: Config with vertex_credentials (file path) and project
 
         Raises:
             ValueError: If file doesn't exist or can't be read
@@ -162,7 +117,8 @@ class VertexAICredentialsMixin:
             raise ValueError(f"Failed to read credentials file {credentials}: {e}")
 
         return {
-            "credentials_path": credentials,
+            "vertex_credentials": credentials,
+            "credentials_source": "file",
             "project": credentials_json.get("project_id"),
         }
 
@@ -200,7 +156,7 @@ class VertexAICredentialsMixin:
             credentials: Either base64-encoded JSON or file path
 
         Returns:
-            dict: Config with credentials_path and project
+            dict: Config with vertex_credentials and project
 
         Raises:
             ValueError: If all methods fail
@@ -235,12 +191,11 @@ class VertexAICredentialsMixin:
         Automatically detects if credentials are base64-encoded or a file path.
 
         Returns:
-            dict: Configuration containing project, location, and credentials_path
+            dict: Configuration containing project, location, and vertex_credentials
 
         Raises:
             ValueError: If configuration is incomplete or invalid
         """
-        # Step 1: Get credentials from the value captured at initialization
         google_credentials = self._original_credentials_env
         if not google_credentials:
             raise ValueError(
@@ -250,19 +205,15 @@ class VertexAICredentialsMixin:
                 "Value can be base64-encoded JSON or file path to service account JSON"
             )
 
-        # Step 2: Load credentials (auto-detect format and normalize to file path)
         config = self._load_credentials(google_credentials)
 
-        # Step 3: Get location (init parameter takes priority)
         config["location"] = self._get_location()
 
-        # Step 4: Set project with priority order
         if self._init_project:
             config["project"] = self._init_project
         elif os.getenv("VERTEX_AI_PROJECT"):
             config["project"] = os.getenv("VERTEX_AI_PROJECT")
 
-        # Verify we have a project from at least one source
         if not config.get("project"):
             raise ValueError(
                 "Could not determine VERTEX_AI_PROJECT. Provide either:\n"
@@ -272,28 +223,6 @@ class VertexAICredentialsMixin:
             )
 
         return config
-
-    def _ensure_credentials_file(self) -> str:
-        """Ensure credentials file exists, recreating if necessary.
-
-        Returns:
-            str: Path to the credentials file
-
-        Raises:
-            ValueError: If credentials file cannot be found or recreated
-        """
-        credentials_path = self._vertex_config["credentials_path"]
-        if not os.path.exists(credentials_path):
-            if hasattr(self, "_original_credentials_env") and self._original_credentials_env:
-                try:
-                    config = self._load_credentials(self._original_credentials_env)
-                    credentials_path = config["credentials_path"]
-                    self._vertex_config["credentials_path"] = credentials_path
-                except Exception as e:
-                    raise ValueError(f"Credentials file missing and could not be recreated: {e}")
-            else:
-                raise ValueError(f"Credentials file not found: {credentials_path}")
-        return credentials_path
 
 
 class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
@@ -362,13 +291,9 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
         The returned config is stored in self.model and used throughout the provider.
 
         Returns:
-            dict: Configuration containing project, location, and credentials_path
+            dict: Configuration containing project, location, and vertex_credentials
         """
         self._vertex_config = self._load_vertex_config()
-        # Ensure GOOGLE_APPLICATION_CREDENTIALS points to the decoded credentials file path,
-        # not the raw base64 string.- prevents google.auth.default from
-        # failling backe to GKE metadata when credentials were only base64 in the env.
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = self._vertex_config["credentials_path"]
         return self._vertex_config
 
     async def a_generate(
@@ -398,7 +323,7 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
         """
         kwargs["vertex_ai_project"] = self.model["project"]
         kwargs["vertex_ai_location"] = self.model["location"]
-        kwargs["vertex_credentials"] = self._ensure_credentials_file()
+        kwargs["vertex_credentials"] = self.model["vertex_credentials"]
 
         return await super().a_generate(
             prompt=prompt,
@@ -433,10 +358,9 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
         Returns:
             List of generated text or dicts (if schema provided)
         """
-        # Inject Vertex AI-specific parameters
         kwargs["vertex_ai_project"] = self.model["project"]
         kwargs["vertex_ai_location"] = self.model["location"]
-        kwargs["vertex_credentials"] = self._ensure_credentials_file()
+        kwargs["vertex_credentials"] = self.model["vertex_credentials"]
 
         return super().generate_batch(
             prompts=prompts,
@@ -462,26 +386,15 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
         try:
             from litellm.main import vertex_chat_completion
 
-            credentials_path = self._ensure_credentials_file()
             project = (self.model or {}).get("project")
             await vertex_chat_completion._ensure_access_token_async(
-                credentials=credentials_path,
+                credentials=self.model["vertex_credentials"],
                 project_id=project,
                 custom_llm_provider="vertex_ai",
             )
             logger.debug("VertexAI credentials pre-warmed (LiteLLM cache populated)")
         except Exception as e:
             logger.warning(f"VertexAI credential pre-warm failed (non-fatal, proceeding): {e}")
-
-    def __del__(self):
-        """
-        Cleanup method - does NOT delete temp credentials file here.
-
-        Temp files are shared across instances and cleaned up at process exit
-        via atexit handler. This prevents race conditions when multiple model
-        instances are created rapidly.
-        """
-        pass
 
     def get_config_info(self) -> dict:
         """
@@ -495,10 +408,7 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
             "model": self.model_name,
             "project": self.model["project"],
             "location": self.model["location"],
-            "credentials_source": "base64"
-            if self._original_credentials_env and not os.path.isfile(self._original_credentials_env)
-            else "file",
-            "credentials_path": self.model["credentials_path"],
+            "credentials_source": self.model.get("credentials_source", "unknown"),
         }
 
 
@@ -541,12 +451,8 @@ class VertexAIEmbedder(VertexAICredentialsMixin, LiteLLMEmbedder):
         project: Optional[str] = None,
         dimensions: Optional[int] = None,
     ):
-        # Initialize credential handling from mixin
         self._init_vertex_credentials(credentials, location, project)
-
-        # Load Vertex AI configuration
         self._vertex_config = self._load_vertex_config()
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = self._vertex_config["credentials_path"]
 
         # Initialize parent LiteLLMEmbedder with vertex_ai prefix
         # Don't pass api_key as Vertex AI uses credentials
@@ -557,7 +463,7 @@ class VertexAIEmbedder(VertexAICredentialsMixin, LiteLLMEmbedder):
         )
 
     def _with_vertex_credentials(self, func, *args, **kwargs):
-        """Execute a function with Vertex AI credentials set in environment.
+        """Execute a function with Vertex AI credentials injected.
 
         Args:
             func: Function to execute
@@ -567,10 +473,9 @@ class VertexAIEmbedder(VertexAICredentialsMixin, LiteLLMEmbedder):
         Returns:
             Result from the function
         """
-        # Inject Vertex AI-specific parameters
         kwargs["vertex_project"] = self._vertex_config["project"]
         kwargs["vertex_location"] = self._vertex_config["location"]
-        kwargs["vertex_credentials"] = self._ensure_credentials_file()
+        kwargs["vertex_credentials"] = self._vertex_config["vertex_credentials"]
 
         return func(*args, **kwargs)
 
@@ -593,7 +498,7 @@ class VertexAIEmbedder(VertexAICredentialsMixin, LiteLLMEmbedder):
         """Async embedding for a single text using Vertex AI."""
         kwargs["vertex_project"] = self._vertex_config["project"]
         kwargs["vertex_location"] = self._vertex_config["location"]
-        kwargs["vertex_credentials"] = self._ensure_credentials_file()
+        kwargs["vertex_credentials"] = self._vertex_config["vertex_credentials"]
         return await super().a_generate(text, **kwargs)
 
     def generate_batch(self, texts: List[str], **kwargs) -> List[Embedding]:
@@ -623,8 +528,5 @@ class VertexAIEmbedder(VertexAICredentialsMixin, LiteLLMEmbedder):
             "model": self.model_name,
             "project": self._vertex_config["project"],
             "location": self._vertex_config["location"],
-            "credentials_source": "base64"
-            if self._original_credentials_env and not os.path.isfile(self._original_credentials_env)
-            else "file",
-            "credentials_path": self._vertex_config["credentials_path"],
+            "credentials_source": self._vertex_config.get("credentials_source", "unknown"),
         }

--- a/tests/sdk/models/providers/test_vertex_ai.py
+++ b/tests/sdk/models/providers/test_vertex_ai.py
@@ -2,7 +2,6 @@ import asyncio
 import base64
 import json
 import os
-import stat
 import tempfile
 from unittest.mock import Mock, patch
 
@@ -110,7 +109,7 @@ class TestVertexAIConfigLoading:
     """Test credential and configuration loading methods."""
 
     def test_load_config_base64_credentials(self):
-        """Test base64-encoded credentials with location."""
+        """Test base64-encoded credentials are kept in memory as JSON."""
         mock_creds = {
             "type": "service_account",
             "project_id": "test-project-123",
@@ -129,9 +128,9 @@ class TestVertexAIConfigLoading:
 
             assert llm.model["project"] == "test-project-123"
             assert llm.model["location"] == "europe-west3"
-            assert llm.model["credentials_path"] is not None
-            # Verify temp file was created and exists
-            assert os.path.exists(llm.model["credentials_path"])
+            assert llm.model["credentials_source"] == "base64"
+            creds_roundtrip = json.loads(llm.model["vertex_credentials"])
+            assert creds_roundtrip["project_id"] == "test-project-123"
 
     def test_load_config_file_credentials(self):
         """Test file path credentials with location."""
@@ -155,8 +154,8 @@ class TestVertexAIConfigLoading:
 
                 assert llm.model["project"] == "test-project-456"
                 assert llm.model["location"] == "us-central1"
-                # When using file path, credentials_path should match the provided path
-                assert llm.model["credentials_path"] == temp_path
+                assert llm.model["credentials_source"] == "file"
+                assert llm.model["vertex_credentials"] == temp_path
         finally:
             os.unlink(temp_path)
 
@@ -185,12 +184,8 @@ class TestVertexAIConfigLoading:
 
                 assert llm.model["project"] == "test-project-789"
                 assert llm.model["location"] == "asia-northeast1"
-                assert llm.model["credentials_path"] == temp_path
-                # Verify file path credentials don't create a temp file
-                assert (
-                    not llm.model["credentials_path"].startswith("/var/folders")
-                    or llm.model["credentials_path"] == temp_path
-                )
+                assert llm.model["vertex_credentials"] == temp_path
+                assert llm.model["credentials_source"] == "file"
         finally:
             os.unlink(temp_path)
 
@@ -407,12 +402,11 @@ class TestVertexAIGenerate:
             assert call_kwargs["vertex_ai_location"] == "europe-west1"
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
-    def test_init_sets_credentials_env_var_to_file_path(self, mock_completion):
-        """Test that init sets GOOGLE_APPLICATION_CREDENTIALS to the decoded file path.
+    def test_init_does_not_modify_credentials_env_var(self, mock_completion):
+        """Test that init does not modify GOOGLE_APPLICATION_CREDENTIALS.
 
-        With the new approach, GOOGLE_APPLICATION_CREDENTIALS is permanently set
-        to the decoded credentials file path at startup (in load_model), so that
-        google.auth.default() never falls back to GKE metadata.
+        Credentials are passed in-memory via vertex_credentials, so
+        the env var should remain untouched.
         """
         mock_creds = {
             "type": "service_account",
@@ -437,15 +431,13 @@ class TestVertexAIGenerate:
         ):
             llm = VertexAILLM(credentials=encoded_creds, location="asia-northeast1")
 
-            # After init, GOOGLE_APPLICATION_CREDENTIALS must point to the decoded file,
-            # not the raw base64 string, so google.auth.default() works correctly.
-            env_creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-            assert env_creds is not None
-            assert env_creds != encoded_creds
-            assert os.path.isfile(env_creds)
-            assert env_creds == llm.model["credentials_path"]
+            assert os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") == encoded_creds
 
             llm.generate("Test prompt")
+
+            call_kwargs = mock_completion.call_args[1]
+            creds_sent = json.loads(call_kwargs["vertex_credentials"])
+            assert creds_sent["project_id"] == "test-project"
 
 
 class TestVertexAIUtilityMethods:
@@ -474,7 +466,6 @@ class TestVertexAIUtilityMethods:
             assert config["project"] == "test-project"
             assert config["location"] == "europe-west3"
             assert config["credentials_source"] == "base64"
-            assert config["credentials_path"] is not None
 
     def test_get_config_info_file_credentials(self):
         """Test get_config_info returns correct information for file credentials."""
@@ -498,7 +489,6 @@ class TestVertexAIUtilityMethods:
                 config = llm.get_config_info()
 
                 assert config["credentials_source"] == "file"
-                assert config["credentials_path"] == temp_path
         finally:
             os.unlink(temp_path)
 
@@ -538,10 +528,10 @@ class TestVertexAIRegionalLocations:
 
 
 class TestVertexAICredentialSecurity:
-    """Test credential security: file permissions, error message masking."""
+    """Test credential security: error message masking, no disk writes."""
 
-    def test_temp_file_has_restricted_permissions(self):
-        """Test that temp credentials files are created with 0600 permissions."""
+    def test_base64_credentials_not_written_to_disk(self):
+        """Test that base64 credentials stay in memory (no temp files)."""
         mock_creds = {
             "type": "service_account",
             "project_id": "test-project",
@@ -556,9 +546,9 @@ class TestVertexAICredentialSecurity:
             clear=True,
         ):
             llm = VertexAILLM()
-            credentials_path = llm.model["credentials_path"]
-            file_mode = stat.S_IMODE(os.stat(credentials_path).st_mode)
-            assert file_mode == 0o600, f"Expected 0600, got {oct(file_mode)}"
+            vertex_creds = llm.model["vertex_credentials"]
+            assert json.loads(vertex_creds)["project_id"] == "test-project"
+            assert llm.model["credentials_source"] == "base64"
 
     def test_error_message_does_not_leak_base64_credentials(self):
         """Test that base64 credential values are never included in error messages."""
@@ -664,28 +654,25 @@ class TestVertexAIGenerateStream:
             clear=True,
         ):
             llm = VertexAILLM(credentials=encoded_creds, location="europe-west3")
-            # load_model() already overwrote the env var with the decoded
-            # temp file path; set a known external value so we can verify
-            # generate_stream leaves it untouched.
-            original_value = "/path/to/original/credentials.json"
-            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = original_value
+            env_before = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
 
             async def run():
                 async for _ in llm.generate_stream("Test"):
                     pass
 
             asyncio.run(run())
-            assert os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") == original_value
+            assert os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") == env_before
 
 
-class TestVertexAICleanup:
-    """Test cleanup of temporary files."""
+class TestVertexAIInMemoryCredentials:
+    """Test that base64 credentials are handled entirely in memory."""
 
-    def test_temp_file_cleanup_on_delete(self):
-        """Test that temporary credentials file is tracked and exists."""
+    def test_credentials_json_roundtrip(self):
+        """Test that decoded credentials faithfully reproduce the original JSON."""
         mock_creds = {
             "type": "service_account",
             "project_id": "test-project",
+            "private_key": "-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----\n",
             "client_email": "test@test.iam.gserviceaccount.com",
         }
 
@@ -697,19 +684,23 @@ class TestVertexAICleanup:
             clear=True,
         ):
             llm = VertexAILLM()
-            credentials_path = llm.model.get("credentials_path")
+            roundtrip = json.loads(llm.model["vertex_credentials"])
+            assert roundtrip == mock_creds
 
-            # Credentials path should be set
-            assert credentials_path is not None
-            # Temp file should exist
-            assert os.path.exists(credentials_path)
+    def test_multiple_instances_share_same_json(self):
+        """Test that two instances with the same credentials get identical JSON."""
+        mock_creds = {
+            "type": "service_account",
+            "project_id": "test-project",
+            "client_email": "test@test.iam.gserviceaccount.com",
+        }
+        encoded_creds = base64.b64encode(json.dumps(mock_creds).encode()).decode()
 
-            # Verify it's a temp file (deterministic path based on credentials hash)
-            assert "vertex_ai_creds_" in credentials_path
-
-            # Delete the instance - temp file will be cleaned up at process exit via atexit
-            del llm
-
-            # Temp file persists until process exit (cleaned up via atexit)
-            # This is intentional to allow multiple instances to share the same file
-            assert os.path.exists(credentials_path)
+        with patch.dict(
+            os.environ,
+            {"GOOGLE_APPLICATION_CREDENTIALS": encoded_creds, "VERTEX_AI_LOCATION": "europe-west3"},
+            clear=True,
+        ):
+            llm1 = VertexAILLM()
+            llm2 = VertexAILLM()
+            assert llm1.model["vertex_credentials"] == llm2.model["vertex_credentials"]


### PR DESCRIPTION
## Purpose

Two fixes: eliminate temp file credential handling in the Vertex AI SDK provider, and work around a Turbopack CPU regression in the frontend dev server.

## What Changed

**SDK — Vertex AI credentials (in-memory)**
- Replaced temp-file-based credential handling with in-memory JSON strings passed via LiteLLM's `vertex_credentials` parameter
- Removed `atexit` cleanup, temp file creation, `_ensure_credentials_file`, and `_temp_credential_files` tracking
- Stopped mutating `GOOGLE_APPLICATION_CREDENTIALS` env var as a side effect of `load_model()`
- Updated all tests to verify in-memory behavior and no disk writes

**Frontend — dev server**
- Switched `next dev` script from `--turbo` to `--webpack` to work around a [known Turbopack bug](https://github.com/vercel/next.js/issues/86893) in Next.js 16.2.x that causes the dev server to spin at ~800% CPU while idle

## Testing

- All 34 Vertex AI unit tests pass
- Frontend dev server verified to run without CPU spike using `--webpack`