### PR TITLE
Fix localhost OAuth redirect and CORS for dev backends

### DIFF
--- a/apps/backend/src/rhesis/backend/app/auth/url_utils.py
+++ b/apps/backend/src/rhesis/backend/app/auth/url_utils.py
@@ -1,7 +1,15 @@
 from urllib.parse import parse_qs, urlparse
 
 from rhesis.backend.app.auth.token_utils import create_auth_code
-from rhesis.backend.app.config.settings import get_frontend_settings
+from rhesis.backend.app.config.settings import (
+    get_application_settings,
+    get_frontend_settings,
+)
+
+# Loopback hostnames accepted as redirect targets in development. Matched
+# exactly against ``urlparse(...).hostname`` so that lookalikes such as
+# ``evil-localhost.com`` or ``localhost.attacker.com`` cannot slip through.
+_LOOPBACK_HOSTNAMES = frozenset(("localhost", "127.0.0.1", "::1"))
 
 
 def build_redirect_url(request, session_token, refresh_token=None):
@@ -20,6 +28,14 @@ def build_redirect_url(request, session_token, refresh_token=None):
         parsed_origin = urlparse(original_frontend)
         # Exact netloc match to prevent open redirects.
         if parsed_origin.netloc == frontend_settings.allowed_domain:
+            frontend_url = f"{parsed_origin.scheme}://{parsed_origin.netloc}"
+        elif _is_loopback_dev_origin(parsed_origin):
+            # Dev-only escape hatch: a frontend running on the developer's
+            # loopback (e.g. ``http://localhost:3000``) is allowed to point
+            # at a remote dev backend and still receive the redirect back.
+            # This branch is gated on BACKEND_ENV so production never
+            # honours loopback origins regardless of the Origin/Referer
+            # the browser sent on /auth/login/{provider}.
             frontend_url = f"{parsed_origin.scheme}://{parsed_origin.netloc}"
 
         # Clean up session
@@ -50,3 +66,26 @@ def build_redirect_url(request, session_token, refresh_token=None):
     final_url = f"{final_url}?code={code}&return_to={return_to}"
 
     return final_url
+
+
+def _is_loopback_dev_origin(parsed_origin) -> bool:
+    """Return True only for safe loopback origins on dev backends.
+
+    Three independent conditions must all hold:
+
+    * The deployment is **not** production (neither ``BACKEND_ENV`` nor
+      ``ENVIRONMENT`` is set to ``production``). Production deployments
+      never accept loopback origins, regardless of what the browser sent.
+    * The hostname is an exact match against the loopback whitelist.
+      ``urlparse`` lowercases the hostname and strips the port, so
+      ``LocalHost:3000`` and ``localhost:9999`` both reduce to
+      ``localhost``; lookalikes such as ``evil-localhost.com`` or
+      ``localhost.attacker.com`` do not.
+    * The scheme is ``http`` or ``https``. This rejects pathological
+      values such as ``javascript:`` if they ever appear in a Referer.
+    """
+    if not get_application_settings().is_development:
+        return False
+    if parsed_origin.scheme not in ("http", "https"):
+        return False
+    return (parsed_origin.hostname or "").lower() in _LOOPBACK_HOSTNAMES

--- a/apps/backend/src/rhesis/backend/app/config/settings.py
+++ b/apps/backend/src/rhesis/backend/app/config/settings.py
@@ -1,7 +1,7 @@
 from functools import lru_cache
 from urllib.parse import urlparse
 
-from pydantic import AnyHttpUrl, Field, TypeAdapter, field_validator
+from pydantic import AliasChoices, AnyHttpUrl, Field, TypeAdapter, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -34,6 +34,12 @@ class FrontendSettings(BaseSettings):
     @property
     def allowed_domain(self) -> str:
         return urlparse(self.url).netloc
+
+    @property
+    def loopback_cors_regex(self) -> str | None:
+        if get_application_settings().is_development:
+            return r"^http://(localhost|127\.0\.0\.1|\[::1\])(:\d{1,5})?$"
+        return None
 
 
 class RedisSettings(BaseSettings):
