### PR TITLE
Fix traces list search with multi-field substring matching

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -4057,10 +4057,7 @@ def query_traces(
             search_filters.append(models.Trace.project_id == project_id)
 
         matching_trace_ids = (
-            db.query(models.Trace.trace_id)
-            .filter(*search_filters)
-            .distinct()
-            .subquery()
+            db.query(models.Trace.trace_id).filter(*search_filters).distinct().subquery()
         )
         query = query.filter(models.Trace.trace_id.in_(select(matching_trace_ids.c.trace_id)))
 

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -10,7 +10,7 @@ from enum import Enum
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 from uuid import UUID
 
-from sqlalchemy import and_, cast, desc, func, or_, text
+from sqlalchemy import and_, cast, desc, func, or_, select, text
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session, joinedload
 
@@ -3869,6 +3869,29 @@ def get_span_by_id(
     )
 
 
+def _escape_like_pattern(term: str) -> str:
+    """Escape SQL LIKE wildcards in user-provided search text."""
+    return term.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _build_trace_search_conditions(pattern: str):
+    """Case-insensitive substring match across common trace text fields."""
+    from rhesis.backend.app.services.invokers.tracing import EndpointAttributes
+
+    attrs = models.Trace.attributes
+
+    return or_(
+        models.Trace.trace_id.ilike(pattern),
+        models.Trace.span_name.ilike(pattern),
+        models.Trace.status_message.ilike(pattern),
+        attrs[EndpointAttributes.ENDPOINT_NAME].astext.ilike(pattern),
+        attrs[EndpointAttributes.ENDPOINT_URL].astext.ilike(pattern),
+        attrs[EndpointAttributes.CONVERSATION_INPUT].astext.ilike(pattern),
+        attrs[EndpointAttributes.CONVERSATION_OUTPUT].astext.ilike(pattern),
+        attrs[EndpointAttributes.RESPONSE_OUTPUT_PREVIEW].astext.ilike(pattern),
+    )
+
+
 def query_traces(
     db: Session,
     organization_id: str,
@@ -3878,6 +3901,7 @@ def query_traces(
     trace_source: TraceSource = TraceSource.ALL,
     trace_type: TraceType = TraceType.ALL,
     environment: Optional[str] = None,
+    search: Optional[str] = None,
     span_name: Optional[str] = None,
     status_code: Optional[Union[str, "StatusCode"]] = None,
     start_time_after: Optional[datetime] = None,
@@ -3913,7 +3937,6 @@ def query_traces(
     from uuid import UUID
 
     from fastapi import HTTPException
-    from sqlalchemy import select
     from sqlalchemy.orm import aliased, joinedload
 
     def validate_uuid_param(value: Optional[str], param_name: str) -> Optional[UUID]:
@@ -4024,7 +4047,24 @@ def query_traces(
     if environment:
         query = query.filter(models.Trace.environment == environment)
 
-    if span_name:
+    if search and search.strip():
+        pattern = f"%{_escape_like_pattern(search.strip())}%"
+        search_filters = [
+            models.Trace.organization_id == org_uuid,
+            _build_trace_search_conditions(pattern),
+        ]
+        if project_id:
+            search_filters.append(models.Trace.project_id == project_id)
+
+        matching_trace_ids = (
+            db.query(models.Trace.trace_id)
+            .filter(*search_filters)
+            .distinct()
+            .subquery()
+        )
+        query = query.filter(models.Trace.trace_id.in_(select(matching_trace_ids.c.trace_id)))
+
+    elif span_name:
         query = query.filter(models.Trace.span_name == span_name)
 
     if status_code:

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -3884,11 +3884,11 @@ def _build_trace_search_conditions(pattern: str):
         models.Trace.trace_id.ilike(pattern),
         models.Trace.span_name.ilike(pattern),
         models.Trace.status_message.ilike(pattern),
-        attrs[EndpointAttributes.ENDPOINT_NAME].astext.ilike(pattern),
-        attrs[EndpointAttributes.ENDPOINT_URL].astext.ilike(pattern),
-        attrs[EndpointAttributes.CONVERSATION_INPUT].astext.ilike(pattern),
-        attrs[EndpointAttributes.CONVERSATION_OUTPUT].astext.ilike(pattern),
-        attrs[EndpointAttributes.RESPONSE_OUTPUT_PREVIEW].astext.ilike(pattern),
+        attrs[EndpointAttributes.ENDPOINT_NAME].as_string().ilike(pattern),
+        attrs[EndpointAttributes.ENDPOINT_URL].as_string().ilike(pattern),
+        attrs[EndpointAttributes.CONVERSATION_INPUT].as_string().ilike(pattern),
+        attrs[EndpointAttributes.CONVERSATION_OUTPUT].as_string().ilike(pattern),
+        attrs[EndpointAttributes.RESPONSE_OUTPUT_PREVIEW].as_string().ilike(pattern),
     )
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -206,7 +206,17 @@ def list_traces(
     ),
     endpoint_id: Optional[str] = Query(None, description="Endpoint ID filter"),
     environment: Optional[str] = Query(None, description="Environment filter"),
-    span_name: Optional[str] = Query(None, description="Span name filter (e.g., 'ai.llm.invoke')"),
+    search: Optional[str] = Query(
+        None,
+        description=(
+            "Case-insensitive search across trace ID, operation names, endpoint metadata, "
+            "and conversation text"
+        ),
+    ),
+    span_name: Optional[str] = Query(
+        None,
+        description="Exact span name filter (e.g., 'ai.llm.invoke'); prefer `search` for UI",
+    ),
     status_code: Optional[str] = Query(None, description="Status code filter (OK, ERROR)"),
     start_time_after: Optional[datetime] = Query(None, description="Start time >= (ISO 8601)"),
     start_time_before: Optional[datetime] = Query(None, description="Start time <= (ISO 8601)"),
@@ -259,7 +269,8 @@ def list_traces(
 
     **Filters**:
     - `environment`: Filter by environment (development, staging, production)
-    - `span_name`: Filter by span name (e.g., "ai.llm.invoke")
+    - `search`: Substring search across trace ID, operations, endpoint name/URL, conversation I/O
+    - `span_name`: Exact match on root span name (legacy; prefer `search`)
     - `status_code`: Filter by span status (OK, ERROR)
     - `trace_metrics_status`: Filter by evaluation status (Pass, Fail, Error)
     - `start_time_after`: Filter by start time >= timestamp
@@ -290,6 +301,7 @@ def list_traces(
             trace_source=trace_source,
             trace_type=trace_type,
             environment=environment,
+            search=search,
             span_name=span_name,
             status_code=status_code,
             start_time_after=start_time_after,

--- a/apps/frontend/src/app/(protected)/traces/components/TraceFilters.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceFilters.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { TEST_TYPES } from '@/constants/test-types';
 import {
   Box,
@@ -64,6 +64,8 @@ export default function TraceFilters({
   );
   const [endpoints, setEndpoints] = useState<Endpoint[]>([]);
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
+  const [searchInput, setSearchInput] = useState(filters.search || '');
+  const searchDebounceRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleFilterChange = (
     key: keyof TraceQueryParams,
@@ -86,6 +88,40 @@ export default function TraceFilters({
 
     onFiltersChange(newFilters);
   };
+
+  useEffect(() => {
+    setSearchInput(filters.search || '');
+  }, [filters.search]);
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setSearchInput(value);
+
+      if (searchDebounceRef.current) {
+        clearTimeout(searchDebounceRef.current);
+      }
+
+      searchDebounceRef.current = setTimeout(() => {
+        searchDebounceRef.current = null;
+        const trimmed = value.trim();
+        const newFilters = {
+          ...filters,
+          search: trimmed || undefined,
+          offset: 0,
+        };
+        onFiltersChange(newFilters);
+      }, 300);
+    },
+    [filters, onFiltersChange]
+  );
+
+  useEffect(() => {
+    return () => {
+      if (searchDebounceRef.current) {
+        clearTimeout(searchDebounceRef.current);
+      }
+    };
+  }, []);
 
   // Fetch projects and endpoints on mount
   useEffect(() => {
@@ -279,12 +315,12 @@ export default function TraceFilters({
       });
     }
 
-    // Operation search
-    if (filters.span_name) {
+    // Quick search
+    if (filters.search) {
       chips.push({
-        key: 'span_name',
-        label: `Operation: ${filters.span_name}`,
-        value: filters.span_name,
+        key: 'search',
+        label: `Search: ${filters.search}`,
+        value: filters.search,
       });
     }
 
@@ -466,19 +502,28 @@ export default function TraceFilters({
           {/* Search */}
           <TextField
             size="small"
-            placeholder="Search operations..."
-            value={filters.span_name || ''}
-            onChange={e =>
-              handleFilterChange('span_name', e.target.value || undefined)
-            }
+            placeholder="Search traces…"
+            value={searchInput}
+            onChange={e => handleSearchChange(e.target.value)}
             InputProps={{
               startAdornment: (
                 <InputAdornment position="start">
                   <SearchIcon fontSize="small" />
                 </InputAdornment>
               ),
+              endAdornment: searchInput ? (
+                <InputAdornment position="end">
+                  <IconButton
+                    size="small"
+                    aria-label="Clear search"
+                    onClick={() => handleSearchChange('')}
+                  >
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                </InputAdornment>
+              ) : undefined,
             }}
-            sx={{ minWidth: 200, flex: { xs: '1 1 100%', sm: '1 1 auto' } }}
+            sx={{ minWidth: 220, flex: { xs: '1 1 100%', sm: '1 1 auto' } }}
           />
         </Box>
 
@@ -934,8 +979,9 @@ export default function TraceFilters({
                 }}
               >
                 <LightbulbIcon sx={{ fontSize: 14 }} />
-                <strong>Pro tip:</strong> Use the search box to filter by
-                operation name (e.g., "ai.llm.invoke")
+                <strong>Pro tip:</strong> Search matches trace ID, operations
+                (e.g. &quot;rest&quot;, &quot;llm&quot;), endpoint names, and
+                conversation text
               </Typography>
               <Typography variant="caption" color="text.secondary">
                 Use Test Run filter to analyze traces from specific test

--- a/apps/frontend/src/app/(protected)/traces/components/TraceFilters.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceFilters.tsx
@@ -74,6 +74,13 @@ export default function TraceFilters({
     filtersRef.current = filters;
   });
 
+  const cancelSearchDebounce = () => {
+    if (searchDebounceRef.current) {
+      clearTimeout(searchDebounceRef.current);
+      searchDebounceRef.current = null;
+    }
+  };
+
   const handleFilterChange = (
     key: keyof TraceQueryParams,
     value: TraceQueryParams[keyof TraceQueryParams]
@@ -102,28 +109,31 @@ export default function TraceFilters({
 
   const handleSearchChange = useCallback((value: string) => {
     setSearchInput(value);
+    cancelSearchDebounce();
 
-    if (searchDebounceRef.current) {
-      clearTimeout(searchDebounceRef.current);
+    const trimmed = value.trim();
+    if (!trimmed) {
+      onFiltersChangeRef.current({
+        ...filtersRef.current,
+        search: undefined,
+        offset: 0,
+      });
+      return;
     }
 
     searchDebounceRef.current = setTimeout(() => {
       searchDebounceRef.current = null;
-      const trimmed = value.trim();
-      const newFilters = {
+      onFiltersChangeRef.current({
         ...filtersRef.current,
-        search: trimmed || undefined,
+        search: trimmed,
         offset: 0,
-      };
-      onFiltersChangeRef.current(newFilters);
+      });
     }, 300);
   }, []);
 
   useEffect(() => {
     return () => {
-      if (searchDebounceRef.current) {
-        clearTimeout(searchDebounceRef.current);
-      }
+      cancelSearchDebounce();
     };
   }, []);
 
@@ -240,6 +250,8 @@ export default function TraceFilters({
   };
 
   const handleClearAllFilters = () => {
+    cancelSearchDebounce();
+    setSearchInput('');
     const clearedFilters: TraceQueryParams = {
       project_id: filters.project_id, // Keep project selection
       limit: filters.limit || 50,
@@ -784,6 +796,10 @@ export default function TraceFilters({
                 label={chip.label}
                 size="small"
                 onDelete={() => {
+                  if (chip.key === 'search') {
+                    handleSearchChange('');
+                    return;
+                  }
                   handleFilterChange(
                     chip.key as keyof TraceQueryParams,
                     undefined

--- a/apps/frontend/src/app/(protected)/traces/components/TraceFilters.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceFilters.tsx
@@ -66,6 +66,13 @@ export default function TraceFilters({
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
   const [searchInput, setSearchInput] = useState(filters.search || '');
   const searchDebounceRef = useRef<NodeJS.Timeout | null>(null);
+  const onFiltersChangeRef = useRef(onFiltersChange);
+  const filtersRef = useRef(filters);
+
+  useEffect(() => {
+    onFiltersChangeRef.current = onFiltersChange;
+    filtersRef.current = filters;
+  });
 
   const handleFilterChange = (
     key: keyof TraceQueryParams,
@@ -93,27 +100,24 @@ export default function TraceFilters({
     setSearchInput(filters.search || '');
   }, [filters.search]);
 
-  const handleSearchChange = useCallback(
-    (value: string) => {
-      setSearchInput(value);
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchInput(value);
 
-      if (searchDebounceRef.current) {
-        clearTimeout(searchDebounceRef.current);
-      }
+    if (searchDebounceRef.current) {
+      clearTimeout(searchDebounceRef.current);
+    }
 
-      searchDebounceRef.current = setTimeout(() => {
-        searchDebounceRef.current = null;
-        const trimmed = value.trim();
-        const newFilters = {
-          ...filters,
-          search: trimmed || undefined,
-          offset: 0,
-        };
-        onFiltersChange(newFilters);
-      }, 300);
-    },
-    [filters, onFiltersChange]
-  );
+    searchDebounceRef.current = setTimeout(() => {
+      searchDebounceRef.current = null;
+      const trimmed = value.trim();
+      const newFilters = {
+        ...filtersRef.current,
+        search: trimmed || undefined,
+        offset: 0,
+      };
+      onFiltersChangeRef.current(newFilters);
+    }, 300);
+  }, []);
 
   useEffect(() => {
     return () => {

--- a/apps/frontend/src/utils/api-client/interfaces/telemetry.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/telemetry.ts
@@ -241,6 +241,9 @@ export interface TraceQueryParams {
   project_id?: string; // Optional - shows all projects if not specified
   conversation_id?: string;
   environment?: string;
+  /** Case-insensitive search across trace ID, operations, endpoint metadata, conversation text */
+  search?: string;
+  /** Exact root span name (legacy API); prefer `search` in the UI */
   span_name?: string;
   status_code?: string;
   start_time_after?: string;

--- a/tests/backend/routes/test_telemetry_query.py
+++ b/tests/backend/routes/test_telemetry_query.py
@@ -97,8 +97,62 @@ class TestTraceListEndpoint:
         for trace in data["traces"]:
             assert trace["environment"] == "development"
 
+    def test_list_traces_search_partial_span_name(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """Search uses case-insensitive substring match on span names (any span in trace)."""
+        root_span = TraceDataFactory.sample_data(project_id=str(db_project.id))
+        root_span["span_name"] = "function.endpoint_rest_invoke"
+        root_span["parent_span_id"] = None
+
+        child_span = TraceDataFactory.sample_data(project_id=str(db_project.id))
+        child_span["trace_id"] = root_span["trace_id"]
+        child_span["span_name"] = "ai.llm.invoke"
+        child_span["parent_span_id"] = root_span["span_id"]
+
+        for span_data in [root_span, child_span]:
+            authenticated_client.post("/telemetry/traces", json={"spans": [span_data]})
+
+        response = authenticated_client.get(
+            f"/telemetry/traces?project_id={db_project.id}&search=llm"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["total"] >= 1
+        assert any(t["trace_id"] == root_span["trace_id"] for t in data["traces"])
+
+        response = authenticated_client.get(
+            f"/telemetry/traces?project_id={db_project.id}&search=rest"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["total"] >= 1
+        assert any(
+            t["root_operation"] == "function.endpoint_rest_invoke" for t in data["traces"]
+        )
+
+    def test_list_traces_search_endpoint_name_in_attributes(
+        self, authenticated_client: TestClient, db_project
+    ):
+        """Search matches endpoint metadata stored on span attributes."""
+        span = TraceDataFactory.sample_data(project_id=str(db_project.id))
+        span["span_name"] = "function.endpoint_rest_invoke"
+        span["attributes"]["endpoint.name"] = "Insurance Chatbot Unique"
+
+        authenticated_client.post("/telemetry/traces", json={"spans": [span]})
+
+        response = authenticated_client.get(
+            f"/telemetry/traces?project_id={db_project.id}&search=insurance%20chatbot"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["total"] >= 1
+        assert any(t["trace_id"] == span["trace_id"] for t in data["traces"])
+
     def test_list_traces_filter_by_span_name(self, authenticated_client: TestClient, db_project):
-        """Test filtering traces by span name"""
+        """Test filtering traces by exact span name (legacy param)"""
         # Create traces with different span names
         llm_span = TraceDataFactory.sample_data(project_id=str(db_project.id))
         llm_span["span_name"] = "ai.llm.invoke"


### PR DESCRIPTION
## Purpose
The traces page search only matched exact root span names. Users expect
substring search like on behaviors and tests.

## What Changed
- Add `search` param on `GET /telemetry/traces` (ILIKE across trace ID,
  operations, endpoint metadata, conversation text; any span in trace)
- Debounced search UI on traces filters; keep `span_name` for exact API use
- Backend tests for partial match and endpoint name search

## Testing
- [x] Backend pytest for search partial span name, endpoint attributes, legacy span_name
- [ ] Manual: search `rest`, `Insurance Chatbot`, conversation text on traces page