### PR TITLE
Fix JWT access token default test expectation

### DIFF
--- a/tests/backend/app/test_settings.py
+++ b/tests/backend/app/test_settings.py
@@ -394,7 +394,7 @@ def test_auth_settings_uses_defaults(clean_auth_env):
     assert settings.session_secret_key is None
     assert settings.jwt_secret_key is None
     assert settings.jwt_algorithm == "HS256"
-    assert settings.jwt_access_token_expire_minutes == 10080
+    assert settings.jwt_access_token_expire_minutes == 15
     assert settings.google_enabled is False
     assert settings.github_enabled is False
 


### PR DESCRIPTION
## Purpose
`test_auth_settings_uses_defaults` still expected the old 10080-minute (7-day) JWT default, but `AuthSettings` now defaults to 15 minutes.

## What Changed
- Updated `test_auth_settings_uses_defaults` to assert `jwt_access_token_expire_minutes == 15`

## Additional Context
No runtime change; settings default was already 15 minutes in `AuthSettings`.

## Testing
- [ ] `cd apps/backend && uv run pytest ../../tests/backend/app/test_settings.py::test_auth_settings_uses_defaults -v`