@@ -72,6 +78,32 @@ class ModelSettings(BaseSettings):
     )
 
 
+class ApplicationSettings(BaseSettings):
+    """General application runtime configuration."""
+
+    model_config = SettingsConfigDict(env_ignore_empty=True)
+
+    quick_start: bool = Field(default=False, alias="QUICK_START")
+    environment: str = Field(
+        default="",
+        validation_alias=AliasChoices("ENVIRONMENT", "ENV"),
+    )
+    backend_env: str = Field(default="development", alias="BACKEND_ENV")
+    # Google Cloud-specific environment variables set by Google Cloud runtimes.
+    gcp_project: str | None = Field(default=None, alias="GCP_PROJECT")
+    google_cloud_project: str | None = Field(default=None, alias="GOOGLE_CLOUD_PROJECT")
+    cloud_run_service: str | None = Field(default=None, alias="K_SERVICE")
+    cloud_run_revision: str | None = Field(default=None, alias="K_REVISION")
+
+    @property
+    def is_production(self) -> bool:
+        return self.backend_env.lower() == "production" or self.environment.lower() == "production"
+
+    @property
+    def is_development(self) -> bool:
+        return not self.is_production
+
+
 @lru_cache
 def get_database_settings() -> DatabaseSettings:
     return DatabaseSettings()  # pyright: ignore[reportCallIssue]
@@ -90,3 +122,8 @@ def get_redis_settings() -> RedisSettings:
 @lru_cache
 def get_model_settings() -> ModelSettings:
     return ModelSettings()
+
+
+@lru_cache
+def get_application_settings() -> ApplicationSettings:
+    return ApplicationSettings()

--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -377,9 +377,11 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 
 
 # Configure CORS
