### PR TITLE
Backfill test embeddings when computing test set cluster graph

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -851,7 +851,9 @@ def compute_test_set_embedding_graph(
     current_user: User = Depends(require_current_user_or_token),
 ):
     """
-    Compute a embedding graph for a test set.
+    Queue embedding graph computation for a test set.
+
+    The worker generates missing test embeddings, then builds and stores the graph.
     """
     db_test_set = resolve_test_set_or_raise(
         test_set_identifier, db, str(current_user.organization_id)

--- a/apps/backend/src/rhesis/backend/app/services/embedding/services.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/services.py
@@ -56,8 +56,8 @@ class EmbeddingService(AsyncService):
             current_user=SimpleNamespace(id=user_id, organization_id=organization_id),
         )
 
-    def _resolve_model_id(self, user_id: str, model_id: str = None) -> str:
-        """Resolve embedding configuration from user settings or defaults."""
+    def resolve_model_id(self, user_id: str, model_id: str | None = None) -> str:
+        """Resolve embedding model ID from explicit value or user settings."""
 
         # 1. Use explicit model_id if provided
         if model_id:
@@ -85,7 +85,7 @@ class EmbeddingService(AsyncService):
     ) -> bool:
         """Enqueue embedding generation using entity identity and precomputed searchable text."""
         try:
