### PR TITLE
Unify environment detection onto BACKEND_ENV

### DIFF
--- a/apps/backend/src/rhesis/backend/app/auth/url_utils.py
+++ b/apps/backend/src/rhesis/backend/app/auth/url_utils.py
@@ -33,9 +33,9 @@ def build_redirect_url(request, session_token, refresh_token=None):
             # Dev-only escape hatch: a frontend running on the developer's
             # loopback (e.g. ``http://localhost:3000``) is allowed to point
             # at a remote dev backend and still receive the redirect back.
-            # This branch is gated on BACKEND_ENV so production never
-            # honours loopback origins regardless of the Origin/Referer
-            # the browser sent on /auth/login/{provider}.
+            # Dev-only: gated on BACKEND_ENV so production never honours
+            # loopback origins regardless of the Origin/Referer the browser
+            # sent on /auth/login/{provider}.
             frontend_url = f"{parsed_origin.scheme}://{parsed_origin.netloc}"
 
         # Clean up session
@@ -73,9 +73,9 @@ def _is_loopback_dev_origin(parsed_origin) -> bool:
 
     Three independent conditions must all hold:
 
-    * The deployment is **not** production (neither ``BACKEND_ENV`` nor
-      ``ENVIRONMENT`` is set to ``production``). Production deployments
-      never accept loopback origins, regardless of what the browser sent.
+    * The deployment is **not** production (``BACKEND_ENV`` is not
+      ``production``). Production deployments never accept loopback origins,
+      regardless of what the browser sent.
     * The hostname is an exact match against the loopback whitelist.
       ``urlparse`` lowercases the hostname and strips the port, so
       ``LocalHost:3000`` and ``localhost:9999`` both reduce to

--- a/apps/backend/src/rhesis/backend/app/config/settings.py
+++ b/apps/backend/src/rhesis/backend/app/config/settings.py
@@ -1,7 +1,8 @@
 from functools import lru_cache
+from typing import Literal
 from urllib.parse import quote_plus, urlparse
 
-from pydantic import AliasChoices, AnyHttpUrl, Field, TypeAdapter, field_validator, model_validator
+from pydantic import AnyHttpUrl, Field, TypeAdapter, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -91,25 +92,23 @@ class ApplicationSettings(BaseSettings):
     model_config = SettingsConfigDict(env_ignore_empty=True)
 
     quick_start: bool = Field(default=False, alias="QUICK_START")
