### PR TITLE
Add Redis-backed chatbot sessions

### DIFF
--- a/.github/workflows/chatbot.yml
+++ b/.github/workflows/chatbot.yml
@@ -237,6 +237,7 @@ jobs:
           WELCOME_CALENDAR_LINK=${{ secrets.WELCOME_CALENDAR_LINK }},
           WELCOME_FROM_EMAIL=${{ secrets.WELCOME_FROM_EMAIL }},
           CHATBOT_API_KEY=${{ secrets.CHATBOT_API_KEY }},
+          BROKER_URL=${{ secrets.BROKER_URL }},
           RHESIS_CONNECTOR_DISABLED=${{ secrets.RHESIS_CONNECTOR_DISABLED || 'true' }},
           EOF
           )"

--- a/apps/backend/src/rhesis/backend/app/services/redis_constants.py
+++ b/apps/backend/src/rhesis/backend/app/services/redis_constants.py
@@ -19,3 +19,4 @@ class RedisDatabase:
     GARAK_PROBE_CACHE = 2
     CONVERSATION_LINKING = 3
     TRACE_METRICS_DEBOUNCE = 3  # shares DB with conversation linking (different key prefixes)
+    CHATBOT_SESSIONS = 4

--- a/apps/chatbot/client.py
+++ b/apps/chatbot/client.py
@@ -4,8 +4,11 @@ import logging
 import os
 import uuid
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Union
+
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Import endpoint module first to initialize RhesisClient
 # This ensures only ONE tracer provider exists (critical for proper trace nesting)
@@ -14,6 +17,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from notifications import send_rate_limit_alert
 from pydantic import BaseModel, field_validator
+from session_store import create_session_store
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
@@ -113,9 +117,8 @@ CHATBOT_API_KEY = os.getenv("CHATBOT_API_KEY")
 
 # Session management configuration
 SESSION_TIMEOUT_HOURS = int(os.getenv("SESSION_TIMEOUT_HOURS", "24"))  # Default 24 hours
-SESSION_CLEANUP_INTERVAL_MINUTES = int(
-    os.getenv("SESSION_CLEANUP_INTERVAL_MINUTES", "60")
-)  # Default 60 minutes
+SESSION_TTL_SECONDS = SESSION_TIMEOUT_HOURS * 60 * 60
+session_store = create_session_store(ttl_seconds=SESSION_TTL_SECONDS)
 
 # HTTP Bearer token security
 security = HTTPBearer(auto_error=False)  # auto_error=False allows optional auth
@@ -147,76 +150,14 @@ def get_rate_limit_identifier(request: Request) -> str:
 limiter = Limiter(key_func=get_rate_limit_identifier)
 
 
