### PR TITLE
Fix chatbot startup: lazy Redis client initialization

### DIFF
--- a/apps/chatbot/session_store.py
+++ b/apps/chatbot/session_store.py
@@ -72,23 +72,32 @@ class InMemorySessionStore:
 
 
 class RedisSessionStore:
-    """Redis-backed session store using one list key per chat session."""
+    """Redis-backed session store using one list key per chat session.
+
+    The Redis client is created lazily on first use so that an unreachable
+    Redis host never blocks gunicorn worker startup.
+    """
 
     def __init__(self, broker_url: str, ttl_seconds: int):
         self.ttl_seconds = ttl_seconds
         self.redis_url = _with_database(broker_url, CHATBOT_SESSIONS_DB)
-        self.client = Redis.from_url(self.redis_url, decode_responses=True)
+        self._client: Redis | None = None
+
+    def _get_client(self) -> Redis:
+        if self._client is None:
+            self._client = Redis.from_url(self.redis_url, decode_responses=True)
+        return self._client
 
     def _key(self, session_id: str) -> str:
         return f"{SESSION_KEY_PREFIX}{session_id}"
 
     async def get(self, session_id: str) -> list[dict[str, Any]]:
         key = self._key(session_id)
-        values = await self.client.lrange(key, 0, -1)
+        values = await self._get_client().lrange(key, 0, -1)
         if not values:
             return []
 
-        await self.client.expire(key, self.ttl_seconds)
+        await self._get_client().expire(key, self.ttl_seconds)
         messages: list[dict[str, Any]] = []
         for value in values:
             try:
@@ -106,19 +115,20 @@ class RedisSessionStore:
 
         key = self._key(session_id)
         encoded = [json.dumps(message, default=str) for message in messages]
-        async with self.client.pipeline(transaction=True) as pipe:
+        async with self._get_client().pipeline(transaction=True) as pipe:
             pipe.rpush(key, *encoded)
             pipe.expire(key, self.ttl_seconds)
             await pipe.execute()
 
     async def exists(self, session_id: str) -> bool:
-        return bool(await self.client.exists(self._key(session_id)))
+        return bool(await self._get_client().exists(self._key(session_id)))
 
     async def delete(self, session_id: str) -> bool:
-        return bool(await self.client.delete(self._key(session_id)))
+        return bool(await self._get_client().delete(self._key(session_id)))
 
     async def close(self) -> None:
-        await self.client.aclose()
+        if self._client is not None:
+            await self._client.aclose()
 
 
 def create_session_store(ttl_seconds: int) -> SessionStore:


### PR DESCRIPTION
## Purpose
Prevent the chatbot from failing Cloud Run startup probes when the Redis
instance is unreachable (e.g. before a VPC connector is attached or during
initial deployment). Without this fix, every new revision would be rejected
with "Deadline exceeded" before the app could even log a single line.

## What Changed
- `RedisSessionStore.__init__` no longer creates the `redis.asyncio.Redis`
  client eagerly at import/startup time
- A new `_get_client()` method creates the client lazily on first use
- All internal references to `self.client` updated to `self._get_client()`
- `close()` guards against a `None` client to avoid errors on teardown

## Additional Context
- Follows up on #1834 (session management + parameter resilience)
- Verified with multi-turn curl tests on dev: 3 independent sessions, each
  confirmed 4–6 messages stored in Redis and accurate recall across turns

## Testing
Multi-turn sessions verified on `dev-chatbot.rhesis.ai`:
- Chatbot correctly recalls car model and state mentioned in earlier turns
- Redis `/sessions/{id}` endpoint confirms messages are persisted