### PR TITLE
Fix preflight dry-run for multi-turn metrics

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/preflight.py
+++ b/apps/backend/src/rhesis/backend/app/services/preflight.py
@@ -609,10 +609,12 @@ async def _evaluate_metrics_dry_run(
     model = get_evaluation_model_with_override(db, user, model_id=evaluation_model_id)
     org_id = str(user.organization_id) if user.organization_id else None
 
-    dummy_conversation = ConversationHistory.from_messages([
-        {"role": "user", "content": "Is this a test?"},
-        {"role": "assistant", "content": "Yes, this is a test."},
-    ])
+    dummy_conversation = ConversationHistory.from_messages(
+        [
+            {"role": "user", "content": "Is this a test?"},
+            {"role": "assistant", "content": "Yes, this is a test."},
+        ]
+    )
 
     evaluator = MetricEvaluator(model=model, db=db, organization_id=org_id)
     eval_results = evaluator.evaluate(

--- a/apps/backend/src/rhesis/backend/app/services/preflight.py
+++ b/apps/backend/src/rhesis/backend/app/services/preflight.py
@@ -604,9 +604,15 @@ async def _evaluate_metrics_dry_run(
         get_evaluation_model_with_override,
     )
     from rhesis.backend.metrics.evaluator import MetricEvaluator
+    from rhesis.sdk.metrics.conversational.types import ConversationHistory
 
     model = get_evaluation_model_with_override(db, user, model_id=evaluation_model_id)
     org_id = str(user.organization_id) if user.organization_id else None
+
+    dummy_conversation = ConversationHistory.from_messages([
+        {"role": "user", "content": "Is this a test?"},
+        {"role": "assistant", "content": "Yes, this is a test."},
+    ])
 
     evaluator = MetricEvaluator(model=model, db=db, organization_id=org_id)
     eval_results = evaluator.evaluate(
@@ -616,6 +622,7 @@ async def _evaluate_metrics_dry_run(
         context=["This is a preflight test."],
         metrics=metrics,
         max_workers=3,
+        conversation_history=dummy_conversation,
     )
 
     failed: list[str] = []


### PR DESCRIPTION
## Summary
- Multi-turn metrics (e.g., `ConversationalJudge`) require `conversation_history` as a mandatory parameter in their `evaluate()` method
- The preflight `_evaluate_metrics_dry_run` was not supplying it, causing these metrics to fail with a missing argument error during preflight checks
- Passes a dummy `ConversationHistory` to the evaluator so all metric types can be validated

## Test plan
- [ ] Run preflight checks on a test set that includes multi-turn metrics — should no longer crash
- [ ] Verify single-turn metrics still pass preflight as before