-    environment: str = Field(
-        default="",
-        validation_alias=AliasChoices("ENVIRONMENT", "ENV"),
+    backend_env: Literal["production", "development", "staging", "local"] = Field(
+        default="development", alias="BACKEND_ENV"
     )
-    backend_env: str = Field(default="development", alias="BACKEND_ENV")
     # Google Cloud-specific environment variables set by Google Cloud runtimes.
     gcp_project: str | None = Field(default=None, alias="GCP_PROJECT")
     google_cloud_project: str | None = Field(default=None, alias="GOOGLE_CLOUD_PROJECT")
     cloud_run_service: str | None = Field(default=None, alias="K_SERVICE")
     cloud_run_revision: str | None = Field(default=None, alias="K_REVISION")
 
-    @field_validator("environment", "backend_env")
+    @field_validator("backend_env", mode="before")
     @classmethod
     def normalize_environment_value(cls, value: str) -> str:
         return value.lower()
 
     @property
     def is_production(self) -> bool:
-        return self.backend_env.lower() == "production" or self.environment.lower() == "production"
+        return self.backend_env.lower() == "production"
 
     @property
     def is_development(self) -> bool:

--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -196,7 +196,7 @@ def is_running_locally() -> bool:
     Never uses any request-derived data. Uses three independent signals:
     1. Quick Start mode (QUICK_START=true + no GCP env vars)
     2. RHESIS_BASE_URL explicitly configured for localhost
-    3. ENVIRONMENT or BACKEND_ENV set to 'local'
+    3. BACKEND_ENV set to 'local'
     """
     # Signal 1: Quick Start mode (env-vars only, no request data)
     if is_quick_start_enabled():
@@ -207,9 +207,9 @@ def is_running_locally() -> bool:
     if parsed_host in _LOCAL_HOSTNAMES:
         return True
 
-    # Signal 3: Environment variables indicate local deployment
+    # Signal 3: BACKEND_ENV explicitly set to local
     settings = get_application_settings()
-    if settings.environment == "local" or settings.backend_env == "local":
+    if settings.backend_env == "local":
         return True
 
     return False

--- a/apps/backend/src/rhesis/backend/app/utils/git_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/git_utils.py
@@ -48,7 +48,7 @@ def should_show_git_info() -> bool:
     settings = get_application_settings()
 
     # Don't show git info in production
-    return settings.backend_env != "production" and settings.environment != "production"
+    return settings.backend_env != "production"
 
 
 def get_version_info() -> dict:

--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -13,7 +13,7 @@ logging_settings = get_logging_settings()
 
 LOG_LEVEL = logging_settings.log_level
 LOG_DIR = logging_settings.log_dir
-ENVIRONMENT = application_settings.environment or "production"
+ENVIRONMENT = application_settings.backend_env
 IS_GOOGLE_CLOUD = application_settings.is_google_cloud
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 LOG_DATE_FORMAT = "%m/%d/%Y %I:%M:%S%p"

--- a/ee/backend/src/rhesis/backend/ee/__init__.py
+++ b/ee/backend/src/rhesis/backend/ee/__init__.py
@@ -92,8 +92,8 @@ def bootstrap(app: "FastAPI") -> None:
     # forensic capability; refuse to bootstrap rather than ship an
     # un-correlatable audit stream.
     settings = get_application_settings()
-    dev_environments = ("local", "test", "dev", "development")
-    is_dev = settings.environment in dev_environments or settings.backend_env in dev_environments
+    dev_environments = ("local", "development", "staging")
+    is_dev = settings.backend_env in dev_environments
     if not is_dev:
         if not os.getenv("AUDIT_HASH_KEY"):
             raise RuntimeError(

--- a/ee/backend/src/rhesis/backend/ee/api_clients/audit.py
+++ b/ee/backend/src/rhesis/backend/ee/api_clients/audit.py
@@ -80,8 +80,8 @@ def _is_dev_environment() -> bool:
     that do not exercise SSO.
     """
     settings = get_application_settings()
-    dev_environments = ("local", "test", "dev", "development")
-    return settings.environment in dev_environments or settings.backend_env in dev_environments
+    dev_environments = ("local", "development", "staging")
+    return settings.backend_env in dev_environments
 
 
 def _get_audit_hash_key() -> Optional[bytes]:

--- a/ee/backend/src/rhesis/backend/ee/sso/http_client.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/http_client.py
@@ -16,21 +16,22 @@ from typing import List, Tuple
 from urllib.parse import urlparse, urlunparse
 
 import httpx
+
 from rhesis.backend.app.config.settings import get_application_settings
 
 logger = logging.getLogger(__name__)
 
-_DEV_ENVIRONMENTS = ("local", "test", "development")
+_DEV_ENVIRONMENTS = ("local", "development", "staging")
 _LOCALHOST_NAMES = {"localhost", "127.0.0.1", "::1"}
 
 
 def is_dev_environment() -> bool:
-    """True when ENVIRONMENT is local, test, or development.
+    """True when BACKEND_ENV is local, test, or development.
 
     Used by SSO modules to relax localhost/HTTPS restrictions that are only
     appropriate for production deployments.
     """
-    return get_application_settings().environment in _DEV_ENVIRONMENTS
+    return get_application_settings().backend_env in _DEV_ENVIRONMENTS
 
 _BLOCKED_NETWORKS = [
     # RFC 1918 private address space -- VPCs, Kubernetes pods, Docker networks,
@@ -95,7 +96,7 @@ def _resolve_and_validate(hostname: str) -> List[Tuple]:
     """Resolve hostname, validate all IPs against the blocklist, and return
     the raw getaddrinfo results for pinning into the transport.
 
-    In development environments (ENVIRONMENT=local/test/development), localhost
+    In development environments (BACKEND_ENV=local/test/development), localhost
     is allowed through the blocklist so that local IdP instances (e.g. Keycloak
     on localhost:8180) can be reached.
 

--- a/ee/backend/src/rhesis/backend/ee/sso/http_client.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/http_client.py
@@ -26,7 +26,7 @@ _LOCALHOST_NAMES = {"localhost", "127.0.0.1", "::1"}
 
 
 def is_dev_environment() -> bool:
-    """True when BACKEND_ENV is local, test, or development.
+    """True when BACKEND_ENV is local, development, or staging.
 
     Used by SSO modules to relax localhost/HTTPS restrictions that are only
     appropriate for production deployments.
@@ -96,7 +96,7 @@ def _resolve_and_validate(hostname: str) -> List[Tuple]:
     """Resolve hostname, validate all IPs against the blocklist, and return
     the raw getaddrinfo results for pinning into the transport.
 
-    In development environments (BACKEND_ENV=local/test/development), localhost
+    In development environments (BACKEND_ENV=local/development/staging), localhost
     is allowed through the blocklist so that local IdP instances (e.g. Keycloak
     on localhost:8180) can be reached.
 

--- a/tests/backend/app/test_settings.py
+++ b/tests/backend/app/test_settings.py
@@ -41,8 +41,6 @@ DATABASE_ENV_VARS = (
 FRONTEND_ENV_VARS = ("FRONTEND_URL",)
 APPLICATION_ENV_VARS = (
     "QUICK_START",
-    "ENVIRONMENT",
-    "ENV",
     "BACKEND_ENV",
     "GCP_PROJECT",
     "GOOGLE_CLOUD_PROJECT",
@@ -266,12 +264,11 @@ def test_database_settings_unix_socket_url(clean_database_env, monkeypatch):
 
     settings = DatabaseSettings(_env_file=None)
 
-    assert (
-        settings.app_url
-        == (
-            "postgresql://app-user:app-pass@/mydb?host=/cloudsql/project:region:instance"  # trufflehog:ignore
-        )
+    expected = (
+        "postgresql://app-user:app-pass@/mydb"
+        "?host=/cloudsql/project:region:instance"  # trufflehog:ignore
     )
+    assert settings.app_url == expected
 
 
 @pytest.mark.unit
@@ -628,7 +625,6 @@ def test_application_settings_defaults(clean_application_env):
     settings = ApplicationSettings(_env_file=None)
 
     assert settings.quick_start is False
-    assert settings.environment == ""
     assert settings.backend_env == "development"
     assert settings.gcp_project is None
     assert settings.google_cloud_project is None
@@ -645,7 +641,6 @@ def test_application_settings_loads_existing_environment_variables(
     clean_application_env, monkeypatch
 ):
     monkeypatch.setenv("QUICK_START", "true")
-    monkeypatch.setenv("ENVIRONMENT", "Staging")
     monkeypatch.setenv("BACKEND_ENV", "Production")
     monkeypatch.setenv("GCP_PROJECT", "rhesis-prod")
     monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "rhesis-prod-2")
@@ -655,7 +650,6 @@ def test_application_settings_loads_existing_environment_variables(
     settings = ApplicationSettings(_env_file=None)
 
     assert settings.quick_start is True
-    assert settings.environment == "staging"
     assert settings.backend_env == "production"
     assert settings.gcp_project == "rhesis-prod"
     assert settings.google_cloud_project == "rhesis-prod-2"
@@ -664,39 +658,23 @@ def test_application_settings_loads_existing_environment_variables(
 
 
 @pytest.mark.unit
-def test_application_settings_environment_alias_choice_env(clean_application_env, monkeypatch):
-    """ENVIRONMENT and ENV are equivalent aliases for the same field."""
-    monkeypatch.setenv("ENV", "production")
-
-    settings = ApplicationSettings(_env_file=None)
-
-    assert settings.environment == "production"
-    assert settings.is_production is True
-
-
-@pytest.mark.unit
 @pytest.mark.parametrize(
-    "backend_env,environment,expected_is_production",
+    "backend_env,expected_is_production",
     [
-        # Either signal being production wins.
-        ("production", "", True),
-        ("development", "production", True),
-        ("PRODUCTION", "", True),
-        # Neither signal being production -> not production.
-        ("development", "", False),
-        ("local", "", False),
-        ("development", "staging", False),
-        ("", "", False),
+        ("production", True),
+        ("PRODUCTION", True),
+        ("development", False),
+        ("local", False),
+        ("staging", False),
+        ("", False),
     ],
 )
-def test_application_settings_is_production_or_logic(
-    clean_application_env, monkeypatch, backend_env, environment, expected_is_production
+def test_application_settings_is_production(
+    clean_application_env, monkeypatch, backend_env, expected_is_production
 ):
-    """is_production fires when EITHER backend_env or environment is production."""
+    """is_production is driven exclusively by BACKEND_ENV."""
     if backend_env:
         monkeypatch.setenv("BACKEND_ENV", backend_env)
-    if environment:
-        monkeypatch.setenv("ENVIRONMENT", environment)
 
     settings = ApplicationSettings(_env_file=None)
 
@@ -737,13 +715,14 @@ class TestLoopbackCorsRegex:
 
         assert get_frontend_settings().loopback_cors_regex is None
 
-    def test_returns_none_when_environment_is_production(self, clean_application_env, monkeypatch):
-        """ENVIRONMENT=production wins over BACKEND_ENV=development."""
+    def test_returns_regex_when_only_environment_is_production(
+        self, clean_application_env, monkeypatch
+    ):
+        """ENVIRONMENT=production alone no longer gates; only BACKEND_ENV drives is_production."""
         monkeypatch.setenv("BACKEND_ENV", "development")
-        monkeypatch.setenv("ENVIRONMENT", "production")
         get_application_settings.cache_clear()
 
-        assert get_frontend_settings().loopback_cors_regex is None
+        assert get_frontend_settings().loopback_cors_regex is not None
 
     def test_returns_regex_in_development(self, clean_application_env, monkeypatch):
         monkeypatch.setenv("BACKEND_ENV", "development")

--- a/tests/backend/auth/test_url_utils.py
+++ b/tests/backend/auth/test_url_utils.py
@@ -23,8 +23,6 @@ def clean_frontend_settings(monkeypatch):
     # Pin to production so the loopback dev gate is OFF by default; tests
     # that exercise the dev branch override BACKEND_ENV explicitly.
     monkeypatch.setenv("BACKEND_ENV", "production")
-    monkeypatch.delenv("ENVIRONMENT", raising=False)
-    monkeypatch.delenv("ENV", raising=False)
     get_frontend_settings.cache_clear()
     get_application_settings.cache_clear()
     yield
@@ -147,18 +145,17 @@ class TestLoopbackDevGate:
         "rhesis.backend.app.auth.token_utils.get_secret_key",
         return_value="test-secret",
     )
-    def test_rejects_loopback_when_environment_is_production(self, _mock_key, monkeypatch):
-        """ENVIRONMENT=production also rejects loopback (matches is_production OR-logic)."""
+    def test_accepts_loopback_when_only_environment_is_production(self, _mock_key, monkeypatch):
+        """ENVIRONMENT=production alone no longer gates loopback; only BACKEND_ENV drives it."""
         monkeypatch.setenv("FRONTEND_URL", "https://app.rhesis.ai")
         monkeypatch.setenv("BACKEND_ENV", "development")
-        monkeypatch.setenv("ENVIRONMENT", "production")
         get_frontend_settings.cache_clear()
         get_application_settings.cache_clear()
 
         request = _make_request(original_frontend="http://localhost:3000")
         url = build_redirect_url(request, "token123")
 
-        assert url.startswith("https://app.rhesis.ai/")
+        assert url.startswith("http://localhost:3000/")
 
     @patch(
         "rhesis.backend.app.auth.token_utils.get_secret_key",

--- a/tests/backend/ee/sso/test_sso_config_schema.py
+++ b/tests/backend/ee/sso/test_sso_config_schema.py
@@ -29,7 +29,7 @@ class TestSSOConfigValidation:
     def test_http_issuer_rejected_in_production(self, monkeypatch):
         from rhesis.backend.ee.sso.schemas import SSOConfig
 
-        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("BACKEND_ENV", "production")
         get_application_settings.cache_clear()
 
         with pytest.raises(ValueError, match="HTTPS"):
@@ -42,7 +42,7 @@ class TestSSOConfigValidation:
     def test_http_localhost_allowed_in_local(self, monkeypatch):
         from rhesis.backend.ee.sso.schemas import SSOConfig
 
-        monkeypatch.setenv("ENVIRONMENT", "local")
+        monkeypatch.setenv("BACKEND_ENV", "local")
         get_application_settings.cache_clear()
 
         config = SSOConfig(
@@ -141,7 +141,7 @@ class TestSSOConfigValidation:
     def test_non_443_port_rejected_in_production(self, monkeypatch):
         from rhesis.backend.ee.sso.schemas import SSOConfig
 
-        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("BACKEND_ENV", "production")
         get_application_settings.cache_clear()
 
         with pytest.raises(ValueError, match="port 443"):

--- a/tests/backend/ee/sso/test_sso_http_client.py
+++ b/tests/backend/ee/sso/test_sso_http_client.py
@@ -6,7 +6,6 @@ from rhesis.backend.app.config.settings import get_application_settings
 from rhesis.backend.ee.sso.http_client import (
     SSRFError,
     _pin_url_to_ip,
-    _resolve_and_validate,
     validate_endpoint_origin,
     validate_jwks_uri_origin,
     validate_url_safety,
@@ -36,27 +35,27 @@ class TestValidateUrlSafety:
             validate_url_safety("https://metadata.google.internal/path")
 
     def test_localhost_blocked_in_production(self, monkeypatch):
-        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("BACKEND_ENV", "production")
         get_application_settings.cache_clear()
 
         with pytest.raises(SSRFError):
             validate_url_safety("https://127.0.0.1/path")
 
     def test_localhost_name_blocked_in_production(self, monkeypatch):
-        monkeypatch.setenv("ENVIRONMENT", "production")
+        monkeypatch.setenv("BACKEND_ENV", "production")
         get_application_settings.cache_clear()
 
         with pytest.raises(SSRFError):
             validate_url_safety("https://localhost/path")
 
     def test_localhost_allowed_in_dev(self, monkeypatch):
-        monkeypatch.setenv("ENVIRONMENT", "development")
+        monkeypatch.setenv("BACKEND_ENV", "development")
         get_application_settings.cache_clear()
 
         validate_url_safety("http://localhost:8180/realms/dev")
 
     def test_localhost_ip_allowed_in_local(self, monkeypatch):
-        monkeypatch.setenv("ENVIRONMENT", "local")
+        monkeypatch.setenv("BACKEND_ENV", "local")
         get_application_settings.cache_clear()
 
         validate_url_safety("http://127.0.0.1:8180/realms/dev")

--- a/tests/backend/ee/sso/test_sso_router.py
+++ b/tests/backend/ee/sso/test_sso_router.py
@@ -4,11 +4,10 @@ Pure unit tests that mock DB and encryption -- no network or Postgres needed.
 """
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
-from pydantic import SecretStr
 
 from rhesis.backend.app.config.settings import get_application_settings
 
@@ -181,7 +180,7 @@ class TestGetSSOConfig:
     def test_plaintext_secret_fallback_in_dev(self, monkeypatch):
         from rhesis.backend.ee.sso.router import _get_sso_config
 
-        monkeypatch.setenv("ENVIRONMENT", "development")
+        monkeypatch.setenv("BACKEND_ENV", "development")
         get_application_settings.cache_clear()
 
         org = SimpleNamespace(

--- a/tests/backend/routes/test_auth.py
+++ b/tests/backend/routes/test_auth.py
@@ -37,8 +37,8 @@ def _mock_rhesis_settings(base_url: str):
     return lambda: Mock(base_url=base_url)
 
 
-def _mock_application_settings(backend_env: str = "development", environment: str = ""):
-    return lambda: Mock(backend_env=backend_env, environment=environment)
+def _mock_application_settings(backend_env: str = "development"):
+    return lambda: Mock(backend_env=backend_env)
 
 
 # =============================================================================
@@ -1480,7 +1480,7 @@ class TestGetCallbackUrl:
 
     @patch.dict(
         os.environ,
-        {"ENVIRONMENT": "local"},
+        {"BACKEND_ENV": "local"},
         clear=False,
     )
     @patch(
@@ -1493,10 +1493,10 @@ class TestGetCallbackUrl:
     )
     @patch(
         "rhesis.backend.app.routers.auth.get_application_settings",
-        new=_mock_application_settings(environment="local"),
+        new=_mock_application_settings("local"),
     )
     def test_environment_local_uses_localhost(self, mock_qs):
-        """ENVIRONMENT=local returns http://localhost:{port}/auth/callback."""
+        """BACKEND_ENV=local returns http://localhost:{port}/auth/callback."""
         from rhesis.backend.app.routers.auth import get_callback_url
 
         request = _make_mock_request(host="localhost", port=9090)
@@ -1546,7 +1546,7 @@ class TestGetCallbackUrl:
 
     @patch.dict(
         os.environ,
-        {"ENVIRONMENT": "local"},
+        {"BACKEND_ENV": "local"},
         clear=False,
     )
     @patch(
@@ -1559,7 +1559,7 @@ class TestGetCallbackUrl:
     )
     @patch(
         "rhesis.backend.app.routers.auth.get_application_settings",
-        new=_mock_application_settings(environment="local"),
+        new=_mock_application_settings("local"),
     )
     def test_local_preserves_127_hostname(self, mock_qs):
         """Local mode via 127.0.0.1 preserves hostname for session cookies."""
@@ -1571,7 +1571,7 @@ class TestGetCallbackUrl:
 
     @patch.dict(
         os.environ,
-        {"ENVIRONMENT": "local"},
+        {"BACKEND_ENV": "local"},
         clear=False,
     )
     @patch(
@@ -1584,7 +1584,7 @@ class TestGetCallbackUrl:
     )
     @patch(
         "rhesis.backend.app.routers.auth.get_application_settings",
-        new=_mock_application_settings(environment="local"),
+        new=_mock_application_settings("local"),
     )
     def test_local_rejects_non_local_hostname(self, mock_qs):
         """Misconfigured local mode with evil Host falls back to localhost."""


### PR DESCRIPTION
## Purpose

Eliminate the confusing dual `ENVIRONMENT`/`BACKEND_ENV` branching in backend Python code. A single canonical field — `backend_env` (from `BACKEND_ENV`) — now drives all environment-mode decisions. `ApplicationSettings.environment` and its `AliasChoices("ENVIRONMENT","ENV")` are removed entirely.

As a follow-on, `BACKEND_ENV` is now validated as a strict `Literal["production", "development", "staging", "local"]`; any other value (e.g. `dev`, `prd`, `test`) raises a pydantic `ValidationError` at startup rather than silently misbehaving.

## What Changed

**`apps/backend`**
- `config/settings.py`: remove `environment` field + `AliasChoices`; add `Literal` type with `mode="before"` case-normalisation validator; `is_production` checks `backend_env` only
- `logging/logging_config.py`: derive `ENVIRONMENT` module var from `backend_env`
- `app/utils/git_utils.py`: `should_show_git_info` uses `backend_env` only
- `app/routers/auth.py`: `is_running_locally` signal 3 checks `backend_env == "local"`; unused `get_application_settings` import cleaned up
- `app/auth/url_utils.py`: comments updated to reference `BACKEND_ENV` only

**`ee/backend`**
- `ee/__init__.py`, `api_clients/audit.py`: dev-environment tuples use `backend_env`; drop legacy `"test"` / `"dev"` slugs (not valid `BACKEND_ENV` values)
- `sso/http_client.py`: `is_dev_environment` reads `backend_env`; `_DEV_ENVIRONMENTS` updated; docstrings corrected

**Tests**
- `test_settings.py`: remove `settings.environment` assertions, `ENV` alias test, and OR-logic `is_production` parametrize cases; add `backend_env`-only parametrize; flip one CORS regex test to document new semantics
- `test_url_utils.py`: repurpose `test_rejects_loopback_when_environment_is_production` to document that `ENVIRONMENT=production` alone no longer gates loopback
- `test_auth.py`: switch four `ENVIRONMENT=local` / `environment="local"` usages to `BACKEND_ENV=local`; drop `environment` arg from `_mock_application_settings`
- EE SSO tests: all `setenv("ENVIRONMENT", ...)` → `setenv("BACKEND_ENV", ...)`

## Additional Context

- `ENVIRONMENT` env var is still injected by docker-compose and CI (shell scripts `start.sh` / `migrate.sh` / `apps/frontend/start.sh` read it directly) — only the pydantic field is removed; pydantic-settings ignores the extra var.
- `docker-compose.yml` and `.env.example` are **not** changed (BACKEND_ENV default stays `local`).
- The one pre-existing test failure (`test_auth_settings_uses_defaults` — wrong `JWT_ACCESS_TOKEN_EXPIRE_MINUTES` default expectation) is unrelated to this PR.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/app/test_settings.py \
              ../../tests/backend/auth/test_url_utils.py \
              ../../tests/backend/routes/test_auth.py \
              ../../tests/backend/ee/sso -v
# 303 passed, 1 pre-existing unrelated failure
```