### PR TITLE
Fix system_prompt stripping and use SDK for multi-turn conversations

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/invokers/base.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/base.py
@@ -53,9 +53,12 @@ class BaseEndpointInvoker(ABC):
     def _strip_meta_keys(self, rendered_body: Any) -> Any:
         """Remove reserved meta keys from a rendered request body.
 
-        Meta keys (e.g. ``system_prompt``) are configuration hints consumed
-        by Rhesis internally and must not be sent on the wire to the
-        external endpoint.
+        Meta keys (e.g. ``system_prompt``) are only stripped for stateless
+        endpoints (those using ``{{ messages }}`` in their request mapping).
+        For stateless endpoints the system_prompt is injected into the
+        ``messages`` array server-side, so sending it again as a top-level
+        field would be redundant.  For all other endpoints the key is left
+        in the wire body so the target can consume it directly.
 
         Args:
             rendered_body: The rendered request body (usually a dict).
@@ -63,10 +66,15 @@ class BaseEndpointInvoker(ABC):
         Returns:
             The same object with meta keys removed (mutates in place for dicts).
         """
-        if isinstance(rendered_body, dict):
+        if not isinstance(rendered_body, dict):
+            return rendered_body
+
+        endpoint = self.context.endpoint if self.context else None
+        if endpoint and ConversationTracker.detect_stateless_mode(endpoint):
             for key in self.RESERVED_META_KEYS:
                 if key in rendered_body:
                     rendered_body.pop(key)
+
         return rendered_body
 
     @abstractmethod

--- a/apps/chatbot/endpoint.py
+++ b/apps/chatbot/endpoint.py
@@ -110,20 +110,20 @@ class ResponseGenerator:
                 raise ValueError(f"Could not initialize language model {model}: {str(e)}")
         else:
             self.model = get_llm_model()
-            
+
         self.use_case = use_case
         self.system_prompt_override = system_prompt_override
         self.temperature = temperature
         self.max_tokens = max_tokens
         self.context_strategy = context_strategy
-        
+
         self.use_case_system_prompt = self._load_system_prompt()
 
     def _load_system_prompt(self) -> str:
-        """Load system prompt from override or from the corresponding .md file in use_cases folder."""
+        """Load system prompt from override or use_cases .md file."""
         if self.system_prompt_override and self.system_prompt_override.strip():
             return self.system_prompt_override.strip()
-            
+
         try:
             # Get the directory of the current script
             current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -181,10 +181,7 @@ class ResponseGenerator:
             for fc in file_contents:
                 filename = fc.get("filename", "unknown")
                 content = fc.get("content", "")
-                file_block += (
-                    f"--- {filename} ---\n{content}\n"
-                    f"--- end of {filename} ---\n\n"
-                )
+                file_block += f"--- {filename} ---\n{content}\n--- end of {filename} ---\n\n"
             current_user_content = (
                 f"[The user has attached the following file(s) "
                 f"with this message:]\n\n"
@@ -200,26 +197,23 @@ class ResponseGenerator:
         model=_model_name,
     )
     async def _invoke_llm(self, messages: List[dict], mode: OutputMode = "text"):
-        """Invoke the language model with structured messages via SDK."""
+        """Invoke the language model via the SDK model's a_generate."""
         kwargs = {
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
         }
         if mode == "json":
-            kwargs["response_format"] = ChatResponse
+            kwargs["schema"] = ChatResponse
 
-        response = await self.model.a_generate(
-            messages=messages,
-            **kwargs,
-        )
-        return response
+        return await self.model.a_generate(messages=messages, **kwargs)
 
     @observe()
     def _extract_response_content(self, response, mode: OutputMode = "text") -> str | dict:
         """Extract text content from LLM response.
 
-        The SDK's ``a_generate`` returns a string (or dict when a schema
-        is provided), so this method normalises the value for the caller.
+        The SDK model's ``a_generate`` returns ``str`` (or ``dict`` when a
+        schema is provided), so this is mostly a pass-through with fallback
+        handling for edge cases.
         """
         if isinstance(response, dict):
             return response
@@ -230,10 +224,6 @@ class ResponseGenerator:
                 except (json.JSONDecodeError, TypeError):
                     return {"response": response} if response else {}
             return response