+_frontend_settings = get_frontend_settings()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=get_frontend_settings().cors_origins,
+    allow_origins=_frontend_settings.cors_origins,
+    allow_origin_regex=_frontend_settings.loopback_cors_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/tests/backend/app/test_settings.py
+++ b/tests/backend/app/test_settings.py
@@ -1,12 +1,16 @@
+import re
+
 import pytest
 from pydantic import ValidationError
 
 from rhesis.backend.app import database
 from rhesis.backend.app.config.settings import (
+    ApplicationSettings,
     DatabaseSettings,
     FrontendSettings,
     ModelSettings,
     RedisSettings,
+    get_application_settings,
     get_frontend_settings,
     get_model_settings,
     get_redis_settings,
@@ -14,6 +18,16 @@ from rhesis.backend.app.config.settings import (
 
 DATABASE_ENV_VARS = ("SQLALCHEMY_DATABASE_URL",)
 FRONTEND_ENV_VARS = ("FRONTEND_URL",)
+APPLICATION_ENV_VARS = (
+    "QUICK_START",
+    "ENVIRONMENT",
+    "ENV",
+    "BACKEND_ENV",
+    "GCP_PROJECT",
+    "GOOGLE_CLOUD_PROJECT",
+    "K_SERVICE",
+    "K_REVISION",
+)
 REDIS_ENV_VARS = ("BROKER_URL", "BROKER_READ_URL", "CELERY_RESULT_BACKEND")
 MODEL_ENV_VARS = (
     "DEFAULT_GENERATION_MODEL",
@@ -36,6 +50,15 @@ def clean_frontend_env(monkeypatch):
     get_frontend_settings.cache_clear()
     yield
     get_frontend_settings.cache_clear()
+
+
+@pytest.fixture
+def clean_application_env(monkeypatch):
+    for env_var in APPLICATION_ENV_VARS:
+        monkeypatch.delenv(env_var, raising=False)
+    get_application_settings.cache_clear()
+    yield
+    get_application_settings.cache_clear()
 
 
 @pytest.fixture
@@ -224,3 +247,163 @@ def test_get_model_settings_cache_clear_allows_env_overrides(clean_model_env, mo
     get_model_settings.cache_clear()
 
     assert get_model_settings().generation_model == "openai/gpt-4o-mini"
+
+
+@pytest.mark.unit
+def test_application_settings_defaults(clean_application_env):
+    """All fields use their declared defaults when no env vars are set."""
+    settings = ApplicationSettings(_env_file=None)
+
+    assert settings.quick_start is False
+    assert settings.environment == ""
+    assert settings.backend_env == "development"
+    assert settings.gcp_project is None
+    assert settings.google_cloud_project is None
+    assert settings.cloud_run_service is None
+    assert settings.cloud_run_revision is None
+    # Default posture is non-production (dev-only affordances are on by
+    # default, matching utils/git_utils.should_show_git_info).
+    assert settings.is_production is False
+    assert settings.is_development is True
+
+
+@pytest.mark.unit
+def test_application_settings_loads_existing_environment_variables(
+    clean_application_env, monkeypatch
+):
+    monkeypatch.setenv("QUICK_START", "true")
+    monkeypatch.setenv("ENVIRONMENT", "staging")
+    monkeypatch.setenv("BACKEND_ENV", "production")
+    monkeypatch.setenv("GCP_PROJECT", "rhesis-prod")
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "rhesis-prod-2")
+    monkeypatch.setenv("K_SERVICE", "rhesis-backend")
+    monkeypatch.setenv("K_REVISION", "rhesis-backend-00042-abc")
+
+    settings = ApplicationSettings(_env_file=None)
+
+    assert settings.quick_start is True
+    assert settings.environment == "staging"
+    assert settings.backend_env == "production"
+    assert settings.gcp_project == "rhesis-prod"
+    assert settings.google_cloud_project == "rhesis-prod-2"
+    assert settings.cloud_run_service == "rhesis-backend"
+    assert settings.cloud_run_revision == "rhesis-backend-00042-abc"
+
+
+@pytest.mark.unit
+def test_application_settings_environment_alias_choice_env(clean_application_env, monkeypatch):
+    """ENVIRONMENT and ENV are equivalent aliases for the same field."""
+    monkeypatch.setenv("ENV", "production")
+
+    settings = ApplicationSettings(_env_file=None)
+
+    assert settings.environment == "production"
+    assert settings.is_production is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "backend_env,environment,expected_is_production",
+    [
+        # Either signal being production wins.
+        ("production", "", True),
+        ("development", "production", True),
+        ("PRODUCTION", "", True),
+        # Neither signal being production -> not production.
+        ("development", "", False),
+        ("local", "", False),
+        ("development", "staging", False),
+        ("", "", False),
+    ],
+)
+def test_application_settings_is_production_or_logic(
+    clean_application_env, monkeypatch, backend_env, environment, expected_is_production
+):
+    """is_production fires when EITHER backend_env or environment is production."""
+    if backend_env:
+        monkeypatch.setenv("BACKEND_ENV", backend_env)
+    if environment:
+        monkeypatch.setenv("ENVIRONMENT", environment)
+
+    settings = ApplicationSettings(_env_file=None)
+
+    assert settings.is_production is expected_is_production
+    assert settings.is_development is (not expected_is_production)
+
+
+@pytest.mark.unit
+def test_get_application_settings_cache_clear_allows_env_overrides(
+    clean_application_env, monkeypatch
+):
+    assert get_application_settings().is_development is True
+
+    monkeypatch.setenv("BACKEND_ENV", "production")
+    get_application_settings.cache_clear()
+
+    assert get_application_settings().is_development is False
+    assert get_application_settings().backend_env == "production"
+
+
+@pytest.mark.unit
+class TestLoopbackCorsRegex:
+    """``FrontendSettings.loopback_cors_regex`` returns a regex only on dev backends.
+
+    Mirrors the loopback redirect gate in ``auth/url_utils.py`` so that
+    a frontend dev server on the developer's loopback can call a remote
+    dev backend (FRONTEND_URL on a different host) without CORS blocking
+    XHR/fetch requests.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _frontend_url(self, clean_frontend_env, monkeypatch):
+        monkeypatch.setenv("FRONTEND_URL", "https://dev-app.rhesis.ai")
+
+    def test_returns_none_in_production(self, clean_application_env, monkeypatch):
+        monkeypatch.setenv("BACKEND_ENV", "production")
+        get_application_settings.cache_clear()
+
+        assert get_frontend_settings().loopback_cors_regex is None
+
+    def test_returns_none_when_environment_is_production(
+        self, clean_application_env, monkeypatch
+    ):
+        """ENVIRONMENT=production wins over BACKEND_ENV=development."""
+        monkeypatch.setenv("BACKEND_ENV", "development")
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        get_application_settings.cache_clear()
+
+        assert get_frontend_settings().loopback_cors_regex is None
+
+    def test_returns_regex_in_development(self, clean_application_env, monkeypatch):
+        monkeypatch.setenv("BACKEND_ENV", "development")
+        get_application_settings.cache_clear()
+
+        regex = get_frontend_settings().loopback_cors_regex
+
+        assert regex is not None
+        compiled = re.compile(regex)
+        assert compiled.match("http://localhost:3000")
+        assert compiled.match("http://localhost:5173")
+        assert compiled.match("http://127.0.0.1:8080")
+        assert compiled.match("http://[::1]:5000")
+        assert compiled.match("http://localhost")  # default port
+
+    def test_regex_rejects_lookalikes(self, clean_application_env, monkeypatch):
+        """The regex must not match localhost-themed lookalike origins."""
+        monkeypatch.setenv("BACKEND_ENV", "development")
+        get_application_settings.cache_clear()
+
+        regex = get_frontend_settings().loopback_cors_regex
+        assert regex is not None
+        compiled = re.compile(regex)
+
+        # Substring/suffix attacks must not slip through.
+        assert not compiled.match("http://evil-localhost.com")
+        assert not compiled.match("http://localhost.attacker.com")
+        assert not compiled.match("http://127.0.0.1.attacker.com")
+        # https on loopback is not honoured (devs serving https locally
+        # would need to register their origin via FRONTEND_URL instead).
+        assert not compiled.match("https://localhost:3000")
+        # Other private ranges are not loopback.
+        assert not compiled.match("http://10.0.0.1:3000")
+        assert not compiled.match("http://192.168.1.1:3000")

--- a/tests/backend/auth/test_url_utils.py
+++ b/tests/backend/auth/test_url_utils.py
@@ -11,15 +11,25 @@ from unittest.mock import Mock, patch
 import pytest
 
 from rhesis.backend.app.auth.url_utils import build_redirect_url
-from rhesis.backend.app.config.settings import get_frontend_settings
+from rhesis.backend.app.config.settings import (
+    get_application_settings,
+    get_frontend_settings,
+)
 
 
 @pytest.fixture(autouse=True)
 def clean_frontend_settings(monkeypatch):
     monkeypatch.setenv("FRONTEND_URL", "http://localhost:3000")
+    # Pin to production so the loopback dev gate is OFF by default; tests
+    # that exercise the dev branch override BACKEND_ENV explicitly.
+    monkeypatch.setenv("BACKEND_ENV", "production")
+    monkeypatch.delenv("ENVIRONMENT", raising=False)
+    monkeypatch.delenv("ENV", raising=False)
     get_frontend_settings.cache_clear()
+    get_application_settings.cache_clear()
     yield
     get_frontend_settings.cache_clear()
+    get_application_settings.cache_clear()
 
 
 def _make_request(original_frontend=None, return_to="/architect"):
@@ -104,6 +114,143 @@ class TestDomainValidation:
         request = _make_request(original_frontend="https://evil-app.rhesis.ai")
         url = build_redirect_url(request, "token123")
         assert "evil-app" not in url
+
+
+@pytest.mark.unit
+class TestLoopbackDevGate:
+    """Loopback origins are accepted only on development backends.
+
+    Regression coverage for the local-dev-against-remote-API workflow:
+    a frontend running on ``http://localhost:3000`` calling a remote
+    dev backend (``FRONTEND_URL=https://dev-app.rhesis.ai``) must end
+    up redirected back to localhost, while a production backend with
+    the same incoming origin must not.
+    """
+
+    @patch(
+        "rhesis.backend.app.auth.token_utils.get_secret_key",
+        return_value="test-secret",
+    )
+    def test_rejects_loopback_in_production(self, _mock_key, monkeypatch):
+        """BACKEND_ENV=production (autouse default in this file) rejects loopback."""
+        monkeypatch.setenv("FRONTEND_URL", "https://app.rhesis.ai")
+        get_frontend_settings.cache_clear()
+        get_application_settings.cache_clear()
+
+        request = _make_request(original_frontend="http://localhost:3000")
+        url = build_redirect_url(request, "token123")
+
+        assert url.startswith("https://app.rhesis.ai/")
+        assert "localhost" not in url
+
+    @patch(
+        "rhesis.backend.app.auth.token_utils.get_secret_key",
+        return_value="test-secret",
+    )
+    def test_rejects_loopback_when_environment_is_production(self, _mock_key, monkeypatch):
+        """ENVIRONMENT=production also rejects loopback (matches is_production OR-logic)."""
+        monkeypatch.setenv("FRONTEND_URL", "https://app.rhesis.ai")
+        monkeypatch.setenv("BACKEND_ENV", "development")
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        get_frontend_settings.cache_clear()
+        get_application_settings.cache_clear()
+
+        request = _make_request(original_frontend="http://localhost:3000")
+        url = build_redirect_url(request, "token123")
+
+        assert url.startswith("https://app.rhesis.ai/")
+
+    @patch(
+        "rhesis.backend.app.auth.token_utils.get_secret_key",
+        return_value="test-secret",
+    )
+    def test_accepts_loopback_when_backend_env_is_development(self, _mock_key, monkeypatch):
+        """Localhost frontend against a remote dev backend redirects home.
+
+        This is the exact regression scenario: developing the frontend
+        on localhost while pointing the API at dev-api.rhesis.ai (whose
+        FRONTEND_URL is dev-app.rhesis.ai) should still bring the user
+        back to localhost after OAuth.
+        """
+        monkeypatch.setenv("FRONTEND_URL", "https://dev-app.rhesis.ai")
+        monkeypatch.setenv("BACKEND_ENV", "development")
+        get_frontend_settings.cache_clear()
+        get_application_settings.cache_clear()
+
+        request = _make_request(original_frontend="http://localhost:3000")
+        url = build_redirect_url(request, "token123")
+
+        assert url.startswith("http://localhost:3000/")
+
+    @patch(
+        "rhesis.backend.app.auth.token_utils.get_secret_key",
+        return_value="test-secret",
+    )
+    def test_accepts_loopback_when_backend_env_is_local(self, _mock_key, monkeypatch):
+        """BACKEND_ENV=local (Quick Start) is treated as non-production."""
+        monkeypatch.setenv("FRONTEND_URL", "https://dev-app.rhesis.ai")
+        monkeypatch.setenv("BACKEND_ENV", "local")
+        get_frontend_settings.cache_clear()
+        get_application_settings.cache_clear()
+
+        request = _make_request(original_frontend="http://localhost:3000")
+        url = build_redirect_url(request, "token123")
+
+        assert url.startswith("http://localhost:3000/")
+
+    @patch(
+        "rhesis.backend.app.auth.token_utils.get_secret_key",
+        return_value="test-secret",
+    )
+    def test_accepts_127_in_development(self, _mock_key, monkeypatch):
+        """127.0.0.1 with an arbitrary port is accepted in development."""
+        monkeypatch.setenv("FRONTEND_URL", "https://dev-app.rhesis.ai")
+        monkeypatch.setenv("BACKEND_ENV", "development")
+        get_frontend_settings.cache_clear()
+        get_application_settings.cache_clear()
+
+        request = _make_request(original_frontend="http://127.0.0.1:5173")
+        url = build_redirect_url(request, "token123")
+
+        assert url.startswith("http://127.0.0.1:5173/")
+
+    @patch(
+        "rhesis.backend.app.auth.token_utils.get_secret_key",
+        return_value="test-secret",
+    )
+    def test_dev_mode_does_not_relax_lookalike_check(self, _mock_key, monkeypatch):
+        """Even in development, ``evil-localhost.com`` is rejected.
+
+        Dev mode opens an exact-match loopback whitelist; it must never
+        accept substring lookalikes that would also be open redirects.
+        """
+        monkeypatch.setenv("FRONTEND_URL", "https://dev-app.rhesis.ai")
+        monkeypatch.setenv("BACKEND_ENV", "development")
+        get_frontend_settings.cache_clear()
+        get_application_settings.cache_clear()
+
+        request = _make_request(original_frontend="https://evil-localhost.com")
+        url = build_redirect_url(request, "token123")
+
+        assert url.startswith("https://dev-app.rhesis.ai/")
+        assert "evil-localhost.com" not in url
+
+    @patch(
+        "rhesis.backend.app.auth.token_utils.get_secret_key",
+        return_value="test-secret",
+    )
+    def test_dev_mode_rejects_localhost_subdomain_attack(self, _mock_key, monkeypatch):
+        """``localhost.attacker.com`` must not be treated as loopback."""
+        monkeypatch.setenv("FRONTEND_URL", "https://dev-app.rhesis.ai")
+        monkeypatch.setenv("BACKEND_ENV", "development")
+        get_frontend_settings.cache_clear()
+        get_application_settings.cache_clear()
+
+        request = _make_request(original_frontend="https://localhost.attacker.com")
+        url = build_redirect_url(request, "token123")
+
+        assert url.startswith("https://dev-app.rhesis.ai/")
+        assert "attacker.com" not in url
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Purpose
After PR #1810, OAuth login from a local frontend (`http://localhost:3000`) against a remote dev API (`https://dev-api.rhesis.ai/`) redirected users to `FRONTEND_URL` (`https://dev-app.rhesis.ai/`) instead of back to localhost. CORS was also restricted to `FRONTEND_URL` only, blocking browser requests from localhost to the dev backend.

## What Changed
- Add `ApplicationSettings` with `BACKEND_ENV` / `ENVIRONMENT` and `is_development` / `is_production` helpers
- Gate OAuth post-login redirects in `build_redirect_url` to accept loopback origins (`localhost`, `127.0.0.1`, `::1`) only on non-production backends
- Add `FrontendSettings.loopback_cors_regex` and wire it into `CORSMiddleware` for dev-only loopback CORS
- Add regression tests for redirect gating, CORS regex, and `ApplicationSettings`

## Additional Context
- Regression introduced by #1810, which replaced the previous `FRONTEND_DOMAINS` + localhost hostname check with a strict single-domain match against `FRONTEND_URL`
- Production safety: loopback is only honoured when neither `BACKEND_ENV` nor `ENVIRONMENT` is `production`
- `ApplicationSettings` shape aligns with a parallel branch the author is working on

## Test plan
- [x] `uv run pytest ../../tests/backend/auth/test_url_utils.py -v`
- [x] `uv run pytest ../../tests/backend/app/test_settings.py -v`
- [x] `uv run pytest ../../tests/backend/auth/ -q` (152 passed)
- [ ] Manual: run frontend on `http://localhost:3000` with API at `https://dev-api.rhesis.ai/`, sign in with Google/GitHub, confirm redirect lands on localhost
- [ ] Manual: confirm API calls from localhost to dev-api succeed (no CORS errors)