### PR TITLE
Fix: MCP tool selection closing import drawer prematurely

### DIFF
--- a/apps/frontend/src/app/(protected)/knowledge/components/MCPToolSelectorPanel.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/MCPToolSelectorPanel.tsx
@@ -95,7 +95,6 @@ export default function MCPToolSelectorPanel({
 
   const handleSelectTool = (tool: Tool) => {
     onSelectTool(tool);
-    handleClose();
   };
 
   const handleClose = () => {


### PR DESCRIPTION
## Purpose
Selecting an MCP tool in the knowledge import drawer was immediately closing it instead of advancing to the import step.

## What Changed
- Removed erroneous `handleClose()` call in `MCPToolSelectorPanel.handleSelectTool` that was triggering the parent's `onClose` callback right after `onSelectTool`

## Testing
Go to Knowledge → click MCP import → select a configured MCP tool → should now advance to the import panel.
