### PR TITLE
Stream test generation incrementally via NDJSON pipeline

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -30,6 +30,7 @@ from rhesis.backend.app.schemas.services import (
     TestConfigResponse,
     TestMCPConnectionRequest,
     TestMCPConnectionResponse,
+    TestPipelineRequest,
     TextResponse,
 )
 from rhesis.backend.app.services.activities import RecentActivitiesService
@@ -52,6 +53,9 @@ from rhesis.backend.app.services.mcp import (
     search_mcp,
 )
 from rhesis.backend.app.services.test_config_generator import TestConfigGeneratorService
+from rhesis.backend.app.services.test_generation_pipeline import (
+    test_generation_pipeline_stream,
+)
 from rhesis.backend.app.utils.execution_validation import validate_generation_model
 
 logger = logging.getLogger(__name__)
@@ -453,6 +457,40 @@ async def generate_text(prompt_request: PromptRequest):
         error_msg = str(e) if str(e) else "Unknown error"
         logger.error(f"Failed to generate text: {error_msg}", exc_info=True)
         raise HTTPException(status_code=400, detail=f"Failed to generate text: {error_msg}")
+
+
+@router.post("/generate/test_pipeline")
+async def test_pipeline_endpoint(
+    request: TestPipelineRequest,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Stream config and test generation as NDJSON events."""
+    organization_id, _ = tenant_context
+    model_id_str = str(request.model_id) if request.model_id else None
+
+    async def _stream():
+        async for chunk in test_generation_pipeline_stream(
+            db=db,
+            user=current_user,
+            prompt=request.prompt,
+            organization_id=organization_id,
+            project_id=(
+                str(request.project_id) if request.project_id else None
+            ),
+            previous_messages=request.previous_messages,
+            test_type=request.test_type,
+            num_tests=request.num_tests,
+            sources=request.sources,
+            model_id=model_id_str,
+            config=request.config,
+        ):
+            yield chunk
+
+    return StreamingResponse(
+        _stream(), media_type="application/x-ndjson"
+    )
 
 
 @router.post("/generate/test_config", response_model=TestConfigResponse)

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -476,9 +476,7 @@ async def test_pipeline_endpoint(
             user=current_user,
             prompt=request.prompt,
             organization_id=organization_id,
-            project_id=(
-                str(request.project_id) if request.project_id else None
-            ),
+            project_id=(str(request.project_id) if request.project_id else None),
             previous_messages=request.previous_messages,
             test_type=request.test_type,
             num_tests=request.num_tests,
@@ -488,9 +486,7 @@ async def test_pipeline_endpoint(
         ):
             yield chunk
 
-    return StreamingResponse(
-        _stream(), media_type="application/x-ndjson"
-    )
+    return StreamingResponse(_stream(), media_type="application/x-ndjson")
 
 
 @router.post("/generate/test_config", response_model=TestConfigResponse)

--- a/apps/backend/src/rhesis/backend/app/schemas/services.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/services.py
@@ -177,12 +177,6 @@ class GenerateEmbeddingRequest(BaseModel):
     text: str
 
 
-class TestConfigRequest(BaseModel):
-    prompt: str
-    project_id: Optional[UUID4] = None
-    previous_messages: Optional[List[IterationMessage]] = None
-
-
 class TestConfigItem(BaseModel):
     name: str
     description: str
@@ -192,6 +186,37 @@ class TestConfigItem(BaseModel):
 class TestConfigResponse(BaseModel):
     behaviors: List[TestConfigItem]
     topics: List[TestConfigItem]
+    categories: List[TestConfigItem]
+
+
+class TestPipelineRequest(BaseModel):
+    """Unified streaming request for config + test generation pipeline."""
+
+    prompt: str
+    project_id: Optional[UUID4] = None
+    previous_messages: Optional[List[IterationMessage]] = None
+    test_type: str = "single_turn"
+    num_tests: int = Field(default=5, ge=1, le=20)
+    sources: Optional[List[SourceData]] = None
+    model_id: Optional[UUID4] = None
+    config: Optional[TestConfigResponse] = None
+
+
+class TestConfigRequest(BaseModel):
+    prompt: str
+    project_id: Optional[UUID4] = None
+    previous_messages: Optional[List[IterationMessage]] = None
+
+
+class BehaviorsResponse(BaseModel):
+    behaviors: List[TestConfigItem]
+
+
+class TopicsResponse(BaseModel):
+    topics: List[TestConfigItem]
+
+
+class CategoriesResponse(BaseModel):
     categories: List[TestConfigItem]
 
 

--- a/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
@@ -73,75 +73,13 @@ def _resolve_llm_model(model_or_provider: Any):
     return model_or_provider
 
 
-class _IncrementalJsonArrayParser:
-    """Extract complete JSON objects from a streaming JSON response.
+from rhesis.backend.app.services.streaming_utils import (
+    IncrementalJsonArrayParser,
+    ndjson as _ndjson,
+)
 
-    Designed for structured output shaped like ``{"suggestions": [{...}, ...]}``.
-    Feeds token chunks incrementally and yields each complete object in the
-    top-level array as soon as its closing brace is detected.  Correctly
-    handles escaped characters and strings containing braces.
-    """
-
-    def __init__(self):
-        self._buffer: str = ""
-        self._pos: int = 0
-        self._in_array: bool = False
-        self._brace_depth: int = 0
-        self._in_string: bool = False
-        self._escape_next: bool = False
-        self._obj_start: int = -1
-
-    def feed(self, chunk: str) -> List[dict]:
-        """Append *chunk* to the internal buffer and return any newly complete objects."""
-        self._buffer += chunk
-        results: List[dict] = []
-
-        while self._pos < len(self._buffer):
-            c = self._buffer[self._pos]
-
-            if self._escape_next:
-                self._escape_next = False
-                self._pos += 1
-                continue
-
-            if c == "\\" and self._in_string:
-                self._escape_next = True
-                self._pos += 1
-                continue
-
-            if c == '"':
-                self._in_string = not self._in_string
-                self._pos += 1
-                continue
-
-            if self._in_string:
-                self._pos += 1
-                continue
-
-            if not self._in_array:
-                if c == "[":
-                    self._in_array = True
-            else:
-                if c == "{":
-                    if self._brace_depth == 0:
-                        self._obj_start = self._pos
-                    self._brace_depth += 1
-                elif c == "}":
-                    self._brace_depth -= 1
-                    if self._brace_depth == 0 and self._obj_start >= 0:
-                        obj_str = self._buffer[self._obj_start : self._pos + 1]
-                        try:
-                            results.append(json.loads(obj_str))
-                        except json.JSONDecodeError:
-                            logger.warning(
-                                "Failed to parse streamed JSON object: %.120s",
-                                obj_str,
-                            )
-                        self._obj_start = -1
-
-            self._pos += 1
-
-        return results
+# Keep the private alias for backward compatibility within this module
+_IncrementalJsonArrayParser = IncrementalJsonArrayParser
 
 
 def _build_suggestion_prompt(
@@ -417,11 +355,6 @@ async def generate_suggestions(
         "suggestions": suggestions,
         "num_examples_used": sample_size,
     }
-
-
-def _ndjson(event: Dict[str, Any]) -> bytes:
-    """Encode a single NDJSON event."""
-    return (json.dumps(event) + "\n").encode("utf-8")
 
 
 async def suggestion_pipeline_stream(

--- a/apps/backend/src/rhesis/backend/app/services/generation.py
+++ b/apps/backend/src/rhesis/backend/app/services/generation.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from functools import partial
-from typing import Dict, List, Optional
+from typing import Any, AsyncGenerator, Dict, List, Optional
 
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
@@ -139,6 +139,40 @@ async def generate_tests(
 
     # Return raw list of tests - router will wrap in response structure
     return test_set.to_dict()["tests"]
+
+
+async def generate_tests_stream(
+    db: Session,
+    user: User,
+    config: GenerationConfig,
+    num_tests: int = 5,
+    model_id: Optional[str] = None,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    """Yield test dicts one-by-one as they parse from the LLM token stream."""
+    model = get_generation_model_with_override(db, user, model_id=model_id)
+    synthesizer = ConfigSynthesizer(config=config, model=model)
+    async for test in synthesizer.generate_stream(num_tests=num_tests):
+        yield test
+
+
+async def generate_multiturn_tests_stream(
+    db: Session,
+    user: User,
+    config: Dict,
+    num_tests: int = 5,
+    model_id: Optional[str] = None,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    """Yield multi-turn test dicts one-by-one as they parse from the LLM."""
+    from rhesis.sdk.synthesizers.multi_turn.base import (
+        GenerationConfig,
+        MultiTurnSynthesizer,
+    )
+
+    model = get_generation_model_with_override(db, user, model_id=model_id)
+    generation_config = GenerationConfig(**config)
+    synthesizer = MultiTurnSynthesizer(config=generation_config, model=model)
+    async for test in synthesizer.generate_stream(num_tests=num_tests):
+        yield test
 
 
 async def generate_multiturn_tests(

--- a/apps/backend/src/rhesis/backend/app/services/streaming_utils.py
+++ b/apps/backend/src/rhesis/backend/app/services/streaming_utils.py
@@ -1,0 +1,57 @@
+"""Shared utilities for NDJSON streaming responses."""
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from rhesis.sdk.synthesizers.streaming import IncrementalJsonArrayParser
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["ndjson", "IncrementalJsonArrayParser", "IncrementalConfigParser"]
+
+
+def ndjson(event: Dict[str, Any]) -> bytes:
+    """Encode a single NDJSON event."""
+    return (json.dumps(event) + "\n").encode("utf-8")
+
+
+_KEY_PATTERN = re.compile(r'"(behaviors|topics|categories)"\s*:')
+
+
+class IncrementalConfigParser:
+    """Parse a streaming config response with multiple named arrays.
+
+    Wraps ``IncrementalJsonArrayParser`` and tracks which top-level key
+    (``behaviors``, ``topics``, ``categories``) each object belongs to by
+    scanning for key names before ``[`` in the token stream.
+
+    Yields ``(category, obj)`` tuples.
+    """
+
+    def __init__(self):
+        self._inner = IncrementalJsonArrayParser()
+        self._raw_buffer: str = ""
+        self._current_key: Optional[str] = None
+        self._scan_pos: int = 0
+
+    def feed(self, chunk: str) -> List[Tuple[str, dict]]:
+        self._raw_buffer += chunk
+
+        # Scan for key names to track which array we're in
+        while self._scan_pos < len(self._raw_buffer):
+            remaining = self._raw_buffer[self._scan_pos :]
+            m = _KEY_PATTERN.search(remaining)
+            if m:
+                self._current_key = m.group(1)
+                self._scan_pos += m.end()
+            else:
+                # No more matches in current buffer -- advance to near the end
+                # but leave enough room for a partial match at the boundary.
+                self._scan_pos = max(0, len(self._raw_buffer) - 30)
+                break
+
+        objects = self._inner.feed(chunk)
+        category = self._current_key or "unknown"
+        return [(category, obj) for obj in objects]

--- a/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
@@ -1,0 +1,341 @@
+"""Streaming test generation pipeline.
+
+Combines config generation and test generation into a single NDJSON stream,
+following the same pattern as the explorer suggestion pipeline.
+"""
+
+import logging
+from pathlib import Path
+from typing import Any, AsyncGenerator, Dict, List, Optional
+
+import anyio
+import jinja2
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import crud
+from rhesis.backend.app.constants import DEFAULT_GENERATION_MODEL
+from rhesis.backend.app.models.user import User
+from rhesis.backend.app.schemas.services import (
+    SourceData,
+    TestConfigItem,
+    TestConfigResponse,
+)
+from rhesis.backend.app.services.generation import (
+    generate_multiturn_tests_stream,
+    generate_tests,
+    generate_tests_stream,
+)
+from rhesis.backend.app.services.streaming_utils import IncrementalConfigParser, ndjson
+from rhesis.backend.app.utils.model_errors import ModelConfigurationError
+from rhesis.backend.app.utils.user_model_utils import get_user_generation_model
+from rhesis.sdk.models.factory import get_model
+from rhesis.sdk.synthesizers.config_synthesizer import (
+    GenerationConfig as SDKGenerationConfig,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_SAMPLE_SIZE = 6
+
+TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
+
+
+def _resolve_config_llm(db: Session, user: User):
+    """Resolve the LLM for test-config generation (same logic as TestConfigGeneratorService)."""
+    gen_settings = getattr(user.settings.models, "generation")
+    model_id = gen_settings.model_id
+    use_fast_default = False
+    if model_id:
+        row = crud.get_model(
+            db=db,
+            model_id=str(model_id),
+            organization_id=str(user.organization_id),
+        )
+        if row and row.provider_type and row.provider_type.type_value == "polyphemus":
+            use_fast_default = True
+    if use_fast_default:
+        logger.info("User generation model is Polyphemus; using fast default for pipeline config")
+        try:
+            return get_model(DEFAULT_GENERATION_MODEL)
+        except ValueError:
+            pass
+
+    user_model = get_user_generation_model(db, user)
+    if isinstance(user_model, str):
+        try:
+            return get_model(user_model, model_type="language")
+        except ValueError as e:
+            raise ModelConfigurationError(
+                f"User model initialization failed: {e}",
+                original_error=e,
+            ) from e
+    return user_model
+
+
+def _fetch_db_context(
+    db: Session,
+    organization_id: str,
+    prompt: str,
+    project_id: Optional[str] = None,
+    previous_messages: Optional[list] = None,
+) -> Dict[str, Any]:
+    """Fetch all DB data needed for config prompts (called once upfront)."""
+    behaviors = crud.get_behaviors(db=db, organization_id=organization_id, skip=0, limit=100)
+    behavior_list = [
+        {"name": b.name, "description": b.description or ""} for b in behaviors
+    ]
+
+    project_name = None
+    project_description = None
+    if project_id:
+        project = crud.get_project(db=db, project_id=project_id, organization_id=organization_id)
+        if not project:
+            raise ValueError(f"Project with id {project_id} not found or not accessible")
+        project_name = project.name
+        project_description = project.description
+
+    return {
+        "prompt": prompt,
+        "sample_size": MAX_SAMPLE_SIZE,
+        "behaviors": behavior_list,
+        "project_name": project_name,
+        "project_description": project_description,
+        "previous_messages": previous_messages or [],
+    }
+
+
+def _render_config_prompt(db_context: Dict[str, Any]) -> str:
+    """Render the unified config template using pre-fetched DB context."""
+    jinja_env = jinja2.Environment(
+        loader=jinja2.FileSystemLoader(str(TEMPLATE_DIR)),
+        autoescape=jinja2.select_autoescape(),
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    template = jinja_env.get_template("test_config_generator.jinja2")
+    return template.render(db_context)
+
+
+async def _stream_config(
+    llm,
+    db_context: Dict[str, Any],
+) -> AsyncGenerator[Dict[str, Any], None]:
+    """Stream config items from a single LLM call.
+
+    The LLM returns a JSON object with ``behaviors``, ``topics``, and
+    ``categories`` arrays.  ``IncrementalConfigParser`` tracks which key
+    each parsed object belongs to so items can be emitted incrementally.
+
+    Yields dicts: ``config_item`` events as they parse,
+    then ``config_done`` and ``_collected`` (internal) when finished.
+    """
+    collected: Dict[str, List[TestConfigItem]] = {
+        "behaviors": [],
+        "topics": [],
+        "categories": [],
+    }
+
+    rendered_prompt = _render_config_prompt(db_context)
+    parser = IncrementalConfigParser()
+
+    try:
+        token_stream = llm.generate_stream(
+            prompt=rendered_prompt,
+            schema=TestConfigResponse,
+        )
+        async for chunk in token_stream:
+            for category, obj in parser.feed(chunk):
+                name = obj.get("name", "")
+                description = obj.get("description", "")
+                active = obj.get("active", True)
+                if not name:
+                    continue
+
+                item = TestConfigItem(
+                    name=name, description=description, active=active
+                )
+                if category in collected:
+                    collected[category].append(item)
+
+                yield {
+                    "type": "config_item",
+                    "category": category,
+                    "name": name,
+                    "description": description,
+                    "active": active,
+                }
+                await anyio.sleep(0)
+    except Exception as e:
+        logger.error("Config streaming failed: %s", e, exc_info=True)
+        yield {
+            "type": "error",
+            "phase": "config",
+            "message": str(e),
+        }
+
+    total = sum(len(v) for v in collected.values())
+    yield {"type": "config_done", "total": total}
+
+    yield {
+        "type": "_collected",
+        "config": TestConfigResponse(
+            behaviors=collected["behaviors"],
+            topics=collected["topics"],
+            categories=collected["categories"],
+        ),
+    }
+
+
+async def test_generation_pipeline_stream(
+    db: Session,
+    user: User,
+    prompt: str,
+    organization_id: str,
+    project_id: Optional[str] = None,
+    previous_messages: Optional[list] = None,
+    test_type: str = "single_turn",
+    num_tests: int = 5,
+    sources: Optional[List[SourceData]] = None,
+    model_id: Optional[str] = None,
+    config: Optional[TestConfigResponse] = None,
+) -> AsyncGenerator[bytes, None]:
+    """Unified NDJSON stream: generate config, then generate tests.
+
+    When *config* is supplied, Phase 1 (config generation) is skipped
+    and the provided config is used directly for test generation.
+
+    Event protocol (one JSON object per line):
+      - ``{"type": "config_item", "category": str, "name": str,
+             "description": str, "active": bool}``
+      - ``{"type": "config_done", "total": int}``
+      - ``{"type": "test", "index": int, "test": dict, "test_type": str}``
+      - ``{"type": "tests_done", "total": int}``
+      - ``{"type": "error", "phase": str, "message": str}``
+      - ``{"type": "done"}``
+    """
+
+    config_response: Optional[TestConfigResponse] = config
+
+    if config_response is None:
+        # ── Phase 1: Streamed config generation ──
+
+        llm = _resolve_config_llm(db, user)
+        db_context = _fetch_db_context(
+            db=db,
+            organization_id=organization_id,
+            prompt=prompt,
+            project_id=project_id,
+            previous_messages=previous_messages,
+        )
+
+        async for event in _stream_config(llm, db_context):
+            if event.get("type") == "_collected":
+                config_response = event["config"]
+                continue
+            yield ndjson(event)
+            await anyio.sleep(0)
+
+    # ── Phase 2: Test generation ──
+
+    if config_response is None:
+        yield ndjson({"type": "error", "phase": "tests", "message": "Config generation failed"})
+        yield ndjson({"type": "done"})
+        return
+
+    active_behaviors = [b.name for b in config_response.behaviors if b.active]
+    active_topics = [t.name for t in config_response.topics if t.active]
+    active_categories = [c.name for c in config_response.categories if c.active]
+
+    if not active_behaviors:
+        active_behaviors = [b.name for b in config_response.behaviors[:1]]
+
+    test_index = 0
+    tests_generated = 0
+
+    try:
+        if test_type == "multi_turn":
+            config_dict = {
+                "generation_prompt": prompt,
+                "behaviors": active_behaviors,
+                "categories": active_categories,
+                "topics": active_topics,
+            }
+            async for test in generate_multiturn_tests_stream(
+                db=db,
+                user=user,
+                config=config_dict,
+                num_tests=num_tests,
+                model_id=model_id,
+            ):
+                yield ndjson({
+                    "type": "test",
+                    "index": test_index,
+                    "test": test,
+                    "test_type": "multi_turn",
+                })
+                test_index += 1
+                tests_generated += 1
+                await anyio.sleep(0)
+        elif sources:
+            generation_prompt = (
+                f"Generate {num_tests} single interaction test cases for: "
+                f"{prompt or 'general testing'}"
+            )
+            sdk_config = SDKGenerationConfig(
+                generation_prompt=generation_prompt,
+                behaviors=active_behaviors,
+                categories=active_categories,
+                topics=active_topics,
+            )
+            tests = await generate_tests(
+                db=db,
+                user=user,
+                config=sdk_config,
+                num_tests=num_tests,
+                sources=sources,
+                model_id=model_id,
+            )
+            for test in tests:
+                yield ndjson({
+                    "type": "test",
+                    "index": test_index,
+                    "test": test,
+                    "test_type": "single_turn",
+                })
+                test_index += 1
+                tests_generated += 1
+                await anyio.sleep(0)
+        else:
+            generation_prompt = (
+                f"Generate {num_tests} single interaction test cases for: "
+                f"{prompt or 'general testing'}"
+            )
+            sdk_config = SDKGenerationConfig(
+                generation_prompt=generation_prompt,
+                behaviors=active_behaviors,
+                categories=active_categories,
+                topics=active_topics,
+            )
+            async for test in generate_tests_stream(
+                db=db,
+                user=user,
+                config=sdk_config,
+                num_tests=num_tests,
+                model_id=model_id,
+            ):
+                yield ndjson({
+                    "type": "test",
+                    "index": test_index,
+                    "test": test,
+                    "test_type": "single_turn",
+                })
+                test_index += 1
+                tests_generated += 1
+                await anyio.sleep(0)
+
+    except Exception as e:
+        logger.error("Test generation failed at index %d: %s", test_index, e, exc_info=True)
+        yield ndjson({"type": "error", "phase": "tests", "message": str(e)})
+
+    yield ndjson({"type": "tests_done", "total": tests_generated})
+    yield ndjson({"type": "done"})

--- a/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
@@ -81,9 +81,7 @@ def _fetch_db_context(
 ) -> Dict[str, Any]:
     """Fetch all DB data needed for config prompts (called once upfront)."""
     behaviors = crud.get_behaviors(db=db, organization_id=organization_id, skip=0, limit=100)
-    behavior_list = [
-        {"name": b.name, "description": b.description or ""} for b in behaviors
-    ]
+    behavior_list = [{"name": b.name, "description": b.description or ""} for b in behaviors]
 
     project_name = None
     project_description = None
@@ -151,9 +149,7 @@ async def _stream_config(
                 if not name:
                     continue
 
-                item = TestConfigItem(
-                    name=name, description=description, active=active
-                )
+                item = TestConfigItem(name=name, description=description, active=active)
                 if category in collected:
                     collected[category].append(item)
 
@@ -172,6 +168,9 @@ async def _stream_config(
             "phase": "config",
             "message": str(e),
         }
+        yield {"type": "config_done", "total": 0}
+        yield {"type": "_collected", "config": None}
+        return
 
     total = sum(len(v) for v in collected.values())
     yield {"type": "config_done", "total": total}
@@ -267,12 +266,14 @@ async def test_generation_pipeline_stream(
                 num_tests=num_tests,
                 model_id=model_id,
             ):
-                yield ndjson({
-                    "type": "test",
-                    "index": test_index,
-                    "test": test,
-                    "test_type": "multi_turn",
-                })
+                yield ndjson(
+                    {
+                        "type": "test",
+                        "index": test_index,
+                        "test": test,
+                        "test_type": "multi_turn",
+                    }
+                )
                 test_index += 1
                 tests_generated += 1
                 await anyio.sleep(0)
@@ -296,12 +297,14 @@ async def test_generation_pipeline_stream(
                 model_id=model_id,
             )
             for test in tests:
-                yield ndjson({
-                    "type": "test",
-                    "index": test_index,
-                    "test": test,
-                    "test_type": "single_turn",
-                })
+                yield ndjson(
+                    {
+                        "type": "test",
+                        "index": test_index,
+                        "test": test,
+                        "test_type": "single_turn",
+                    }
+                )
                 test_index += 1
                 tests_generated += 1
                 await anyio.sleep(0)
@@ -323,12 +326,14 @@ async def test_generation_pipeline_stream(
                 num_tests=num_tests,
                 model_id=model_id,
             ):
-                yield ndjson({
-                    "type": "test",
-                    "index": test_index,
-                    "test": test,
-                    "test_type": "single_turn",
-                })
+                yield ndjson(
+                    {
+                        "type": "test",
+                        "index": test_index,
+                        "test": test,
+                        "test_type": "single_turn",
+                    }
+                )
                 test_index += 1
                 tests_generated += 1
                 await anyio.sleep(0)

--- a/apps/frontend/src/app/(protected)/models/page.tsx
+++ b/apps/frontend/src/app/(protected)/models/page.tsx
@@ -6,6 +6,7 @@ import { PageContainer } from '@toolpad/core/PageContainer';
 import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { Model, ModelCreate } from '@/utils/api-client/interfaces/model';
+import { Organization } from '@/utils/api-client/interfaces/organization';
 import { TypeLookup } from '@/utils/api-client/interfaces/type-lookup';
 import { UserSettings } from '@/utils/api-client/interfaces/user';
 import { DeleteModal } from '@/components/common/DeleteModal';
@@ -43,7 +44,7 @@ export default function ModelsPage() {
     'language' | 'embedding'
   >('language');
   const [polyphemusModalOpen, setPolyphemusModalOpen] = useState(false);
-  const [organization, setOrganization] = useState<any>(null);
+  const [organization, setOrganization] = useState<Organization | undefined>();
 
   useEffect(() => {
     async function loadData() {
@@ -346,7 +347,7 @@ export default function ModelsPage() {
     }
   };
 
-  const handleRequestPolyphemusAccess = (model: Model) => {
+  const handleRequestPolyphemusAccess = (_model: Model) => {
     setPolyphemusModalOpen(true);
   };
 

--- a/apps/frontend/src/app/(protected)/playground/components/PlaygroundChat.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/PlaygroundChat.tsx
@@ -150,8 +150,9 @@ export default function PlaygroundChat({
   };
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files) {
-      setStagedFiles(prev => [...prev, ...Array.from(e.target.files!)]);
+    const selectedFiles = e.target.files;
+    if (selectedFiles) {
+      setStagedFiles(prev => [...prev, ...Array.from(selectedFiles)]);
     }
     // Reset so the same file can be selected again
     e.target.value = '';

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
@@ -166,6 +166,9 @@ export default function TestDetailOverviewTab({
   // Determine if this is a multi-turn test
   const isMultiTurn =
     testSetType?.toLowerCase().includes('multi-turn') || false;
+  const expectedResponse = test.prompt_id
+    ? prompts[test.prompt_id]?.expected_response
+    : undefined;
 
   // Get test configuration from test_output (multi-turn data lives here)
   const testConfig = test.test_output?.test_configuration;
@@ -315,8 +318,8 @@ export default function TestDetailOverviewTab({
               overflow: 'auto',
             }}
           >
-            {test.prompt_id && prompts[test.prompt_id]?.expected_response ? (
-              renderTextContent(prompts[test.prompt_id].expected_response!)
+            {expectedResponse ? (
+              renderTextContent(expectedResponse)
             ) : (
               <Typography
                 variant="body2"

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -31,7 +31,7 @@ import TestsTableView from './TestsTableView';
 import ComparisonView from './ComparisonView';
 import TestRunHeader from './TestRunHeader';
 import TestRunTags from './TestRunTags';
-import RunDrawer, { type RerunConfig } from '@/components/common/RunDrawer';
+import RunDrawer from '@/components/common/RunDrawer';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 import { useNotifications } from '@/components/common/NotificationContext';

--- a/apps/frontend/src/app/(protected)/test-sets/components/GarakImportDialog.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/GarakImportDialog.tsx
@@ -339,7 +339,8 @@ export default function GarakImportDialog({
           isComplete: false,
         });
 
-        const maxSimulated = Math.floor(previewData.total_tests * 0.95);
+        const totalTests = previewData.total_tests;
+        const maxSimulated = Math.floor(totalTests * 0.95);
         const progressInterval = setInterval(() => {
           setImportProgress(prev => {
             if (
@@ -349,10 +350,7 @@ export default function GarakImportDialog({
               !previewData
             )
               return prev;
-            const testsPerInterval = Math.max(
-              1,
-              Math.ceil(previewData.total_tests / 60)
-            );
+            const testsPerInterval = Math.max(1, Math.ceil(totalTests / 60));
             const nextTestCount = Math.min(
               prev.currentTestCount + testsPerInterval,
               maxSimulated
@@ -385,7 +383,7 @@ export default function GarakImportDialog({
           prev
             ? {
                 ...prev,
-                currentTestCount: previewData!.total_tests,
+                currentTestCount: totalTests,
                 staticImported: staticProbes.length,
               }
             : prev

--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationFlow.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationFlow.tsx
@@ -182,9 +182,7 @@ const generateSamplesForTestType = async (
   return [];
 };
 
-const mapCategoryToChipKey = (
-  category: string
-): keyof ConfigChips | null => {
+const mapCategoryToChipKey = (category: string): keyof ConfigChips | null => {
   switch (category) {
     case 'behaviors':
       return 'behavior';
@@ -457,8 +455,7 @@ export default function TestGenerationFlow({
       if (projectId) {
         try {
           const projectsClient = apiFactory.getProjectsClient();
-          const fetchedProject =
-            await projectsClient.getProject(projectId);
+          const fetchedProject = await projectsClient.getProject(projectId);
           setProject(fetchedProject);
         } catch (_error) {
           show('Failed to load project', { severity: 'warning' });
@@ -481,10 +478,9 @@ export default function TestGenerationFlow({
           { onEvent: handlePipelineEvent }
         );
       } catch (error) {
-        show(
-          getApiErrorMessage(error, 'Failed to generate configuration'),
-          { severity: 'error' }
-        );
+        show(getApiErrorMessage(error, 'Failed to generate configuration'), {
+          severity: 'error',
+        });
         setIsLoadingConfig(false);
         setIsLoadingSamples(false);
       }

--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationFlow.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationFlow.tsx
@@ -24,6 +24,7 @@ import {
   GenerateTestsRequest,
   GenerationConfig,
   SourceData,
+  TestPipelineEvent,
 } from '@/utils/api-client/interfaces/test-set';
 import TestInputScreen from './TestInputScreen';
 import TestGenerationInterface from './TestGenerationInterface';
@@ -162,7 +163,6 @@ const generateSamplesForTestType = async (
           id: `sample-${Date.now()}-${index}`,
           testType: 'single_turn',
           prompt: t.prompt.content,
-          response: t.prompt.expected_response,
           behavior: t.behavior,
           topic: t.topic,
           rating: null,
@@ -180,6 +180,71 @@ const generateSamplesForTestType = async (
   }
 
   return [];
+};
+
+const mapCategoryToChipKey = (
+  category: string
+): keyof ConfigChips | null => {
+  switch (category) {
+    case 'behaviors':
+      return 'behavior';
+    case 'topics':
+      return 'topics';
+    case 'categories':
+      return 'category';
+    default:
+      return null;
+  }
+};
+
+const categoryColorVariant: Record<
+  string,
+  'blue' | 'purple' | 'orange' | 'green'
+> = {
+  behaviors: 'blue',
+  topics: 'green',
+  categories: 'purple',
+};
+
+const convertTestEventToSample = (
+  event: Extract<TestPipelineEvent, { type: 'test' }>
+): AnyTestSample => {
+  if (event.test_type === 'multi_turn') {
+    const t = event.test as unknown as GeneratedMultiTurnTest;
+    return {
+      id: `sample-${Date.now()}-${event.index}`,
+      testType: 'multi_turn',
+      prompt: {
+        goal: t.test_configuration.goal,
+        instructions: t.test_configuration.instructions,
+        restrictions: t.test_configuration.restrictions,
+        scenario: t.test_configuration.scenario,
+      },
+      behavior: t.behavior,
+      topic: t.topic,
+      category: t.category,
+      rating: null,
+      feedback: '',
+      context: [],
+    };
+  }
+  const t = event.test as unknown as GeneratedSingleTurnTest;
+  return {
+    id: `sample-${Date.now()}-${event.index}`,
+    testType: 'single_turn',
+    prompt: t.prompt.content,
+    behavior: t.behavior,
+    topic: t.topic,
+    rating: null,
+    feedback: '',
+    context: t.metadata?.sources
+      ?.map(source => ({
+        name: source.name || source.source || source.title || '',
+        description: source.description || '',
+        content: source.content || '',
+      }))
+      .filter(src => src.name && src.name.trim().length > 0),
+  };
 };
 
 /**
@@ -246,114 +311,100 @@ export default function TestGenerationFlow({
     string | null
   >(null);
 
-  // Check for template on mount and directly create config from template values
+  const handlePipelineEvent = useCallback(
+    (event: TestPipelineEvent) => {
+      switch (event.type) {
+        case 'config_item': {
+          const chipKey = mapCategoryToChipKey(event.category);
+          if (!chipKey) break;
+          const chip: ChipConfig = {
+            id: event.name.toLowerCase().replace(/\s+/g, '-'),
+            label: event.name,
+            description: event.description,
+            active: event.active,
+            colorVariant: categoryColorVariant[event.category] || 'blue',
+          };
+          setConfigChips(prev => ({
+            ...prev,
+            [chipKey]: [...prev[chipKey], chip],
+          }));
+          break;
+        }
+        case 'config_done':
+          setIsLoadingConfig(false);
+          break;
+        case 'test': {
+          const sample = convertTestEventToSample(event);
+          setTestSamples(prev => [...prev, sample]);
+          break;
+        }
+        case 'tests_done':
+          setIsLoadingSamples(false);
+          break;
+        case 'error':
+          show(`Generation error: ${event.message}`, {
+            severity: 'error',
+          });
+          if (event.phase === 'config') setIsLoadingConfig(false);
+          if (event.phase === 'tests') setIsLoadingSamples(false);
+          break;
+        case 'done':
+          setIsLoadingConfig(false);
+          setIsLoadingSamples(false);
+          break;
+      }
+    },
+    [show]
+  );
+
+  // Check for template on mount and stream config + tests via pipeline
   useEffect(() => {
     const initializeFromTemplate = async () => {
+      const templateId = sessionStorage.getItem('selectedTemplateId');
+      if (!templateId) return;
+
       try {
-        // Check if coming from template selection
-        const templateId = sessionStorage.getItem('selectedTemplateId');
-        if (templateId) {
-          try {
-            // Look up template by ID
-            const template = TEMPLATES.find(t => t.id === templateId);
-            if (!template) {
-              throw new Error(`Template with ID ${templateId} not found`);
-            }
-            sessionStorage.removeItem('selectedTemplateId');
-
-            setMode('template');
-            setDescription(template.description);
-            setIsGenerating(true);
-
-            // Generate behaviors from template prompt using API
-            const apiFactory = new ApiClientFactory(sessionToken);
-            const servicesClient = apiFactory.getServicesClient();
-
-            // Call generate/test_config with template prompt to get behaviors
-            const configResponse = await servicesClient.generateTestConfig({
-              prompt: template.prompt,
-              project_id: selectedProjectId || undefined,
-            });
-
-            // Create chips from API response and template values
-            const createChipsFromArray = (
-              items: Array<{ name: string; description: string }> | undefined,
-              colorVariant: 'blue' | 'purple' | 'orange' | 'green'
-            ): ChipConfig[] => {
-              if (!items || !Array.isArray(items)) {
-                return [];
-              }
-              return items.map((item, _index) => ({
-                id: item.name.toLowerCase().replace(/\s+/g, '-'),
-                label: item.name,
-                description: item.description,
-                active: true, // All template chips are active
-                colorVariant,
-              }));
-            };
-
-            const createChipsFromStringArray = (
-              items: string[],
-              colorVariant: 'blue' | 'purple' | 'orange' | 'green'
-            ): ChipConfig[] => {
-              return items.map(item => ({
-                id: item.toLowerCase().replace(/\s+/g, '-'),
-                label: item,
-                description: '',
-                active: true, // All template chips are active
-                colorVariant,
-              }));
-            };
-
-            const newConfigChips: ConfigChips = {
-              behavior: createChipsFromArray(configResponse.behaviors, 'blue'),
-              topics: createChipsFromStringArray(template.topics, 'green'),
-              category: createChipsFromStringArray(template.category, 'purple'),
-            };
-
-            setConfigChips(newConfigChips);
-
-            // Generate initial test samples directly
-            const behaviorLabels = newConfigChips.behavior.map(
-              chip => chip.label
-            );
-
-            const newSamples = await generateSamplesForTestType(
-              servicesClient,
-              testType,
-              behaviorLabels,
-              template.topics,
-              template.category,
-              template.description,
-              project?.name || 'General',
-              selectedSources,
-              5,
-              selectedModelId
-            );
-
-            setTestSamples(newSamples);
-
-            // Navigate to interface screen after samples are generated
-            setCurrentScreen('interface');
-            setIsGenerating(false);
-          } catch (e) {
-            setIsGenerating(false);
-            show(getApiErrorMessage(e, 'Failed to load template'), {
-              severity: 'error',
-            });
-          }
+        const template = TEMPLATES.find(t => t.id === templateId);
+        if (!template) {
+          throw new Error(`Template with ID ${templateId} not found`);
         }
-      } catch (error) {
-        show(getApiErrorMessage(error, 'Failed to load template'), {
+        sessionStorage.removeItem('selectedTemplateId');
+
+        setMode('template');
+        setDescription(template.description);
+        setCurrentScreen('interface');
+        setConfigChips(createEmptyChips());
+        setTestSamples([]);
+        setIsLoadingConfig(true);
+        setIsLoadingSamples(true);
+
+        const apiFactory = new ApiClientFactory(sessionToken);
+        const servicesClient = apiFactory.getServicesClient();
+
+        await servicesClient.generateTestPipelineStream(
+          {
+            prompt: template.prompt,
+            project_id: selectedProjectId || undefined,
+            test_type: testType,
+            num_tests: 5,
+            sources: selectedSources,
+            ...(selectedModelId ? { model_id: selectedModelId } : {}),
+          },
+          { onEvent: handlePipelineEvent }
+        );
+      } catch (e) {
+        setIsLoadingConfig(false);
+        setIsLoadingSamples(false);
+        show(getApiErrorMessage(e, 'Failed to load template'), {
           severity: 'error',
         });
       }
     };
 
     initializeFromTemplate();
-    // selectedProjectId, selectedSources, testType intentionally excluded - template init runs once on mount
+    // selectedProjectId, selectedSources, testType, selectedModelId intentionally excluded - template init runs once on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionToken, show, project]);
+  }, [sessionToken, show, handlePipelineEvent]);
 
   // Fetch available models for the model selector
   useEffect(() => {
@@ -386,19 +437,15 @@ export default function TestGenerationFlow({
       setSelectedSources(sources);
       setSelectedSourceIds(sources.map(s => s.id));
       setSelectedProjectId(projectId);
-      // Navigate immediately to interface screen
       setCurrentScreen('interface');
+      setConfigChips(createEmptyChips());
+      setTestSamples([]);
       setIsLoadingConfig(true);
       setIsLoadingSamples(true);
 
-      let apiFactory: ApiClientFactory | undefined;
-      let servicesClient:
-        | ReturnType<ApiClientFactory['getServicesClient']>
-        | undefined;
-
+      let apiFactory: ApiClientFactory;
       try {
         apiFactory = new ApiClientFactory(sessionToken);
-        servicesClient = apiFactory.getServicesClient();
       } catch (_error) {
         setIsLoadingConfig(false);
         setIsLoadingSamples(false);
@@ -406,166 +453,97 @@ export default function TestGenerationFlow({
         return;
       }
 
-      if (!apiFactory || !servicesClient) {
-        setIsLoadingConfig(false);
-        setIsLoadingSamples(false);
-        show('Failed to initialize services', { severity: 'error' });
-        return;
-      }
-
-      // Keep track of the freshest project data for prompt context
-      let latestProject: Project | null = project;
-
-      // Fetch project if selected
+      // Fetch project for display purposes
       if (projectId) {
         try {
           const projectsClient = apiFactory.getProjectsClient();
-          const fetchedProject = await projectsClient.getProject(projectId);
+          const fetchedProject =
+            await projectsClient.getProject(projectId);
           setProject(fetchedProject);
-          latestProject = fetchedProject;
         } catch (_error) {
-          show(`Failed to load project`, { severity: 'warning' });
+          show('Failed to load project', { severity: 'warning' });
         }
       } else {
         setProject(null);
-        latestProject = null;
       }
 
-      // Helper function to create chips from config response
-      const createChipsFromArray = (
-        items:
-          | Array<{ name: string; description: string; active: boolean }>
-          | undefined,
-        colorVariant: 'blue' | 'purple' | 'orange' | 'green'
-      ): ChipConfig[] => {
-        if (!items || !Array.isArray(items)) {
-          return [];
-        }
-        return items.map(item => {
-          return {
-            id: item.name.toLowerCase().replace(/\s+/g, '-'),
-            label: item.name,
-            description: item.description,
-            active: item.active,
-            colorVariant,
-          };
-        });
-      };
-
-      // Step 1: Generate test configuration
       try {
-        const configResponse = await servicesClient.generateTestConfig({
-          prompt: desc,
-          project_id: projectId || undefined,
-        });
-
-        const newConfigChips: ConfigChips = {
-          behavior: createChipsFromArray(
-            configResponse.behaviors || [],
-            'blue'
-          ),
-          topics: createChipsFromArray(configResponse.topics || [], 'green'),
-          category: createChipsFromArray(
-            configResponse.categories || [],
-            'purple'
-          ),
-        };
-
-        setConfigChips(newConfigChips);
-        setIsLoadingConfig(false);
-
-        // Step 2: Generate initial test samples (after config is ready)
-        try {
-          const activeBehaviors = newConfigChips.behavior
-            .filter(c => c.active)
-            .map(c => c.label);
-          const activeTopics = newConfigChips.topics
-            .filter(c => c.active)
-            .map(c => c.label);
-          const activeCategories = newConfigChips.category
-            .filter(c => c.active)
-            .map(c => c.label);
-
-          const projectContext = latestProject?.name || 'General';
-
-          const newSamples = await generateSamplesForTestType(
-            servicesClient,
-            testType,
-            activeBehaviors,
-            activeTopics,
-            activeCategories,
-            desc,
-            projectContext,
-            sources,
-            5,
-            selectedModelId
-          );
-
-          setTestSamples(newSamples);
-        } catch (_error) {
-          show(getApiErrorMessage(_error, 'Failed to generate test samples'), {
-            severity: 'error',
-          });
-        } finally {
-          setIsLoadingSamples(false);
-        }
+        const servicesClient = apiFactory.getServicesClient();
+        await servicesClient.generateTestPipelineStream(
+          {
+            prompt: desc,
+            project_id: projectId || undefined,
+            test_type: testType,
+            num_tests: 5,
+            sources: sources,
+            ...(selectedModelId ? { model_id: selectedModelId } : {}),
+          },
+          { onEvent: handlePipelineEvent }
+        );
       } catch (error) {
-        show(getApiErrorMessage(error, 'Failed to generate configuration'), {
-          severity: 'error',
-        });
+        show(
+          getApiErrorMessage(error, 'Failed to generate configuration'),
+          { severity: 'error' }
+        );
         setIsLoadingConfig(false);
         setIsLoadingSamples(false);
       }
     },
-    [sessionToken, project, show, testType]
+    [sessionToken, show, testType, selectedModelId, handlePipelineEvent]
   );
 
   // Generate test samples
   const generateSamples = useCallback(async () => {
+    setTestSamples([]);
     setIsLoadingSamples(true);
+
     try {
       const apiFactory = new ApiClientFactory(sessionToken);
       const servicesClient = apiFactory.getServicesClient();
 
-      // Build config from configuration
-      const activeBehaviors = configChips.behavior
-        .filter(c => c.active)
-        .map(c => c.label);
-      const activeTopics = configChips.topics
-        .filter(c => c.active)
-        .map(c => c.label);
-      const activeCategories = configChips.category
-        .filter(c => c.active)
-        .map(c => c.label);
+      const pipelineConfig = {
+        behaviors: configChips.behavior.map(c => ({
+          name: c.label,
+          description: c.description || '',
+          active: c.active,
+        })),
+        topics: configChips.topics.map(c => ({
+          name: c.label,
+          description: c.description || '',
+          active: c.active,
+        })),
+        categories: configChips.category.map(c => ({
+          name: c.label,
+          description: c.description || '',
+          active: c.active,
+        })),
+      };
 
-      const newSamples = await generateSamplesForTestType(
-        servicesClient,
-        testType,
-        activeBehaviors,
-        activeTopics,
-        activeCategories,
-        description,
-        project?.name || 'General',
-        selectedSources,
-        5,
-        selectedModelId
+      await servicesClient.generateTestPipelineStream(
+        {
+          prompt: description,
+          project_id: selectedProjectId || undefined,
+          test_type: testType,
+          num_tests: 5,
+          sources: selectedSources.length > 0 ? selectedSources : undefined,
+          model_id: selectedModelId || undefined,
+          config: pipelineConfig,
+        },
+        { onEvent: handlePipelineEvent }
       );
-
-      setTestSamples(newSamples);
-      show('Samples regenerated successfully', { severity: 'success' });
     } catch (_error) {
       show('Failed to regenerate samples', { severity: 'error' });
-    } finally {
       setIsLoadingSamples(false);
     }
   }, [
     sessionToken,
     description,
-    configChips,
+    selectedProjectId,
     selectedSources,
-    project,
+    configChips,
     testType,
     selectedModelId,
+    handlePipelineEvent,
     show,
   ]);
 
@@ -630,7 +608,6 @@ export default function TestGenerationFlow({
               id: `sample-${Date.now()}-regenerated`,
               testType: 'single_turn',
               prompt: t?.prompt?.content || '',
-              response: t?.prompt?.expected_response || '',
               behavior: t?.behavior || '',
               topic: t?.topic || '',
               rating: null,
@@ -723,7 +700,6 @@ export default function TestGenerationFlow({
 
   const handleSendMessage = useCallback(
     async (message: string) => {
-      // 1. Collect all chip states (both selected and deselected) for this message
       const chipStates: Array<{
         label: string;
         description: string;
@@ -760,26 +736,15 @@ export default function TestGenerationFlow({
       setChatMessages(prev => [...prev, newMessage]);
 
       setIsGenerating(true);
+      setConfigChips(createEmptyChips());
+      setTestSamples([]);
+      setIsLoadingConfig(true);
+      setIsLoadingSamples(true);
+
       try {
         const apiFactory = new ApiClientFactory(sessionToken);
         const servicesClient = apiFactory.getServicesClient();
 
-        // Build complete iteration context
-
-        // 1. Collect all rated samples with feedback
-        const _ratedSamples = testSamples
-          .filter(sample => sample.rating !== null)
-          .map(sample => ({
-            prompt: sample.prompt,
-            response: sample.response || '',
-            rating: sample.rating as number,
-            feedback:
-              sample.feedback && sample.feedback.trim()
-                ? sample.feedback
-                : undefined,
-          }));
-
-        // 2. Collect all previous user messages (not assistant responses) with their chip_states
         const previousMessages = chatMessages
           .filter(msg => msg.type === 'user')
           .map(msg => ({
@@ -788,100 +753,42 @@ export default function TestGenerationFlow({
             chip_states: msg.chip_states,
           }));
 
-        // Step 1: Regenerate test configuration with full iteration context
-        const configResponse = await servicesClient.generateTestConfig({
-          prompt: description, // Keep original prompt separate
-          project_id: selectedProjectId || undefined,
-          previous_messages: [
-            ...previousMessages,
-            {
-              content: message,
-              timestamp: newMessage.timestamp.toISOString(),
-              chip_states: chipStates,
-            },
-          ],
-        });
-
-        // Step 2: Create chips from config response
-        const createChipsFromArray = (
-          items:
-            | Array<{ name: string; description: string; active: boolean }>
-            | undefined,
-          colorVariant: 'blue' | 'purple' | 'orange' | 'green'
-        ): ChipConfig[] => {
-          if (!items || !Array.isArray(items)) {
-            return [];
-          }
-          return items.map(item => {
-            return {
-              id: item.name.toLowerCase().replace(/\s+/g, '-'),
-              label: item.name,
-              description: item.description,
-              active: item.active,
-              colorVariant,
-            };
-          });
-        };
-
-        const newConfigChips: ConfigChips = {
-          behavior: createChipsFromArray(
-            configResponse.behaviors || [],
-            'blue'
-          ),
-          topics: createChipsFromArray(configResponse.topics || [], 'green'),
-          category: createChipsFromArray(
-            configResponse.categories || [],
-            'purple'
-          ),
-        };
-
-        setConfigChips(newConfigChips);
-
-        // Step 3: Generate new test samples with updated configuration
-        const activeBehaviors = newConfigChips.behavior
-          .filter(c => c.active)
-          .map(c => c.label);
-        const activeTopics = newConfigChips.topics
-          .filter(c => c.active)
-          .map(c => c.label);
-        const activeCategories = newConfigChips.category
-          .filter(c => c.active)
-          .map(c => c.label);
-
-        const newSamples = await generateSamplesForTestType(
-          servicesClient,
-          testType,
-          activeBehaviors,
-          activeTopics,
-          activeCategories,
-          description,
-          project?.name || 'General',
-          selectedSources,
-          5,
-          selectedModelId
+        await servicesClient.generateTestPipelineStream(
+          {
+            prompt: description,
+            project_id: selectedProjectId || undefined,
+            previous_messages: [
+              ...previousMessages,
+              {
+                content: message,
+                timestamp: newMessage.timestamp.toISOString(),
+                chip_states: chipStates,
+              },
+            ],
+            test_type: testType,
+            num_tests: 5,
+            sources: selectedSources.length > 0 ? selectedSources : undefined,
+            model_id: selectedModelId || undefined,
+          },
+          { onEvent: handlePipelineEvent }
         );
 
-        setTestSamples(newSamples);
-
-        if (newSamples.length > 0) {
-          // Add assistant response to chat
-          const assistantMessage: ChatMessage = {
-            id: `msg-${Date.now()}-assistant`,
-            type: 'assistant',
-            content:
-              'Configuration and samples updated based on your refinement.',
-            timestamp: new Date(),
-          };
-          setChatMessages(prev => [...prev, assistantMessage]);
-
-          show('Test generation refined successfully', { severity: 'success' });
-        }
+        const assistantMessage: ChatMessage = {
+          id: `msg-${Date.now()}-assistant`,
+          type: 'assistant',
+          content:
+            'Configuration and samples updated based on your refinement.',
+          timestamp: new Date(),
+        };
+        setChatMessages(prev => [...prev, assistantMessage]);
       } catch (_error) {
         show(getApiErrorMessage(_error, 'Failed to refine test generation'), {
           severity: 'error',
         });
       } finally {
         setIsGenerating(false);
+        setIsLoadingConfig(false);
+        setIsLoadingSamples(false);
       }
     },
     [
@@ -890,12 +797,11 @@ export default function TestGenerationFlow({
       selectedProjectId,
       selectedSources,
       selectedModelId,
-      project,
       show,
       configChips,
-      testSamples,
       chatMessages,
       testType,
+      handlePipelineEvent,
     ]
   );
 

--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationInterface.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationInterface.tsx
@@ -212,6 +212,13 @@ export default function TestGenerationInterface({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [testSamples]);
 
+  // Notify parent whenever local samples change
+  useEffect(() => {
+    if (onSamplesUpdate) onSamplesUpdate(localTestSamples);
+    // onSamplesUpdate intentionally excluded to avoid re-triggering on callback identity change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [localTestSamples]);
+
   // Load endpoint information when selectedEndpointId changes
   useEffect(() => {
     const loadEndpointInfo = async () => {
@@ -420,11 +427,6 @@ export default function TestGenerationInterface({
       }
       setProcessedSampleIds(newProcessedIds);
 
-      setLocalTestSamples(prev => {
-        if (onSamplesUpdate) onSamplesUpdate(prev);
-        return prev;
-      });
-
       setIsFetchingResponses(false);
     };
 
@@ -562,11 +564,6 @@ export default function TestGenerationInterface({
         }
 
         setProcessedSampleIds(prev => new Set(prev).add(sampleId));
-
-        setLocalTestSamples(prev => {
-          if (onSamplesUpdate) onSamplesUpdate(prev);
-          return prev;
-        });
       } catch (error) {
         const errorMsg =
           error instanceof Error ? error.message : 'Failed to fetch response';
@@ -588,7 +585,6 @@ export default function TestGenerationInterface({
       session?.session_token,
       localTestSamples,
       processedSampleIds,
-      onSamplesUpdate,
     ]
   );
 

--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationInterface.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationInterface.tsx
@@ -1116,68 +1116,67 @@ export default function TestGenerationInterface({
 
                     {(isLoadingConfig || isLoadingSamples || isGenerating) && (
                       <Box>
-                        {[...Array(localTestSamples.length === 0 ? 3 : 1)].map(
-                          (_, i) => (
-                            <Card
-                              key={`skeleton-${i}`}
-                              elevation={0}
-                              sx={{
-                                mb: 2,
-                                borderRadius: theme => theme.shape.borderRadius,
-                                border: 1,
-                                borderColor: 'divider',
-                                bgcolor: 'background.paper',
-                              }}
+                        {(localTestSamples.length === 0
+                          ? ['initial-1', 'initial-2', 'initial-3']
+                          : ['loading']
+                        ).map(skeletonKey => (
+                          <Card
+                            key={`skeleton-${skeletonKey}`}
+                            elevation={0}
+                            sx={{
+                              mb: 2,
+                              borderRadius: theme => theme.shape.borderRadius,
+                              border: 1,
+                              borderColor: 'divider',
+                              bgcolor: 'background.paper',
+                            }}
+                          >
+                            <CardContent
+                              sx={{ p: 2, '&:last-child': { pb: 2 } }}
                             >
-                              <CardContent
-                                sx={{ p: 2, '&:last-child': { pb: 2 } }}
-                              >
-                                <Box
-                                  sx={{ display: 'flex', gap: 0.5, mb: 1.5 }}
-                                >
-                                  <Skeleton
-                                    variant="rounded"
-                                    width="20%"
-                                    height={24}
-                                    sx={{
-                                      borderRadius: theme =>
-                                        theme.shape.borderRadius,
-                                    }}
-                                  />
-                                  <Skeleton
-                                    variant="rounded"
-                                    width="15%"
-                                    height={24}
-                                    sx={{
-                                      borderRadius: theme =>
-                                        theme.shape.borderRadius,
-                                    }}
-                                  />
-                                  <Skeleton
-                                    variant="rounded"
-                                    width="18%"
-                                    height={24}
-                                    sx={{
-                                      borderRadius: theme =>
-                                        theme.shape.borderRadius,
-                                    }}
-                                  />
-                                </Box>
+                              <Box sx={{ display: 'flex', gap: 0.5, mb: 1.5 }}>
                                 <Skeleton
                                   variant="rounded"
-                                  width="85%"
-                                  height={56}
+                                  width="20%"
+                                  height={24}
                                   sx={{
                                     borderRadius: theme =>
                                       theme.shape.borderRadius,
-                                    mb: 1,
                                   }}
                                 />
-                                <Skeleton variant="text" width="40%" />
-                              </CardContent>
-                            </Card>
-                          )
-                        )}
+                                <Skeleton
+                                  variant="rounded"
+                                  width="15%"
+                                  height={24}
+                                  sx={{
+                                    borderRadius: theme =>
+                                      theme.shape.borderRadius,
+                                  }}
+                                />
+                                <Skeleton
+                                  variant="rounded"
+                                  width="18%"
+                                  height={24}
+                                  sx={{
+                                    borderRadius: theme =>
+                                      theme.shape.borderRadius,
+                                  }}
+                                />
+                              </Box>
+                              <Skeleton
+                                variant="rounded"
+                                width="85%"
+                                height={56}
+                                sx={{
+                                  borderRadius: theme =>
+                                    theme.shape.borderRadius,
+                                  mb: 1,
+                                }}
+                              />
+                              <Skeleton variant="text" width="40%" />
+                            </CardContent>
+                          </Card>
+                        ))}
                       </Box>
                     )}
 

--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationInterface.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationInterface.tsx
@@ -18,6 +18,7 @@ import {
   DialogTitle,
   DialogContent,
   DialogActions,
+  Skeleton,
 } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import SendIcon from '@mui/icons-material/Send';
@@ -29,6 +30,7 @@ import ApiIcon from '@mui/icons-material/Api';
 import SwapHorizIcon from '@mui/icons-material/SwapHoriz';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import CloseIcon from '@mui/icons-material/Close';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import FolderIcon from '@mui/icons-material/Folder';
 import {
   ConfigChips,
@@ -38,6 +40,7 @@ import {
   TestType,
 } from './shared/types';
 import { SourceData } from '@/utils/api-client/interfaces/test-set';
+import { ConversationTurn } from '@/utils/api-client/interfaces/test-results';
 import ChipGroup from './shared/ChipGroup';
 import TestSampleCard from './shared/TestSampleCard';
 import ActionBar from '@/components/common/ActionBar';
@@ -45,6 +48,16 @@ import EndpointSelector from './shared/EndpointSelector';
 import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { TEST_TYPES } from '@/constants/test-types';
+
+function extractResponseText(response: unknown): string {
+  if (typeof response === 'string') return response;
+  const r = response as Record<string, unknown> | null;
+  if (r?.output != null) return String(r.output);
+  if (r?.text != null) return String(r.text);
+  if (r?.response != null) return String(r.response);
+  if (r?.content != null) return String(r.content);
+  return JSON.stringify(response);
+}
 
 interface TestGenerationInterfaceProps {
   testType: TestType;
@@ -134,10 +147,8 @@ export default function TestGenerationInterface({
       testSamples.length !== localTestSamples.length ||
       testSamples.some(s => !existingSampleIds.has(s.id));
 
-    // If sample IDs changed, reset processed IDs and trigger endpoint fetch
     if (sampleIdsChanged) {
       setProcessedSampleIds(new Set());
-      setFetchTrigger(prev => prev + 1);
     }
 
     // Create a map of existing samples with responses
@@ -258,20 +269,21 @@ export default function TestGenerationInterface({
     loadEndpointInfo();
   }, [selectedEndpointId, session]);
 
-  // Fetch responses from endpoint for all samples (only auto-fetch for single-turn)
+  // Fetch responses from endpoint for all unprocessed samples (in parallel).
+  // Only triggered explicitly via fetchTrigger (e.g. "Generate Responses" button).
   useEffect(() => {
+    if (fetchTrigger === 0) return;
+
     const fetchResponses = async () => {
       if (
         !selectedEndpointId ||
         !session?.session_token ||
         localTestSamples.length === 0 ||
-        isFetchingResponses ||
-        testType === 'multi_turn' // Don't auto-fetch for multi-turn
+        isFetchingResponses
       ) {
         return;
       }
 
-      // Find samples that haven't been processed yet
       const samplesToFetch = localTestSamples.filter(
         sample =>
           !processedSampleIds.has(sample.id) &&
@@ -285,179 +297,140 @@ export default function TestGenerationInterface({
 
       setIsFetchingResponses(true);
 
-      try {
-        const apiFactory = new ApiClientFactory(session.session_token);
-        const endpointsClient = apiFactory.getEndpointsClient();
-        const testsClient = apiFactory.getTestsClient();
+      const apiFactory = new ApiClientFactory(session.session_token);
+      const endpointsClient = apiFactory.getEndpointsClient();
+      const testsClient = apiFactory.getTestsClient();
 
-        // Mark samples to fetch as loading
-        const updatedSamples = localTestSamples.map(sample => {
-          if (samplesToFetch.some(s => s.id === sample.id)) {
-            if (sample.testType === 'single_turn') {
-              const newSample = {
-                ...sample,
-                isLoadingResponse: true,
-              };
-              delete newSample.response;
-              delete newSample.responseError;
-              return newSample;
-            } else {
-              const newSample = {
-                ...sample,
-                isLoadingConversation: true,
-              };
-              delete newSample.response;
-              delete newSample.responseError;
-              delete newSample.conversation;
-              delete newSample.conversationError;
-              return newSample;
+      // Mark all samples as loading
+      setLocalTestSamples(prev =>
+        prev.map(sample => {
+          if (!samplesToFetch.some(s => s.id === sample.id)) return sample;
+          if (sample.testType === 'single_turn') {
+            const s = { ...sample, isLoadingResponse: true };
+            delete s.response;
+            delete s.responseError;
+            return s;
+          }
+          const s = { ...sample, isLoadingConversation: true };
+          delete s.response;
+          delete s.responseError;
+          delete s.conversation;
+          delete s.conversationError;
+          return s;
+        })
+      );
+
+      // Fire all requests in parallel, updating each card as it resolves
+      const promises = samplesToFetch.map(async sample => {
+        try {
+          if (sample.testType === 'single_turn') {
+            const response = await endpointsClient.invokeEndpoint(
+              selectedEndpointId,
+              { input: sample.prompt }
+            );
+
+            const responseText = extractResponseText(response);
+
+            setLocalTestSamples(prev =>
+              prev.map(s =>
+                s.id === sample.id
+                  ? { ...s, response: responseText, isLoadingResponse: false, responseError: undefined }
+                  : s
+              )
+            );
+          } else {
+            const executeResponse = await testsClient.executeTest({
+              endpoint_id:
+                selectedEndpointId as `${string}-${string}-${string}-${string}-${string}`,
+              test_configuration: {
+                goal: sample.prompt.goal,
+                instructions: sample.prompt.instructions,
+                restrictions: sample.prompt.restrictions,
+                scenario: sample.prompt.scenario,
+              },
+              behavior: sample.behavior,
+              topic: sample.topic,
+              category: sample.category,
+              evaluate_metrics: false,
+            });
+
+            let conversation: ConversationTurn[] = [];
+            if (
+              executeResponse.test_output &&
+              typeof executeResponse.test_output === 'object'
+            ) {
+              conversation = Array.isArray(
+                executeResponse.test_output.conversation_summary
+              )
+                ? executeResponse.test_output.conversation_summary
+                : [];
             }
+
+            setLocalTestSamples(prev =>
+              prev.map(s =>
+                s.id === sample.id
+                  ? {
+                      ...s,
+                      conversation,
+                      isLoadingConversation: false,
+                      response: `Goal: ${sample.prompt.goal} (${conversation.length} turns)`,
+                      conversationError: undefined,
+                    }
+                  : s
+              )
+            );
           }
-          return sample;
-        });
-        setLocalTestSamples(updatedSamples);
 
-        // Fetch responses for each new sample
-        const newProcessedIds = new Set(processedSampleIds);
+          return { id: sample.id, success: true };
+        } catch (error) {
+          const errorMsg =
+            error instanceof Error ? error.message : 'Failed to fetch response';
 
-        for (let i = 0; i < updatedSamples.length; i++) {
-          const sample = updatedSamples[i];
-
-          // Skip samples that were already processed or not in the fetch list
-          if (!samplesToFetch.some(s => s.id === sample.id)) {
-            continue;
-          }
-
-          try {
-            if (sample.testType === 'single_turn') {
-              // Single-turn: use old invoke endpoint
-              const response = await endpointsClient.invokeEndpoint(
-                selectedEndpointId,
-                {
-                  input: sample.prompt,
-                }
-              );
-
-              // Extract response text from various possible response formats
-              let responseText = '';
-              if (typeof response === 'string') {
-                responseText = response;
-              } else if (response?.output != null) {
-                responseText = String(response.output);
-              } else if (response?.text != null) {
-                responseText = String(response.text);
-              } else if (response?.response != null) {
-                responseText = String(response.response);
-              } else if (response?.content != null) {
-                responseText = String(response.content);
-              } else {
-                responseText = JSON.stringify(response);
-              }
-
-              updatedSamples[i] = {
-                ...sample,
-                response: responseText,
-                isLoadingResponse: false,
-              };
-              delete updatedSamples[i].responseError;
-            } else {
-              // Multi-turn: use new /tests/execute endpoint
-              const executeRequest = {
-                endpoint_id:
-                  selectedEndpointId as `${string}-${string}-${string}-${string}-${string}`,
-                test_configuration: {
-                  goal: sample.prompt.goal,
-                  instructions: sample.prompt.instructions,
-                  restrictions: sample.prompt.restrictions,
-                  scenario: sample.prompt.scenario,
-                },
-                behavior: sample.behavior,
-                topic: sample.topic,
-                category: sample.category,
-                evaluate_metrics: false, // We just want conversation output
-              };
-
-              const executeResponse =
-                await testsClient.executeTest(executeRequest);
-
-              // Extract conversation from test_output
-              let conversation = [];
-              if (
-                executeResponse.test_output &&
-                typeof executeResponse.test_output === 'object'
-              ) {
-                conversation = Array.isArray(
-                  executeResponse.test_output.conversation_summary
-                )
-                  ? executeResponse.test_output.conversation_summary
-                  : [];
-              }
-
-              if (sample.testType === 'multi_turn') {
-                const newSample = {
-                  ...sample,
-                  conversation,
-                  isLoadingConversation: false,
-                  response: `Goal: ${sample.prompt.goal} (${conversation.length} turns)`,
+          setLocalTestSamples(prev =>
+            prev.map(s => {
+              if (s.id !== sample.id) return s;
+              if (s.testType === 'single_turn') {
+                return {
+                  ...s,
+                  isLoadingResponse: false,
+                  responseError: errorMsg,
+                  response: undefined,
                 };
-                delete newSample.conversationError;
-                updatedSamples[i] = newSample;
               }
-            }
-
-            newProcessedIds.add(sample.id);
-          } catch (error) {
-            if (sample.testType === 'single_turn') {
-              const newSample = {
-                ...sample,
-                isLoadingResponse: false,
-                responseError:
-                  error instanceof Error
-                    ? error.message
-                    : 'Failed to fetch response',
-              };
-              delete newSample.response;
-              updatedSamples[i] = newSample;
-            } else if (sample.testType === 'multi_turn') {
-              const newSample = {
-                ...sample,
+              return {
+                ...s,
                 isLoadingConversation: false,
-                conversationError:
-                  error instanceof Error
-                    ? error.message
-                    : 'Failed to execute test',
+                conversationError: errorMsg,
+                conversation: undefined,
               };
-              delete newSample.conversation;
-              updatedSamples[i] = newSample;
-            }
-            newProcessedIds.add(sample.id);
-          }
+            })
+          );
 
-          // Update state after each response to show progress
-          setLocalTestSamples([...updatedSamples]);
+          return { id: sample.id, success: false };
         }
+      });
 
-        // Update processed IDs
-        setProcessedSampleIds(newProcessedIds);
+      const results = await Promise.allSettled(promises);
 
-        // Notify parent component of updates if callback provided
-        if (onSamplesUpdate) {
-          onSamplesUpdate(updatedSamples);
+      const newProcessedIds = new Set(processedSampleIds);
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          newProcessedIds.add(result.value.id);
         }
-      } finally {
-        setIsFetchingResponses(false);
       }
+      setProcessedSampleIds(newProcessedIds);
+
+      setLocalTestSamples(prev => {
+        if (onSamplesUpdate) onSamplesUpdate(prev);
+        return prev;
+      });
+
+      setIsFetchingResponses(false);
     };
 
     fetchResponses();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    selectedEndpointId,
-    session?.session_token,
-    localTestSamples.length,
-    fetchTrigger,
-    testType,
-  ]);
+  }, [fetchTrigger]);
 
   const handleSendMessage = useCallback(() => {
     if (inputMessage.trim()) {
@@ -506,85 +479,47 @@ export default function TestGenerationInterface({
     [onSampleFeedbackChange]
   );
 
-  // Manual fetch for a single sample (for multi-turn)
+  // Manual fetch for a single sample (for multi-turn "Simulate Response" button)
   const handleFetchSampleResponse = useCallback(
     async (sampleId: string) => {
-      if (!selectedEndpointId || !session?.session_token) {
-        return;
-      }
+      if (!selectedEndpointId || !session?.session_token) return;
 
-      const sampleIndex = localTestSamples.findIndex(s => s.id === sampleId);
-      if (sampleIndex === -1) return;
+      const sample = localTestSamples.find(s => s.id === sampleId);
+      if (!sample) return;
+      if (processedSampleIds.has(sampleId) || sample.isLoadingResponse) return;
+      if (sample.testType === 'multi_turn' && sample.isLoadingConversation) return;
 
-      const sample = localTestSamples[sampleIndex];
+      const apiFactory = new ApiClientFactory(session.session_token);
+      const endpointsClient = apiFactory.getEndpointsClient();
+      const testsClient = apiFactory.getTestsClient();
 
-      // Skip if already processed or loading
-      if (processedSampleIds.has(sample.id) || sample.isLoadingResponse) {
-        return;
-      }
-
-      // Additional check for multi-turn
-      if (sample.testType === 'multi_turn' && sample.isLoadingConversation) {
-        return;
-      }
+      // Mark sample as loading
+      setLocalTestSamples(prev =>
+        prev.map(s => {
+          if (s.id !== sampleId) return s;
+          return s.testType === 'single_turn'
+            ? { ...s, isLoadingResponse: true, response: undefined, responseError: undefined }
+            : { ...s, isLoadingConversation: true, response: undefined, responseError: undefined, conversation: undefined, conversationError: undefined };
+        })
+      );
 
       try {
-        const apiFactory = new ApiClientFactory(session.session_token);
-        const endpointsClient = apiFactory.getEndpointsClient();
-        const testsClient = apiFactory.getTestsClient();
-
-        // Mark sample as loading
-        const updatedSamples = [...localTestSamples];
         if (sample.testType === 'single_turn') {
-          const newSample = { ...sample, isLoadingResponse: true };
-          delete newSample.response;
-          delete newSample.responseError;
-          updatedSamples[sampleIndex] = newSample;
-        } else {
-          const newSample = { ...sample, isLoadingConversation: true };
-          delete newSample.response;
-          delete newSample.responseError;
-          delete newSample.conversation;
-          delete newSample.conversationError;
-          updatedSamples[sampleIndex] = newSample;
-        }
-        setLocalTestSamples(updatedSamples);
-
-        if (sample.testType === 'single_turn') {
-          // Single-turn: use old invoke endpoint
           const response = await endpointsClient.invokeEndpoint(
             selectedEndpointId,
-            {
-              input: sample.prompt,
-            }
+            { input: sample.prompt }
           );
+          const responseText = extractResponseText(response);
 
-          // Extract response text
-          let responseText = '';
-          if (typeof response === 'string') {
-            responseText = response;
-          } else if (response?.output != null) {
-            responseText = String(response.output);
-          } else if (response?.text != null) {
-            responseText = String(response.text);
-          } else if (response?.response != null) {
-            responseText = String(response.response);
-          } else if (response?.content != null) {
-            responseText = String(response.content);
-          } else {
-            responseText = JSON.stringify(response);
-          }
-
-          const newSample = {
-            ...sample,
-            response: responseText,
-            isLoadingResponse: false,
-          };
-          delete newSample.responseError;
-          updatedSamples[sampleIndex] = newSample;
+          setLocalTestSamples(prev =>
+            prev.map(s =>
+              s.id === sampleId
+                ? { ...s, response: responseText, isLoadingResponse: false, responseError: undefined }
+                : s
+            )
+          );
         } else {
-          // Multi-turn: use /tests/execute endpoint
-          const executeRequest = {
+          const executeResponse = await testsClient.executeTest({
             endpoint_id:
               selectedEndpointId as `${string}-${string}-${string}-${string}-${string}`,
             test_configuration: {
@@ -597,12 +532,9 @@ export default function TestGenerationInterface({
             topic: sample.topic,
             category: sample.category,
             evaluate_metrics: false,
-          };
+          });
 
-          const executeResponse = await testsClient.executeTest(executeRequest);
-
-          // Extract conversation from test_output
-          let conversation = [];
+          let conversation: ConversationTurn[] = [];
           if (
             executeResponse.test_output &&
             typeof executeResponse.test_output === 'object'
@@ -614,58 +546,41 @@ export default function TestGenerationInterface({
               : [];
           }
 
-          const newSample = {
-            ...sample,
-            conversation,
-            isLoadingConversation: false,
-            response: `Goal: ${sample.prompt.goal} (${conversation.length} turns)`,
-          };
-          delete newSample.conversationError;
-          updatedSamples[sampleIndex] = newSample;
+          setLocalTestSamples(prev =>
+            prev.map(s =>
+              s.id === sampleId
+                ? {
+                    ...s,
+                    conversation,
+                    isLoadingConversation: false,
+                    response: `Goal: ${sample.prompt.goal} (${conversation.length} turns)`,
+                    conversationError: undefined,
+                  }
+                : s
+            )
+          );
         }
 
-        // Mark as processed
-        const newProcessedIds = new Set(processedSampleIds);
-        newProcessedIds.add(sample.id);
-        setProcessedSampleIds(newProcessedIds);
+        setProcessedSampleIds(prev => new Set(prev).add(sampleId));
 
-        // Update state
-        setLocalTestSamples(updatedSamples);
-
-        // Notify parent component
-        if (onSamplesUpdate) {
-          onSamplesUpdate(updatedSamples);
-        }
+        setLocalTestSamples(prev => {
+          if (onSamplesUpdate) onSamplesUpdate(prev);
+          return prev;
+        });
       } catch (error) {
-        const updatedSamples = [...localTestSamples];
-        if (sample.testType === 'single_turn') {
-          const newSample = {
-            ...sample,
-            isLoadingResponse: false,
-            responseError:
-              error instanceof Error
-                ? error.message
-                : 'Failed to fetch response',
-          };
-          delete newSample.response;
-          updatedSamples[sampleIndex] = newSample;
-        } else {
-          const newSample = {
-            ...sample,
-            isLoadingConversation: false,
-            conversationError:
-              error instanceof Error ? error.message : 'Failed to execute test',
-          };
-          delete newSample.conversation;
-          updatedSamples[sampleIndex] = newSample;
-        }
+        const errorMsg =
+          error instanceof Error ? error.message : 'Failed to fetch response';
 
-        // Mark as processed even on error
-        const newProcessedIds = new Set(processedSampleIds);
-        newProcessedIds.add(sample.id);
-        setProcessedSampleIds(newProcessedIds);
+        setLocalTestSamples(prev =>
+          prev.map(s => {
+            if (s.id !== sampleId) return s;
+            return s.testType === 'single_turn'
+              ? { ...s, isLoadingResponse: false, responseError: errorMsg, response: undefined }
+              : { ...s, isLoadingConversation: false, conversationError: errorMsg, conversation: undefined };
+          })
+        );
 
-        setLocalTestSamples(updatedSamples);
+        setProcessedSampleIds(prev => new Set(prev).add(sampleId));
       }
     },
     [
@@ -736,7 +651,7 @@ export default function TestGenerationInterface({
                     >
                       <InfoOutlinedIcon
                         sx={{
-                          fontSize: 16,
+                          fontSize: theme => theme.iconSizes.small,
                           color: 'text.secondary',
                           cursor: 'help',
                         }}
@@ -750,37 +665,11 @@ export default function TestGenerationInterface({
               <Box
                 sx={{
                   flex: 1,
-                  overflow: isLoadingConfig || isGenerating ? 'hidden' : 'auto',
+                  overflow: 'auto',
                   p: 3,
                   position: 'relative',
                 }}
               >
-                {/* Loading Overlay */}
-                {(isLoadingConfig || isGenerating) && (
-                  <Box
-                    sx={{
-                      position: 'absolute',
-                      top: 0,
-                      left: 0,
-                      right: 0,
-                      bottom: 0,
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      bgcolor: 'background.paper',
-                      opacity: 0.95,
-                      zIndex: 1,
-                    }}
-                  >
-                    <CircularProgress sx={{ mb: 2 }} />
-                    <Typography variant="body1">
-                      {isLoadingConfig
-                        ? 'Loading configuration...'
-                        : 'Updating configuration...'}
-                    </Typography>
-                  </Box>
-                )}
 
                 {/* Behavior Testing */}
                 <Box sx={{ mb: 4 }}>
@@ -808,6 +697,13 @@ export default function TestGenerationInterface({
                     chips={configChips.behavior}
                     onToggle={chipId => onChipToggle('behavior', chipId)}
                   />
+                  {isLoadingConfig && configChips.behavior.length === 0 && (
+                    <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+                      <Skeleton variant="rounded" width="30%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                      <Skeleton variant="rounded" width="22%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                      <Skeleton variant="rounded" width="35%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                    </Box>
+                  )}
                 </Box>
 
                 {/* Topics */}
@@ -836,6 +732,13 @@ export default function TestGenerationInterface({
                     chips={configChips.topics}
                     onToggle={chipId => onChipToggle('topics', chipId)}
                   />
+                  {isLoadingConfig && configChips.topics.length === 0 && (
+                    <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+                      <Skeleton variant="rounded" width="25%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                      <Skeleton variant="rounded" width="20%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                      <Skeleton variant="rounded" width="28%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                    </Box>
+                  )}
                 </Box>
 
                 {/* Category */}
@@ -864,6 +767,12 @@ export default function TestGenerationInterface({
                     chips={configChips.category}
                     onToggle={chipId => onChipToggle('category', chipId)}
                   />
+                  {isLoadingConfig && configChips.category.length === 0 && (
+                    <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
+                      <Skeleton variant="rounded" width="32%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                      <Skeleton variant="rounded" width="22%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                    </Box>
+                  )}
                 </Box>
               </Box>
 
@@ -939,7 +848,7 @@ export default function TestGenerationInterface({
                     disabled={!inputMessage.trim()}
                     sx={{
                       bgcolor: 'primary.main',
-                      color: 'white',
+                      color: 'primary.contrastText',
                       '&:hover': {
                         bgcolor: 'primary.dark',
                       },
@@ -982,6 +891,7 @@ export default function TestGenerationInterface({
                   bgcolor: 'background.paper',
                   minHeight: 64,
                   alignItems: 'center',
+                  '& .MuiCardHeader-action': { alignSelf: 'center', m: 0 },
                 }}
                 title={
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -1007,7 +917,7 @@ export default function TestGenerationInterface({
                     >
                       <InfoOutlinedIcon
                         sx={{
-                          fontSize: 16,
+                          fontSize: theme => theme.iconSizes.small,
                           color: 'text.secondary',
                           cursor: 'help',
                         }}
@@ -1055,7 +965,7 @@ export default function TestGenerationInterface({
                         ? endpointInfo.name
                         : testType === 'multi_turn'
                           ? 'Activate Live Responses'
-                          : 'Show Live Responses'}
+                          : 'Get Endpoint Responses'}
                     </Button>
                   </Box>
                 }
@@ -1072,24 +982,9 @@ export default function TestGenerationInterface({
                   flexDirection: 'column',
                 }}
               >
-                {isLoadingSamples || isGenerating ? (
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      flex: 1,
-                    }}
-                  >
-                    <CircularProgress sx={{ mb: 2 }} />
-                    <Typography variant="body1">
-                      {isLoadingSamples
-                        ? 'Loading test samples...'
-                        : 'Generating test samples...'}
-                    </Typography>
-                  </Box>
-                ) : localTestSamples.length === 0 ? (
+                {localTestSamples.length === 0 &&
+                !isLoadingSamples &&
+                !isGenerating ? (
                   <Box
                     sx={{
                       display: 'flex',
@@ -1101,7 +996,7 @@ export default function TestGenerationInterface({
                     }}
                   >
                     <VisibilityIcon
-                      sx={{ fontSize: 64, opacity: 0.3, mb: 2 }}
+                      sx={{ fontSize: theme => theme.iconSizes.xlarge, opacity: 0.3, mb: 2 }}
                     />
                     <Typography
                       variant="h6"
@@ -1147,7 +1042,41 @@ export default function TestGenerationInterface({
                       />
                     ))}
 
+                    {(isLoadingConfig || isLoadingSamples || isGenerating) && (
+                      <Box>
+                        {[...Array(localTestSamples.length === 0 ? 3 : 1)].map((_, i) => (
+                          <Card
+                            key={`skeleton-${i}`}
+                            elevation={0}
+                            sx={{
+                              mb: 2,
+                              borderRadius: theme => theme.shape.borderRadius,
+                              border: 1,
+                              borderColor: 'divider',
+                              bgcolor: 'background.paper',
+                            }}
+                          >
+                            <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
+                              <Box sx={{ display: 'flex', gap: 0.5, mb: 1.5 }}>
+                                <Skeleton variant="rounded" width="20%" height={24} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                                <Skeleton variant="rounded" width="15%" height={24} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                                <Skeleton variant="rounded" width="18%" height={24} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                              </Box>
+                              <Skeleton
+                                variant="rounded"
+                                width="85%"
+                                height={56}
+                                sx={{ borderRadius: theme => theme.shape.borderRadius, mb: 1 }}
+                              />
+                              <Skeleton variant="text" width="40%" />
+                            </CardContent>
+                          </Card>
+                        ))}
+                      </Box>
+                    )}
+
                     {/* Load More Button */}
+                    {!isLoadingSamples && !isGenerating && localTestSamples.length > 0 && (
                     <Box sx={{ textAlign: 'center', mt: 3 }}>
                       <Button
                         variant="outlined"
@@ -1164,6 +1093,7 @@ export default function TestGenerationInterface({
                         {isLoadingMore ? 'Loading...' : 'Load More Samples'}
                       </Button>
                     </Box>
+                    )}
                   </Box>
                 )}
               </CardContent>
@@ -1208,6 +1138,17 @@ export default function TestGenerationInterface({
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setShowEndpointModal(false)}>Close</Button>
+          <Button
+            variant="contained"
+            startIcon={<PlayArrowIcon />}
+            onClick={() => {
+              setFetchTrigger(prev => prev + 1);
+              setShowEndpointModal(false);
+            }}
+            disabled={!selectedEndpointId || localTestSamples.length === 0 || isFetchingResponses || isLoadingSamples}
+          >
+            {isFetchingResponses ? 'Getting...' : 'Get Responses'}
+          </Button>
         </DialogActions>
       </Dialog>
     </Box>

--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationInterface.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/TestGenerationInterface.tsx
@@ -341,7 +341,12 @@ export default function TestGenerationInterface({
             setLocalTestSamples(prev =>
               prev.map(s =>
                 s.id === sample.id
-                  ? { ...s, response: responseText, isLoadingResponse: false, responseError: undefined }
+                  ? {
+                      ...s,
+                      response: responseText,
+                      isLoadingResponse: false,
+                      responseError: undefined,
+                    }
                   : s
               )
             );
@@ -489,7 +494,8 @@ export default function TestGenerationInterface({
       const sample = localTestSamples.find(s => s.id === sampleId);
       if (!sample) return;
       if (processedSampleIds.has(sampleId) || sample.isLoadingResponse) return;
-      if (sample.testType === 'multi_turn' && sample.isLoadingConversation) return;
+      if (sample.testType === 'multi_turn' && sample.isLoadingConversation)
+        return;
 
       const apiFactory = new ApiClientFactory(session.session_token);
       const endpointsClient = apiFactory.getEndpointsClient();
@@ -500,8 +506,20 @@ export default function TestGenerationInterface({
         prev.map(s => {
           if (s.id !== sampleId) return s;
           return s.testType === 'single_turn'
-            ? { ...s, isLoadingResponse: true, response: undefined, responseError: undefined }
-            : { ...s, isLoadingConversation: true, response: undefined, responseError: undefined, conversation: undefined, conversationError: undefined };
+            ? {
+                ...s,
+                isLoadingResponse: true,
+                response: undefined,
+                responseError: undefined,
+              }
+            : {
+                ...s,
+                isLoadingConversation: true,
+                response: undefined,
+                responseError: undefined,
+                conversation: undefined,
+                conversationError: undefined,
+              };
         })
       );
 
@@ -516,7 +534,12 @@ export default function TestGenerationInterface({
           setLocalTestSamples(prev =>
             prev.map(s =>
               s.id === sampleId
-                ? { ...s, response: responseText, isLoadingResponse: false, responseError: undefined }
+                ? {
+                    ...s,
+                    response: responseText,
+                    isLoadingResponse: false,
+                    responseError: undefined,
+                  }
                 : s
             )
           );
@@ -572,8 +595,18 @@ export default function TestGenerationInterface({
           prev.map(s => {
             if (s.id !== sampleId) return s;
             return s.testType === 'single_turn'
-              ? { ...s, isLoadingResponse: false, responseError: errorMsg, response: undefined }
-              : { ...s, isLoadingConversation: false, conversationError: errorMsg, conversation: undefined };
+              ? {
+                  ...s,
+                  isLoadingResponse: false,
+                  responseError: errorMsg,
+                  response: undefined,
+                }
+              : {
+                  ...s,
+                  isLoadingConversation: false,
+                  conversationError: errorMsg,
+                  conversation: undefined,
+                };
           })
         );
 
@@ -666,7 +699,6 @@ export default function TestGenerationInterface({
                   position: 'relative',
                 }}
               >
-
                 {/* Behavior Testing */}
                 <Box sx={{ mb: 4 }}>
                   <Box
@@ -695,9 +727,24 @@ export default function TestGenerationInterface({
                   />
                   {isLoadingConfig && configChips.behavior.length === 0 && (
                     <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
-                      <Skeleton variant="rounded" width="30%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
-                      <Skeleton variant="rounded" width="22%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
-                      <Skeleton variant="rounded" width="35%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                      <Skeleton
+                        variant="rounded"
+                        width="30%"
+                        height={28}
+                        sx={{ borderRadius: theme => theme.shape.borderRadius }}
+                      />
+                      <Skeleton
+                        variant="rounded"
+                        width="22%"
+                        height={28}
+                        sx={{ borderRadius: theme => theme.shape.borderRadius }}
+                      />
+                      <Skeleton
+                        variant="rounded"
+                        width="35%"
+                        height={28}
+                        sx={{ borderRadius: theme => theme.shape.borderRadius }}
+                      />
                     </Box>
                   )}
                 </Box>
@@ -730,9 +777,24 @@ export default function TestGenerationInterface({
                   />
                   {isLoadingConfig && configChips.topics.length === 0 && (
                     <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
-                      <Skeleton variant="rounded" width="25%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
-                      <Skeleton variant="rounded" width="20%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
-                      <Skeleton variant="rounded" width="28%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                      <Skeleton
+                        variant="rounded"
+                        width="25%"
+                        height={28}
+                        sx={{ borderRadius: theme => theme.shape.borderRadius }}
+                      />
+                      <Skeleton
+                        variant="rounded"
+                        width="20%"
+                        height={28}
+                        sx={{ borderRadius: theme => theme.shape.borderRadius }}
+                      />
+                      <Skeleton
+                        variant="rounded"
+                        width="28%"
+                        height={28}
+                        sx={{ borderRadius: theme => theme.shape.borderRadius }}
+                      />
                     </Box>
                   )}
                 </Box>
@@ -765,8 +827,18 @@ export default function TestGenerationInterface({
                   />
                   {isLoadingConfig && configChips.category.length === 0 && (
                     <Box sx={{ display: 'flex', gap: 0.75, flexWrap: 'wrap' }}>
-                      <Skeleton variant="rounded" width="32%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
-                      <Skeleton variant="rounded" width="22%" height={28} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
+                      <Skeleton
+                        variant="rounded"
+                        width="32%"
+                        height={28}
+                        sx={{ borderRadius: theme => theme.shape.borderRadius }}
+                      />
+                      <Skeleton
+                        variant="rounded"
+                        width="22%"
+                        height={28}
+                        sx={{ borderRadius: theme => theme.shape.borderRadius }}
+                      />
                     </Box>
                   )}
                 </Box>
@@ -992,7 +1064,11 @@ export default function TestGenerationInterface({
                     }}
                   >
                     <VisibilityIcon
-                      sx={{ fontSize: theme => theme.iconSizes.xlarge, opacity: 0.3, mb: 2 }}
+                      sx={{
+                        fontSize: theme => theme.iconSizes.xlarge,
+                        opacity: 0.3,
+                        mb: 2,
+                      }}
                     />
                     <Typography
                       variant="h6"
@@ -1040,56 +1116,92 @@ export default function TestGenerationInterface({
 
                     {(isLoadingConfig || isLoadingSamples || isGenerating) && (
                       <Box>
-                        {[...Array(localTestSamples.length === 0 ? 3 : 1)].map((_, i) => (
-                          <Card
-                            key={`skeleton-${i}`}
-                            elevation={0}
-                            sx={{
-                              mb: 2,
-                              borderRadius: theme => theme.shape.borderRadius,
-                              border: 1,
-                              borderColor: 'divider',
-                              bgcolor: 'background.paper',
-                            }}
-                          >
-                            <CardContent sx={{ p: 2, '&:last-child': { pb: 2 } }}>
-                              <Box sx={{ display: 'flex', gap: 0.5, mb: 1.5 }}>
-                                <Skeleton variant="rounded" width="20%" height={24} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
-                                <Skeleton variant="rounded" width="15%" height={24} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
-                                <Skeleton variant="rounded" width="18%" height={24} sx={{ borderRadius: theme => theme.shape.borderRadius }} />
-                              </Box>
-                              <Skeleton
-                                variant="rounded"
-                                width="85%"
-                                height={56}
-                                sx={{ borderRadius: theme => theme.shape.borderRadius, mb: 1 }}
-                              />
-                              <Skeleton variant="text" width="40%" />
-                            </CardContent>
-                          </Card>
-                        ))}
+                        {[...Array(localTestSamples.length === 0 ? 3 : 1)].map(
+                          (_, i) => (
+                            <Card
+                              key={`skeleton-${i}`}
+                              elevation={0}
+                              sx={{
+                                mb: 2,
+                                borderRadius: theme => theme.shape.borderRadius,
+                                border: 1,
+                                borderColor: 'divider',
+                                bgcolor: 'background.paper',
+                              }}
+                            >
+                              <CardContent
+                                sx={{ p: 2, '&:last-child': { pb: 2 } }}
+                              >
+                                <Box
+                                  sx={{ display: 'flex', gap: 0.5, mb: 1.5 }}
+                                >
+                                  <Skeleton
+                                    variant="rounded"
+                                    width="20%"
+                                    height={24}
+                                    sx={{
+                                      borderRadius: theme =>
+                                        theme.shape.borderRadius,
+                                    }}
+                                  />
+                                  <Skeleton
+                                    variant="rounded"
+                                    width="15%"
+                                    height={24}
+                                    sx={{
+                                      borderRadius: theme =>
+                                        theme.shape.borderRadius,
+                                    }}
+                                  />
+                                  <Skeleton
+                                    variant="rounded"
+                                    width="18%"
+                                    height={24}
+                                    sx={{
+                                      borderRadius: theme =>
+                                        theme.shape.borderRadius,
+                                    }}
+                                  />
+                                </Box>
+                                <Skeleton
+                                  variant="rounded"
+                                  width="85%"
+                                  height={56}
+                                  sx={{
+                                    borderRadius: theme =>
+                                      theme.shape.borderRadius,
+                                    mb: 1,
+                                  }}
+                                />
+                                <Skeleton variant="text" width="40%" />
+                              </CardContent>
+                            </Card>
+                          )
+                        )}
                       </Box>
                     )}
 
                     {/* Load More Button */}
-                    {!isLoadingSamples && !isGenerating && localTestSamples.length > 0 && (
-                    <Box sx={{ textAlign: 'center', mt: 3 }}>
-                      <Button
-                        variant="outlined"
-                        startIcon={
-                          isLoadingMore ? (
-                            <CircularProgress size={16} />
-                          ) : (
-                            <AutoFixHighIcon />
-                          )
-                        }
-                        onClick={onLoadMoreSamples}
-                        disabled={isLoadingMore}
-                      >
-                        {isLoadingMore ? 'Loading...' : 'Load More Samples'}
-                      </Button>
-                    </Box>
-                    )}
+                    {!isLoadingSamples &&
+                      !isGenerating &&
+                      localTestSamples.length > 0 && (
+                        <Box sx={{ textAlign: 'center', mt: 3 }}>
+                          <Button
+                            variant="outlined"
+                            startIcon={
+                              isLoadingMore ? (
+                                <CircularProgress size={16} />
+                              ) : (
+                                <AutoFixHighIcon />
+                              )
+                            }
+                            onClick={onLoadMoreSamples}
+                            disabled={isLoadingMore}
+                          >
+                            {isLoadingMore ? 'Loading...' : 'Load More Samples'}
+                          </Button>
+                        </Box>
+                      )}
                   </Box>
                 )}
               </CardContent>
@@ -1141,7 +1253,12 @@ export default function TestGenerationInterface({
               setFetchTrigger(prev => prev + 1);
               setShowEndpointModal(false);
             }}
-            disabled={!selectedEndpointId || localTestSamples.length === 0 || isFetchingResponses || isLoadingSamples}
+            disabled={
+              !selectedEndpointId ||
+              localTestSamples.length === 0 ||
+              isFetchingResponses ||
+              isLoadingSamples
+            }
           >
             {isFetchingResponses ? 'Getting...' : 'Get Responses'}
           </Button>

--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/shared/TestSampleCard.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/shared/TestSampleCard.tsx
@@ -13,6 +13,7 @@ import {
   Fade,
   Button,
   Collapse,
+  Skeleton,
 } from '@mui/material';
 import ThumbUpIcon from '@mui/icons-material/ThumbUp';
 import ThumbUpOutlinedIcon from '@mui/icons-material/ThumbUpOutlined';
@@ -352,13 +353,9 @@ export default function TestSampleCard({
                     }}
                   >
                     {sample.isLoadingResponse ? (
-                      <Box
-                        sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                      >
-                        <CircularProgress size={16} />
-                        <Typography variant="body2" color="text.secondary">
-                          Loading response...
-                        </Typography>
+                      <Box sx={{ minWidth: theme => theme.spacing(30) }}>
+                        <Skeleton variant="text" width="90%" />
+                        <Skeleton variant="text" width="70%" />
                       </Box>
                     ) : sample.responseError ? (
                       <Typography variant="body2" color="error.main">
@@ -464,19 +461,9 @@ export default function TestSampleCard({
               }}
             >
               {sample.isLoadingConversation ? (
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1,
-                    px: 2,
-                    py: 1,
-                  }}
-                >
-                  <CircularProgress size={16} />
-                  <Typography variant="body2" color="text.secondary">
-                    Simulating conversation...
-                  </Typography>
+                <Box sx={{ px: 2, py: 1, minWidth: theme => theme.spacing(30) }}>
+                  <Skeleton variant="text" width="90%" />
+                  <Skeleton variant="text" width="60%" />
                 </Box>
               ) : sample.conversationError ? (
                 <Typography variant="body2" color="error.main">

--- a/apps/frontend/src/app/(protected)/tests/new-generated/components/shared/TestSampleCard.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-generated/components/shared/TestSampleCard.tsx
@@ -461,7 +461,9 @@ export default function TestSampleCard({
               }}
             >
               {sample.isLoadingConversation ? (
-                <Box sx={{ px: 2, py: 1, minWidth: theme => theme.spacing(30) }}>
+                <Box
+                  sx={{ px: 2, py: 1, minWidth: theme => theme.spacing(30) }}
+                >
                   <Skeleton variant="text" width="90%" />
                   <Skeleton variant="text" width="60%" />
                 </Box>

--- a/apps/frontend/src/app/(protected)/tests/new-manual/components/ManualTestWriter.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-manual/components/ManualTestWriter.tsx
@@ -215,7 +215,7 @@ export default function ManualTestWriter({ onBack }: ManualTestWriterProps) {
     };
 
     fetchData();
-  }, [session, notifications]);
+  }, [session, notifications, testType]);
 
   const addNewRow = () => {
     const newTestCase: TestCase =

--- a/apps/frontend/src/app/(protected)/traces/components/SpanGraphView.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/SpanGraphView.tsx
@@ -1199,7 +1199,6 @@ export default function SpanGraphView({
     effectiveSpans,
     theme.palette.info.main,
     theme.palette.warning.main,
-    activeTurn,
     isConversationTrace,
     rootSpans,
   ]);
@@ -1623,7 +1622,7 @@ export default function SpanGraphView({
             >
               All
             </Button>
-            {rootSpans!.map((span, i) => (
+            {(rootSpans ?? []).map((span, i) => (
               <Button
                 key={span.span_id}
                 onClick={() => setActiveTurn(i)}

--- a/apps/frontend/src/app/(protected)/traces/components/SpanSequenceView.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/SpanSequenceView.tsx
@@ -334,7 +334,7 @@ export default function SpanSequenceView({
             >
               All
             </Button>
-            {rootSpans!.map((span, i) => (
+            {(rootSpans ?? []).map((span, i) => (
               <Button
                 key={span.span_id}
                 onClick={() => setActiveTurn(i)}

--- a/apps/frontend/src/utils/api-client/interfaces/test-set.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/test-set.ts
@@ -363,6 +363,55 @@ export interface TestSetGenerationRequest extends GenerateTestsRequest {
 /** @deprecated Use GenerateTestSetResponse instead */
 export type TestSetGenerationResponse = GenerateTestSetResponse;
 
+// ── Streaming test pipeline types ──
+
+export interface IterationMessage {
+  content: string;
+  timestamp: string;
+  chip_states?: Array<{
+    label: string;
+    description: string;
+    active: boolean;
+    category: string;
+  }>;
+}
+
+export interface TestPipelineConfig {
+  behaviors: Array<{ name: string; description: string; active: boolean }>;
+  topics: Array<{ name: string; description: string; active: boolean }>;
+  categories: Array<{ name: string; description: string; active: boolean }>;
+}
+
+export interface TestPipelineRequest {
+  prompt: string;
+  project_id?: string;
+  previous_messages?: IterationMessage[];
+  test_type?: string;
+  num_tests?: number;
+  sources?: SourceData[];
+  model_id?: string;
+  config?: TestPipelineConfig;
+}
+
+export type TestPipelineEvent =
+  | {
+      type: 'config_item';
+      category: 'behaviors' | 'topics' | 'categories';
+      name: string;
+      description: string;
+      active: boolean;
+    }
+  | { type: 'config_done'; total: number }
+  | {
+      type: 'test';
+      index: number;
+      test: Record<string, unknown>;
+      test_type: string;
+    }
+  | { type: 'tests_done'; total: number }
+  | { type: 'error'; phase: string; message: string }
+  | { type: 'done' };
+
 /** Summary of the most recent test run for a test set + endpoint combo. */
 export interface LastTestRunSummary {
   id: string;

--- a/apps/frontend/src/utils/api-client/services-client.ts
+++ b/apps/frontend/src/utils/api-client/services-client.ts
@@ -32,6 +32,8 @@ import { RecentActivitiesResponse } from './interfaces/activities';
 import {
   GenerateTestsRequest,
   GenerateTestsResponse,
+  TestPipelineEvent,
+  TestPipelineRequest,
 } from './interfaces/test-set';
 
 interface ChipState {
@@ -138,6 +140,69 @@ export interface CreateJiraTicketFromTaskResponse {
 }
 
 export class ServicesClient extends BaseApiClient {
+  private async *readNdjsonStream(
+    response: Response
+  ): AsyncGenerator<unknown, void, void> {
+    const reader = response.body?.getReader();
+    if (!reader) {
+      throw new Error('Streaming response body is not available.');
+    }
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let newlineIndex = buffer.indexOf('\n');
+      while (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex).trim();
+        buffer = buffer.slice(newlineIndex + 1);
+        if (line) {
+          yield JSON.parse(line) as unknown;
+        }
+        newlineIndex = buffer.indexOf('\n');
+      }
+    }
+
+    const remaining = buffer.trim();
+    if (remaining) {
+      yield JSON.parse(remaining) as unknown;
+    }
+  }
+
+  async generateTestPipelineStream(
+    request: TestPipelineRequest,
+    options: {
+      onEvent: (event: TestPipelineEvent) => void;
+      signal?: AbortSignal;
+    }
+  ): Promise<void> {
+    const headers = this.getHeaders();
+    const response = await fetch(
+      `${this.baseUrl}${API_ENDPOINTS.services}/generate/test_pipeline`,
+      {
+        method: 'POST',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+        signal: options.signal,
+      }
+    );
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(
+        `Test pipeline request failed (${response.status}): ${errorBody}`
+      );
+    }
+
+    for await (const event of this.readNdjsonStream(response)) {
+      options.onEvent(event as TestPipelineEvent);
+    }
+  }
+
   async getGitHubContents(repo_url: string): Promise<string> {
     return this.fetch<string>(
       `${API_ENDPOINTS.services}/github/contents?repo_url=${encodeURIComponent(repo_url)}`

--- a/sdk/src/rhesis/sdk/synthesizers/base.py
+++ b/sdk/src/rhesis/sdk/synthesizers/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import time
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Union, cast
 
 from pydantic import BaseModel
 
@@ -521,3 +521,34 @@ class TestSetSynthesizer(ABC):
             total_elapsed,
         )
         return test_set
+
+    async def generate_stream(
+        self, num_tests: int = 5, **kwargs: Any
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Yield test dicts one-by-one as they parse from the LLM token stream.
+
+        Uses ``model.generate_stream()`` with ``IncrementalJsonArrayParser``
+        for incremental delivery. Falls back gracefully when the model's
+        ``generate_stream()`` returns the full response in a single chunk.
+        """
+        from rhesis.sdk.synthesizers.streaming import IncrementalJsonArrayParser
+
+        template_context = self._get_template_context(**kwargs)
+        template_context.setdefault("harmful", self.harmful)
+        template_context["num_tests"] = num_tests
+
+        prompt = self.prompt_template.render(**template_context)
+        parser = IncrementalJsonArrayParser()
+
+        token_stream = self.model.generate_stream(
+            prompt=prompt, schema=FlatTests
+        )
+        async for chunk in token_stream:
+            for flat in parser.feed(chunk):
+                yield {
+                    **self._flat_test_to_nested(flat),
+                    "test_type": TestType.SINGLE_TURN.value,
+                    "metadata": {
+                        "generated_by": self._get_synthesizer_name(),
+                    },
+                }

--- a/sdk/src/rhesis/sdk/synthesizers/base.py
+++ b/sdk/src/rhesis/sdk/synthesizers/base.py
@@ -540,9 +540,7 @@ class TestSetSynthesizer(ABC):
         prompt = self.prompt_template.render(**template_context)
         parser = IncrementalJsonArrayParser()
 
-        token_stream = self.model.generate_stream(
-            prompt=prompt, schema=FlatTests
-        )
+        token_stream = self.model.generate_stream(prompt=prompt, schema=FlatTests)
         async for chunk in token_stream:
             for flat in parser.feed(chunk):
                 yield {

--- a/sdk/src/rhesis/sdk/synthesizers/multi_turn/base.py
+++ b/sdk/src/rhesis/sdk/synthesizers/multi_turn/base.py
@@ -122,9 +122,7 @@ class MultiTurnSynthesizer:
 
         return batch_tests
 
-    async def generate_stream(
-        self, num_tests: int = 5
-    ) -> AsyncGenerator[Dict[str, Any], None]:
+    async def generate_stream(self, num_tests: int = 5) -> AsyncGenerator[Dict[str, Any], None]:
         """Yield multi-turn test dicts one-by-one as they parse from the LLM."""
         from rhesis.sdk.synthesizers.streaming import IncrementalJsonArrayParser
 
@@ -137,9 +135,7 @@ class MultiTurnSynthesizer:
         prompt = prompt_template.render(template_context)
         parser = IncrementalJsonArrayParser()
 
-        token_stream = self.model.generate_stream(
-            prompt=prompt, schema=FlatTests
-        )
+        token_stream = self.model.generate_stream(prompt=prompt, schema=FlatTests)
         async for chunk in token_stream:
             for flat in parser.feed(chunk):
                 yield {

--- a/sdk/src/rhesis/sdk/synthesizers/multi_turn/base.py
+++ b/sdk/src/rhesis/sdk/synthesizers/multi_turn/base.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 from jinja2 import Environment, FileSystemLoader, Template
 from pydantic import BaseModel
@@ -121,6 +121,31 @@ class MultiTurnSynthesizer:
         ]
 
         return batch_tests
+
+    async def generate_stream(
+        self, num_tests: int = 5
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Yield multi-turn test dicts one-by-one as they parse from the LLM."""
+        from rhesis.sdk.synthesizers.streaming import IncrementalJsonArrayParser
+
+        prompt_template = self.load_prompt_template(self.prompt_template_file)
+        template_context = {
+            "num_tests": num_tests,
+            "harmful": self.harmful,
+            **self.config.model_dump(),
+        }
+        prompt = prompt_template.render(template_context)
+        parser = IncrementalJsonArrayParser()
+
+        token_stream = self.model.generate_stream(
+            prompt=prompt, schema=FlatTests
+        )
+        async for chunk in token_stream:
+            for flat in parser.feed(chunk):
+                yield {
+                    **self._flat_test_to_nested(flat),
+                    "test_type": TestType.MULTI_TURN.value,
+                }
 
     def generate(self, num_tests: int = 5) -> TestSet:
         num_batches = num_tests // self.batch_size

--- a/sdk/src/rhesis/sdk/synthesizers/streaming.py
+++ b/sdk/src/rhesis/sdk/synthesizers/streaming.py
@@ -1,0 +1,80 @@
+"""Incremental JSON parsing utilities for streaming LLM responses."""
+
+import json
+import logging
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+class IncrementalJsonArrayParser:
+    """Extract complete JSON objects from a streaming JSON response.
+
+    Designed for structured output shaped like ``{"key": [{...}, ...]}``.
+    Feeds token chunks incrementally and yields each complete object in the
+    top-level array as soon as its closing brace is detected.  Correctly
+    handles escaped characters and strings containing braces.
+    """
+
+    def __init__(self):
+        self._buffer: str = ""
+        self._pos: int = 0
+        self._in_array: bool = False
+        self._brace_depth: int = 0
+        self._in_string: bool = False
+        self._escape_next: bool = False
+        self._obj_start: int = -1
+
+    def feed(self, chunk: str) -> List[dict]:
+        """Append *chunk* to the internal buffer and return any newly complete objects."""
+        self._buffer += chunk
+        results: List[dict] = []
+
+        while self._pos < len(self._buffer):
+            c = self._buffer[self._pos]
+
+            if self._escape_next:
+                self._escape_next = False
+                self._pos += 1
+                continue
+
+            if c == "\\" and self._in_string:
+                self._escape_next = True
+                self._pos += 1
+                continue
+
+            if c == '"':
+                self._in_string = not self._in_string
+                self._pos += 1
+                continue
+
+            if self._in_string:
+                self._pos += 1
+                continue
+
+            if not self._in_array:
+                if c == "[":
+                    self._in_array = True
+            else:
+                if c == "{":
+                    if self._brace_depth == 0:
+                        self._obj_start = self._pos
+                    self._brace_depth += 1
+                elif c == "}":
+                    self._brace_depth -= 1
+                    if self._brace_depth == 0 and self._obj_start >= 0:
+                        obj_str = self._buffer[self._obj_start : self._pos + 1]
+                        try:
+                            results.append(json.loads(obj_str))
+                        except json.JSONDecodeError:
+                            logger.warning(
+                                "Failed to parse streamed JSON object: %.120s",
+                                obj_str,
+                            )
+                        self._obj_start = -1
+                elif c == "]":
+                    self._in_array = False
+
+            self._pos += 1
+
+        return results

--- a/sdk/src/rhesis/sdk/synthesizers/streaming.py
+++ b/sdk/src/rhesis/sdk/synthesizers/streaming.py
@@ -21,6 +21,7 @@ class IncrementalJsonArrayParser:
         self._pos: int = 0
         self._in_array: bool = False
         self._brace_depth: int = 0
+        self._bracket_depth: int = 0
         self._in_string: bool = False
         self._escape_next: bool = False
         self._obj_start: int = -1
@@ -55,8 +56,11 @@ class IncrementalJsonArrayParser:
             if not self._in_array:
                 if c == "[":
                     self._in_array = True
+                    self._bracket_depth = 1
             else:
-                if c == "{":
+                if c == "[":
+                    self._bracket_depth += 1
+                elif c == "{":
                     if self._brace_depth == 0:
                         self._obj_start = self._pos
                     self._brace_depth += 1
@@ -73,8 +77,21 @@ class IncrementalJsonArrayParser:
                             )
                         self._obj_start = -1
                 elif c == "]":
-                    self._in_array = False
+                    self._bracket_depth -= 1
+                    if self._bracket_depth == 0:
+                        self._in_array = False
 
             self._pos += 1
+
+        # Trim consumed prefix to keep memory bounded
+        if self._obj_start >= 0:
+            trim_to = self._obj_start
+        else:
+            trim_to = self._pos
+        if trim_to > 0:
+            self._buffer = self._buffer[trim_to:]
+            if self._obj_start >= 0:
+                self._obj_start -= trim_to
+            self._pos -= trim_to
 
         return results

--- a/tests/backend/services/test_test_generation_pipeline.py
+++ b/tests/backend/services/test_test_generation_pipeline.py
@@ -18,6 +18,7 @@ from rhesis.backend.app.services.test_generation_pipeline import (
     _stream_config,
     test_generation_pipeline_stream,
 )
+from rhesis.sdk.synthesizers.streaming import IncrementalJsonArrayParser
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -50,11 +51,13 @@ def _streaming_llm(behaviors=None, topics=None, categories=None):
     ``categories`` arrays, streamed character-by-character so the
     ``IncrementalConfigParser`` can parse items incrementally.
     """
-    response = json.dumps({
-        "behaviors": behaviors or [],
-        "topics": topics or [],
-        "categories": categories or [],
-    })
+    response = json.dumps(
+        {
+            "behaviors": behaviors or [],
+            "topics": topics or [],
+            "categories": categories or [],
+        }
+    )
 
     async def _fake_stream(prompt, schema=None):
         for ch in response:
@@ -307,6 +310,55 @@ class TestStreamConfig:
 
 
 # ---------------------------------------------------------------------------
+# IncrementalJsonArrayParser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.services
+class TestIncrementalJsonArrayParser:
+    def test_nested_arrays_do_not_break_parsing(self):
+        """Objects containing nested arrays must not prematurely close the top-level array."""
+        stream = json.dumps(
+            {
+                "tests": [
+                    {"name": "A", "tags": ["x", "y"]},
+                    {"name": "B", "tags": ["z"]},
+                ]
+            }
+        )
+        parser = IncrementalJsonArrayParser()
+        results = parser.feed(stream)
+        assert len(results) == 2
+        assert results[0]["name"] == "A"
+        assert results[0]["tags"] == ["x", "y"]
+        assert results[1]["name"] == "B"
+
+    def test_buffer_is_trimmed(self):
+        """After emitting objects the consumed buffer prefix should be trimmed."""
+        parser = IncrementalJsonArrayParser()
+        parser.feed('{"items": [{"a": 1}')
+        assert len(parser._buffer) < 25
+        parser.feed(', {"b": 2}]}')
+        assert len(parser._buffer) < 15
+
+    def test_strings_with_braces_and_brackets(self):
+        """Braces and brackets inside JSON strings must not affect parsing."""
+        stream = json.dumps(
+            {
+                "items": [
+                    {"val": "has { and [ and ] and }"},
+                    {"val": "ok"},
+                ]
+            }
+        )
+        parser = IncrementalJsonArrayParser()
+        results = parser.feed(stream)
+        assert len(results) == 2
+        assert results[0]["val"] == "has { and [ and ] and }"
+
+
+# ---------------------------------------------------------------------------
 # test_generation_pipeline_stream (end-to-end)
 # ---------------------------------------------------------------------------
 
@@ -439,7 +491,7 @@ class TestPipelineStream:
         mock_gen.assert_called_once()
 
     async def test_config_failure_aborts_pipeline(self):
-        """If config generation fails, pipeline emits error and done."""
+        """If config generation fails, pipeline skips Phase 2 entirely."""
         user = _make_user()
         mock_db = MagicMock()
 
@@ -471,6 +523,7 @@ class TestPipelineStream:
 
         types = [e["type"] for e in events]
         assert "error" in types
+        assert "test" not in types
         assert types[-1] == "done"
 
     async def test_test_generation_failure_reports_error(self):

--- a/tests/backend/services/test_test_generation_pipeline.py
+++ b/tests/backend/services/test_test_generation_pipeline.py
@@ -1,0 +1,607 @@
+"""Tests for the streaming test generation pipeline.
+
+Covers streamed config generation, test generation, DB context fetching,
+and error handling across both phases.
+"""
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rhesis.backend.app.schemas.services import TestConfigResponse
+from rhesis.backend.app.services.test_generation_pipeline import (
+    _fetch_db_context,
+    _render_config_prompt,
+    _stream_config,
+    test_generation_pipeline_stream,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(model_id=None):
+    """Build a minimal User-like object with settings."""
+    gen = SimpleNamespace(model_id=model_id)
+    models = SimpleNamespace(generation=gen)
+    settings = SimpleNamespace(models=models)
+    return SimpleNamespace(
+        settings=settings,
+        organization_id=uuid.uuid4(),
+    )
+
+
+def _make_behavior(name, description=""):
+    return SimpleNamespace(name=name, description=description)
+
+
+def _make_project(name="TestProject", description="A test project"):
+    return SimpleNamespace(name=name, description=description)
+
+
+def _streaming_llm(behaviors=None, topics=None, categories=None):
+    """Return a mock LLM whose generate_stream yields a single combined JSON.
+
+    The response is a JSON object with ``behaviors``, ``topics``, and
+    ``categories`` arrays, streamed character-by-character so the
+    ``IncrementalConfigParser`` can parse items incrementally.
+    """
+    response = json.dumps({
+        "behaviors": behaviors or [],
+        "topics": topics or [],
+        "categories": categories or [],
+    })
+
+    async def _fake_stream(prompt, schema=None):
+        for ch in response:
+            yield ch
+
+    llm = MagicMock()
+    llm.generate_stream = MagicMock(side_effect=_fake_stream)
+    return llm
+
+
+def _db_context(**overrides):
+    ctx = {
+        "prompt": "test a chatbot",
+        "sample_size": 6,
+        "behaviors": [{"name": "Accuracy", "description": "Correct answers"}],
+        "project_name": None,
+        "project_description": None,
+        "previous_messages": [],
+    }
+    ctx.update(overrides)
+    return ctx
+
+
+async def _collect_ndjson(async_gen):
+    """Consume an async bytes generator and parse NDJSON events."""
+    events = []
+    async for chunk in async_gen:
+        line = chunk.decode("utf-8").strip()
+        if line:
+            events.append(json.loads(line))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# _fetch_db_context
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.services
+class TestFetchDbContext:
+    def test_returns_behaviors_and_prompt(self):
+        mock_db = MagicMock()
+        behaviors = [_make_behavior("Accuracy", "Be accurate")]
+        org_id = str(uuid.uuid4())
+
+        with patch("rhesis.backend.app.services.test_generation_pipeline.crud") as crud:
+            crud.get_behaviors.return_value = behaviors
+            ctx = _fetch_db_context(
+                db=mock_db,
+                organization_id=org_id,
+                prompt="test chatbot",
+            )
+
+        assert ctx["prompt"] == "test chatbot"
+        assert len(ctx["behaviors"]) == 1
+        assert ctx["behaviors"][0]["name"] == "Accuracy"
+        assert ctx["project_name"] is None
+        assert ctx["previous_messages"] == []
+
+    def test_fetches_project_when_id_provided(self):
+        mock_db = MagicMock()
+        org_id = str(uuid.uuid4())
+        project_id = str(uuid.uuid4())
+        project = _make_project("MyProject", "A chatbot")
+
+        with patch("rhesis.backend.app.services.test_generation_pipeline.crud") as crud:
+            crud.get_behaviors.return_value = []
+            crud.get_project.return_value = project
+            ctx = _fetch_db_context(
+                db=mock_db,
+                organization_id=org_id,
+                prompt="test",
+                project_id=project_id,
+            )
+
+        assert ctx["project_name"] == "MyProject"
+        assert ctx["project_description"] == "A chatbot"
+
+    def test_raises_when_project_not_found(self):
+        mock_db = MagicMock()
+        org_id = str(uuid.uuid4())
+
+        with patch("rhesis.backend.app.services.test_generation_pipeline.crud") as crud:
+            crud.get_behaviors.return_value = []
+            crud.get_project.return_value = None
+            with pytest.raises(ValueError, match="not found"):
+                _fetch_db_context(
+                    db=mock_db,
+                    organization_id=org_id,
+                    prompt="test",
+                    project_id=str(uuid.uuid4()),
+                )
+
+    def test_passes_previous_messages(self):
+        mock_db = MagicMock()
+        msgs = [{"content": "refine"}]
+
+        with patch("rhesis.backend.app.services.test_generation_pipeline.crud") as crud:
+            crud.get_behaviors.return_value = []
+            ctx = _fetch_db_context(
+                db=mock_db,
+                organization_id=str(uuid.uuid4()),
+                prompt="test",
+                previous_messages=msgs,
+            )
+
+        assert ctx["previous_messages"] == msgs
+
+
+# ---------------------------------------------------------------------------
+# _render_config_prompt
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.services
+class TestRenderConfigPrompt:
+    def test_renders_template_with_behaviors(self):
+        ctx = _db_context()
+        result = _render_config_prompt(ctx)
+        assert "Accuracy" in result
+        assert "test a chatbot" in result
+
+    def test_includes_project_context(self):
+        ctx = _db_context(
+            project_name="FinBot",
+            project_description="Financial advisor",
+        )
+        result = _render_config_prompt(ctx)
+        assert "FinBot" in result
+        assert "Financial advisor" in result
+
+
+# ---------------------------------------------------------------------------
+# _stream_config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.services
+@pytest.mark.asyncio
+class TestStreamConfig:
+    async def test_yields_config_items_from_all_dimensions(self):
+        llm = _streaming_llm(
+            behaviors=[
+                {"name": "Accuracy", "description": "Be accurate", "active": True},
+            ],
+            topics=[
+                {"name": "Auth", "description": "Authentication", "active": True},
+            ],
+            categories=[
+                {"name": "Security", "description": "Security tests", "active": False},
+            ],
+        )
+
+        events = []
+        async for event in _stream_config(llm, _db_context()):
+            events.append(event)
+
+        config_items = [e for e in events if e["type"] == "config_item"]
+        categories_seen = {e["category"] for e in config_items}
+
+        assert categories_seen == {"behaviors", "topics", "categories"}
+        assert len(config_items) == 3
+
+    async def test_yields_config_done_with_total(self):
+        llm = _streaming_llm(
+            behaviors=[
+                {"name": "B1", "description": "d", "active": True},
+                {"name": "B2", "description": "d", "active": True},
+            ],
+            topics=[
+                {"name": "T1", "description": "d", "active": True},
+            ],
+            categories=[],
+        )
+
+        events = []
+        async for event in _stream_config(llm, _db_context()):
+            events.append(event)
+
+        done_events = [e for e in events if e["type"] == "config_done"]
+        assert len(done_events) == 1
+        assert done_events[0]["total"] == 3
+
+    async def test_yields_collected_config_response(self):
+        llm = _streaming_llm(
+            behaviors=[
+                {"name": "B1", "description": "d", "active": True},
+            ],
+            topics=[
+                {"name": "T1", "description": "d", "active": False},
+            ],
+            categories=[
+                {"name": "C1", "description": "d", "active": True},
+            ],
+        )
+
+        collected = None
+        async for event in _stream_config(llm, _db_context()):
+            if event.get("type") == "_collected":
+                collected = event["config"]
+
+        assert collected is not None
+        assert isinstance(collected, TestConfigResponse)
+        assert len(collected.behaviors) == 1
+        assert len(collected.topics) == 1
+        assert len(collected.categories) == 1
+
+    async def test_skips_items_without_name(self):
+        llm = _streaming_llm(
+            behaviors=[
+                {"name": "", "description": "no name", "active": True},
+                {"name": "Valid", "description": "ok", "active": True},
+            ],
+            topics=[],
+            categories=[],
+        )
+
+        events = []
+        async for event in _stream_config(llm, _db_context()):
+            events.append(event)
+
+        config_items = [e for e in events if e["type"] == "config_item"]
+        assert len(config_items) == 1
+        assert config_items[0]["name"] == "Valid"
+
+    async def test_handles_llm_error_gracefully(self):
+        """If the LLM call fails, an error event is emitted."""
+
+        async def _failing_stream(prompt, schema=None):
+            raise RuntimeError("LLM exploded")
+            yield  # noqa: RET503
+
+        llm = MagicMock()
+        llm.generate_stream = MagicMock(side_effect=_failing_stream)
+
+        events = []
+        async for event in _stream_config(llm, _db_context()):
+            events.append(event)
+
+        error_events = [e for e in events if e["type"] == "error"]
+        assert len(error_events) == 1
+        assert "LLM exploded" in error_events[0]["message"]
+
+        done_events = [e for e in events if e["type"] == "config_done"]
+        assert len(done_events) == 1
+        assert done_events[0]["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# test_generation_pipeline_stream (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.services
+@pytest.mark.asyncio
+class TestPipelineStream:
+    async def test_single_turn_pipeline(self):
+        """Full pipeline: config → single-turn streaming tests → done."""
+        user = _make_user()
+        mock_db = MagicMock()
+        org_id = str(uuid.uuid4())
+
+        llm = _streaming_llm(
+            behaviors=[
+                {"name": "Accuracy", "description": "d", "active": True},
+            ],
+            topics=[
+                {"name": "Auth", "description": "d", "active": True},
+            ],
+            categories=[
+                {"name": "Functional", "description": "d", "active": True},
+            ],
+        )
+
+        fake_tests = [
+            {"prompt": {"content": "test1"}, "behavior": "Accuracy"},
+            {"prompt": {"content": "test2"}, "behavior": "Accuracy"},
+        ]
+
+        async def _fake_stream(**kwargs):
+            for t in fake_tests:
+                yield t
+
+        with (
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._resolve_config_llm",
+                return_value=llm,
+            ),
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._fetch_db_context",
+                return_value=_db_context(),
+            ),
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline.generate_tests_stream",
+                side_effect=_fake_stream,
+            ) as mock_gen,
+        ):
+            events = await _collect_ndjson(
+                test_generation_pipeline_stream(
+                    db=mock_db,
+                    user=user,
+                    prompt="test a chatbot",
+                    organization_id=org_id,
+                    num_tests=2,
+                )
+            )
+
+        types = [e["type"] for e in events]
+        assert "config_item" in types
+        assert "config_done" in types
+        assert "test" in types
+        assert "tests_done" in types
+        assert types[-1] == "done"
+
+        test_events = [e for e in events if e["type"] == "test"]
+        assert len(test_events) == 2
+        assert all(e["test_type"] == "single_turn" for e in test_events)
+
+        done_event = next(e for e in events if e["type"] == "tests_done")
+        assert done_event["total"] == 2
+
+        mock_gen.assert_called_once()
+
+    async def test_multi_turn_pipeline(self):
+        """Full pipeline with multi-turn streaming test type."""
+        user = _make_user()
+        mock_db = MagicMock()
+        org_id = str(uuid.uuid4())
+
+        llm = _streaming_llm(
+            behaviors=[
+                {"name": "B", "description": "d", "active": True},
+            ],
+            topics=[
+                {"name": "T", "description": "d", "active": True},
+            ],
+            categories=[
+                {"name": "C", "description": "d", "active": True},
+            ],
+        )
+
+        fake_tests = [
+            {"test_configuration": {"goal": "test goal"}, "behavior": "B"},
+        ]
+
+        async def _fake_stream(**kwargs):
+            for t in fake_tests:
+                yield t
+
+        with (
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._resolve_config_llm",
+                return_value=llm,
+            ),
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._fetch_db_context",
+                return_value=_db_context(),
+            ),
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline.generate_multiturn_tests_stream",
+                side_effect=_fake_stream,
+            ) as mock_gen,
+        ):
+            events = await _collect_ndjson(
+                test_generation_pipeline_stream(
+                    db=mock_db,
+                    user=user,
+                    prompt="test chatbot",
+                    organization_id=org_id,
+                    test_type="multi_turn",
+                    num_tests=1,
+                )
+            )
+
+        test_events = [e for e in events if e["type"] == "test"]
+        assert len(test_events) == 1
+        assert test_events[0]["test_type"] == "multi_turn"
+        mock_gen.assert_called_once()
+
+    async def test_config_failure_aborts_pipeline(self):
+        """If config generation fails, pipeline emits error and done."""
+        user = _make_user()
+        mock_db = MagicMock()
+
+        async def _always_fail(prompt, schema=None):
+            raise RuntimeError("LLM down")
+            yield  # noqa: RET503
+
+        llm = MagicMock()
+        llm.generate_stream = MagicMock(side_effect=_always_fail)
+
+        with (
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._resolve_config_llm",
+                return_value=llm,
+            ),
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._fetch_db_context",
+                return_value=_db_context(),
+            ),
+        ):
+            events = await _collect_ndjson(
+                test_generation_pipeline_stream(
+                    db=mock_db,
+                    user=user,
+                    prompt="test",
+                    organization_id=str(uuid.uuid4()),
+                )
+            )
+
+        types = [e["type"] for e in events]
+        assert "error" in types
+        assert types[-1] == "done"
+
+    async def test_test_generation_failure_reports_error(self):
+        """If test generation raises, error event is emitted but pipeline finishes."""
+        user = _make_user()
+        mock_db = MagicMock()
+
+        llm = _streaming_llm(
+            behaviors=[
+                {"name": "B", "description": "d", "active": True},
+            ],
+            topics=[
+                {"name": "T", "description": "d", "active": True},
+            ],
+            categories=[
+                {"name": "C", "description": "d", "active": True},
+            ],
+        )
+
+        async def _failing_stream(**kwargs):
+            raise RuntimeError("generation boom")
+            yield  # noqa: RET503
+
+        with (
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._resolve_config_llm",
+                return_value=llm,
+            ),
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._fetch_db_context",
+                return_value=_db_context(),
+            ),
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline.generate_tests_stream",
+                side_effect=_failing_stream,
+            ),
+        ):
+            events = await _collect_ndjson(
+                test_generation_pipeline_stream(
+                    db=mock_db,
+                    user=user,
+                    prompt="test",
+                    organization_id=str(uuid.uuid4()),
+                )
+            )
+
+        types = [e["type"] for e in events]
+        assert "config_done" in types
+        error_events = [e for e in events if e["type"] == "error"]
+        assert any("generation boom" in e["message"] for e in error_events)
+        assert "tests_done" in types
+        assert types[-1] == "done"
+
+    async def test_inactive_behaviors_fallback(self):
+        """When all behaviors are inactive, pipeline uses the first one."""
+        user = _make_user()
+        mock_db = MagicMock()
+
+        llm = _streaming_llm(
+            behaviors=[
+                {"name": "OnlyBehavior", "description": "d", "active": False},
+            ],
+            topics=[
+                {"name": "T", "description": "d", "active": True},
+            ],
+            categories=[
+                {"name": "C", "description": "d", "active": True},
+            ],
+        )
+
+        async def _empty_stream(**kwargs):
+            return
+            yield  # noqa: RET503
+
+        with (
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._resolve_config_llm",
+                return_value=llm,
+            ),
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._fetch_db_context",
+                return_value=_db_context(),
+            ),
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline.generate_tests_stream",
+                side_effect=_empty_stream,
+            ) as mock_gen,
+        ):
+            await _collect_ndjson(
+                test_generation_pipeline_stream(
+                    db=mock_db,
+                    user=user,
+                    prompt="test",
+                    organization_id=str(uuid.uuid4()),
+                )
+            )
+
+        call_kwargs = mock_gen.call_args
+        sdk_config = call_kwargs.kwargs.get("config") or call_kwargs[1].get("config")
+        assert sdk_config.behaviors == ["OnlyBehavior"]
+
+    async def test_skips_config_when_provided(self):
+        """When config is provided, Phase 1 is skipped entirely."""
+        user = _make_user()
+        mock_db = MagicMock()
+
+        config = TestConfigResponse(
+            behaviors=[{"name": "B1", "description": "d", "active": True}],
+            topics=[{"name": "T1", "description": "d", "active": True}],
+            categories=[{"name": "C1", "description": "d", "active": True}],
+        )
+
+        async def _fake_stream(**kwargs):
+            yield {"prompt": {"content": "test1"}, "behavior": "B1"}
+
+        with patch(
+            "rhesis.backend.app.services.test_generation_pipeline.generate_tests_stream",
+            side_effect=_fake_stream,
+        ):
+            events = await _collect_ndjson(
+                test_generation_pipeline_stream(
+                    db=mock_db,
+                    user=user,
+                    prompt="test",
+                    organization_id=str(uuid.uuid4()),
+                    config=config,
+                )
+            )
+
+        types = [e["type"] for e in events]
+        assert "config_item" not in types
+        assert "config_done" not in types
+        assert "test" in types
+        assert types[-1] == "done"


### PR DESCRIPTION
## Summary

- Add a unified streaming pipeline that delivers config items and test samples to the UI one-by-one as they parse from the LLM token stream, instead of waiting for the full response
- SDK gains `generate_stream()` on both `TestSetSynthesizer` and `MultiTurnSynthesizer`, plus a shared `IncrementalJsonArrayParser` in `sdk/synthesizers/streaming.py`
- Backend adds `POST /services/generate/test_pipeline` endpoint, single-call streamed config generation using `IncrementalConfigParser`, and streaming wrappers in `generation.py`
- Frontend wires both initial generation and "Regenerate Samples" to the streaming pipeline, with config passthrough to skip Phase 1 on regeneration
- Skeleton loading placeholders use responsive widths instead of hardcoded pixels

## Test plan

- [ ] Run backend pipeline tests: `RHESIS_SKIP_MIGRATIONS=1 uv run pytest tests/backend/services/test_test_generation_pipeline.py -v`
- [ ] Navigate to `/tests/new-generated`, describe a chatbot, and verify config chips and test cards appear incrementally
- [ ] Click "Regenerate Samples" and verify only test cards regenerate (config chips stay)
- [ ] Switch to multi-turn test type and verify streaming works
- [ ] Verify source-based generation still works (batch fallback path)