### PR TITLE
Fix frontend Docker build context for local and GHCR builds

### DIFF
--- a/.github/workflows/backend-ghcr.yml
+++ b/.github/workflows/backend-ghcr.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Build and push frontend image
         uses: docker/build-push-action@v7
         with:
-          context: ./apps/frontend
+          context: .
           file: ./apps/frontend/Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,8 +194,8 @@ services:
   # Frontend
   frontend:
     build:
-      context: ./apps/frontend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: apps/frontend/Dockerfile
       args:
         FRONTEND_ENV: ${FRONTEND_ENV:-local}
     environment:


### PR DESCRIPTION
## Purpose
`./rh restart --build` failed because the frontend Dockerfile expects the repository root as build context (to copy `ee/frontend/` and `apps/frontend/`), but Compose and the GHCR workflow used `apps/frontend` as context.

## What Changed
- Set `docker-compose.yml` frontend build context to `.` with `dockerfile: apps/frontend/Dockerfile`
- Align `.github/workflows/backend-ghcr.yml` frontend build context to repo root

## Testing
- `./rh restart --build` should not fail
