### PR TITLE
Fix experiment execution and version history UI

### DIFF
--- a/apps/chatbot/endpoint.py
+++ b/apps/chatbot/endpoint.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 
 from rhesis.sdk import RhesisClient, endpoint, observe
 from rhesis.sdk.async_utils import run_sync
+from rhesis.sdk.models.defaults import parse_model_id
 from rhesis.sdk.models.factory import get_model
 
 # Output mode type
@@ -66,6 +67,18 @@ class IntentClassification(BaseModel):
     )
 
 
+def _resolve_model_id(model_id: str) -> str:
+    """Resolve Rhesis system model placeholders to the chatbot's configured default."""
+    provider, _ = parse_model_id(model_id)
+    if provider == "rhesis":
+        logger.info(
+            f"Rhesis system model '{model_id}' resolved to "
+            f"chatbot default: {DEFAULT_GENERATION_MODEL}"
+        )
+        return DEFAULT_GENERATION_MODEL
+    return model_id
+
+
 def get_llm_model():
     """Get the configured language model using SDK factory."""
     try:
@@ -90,7 +103,8 @@ class ResponseGenerator:
         """Initialize with SDK model and use case."""
         if model:
             try:
-                self.model = get_model(model)
+                resolved = _resolve_model_id(model)
+                self.model = get_model(resolved)
             except Exception as e:
                 logger.error(f"Failed to initialize language model {model}: {str(e)}")
                 raise ValueError(f"Could not initialize language model {model}: {str(e)}")

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rhesis-app",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhesis-app",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "dependencies": {
         "@emotion/react": "^11",

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/components/VersionHistory.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/components/VersionHistory.tsx
@@ -301,11 +301,10 @@ export default function VersionHistory({
                 >
                   <span>
                     <Button
-                      component="span"
                       size="small"
                       startIcon={<PromoteIcon />}
                       disabled={!canPromote}
-                      onClick={e => {
+                      onClick={(e: React.MouseEvent) => {
                         e.stopPropagation();
                         onPromoteVersion(version.version);
                       }}


### PR DESCRIPTION
## Summary
- **fix(frontend):** Remove `component="span"` from the Promote button in version history so clicks are properly captured instead of toggling the accordion row
- **fix(chatbot):** Resolve Rhesis system model placeholders (`rhesis/rhesis-default`) to the chatbot's configured `DEFAULT_GENERATION_MODEL`, mirroring the backend's existing fallback. Fixes HTTP 500 errors when experiments use the default model identifier

## Test plan
- [ ] Verify the Promote button in version history opens the promote dialog without toggling the row
- [ ] Run an experiment with `rhesis/rhesis-default` as the model against the chatbot endpoint and confirm it resolves to the configured default