### PR TITLE
Fix dot-decimal notation on number parameter inputs

### DIFF
--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/components/TypedValueEditor.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/components/TypedValueEditor.tsx
@@ -84,7 +84,7 @@ export default function TypedValueEditor({
             );
           }}
           size="small"
-          inputProps={{ step: 1 }}
+          inputProps={{ step: 1, lang: 'en-US' }}
           helperText={helper}
         />
       );
@@ -103,7 +103,7 @@ export default function TypedValueEditor({
             );
           }}
           size="small"
-          inputProps={{ step: 'any' }}
+          inputProps={{ step: 'any', lang: 'en-US' }}
           helperText={helper}
         />
       );

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/parameter-schema-shared.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/parameter-schema-shared.tsx
@@ -539,7 +539,7 @@ export function DefaultValueEditor({
             );
           }}
           size="small"
-          inputProps={{ step: 1 }}
+          inputProps={{ step: 1, lang: 'en-US' }}
         />
       );
     }
@@ -560,7 +560,7 @@ export function DefaultValueEditor({
             );
           }}
           size="small"
-          inputProps={{ step: 'any' }}
+          inputProps={{ step: 'any', lang: 'en-US' }}
         />
       );
     }


### PR DESCRIPTION
## Summary
- Number inputs for parameters (e.g. temperature) displayed comma decimals (`0,7`) in browsers with European locales instead of dot decimals (`0.7`)
- Added `lang="en-US"` to all number `<input>` elements in experiment and project parameter editors to force consistent dot-decimal notation

## Test plan
- [ ] Open an experiment with a `number` parameter (e.g. temperature) in a browser set to a European locale (e.g. `de-DE`)
- [ ] Verify the input displays `0.7` not `0,7`
- [ ] Verify typing decimal values still works correctly
- [ ] Check the same behavior on the project parameter schema default value editors