-
-        # Fallback for unexpected types (e.g. raw litellm response objects)
-        if hasattr(response, "choices") and len(response.choices) > 0:
-            return response.choices[0].message.content or ""
         return str(response) if response else ""
 
     @observe()
@@ -257,9 +247,7 @@ class ResponseGenerator:
         """
         try:
             # Build structured messages with conversation history and file contents
-            messages = self._build_messages(
-                prompt, conversation_history, file_contents
-            )
+            messages = self._build_messages(prompt, conversation_history, file_contents)
 
             # Invoke LLM
             response = await self._invoke_llm(messages, mode=mode)
@@ -320,11 +308,13 @@ class ResponseGenerator:
         """Generate context fragments for a prompt."""
         if self.context_strategy == "none":
             return []
-        
+
         # RAG implementation would go here
         if self.context_strategy == "rag":
             # For now fall back to heuristic
-            logger.info("RAG context strategy requested but not implemented yet, falling back to heuristic")
+            logger.info(
+                "RAG context strategy requested but not implemented yet, falling back to heuristic"
+            )
 
         try:
             # Build prompt
@@ -659,10 +649,10 @@ def _collect_stream_chunks(
     async def _collect() -> List[str]:
         chunks = []
         async for chunk in stream_assistant_response(
-            prompt=prompt, 
-            use_case=use_case, 
-            conversation_history=conversation_history, 
-            file_contents=file_contents, 
+            prompt=prompt,
+            use_case=use_case,
+            conversation_history=conversation_history,
+            file_contents=file_contents,
             mode=mode,
             system_prompt_override=system_prompt_override,
             model=model,
@@ -693,10 +683,10 @@ def stream_assistant_response_sync(
     Yields chunks after collecting them from the async implementation.
     """
     chunks = _collect_stream_chunks(
-        prompt=prompt, 
-        use_case=use_case, 
-        conversation_history=conversation_history, 
-        file_contents=file_contents, 
+        prompt=prompt,
+        use_case=use_case,
+        conversation_history=conversation_history,
+        file_contents=file_contents,
         mode=mode,
         system_prompt_override=system_prompt_override,
         model=model,

--- a/apps/chatbot/endpoint.py
+++ b/apps/chatbot/endpoint.py
@@ -156,24 +156,22 @@ class ResponseGenerator:
         return "".join(chunks)
 
     @observe()
-    def _build_conversation_prompt(
+    def _build_messages(
         self,
         prompt: str,
         conversation_history: List[dict] = None,
         file_contents: list[dict] | None = None,
-    ) -> str:
-        """Build the full prompt with file contents and conversation history."""
-        full_prompt = self.use_case_system_prompt + "\n\n"
+    ) -> List[dict]:
+        """Build structured messages for the LLM with proper role separation."""
+        messages = [{"role": "system", "content": self.use_case_system_prompt}]
 
-        # Add conversation history if provided
         if conversation_history:
             for msg in conversation_history:
                 if isinstance(msg, dict):
-                    role = "User" if msg.get("role") == "user" else "Assistant"
+                    role = msg.get("role", "user")
                     content = msg.get("content", "")
-                    full_prompt += f"{role}: {content}\n\n"
-                elif isinstance(msg, str):
-                    full_prompt += f"User: {msg}\n\n"
+                    if role in ("user", "assistant", "system") and content:
+                        messages.append({"role": role, "content": content})
 
         # Attach file contents to the current user message so the LLM clearly
         # associates them with this specific turn (not previous turns).
@@ -183,49 +181,73 @@ class ResponseGenerator:
             for fc in file_contents:
                 filename = fc.get("filename", "unknown")
                 content = fc.get("content", "")
-                file_block += f"--- {filename} ---\n{content}\n--- end of {filename} ---\n\n"
+                file_block += (
+                    f"--- {filename} ---\n{content}\n"
+                    f"--- end of {filename} ---\n\n"
+                )
             current_user_content = (
-                f"[The user has attached the following file(s) with this message:]\n\n"
+                f"[The user has attached the following file(s) "
+                f"with this message:]\n\n"
                 f"{file_block}"
                 f"[User message:] {prompt}"
             )
 
-        full_prompt += f"User: {current_user_content}\n\nAssistant:"
-        return full_prompt
+        messages.append({"role": "user", "content": current_user_content})
+        return messages
 
     @observe.llm(
         provider=_provider,
         model=_model_name,
     )
-    async def _invoke_llm(self, full_prompt: str, mode: OutputMode = "text"):
-        """Invoke the language model to generate a response."""
-        # Vertex AI via LiteLLM has issues with streaming (CustomStreamWrapper)
-        # Use non-streaming response which works reliably
-        kwargs = {"stream": False, "temperature": self.temperature, "max_tokens": self.max_tokens}
+    async def _invoke_llm(self, messages: List[dict], mode: OutputMode = "text"):
+        """Invoke the language model with structured messages."""
+        from litellm import acompletion
+
+        kwargs = {
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+        }
         if mode == "json":
-            kwargs["schema"] = ChatResponse
-        response = await self.model.a_generate(full_prompt, **kwargs)
+            kwargs["response_format"] = ChatResponse
+
+        if hasattr(self.model, "api_key") and self.model.api_key:
+            kwargs["api_key"] = self.model.api_key
+        if hasattr(self.model, "api_base") and self.model.api_base:
+            kwargs["api_base"] = self.model.api_base
+        if hasattr(self.model, "api_version") and self.model.api_version:
+            kwargs["api_version"] = self.model.api_version
+
+        response = await acompletion(
+            model=self.model.model_name,
+            messages=messages,
+            **kwargs,
+        )
         return response
 
     @observe()
     def _extract_response_content(self, response, mode: OutputMode = "text") -> str | dict:
         """Extract text content from LLM response."""
-        if mode == "json":
-            if isinstance(response, ChatResponse):
-                return response.model_dump()
-            if isinstance(response, dict):
-                return response
+        content = None
 
-        if isinstance(response, str):
-            return response
-
-        # Try to extract content from response object
+        # Extract content from response object (acompletion returns this)
         if hasattr(response, "choices") and len(response.choices) > 0:
             content = response.choices[0].message.content
-            return content if content else ""
+        elif isinstance(response, str):
+            content = response
+        elif isinstance(response, dict):
+            content = response
+        else:
+            content = str(response) if response else ""
 
-        # Fallback to string conversion
-        return str(response) if response else ""
+        if mode == "json" and isinstance(content, str):
+            try:
+                return json.loads(content)
+            except (json.JSONDecodeError, TypeError):
+                return {"response": content} if content else {}
+        if mode == "json" and isinstance(content, dict):
+            return content
+
+        return content if content else ""
 
     @observe()
     async def stream_assistant_response(
@@ -247,13 +269,13 @@ class ResponseGenerator:
                 JSON output.
         """
         try:
-            # Build the full prompt with conversation history and file contents
-            full_prompt = self._build_conversation_prompt(
+            # Build structured messages with conversation history and file contents
+            messages = self._build_messages(
                 prompt, conversation_history, file_contents
             )
 
             # Invoke LLM
-            response = await self._invoke_llm(full_prompt, mode=mode)
+            response = await self._invoke_llm(messages, mode=mode)
 
             # Extract and yield content
             content = self._extract_response_content(response, mode=mode)

--- a/apps/chatbot/endpoint.py
+++ b/apps/chatbot/endpoint.py
@@ -200,9 +200,7 @@ class ResponseGenerator:
         model=_model_name,
     )
     async def _invoke_llm(self, messages: List[dict], mode: OutputMode = "text"):
-        """Invoke the language model with structured messages."""
-        from litellm import acompletion
-
+        """Invoke the language model with structured messages via SDK."""
         kwargs = {
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
@@ -210,15 +208,7 @@ class ResponseGenerator:
         if mode == "json":
             kwargs["response_format"] = ChatResponse
 
-        if hasattr(self.model, "api_key") and self.model.api_key:
-            kwargs["api_key"] = self.model.api_key
-        if hasattr(self.model, "api_base") and self.model.api_base:
-            kwargs["api_base"] = self.model.api_base
-        if hasattr(self.model, "api_version") and self.model.api_version:
-            kwargs["api_version"] = self.model.api_version
-
-        response = await acompletion(
-            model=self.model.model_name,
+        response = await self.model.a_generate(
             messages=messages,
             **kwargs,
         )
@@ -226,28 +216,25 @@ class ResponseGenerator:
 
     @observe()
     def _extract_response_content(self, response, mode: OutputMode = "text") -> str | dict:
-        """Extract text content from LLM response."""
-        content = None
+        """Extract text content from LLM response.
 
-        # Extract content from response object (acompletion returns this)
+        The SDK's ``a_generate`` returns a string (or dict when a schema
+        is provided), so this method normalises the value for the caller.
+        """
+        if isinstance(response, dict):
+            return response
+        if isinstance(response, str):
+            if mode == "json":
+                try:
+                    return json.loads(response)
+                except (json.JSONDecodeError, TypeError):
+                    return {"response": response} if response else {}
+            return response
+
+        # Fallback for unexpected types (e.g. raw litellm response objects)
         if hasattr(response, "choices") and len(response.choices) > 0:
-            content = response.choices[0].message.content
-        elif isinstance(response, str):
-            content = response
-        elif isinstance(response, dict):
-            content = response
-        else:
-            content = str(response) if response else ""
-
-        if mode == "json" and isinstance(content, str):
-            try:
-                return json.loads(content)
-            except (json.JSONDecodeError, TypeError):
-                return {"response": content} if content else {}
-        if mode == "json" and isinstance(content, dict):
-            return content
-
-        return content if content else ""
+            return response.choices[0].message.content or ""
+        return str(response) if response else ""
 
     @observe()
     async def stream_assistant_response(

--- a/sdk/src/rhesis/sdk/models/providers/litellm.py
+++ b/sdk/src/rhesis/sdk/models/providers/litellm.py
@@ -74,6 +74,7 @@ class LiteLLM(BaseLLM):
         system_prompt: Optional[str] = None,
         schema: Optional[Union[Type[BaseModel], dict]] = None,
         stream: bool = False,
+        messages: Optional[List[dict]] = None,
         *args,
         **kwargs,
     ) -> Union[str, dict, AsyncGenerator[str, None]]:
@@ -85,23 +86,20 @@ class LiteLLM(BaseLLM):
         through ``model.generate(...)`` which bridges via ``run_sync()``.
 
         Args:
-            prompt: The user prompt.  Optional when ``messages`` is provided.
+            prompt: The user prompt (ignored when ``messages`` is provided)
             system_prompt: Optional system prompt (ignored when ``messages``
-                is provided).
+                is provided)
             schema: Either a Pydantic model or OpenAI-wrapped JSON schema dict
             stream: When True, return an async generator of token chunks.
                 Schema validation is skipped; the caller is responsible
                 for parsing and validating the accumulated output.
-            messages: Pre-built list of message dicts (keyword-only, via
-                ``**kwargs``).  When provided, ``prompt`` and
-                ``system_prompt`` are ignored.  Use this for multi-turn
-                conversations where the caller manages the message history.
+            messages: Pre-built messages list for multi-turn conversations.
+                When provided, ``prompt`` and ``system_prompt`` are ignored.
 
         Returns:
             str or dict when stream=False; AsyncGenerator[str, None] when
             stream=True.
         """
-        messages = kwargs.pop("messages", None)
         if messages is None:
             messages = (
                 [

--- a/sdk/src/rhesis/sdk/models/providers/litellm.py
+++ b/sdk/src/rhesis/sdk/models/providers/litellm.py
@@ -70,7 +70,7 @@ class LiteLLM(BaseLLM):
 
     async def a_generate(
         self,
-        prompt: str,
+        prompt: str = "",
         system_prompt: Optional[str] = None,
         schema: Optional[Union[Type[BaseModel], dict]] = None,
         stream: bool = False,
@@ -85,25 +85,32 @@ class LiteLLM(BaseLLM):
         through ``model.generate(...)`` which bridges via ``run_sync()``.
 
         Args:
-            prompt: The user prompt
-            system_prompt: Optional system prompt
+            prompt: The user prompt.  Optional when ``messages`` is provided.
+            system_prompt: Optional system prompt (ignored when ``messages``
+                is provided).
             schema: Either a Pydantic model or OpenAI-wrapped JSON schema dict
             stream: When True, return an async generator of token chunks.
                 Schema validation is skipped; the caller is responsible
                 for parsing and validating the accumulated output.
+            messages: Pre-built list of message dicts (keyword-only, via
+                ``**kwargs``).  When provided, ``prompt`` and
+                ``system_prompt`` are ignored.  Use this for multi-turn
+                conversations where the caller manages the message history.
 
         Returns:
             str or dict when stream=False; AsyncGenerator[str, None] when
             stream=True.
         """
-        messages = (
-            [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": prompt},
-            ]
-            if system_prompt
-            else [{"role": "user", "content": prompt}]
-        )
+        messages = kwargs.pop("messages", None)
+        if messages is None:
+            messages = (
+                [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": prompt},
+                ]
+                if system_prompt
+                else [{"role": "user", "content": prompt}]
+            )
 
         if stream:
             return self._a_generate_stream(messages, schema, *args, **kwargs)

--- a/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
+++ b/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
@@ -312,8 +312,8 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
         through ``model.generate(...)`` which bridges via ``run_sync()``.
 
         Args:
-            prompt: The text prompt.  Optional when ``messages`` is provided
-                via ``**kwargs``.
+            prompt: The text prompt (ignored when ``messages`` is provided
+                via ``**kwargs``)
             system_prompt: Optional system prompt
             schema: Optional Pydantic schema for structured output
             *args: Additional positional arguments

--- a/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
+++ b/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
@@ -298,7 +298,7 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
 
     async def a_generate(
         self,
-        prompt: str,
+        prompt: str = "",
         system_prompt: Optional[str] = None,
         schema: Optional[Union[Type[BaseModel], dict]] = None,
         *args,
@@ -312,11 +312,13 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
         through ``model.generate(...)`` which bridges via ``run_sync()``.
 
         Args:
-            prompt: The text prompt
+            prompt: The text prompt.  Optional when ``messages`` is provided
+                via ``**kwargs``.
             system_prompt: Optional system prompt
             schema: Optional Pydantic schema for structured output
             *args: Additional positional arguments
-            **kwargs: Additional keyword arguments
+            **kwargs: Additional keyword arguments (including ``messages``
+                for multi-turn conversations)
 
         Returns:
             Generated text or dict (if schema provided)


### PR DESCRIPTION
## Purpose

Two issues fixed:

1. **system_prompt silently stripped from non-stateless endpoints** — When a `system_prompt` was configured in an endpoint's request mapping, it was removed from the wire body before the HTTP request was sent. This caused REST and WebSocket endpoints to never receive the configured system prompt.

2. **Chatbot bypassed SDK model layer** — The chatbot called `litellm.acompletion` directly, manually forwarding API keys and Vertex AI credentials. This bypassed the SDK's provider abstraction and made the code brittle.

## What Changed

### Backend invoker fix
- Scoped `_strip_meta_keys` in `BaseEndpointInvoker` to only strip reserved meta keys for **stateless endpoints** (those using `{{ messages }}` in their request mapping)
- For stateless endpoints, `system_prompt` is still stripped (it's injected into the `messages` array server-side)
- For all other endpoints, `system_prompt` is left in the wire body

### SDK: messages support in LiteLLM.a_generate
- Added optional `messages` parameter to `LiteLLM.a_generate()` for pre-built message lists
- When `messages` is provided, `prompt`/`system_prompt` are ignored and messages are forwarded directly
- Updated `VertexAILLM.a_generate()` signature to match
- Fully backward compatible — existing callers are unaffected

### Chatbot: use SDK model layer
- Replaced direct `litellm.acompletion` call with `self.model.a_generate(messages=...)`
- Eliminated manual credential forwarding (API keys, Vertex AI config) — the SDK model handles this
- Simplified `_extract_response_content` since SDK returns `str`/`dict` directly

## Testing

- All 209 backend invoker tests pass
- All 286 SDK model tests pass
- Manually verified via curl:
  - Single message works
  - Multi-turn conversation maintains context (chatbot remembers user's name across turns)
  - Custom `system_prompt` override works (chatbot adopts the provided persona)
  - Default use case (insurance) works when no `system_prompt` is set