-# Session storage with metadata
-class SessionData:
-    """Session data with metadata for garbage collection."""
-
-    def __init__(self, messages: List[dict] = None):
-        self.messages = messages or []
-        self.last_accessed = datetime.utcnow()
-        self.created_at = datetime.utcnow()
-
-    def update_access_time(self):
-        """Update the last accessed timestamp."""
-        self.last_accessed = datetime.utcnow()
-
-    def is_stale(self, timeout_hours: int) -> bool:
-        """Check if session is stale based on last access time."""
-        age = datetime.utcnow() - self.last_accessed
-        return age > timedelta(hours=timeout_hours)
-
-
-# Store chat sessions with metadata
-sessions: Dict[str, SessionData] = {}
-
-
-async def cleanup_stale_sessions():
-    """Background task to periodically clean up stale sessions."""
-    while True:
-        try:
-            await asyncio.sleep(SESSION_CLEANUP_INTERVAL_MINUTES * 60)
-
-            # Find stale sessions
-            stale_session_ids = [
-                session_id
-                for session_id, session_data in sessions.items()
-                if session_data.is_stale(SESSION_TIMEOUT_HOURS)
-            ]
-
-            # Remove stale sessions (pop avoids KeyError if already removed)
-            for session_id in stale_session_ids:
-                sessions.pop(session_id, None)
-
-            if stale_session_ids:
-                logger.info(
-                    f"🧹 Cleaned up {len(stale_session_ids)} stale sessions. "
-                    f"Active sessions: {len(sessions)}"
-                )
-            else:
-                logger.debug(f"🧹 Session cleanup: {len(sessions)} active sessions, 0 stale")
-
-        except Exception as e:
-            logger.error(f"❌ Error in session cleanup task: {e}")
-
-
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Lifespan context manager to run background tasks."""
-    # Start cleanup task
-    cleanup_task = asyncio.create_task(cleanup_stale_sessions())
-    logger.info(
-        f"🚀 Started session cleanup task (interval: {SESSION_CLEANUP_INTERVAL_MINUTES}min, "
-        f"timeout: {SESSION_TIMEOUT_HOURS}h)"
-    )
+    """Lifespan context manager for app startup and shutdown."""
+    logger.info("🚀 Chatbot session TTL configured for %sh", SESSION_TIMEOUT_HOURS)
 
     yield
 
-    # Cleanup on shutdown
-    cleanup_task.cancel()
-    try:
-        await cleanup_task
-    except asyncio.CancelledError:
-        logger.info("🛑 Session cleanup task cancelled")
+    await session_store.close()
 
 
 def verify_api_key(
@@ -558,17 +499,13 @@ async def chat(
 
     # Resolve session – reuse existing or create new
     session_id = session_id or str(uuid.uuid4())
-    if session_id not in sessions:
-        sessions[session_id] = SessionData()
-        logger.info(f"Created new session: {session_id}")
-    sessions[session_id].update_access_time()
 
     # Use explicit history if provided, otherwise fetch from session.
     # The isinstance guard is necessary because Jinja2 renders
     # ``{{ conversation_history | default(none) }}`` as the *string*
     # ``"None"`` rather than Python ``None``.
     if not isinstance(conversation_history, list):
-        conversation_history = sessions[session_id].messages.copy()
+        conversation_history = await session_store.get(session_id)
 
     # Derive file_contents from enriched files when present (connector path).
     # Each file dict from the backend carries an ``extracted_text`` field set
@@ -644,8 +581,13 @@ async def chat(
 
     # Echo use case: return input directly without any LLM call
     if use_case == "echo":
-        sessions[session_id].messages.append({"role": "user", "content": message})
-        sessions[session_id].messages.append({"role": "assistant", "content": message})
+        await session_store.append(
+            session_id,
+            [
+                {"role": "user", "content": message},
+                {"role": "assistant", "content": message},
+            ],
+        )
         return ChatResponse(
             message=message,
             session_id=session_id,
@@ -712,8 +654,13 @@ async def chat(
     ])
 
     # Persist the exchange in the session store
-    sessions[session_id].messages.append({"role": "user", "content": message})
-    sessions[session_id].messages.append({"role": "assistant", "content": response_message})
+    await session_store.append(
+        session_id,
+        [
+            {"role": "user", "content": message},
+            {"role": "assistant", "content": response_message},
+        ],
+    )
 
     # Return Pydantic model
     return ChatResponse(
@@ -834,16 +781,12 @@ async def chat_endpoint(
 async def get_session(
     request: Request, session_id: str, auth: dict = Depends(check_rate_limit_chatbot)
 ):
-    if session_id not in sessions:
+    if not await session_store.exists(session_id):
         raise HTTPException(status_code=404, detail="Session not found")
 
-    # Update access time when retrieving session
-    sessions[session_id].update_access_time()
-
     return {
-        "messages": sessions[session_id].messages,
-        "created_at": sessions[session_id].created_at.isoformat(),
-        "last_accessed": sessions[session_id].last_accessed.isoformat(),
+        "messages": await session_store.get(session_id),
+        "ttl_hours": SESSION_TIMEOUT_HOURS,
     }
 
 
@@ -851,9 +794,8 @@ async def get_session(
 async def delete_session(
     request: Request, session_id: str, auth: dict = Depends(check_rate_limit_chatbot)
 ):
-    if session_id not in sessions:
+    if not await session_store.delete(session_id):
         raise HTTPException(status_code=404, detail="Session not found")
-    del sessions[session_id]
     logger.info(f"🗑️ Manually deleted session: {session_id}")
     return {"message": "Session deleted"}
 

--- a/apps/chatbot/pyproject.toml
+++ b/apps/chatbot/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "slowapi>=0.1.9",
     "pydantic>=2.11.7",
     "python-dotenv>=1.2.2",
+    "redis>=5.0.0",
     "streamlit>=1.41.1",
     "rhesis-sdk",
 ]

--- a/apps/chatbot/session_store.py
+++ b/apps/chatbot/session_store.py
@@ -1,0 +1,136 @@
+import json
+import logging
+import os
+import time
+from typing import Any, Protocol
+from urllib.parse import urlsplit, urlunsplit
+
+from redis.asyncio import Redis  # type: ignore[reportMissingImports]
+
+logger = logging.getLogger(__name__)
+
+CHATBOT_SESSIONS_DB = 4
+SESSION_KEY_PREFIX = "chatbot:session:"
+
+
+class SessionStore(Protocol):
+    async def get(self, session_id: str) -> list[dict[str, Any]]:
+        """Return messages for a session and refresh its TTL."""
+
+    async def append(self, session_id: str, messages: list[dict[str, Any]]) -> None:
+        """Append messages to a session and refresh its TTL."""
+
+    async def exists(self, session_id: str) -> bool:
+        """Return whether a session exists."""
+
+    async def delete(self, session_id: str) -> bool:
+        """Delete a session."""
+
+    async def close(self) -> None:
+        """Close store resources."""
+
+
+class InMemorySessionStore:
+    """Local development fallback used when BROKER_URL is not configured."""
+
+    def __init__(self, ttl_seconds: int):
+        self.ttl_seconds = ttl_seconds
+        self._sessions: dict[str, tuple[list[dict[str, Any]], float]] = {}
+
+    def _expires_at(self) -> float:
+        return time.time() + self.ttl_seconds
+
+    def _purge_if_expired(self, session_id: str) -> None:
+        session = self._sessions.get(session_id)
+        if session and session[1] <= time.time():
+            self._sessions.pop(session_id, None)
+
+    async def get(self, session_id: str) -> list[dict[str, Any]]:
+        self._purge_if_expired(session_id)
+        session = self._sessions.get(session_id)
+        if not session:
+            return []
+
+        messages, _ = session
+        self._sessions[session_id] = (messages, self._expires_at())
+        return list(messages)
+
+    async def append(self, session_id: str, messages: list[dict[str, Any]]) -> None:
+        current = await self.get(session_id)
+        current.extend(messages)
+        self._sessions[session_id] = (current, self._expires_at())
+
+    async def exists(self, session_id: str) -> bool:
+        self._purge_if_expired(session_id)
+        return session_id in self._sessions
+
+    async def delete(self, session_id: str) -> bool:
+        return self._sessions.pop(session_id, None) is not None
+
+    async def close(self) -> None:
+        return None
+
+
+class RedisSessionStore:
+    """Redis-backed session store using one list key per chat session."""
+
+    def __init__(self, broker_url: str, ttl_seconds: int):
+        self.ttl_seconds = ttl_seconds
+        self.redis_url = _with_database(broker_url, CHATBOT_SESSIONS_DB)
+        self.client = Redis.from_url(self.redis_url, decode_responses=True)
+
+    def _key(self, session_id: str) -> str:
+        return f"{SESSION_KEY_PREFIX}{session_id}"
+
+    async def get(self, session_id: str) -> list[dict[str, Any]]:
+        key = self._key(session_id)
+        values = await self.client.lrange(key, 0, -1)
+        if not values:
+            return []
+
+        await self.client.expire(key, self.ttl_seconds)
+        messages: list[dict[str, Any]] = []
+        for value in values:
+            try:
+                decoded = json.loads(value)
+            except json.JSONDecodeError:
+                logger.warning("Skipping invalid session message for %s", session_id)
+                continue
+            if isinstance(decoded, dict):
+                messages.append(decoded)
+        return messages
+
+    async def append(self, session_id: str, messages: list[dict[str, Any]]) -> None:
+        if not messages:
+            return
+
+        key = self._key(session_id)
+        encoded = [json.dumps(message, default=str) for message in messages]
+        async with self.client.pipeline(transaction=True) as pipe:
+            pipe.rpush(key, *encoded)
+            pipe.expire(key, self.ttl_seconds)
+            await pipe.execute()
+
+    async def exists(self, session_id: str) -> bool:
+        return bool(await self.client.exists(self._key(session_id)))
+
+    async def delete(self, session_id: str) -> bool:
+        return bool(await self.client.delete(self._key(session_id)))
+
+    async def close(self) -> None:
+        await self.client.aclose()
+
+
+def create_session_store(ttl_seconds: int) -> SessionStore:
+    broker_url = os.getenv("BROKER_URL")
+    if not broker_url:
+        logger.info("BROKER_URL not set; using in-memory chatbot session store")
+        return InMemorySessionStore(ttl_seconds=ttl_seconds)
+
+    logger.info("Using Redis chatbot session store on DB %s", CHATBOT_SESSIONS_DB)
+    return RedisSessionStore(broker_url=broker_url, ttl_seconds=ttl_seconds)
+
+
+def _with_database(redis_url: str, database: int) -> str:
+    parts = urlsplit(redis_url)
+    return urlunsplit((parts.scheme, parts.netloc, f"/{database}", parts.query, parts.fragment))

--- a/apps/chatbot/uv.lock
+++ b/apps/chatbot/uv.lock
@@ -12,7 +12,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-20T10:09:59.654239Z"
+exclude-newer = "2026-05-20T15:12:06.951732Z"
 exclude-newer-span = "P1W"
 
 [manifest]
@@ -3591,6 +3591,15 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3750,6 +3759,7 @@ dependencies = [
     { name = "gunicorn" },
     { name = "pydantic" },
     { name = "python-dotenv" },
+    { name = "redis" },
     { name = "rhesis-sdk" },
     { name = "slowapi" },
     { name = "streamlit" },
@@ -3762,6 +3772,7 @@ requires-dist = [
     { name = "gunicorn", specifier = ">=21.2.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "redis", specifier = ">=5.0.0" },
     { name = "rhesis-sdk", editable = "../../sdk" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "streamlit", specifier = ">=1.41.1" },

--- a/charts/rhesis/templates/chatbot/deployment.yaml
+++ b/charts/rhesis/templates/chatbot/deployment.yaml
@@ -37,8 +37,14 @@ spec:
                 name: {{ include "rhesis.fullname" . }}-config
             - secretRef:
                 name: {{ .Values.existingSecret }}
-          {{ with .Values.chatbot.env }}
           env:
+            - name: BROKER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.existingSecret }}
+                  key: BROKER_URL
+                  optional: true
+          {{ with .Values.chatbot.env }}
 {{ toYaml . | nindent 12 }}
           {{ end }}
           resources:


### PR DESCRIPTION
## Purpose

Make chatbot multi-turn sessions survive multiple workers and replicas by storing conversation history in Redis when `BROKER_URL` is configured.

## What Changed

- Added a chatbot session store abstraction with Redis-backed storage on DB 4 and an in-memory fallback for local development
- Refactored the chatbot to load history from the session store, persist user/assistant turns, and use Redis TTL instead of a cleanup task
- Added the `redis` dependency and registered the chatbot session Redis DB allocation
- Wired `BROKER_URL` into the Cloud Run chatbot workflow and future Helm deployment path

## Additional Context

- Redis keys use `chatbot:session:{session_id}`
- Session TTL follows `SESSION_TIMEOUT_HOURS` and refreshes on reads/writes
- If `BROKER_URL` is absent, the app keeps local in-memory behavior

## Testing

- `uv run python -m py_compile client.py session_store.py`
- IDE lints passed for changed Python files
- Verified locally with `BROKER_URL` from `apps/chatbot/.env`: `/chat` persisted echo messages and `/sessions/{session_id}` returned them
- Verified real multi-turn recall via curl: second turn remembered the name and reported `history_length: 2`