### PR TITLE
Fix test set embedding visualization bugs

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
@@ -50,7 +50,9 @@ def _reduce_dimensions(X: np.ndarray, purpose: str) -> np.ndarray:
     max_neighbors = max(1, n_samples - 1)
 
     if purpose == "clustering":
-        n_components = max(2, min(50, n_samples - 1))
+        # n_components must be < n_samples; UMAP spectral init calls eigsh(k=n_components+1)
+        # so we cap at n_samples - 2 to satisfy k < N. Use random init to avoid eigsh entirely.
+        n_components = max(2, min(50, n_samples - 2)) if n_samples > 3 else 2
         n_neighbors = max(3, min(15, int(0.08 * n_samples)))
         n_neighbors = min(n_neighbors, max_neighbors)
         n_neighbors = max(2, n_neighbors)
@@ -62,7 +64,7 @@ def _reduce_dimensions(X: np.ndarray, purpose: str) -> np.ndarray:
     else:
         raise ValueError(f"Invalid purpose: {purpose}")
 
-    umap = UMAP(n_components=n_components, n_neighbors=n_neighbors, random_state=42)
+    umap = UMAP(n_components=n_components, n_neighbors=n_neighbors, random_state=42, init="random")
     return umap.fit_transform(X)
 
 
@@ -95,6 +97,20 @@ def _cluster_with_hdbscan(X: np.ndarray) -> tuple[np.ndarray, dict[int, np.ndarr
         centroids[int(cluster_id)] = X[mask].mean(axis=0)
 
     return cluster_ids, centroids
+
+
+_CLUSTER_LABEL_PROMPT = """\
+You name clusters of similar text items for a scatter-plot legend.
+
+Samples from one cluster:
+{samples}
+
+Reply with exactly ONE label for this cluster:
+- 1 to 3 words (short noun phrase describing the shared theme)
+- Plain text only: no markdown, bullets, numbering, asterisks, bold, quotes, or colons
+- No preamble, explanation, or multiple options — output the label alone
+
+Label:"""
 
 
 def _generate_cluster_labels(
@@ -145,7 +161,7 @@ def _generate_cluster_labels(
             continue
 
         combined_text = "\n".join(sample_text)
-        prompt = "Create a very short label for these items (1-2-3 words max): " + combined_text
+        prompt = _CLUSTER_LABEL_PROMPT.format(samples=combined_text)
 
         try:
             label = _model.generate(prompt)
@@ -269,7 +285,9 @@ def build_2d_graph(
     X = np.array([e.embedding for e in embeddings], dtype=np.float64)
 
     umap_50d = _reduce_dimensions(X, purpose="clustering")
-    umap_2d = _reduce_dimensions(X, purpose="visualization")
+    umap_2d = umap_50d if umap_50d.shape[1] == 2 else _reduce_dimensions(
+        umap_50d, purpose="visualization"
+        )
 
     cluster_ids, centroids = _cluster_with_hdbscan(umap_50d)
 

--- a/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/graph_builder.py
@@ -285,9 +285,11 @@ def build_2d_graph(
     X = np.array([e.embedding for e in embeddings], dtype=np.float64)
 
     umap_50d = _reduce_dimensions(X, purpose="clustering")
-    umap_2d = umap_50d if umap_50d.shape[1] == 2 else _reduce_dimensions(
-        umap_50d, purpose="visualization"
-        )
+    umap_2d = (
+        umap_50d
+        if umap_50d.shape[1] == 2
+        else _reduce_dimensions(umap_50d, purpose="visualization")
+    )
 
     cluster_ids, centroids = _cluster_with_hdbscan(umap_50d)
 

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingAtlasView.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingAtlasView.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useMemo, useRef } from 'react';
+import { Box } from '@mui/material';
 import { alpha, useTheme } from '@mui/material/styles';
 import {
   EmbeddingView,
@@ -13,6 +14,7 @@ import {
   graphToEmbeddingViewData,
   type EmbeddingViewData,
 } from '@/utils/embedding/graphToEmbeddingViewData';
+import { getEmbeddingViewSurfaceBg } from '@/utils/embedding/embeddingViewSurface';
 
 const VIEW_HEIGHT = 560;
 const HOVER_PIXEL_RADIUS = 8;
@@ -210,11 +212,23 @@ export default function EmbeddingAtlasView({
 
   if (!viewData) return null;
 
+  const surfaceBg = getEmbeddingViewSurfaceBg(theme);
+
   return (
-    <div
+    <Box
       ref={wrapperRef}
       onMouseMove={handleMouseMove}
       onMouseLeave={() => onPointHover?.(null)}
+      sx={{
+        width: '100%',
+        height: VIEW_HEIGHT,
+        bgcolor: surfaceBg,
+        '& > div': {
+          width: '100%',
+          height: '100%',
+          bgcolor: surfaceBg,
+        },
+      }}
     >
       <EmbeddingView
         data={{
@@ -229,7 +243,7 @@ export default function EmbeddingAtlasView({
         config={{
           autoLabelEnabled: false,
           mode: colorConfig.viewMode,
-          colorScheme: 'light',
+          colorScheme: theme.palette.mode === 'dark' ? 'dark' : 'light',
         }}
         tooltip={highlightedPoint}
         customTooltip={EmptyTooltip}
@@ -237,6 +251,6 @@ export default function EmbeddingAtlasView({
         querySelection={querySelection}
         onSelection={handleSelection}
       />
-    </div>
+    </Box>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingColorLegend.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingColorLegend.tsx
@@ -2,6 +2,7 @@
 
 import { Box, Stack, Typography } from '@mui/material';
 import type { EmbeddingColorLegendEntry } from '@/utils/embedding/embeddingColorBy';
+import { getEmbeddingViewSurfaceBg } from '@/utils/embedding/embeddingViewSurface';
 
 interface EmbeddingColorLegendProps {
   entries: EmbeddingColorLegendEntry[];
@@ -24,7 +25,7 @@ export default function EmbeddingColorLegend({
         overflow: 'auto',
         p: 1,
         borderRadius: theme => theme.shape.borderRadius,
-        bgcolor: 'background.paper',
+        bgcolor: theme => getEmbeddingViewSurfaceBg(theme),
         border: 1,
         borderColor: 'divider',
         boxShadow: 1,

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
@@ -382,7 +382,9 @@ export default function EmbeddingTestsPanel({
                 onClick={() => void computeGraph()}
                 disabled={isLoading || isComputing}
               >
-                {graph && hasPoints ? 'Recompute clusters' : 'Compute clusters'}
+                {graph && graph.points.length > 0
+                  ? 'Recompute clusters'
+                  : 'Compute clusters'}
               </Button>
             </Stack>
           </Stack>
@@ -443,23 +445,26 @@ export default function EmbeddingTestsPanel({
                 </Box>
               )}
 
-              {!isLoading && !isComputing && graph && !hasPoints && (
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    height: '100%',
-                    p: 2,
-                  }}
-                >
-                  <Alert severity="info" icon={<RefreshIcon />}>
-                    No tests could be embedded (empty content or missing
-                    embedding model). Add content to tests or configure an
-                    embedding model, then compute clusters again.
-                  </Alert>
-                </Box>
-              )}
+              {!isLoading &&
+                !isComputing &&
+                graph &&
+                graph.points.length === 0 && (
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      height: '100%',
+                      p: 2,
+                    }}
+                  >
+                    <Alert severity="info" icon={<RefreshIcon />}>
+                      No tests could be embedded (empty content or missing
+                      embedding model). Add content to tests or configure an
+                      embedding model, then compute clusters again.
+                    </Alert>
+                  </Box>
+                )}
 
               {!isLoading && !isComputing && !graph && (
                 <Box

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
@@ -8,7 +8,6 @@ import {
   Box,
   Button,
   Card,
-  CardContent,
   Chip,
   CircularProgress,
   FormControl,
@@ -38,6 +37,7 @@ import {
   getEmbeddingChartColors,
   type EmbeddingColorBy,
 } from '@/utils/embedding/embeddingColorBy';
+import { getEmbeddingViewSurfaceBg } from '@/utils/embedding/embeddingViewSurface';
 import TestSetTestsGrid from './TestSetTestsGrid';
 import EmbeddingColorLegend from './EmbeddingColorLegend';
 
@@ -60,8 +60,8 @@ const EmbeddingAtlasView = dynamic(() => import('./EmbeddingAtlasView'), {
 const PANEL_HEIGHT = 560;
 const HOVER_LIST_WIDTH = '38%';
 
-const LIST_TAB = 0;
-const CLUSTERS_TAB = 1;
+const LIST_VIEW_TAB = 0;
+const CLUSTER_VIEW_TAB = 1;
 
 interface EmbeddingTestsPanelProps {
   testSetId: string;
@@ -76,8 +76,8 @@ export default function EmbeddingTestsPanel({
 }: EmbeddingTestsPanelProps) {
   const theme = useTheme();
   const router = useRouter();
-  const [activeTab, setActiveTab] = useState(LIST_TAB);
-  const clustersActive = activeTab === CLUSTERS_TAB;
+  const [activeTab, setActiveTab] = useState(LIST_VIEW_TAB);
+  const clustersActive = activeTab === CLUSTER_VIEW_TAB;
 
   const { graph, isLoading, isComputing, error, computeGraph } =
     useEmbeddingGraph(testSetId, sessionToken, { enabled: clustersActive });
@@ -232,381 +232,371 @@ export default function EmbeddingTestsPanel({
   );
 
   return (
-    <Card elevation={2} sx={{ mb: 4 }}>
-      <Tabs
-        value={activeTab}
-        onChange={(_, tabIndex: number) => setActiveTab(tabIndex)}
-        variant="fullWidth"
-        aria-label="Tests view"
-        sx={{
-          minHeight: 64,
-          bgcolor: 'action.hover',
-          borderBottom: 1,
-          borderColor: 'divider',
-          '& .MuiTabs-indicator': {
-            height: 3,
-          },
-          '& .MuiTab-root': {
-            minHeight: 64,
-            py: 2,
-            fontSize: theme => theme.typography.body1.fontSize,
-            fontWeight: 600,
-            textTransform: 'none',
-            color: 'text.secondary',
-            gap: 1,
-            '&.Mui-selected': {
-              color: 'primary.main',
-              bgcolor: 'background.paper',
-            },
-          },
-        }}
-      >
-        <Tab
-          label="List"
-          icon={<ViewListIcon sx={{ fontSize: 26 }} />}
-          iconPosition="start"
-        />
-        <Tab
-          label="Clusters"
-          icon={<BubbleChartOutlinedIcon sx={{ fontSize: 26 }} />}
-          iconPosition="start"
-        />
-      </Tabs>
+    <Card
+      elevation={2}
+      sx={{
+        mb: 4,
+        overflow: 'visible',
+        bgcolor: theme =>
+          activeTab === CLUSTER_VIEW_TAB && theme.palette.mode === 'dark'
+            ? getEmbeddingViewSurfaceBg(theme)
+            : undefined,
+      }}
+    >
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs
+          value={activeTab}
+          onChange={(_, tabIndex: number) => setActiveTab(tabIndex)}
+          aria-label="Tests view"
+        >
+          <Tab
+            label="List View"
+            icon={<ViewListIcon fontSize="small" />}
+            iconPosition="start"
+          />
+          <Tab
+            label="Cluster View"
+            icon={<BubbleChartOutlinedIcon fontSize="small" />}
+            iconPosition="start"
+          />
+        </Tabs>
+      </Box>
 
-      <CardContent sx={{ pt: 2.5, overflow: 'visible' }}>
-        {activeTab === LIST_TAB && (
-          <Box role="tabpanel" sx={{ width: '100%', minHeight: 400 }}>
-            <TestSetTestsGrid
-              testSetId={testSetId}
-              sessionToken={sessionToken}
-              testSetType={testSetType}
-              embedded
-            />
-          </Box>
-        )}
+      {activeTab === LIST_VIEW_TAB && (
+        <Box sx={{ p: 2.5, width: '100%', minHeight: 400 }}>
+          <TestSetTestsGrid
+            testSetId={testSetId}
+            sessionToken={sessionToken}
+            testSetType={testSetType}
+            embedded
+          />
+        </Box>
+      )}
 
-        {activeTab === CLUSTERS_TAB && (
-          <Box role="tabpanel">
+      {activeTab === CLUSTER_VIEW_TAB && (
+        <Box
+          sx={{
+            p: 2.5,
+            bgcolor: theme => getEmbeddingViewSurfaceBg(theme),
+          }}
+        >
+          <Stack
+            direction="row"
+            alignItems="center"
+            justifyContent="space-between"
+            spacing={2}
+            sx={{ mb: 2 }}
+            flexWrap="wrap"
+            useFlexGap
+          >
             <Stack
               direction="row"
               alignItems="center"
-              justifyContent="space-between"
               spacing={2}
-              sx={{ mb: 2 }}
               flexWrap="wrap"
               useFlexGap
             >
-              <Stack
-                direction="row"
-                alignItems="center"
-                spacing={2}
-                flexWrap="wrap"
-                useFlexGap
-              >
-                <BetaBadge />
-                {showChart && (
-                  <FormControl size="small" sx={{ minWidth: 140 }}>
-                    <InputLabel id="embedding-color-by-label">
-                      Color by
-                    </InputLabel>
-                    <Select
-                      labelId="embedding-color-by-label"
-                      label="Color by"
-                      value={colorBy}
-                      onChange={handleColorByChange}
-                    >
-                      {EMBEDDING_COLOR_BY_OPTIONS.map(opt => (
-                        <MenuItem key={opt.value} value={opt.value}>
-                          {opt.label}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                )}
-              </Stack>
-              <Stack
-                direction="row"
-                alignItems="center"
-                spacing={2}
-                flexWrap="wrap"
-                useFlexGap
-              >
-                {graph?.computed_at && (
-                  <Typography variant="body2" color="text.secondary">
-                    Last computed{' '}
-                    {formatDistanceToNow(new Date(graph.computed_at), {
-                      addSuffix: true,
-                    })}
-                  </Typography>
-                )}
-                <Button
-                  variant="contained"
-                  startIcon={
-                    isComputing ? (
-                      <CircularProgress size={18} color="inherit" />
-                    ) : (
-                      <AutoAwesomeOutlinedIcon />
-                    )
-                  }
-                  onClick={() => void computeGraph()}
-                  disabled={isLoading || isComputing}
-                >
-                  {graph && hasPoints
-                    ? 'Recompute clusters'
-                    : 'Compute clusters'}
-                </Button>
-              </Stack>
+              <BetaBadge />
+              {showChart && (
+                <FormControl size="small" sx={{ minWidth: 140 }}>
+                  <InputLabel id="embedding-color-by-label">
+                    Color by
+                  </InputLabel>
+                  <Select
+                    labelId="embedding-color-by-label"
+                    label="Color by"
+                    value={colorBy}
+                    onChange={handleColorByChange}
+                  >
+                    {EMBEDDING_COLOR_BY_OPTIONS.map(opt => (
+                      <MenuItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
             </Stack>
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={2}
+              flexWrap="wrap"
+              useFlexGap
+            >
+              {graph?.computed_at && (
+                <Typography variant="body2" color="text.secondary">
+                  Last computed{' '}
+                  {formatDistanceToNow(new Date(graph.computed_at), {
+                    addSuffix: true,
+                  })}
+                </Typography>
+              )}
+              <Button
+                variant="contained"
+                startIcon={
+                  isComputing ? (
+                    <CircularProgress size={18} color="inherit" />
+                  ) : (
+                    <AutoAwesomeOutlinedIcon />
+                  )
+                }
+                onClick={() => void computeGraph()}
+                disabled={isLoading || isComputing}
+              >
+                {graph && hasPoints ? 'Recompute clusters' : 'Compute clusters'}
+              </Button>
+            </Stack>
+          </Stack>
 
-            {error && (
-              <Alert severity="error" sx={{ mb: 2 }}>
-                {error}
-              </Alert>
-            )}
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {error}
+            </Alert>
+          )}
 
+          <Box
+            sx={{
+              height: PANEL_HEIGHT,
+              position: 'relative',
+              borderRadius: theme => theme.shape.borderRadius,
+              border: theme => (theme.palette.mode === 'dark' ? 0 : 1),
+              borderStyle: 'solid',
+              borderColor: 'divider',
+              overflow: 'hidden',
+              bgcolor: theme => getEmbeddingViewSurfaceBg(theme),
+            }}
+          >
             <Box
               sx={{
-                height: PANEL_HEIGHT,
-                position: 'relative',
-                borderRadius: theme => theme.shape.borderRadius,
-                border: 1,
-                borderColor: 'divider',
+                height: '100%',
                 overflow: 'hidden',
-                bgcolor: 'background.default',
+                position: 'relative',
               }}
             >
-              <Box
-                sx={{
-                  height: '100%',
-                  overflow: 'hidden',
-                  position: 'relative',
-                  pr: listVisible ? HOVER_LIST_WIDTH : 0,
-                  transition: theme =>
-                    theme.transitions.create('padding-right', {
-                      duration: theme.transitions.duration.short,
-                    }),
-                }}
-              >
-                {isLoading && (
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      height: '100%',
-                    }}
-                  >
-                    <CircularProgress />
-                  </Box>
-                )}
+              {isLoading && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100%',
+                  }}
+                >
+                  <CircularProgress />
+                </Box>
+              )}
 
-                {!isLoading && isComputing && (
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      height: '100%',
-                      gap: 2,
-                    }}
-                  >
-                    <CircularProgress />
-                    <Typography variant="body2" color="text.secondary">
-                      Computing clusters and labels…
-                    </Typography>
-                  </Box>
-                )}
-
-                {!isLoading && !isComputing && graph && !hasPoints && (
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      height: '100%',
-                      p: 2,
-                    }}
-                  >
-                    <Alert severity="info" icon={<RefreshIcon />}>
-                      No tests could be embedded (empty content or missing
-                      embedding model). Add content to tests or configure an
-                      embedding model, then compute clusters again.
-                    </Alert>
-                  </Box>
-                )}
-
-                {!isLoading && !isComputing && !graph && (
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      height: '100%',
-                      p: 2,
-                    }}
-                  >
-                    <Alert severity="info">
-                      Visualize how tests cluster in embedding space. Click
-                      &quot;Compute clusters&quot; to generate embeddings for
-                      tests that need them, then build a 2D projection with
-                      automatic cluster labels.
-                    </Alert>
-                  </Box>
-                )}
-
-                {showChart && graph && colorConfig && (
-                  <>
-                    <EmbeddingAtlasView
-                      graph={graph}
-                      colorConfig={colorConfig}
-                      highlightedEntityId={hoveredEntityId}
-                      onPointSelect={handlePointSelect}
-                      onPointHover={handlePointHover}
-                    />
-                    <EmbeddingColorLegend entries={colorConfig.legend} />
-                  </>
-                )}
-              </Box>
-
-              {/* Tests list — slides in when hovering chart points */}
-              <Box
-                onMouseLeave={() => setListHoveredId(null)}
-                sx={{
-                  position: 'absolute',
-                  top: 0,
-                  right: 0,
-                  bottom: 0,
-                  width: listVisible ? HOVER_LIST_WIDTH : 0,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  overflow: 'hidden',
-                  borderLeft: listVisible ? 1 : 0,
-                  borderColor: 'divider',
-                  bgcolor: 'background.paper',
-                  zIndex: 1,
-                  pointerEvents: listVisible ? 'auto' : 'none',
-                  transition: theme =>
-                    theme.transitions.create('width', {
-                      duration: theme.transitions.duration.short,
-                    }),
-                }}
-              >
+              {!isLoading && isComputing && (
                 <Box
                   sx={{
                     display: 'flex',
                     flexDirection: 'column',
-                    overflow: 'hidden',
+                    alignItems: 'center',
+                    justifyContent: 'center',
                     height: '100%',
-                    minWidth: HOVER_LIST_WIDTH,
-                    pl: 2,
-                    pr: 1,
+                    gap: 2,
                   }}
                 >
-                  <Typography
-                    variant="subtitle2"
-                    color="text.secondary"
-                    sx={{ py: 1, flexShrink: 0 }}
-                  >
-                    Tests{tests.length > 0 ? ` · ${tests.length}` : ''}
+                  <CircularProgress />
+                  <Typography variant="body2" color="text.secondary">
+                    Computing clusters and labels…
                   </Typography>
+                </Box>
+              )}
 
-                  {testsLoading && (
-                    <Box
-                      sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}
-                    >
-                      <CircularProgress size={24} />
-                    </Box>
+              {!isLoading && !isComputing && graph && !hasPoints && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100%',
+                    p: 2,
+                  }}
+                >
+                  <Alert severity="info" icon={<RefreshIcon />}>
+                    No tests could be embedded (empty content or missing
+                    embedding model). Add content to tests or configure an
+                    embedding model, then compute clusters again.
+                  </Alert>
+                </Box>
+              )}
+
+              {!isLoading && !isComputing && !graph && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100%',
+                    p: 2,
+                  }}
+                >
+                  <Alert severity="info">
+                    Visualize how tests cluster in embedding space. Click
+                    &quot;Compute clusters&quot; to generate embeddings for
+                    tests that need them, then build a 2D projection with
+                    automatic cluster labels.
+                  </Alert>
+                </Box>
+              )}
+
+              {showChart && graph && colorConfig && (
+                <>
+                  <EmbeddingAtlasView
+                    graph={graph}
+                    colorConfig={colorConfig}
+                    highlightedEntityId={hoveredEntityId}
+                    onPointSelect={handlePointSelect}
+                    onPointHover={handlePointHover}
+                  />
+                  {colorBy !== 'cluster' && (
+                    <EmbeddingColorLegend entries={colorConfig.legend} />
                   )}
+                </>
+              )}
+            </Box>
 
-                  {testsError && (
-                    <Alert severity="error" sx={{ mx: 0 }}>
-                      {testsError}
-                    </Alert>
-                  )}
+            {/* Tests list — slides in when hovering chart points */}
+            <Box
+              onMouseLeave={() => setListHoveredId(null)}
+              sx={{
+                position: 'absolute',
+                top: 0,
+                right: 0,
+                bottom: 0,
+                width: listVisible ? HOVER_LIST_WIDTH : 0,
+                display: 'flex',
+                flexDirection: 'column',
+                overflow: 'hidden',
+                borderLeft: listVisible
+                  ? theme => (theme.palette.mode === 'dark' ? 0 : 1)
+                  : 0,
+                borderColor: 'divider',
+                bgcolor: theme => getEmbeddingViewSurfaceBg(theme),
+                zIndex: 1,
+                pointerEvents: listVisible ? 'auto' : 'none',
+                transition: theme =>
+                  theme.transitions.create('width', {
+                    duration: theme.transitions.duration.short,
+                  }),
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  overflow: 'hidden',
+                  height: '100%',
+                  minWidth: HOVER_LIST_WIDTH,
+                  pl: 2,
+                  pr: 1,
+                }}
+              >
+                <Typography
+                  variant="subtitle2"
+                  color="text.secondary"
+                  sx={{ py: 1, flexShrink: 0 }}
+                >
+                  Tests{tests.length > 0 ? ` · ${tests.length}` : ''}
+                </Typography>
 
-                  <Box ref={listRef} sx={{ overflow: 'auto', flex: 1 }}>
-                    {sortedTests.map(test => {
-                      const isHighlighted = hoveredEntityId === test.id;
-                      const content = getTestDisplayContent(test);
-                      return (
-                        <Box
-                          key={test.id}
-                          ref={el =>
-                            setItemRef(test.id, el as HTMLElement | null)
-                          }
-                          onMouseEnter={() => setListHoveredId(test.id)}
-                          onClick={() => router.push(`/tests/${test.id}`)}
-                          sx={{
-                            p: '8px 10px',
-                            mb: '3px',
-                            borderRadius: theme => theme.shape.borderRadius,
-                            cursor: 'pointer',
-                            border: '1px solid',
-                            borderColor: isHighlighted
-                              ? 'primary.main'
-                              : 'transparent',
+                {testsLoading && (
+                  <Box
+                    sx={{ display: 'flex', justifyContent: 'center', pt: 4 }}
+                  >
+                    <CircularProgress size={24} />
+                  </Box>
+                )}
+
+                {testsError && (
+                  <Alert severity="error" sx={{ mx: 0 }}>
+                    {testsError}
+                  </Alert>
+                )}
+
+                <Box ref={listRef} sx={{ overflow: 'auto', flex: 1 }}>
+                  {sortedTests.map(test => {
+                    const isHighlighted = hoveredEntityId === test.id;
+                    const content = getTestDisplayContent(test);
+                    return (
+                      <Box
+                        key={test.id}
+                        ref={el =>
+                          setItemRef(test.id, el as HTMLElement | null)
+                        }
+                        onMouseEnter={() => setListHoveredId(test.id)}
+                        onClick={() => router.push(`/tests/${test.id}`)}
+                        sx={{
+                          p: '8px 10px',
+                          mb: '3px',
+                          borderRadius: theme => theme.shape.borderRadius,
+                          cursor: 'pointer',
+                          border: '1px solid',
+                          borderColor: isHighlighted
+                            ? 'primary.main'
+                            : 'transparent',
+                          bgcolor: isHighlighted
+                            ? 'action.selected'
+                            : 'transparent',
+                          transition:
+                            'background-color 0.1s, border-color 0.1s',
+                          '&:hover': {
                             bgcolor: isHighlighted
                               ? 'action.selected'
-                              : 'transparent',
-                            transition:
-                              'background-color 0.1s, border-color 0.1s',
-                            '&:hover': {
-                              bgcolor: isHighlighted
-                                ? 'action.selected'
-                                : 'action.hover',
-                            },
+                              : 'action.hover',
+                          },
+                        }}
+                      >
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            fontSize: 12,
+                            lineHeight: 1.4,
+                            mb: 0.5,
+                            color: 'text.primary',
                           }}
                         >
-                          <Typography
-                            variant="body2"
-                            sx={{
-                              fontSize: 12,
-                              lineHeight: 1.4,
-                              mb: 0.5,
-                              color: 'text.primary',
-                            }}
-                          >
-                            {content.length > 120
-                              ? `${content.slice(0, 120)}…`
-                              : content}
-                          </Typography>
-                          <Stack direction="row" spacing={0.5} flexWrap="wrap">
-                            {test.behavior?.name && (
-                              <Chip
-                                label={test.behavior.name}
-                                size="small"
-                                variant="outlined"
-                                sx={{ height: 18, fontSize: 10 }}
-                              />
-                            )}
-                            {test.category?.name && (
-                              <Chip
-                                label={test.category.name}
-                                size="small"
-                                variant="outlined"
-                                sx={{ height: 18, fontSize: 10 }}
-                              />
-                            )}
-                            {test.topic?.name && (
-                              <Chip
-                                label={test.topic.name}
-                                size="small"
-                                variant="outlined"
-                                sx={{ height: 18, fontSize: 10 }}
-                              />
-                            )}
-                          </Stack>
-                        </Box>
-                      );
-                    })}
-                  </Box>
+                          {content.length > 120
+                            ? `${content.slice(0, 120)}…`
+                            : content}
+                        </Typography>
+                        <Stack direction="row" spacing={0.5} flexWrap="wrap">
+                          {test.behavior?.name && (
+                            <Chip
+                              label={test.behavior.name}
+                              size="small"
+                              variant="outlined"
+                              sx={{ height: 18, fontSize: 10 }}
+                            />
+                          )}
+                          {test.category?.name && (
+                            <Chip
+                              label={test.category.name}
+                              size="small"
+                              variant="outlined"
+                              sx={{ height: 18, fontSize: 10 }}
+                            />
+                          )}
+                          {test.topic?.name && (
+                            <Chip
+                              label={test.topic.name}
+                              size="small"
+                              variant="outlined"
+                              sx={{ height: 18, fontSize: 10 }}
+                            />
+                          )}
+                        </Stack>
+                      </Box>
+                    );
+                  })}
                 </Box>
               </Box>
             </Box>
           </Box>
-        )}
-      </CardContent>
+        </Box>
+      )}
     </Card>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
+import type { GridFilterModel } from '@mui/x-data-grid';
 import {
   Alert,
   Box,
@@ -29,6 +30,9 @@ import { formatDistanceToNow } from 'date-fns';
 import { BetaBadge } from '@/components/common/BetaBadge';
 import { useEmbeddingGraph } from '@/hooks/useEmbeddingGraph';
 import { getTestDisplayContent } from '@/app/(protected)/tests/components/test-grid-helpers';
+import TestsQuickFilterField from '@/app/(protected)/tests/components/TestsQuickFilterField';
+import { combineTestFiltersToOData } from '@/utils/odata-filter';
+import { filterScatter2DGraph } from '@/utils/embedding/filterScatter2DGraph';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import type { TestDetail } from '@/utils/api-client/interfaces/tests';
 import {
@@ -89,12 +93,18 @@ export default function EmbeddingTestsPanel({
   const [listHoveredId, setListHoveredId] = useState<string | null>(null);
   const [listVisible, setListVisible] = useState(false);
   const [colorBy, setColorBy] = useState<EmbeddingColorBy>('cluster');
+  const [filterModel, setFilterModel] = useState<GridFilterModel>({
+    items: [],
+  });
+
+  const handleFilterModelChange = useCallback((model: GridFilterModel) => {
+    setFilterModel(model);
+    setChartHoveredId(null);
+    setListHoveredId(null);
+  }, []);
   const hoveredEntityId = listHoveredId ?? chartHoveredId;
   const itemRefs = useRef<Map<string, HTMLElement>>(new Map());
   const listRef = useRef<HTMLDivElement>(null);
-
-  const hasPoints = (graph?.points.length ?? 0) > 0;
-  const showChart = hasPoints && !isComputing;
 
   useEffect(() => {
     setListVisible(false);
@@ -107,6 +117,7 @@ export default function EmbeddingTestsPanel({
 
     let cancelled = false;
     const PAGE_SIZE = 100;
+    const filterString = combineTestFiltersToOData(filterModel);
 
     async function fetchAll() {
       setTestsLoading(true);
@@ -120,6 +131,7 @@ export default function EmbeddingTestsPanel({
           const res = await client.getTestSetTests(testSetId, {
             skip,
             limit: PAGE_SIZE,
+            ...(filterString && { $filter: filterString }),
           });
           if (cancelled) return;
           accumulated.push(...res.data);
@@ -147,26 +159,39 @@ export default function EmbeddingTestsPanel({
     return () => {
       cancelled = true;
     };
-  }, [clustersActive, sessionToken, testSetId]);
+  }, [clustersActive, sessionToken, testSetId, filterModel]);
 
   const embeddingColors = useMemo(
     () => getEmbeddingChartColors(theme),
     [theme]
   );
 
+  const filteredEntityIds = useMemo((): Set<string> => {
+    return new Set(tests.map(t => String(t.id)));
+  }, [tests]);
+
+  const displayGraph = useMemo(() => {
+    if (!graph) return null;
+    const needsFilter = graph.points.some(
+      p => !filteredEntityIds.has(p.entity_id)
+    );
+    if (!needsFilter) return graph;
+    return filterScatter2DGraph(graph, filteredEntityIds);
+  }, [graph, filteredEntityIds]);
+
   const colorConfig = useMemo(() => {
-    if (!graph || graph.points.length === 0) return null;
+    if (!displayGraph || displayGraph.points.length === 0) return null;
     return buildEmbeddingChartColorConfig(
-      graph,
+      displayGraph,
       tests,
       colorBy,
       embeddingColors
     );
-  }, [graph, tests, colorBy, embeddingColors]);
+  }, [displayGraph, tests, colorBy, embeddingColors]);
 
   const sortedTests = useMemo(() => {
-    if (!graph || graph.points.length === 0) return tests;
-    const pointMap = new Map(graph.points.map(p => [p.entity_id, p]));
+    if (!displayGraph || displayGraph.points.length === 0) return tests;
+    const pointMap = new Map(displayGraph.points.map(p => [p.entity_id, p]));
 
     const metadataKey = (test: TestDetail): string => {
       switch (colorBy) {
@@ -196,7 +221,16 @@ export default function EmbeddingTestsPanel({
       }
       return pa.x - pb.x;
     });
-  }, [tests, graph, colorBy]);
+  }, [tests, displayGraph, colorBy]);
+
+  const hasPoints = (displayGraph?.points.length ?? 0) > 0;
+  const showChart = hasPoints && !isComputing;
+  const hasActiveFilters =
+    filterModel.items.length > 0 &&
+    !testsLoading &&
+    graph != null &&
+    graph.points.length > 0 &&
+    !hasPoints;
 
   const handleColorByChange = useCallback((event: SelectChangeEvent) => {
     setColorBy(event.target.value as EmbeddingColorBy);
@@ -324,6 +358,10 @@ export default function EmbeddingTestsPanel({
               flexWrap="wrap"
               useFlexGap
             >
+              <TestsQuickFilterField
+                filterModel={filterModel}
+                onFilterModelChange={handleFilterModelChange}
+              />
               {graph?.computed_at && (
                 <Typography variant="body2" color="text.secondary">
                   Last computed{' '}
@@ -442,20 +480,40 @@ export default function EmbeddingTestsPanel({
                 </Box>
               )}
 
-              {showChart && graph && colorConfig && (
-                <>
-                  <EmbeddingAtlasView
-                    graph={graph}
-                    colorConfig={colorConfig}
-                    highlightedEntityId={hoveredEntityId}
-                    onPointSelect={handlePointSelect}
-                    onPointHover={handlePointHover}
-                  />
-                  {colorBy !== 'cluster' && (
-                    <EmbeddingColorLegend entries={colorConfig.legend} />
-                  )}
-                </>
+              {hasActiveFilters && (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100%',
+                    p: 2,
+                  }}
+                >
+                  <Alert severity="info">
+                    No tests match the current search or filters. Adjust filters
+                    or clear search to see clusters.
+                  </Alert>
+                </Box>
               )}
+
+              {showChart &&
+                displayGraph &&
+                colorConfig &&
+                !hasActiveFilters && (
+                  <>
+                    <EmbeddingAtlasView
+                      graph={displayGraph}
+                      colorConfig={colorConfig}
+                      highlightedEntityId={hoveredEntityId}
+                      onPointSelect={handlePointSelect}
+                      onPointHover={handlePointHover}
+                    />
+                    {colorBy !== 'cluster' && (
+                      <EmbeddingColorLegend entries={colorConfig.legend} />
+                    )}
+                  </>
+                )}
             </Box>
 
             {/* Tests list — slides in when hovering chart points */}
@@ -499,7 +557,10 @@ export default function EmbeddingTestsPanel({
                   color="text.secondary"
                   sx={{ py: 1, flexShrink: 0 }}
                 >
-                  Tests{tests.length > 0 ? ` · ${tests.length}` : ''}
+                  Tests
+                  {tests.length > 0
+                    ? ` · ${tests.length}${graph && tests.length < graph.points.length ? ` of ${graph.points.length}` : ''}`
+                    : ''}
                 </Typography>
 
                 {testsLoading && (

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
@@ -6,6 +6,7 @@ import {
   GridRowParams,
   GridRowSelectionModel,
   GridPaginationModel,
+  GridFilterModel,
 } from '@mui/x-data-grid';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
 import { Typography, Box, Alert, Chip } from '@mui/material';
@@ -21,6 +22,8 @@ import {
   renderTestContentCell,
 } from '@/app/(protected)/tests/components/test-grid-helpers';
 import { isMultiTurnTest } from '@/constants/test-types';
+import { combineTestFiltersToOData } from '@/utils/odata-filter';
+import { formatDate } from '@/utils/date';
 
 interface TestSetTestsGridProps {
   sessionToken: string;
@@ -46,7 +49,10 @@ export default function TestSetTestsGrid({
   const [totalCount, setTotalCount] = useState<number>(0);
   const [paginationModel, setPaginationModel] = useState({
     page: 0,
-    pageSize: 50,
+    pageSize: 25,
+  });
+  const [filterModel, setFilterModel] = useState<GridFilterModel>({
+    items: [],
   });
 
   // Data fetching function
@@ -61,11 +67,14 @@ export default function TestSetTestsGrid({
       const clientFactory = new ApiClientFactory(sessionToken);
       const testSetsClient = clientFactory.getTestSetsClient();
 
+      const filterString = combineTestFiltersToOData(filterModel);
+
       const response = await testSetsClient.getTestSetTests(testSetId, {
         skip: paginationModel.page * paginationModel.pageSize,
         limit: paginationModel.pageSize,
-        sort_by: 'topic',
-        sort_order: 'asc',
+        sort_by: 'created_at',
+        sort_order: 'desc',
+        ...(filterString && { $filter: filterString }),
       });
 
       if (isMounted.current) {
@@ -83,7 +92,13 @@ export default function TestSetTestsGrid({
         setLoading(false);
       }
     }
-  }, [sessionToken, testSetId, paginationModel.page, paginationModel.pageSize]);
+  }, [
+    sessionToken,
+    testSetId,
+    paginationModel.page,
+    paginationModel.pageSize,
+    filterModel,
+  ]);
 
   useEffect(() => {
     isMounted.current = true;
@@ -100,19 +115,27 @@ export default function TestSetTestsGrid({
     []
   );
 
+  const handleFilterModelChange = useCallback((newModel: GridFilterModel) => {
+    setFilterModel(newModel);
+    setPaginationModel(prev => ({ ...prev, page: 0 }));
+  }, []);
+
   const columns: GridColDef[] = React.useMemo(
     () => [
       {
         field: 'prompt.content',
         headerName: isMultiTurnTest(testSetType) ? 'Goal' : 'Content',
         flex: 3,
+        filterable: true,
         valueGetter: getTestContentValue,
         renderCell: renderTestContentCell,
       },
       {
-        field: 'behavior',
+        field: 'behavior.name',
         headerName: 'Behavior',
         flex: 1,
+        filterable: true,
+        valueGetter: (value, row) => row.behavior?.name || '',
         renderCell: params => {
           const behaviorName = params.row.behavior?.name;
           if (!behaviorName) return null;
@@ -128,9 +151,11 @@ export default function TestSetTestsGrid({
         },
       },
       {
-        field: 'topic',
+        field: 'topic.name',
         headerName: 'Topic',
         flex: 1,
+        filterable: true,
+        valueGetter: (value, row) => row.topic?.name || '',
         renderCell: params => {
           const topicName = params.row.topic?.name;
           if (!topicName) return null;
@@ -146,9 +171,11 @@ export default function TestSetTestsGrid({
         },
       },
       {
-        field: 'category',
+        field: 'category.name',
         headerName: 'Category',
         flex: 1,
+        filterable: true,
+        valueGetter: (value, row) => row.category?.name || '',
         renderCell: params => {
           const categoryName = params.row.category?.name;
           if (!categoryName) return null;
@@ -167,6 +194,7 @@ export default function TestSetTestsGrid({
         field: 'test_type.type_value',
         headerName: 'Test Type',
         flex: 1,
+        filterable: true,
         valueGetter: (value, row) => row.test_type?.type_value || '',
         renderCell: params => {
           const testType = params.row.test_type?.type_value;
@@ -176,11 +204,24 @@ export default function TestSetTestsGrid({
         },
       },
       {
+        field: 'created_at',
+        headerName: 'Created',
+        flex: 0.8,
+        minWidth: 120,
+        filterable: false,
+        renderCell: params => (
+          <Typography variant="body2" color="text.secondary">
+            {formatDate(params.row.created_at)}
+          </Typography>
+        ),
+      },
+      {
         field: 'tags',
         headerName: 'Tags',
         flex: 1.5,
         minWidth: 140,
         sortable: false,
+        filterable: true,
         renderCell: params => {
           const test = params.row;
           if (!test.tags || test.tags.length === 0) {
@@ -331,7 +372,12 @@ export default function TestSetTestsGrid({
         serverSidePagination={true}
         totalRows={totalCount}
         pageSizeOptions={[10, 25, 50]}
+        serverSideFiltering={true}
+        filterModel={filterModel}
+        onFilterModelChange={handleFilterModelChange}
+        showToolbar={true}
         disablePaperWrapper={true}
+        persistState
       />
     </>
   );

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
@@ -377,7 +377,7 @@ export default function TestSetTestsGrid({
         onFilterModelChange={handleFilterModelChange}
         showToolbar={true}
         disablePaperWrapper={true}
-        persistState
+        persistState={!embedded}
       />
     </>
   );

--- a/apps/frontend/src/app/(protected)/tests/components/TestsQuickFilterField.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsQuickFilterField.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { IconButton, InputAdornment, TextField } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
+import SearchIcon from '@mui/icons-material/Search';
+import ClearIcon from '@mui/icons-material/Clear';
+import type { GridFilterModel } from '@mui/x-data-grid';
+
+interface TestsQuickFilterFieldProps {
+  filterModel: GridFilterModel;
+  onFilterModelChange: (model: GridFilterModel) => void;
+  sx?: SxProps<Theme>;
+}
+
+/** Debounced quick search matching the main Tests grid filter fields. */
+export default function TestsQuickFilterField({
+  filterModel,
+  onFilterModelChange,
+  sx,
+}: TestsQuickFilterFieldProps) {
+  const quickFilterInputRef = useRef<HTMLInputElement | null>(null);
+  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const onFilterModelChangeRef = useRef(onFilterModelChange);
+  const filterModelRef = useRef(filterModel);
+
+  useEffect(() => {
+    onFilterModelChangeRef.current = onFilterModelChange;
+    filterModelRef.current = filterModel;
+  });
+
+  useEffect(() => {
+    if (!quickFilterInputRef.current) return;
+
+    const quickFilterItem = filterModel.items.find(
+      item => item.field === 'quickFilter' || item.field === '__quickFilter__'
+    );
+    const newValue = quickFilterItem?.value || '';
+
+    if (
+      quickFilterInputRef.current.value !== newValue &&
+      !debounceTimerRef.current
+    ) {
+      quickFilterInputRef.current.value =
+        typeof newValue === 'string' ? newValue : String(newValue ?? '');
+    }
+  }, [filterModel]);
+
+  const handleQuickFilterChange = useCallback(() => {
+    const value = quickFilterInputRef.current?.value || '';
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null;
+
+      if (!onFilterModelChangeRef.current || !filterModelRef.current) return;
+
+      const otherFilters = filterModelRef.current.items.filter(
+        item => item.field !== 'quickFilter' && item.field !== '__quickFilter__'
+      );
+
+      onFilterModelChangeRef.current({
+        ...filterModelRef.current,
+        items: value
+          ? [
+              ...otherFilters,
+              { field: 'quickFilter', operator: 'contains', value },
+            ]
+          : otherFilters,
+      });
+    }, 300);
+  }, []);
+
+  const handleQuickFilterClear = useCallback(() => {
+    if (quickFilterInputRef.current) {
+      quickFilterInputRef.current.value = '';
+    }
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+
+    if (!onFilterModelChangeRef.current || !filterModelRef.current) return;
+
+    const otherFilters = filterModelRef.current.items.filter(
+      item => item.field !== 'quickFilter' && item.field !== '__quickFilter__'
+    );
+    onFilterModelChangeRef.current({
+      ...filterModelRef.current,
+      items: otherFilters,
+    });
+  }, []);
+
+  return (
+    <TextField
+      inputRef={quickFilterInputRef}
+      size="small"
+      placeholder="Search tests…"
+      defaultValue=""
+      onChange={handleQuickFilterChange}
+      sx={{ minWidth: 220, ...sx }}
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SearchIcon fontSize="small" />
+          </InputAdornment>
+        ),
+        endAdornment: (
+          <InputAdornment position="end">
+            <IconButton
+              size="small"
+              onClick={handleQuickFilterClear}
+              aria-label="Clear search"
+            >
+              <ClearIcon fontSize="small" />
+            </IconButton>
+          </InputAdornment>
+        ),
+      }}
+    />
+  );
+}

--- a/apps/frontend/src/utils/embedding/embeddingViewSurface.ts
+++ b/apps/frontend/src/utils/embedding/embeddingViewSurface.ts
@@ -1,0 +1,11 @@
+import type { Theme } from '@mui/material/styles';
+
+/** WebGL clear color for embedding-atlas `colorScheme: "dark"` (clearColor 0,0,0,1). */
+export const EMBEDDING_ATLAS_DARK_SURFACE = '#000000';
+
+/** Match the embedding scatter canvas so panels and overlays do not show a color seam. */
+export function getEmbeddingViewSurfaceBg(theme: Theme): string {
+  return theme.palette.mode === 'dark'
+    ? EMBEDDING_ATLAS_DARK_SURFACE
+    : theme.palette.background.paper;
+}

--- a/apps/frontend/src/utils/embedding/filterScatter2DGraph.ts
+++ b/apps/frontend/src/utils/embedding/filterScatter2DGraph.ts
@@ -1,0 +1,19 @@
+import type { Scatter2DGraph } from '@/utils/api-client/interfaces/embedding';
+
+/** Keep only points whose entity_id is in the allowed set. */
+export function filterScatter2DGraph(
+  graph: Scatter2DGraph,
+  allowedEntityIds: ReadonlySet<string>
+): Scatter2DGraph {
+  if (allowedEntityIds.size === 0) {
+    return { ...graph, points: [], clusters: [] };
+  }
+
+  const points = graph.points.filter(p => allowedEntityIds.has(p.entity_id));
+  const clusterIndices = new Set(points.map(p => p.cluster_index));
+  const clusters = graph.clusters.filter(c =>
+    clusterIndices.has(c.cluster_index)
+  );
+
+  return { ...graph, points, clusters };
+}

--- a/tests/backend/services/embedding/test_graph_builder.py
+++ b/tests/backend/services/embedding/test_graph_builder.py
@@ -164,12 +164,16 @@ class TestBuild2DGraph:
             _mock_embedding(entity_id=uids[1], vector=[1.0] * 8, searchable_text="b"),
             _mock_embedding(entity_id=uids[2], vector=[0.5] * 8, searchable_text="c"),
         ]
-        umap_50 = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]], dtype=np.float64)
+        # Clustering UMAP must be >2D so build_2d_graph runs the visualization pass.
+        umap_50 = np.array(
+            [[0.0, 0.0, 0.1], [1.0, 0.0, 0.2], [0.5, 1.0, 0.3]],
+            dtype=np.float64,
+        )
         umap_2 = np.array([[0.0, 0.0], [2.0, 0.0], [1.0, 3.0]], dtype=np.float64)
         mock_reduce.side_effect = [umap_50, umap_2]
         mock_cluster.return_value = (
             np.array([0, 0, -1]),
-            {0: np.array([0.33, 0.33])},
+            {0: np.array([0.33, 0.33, 0.15])},
         )
         mock_labels.return_value = {0: "Alpha"}
 
@@ -212,17 +216,21 @@ class TestBuild2DGraph:
             _mock_embedding(entity_id=uids[1], vector=[1.0] * 8),
             _mock_embedding(entity_id=uids[2], vector=[0.5] * 8),
         ]
-        umap_50 = np.array([[0.0, 0.0], [1.0, 0.0], [0.5, 1.0]], dtype=np.float64)
+        umap_50 = np.array(
+            [[0.0, 0.0, 0.1], [1.0, 0.0, 0.2], [0.5, 1.0, 0.3]],
+            dtype=np.float64,
+        )
         umap_2 = np.array([[0.0, 0.0], [2.0, 0.0], [1.0, 3.0]], dtype=np.float64)
         mock_reduce.side_effect = [umap_50, umap_2]
         mock_cluster.return_value = (
             np.array([0, 0, -1]),
-            {0: np.array([0.33, 0.33])},
+            {0: np.array([0.33, 0.33, 0.15])},
         )
 
         with patch.object(graph_builder, "fetch_embeddings", return_value=embs):
             graph = build_2d_graph(test_db, uids, user)
 
+        assert mock_reduce.call_count == 2
         assert len(graph.points) == 3
         assert len(graph.clusters) == 1
         assert graph.clusters[0].label == "Unlabeled"


### PR DESCRIPTION
## Purpose
Fixes bugs in the test set embedding cluster visualization on the v0.8.0 release line: UMAP failures on small test sets, dark mode background seams, and keeping the scatter chart in sync with list filters.

## What Changed

### Backend
- Stabilize UMAP for small test sets by capping `n_components`, using `init="random"`, and reusing the clustering projection when it is already 2D
- Tighten cluster label generation prompt for cleaner legend text

### Frontend
- Add quick search/filter on cluster view; filter scatter chart points to match the filtered test list (`filterScatter2DGraph`, `TestsQuickFilterField`)
- Align embedding atlas background with theme (dark/light) via `embeddingViewSurface` so chart, legend, and panels do not show color seams
- Rename list/cluster tabs and improve cluster view layout (hover list, grid integration)

## Testing
- [ ] Open a test set with few tests (< 5) and compute the cluster graph — should succeed without UMAP errors
- [ ] Open cluster view on a larger test set; use quick filter/search — chart and list should stay in sync
- [ ] Toggle dark mode — embedding chart background should match surrounding UI (no white/black seam)