### PR TITLE
Add metric-endpoint compatibility preflight check

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/preflight.py
+++ b/apps/backend/src/rhesis/backend/app/services/preflight.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app.models.behavior import Behavior
 from rhesis.backend.app.models.endpoint import Endpoint
 from rhesis.backend.app.models.metric import Metric, behavior_metric_association
+from rhesis.backend.app.models.prompt import Prompt
 from rhesis.backend.app.models.test import Test
 from rhesis.backend.app.models.test_set import TestSet, test_test_set_association
 from rhesis.backend.app.models.user import User
@@ -22,6 +23,7 @@ CHECK_ENDPOINT_CONNECTIVITY = "endpoint_connectivity"
 CHECK_EVALUATION_MODEL = "evaluation_model"
 CHECK_EXECUTION_MODEL = "execution_model"
 CHECK_BEHAVIOR_METRIC_COVERAGE = "behavior_metric_coverage"
+CHECK_METRIC_COMPATIBILITY = "metric_compatibility"
 CHECK_METRIC_FUNCTIONALITY = "metric_functionality"
 CHECK_TEST_SET_NOT_EMPTY = "test_set_not_empty"
 
@@ -34,6 +36,7 @@ SHARED_CHECKS = {
 PER_TEST_SET_CHECKS = {
     CHECK_TEST_SET_NOT_EMPTY,
     CHECK_BEHAVIOR_METRIC_COVERAGE,
+    CHECK_METRIC_COMPATIBILITY,
     CHECK_METRIC_FUNCTIONALITY,
 }
 
@@ -42,6 +45,7 @@ LABELS = {
     CHECK_EVALUATION_MODEL: "Evaluation Model",
     CHECK_EXECUTION_MODEL: "Execution Model",
     CHECK_BEHAVIOR_METRIC_COVERAGE: "Behavior-Metric Coverage",
+    CHECK_METRIC_COMPATIBILITY: "Metric-Endpoint Compatibility",
     CHECK_METRIC_FUNCTIONALITY: "Metric Functionality",
     CHECK_TEST_SET_NOT_EMPTY: "Test Set Has Tests",
 }
@@ -591,6 +595,190 @@ async def check_behavior_metric_coverage(
     return result
 
 
+def _resolve_metrics(
+    db: Session,
+    test_set_id: UUID,
+    metric_mode: str,
+    selected_metrics: Optional[list] = None,
+) -> List[Metric]:
+    """Load metrics based on the metric mode and test set."""
+    if metric_mode == "define_custom" and selected_metrics:
+        metric_ids = [m.id for m in selected_metrics]
+        return db.query(Metric).filter(Metric.id.in_(metric_ids)).all()
+
+    if metric_mode == "use_test_set":
+        test_set = db.query(TestSet).filter(TestSet.id == test_set_id).first()
+        if test_set:
+            return list(test_set.metrics)
+        return []
+
+    behavior_ids = (
+        db.query(Test.behavior_id)
+        .join(
+            test_test_set_association,
+            Test.id == test_test_set_association.c.test_id,
+        )
+        .filter(test_test_set_association.c.test_set_id == test_set_id)
+        .filter(Test.behavior_id.isnot(None))
+        .distinct()
+        .all()
+    )
+    behavior_id_set = {b[0] for b in behavior_ids}
+    if not behavior_id_set:
+        return []
+    return (
+        db.query(Metric)
+        .join(
+            behavior_metric_association,
+            Metric.id == behavior_metric_association.c.metric_id,
+        )
+        .filter(behavior_metric_association.c.behavior_id.in_(behavior_id_set))
+        .distinct()
+        .all()
+    )
+
+
+def _infer_endpoint_capabilities(endpoint: Endpoint) -> dict[str, bool]:
+    """Derive what data the endpoint provides from its response_mapping."""
+    mapping = endpoint.response_mapping or {}
+    return {
+        "context": "context" in mapping,
+        "tool_calls": "tool_calls" in mapping,
+        "metadata": "metadata" in mapping,
+    }
+
+
+TOOL_CALLS_CLASS_NAMES = {"DeepEvalToolUse"}
+
+
+def _check_metric_endpoint_issues(
+    metrics: List[Metric],
+    capabilities: dict[str, bool],
+    has_expected_output: bool,
+) -> list[str]:
+    """Return a list of incompatibility descriptions."""
+    issues: list[str] = []
+    for m in metrics:
+        name = m.name or m.class_name or "Unknown"
+        if m.context_required and not capabilities["context"]:
+            issues.append(
+                f"{name} requires context but endpoint response mapping has no context field"
+            )
+        if m.ground_truth_required and not has_expected_output:
+            issues.append(
+                f"{name} requires ground truth (expected_output) but test data does not include it"
+            )
+        if m.class_name in TOOL_CALLS_CLASS_NAMES and not capabilities["tool_calls"]:
+            issues.append(
+                f"{name} requires tool_calls but endpoint response mapping has no tool_calls field"
+            )
+    return issues
+
+
+async def check_metric_compatibility(
+    db: Session,
+    endpoint: Endpoint,
+    test_set_id: UUID,
+    metric_mode: str,
+    selected_metrics: Optional[list] = None,
+    is_multi_turn: bool = False,
+    correlation_id: Optional[str] = None,
+    publish: bool = True,
+    test_set_name: Optional[str] = None,
+) -> PreflightCheckResult:
+    """Check whether metrics' data requirements match endpoint capabilities."""
+    check_id = CHECK_METRIC_COMPATIBILITY
+    ts_id_str = str(test_set_id) if test_set_name else None
+    comp_key = _make_composite_key(check_id, ts_id_str)
+
+    if publish and correlation_id:
+        await _publish_check_status(
+            correlation_id,
+            check_id,
+            PreflightCheckStatus.RUNNING,
+            test_set_id=ts_id_str,
+            test_set_name=test_set_name,
+            composite_key=comp_key,
+        )
+
+    try:
+        from rhesis.backend.app.schemas.metric import MetricScope
+
+        metrics = _resolve_metrics(db, test_set_id, metric_mode, selected_metrics)
+        if not metrics:
+            result = _make_result(
+                check_id,
+                PreflightCheckStatus.SKIPPED,
+                "No metrics to check compatibility for",
+            )
+        else:
+            required_scope = MetricScope.MULTI_TURN if is_multi_turn else MetricScope.SINGLE_TURN
+            scope_compatible = [
+                m
+                for m in metrics
+                if m.class_name and m.metric_scope and required_scope.value in m.metric_scope
+            ]
+
+            if not scope_compatible:
+                result = _make_result(
+                    check_id,
+                    PreflightCheckStatus.SKIPPED,
+                    "No scope-compatible metrics to validate",
+                )
+            else:
+                capabilities = _infer_endpoint_capabilities(endpoint)
+
+                has_expected_output = (
+                    db.query(Prompt.id)
+                    .join(Test, Test.prompt_id == Prompt.id)
+                    .join(
+                        test_test_set_association,
+                        Test.id == test_test_set_association.c.test_id,
+                    )
+                    .filter(test_test_set_association.c.test_set_id == test_set_id)
+                    .filter(
+                        Prompt.expected_response.isnot(None),
+                        Prompt.expected_response != "",
+                    )
+                    .limit(1)
+                    .first()
+                    is not None
+                )
+
+                issues = _check_metric_endpoint_issues(
+                    scope_compatible, capabilities, has_expected_output
+                )
+
+                if issues:
+                    result = _make_result(
+                        check_id,
+                        PreflightCheckStatus.WARNING,
+                        f"{len(issues)} metric(s) may not receive required data from this endpoint",
+                        "; ".join(issues[:5]),
+                    )
+                else:
+                    metric_names = [m.name for m in scope_compatible if m.name]
+                    result = _make_result(
+                        check_id,
+                        PreflightCheckStatus.PASSED,
+                        f"All {len(scope_compatible)} metric(s) are "
+                        "compatible with endpoint configuration",
+                        ", ".join(metric_names) if metric_names else None,
+                    )
+
+    except Exception as e:
+        result = _make_result(
+            check_id,
+            PreflightCheckStatus.FAILED,
+            "Error checking metric compatibility",
+            str(e),
+        )
+
+    _apply_test_set_fields(result, ts_id_str, test_set_name)
+    await _publish_result(result, correlation_id, publish)
+    return result
+
+
 async def _evaluate_metrics_dry_run(
     db: Session,
     user: User,
@@ -671,39 +859,7 @@ async def check_metric_functionality(
         )
 
     try:
-        metrics: List[Metric] = []
-
-        if metric_mode == "define_custom" and selected_metrics:
-            metric_ids = [m.id for m in selected_metrics]
-            metrics = db.query(Metric).filter(Metric.id.in_(metric_ids)).all()
-        elif metric_mode == "use_test_set":
-            test_set = db.query(TestSet).filter(TestSet.id == test_set_id).first()
-            if test_set:
-                metrics = list(test_set.metrics)
-        else:
-            behavior_ids = (
-                db.query(Test.behavior_id)
-                .join(
-                    test_test_set_association,
-                    Test.id == test_test_set_association.c.test_id,
-                )
-                .filter(test_test_set_association.c.test_set_id == test_set_id)
-                .filter(Test.behavior_id.isnot(None))
-                .distinct()
-                .all()
-            )
-            behavior_id_set = {b[0] for b in behavior_ids}
-            if behavior_id_set:
-                metrics = (
-                    db.query(Metric)
-                    .join(
-                        behavior_metric_association,
-                        Metric.id == behavior_metric_association.c.metric_id,
-                    )
-                    .filter(behavior_metric_association.c.behavior_id.in_(behavior_id_set))
-                    .distinct()
-                    .all()
-                )
+        metrics = _resolve_metrics(db, test_set_id, metric_mode, selected_metrics)
 
         if not metrics:
             result = _make_result(
@@ -897,6 +1053,24 @@ async def run_preflight_checks_multi(
                 ),
             )
         )
+
+        if endpoint:
+            tasks.append(
+                (
+                    _make_composite_key(CHECK_METRIC_COMPATIBILITY, ts_id_str),
+                    check_metric_compatibility(
+                        db,
+                        endpoint,
+                        ts_id,
+                        metric_mode,
+                        selected_metrics,
+                        is_mt,
+                        correlation_id,
+                        publish,
+                        test_set_name=ts_label,
+                    ),
+                )
+            )
 
         tasks.append(
             (


### PR DESCRIPTION
## Purpose
Adds a new preflight check that validates metric data requirements against endpoint capabilities before test execution begins. Previously, metrics requiring context (e.g., RAG faithfulness) or tool calls would silently fail at execution time if the endpoint didn't provide that data.

## What Changed
- Added `check_metric_compatibility` preflight check that inspects each metric's requirements (`context_required`, `ground_truth_required`, tool_calls class names) against the endpoint's `response_mapping`
- Extracted shared metric resolution logic into `_resolve_metrics()` helper, used by both compatibility and functionality checks
- Added `_infer_endpoint_capabilities()` to derive endpoint data capabilities from its response mapping
- Added `_check_metric_endpoint_issues()` to identify specific incompatibilities per metric

## Additional Context
- Incompatibilities are reported as **warnings** (not failures) so users can still proceed if they know what they're doing
- Ground truth check queries `Prompt.expected_response` via the test set's tests
- Tool calls check uses a known set of class names (`TOOL_CALLS_CLASS_NAMES`)
- All queries follow existing RLS patterns (no explicit org filters)

## Testing
1. Configure an endpoint without `context` in its `response_mapping`
2. Assign a metric with `context_required=True` to the test set
3. Run preflight — should see a WARNING for metric compatibility
4. With matching endpoint capabilities — should see PASSED