### PR TITLE
feat(behaviors): add tags for grouping behaviors

### DIFF
--- a/apps/backend/src/rhesis/backend/app/models/behavior.py
+++ b/apps/backend/src/rhesis/backend/app/models/behavior.py
@@ -8,12 +8,19 @@ from .mixins import (
     CommentsMixin,
     CountsMixin,
     OrganizationAndUserMixin,
+    TagsMixin,
     TasksMixin,
 )
 
 
 class Behavior(
-    Base, ActivityTrackableMixin, OrganizationAndUserMixin, CommentsMixin, TasksMixin, CountsMixin
+    Base,
+    ActivityTrackableMixin,
+    OrganizationAndUserMixin,
+    TagsMixin,
+    CommentsMixin,
+    TasksMixin,
+    CountsMixin,
 ):
     __tablename__ = "behavior"
     name = Column(String, nullable=False)

--- a/apps/backend/src/rhesis/backend/app/routers/behavior.py
+++ b/apps/backend/src/rhesis/backend/app/routers/behavior.py
@@ -87,6 +87,7 @@ def read_behaviors(
         sort_order=sort_order,
         filter=filter,
         nested_relationships={"metrics": ["metric_type", "backend_type"]},
+        selectin_chains=[["_tags_relationship", "tag"]],
         organization_id=organization_id,
         user_id=user_id,
     )

--- a/apps/backend/src/rhesis/backend/app/schemas/behavior.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/behavior.py
@@ -1,8 +1,9 @@
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import UUID4
 
 from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.tag import Tag
 
 
 # Behavior schemas
@@ -23,4 +24,4 @@ class BehaviorUpdate(BehaviorBase):
 
 
 class Behavior(BehaviorBase):
-    pass
+    tags: Optional[List[Tag]] = []

--- a/apps/backend/src/rhesis/backend/app/schemas/behavior.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/behavior.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 
-from pydantic import UUID4
+from pydantic import UUID4, Field
 
 from rhesis.backend.app.schemas import Base
 from rhesis.backend.app.schemas.tag import Tag
@@ -24,4 +24,4 @@ class BehaviorUpdate(BehaviorBase):
 
 
 class Behavior(BehaviorBase):