-            resolved_model_id = self._resolve_model_id(str(user_id), model_id)
+            resolved_model_id = self.resolve_model_id(str(user_id), model_id)
             was_async, _ = self.execute_with_fallback(
                 resolved_model_id,
                 entity_type=entity_type,

--- a/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
+++ b/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
@@ -14,6 +14,98 @@ _GRAPH_KEY = "graph"
 _PAGE_SIZE = 100
 
 
+def _embedding_entity_type_key(model_or_name: type | str) -> str:
+    return model_or_name if isinstance(model_or_name, str) else model_or_name.__name__
+
+
+def _ensure_embeddings_for_entities(
+    db,
+    *,
+    entity_ids: list[UUID],
+    user,
+    embedded_entity: type | str,
+) -> None:
+    """Generate and persist active embeddings for entities that do not have one yet."""
+    if not entity_ids:
+        return
+
+    from rhesis.backend.app.services.embedding.generator import EmbeddingGenerator
+    from rhesis.backend.app.services.embedding.graph_builder import fetch_embeddings
+    from rhesis.backend.app.services.embedding.services import EmbeddingService
+
+    entity_type = _embedding_entity_type_key(embedded_entity)
+    org_id = str(user.organization_id)
+    user_id = str(user.id)
+
+    existing = fetch_embeddings(
+        db,
+        entity_ids,
+        embedded_entity=embedded_entity,
+        organization_id=org_id,
+        user_id=user_id,
+    )
+    covered = {e.entity_id for e in existing}
+    missing_ids = [entity_id for entity_id in entity_ids if entity_id not in covered]
+    if not missing_ids:
+        logger.info(
+            "Embedding backfill: all %s %s entities already have active embeddings",
+            len(entity_ids),
+            entity_type,
+        )
+        return
+
+    try:
+        model_id = EmbeddingService(db)._resolve_model_id(user_id)
+    except ValueError as exc:
+        logger.warning(
+            "Embedding backfill skipped for %s entities: no embedding model (%s)",
+            len(missing_ids),
+            exc,
+        )
+        return
+
+    generator = EmbeddingGenerator(db)
+    generated = 0
+    skipped_empty = 0
+    failed = 0
+    for entity_id in missing_ids:
+        try:
+            result = generator.generate(
+                entity_id=str(entity_id),
+                entity_type=entity_type,
+                organization_id=org_id,
+                user_id=user_id,
+                model_id=model_id,
+            )
+        except Exception as exc:
+            failed += 1
+            logger.warning(
+                "Embedding backfill failed for %s:%s: %s",
+                entity_type,
+                entity_id,
+                exc,
+                exc_info=True,
+            )
+            continue
+
+        status = result.get("status")
+        if status == "success":
+            generated += 1
+        elif status == "skipped_empty_text":
+            skipped_empty += 1
+        else:
+            failed += 1
+
+    logger.info(
+        "Embedding backfill for %s: missing=%s generated=%s skipped_empty=%s failed=%s",
+        entity_type,
+        len(missing_ids),
+        generated,
+        skipped_empty,
+        failed,
+    )
+
+
 def _collect_test_set_entity_ids(db, test_set_id: UUID) -> list[UUID]:
     """Return visible test IDs for a test set (excludes soft-deleted tests)."""
     from rhesis.backend.app import crud
@@ -84,6 +176,12 @@ def _run_embedding_graph(
         return
 
     entity_ids = resolve_entity_ids(db, user, parent)
+    _ensure_embeddings_for_entities(
+        db,
+        entity_ids=entity_ids,
+        user=user,
+        embedded_entity=embedded_entity,
+    )
     graph = build_2d_graph(db, entity_ids, user, embedded_entity=embedded_entity)
     persist_graph(parent, graph)
     db.add(parent)

--- a/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
+++ b/apps/backend/src/rhesis/backend/tasks/embedding/graph.py
@@ -55,7 +55,7 @@ def _ensure_embeddings_for_entities(
         return
 
     try:
-        model_id = EmbeddingService(db)._resolve_model_id(user_id)
+        model_id = EmbeddingService(db).resolve_model_id(user_id)
     except ValueError as exc:
         logger.warning(
             "Embedding backfill skipped for %s entities: no embedding model (%s)",

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
@@ -429,8 +429,9 @@ export default function EmbeddingTestsPanel({
                     }}
                   >
                     <Alert severity="info" icon={<RefreshIcon />}>
-                      No embeddings available yet. Add tests with embeddings,
-                      then compute clusters.
+                      No tests could be embedded (empty content or missing
+                      embedding model). Add content to tests or configure an
+                      embedding model, then compute clusters again.
                     </Alert>
                   </Box>
                 )}
@@ -447,8 +448,9 @@ export default function EmbeddingTestsPanel({
                   >
                     <Alert severity="info">
                       Visualize how tests cluster in embedding space. Click
-                      &quot;Compute clusters&quot; to generate a 2D projection
-                      with automatic cluster labels.
+                      &quot;Compute clusters&quot; to generate embeddings for
+                      tests that need them, then build a 2D projection with
+                      automatic cluster labels.
                     </Alert>
                   </Box>
                 )}

--- a/apps/frontend/src/hooks/__tests__/useEmbeddingGraph.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useEmbeddingGraph.test.ts
@@ -154,6 +154,58 @@ describe('useEmbeddingGraph', () => {
     expect(mockTestSetsClient.getEmbeddingGraph).toHaveBeenCalledTimes(1);
   });
 
+  it('ignores stale poll responses after enabled becomes false', async () => {
+    let resolveSecondFetch: (value: {
+      status: 'ready';
+      graph: Scatter2DGraph;
+    }) => void = () => undefined;
+    const secondFetch = new Promise<{ status: 'ready'; graph: Scatter2DGraph }>(
+      resolve => {
+        resolveSecondFetch = resolve;
+      }
+    );
+
+    mockTestSetsClient.getEmbeddingGraph
+      .mockResolvedValueOnce({ status: 'ready', graph: oldGraph })
+      .mockReturnValueOnce(secondFetch)
+      .mockResolvedValue({ status: 'ready', graph: newGraph });
+    mockTestSetsClient.computeEmbeddingGraph.mockResolvedValue({
+      status: 'pending',
+      task_id: 'task-1',
+    });
+
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useEmbeddingGraph('test-set-1', 'token', { enabled }),
+      { initialProps: { enabled: true } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      void result.current.computeGraph();
+    });
+
+    await waitFor(() => {
+      expect(mockTestSetsClient.getEmbeddingGraph.mock.calls.length).toBe(2);
+    });
+
+    rerender({ enabled: false });
+
+    await waitFor(() => {
+      expect(result.current.isComputing).toBe(false);
+    });
+
+    await act(async () => {
+      resolveSecondFetch({ status: 'ready', graph: newGraph });
+      await Promise.resolve();
+    });
+
+    expect(result.current.graph).toEqual(oldGraph);
+  });
+
   it('resumes polling when enabled returns during recompute', async () => {
     mockTestSetsClient.getEmbeddingGraph
       .mockResolvedValueOnce({ status: 'ready', graph: oldGraph })

--- a/apps/frontend/src/hooks/__tests__/useEmbeddingGraph.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useEmbeddingGraph.test.ts
@@ -131,51 +131,27 @@ describe('useEmbeddingGraph', () => {
     });
   });
 
-  it('does not schedule further polls after enabled becomes false', async () => {
-    mockTestSetsClient.getEmbeddingGraph
-      .mockResolvedValueOnce({ status: 'ready', graph: oldGraph })
-      .mockResolvedValue({ status: 'ready', graph: oldGraph });
-    mockTestSetsClient.computeEmbeddingGraph.mockResolvedValue({
+  it('does not poll when graph has never been computed', async () => {
+    mockTestSetsClient.getEmbeddingGraph.mockResolvedValue({
       status: 'pending',
-      task_id: 'task-1',
     });
 
-    const { result, rerender } = renderHook(
-      ({ enabled }: { enabled: boolean }) =>
-        useEmbeddingGraph('test-set-1', 'token', { enabled }),
-      { initialProps: { enabled: true } }
+    const { result } = renderHook(() =>
+      useEmbeddingGraph('test-set-1', 'token', { enabled: true })
     );
 
     await waitFor(() => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    await act(async () => {
-      void result.current.computeGraph();
-    });
-
-    await waitFor(() => {
-      expect(
-        mockTestSetsClient.getEmbeddingGraph.mock.calls.length
-      ).toBeGreaterThan(1);
-    });
-
-    const callsBeforeDisable =
-      mockTestSetsClient.getEmbeddingGraph.mock.calls.length;
-
-    rerender({ enabled: false });
-
-    await waitFor(() => {
-      expect(result.current.isComputing).toBe(false);
-    });
+    expect(result.current.isComputing).toBe(false);
+    expect(result.current.graph).toBeNull();
 
     await act(async () => {
       await jest.advanceTimersByTimeAsync(30_000);
     });
 
-    expect(mockTestSetsClient.getEmbeddingGraph.mock.calls.length).toBe(
-      callsBeforeDisable
-    );
+    expect(mockTestSetsClient.getEmbeddingGraph).toHaveBeenCalledTimes(1);
   });
 
   it('resumes polling when enabled returns during recompute', async () => {

--- a/apps/frontend/src/hooks/useEmbeddingGraph.ts
+++ b/apps/frontend/src/hooks/useEmbeddingGraph.ts
@@ -29,6 +29,8 @@ export function useEmbeddingGraph(
   const [error, setError] = useState<string | null>(null);
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollAttemptsRef = useRef(0);
+  /** Bumped to cancel in-flight polls (disable, unmount, or new poll session). */
+  const pollGenerationRef = useRef(0);
   /** Set when compute/recompute starts; poll until graph computed_at is newer. */
   const computeBaselineRef = useRef<string | null>(null);
 
@@ -40,10 +42,15 @@ export function useEmbeddingGraph(
     pollAttemptsRef.current = 0;
   }, []);
 
+  const invalidatePollSession = useCallback(() => {
+    pollGenerationRef.current += 1;
+  }, []);
+
   const stopPolling = useCallback(() => {
+    invalidatePollSession();
     resetPollTimer();
     setIsComputing(false);
-  }, [resetPollTimer]);
+  }, [invalidatePollSession, resetPollTimer]);
 
   const clearPoll = useCallback(() => {
     stopPolling();
@@ -53,6 +60,7 @@ export function useEmbeddingGraph(
   const fetchGraph = useCallback(
     async (options?: {
       waitForNewerThanBaseline: boolean;
+      pollGeneration?: number;
     }): Promise<
       { status: 'ready'; graph: Scatter2DGraph } | { status: 'pending' }
     > => {
@@ -68,7 +76,12 @@ export function useEmbeddingGraph(
         ) {
           return { status: 'pending' };
         }
-        setGraph(response.graph);
+        if (
+          options?.pollGeneration !== undefined &&
+          pollGenerationRef.current !== options.pollGeneration
+        ) {
+          return { status: 'pending' };
+        }
         return { status: 'ready', graph: response.graph };
       }
       return { status: 'pending' };
@@ -78,13 +91,29 @@ export function useEmbeddingGraph(
 
   const pollUntilReady = useCallback(() => {
     resetPollTimer();
+    invalidatePollSession();
+    const pollGeneration = pollGenerationRef.current;
     setIsComputing(true);
 
+    const isPollSessionActive = () =>
+      pollGenerationRef.current === pollGeneration;
+
     const poll = async () => {
+      if (!isPollSessionActive()) {
+        return;
+      }
+
       pollAttemptsRef.current += 1;
       try {
-        const result = await fetchGraph({ waitForNewerThanBaseline: true });
+        const result = await fetchGraph({
+          waitForNewerThanBaseline: true,
+          pollGeneration,
+        });
+        if (!isPollSessionActive()) {
+          return;
+        }
         if (result.status === 'ready') {
+          setGraph(result.graph);
           clearPoll();
           return;
         }
@@ -93,8 +122,14 @@ export function useEmbeddingGraph(
           clearPoll();
           return;
         }
+        if (!isPollSessionActive()) {
+          return;
+        }
         pollTimeoutRef.current = setTimeout(poll, POLL_INTERVAL_MS);
       } catch (err) {
+        if (!isPollSessionActive()) {
+          return;
+        }
         const message =
           err instanceof Error ? err.message : 'Failed to load embedding map';
         setError(message);
@@ -103,12 +138,15 @@ export function useEmbeddingGraph(
     };
 
     void poll();
-  }, [clearPoll, fetchGraph, resetPollTimer]);
+  }, [clearPoll, fetchGraph, invalidatePollSession, resetPollTimer]);
 
   const refresh = useCallback(async () => {
     setError(null);
     try {
-      await fetchGraph();
+      const result = await fetchGraph();
+      if (result.status === 'ready') {
+        setGraph(result.graph);
+      }
     } catch (err) {
       const message =
         err instanceof Error ? err.message : 'Failed to load embedding map';
@@ -158,6 +196,8 @@ export function useEmbeddingGraph(
           setGraph(null);
           return;
         }
+
+        setGraph(result.graph);
 
         const baseline = computeBaselineRef.current;
         if (

--- a/apps/frontend/src/hooks/useEmbeddingGraph.ts
+++ b/apps/frontend/src/hooks/useEmbeddingGraph.ts
@@ -29,8 +29,6 @@ export function useEmbeddingGraph(
   const [error, setError] = useState<string | null>(null);
   const pollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollAttemptsRef = useRef(0);
-  /** Bumped to cancel in-flight polls (disable, unmount, or new poll session). */
-  const pollGenerationRef = useRef(0);
   /** Set when compute/recompute starts; poll until graph computed_at is newer. */
   const computeBaselineRef = useRef<string | null>(null);
 
@@ -42,15 +40,10 @@ export function useEmbeddingGraph(
     pollAttemptsRef.current = 0;
   }, []);
 
-  const invalidatePollSession = useCallback(() => {
-    pollGenerationRef.current += 1;
-  }, []);
-
   const stopPolling = useCallback(() => {
-    invalidatePollSession();
     resetPollTimer();
     setIsComputing(false);
-  }, [invalidatePollSession, resetPollTimer]);
+  }, [resetPollTimer]);
 
   const clearPoll = useCallback(() => {
     stopPolling();
@@ -60,7 +53,6 @@ export function useEmbeddingGraph(
   const fetchGraph = useCallback(
     async (options?: {
       waitForNewerThanBaseline: boolean;
-      pollGeneration?: number;
     }): Promise<
       { status: 'ready'; graph: Scatter2DGraph } | { status: 'pending' }
     > => {
@@ -76,12 +68,6 @@ export function useEmbeddingGraph(
         ) {
           return { status: 'pending' };
         }
-        if (
-          options?.pollGeneration !== undefined &&
-          pollGenerationRef.current !== options.pollGeneration
-        ) {
-          return { status: 'pending' };
-        }
         setGraph(response.graph);
         return { status: 'ready', graph: response.graph };
       }
@@ -92,27 +78,12 @@ export function useEmbeddingGraph(
 
   const pollUntilReady = useCallback(() => {
     resetPollTimer();
-    invalidatePollSession();
-    const pollGeneration = pollGenerationRef.current;
     setIsComputing(true);
 
-    const isPollSessionActive = () =>
-      pollGenerationRef.current === pollGeneration;
-
     const poll = async () => {
-      if (!isPollSessionActive()) {
-        return;
-      }
-
       pollAttemptsRef.current += 1;
       try {
-        const result = await fetchGraph({
-          waitForNewerThanBaseline: true,
-          pollGeneration,
-        });
-        if (!isPollSessionActive()) {
-          return;
-        }
+        const result = await fetchGraph({ waitForNewerThanBaseline: true });
         if (result.status === 'ready') {
           clearPoll();
           return;
@@ -122,14 +93,8 @@ export function useEmbeddingGraph(
           clearPoll();
           return;
         }
-        if (!isPollSessionActive()) {
-          return;
-        }
         pollTimeoutRef.current = setTimeout(poll, POLL_INTERVAL_MS);
       } catch (err) {
-        if (!isPollSessionActive()) {
-          return;
-        }
         const message =
           err instanceof Error ? err.message : 'Failed to load embedding map';
         setError(message);
@@ -138,7 +103,7 @@ export function useEmbeddingGraph(
     };
 
     void poll();
-  }, [clearPoll, fetchGraph, invalidatePollSession, resetPollTimer]);
+  }, [clearPoll, fetchGraph, resetPollTimer]);
 
   const refresh = useCallback(async () => {
     setError(null);
@@ -191,7 +156,6 @@ export function useEmbeddingGraph(
 
         if (result.status === 'pending') {
           setGraph(null);
-          pollUntilReady();
           return;
         }
 

--- a/tests/backend/services/test_embedding_service.py
+++ b/tests/backend/services/test_embedding_service.py
@@ -230,7 +230,7 @@ class TestEmbeddingService:
         """Test resolving model ID when explicitly provided."""
         service = EmbeddingService(test_db)
 
-        result = service._resolve_model_id(authenticated_user_id, str(embedding_model.id))
+        result = service.resolve_model_id(authenticated_user_id, str(embedding_model.id))
 
         assert result == str(embedding_model.id)
 
@@ -240,7 +240,7 @@ class TestEmbeddingService:
         """Test resolving model ID from user settings."""
         service = EmbeddingService(test_db)
 
-        result = service._resolve_model_id(str(user_with_embedding_model.id), None)
+        result = service.resolve_model_id(str(user_with_embedding_model.id), None)
 
         assert result == str(embedding_model.id)
 
@@ -249,14 +249,14 @@ class TestEmbeddingService:
         service = EmbeddingService(test_db)
 
         with pytest.raises(ValueError, match="No embedding model found"):
-            service._resolve_model_id(str(db_user.id), None)
+            service.resolve_model_id(str(db_user.id), None)
 
     def test_resolve_model_id_user_not_found(self, test_db):
         """Test error when user is not found."""
         service = EmbeddingService(test_db)
 
         with pytest.raises(ValueError, match="No embedding model found"):
-            service._resolve_model_id("00000000-0000-0000-0000-000000000000", None)
+            service.resolve_model_id("00000000-0000-0000-0000-000000000000", None)
 
     @patch.object(EmbeddingService, "_execute_sync")
     @patch.object(EmbeddingService, "_enqueue_async")
@@ -354,7 +354,7 @@ class TestEmbeddingService:
         mock_enqueue.assert_called_once()
         mock_execute.assert_called_once()
 
-    @patch.object(EmbeddingService, "_resolve_model_id")
+    @patch.object(EmbeddingService, "resolve_model_id")
     def test_enqueue_embedding_handles_exception(
         self,
         mock_resolve,

--- a/tests/backend/tasks/test_embedding_graph_task.py
+++ b/tests/backend/tasks/test_embedding_graph_task.py
@@ -1,0 +1,88 @@
+"""Tests for embedding graph Celery helpers."""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rhesis.backend.tasks.embedding.graph import _ensure_embeddings_for_entities
+
+
+@pytest.mark.unit
+class TestEnsureEmbeddingsForEntities:
+    def test_skips_when_all_entities_already_embedded(self):
+        entity_id = uuid.uuid4()
+        user = MagicMock(organization_id=uuid.uuid4(), id=uuid.uuid4())
+
+        with patch(
+            "rhesis.backend.app.services.embedding.graph_builder.fetch_embeddings",
+            return_value=[MagicMock(entity_id=entity_id)],
+        ):
+            with patch(
+                "rhesis.backend.app.services.embedding.services.EmbeddingService"
+            ) as mock_service:
+                _ensure_embeddings_for_entities(
+                    MagicMock(),
+                    entity_ids=[entity_id],
+                    user=user,
+                    embedded_entity="Test",
+                )
+                mock_service.assert_not_called()
+
+    @patch("rhesis.backend.app.services.embedding.generator.EmbeddingGenerator")
+    @patch("rhesis.backend.app.services.embedding.services.EmbeddingService")
+    @patch("rhesis.backend.app.services.embedding.graph_builder.fetch_embeddings")
+    def test_generates_missing_embeddings(
+        self, mock_fetch, mock_service_cls, mock_generator_cls
+    ):
+        missing_id = uuid.uuid4()
+        existing_id = uuid.uuid4()
+        user = MagicMock(organization_id=uuid.uuid4(), id=uuid.uuid4())
+
+        mock_fetch.return_value = [MagicMock(entity_id=existing_id)]
+        mock_service_cls.return_value._resolve_model_id.return_value = "model-1"
+
+        mock_generator = mock_generator_cls.return_value
+        mock_generator.generate.return_value = {
+            "status": "success",
+            "embedding_id": str(uuid.uuid4()),
+        }
+
+        _ensure_embeddings_for_entities(
+            MagicMock(),
+            entity_ids=[existing_id, missing_id],
+            user=user,
+            embedded_entity="Test",
+        )
+
+        mock_generator.generate.assert_called_once_with(
+            entity_id=str(missing_id),
+            entity_type="Test",
+            organization_id=str(user.organization_id),
+            user_id=str(user.id),
+            model_id="model-1",
+        )
+
+    @patch("rhesis.backend.app.services.embedding.services.EmbeddingService")
+    @patch("rhesis.backend.app.services.embedding.graph_builder.fetch_embeddings")
+    def test_skips_backfill_when_no_embedding_model(
+        self, mock_fetch, mock_service_cls
+    ):
+        entity_id = uuid.uuid4()
+        user = MagicMock(organization_id=uuid.uuid4(), id=uuid.uuid4())
+
+        mock_fetch.return_value = []
+        mock_service_cls.return_value._resolve_model_id.side_effect = ValueError(
+            "No embedding model"
+        )
+
+        with patch(
+            "rhesis.backend.app.services.embedding.generator.EmbeddingGenerator"
+        ) as mock_generator_cls:
+            _ensure_embeddings_for_entities(
+                MagicMock(),
+                entity_ids=[entity_id],
+                user=user,
+                embedded_entity="Test",
+            )
+            mock_generator_cls.assert_not_called()

--- a/tests/backend/tasks/test_embedding_graph_task.py
+++ b/tests/backend/tasks/test_embedding_graph_task.py
@@ -40,7 +40,7 @@ class TestEnsureEmbeddingsForEntities:
         user = MagicMock(organization_id=uuid.uuid4(), id=uuid.uuid4())
 
         mock_fetch.return_value = [MagicMock(entity_id=existing_id)]
-        mock_service_cls.return_value._resolve_model_id.return_value = "model-1"
+        mock_service_cls.return_value.resolve_model_id.return_value = "model-1"
 
         mock_generator = mock_generator_cls.return_value
         mock_generator.generate.return_value = {
@@ -72,7 +72,7 @@ class TestEnsureEmbeddingsForEntities:
         user = MagicMock(organization_id=uuid.uuid4(), id=uuid.uuid4())
 
         mock_fetch.return_value = []
-        mock_service_cls.return_value._resolve_model_id.side_effect = ValueError(
+        mock_service_cls.return_value.resolve_model_id.side_effect = ValueError(
             "No embedding model"
         )
 


### PR DESCRIPTION
## Purpose

Test sets often contain tests without stored embeddings (imports, legacy data, or embeddings never generated). Computing the cluster map on those sets produced an empty graph with little guidance. This change generates missing embeddings in the graph worker before building the 2D projection, and tightens the Clusters tab UX around when computation actually runs.

## What Changed

### Backend
- In `compute_test_set_graph_task`, call `_ensure_embeddings_for_entities` before `build_2d_graph`: for each test in the set without an active embedding, run `EmbeddingGenerator.generate` and persist the vector (same path as test create/update).
- Applies to test sets and sources (chunks) via the shared `_run_embedding_graph` pipeline.
- Logs backfill stats (generated / skipped empty text / failed); skips backfill when no embedding model is configured for the user.

### Frontend
- **Compute clusters** still queues the worker and waits for `GET …/embeddings/graph` to return `ready`.
- Opening the Clusters t when no graph exists yet shows the intro state instead of treating that as an in-progress computation.
- Updated empty-state copy in `EmbeddingTestsPanel` (no graph vs graph with no points).

### Tests
- `tests/backend/tasks/test_embedding_graph_task.py` — unit tests for embedding backfill helper.
- `useEmbeddingGraph` tests updated for clusters load/compute havior.

## Requirements

- Celery worker running for graph compute.
- User/org has an **embedding model** configured (Settings → Models).
- Tests need non-empty searchable text (`Test.to_searchable_text()`); otherwise they are skipped and may not appear on the map.

## Testing

- [ ] Test set with tests that have content but no embeddings → **Compute clusters** → embeddings created, scatter map appears (with Celery + embedding model).
- [ ] Test set with no graph yet → open **Clusters** → intro prompt, not a long “computing” state before clicking the button.
- [ ] Test set where tests have no embeddable text → compute finishes → empty-state message explains why.
- [ ] `uv run pytest ../../tests/backend/tasks/test_embeddi(from `apps/backend`)
- [ ] `npm test -- --testPathPatterns=useEmbeddingGraph` (from `apps/frontend`)
