### PR TITLE
Fix E2E tests: use Turbopack for dev server

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.1",
   "scripts": {
     "dev": "next dev --webpack -H 0.0.0.0 -p 3000",
+    "dev:turbo": "next dev --turbo -H 0.0.0.0 -p 3000",
     "build": "npm run clean && next build --webpack",
     "postinstall": "patch-package",
     "start": "next start -p ${PORT}",

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -100,7 +100,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run dev',
+    command: 'npm run dev:turbo',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,


### PR DESCRIPTION
## Purpose
E2E tests have been failing on all branches since #1779 changed the dev script from `--turbo` to `--webpack`. Webpack's slower compilation causes the Quick Start auth setup to timeout (30s) waiting for the `/dashboard` redirect — the page never finishes loading in time.

## What Changed
- Added `dev:turbo` script to `package.json` that uses Turbopack
- Updated `playwright.config.ts` to use `dev:turbo` for the E2E webServer

## Testing
- This should fix the E2E failures visible on main (run 26176505509) and PR #1783 (run 26176732396)