-    tags: Optional[List[Tag]] = []
+    tags: List[Tag] = Field(default_factory=list)

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -435,6 +435,7 @@ def get_items_detail(
     sort_order: str = "desc",
     filter: str | None = None,
     nested_relationships: dict = None,
+    selectin_chains: list | None = None,
     organization_id: str = None,
     user_id: str = None,
     secondary_sort_by: str | None = None,
@@ -448,14 +449,23 @@ def get_items_detail(
     Args:
         nested_relationships: Dict specifying nested relationships to load.
                             Format: {"relationship_name": ["nested_rel1", "nested_rel2"]}
+        selectin_chains: List of relationship-name chains to load with nested selectinload.
+                        Use for polymorphic one-to-many collections (e.g. TagsMixin) that
+                        are skipped by with_optimized_loads.
+                        Format: [["_tags_relationship", "tag"], ...]
     """
-    return (
+    builder = (
         QueryBuilder(db, model)
         .with_optimized_loads(
             skip_many_to_many=False,
             skip_one_to_many=True,
             nested_relationships=nested_relationships,
         )
+    )
+    for chain in selectin_chains or []:
+        builder = builder.with_selectin_chain(*chain)
+    return (
+        builder
         .with_organization_filter(organization_id)
         .with_visibility_filter()
         .with_odata_filter(filter)

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -454,19 +454,15 @@ def get_items_detail(
                         are skipped by with_optimized_loads.
                         Format: [["_tags_relationship", "tag"], ...]
     """
-    builder = (
-        QueryBuilder(db, model)
-        .with_optimized_loads(
-            skip_many_to_many=False,
-            skip_one_to_many=True,
-            nested_relationships=nested_relationships,
-        )
+    builder = QueryBuilder(db, model).with_optimized_loads(
+        skip_many_to_many=False,
+        skip_one_to_many=True,
+        nested_relationships=nested_relationships,
     )
     for chain in selectin_chains or []:
         builder = builder.with_selectin_chain(*chain)
     return (
-        builder
-        .with_organization_filter(organization_id)
+        builder.with_organization_filter(organization_id)
         .with_visibility_filter()
         .with_odata_filter(filter)
         .with_pagination(skip, limit)

--- a/apps/backend/src/rhesis/backend/app/utils/query_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/query_utils.py
@@ -148,7 +148,10 @@ class QueryBuilder:
             load = selectinload(attr) if load is None else load.selectinload(attr)
             rel_prop = inspect(current_model).relationships.get(rel_name)
             if rel_prop is None:
-                break
+                raise ValueError(
+                    f"with_selectin_chain: {current_model.__name__!r}.{rel_name!r} "
+                    f"is not a relationship"
+                )
             current_model = rel_prop.mapper.class_
         if load is not None:
             self.query = self.query.options(load)

--- a/apps/backend/src/rhesis/backend/app/utils/query_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/query_utils.py
@@ -120,6 +120,42 @@ class QueryBuilder:
         self._maybe_warn_load_count()
         return self
 
+    def with_selectin_chain(self, *chain: str) -> "QueryBuilder":
+        """Eager-load a chain of relationships with nested ``selectinload``.
+
+        Use this for polymorphic one-to-many collections (e.g. TagsMixin) that
+        ``with_optimized_loads`` skips because they have no ``secondary`` table.
+        Each element resolves against the target model of the previous step, so
+        the full chain is batched into exactly two SELECT IN queries instead of
+        N + N*M lazy loads.
+
+        Example::
+
+            .with_selectin_chain("_tags_relationship", "tag")
+            # → selectinload(Model._tags_relationship).selectinload(TaggedItem.tag)
+        """
+        if not chain:
+            return self
+        current_model: type = self.model
+        load = None
+        for rel_name in chain:
+            attr = getattr(current_model, rel_name, None)
+            if attr is None:
+                raise ValueError(
+                    f"with_selectin_chain: {current_model.__name__!r} has no "
+                    f"relationship named {rel_name!r}"
+                )
+            load = selectinload(attr) if load is None else load.selectinload(attr)
+            rel_prop = inspect(current_model).relationships.get(rel_name)
+            if rel_prop is None:
+                break
+            current_model = rel_prop.mapper.class_
+        if load is not None:
+            self.query = self.query.options(load)
+            self._selectin_count += 1
+            self._maybe_warn_load_count()
+        return self
+
     def _maybe_warn_load_count(self) -> None:
         total = self._joined_count + self._selectin_count
         if total >= _MAX_EAGER_LOADS_WARN:

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorCard.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorCard.tsx
@@ -55,6 +55,10 @@ export default function BehaviorCard({
   const metricsCount = behavior.metrics?.length || 0;
   const canDelete = metricsCount === 0;
 
+  const tags = behavior.tags ?? [];
+  const tagsCount = tags.length;
+  const MAX_VISIBLE_TAGS = 5;
+
   const chipSections: ChipSection[] = [
     {
       label: 'Metrics',
@@ -69,6 +73,25 @@ export default function BehaviorCard({
           : []),
       ],
       emptyText: 'No metrics assigned',
+    },
+    {
+      label: 'Tags',
+      chips: [
+        ...tags.slice(0, MAX_VISIBLE_TAGS).map(tag => ({
+          key: tag.id,
+          label: tag.name,
+          maxWidth: '150px',
+        })),
+        ...(tagsCount > MAX_VISIBLE_TAGS
+          ? [
+              {
+                key: 'more-tags',
+                label: `+${tagsCount - MAX_VISIBLE_TAGS} more`,
+              },
+            ]
+          : []),
+      ],
+      emptyText: 'No tags assigned',
     },
   ];
 

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorDrawer.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import React from 'react';
 import {
   Typography,

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorDrawer.tsx
@@ -1,5 +1,13 @@
 import React from 'react';
-import { Typography, TextField, Button, Stack, Divider } from '@mui/material';
+import {
+  Typography,
+  TextField,
+  Button,
+  Stack,
+  Divider,
+  Autocomplete,
+  Chip,
+} from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import BaseDrawer from '@/components/common/BaseDrawer';
@@ -10,7 +18,9 @@ interface BehaviorDrawerProps {
   onClose: () => void;
   name: string;
   description: string;
-  onSave: (name: string, description: string) => void;
+  initialTagNames?: string[];
+  tagSuggestions?: string[];
+  onSave: (name: string, description: string, tagNames: string[]) => void;
   onDuplicate?: () => void;
   onDelete?: () => void;
   isNew?: boolean;
@@ -18,11 +28,16 @@ interface BehaviorDrawerProps {
   error?: string;
 }
 
+const sortedUnique = (values: string[]) =>
+  Array.from(new Set(values.filter(v => v.trim().length > 0))).sort();
+
 const BehaviorDrawer = ({
   open,
   onClose,
   name: initialName,
   description: initialDescription,
+  initialTagNames = [],
+  tagSuggestions = [],
   onSave,
   onDuplicate,
   onDelete,
@@ -33,16 +48,29 @@ const BehaviorDrawer = ({
   const [currentName, setCurrentName] = React.useState(initialName);
   const [currentDescription, setCurrentDescription] =
     React.useState(initialDescription);
+  const [currentTagNames, setCurrentTagNames] =
+    React.useState<string[]>(initialTagNames);
   const [validationError, setValidationError] = React.useState<string>('');
+
+  const initialTagsSorted = React.useMemo(
+    () => sortedUnique(initialTagNames),
+    [initialTagNames]
+  );
+  const currentTagsSorted = React.useMemo(
+    () => sortedUnique(currentTagNames),
+    [currentTagNames]
+  );
 
   const { hasChanges } = useFormChangeDetection({
     initialData: {
       name: initialName,
       description: initialDescription,
+      tags: initialTagsSorted.join('\u0001'),
     },
     currentData: {
       name: currentName,
       description: currentDescription,
+      tags: currentTagsSorted.join('\u0001'),
     },
   });
 
@@ -50,9 +78,10 @@ const BehaviorDrawer = ({
     if (open) {
       setCurrentName(initialName);
       setCurrentDescription(initialDescription);
+      setCurrentTagNames(initialTagNames);
       setValidationError('');
     }
-  }, [initialName, initialDescription, open]);
+  }, [initialName, initialDescription, initialTagNames, open]);
 
   const handleSaveInternal = () => {
     setValidationError('');
@@ -73,7 +102,11 @@ const BehaviorDrawer = ({
       return;
     }
 
-    onSave(trimmedName, currentDescription.trim());
+    onSave(
+      trimmedName,
+      currentDescription.trim(),
+      sortedUnique(currentTagNames)
+    );
   };
 
   const drawerTitle = isNew ? 'Add New Behavior' : 'Edit Behavior';
@@ -125,6 +158,40 @@ const BehaviorDrawer = ({
             variant="outlined"
             disabled={loading}
             helperText="Describe what this behavior measures and why it matters"
+          />
+
+          <Autocomplete
+            multiple
+            freeSolo
+            options={tagSuggestions}
+            value={currentTagNames}
+            onChange={(_event, value) => {
+              const normalized = value
+                .map(v => v.trim())
+                .filter(v => v.length > 0);
+              setCurrentTagNames(Array.from(new Set(normalized)));
+            }}
+            disabled={loading}
+            renderTags={(value: readonly string[], getTagProps) =>
+              value.map((option, index) => {
+                const { key, ...chipProps } = getTagProps({ index });
+                return (
+                  <Chip key={key} label={option} size="small" {...chipProps} />
+                );
+              })
+            }
+            renderInput={params => (
+              <TextField
+                {...params}
+                label="Tags"
+                placeholder={
+                  currentTagNames.length === 0
+                    ? 'Add tags to group behaviors (e.g. Marketing, US 1)'
+                    : ''
+                }
+                helperText="Press Enter to add. Reuse tags from other behaviors to group them."
+              />
+            )}
           />
         </Stack>
 

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorFilterDrawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { Box } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import {
   FilterDrawerShell,
   FilterSection,
@@ -12,14 +12,16 @@ export type MetricFilter = 'all' | 'has_metrics' | 'no_metrics';
 
 export interface BehaviorFilters {
   metricCount: MetricFilter;
+  tagNames: string[];
 }
 
 export const EMPTY_BEHAVIOR_FILTERS: BehaviorFilters = {
   metricCount: 'all',
+  tagNames: [],
 };
 
 export function hasActiveBehaviorFilters(f: BehaviorFilters): boolean {
-  return f.metricCount !== 'all';
+  return f.metricCount !== 'all' || f.tagNames.length > 0;
 }
 
 const METRIC_OPTIONS: { value: MetricFilter; label: string }[] = [
@@ -32,6 +34,8 @@ interface BehaviorFilterDrawerProps {
   open: boolean;
   onClose: () => void;
   filters: BehaviorFilters;
+  /** Unique tag names available across the loaded behaviors. */
+  availableTagNames?: string[];
   onApply: (filters: BehaviorFilters) => void;
 }
 
@@ -39,6 +43,7 @@ export default function BehaviorFilterDrawer({
   open,
   onClose,
   filters,
+  availableTagNames = [],
   onApply,
 }: BehaviorFilterDrawerProps) {
   const [draft, setDraft] = React.useState<BehaviorFilters>(filters);
@@ -52,6 +57,15 @@ export default function BehaviorFilterDrawer({
   const handleApply = () => {
     onApply(draft);
     onClose();
+  };
+
+  const toggleTag = (name: string) => {
+    setDraft(prev => {
+      const next = prev.tagNames.includes(name)
+        ? prev.tagNames.filter(n => n !== name)
+        : [...prev.tagNames, name];
+      return { ...prev, tagNames: next };
+    });
   };
 
   return (
@@ -76,6 +90,28 @@ export default function BehaviorFilterDrawer({
             </Box>
           ))}
         </Box>
+      </FilterSection>
+
+      <FilterSection title="Tags">
+        {availableTagNames.length === 0 ? (
+          <Typography variant="body2" color="text.secondary">
+            No tags yet. Add tags from the behavior edit drawer to group your
+            behaviors.
+          </Typography>
+        ) : (
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            {availableTagNames.map(name => (
+              <Box
+                key={name}
+                component="button"
+                onClick={() => toggleTag(name)}
+                sx={filterChipSx(draft.tagNames.includes(name))}
+              >
+                {name}
+              </Box>
+            ))}
+          </Box>
+        )}
       </FilterSection>
     </FilterDrawerShell>
   );

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -144,18 +144,42 @@ export default function BehaviorsClient({
     setDrawerOpen(true);
   };
 
+  const normalizeTagName = (name: string) => name.trim().toLowerCase();
+
   /**
    * Diff initial vs. new tag names and apply assign/remove against TagsClient.
-   * Returns the updated tag list resolved from a fresh fetch.
+   * Compares on normalized names (trim + lowercase) while sending trimmed
+   * display values to the API.
    */
   const syncBehaviorTags = async (
     behaviorId: UUID,
     initialTags: Tag[],
     nextTagNames: string[]
   ): Promise<void> => {
-    const initialNames = initialTags.map(t => t.name);
-    const toRemove = initialTags.filter(t => !nextTagNames.includes(t.name));
-    const toAdd = nextTagNames.filter(n => !initialNames.includes(n));
+    const normalizedNext = new Set(
+      nextTagNames.map(normalizeTagName).filter(name => name.length > 0)
+    );
+    const normalizedInitial = new Map(
+      initialTags.map(tag => [normalizeTagName(tag.name), tag])
+    );
+
+    const toRemove = initialTags.filter(
+      tag => !normalizedNext.has(normalizeTagName(tag.name))
+    );
+
+    const seen = new Set<string>();
+    const toAdd = nextTagNames
+      .map(name => name.trim())
+      .filter(name => name.length > 0)
+      .filter(name => !normalizedInitial.has(normalizeTagName(name)))
+      .filter(name => {
+        const key = normalizeTagName(name);
+        if (seen.has(key)) {
+          return false;
+        }
+        seen.add(key);
+        return true;
+      });
 
     if (toRemove.length === 0 && toAdd.length === 0) {
       return;
@@ -163,21 +187,21 @@ export default function BehaviorsClient({
 
     const tagsClient = new TagsClient(sessionToken);
 
-    for (const tag of toRemove) {
-      await tagsClient.removeTagFromEntity(
-        EntityType.BEHAVIOR,
-        behaviorId,
-        tag.id
-      );
-    }
+    await Promise.all(
+      toRemove.map(tag =>
+        tagsClient.removeTagFromEntity(EntityType.BEHAVIOR, behaviorId, tag.id)
+      )
+    );
 
-    for (const name of toAdd) {
-      await tagsClient.assignTagToEntity(EntityType.BEHAVIOR, behaviorId, {
-        name,
-        organization_id: organizationId,
-        ...(userId ? { user_id: userId } : {}),
-      });
-    }
+    await Promise.all(
+      toAdd.map(name =>
+        tagsClient.assignTagToEntity(EntityType.BEHAVIOR, behaviorId, {
+          name,
+          organization_id: organizationId,
+          ...(userId ? { user_id: userId } : {}),
+        })
+      )
+    );
   };
 
   const handleSaveBehavior = async (
@@ -190,6 +214,7 @@ export default function BehaviorsClient({
       setDrawerError(undefined);
 
       const behaviorClient = new BehaviorClient(sessionToken);
+      let tagSyncFailed = false;
 
       if (isNewBehavior) {
         const created = await behaviorClient.createBehavior({
@@ -199,7 +224,11 @@ export default function BehaviorsClient({
         });
 
         if (tagNames.length > 0) {
-          await syncBehaviorTags(created.id, [], tagNames);
+          try {
+            await syncBehaviorTags(created.id, [], tagNames);
+          } catch {
+            tagSyncFailed = true;
+          }
         }
 
         const createdWithMetrics = await behaviorClient.getBehaviorWithMetrics(
@@ -208,10 +237,15 @@ export default function BehaviorsClient({
 
         setBehaviors(prev => [...prev, createdWithMetrics]);
 
-        notifications.show('Behavior created successfully', {
-          severity: 'success',
-          autoHideDuration: 4000,
-        });
+        notifications.show(
+          tagSyncFailed
+            ? 'Behavior created, but some tags failed to sync'
+            : 'Behavior created successfully',
+          {
+            severity: tagSyncFailed ? 'warning' : 'success',
+            autoHideDuration: 4000,
+          }
+        );
       } else if (editingBehavior && editingBehavior.id) {
         const editingId = editingBehavior.id;
         const existing = behaviors.find(b => b.id === editingId);
@@ -220,9 +254,12 @@ export default function BehaviorsClient({
           description: description?.trim() || null,
         });
 
-        await syncBehaviorTags(editingId, existing?.tags ?? [], tagNames);
+        try {
+          await syncBehaviorTags(editingId, existing?.tags ?? [], tagNames);
+        } catch {
+          tagSyncFailed = true;
+        }
 
-        // Re-fetch to capture the new tags array reliably.
         const refreshed =
           await behaviorClient.getBehaviorWithMetrics(editingId);
 
@@ -239,10 +276,15 @@ export default function BehaviorsClient({
           )
         );
 
-        notifications.show('Behavior updated successfully', {
-          severity: 'success',
-          autoHideDuration: 4000,
-        });
+        notifications.show(
+          tagSyncFailed
+            ? 'Behavior updated, but some tags failed to sync'
+            : 'Behavior updated successfully',
+          {
+            severity: tagSyncFailed ? 'warning' : 'success',
+            autoHideDuration: 4000,
+          }
+        );
       }
 
       setDrawerOpen(false);

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -12,6 +12,8 @@ import GridToolbar, {
 } from '@/components/common/GridToolbar';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { BehaviorClient } from '@/utils/api-client/behavior-client';
+import { TagsClient } from '@/utils/api-client/tags-client';
+import { EntityType, type Tag } from '@/utils/api-client/interfaces/tag';
 import type { BehaviorWithMetrics } from '@/utils/api-client/interfaces/behavior';
 import type { UUID } from 'crypto';
 import BehaviorCard from './BehaviorCard';
@@ -32,12 +34,14 @@ import BehaviorFilterDrawer, {
 interface BehaviorsClientProps {
   sessionToken: string;
   organizationId: UUID;
+  userId?: UUID;
   sessionStatus?: 'loading' | 'authenticated' | 'unauthenticated';
 }
 
 export default function BehaviorsClient({
   sessionToken,
   organizationId,
+  userId,
   sessionStatus,
 }: BehaviorsClientProps) {
   const notifications = useNotifications();
@@ -53,6 +57,7 @@ export default function BehaviorsClient({
     id: UUID | null;
     name: string;
     description: string;
+    tagNames: string[];
   } | null>(null);
   const [isNewBehavior, setIsNewBehavior] = React.useState(false);
   const [drawerLoading, setDrawerLoading] = React.useState(false);
@@ -123,18 +128,63 @@ export default function BehaviorsClient({
   }, [sessionToken, refreshKey, sessionStatus]);
 
   const handleAddNewBehavior = () => {
-    setEditingBehavior({ id: null, name: '', description: '' });
+    setEditingBehavior({ id: null, name: '', description: '', tagNames: [] });
     setIsNewBehavior(true);
     setDrawerOpen(true);
   };
 
-  const handleEditBehavior = (id: UUID, name: string, description: string) => {
-    setEditingBehavior({ id, name, description });
+  const handleEditBehavior = (
+    id: UUID,
+    name: string,
+    description: string,
+    tagNames: string[] = []
+  ) => {
+    setEditingBehavior({ id, name, description, tagNames });
     setIsNewBehavior(false);
     setDrawerOpen(true);
   };
 
-  const handleSaveBehavior = async (name: string, description: string) => {
+  /**
+   * Diff initial vs. new tag names and apply assign/remove against TagsClient.
+   * Returns the updated tag list resolved from a fresh fetch.
+   */
+  const syncBehaviorTags = async (
+    behaviorId: UUID,
+    initialTags: Tag[],
+    nextTagNames: string[]
+  ): Promise<void> => {
+    const initialNames = initialTags.map(t => t.name);
+    const toRemove = initialTags.filter(t => !nextTagNames.includes(t.name));
+    const toAdd = nextTagNames.filter(n => !initialNames.includes(n));
+
+    if (toRemove.length === 0 && toAdd.length === 0) {
+      return;
+    }
+
+    const tagsClient = new TagsClient(sessionToken);
+
+    for (const tag of toRemove) {
+      await tagsClient.removeTagFromEntity(
+        EntityType.BEHAVIOR,
+        behaviorId,
+        tag.id
+      );
+    }
+
+    for (const name of toAdd) {
+      await tagsClient.assignTagToEntity(EntityType.BEHAVIOR, behaviorId, {
+        name,
+        organization_id: organizationId,
+        ...(userId ? { user_id: userId } : {}),
+      });
+    }
+  };
+
+  const handleSaveBehavior = async (
+    name: string,
+    description: string,
+    tagNames: string[]
+  ) => {
     try {
       setDrawerLoading(true);
       setDrawerError(undefined);
@@ -148,6 +198,10 @@ export default function BehaviorsClient({
           organization_id: organizationId,
         });
 
+        if (tagNames.length > 0) {
+          await syncBehaviorTags(created.id, [], tagNames);
+        }
+
         const createdWithMetrics = await behaviorClient.getBehaviorWithMetrics(
           created.id
         );
@@ -159,18 +213,28 @@ export default function BehaviorsClient({
           autoHideDuration: 4000,
         });
       } else if (editingBehavior && editingBehavior.id) {
-        const updated = await behaviorClient.updateBehavior(
-          editingBehavior.id,
-          {
-            name: name.trim(),
-            description: description?.trim() || null,
-          }
-        );
+        const editingId = editingBehavior.id;
+        const existing = behaviors.find(b => b.id === editingId);
+        const updated = await behaviorClient.updateBehavior(editingId, {
+          name: name.trim(),
+          description: description?.trim() || null,
+        });
+
+        await syncBehaviorTags(editingId, existing?.tags ?? [], tagNames);
+
+        // Re-fetch to capture the new tags array reliably.
+        const refreshed =
+          await behaviorClient.getBehaviorWithMetrics(editingId);
 
         setBehaviors(prev =>
           prev.map(b =>
-            b.id === editingBehavior.id
-              ? { ...b, name: updated.name, description: updated.description }
+            b.id === editingId
+              ? {
+                  ...b,
+                  name: updated.name,
+                  description: updated.description,
+                  tags: refreshed.tags ?? [],
+                }
               : b
           )
         );
@@ -315,6 +379,16 @@ export default function BehaviorsClient({
     }
   };
 
+  /** Unique tag names across all loaded behaviors. Reused for drawer
+   *  suggestions and filter chips so users group across behaviors. */
+  const availableTagNames = React.useMemo(
+    () =>
+      Array.from(
+        new Set(behaviors.flatMap(b => (b.tags ?? []).map(t => t.name)))
+      ).sort((a, b) => a.localeCompare(b)),
+    [behaviors]
+  );
+
   const filteredBehaviors = React.useMemo(() => {
     let filtered = behaviors;
 
@@ -325,6 +399,13 @@ export default function BehaviorsClient({
         if (metricCountFilter === 'no_metrics') return !hasMetrics;
         return true;
       });
+    }
+
+    if (drawerFilters.tagNames.length > 0) {
+      const selected = new Set(drawerFilters.tagNames);
+      filtered = filtered.filter(behavior =>
+        (behavior.tags ?? []).some(t => selected.has(t.name))
+      );
     }
 
     if (searchQuery.trim()) {
@@ -339,7 +420,10 @@ export default function BehaviorsClient({
             metric.name?.toLowerCase().includes(query) ||
             metric.description?.toLowerCase().includes(query)
         );
-        return nameMatch || descriptionMatch || metricMatch;
+        const tagMatch = (behavior.tags ?? []).some(t =>
+          t.name?.toLowerCase().includes(query)
+        );
+        return nameMatch || descriptionMatch || metricMatch || tagMatch;
       });
     }
 
@@ -481,7 +565,8 @@ export default function BehaviorsClient({
                   handleEditBehavior(
                     behavior.id,
                     behavior.name,
-                    behavior.description || ''
+                    behavior.description || '',
+                    (behavior.tags ?? []).map(t => t.name)
                   )
                 }
                 onDuplicate={() =>
@@ -506,6 +591,8 @@ export default function BehaviorsClient({
           onClose={() => setDrawerOpen(false)}
           name={editingBehavior.name}
           description={editingBehavior.description}
+          initialTagNames={editingBehavior.tagNames}
+          tagSuggestions={availableTagNames}
           onSave={handleSaveBehavior}
           onDuplicate={
             editingBehaviorId
@@ -543,6 +630,7 @@ export default function BehaviorsClient({
         open={filterDrawerOpen}
         onClose={() => setFilterDrawerOpen(false)}
         filters={drawerFilters}
+        availableTagNames={availableTagNames}
         onApply={f => {
           setDrawerFilters(f);
           setMetricCountFilter(f.metricCount);

--- a/apps/frontend/src/app/(protected)/behaviors/components/__tests__/BehaviorCard.test.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/__tests__/BehaviorCard.test.tsx
@@ -25,14 +25,37 @@ jest.mock('@/components/common/EntityCard', () => ({
     title,
     description,
     onDelete,
+    chipSections,
   }: {
     title: string;
     description: string;
     onDelete?: () => void;
+    chipSections?: Array<{
+      label?: string;
+      chips: Array<{ key: string; label: string }>;
+      emptyText?: string;
+    }>;
   }) => (
     <div data-testid="entity-card">
       <h3>{title}</h3>
       <p>{description}</p>
+      {chipSections?.map((section, idx) => (
+        <div
+          key={section.label ?? `section-${idx}`}
+          data-testid={`chip-section-${(section.label ?? `section-${idx}`).toLowerCase()}`}
+        >
+          {section.label && <h4>{section.label}</h4>}
+          {section.chips.length > 0 ? (
+            section.chips.map(chip => (
+              <span key={chip.key} data-testid={`chip-${chip.key}`}>
+                {chip.label}
+              </span>
+            ))
+          ) : (
+            <span data-testid="chip-empty">{section.emptyText}</span>
+          )}
+        </div>
+      ))}
       {onDelete && (
         <button aria-label="delete behavior" onClick={onDelete}>
           delete
@@ -161,6 +184,47 @@ describe('BehaviorCard', () => {
 
     await user.click(screen.getByRole('button', { name: /cancel-delete/i }));
     expect(screen.queryByTestId('delete-modal')).not.toBeInTheDocument();
+  });
+
+  it('renders a Tags section with each tag chip when tags are present', () => {
+    renderCard({
+      ...DEFAULT_PROPS,
+      behavior: makeBehavior({
+        tags: [
+          { id: 't1', name: 'Marketing' },
+          { id: 't2', name: 'US 1' },
+        ],
+      }),
+    });
+
+    const section = screen.getByTestId('chip-section-tags');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent('Marketing');
+    expect(section).toHaveTextContent('US 1');
+  });
+
+  it('renders Tags section empty text when behavior has no tags', () => {
+    renderCard();
+    const section = screen.getByTestId('chip-section-tags');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveTextContent('No tags assigned');
+  });
+
+  it('caps visible tag chips at 5 and shows a +N more pill', () => {
+    const manyTags = Array.from({ length: 7 }, (_, i) => ({
+      id: `t${i + 1}`,
+      name: `Tag ${i + 1}`,
+    }));
+    renderCard({
+      ...DEFAULT_PROPS,
+      behavior: makeBehavior({ tags: manyTags }),
+    });
+
+    const section = screen.getByTestId('chip-section-tags');
+    expect(section).toHaveTextContent('Tag 1');
+    expect(section).toHaveTextContent('Tag 5');
+    expect(section).not.toHaveTextContent('Tag 6');
+    expect(section).toHaveTextContent('+2 more');
   });
 
   it('does not render edit, duplicate, view metrics or add metric icons', () => {

--- a/apps/frontend/src/app/(protected)/behaviors/page.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/page.tsx
@@ -16,11 +16,16 @@ export default function BehaviorsPage() {
     () => session?.user?.organization_id as UUID,
     [session?.user?.organization_id]
   );
+  const userId = React.useMemo(
+    () => (session?.user?.id as UUID | undefined) ?? undefined,
+    [session?.user?.id]
+  );
 
   return (
     <BehaviorsClient
       sessionToken={sessionToken}
       organizationId={organizationId}
+      userId={userId}
       sessionStatus={status}
     />
   );

--- a/apps/frontend/src/utils/api-client/interfaces/behavior.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/behavior.ts
@@ -25,6 +25,7 @@ export interface Behavior extends BehaviorBase {
   user?: User | null;
   organization?: Organization | null;
   metrics?: MetricWithRelationships[]; // Optional metrics when using include=metrics
+  tags?: Tag[];
 }
 
 export interface Organization {
@@ -102,6 +103,7 @@ export interface BehaviorWithMetrics extends BehaviorBase {
   user?: User | null;
   organization: Organization;
   metrics: MetricWithRelationships[]; // Full metric objects with type relationships
+  tags?: Tag[];
 }
 
 export interface MetricReference {

--- a/tests/backend/routes/test_behavior.py
+++ b/tests/backend/routes/test_behavior.py
@@ -140,6 +140,76 @@ class TestBehaviorMetricRelationships(BehaviorTestMixin, BaseEntityTests):
         assert len(returned_metrics) == len(metrics)
 
 
+# === TAG RELATIONSHIP TESTS ===
+
+
+@pytest.mark.integration
+class TestBehaviorTags(BehaviorTestMixin, BaseEntityTests):
+    """Verify the polymorphic tags relationship surfaces on behavior responses."""
+
+    def test_behavior_response_includes_empty_tags_by_default(self, behavior_factory):
+        """A newly created behavior has an empty `tags` list in the response."""
+        behavior = behavior_factory.create(self.get_sample_data())
+
+        # The factory returns the create response body; verify the field is present
+        assert "tags" in behavior
+        assert behavior["tags"] == []
+
+    def test_behavior_list_includes_tags_field(self, behavior_factory):
+        """`GET /behaviors/` exposes `tags` (empty list when none assigned)."""
+        behavior_factory.create(self.get_sample_data())
+
+        response = behavior_factory.client.get(self.endpoints.list)
+
+        assert response.status_code == status.HTTP_200_OK
+        behaviors = response.json()
+        assert len(behaviors) >= 1
+        for entry in behaviors:
+            assert "tags" in entry
+            assert isinstance(entry["tags"], list)
+
+    def test_assigning_tag_to_behavior_updates_read_response(self, behavior_factory):
+        """Assigning a tag via /tags/Behavior/{id} reflects in the behavior read."""
+        behavior = behavior_factory.create(self.get_sample_data())
+        behavior_id = behavior["id"]
+
+        tag_payload = {"name": f"marketing-{fake.uuid4()}"}
+        assign_response = behavior_factory.client.post(
+            f"/tags/Behavior/{behavior_id}",
+            json=tag_payload,
+        )
+        assert assign_response.status_code == status.HTTP_200_OK
+
+        # Fetch the behavior and confirm the tag is now attached.
+        get_response = behavior_factory.client.get(self.endpoints.get(behavior_id))
+        assert get_response.status_code == status.HTTP_200_OK
+        body = get_response.json()
+        assert "tags" in body
+        tag_names = [tag["name"] for tag in body["tags"]]
+        assert tag_payload["name"] in tag_names
+
+    def test_removing_tag_from_behavior_updates_read_response(self, behavior_factory):
+        """Removing a tag clears it from the behavior's `tags` list."""
+        behavior = behavior_factory.create(self.get_sample_data())
+        behavior_id = behavior["id"]
+
+        tag_payload = {"name": f"legal-{fake.uuid4()}"}
+        assign_response = behavior_factory.client.post(
+            f"/tags/Behavior/{behavior_id}",
+            json=tag_payload,
+        )
+        assert assign_response.status_code == status.HTTP_200_OK
+        tag_id = assign_response.json()["id"]
+
+        remove_response = behavior_factory.client.delete(f"/tags/Behavior/{behavior_id}/{tag_id}")
+        assert remove_response.status_code == status.HTTP_200_OK
+
+        get_response = behavior_factory.client.get(self.endpoints.get(behavior_id))
+        assert get_response.status_code == status.HTTP_200_OK
+        body = get_response.json()
+        assert tag_payload["name"] not in [tag["name"] for tag in body["tags"]]
+
+
 # === EDGE CASE TESTS (Enhanced with Factory Data) ===
 
 


### PR DESCRIPTION
## Purpose

Let users group behaviors by tag — e.g. by department (Marketing, Customer Support, Legal) or by user story (US 1, US 2, US 3) — so they can quickly slice the directory by logical category. Implements the chip-section pattern from [Figma node 841:38558](https://www.figma.com/design/RCN0J2AjA0UlStdPpdjUCu/Frontend?node-id=841-38558&m=dev).

## What changed

**Backend**
- `Behavior` model now mixes in `TagsMixin` (polymorphic via the existing `TaggedItem` table — no migration needed).
- `schemas.Behavior` exposes `tags: list[Tag]`; `BehaviorWithMetricsSchema` inherits it.
- `tests/backend/routes/test_behavior.py`: new `TestBehaviorTags` suite — empty default, list/detail response shape, assign reflects, remove reflects.

**Frontend**
- `BehaviorCard` renders a Tags chip section below Metrics (caps at 5 visible + `+N more`).
- `BehaviorDrawer` includes an Autocomplete (`multiple`, `freeSolo`) seeded by tag names already in use on other behaviors, so typing "Mar" suggests "Marketing".
- `BehaviorsClient` diffs old vs new tag names on save and applies them via `TagsClient.assignTagToEntity` / `removeTagFromEntity`. Works for both create and edit. Tag matches also flow through the search box.
- `BehaviorFilterDrawer` has a new Tags section with multi-select chip toggles (OR semantics). Applied client-side alongside the existing metric-count filter.
- Tag suggestions and filter chips share a single memoised `availableTagNames` derived from the loaded list — no new endpoint.

## Testing

- Frontend: \`cd apps/frontend && npx jest BehaviorCard.test --no-coverage\` — 11/11 pass (3 new tests for the Tags section).
- TypeScript: \`npx tsc --noEmit\` clean.
- ESLint: clean on all modified files.
- Backend: ruff check + format clean on modified files. Full backend pytest run blocked locally by a pre-existing `pyproject.toml` issue (\`exclude-newer = "1 week"\`) unrelated to this PR; CI will validate.

## Manual test plan

- [ ] Load `/behaviors`; Metrics section unchanged.
- [ ] Confirm a Tags section renders below Metrics with "No tags assigned" for untagged behaviors.
- [ ] Open the drawer for an existing behavior; add an existing tag (suggestion) and a new tag; save; card reflects both.
- [ ] Edit the same behavior; remove a tag; save; card reflects removal.
- [ ] Create a new behavior with two tags; verify both are attached after save.
- [ ] Open the filter drawer; pick one or more tags; verify list narrows; reset clears.
- [ ] Search by tag name in the toolbar; verify it matches.

## Out of scope

- No alembic migration — uses the existing polymorphic `TaggedItem` table.
- No server-side `?tag=` filter; client-side over the loaded list (100 max). Revisit if behaviors are paginated.
- No tag display in `SelectBehaviorsDialog` (the behavior picker dialog).