### PR TITLE
fix(ee): align AUDIT_HASH_KEY bootstrap check with BACKEND_ENV

### DIFF
--- a/ee/backend/src/rhesis/backend/ee/__init__.py
+++ b/ee/backend/src/rhesis/backend/ee/__init__.py
@@ -91,7 +91,14 @@ def bootstrap(app: "FastAPI") -> None:
     # forensic capability; refuse to bootstrap rather than ship an
     # un-correlatable audit stream.
     env = os.getenv("ENVIRONMENT", "").lower()
-    if env not in ("local", "test", "dev", "development"):
+    backend_env = os.getenv("BACKEND_ENV", "").lower()
+    is_dev = env in ("local", "test", "dev", "development") or backend_env in (
+        "local",
+        "test",
+        "dev",
+        "development",
+    )
+    if not is_dev:
         if not os.getenv("AUDIT_HASH_KEY"):
             raise RuntimeError(
                 "AUDIT_HASH_KEY must be set in non-dev environments; "


### PR DESCRIPTION
## Purpose
Dev Cloud Run deploys were failing at startup with:

`RuntimeError: AUDIT_HASH_KEY must be set in non-dev environments`

Regular backend deploys set `BACKEND_ENV` from GitHub secrets but often omit `ENVIRONMENT` on the container. EE bootstrap only checked `ENVIRONMENT`, while `audit.py` already treats either variable as dev.

## What changed
- Updated `ee/backend/src/rhesis/backend/ee/__init__.py` bootstrap to mirror `audit._is_dev_environment()`: dev when `ENVIRONMENT` or `BACKEND_ENV` is `local`, `test`, `dev`, or `development`.
- `AUDIT_HASH_KEY` is still required for non-dev envs (e.g. `staging`, `production`).
