### PR TITLE
Redesign Test Runs detail experience (Figma)

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_run.py
@@ -116,7 +116,25 @@ def read_test_runs(
     if select:
         serialized = jsonable_encoder(results)
         return JSONResponse(content=apply_select(serialized, select))
-    return results
+
+    # Attach accurate per-run pass/fail counts so list views (e.g. the test
+    # runs grid pass-rate column) don't rely on the stale
+    # ``attributes.completed_tests`` / ``failed_tests`` counters. Aggregated in
+    # a single query to avoid the N+1 cost of one stats query per run.
+    from rhesis.backend.tasks.execution.result_processor import get_test_statistics_for_runs
+
+    run_stats = get_test_statistics_for_runs(
+        db,
+        [run.id for run in results],
+        organization_id=str(current_user.organization_id),
+    )
+    serialized = jsonable_encoder(results)
+    for item in serialized:
+        item["stats"] = run_stats.get(
+            str(item.get("id")),
+            {"total": 0, "passed": 0, "failed": 0, "errors": 0},
+        )
+    return JSONResponse(content=serialized)
 
 
 @router.get("/stats", response_model=schemas.TestRunStatsResponse)

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -5,7 +5,6 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
-import AddIcon from '@mui/icons-material/Add';
 import GridToolbar, {
   ToolbarPillTabs,
   directoryToolbarSx,
@@ -23,7 +22,7 @@ import { generateCopyName } from '@/utils/entity-helpers';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { PsychologyIcon } from '@/components/icons';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import BehaviorFilterDrawer, {
   type BehaviorFilters,
   type MetricFilter,
@@ -534,7 +533,7 @@ export default function BehaviorsClient({
       actions={
         <FabGroup>
           <Fab
-            icon={<AddIcon />}
+            icon={<FabAddIcon />}
             tooltip="Create behavior"
             aria-label="Create behavior"
             onClick={handleAddNewBehavior}

--- a/apps/frontend/src/app/(protected)/endpoints/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/page.tsx
@@ -4,11 +4,10 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import AddIcon from '@mui/icons-material/Add';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { ApiIcon } from '@/components/icons';
 import EndpointsGrid from './components/EndpointsGrid';
@@ -78,7 +77,7 @@ export default function EndpointsPage() {
       actions={
         <FabGroup>
           <Fab
-            icon={<AddIcon />}
+            icon={<FabAddIcon />}
             tooltip="New Endpoint"
             onClick={() => router.push('/endpoints/new')}
             data-tour="create-endpoint-button"

--- a/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
@@ -16,7 +16,7 @@ import {
 } from '@mui/x-data-grid';
 import { useRouter } from 'next/navigation';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -266,7 +266,7 @@ export default function ExperimentsClientWrapper({
       actions={
         <FabGroup>
           <Fab
-            icon={<AddIcon />}
+            icon={<FabAddIcon />}
             tooltip="New Experiment"
             aria-label="New Experiment"
             onClick={() => setCreateOpen(true)}

--- a/apps/frontend/src/app/(protected)/explorer/ExplorerClient.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/ExplorerClient.tsx
@@ -5,11 +5,10 @@ import { useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import AddIcon from '@mui/icons-material/Add';
 import FileUploadIcon from '@mui/icons-material/FileUploadOutlined';
 import { useSession } from 'next-auth/react';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { AccountTreeIcon } from '@/components/icons';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
@@ -105,7 +104,7 @@ export default function ExplorerClient() {
               onClick={() => setImportDialogOpen(true)}
             />
             <Fab
-              icon={<AddIcon />}
+              icon={<FabAddIcon />}
               tooltip="New session"
               onClick={() => setCreateDialogOpen(true)}
             />

--- a/apps/frontend/src/app/(protected)/insights/components/dashboard/TestRunPerformance.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/dashboard/TestRunPerformance.tsx
@@ -21,8 +21,7 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 import type { TestRunSummaryItem } from '@/utils/api-client/interfaces/test-results';
 
-// Extended interface to include stats
-interface TestRunWithStats extends TestRunDetail {
+interface TestRunWithStats extends Omit<TestRunDetail, 'stats'> {
   stats?: {
     total: number;
     passed: number;

--- a/apps/frontend/src/app/(protected)/layout.tsx
+++ b/apps/frontend/src/app/(protected)/layout.tsx
@@ -19,6 +19,18 @@ interface ExtendedUser {
   organization_id?: string | null;
 }
 
+/**
+ * Routes that render as standalone full-screen views without the app
+ * navigation chrome (sidebar). The test-run comparison view opens in its own
+ * tab and, per design, should not show the sidebar/navbar.
+ */
+const CHROMELESS_ROUTE_PATTERNS = [/^\/test-runs\/[^/]+\/compare\/?$/];
+
+function isChromelessRoute(pathname: string | null): boolean {
+  if (!pathname) return false;
+  return CHROMELESS_ROUTE_PATTERNS.some(pattern => pattern.test(pathname));
+}
+
 export default function ProtectedLayout({
   children,
 }: {
@@ -42,21 +54,24 @@ export default function ProtectedLayout({
   const isOnboarding =
     pathname === '/onboarding' ||
     (pathname?.startsWith('/onboarding/') ?? false);
+  const chromeless = isChromelessRoute(pathname);
   const hasOrganization = !!user?.organization_id && !isOnboarding;
 
-  const content = hasOrganization ? (
-    <AppShell sidebar={<Sidebar />}>{children}</AppShell>
-  ) : (
-    // During onboarding (or when org is missing) render without nav chrome
-    <>{children}</>
-  );
+  const content =
+    hasOrganization && !chromeless ? (
+      <AppShell sidebar={<Sidebar />}>{children}</AppShell>
+    ) : (
+      // During onboarding, when org is missing, or for chromeless routes
+      // (e.g. the comparison tab) render without nav chrome
+      <>{children}</>
+    );
 
   return (
     <QueryClientProvider client={queryClient}>
       <AuthErrorBoundary>
         <FeaturesProvider>
           <WebSocketProvider>
-            {!isOnboarding && <VerificationBanner />}
+            {!isOnboarding && !chromeless && <VerificationBanner />}
             {content}
           </WebSocketProvider>
         </FeaturesProvider>

--- a/apps/frontend/src/app/(protected)/mcp/page.tsx
+++ b/apps/frontend/src/app/(protected)/mcp/page.tsx
@@ -2,12 +2,11 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import { Box, Alert, CircularProgress, Typography } from '@mui/material';
-import AddIcon from '@mui/icons-material/Add';
 import GridToolbar, {
   directoryToolbarSx,
 } from '@/components/common/GridToolbar';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import {
@@ -194,7 +193,7 @@ export default function MCPSPage() {
       actions={
         <FabGroup>
           <Fab
-            icon={<AddIcon />}
+            icon={<FabAddIcon />}
             tooltip="Add MCP connection"
             aria-label="Add MCP connection"
             onClick={() => setConnectionDrawerOpen(true)}

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
@@ -5,7 +5,6 @@ import { useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
-import AddIcon from '@mui/icons-material/Add';
 import TablePagination from '@mui/material/TablePagination';
 import GridToolbar, {
   PrimarySegmentedPills,
@@ -17,7 +16,7 @@ import { DeleteModal } from '@/components/common/DeleteModal';
 import SelectBehaviorsDialog from '@/components/common/SelectBehaviorsDialog';
 import MetricFilterDrawer from './MetricFilterDrawer';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import MetricCard from './MetricCard';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
@@ -493,7 +492,7 @@ export default function MetricsDirectoryTab({
       actions={
         <FabGroup>
           <Fab
-            icon={<AddIcon />}
+            icon={<FabAddIcon />}
             tooltip="Create metric"
             aria-label="Create metric"
             onClick={e => setFabAnchorEl(e.currentTarget)}

--- a/apps/frontend/src/app/(protected)/models/page.tsx
+++ b/apps/frontend/src/app/(protected)/models/page.tsx
@@ -4,9 +4,8 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { Box, Alert, CircularProgress, Typography } from '@mui/material';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
-import AddIcon from '@mui/icons-material/Add';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import GridToolbar, {
   ToolbarPillTabs,
   directoryToolbarSx,
@@ -385,7 +384,7 @@ export default function ModelsPage() {
       actions={
         <FabGroup>
           <Fab
-            icon={<AddIcon />}
+            icon={<FabAddIcon />}
             tooltip="Add model"
             aria-label="Add model"
             onClick={handleFabClick}

--- a/apps/frontend/src/app/(protected)/organizations/team/page.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/page.tsx
@@ -5,9 +5,8 @@ import { useState, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
-import AddIcon from '@mui/icons-material/Add';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import TeamInviteDrawer from './components/TeamInviteDrawer';
 import TeamMembersGrid from './components/TeamMembersGrid';
@@ -57,7 +56,7 @@ export default function TeamPage() {
         actions={
           <FabGroup>
             <Fab
-              icon={<AddIcon />}
+              icon={<FabAddIcon />}
               tooltip="Invite team members"
               onClick={() => setInviteDrawerOpen(true)}
               disabled={isOnInviteTour}

--- a/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
@@ -17,8 +17,7 @@ import ProjectFilterDrawer, {
   EMPTY_FILTERS,
   hasActiveProjectFilters,
 } from './ProjectFilterDrawer';
-import AddIcon from '@mui/icons-material/Add';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import GridToolbar, {
   ToolbarPillTabs,
   directoryToolbarSx,
@@ -200,7 +199,7 @@ export default function ProjectsClientWrapper({
       actions={
         <FabGroup>
           <Fab
-            icon={<AddIcon />}
+            icon={<FabAddIcon />}
             tooltip="Create project"
             aria-label="Create project"
             data-tour="create-project-button"

--- a/apps/frontend/src/app/(protected)/tasks/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/page.tsx
@@ -4,12 +4,11 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import AddIcon from '@mui/icons-material/Add';
 import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import TasksGrid from './components/TasksGrid';
 import TaskDrawer, {
@@ -131,7 +130,7 @@ export default function TasksPage() {
         actions={
           <FabGroup>
             <Fab
-              icon={<AddIcon />}
+              icon={<FabAddIcon />}
               tooltip="New Task"
               aria-label="New Task"
               onClick={() => {

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/ComparePageClient.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/ComparePageClient.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardActionArea,
+  CardContent,
+  Typography,
+} from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+import { useRouter } from 'next/navigation';
+import ComparisonView from '../components/ComparisonView';
+import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { formatDate } from '@/utils/date';
+import { useNotifications } from '@/components/common/NotificationContext';
+
+interface ComparePageClientProps {
+  currentTestRun: {
+    id: string;
+    name?: string;
+    created_at: string;
+    experiment_id?: string;
+    parameter_version?: string;
+    experiment_name?: string;
+  };
+  currentTestResults: TestResultDetail[];
+  availableTestRuns: Array<{
+    id: string;
+    name?: string;
+    created_at: string;
+    pass_rate?: number;
+    experiment_id?: string;
+    parameter_version?: string;
+    experiment_name?: string;
+  }>;
+  prompts: Record<string, { content: string; name?: string }>;
+  behaviors: Array<{
+    id: string;
+    name: string;
+    description?: string;
+    metrics: Array<{ name: string; description?: string }>;
+  }>;
+  sessionToken: string;
+  initialBaselineId?: string;
+  testSetType?: string;
+  project?: { icon?: string; useCase?: string; name?: string };
+  projectName?: string;
+}
+
+export default function ComparePageClient({
+  currentTestRun,
+  currentTestResults,
+  availableTestRuns,
+  prompts,
+  behaviors,
+  sessionToken,
+  initialBaselineId,
+  testSetType,
+  project,
+  projectName,
+}: ComparePageClientProps) {
+  const router = useRouter();
+  const notifications = useNotifications();
+  const [selectedBaselineId, setSelectedBaselineId] = useState<
+    string | undefined
+  >(
+    initialBaselineId && availableTestRuns.some(r => r.id === initialBaselineId)
+      ? initialBaselineId
+      : undefined
+  );
+
+  const handleClose = useCallback(() => {
+    if (window.opener) {
+      window.close();
+    } else {
+      router.push(`/test-runs/${currentTestRun.id}`);
+    }
+  }, [router, currentTestRun.id]);
+
+  const handleLoadBaseline = useCallback(
+    async (baselineTestRunId: string): Promise<TestResultDetail[]> => {
+      try {
+        const testResultsClient = new ApiClientFactory(
+          sessionToken
+        ).getTestResultsClient();
+        let testResults: TestResultDetail[] = [];
+        let skip = 0;
+        const batchSize = 100;
+        let hasMore = true;
+
+        while (hasMore) {
+          const testResultsResponse = await testResultsClient.getTestResults({
+            filter: `test_run_id eq '${baselineTestRunId}'`,
+            limit: batchSize,
+            skip,
+            sort_by: 'created_at',
+            sort_order: 'desc',
+          });
+          testResults = [...testResults, ...testResultsResponse.data];
+          const totalCount = testResultsResponse.pagination?.totalCount || 0;
+          hasMore = testResults.length < totalCount;
+          skip += batchSize;
+          if (skip > 10000) break;
+        }
+        return testResults;
+      } catch {
+        notifications.show('Failed to load baseline test results', {
+          severity: 'error',
+        });
+        return [];
+      }
+    },
+    [sessionToken, notifications]
+  );
+
+  const handleSelectBaseline = (runId: string) => {
+    setSelectedBaselineId(runId);
+    const url = new URL(window.location.href);
+    url.searchParams.set('baseline', runId);
+    window.history.replaceState({}, '', url.toString());
+  };
+
+  if (!selectedBaselineId) {
+    return (
+      <Box sx={{ maxWidth: 720, mx: 'auto' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            mb: 4,
+          }}
+        >
+          <Typography variant="h4" fontWeight={700}>
+            Compare: {currentTestRun.name || 'Test Run'}
+          </Typography>
+          <Button
+            startIcon={<CloseIcon />}
+            onClick={handleClose}
+            variant="outlined"
+          >
+            Close Comparison
+          </Button>
+        </Box>
+
+        <Typography variant="h6" sx={{ mb: 2 }}>
+          Select a baseline run
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          Choose a previous test run on the same test set to compare against the
+          current run.
+        </Typography>
+
+        {availableTestRuns.length === 0 ? (
+          <Typography color="text.secondary">
+            No other test runs are available for comparison on this test set.
+          </Typography>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {availableTestRuns.map(run => (
+              <Card key={run.id} variant="outlined">
+                <CardActionArea onClick={() => handleSelectBaseline(run.id)}>
+                  <CardContent>
+                    <Typography variant="subtitle1" fontWeight={600}>
+                      {run.name || `Run ${run.id.slice(0, 8)}`}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {formatDate(run.created_at)}
+                    </Typography>
+                  </CardContent>
+                </CardActionArea>
+              </Card>
+            ))}
+          </Box>
+        )}
+      </Box>
+    );
+  }
+
+  const filteredRuns = availableTestRuns.filter(
+    r => r.id === selectedBaselineId
+  );
+
+  return (
+    <ComparisonView
+      currentTestRun={currentTestRun}
+      currentTestResults={currentTestResults}
+      availableTestRuns={
+        filteredRuns.length > 0 ? filteredRuns : availableTestRuns
+      }
+      initialBaselineId={selectedBaselineId}
+      onClose={handleClose}
+      onLoadBaseline={handleLoadBaseline}
+      prompts={prompts}
+      behaviors={behaviors}
+      testSetType={testSetType}
+      project={project}
+      projectName={projectName}
+      closeButtonLabel="Close Comparison"
+    />
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/ComparePageClient.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/ComparePageClient.tsx
@@ -1,20 +1,12 @@
 'use client';
 
 import React, { useCallback, useState } from 'react';
-import {
-  Box,
-  Button,
-  Card,
-  CardActionArea,
-  CardContent,
-  Typography,
-} from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 import { useRouter } from 'next/navigation';
 import ComparisonView from '../components/ComparisonView';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { formatDate } from '@/utils/date';
 import { useNotifications } from '@/components/common/NotificationContext';
 
 interface ComparePageClientProps {
@@ -64,20 +56,25 @@ export default function ComparePageClient({
 }: ComparePageClientProps) {
   const router = useRouter();
   const notifications = useNotifications();
-  const [selectedBaselineId, setSelectedBaselineId] = useState<
-    string | undefined
-  >(
+  // Always default to a baseline run so the comparison view (with its own
+  // baseline selector) renders directly. There is no intermediate "select a
+  // baseline" screen — the design (Figma node 1645:25316) goes straight to the
+  // comparison layout.
+  const [selectedBaselineId] = useState<string | undefined>(
     initialBaselineId && availableTestRuns.some(r => r.id === initialBaselineId)
       ? initialBaselineId
-      : undefined
+      : availableTestRuns[0]?.id
   );
 
   const handleClose = useCallback(() => {
-    if (window.opener) {
-      window.close();
-    } else {
+    // The comparison view opens in its own tab, so closing it is the expected
+    // behaviour. window.close() works for script-opened tabs even when
+    // window.opener is null (the tab is opened with `noopener`). If the tab
+    // can't be closed programmatically, fall back to navigating back.
+    window.close();
+    setTimeout(() => {
       router.push(`/test-runs/${currentTestRun.id}`);
-    }
+    }, 100);
   }, [router, currentTestRun.id]);
 
   const handleLoadBaseline = useCallback(
@@ -116,13 +113,9 @@ export default function ComparePageClient({
     [sessionToken, notifications]
   );
 
-  const handleSelectBaseline = (runId: string) => {
-    setSelectedBaselineId(runId);
-    const url = new URL(window.location.href);
-    url.searchParams.set('baseline', runId);
-    window.history.replaceState({}, '', url.toString());
-  };
-
+  // No baseline available to compare against. This should not normally be
+  // reachable because the "Compare" action is disabled when no comparison run
+  // exists, but guard against direct navigation.
   if (!selectedBaselineId) {
     return (
       <Box sx={{ maxWidth: 720, mx: 'auto' }}>
@@ -145,52 +138,18 @@ export default function ComparePageClient({
             Close Comparison
           </Button>
         </Box>
-
-        <Typography variant="h6" sx={{ mb: 2 }}>
-          Select a baseline run
+        <Typography color="text.secondary">
+          No other test runs are available for comparison on this test set.
         </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-          Choose a previous test run on the same test set to compare against the
-          current run.
-        </Typography>
-
-        {availableTestRuns.length === 0 ? (
-          <Typography color="text.secondary">
-            No other test runs are available for comparison on this test set.
-          </Typography>
-        ) : (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            {availableTestRuns.map(run => (
-              <Card key={run.id} variant="outlined">
-                <CardActionArea onClick={() => handleSelectBaseline(run.id)}>
-                  <CardContent>
-                    <Typography variant="subtitle1" fontWeight={600}>
-                      {run.name || `Run ${run.id.slice(0, 8)}`}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      {formatDate(run.created_at)}
-                    </Typography>
-                  </CardContent>
-                </CardActionArea>
-              </Card>
-            ))}
-          </Box>
-        )}
       </Box>
     );
   }
-
-  const filteredRuns = availableTestRuns.filter(
-    r => r.id === selectedBaselineId
-  );
 
   return (
     <ComparisonView
       currentTestRun={currentTestRun}
       currentTestResults={currentTestResults}
-      availableTestRuns={
-        filteredRuns.length > 0 ? filteredRuns : availableTestRuns
-      }
+      availableTestRuns={availableTestRuns}
       initialBaselineId={selectedBaselineId}
       onClose={handleClose}
       onLoadBaseline={handleLoadBaseline}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
@@ -183,39 +183,52 @@ export default async function TestRunComparePage({
   }
 
   return (
-    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default', p: 3 }}>
-      <ComparePageClient
-        currentTestRun={{
-          id: testRun.id,
-          name: testRun.name,
-          created_at:
-            (typeof testRun.attributes?.started_at === 'string'
-              ? testRun.attributes.started_at
-              : null) ||
-            testRun.created_at ||
-            '',
-          experiment_id: testRun.experiment_id ?? undefined,
-          parameter_version:
-            typeof testRun.attributes?.parameter_version === 'string'
-              ? (testRun.attributes.parameter_version as string)
-              : undefined,
-          experiment_name:
-            typeof testRun.attributes?.parameter_experiment_name === 'string'
-              ? (testRun.attributes.parameter_experiment_name as string)
-              : undefined,
+    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
+      {/* Spacing per Figma "Content" frame (node 1645:25346):
+          margins 120 (left/right) and 35 (bottom); padding 80 (top),
+          37 (left/right), 30 (bottom). */}
+      <Box
+        sx={{
+          mx: '120px',
+          mb: '35px',
+          pt: '80px',
+          px: '37px',
+          pb: '30px',
         }}
-        currentTestResults={testResults}
-        availableTestRuns={availableTestRuns}
-        prompts={promptsMap}
-        behaviors={behaviors}
-        sessionToken={session.session_token}
-        initialBaselineId={initialBaselineId}
-        testSetType={
-          testRun.test_configuration?.test_set?.test_set_type?.type_value
-        }
-        project={testRun.test_configuration?.endpoint?.project}
-        projectName={testRun.test_configuration?.endpoint?.project?.name}
-      />
+      >
+        <ComparePageClient
+          currentTestRun={{
+            id: testRun.id,
+            name: testRun.name,
+            created_at:
+              (typeof testRun.attributes?.started_at === 'string'
+                ? testRun.attributes.started_at
+                : null) ||
+              testRun.created_at ||
+              '',
+            experiment_id: testRun.experiment_id ?? undefined,
+            parameter_version:
+              typeof testRun.attributes?.parameter_version === 'string'
+                ? (testRun.attributes.parameter_version as string)
+                : undefined,
+            experiment_name:
+              typeof testRun.attributes?.parameter_experiment_name === 'string'
+                ? (testRun.attributes.parameter_experiment_name as string)
+                : undefined,
+          }}
+          currentTestResults={testResults}
+          availableTestRuns={availableTestRuns}
+          prompts={promptsMap}
+          behaviors={behaviors}
+          sessionToken={session.session_token}
+          initialBaselineId={initialBaselineId}
+          testSetType={
+            testRun.test_configuration?.test_set?.test_set_type?.type_value
+          }
+          project={testRun.test_configuration?.endpoint?.project}
+          projectName={testRun.test_configuration?.endpoint?.project?.name}
+        />
+      </Box>
     </Box>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
@@ -1,0 +1,214 @@
+import { Box } from '@mui/material';
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { auth } from '@/auth';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+import type { UUID } from 'crypto';
+import ComparePageClient from './ComparePageClient';
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ identifier: string }>;
+}): Promise<Metadata> {
+  const { identifier } = await params;
+  return {
+    title: 'Compare Test Runs',
+    description: `Compare test run ${identifier} against a baseline`,
+  };
+}
+
+export default async function TestRunComparePage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ identifier: string }>;
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const { identifier } = await params;
+  const resolvedSearchParams = await searchParams;
+  const baselineParam = resolvedSearchParams?.baseline;
+  const initialBaselineId =
+    typeof baselineParam === 'string' ? baselineParam : undefined;
+
+  const session = await auth();
+  if (!session?.session_token) {
+    throw new Error('Authentication required');
+  }
+
+  const apiFactory = new ApiClientFactory(session.session_token);
+  const testRunsClient = apiFactory.getTestRunsClient();
+  const testResultsClient = apiFactory.getTestResultsClient();
+  const behaviorClient = apiFactory.getBehaviorClient();
+
+  const testRun = await testRunsClient
+    .getTestRun(identifier)
+    .catch(() => notFound());
+
+  let testResults: TestResultDetail[] = [];
+  let skip = 0;
+  const batchSize = 100;
+  let hasMore = true;
+
+  while (hasMore) {
+    const testResultsResponse = await testResultsClient.getTestResults({
+      filter: `test_run_id eq '${identifier}'`,
+      limit: batchSize,
+      skip,
+      sort_by: 'created_at',
+      sort_order: 'desc',
+    });
+    testResults = [...testResults, ...testResultsResponse.data];
+    const totalCount = testResultsResponse.pagination?.totalCount || 0;
+    hasMore = testResults.length < totalCount;
+    skip += batchSize;
+    if (skip > 10000) break;
+  }
+
+  const promptsMap = testResults.reduce(
+    (acc, testResult) => {
+      if (testResult.test?.prompt) {
+        acc[testResult.test.prompt.id] = {
+          id: testResult.test.prompt.id,
+          content: testResult.test.prompt.content,
+          expected_response: testResult.test.prompt.expected_response,
+          nano_id: testResult.test.prompt.nano_id,
+          counts: testResult.test.prompt.counts,
+        };
+      }
+      return acc;
+    },
+    {} as Record<
+      string,
+      {
+        id: string;
+        content: string;
+        expected_response?: string;
+        nano_id?: string;
+        counts?: unknown;
+      }
+    >
+  );
+
+  const testSetId = testRun.test_configuration?.test_set?.id;
+  let availableTestRuns: Array<{
+    id: string;
+    name?: string;
+    created_at: string;
+    pass_rate?: number;
+    experiment_id?: string;
+    parameter_version?: string;
+    experiment_name?: string;
+  }> = [];
+
+  if (testSetId) {
+    try {
+      const response = await testRunsClient.getTestRuns({
+        limit: 50,
+        skip: 0,
+        sort_by: 'created_at',
+        sort_order: 'desc',
+        filter: `test_configuration/test_set/id eq '${testSetId}'`,
+      });
+      availableTestRuns = response.data
+        .filter(run => run.id !== identifier)
+        .map(run => ({
+          id: run.id,
+          name: run.name,
+          created_at:
+            (typeof run.attributes?.started_at === 'string'
+              ? run.attributes.started_at
+              : null) ||
+            (typeof run.created_at === 'string' ? run.created_at : '') ||
+            '',
+          experiment_id: run.experiment_id ?? undefined,
+          parameter_version:
+            typeof run.attributes?.parameter_version === 'string'
+              ? (run.attributes.parameter_version as string)
+              : undefined,
+          experiment_name:
+            typeof run.attributes?.parameter_experiment_name === 'string'
+              ? (run.attributes.parameter_experiment_name as string)
+              : undefined,
+        }));
+    } catch {
+      availableTestRuns = [];
+    }
+  }
+
+  let behaviors: Array<{
+    id: string;
+    name: string;
+    description?: string;
+    metrics: Array<{ name: string; description?: string }>;
+  }> = [];
+
+  try {
+    const behaviorsData = await testRunsClient.getTestRunBehaviors(identifier);
+    behaviors = await Promise.all(
+      behaviorsData.map(async behavior => {
+        try {
+          const behaviorMetrics = await behaviorClient.getBehaviorMetrics(
+            behavior.id as UUID
+          );
+          return {
+            id: behavior.id as string,
+            name: behavior.name,
+            description: behavior.description ?? undefined,
+            metrics: behaviorMetrics.map(m => ({
+              name: m.name,
+              description: m.description ?? undefined,
+            })),
+          };
+        } catch {
+          return {
+            id: behavior.id as string,
+            name: behavior.name,
+            description: behavior.description ?? undefined,
+            metrics: [] as Array<{ name: string; description?: string }>,
+          };
+        }
+      })
+    );
+  } catch {
+    behaviors = [];
+  }
+
+  return (
+    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default', p: 3 }}>
+      <ComparePageClient
+        currentTestRun={{
+          id: testRun.id,
+          name: testRun.name,
+          created_at:
+            (typeof testRun.attributes?.started_at === 'string'
+              ? testRun.attributes.started_at
+              : null) ||
+            testRun.created_at ||
+            '',
+          experiment_id: testRun.experiment_id ?? undefined,
+          parameter_version:
+            typeof testRun.attributes?.parameter_version === 'string'
+              ? (testRun.attributes.parameter_version as string)
+              : undefined,
+          experiment_name:
+            typeof testRun.attributes?.parameter_experiment_name === 'string'
+              ? (testRun.attributes.parameter_experiment_name as string)
+              : undefined,
+        }}
+        currentTestResults={testResults}
+        availableTestRuns={availableTestRuns}
+        prompts={promptsMap}
+        behaviors={behaviors}
+        sessionToken={session.session_token}
+        initialBaselineId={initialBaselineId}
+        testSetType={
+          testRun.test_configuration?.test_set?.test_set_type?.type_value
+        }
+        project={testRun.test_configuration?.endpoint?.project}
+        projectName={testRun.test_configuration?.endpoint?.project?.name}
+      />
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@mui/material';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
+import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 import { auth } from '@/auth';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
@@ -42,9 +43,15 @@ export default async function TestRunComparePage({
   const testResultsClient = apiFactory.getTestResultsClient();
   const behaviorClient = apiFactory.getBehaviorClient();
 
-  const testRun = await testRunsClient
-    .getTestRun(identifier)
-    .catch(() => notFound());
+  let testRun;
+  try {
+    testRun = await testRunsClient.getTestRun(identifier);
+  } catch (error) {
+    if (isNotFoundApiError(error)) {
+      notFound();
+    }
+    throw error;
+  }
 
   let testResults: TestResultDetail[] = [];
   let skip = 0;

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ComparisonView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ComparisonView.tsx
@@ -13,19 +13,13 @@ import {
   FormControl,
   InputLabel,
   Dialog,
-  DialogTitle,
   DialogContent,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
+  Collapse,
   LinearProgress,
   Chip,
   Grid,
   Paper,
   useTheme,
-  TextField,
-  InputAdornment,
-  ButtonGroup,
   alpha,
 } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
@@ -33,16 +27,20 @@ import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 import CancelIcon from '@mui/icons-material/Cancel';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import TrendingDownIcon from '@mui/icons-material/TrendingDown';
-import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
-import SearchIcon from '@mui/icons-material/Search';
-import RemoveIcon from '@mui/icons-material/Remove';
-import ListIcon from '@mui/icons-material/List';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import Link from 'next/link';
-import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+import Image from 'next/image';
+import {
+  TestResultDetail,
+  MetricResult,
+} from '@/utils/api-client/interfaces/test-results';
 import { experimentHref } from '@/utils/experiment-links';
 import { MetricStatusChip } from '@/components/common/StatusChip';
 import ConversationHistory from '@/components/common/ConversationHistory';
+import { SearchPill } from '@/components/common/SearchPill';
+import { PrimarySegmentedPills } from '@/components/common/GridToolbar';
 import { BiotechIcon } from '@/components/icons';
 import { shortVersion } from '@/utils/api-client/interfaces/parameters';
 
@@ -76,7 +74,7 @@ interface ComparisonViewProps {
     description?: string;
     metrics: Array<{ name: string; description?: string }>;
   }>;
-  testSetType?: string; // e.g., "Multi-turn" or "Single-turn"
+  testSetType?: string;
   project?: { icon?: string; useCase?: string; name?: string };
   projectName?: string;
   initialBaselineId?: string;
@@ -134,6 +132,198 @@ function ExperimentRunLink({
         <OpenInNewIcon fontSize="inherit" sx={{ color: 'text.disabled' }} />
       </Box>
     </Link>
+  );
+}
+
+// Individual metric result row matching Figma "Testrun Comparison" component
+function MetricRow({
+  metricName,
+  result,
+}: {
+  metricName: string;
+  result?: MetricResult;
+}) {
+  const isPassed = result?.is_successful ?? false;
+  return (
+    <Paper
+      variant="outlined"
+      sx={{ borderRadius: '4px', pt: '30px', pb: '20px', px: '30px' }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: '10px' }}>
+        {isPassed ? (
+          <CheckCircleIcon
+            sx={{
+              color: 'success.main',
+              fontSize: 24,
+              flexShrink: 0,
+              mt: '2px',
+            }}
+          />
+        ) : (
+          <CancelIcon
+            sx={{ color: 'error.main', fontSize: 24, flexShrink: 0, mt: '2px' }}
+          />
+        )}
+        <Box sx={{ flex: 1 }}>
+          <Typography
+            sx={{ fontWeight: 700, fontSize: 16, lineHeight: '24px' }}
+          >
+            {metricName}
+          </Typography>
+          {result != null && result.score != null && (
+            <Box sx={{ mt: 1 }}>
+              <Box
+                sx={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  mb: 0.5,
+                }}
+              >
+                <Typography sx={{ fontSize: 14, lineHeight: '22px' }}>
+                  Score: {Number(result.score).toFixed(2)}
+                </Typography>
+                {result.threshold != null && (
+                  <Typography
+                    sx={{
+                      fontSize: 14,
+                      lineHeight: '22px',
+                      color: 'text.secondary',
+                    }}
+                  >
+                    Threshold: ≥{Number(result.threshold).toFixed(2)}
+                  </Typography>
+                )}
+              </Box>
+              <LinearProgress
+                variant="determinate"
+                value={Math.min(Number(result.score) * 100, 100)}
+                color={isPassed ? 'success' : 'error'}
+                sx={{
+                  height: 8,
+                  borderRadius: '999px',
+                  bgcolor: theme => theme.palette.background.light2,
+                }}
+              />
+              {result.reason && (
+                <Typography
+                  sx={{
+                    mt: 1,
+                    fontSize: 14,
+                    lineHeight: '22px',
+                    color: theme => theme.palette.greyscale.body,
+                  }}
+                >
+                  {result.reason}
+                </Typography>
+              )}
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Paper>
+  );
+}
+
+// Collapsible behavior section card matching Figma "section 1" component
+function BehaviorSection({
+  behaviorName,
+  passedCount,
+  totalCount,
+  children,
+}: {
+  behaviorName: string;
+  passedCount: number;
+  totalCount: number;
+  children: React.ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(true);
+  return (
+    <Box
+      sx={{
+        border: theme => `1px solid ${theme.palette.greyscale.border}`,
+        borderRadius: '12px',
+        boxShadow: '0px 2px 2px rgba(84, 90, 101, 0.25)',
+        bgcolor: 'background.paper',
+        overflow: 'hidden',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          px: '30px',
+          pt: '30px',
+          pb: '30px',
+        }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '20px' }}>
+          <Typography
+            sx={{
+              fontSize: 20,
+              fontWeight: 600,
+              lineHeight: '24px',
+              color: theme => theme.palette.greyscale.title,
+            }}
+          >
+            {behaviorName}
+          </Typography>
+          <Chip
+            label={`${passedCount}/${totalCount}`}
+            size="small"
+            color={passedCount === totalCount ? 'success' : 'error'}
+          />
+        </Box>
+        <IconButton
+          onClick={() => setExpanded(prev => !prev)}
+          size="small"
+          sx={{
+            transform: expanded ? 'rotate(0deg)' : 'rotate(180deg)',
+            transition: 'transform 0.2s',
+          }}
+        >
+          <KeyboardArrowUpIcon />
+        </IconButton>
+      </Box>
+      <Collapse in={expanded}>
+        <Box
+          sx={{
+            px: '30px',
+            pb: '30px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '20px',
+          }}
+        >
+          {children}
+        </Box>
+      </Collapse>
+    </Box>
+  );
+}
+
+// Response text box for a single run
+function RunResponseBox({ response }: { response: string }) {
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        bgcolor: theme => theme.palette.background.light1,
+        borderRadius: '4px',
+        p: '30px',
+        borderColor: theme => theme.palette.greyscale.border,
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: 14,
+          lineHeight: '22px',
+          color: theme => theme.palette.greyscale.body,
+        }}
+      >
+        {response}
+      </Typography>
+    </Paper>
   );
 }
 
@@ -361,402 +551,344 @@ export default function ComparisonView({
   }
 
   return (
-    <Box sx={{ pb: 4 }}>
-      {/* Filter Bar with integrated Close Button */}
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: '40px' }}>
+      {/* Header: Close Comparison (top-right) above logo + current run name */}
+      <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            mb: '12px',
+          }}
+        >
+          <Button
+            onClick={onClose}
+            variant="contained"
+            startIcon={<CloseIcon />}
+            sx={{
+              borderRadius: '8px',
+              px: '16px',
+              py: '8px',
+              fontWeight: 700,
+              fontSize: 14,
+              whiteSpace: 'nowrap',
+              flexShrink: 0,
+            }}
+          >
+            {closeButtonLabel}
+          </Button>
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+          <Box
+            sx={{
+              width: 40,
+              height: 40,
+              flexShrink: 0,
+              position: 'relative',
+            }}
+          >
+            <Image
+              src="/logos/rhesis-logo-favicon-transparent.svg"
+              alt="Rhesis"
+              fill
+              sizes="40px"
+              style={{ objectFit: 'contain' }}
+            />
+          </Box>
+          <Typography
+            sx={{
+              fontSize: 28,
+              fontWeight: 700,
+              lineHeight: '33.6px',
+              color: theme => theme.palette.greyscale.title,
+            }}
+          >
+            {currentTestRun.name || 'Test Run'}
+          </Typography>
+        </Box>
+      </Box>
+      {/* Comparison Headers */}
       {baselineTestResults && (
         <Box
           sx={{
             display: 'flex',
-            flexDirection: { xs: 'column', sm: 'row' },
-            gap: 2,
-            mb: 3,
-            alignItems: { xs: 'stretch', sm: 'center' },
-            justifyContent: 'space-between',
+            flexDirection: { xs: 'column', md: 'row' },
+            gap: '20px',
+            alignItems: 'stretch',
           }}
         >
-          {/* Left side: Search and Filters */}
-          <Box
+          {/* Baseline Run */}
+          <Paper
+            variant="outlined"
             sx={{
-              display: 'flex',
-              flexDirection: { xs: 'column', sm: 'row' },
-              gap: 2,
-              alignItems: { xs: 'stretch', sm: 'center' },
               flex: 1,
+              minWidth: 0,
+              p: '30px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '20px',
+              borderRadius: '4px',
             }}
           >
-            {/* Search */}
-            <TextField
-              size="small"
-              placeholder="Search tests..."
-              value={searchQuery}
-              onChange={e => setSearchQuery(e.target.value)}
-              InputProps={{
-                startAdornment: (
-                  <InputAdornment position="start">
-                    <SearchIcon fontSize="small" />
-                  </InputAdornment>
-                ),
-              }}
-              sx={{ minWidth: { xs: '100%', sm: 250 } }}
-            />
-
-            {/* Status Filter Buttons */}
-            <ButtonGroup size="small" variant="outlined">
-              <Button
-                onClick={() => setStatusFilter('all')}
-                variant={statusFilter === 'all' ? 'contained' : 'outlined'}
-                startIcon={<ListIcon fontSize="small" />}
-              >
-                All
-              </Button>
-              <Button
-                onClick={() => setStatusFilter('improved')}
-                variant={statusFilter === 'improved' ? 'contained' : 'outlined'}
-                startIcon={<TrendingUpIcon fontSize="small" />}
-                sx={{
-                  ...(statusFilter === 'improved' && {
-                    bgcolor: theme.palette.success.main,
-                    color: 'white',
-                    '&:hover': {
-                      bgcolor: theme.palette.success.dark,
-                    },
-                  }),
-                }}
-              >
-                Improved
-              </Button>
-              <Button
-                onClick={() => setStatusFilter('regressed')}
-                variant={
-                  statusFilter === 'regressed' ? 'contained' : 'outlined'
-                }
-                startIcon={<TrendingDownIcon fontSize="small" />}
-                sx={{
-                  ...(statusFilter === 'regressed' && {
-                    bgcolor: theme.palette.error.main,
-                    color: 'white',
-                    '&:hover': {
-                      bgcolor: theme.palette.error.dark,
-                    },
-                  }),
-                }}
-              >
-                Regressed
-              </Button>
-              <Button
-                onClick={() => setStatusFilter('unchanged')}
-                variant={
-                  statusFilter === 'unchanged' ? 'contained' : 'outlined'
-                }
-                startIcon={<RemoveIcon fontSize="small" />}
-              >
-                Unchanged
-              </Button>
-            </ButtonGroup>
-
-            {/* Results count */}
             <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{ display: 'flex', alignItems: 'center' }}
+              sx={{
+                fontSize: 20,
+                fontWeight: 600,
+                lineHeight: '24px',
+                color: theme => theme.palette.greyscale.title,
+              }}
             >
-              {comparisonTests.length} test
-              {comparisonTests.length !== 1 ? 's' : ''}
+              Baseline Run
             </Typography>
-          </Box>
+            <FormControl fullWidth>
+              <InputLabel>Select baseline run</InputLabel>
+              <Select
+                value={selectedBaselineId}
+                onChange={e => setSelectedBaselineId(e.target.value)}
+                label="Select baseline run"
+                renderValue={value => {
+                  const run = availableTestRuns.find(r => r.id === value);
+                  const name = run?.name || `Run #${String(value).slice(0, 8)}`;
+                  return (
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'baseline',
+                        gap: 1,
+                        minWidth: 0,
+                      }}
+                    >
+                      <Box
+                        component="span"
+                        sx={{
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                        }}
+                      >
+                        {name}
+                      </Box>
+                      {run?.created_at && (
+                        <Typography
+                          component="span"
+                          variant="caption"
+                          color="text.secondary"
+                          sx={{ flexShrink: 0 }}
+                        >
+                          {formatDate(run.created_at)}
+                        </Typography>
+                      )}
+                    </Box>
+                  );
+                }}
+              >
+                {availableTestRuns.map(run => (
+                  <MenuItem key={run.id} value={run.id}>
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        gap: 2,
+                        width: '100%',
+                      }}
+                    >
+                      <span>{run.name || `Run #${run.id.slice(0, 8)}`}</span>
+                      <Typography variant="caption" color="text.secondary">
+                        {formatDate(run.created_at)}
+                      </Typography>
+                    </Box>
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            {baselineRun && (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                {baselinePassRate !== undefined && (
+                  <Typography variant="body2" color="text.secondary">
+                    Pass rate:{' '}
+                    <Box
+                      component="span"
+                      sx={{ fontWeight: 700, color: 'text.primary' }}
+                    >
+                      {Math.round(baselinePassRate)}%
+                    </Box>
+                  </Typography>
+                )}
+                {baselineRun.experiment_id && baselineRun.parameter_version && (
+                  <ExperimentRunLink
+                    experimentId={baselineRun.experiment_id}
+                    parameterVersion={baselineRun.parameter_version}
+                    experimentName={baselineRun.experiment_name}
+                  />
+                )}
+              </Box>
+            )}
+          </Paper>
 
-          {/* Right side: Close Button */}
+          {/* Compare arrows */}
           <Box
             sx={{
               display: 'flex',
               alignItems: 'center',
-              justifyContent: { xs: 'flex-start', sm: 'flex-end' },
+              justifyContent: 'center',
+              flexShrink: 0,
             }}
           >
-            <Button
-              onClick={onClose}
-              variant="outlined"
-              size="small"
-              startIcon={<CloseIcon />}
-            >
-              {closeButtonLabel}
-            </Button>
-          </Box>
-        </Box>
-      )}
-      {/* Statistics */}
-      {baselineTestResults && (
-        <Paper
-          variant="outlined"
-          sx={{
-            p: 2.5,
-            mb: 4,
-            display: 'flex',
-            gap: 4,
-            flexWrap: 'wrap',
-            alignItems: 'center',
-            bgcolor: theme.palette.background.default,
-          }}
-        >
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-            <TrendingUpIcon
-              fontSize="small"
-              sx={{ color: theme.palette.success.main }}
-            />
-            <Box>
-              <Typography variant="h6" component="span" sx={{ mr: 0.5 }}>
-                {stats.improved}
-              </Typography>
-              <Typography
-                variant="body2"
-                component="span"
-                color="text.secondary"
-              >
-                improved
-              </Typography>
-            </Box>
-          </Box>
-
-          {stats.regressed > 0 && (
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-              <TrendingDownIcon
-                fontSize="small"
-                sx={{ color: theme.palette.error.main }}
-              />
-              <Box>
-                <Typography variant="h6" component="span" sx={{ mr: 0.5 }}>
-                  {stats.regressed}
-                </Typography>
-                <Typography
-                  variant="body2"
-                  component="span"
-                  color="text.secondary"
-                >
-                  regressed
-                </Typography>
-              </Box>
-            </Box>
-          )}
-
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-            <Box
+            <CompareArrowsIcon
               sx={{
-                width: 20,
-                height: 20,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
+                fontSize: 48,
+                color: theme => theme.palette.greyscale.body,
               }}
-            >
-              <Box
-                sx={{
-                  width: 16,
-                  height: 2,
-                  bgcolor: theme.palette.text.secondary,
-                  borderRadius: theme.shape.borderRadius / 4,
-                }}
-              />
-            </Box>
-            <Box>
-              <Typography variant="h6" component="span" sx={{ mr: 0.5 }}>
-                {stats.unchanged}
-              </Typography>
-              <Typography
-                variant="body2"
-                component="span"
-                color="text.secondary"
-              >
-                unchanged
-              </Typography>
-            </Box>
+            />
           </Box>
-        </Paper>
-      )}
-      {/* Comparison Headers - Moved Here */}
-      {baselineTestResults && (
-        <Grid container spacing={3} sx={{ mb: 3 }}>
-          {/* Baseline Run */}
-          <Grid
-            size={{
-              xs: 12,
-              md: 6,
-            }}
-          >
-            <Card sx={{ height: '100%' }}>
-              <CardContent sx={{ p: 3 }}>
-                <Typography
-                  variant="overline"
-                  color="text.secondary"
-                  display="block"
-                  sx={{ mb: 1 }}
-                >
-                  Baseline Run
-                </Typography>
-                <FormControl fullWidth size="small" sx={{ mb: 2 }}>
-                  <InputLabel>Select baseline run</InputLabel>
-                  <Select
-                    value={selectedBaselineId}
-                    onChange={e => setSelectedBaselineId(e.target.value)}
-                    label="Select baseline run"
-                  >
-                    {availableTestRuns.map(run => (
-                      <MenuItem key={run.id} value={run.id}>
-                        <Box
-                          sx={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            width: '100%',
-                          }}
-                        >
-                          <span>
-                            {run.name || `Run #${run.id.slice(0, 8)}`}
-                          </span>
-                          <Typography variant="caption" color="text.secondary">
-                            {formatDate(run.created_at)}
-                          </Typography>
-                        </Box>
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-                {baselineRun && (
-                  <>
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      display="block"
-                    >
-                      {formatDate(baselineRun.created_at)}
-                    </Typography>
-                    {baselinePassRate !== undefined && (
-                      <Box
-                        sx={{
-                          mt: 1,
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 1,
-                        }}
-                      >
-                        <Typography variant="caption" color="text.secondary">
-                          Pass rate:
-                        </Typography>
-                        <Chip
-                          label={`${Math.round(baselinePassRate)}%`}
-                          size="small"
-                        />
-                      </Box>
-                    )}
-                    {baselineRun.experiment_id &&
-                      baselineRun.parameter_version && (
-                        <Box sx={{ mt: 1 }}>
-                          <ExperimentRunLink
-                            experimentId={baselineRun.experiment_id}
-                            parameterVersion={baselineRun.parameter_version}
-                            experimentName={baselineRun.experiment_name}
-                          />
-                        </Box>
-                      )}
-                  </>
-                )}
-              </CardContent>
-            </Card>
-          </Grid>
 
           {/* Current Run */}
-          <Grid
-            size={{
-              xs: 12,
-              md: 6,
+          <Paper
+            variant="outlined"
+            sx={{
+              flex: 1,
+              minWidth: 0,
+              p: '30px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '20px',
+              borderRadius: '4px',
+              bgcolor: theme => theme.palette.background.light2,
+              border: theme => `1px solid ${theme.palette.primary.main}`,
             }}
           >
-            <Card
+            <Typography
               sx={{
-                bgcolor: theme.palette.background.light2,
-                border: `2px solid ${theme.palette.primary.main}`,
-                height: '100%',
+                fontSize: 20,
+                fontWeight: 600,
+                lineHeight: '24px',
+                color: theme => theme.palette.greyscale.title,
               }}
             >
-              <CardContent sx={{ p: 3 }}>
-                <Typography
-                  variant="overline"
-                  color="text.secondary"
-                  display="block"
-                  sx={{ mb: 1 }}
+              Current Run
+            </Typography>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'baseline',
+                gap: 1,
+              }}
+            >
+              <Typography sx={{ fontWeight: 700, fontSize: 16 }}>
+                {currentTestRun.name || `Run #${currentTestRun.id.slice(0, 8)}`}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {formatDate(currentTestRun.created_at)}
+              </Typography>
+            </Box>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+              <Typography variant="body2" color="text.secondary">
+                Pass rate:{' '}
+                <Box
+                  component="span"
+                  sx={{ fontWeight: 700, color: 'text.primary' }}
                 >
-                  Current Run
-                </Typography>
-                <Typography variant="subtitle2" gutterBottom>
-                  {currentTestRun.name ||
-                    `Run #${currentTestRun.id.slice(0, 8)}`}
-                </Typography>
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  display="block"
-                  sx={{ mb: 2 }}
-                >
-                  {formatDate(currentTestRun.created_at)}
-                </Typography>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <Typography variant="caption" color="text.secondary">
-                    Pass rate:
-                  </Typography>
-                  <Typography variant="body2" fontWeight={600}>
-                    {currentPassRate}%
-                  </Typography>
-                  {baselinePassRate !== undefined && (
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        color:
-                          currentPassRate > baselinePassRate
-                            ? theme.palette.success.main
-                            : currentPassRate < baselinePassRate
-                              ? theme.palette.error.main
-                              : theme.palette.text.secondary,
-                        fontWeight: 500,
-                      }}
-                    >
-                      ({currentPassRate > baselinePassRate ? '+' : ''}
-                      {(currentPassRate - baselinePassRate).toFixed(1)}%)
-                    </Typography>
-                  )}
+                  {currentPassRate}%
                 </Box>
-                {currentTestRun.experiment_id &&
-                  currentTestRun.parameter_version && (
-                    <Box sx={{ mt: 1 }}>
-                      <ExperimentRunLink
-                        experimentId={currentTestRun.experiment_id}
-                        parameterVersion={currentTestRun.parameter_version}
-                        experimentName={currentTestRun.experiment_name}
-                      />
-                    </Box>
-                  )}
-              </CardContent>
-            </Card>
-          </Grid>
-        </Grid>
+                {baselinePassRate !== undefined && (
+                  <Box
+                    component="span"
+                    sx={{
+                      ml: 0.5,
+                      fontWeight: 700,
+                      color:
+                        currentPassRate > baselinePassRate
+                          ? theme.palette.success.main
+                          : currentPassRate < baselinePassRate
+                            ? theme.palette.error.main
+                            : theme.palette.text.secondary,
+                    }}
+                  >
+                    ({currentPassRate > baselinePassRate ? '+' : ''}
+                    {(currentPassRate - baselinePassRate).toFixed(1)}%)
+                  </Box>
+                )}
+              </Typography>
+              {currentTestRun.experiment_id &&
+                currentTestRun.parameter_version && (
+                  <ExperimentRunLink
+                    experimentId={currentTestRun.experiment_id}
+                    parameterVersion={currentTestRun.parameter_version}
+                    experimentName={currentTestRun.experiment_name}
+                  />
+                )}
+            </Box>
+          </Paper>
+        </Box>
+      )}
+
+      {/* Toolbar: search + status filter pills */}
+      {baselineTestResults && (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: { xs: 'column', md: 'row' },
+            gap: 2,
+            alignItems: { xs: 'stretch', md: 'center' },
+          }}
+        >
+          <SearchPill
+            value={searchQuery}
+            onChange={setSearchQuery}
+            placeholder="Search tests..."
+            width={288}
+          />
+          <PrimarySegmentedPills
+            mode="single"
+            activeValue={statusFilter}
+            onSingleChange={value =>
+              setStatusFilter(
+                value as 'all' | 'improved' | 'regressed' | 'unchanged'
+              )
+            }
+            tabs={[
+              { value: 'all', label: 'All' },
+              { value: 'improved', label: `Improved (${stats.improved})` },
+              { value: 'regressed', label: `Regressed (${stats.regressed})` },
+              { value: 'unchanged', label: `Unchanged (${stats.unchanged})` },
+            ]}
+          />
+        </Box>
       )}
       {/* Test-by-Test Comparison */}
       {baselineTestResults && (
-        <Card>
-          <CardContent sx={{ p: 3 }}>
+        <Card
+          sx={{
+            borderRadius: '12px',
+            border: theme => `1px solid ${theme.palette.greyscale.border}`,
+          }}
+        >
+          <CardContent sx={{ p: '30px' }}>
             <Box
               sx={{
                 display: 'flex',
                 justifyContent: 'space-between',
                 alignItems: 'center',
-                mb: 3,
+                mb: '20px',
               }}
             >
-              <Typography variant="h6">Test-by-Test Comparison</Typography>
+              <Typography
+                sx={{
+                  fontSize: 20,
+                  fontWeight: 600,
+                  lineHeight: '24px',
+                  color: 'primary.main',
+                }}
+              >
+                Test-by-Test Comparison
+              </Typography>
               <Typography variant="caption" color="text.secondary">
                 Click any test to view details
               </Typography>
             </Box>
             <Box
               sx={{
-                // Increase height by 50% if there are 5+ tests to display
                 maxHeight:
                   comparisonTests.length >= 5 ? 'calc(70vh * 1.5)' : '70vh',
                 overflow: 'auto',
@@ -813,13 +945,16 @@ export default function ComparisonView({
                     key={test.id}
                     variant="outlined"
                     sx={{
-                      mb: 2,
+                      mb: '20px',
+                      borderRadius: '4px',
+                      overflow: 'hidden',
                       cursor: 'pointer',
                       transition: 'all 0.2s ease-in-out',
+                      pt: '30px',
+                      pb: '20px',
                       '&:hover': {
-                        boxShadow: theme.shadows[2],
-                        borderColor: theme.palette.primary.main,
-                        bgcolor: theme.palette.background.light1,
+                        boxShadow: theme.shadows[6],
+                        borderColor: theme.palette.greyscale.subtitle,
                       },
                     }}
                     onClick={() => setSelectedTestId(test.id)}
@@ -828,41 +963,39 @@ export default function ComparisonView({
                       {/* Prompt/Goal Section - Full Width, Inline */}
                       <Box
                         sx={{
-                          p: 2,
-                          borderBottom: 1,
-                          borderColor: 'divider',
-                          bgcolor: theme.palette.background.default,
+                          px: '30px',
+                          pb: '20px',
                           display: 'flex',
                           alignItems: 'flex-start',
-                          gap: 1,
+                          gap: '10px',
                         }}
                       >
                         <Typography
-                          variant="caption"
-                          color="text.secondary"
-                          sx={{ fontWeight: 600, flexShrink: 0 }}
+                          variant="body2"
+                          sx={{ fontWeight: 700, color: '#000', flexShrink: 0 }}
                         >
                           {contentLabel}:
                         </Typography>
                         <Typography
                           variant="body2"
-                          sx={{
-                            flex: 1,
-                            fontWeight: 500,
-                          }}
+                          sx={{ flex: 1, color: theme.palette.greyscale.body }}
                         >
                           {promptContent}
                         </Typography>
                       </Box>
 
                       {/* Responses/Evaluations Side by Side */}
-                      <Grid container spacing={0}>
+                      <Grid container spacing={0} sx={{ px: '20px' }}>
                         {/* Baseline Response/Evaluation */}
                         <Grid
                           sx={{
-                            p: 2,
+                            px: '10px',
+                            py: '20px',
                             borderRight: { md: 1 },
                             borderColor: 'divider',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: '10px',
                             bgcolor: isImproved
                               ? `${theme.palette.background.default}`
                               : isRegressed
@@ -879,17 +1012,15 @@ export default function ComparisonView({
                             sx={{
                               display: 'flex',
                               alignItems: 'center',
-                              gap: 1,
-                              mb: 1,
+                              gap: '10px',
                               flexWrap: 'wrap',
                             }}
                           >
                             <Typography
-                              variant="caption"
-                              color="text.secondary"
-                              sx={{ fontWeight: 600 }}
+                              variant="body2"
+                              sx={{ fontWeight: 700, color: '#000' }}
                             >
-                              Baseline:
+                              Baseline
                             </Typography>
                             {baselinePassed !== null && (
                               <MetricStatusChip
@@ -932,7 +1063,12 @@ export default function ComparisonView({
                         {/* Current Response/Evaluation */}
                         <Grid
                           sx={{
-                            p: 2,
+                            pl: '10px',
+                            pr: 0,
+                            py: '20px',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: '10px',
                             bgcolor: isImproved
                               ? theme.palette.mode === 'light'
                                 ? alpha(theme.palette.success.main, 0.08)
@@ -953,17 +1089,15 @@ export default function ComparisonView({
                             sx={{
                               display: 'flex',
                               alignItems: 'center',
-                              gap: 1,
-                              mb: 1,
+                              gap: '10px',
                               flexWrap: 'wrap',
                             }}
                           >
                             <Typography
-                              variant="caption"
-                              color="text.secondary"
-                              sx={{ fontWeight: 600 }}
+                              variant="body2"
+                              sx={{ fontWeight: 700, color: '#000' }}
                             >
-                              Current:
+                              Current
                             </Typography>
                             <MetricStatusChip
                               passedCount={currentPassedCount}
@@ -1017,31 +1151,53 @@ export default function ComparisonView({
           </CardContent>
         </Card>
       )}
+
       {/* Detailed Comparison Dialog */}
-      {/* For multi-turn tests, show side-by-side conversations. For single-turn, show detailed metrics. */}
       <Dialog
         open={selectedTestId !== null}
         onClose={() => setSelectedTestId(null)}
-        maxWidth="lg"
+        maxWidth="xl"
         fullWidth
         PaperProps={{
           sx: {
-            height: '90vh',
+            borderRadius: '16px',
+            maxHeight: '90vh',
+            overflow: 'hidden',
+            display: 'flex',
+            flexDirection: 'column',
           },
         }}
       >
-        <DialogTitle>
-          <Box
+        {/* Custom header: close icon + test title */}
+        <Box
+          sx={{
+            position: 'relative',
+            px: '37px',
+            pt: '30px',
+            pb: 0,
+            flexShrink: 0,
+          }}
+        >
+          <IconButton
+            onClick={() => setSelectedTestId(null)}
+            size="small"
+            sx={{ position: 'absolute', top: 16, right: 16 }}
+          >
+            <CloseIcon />
+          </IconButton>
+          <Typography
             sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-              gap: 2,
+              fontSize: 20,
+              lineHeight: '24px',
+              pr: '48px',
+              color: theme.palette.greyscale.title,
             }}
           >
-            <Typography variant="h6" sx={{ flex: 1, pr: 2 }}>
+            <Box component="span" sx={{ fontWeight: 600 }}>
               Test #
-              {comparisonTests.findIndex(t => t.id === selectedTestId) + 1}:{' '}
+              {allComparisonTests.findIndex(t => t.id === selectedTestId) + 1}:
+            </Box>{' '}
+            <Box component="span" sx={{ fontWeight: 400 }}>
               {selectedTest
                 ? isMultiTurn
                   ? selectedTest.current.test_output?.test_configuration
@@ -1051,21 +1207,17 @@ export default function ComparisonView({
                     ? prompts[selectedTest.current.prompt_id].content
                     : 'No prompt available'
                 : ''}
-            </Typography>
-            <IconButton
-              onClick={() => setSelectedTestId(null)}
-              size="small"
-              sx={{ flexShrink: 0 }}
-            >
-              <CloseIcon />
-            </IconButton>
-          </Box>
-        </DialogTitle>
-        <DialogContent dividers>
+            </Box>
+          </Typography>
+        </Box>
+
+        <DialogContent
+          sx={{ px: '37px', pt: '40px', pb: '30px', overflow: 'auto', flex: 1 }}
+        >
           {selectedTest && (
             <Box>
               {isMultiTurn ? (
-                /* Multi-turn: Show side-by-side conversations */
+                /* Multi-turn: side-by-side ConversationHistory */
                 <Grid
                   container
                   spacing={0}
@@ -1077,10 +1229,7 @@ export default function ComparisonView({
                       borderRight: { md: 1 },
                       borderColor: 'divider',
                     }}
-                    size={{
-                      xs: 12,
-                      md: 6,
-                    }}
+                    size={{ xs: 12, md: 6 }}
                   >
                     <Box
                       sx={{
@@ -1175,12 +1324,7 @@ export default function ComparisonView({
                     </Box>
                   </Grid>
                   {/* Current Conversation Column */}
-                  <Grid
-                    size={{
-                      xs: 12,
-                      md: 6,
-                    }}
-                  >
+                  <Grid size={{ xs: 12, md: 6 }}>
                     <Box
                       sx={{
                         height: '100%',
@@ -1287,731 +1431,237 @@ export default function ComparisonView({
                   </Grid>
                 </Grid>
               ) : (
-                /* Single-turn: Show detailed metrics comparison */
-                <Grid
-                  container
-                  spacing={0}
-                  sx={{ height: 'calc(90vh - 200px)' }}
+                /* Single-turn: Figma "Detail Test Compare Popup" layout */
+                <Box
+                  sx={{ display: 'flex', flexDirection: 'column', gap: '40px' }}
                 >
-                  {/* Baseline Column */}
-                  <Grid
-                    sx={{
-                      borderRight: { md: 1 },
-                      borderColor: 'divider',
-                    }}
-                    size={{
-                      xs: 12,
-                      md: 6,
-                    }}
-                  >
+                  {/* Row 1: Run headers with pass/fail badge */}
+                  <Box sx={{ display: 'flex', gap: '40px' }}>
                     <Box
                       sx={{
-                        p: 3,
-                        height: '100%',
-                        overflow: 'auto',
+                        flex: 1,
+                        display: 'flex',
+                        gap: '10px',
+                        alignItems: 'center',
                       }}
                     >
-                      <Box
+                      <Typography
                         sx={{
-                          mb: 3,
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 1,
-                          flexWrap: 'wrap',
+                          fontSize: 23,
+                          fontWeight: 700,
+                          lineHeight: '27.6px',
+                          color: theme.palette.greyscale.title,
                         }}
                       >
-                        <Typography
-                          variant="overline"
-                          color="text.secondary"
-                          sx={{ fontWeight: 600 }}
-                        >
-                          Baseline Run
-                        </Typography>
-                        {selectedTest.baseline ? (
-                          <MetricStatusChip
-                            passedCount={
-                              Object.values(
-                                selectedTest.baseline.test_metrics?.metrics ||
-                                  {}
-                              ).filter(m => m.is_successful).length
-                            }
-                            totalCount={
-                              Object.values(
-                                selectedTest.baseline.test_metrics?.metrics ||
-                                  {}
-                              ).length
-                            }
-                            size="small"
-                            variant="filled"
-                          />
-                        ) : (
-                          <Chip label="No data" size="small" color="default" />
-                        )}
-                        <ExperimentRunLink
-                          experimentId={baselineRun?.experiment_id}
-                          parameterVersion={baselineRun?.parameter_version}
-                          experimentName={baselineRun?.experiment_name}
-                        />
-                      </Box>
-
-                      {selectedTest.baseline && (
-                        <>
-                          {/* Response */}
-                          <Box sx={{ mb: 3 }}>
-                            <Typography
-                              variant="overline"
-                              color="text.secondary"
-                              display="block"
-                              gutterBottom
-                            >
-                              Response
-                            </Typography>
-                            <Paper
-                              variant="outlined"
-                              sx={{
-                                p: 2.5,
-                                bgcolor: theme.palette.background.light1,
-                              }}
-                            >
-                              <Typography variant="body2">
-                                {selectedTest.baseline.test_output?.output ||
-                                  'No response available'}
-                              </Typography>
-                            </Paper>
-                          </Box>
-
-                          {/* Metrics */}
-                          {behaviors.map(behavior => {
-                            const behaviorMetrics = behavior.metrics
-                              .map(metric => ({
-                                ...metric,
-                                baselineResult:
-                                  selectedTest.baseline?.test_metrics
-                                    ?.metrics?.[metric.name],
-                                currentResult:
-                                  selectedTest.current?.test_metrics?.metrics?.[
-                                    metric.name
-                                  ],
-                              }))
-                              .filter(m => m.baselineResult || m.currentResult);
-
-                            if (behaviorMetrics.length === 0) return null;
-
-                            const baselinePassedCount = behaviorMetrics.filter(
-                              m => m.baselineResult?.is_successful
-                            ).length;
-                            const currentPassedCount = behaviorMetrics.filter(
-                              m => m.currentResult?.is_successful
-                            ).length;
-                            const hasChanges =
-                              baselinePassedCount !== currentPassedCount;
-
-                            return (
-                              <Accordion
-                                key={behavior.id}
-                                sx={{
-                                  mb: 2,
-                                  '&:before': { display: 'none' },
-                                  boxShadow: 'none',
-                                  border: 1,
-                                  borderColor: 'divider',
-                                }}
-                                defaultExpanded={hasChanges}
-                              >
-                                <AccordionSummary
-                                  expandIcon={<ExpandMoreIcon />}
-                                  sx={{ py: 2 }}
-                                >
-                                  <Box
-                                    sx={{
-                                      display: 'flex',
-                                      alignItems: 'center',
-                                      gap: 1,
-                                      width: '100%',
-                                    }}
-                                  >
-                                    <Typography
-                                      variant="body1"
-                                      sx={{ fontWeight: 600 }}
-                                    >
-                                      {behavior.name}
-                                    </Typography>
-                                    <Chip
-                                      label={`${baselinePassedCount}/${behaviorMetrics.length}`}
-                                      size="small"
-                                      color={
-                                        baselinePassedCount ===
-                                        behaviorMetrics.length
-                                          ? 'success'
-                                          : 'error'
-                                      }
-                                    />
-                                  </Box>
-                                </AccordionSummary>
-                                <AccordionDetails sx={{ p: 3 }}>
-                                  <Box
-                                    sx={{
-                                      display: 'flex',
-                                      flexDirection: 'column',
-                                      gap: 3,
-                                    }}
-                                  >
-                                    {behaviorMetrics.map(metric => {
-                                      const scoreDiff =
-                                        metric.currentResult?.score != null &&
-                                        metric.baselineResult?.score != null
-                                          ? Number(metric.currentResult.score) -
-                                            Number(metric.baselineResult.score)
-                                          : null;
-                                      const hasScoreChange =
-                                        scoreDiff !== null &&
-                                        Math.abs(scoreDiff) > 0.01;
-
-                                      return (
-                                        <Paper
-                                          key={metric.name}
-                                          variant="outlined"
-                                          sx={{ p: 3 }}
-                                        >
-                                          <Box
-                                            sx={{
-                                              display: 'flex',
-                                              alignItems: 'flex-start',
-                                              gap: 1,
-                                            }}
-                                          >
-                                            {metric.baselineResult
-                                              ?.is_successful ? (
-                                              <CheckCircleIcon
-                                                fontSize="small"
-                                                sx={{
-                                                  color:
-                                                    theme.palette.success.main,
-                                                }}
-                                              />
-                                            ) : (
-                                              <CancelIcon
-                                                fontSize="small"
-                                                sx={{
-                                                  color:
-                                                    theme.palette.error.main,
-                                                }}
-                                              />
-                                            )}
-                                            <Box sx={{ flex: 1 }}>
-                                              <Typography
-                                                variant="subtitle2"
-                                                gutterBottom
-                                              >
-                                                {metric.name}
-                                              </Typography>
-                                              {metric.baselineResult?.score !=
-                                                null && (
-                                                <Box sx={{ mb: 1 }}>
-                                                  <Box
-                                                    sx={{
-                                                      display: 'flex',
-                                                      justifyContent:
-                                                        'space-between',
-                                                      mb: 0.5,
-                                                    }}
-                                                  >
-                                                    <Typography variant="caption">
-                                                      Score:{' '}
-                                                      {Number(
-                                                        metric.baselineResult
-                                                          .score
-                                                      ).toFixed(2)}
-                                                      {hasScoreChange &&
-                                                        scoreDiff !== null && (
-                                                          <Typography
-                                                            component="span"
-                                                            variant="caption"
-                                                            sx={{
-                                                              ml: 0.5,
-                                                              color:
-                                                                scoreDiff > 0
-                                                                  ? theme
-                                                                      .palette
-                                                                      .success
-                                                                      .main
-                                                                  : theme
-                                                                      .palette
-                                                                      .error
-                                                                      .main,
-                                                              fontWeight: 500,
-                                                            }}
-                                                          >
-                                                            (
-                                                            {scoreDiff > 0
-                                                              ? '+'
-                                                              : ''}
-                                                            {scoreDiff.toFixed(
-                                                              2
-                                                            )}
-                                                            )
-                                                          </Typography>
-                                                        )}
-                                                    </Typography>
-                                                    {metric.baselineResult
-                                                      .threshold != null && (
-                                                      <Typography
-                                                        variant="caption"
-                                                        color="text.secondary"
-                                                      >
-                                                        Threshold: ≥
-                                                        {Number(
-                                                          metric.baselineResult
-                                                            .threshold
-                                                        ).toFixed(2)}
-                                                      </Typography>
-                                                    )}
-                                                  </Box>
-                                                  <LinearProgress
-                                                    variant="determinate"
-                                                    value={
-                                                      Number(
-                                                        metric.baselineResult
-                                                          .score
-                                                      ) * 100
-                                                    }
-                                                    color={
-                                                      metric.baselineResult
-                                                        .is_successful
-                                                        ? 'success'
-                                                        : 'error'
-                                                    }
-                                                    sx={{
-                                                      height: 8,
-                                                      borderRadius:
-                                                        theme.shape
-                                                          .borderRadius / 4,
-                                                      bgcolor:
-                                                        theme.palette.background
-                                                          .light2,
-                                                    }}
-                                                  />
-                                                </Box>
-                                              )}
-                                              {metric.baselineResult
-                                                ?.reason && (
-                                                <Typography
-                                                  variant="caption"
-                                                  color="text.secondary"
-                                                >
-                                                  {metric.baselineResult.reason}
-                                                </Typography>
-                                              )}
-                                            </Box>
-                                          </Box>
-                                        </Paper>
-                                      );
-                                    })}
-                                  </Box>
-                                </AccordionDetails>
-                              </Accordion>
-                            );
-                          })}
-                        </>
-                      )}
-                    </Box>
-                  </Grid>
-                  {/* Current Column */}
-                  <Grid
-                    size={{
-                      xs: 12,
-                      md: 6,
-                    }}
-                  >
-                    <Box
-                      sx={{
-                        p: 3,
-                        height: '100%',
-                        overflow: 'auto',
-                      }}
-                    >
-                      <Box
-                        sx={{
-                          mb: 3,
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 1,
-                          flexWrap: 'wrap',
-                        }}
-                      >
-                        <Typography
-                          variant="overline"
-                          color="text.secondary"
-                          sx={{ fontWeight: 600 }}
-                        >
-                          Current Run
-                        </Typography>
+                        Baseline Run
+                      </Typography>
+                      {selectedTest.baseline ? (
                         <MetricStatusChip
                           passedCount={
                             Object.values(
-                              selectedTest.current.test_metrics?.metrics || {}
+                              selectedTest.baseline.test_metrics?.metrics || {}
                             ).filter(m => m.is_successful).length
                           }
                           totalCount={
                             Object.values(
-                              selectedTest.current.test_metrics?.metrics || {}
+                              selectedTest.baseline.test_metrics?.metrics || {}
                             ).length
                           }
                           size="small"
                           variant="filled"
                         />
-                        {selectedTest.baseline && (
-                          <>
-                            {isTestPassed(selectedTest.current) &&
-                              !isTestPassed(selectedTest.baseline) && (
-                                <TrendingUpIcon
-                                  fontSize="small"
-                                  sx={{ color: theme.palette.success.main }}
-                                />
-                              )}
-                            {!isTestPassed(selectedTest.current) &&
-                              isTestPassed(selectedTest.baseline) && (
-                                <TrendingDownIcon
-                                  fontSize="small"
-                                  sx={{ color: theme.palette.error.main }}
-                                />
-                              )}
-                          </>
-                        )}
-                        <ExperimentRunLink
-                          experimentId={currentTestRun.experiment_id}
-                          parameterVersion={currentTestRun.parameter_version}
-                          experimentName={currentTestRun.experiment_name}
-                        />
-                      </Box>
+                      ) : (
+                        <Chip label="No data" size="small" />
+                      )}
+                    </Box>
+                    <Box
+                      sx={{
+                        flex: 1,
+                        display: 'flex',
+                        gap: '10px',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <Typography
+                        sx={{
+                          fontSize: 23,
+                          fontWeight: 700,
+                          lineHeight: '27.6px',
+                          color: theme.palette.greyscale.title,
+                        }}
+                      >
+                        Current Run
+                      </Typography>
+                      <MetricStatusChip
+                        passedCount={
+                          Object.values(
+                            selectedTest.current.test_metrics?.metrics || {}
+                          ).filter(m => m.is_successful).length
+                        }
+                        totalCount={
+                          Object.values(
+                            selectedTest.current.test_metrics?.metrics || {}
+                          ).length
+                        }
+                        size="small"
+                        variant="filled"
+                      />
+                    </Box>
+                  </Box>
 
-                      {/* Response */}
-                      <Box sx={{ mb: 3 }}>
-                        <Typography
-                          variant="overline"
-                          color="text.secondary"
-                          display="block"
-                          gutterBottom
-                        >
-                          Response
-                        </Typography>
-                        <Paper
-                          variant="outlined"
-                          sx={{
-                            p: 2.5,
-                            bgcolor: theme.palette.background.light1,
-                          }}
-                        >
-                          <Typography variant="body2">
-                            {selectedTest.current.test_output?.output ||
-                              'No response available'}
-                          </Typography>
-                        </Paper>
-                      </Box>
+                  {/* Row 2: Response boxes */}
+                  <Box sx={{ display: 'flex', gap: '40px' }}>
+                    <Box
+                      sx={{
+                        flex: 1,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '20px',
+                      }}
+                    >
+                      <Typography
+                        sx={{
+                          fontWeight: 700,
+                          fontSize: 16,
+                          lineHeight: '24px',
+                          color: theme.palette.greyscale.title,
+                        }}
+                      >
+                        Response
+                      </Typography>
+                      <RunResponseBox
+                        response={
+                          selectedTest.baseline?.test_output?.output ||
+                          'No response available'
+                        }
+                      />
+                    </Box>
+                    <Box
+                      sx={{
+                        flex: 1,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '20px',
+                      }}
+                    >
+                      <Typography
+                        sx={{
+                          fontWeight: 700,
+                          fontSize: 16,
+                          lineHeight: '24px',
+                          color: theme.palette.greyscale.title,
+                        }}
+                      >
+                        Response
+                      </Typography>
+                      <RunResponseBox
+                        response={
+                          selectedTest.current.test_output?.output ||
+                          'No response available'
+                        }
+                      />
+                    </Box>
+                  </Box>
 
-                      {/* Metrics */}
+                  {/* Row 3: Behavior sections — baseline left, current right */}
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      gap: '40px',
+                      alignItems: 'flex-start',
+                    }}
+                  >
+                    {/* Baseline column */}
+                    <Box
+                      sx={{
+                        flex: 1,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '40px',
+                      }}
+                    >
                       {behaviors.map(behavior => {
-                        const behaviorMetrics = behavior.metrics
+                        const bMetrics = behavior.metrics
                           .map(metric => ({
-                            ...metric,
-                            currentResult:
-                              selectedTest.current?.test_metrics?.metrics?.[
-                                metric.name
-                              ],
-                            baselineResult:
+                            name: metric.name,
+                            result:
                               selectedTest.baseline?.test_metrics?.metrics?.[
                                 metric.name
                               ],
                           }))
-                          .filter(m => m.currentResult || m.baselineResult);
-
-                        if (behaviorMetrics.length === 0) return null;
-
-                        const currentPassedCount = behaviorMetrics.filter(
-                          m => m.currentResult?.is_successful
+                          .filter(
+                            (m): m is { name: string; result: MetricResult } =>
+                              m.result !== undefined
+                          );
+                        if (bMetrics.length === 0) return null;
+                        const passed = bMetrics.filter(
+                          m => m.result.is_successful
                         ).length;
-                        const baselinePassedCount = behaviorMetrics.filter(
-                          m => m.baselineResult?.is_successful
-                        ).length;
-                        const hasChanges =
-                          currentPassedCount !== baselinePassedCount;
-
                         return (
-                          <Accordion
+                          <BehaviorSection
                             key={behavior.id}
-                            sx={{
-                              mb: 2,
-                              '&:before': { display: 'none' },
-                              boxShadow: 'none',
-                              border: 1,
-                              borderColor: 'divider',
-                            }}
-                            defaultExpanded={hasChanges}
+                            behaviorName={behavior.name}
+                            passedCount={passed}
+                            totalCount={bMetrics.length}
                           >
-                            <AccordionSummary
-                              expandIcon={<ExpandMoreIcon />}
-                              sx={{ py: 2 }}
-                            >
-                              <Box
-                                sx={{
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  gap: 1,
-                                  width: '100%',
-                                }}
-                              >
-                                <Typography
-                                  variant="body1"
-                                  sx={{ fontWeight: 600 }}
-                                >
-                                  {behavior.name}
-                                </Typography>
-                                <Box
-                                  sx={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    gap: 0.5,
-                                  }}
-                                >
-                                  <Chip
-                                    label={`${currentPassedCount}/${behaviorMetrics.length}`}
-                                    size="small"
-                                    color={
-                                      currentPassedCount ===
-                                      behaviorMetrics.length
-                                        ? 'success'
-                                        : 'error'
-                                    }
-                                  />
-                                  {hasChanges && (
-                                    <>
-                                      {currentPassedCount >
-                                      baselinePassedCount ? (
-                                        <TrendingUpIcon
-                                          fontSize="small"
-                                          sx={{
-                                            color: theme.palette.success.main,
-                                          }}
-                                        />
-                                      ) : (
-                                        <TrendingDownIcon
-                                          fontSize="small"
-                                          sx={{
-                                            color: theme.palette.error.main,
-                                          }}
-                                        />
-                                      )}
-                                    </>
-                                  )}
-                                </Box>
-                              </Box>
-                            </AccordionSummary>
-                            <AccordionDetails sx={{ p: 3 }}>
-                              <Box
-                                sx={{
-                                  display: 'flex',
-                                  flexDirection: 'column',
-                                  gap: 3,
-                                }}
-                              >
-                                {behaviorMetrics.map(metric => {
-                                  const scoreDiff =
-                                    metric.currentResult?.score != null &&
-                                    metric.baselineResult?.score != null
-                                      ? Number(metric.currentResult.score) -
-                                        Number(metric.baselineResult.score)
-                                      : null;
-                                  const hasScoreChange =
-                                    scoreDiff !== null &&
-                                    Math.abs(scoreDiff) > 0.01;
-                                  const statusChanged =
-                                    metric.baselineResult &&
-                                    metric.currentResult &&
-                                    metric.baselineResult.is_successful !==
-                                      metric.currentResult.is_successful;
-
-                                  return (
-                                    <Paper
-                                      key={metric.name}
-                                      variant="outlined"
-                                      sx={{
-                                        p: 3,
-                                        bgcolor: statusChanged
-                                          ? metric.currentResult?.is_successful
-                                            ? theme.palette.mode === 'light'
-                                              ? alpha(
-                                                  theme.palette.success.main,
-                                                  0.08
-                                                )
-                                              : theme.palette.background.light3
-                                            : theme.palette.mode === 'light'
-                                              ? alpha(
-                                                  theme.palette.error.main,
-                                                  0.08
-                                                )
-                                              : theme.palette.background.light3
-                                          : 'transparent',
-                                      }}
-                                    >
-                                      <Box
-                                        sx={{
-                                          display: 'flex',
-                                          alignItems: 'flex-start',
-                                          gap: 1,
-                                        }}
-                                      >
-                                        {metric.currentResult?.is_successful ? (
-                                          <CheckCircleIcon
-                                            fontSize="small"
-                                            sx={{
-                                              color: theme.palette.success.main,
-                                            }}
-                                          />
-                                        ) : (
-                                          <CancelIcon
-                                            fontSize="small"
-                                            sx={{
-                                              color: theme.palette.error.main,
-                                            }}
-                                          />
-                                        )}
-                                        <Box sx={{ flex: 1 }}>
-                                          <Box
-                                            sx={{
-                                              display: 'flex',
-                                              alignItems: 'center',
-                                              gap: 1,
-                                              mb: 1,
-                                            }}
-                                          >
-                                            <Typography variant="subtitle2">
-                                              {metric.name}
-                                            </Typography>
-                                            {statusChanged && (
-                                              <>
-                                                {metric.currentResult
-                                                  ?.is_successful ? (
-                                                  <TrendingUpIcon
-                                                    fontSize="small"
-                                                    sx={{
-                                                      color:
-                                                        theme.palette.success
-                                                          .main,
-                                                    }}
-                                                  />
-                                                ) : (
-                                                  <TrendingDownIcon
-                                                    fontSize="small"
-                                                    sx={{
-                                                      color:
-                                                        theme.palette.error
-                                                          .main,
-                                                    }}
-                                                  />
-                                                )}
-                                              </>
-                                            )}
-                                          </Box>
-                                          {metric.currentResult?.score !=
-                                            null && (
-                                            <Box sx={{ mb: 1 }}>
-                                              <Box
-                                                sx={{
-                                                  display: 'flex',
-                                                  justifyContent:
-                                                    'space-between',
-                                                  mb: 0.5,
-                                                }}
-                                              >
-                                                <Typography variant="caption">
-                                                  Score:{' '}
-                                                  {Number(
-                                                    metric.currentResult.score
-                                                  ).toFixed(2)}
-                                                  {hasScoreChange &&
-                                                    scoreDiff !== null && (
-                                                      <Typography
-                                                        component="span"
-                                                        variant="caption"
-                                                        sx={{
-                                                          ml: 0.5,
-                                                          color:
-                                                            scoreDiff > 0
-                                                              ? theme.palette
-                                                                  .success.main
-                                                              : theme.palette
-                                                                  .error.main,
-                                                          fontWeight: 500,
-                                                        }}
-                                                      >
-                                                        (
-                                                        {scoreDiff > 0
-                                                          ? '+'
-                                                          : ''}
-                                                        {scoreDiff.toFixed(2)})
-                                                      </Typography>
-                                                    )}
-                                                </Typography>
-                                                {metric.currentResult
-                                                  .threshold != null && (
-                                                  <Typography
-                                                    variant="caption"
-                                                    color="text.secondary"
-                                                  >
-                                                    Threshold: ≥
-                                                    {Number(
-                                                      metric.currentResult
-                                                        .threshold
-                                                    ).toFixed(2)}
-                                                  </Typography>
-                                                )}
-                                              </Box>
-                                              <LinearProgress
-                                                variant="determinate"
-                                                value={
-                                                  Number(
-                                                    metric.currentResult.score
-                                                  ) * 100
-                                                }
-                                                color={
-                                                  metric.currentResult
-                                                    .is_successful
-                                                    ? 'success'
-                                                    : 'error'
-                                                }
-                                                sx={{
-                                                  height: 8,
-                                                  borderRadius:
-                                                    theme.shape.borderRadius /
-                                                    4,
-                                                  bgcolor:
-                                                    theme.palette.background
-                                                      .light2,
-                                                }}
-                                              />
-                                            </Box>
-                                          )}
-                                          {metric.currentResult?.reason && (
-                                            <Typography
-                                              variant="caption"
-                                              color="text.secondary"
-                                            >
-                                              {metric.currentResult.reason}
-                                            </Typography>
-                                          )}
-                                        </Box>
-                                      </Box>
-                                    </Paper>
-                                  );
-                                })}
-                              </Box>
-                            </AccordionDetails>
-                          </Accordion>
+                            {bMetrics.map(m => (
+                              <MetricRow
+                                key={m.name}
+                                metricName={m.name}
+                                result={m.result}
+                              />
+                            ))}
+                          </BehaviorSection>
                         );
                       })}
                     </Box>
-                  </Grid>
-                </Grid>
+
+                    {/* Current column */}
+                    <Box
+                      sx={{
+                        flex: 1,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '40px',
+                      }}
+                    >
+                      {behaviors.map(behavior => {
+                        const bMetrics = behavior.metrics
+                          .map(metric => ({
+                            name: metric.name,
+                            result:
+                              selectedTest.current.test_metrics?.metrics?.[
+                                metric.name
+                              ],
+                          }))
+                          .filter(
+                            (m): m is { name: string; result: MetricResult } =>
+                              m.result !== undefined
+                          );
+                        if (bMetrics.length === 0) return null;
+                        const passed = bMetrics.filter(
+                          m => m.result.is_successful
+                        ).length;
+                        return (
+                          <BehaviorSection
+                            key={behavior.id}
+                            behaviorName={behavior.name}
+                            passedCount={passed}
+                            totalCount={bMetrics.length}
+                          >
+                            {bMetrics.map(m => (
+                              <MetricRow
+                                key={m.name}
+                                metricName={m.name}
+                                result={m.result}
+                              />
+                            ))}
+                          </BehaviorSection>
+                        );
+                      })}
+                    </Box>
+                  </Box>
+                </Box>
               )}
             </Box>
           )}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ComparisonView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ComparisonView.tsx
@@ -1167,6 +1167,11 @@ export default function ComparisonView({
             flexDirection: 'column',
           },
         }}
+        slotProps={{
+          backdrop: {
+            sx: { backgroundColor: 'rgba(0, 101, 140, 0.8)' },
+          },
+        }}
       >
         {/* Custom header: close icon + test title */}
         <Box

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ComparisonView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ComparisonView.tsx
@@ -79,6 +79,8 @@ interface ComparisonViewProps {
   testSetType?: string; // e.g., "Multi-turn" or "Single-turn"
   project?: { icon?: string; useCase?: string; name?: string };
   projectName?: string;
+  initialBaselineId?: string;
+  closeButtonLabel?: string;
 }
 
 interface ComparisonTest {
@@ -146,10 +148,12 @@ export default function ComparisonView({
   testSetType,
   project,
   projectName,
+  initialBaselineId,
+  closeButtonLabel = 'Close Comparison',
 }: ComparisonViewProps) {
   const theme = useTheme();
   const [selectedBaselineId, setSelectedBaselineId] = useState<string>(
-    availableTestRuns[0]?.id || ''
+    initialBaselineId || availableTestRuns[0]?.id || ''
   );
   const [baselineTestResults, setBaselineTestResults] = useState<
     TestResultDetail[] | null
@@ -475,7 +479,7 @@ export default function ComparisonView({
               size="small"
               startIcon={<CloseIcon />}
             >
-              Close Comparison
+              {closeButtonLabel}
             </Button>
           </Box>
         </Box>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ReviewJudgementDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ReviewJudgementDrawer.tsx
@@ -3,27 +3,23 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Box,
-  Typography,
   ToggleButton,
   ToggleButtonGroup,
-  Stack,
-  Chip,
-  useTheme,
+  Typography,
 } from '@mui/material';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
-import RateReviewOutlinedIcon from '@mui/icons-material/RateReviewOutlined';
-import TrackChangesIcon from '@mui/icons-material/TrackChanges';
 import BaseDrawer from '@/components/common/BaseDrawer';
 import {
   TestResultDetail,
   REVIEW_TARGET_TYPES,
-  REVIEW_TARGET_LABELS,
 } from '@/utils/api-client/interfaces/test-results';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { Status } from '@/utils/api-client/interfaces/status';
-import StatusChip from '@/components/common/StatusChip';
-import { findStatusByCategory } from '@/utils/test-result-status';
+import {
+  findStatusByCategory,
+  isPassedStatusName,
+} from '@/utils/test-result-status';
 import MentionTextInput, {
   MentionOption,
   inferReviewTarget,
@@ -53,26 +49,68 @@ export default function ReviewJudgementDrawer({
   mentionableMetrics = [],
   mentionableTurns = [],
 }: ReviewJudgementDrawerProps) {
-  const theme = useTheme();
-  const [newStatus, setNewStatus] = useState<'passed' | 'failed'>('passed');
+  const [selectedStatusId, setSelectedStatusId] = useState('');
   const [reason, setReason] = useState('');
   const [error, setError] = useState('');
   const [statuses, setStatuses] = useState<Status[]>([]);
   const [loadingStatuses, setLoadingStatuses] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
-  // Infer target from comment text
+  // Infer review target from mention syntax in comment text
   const inferredTarget: InferredTarget = useMemo(
     () => inferReviewTarget(reason),
     [reason]
   );
 
-  const targetLabel = useMemo(
-    () => REVIEW_TARGET_LABELS[inferredTarget.type] ?? inferredTarget.type,
-    [inferredTarget]
+  const passStatus = useMemo(
+    () => findStatusByCategory(statuses, 'passed'),
+    [statuses]
+  );
+  const failStatus = useMemo(
+    () => findStatusByCategory(statuses, 'failed'),
+    [statuses]
   );
 
-  // Calculate automated status of the targeted item
+  // Fetch statuses for TestResult entity type on mount
+  useEffect(() => {
+    const fetchStatuses = async () => {
+      if (!sessionToken || statuses.length > 0) return;
+      try {
+        setLoadingStatuses(true);
+        const clientFactory = new ApiClientFactory(sessionToken);
+        const statusClient = clientFactory.getStatusClient();
+        const fetched = await statusClient.getStatuses({
+          entity_type: 'TestResult',
+        });
+        setStatuses(fetched);
+      } catch (_err) {
+        setError('Failed to load status options');
+      } finally {
+        setLoadingStatuses(false);
+      }
+    };
+    fetchStatuses();
+  }, [sessionToken, statuses.length]);
+
+  // Reset form when drawer opens (intentionally excludes initialComment/initialStatus
+  // from deps so parent state resets don't clear a form the user is actively filling)
+  useEffect(() => {
+    if (!open) return;
+    setReason(initialComment ?? '');
+    setError('');
+    setSelectedStatusId('');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  // Pre-select initial status once statuses are available and nothing is selected yet
+  useEffect(() => {
+    if (!open || selectedStatusId || statuses.length === 0 || !initialStatus)
+      return;
+    const matching = findStatusByCategory(statuses, initialStatus);
+    if (matching) setSelectedStatusId(String(matching.id));
+  }, [open, statuses, initialStatus, selectedStatusId]);
+
+  // Automated status of the review target (used for conflict validation)
   const getOriginalStatus = useCallback((): 'passed' | 'failed' => {
     if (!test) return 'failed';
 
@@ -81,10 +119,10 @@ export default function ReviewJudgementDrawer({
       inferredTarget.reference
     ) {
       const metrics = test.test_metrics?.metrics || {};
-      const metric = Object.entries(metrics).find(
+      const entry = Object.entries(metrics).find(
         ([name]) => name === inferredTarget.reference
       );
-      return metric?.[1]?.is_successful ? 'passed' : 'failed';
+      return entry?.[1]?.is_successful ? 'passed' : 'failed';
     }
 
     if (
@@ -108,104 +146,55 @@ export default function ReviewJudgementDrawer({
 
   const originalStatus = getOriginalStatus();
 
-  // Fetch statuses for TestResult entity type
-  useEffect(() => {
-    const fetchStatuses = async () => {
-      if (!sessionToken || statuses.length > 0) return;
-
-      try {
-        setLoadingStatuses(true);
-        const clientFactory = new ApiClientFactory(sessionToken);
-        const statusClient = clientFactory.getStatusClient();
-        const fetchedStatuses = await statusClient.getStatuses({
-          entity_type: 'TestResult',
-        });
-        setStatuses(fetchedStatuses);
-      } catch (_err) {
-        setError('Failed to load status options');
-      } finally {
-        setLoadingStatuses(false);
-      }
-    };
-
-    fetchStatuses();
-  }, [sessionToken, statuses.length]);
-
-  // Reset form when drawer opens or test changes
-  useEffect(() => {
-    if (open && test) {
-      const metrics = test.test_metrics?.metrics || {};
-      const metricValues = Object.values(metrics);
-      const allPassed =
-        metricValues.length > 0 && metricValues.every(m => m.is_successful);
-      const defaultOriginal = allPassed ? 'passed' : 'failed';
-      setNewStatus(
-        initialStatus ?? (defaultOriginal === 'passed' ? 'failed' : 'passed')
-      );
-      setReason(initialComment ?? '');
-      setError('');
-    }
-  }, [open, test, initialComment, initialStatus]);
-
-  const handleStatusChange = (
-    _event: React.MouseEvent<HTMLElement>,
-    value: 'passed' | 'failed' | null
-  ) => {
-    if (value !== null) {
-      setNewStatus(value);
-      setError('');
-    }
-  };
-
   const handleSave = async () => {
-    // Validation
     if (!reason.trim()) {
-      setError('Please provide a reason for the review.');
+      setError('Please provide a comment for your review.');
       return;
     }
 
     if (reason.trim().length < 10) {
-      setError('Reason must be at least 10 characters long.');
+      setError('Comment must be at least 10 characters long.');
+      return;
+    }
+
+    if (!selectedStatusId) {
+      setError('Please select a status for this review.');
       return;
     }
 
     if (!test || !sessionToken) return;
 
-    // For test_result targets without an existing review, prevent matching original
-    // For metric/turn targets, always allow (they're specific overrides)
+    const selectedStatus = statuses.find(
+      s => String(s.id) === selectedStatusId
+    );
+
+    // For test_result-level first reviews, block matching the automated outcome
     if (inferredTarget.type === REVIEW_TARGET_TYPES.TEST_RESULT) {
       const hasExistingReview = !!test.last_review;
-      if (newStatus === originalStatus && !hasExistingReview) {
+      if (
+        !hasExistingReview &&
+        selectedStatus &&
+        isPassedStatusName(selectedStatus.name) ===
+          (originalStatus === 'passed')
+      ) {
         setError(
-          'New status must be different from the automated result. ' +
-            'Use "Confirm Review" to agree with the automated result.'
+          'The selected status matches the automated result. ' +
+            'Please select a different status, or add a comment confirming your agreement.'
         );
         return;
       }
-    }
-
-    // Find the status ID for the new status using centralized utility
-    const targetStatus = findStatusByCategory(
-      statuses,
-      newStatus === 'passed' ? 'passed' : 'failed'
-    );
-
-    if (!targetStatus) {
-      setError('Could not find appropriate status. Please try again.');
-      return;
     }
 
     try {
       setSubmitting(true);
       setError('');
 
-      // Create the review via API
       const clientFactory = new ApiClientFactory(sessionToken);
       const testResultsClient = clientFactory.getTestResultsClient();
 
       await testResultsClient.createReview(
         test.id,
-        targetStatus.id,
+        selectedStatusId,
         reason.trim(),
         inferredTarget
       );
@@ -225,145 +214,103 @@ export default function ReviewJudgementDrawer({
     onClose();
   };
 
-  if (!test) return null;
+  const isSaveDisabled =
+    !selectedStatusId ||
+    reason.trim().length < 10 ||
+    submitting ||
+    loadingStatuses;
 
-  const metrics = test.test_metrics?.metrics || {};
-  const metricValues = Object.values(metrics);
-  const totalMetrics = metricValues.length;
-  const passedMetrics = metricValues.filter(m => m.is_successful).length;
+  if (!test) return null;
 
   return (
     <BaseDrawer
       open={open}
       onClose={handleCancel}
-      title="Provide Test Review"
-      titleIcon={<RateReviewOutlinedIcon />}
+      title="Create Review"
       onSave={handleSave}
       anchor="right"
-      saveButtonText={submitting ? 'Saving...' : 'Submit Review'}
+      saveButtonText="Save"
+      saveDisabled={isSaveDisabled}
       error={error}
-      width={theme.spacing(75)}
       loading={submitting || loadingStatuses}
     >
-      <Stack spacing={3}>
-        {/* Review Target Indicator */}
-        <Box>
-          <Typography variant="body2" fontWeight={600} gutterBottom>
-            Review Target
-          </Typography>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
-            <Chip
-              icon={<TrackChangesIcon />}
-              label={targetLabel}
-              size="small"
-              color={
-                inferredTarget.type === REVIEW_TARGET_TYPES.METRIC
-                  ? 'secondary'
-                  : inferredTarget.type === REVIEW_TARGET_TYPES.TURN
-                    ? 'info'
-                    : 'default'
-              }
-              variant="outlined"
-            />
-          </Box>
-        </Box>
-
-        {/* Automated Status of Target */}
-        <Box>
-          <Typography variant="body2" fontWeight={600} gutterBottom>
-            Current Automated Status
-          </Typography>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1 }}>
-            <StatusChip
-              passed={originalStatus === 'passed'}
-              label={originalStatus === 'passed' ? 'Passed' : 'Failed'}
-              size="small"
-              variant="filled"
-            />
-            {inferredTarget.type === REVIEW_TARGET_TYPES.TEST_RESULT && (
-              <Typography variant="body2" color="text.secondary">
-                {passedMetrics}/{totalMetrics} metrics passed
-              </Typography>
-            )}
-            {inferredTarget.type === REVIEW_TARGET_TYPES.METRIC &&
-              inferredTarget.reference && (
-                <Typography variant="body2" color="text.secondary">
-                  Score: {metrics[inferredTarget.reference]?.score ?? 'N/A'}
-                </Typography>
-              )}
-          </Box>
-        </Box>
-
-        {/* New Status Selection */}
-        <Box>
-          <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
-            New Status *
-          </Typography>
-          <ToggleButtonGroup
-            value={newStatus}
-            exclusive
-            onChange={handleStatusChange}
-            aria-label="test status"
-            size="small"
-            fullWidth
-          >
+      {/* Pass / Fail toggle */}
+      <Box>
+        <Typography
+          variant="body2"
+          sx={{ mb: 1, fontWeight: 500, color: 'text.secondary' }}
+        >
+          New Status
+        </Typography>
+        <ToggleButtonGroup
+          value={selectedStatusId}
+          exclusive
+          onChange={(_, val) => {
+            if (val !== null) {
+              setSelectedStatusId(val);
+              setError('');
+            }
+          }}
+          fullWidth
+          disabled={loadingStatuses}
+          sx={{ height: 44 }}
+        >
+          {passStatus && (
             <ToggleButton
-              value="passed"
-              aria-label="passed"
+              value={String(passStatus.id)}
               sx={{
+                flex: 1,
+                gap: 1,
+                fontWeight: 500,
                 '&.Mui-selected': {
-                  backgroundColor: theme.palette.success.main,
-                  color: theme.palette.success.contrastText,
-                  '& .MuiSvgIcon-root': { color: 'inherit' },
-                  '&:hover': {
-                    backgroundColor: theme.palette.success.dark,
-                  },
+                  bgcolor: 'success.main',
+                  color: '#fff',
+                  '&:hover': { bgcolor: 'success.dark' },
+                  '& .MuiSvgIcon-root': { color: '#fff' },
                 },
               }}
             >
-              <CheckCircleOutlineIcon
-                sx={{ mr: 1, fontSize: 'body2.fontSize' }}
-              />
+              <CheckCircleOutlineIcon sx={{ fontSize: 18 }} />
               Pass
             </ToggleButton>
+          )}
+          {failStatus && (
             <ToggleButton
-              value="failed"
-              aria-label="failed"
+              value={String(failStatus.id)}
               sx={{
+                flex: 1,
+                gap: 1,
+                fontWeight: 500,
                 '&.Mui-selected': {
-                  backgroundColor: theme.palette.error.main,
-                  color: theme.palette.error.contrastText,
-                  '& .MuiSvgIcon-root': { color: 'inherit' },
-                  '&:hover': {
-                    backgroundColor: theme.palette.error.dark,
-                  },
+                  bgcolor: 'error.main',
+                  color: '#fff',
+                  '&:hover': { bgcolor: 'error.dark' },
+                  '& .MuiSvgIcon-root': { color: '#fff' },
                 },
               }}
             >
-              <CancelOutlinedIcon sx={{ mr: 1, fontSize: 'body2.fontSize' }} />
+              <CancelOutlinedIcon sx={{ fontSize: 18 }} />
               Fail
             </ToggleButton>
-          </ToggleButtonGroup>
-        </Box>
+          )}
+        </ToggleButtonGroup>
+      </Box>
 
-        {/* Review Comments */}
-        <MentionTextInput
-          label="Review Comments *"
-          value={reason}
-          onChange={val => {
-            setReason(val);
-            setError('');
-          }}
-          placeholder="Explain your review decision... Type @ to mention"
-          mentionableMetrics={mentionableMetrics}
-          mentionableTurns={mentionableTurns}
-          error={!!error}
-          helperText={
-            error || `${reason.length} characters (minimum 10 required)`
-          }
-          minRows={4}
-        />
-      </Stack>
+      {/* Comment field */}
+      <MentionTextInput
+        label="Comment"
+        value={reason}
+        onChange={val => {
+          setReason(val);
+          setError('');
+        }}
+        placeholder="Explain your review decision... Type @ to mention"
+        mentionableMetrics={mentionableMetrics}
+        mentionableTurns={mentionableTurns}
+        error={!!error && !selectedStatusId}
+        helperText="Add a comment to support your review decision"
+        minRows={4}
+      />
     </BaseDrawer>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailConversationTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailConversationTab.tsx
@@ -1,18 +1,24 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Box, Typography } from '@mui/material';
+import { Box, CircularProgress, Typography } from '@mui/material';
 import {
   TestResultDetail,
-  ConversationTurn,
   Review,
   REVIEW_TARGET_TYPES,
 } from '@/utils/api-client/interfaces/test-results';
-import { TraceSummary } from '@/utils/api-client/interfaces/telemetry';
 import type { FileResponse } from '@/utils/api-client/interfaces/file';
+import type {
+  SpanNode,
+  TraceSummary,
+} from '@/utils/api-client/interfaces/telemetry';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import ConversationHistory from '@/components/common/ConversationHistory';
 import TraceDrawer from '@/app/(protected)/traces/components/TraceDrawer';
+import {
+  isMultiTurnTestResult,
+  resolveConversationSummary,
+} from '@/utils/conversation-from-spans';
 
 interface TestDetailConversationTabProps {
   test: TestResultDetail;
@@ -36,22 +42,27 @@ export default function TestDetailConversationTab({
   isConfirmingReview = false,
 }: TestDetailConversationTabProps) {
   const [traces, setTraces] = useState<TraceSummary[]>([]);
+  const [rootSpans, setRootSpans] = useState<SpanNode[]>([]);
   const [spanFiles, setSpanFiles] = useState<FileResponse[][]>([]);
+  const [tracesLoading, setTracesLoading] = useState(false);
   const [traceDrawerOpen, setTraceDrawerOpen] = useState(false);
   const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
   const [selectedTurnNumber, setSelectedTurnNumber] = useState<number | null>(
     null
   );
 
+  const isMultiTurn = isMultiTurnTestResult(test, testSetType);
+
   // Fetch traces, trace detail, and span files in one chain.
-  // All state is set together at the end to avoid intermediate renders.
   useEffect(() => {
     setSpanFiles([]);
     setTraces([]);
+    setRootSpans([]);
 
-    if (!test.id || !sessionToken) return;
+    if (!test.id || !sessionToken || !isMultiTurn) return;
 
     const load = async () => {
+      setTracesLoading(true);
       try {
         const factory = new ApiClientFactory(sessionToken);
         const telemetryClient = factory.getTelemetryClient();
@@ -65,15 +76,17 @@ export default function TestDetailConversationTab({
         );
 
         let files: FileResponse[][] = [];
+        let spans: SpanNode[] = [];
         if (sorted.length > 0) {
           const detail = await telemetryClient.getTrace(
             sorted[0].trace_id,
             sorted[0].project_id
           );
+          spans = detail.root_spans ?? [];
 
           const filesClient = factory.getFilesClient();
           files = await Promise.all(
-            detail.root_spans.map(async span => {
+            spans.map(async span => {
               if (!span.id) return [] as FileResponse[];
               try {
                 return await filesClient.getSpanFiles(span.id);
@@ -85,31 +98,37 @@ export default function TestDetailConversationTab({
         }
 
         setTraces(sorted);
+        setRootSpans(spans);
         setSpanFiles(files);
       } catch {
-        // Silently fail — traces and files are optional
+        // Traces are optional; conversation may still come from test_output
+      } finally {
+        setTracesLoading(false);
       }
     };
 
-    load();
-  }, [test.id, sessionToken]);
+    void load();
+  }, [test.id, sessionToken, isMultiTurn]);
 
-  // Map turn numbers to trace — multi-turn conversations share a single trace
-  // with each turn as a root span, so all turns map to the same trace
+  const conversationSummary = useMemo(
+    () => resolveConversationSummary(test, rootSpans, spanFiles),
+    [test, rootSpans, spanFiles]
+  );
+
+  const hasConversation = isMultiTurn && conversationSummary.length > 0;
+
   const turnTraceMap = useMemo(() => {
     const map = new Map<number, TraceSummary>();
     if (traces.length > 0) {
       const trace = traces[0];
-      const conversationTurns =
-        test.test_output?.conversation_summary?.filter(
-          t => t.target_response
-        ) || [];
-      conversationTurns.forEach(turn => {
-        map.set(turn.turn, trace);
-      });
+      conversationSummary
+        .filter(t => t.target_response)
+        .forEach(turn => {
+          map.set(turn.turn, trace);
+        });
     }
     return map;
-  }, [traces, test.test_output?.conversation_summary]);
+  }, [traces, conversationSummary]);
 
   const projectId = traces[0]?.project_id || '';
 
@@ -125,7 +144,6 @@ export default function TestDetailConversationTab({
     [turnTraceMap]
   );
 
-  // Build a map of turn number -> latest review targeting that turn
   const turnReviewMap = useMemo(() => {
     const map = new Map<number, Review>();
     const reviews = test.test_reviews?.reviews || [];
@@ -152,24 +170,6 @@ export default function TestDetailConversationTab({
     return map;
   }, [test.test_reviews]);
 
-  // Determine if this is a multi-turn test
-  const isMultiTurn =
-    testSetType?.toLowerCase().includes('multi-turn') || false;
-
-  // Get conversation summary, merging any span files as penelope_files
-  const baseConversation = test.test_output?.conversation_summary;
-  const conversationSummary: ConversationTurn[] | undefined = useMemo(() => {
-    if (!baseConversation) return undefined;
-    if (spanFiles.length === 0) return baseConversation;
-    return baseConversation.map((turn, i) => ({
-      ...turn,
-      penelope_files: spanFiles[i] ?? [],
-    }));
-  }, [baseConversation, spanFiles]);
-  const hasConversation =
-    isMultiTurn && conversationSummary && conversationSummary.length > 0;
-
-  // Single-turn: show one prompt / response pair
   if (!isMultiTurn) {
     const promptText = test.test?.prompt?.content ?? '';
     const outputText = test.test_output?.output ?? '';
@@ -204,7 +204,22 @@ export default function TestDetailConversationTab({
     );
   }
 
-  // If no conversation available
+  if (tracesLoading && !hasConversation) {
+    return (
+      <Box
+        sx={{
+          p: 3,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          minHeight: 300,
+        }}
+      >
+        <CircularProgress size={32} />
+      </Box>
+    );
+  }
+
   if (!hasConversation) {
     return (
       <Box

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailConversationTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailConversationTab.tsx
@@ -169,21 +169,37 @@ export default function TestDetailConversationTab({
   const hasConversation =
     isMultiTurn && conversationSummary && conversationSummary.length > 0;
 
-  // If not a multi-turn test, show message
+  // Single-turn: show one prompt / response pair
   if (!isMultiTurn) {
+    const promptText = test.test?.prompt?.content ?? '';
+    const outputText = test.test_output?.output ?? '';
+
     return (
-      <Box
-        sx={{
-          p: 3,
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          minHeight: 300,
-        }}
-      >
-        <Typography variant="body1" color="text.secondary">
-          Conversation history is only available for multi-turn tests.
-        </Typography>
+      <Box sx={{ p: 3, display: 'flex', flexDirection: 'column', gap: 3 }}>
+        <Box>
+          <Typography
+            variant="overline"
+            color="text.secondary"
+            sx={{ display: 'block', mb: 1 }}
+          >
+            Prompt
+          </Typography>
+          <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap' }}>
+            {promptText || '—'}
+          </Typography>
+        </Box>
+        <Box>
+          <Typography
+            variant="overline"
+            color="text.secondary"
+            sx={{ display: 'block', mb: 1 }}
+          >
+            Response
+          </Typography>
+          <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap' }}>
+            {outputText || '—'}
+          </Typography>
+        </Box>
       </Box>
     );
   }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailConversationTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailConversationTab.tsx
@@ -171,35 +171,34 @@ export default function TestDetailConversationTab({
   }, [test.test_reviews]);
 
   if (!isMultiTurn) {
-    const promptText = test.test?.prompt?.content ?? '';
-    const outputText = test.test_output?.output ?? '';
+    const singleTurnSummary = [
+      {
+        turn: 1,
+        timestamp: '',
+        session_id: '',
+        penelope_reasoning: '',
+        penelope_message: test.test?.prompt?.content ?? '',
+        target_response: test.test_output?.output ?? '',
+        success: test.test_output?.goal_evaluation?.all_criteria_met ?? false,
+      },
+    ];
 
     return (
-      <Box sx={{ p: 3, display: 'flex', flexDirection: 'column', gap: 3 }}>
-        <Box>
-          <Typography
-            variant="overline"
-            color="text.secondary"
-            sx={{ display: 'block', mb: 1 }}
-          >
-            Prompt
-          </Typography>
-          <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap' }}>
-            {promptText || '—'}
-          </Typography>
-        </Box>
-        <Box>
-          <Typography
-            variant="overline"
-            color="text.secondary"
-            sx={{ display: 'block', mb: 1 }}
-          >
-            Response
-          </Typography>
-          <Typography variant="body1" sx={{ whiteSpace: 'pre-wrap' }}>
-            {outputText || '—'}
-          </Typography>
-        </Box>
+      <Box
+        sx={{ p: 3, height: '100%', display: 'flex', flexDirection: 'column' }}
+      >
+        <ConversationHistory
+          conversationSummary={singleTurnSummary}
+          goalEvaluation={test.test_output?.goal_evaluation}
+          project={project}
+          projectName={projectName}
+          onConfirmAutomatedReview={onConfirmAutomatedReview}
+          hasExistingReview={!!test.last_review}
+          reviewMatchesAutomated={test.matches_review === true}
+          isConfirmingReview={isConfirmingReview}
+          maxHeight="100%"
+          sessionToken={sessionToken}
+        />
       </Box>
     );
   }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailHistoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailHistoryTab.tsx
@@ -10,7 +10,6 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Paper,
   Chip,
   CircularProgress,
   Alert,
@@ -183,177 +182,253 @@ export default function TestDetailHistoryTab({
 
   return (
     <Box sx={{ p: 3 }}>
-      <Typography variant="subtitle2" fontWeight={600} gutterBottom>
-        Test Execution History
-      </Typography>
-      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        Last 10 test runs where this test was executed
-      </Typography>
+      {/* Summary Statistics */}
+      {history.length > 0 && (
+        <Box sx={{ display: 'flex', gap: '26px', mb: 3 }}>
+          {[
+            {
+              label: 'Total Executions',
+              value: history.length,
+              color: '#1a1c20',
+            },
+            {
+              label: 'Pass Rate',
+              value: `${((history.filter(h => h.passed).length / history.length) * 100).toFixed(1)}%`,
+              color:
+                history.filter(h => h.passed).length / history.length >= 0.8
+                  ? '#38ad87'
+                  : '#de3355',
+            },
+            {
+              label: 'Passed',
+              value: history.filter(h => h.passed).length,
+              color: '#38ad87',
+            },
+            {
+              label: 'Failed',
+              value: history.filter(h => !h.passed).length,
+              color: '#de3355',
+            },
+          ].map(stat => (
+            <Box
+              key={stat.label}
+              sx={{
+                flex: 1,
+                bgcolor: '#f3f4f6',
+                borderRadius: '10px',
+                boxShadow: '0px 3px 5px rgba(0,0,0,0.09)',
+                p: '30px',
+                height: '140px',
+                display: 'flex',
+                flexDirection: 'column',
+                justifyContent: 'space-between',
+              }}
+            >
+              <Typography
+                sx={{
+                  fontSize: 12,
+                  lineHeight: '18px',
+                  color: '#1a1c20',
+                }}
+              >
+                {stat.label}
+              </Typography>
+              <Typography
+                sx={{
+                  fontSize: 36,
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  color: stat.color,
+                }}
+              >
+                {stat.value}
+              </Typography>
+            </Box>
+          ))}
+        </Box>
+      )}
 
       {history.length === 0 ? (
-        <Paper variant="outlined" sx={{ p: 3, textAlign: 'center' }}>
+        <Box
+          sx={{
+            bgcolor: 'background.paper',
+            borderRadius: '12px',
+            border: '1px solid #cdd2da',
+            boxShadow: '0px 2px 4px rgba(84,90,101,0.25)',
+            p: 3,
+            textAlign: 'center',
+          }}
+        >
           <Typography variant="body2" color="text.secondary">
             No historical data available for this test
           </Typography>
-        </Paper>
+        </Box>
       ) : (
-        <TableContainer component={Paper} variant="outlined">
-          <Table size="small">
-            <TableHead>
-              <TableRow>
-                <TableCell>Status</TableCell>
-                <TableCell>Test Run</TableCell>
-                <TableCell>Metrics</TableCell>
-                <TableCell>Executed At</TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {history.map(item => (
-                <TableRow
-                  key={item.id}
-                  sx={{
-                    backgroundColor:
-                      item.testRunId === testRunId
-                        ? theme.palette.action.selected
-                        : 'transparent',
-                    '&:hover': {
-                      backgroundColor: theme.palette.action.hover,
-                    },
-                  }}
-                >
-                  <TableCell>
-                    <StatusChip
-                      passed={item.passed}
-                      label={item.passed ? 'Pass' : 'Fail'}
-                      size="small"
-                      variant="filled"
-                      sx={{ minWidth: 80 }}
-                    />
+        <Box
+          sx={{
+            bgcolor: 'background.paper',
+            borderRadius: '12px',
+            border: '1px solid #cdd2da',
+            boxShadow: '0px 2px 4px rgba(84,90,101,0.25)',
+            overflow: 'hidden',
+          }}
+        >
+          <TableContainer>
+            <Table
+              sx={{
+                '& .MuiTableCell-root': {
+                  borderBottom: '1px solid #cdd2da',
+                  fontSize: 14,
+                  lineHeight: '22px',
+                  py: '13px',
+                  px: '12px',
+                  backgroundColor: '#ffffff',
+                },
+                '& .MuiTableBody-root .MuiTableRow-root:last-child .MuiTableCell-root':
+                  {
+                    borderBottom: 'none',
+                  },
+                '& .MuiTableRow-root:hover .MuiTableCell-root': {
+                  backgroundColor: '#f9fafb',
+                },
+              }}
+            >
+              <TableHead>
+                <TableRow>
+                  <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
+                    Status
                   </TableCell>
-                  <TableCell>
-                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      {item.testRunId !== 'unknown' ? (
-                        <Link
-                          href={`/test-runs/${item.testRunId}${test.test_id ? `?selectedresult=${test.test_id}` : ''}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          style={{ textDecoration: 'none' }}
-                          onClick={() => {}}
-                        >
-                          <Box
-                            sx={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: 0.5,
-                              '&:hover': {
-                                '& .test-run-name': {
-                                  color: theme.palette.primary.main,
-                                  textDecoration: 'underline',
-                                },
-                              },
-                            }}
-                          >
-                            <Typography
-                              variant="body2"
-                              className="test-run-name"
-                              sx={{
-                                transition: 'color 0.2s',
-                                color:
-                                  item.testRunId === testRunId
-                                    ? 'primary.main'
-                                    : 'text.primary',
-                                fontWeight:
-                                  item.testRunId === testRunId ? 600 : 400,
-                              }}
-                            >
-                              {item.testRunName}
-                            </Typography>
-                            <OpenInNewIcon
-                              sx={{
-                                fontSize: 14,
-                                color: 'text.disabled',
-                              }}
-                            />
-                          </Box>
-                        </Link>
-                      ) : (
-                        <Typography variant="body2">
-                          {item.testRunName}
-                        </Typography>
-                      )}
-                      {item.testRunId === testRunId && (
-                        <Chip label="Current" size="small" color="primary" />
-                      )}
-                    </Box>
+                  <TableCell
+                    sx={{
+                      fontWeight: 700,
+                      color: '#2a2e36',
+                      borderLeft: '1px solid #cdd2da',
+                    }}
+                  >
+                    Test Run
                   </TableCell>
-                  <TableCell>
-                    <Typography variant="body2">
-                      {item.passedMetrics}/{item.totalMetrics} passed
-                    </Typography>
+                  <TableCell
+                    sx={{
+                      fontWeight: 700,
+                      color: '#2a2e36',
+                      borderLeft: '1px solid #cdd2da',
+                    }}
+                  >
+                    Metrics
                   </TableCell>
-                  <TableCell>
-                    <Typography variant="body2" color="text.secondary">
-                      {formatDate(item.executedAt)}
-                    </Typography>
+                  <TableCell
+                    sx={{
+                      fontWeight: 700,
+                      color: '#2a2e36',
+                      borderLeft: '1px solid #cdd2da',
+                    }}
+                  >
+                    Executed At
                   </TableCell>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      )}
-
-      {/* Summary Statistics */}
-      {history.length > 0 && (
-        <Box sx={{ mt: 3 }}>
-          <Paper variant="outlined" sx={{ p: 2 }}>
-            <Typography variant="subtitle2" fontWeight={600} gutterBottom>
-              Summary Statistics
-            </Typography>
-            <Box sx={{ display: 'flex', gap: 4, mt: 2 }}>
-              <Box>
-                <Typography variant="caption" color="text.secondary">
-                  Total Executions
-                </Typography>
-                <Typography variant="h6">{history.length}</Typography>
-              </Box>
-              <Box>
-                <Typography variant="caption" color="text.secondary">
-                  Pass Rate
-                </Typography>
-                <Typography
-                  variant="h6"
-                  color={
-                    history.filter(h => h.passed).length / history.length >= 0.8
-                      ? 'success.main'
-                      : 'error.main'
-                  }
-                >
-                  {(
-                    (history.filter(h => h.passed).length / history.length) *
-                    100
-                  ).toFixed(1)}
-                  %
-                </Typography>
-              </Box>
-              <Box>
-                <Typography variant="caption" color="text.secondary">
-                  Passed
-                </Typography>
-                <Typography variant="h6" color="success.main">
-                  {history.filter(h => h.passed).length}
-                </Typography>
-              </Box>
-              <Box>
-                <Typography variant="caption" color="text.secondary">
-                  Failed
-                </Typography>
-                <Typography variant="h6" color="error.main">
-                  {history.filter(h => !h.passed).length}
-                </Typography>
-              </Box>
-            </Box>
-          </Paper>
+              </TableHead>
+              <TableBody>
+                {history.map(item => (
+                  <TableRow
+                    key={item.id}
+                    sx={{
+                      '&:hover .MuiTableCell-root': {
+                        bgcolor: '#f9fafb',
+                      },
+                    }}
+                  >
+                    <TableCell>
+                      <StatusChip
+                        passed={item.passed}
+                        label={item.passed ? 'Pass' : 'Fail'}
+                        size="small"
+                        variant="outlined"
+                        sx={{
+                          borderColor: item.passed ? '#38ad87' : '#de3355',
+                          color: item.passed ? '#38ad87' : '#de3355',
+                          '& .MuiChip-icon': { color: 'inherit' },
+                        }}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <Box
+                        sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                      >
+                        {item.testRunId !== 'unknown' ? (
+                          <Link
+                            href={`/test-runs/${item.testRunId}${test.test_id ? `?selectedresult=${test.test_id}` : ''}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{ textDecoration: 'none' }}
+                            onClick={() => {}}
+                          >
+                            <Box
+                              sx={{
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 0.5,
+                                '&:hover': {
+                                  '& .test-run-name': {
+                                    color: theme.palette.primary.main,
+                                    textDecoration: 'underline',
+                                  },
+                                },
+                              }}
+                            >
+                              <Typography
+                                className="test-run-name"
+                                sx={{
+                                  fontSize: 14,
+                                  lineHeight: '22px',
+                                  transition: 'color 0.2s',
+                                  color: '#2a2e36',
+                                  fontWeight:
+                                    item.testRunId === testRunId ? 600 : 400,
+                                }}
+                              >
+                                {item.testRunName}
+                              </Typography>
+                              <OpenInNewIcon
+                                sx={{ fontSize: 14, color: 'text.disabled' }}
+                              />
+                            </Box>
+                          </Link>
+                        ) : (
+                          <Typography
+                            sx={{
+                              fontSize: 14,
+                              lineHeight: '22px',
+                              color: '#2a2e36',
+                            }}
+                          >
+                            {item.testRunName}
+                          </Typography>
+                        )}
+                        {item.testRunId === testRunId && (
+                          <Chip
+                            label="Current"
+                            size="small"
+                            variant="outlined"
+                            sx={{
+                              borderColor: '#cdd2da',
+                              color: '#2a2e36',
+                              fontSize: 12,
+                            }}
+                          />
+                        )}
+                      </Box>
+                    </TableCell>
+                    <TableCell sx={{ color: '#2a2e36' }}>
+                      {item.passedMetrics}/{item.totalMetrics} passed
+                    </TableCell>
+                    <TableCell sx={{ color: 'text.secondary' }}>
+                      {formatDate(item.executedAt)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
         </Box>
       )}
     </Box>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailHistoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailHistoryTab.tsx
@@ -298,31 +298,13 @@ export default function TestDetailHistoryTab({
                   <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
                     Status
                   </TableCell>
-                  <TableCell
-                    sx={{
-                      fontWeight: 700,
-                      color: '#2a2e36',
-                      borderLeft: '1px solid #cdd2da',
-                    }}
-                  >
+                  <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
                     Test Run
                   </TableCell>
-                  <TableCell
-                    sx={{
-                      fontWeight: 700,
-                      color: '#2a2e36',
-                      borderLeft: '1px solid #cdd2da',
-                    }}
-                  >
+                  <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
                     Metrics
                   </TableCell>
-                  <TableCell
-                    sx={{
-                      fontWeight: 700,
-                      color: '#2a2e36',
-                      borderLeft: '1px solid #cdd2da',
-                    }}
-                  >
+                  <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
                     Executed At
                   </TableCell>
                 </TableRow>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailMetricsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailMetricsTab.tsx
@@ -7,6 +7,7 @@ import {
   Grid,
   Card,
   CardContent,
+  Paper,
   ToggleButtonGroup,
   ToggleButton,
   useTheme,
@@ -25,7 +26,6 @@ import {
   TableCell,
   Tooltip,
 } from '@mui/material';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import RateReviewIcon from '@mui/icons-material/RateReview';
 import { alpha } from '@mui/material/styles';
@@ -319,24 +319,49 @@ export default function TestDetailMetricsTab({
   return (
     <Box sx={{ p: 3 }}>
       {/* Filter Toggle - Only for Single-turn tests */}
-      <Box
-        sx={{
-          mb: 3,
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-        }}
-      >
-        <Typography variant="h6" fontWeight={600}>
-          Metrics Overview
-        </Typography>
-        {(!isMultiTurn || hasAdditionalMultiTurnMetrics) && (
+      {(!isMultiTurn || hasAdditionalMultiTurnMetrics) && (
+        <Box sx={{ mb: 3 }}>
           <ToggleButtonGroup
             value={filterStatus}
             exclusive
             onChange={handleFilterChange}
-            size="small"
             aria-label="metric status filter"
+            sx={{
+              borderRadius: '999px',
+              border: '1px solid',
+              borderColor: 'primary.main',
+              overflow: 'hidden',
+              height: '38px',
+              '& .MuiToggleButtonGroup-grouped': {
+                border: 'none',
+                borderLeft: '1px solid',
+                borderLeftColor: 'primary.main',
+                borderRadius: 0,
+                px: 2,
+                py: 1,
+                fontWeight: 700,
+                fontSize: '14px',
+                lineHeight: '22px',
+                textTransform: 'none',
+                color: 'primary.main',
+                '&:first-of-type': {
+                  borderLeft: 'none',
+                },
+                '&.Mui-selected': {
+                  backgroundColor: 'primary.main',
+                  color: 'white',
+                  '&:hover': {
+                    backgroundColor: 'primary.dark',
+                  },
+                },
+                '&:hover': {
+                  backgroundColor: alpha(
+                    theme.palette.primary.main,
+                    theme.palette.action.hoverOpacity
+                  ),
+                },
+              },
+            }}
           >
             <ToggleButton value="all" aria-label="all metrics">
               All
@@ -348,8 +373,8 @@ export default function TestDetailMetricsTab({
               Failed
             </ToggleButton>
           </ToggleButtonGroup>
-        )}
-      </Box>
+        </Box>
+      )}
       {/* Summary Cards */}
       <Grid container spacing={2} sx={{ mb: 3 }}>
         <Grid
@@ -358,7 +383,14 @@ export default function TestDetailMetricsTab({
             md: behaviorStats.hasMultipleBehaviors ? 4 : 6,
           }}
         >
-          <Card>
+          <Card
+            variant="outlined"
+            sx={{
+              borderRadius: '12px',
+              borderColor: 'divider',
+              boxShadow: '0px 2px 2px rgba(84,90,101,0.25)',
+            }}
+          >
             <CardContent>
               <Typography variant="body2" color="text.secondary" gutterBottom>
                 Overall Performance
@@ -381,7 +413,14 @@ export default function TestDetailMetricsTab({
                 md: 4,
               }}
             >
-              <Card>
+              <Card
+                variant="outlined"
+                sx={{
+                  borderRadius: '12px',
+                  borderColor: 'divider',
+                  boxShadow: '0px 2px 2px rgba(84,90,101,0.25)',
+                }}
+              >
                 <CardContent>
                   <Typography
                     variant="body2"
@@ -410,7 +449,14 @@ export default function TestDetailMetricsTab({
                 md: 4,
               }}
             >
-              <Card>
+              <Card
+                variant="outlined"
+                sx={{
+                  borderRadius: '12px',
+                  borderColor: 'divider',
+                  boxShadow: '0px 2px 2px rgba(84,90,101,0.25)',
+                }}
+              >
                 <CardContent>
                   <Typography
                     variant="body2"
@@ -440,7 +486,14 @@ export default function TestDetailMetricsTab({
               md: 6,
             }}
           >
-            <Card>
+            <Card
+              variant="outlined"
+              sx={{
+                borderRadius: '12px',
+                borderColor: 'divider',
+                boxShadow: '0px 2px 2px rgba(84,90,101,0.25)',
+              }}
+            >
               <CardContent>
                 <Typography variant="body2" color="text.secondary" gutterBottom>
                   {metricsSource === MetricsSource.BEHAVIOR || !metricsSource
@@ -474,6 +527,9 @@ export default function TestDetailMetricsTab({
             <Card
               sx={{
                 mb: 3,
+                borderRadius: '12px',
+                borderColor: 'divider',
+                boxShadow: '0px 2px 2px rgba(84,90,101,0.25)',
                 ...(goalIsOverruled && {
                   borderLeft: `${theme.spacing(0.375)} solid ${theme.palette.warning.main}`,
                 }),
@@ -492,14 +548,6 @@ export default function TestDetailMetricsTab({
                     mb: 3,
                   }}
                 >
-                  <CheckCircleOutlineIcon
-                    sx={{
-                      color: goalAchievementData.isSuccessful
-                        ? 'success.main'
-                        : 'error.main',
-                      fontSize: theme.typography.body1.fontSize,
-                    }}
-                  />
                   <Typography variant="subtitle1" fontWeight={600}>
                     {goalMetricName}
                   </Typography>
@@ -796,162 +844,173 @@ export default function TestDetailMetricsTab({
         })()}
       {/* Metrics Details Table */}
       {(!isMultiTurn || hasAdditionalMultiTurnMetrics) && (
-        <TableContainer>
-          <Table>
-            <TableHead>
-              <TableRow>
-                <TableCell width={onReviewMetric ? '15%' : '15%'}>
-                  Status
-                </TableCell>
-                <TableCell width={onReviewMetric ? '28%' : '30%'}>
-                  Metric
-                </TableCell>
-                <TableCell width={onReviewMetric ? '47%' : '55%'}>
-                  Reason
-                </TableCell>
-                {onReviewMetric && <TableCell width="10%" align="right" />}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {filteredMetricsForTable.length === 0 ? (
+        <Paper
+          variant="outlined"
+          sx={{
+            borderRadius: '12px',
+            borderColor: 'divider',
+            boxShadow: '0px 2px 2px rgba(84,90,101,0.25)',
+            bgcolor: 'background.paper',
+            overflow: 'hidden',
+          }}
+        >
+          <TableContainer>
+            <Table>
+              <TableHead>
                 <TableRow>
-                  <TableCell colSpan={onReviewMetric ? 4 : 3} align="center">
-                    <Typography
-                      variant="body2"
-                      color="text.secondary"
-                      sx={{ py: 2 }}
-                    >
-                      No metrics found
-                    </Typography>
+                  <TableCell width={onReviewMetric ? '15%' : '15%'}>
+                    Status
                   </TableCell>
+                  <TableCell width={onReviewMetric ? '28%' : '30%'}>
+                    Metric
+                  </TableCell>
+                  <TableCell width={onReviewMetric ? '47%' : '55%'}>
+                    Reason
+                  </TableCell>
+                  {onReviewMetric && <TableCell width="10%" align="right" />}
                 </TableRow>
-              ) : (
-                filteredMetricsForTable.map(metric => {
-                  const metricReview = metricReviewMap.get(metric.name);
-                  const isOverruled = !!metric.fullMetricData.override;
-                  const isConfirmed = !!metricReview && !isOverruled;
+              </TableHead>
+              <TableBody>
+                {filteredMetricsForTable.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={onReviewMetric ? 4 : 3} align="center">
+                      <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={{ py: 2 }}
+                      >
+                        No metrics found
+                      </Typography>
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  filteredMetricsForTable.map(metric => {
+                    const metricReview = metricReviewMap.get(metric.name);
+                    const isOverruled = !!metric.fullMetricData.override;
+                    const isConfirmed = !!metricReview && !isOverruled;
 
-                  return (
-                    <TableRow
-                      key={`${metric.behaviorName}-${metric.name}`}
-                      sx={{
-                        '&:hover': {
-                          backgroundColor: theme.palette.action.hover,
-                        },
-                        ...(isOverruled && {
-                          borderLeft: `${theme.spacing(0.375)} solid ${theme.palette.warning.main}`,
-                        }),
-                        ...(isConfirmed && {
-                          borderLeft: `${theme.spacing(0.375)} solid ${theme.palette.success.light}`,
-                        }),
-                      }}
-                    >
-                      <TableCell>
-                        <Tooltip
-                          title={
-                            isOverruled
-                              ? `Reviewed by ${metricReview?.user?.name}: status changed to ${metricReview?.status?.name}`
-                              : isConfirmed
-                                ? `Confirmed by ${metricReview?.user?.name}`
-                                : ''
-                          }
-                          disableHoverListener={!metricReview}
-                          arrow
-                        >
-                          <Box>
-                            <StatusChip
-                              passed={metric.passed}
-                              label={metric.passed ? 'Pass' : 'Fail'}
-                              size="small"
-                              variant="filled"
-                              sx={{ minWidth: theme.spacing(10) }}
-                            />
-                          </Box>
-                        </Tooltip>
-                      </TableCell>
-                      <TableCell>
-                        <Tooltip
-                          title={metric.description || ''}
-                          arrow
-                          placement="top"
-                          enterDelay={300}
-                          leaveDelay={0}
-                          disableHoverListener={!metric.description}
-                        >
-                          <Typography
-                            variant="body2"
-                            fontWeight={500}
-                            sx={{
-                              ...(onReviewMetric && {
-                                color: theme.palette.primary.main,
-                                cursor: 'pointer',
-                                '&:hover': {
-                                  textDecoration: 'underline',
-                                },
-                              }),
-                            }}
-                            onClick={
-                              onReviewMetric
-                                ? () => onReviewMetric(metric.name)
-                                : undefined
+                    return (
+                      <TableRow
+                        key={`${metric.behaviorName}-${metric.name}`}
+                        sx={{
+                          '&:hover': {
+                            backgroundColor: theme.palette.action.hover,
+                          },
+                          ...(isOverruled && {
+                            borderLeft: `${theme.spacing(0.375)} solid ${theme.palette.warning.main}`,
+                          }),
+                          ...(isConfirmed && {
+                            borderLeft: `${theme.spacing(0.375)} solid ${theme.palette.success.light}`,
+                          }),
+                        }}
+                      >
+                        <TableCell>
+                          <Tooltip
+                            title={
+                              isOverruled
+                                ? `Reviewed by ${metricReview?.user?.name}: status changed to ${metricReview?.status?.name}`
+                                : isConfirmed
+                                  ? `Confirmed by ${metricReview?.user?.name}`
+                                  : ''
                             }
+                            disableHoverListener={!metricReview}
+                            arrow
                           >
-                            {metric.name}
-                          </Typography>
-                        </Tooltip>
-                      </TableCell>
-                      <TableCell>
-                        {metric.fullMetricData.reason ? (
-                          <Typography
-                            variant="caption"
-                            sx={{
-                              wordBreak: 'break-word',
-                            }}
-                          >
-                            {metric.fullMetricData.reason}
-                          </Typography>
-                        ) : (
-                          <Typography
-                            variant="caption"
-                            color="text.disabled"
-                            fontStyle="italic"
-                          >
-                            No reason provided
-                          </Typography>
-                        )}
-                      </TableCell>
-                      {onReviewMetric && (
-                        <TableCell align="right">
-                          <Tooltip title="Review this metric">
-                            <IconButton
-                              size="small"
-                              onClick={() => onReviewMetric(metric.name)}
-                              sx={{
-                                padding: 0.5,
-                                color: theme.palette.text.secondary,
-                                '&:hover': {
-                                  color: theme.palette.primary.main,
-                                  backgroundColor: alpha(
-                                    theme.palette.primary.main,
-                                    theme.palette.action.hoverOpacity
-                                  ),
-                                },
-                              }}
-                            >
-                              <RateReviewIcon
-                                sx={{ fontSize: theme.spacing(2) }}
+                            <Box>
+                              <StatusChip
+                                passed={metric.passed}
+                                label={metric.passed ? 'Pass' : 'Fail'}
+                                size="small"
+                                variant="filled"
+                                sx={{ minWidth: theme.spacing(10) }}
                               />
-                            </IconButton>
+                            </Box>
                           </Tooltip>
                         </TableCell>
-                      )}
-                    </TableRow>
-                  );
-                })
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
+                        <TableCell>
+                          <Tooltip
+                            title={metric.description || ''}
+                            arrow
+                            placement="top"
+                            enterDelay={300}
+                            leaveDelay={0}
+                            disableHoverListener={!metric.description}
+                          >
+                            <Typography
+                              variant="body2"
+                              fontWeight={500}
+                              sx={{
+                                ...(onReviewMetric && {
+                                  color: theme.palette.primary.main,
+                                  cursor: 'pointer',
+                                  '&:hover': {
+                                    textDecoration: 'underline',
+                                  },
+                                }),
+                              }}
+                              onClick={
+                                onReviewMetric
+                                  ? () => onReviewMetric(metric.name)
+                                  : undefined
+                              }
+                            >
+                              {metric.name}
+                            </Typography>
+                          </Tooltip>
+                        </TableCell>
+                        <TableCell>
+                          {metric.fullMetricData.reason ? (
+                            <Typography
+                              variant="caption"
+                              sx={{
+                                wordBreak: 'break-word',
+                              }}
+                            >
+                              {metric.fullMetricData.reason}
+                            </Typography>
+                          ) : (
+                            <Typography
+                              variant="caption"
+                              color="text.disabled"
+                              fontStyle="italic"
+                            >
+                              No reason provided
+                            </Typography>
+                          )}
+                        </TableCell>
+                        {onReviewMetric && (
+                          <TableCell align="right">
+                            <Tooltip title="Review this metric">
+                              <IconButton
+                                size="small"
+                                onClick={() => onReviewMetric(metric.name)}
+                                sx={{
+                                  padding: 0.5,
+                                  color: theme.palette.text.secondary,
+                                  '&:hover': {
+                                    color: theme.palette.primary.main,
+                                    backgroundColor: alpha(
+                                      theme.palette.primary.main,
+                                      theme.palette.action.hoverOpacity
+                                    ),
+                                  },
+                                }}
+                              >
+                                <RateReviewIcon
+                                  sx={{ fontSize: theme.spacing(2) }}
+                                />
+                              </IconButton>
+                            </Tooltip>
+                          </TableCell>
+                        )}
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
       )}
     </Box>
   );

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
@@ -3,7 +3,6 @@
 import React, { useMemo, useState } from 'react';
 import {
   Box,
-  Button,
   Typography,
   Paper,
   Chip,
@@ -12,15 +11,16 @@ import {
   Collapse,
   IconButton,
 } from '@mui/material';
-import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import CheckIcon from '@mui/icons-material/Check';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import TestResultTags from './TestResultTags';
 import StatusChip from '@/components/common/StatusChip';
+import ViewField from '@/components/common/ViewField';
 import FileAttachmentList from '@/components/common/FileAttachmentList';
 import { useFiles } from '@/hooks/useFiles';
 import { getEffectiveTestResultStatus } from '@/utils/test-result-status';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
 
 interface TestDetailOverviewTabProps {
   test: TestResultDetail;
@@ -58,9 +58,7 @@ const renderFormattedText = (text: string) => {
   lines.forEach((line, index) => {
     const trimmedLine = line.trim();
 
-    // Check if line starts with a dash (bullet point)
     if (trimmedLine.startsWith('- ')) {
-      // Flush current paragraph if exists
       if (currentParagraph.length > 0) {
         const paragraphKey = `p-${index}-${currentParagraph.join(' ').substring(0, 20)}`;
         elements.push(
@@ -71,7 +69,6 @@ const renderFormattedText = (text: string) => {
         currentParagraph = [];
       }
 
-      // Add bullet point with content-based key
       const bulletKey = `bullet-${index}-${trimmedLine.substring(0, 20)}`;
       elements.push(
         <Box key={bulletKey} sx={{ display: 'flex', gap: 1, mb: 0.5, pl: 2 }}>
@@ -82,10 +79,8 @@ const renderFormattedText = (text: string) => {
         </Box>
       );
     } else if (trimmedLine) {
-      // Non-empty line without dash
       currentParagraph.push(trimmedLine);
     } else if (currentParagraph.length > 0) {
-      // Empty line - flush paragraph
       const paragraphKey = `p-${index}-${currentParagraph.join(' ').substring(0, 20)}`;
       elements.push(
         <Typography key={paragraphKey} variant="body2" sx={{ mb: 1 }}>
@@ -96,7 +91,6 @@ const renderFormattedText = (text: string) => {
     }
   });
 
-  // Flush remaining paragraph
   if (currentParagraph.length > 0) {
     elements.push(
       <Typography key="p-final" variant="body2">
@@ -117,7 +111,6 @@ export default function TestDetailOverviewTab({
 }: TestDetailOverviewTabProps) {
   const theme = useTheme();
   const [evidenceExpanded, setEvidenceExpanded] = useState(false);
-  const [contextExpanded, setContextExpanded] = useState(false);
   const [metadataExpanded, setMetadataExpanded] = useState(false);
   const [filesExpanded, setFilesExpanded] = useState(false);
   const [outputFilesExpanded, setOutputFilesExpanded] = useState(false);
@@ -163,17 +156,14 @@ export default function TestDetailOverviewTab({
     );
   };
 
-  // Determine if this is a multi-turn test
   const isMultiTurn =
     testSetType?.toLowerCase().includes('multi-turn') || false;
   const expectedResponse = test.prompt_id
     ? prompts[test.prompt_id]?.expected_response
     : undefined;
 
-  // Get test configuration from test_output (multi-turn data lives here)
   const testConfig = test.test_output?.test_configuration;
 
-  // Get content based on test type
   const promptContent = useMemo(() => {
     if (isMultiTurn) {
       return testConfig?.goal || 'No goal available';
@@ -207,194 +197,116 @@ export default function TestDetailOverviewTab({
     }
   }, [testStatus]);
 
-  // Render for Single-turn tests (original simple design)
+  // Shared status header used in both branches
+  const statusHeader = (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 3 }}>
+      <Typography variant="body2" color="text.secondary">
+        Status
+      </Typography>
+      <StatusChip
+        status={testStatus}
+        label={testLabel}
+        size="small"
+        variant="outlined"
+      />
+      {test.last_review && (
+        <Chip
+          icon={<CheckIcon sx={{ fontSize: 16 }} />}
+          label="Confirmed"
+          size="small"
+          color="success"
+          variant="filled"
+          sx={{ fontWeight: 600 }}
+        />
+      )}
+    </Box>
+  );
+
+  // Shared card styling matching Figma "Data Output Textfield" card
+  const cardSx = {
+    p: '30px',
+    borderRadius: BORDER_RADIUS.md,
+    boxShadow: ELEVATION.xs,
+    mb: 3,
+  };
+
+  // Single-turn render
   if (!isMultiTurn) {
+    const contextItems =
+      test.test_output?.context?.filter(item => item.trim()) ?? [];
+
     return (
       <Box sx={{ p: 3 }}>
-        {/* Overall Status */}
-        <Box sx={{ mb: 3 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
-            <Typography variant="h6" fontWeight={600}>
-              Test Result
-            </Typography>
-            <StatusChip
-              status={testStatus}
-              label={testLabel}
-              size="medium"
-              variant="filled"
-              sx={{ fontWeight: 600 }}
-            />
-            {/* Show Review Confirmed indicator if review exists */}
-            {test.last_review && (
-              <Chip
-                icon={<CheckIcon sx={{ fontSize: 16 }} />}
-                label="Confirmed"
-                size="medium"
-                color="success"
-                variant="filled"
-                sx={{
-                  fontWeight: 600,
-                }}
-              />
-            )}
-            <Box sx={{ flexGrow: 1 }} />
-            {test.test_id && (
-              <Button
-                size="small"
-                href={`/tests/${test.test_id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                sx={{
-                  borderRadius: theme.shape.borderRadius,
-                  backgroundColor: 'background.paper',
-                  color: 'text.secondary',
-                  border: '1px solid',
-                  borderColor: 'divider',
-                  px: 2,
-                  py: 0.5,
-                  '&:hover': {
-                    backgroundColor: 'action.hover',
-                    color: 'text.primary',
-                    borderColor: 'primary.main',
-                  },
-                }}
-                endIcon={
-                  <ArrowOutwardIcon sx={{ fontSize: theme.iconSizes.small }} />
-                }
-              >
-                Go to Test
-              </Button>
-            )}
-          </Box>
-        </Box>
+        {statusHeader}
 
-        {/* Prompt Section */}
-        <Box sx={{ mb: 3 }}>
-          <Typography variant="subtitle2" fontWeight={600} gutterBottom>
-            Prompt
-          </Typography>
-          <Paper
-            variant="outlined"
-            sx={{
-              p: 2,
-              backgroundColor: theme.palette.background.default,
-              maxHeight: 200,
-              overflow: 'auto',
-            }}
-          >
-            {renderTextContent(promptContent)}
-          </Paper>
-        </Box>
-
-        {/* Response Section */}
-        <Box sx={{ mb: 3 }}>
-          <Typography variant="subtitle2" fontWeight={600} gutterBottom>
-            Response
-          </Typography>
-          <Paper
-            variant="outlined"
-            sx={{
-              p: 2,
-              backgroundColor: theme.palette.background.default,
-              maxHeight: 200,
-              overflow: 'auto',
-            }}
-          >
-            {renderTextContent(responseContent)}
-          </Paper>
-        </Box>
-
-        {/* Expected Response Section */}
-        <Box sx={{ mb: 3 }}>
-          <Typography variant="subtitle2" fontWeight={600} gutterBottom>
-            Expected Response
-          </Typography>
-          <Paper
-            variant="outlined"
-            sx={{
-              p: 2,
-              backgroundColor: theme.palette.background.default,
-              maxHeight: 200,
-              overflow: 'auto',
-            }}
-          >
-            {expectedResponse ? (
-              renderTextContent(expectedResponse)
-            ) : (
-              <Typography
-                variant="body2"
-                sx={{ color: 'text.secondary', fontStyle: 'italic' }}
-              >
-                No expected response provided
-              </Typography>
-            )}
-          </Paper>
-        </Box>
-
-        {/* Context Section (collapsible) */}
-        {test.test_output?.context &&
-          test.test_output.context.filter(item => item.trim()).length > 0 && (
-            <Box sx={{ mb: 3 }}>
-              <Box
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 0.5,
-                  cursor: 'pointer',
-                  mb: 1,
-                  '&:hover': { opacity: 0.7 },
-                }}
-                onClick={() => setContextExpanded(!contextExpanded)}
-              >
-                <Typography variant="subtitle2" fontWeight={600}>
-                  Context (
-                  {test.test_output.context.filter(item => item.trim()).length})
-                </Typography>
-                <IconButton
-                  size="small"
-                  sx={{
-                    padding: 0,
-                    transform: contextExpanded
-                      ? 'rotate(180deg)'
-                      : 'rotate(0deg)',
-                    transition: 'transform 0.2s',
-                  }}
-                >
-                  <ExpandMoreIcon sx={{ fontSize: 18 }} />
-                </IconButton>
+        <Paper variant="outlined" sx={cardSx}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+            {/* Prompt — full width */}
+            <ViewField label="Prompt" multiline>
+              <Box sx={{ maxHeight: 200, overflow: 'auto' }}>
+                {renderTextContent(promptContent)}
               </Box>
-              <Collapse in={contextExpanded} timeout="auto" unmountOnExit>
-                <Paper
-                  variant="outlined"
-                  sx={{
-                    p: 2,
-                    backgroundColor: theme.palette.background.default,
-                    maxHeight: 200,
-                    overflow: 'auto',
-                  }}
-                >
-                  {test.test_output.context
-                    .filter(item => item.trim())
-                    .map((item, index, filteredArray) => {
-                      const contextKey = `context-${item.slice(0, 30).replace(/\s+/g, '-')}`;
-                      return (
-                        <Box
-                          key={contextKey}
-                          sx={{
-                            display: 'flex',
-                            gap: 1,
-                            mb: index < filteredArray.length - 1 ? 0.5 : 0,
-                          }}
-                        >
-                          <Typography variant="body2">•</Typography>
-                          <Box sx={{ flex: 1 }}>{renderTextContent(item)}</Box>
-                        </Box>
-                      );
-                    })}
-                </Paper>
-              </Collapse>
+            </ViewField>
+
+            {/* Response + Expected Response — side by side */}
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              <Box sx={{ flex: 1 }}>
+                <ViewField label="Response" multiline>
+                  <Box sx={{ maxHeight: 200, overflow: 'auto' }}>
+                    {renderTextContent(responseContent)}
+                  </Box>
+                </ViewField>
+              </Box>
+              <Box sx={{ flex: 1 }}>
+                <ViewField label="Expected Response" multiline>
+                  <Box sx={{ maxHeight: 200, overflow: 'auto' }}>
+                    {expectedResponse ? (
+                      renderTextContent(expectedResponse)
+                    ) : (
+                      <Typography
+                        variant="body2"
+                        sx={{ color: 'text.secondary', fontStyle: 'italic' }}
+                      >
+                        No expected response provided
+                      </Typography>
+                    )}
+                  </Box>
+                </ViewField>
+              </Box>
             </Box>
-          )}
+
+            {/* Context — always expanded when present */}
+            {contextItems.length > 0 && (
+              <ViewField label={`Context (${contextItems.length})`} multiline>
+                <Box sx={{ maxHeight: 200, overflow: 'auto' }}>
+                  {contextItems.map((item, index, arr) => {
+                    const contextKey = `context-${item.slice(0, 30).replace(/\s+/g, '-')}`;
+                    return (
+                      <Box
+                        key={contextKey}
+                        sx={{
+                          display: 'flex',
+                          gap: 1,
+                          mb: index < arr.length - 1 ? 0.5 : 0,
+                        }}
+                      >
+                        <Typography variant="body2">•</Typography>
+                        <Box sx={{ flex: 1 }}>{renderTextContent(item)}</Box>
+                      </Box>
+                    );
+                  })}
+                </Box>
+              </ViewField>
+            )}
+
+            {/* Tags */}
+            <TestResultTags
+              sessionToken={sessionToken}
+              testResult={test}
+              onUpdate={onTestResultUpdate}
+            />
+          </Box>
+        </Paper>
 
         {/* Metadata Section (collapsible) */}
         {test.test_output?.metadata &&
@@ -531,244 +443,156 @@ export default function TestDetailOverviewTab({
             </Collapse>
           </Box>
         )}
+      </Box>
+    );
+  }
 
-        {/* Tags Section */}
-        <Box sx={{ mb: 3 }}>
+  // Multi-turn render
+  return (
+    <Box sx={{ p: 3 }}>
+      {statusHeader}
+
+      <Paper variant="outlined" sx={cardSx}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 5 }}>
+          {/* Goal */}
+          <ViewField label="Goal" multiline>
+            <Box sx={{ maxHeight: 200, overflow: 'auto' }}>
+              <Typography
+                variant="body2"
+                sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+              >
+                {promptContent}
+              </Typography>
+            </Box>
+          </ViewField>
+
+          {/* Instructions */}
+          {testConfig?.instructions && (
+            <ViewField label="Instructions" multiline>
+              <Box sx={{ maxHeight: 200, overflow: 'auto' }}>
+                {renderFormattedText(testConfig.instructions)}
+              </Box>
+            </ViewField>
+          )}
+
+          {/* Restrictions */}
+          {testConfig?.restrictions && (
+            <ViewField label="Restrictions" multiline>
+              <Box sx={{ maxHeight: 200, overflow: 'auto' }}>
+                {renderFormattedText(testConfig.restrictions)}
+              </Box>
+            </ViewField>
+          )}
+
+          {/* Scenario */}
+          {testConfig?.scenario && (
+            <ViewField label="Scenario" multiline>
+              <Box sx={{ maxHeight: 200, overflow: 'auto' }}>
+                {renderFormattedText(testConfig.scenario)}
+              </Box>
+            </ViewField>
+          )}
+
+          {/* Reasoning & Evidence */}
+          {test.test_output?.goal_evaluation?.reason && (
+            <Box>
+              <ViewField label="Reasoning" multiline>
+                <Box sx={{ maxHeight: 200, overflow: 'auto' }}>
+                  <Typography
+                    variant="body2"
+                    sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+                  >
+                    {test.test_output.goal_evaluation.reason}
+                  </Typography>
+                </Box>
+              </ViewField>
+
+              {/* Evidence — collapsible */}
+              {test.test_output?.goal_evaluation?.evidence &&
+                test.test_output.goal_evaluation.evidence.length > 0 && (
+                  <Box sx={{ mt: 1.5 }}>
+                    <Divider sx={{ mb: 1.5 }} />
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 0.5,
+                        cursor: 'pointer',
+                        '&:hover': { opacity: 0.7 },
+                      }}
+                      onClick={() => setEvidenceExpanded(!evidenceExpanded)}
+                    >
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: 'text.secondary',
+                          fontWeight: 600,
+                          textTransform: 'uppercase',
+                          letterSpacing: 0.5,
+                        }}
+                      >
+                        {evidenceExpanded ? 'Hide' : 'Show'} Evidence (
+                        {test.test_output.goal_evaluation.evidence.length})
+                      </Typography>
+                      <IconButton
+                        size="small"
+                        sx={{
+                          padding: 0,
+                          transform: evidenceExpanded
+                            ? 'rotate(180deg)'
+                            : 'rotate(0deg)',
+                          transition: 'transform 0.2s',
+                        }}
+                      >
+                        <ExpandMoreIcon sx={{ fontSize: 16 }} />
+                      </IconButton>
+                    </Box>
+
+                    <Collapse
+                      in={evidenceExpanded}
+                      timeout="auto"
+                      unmountOnExit
+                    >
+                      <Box sx={{ mt: 1, pl: 2 }}>
+                        {test.test_output.goal_evaluation.evidence.map(
+                          (item, index) => {
+                            const evidenceKey = `evidence-${index}-${item.substring(0, 30).replace(/\s+/g, '-')}`;
+                            return (
+                              <Box
+                                key={evidenceKey}
+                                sx={{ display: 'flex', gap: 1, mb: 0.5 }}
+                              >
+                                <Typography
+                                  variant="body2"
+                                  sx={{ color: 'text.secondary' }}
+                                >
+                                  •
+                                </Typography>
+                                <Typography
+                                  variant="body2"
+                                  sx={{ color: 'text.secondary', flex: 1 }}
+                                >
+                                  {item}
+                                </Typography>
+                              </Box>
+                            );
+                          }
+                        )}
+                      </Box>
+                    </Collapse>
+                  </Box>
+                )}
+            </Box>
+          )}
+
+          {/* Tags */}
           <TestResultTags
             sessionToken={sessionToken}
             testResult={test}
             onUpdate={onTestResultUpdate}
           />
         </Box>
-      </Box>
-    );
-  }
-
-  // Render for Multi-turn tests (structured design)
-  return (
-    <Box sx={{ p: 3 }}>
-      {/* Test Result Section */}
-      <Box sx={{ mb: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 2 }}>
-          <Typography variant="subtitle2" fontWeight={600}>
-            Test Result
-          </Typography>
-          <StatusChip
-            status={testStatus}
-            label={testLabel}
-            size="medium"
-            variant="filled"
-            sx={{ fontWeight: 600 }}
-          />
-          {/* Show Review Confirmed indicator if review exists */}
-          {test.last_review && (
-            <Chip
-              icon={<CheckIcon sx={{ fontSize: 16 }} />}
-              label="Confirmed"
-              size="medium"
-              color="success"
-              variant="filled"
-              sx={{
-                fontWeight: 600,
-              }}
-            />
-          )}
-        </Box>
-
-        {/* Reasoning and Evidence */}
-        {test.test_output?.goal_evaluation?.reason && (
-          <Paper
-            variant="outlined"
-            sx={{
-              p: 2,
-              backgroundColor: theme.palette.background.default,
-              mb: 2,
-            }}
-          >
-            <Typography
-              variant="body2"
-              sx={{
-                whiteSpace: 'pre-wrap',
-                wordBreak: 'break-word',
-                mb: test.test_output?.goal_evaluation?.evidence ? 1.5 : 0,
-              }}
-            >
-              {test.test_output.goal_evaluation.reason}
-            </Typography>
-
-            {/* Evidence - Collapsible */}
-            {test.test_output?.goal_evaluation?.evidence &&
-              test.test_output.goal_evaluation.evidence.length > 0 && (
-                <Box>
-                  <Divider sx={{ mb: 1.5 }} />
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 0.5,
-                      cursor: 'pointer',
-                      '&:hover': { opacity: 0.7 },
-                    }}
-                    onClick={() => setEvidenceExpanded(!evidenceExpanded)}
-                  >
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        color: 'text.secondary',
-                        fontWeight: 600,
-                        textTransform: 'uppercase',
-                        letterSpacing: 0.5,
-                      }}
-                    >
-                      {evidenceExpanded ? 'Hide' : 'Show'} Evidence (
-                      {test.test_output.goal_evaluation.evidence.length})
-                    </Typography>
-                    <IconButton
-                      size="small"
-                      sx={{
-                        padding: 0,
-                        transform: evidenceExpanded
-                          ? 'rotate(180deg)'
-                          : 'rotate(0deg)',
-                        transition: 'transform 0.2s',
-                      }}
-                    >
-                      <ExpandMoreIcon sx={{ fontSize: 16 }} />
-                    </IconButton>
-                  </Box>
-
-                  <Collapse in={evidenceExpanded} timeout="auto" unmountOnExit>
-                    <Box sx={{ mt: 1, pl: 2 }}>
-                      {test.test_output.goal_evaluation.evidence.map(
-                        (item, index) => {
-                          // Create stable key from evidence content
-                          const evidenceKey = `evidence-${index}-${item.substring(0, 30).replace(/\s+/g, '-')}`;
-                          return (
-                            <Box
-                              key={evidenceKey}
-                              sx={{
-                                display: 'flex',
-                                gap: 1,
-                                mb: 0.5,
-                              }}
-                            >
-                              <Typography
-                                variant="body2"
-                                sx={{
-                                  color: 'text.secondary',
-                                }}
-                              >
-                                •
-                              </Typography>
-                              <Typography
-                                variant="body2"
-                                sx={{
-                                  color: 'text.secondary',
-                                  flex: 1,
-                                }}
-                              >
-                                {item}
-                              </Typography>
-                            </Box>
-                          );
-                        }
-                      )}
-                    </Box>
-                  </Collapse>
-                </Box>
-              )}
-          </Paper>
-        )}
-      </Box>
-
-      {/* Divider */}
-      <Divider sx={{ mb: 3 }} />
-
-      {/* Goal Section */}
-      <Box sx={{ mb: 3 }}>
-        <Typography variant="subtitle2" fontWeight={600} gutterBottom>
-          Goal
-        </Typography>
-        <Paper
-          variant="outlined"
-          sx={{
-            p: 2,
-            backgroundColor: theme.palette.background.default,
-            maxHeight: 200,
-            overflow: 'auto',
-          }}
-        >
-          <Typography
-            variant="body2"
-            sx={{
-              whiteSpace: 'pre-wrap',
-              wordBreak: 'break-word',
-            }}
-          >
-            {promptContent}
-          </Typography>
-        </Paper>
-      </Box>
-
-      {/* Instructions */}
-      {testConfig?.instructions && (
-        <Box sx={{ mb: 3 }}>
-          <Typography variant="subtitle2" fontWeight={600} gutterBottom>
-            Instructions
-          </Typography>
-          <Paper
-            variant="outlined"
-            sx={{
-              p: 2,
-              backgroundColor: theme.palette.background.default,
-              maxHeight: 200,
-              overflow: 'auto',
-            }}
-          >
-            {renderFormattedText(testConfig.instructions)}
-          </Paper>
-        </Box>
-      )}
-
-      {/* Restrictions */}
-      {testConfig?.restrictions && (
-        <Box sx={{ mb: 3 }}>
-          <Typography variant="subtitle2" fontWeight={600} gutterBottom>
-            Restrictions
-          </Typography>
-          <Paper
-            variant="outlined"
-            sx={{
-              p: 2,
-              backgroundColor: theme.palette.background.default,
-              maxHeight: 200,
-              overflow: 'auto',
-            }}
-          >
-            {renderFormattedText(testConfig.restrictions)}
-          </Paper>
-        </Box>
-      )}
-
-      {/* Scenario */}
-      {testConfig?.scenario && (
-        <Box sx={{ mb: 3 }}>
-          <Typography variant="subtitle2" fontWeight={600} gutterBottom>
-            Scenario
-          </Typography>
-          <Paper
-            variant="outlined"
-            sx={{
-              p: 2,
-              backgroundColor: theme.palette.background.default,
-              maxHeight: 200,
-              overflow: 'auto',
-            }}
-          >
-            {renderFormattedText(testConfig.scenario)}
-          </Paper>
-        </Box>
-      )}
+      </Paper>
 
       {/* Files Section (collapsible) */}
       {(testFilesLoading || testFiles.length > 0) && (
@@ -847,15 +671,6 @@ export default function TestDetailOverviewTab({
           </Collapse>
         </Box>
       )}
-
-      {/* Tags Section */}
-      <Box sx={{ mb: 3 }}>
-        <TestResultTags
-          sessionToken={sessionToken}
-          testResult={test}
-          onUpdate={onTestResultUpdate}
-        />
-      </Box>
     </Box>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailPanel.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailPanel.tsx
@@ -453,7 +453,6 @@ export default function TestDetailPanel({
             currentUserId={currentUserId}
             currentUserName={currentUserName}
             currentUserPicture={currentUserPicture}
-            elevation={0}
             additionalMetadata={{ test_run_id: testRunId }}
           />
         </TabPanel>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailReviewsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailReviewsTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import {
   Box,
   Typography,
@@ -8,43 +8,31 @@ import {
   Chip,
   Avatar,
   Stack,
-  Divider,
-  Alert,
-  useTheme,
   Button,
-  ToggleButton,
-  ToggleButtonGroup,
-  Collapse,
   IconButton,
   Tooltip,
+  useTheme,
 } from '@mui/material';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
-import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
+import { formatDistanceToNow } from 'date-fns';
 import {
   TestResultDetail,
   Review,
-  REVIEW_TARGET_TYPES,
-  REVIEW_TARGET_LABELS,
 } from '@/utils/api-client/interfaces/test-results';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { Status } from '@/utils/api-client/interfaces/status';
 import { alpha } from '@mui/material/styles';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import StatusChip from '@/components/common/StatusChip';
+import { isPassedStatusName } from '@/utils/test-result-status';
 import {
-  findStatusByCategory,
-  isPassedStatusName,
-} from '@/utils/test-result-status';
-import TrackChangesIcon from '@mui/icons-material/TrackChanges';
-import MentionTextInput, {
   MentionOption,
   renderMentionText,
-  inferReviewTarget,
 } from '@/components/common/MentionTextInput';
+import ReviewJudgementDrawer from './ReviewJudgementDrawer';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 
 interface TestDetailReviewsTabProps {
   test: TestResultDetail;
@@ -71,106 +59,45 @@ export default function TestDetailReviewsTab({
 }: TestDetailReviewsTabProps) {
   const theme = useTheme();
 
-  // Review creation state
-  const [showReviewForm, setShowReviewForm] = useState(false);
-  const [newStatus, setNewStatus] = useState<'passed' | 'failed'>('passed');
-  const [reason, setReason] = useState('');
-  const [error, setError] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-  const [statuses, setStatuses] = useState<Status[]>([]);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [showOthers, setShowOthers] = useState(false);
+
+  // Stable capture of initial comment for the drawer (survives parent reset)
+  const pendingCommentRef = useRef<{
+    comment: string;
+    status?: 'passed' | 'failed';
+  } | null>(null);
 
   // Delete confirmation state
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [reviewToDelete, setReviewToDelete] = useState<Review | null>(null);
   const [deleting, setDeleting] = useState(false);
 
-  // Handle initial comment and status from turn review
+  // Open the create drawer when a pre-filled comment arrives (e.g. from turn review)
   useEffect(() => {
     if (initialComment) {
-      setReason(initialComment);
-      setShowReviewForm(true);
-      if (initialStatus) {
-        setNewStatus(initialStatus);
-      }
+      pendingCommentRef.current = {
+        comment: initialComment,
+        status: initialStatus,
+      };
+      setCreateOpen(true);
       onCommentUsed?.();
     }
   }, [initialComment, initialStatus, onCommentUsed]);
 
-  // Fetch available statuses
-  useEffect(() => {
-    const fetchStatuses = async () => {
-      try {
-        const clientFactory = new ApiClientFactory(sessionToken);
-        const statusClient = clientFactory.getStatusClient();
-        const statusList = await statusClient.getStatuses({
-          entity_type: 'TestResult',
-        });
-        setStatuses(statusList);
-      } catch (err) {
-        console.error('Failed to fetch statuses:', err);
-      }
-    };
-
-    if (showReviewForm) {
-      fetchStatuses();
-    }
-  }, [sessionToken, showReviewForm]);
-
-  // Handle review submission
-  const handleSubmitReview = async () => {
-    if (!reason.trim()) {
-      setError('Please provide a reason for your review.');
-      return;
-    }
-
-    // Find the appropriate status using centralized utility
-    const targetStatus = findStatusByCategory(
-      statuses,
-      newStatus === 'passed' ? 'passed' : 'failed'
-    );
-
-    if (!targetStatus) {
-      setError('Could not find appropriate status. Please try again.');
-      return;
-    }
-
-    try {
-      setSubmitting(true);
-      setError('');
-
-      // Create the review via API
-      const clientFactory = new ApiClientFactory(sessionToken);
-      const testResultsClient = clientFactory.getTestResultsClient();
-
-      const reviewTarget = inferReviewTarget(reason);
-      await testResultsClient.createReview(
-        test.id,
-        targetStatus.id,
-        reason.trim(),
-        reviewTarget
-      );
-
-      // Refresh the test result to get updated reviews
-      const updatedTest = await testResultsClient.getTestResult(test.id);
-      onTestResultUpdate(updatedTest);
-
-      // Reset form
-      setReason('');
-      setShowReviewForm(false);
-    } catch (_err) {
-      setError('Failed to save review. Please try again.');
-    } finally {
-      setSubmitting(false);
-    }
+  const handleCloseCreateDrawer = () => {
+    pendingCommentRef.current = null;
+    setCreateOpen(false);
   };
 
-  const handleCancelReview = () => {
-    setReason('');
-    setError('');
-    setShowReviewForm(false);
+  const handleReviewSaved = async (testId: string) => {
+    const clientFactory = new ApiClientFactory(sessionToken);
+    const testResultsClient = clientFactory.getTestResultsClient();
+    const updatedTest = await testResultsClient.getTestResult(testId);
+    onTestResultUpdate(updatedTest);
   };
 
-  // Handle delete review
+  // Delete handlers
   const handleDeleteReview = (review: Review) => {
     setReviewToDelete(review);
     setDeleteDialogOpen(true);
@@ -178,25 +105,17 @@ export default function TestDetailReviewsTab({
 
   const handleConfirmDelete = async () => {
     if (!reviewToDelete) return;
-
     try {
       setDeleting(true);
-
-      // Delete the review via API
       const clientFactory = new ApiClientFactory(sessionToken);
       const testResultsClient = clientFactory.getTestResultsClient();
-
       await testResultsClient.deleteReview(test.id, reviewToDelete.review_id);
-
-      // Refresh the test result to get updated reviews
       const updatedTest = await testResultsClient.getTestResult(test.id);
       onTestResultUpdate(updatedTest);
-
-      // Close dialog
       setDeleteDialogOpen(false);
       setReviewToDelete(null);
     } catch (_err) {
-      // Could add error handling here
+      // Silently fail; no error state change to avoid breaking the delete flow
     } finally {
       setDeleting(false);
     }
@@ -207,8 +126,8 @@ export default function TestDetailReviewsTab({
     setReviewToDelete(null);
   };
 
-  // Calculate automated status for comparison
-  const getAutomatedStatus = () => {
+  // Automated status computation
+  const automatedStatus = useMemo(() => {
     const metrics = test.test_metrics?.metrics || {};
     const metricValues = Object.values(metrics);
     const totalMetrics = metricValues.length;
@@ -221,500 +140,365 @@ export default function TestDetailReviewsTab({
           : 'Failed',
       count: `${passedMetrics}/${totalMetrics}`,
     };
-  };
+  }, [test]);
 
-  const automatedStatus = getAutomatedStatus();
-  const hasReviews =
-    test.test_reviews?.reviews && test.test_reviews.reviews.length > 0;
   const lastReview = test.last_review;
 
-  // Calculate conflict ourselves (don't trust backend's matches_review)
-  // A conflict exists if the review decision differs from the automated decision
-  let hasConflict = false;
-  if (lastReview && lastReview.status?.name) {
-    const reviewPassed = isPassedStatusName(lastReview.status.name);
-    hasConflict = reviewPassed !== automatedStatus.passed;
-  }
+  // Conflict: human review disagrees with automated
+  const hasConflict = useMemo(() => {
+    if (!lastReview?.status?.name) return false;
+    return (
+      isPassedStatusName(lastReview.status.name) !== automatedStatus.passed
+    );
+  }, [lastReview, automatedStatus]);
 
-  // Format date helper
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    if (isNaN(date.getTime())) return 'N/A';
-    return date.toLocaleString();
-  };
-
-  // Get review status with normalized display label
   const getReviewStatusDisplay = (
     statusName: string
-  ): {
-    passed: boolean;
-    label: string;
-  } => {
+  ): { passed: boolean; label: string } => {
     const isPassed = isPassedStatusName(statusName);
     const name = statusName.toLowerCase();
-
     let label = statusName;
-    if (name === 'fail') {
-      label = 'Failed';
-    } else if (name === 'pass') {
-      label = 'Passed';
-    }
-
-    return {
-      passed: isPassed,
-      label,
-    };
+    if (name === 'fail') label = 'Failed';
+    else if (name === 'pass') label = 'Passed';
+    return { passed: isPassed, label };
   };
 
+  const formatRelativeTime = (dateString: string) => {
+    try {
+      return formatDistanceToNow(new Date(dateString), {
+        addSuffix: true,
+      }).toUpperCase();
+    } catch {
+      return 'N/A';
+    }
+  };
+
+  // Split reviews: mine vs others
+  const allReviews = useMemo(
+    () => test.test_reviews?.reviews ?? [],
+    [test.test_reviews]
+  );
+
+  const sortedReviews = useMemo(
+    () =>
+      [...allReviews].sort(
+        (a, b) =>
+          new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+      ),
+    [allReviews]
+  );
+
+  const myReviews = useMemo(
+    () => sortedReviews.filter(r => String(r.user.user_id) === currentUserId),
+    [sortedReviews, currentUserId]
+  );
+
+  const otherReviews = useMemo(
+    () => sortedReviews.filter(r => String(r.user.user_id) !== currentUserId),
+    [sortedReviews, currentUserId]
+  );
+
+  // Once the user has their own review, always show all reviews automatically.
+  // The showOthers toggle only matters before the user has reviewed.
+  const visibleReviews =
+    myReviews.length > 0 || showOthers ? sortedReviews : myReviews;
+
+  const noReviewsAtAll = allReviews.length === 0;
+  const myReviewsEmpty = myReviews.length === 0;
+
   return (
-    <Box sx={{ p: 3 }}>
-      {/* Status Overview */}
-      <Box sx={{ mb: 3 }}>
-        <Typography variant="h6" fontWeight={600} gutterBottom>
-          Test Result
-        </Typography>
-
-        {/* Automated vs Review Status Comparison */}
-        <Paper
-          variant="outlined"
-          sx={{
-            p: 2,
-            backgroundColor: hasConflict
-              ? alpha(
-                  theme.palette.warning.main,
-                  theme.palette.action.hoverOpacity
-                )
-              : theme.palette.background.default,
-            border: hasConflict
-              ? `1px solid ${theme.palette.warning.light}`
-              : undefined,
-          }}
-        >
-          <Stack spacing={2}>
-            {/* Automated Status */}
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-              <Typography
-                variant="body2"
-                fontWeight={600}
-                sx={{ minWidth: 120 }}
-              >
-                Automated:
-              </Typography>
-              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                <StatusChip
-                  passed={automatedStatus.passed}
-                  label={`${automatedStatus.label} ${automatedStatus.count}`}
-                  size="small"
-                  variant="outlined"
-                />
-              </Box>
-            </Box>
-
-            {/* Review Status */}
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-              <Typography
-                variant="body2"
-                fontWeight={600}
-                sx={{ minWidth: 120 }}
-              >
-                Human Review:
-              </Typography>
-              {lastReview ? (
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  {(() => {
-                    const display = getReviewStatusDisplay(
-                      lastReview.status.name
-                    );
-                    return (
-                      <>
-                        <StatusChip
-                          passed={display.passed}
-                          label={display.label}
-                          size="small"
-                          variant="outlined"
-                        />
-                        {hasConflict && (
-                          <Chip
-                            icon={
-                              <WarningAmberIcon
-                                sx={{ fontSize: 'caption.fontSize' }}
-                              />
-                            }
-                            label="Conflict"
-                            size="small"
-                            color="warning"
-                            variant="filled"
-                            sx={{ ml: 1 }}
-                          />
-                        )}
-                      </>
-                    );
-                  })()}
-                </Box>
-              ) : (
-                <Chip
-                  label="No Review"
-                  size="small"
-                  color="default"
-                  variant="outlined"
-                />
-              )}
-            </Box>
-          </Stack>
-        </Paper>
-
-        {/* Conflict Alert */}
-        {hasConflict && (
-          <Alert severity="warning" icon={<WarningAmberIcon />} sx={{ mt: 2 }}>
-            <Typography variant="body2">
-              <strong>Status Conflict Detected:</strong> The human review status
-              differs from the automated test result. This indicates the
-              reviewer disagreed with the automation.
-            </Typography>
-          </Alert>
-        )}
-      </Box>
-
-      <Divider sx={{ my: 3 }} />
-
-      {/* Reviews History */}
-      <Box>
-        <Typography variant="h6" fontWeight={600} gutterBottom>
-          Review History
-        </Typography>
-
-        {hasReviews && test.test_reviews?.reviews ? (
-          <Stack spacing={2}>
-            {test.test_reviews.reviews
-              .sort(
-                (a, b) =>
-                  new Date(b.updated_at).getTime() -
-                  new Date(a.updated_at).getTime()
-              )
-              .map((review, index) => {
-                const isLatest = index === 0;
-                const display = getReviewStatusDisplay(review.status.name);
-
-                return (
-                  <Paper
-                    key={review.review_id}
-                    variant="outlined"
-                    sx={{
-                      p: 2,
-                      backgroundColor: isLatest
-                        ? alpha(
-                            theme.palette.primary.main,
-                            theme.palette.action.hoverOpacity
-                          )
-                        : theme.palette.background.default,
-                      border: isLatest
-                        ? `1px solid ${theme.palette.primary.light}`
-                        : undefined,
-                    }}
-                  >
-                    <Stack spacing={2}>
-                      {/* Review Header */}
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'space-between',
-                        }}
-                      >
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 2 }}
-                        >
-                          <Avatar
-                            sx={{
-                              width: theme.spacing(4),
-                              height: theme.spacing(4),
-                              fontSize: 'caption.fontSize',
-                            }}
-                          >
-                            {review.user.name.charAt(0).toUpperCase()}
-                          </Avatar>
-                          <Box>
-                            <Typography variant="body2" fontWeight={600}>
-                              {review.user.name}
-                            </Typography>
-                            <Typography
-                              variant="caption"
-                              color="text.secondary"
-                            >
-                              {formatDate(review.updated_at)}
-                            </Typography>
-                          </Box>
-                        </Box>
-
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                        >
-                          {isLatest && (
-                            <Chip
-                              label="Latest"
-                              size="small"
-                              color="primary"
-                              variant="filled"
-                              sx={{ mr: 1 }}
-                            />
-                          )}
-                          <StatusChip
-                            passed={display.passed}
-                            label={display.label}
-                            size="small"
-                            variant="outlined"
-                          />
-                          {/* Delete button - only show for review owner */}
-                          {review.user.user_id === currentUserId && (
-                            <Tooltip title="Delete review">
-                              <IconButton
-                                size="small"
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  handleDeleteReview(review);
-                                }}
-                                sx={{
-                                  ml: 0.5,
-                                  '&:hover': {
-                                    backgroundColor: alpha(
-                                      theme.palette.error.main,
-                                      theme.palette.action.focusOpacity
-                                    ),
-                                    color: theme.palette.error.main,
-                                  },
-                                }}
-                              >
-                                <DeleteOutlineIcon
-                                  sx={{ fontSize: 'body2.fontSize' }}
-                                />
-                              </IconButton>
-                            </Tooltip>
-                          )}
-                        </Box>
-                      </Box>
-
-                      {/* Review Content */}
-                      <Box>
-                        <Typography variant="body2" sx={{ mb: 1 }}>
-                          <strong>Comments:</strong>
-                        </Typography>
-                        <Paper
-                          variant="outlined"
-                          sx={{
-                            p: 1.5,
-                            backgroundColor: theme.palette.background.paper,
-                          }}
-                        >
-                          <Typography
-                            variant="body2"
-                            sx={{
-                              whiteSpace: 'pre-wrap',
-                              wordBreak: 'break-word',
-                            }}
-                          >
-                            {renderMentionText(
-                              review.comments,
-                              {
-                                user: theme.palette.success.main,
-                                metric: theme.palette.secondary.main,
-                                turn: theme.palette.info.main,
-                              },
-                              {
-                                user: alpha(
-                                  theme.palette.success.main,
-                                  theme.palette.action.disabledOpacity
-                                ),
-                                metric: alpha(
-                                  theme.palette.secondary.main,
-                                  theme.palette.action.disabledOpacity
-                                ),
-                                turn: alpha(
-                                  theme.palette.info.main,
-                                  theme.palette.action.disabledOpacity
-                                ),
-                              }
-                            )}
-                          </Typography>
-                        </Paper>
-                      </Box>
-
-                      {/* Review Metadata */}
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          gap: 2,
-                          flexWrap: 'wrap',
-                          alignItems: 'center',
-                        }}
-                      >
-                        <Chip
-                          icon={<TrackChangesIcon />}
-                          label={
-                            REVIEW_TARGET_LABELS[
-                              review.target
-                                ?.type as keyof typeof REVIEW_TARGET_LABELS
-                            ] ??
-                            REVIEW_TARGET_LABELS[
-                              REVIEW_TARGET_TYPES.TEST_RESULT
-                            ]
-                          }
-                          size="small"
-                          variant="outlined"
-                          color={
-                            review.target?.type === REVIEW_TARGET_TYPES.METRIC
-                              ? 'secondary'
-                              : review.target?.type === REVIEW_TARGET_TYPES.TURN
-                                ? 'info'
-                                : 'default'
-                          }
-                        />
-                        {review.created_at !== review.updated_at && (
-                          <Chip
-                            label="Edited"
-                            size="small"
-                            variant="outlined"
-                            color="info"
-                          />
-                        )}
-                      </Box>
-                    </Stack>
-                  </Paper>
-                );
-              })}
-          </Stack>
-        ) : (
-          <Paper
+    <Box sx={{ p: 3, display: 'flex', flexDirection: 'column', gap: 2 }}>
+      {/* Metadata row */}
+      <Box
+        sx={{ display: 'flex', alignItems: 'center', gap: 3, flexWrap: 'wrap' }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2" color="text.primary">
+            Automated:
+          </Typography>
+          <StatusChip
+            passed={automatedStatus.passed}
+            label={`${automatedStatus.label} ${automatedStatus.count}`}
+            size="small"
             variant="outlined"
-            sx={{
-              p: 4,
-              textAlign: 'center',
-              backgroundColor: theme.palette.background.default,
-            }}
-          >
-            <InfoOutlinedIcon
-              sx={{
-                fontSize: theme.typography.h3.fontSize,
-                color: theme.palette.text.disabled,
-                mb: 2,
-              }}
-            />
-            <Typography variant="h6" color="text.secondary" gutterBottom>
-              No Reviews Yet
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              This test result has not been reviewed by any human evaluators.
-            </Typography>
-          </Paper>
-        )}
-
-        {/* Add Review Section */}
-        <Box sx={{ mt: 3 }}>
-          {!showReviewForm ? (
-            <Button
-              variant="outlined"
-              startIcon={<AddIcon />}
-              onClick={() => setShowReviewForm(true)}
-              fullWidth
-              sx={{ py: 1.5 }}
-            >
-              Add Review
-            </Button>
+          />
+        </Box>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2" color="text.primary">
+            Human Review:
+          </Typography>
+          {lastReview ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              {(() => {
+                const display = getReviewStatusDisplay(lastReview.status.name);
+                return (
+                  <>
+                    <StatusChip
+                      passed={display.passed}
+                      label={display.label}
+                      size="small"
+                      variant="outlined"
+                    />
+                    {hasConflict && (
+                      <Chip
+                        icon={
+                          <WarningAmberIcon
+                            sx={{
+                              fontSize: '14px !important',
+                              color: '#de3355 !important',
+                            }}
+                          />
+                        }
+                        label="Conflict"
+                        size="small"
+                        sx={{
+                          borderRadius: BORDER_RADIUS.pill,
+                          bgcolor: '#fdedee',
+                          color: '#de3355',
+                          border: 'none',
+                          '& .MuiChip-label': { color: '#de3355' },
+                        }}
+                      />
+                    )}
+                  </>
+                );
+              })()}
+            </Box>
           ) : (
-            <Collapse in={showReviewForm}>
-              <Paper
-                variant="outlined"
-                sx={{
-                  p: 3,
-                  backgroundColor: theme.palette.background.default,
-                  border: `1px solid ${theme.palette.primary.light}`,
-                }}
-              >
-                <Typography variant="h6" fontWeight={600} gutterBottom>
-                  Add Your Review
-                </Typography>
-
-                {/* Status Toggle */}
-                <Box sx={{ mb: 3 }}>
-                  <Typography variant="body2" fontWeight={600} sx={{ mb: 1 }}>
-                    New Status
-                  </Typography>
-                  <ToggleButtonGroup
-                    value={newStatus}
-                    exclusive
-                    onChange={(_, value) => value && setNewStatus(value)}
-                    size="small"
-                    fullWidth
-                  >
-                    <ToggleButton
-                      value="passed"
-                      sx={{
-                        '&.Mui-selected': {
-                          backgroundColor: theme.palette.success.main,
-                          color: theme.palette.success.contrastText,
-                          '&:hover': {
-                            backgroundColor: theme.palette.success.dark,
-                          },
-                        },
-                      }}
-                    >
-                      <CheckCircleOutlineIcon
-                        sx={{ mr: 1, fontSize: 'body2.fontSize' }}
-                      />
-                      Pass
-                    </ToggleButton>
-                    <ToggleButton
-                      value="failed"
-                      sx={{
-                        '&.Mui-selected': {
-                          backgroundColor: theme.palette.error.main,
-                          color: theme.palette.error.contrastText,
-                          '&:hover': {
-                            backgroundColor: theme.palette.error.dark,
-                          },
-                        },
-                      }}
-                    >
-                      <CancelOutlinedIcon
-                        sx={{ mr: 1, fontSize: 'body2.fontSize' }}
-                      />
-                      Fail
-                    </ToggleButton>
-                  </ToggleButtonGroup>
-                </Box>
-
-                {/* Comments */}
-                <Box sx={{ mb: 3 }}>
-                  <MentionTextInput
-                    label="Comments"
-                    value={reason}
-                    onChange={setReason}
-                    placeholder="Explain your review decision... Type @ to mention"
-                    mentionableMetrics={mentionableMetrics}
-                    mentionableTurns={mentionableTurns}
-                    error={!!error}
-                    helperText={error}
-                    minRows={4}
-                  />
-                </Box>
-
-                {/* Actions */}
-                <Stack direction="row" spacing={2} justifyContent="flex-end">
-                  <Button onClick={handleCancelReview} disabled={submitting}>
-                    Cancel
-                  </Button>
-                  <Button
-                    variant="contained"
-                    onClick={handleSubmitReview}
-                    disabled={submitting || !reason.trim()}
-                  >
-                    {submitting ? 'Submitting...' : 'Submit Review'}
-                  </Button>
-                </Stack>
-              </Paper>
-            </Collapse>
+            <Chip
+              label="No Review"
+              size="small"
+              variant="outlined"
+              sx={{ borderRadius: BORDER_RADIUS.pill }}
+            />
           )}
         </Box>
       </Box>
+
+      {/* Conflict banner */}
+      {hasConflict && (
+        <Box
+          sx={{
+            bgcolor: '#ffab24',
+            borderRadius: BORDER_RADIUS.xs,
+            px: '30px',
+            py: '12px',
+            display: 'flex',
+            alignItems: 'flex-start',
+            overflow: 'hidden',
+          }}
+        >
+          <Box sx={{ pr: '12px', py: '7px', flexShrink: 0 }}>
+            <WarningAmberIcon sx={{ fontSize: 22, color: '#fff !important' }} />
+          </Box>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '4px',
+              py: '8px',
+              flex: '1 0 0',
+            }}
+          >
+            <Typography
+              sx={{
+                color: 'white',
+                fontWeight: 700,
+                fontSize: 18,
+                lineHeight: '25px',
+              }}
+            >
+              Status Conflict Detected:
+            </Typography>
+            <Typography
+              sx={{ color: 'white', fontSize: 16, lineHeight: '24px' }}
+            >
+              The human review status differs from the automated test result.
+              This indicates the reviewer disagreed with the automation.
+            </Typography>
+          </Box>
+        </Box>
+      )}
+
+      {/* Reviews section */}
+      {noReviewsAtAll ? (
+        <EmptyStateCard
+          title="No reviews created yet"
+          onCreateReview={() => setCreateOpen(true)}
+        />
+      ) : myReviewsEmpty && !showOthers ? (
+        <EmptyStateCard
+          title="You have not created any reviews yet"
+          onCreateReview={() => setCreateOpen(true)}
+          showOthersCount={otherReviews.length}
+          onShowOthers={() => setShowOthers(true)}
+        />
+      ) : (
+        <Paper
+          variant="outlined"
+          sx={{
+            boxShadow: ELEVATION.xs,
+            borderRadius: BORDER_RADIUS.md,
+            overflow: 'hidden',
+          }}
+        >
+          {/* Card header */}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              px: 3,
+              pt: 3,
+              pb: 2,
+            }}
+          >
+            <Typography variant="h6" color="primary" fontWeight={600}>
+              Reviews
+            </Typography>
+            <Button
+              variant="outlined"
+              size="small"
+              startIcon={<AddIcon />}
+              onClick={() => setCreateOpen(true)}
+              sx={{ '& .MuiSvgIcon-root': { color: 'primary.main' } }}
+            >
+              Create
+            </Button>
+          </Box>
+
+          {/* Review items */}
+          <Stack
+            divider={<Box sx={{ borderTop: 1, borderColor: 'divider' }} />}
+          >
+            {visibleReviews.map(review => {
+              const display = getReviewStatusDisplay(review.status.name);
+              return (
+                <Box key={review.review_id} sx={{ px: 3, py: 2 }}>
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      mb: 1.5,
+                    }}
+                  >
+                    <Box
+                      sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}
+                    >
+                      <Avatar
+                        sx={{
+                          width: 32,
+                          height: 32,
+                          fontSize: '0.75rem',
+                          bgcolor: 'primary.main',
+                        }}
+                      >
+                        {review.user.name.charAt(0).toUpperCase()}
+                      </Avatar>
+                      <Typography variant="body2" fontWeight={700}>
+                        {review.user.name}
+                      </Typography>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ letterSpacing: 0.5 }}
+                      >
+                        {formatRelativeTime(review.updated_at)}
+                      </Typography>
+                    </Box>
+                    <Box
+                      sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+                    >
+                      <StatusChip
+                        passed={display.passed}
+                        label={display.label}
+                        size="small"
+                        variant="outlined"
+                      />
+                      {String(review.user.user_id) === currentUserId && (
+                        <Tooltip title="Delete review">
+                          <IconButton
+                            size="small"
+                            onClick={e => {
+                              e.stopPropagation();
+                              handleDeleteReview(review);
+                            }}
+                            sx={{
+                              color: 'primary.main',
+                              '& .MuiSvgIcon-root': { color: 'primary.main' },
+                              '&:hover': {
+                                bgcolor: alpha(
+                                  theme.palette.error.main,
+                                  theme.palette.action.focusOpacity
+                                ),
+                                color: 'error.main',
+                                '& .MuiSvgIcon-root': { color: 'error.main' },
+                              },
+                            }}
+                          >
+                            <DeleteOutlineIcon sx={{ fontSize: 18 }} />
+                          </IconButton>
+                        </Tooltip>
+                      )}
+                    </Box>
+                  </Box>
+
+                  {/* Comment */}
+                  <Box
+                    sx={{
+                      bgcolor: theme.palette.greyscale.fieldSurface,
+                      borderRadius: BORDER_RADIUS.xs,
+                      p: 2,
+                    }}
+                  >
+                    <Typography
+                      variant="body2"
+                      sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+                    >
+                      {renderMentionText(
+                        review.comments,
+                        {
+                          user: theme.palette.success.main,
+                          metric: theme.palette.secondary.main,
+                          turn: theme.palette.info.main,
+                        },
+                        {
+                          user: alpha(
+                            theme.palette.success.main,
+                            theme.palette.action.disabledOpacity
+                          ),
+                          metric: alpha(
+                            theme.palette.secondary.main,
+                            theme.palette.action.disabledOpacity
+                          ),
+                          turn: alpha(
+                            theme.palette.info.main,
+                            theme.palette.action.disabledOpacity
+                          ),
+                        }
+                      )}
+                    </Typography>
+                  </Box>
+                </Box>
+              );
+            })}
+          </Stack>
+        </Paper>
+      )}
+
+      {/* Create Review Drawer */}
+      <ReviewJudgementDrawer
+        open={createOpen}
+        onClose={handleCloseCreateDrawer}
+        test={test}
+        sessionToken={sessionToken}
+        onSave={handleReviewSaved}
+        initialComment={pendingCommentRef.current?.comment}
+        initialStatus={pendingCommentRef.current?.status}
+        mentionableMetrics={mentionableMetrics}
+        mentionableTurns={mentionableTurns}
+      />
 
       {/* Delete Confirmation Modal */}
       <DeleteModal
@@ -729,5 +513,70 @@ export default function TestDetailReviewsTab({
         showTopBorder={true}
       />
     </Box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface EmptyStateCardProps {
+  title: string;
+  onCreateReview: () => void;
+  showOthersCount?: number;
+  onShowOthers?: () => void;
+}
+
+function EmptyStateCard({
+  title,
+  onCreateReview,
+  showOthersCount,
+  onShowOthers,
+}: EmptyStateCardProps) {
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 4,
+        boxShadow: ELEVATION.xs,
+        borderRadius: BORDER_RADIUS.md,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: 2,
+        textAlign: 'center',
+      }}
+    >
+      <InfoOutlinedIcon sx={{ fontSize: 32, color: 'primary.main' }} />
+      <Typography variant="h6" color="primary" fontWeight={600}>
+        {title}
+      </Typography>
+      <Typography variant="body2">
+        Create a review to evaluate this test result and provide your assessment
+        of the automated findings.
+      </Typography>
+      <Button
+        variant="contained"
+        startIcon={<AddIcon />}
+        onClick={onCreateReview}
+        sx={{
+          borderRadius: BORDER_RADIUS.md,
+          // Override the MuiDrawer theme rule that sets all icons to body color
+          '& .MuiSvgIcon-root': { color: '#FFFFFF' },
+        }}
+      >
+        Create review
+      </Button>
+      {showOthersCount !== undefined && showOthersCount > 0 && onShowOthers && (
+        <Button
+          variant="text"
+          color="primary"
+          onClick={onShowOthers}
+          sx={{ textTransform: 'none', textDecoration: 'underline' }}
+        >
+          {`Show reviews from other users (${showOthersCount})`}
+        </Button>
+      )}
+    </Paper>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
@@ -61,13 +61,17 @@ interface TabPanelProps {
 }
 
 function TabPanel({ children, value, index }: TabPanelProps) {
+  const isActive = value === index;
   return (
     <div
       role="tabpanel"
-      hidden={value !== index}
       id={`test-detail-tabpanel-${index}`}
       aria-labelledby={`test-detail-tab-${index}`}
-      style={{ height: '100%', display: value !== index ? 'none' : undefined }}
+      style={{
+        height: isActive ? '100%' : 0,
+        overflow: isActive ? undefined : 'hidden',
+        visibility: isActive ? undefined : 'hidden',
+      }}
     >
       <Box sx={{ height: '100%' }}>{children}</Box>
     </div>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
@@ -1,7 +1,18 @@
 'use client';
 
 import React, { useState, useRef, useMemo } from 'react';
-import { Box, Tabs, Tab, Typography, Skeleton, useTheme } from '@mui/material';
+import {
+  Box,
+  Tabs,
+  Tab,
+  Typography,
+  Skeleton,
+  useTheme,
+  Button,
+  Stack,
+} from '@mui/material';
+import Link from 'next/link';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import ChatOutlinedIcon from '@mui/icons-material/ChatOutlined';
 import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
@@ -140,9 +151,17 @@ export default function TestResultDrawer({
   const isConfirmingRef = useRef(false);
   const theme = useTheme();
 
-  // Determine if this is a multi-turn test
   const isMultiTurn =
     testSetType?.toLowerCase().includes('multi-turn') || false;
+
+  const TAB = {
+    overview: 0,
+    conversation: 1,
+    metrics: 2,
+    reviews: 3,
+    history: 4,
+    tasks: 5,
+  } as const;
 
   // Update active tab when initialTab changes (when drawer opens with specific tab)
   React.useEffect(() => {
@@ -158,7 +177,7 @@ export default function TestResultDrawer({
   const handleReviewTurn = (turnNumber: number, turnSuccess: boolean) => {
     setReviewInitialComment(`@[Turn ${turnNumber}](turn:${turnNumber}) `);
     setReviewInitialStatus(turnSuccess ? 'failed' : 'passed');
-    setActiveTab(isMultiTurn ? 3 : 2);
+    setActiveTab(TAB.reviews);
   };
 
   const mentionableMetrics: MentionOption[] = useMemo(() => {
@@ -329,42 +348,40 @@ export default function TestResultDrawer({
               id="test-detail-tab-0"
               aria-controls="test-detail-tabpanel-0"
             />
-            {isMultiTurn && (
-              <Tab
-                icon={<ChatOutlinedIcon fontSize="small" />}
-                iconPosition="start"
-                label="Conversation"
-                id="test-detail-tab-1"
-                aria-controls="test-detail-tabpanel-1"
-              />
-            )}
+            <Tab
+              icon={<ChatOutlinedIcon fontSize="small" />}
+              iconPosition="start"
+              label="Conversation"
+              id="test-detail-tab-1"
+              aria-controls="test-detail-tabpanel-1"
+            />
             <Tab
               icon={<AssessmentOutlinedIcon fontSize="small" />}
               iconPosition="start"
               label="Metrics"
-              id={`test-detail-tab-${isMultiTurn ? '2' : '1'}`}
-              aria-controls={`test-detail-tabpanel-${isMultiTurn ? '2' : '1'}`}
+              id="test-detail-tab-2"
+              aria-controls="test-detail-tabpanel-2"
             />
             <Tab
               icon={<RateReviewIcon fontSize="small" />}
               iconPosition="start"
               label="Reviews"
-              id={`test-detail-tab-${isMultiTurn ? '3' : '2'}`}
-              aria-controls={`test-detail-tabpanel-${isMultiTurn ? '3' : '2'}`}
+              id="test-detail-tab-3"
+              aria-controls="test-detail-tabpanel-3"
             />
             <Tab
               icon={<HistoryIcon fontSize="small" />}
               iconPosition="start"
               label="History"
-              id={`test-detail-tab-${isMultiTurn ? '4' : '3'}`}
-              aria-controls={`test-detail-tabpanel-${isMultiTurn ? '4' : '3'}`}
+              id="test-detail-tab-4"
+              aria-controls="test-detail-tabpanel-4"
             />
             <Tab
               icon={<CommentOutlinedIcon fontSize="small" />}
               iconPosition="start"
               label="Tasks & Comments"
-              id={`test-detail-tab-${isMultiTurn ? '5' : '4'}`}
-              aria-controls={`test-detail-tabpanel-${isMultiTurn ? '5' : '4'}`}
+              id="test-detail-tab-5"
+              aria-controls="test-detail-tabpanel-5"
             />
           </Tabs>
         </Box>
@@ -391,7 +408,7 @@ export default function TestResultDrawer({
             },
           }}
         >
-          <TabPanel value={activeTab} index={0}>
+          <TabPanel value={activeTab} index={TAB.overview}>
             <TestDetailOverviewTab
               test={test}
               prompts={prompts}
@@ -401,22 +418,20 @@ export default function TestResultDrawer({
             />
           </TabPanel>
 
-          {isMultiTurn && (
-            <TabPanel value={activeTab} index={1}>
-              <TestDetailConversationTab
-                test={test}
-                testSetType={testSetType}
-                sessionToken={sessionToken}
-                project={project}
-                projectName={projectName}
-                onReviewTurn={handleReviewTurn}
-                onConfirmAutomatedReview={handleConfirmAutomatedReview}
-                isConfirmingReview={isConfirmingReview}
-              />
-            </TabPanel>
-          )}
+          <TabPanel value={activeTab} index={TAB.conversation}>
+            <TestDetailConversationTab
+              test={test}
+              testSetType={testSetType}
+              sessionToken={sessionToken}
+              project={project}
+              projectName={projectName}
+              onReviewTurn={isMultiTurn ? handleReviewTurn : undefined}
+              onConfirmAutomatedReview={handleConfirmAutomatedReview}
+              isConfirmingReview={isConfirmingReview}
+            />
+          </TabPanel>
 
-          <TabPanel value={activeTab} index={isMultiTurn ? 2 : 1}>
+          <TabPanel value={activeTab} index={TAB.metrics}>
             <TestDetailMetricsTab
               test={test}
               behaviors={behaviors}
@@ -424,7 +439,7 @@ export default function TestResultDrawer({
             />
           </TabPanel>
 
-          <TabPanel value={activeTab} index={isMultiTurn ? 3 : 2}>
+          <TabPanel value={activeTab} index={TAB.reviews}>
             <TestDetailReviewsTab
               test={test}
               sessionToken={sessionToken}
@@ -441,7 +456,7 @@ export default function TestResultDrawer({
             />
           </TabPanel>
 
-          <TabPanel value={activeTab} index={isMultiTurn ? 4 : 3}>
+          <TabPanel value={activeTab} index={TAB.history}>
             <TestDetailHistoryTab
               test={test}
               testRunId={testRunId}
@@ -449,7 +464,7 @@ export default function TestResultDrawer({
             />
           </TabPanel>
 
-          <TabPanel value={activeTab} index={isMultiTurn ? 5 : 4}>
+          <TabPanel value={activeTab} index={TAB.tasks}>
             <TasksAndCommentsWrapper
               entityType="TestResult"
               entityId={test.id}
@@ -463,18 +478,41 @@ export default function TestResultDrawer({
             />
           </TabPanel>
         </Box>
+
+        <Box
+          sx={{
+            flexShrink: 0,
+            borderTop: 1,
+            borderColor: 'divider',
+            px: 2,
+            py: 2,
+            bgcolor: 'background.paper',
+          }}
+        >
+          <Stack direction="row" spacing={2} justifyContent="flex-end">
+            {test.test_id && (
+              <Button
+                component={Link}
+                href={`/tests/${test.test_id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                variant="outlined"
+                endIcon={<OpenInNewIcon />}
+              >
+                Go to Test
+              </Button>
+            )}
+            <Button variant="contained" onClick={onClose}>
+              Close
+            </Button>
+          </Stack>
+        </Box>
       </Box>
     );
   };
 
   return (
-    <BaseDrawer
-      open={open}
-      onClose={onClose}
-      width="60%"
-      showHeader={false}
-      closeButtonText="Close"
-    >
+    <BaseDrawer open={open} onClose={onClose} width="60%" showHeader={false}>
       {drawerContent()}
     </BaseDrawer>
   );

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
@@ -287,8 +287,6 @@ export default function TestResultDrawer({
         {/* Tabs Header */}
         <Box
           sx={{
-            borderBottom: 1,
-            borderColor: 'divider',
             backgroundColor: theme.palette.background.paper,
             position: 'sticky',
             top: 0,
@@ -462,15 +460,13 @@ export default function TestResultDrawer({
         <Box
           sx={{
             flexShrink: 0,
-            borderTop: 1,
-            borderColor: 'divider',
             px: 2,
             py: 2,
             bgcolor: 'background.paper',
           }}
         >
           <Stack direction="row" spacing={2} justifyContent="flex-end">
-            <Button variant="contained" onClick={onClose}>
+            <Button variant="outlined" onClick={onClose}>
               Close
             </Button>
           </Stack>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
@@ -1,18 +1,7 @@
 'use client';
 
 import React, { useState, useRef, useMemo } from 'react';
-import {
-  Box,
-  Tabs,
-  Tab,
-  Typography,
-  Skeleton,
-  useTheme,
-  Button,
-  Stack,
-} from '@mui/material';
-import Link from 'next/link';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { Box, Tabs, Tab, Typography, Skeleton, useTheme } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import ChatOutlinedIcon from '@mui/icons-material/ChatOutlined';
 import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
@@ -478,41 +467,12 @@ export default function TestResultDrawer({
             />
           </TabPanel>
         </Box>
-
-        <Box
-          sx={{
-            flexShrink: 0,
-            borderTop: 1,
-            borderColor: 'divider',
-            px: 2,
-            py: 2,
-            bgcolor: 'background.paper',
-          }}
-        >
-          <Stack direction="row" spacing={2} justifyContent="flex-end">
-            {test.test_id && (
-              <Button
-                component={Link}
-                href={`/tests/${test.test_id}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                variant="outlined"
-                endIcon={<OpenInNewIcon />}
-              >
-                Go to Test
-              </Button>
-            )}
-            <Button variant="contained" onClick={onClose}>
-              Close
-            </Button>
-          </Stack>
-        </Box>
       </Box>
     );
   };
 
   return (
-    <BaseDrawer open={open} onClose={onClose} width="60%" showHeader={false}>
+    <BaseDrawer open={open} onClose={onClose} width="75%" showHeader={false}>
       {drawerContent()}
     </BaseDrawer>
   );

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
@@ -1,13 +1,17 @@
 'use client';
 
 import React, { useState, useRef, useMemo } from 'react';
-import { Box, Tabs, Tab, Typography, Skeleton, useTheme } from '@mui/material';
+import {
+  Box,
+  Tabs,
+  Tab,
+  Typography,
+  Skeleton,
+  useTheme,
+  Button,
+  Stack,
+} from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import ChatOutlinedIcon from '@mui/icons-material/ChatOutlined';
-import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
-import HistoryIcon from '@mui/icons-material/History';
-import CommentOutlinedIcon from '@mui/icons-material/CommentOutlined';
-import RateReviewIcon from '@mui/icons-material/RateReview';
 import {
   TestResultDetail,
   REVIEW_TARGET_TYPES,
@@ -299,75 +303,61 @@ export default function TestResultDrawer({
             scrollButtons="auto"
             sx={{
               '& .MuiTab-root': {
-                minHeight: 56,
+                minHeight: 43,
+                minWidth: 'auto',
+                paddingX: 0,
+                paddingY: '5px',
+                marginRight: '50px',
                 textTransform: 'none',
-                fontWeight: 500,
-                color: theme.palette.text.secondary,
-                '& .MuiSvgIcon-root': {
-                  color: 'inherit',
-                },
+                fontSize: '18px',
+                fontWeight: 700,
+                lineHeight: '25px',
+                color: theme.palette.text.disabled,
                 '&:hover:not(.Mui-selected)': {
-                  backgroundColor: theme.palette.action.hover,
-                  color: theme.palette.text.primary,
+                  color: theme.palette.text.secondary,
+                  backgroundColor: 'transparent',
                 },
                 '&.Mui-selected': {
+                  color: theme.palette.text.primary,
+                  fontWeight: 700,
                   backgroundColor: 'transparent',
-                  color: theme.palette.primary.main,
-                  fontWeight: 600,
-                  '& .MuiSvgIcon-root': {
-                    color: theme.palette.primary.main,
-                  },
-                  '& .MuiTab-iconWrapper': {
-                    color: theme.palette.primary.main,
-                  },
                 },
               },
               '& .MuiTabs-indicator': {
-                height: 3,
-                backgroundColor: theme.palette.primary.main,
-                borderTopLeftRadius: theme.shape.borderRadius,
-                borderTopRightRadius: theme.shape.borderRadius,
+                height: 2,
+                backgroundColor: theme.palette.text.primary,
+              },
+              '& .MuiTabs-flexContainer': {
+                gap: 0,
               },
             }}
           >
             <Tab
-              icon={<InfoOutlinedIcon fontSize="small" />}
-              iconPosition="start"
               label="Overview"
               id="test-detail-tab-0"
               aria-controls="test-detail-tabpanel-0"
             />
             <Tab
-              icon={<ChatOutlinedIcon fontSize="small" />}
-              iconPosition="start"
               label="Conversation"
               id="test-detail-tab-1"
               aria-controls="test-detail-tabpanel-1"
             />
             <Tab
-              icon={<AssessmentOutlinedIcon fontSize="small" />}
-              iconPosition="start"
               label="Metrics"
               id="test-detail-tab-2"
               aria-controls="test-detail-tabpanel-2"
             />
             <Tab
-              icon={<RateReviewIcon fontSize="small" />}
-              iconPosition="start"
               label="Reviews"
               id="test-detail-tab-3"
               aria-controls="test-detail-tabpanel-3"
             />
             <Tab
-              icon={<HistoryIcon fontSize="small" />}
-              iconPosition="start"
               label="History"
               id="test-detail-tab-4"
               aria-controls="test-detail-tabpanel-4"
             />
             <Tab
-              icon={<CommentOutlinedIcon fontSize="small" />}
-              iconPosition="start"
               label="Tasks & Comments"
               id="test-detail-tab-5"
               aria-controls="test-detail-tabpanel-5"
@@ -454,25 +444,49 @@ export default function TestResultDrawer({
           </TabPanel>
 
           <TabPanel value={activeTab} index={TAB.tasks}>
-            <TasksAndCommentsWrapper
-              entityType="TestResult"
-              entityId={test.id}
-              sessionToken={sessionToken}
-              currentUserId={currentUserId}
-              currentUserName={currentUserName}
-              currentUserPicture={currentUserPicture}
-              elevation={0}
-              onCountsChange={handleCountsChange}
-              additionalMetadata={{ test_run_id: testRunId }}
-            />
+            <Box sx={{ pt: '40px' }}>
+              <TasksAndCommentsWrapper
+                entityType="TestResult"
+                entityId={test.id}
+                sessionToken={sessionToken}
+                currentUserId={currentUserId}
+                currentUserName={currentUserName}
+                currentUserPicture={currentUserPicture}
+                onCountsChange={handleCountsChange}
+                additionalMetadata={{ test_run_id: testRunId }}
+              />
+            </Box>
           </TabPanel>
+        </Box>
+
+        <Box
+          sx={{
+            flexShrink: 0,
+            borderTop: 1,
+            borderColor: 'divider',
+            px: 2,
+            py: 2,
+            bgcolor: 'background.paper',
+          }}
+        >
+          <Stack direction="row" spacing={2} justifyContent="flex-end">
+            <Button variant="contained" onClick={onClose}>
+              Close
+            </Button>
+          </Stack>
         </Box>
       </Box>
     );
   };
 
   return (
-    <BaseDrawer open={open} onClose={onClose} width="75%" showHeader={false}>
+    <BaseDrawer
+      open={open}
+      onClose={onClose}
+      width="75%"
+      showHeader={false}
+      closeButtonText=""
+    >
       {drawerContent()}
     </BaseDrawer>
   );

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
@@ -12,6 +12,7 @@ import {
   Stack,
 } from '@mui/material';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import {
   TestResultDetail,
   REVIEW_TARGET_TYPES,
@@ -66,9 +67,9 @@ function TabPanel({ children, value, index }: TabPanelProps) {
       hidden={value !== index}
       id={`test-detail-tabpanel-${index}`}
       aria-labelledby={`test-detail-tab-${index}`}
-      style={{ height: '100%' }}
+      style={{ height: '100%', display: value !== index ? 'none' : undefined }}
     >
-      {value === index && <Box sx={{ height: '100%' }}>{children}</Box>}
+      <Box sx={{ height: '100%' }}>{children}</Box>
     </div>
   );
 }
@@ -466,7 +467,21 @@ export default function TestResultDrawer({
           }}
         >
           <Stack direction="row" spacing={2} justifyContent="flex-end">
-            <Button variant="outlined" onClick={onClose}>
+            {(test?.test?.id ?? test?.test_id) && (
+              <Button
+                variant="outlined"
+                endIcon={
+                  <OpenInNewIcon sx={{ color: 'primary.main !important' }} />
+                }
+                component="a"
+                href={`/tests/${test.test?.id ?? test.test_id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Go to Test
+              </Button>
+            )}
+            <Button variant="contained" onClick={onClose}>
               Close
             </Button>
           </Stack>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunConfigurationTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunConfigurationTab.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import React from 'react';
+import {
+  Box,
+  Grid,
+  Chip,
+  Switch,
+  FormControlLabel,
+  Typography,
+} from '@mui/material';
+import { SectionCard } from '@/components/common/SectionCard';
+import ViewField from '@/components/common/ViewField';
+import {
+  getMetricsSourceLabel,
+  type ExecutionMetric,
+} from '@/utils/api-client/interfaces/test-configuration';
+import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
+import TestRunTags from './TestRunTags';
+
+interface TestRunConfigurationTabProps {
+  testRun: TestRunDetail;
+  sessionToken: string;
+}
+
+export default function TestRunConfigurationTab({
+  testRun,
+  sessionToken,
+}: TestRunConfigurationTabProps) {
+  const config = testRun.test_configuration;
+  const attrs = config?.attributes as Record<string, unknown> | undefined;
+  const execMetrics = (attrs?.metrics as ExecutionMetric[] | undefined) ?? [];
+  const metricsSource = attrs?.metrics_source as string | undefined;
+  const executionMode = attrs?.execution_mode as string | undefined;
+  const scoringTarget =
+    (attrs?.is_rescore as boolean | undefined) === true
+      ? 'Reuse Outputs'
+      : 'Fresh Outputs';
+  const evaluationModel =
+    (attrs?.evaluation_model_name as string | undefined) ||
+    (attrs?.evaluation_model_id as string | undefined) ||
+    'Default Model';
+  const preflightEnabled =
+    (attrs?.run_preflight_checks as boolean | undefined) ?? true;
+
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+      <SectionCard title="Execution Target">
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <ViewField label="Test Set" value={config?.test_set?.name ?? '—'} />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <ViewField
+              label="Project"
+              value={config?.endpoint?.project?.name ?? '—'}
+            />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <ViewField label="Endpoint" value={config?.endpoint?.name ?? '—'} />
+          </Grid>
+        </Grid>
+      </SectionCard>
+
+      <SectionCard title="Configuration Options">
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <ViewField label="Execution Mode" value={executionMode ?? '—'} />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <ViewField label="Scoring Target" value={scoringTarget} />
+          </Grid>
+        </Grid>
+      </SectionCard>
+
+      <SectionCard title="Test Run Metrics">
+        <ViewField
+          label="Metric Source"
+          value={metricsSource ? getMetricsSourceLabel(metricsSource) : '—'}
+        />
+        {execMetrics.length > 0 && (
+          <Box sx={{ mt: 2 }}>
+            <Typography
+              variant="body2"
+              sx={{
+                fontSize: 14,
+                color: theme => theme.palette.greyscale.subtitle,
+                px: '14px',
+                mb: '6px',
+              }}
+            >
+              Metrics
+            </Typography>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, px: '14px' }}>
+              {execMetrics.map(m => (
+                <Chip
+                  key={m.id}
+                  label={m.name}
+                  size="small"
+                  variant="outlined"
+                />
+              ))}
+            </Box>
+          </Box>
+        )}
+      </SectionCard>
+
+      <SectionCard title="Model Settings">
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12 }}>
+            <ViewField label="Evaluation Model" value={evaluationModel} />
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            <FormControlLabel
+              control={<Switch checked={preflightEnabled} disabled />}
+              label="Run Preflight Checks"
+            />
+          </Grid>
+        </Grid>
+      </SectionCard>
+
+      <SectionCard title="Test Run Tags">
+        <TestRunTags sessionToken={sessionToken} testRun={testRun} />
+      </SectionCard>
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunConfigurationTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunConfigurationTab.tsx
@@ -1,31 +1,51 @@
 'use client';
 
 import React from 'react';
-import {
-  Box,
-  Grid,
-  Chip,
-  Switch,
-  FormControlLabel,
-  Typography,
-} from '@mui/material';
-import { SectionCard } from '@/components/common/SectionCard';
+import { Box, Chip, Grid, Paper, Switch, Typography } from '@mui/material';
+import type { Theme } from '@mui/material/styles';
+import FormSectionDivider from '@/components/common/FormSectionDivider';
 import ViewField from '@/components/common/ViewField';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import {
   getMetricsSourceLabel,
   type ExecutionMetric,
 } from '@/utils/api-client/interfaces/test-configuration';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
-import TestRunTags from './TestRunTags';
 
 interface TestRunConfigurationTabProps {
   testRun: TestRunDetail;
-  sessionToken: string;
 }
+
+const combinedCardSx = {
+  p: '30px',
+  borderRadius: BORDER_RADIUS.md,
+  boxShadow: (theme: Theme) =>
+    theme.palette.mode === 'light' ? ELEVATION.xs : 'none',
+  bgcolor: (theme: Theme) =>
+    theme.palette.mode === 'light'
+      ? '#ffffff'
+      : theme.palette.greyscale.surface1,
+  border: (theme: Theme) => `1px solid ${theme.palette.greyscale.border}`,
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '50px',
+} as const;
+
+const sectionSx = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '20px',
+} as const;
+
+const fieldsSx = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '30px',
+  width: '100%',
+} as const;
 
 export default function TestRunConfigurationTab({
   testRun,
-  sessionToken,
 }: TestRunConfigurationTabProps) {
   const config = testRun.test_configuration;
   const attrs = config?.attributes as Record<string, unknown> | undefined;
@@ -44,84 +64,98 @@ export default function TestRunConfigurationTab({
     (attrs?.run_preflight_checks as boolean | undefined) ?? true;
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-      <SectionCard title="Execution Target">
-        <Grid container spacing={3}>
-          <Grid size={{ xs: 12, sm: 6 }}>
-            <ViewField label="Test Set" value={config?.test_set?.name ?? '—'} />
+    <Paper elevation={0} sx={combinedCardSx}>
+      <Box sx={sectionSx}>
+        <FormSectionDivider headline="Execution Target" />
+        <Box sx={fieldsSx}>
+          <Grid container spacing="30px">
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <ViewField label="Test Set" value={config?.test_set?.name} />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <ViewField
+                label="Project"
+                value={config?.endpoint?.project?.name}
+              />
+            </Grid>
+            <Grid size={{ xs: 12 }}>
+              <ViewField label="Endpoint" value={config?.endpoint?.name} />
+            </Grid>
           </Grid>
-          <Grid size={{ xs: 12, sm: 6 }}>
-            <ViewField
-              label="Project"
-              value={config?.endpoint?.project?.name ?? '—'}
-            />
-          </Grid>
-          <Grid size={{ xs: 12 }}>
-            <ViewField label="Endpoint" value={config?.endpoint?.name ?? '—'} />
-          </Grid>
-        </Grid>
-      </SectionCard>
+        </Box>
+      </Box>
 
-      <SectionCard title="Configuration Options">
-        <Grid container spacing={3}>
-          <Grid size={{ xs: 12, sm: 6 }}>
-            <ViewField label="Execution Mode" value={executionMode ?? '—'} />
+      <Box sx={sectionSx}>
+        <FormSectionDivider headline="Configuration Options" />
+        <Box sx={fieldsSx}>
+          <Grid container spacing="30px">
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <ViewField label="Execution Mode" value={executionMode} />
+            </Grid>
+            <Grid size={{ xs: 12, sm: 6 }}>
+              <ViewField label="Scoring Target" value={scoringTarget} />
+            </Grid>
           </Grid>
-          <Grid size={{ xs: 12, sm: 6 }}>
-            <ViewField label="Scoring Target" value={scoringTarget} />
-          </Grid>
-        </Grid>
-      </SectionCard>
+        </Box>
+      </Box>
 
-      <SectionCard title="Test Run Metrics">
-        <ViewField
-          label="Metric Source"
-          value={metricsSource ? getMetricsSourceLabel(metricsSource) : '—'}
-        />
-        {execMetrics.length > 0 && (
-          <Box sx={{ mt: 2 }}>
+      <Box sx={sectionSx}>
+        <FormSectionDivider headline="Test Run Metrics" />
+        <Box sx={fieldsSx}>
+          <ViewField
+            label="Metric Source"
+            value={
+              metricsSource ? getMetricsSourceLabel(metricsSource) : undefined
+            }
+          />
+          {execMetrics.length > 0 && (
+            <Box>
+              <Typography
+                sx={{
+                  fontSize: 14,
+                  lineHeight: '22px',
+                  color: theme => theme.palette.greyscale.subtitle,
+                  px: '14px',
+                  mb: '6px',
+                }}
+              >
+                Metrics
+              </Typography>
+              <Box
+                sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, px: '14px' }}
+              >
+                {execMetrics.map(m => (
+                  <Chip
+                    key={m.id}
+                    label={m.name}
+                    size="small"
+                    variant="outlined"
+                  />
+                ))}
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </Box>
+
+      <Box sx={sectionSx}>
+        <FormSectionDivider headline="Model Settings" />
+        <Box sx={fieldsSx}>
+          <ViewField label="Evaluation Model" value={evaluationModel} />
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            <Switch checked={preflightEnabled} disabled size="small" />
             <Typography
-              variant="body2"
               sx={{
-                fontSize: 14,
-                color: theme => theme.palette.greyscale.subtitle,
-                px: '14px',
-                mb: '6px',
+                fontSize: 16,
+                lineHeight: '24px',
+                color: theme => theme.palette.greyscale.title,
               }}
             >
-              Metrics
+              Run Preflight Checks
             </Typography>
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, px: '14px' }}>
-              {execMetrics.map(m => (
-                <Chip
-                  key={m.id}
-                  label={m.name}
-                  size="small"
-                  variant="outlined"
-                />
-              ))}
-            </Box>
           </Box>
-        )}
-      </SectionCard>
-
-      <SectionCard title="Model Settings">
-        <Grid container spacing={3}>
-          <Grid size={{ xs: 12 }}>
-            <ViewField label="Evaluation Model" value={evaluationModel} />
-          </Grid>
-          <Grid size={{ xs: 12 }}>
-            <FormControlLabel
-              control={<Switch checked={preflightEnabled} disabled />}
-              label="Run Preflight Checks"
-            />
-          </Grid>
-        </Grid>
-      </SectionCard>
-
-      <SectionCard title="Test Run Tags">
-        <TestRunTags sessionToken={sessionToken} testRun={testRun} />
-      </SectionCard>
-    </Box>
+        </Box>
+      </Box>
+    </Paper>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailFilterDrawer.tsx
@@ -1,0 +1,330 @@
+'use client';
+
+import * as React from 'react';
+import {
+  Box,
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
+  Typography,
+} from '@mui/material';
+import {
+  FilterDrawerShell,
+  FilterSection,
+  filterChipSx,
+  useFilterDrawerDraft,
+} from '@/components/common/FilterDrawer';
+
+export type TestRunDetailDrawerFilters = {
+  overruleFilter: 'all' | 'overruled' | 'original' | 'conflicting';
+  commentFilter: 'all' | 'with_comments' | 'without_comments' | 'range';
+  taskFilter: 'all' | 'with_tasks' | 'without_tasks' | 'range';
+  selectedMetrics: string[];
+  selectedBehaviors: string[];
+};
+
+export const EMPTY_TEST_RUN_DETAIL_DRAWER_FILTERS: TestRunDetailDrawerFilters =
+  {
+    overruleFilter: 'all',
+    commentFilter: 'all',
+    taskFilter: 'all',
+    selectedMetrics: [],
+    selectedBehaviors: [],
+  };
+
+export function extractDetailDrawerFilters(filter: {
+  overruleFilter: TestRunDetailDrawerFilters['overruleFilter'];
+  commentFilter: TestRunDetailDrawerFilters['commentFilter'];
+  taskFilter: TestRunDetailDrawerFilters['taskFilter'];
+  selectedMetrics: string[];
+  selectedBehaviors: string[];
+}): TestRunDetailDrawerFilters {
+  return {
+    overruleFilter: filter.overruleFilter,
+    commentFilter: filter.commentFilter,
+    taskFilter: filter.taskFilter,
+    selectedMetrics: filter.selectedMetrics,
+    selectedBehaviors: filter.selectedBehaviors,
+  };
+}
+
+export function hasActiveTestRunDetailDrawerFilters(
+  filters: TestRunDetailDrawerFilters
+): boolean {
+  return (
+    filters.overruleFilter !== 'all' ||
+    filters.commentFilter !== 'all' ||
+    filters.taskFilter !== 'all' ||
+    filters.selectedMetrics.length > 0 ||
+    filters.selectedBehaviors.length > 0
+  );
+}
+
+const REVIEW_STATUS_OPTIONS = [
+  { value: 'all', label: 'All' },
+  { value: 'overruled', label: 'Reviewed' },
+  { value: 'original', label: 'Not Reviewed' },
+  { value: 'conflicting', label: 'Conflicting' },
+] as const;
+
+const COMMENT_OPTIONS = [
+  { value: 'all', label: 'All' },
+  { value: 'with_comments', label: 'With' },
+  { value: 'without_comments', label: 'Without' },
+] as const;
+
+const TASK_OPTIONS = [
+  { value: 'all', label: 'All' },
+  { value: 'with_tasks', label: 'With' },
+  { value: 'without_tasks', label: 'Without' },
+] as const;
+
+interface CompactSegmentedPillsProps {
+  tabs: { value: string; label: string }[];
+  activeValue: string;
+  onChange: (value: string) => void;
+}
+
+/** Right-aligned segmented pills for drawer sub-rows (Activity). */
+function CompactSegmentedPills({
+  tabs,
+  activeValue,
+  onChange,
+}: CompactSegmentedPillsProps) {
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', flexShrink: 0 }}>
+      {tabs.map(({ value, label }, idx, arr) => {
+        const isSelected = activeValue === value;
+        const isFirst = idx === 0;
+        const isLast = idx === arr.length - 1;
+
+        return (
+          <Box
+            key={value}
+            component="button"
+            type="button"
+            onClick={() => onChange(value)}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              px: '12px',
+              py: '6px',
+              fontSize: 13,
+              fontWeight: 700,
+              lineHeight: '20px',
+              cursor: 'pointer',
+              border: '1px solid',
+              borderColor: 'primary.main',
+              borderLeft: isFirst ? '1px solid' : 'none',
+              borderRight: isLast ? '1px solid' : 'none',
+              borderRadius: isFirst
+                ? '999px 0 0 999px'
+                : isLast
+                  ? '0 999px 999px 0'
+                  : 0,
+              bgcolor: isSelected ? 'primary.main' : 'transparent',
+              color: isSelected ? '#fff' : 'primary.main',
+              whiteSpace: 'nowrap',
+              '&:hover': {
+                bgcolor: isSelected
+                  ? 'primary.dark'
+                  : theme => `${theme.palette.primary.main}0f`,
+              },
+            }}
+          >
+            {label}
+          </Box>
+        );
+      })}
+    </Box>
+  );
+}
+
+interface ActivityRowProps {
+  label: string;
+  tabs: { value: string; label: string }[];
+  activeValue: string;
+  onChange: (value: string) => void;
+}
+
+function ActivityFilterRow({
+  label,
+  tabs,
+  activeValue,
+  onChange,
+}: ActivityRowProps) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 2,
+      }}
+    >
+      <Typography
+        sx={{
+          fontSize: 14,
+          color: theme => theme.palette.greyscale.body,
+          flexShrink: 0,
+        }}
+      >
+        {label}
+      </Typography>
+      <CompactSegmentedPills
+        tabs={tabs}
+        activeValue={activeValue}
+        onChange={onChange}
+      />
+    </Box>
+  );
+}
+
+interface TestRunDetailFilterDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  filters: TestRunDetailDrawerFilters;
+  availableBehaviors: Array<{ id: string; name: string }>;
+  availableMetrics: Array<{ name: string; description?: string }>;
+  onApply: (filters: TestRunDetailDrawerFilters) => void;
+}
+
+export default function TestRunDetailFilterDrawer({
+  open,
+  onClose,
+  filters,
+  availableBehaviors,
+  availableMetrics,
+  onApply,
+}: TestRunDetailFilterDrawerProps) {
+  const { draft, setDraft, handleReset, handleApply } = useFilterDrawerDraft(
+    open,
+    filters,
+    EMPTY_TEST_RUN_DETAIL_DRAWER_FILTERS,
+    onApply,
+    onClose
+  );
+
+  const toggleMetric = (metricName: string) => {
+    setDraft(prev => ({
+      ...prev,
+      selectedMetrics: prev.selectedMetrics.includes(metricName)
+        ? prev.selectedMetrics.filter(name => name !== metricName)
+        : [...prev.selectedMetrics, metricName],
+    }));
+  };
+
+  const toggleBehavior = (behaviorId: string) => {
+    setDraft(prev => ({
+      ...prev,
+      selectedBehaviors: prev.selectedBehaviors.includes(behaviorId)
+        ? prev.selectedBehaviors.filter(id => id !== behaviorId)
+        : [...prev.selectedBehaviors, behaviorId],
+    }));
+  };
+
+  return (
+    <FilterDrawerShell
+      open={open}
+      onClose={onClose}
+      onReset={handleReset}
+      onApply={handleApply}
+    >
+      <FilterSection title="Review Status">
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          {REVIEW_STATUS_OPTIONS.map(option => (
+            <Box
+              key={option.value}
+              component="button"
+              type="button"
+              onClick={() =>
+                setDraft(prev => ({
+                  ...prev,
+                  overruleFilter: option.value,
+                }))
+              }
+              sx={filterChipSx(draft.overruleFilter === option.value)}
+            >
+              {option.label}
+            </Box>
+          ))}
+        </Box>
+      </FilterSection>
+
+      <FilterSection title="Activity">
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <ActivityFilterRow
+            label="Comments"
+            tabs={[...COMMENT_OPTIONS]}
+            activeValue={draft.commentFilter}
+            onChange={value =>
+              setDraft(prev => ({
+                ...prev,
+                commentFilter:
+                  value as TestRunDetailDrawerFilters['commentFilter'],
+              }))
+            }
+          />
+          <ActivityFilterRow
+            label="Tasks"
+            tabs={[...TASK_OPTIONS]}
+            activeValue={draft.taskFilter}
+            onChange={value =>
+              setDraft(prev => ({
+                ...prev,
+                taskFilter: value as TestRunDetailDrawerFilters['taskFilter'],
+              }))
+            }
+          />
+        </Box>
+      </FilterSection>
+
+      {availableMetrics.length > 0 && (
+        <FilterSection title="Metrics">
+          <FormGroup>
+            {availableMetrics.map(metric => (
+              <FormControlLabel
+                key={metric.name}
+                control={
+                  <Checkbox
+                    checked={draft.selectedMetrics.includes(metric.name)}
+                    onChange={() => toggleMetric(metric.name)}
+                    size="small"
+                  />
+                }
+                label={
+                  <Typography sx={{ fontSize: 14 }}>{metric.name}</Typography>
+                }
+                sx={{ ml: 0, mb: 0.5 }}
+              />
+            ))}
+          </FormGroup>
+        </FilterSection>
+      )}
+
+      {availableBehaviors.length > 0 && (
+        <FilterSection title="Behaviors">
+          <FormGroup>
+            {availableBehaviors.map(behavior => (
+              <FormControlLabel
+                key={behavior.id}
+                control={
+                  <Checkbox
+                    checked={draft.selectedBehaviors.includes(behavior.id)}
+                    onChange={() => toggleBehavior(behavior.id)}
+                    size="small"
+                  />
+                }
+                label={
+                  <Typography sx={{ fontSize: 14 }}>{behavior.name}</Typography>
+                }
+                sx={{ ml: 0, mb: 0.5 }}
+              />
+            ))}
+          </FormGroup>
+        </FilterSection>
+      )}
+    </FilterDrawerShell>
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailHeader.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailHeader.tsx
@@ -19,6 +19,7 @@ interface TestRunDetailHeaderProps {
   onRerun: () => void;
   isDownloading?: boolean;
   canRerun?: boolean;
+  canCompare?: boolean;
 }
 
 export default function TestRunDetailHeader({
@@ -29,6 +30,7 @@ export default function TestRunDetailHeader({
   onRerun,
   isDownloading = false,
   canRerun = true,
+  canCompare = true,
 }: TestRunDetailHeaderProps) {
   const creatorName =
     testRun.user?.name || testRun.user?.email || 'Unknown user';
@@ -78,8 +80,13 @@ export default function TestRunDetailHeader({
       <FabGroup>
         <Fab
           icon={<CompareArrowsOutlinedIcon />}
-          tooltip="Compare runs"
+          tooltip={
+            canCompare
+              ? 'Compare runs'
+              : 'No other test runs on this test set to compare against'
+          }
           onClick={onCompare}
+          disabled={!canCompare}
           aria-label="Compare runs"
         />
         <Fab

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailHeader.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailHeader.tsx
@@ -1,18 +1,14 @@
 'use client';
 
 import React from 'react';
-import {
-  Box,
-  Typography,
-  IconButton,
-  Tooltip,
-  CircularProgress,
-} from '@mui/material';
+import { Box, Typography, IconButton, Tooltip } from '@mui/material';
 import EditIcon from '@mui/icons-material/Edit';
-import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
-import DownloadIcon from '@mui/icons-material/Download';
-import ReplayIcon from '@mui/icons-material/Replay';
+import CompareArrowsOutlinedIcon from '@mui/icons-material/CompareArrowsOutlined';
+import RestartAltOutlinedIcon from '@mui/icons-material/RestartAltOutlined';
+import { Fab, FabGroup } from '@/components/common/Fab';
+import { DownloadIcon } from '@/components/icons';
 import { formatDate } from '@/utils/date';
+import { getTestRunDisplayTimestamp } from '@/utils/test-run-utils';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 
 interface TestRunDetailHeaderProps {
@@ -23,45 +19,6 @@ interface TestRunDetailHeaderProps {
   onRerun: () => void;
   isDownloading?: boolean;
   canRerun?: boolean;
-}
-
-function CircularActionButton({
-  title,
-  onClick,
-  disabled,
-  children,
-}: {
-  title: string;
-  onClick: () => void;
-  disabled?: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <Tooltip title={title}>
-      <span>
-        <IconButton
-          onClick={onClick}
-          disabled={disabled}
-          aria-label={title}
-          sx={{
-            width: 40,
-            height: 40,
-            bgcolor: 'primary.main',
-            color: 'primary.contrastText',
-            '&:hover': {
-              bgcolor: 'primary.dark',
-            },
-            '&.Mui-disabled': {
-              bgcolor: theme => theme.palette.action.disabledBackground,
-              color: theme => theme.palette.action.disabled,
-            },
-          }}
-        >
-          {children}
-        </IconButton>
-      </span>
-    </Tooltip>
-  );
 }
 
 export default function TestRunDetailHeader({
@@ -75,7 +32,7 @@ export default function TestRunDetailHeader({
 }: TestRunDetailHeaderProps) {
   const creatorName =
     testRun.user?.name || testRun.user?.email || 'Unknown user';
-  const createdOn = formatDate(testRun.created_at);
+  const createdOn = formatDate(getTestRunDisplayTimestamp(testRun));
 
   return (
     <Box
@@ -118,29 +75,28 @@ export default function TestRunDetailHeader({
         </Typography>
       </Box>
 
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-        <CircularActionButton title="Compare runs" onClick={onCompare}>
-          <CompareArrowsIcon fontSize="small" />
-        </CircularActionButton>
-        <CircularActionButton
-          title="Download results"
+      <FabGroup>
+        <Fab
+          icon={<CompareArrowsOutlinedIcon />}
+          tooltip="Compare runs"
+          onClick={onCompare}
+          aria-label="Compare runs"
+        />
+        <Fab
+          icon={<DownloadIcon />}
+          tooltip="Download results"
           onClick={onDownload}
-          disabled={isDownloading}
-        >
-          {isDownloading ? (
-            <CircularProgress size={20} color="inherit" />
-          ) : (
-            <DownloadIcon fontSize="small" />
-          )}
-        </CircularActionButton>
-        <CircularActionButton
-          title="Re-run test"
+          loading={isDownloading}
+          aria-label="Download results"
+        />
+        <Fab
+          icon={<RestartAltOutlinedIcon />}
+          tooltip="Re-run test"
           onClick={onRerun}
           disabled={!canRerun}
-        >
-          <ReplayIcon fontSize="small" />
-        </CircularActionButton>
-      </Box>
+          aria-label="Re-run test"
+        />
+      </FabGroup>
     </Box>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailHeader.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailHeader.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import React from 'react';
+import {
+  Box,
+  Typography,
+  IconButton,
+  Tooltip,
+  CircularProgress,
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
+import DownloadIcon from '@mui/icons-material/Download';
+import ReplayIcon from '@mui/icons-material/Replay';
+import { formatDate } from '@/utils/date';
+import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
+
+interface TestRunDetailHeaderProps {
+  testRun: TestRunDetail;
+  onRename: () => void;
+  onCompare: () => void;
+  onDownload: () => void;
+  onRerun: () => void;
+  isDownloading?: boolean;
+  canRerun?: boolean;
+}
+
+function CircularActionButton({
+  title,
+  onClick,
+  disabled,
+  children,
+}: {
+  title: string;
+  onClick: () => void;
+  disabled?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip title={title}>
+      <span>
+        <IconButton
+          onClick={onClick}
+          disabled={disabled}
+          aria-label={title}
+          sx={{
+            width: 40,
+            height: 40,
+            bgcolor: 'primary.main',
+            color: 'primary.contrastText',
+            '&:hover': {
+              bgcolor: 'primary.dark',
+            },
+            '&.Mui-disabled': {
+              bgcolor: theme => theme.palette.action.disabledBackground,
+              color: theme => theme.palette.action.disabled,
+            },
+          }}
+        >
+          {children}
+        </IconButton>
+      </span>
+    </Tooltip>
+  );
+}
+
+export default function TestRunDetailHeader({
+  testRun,
+  onRename,
+  onCompare,
+  onDownload,
+  onRerun,
+  isDownloading = false,
+  canRerun = true,
+}: TestRunDetailHeaderProps) {
+  const creatorName =
+    testRun.user?.name || testRun.user?.email || 'Unknown user';
+  const createdOn = formatDate(testRun.created_at);
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'space-between',
+        gap: 2,
+        mb: 3,
+        flexWrap: 'wrap',
+      }}
+    >
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
+          <Typography
+            variant="h4"
+            component="h1"
+            sx={{
+              fontWeight: 700,
+              color: theme => theme.palette.greyscale.title,
+            }}
+          >
+            {testRun.name || 'Test Run'}
+          </Typography>
+          <Tooltip title="Rename test run">
+            <IconButton size="small" onClick={onRename} aria-label="Rename">
+              <EditIcon fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        </Box>
+        <Typography
+          variant="body2"
+          sx={{ color: theme => theme.palette.greyscale.subtitle }}
+        >
+          created by: {creatorName}
+          <Box component="span" sx={{ mx: 2 }}>
+            |
+          </Box>
+          created on: {createdOn}
+        </Typography>
+      </Box>
+
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+        <CircularActionButton title="Compare runs" onClick={onCompare}>
+          <CompareArrowsIcon fontSize="small" />
+        </CircularActionButton>
+        <CircularActionButton
+          title="Download results"
+          onClick={onDownload}
+          disabled={isDownloading}
+        >
+          {isDownloading ? (
+            <CircularProgress size={20} color="inherit" />
+          ) : (
+            <DownloadIcon fontSize="small" />
+          )}
+        </CircularActionButton>
+        <CircularActionButton
+          title="Re-run test"
+          onClick={onRerun}
+          disabled={!canRerun}
+        >
+          <ReplayIcon fontSize="small" />
+        </CircularActionButton>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunFilterBar.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunFilterBar.tsx
@@ -8,30 +8,26 @@ import {
   ButtonGroup,
   InputAdornment,
   Badge,
-  Popover,
-  FormGroup,
-  FormControlLabel,
-  Checkbox,
-  Typography,
-  Divider,
   useTheme,
-  Chip,
-  Stack,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import FilterListIcon from '@mui/icons-material/FilterList';
 import DownloadIcon from '@mui/icons-material/Download';
 import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
-import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
-import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
+import BlockOutlinedIcon from '@mui/icons-material/BlockOutlined';
 import ListIcon from '@mui/icons-material/List';
 import ViewColumnIcon from '@mui/icons-material/ViewColumn';
 import TableRowsIcon from '@mui/icons-material/TableRows';
-import RateReviewIcon from '@mui/icons-material/RateReview';
-import CommentOutlinedIcon from '@mui/icons-material/CommentOutlined';
-import ClearAllIcon from '@mui/icons-material/ClearAll';
 import ReplayIcon from '@mui/icons-material/Replay';
+import GridToolbar, {
+  PrimarySegmentedPills,
+} from '@/components/common/GridToolbar';
+import TestRunDetailFilterDrawer, {
+  extractDetailDrawerFilters,
+  hasActiveTestRunDetailDrawerFilters,
+  type TestRunDetailDrawerFilters,
+} from './TestRunDetailFilterDrawer';
 
 export interface FilterState {
   searchQuery: string;
@@ -86,14 +82,7 @@ export default function TestRunFilterBar({
   const showHeaderActions = variant !== 'linkedEntities';
   const showViewMode = !hideViewModeToggle && onViewModeChange;
   const theme = useTheme();
-  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
-  const handleFilterClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleFilterClose = () => {
-    setAnchorEl(null);
-  };
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     onFilterChange({
@@ -109,97 +98,76 @@ export default function TestRunFilterBar({
     });
   };
 
-  const handleBehaviorToggle = (behaviorId: string) => {
-    const newBehaviors = filter.selectedBehaviors.includes(behaviorId)
-      ? filter.selectedBehaviors.filter(id => id !== behaviorId)
-      : [...filter.selectedBehaviors, behaviorId];
-
+  const handleDrawerApply = (drawerFilters: TestRunDetailDrawerFilters) => {
     onFilterChange({
       ...filter,
-      selectedBehaviors: newBehaviors,
+      ...drawerFilters,
     });
   };
 
-  const _handleClearBehaviors = () => {
-    onFilterChange({
-      ...filter,
-      selectedBehaviors: [],
-    });
-  };
+  const drawerFilters = extractDetailDrawerFilters(filter);
+  const hasActiveDrawerFilters =
+    hasActiveTestRunDetailDrawerFilters(drawerFilters);
 
-  const handleOverruleFilterChange = (
-    overruleFilter: 'all' | 'overruled' | 'original' | 'conflicting'
-  ) => {
-    onFilterChange({
-      ...filter,
-      overruleFilter,
-    });
-  };
+  const advancedFilterDrawer = (
+    <TestRunDetailFilterDrawer
+      open={filterDrawerOpen}
+      onClose={() => setFilterDrawerOpen(false)}
+      filters={drawerFilters}
+      availableBehaviors={availableBehaviors}
+      availableMetrics={availableMetrics}
+      onApply={handleDrawerApply}
+    />
+  );
 
-  const handleMetricToggle = (metricName: string) => {
-    const newMetrics = filter.selectedMetrics.includes(metricName)
-      ? filter.selectedMetrics.filter(name => name !== metricName)
-      : [...filter.selectedMetrics, metricName];
-
-    onFilterChange({
-      ...filter,
-      selectedMetrics: newMetrics,
-    });
-  };
-
-  const handleCommentFilterChange = (
-    commentFilter: 'all' | 'with_comments' | 'without_comments' | 'range'
-  ) => {
-    onFilterChange({
-      ...filter,
-      commentFilter,
-    });
-  };
-
-  const _handleCommentRangeChange = (range: { min: number; max: number }) => {
-    onFilterChange({
-      ...filter,
-      commentCountRange: range,
-    });
-  };
-
-  const handleTaskFilterChange = (
-    taskFilter: 'all' | 'with_tasks' | 'without_tasks' | 'range'
-  ) => {
-    onFilterChange({
-      ...filter,
-      taskFilter,
-    });
-  };
-
-  const _handleTaskRangeChange = (range: { min: number; max: number }) => {
-    onFilterChange({
-      ...filter,
-      taskCountRange: range,
-    });
-  };
-
-  const handleClearAllFilters = () => {
-    onFilterChange({
-      ...filter,
-      selectedBehaviors: [],
-      overruleFilter: 'all',
-      selectedMetrics: [],
-      commentFilter: 'all',
-      taskFilter: 'all',
-    });
-  };
-
-  const activeFilterCount =
-    filter.selectedBehaviors.length +
-    (filter.statusFilter !== 'all' ? 1 : 0) +
-    (filter.overruleFilter !== 'all' ? 1 : 0) +
-    filter.selectedMetrics.length +
-    (filter.commentFilter !== 'all' ? 1 : 0) +
-    (filter.taskFilter !== 'all' ? 1 : 0);
-
-  const hasActiveFilters = activeFilterCount > 0;
-  const open = Boolean(anchorEl);
+  if (variant === 'linkedEntities') {
+    return (
+      <>
+        <GridToolbar
+          searchQuery={filter.searchQuery}
+          onSearchChange={value =>
+            onFilterChange({ ...filter, searchQuery: value })
+          }
+          searchPlaceholder="Search tests..."
+          searchWidth={288}
+          onFilterClick={() => setFilterDrawerOpen(true)}
+          hasActiveFilters={hasActiveDrawerFilters}
+          sx={{
+            px: 0,
+            py: 0,
+            minHeight: 'auto',
+            gap: 2.5,
+            width: '100%',
+            flexWrap: { xs: 'wrap', lg: 'nowrap' },
+            justifyContent: 'space-between',
+          }}
+          middleContent={
+            <PrimarySegmentedPills
+              mode="single"
+              tabs={[
+                { value: 'all', label: 'All' },
+                {
+                  value: 'passed',
+                  label: 'Passed',
+                  icon: <CheckCircleOutlineIcon />,
+                },
+                {
+                  value: 'failed',
+                  label: 'Failed',
+                  icon: <BlockOutlinedIcon />,
+                },
+              ]}
+              activeValue={filter.statusFilter}
+              onSingleChange={value =>
+                handleStatusFilterChange(value as 'all' | 'passed' | 'failed')
+              }
+            />
+          }
+        />
+        {advancedFilterDrawer}
+      </>
+    );
+  }
 
   return (
     <Box
@@ -212,7 +180,6 @@ export default function TestRunFilterBar({
         justifyContent: 'space-between',
       }}
     >
-      {/* Left side: Search and Filters */}
       <Box
         sx={{
           display: 'flex',
@@ -222,7 +189,6 @@ export default function TestRunFilterBar({
           alignItems: { xs: 'stretch', sm: 'center' },
         }}
       >
-        {/* Search */}
         <TextField
           size="small"
           placeholder="Search tests..."
@@ -238,7 +204,6 @@ export default function TestRunFilterBar({
           sx={{ minWidth: { xs: '100%', sm: 250 } }}
         />
 
-        {/* Status Filter Buttons */}
         <ButtonGroup size="small" variant="outlined">
           <Button
             onClick={() => handleStatusFilterChange('all')}
@@ -269,7 +234,7 @@ export default function TestRunFilterBar({
             variant={
               filter.statusFilter === 'failed' ? 'contained' : 'outlined'
             }
-            startIcon={<CancelOutlinedIcon fontSize="small" />}
+            startIcon={<BlockOutlinedIcon fontSize="small" />}
             sx={{
               ...(filter.statusFilter === 'failed' && {
                 backgroundColor: theme.palette.error.main,
@@ -283,22 +248,23 @@ export default function TestRunFilterBar({
           </Button>
         </ButtonGroup>
 
-        {/* Behavior Filter */}
-        {availableBehaviors.length > 0 && (
-          <Badge badgeContent={activeFilterCount} color="primary">
-            <Button
-              size="small"
-              variant="outlined"
-              startIcon={<FilterListIcon />}
-              onClick={handleFilterClick}
-            >
-              Filters
-            </Button>
-          </Badge>
-        )}
+        <Badge
+          badgeContent={hasActiveDrawerFilters ? ' ' : 0}
+          color="primary"
+          variant="dot"
+          invisible={!hasActiveDrawerFilters}
+        >
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<FilterListIcon />}
+            onClick={() => setFilterDrawerOpen(true)}
+          >
+            Filters
+          </Button>
+        </Badge>
       </Box>
 
-      {/* Right side: View Mode and Actions */}
       <Box
         sx={{
           display: 'flex',
@@ -308,7 +274,6 @@ export default function TestRunFilterBar({
           alignItems: 'center',
         }}
       >
-        {/* View Mode Toggle */}
         {showViewMode && (
           <Box
             sx={{
@@ -374,351 +339,7 @@ export default function TestRunFilterBar({
         )}
       </Box>
 
-      {/* Advanced Filter Popover */}
-      <Popover
-        open={open}
-        anchorEl={anchorEl}
-        onClose={handleFilterClose}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'left',
-        }}
-        PaperProps={{
-          sx: {
-            p: 0,
-            width: 400,
-            maxHeight: 600,
-          },
-        }}
-      >
-        {/* Header */}
-        <Box
-          sx={{
-            p: 2,
-            borderBottom: 1,
-            borderColor: 'divider',
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-          }}
-        >
-          <Typography variant="subtitle1" fontWeight={600}>
-            Advanced Filters
-          </Typography>
-          {hasActiveFilters && (
-            <Button
-              size="small"
-              startIcon={<ClearAllIcon />}
-              onClick={handleClearAllFilters}
-              color="secondary"
-            >
-              Clear All
-            </Button>
-          )}
-        </Box>
-
-        {/* Content */}
-        <Box sx={{ p: 2.5, maxHeight: 520, overflow: 'auto' }}>
-          <Stack spacing={3}>
-            {/* Review Status */}
-            <Box>
-              <Box
-                sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}
-              >
-                <RateReviewIcon fontSize="small" color="action" />
-                <Typography variant="subtitle2" fontWeight={600}>
-                  Review Status
-                </Typography>
-              </Box>
-              <Stack direction="row" spacing={1} flexWrap="wrap">
-                <Chip
-                  label="All"
-                  size="small"
-                  onClick={() => handleOverruleFilterChange('all')}
-                  color={
-                    filter.overruleFilter === 'all' ? 'primary' : 'default'
-                  }
-                  variant={
-                    filter.overruleFilter === 'all' ? 'filled' : 'outlined'
-                  }
-                />
-                <Chip
-                  label="Reviewed"
-                  size="small"
-                  onClick={() => handleOverruleFilterChange('overruled')}
-                  color={
-                    filter.overruleFilter === 'overruled'
-                      ? 'primary'
-                      : 'default'
-                  }
-                  variant={
-                    filter.overruleFilter === 'overruled'
-                      ? 'filled'
-                      : 'outlined'
-                  }
-                />
-                <Chip
-                  label="Not Reviewed"
-                  size="small"
-                  onClick={() => handleOverruleFilterChange('original')}
-                  color={
-                    filter.overruleFilter === 'original' ? 'primary' : 'default'
-                  }
-                  variant={
-                    filter.overruleFilter === 'original' ? 'filled' : 'outlined'
-                  }
-                />
-                <Chip
-                  label="Conflicting"
-                  size="small"
-                  onClick={() => handleOverruleFilterChange('conflicting')}
-                  color={
-                    filter.overruleFilter === 'conflicting'
-                      ? 'warning'
-                      : 'default'
-                  }
-                  variant={
-                    filter.overruleFilter === 'conflicting'
-                      ? 'filled'
-                      : 'outlined'
-                  }
-                />
-              </Stack>
-            </Box>
-
-            <Divider />
-
-            {/* Activity Filters */}
-            <Box>
-              <Box
-                sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}
-              >
-                <CommentOutlinedIcon fontSize="small" color="action" />
-                <Typography variant="subtitle2" fontWeight={600}>
-                  Activity
-                </Typography>
-              </Box>
-
-              {/* Comments */}
-              <Box sx={{ mb: 2 }}>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    mb: 1,
-                  }}
-                >
-                  <Typography variant="body2" color="text.secondary">
-                    Comments
-                  </Typography>
-                  <ButtonGroup size="small" variant="outlined">
-                    <Button
-                      onClick={() => handleCommentFilterChange('all')}
-                      variant={
-                        filter.commentFilter === 'all'
-                          ? 'contained'
-                          : 'outlined'
-                      }
-                      sx={{ fontSize: '0.75rem', px: 1.5, py: 0.5 }}
-                    >
-                      All
-                    </Button>
-                    <Button
-                      onClick={() => handleCommentFilterChange('with_comments')}
-                      variant={
-                        filter.commentFilter === 'with_comments'
-                          ? 'contained'
-                          : 'outlined'
-                      }
-                      sx={{ fontSize: '0.75rem', px: 1.5, py: 0.5 }}
-                    >
-                      With
-                    </Button>
-                    <Button
-                      onClick={() =>
-                        handleCommentFilterChange('without_comments')
-                      }
-                      variant={
-                        filter.commentFilter === 'without_comments'
-                          ? 'contained'
-                          : 'outlined'
-                      }
-                      sx={{ fontSize: '0.75rem', px: 1.5, py: 0.5 }}
-                    >
-                      Without
-                    </Button>
-                  </ButtonGroup>
-                </Box>
-              </Box>
-
-              {/* Tasks */}
-              <Box>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    mb: 1,
-                  }}
-                >
-                  <Typography variant="body2" color="text.secondary">
-                    Tasks
-                  </Typography>
-                  <ButtonGroup size="small" variant="outlined">
-                    <Button
-                      onClick={() => handleTaskFilterChange('all')}
-                      variant={
-                        filter.taskFilter === 'all' ? 'contained' : 'outlined'
-                      }
-                      sx={{ fontSize: '0.75rem', px: 1.5, py: 0.5 }}
-                    >
-                      All
-                    </Button>
-                    <Button
-                      onClick={() => handleTaskFilterChange('with_tasks')}
-                      variant={
-                        filter.taskFilter === 'with_tasks'
-                          ? 'contained'
-                          : 'outlined'
-                      }
-                      sx={{ fontSize: '0.75rem', px: 1.5, py: 0.5 }}
-                    >
-                      With
-                    </Button>
-                    <Button
-                      onClick={() => handleTaskFilterChange('without_tasks')}
-                      variant={
-                        filter.taskFilter === 'without_tasks'
-                          ? 'contained'
-                          : 'outlined'
-                      }
-                      sx={{ fontSize: '0.75rem', px: 1.5, py: 0.5 }}
-                    >
-                      Without
-                    </Button>
-                  </ButtonGroup>
-                </Box>
-              </Box>
-            </Box>
-
-            <Divider />
-
-            {/* Metrics */}
-            {availableMetrics && availableMetrics.length > 0 && (
-              <>
-                <Box>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 1,
-                      mb: 1.5,
-                    }}
-                  >
-                    <AssessmentOutlinedIcon fontSize="small" color="action" />
-                    <Typography variant="subtitle2" fontWeight={600}>
-                      Metrics
-                    </Typography>
-                    {filter.selectedMetrics.length > 0 && (
-                      <Chip
-                        label={filter.selectedMetrics.length}
-                        size="small"
-                        color="primary"
-                        sx={{
-                          height: 20,
-                          fontSize: theme => theme.typography.caption.fontSize,
-                          '& .MuiChip-label': {
-                            fontSize: 'inherit',
-                          },
-                        }}
-                      />
-                    )}
-                  </Box>
-                  <FormGroup>
-                    {availableMetrics.map(metric => (
-                      <FormControlLabel
-                        key={metric.name}
-                        control={
-                          <Checkbox
-                            checked={filter.selectedMetrics.includes(
-                              metric.name
-                            )}
-                            onChange={() => handleMetricToggle(metric.name)}
-                            size="small"
-                          />
-                        }
-                        label={
-                          <Typography variant="body2">{metric.name}</Typography>
-                        }
-                        sx={{ mb: 0.5 }}
-                      />
-                    ))}
-                  </FormGroup>
-                </Box>
-                <Divider />
-              </>
-            )}
-
-            {/* Behaviors */}
-            {availableBehaviors.length > 0 && (
-              <Box>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    gap: 1,
-                    mb: 1.5,
-                  }}
-                >
-                  <ListIcon fontSize="small" color="action" />
-                  <Typography variant="subtitle2" fontWeight={600}>
-                    Behaviors
-                  </Typography>
-                  {filter.selectedBehaviors.length > 0 && (
-                    <Chip
-                      label={filter.selectedBehaviors.length}
-                      size="small"
-                      color="primary"
-                      sx={{
-                        height: 20,
-                        fontSize: theme => theme.typography.caption.fontSize,
-                        '& .MuiChip-label': {
-                          fontSize: 'inherit',
-                        },
-                      }}
-                    />
-                  )}
-                </Box>
-                <FormGroup>
-                  {availableBehaviors.map(behavior => (
-                    <FormControlLabel
-                      key={behavior.id}
-                      control={
-                        <Checkbox
-                          checked={filter.selectedBehaviors.includes(
-                            behavior.id
-                          )}
-                          onChange={() => handleBehaviorToggle(behavior.id)}
-                          size="small"
-                        />
-                      }
-                      label={
-                        <Typography variant="body2">{behavior.name}</Typography>
-                      }
-                      sx={{ mb: 0.5 }}
-                    />
-                  ))}
-                </FormGroup>
-              </Box>
-            )}
-          </Stack>
-        </Box>
-      </Popover>
+      {advancedFilterDrawer}
     </Box>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunFilterBar.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunFilterBar.tsx
@@ -60,6 +60,9 @@ interface TestRunFilterBarProps {
   onRerun?: () => void;
   isRerunning?: boolean;
   canRerun?: boolean;
+  /** Linked entities tab: search + status pills + advanced filters only */
+  variant?: 'default' | 'linkedEntities';
+  hideViewModeToggle?: boolean;
 }
 
 export default function TestRunFilterBar({
@@ -77,7 +80,11 @@ export default function TestRunFilterBar({
   onRerun,
   isRerunning = false,
   canRerun = false,
+  variant = 'default',
+  hideViewModeToggle = false,
 }: TestRunFilterBarProps) {
+  const showHeaderActions = variant !== 'linkedEntities';
+  const showViewMode = !hideViewModeToggle && onViewModeChange;
   const theme = useTheme();
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
   const handleFilterClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -302,7 +309,7 @@ export default function TestRunFilterBar({
         }}
       >
         {/* View Mode Toggle */}
-        {onViewModeChange && (
+        {showViewMode && (
           <Box
             sx={{
               display: 'flex',
@@ -332,24 +339,28 @@ export default function TestRunFilterBar({
           </Box>
         )}
 
-        <Button
-          size="small"
-          variant="outlined"
-          startIcon={<CompareArrowsIcon />}
-          onClick={onCompare}
-        >
-          Compare
-        </Button>
-        <Button
-          size="small"
-          variant="outlined"
-          startIcon={<DownloadIcon />}
-          onClick={onDownload}
-          disabled={isDownloading}
-        >
-          {isDownloading ? 'Downloading...' : 'Download'}
-        </Button>
-        {onRerun && (
+        {showHeaderActions && (
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<CompareArrowsIcon />}
+            onClick={onCompare}
+          >
+            Compare
+          </Button>
+        )}
+        {showHeaderActions && (
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<DownloadIcon />}
+            onClick={onDownload}
+            disabled={isDownloading}
+          >
+            {isDownloading ? 'Downloading...' : 'Download'}
+          </Button>
+        )}
+        {showHeaderActions && onRerun && (
           <Button
             size="small"
             variant="contained"

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunFilterBar.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunFilterBar.tsx
@@ -8,6 +8,7 @@ import {
   ButtonGroup,
   InputAdornment,
   Badge,
+  Tooltip,
   useTheme,
 } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
@@ -48,6 +49,7 @@ interface TestRunFilterBarProps {
   availableMetrics: Array<{ name: string; description?: string }>;
   onDownload: () => void;
   onCompare: () => void;
+  canCompare?: boolean;
   isDownloading?: boolean;
   totalTests: number;
   filteredTests: number;
@@ -68,6 +70,7 @@ export default function TestRunFilterBar({
   availableMetrics,
   onDownload,
   onCompare,
+  canCompare = true,
   isDownloading = false,
   totalTests: _totalTests,
   filteredTests: _filteredTests,
@@ -305,14 +308,25 @@ export default function TestRunFilterBar({
         )}
 
         {showHeaderActions && (
-          <Button
-            size="small"
-            variant="outlined"
-            startIcon={<CompareArrowsIcon />}
-            onClick={onCompare}
+          <Tooltip
+            title={
+              canCompare
+                ? ''
+                : 'No other test runs on this test set to compare against'
+            }
           >
-            Compare
-          </Button>
+            <span>
+              <Button
+                size="small"
+                variant="outlined"
+                startIcon={<CompareArrowsIcon />}
+                onClick={onCompare}
+                disabled={!canCompare}
+              >
+                Compare
+              </Button>
+            </span>
+          </Tooltip>
         )}
         {showHeaderActions && (
           <Button

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunLinkedEntitiesTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunLinkedEntitiesTab.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import React from 'react';
+import { Paper } from '@mui/material';
+import TestRunFilterBar, { FilterState } from './TestRunFilterBar';
+import TestsTableView from './TestsTableView';
+import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+
+interface TestRunLinkedEntitiesTabProps {
+  filteredTests: TestResultDetail[];
+  filter: FilterState;
+  onFilterChange: (filter: FilterState) => void;
+  availableBehaviors: Array<{
+    id: string;
+    name: string;
+    description?: string;
+    metrics: Array<{ name: string; description?: string }>;
+  }>;
+  availableMetrics: string[];
+  isDownloading: boolean;
+  onDownload: () => void;
+  onCompare: () => void;
+  onRerun: () => void;
+  isRerunning: boolean;
+  canRerun: boolean;
+  totalTests: number;
+  testRunId: string;
+  sessionToken: string;
+  loading?: boolean;
+  prompts: Record<string, { content: string; name?: string }>;
+  behaviors: Array<{
+    id: string;
+    name: string;
+    description?: string;
+    metrics: Array<{ name: string; description?: string }>;
+  }>;
+  onTestResultUpdate: (updated: TestResultDetail) => void;
+  currentUserId: string;
+  currentUserName: string;
+  currentUserPicture?: string;
+  initialSelectedTestId?: string;
+  testSetType?: string;
+  project?: { icon?: string; useCase?: string; name?: string };
+  projectName?: string;
+  metricsSource?: string;
+}
+
+export default function TestRunLinkedEntitiesTab({
+  filteredTests,
+  filter,
+  onFilterChange,
+  availableBehaviors,
+  availableMetrics,
+  isDownloading,
+  onDownload,
+  onCompare,
+  onRerun,
+  isRerunning,
+  canRerun,
+  totalTests,
+  testRunId,
+  sessionToken,
+  loading = false,
+  prompts,
+  behaviors,
+  onTestResultUpdate,
+  currentUserId,
+  currentUserName,
+  currentUserPicture,
+  initialSelectedTestId,
+  testSetType,
+  project,
+  projectName,
+  metricsSource,
+}: TestRunLinkedEntitiesTabProps) {
+  return (
+    <>
+      <TestRunFilterBar
+        filter={filter}
+        onFilterChange={onFilterChange}
+        availableBehaviors={availableBehaviors}
+        availableMetrics={availableMetrics.map(name => ({ name }))}
+        onDownload={onDownload}
+        onCompare={onCompare}
+        isDownloading={isDownloading}
+        totalTests={totalTests}
+        filteredTests={filteredTests.length}
+        onRerun={onRerun}
+        isRerunning={isRerunning}
+        canRerun={canRerun}
+        variant="linkedEntities"
+        hideViewModeToggle
+      />
+
+      <Paper
+        elevation={0}
+        sx={{
+          border: 1,
+          borderColor: 'divider',
+          borderRadius: 2,
+          overflow: 'hidden',
+        }}
+      >
+        <TestsTableView
+          tests={filteredTests}
+          prompts={prompts}
+          behaviors={behaviors}
+          testRunId={testRunId}
+          sessionToken={sessionToken}
+          loading={loading}
+          onTestResultUpdate={onTestResultUpdate}
+          currentUserId={currentUserId}
+          currentUserName={currentUserName}
+          currentUserPicture={currentUserPicture}
+          initialSelectedTestId={initialSelectedTestId}
+          testSetType={testSetType}
+          project={project}
+          projectName={projectName}
+          metricsSource={metricsSource}
+        />
+      </Paper>
+    </>
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunLinkedEntitiesTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunLinkedEntitiesTab.tsx
@@ -2,9 +2,11 @@
 
 import React from 'react';
 import { Paper } from '@mui/material';
+import type { Theme } from '@mui/material/styles';
 import TestRunFilterBar, { FilterState } from './TestRunFilterBar';
 import TestsTableView from './TestsTableView';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 
 interface TestRunLinkedEntitiesTabProps {
   filteredTests: TestResultDetail[];
@@ -74,7 +76,24 @@ export default function TestRunLinkedEntitiesTab({
   metricsSource,
 }: TestRunLinkedEntitiesTabProps) {
   return (
-    <>
+    <Paper
+      elevation={0}
+      sx={{
+        p: '30px',
+        borderRadius: BORDER_RADIUS.md,
+        boxShadow: (theme: Theme) =>
+          theme.palette.mode === 'light' ? ELEVATION.xs : 'none',
+        border: (theme: Theme) => `1px solid ${theme.palette.greyscale.border}`,
+        bgcolor: (theme: Theme) =>
+          theme.palette.mode === 'light'
+            ? '#ffffff'
+            : theme.palette.greyscale.surface1,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '30px',
+        minWidth: 0,
+      }}
+    >
       <TestRunFilterBar
         filter={filter}
         onFilterChange={onFilterChange}
@@ -92,33 +111,24 @@ export default function TestRunLinkedEntitiesTab({
         hideViewModeToggle
       />
 
-      <Paper
-        elevation={0}
-        sx={{
-          border: 1,
-          borderColor: 'divider',
-          borderRadius: 2,
-          overflow: 'hidden',
-        }}
-      >
-        <TestsTableView
-          tests={filteredTests}
-          prompts={prompts}
-          behaviors={behaviors}
-          testRunId={testRunId}
-          sessionToken={sessionToken}
-          loading={loading}
-          onTestResultUpdate={onTestResultUpdate}
-          currentUserId={currentUserId}
-          currentUserName={currentUserName}
-          currentUserPicture={currentUserPicture}
-          initialSelectedTestId={initialSelectedTestId}
-          testSetType={testSetType}
-          project={project}
-          projectName={projectName}
-          metricsSource={metricsSource}
-        />
-      </Paper>
-    </>
+      <TestsTableView
+        tests={filteredTests}
+        prompts={prompts}
+        behaviors={behaviors}
+        testRunId={testRunId}
+        sessionToken={sessionToken}
+        loading={loading}
+        onTestResultUpdate={onTestResultUpdate}
+        currentUserId={currentUserId}
+        currentUserName={currentUserName}
+        currentUserPicture={currentUserPicture}
+        initialSelectedTestId={initialSelectedTestId}
+        testSetType={testSetType}
+        project={project}
+        projectName={projectName}
+        metricsSource={metricsSource}
+        embedded
+      />
+    </Paper>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunLinkedEntitiesTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunLinkedEntitiesTab.tsx
@@ -22,6 +22,7 @@ interface TestRunLinkedEntitiesTabProps {
   isDownloading: boolean;
   onDownload: () => void;
   onCompare: () => void;
+  canCompare?: boolean;
   onRerun: () => void;
   isRerunning: boolean;
   canRerun: boolean;
@@ -56,6 +57,7 @@ export default function TestRunLinkedEntitiesTab({
   isDownloading,
   onDownload,
   onCompare,
+  canCompare = true,
   onRerun,
   isRerunning,
   canRerun,
@@ -101,6 +103,7 @@ export default function TestRunLinkedEntitiesTab({
         availableMetrics={availableMetrics.map(name => ({ name }))}
         onDownload={onDownload}
         onCompare={onCompare}
+        canCompare={canCompare}
         isDownloading={isDownloading}
         totalTests={totalTests}
         filteredTests={filteredTests.length}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -11,22 +11,36 @@ import {
   Button,
   TextField,
 } from '@mui/material';
-import ConstructionOutlinedIcon from '@mui/icons-material/ConstructionOutlined';
 import { useRouter, useSearchParams } from 'next/navigation';
 import DetailTabNav from '@/components/common/DetailTabNav';
 import TestRunDetailHeader from './TestRunDetailHeader';
 import TestRunConfigurationTab from './TestRunConfigurationTab';
 import TestRunStatsTab from './TestRunStatsTab';
 import TestRunLinkedEntitiesTab from './TestRunLinkedEntitiesTab';
-import RunDrawer from '@/components/common/RunDrawer';
+import TestRunTracesTab from './TestRunTracesTab';
+import RerunTestRunDrawer from '@/components/common/RerunTestRunDrawer';
 import { FilterState } from './TestRunFilterBar';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { useTestRunDetailData } from '../hooks/useTestRunDetailData';
+import { getTestEvaluationSummary } from '@/utils/test-result-status';
 
-const TAB_KEYS = ['configuration', 'stats', 'linked_entities', 'logs'] as const;
+const TAB_KEYS = [
+  'summary',
+  'linked_entities',
+  'configuration',
+  'traces',
+] as const;
 type TabKey = (typeof TAB_KEYS)[number];
+
+const TAB_LABELS: Record<TabKey, string> = {
+  summary: 'Summary',
+  configuration: 'Configuration',
+  linked_entities: 'Test Cases',
+  traces: 'Traces',
+};
 
 function tabIndexFromKey(
   key: string | null,
@@ -34,6 +48,12 @@ function tabIndexFromKey(
 ): number {
   if (key === 'results') {
     return TAB_KEYS.indexOf('linked_entities');
+  }
+  if (key === 'stats') {
+    return TAB_KEYS.indexOf('summary');
+  }
+  if (key === 'logs') {
+    return TAB_KEYS.indexOf('traces');
   }
   const idx = TAB_KEYS.indexOf(key as TabKey);
   if (idx >= 0) return idx;
@@ -69,16 +89,6 @@ interface TestRunMainViewProps {
   };
   testRun: TestRunDetail;
   sessionToken: string;
-  testResults: TestResultDetail[];
-  prompts: Record<string, { content: string; name?: string }>;
-  behaviors: Array<{
-    id: string;
-    name: string;
-    description?: string;
-    metrics: Array<{ name: string; description?: string }>;
-  }>;
-  availableMetrics: string[];
-  loading?: boolean;
   currentUserId: string;
   currentUserName: string;
   currentUserPicture?: string;
@@ -90,11 +100,6 @@ export default function TestRunMainView({
   testRunData: _testRunData,
   testRun,
   sessionToken,
-  testResults: initialTestResults,
-  prompts,
-  behaviors,
-  availableMetrics,
-  loading = false,
   currentUserId,
   currentUserName,
   currentUserPicture,
@@ -103,6 +108,18 @@ export default function TestRunMainView({
   const notifications = useNotifications();
   const router = useRouter();
   const searchParams = useSearchParams();
+
+  const {
+    testResults: loadedTestResults,
+    prompts,
+    behaviors,
+    availableMetrics,
+    loading,
+    error: loadError,
+  } = useTestRunDetailData({
+    testRunId,
+    sessionToken,
+  });
 
   const preferLinkedEntities = Boolean(initialSelectedTestId);
   const activeTab = tabIndexFromKey(
@@ -142,11 +159,11 @@ export default function TestRunMainView({
   });
 
   const testResults = useMemo(() => {
-    if (testResultUpdates.size === 0) return initialTestResults;
-    return initialTestResults.map(
+    if (testResultUpdates.size === 0) return loadedTestResults;
+    return loadedTestResults.map(
       test => testResultUpdates.get(test.id) || test
     );
-  }, [initialTestResults, testResultUpdates]);
+  }, [loadedTestResults, testResultUpdates]);
 
   const filteredTests = useMemo(() => {
     let filtered = [...testResults];
@@ -161,11 +178,11 @@ export default function TestRunMainView({
         ).toLowerCase();
         const goalContent =
           test.test_output?.test_configuration?.goal?.toLowerCase() || '';
-        const responseContent = test.test_output?.output?.toLowerCase() || '';
+        const evaluationContent = getTestEvaluationSummary(test).toLowerCase();
         return (
           promptContent.includes(query) ||
           goalContent.includes(query) ||
-          responseContent.includes(query)
+          evaluationContent.includes(query)
         );
       });
     }
@@ -369,10 +386,7 @@ export default function TestRunMainView({
 
   const navTabs = TAB_KEYS.map((key, index) => ({
     key,
-    label:
-      key === 'linked_entities'
-        ? 'Linked entities'
-        : key.charAt(0).toUpperCase() + key.slice(1),
+    label: TAB_LABELS[key],
     id: `test-run-tab-${index}`,
     'aria-controls': `test-run-tabpanel-${index}`,
   }));
@@ -381,6 +395,12 @@ export default function TestRunMainView({
 
   return (
     <Box>
+      {loadError && (
+        <Typography color="error" sx={{ mb: 2 }}>
+          {loadError}
+        </Typography>
+      )}
+
       <TestRunDetailHeader
         testRun={testRun}
         onRename={handleRenameOpen}
@@ -436,13 +456,6 @@ export default function TestRunMainView({
       />
 
       <TabPanel value={activeTab} index={0}>
-        <TestRunConfigurationTab
-          testRun={testRun}
-          sessionToken={sessionToken}
-        />
-      </TabPanel>
-
-      <TabPanel value={activeTab} index={1}>
         <TestRunStatsTab
           testRun={testRun}
           testRunId={testRunId}
@@ -453,7 +466,7 @@ export default function TestRunMainView({
         />
       </TabPanel>
 
-      <TabPanel value={activeTab} index={2}>
+      <TabPanel value={activeTab} index={1}>
         <TestRunLinkedEntitiesTab
           filteredTests={filteredTests}
           filter={filter}
@@ -486,31 +499,21 @@ export default function TestRunMainView({
         />
       </TabPanel>
 
-      <TabPanel value={activeTab} index={3}>
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-            py: 10,
-            gap: 2,
-            color: 'text.secondary',
-          }}
-        >
-          <ConstructionOutlinedIcon sx={{ fontSize: 48, opacity: 0.4 }} />
-          <Typography variant="h6" color="text.secondary">
-            Logs coming soon
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Execution logs will be available here once the backend endpoint is
-            ready.
-          </Typography>
-        </Box>
+      <TabPanel value={activeTab} index={2}>
+        <TestRunConfigurationTab testRun={testRun} />
       </TabPanel>
 
-      <RunDrawer
-        mode="rerunTestRun"
+      <TabPanel value={activeTab} index={3}>
+        <TestRunTracesTab
+          testRunId={testRunId}
+          sessionToken={sessionToken}
+          currentUserId={currentUserId}
+          currentUserName={currentUserName}
+          currentUserPicture={currentUserPicture}
+        />
+      </TabPanel>
+
+      <RerunTestRunDrawer
         open={isRerunDrawerOpen}
         onClose={() => setIsRerunDrawerOpen(false)}
         data={{

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -1,19 +1,8 @@
 'use client';
 
-import React, {
-  useState,
-  useMemo,
-  useCallback,
-  useRef,
-  useEffect,
-} from 'react';
+import React, { useState, useMemo, useCallback, useEffect } from 'react';
 import {
   Box,
-  Paper,
-  useTheme,
-  TablePagination,
-  IconButton,
-  Tooltip,
   Typography,
   Dialog,
   DialogTitle,
@@ -22,20 +11,53 @@ import {
   Button,
   TextField,
 } from '@mui/material';
-import EditIcon from '@mui/icons-material/Edit';
-import { useRouter } from 'next/navigation';
-import TestRunFilterBar, { FilterState } from './TestRunFilterBar';
-import TestsList from './TestsList';
-import TestDetailPanel from './TestDetailPanel';
-import TestsTableView from './TestsTableView';
-import ComparisonView from './ComparisonView';
-import TestRunHeader from './TestRunHeader';
-import TestRunTags from './TestRunTags';
+import ConstructionOutlinedIcon from '@mui/icons-material/ConstructionOutlined';
+import { useRouter, useSearchParams } from 'next/navigation';
+import DetailTabNav from '@/components/common/DetailTabNav';
+import TestRunDetailHeader from './TestRunDetailHeader';
+import TestRunConfigurationTab from './TestRunConfigurationTab';
+import TestRunStatsTab from './TestRunStatsTab';
+import TestRunLinkedEntitiesTab from './TestRunLinkedEntitiesTab';
 import RunDrawer from '@/components/common/RunDrawer';
+import { FilterState } from './TestRunFilterBar';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
+
+const TAB_KEYS = ['configuration', 'stats', 'linked_entities', 'logs'] as const;
+type TabKey = (typeof TAB_KEYS)[number];
+
+function tabIndexFromKey(
+  key: string | null,
+  preferLinkedEntities: boolean
+): number {
+  if (key === 'results') {
+    return TAB_KEYS.indexOf('linked_entities');
+  }
+  const idx = TAB_KEYS.indexOf(key as TabKey);
+  if (idx >= 0) return idx;
+  return preferLinkedEntities ? TAB_KEYS.indexOf('linked_entities') : 0;
+}
+
+interface TabPanelProps {
+  children?: React.ReactNode;
+  index: number;
+  value: number;
+}
+
+function TabPanel({ children, value, index }: TabPanelProps) {
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`test-run-tabpanel-${index}`}
+      aria-labelledby={`test-run-tab-${index}`}
+    >
+      {value === index && <Box sx={{ pt: 3 }}>{children}</Box>}
+    </div>
+  );
+}
 
 interface TestRunMainViewProps {
   testRunId: string;
@@ -65,7 +87,7 @@ interface TestRunMainViewProps {
 
 export default function TestRunMainView({
   testRunId,
-  testRunData,
+  testRunData: _testRunData,
   testRun,
   sessionToken,
   testResults: initialTestResults,
@@ -78,80 +100,35 @@ export default function TestRunMainView({
   currentUserPicture,
   initialSelectedTestId,
 }: TestRunMainViewProps) {
-  const theme = useTheme();
   const notifications = useNotifications();
   const router = useRouter();
-  const [selectedTestId, setSelectedTestId] = useState<string | null>(null);
+  const searchParams = useSearchParams();
+
+  const preferLinkedEntities = Boolean(initialSelectedTestId);
+  const activeTab = tabIndexFromKey(
+    searchParams.get('tab'),
+    preferLinkedEntities && !searchParams.get('tab')
+  );
+
+  const handleTabChange = useCallback(
+    (newValue: number) => {
+      const key = TAB_KEYS[newValue];
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('tab', key);
+      router.push(`?${params.toString()}`, { scroll: false });
+    },
+    [router, searchParams]
+  );
+
   const [isDownloading, setIsDownloading] = useState(false);
   const [isRerunDrawerOpen, setIsRerunDrawerOpen] = useState(false);
-  const [isComparisonMode, setIsComparisonMode] = useState(false);
-  const [viewMode, setViewMode] = useState<'split' | 'table'>('split');
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(25);
-  const [hasInitialSelection, setHasInitialSelection] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [renameValue, setRenameValue] = useState('');
-  const [availableTestRuns, setAvailableTestRuns] = useState<
-    Array<{
-      id: string;
-      name?: string;
-      created_at: string;
-      pass_rate?: number;
-      experiment_id?: string;
-      parameter_version?: string;
-    }>
-  >([]);
 
-  // Resizable split panel
-  const [listWidthPercent, setListWidthPercent] = useState(33.33);
-  const splitContainerRef = useRef<HTMLDivElement>(null);
-  const isDraggingRef = useRef(false);
-
-  const handleResizeStart = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    isDraggingRef.current = true;
-
-    const handleMouseMove = (moveEvent: MouseEvent) => {
-      if (!isDraggingRef.current || !splitContainerRef.current) return;
-      const rect = splitContainerRef.current.getBoundingClientRect();
-      const offsetX = moveEvent.clientX - rect.left;
-      const percent = (offsetX / rect.width) * 100;
-      const clamped = Math.min(Math.max(percent, 20), 60);
-      setListWidthPercent(clamped);
-    };
-
-    const handleMouseUp = () => {
-      isDraggingRef.current = false;
-      document.removeEventListener('mousemove', handleMouseMove);
-      document.removeEventListener('mouseup', handleMouseUp);
-      document.body.style.cursor = '';
-      document.body.style.userSelect = '';
-    };
-
-    document.addEventListener('mousemove', handleMouseMove);
-    document.addEventListener('mouseup', handleMouseUp);
-    document.body.style.cursor = 'col-resize';
-    document.body.style.userSelect = 'none';
-  }, []);
-
-  // Restore body styles if the component unmounts mid-drag (e.g. client-side navigation).
-  // We cannot remove the per-drag closure listeners without storing them in refs, but
-  // resetting the body styles prevents the stuck cursor / non-selectable text bug.
-  useEffect(() => {
-    return () => {
-      if (isDraggingRef.current) {
-        document.body.style.cursor = '';
-        document.body.style.userSelect = '';
-      }
-    };
-  }, []);
-
-  // Track only updates to test results (not all test results)
   const [testResultUpdates, setTestResultUpdates] = useState<
     Map<string, TestResultDetail>
   >(new Map());
 
-  // Filter state
   const [filter, setFilter] = useState<FilterState>({
     searchQuery: '',
     statusFilter: 'all',
@@ -164,26 +141,16 @@ export default function TestRunMainView({
     taskCountRange: { min: 0, max: 10 },
   });
 
-  // Merge prop data with any updates
   const testResults = useMemo(() => {
-    if (testResultUpdates.size === 0) {
-      return initialTestResults;
-    }
+    if (testResultUpdates.size === 0) return initialTestResults;
     return initialTestResults.map(
       test => testResultUpdates.get(test.id) || test
     );
   }, [initialTestResults, testResultUpdates]);
 
-  // Get selected test
-  const selectedTest = useMemo(() => {
-    return testResults.find(t => t.id === selectedTestId) || null;
-  }, [testResults, selectedTestId]);
-
-  // Filter tests based on current filter state
   const filteredTests = useMemo(() => {
     let filtered = [...testResults];
 
-    // Apply search filter
     if (filter.searchQuery) {
       const query = filter.searchQuery.toLowerCase();
       filtered = filtered.filter(test => {
@@ -203,7 +170,6 @@ export default function TestRunMainView({
       });
     }
 
-    // Apply status filter
     if (filter.statusFilter !== 'all') {
       filtered = filtered.filter(test => {
         const metrics = test.test_metrics?.metrics || {};
@@ -211,27 +177,21 @@ export default function TestRunMainView({
         const totalMetrics = metricValues.length;
         const passedMetrics = metricValues.filter(m => m.is_successful).length;
         const isPassed = totalMetrics > 0 && passedMetrics === totalMetrics;
-
         return filter.statusFilter === 'passed' ? isPassed : !isPassed;
       });
     }
 
-    // Apply behavior filter
     if (filter.selectedBehaviors.length > 0) {
       filtered = filtered.filter(test => {
         const metrics = test.test_metrics?.metrics || {};
-
-        // Check if test has at least one metric from selected behaviors
         return filter.selectedBehaviors.some(behaviorId => {
           const behavior = behaviors.find(b => b.id === behaviorId);
           if (!behavior) return false;
-
           return behavior.metrics.some(metric => metrics[metric.name]);
         });
       });
     }
 
-    // Apply metrics filter — show results that contain any of the selected metrics
     if (filter.selectedMetrics.length > 0) {
       filtered = filtered.filter(test => {
         const metrics = test.test_metrics?.metrics || {};
@@ -241,33 +201,25 @@ export default function TestRunMainView({
       });
     }
 
-    // Apply review status filter
     if (filter.overruleFilter !== 'all') {
       filtered = filtered.filter(test => {
         const hasReview = !!test.last_review;
         const hasConflict = !test.matches_review;
-
-        if (filter.overruleFilter === 'overruled') {
-          return hasReview;
-        } else if (filter.overruleFilter === 'original') {
-          return !hasReview;
-        } else if (filter.overruleFilter === 'conflicting') {
+        if (filter.overruleFilter === 'overruled') return hasReview;
+        if (filter.overruleFilter === 'original') return !hasReview;
+        if (filter.overruleFilter === 'conflicting')
           return hasReview && hasConflict;
-        }
         return true;
       });
     }
 
-    // Apply comment filter
     if (filter.commentFilter !== 'all') {
       filtered = filtered.filter(test => {
         const commentCount = test.counts?.comments || 0;
-
-        if (filter.commentFilter === 'with_comments') {
-          return commentCount > 0;
-        } else if (filter.commentFilter === 'without_comments') {
+        if (filter.commentFilter === 'with_comments') return commentCount > 0;
+        if (filter.commentFilter === 'without_comments')
           return commentCount === 0;
-        } else if (filter.commentFilter === 'range') {
+        if (filter.commentFilter === 'range') {
           return (
             commentCount >= filter.commentCountRange.min &&
             commentCount <= filter.commentCountRange.max
@@ -277,16 +229,12 @@ export default function TestRunMainView({
       });
     }
 
-    // Apply task filter
     if (filter.taskFilter !== 'all') {
       filtered = filtered.filter(test => {
         const taskCount = test.counts?.tasks || 0;
-
-        if (filter.taskFilter === 'with_tasks') {
-          return taskCount > 0;
-        } else if (filter.taskFilter === 'without_tasks') {
-          return taskCount === 0;
-        } else if (filter.taskFilter === 'range') {
+        if (filter.taskFilter === 'with_tasks') return taskCount > 0;
+        if (filter.taskFilter === 'without_tasks') return taskCount === 0;
+        if (filter.taskFilter === 'range') {
           return (
             taskCount >= filter.taskCountRange.min &&
             taskCount <= filter.taskCountRange.max
@@ -299,26 +247,10 @@ export default function TestRunMainView({
     return filtered;
   }, [testResults, filter, prompts, behaviors]);
 
-  // Handle test selection
-  const handleTestSelect = useCallback((testId: string) => {
-    setSelectedTestId(testId);
+  const handleFilterChange = useCallback((newFilter: FilterState) => {
+    setFilter(newFilter);
   }, []);
 
-  // Handle filter changes
-  const handleFilterChange = useCallback(
-    (newFilter: FilterState) => {
-      setFilter(newFilter);
-      setPage(0);
-      // If current selected test is not in filtered list, clear selection
-      const testStillVisible = testResults.some(t => t.id === selectedTestId);
-      if (!testStillVisible) {
-        setSelectedTestId(null);
-      }
-    },
-    [testResults, selectedTestId]
-  );
-
-  // Handle test result updates (e.g., when tags change)
   const handleTestResultUpdate = useCallback(
     (updatedTest: TestResultDetail) => {
       setTestResultUpdates(prev => {
@@ -330,28 +262,6 @@ export default function TestRunMainView({
     []
   );
 
-  // Handle pagination
-  const handleChangePage = useCallback((_event: unknown, newPage: number) => {
-    setPage(newPage);
-  }, []);
-
-  const handleChangeRowsPerPage = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      setRowsPerPage(parseInt(event.target.value, 10));
-      setPage(0);
-    },
-    []
-  );
-
-  // Paginated tests for split view
-  const paginatedTests = useMemo(() => {
-    return filteredTests.slice(
-      page * rowsPerPage,
-      page * rowsPerPage + rowsPerPage
-    );
-  }, [filteredTests, page, rowsPerPage]);
-
-  // Handle download
   const handleDownload = useCallback(async () => {
     setIsDownloading(true);
     try {
@@ -359,8 +269,6 @@ export default function TestRunMainView({
         sessionToken
       ).getTestRunsClient();
       const blob = await testRunsClient.downloadTestRun(testRunId);
-
-      // Create download link
       const url = window.URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
@@ -369,11 +277,10 @@ export default function TestRunMainView({
       link.click();
       document.body.removeChild(link);
       window.URL.revokeObjectURL(url);
-
       notifications.show('Test run results downloaded successfully', {
         severity: 'success',
       });
-    } catch (_error) {
+    } catch {
       notifications.show('Failed to download test run results', {
         severity: 'error',
       });
@@ -382,7 +289,6 @@ export default function TestRunMainView({
     }
   }, [testRunId, sessionToken, notifications]);
 
-  // Handle re-run button click - opens the rerun drawer
   const handleRerun = useCallback(() => {
     if (!testRun.test_configuration_id) {
       notifications.show('Cannot re-run: No test configuration found', {
@@ -390,26 +296,25 @@ export default function TestRunMainView({
       });
       return;
     }
-
-    // Check if we have the required data for re-run
     const testSet = testRun.test_configuration?.test_set;
     const endpoint = testRun.test_configuration?.endpoint;
-
     if (!testSet?.id || !endpoint?.id) {
       notifications.show('Cannot re-run: Missing test set or endpoint data', {
         severity: 'error',
       });
       return;
     }
-
     setIsRerunDrawerOpen(true);
-  }, [
-    testRun.test_configuration_id,
-    testRun.test_configuration,
-    notifications,
-  ]);
+  }, [testRun, notifications]);
 
-  // Handle rename
+  const handleCompare = useCallback(() => {
+    window.open(
+      `/test-runs/${testRunId}/compare`,
+      '_blank',
+      'noopener,noreferrer'
+    );
+  }, [testRunId]);
+
   const handleRenameOpen = useCallback(() => {
     setRenameValue(testRun.name || '');
     setRenameDialogOpen(true);
@@ -426,15 +331,16 @@ export default function TestRunMainView({
       return;
     }
     try {
-      const factory = new ApiClientFactory(sessionToken);
-      const testRunsClient = factory.getTestRunsClient();
+      const testRunsClient = new ApiClientFactory(
+        sessionToken
+      ).getTestRunsClient();
       await testRunsClient.updateTestRun(testRunId, { name: trimmed });
       notifications.show('Test run renamed successfully', {
         severity: 'success',
       });
       setRenameDialogOpen(false);
       router.refresh();
-    } catch (_error) {
+    } catch {
       notifications.show('Failed to rename test run', {
         severity: 'error',
       });
@@ -448,207 +354,43 @@ export default function TestRunMainView({
     router,
   ]);
 
-  // Handle rerun drawer success
   const handleRerunSuccess = useCallback(() => {
-    // Navigate to the test runs page to see the new test run
     router.push('/test-runs');
   }, [router]);
 
-  // Fetch available test runs for comparison (lazy-loaded when compare is clicked)
-  const fetchTestRuns = useCallback(async () => {
-    try {
-      // Get test_set_id from the nested test_set object
-      const testSetId = testRun.test_configuration?.test_set?.id;
-
-      if (!testSetId) {
-        setAvailableTestRuns([]);
-        return [];
-      }
-
-      const testRunsClient = new ApiClientFactory(
-        sessionToken
-      ).getTestRunsClient();
-
-      // Use OData filter to get all test runs for the same test set
-      const params = {
-        limit: 50,
-        skip: 0,
-        sort_by: 'created_at' as const,
-        sort_order: 'desc' as const,
-        filter: `test_configuration/test_set/id eq '${testSetId}'`,
-      };
-
-      const response = await testRunsClient.getTestRuns(params);
-
-      // Filter out current test run
-      const runs = response.data
-        .filter(run => run.id !== testRunId)
-        .map(run => ({
-          id: run.id,
-          name: run.name,
-          created_at:
-            (typeof run.attributes?.started_at === 'string'
-              ? run.attributes.started_at
-              : null) ||
-            (typeof run.created_at === 'string' ? run.created_at : '') ||
-            '',
-          pass_rate: undefined, // Will be calculated from test results if needed
-          experiment_id: run.experiment_id ?? undefined,
-          parameter_version:
-            typeof run.attributes?.parameter_version === 'string'
-              ? (run.attributes.parameter_version as string)
-              : undefined,
-          experiment_name:
-            typeof run.attributes?.parameter_experiment_name === 'string'
-              ? (run.attributes.parameter_experiment_name as string)
-              : undefined,
-        }));
-
-      setAvailableTestRuns(runs);
-      return runs;
-    } catch (_error) {
-      setAvailableTestRuns([]);
-      return [];
+  useEffect(() => {
+    const tab = searchParams.get('tab');
+    if (initialSelectedTestId && (!tab || tab === 'results')) {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('tab', 'linked_entities');
+      router.replace(`?${params.toString()}`, { scroll: false });
     }
-  }, [testRunId, sessionToken, testRun.test_configuration?.test_set?.id]);
+  }, [initialSelectedTestId, router, searchParams]);
 
-  // Handle compare
-  const handleCompare = useCallback(async () => {
-    // Fetch test runs only when compare is clicked
-    const runs = await fetchTestRuns();
+  const navTabs = TAB_KEYS.map((key, index) => ({
+    key,
+    label:
+      key === 'linked_entities'
+        ? 'Linked entities'
+        : key.charAt(0).toUpperCase() + key.slice(1),
+    id: `test-run-tab-${index}`,
+    'aria-controls': `test-run-tabpanel-${index}`,
+  }));
 
-    if (runs.length === 0) {
-      notifications.show('No other test runs available for comparison', {
-        severity: 'info',
-      });
-      return;
-    }
-    setIsComparisonMode(true);
-  }, [fetchTestRuns, notifications]);
-
-  // Handle load baseline test results
-  const handleLoadBaseline = useCallback(
-    async (baselineTestRunId: string): Promise<TestResultDetail[]> => {
-      try {
-        const testResultsClient = new ApiClientFactory(
-          sessionToken
-        ).getTestResultsClient();
-
-        // Fetch all test results for baseline test run
-        let testResults: TestResultDetail[] = [];
-        let skip = 0;
-        const batchSize = 100;
-        let hasMore = true;
-
-        while (hasMore) {
-          const testResultsResponse = await testResultsClient.getTestResults({
-            filter: `test_run_id eq '${baselineTestRunId}'`,
-            limit: batchSize,
-            skip: skip,
-            sort_by: 'created_at',
-            sort_order: 'desc',
-          });
-
-          testResults = [...testResults, ...testResultsResponse.data];
-
-          const totalCount = testResultsResponse.pagination?.totalCount || 0;
-          hasMore = testResults.length < totalCount;
-          skip += batchSize;
-
-          if (skip > 10000) break;
-        }
-
-        return testResults;
-      } catch (_error) {
-        notifications.show('Failed to load baseline test results', {
-          severity: 'error',
-        });
-        return [];
-      }
-    },
-    [sessionToken, notifications]
-  );
-
-  // Handle initial selection and pagination when initialSelectedTestId is provided
-  React.useEffect(() => {
-    if (
-      initialSelectedTestId &&
-      filteredTests.length > 0 &&
-      !hasInitialSelection
-    ) {
-      // First try to match by test result ID (direct match)
-      let testIndex = filteredTests.findIndex(
-        t => t.id === initialSelectedTestId
-      );
-
-      // If not found, try to match by test_id (for cross-run navigation)
-      if (testIndex === -1) {
-        testIndex = filteredTests.findIndex(
-          t => t.test_id === initialSelectedTestId
-        );
-        if (testIndex !== -1) {
-        }
-      }
-
-      if (testIndex !== -1) {
-        // Calculate which page the test is on
-        const testPage = Math.floor(testIndex / rowsPerPage);
-        setPage(testPage);
-        setSelectedTestId(filteredTests[testIndex].id);
-        setHasInitialSelection(true);
-      } else {
-      }
-    }
-  }, [initialSelectedTestId, filteredTests, rowsPerPage, hasInitialSelection]);
-
-  // Auto-select first test if none selected and tests are available
-  // But DON'T auto-select if we have an initialSelectedTestId that hasn't loaded yet
-  React.useEffect(() => {
-    // Skip auto-selection if we're waiting for initial selection
-    if (initialSelectedTestId && !hasInitialSelection) {
-      return;
-    }
-
-    if (!selectedTestId && filteredTests.length > 0) {
-      setSelectedTestId(filteredTests[0].id);
-    } else if (
-      selectedTestId &&
-      !filteredTests.some(t => t.id === selectedTestId)
-    ) {
-      // If selected test is not in filtered list, select first available or clear selection
-      if (filteredTests.length > 0) {
-        setSelectedTestId(filteredTests[0].id);
-      } else {
-        setSelectedTestId(null);
-      }
-    }
-  }, [
-    selectedTestId,
-    filteredTests,
-    initialSelectedTestId,
-    hasInitialSelection,
-  ]);
+  const canRerun = Boolean(testRun.test_configuration_id);
 
   return (
     <Box>
-      {/* Title with rename pencil icon */}
-      <Box
-        sx={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 1,
-          mb: 3,
-        }}
-      >
-        <Typography variant="h4">{testRun.name || `Test Run`}</Typography>
-        <Tooltip title="Rename test run">
-          <IconButton size="small" onClick={handleRenameOpen}>
-            <EditIcon fontSize="small" />
-          </IconButton>
-        </Tooltip>
-      </Box>
+      <TestRunDetailHeader
+        testRun={testRun}
+        onRename={handleRenameOpen}
+        onCompare={handleCompare}
+        onDownload={handleDownload}
+        onRerun={handleRerun}
+        isDownloading={isDownloading}
+        canRerun={canRerun}
+      />
 
-      {/* Rename Dialog */}
       <Dialog
         open={renameDialogOpen}
         onClose={handleRenameClose}
@@ -666,7 +408,7 @@ export default function TestRunMainView({
             onKeyDown={e => {
               if (e.key === 'Enter') {
                 e.preventDefault();
-                handleRenameSubmit();
+                void handleRenameSubmit();
               }
             }}
             sx={{ mt: 1 }}
@@ -675,7 +417,7 @@ export default function TestRunMainView({
         <DialogActions>
           <Button onClick={handleRenameClose}>Cancel</Button>
           <Button
-            onClick={handleRenameSubmit}
+            onClick={() => void handleRenameSubmit()}
             variant="contained"
             disabled={
               !renameValue.trim() || renameValue.trim() === testRun.name
@@ -686,225 +428,87 @@ export default function TestRunMainView({
         </DialogActions>
       </Dialog>
 
-      {/* Header with Summary Cards - only show when not in comparison mode */}
-      {!isComparisonMode && (
-        <TestRunHeader
+      <DetailTabNav
+        tabs={navTabs}
+        activeIndex={activeTab}
+        onChange={handleTabChange}
+        aria-label="Test run detail tabs"
+      />
+
+      <TabPanel value={activeTab} index={0}>
+        <TestRunConfigurationTab
           testRun={testRun}
+          sessionToken={sessionToken}
+        />
+      </TabPanel>
+
+      <TabPanel value={activeTab} index={1}>
+        <TestRunStatsTab
+          testRun={testRun}
+          testRunId={testRunId}
           testResults={testResults}
+          sessionToken={sessionToken}
           loading={loading}
           onRefresh={() => router.refresh()}
         />
-      )}
+      </TabPanel>
 
-      {!isComparisonMode ? (
-        <>
-          {/* Filter Bar */}
-          <TestRunFilterBar
-            filter={filter}
-            onFilterChange={handleFilterChange}
-            availableBehaviors={behaviors}
-            availableMetrics={availableMetrics.map(name => ({ name }))}
-            onDownload={handleDownload}
-            onCompare={handleCompare}
-            isDownloading={isDownloading}
-            totalTests={testResults.length}
-            filteredTests={filteredTests.length}
-            viewMode={viewMode}
-            onViewModeChange={setViewMode}
-            onRerun={handleRerun}
-            isRerunning={isRerunDrawerOpen}
-            canRerun={!!testRun.test_configuration_id}
-          />
-
-          {/* Conditional Layout based on viewMode */}
-          {viewMode === 'split' ? (
-            <Paper
-              elevation={2}
-              sx={{
-                height: { xs: 900, md: 'calc(100vh - 240px)' },
-                minHeight: 900,
-                display: 'flex',
-                flexDirection: 'column',
-                overflow: 'hidden',
-              }}
-            >
-              {/* Content Area with Resizable Split View */}
-              <Box
-                ref={splitContainerRef}
-                sx={{
-                  flex: 1,
-                  display: 'flex',
-                  overflow: 'hidden',
-                  position: 'relative',
-                }}
-              >
-                {/* Left: Tests List */}
-                <Box
-                  sx={{
-                    width: {
-                      xs: '100%',
-                      md: `${listWidthPercent}%`,
-                    },
-                    display: 'flex',
-                    flexDirection: 'column',
-                    overflow: 'hidden',
-                    flexShrink: 0,
-                  }}
-                >
-                  <TestsList
-                    tests={paginatedTests}
-                    selectedTestId={selectedTestId}
-                    onTestSelect={handleTestSelect}
-                    loading={loading}
-                    prompts={prompts}
-                    testSetType={
-                      testRun.test_configuration?.test_set?.test_set_type
-                        ?.type_value
-                    }
-                  />
-                </Box>
-
-                {/* Resize Handle */}
-                <Box
-                  onMouseDown={handleResizeStart}
-                  sx={{
-                    width: 6,
-                    flexShrink: 0,
-                    cursor: 'col-resize',
-                    display: { xs: 'none', md: 'flex' },
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    bgcolor: 'transparent',
-                    transition: 'background-color 0.15s',
-                    '&:hover, &:active': {
-                      bgcolor: 'action.hover',
-                    },
-                    '&::after': {
-                      content: '""',
-                      width: 2,
-                      height: 32,
-                      borderRadius: theme.shape.borderRadius,
-                      bgcolor: 'divider',
-                      transition: 'background-color 0.15s, height 0.15s',
-                    },
-                    '&:hover::after, &:active::after': {
-                      bgcolor: 'primary.main',
-                      height: 48,
-                    },
-                  }}
-                />
-
-                {/* Right: Test Detail Panel */}
-                <Box
-                  sx={{
-                    flex: 1,
-                    minWidth: 0,
-                    display: 'flex',
-                    flexDirection: 'column',
-                    overflow: 'hidden',
-                  }}
-                >
-                  <TestDetailPanel
-                    test={selectedTest}
-                    loading={loading}
-                    prompts={prompts}
-                    behaviors={behaviors}
-                    testRunId={testRunId}
-                    sessionToken={sessionToken}
-                    onTestResultUpdate={handleTestResultUpdate}
-                    currentUserId={currentUserId}
-                    currentUserName={currentUserName}
-                    currentUserPicture={currentUserPicture}
-                    testSetType={
-                      testRun.test_configuration?.test_set?.test_set_type
-                        ?.type_value
-                    }
-                    project={testRun.test_configuration?.endpoint?.project}
-                    projectName={
-                      testRun.test_configuration?.endpoint?.project?.name
-                    }
-                    metricsSource={
-                      testRun.test_configuration?.attributes?.metrics_source
-                    }
-                  />
-                </Box>
-              </Box>
-
-              {/* Shared Pagination at Bottom */}
-              <TablePagination
-                rowsPerPageOptions={[10, 25, 50, 100]}
-                component="div"
-                count={filteredTests.length}
-                rowsPerPage={rowsPerPage}
-                page={page}
-                onPageChange={handleChangePage}
-                onRowsPerPageChange={handleChangeRowsPerPage}
-                sx={{
-                  borderTop: 1,
-                  borderColor: 'divider',
-                  backgroundColor: theme.palette.background.paper,
-                  flexShrink: 0,
-                }}
-              />
-            </Paper>
-          ) : (
-            <TestsTableView
-              tests={filteredTests}
-              prompts={prompts}
-              behaviors={behaviors}
-              testRunId={testRunId}
-              sessionToken={sessionToken}
-              loading={loading}
-              onTestResultUpdate={handleTestResultUpdate}
-              currentUserId={currentUserId}
-              currentUserName={currentUserName}
-              currentUserPicture={currentUserPicture}
-              initialSelectedTestId={initialSelectedTestId}
-              testSetType={
-                testRun.test_configuration?.test_set?.test_set_type?.type_value
-              }
-              project={testRun.test_configuration?.endpoint?.project}
-              projectName={testRun.test_configuration?.endpoint?.project?.name}
-              metricsSource={
-                testRun.test_configuration?.attributes?.metrics_source
-              }
-            />
-          )}
-
-          {/* Test Run Tags - moved to bottom */}
-          <Paper elevation={2} sx={{ mt: 3, p: 2 }}>
-            <TestRunTags sessionToken={sessionToken} testRun={testRun} />
-          </Paper>
-        </>
-      ) : (
-        <ComparisonView
-          currentTestRun={{
-            ...testRunData,
-            experiment_id: testRun.experiment_id ?? undefined,
-            parameter_version:
-              typeof testRun.attributes?.parameter_version === 'string'
-                ? (testRun.attributes.parameter_version as string)
-                : undefined,
-            experiment_name:
-              typeof testRun.attributes?.parameter_experiment_name === 'string'
-                ? (testRun.attributes.parameter_experiment_name as string)
-                : undefined,
-          }}
-          currentTestResults={testResults}
-          availableTestRuns={availableTestRuns}
-          onClose={() => setIsComparisonMode(false)}
-          onLoadBaseline={handleLoadBaseline}
+      <TabPanel value={activeTab} index={2}>
+        <TestRunLinkedEntitiesTab
+          filteredTests={filteredTests}
+          filter={filter}
+          onFilterChange={handleFilterChange}
+          availableBehaviors={behaviors}
+          availableMetrics={availableMetrics}
+          isDownloading={isDownloading}
+          onDownload={handleDownload}
+          onCompare={handleCompare}
+          onRerun={handleRerun}
+          isRerunning={isRerunDrawerOpen}
+          canRerun={canRerun}
+          totalTests={testResults.length}
+          testRunId={testRunId}
+          sessionToken={sessionToken}
+          loading={loading}
           prompts={prompts}
           behaviors={behaviors}
+          onTestResultUpdate={handleTestResultUpdate}
+          currentUserId={currentUserId}
+          currentUserName={currentUserName}
+          currentUserPicture={currentUserPicture}
+          initialSelectedTestId={initialSelectedTestId}
           testSetType={
             testRun.test_configuration?.test_set?.test_set_type?.type_value
           }
           project={testRun.test_configuration?.endpoint?.project}
           projectName={testRun.test_configuration?.endpoint?.project?.name}
+          metricsSource={testRun.test_configuration?.attributes?.metrics_source}
         />
-      )}
+      </TabPanel>
 
-      {/* Re-run Test Run Drawer */}
+      <TabPanel value={activeTab} index={3}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            py: 10,
+            gap: 2,
+            color: 'text.secondary',
+          }}
+        >
+          <ConstructionOutlinedIcon sx={{ fontSize: 48, opacity: 0.4 }} />
+          <Typography variant="h6" color="text.secondary">
+            Logs coming soon
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Execution logs will be available here once the backend endpoint is
+            ready.
+          </Typography>
+        </Box>
+      </TabPanel>
+
       <RunDrawer
         mode="rerunTestRun"
         open={isRerunDrawerOpen}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -1,16 +1,7 @@
 'use client';
 
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
-import {
-  Box,
-  Typography,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Button,
-  TextField,
-} from '@mui/material';
+import { Box, Typography, TextField } from '@mui/material';
 import { useRouter, useSearchParams } from 'next/navigation';
 import DetailTabNav from '@/components/common/DetailTabNav';
 import TestRunDetailHeader from './TestRunDetailHeader';
@@ -19,6 +10,7 @@ import TestRunStatsTab from './TestRunStatsTab';
 import TestRunLinkedEntitiesTab from './TestRunLinkedEntitiesTab';
 import TestRunTracesTab from './TestRunTracesTab';
 import RerunTestRunDrawer from '@/components/common/RerunTestRunDrawer';
+import BaseDrawer from '@/components/common/BaseDrawer';
 import { FilterState } from './TestRunFilterBar';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
@@ -141,6 +133,8 @@ export default function TestRunMainView({
   const [isRerunDrawerOpen, setIsRerunDrawerOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [renameValue, setRenameValue] = useState('');
+  // Whether another test run exists on the same test set to compare against.
+  const [hasComparisonRuns, setHasComparisonRuns] = useState(false);
 
   const [testResultUpdates, setTestResultUpdates] = useState<
     Map<string, TestResultDetail>
@@ -268,6 +262,30 @@ export default function TestRunMainView({
     setFilter(newFilter);
   }, []);
 
+  const handleDrilldownToBehavior = useCallback(
+    (behaviorId: string) => {
+      setFilter(prev => ({
+        ...prev,
+        selectedBehaviors: [behaviorId],
+        statusFilter: 'failed',
+      }));
+      handleTabChange(TAB_KEYS.indexOf('linked_entities'));
+    },
+    [handleTabChange]
+  );
+
+  const handleDrilldownToMetric = useCallback(
+    (metricName: string) => {
+      setFilter(prev => ({
+        ...prev,
+        selectedMetrics: [metricName],
+        statusFilter: 'failed',
+      }));
+      handleTabChange(TAB_KEYS.indexOf('linked_entities'));
+    },
+    [handleTabChange]
+  );
+
   const handleTestResultUpdate = useCallback(
     (updatedTest: TestResultDetail) => {
       setTestResultUpdates(prev => {
@@ -323,6 +341,39 @@ export default function TestRunMainView({
     }
     setIsRerunDrawerOpen(true);
   }, [testRun, notifications]);
+
+  const testSetId = testRun.test_configuration?.test_set?.id;
+
+  useEffect(() => {
+    if (!testSetId) {
+      setHasComparisonRuns(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const testRunsClient = new ApiClientFactory(
+          sessionToken
+        ).getTestRunsClient();
+        const response = await testRunsClient.getTestRuns({
+          limit: 2,
+          skip: 0,
+          sort_by: 'created_at',
+          sort_order: 'desc',
+          filter: `test_configuration/test_set/id eq '${testSetId}'`,
+        });
+        if (!cancelled) {
+          const others = response.data.filter(run => run.id !== testRunId);
+          setHasComparisonRuns(others.length > 0);
+        }
+      } catch {
+        if (!cancelled) setHasComparisonRuns(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [testSetId, testRunId, sessionToken]);
 
   const handleCompare = useCallback(() => {
     window.open(
@@ -409,44 +460,34 @@ export default function TestRunMainView({
         onRerun={handleRerun}
         isDownloading={isDownloading}
         canRerun={canRerun}
+        canCompare={hasComparisonRuns}
       />
 
-      <Dialog
+      <BaseDrawer
         open={renameDialogOpen}
         onClose={handleRenameClose}
-        maxWidth="sm"
-        fullWidth
+        title="Rename Test Run"
+        onSave={() => void handleRenameSubmit()}
+        saveDisabled={
+          !renameValue.trim() || renameValue.trim() === testRun.name
+        }
+        saveButtonText="Save"
       >
-        <DialogTitle>Rename Test Run</DialogTitle>
-        <DialogContent>
-          <TextField
-            autoFocus
-            fullWidth
-            label="Name"
-            value={renameValue}
-            onChange={e => setRenameValue(e.target.value)}
-            onKeyDown={e => {
-              if (e.key === 'Enter') {
-                e.preventDefault();
-                void handleRenameSubmit();
-              }
-            }}
-            sx={{ mt: 1 }}
-          />
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={handleRenameClose}>Cancel</Button>
-          <Button
-            onClick={() => void handleRenameSubmit()}
-            variant="contained"
-            disabled={
-              !renameValue.trim() || renameValue.trim() === testRun.name
+        <TextField
+          autoFocus
+          fullWidth
+          label="Name"
+          value={renameValue}
+          onChange={e => setRenameValue(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              void handleRenameSubmit();
             }
-          >
-            Save
-          </Button>
-        </DialogActions>
-      </Dialog>
+          }}
+          sx={{ flexShrink: 0 }}
+        />
+      </BaseDrawer>
 
       <DetailTabNav
         tabs={navTabs}
@@ -463,6 +504,9 @@ export default function TestRunMainView({
           sessionToken={sessionToken}
           loading={loading}
           onRefresh={() => router.refresh()}
+          behaviors={behaviors}
+          onViewBehavior={handleDrilldownToBehavior}
+          onViewMetric={handleDrilldownToMetric}
         />
       </TabPanel>
 
@@ -476,6 +520,7 @@ export default function TestRunMainView({
           isDownloading={isDownloading}
           onDownload={handleDownload}
           onCompare={handleCompare}
+          canCompare={hasComparisonRuns}
           onRerun={handleRerun}
           isRerunning={isRerunDrawerOpen}
           canRerun={canRerun}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunStatsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunStatsTab.tsx
@@ -1,15 +1,54 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
-import { Box, CircularProgress, Grid, Paper, Typography } from '@mui/material';
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import { BasePieChart } from '@/components/common/BaseCharts';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Chip,
+  CircularProgress,
+  Grid,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+  Tooltip,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip as RechartsTooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { TestRunStatsAll } from '@/utils/api-client/interfaces/test-run-stats';
-import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+import {
+  TestResultDetail,
+  TestResultsStats,
+} from '@/utils/api-client/interfaces/test-results';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
+import { BehaviorWithMetrics } from '../hooks/useTestRunDetailData';
 import TestRunHeader from './TestRunHeader';
 import TestRunTags from './TestRunTags';
+import {
+  aggregateBehaviorStats,
+  aggregateMetricStats,
+  BehaviorStat,
+  getReviewBand,
+  MetricStat,
+} from './test-run-summary-utils';
 
 interface TestRunStatsTabProps {
   testRun: TestRunDetail;
@@ -18,9 +57,12 @@ interface TestRunStatsTabProps {
   sessionToken: string;
   loading?: boolean;
   onRefresh?: () => void;
+  behaviors?: BehaviorWithMetrics[];
+  onViewBehavior?: (behaviorId: string) => void;
+  onViewMetric?: (metricName: string) => void;
 }
 
-function ChartCard({
+function SectionCard({
   title,
   children,
 }: {
@@ -28,17 +70,7 @@ function ChartCard({
   children: React.ReactNode;
 }) {
   return (
-    <Paper
-      variant="outlined"
-      sx={{
-        p: 2,
-        height: '100%',
-        minHeight: 280,
-        borderRadius: 2,
-        display: 'flex',
-        flexDirection: 'column',
-      }}
-    >
+    <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
       <Typography
         variant="subtitle1"
         fontWeight={600}
@@ -46,8 +78,630 @@ function ChartCard({
       >
         {title}
       </Typography>
-      <Box sx={{ flex: 1, minHeight: 200 }}>{children}</Box>
+      {children}
     </Paper>
+  );
+}
+
+function BandChip({ passRate }: { passRate: number }) {
+  const band = getReviewBand(passRate);
+  return (
+    <Chip
+      label={band.label}
+      size="small"
+      color={band.colorKey}
+      sx={{ fontWeight: 500 }}
+    />
+  );
+}
+
+type BehaviorSortField = 'name' | 'total' | 'passRate';
+
+function BehaviorTable({
+  stats,
+  behaviors,
+  onViewBehavior,
+}: {
+  stats: BehaviorStat[];
+  behaviors?: BehaviorWithMetrics[];
+  onViewBehavior?: (behaviorId: string) => void;
+}) {
+  const [sortField, setSortField] = useState<BehaviorSortField>('passRate');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  const handleSort = (field: BehaviorSortField) => {
+    if (field === sortField) {
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir('asc');
+    }
+  };
+
+  const sorted = useMemo(() => {
+    return [...stats].sort((a, b) => {
+      const mul = sortDir === 'asc' ? 1 : -1;
+      if (sortField === 'name') return mul * a.name.localeCompare(b.name);
+      if (sortField === 'total') return mul * (a.total - b.total);
+      return mul * (a.passRate - b.passRate);
+    });
+  }, [stats, sortField, sortDir]);
+
+  return (
+    <Box sx={{ overflowX: 'auto' }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ whiteSpace: 'nowrap' }}>
+              <TableSortLabel
+                active={sortField === 'name'}
+                direction={sortField === 'name' ? sortDir : 'asc'}
+                onClick={() => handleSort('name')}
+              >
+                Behavior
+              </TableSortLabel>
+            </TableCell>
+            <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
+              <TableSortLabel
+                active={sortField === 'total'}
+                direction={sortField === 'total' ? sortDir : 'asc'}
+                onClick={() => handleSort('total')}
+              >
+                Tests
+              </TableSortLabel>
+            </TableCell>
+            <TableCell align="right">Passed</TableCell>
+            <TableCell align="right">Failed</TableCell>
+            <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
+              <TableSortLabel
+                active={sortField === 'passRate'}
+                direction={sortField === 'passRate' ? sortDir : 'asc'}
+                onClick={() => handleSort('passRate')}
+              >
+                Pass Rate
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>Status</TableCell>
+            {onViewBehavior && <TableCell />}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sorted.map(stat => {
+            const behavior = behaviors?.find(b => b.name === stat.name);
+            const canDrilldown =
+              stat.failed > 0 && !!onViewBehavior && !!behavior;
+            return (
+              <TableRow
+                key={stat.name}
+                hover={canDrilldown}
+                sx={{ cursor: canDrilldown ? 'pointer' : 'default' }}
+                onClick={
+                  canDrilldown ? () => onViewBehavior!(behavior!.id) : undefined
+                }
+              >
+                <TableCell sx={{ maxWidth: 300 }}>
+                  <Tooltip title={stat.name} placement="top" arrow>
+                    <Typography
+                      variant="body2"
+                      noWrap
+                      sx={{ maxWidth: 280, display: 'block' }}
+                    >
+                      {stat.name}
+                    </Typography>
+                  </Tooltip>
+                </TableCell>
+                <TableCell align="right">{stat.total}</TableCell>
+                <TableCell
+                  align="right"
+                  sx={{ color: theme => theme.palette.success.main }}
+                >
+                  {stat.passed}
+                </TableCell>
+                <TableCell
+                  align="right"
+                  sx={{
+                    color: theme =>
+                      stat.failed > 0
+                        ? theme.palette.error.main
+                        : 'text.secondary',
+                    fontWeight: stat.failed > 0 ? 600 : 400,
+                  }}
+                >
+                  {stat.failed}
+                </TableCell>
+                <TableCell align="right" sx={{ fontWeight: 600 }}>
+                  {stat.passRate.toFixed(1)}%
+                </TableCell>
+                <TableCell>
+                  <BandChip passRate={stat.passRate} />
+                </TableCell>
+                {onViewBehavior && (
+                  <TableCell sx={{ width: 32, p: 0.5 }}>
+                    {canDrilldown && (
+                      <Tooltip title="View failures in Test Cases">
+                        <OpenInNewIcon
+                          fontSize="small"
+                          sx={{
+                            color: 'text.secondary',
+                            verticalAlign: 'middle',
+                          }}
+                        />
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                )}
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}
+
+function BehaviorPerformanceSection({
+  stats,
+  behaviors,
+  onViewBehavior,
+}: {
+  stats: BehaviorStat[];
+  behaviors?: BehaviorWithMetrics[];
+  onViewBehavior?: (behaviorId: string) => void;
+}) {
+  const theme = useTheme();
+
+  const chartData = useMemo(
+    () => [...stats].sort((a, b) => a.passRate - b.passRate),
+    [stats]
+  );
+
+  const chartHeight = Math.max(200, chartData.length * 52 + 40);
+
+  const getBandColor = (passRate: number) =>
+    theme.palette[getReviewBand(passRate).colorKey].main;
+
+  return (
+    <SectionCard title="Behavior Performance">
+      <ResponsiveContainer width="100%" height={chartHeight}>
+        <BarChart
+          layout="vertical"
+          data={chartData}
+          margin={{ top: 4, right: 48, bottom: 8, left: 4 }}
+        >
+          <CartesianGrid
+            strokeDasharray="3 3"
+            horizontal={false}
+            stroke={theme.palette.divider}
+          />
+          <XAxis
+            type="number"
+            domain={[0, 100]}
+            tickFormatter={(v: number) => `${v}%`}
+            tick={{
+              fontSize: 12,
+              fill: theme.palette.text.secondary as string,
+            }}
+          />
+          <YAxis
+            type="category"
+            dataKey="name"
+            width={160}
+            tick={{
+              fontSize: 12,
+              fill: theme.palette.text.secondary as string,
+            }}
+            tickFormatter={(name: string) =>
+              name.length > 22 ? `${name.slice(0, 19)}\u2026` : name
+            }
+          />
+          <RechartsTooltip
+            cursor={{ fill: theme.palette.action.hover }}
+            formatter={(value: number) => [`${value.toFixed(1)}%`, 'Pass Rate']}
+            labelStyle={{ fontWeight: 600 }}
+          />
+          <Bar dataKey="passRate" radius={[0, 4, 4, 0]} maxBarSize={30}>
+            {chartData.map(entry => (
+              <Cell key={entry.name} fill={getBandColor(entry.passRate)} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+
+      <Box sx={{ mt: 3 }}>
+        <BehaviorTable
+          stats={stats}
+          behaviors={behaviors}
+          onViewBehavior={onViewBehavior}
+        />
+      </Box>
+    </SectionCard>
+  );
+}
+
+type MetricSortField = 'name' | 'total' | 'failRate';
+
+function MetricTable({
+  stats,
+  onViewMetric,
+}: {
+  stats: MetricStat[];
+  onViewMetric?: (metricName: string) => void;
+}) {
+  const [sortField, setSortField] = useState<MetricSortField>('failRate');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+
+  const handleSort = (field: MetricSortField) => {
+    if (field === sortField) {
+      setSortDir(d => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir(field === 'failRate' ? 'desc' : 'asc');
+    }
+  };
+
+  const sorted = useMemo(() => {
+    return [...stats].sort((a, b) => {
+      const mul = sortDir === 'asc' ? 1 : -1;
+      if (sortField === 'name') return mul * a.name.localeCompare(b.name);
+      if (sortField === 'total') return mul * (a.total - b.total);
+      return mul * (a.failRate - b.failRate);
+    });
+  }, [stats, sortField, sortDir]);
+
+  return (
+    <Box sx={{ overflowX: 'auto' }}>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell sx={{ whiteSpace: 'nowrap' }}>
+              <TableSortLabel
+                active={sortField === 'name'}
+                direction={sortField === 'name' ? sortDir : 'asc'}
+                onClick={() => handleSort('name')}
+              >
+                Metric
+              </TableSortLabel>
+            </TableCell>
+            <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
+              <TableSortLabel
+                active={sortField === 'total'}
+                direction={sortField === 'total' ? sortDir : 'asc'}
+                onClick={() => handleSort('total')}
+              >
+                Total
+              </TableSortLabel>
+            </TableCell>
+            <TableCell align="right">Passed</TableCell>
+            <TableCell align="right">Failed</TableCell>
+            <TableCell align="right" sx={{ whiteSpace: 'nowrap' }}>
+              <TableSortLabel
+                active={sortField === 'failRate'}
+                direction={sortField === 'failRate' ? sortDir : 'desc'}
+                onClick={() => handleSort('failRate')}
+              >
+                Fail Rate
+              </TableSortLabel>
+            </TableCell>
+            <TableCell>Status</TableCell>
+            {onViewMetric && <TableCell />}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {sorted.map(stat => {
+            const passRate = 100 - stat.failRate;
+            const canDrilldown = stat.failed > 0 && !!onViewMetric;
+            return (
+              <TableRow
+                key={stat.name}
+                hover={canDrilldown}
+                sx={{ cursor: canDrilldown ? 'pointer' : 'default' }}
+                onClick={
+                  canDrilldown ? () => onViewMetric!(stat.name) : undefined
+                }
+              >
+                <TableCell sx={{ maxWidth: 300 }}>
+                  <Tooltip title={stat.name} placement="top" arrow>
+                    <Typography
+                      variant="body2"
+                      noWrap
+                      sx={{ maxWidth: 280, display: 'block' }}
+                    >
+                      {stat.name}
+                    </Typography>
+                  </Tooltip>
+                </TableCell>
+                <TableCell align="right">{stat.total}</TableCell>
+                <TableCell
+                  align="right"
+                  sx={{ color: theme => theme.palette.success.main }}
+                >
+                  {stat.passed}
+                </TableCell>
+                <TableCell
+                  align="right"
+                  sx={{
+                    color: theme =>
+                      stat.failed > 0
+                        ? theme.palette.error.main
+                        : 'text.secondary',
+                    fontWeight: stat.failed > 0 ? 600 : 400,
+                  }}
+                >
+                  {stat.failed}
+                </TableCell>
+                <TableCell align="right" sx={{ fontWeight: 600 }}>
+                  {stat.failRate.toFixed(1)}%
+                </TableCell>
+                <TableCell>
+                  <BandChip passRate={passRate} />
+                </TableCell>
+                {onViewMetric && (
+                  <TableCell sx={{ width: 32, p: 0.5 }}>
+                    {canDrilldown && (
+                      <Tooltip title="View failures in Test Cases">
+                        <OpenInNewIcon
+                          fontSize="small"
+                          sx={{
+                            color: 'text.secondary',
+                            verticalAlign: 'middle',
+                          }}
+                        />
+                      </Tooltip>
+                    )}
+                  </TableCell>
+                )}
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </Box>
+  );
+}
+
+function MetricPerformanceSection({
+  stats,
+  onViewMetric,
+}: {
+  stats: MetricStat[];
+  onViewMetric?: (metricName: string) => void;
+}) {
+  const theme = useTheme();
+
+  const chartData = useMemo(
+    () => [...stats].sort((a, b) => b.failRate - a.failRate),
+    [stats]
+  );
+
+  const chartHeight = Math.max(200, chartData.length * 52 + 40);
+
+  const getBandColor = (failRate: number) =>
+    theme.palette[getReviewBand(100 - failRate).colorKey].main;
+
+  return (
+    <SectionCard title="Metric Performance">
+      <ResponsiveContainer width="100%" height={chartHeight}>
+        <BarChart
+          layout="vertical"
+          data={chartData}
+          margin={{ top: 4, right: 48, bottom: 8, left: 4 }}
+        >
+          <CartesianGrid
+            strokeDasharray="3 3"
+            horizontal={false}
+            stroke={theme.palette.divider}
+          />
+          <XAxis
+            type="number"
+            domain={[0, 100]}
+            tickFormatter={(v: number) => `${v}%`}
+            tick={{
+              fontSize: 12,
+              fill: theme.palette.text.secondary as string,
+            }}
+          />
+          <YAxis
+            type="category"
+            dataKey="name"
+            width={160}
+            tick={{
+              fontSize: 12,
+              fill: theme.palette.text.secondary as string,
+            }}
+            tickFormatter={(name: string) =>
+              name.length > 22 ? `${name.slice(0, 19)}\u2026` : name
+            }
+          />
+          <RechartsTooltip
+            cursor={{ fill: theme.palette.action.hover }}
+            formatter={(value: number) => [`${value.toFixed(1)}%`, 'Fail Rate']}
+            labelStyle={{ fontWeight: 600 }}
+          />
+          <Bar dataKey="failRate" radius={[0, 4, 4, 0]} maxBarSize={30}>
+            {chartData.map(entry => (
+              <Cell key={entry.name} fill={getBandColor(entry.failRate)} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+
+      <Box sx={{ mt: 3 }}>
+        <MetricTable stats={stats} onViewMetric={onViewMetric} />
+      </Box>
+    </SectionCard>
+  );
+}
+
+interface DimensionItem {
+  name: string;
+  total: number;
+  passed: number;
+  failed: number;
+  pass_rate: number;
+}
+
+function DimensionList({ items }: { items: DimensionItem[] }) {
+  return (
+    <Stack spacing={0.5}>
+      {items.map(item => (
+        <Box
+          key={item.name}
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1.5,
+            py: 0.75,
+            borderBottom: 1,
+            borderColor: 'divider',
+            '&:last-child': { borderBottom: 0 },
+          }}
+        >
+          <Typography
+            variant="body2"
+            sx={{
+              flex: 1,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }}
+            title={item.name}
+          >
+            {item.name}
+          </Typography>
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ whiteSpace: 'nowrap', minWidth: 48, textAlign: 'right' }}
+          >
+            {item.total} tests
+          </Typography>
+          <Typography
+            variant="body2"
+            fontWeight={600}
+            sx={{ whiteSpace: 'nowrap', minWidth: 52, textAlign: 'right' }}
+          >
+            {item.pass_rate.toFixed(1)}%
+          </Typography>
+          <Box sx={{ minWidth: 108 }}>
+            <BandChip passRate={item.pass_rate} />
+          </Box>
+        </Box>
+      ))}
+    </Stack>
+  );
+}
+
+function MoreBreakdownsSection({
+  testRunId,
+  sessionToken,
+}: {
+  testRunId: string;
+  sessionToken: string;
+}) {
+  const isMounted = useRef(false);
+  const [data, setData] = useState<TestResultsStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+
+    const fetchData = async () => {
+      if (!sessionToken) return;
+      try {
+        setIsLoading(true);
+        const client = new ApiClientFactory(
+          sessionToken
+        ).getTestResultsClient();
+        const result = await client.getComprehensiveTestResultsStats({
+          test_run_ids: [testRunId],
+          mode: 'all',
+        });
+        if (isMounted.current) {
+          setData(result);
+          setIsLoading(false);
+        }
+      } catch {
+        if (isMounted.current) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void fetchData();
+    return () => {
+      isMounted.current = false;
+    };
+  }, [testRunId, sessionToken]);
+
+  const categoryStats = useMemo((): DimensionItem[] => {
+    if (!data?.category_pass_rates) return [];
+    return Object.entries(data.category_pass_rates)
+      .map(([name, s]) => ({ name, ...s }))
+      .sort((a, b) => a.pass_rate - b.pass_rate);
+  }, [data]);
+
+  const topicStats = useMemo((): DimensionItem[] => {
+    if (!data?.topic_pass_rates) return [];
+    return Object.entries(data.topic_pass_rates)
+      .map(([name, s]) => ({ name, ...s }))
+      .sort((a, b) => a.pass_rate - b.pass_rate);
+  }, [data]);
+
+  const hasData = categoryStats.length > 0 || topicStats.length > 0;
+
+  if (!isLoading && !hasData) return null;
+
+  return (
+    <Accordion
+      expanded={expanded}
+      onChange={(_, exp) => setExpanded(exp)}
+      variant="outlined"
+      sx={{
+        borderRadius: '8px !important',
+        '&:before': { display: 'none' },
+      }}
+    >
+      <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+        <Typography variant="subtitle1" fontWeight={600}>
+          More Breakdowns
+        </Typography>
+      </AccordionSummary>
+      <AccordionDetails sx={{ pt: 0 }}>
+        {isLoading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : (
+          <Grid container spacing={4}>
+            {categoryStats.length > 0 && (
+              <Grid size={{ xs: 12, md: 6 }}>
+                <Typography
+                  variant="subtitle2"
+                  fontWeight={600}
+                  sx={{ mb: 1.5 }}
+                >
+                  Categories
+                </Typography>
+                <DimensionList items={categoryStats} />
+              </Grid>
+            )}
+            {topicStats.length > 0 && (
+              <Grid size={{ xs: 12, md: 6 }}>
+                <Typography
+                  variant="subtitle2"
+                  fontWeight={600}
+                  sx={{ mb: 1.5 }}
+                >
+                  Topics
+                </Typography>
+                <DimensionList items={topicStats} />
+              </Grid>
+            )}
+          </Grid>
+        )}
+      </AccordionDetails>
+    </Accordion>
   );
 }
 
@@ -58,105 +712,21 @@ export default function TestRunStatsTab({
   sessionToken,
   loading = false,
   onRefresh,
+  behaviors,
+  onViewBehavior,
+  onViewMetric,
 }: TestRunStatsTabProps) {
-  const isMounted = useRef(false);
-  const [stats, setStats] = useState<TestRunStatsAll | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [hasError, setHasError] = useState(false);
+  const behaviorStats = useMemo(
+    () => aggregateBehaviorStats(testResults),
+    [testResults]
+  );
 
-  useEffect(() => {
-    isMounted.current = true;
+  const metricStats = useMemo(
+    () => aggregateMetricStats(testResults),
+    [testResults]
+  );
 
-    const fetchStats = async () => {
-      if (!sessionToken) return;
-      try {
-        setIsLoading(true);
-        setHasError(false);
-        const client = new ApiClientFactory(sessionToken).getTestRunsClient();
-        const data = (await client.getTestRunStats({
-          mode: 'all',
-          test_run_ids: [testRunId],
-          top: 10,
-          months: 6,
-        })) as TestRunStatsAll;
-        if (isMounted.current) {
-          setStats(data);
-          setIsLoading(false);
-        }
-      } catch {
-        if (isMounted.current) {
-          setHasError(true);
-          setIsLoading(false);
-        }
-      }
-    };
-
-    void fetchStats();
-    return () => {
-      isMounted.current = false;
-    };
-  }, [sessionToken, testRunId]);
-
-  const resultData = stats?.result_distribution
-    ? [
-        {
-          name: 'Passed',
-          value: stats.result_distribution.passed,
-          fullName: 'Passed',
-        },
-        {
-          name: 'Failed',
-          value: stats.result_distribution.failed,
-          fullName: 'Failed',
-        },
-        {
-          name: 'Pending',
-          value: stats.result_distribution.pending,
-          fullName: 'Pending',
-        },
-      ].filter(item => item.value > 0)
-    : [];
-
-  const statusData =
-    stats?.status_distribution?.map(item => ({
-      name: item.status,
-      value: item.count,
-      fullName: item.status,
-    })) ?? [];
-
-  const behaviorData = React.useMemo(() => {
-    const counts = new Map<string, number>();
-    testResults.forEach(result => {
-      const behaviorName =
-        result.test?.behavior?.name ||
-        (result.test as { behavior?: { name?: string } })?.behavior?.name;
-      if (!behaviorName) return;
-      counts.set(behaviorName, (counts.get(behaviorName) ?? 0) + 1);
-    });
-    return Array.from(counts.entries()).map(([name, value]) => ({
-      name,
-      value,
-      fullName: name,
-    }));
-  }, [testResults]);
-
-  const metricData = React.useMemo(() => {
-    const counts = new Map<string, { pass: number; fail: number }>();
-    testResults.forEach(result => {
-      const metrics = result.test_metrics?.metrics ?? {};
-      Object.entries(metrics).forEach(([name, m]) => {
-        const entry = counts.get(name) ?? { pass: 0, fail: 0 };
-        if (m.is_successful) entry.pass += 1;
-        else entry.fail += 1;
-        counts.set(name, entry);
-      });
-    });
-    return Array.from(counts.entries()).map(([name, { pass, fail }]) => ({
-      name,
-      value: pass + fail,
-      fullName: `${name} (${pass} pass / ${fail} fail)`,
-    }));
-  }, [testResults]);
+  const hasInsights = behaviorStats.length > 0 || metricStats.length > 0;
 
   return (
     <Box>
@@ -167,125 +737,39 @@ export default function TestRunStatsTab({
         onRefresh={onRefresh}
       />
 
-      {isLoading ? (
-        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
-          <CircularProgress />
-        </Box>
-      ) : hasError ? (
-        <Paper sx={{ p: 2, display: 'flex', alignItems: 'center', gap: 2 }}>
-          <InfoOutlinedIcon color="info" />
-          <Typography color="text.secondary">
-            Could not load run statistics. Summary cards above still reflect
-            current results.
-          </Typography>
-        </Paper>
-      ) : (
-        <Grid container spacing={3}>
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-            <ChartCard title="Pass / Fail">
-              <BasePieChart
-                title=""
-                data={
-                  resultData.length > 0
-                    ? resultData
-                    : [{ name: 'No data', value: 1, fullName: 'No data' }]
-                }
-                useThemeColors
-                colorPalette="pie"
+      <Stack spacing={3} sx={{ mt: 3 }}>
+        {loading && testResults.length === 0 ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+            <CircularProgress />
+          </Box>
+        ) : !hasInsights ? (
+          <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+            <Typography color="text.secondary">
+              No test result data available to summarize.
+            </Typography>
+          </Paper>
+        ) : (
+          <>
+            {behaviorStats.length > 0 && (
+              <BehaviorPerformanceSection
+                stats={behaviorStats}
+                behaviors={behaviors}
+                onViewBehavior={onViewBehavior}
               />
-            </ChartCard>
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-            <ChartCard title="Status breakdown">
-              <BasePieChart
-                title=""
-                data={
-                  statusData.length > 0
-                    ? statusData
-                    : [{ name: 'No data', value: 1, fullName: 'No data' }]
-                }
-                useThemeColors
-                colorPalette="pie"
+            )}
+            {metricStats.length > 0 && (
+              <MetricPerformanceSection
+                stats={metricStats}
+                onViewMetric={onViewMetric}
               />
-            </ChartCard>
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-            <ChartCard title="By behavior">
-              <BasePieChart
-                title=""
-                data={
-                  behaviorData.length > 0
-                    ? behaviorData
-                    : [{ name: 'No data', value: 1, fullName: 'No data' }]
-                }
-                useThemeColors
-                colorPalette="pie"
-              />
-            </ChartCard>
-          </Grid>
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-            <ChartCard title="By metric">
-              <BasePieChart
-                title=""
-                data={
-                  metricData.length > 0
-                    ? metricData
-                    : [{ name: 'No data', value: 1, fullName: 'No data' }]
-                }
-                useThemeColors
-                colorPalette="pie"
-              />
-            </ChartCard>
-          </Grid>
-          {stats?.overall_summary && (
-            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-              <ChartCard title="Overall pass rate">
-                <Box
-                  sx={{
-                    display: 'flex',
-                    flexDirection: 'column',
-                    justifyContent: 'center',
-                    height: '100%',
-                    px: 2,
-                  }}
-                >
-                  <Typography variant="h3" fontWeight={700}>
-                    {stats.overall_summary.pass_rate.toFixed(1)}%
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    {stats.overall_summary.total_runs} run(s) in scope
-                  </Typography>
-                </Box>
-              </ChartCard>
-            </Grid>
-          )}
-          {stats?.timeline && stats.timeline.length > 0 && (
-            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-              <ChartCard title="Timeline">
-                <Box sx={{ px: 1 }}>
-                  {stats.timeline.slice(0, 5).map(point => (
-                    <Box
-                      key={point.date}
-                      sx={{
-                        display: 'flex',
-                        justifyContent: 'space-between',
-                        py: 0.75,
-                        borderBottom: 1,
-                        borderColor: 'divider',
-                      }}
-                    >
-                      <Typography variant="body2">{point.date}</Typography>
-                      <Typography variant="body2" fontWeight={600}>
-                        {point.total_runs} runs
-                      </Typography>
-                    </Box>
-                  ))}
-                </Box>
-              </ChartCard>
-            </Grid>
-          )}
-        </Grid>
-      )}
+            )}
+            <MoreBreakdownsSection
+              testRunId={testRunId}
+              sessionToken={sessionToken}
+            />
+          </>
+        )}
+      </Stack>
 
       <TestRunTags sessionToken={sessionToken} testRun={testRun} />
     </Box>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunStatsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunStatsTab.tsx
@@ -1,0 +1,290 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { Box, CircularProgress, Grid, Paper, Typography } from '@mui/material';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { BasePieChart } from '@/components/common/BaseCharts';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { TestRunStatsAll } from '@/utils/api-client/interfaces/test-run-stats';
+import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
+import TestRunHeader from './TestRunHeader';
+
+interface TestRunStatsTabProps {
+  testRun: TestRunDetail;
+  testRunId: string;
+  testResults: TestResultDetail[];
+  sessionToken: string;
+  loading?: boolean;
+  onRefresh?: () => void;
+}
+
+function ChartCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Paper
+      variant="outlined"
+      sx={{
+        p: 2,
+        height: '100%',
+        minHeight: 280,
+        borderRadius: 2,
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <Typography
+        variant="subtitle1"
+        fontWeight={600}
+        sx={{ mb: 2, color: theme => theme.palette.greyscale.title }}
+      >
+        {title}
+      </Typography>
+      <Box sx={{ flex: 1, minHeight: 200 }}>{children}</Box>
+    </Paper>
+  );
+}
+
+export default function TestRunStatsTab({
+  testRun,
+  testRunId,
+  testResults,
+  sessionToken,
+  loading = false,
+  onRefresh,
+}: TestRunStatsTabProps) {
+  const isMounted = useRef(false);
+  const [stats, setStats] = useState<TestRunStatsAll | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+
+    const fetchStats = async () => {
+      if (!sessionToken) return;
+      try {
+        setIsLoading(true);
+        setHasError(false);
+        const client = new ApiClientFactory(sessionToken).getTestRunsClient();
+        const data = (await client.getTestRunStats({
+          mode: 'all',
+          test_run_ids: [testRunId],
+          top: 10,
+          months: 6,
+        })) as TestRunStatsAll;
+        if (isMounted.current) {
+          setStats(data);
+          setIsLoading(false);
+        }
+      } catch {
+        if (isMounted.current) {
+          setHasError(true);
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void fetchStats();
+    return () => {
+      isMounted.current = false;
+    };
+  }, [sessionToken, testRunId]);
+
+  const resultData = stats?.result_distribution
+    ? [
+        {
+          name: 'Passed',
+          value: stats.result_distribution.passed,
+          fullName: 'Passed',
+        },
+        {
+          name: 'Failed',
+          value: stats.result_distribution.failed,
+          fullName: 'Failed',
+        },
+        {
+          name: 'Pending',
+          value: stats.result_distribution.pending,
+          fullName: 'Pending',
+        },
+      ].filter(item => item.value > 0)
+    : [];
+
+  const statusData =
+    stats?.status_distribution?.map(item => ({
+      name: item.status,
+      value: item.count,
+      fullName: item.status,
+    })) ?? [];
+
+  const behaviorData = React.useMemo(() => {
+    const counts = new Map<string, number>();
+    testResults.forEach(result => {
+      const behaviorName =
+        result.test?.behavior?.name ||
+        (result.test as { behavior?: { name?: string } })?.behavior?.name;
+      if (!behaviorName) return;
+      counts.set(behaviorName, (counts.get(behaviorName) ?? 0) + 1);
+    });
+    return Array.from(counts.entries()).map(([name, value]) => ({
+      name,
+      value,
+      fullName: name,
+    }));
+  }, [testResults]);
+
+  const metricData = React.useMemo(() => {
+    const counts = new Map<string, { pass: number; fail: number }>();
+    testResults.forEach(result => {
+      const metrics = result.test_metrics?.metrics ?? {};
+      Object.entries(metrics).forEach(([name, m]) => {
+        const entry = counts.get(name) ?? { pass: 0, fail: 0 };
+        if (m.is_successful) entry.pass += 1;
+        else entry.fail += 1;
+        counts.set(name, entry);
+      });
+    });
+    return Array.from(counts.entries()).map(([name, { pass, fail }]) => ({
+      name,
+      value: pass + fail,
+      fullName: `${name} (${pass} pass / ${fail} fail)`,
+    }));
+  }, [testResults]);
+
+  return (
+    <Box>
+      <TestRunHeader
+        testRun={testRun}
+        testResults={testResults}
+        loading={loading}
+        onRefresh={onRefresh}
+      />
+
+      {isLoading ? (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+          <CircularProgress />
+        </Box>
+      ) : hasError ? (
+        <Paper sx={{ p: 2, display: 'flex', alignItems: 'center', gap: 2 }}>
+          <InfoOutlinedIcon color="info" />
+          <Typography color="text.secondary">
+            Could not load run statistics. Summary cards above still reflect
+            current results.
+          </Typography>
+        </Paper>
+      ) : (
+        <Grid container spacing={3}>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <ChartCard title="Pass / Fail">
+              <BasePieChart
+                title=""
+                data={
+                  resultData.length > 0
+                    ? resultData
+                    : [{ name: 'No data', value: 1, fullName: 'No data' }]
+                }
+                useThemeColors
+                colorPalette="pie"
+              />
+            </ChartCard>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <ChartCard title="Status breakdown">
+              <BasePieChart
+                title=""
+                data={
+                  statusData.length > 0
+                    ? statusData
+                    : [{ name: 'No data', value: 1, fullName: 'No data' }]
+                }
+                useThemeColors
+                colorPalette="pie"
+              />
+            </ChartCard>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <ChartCard title="By behavior">
+              <BasePieChart
+                title=""
+                data={
+                  behaviorData.length > 0
+                    ? behaviorData
+                    : [{ name: 'No data', value: 1, fullName: 'No data' }]
+                }
+                useThemeColors
+                colorPalette="pie"
+              />
+            </ChartCard>
+          </Grid>
+          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+            <ChartCard title="By metric">
+              <BasePieChart
+                title=""
+                data={
+                  metricData.length > 0
+                    ? metricData
+                    : [{ name: 'No data', value: 1, fullName: 'No data' }]
+                }
+                useThemeColors
+                colorPalette="pie"
+              />
+            </ChartCard>
+          </Grid>
+          {stats?.overall_summary && (
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+              <ChartCard title="Overall pass rate">
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'center',
+                    height: '100%',
+                    px: 2,
+                  }}
+                >
+                  <Typography variant="h3" fontWeight={700}>
+                    {stats.overall_summary.pass_rate.toFixed(1)}%
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    {stats.overall_summary.total_runs} run(s) in scope
+                  </Typography>
+                </Box>
+              </ChartCard>
+            </Grid>
+          )}
+          {stats?.timeline && stats.timeline.length > 0 && (
+            <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+              <ChartCard title="Timeline">
+                <Box sx={{ px: 1 }}>
+                  {stats.timeline.slice(0, 5).map(point => (
+                    <Box
+                      key={point.date}
+                      sx={{
+                        display: 'flex',
+                        justifyContent: 'space-between',
+                        py: 0.75,
+                        borderBottom: 1,
+                        borderColor: 'divider',
+                      }}
+                    >
+                      <Typography variant="body2">{point.date}</Typography>
+                      <Typography variant="body2" fontWeight={600}>
+                        {point.total_runs} runs
+                      </Typography>
+                    </Box>
+                  ))}
+                </Box>
+              </ChartCard>
+            </Grid>
+          )}
+        </Grid>
+      )}
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunStatsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunStatsTab.tsx
@@ -9,6 +9,7 @@ import { TestRunStatsAll } from '@/utils/api-client/interfaces/test-run-stats';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 import TestRunHeader from './TestRunHeader';
+import TestRunTags from './TestRunTags';
 
 interface TestRunStatsTabProps {
   testRun: TestRunDetail;
@@ -285,6 +286,8 @@ export default function TestRunStatsTab({
           )}
         </Grid>
       )}
+
+      <TestRunTags sessionToken={sessionToken} testRun={testRun} />
     </Box>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTags.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTags.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { Box } from '@mui/material';
+import { Paper, Typography } from '@mui/material';
+import type { Theme } from '@mui/material/styles';
 import BaseTag from '@/components/common/BaseTag';
+import { drawerTagFieldSx } from '@/components/common/drawerFormFieldSx';
 import { EntityType } from '@/utils/api-client/interfaces/tag';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 
 interface TestRunTagsProps {
   sessionToken: string;
@@ -17,31 +20,61 @@ export default function TestRunTags({
 }: TestRunTagsProps) {
   const [tagNames, setTagNames] = useState<string[]>([]);
 
-  // Initialize and update tag names when testRun changes
   useEffect(() => {
     if (testRun.tags) {
       setTagNames(testRun.tags.map(tag => tag.name));
+    } else {
+      setTagNames([]);
     }
   }, [testRun.tags]);
 
   return (
-    <Box sx={{ width: '100%' }}>
+    <Paper
+      elevation={0}
+      sx={{
+        p: '30px',
+        mt: 3,
+        borderRadius: BORDER_RADIUS.md,
+        boxShadow: (theme: Theme) =>
+          theme.palette.mode === 'light' ? ELEVATION.xs : 'none',
+        bgcolor: (theme: Theme) =>
+          theme.palette.mode === 'light'
+            ? '#ffffff'
+            : theme.palette.greyscale.surface1,
+        border: (theme: Theme) => `1px solid ${theme.palette.greyscale.border}`,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '20px',
+      }}
+    >
+      <Typography
+        component="h2"
+        sx={{
+          fontSize: 20,
+          fontWeight: 600,
+          lineHeight: '24px',
+          color: 'primary.main',
+        }}
+      >
+        Tags
+      </Typography>
+
       <BaseTag
         value={tagNames}
         onChange={setTagNames}
         label="Tags"
         placeholder="Add tags (press Enter or comma to add)"
-        helperText="These tags help categorize and find this test run"
         chipColor="default"
         addOnBlur
         delimiters={[',', 'Enter']}
         size="small"
-        margin="normal"
+        margin="none"
         fullWidth
         sessionToken={sessionToken}
         entityType={EntityType.TEST_RUN}
         entity={testRun}
+        sx={drawerTagFieldSx}
       />
-    </Box>
+    </Paper>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTracesTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTracesTab.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { Box, Paper } from '@mui/material';
+import TimelineOutlinedIcon from '@mui/icons-material/TimelineOutlined';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
+import TracesClient from '@/app/(protected)/traces/components/TracesClient';
+
+interface TestRunTracesTabProps {
+  testRunId: string;
+  sessionToken: string;
+  currentUserId: string;
+  currentUserName: string;
+  currentUserPicture?: string;
+}
+
+export default function TestRunTracesTab({
+  testRunId,
+  sessionToken,
+  currentUserId,
+  currentUserName,
+  currentUserPicture,
+}: TestRunTracesTabProps) {
+  const [showEmptyHint, setShowEmptyHint] = useState(false);
+
+  const handleUnfilteredEmpty = useCallback((empty: boolean) => {
+    setShowEmptyHint(empty);
+  }, []);
+
+  return (
+    <Box>
+      <Paper
+        sx={{
+          width: '100%',
+          borderRadius: BORDER_RADIUS.md,
+          boxShadow: ELEVATION.xs,
+          border: theme => `1px solid ${theme.palette.greyscale.border}`,
+          overflow: 'hidden',
+        }}
+      >
+        <TracesClient
+          sessionToken={sessionToken}
+          currentUserId={currentUserId}
+          currentUserName={currentUserName}
+          currentUserPicture={currentUserPicture}
+          fixedTestRunId={testRunId}
+          onUnfilteredEmpty={handleUnfilteredEmpty}
+        />
+      </Paper>
+
+      {showEmptyHint && (
+        <Box sx={{ mt: 3 }}>
+          <EntityEmptyState
+            icon={TimelineOutlinedIcon}
+            title="No traces for this test run"
+            description="Traces appear after test execution when endpoints are instrumented with OpenTelemetry."
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsTableView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsTableView.tsx
@@ -1,23 +1,25 @@
 'use client';
 
-import React, { useState, useMemo, useRef } from 'react';
+import React, {
+  useState,
+  useMemo,
+  useRef,
+  useCallback,
+  useEffect,
+} from 'react';
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Paper,
   Box,
   Typography,
-  Chip,
   IconButton,
   Tooltip,
-  TablePagination,
   useTheme,
   alpha,
 } from '@mui/material';
+import {
+  GridColDef,
+  GridPaginationModel,
+  GridRowParams,
+} from '@mui/x-data-grid';
 import CloseIcon from '@mui/icons-material/Close';
 import RateReviewOutlinedIcon from '@mui/icons-material/RateReviewOutlined';
 import CommentOutlinedIcon from '@mui/icons-material/CommentOutlined';
@@ -27,6 +29,8 @@ import CheckIcon from '@mui/icons-material/Check';
 import SmartToyOutlinedIcon from '@mui/icons-material/SmartToyOutlined';
 import PersonOutlineIcon from '@mui/icons-material/PersonOutline';
 import CircleOutlinedIcon from '@mui/icons-material/CircleOutlined';
+import BaseDataGrid from '@/components/common/BaseDataGrid';
+import GridBadge from '@/components/common/GridBadge';
 import {
   TestResultDetail,
   REVIEW_TARGET_TYPES,
@@ -34,10 +38,14 @@ import {
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import TestResultDrawer from './TestResultDrawer';
 import ReviewJudgementDrawer from './ReviewJudgementDrawer';
+import { findStatusByCategory } from '@/utils/test-result-status';
 import {
-  findStatusByCategory,
-  isPassedStatusName,
-} from '@/utils/test-result-status';
+  getEvaluationContent,
+  getFailedMetricNames,
+  getGoalContent,
+  getTestResultDisplayStatus,
+  truncateText,
+} from './test-run-results-grid-utils';
 
 interface TestsTableViewProps {
   tests: TestResultDetail[];
@@ -56,11 +64,12 @@ interface TestsTableViewProps {
   currentUserName: string;
   currentUserPicture?: string;
   initialSelectedTestId?: string;
-  testSetType?: string; // e.g., "Multi-turn" or "Single-turn"
+  testSetType?: string;
   project?: { icon?: string; useCase?: string; name?: string };
   projectName?: string;
-  /** Source of metrics used in this test run */
   metricsSource?: string;
+  /** When true, grid renders inside a parent card without its own Paper shell */
+  embedded?: boolean;
 }
 
 export default function TestsTableView({
@@ -79,16 +88,18 @@ export default function TestsTableView({
   project,
   projectName,
   metricsSource,
+  embedded = false,
 }: TestsTableViewProps) {
   const isMultiTurn =
     testSetType?.toLowerCase().includes('multi-turn') || false;
   const theme = useTheme();
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(25);
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
+    page: 0,
+    pageSize: 25,
+  });
   const [selectedTest, setSelectedTest] = useState<TestResultDetail | null>(
     null
   );
-  const [selectedRowIndex, setSelectedRowIndex] = useState<number | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [initialTab, setInitialTab] = useState<number>(0);
   const [overruleDrawerOpen, setOverruleDrawerOpen] = useState(false);
@@ -98,69 +109,60 @@ export default function TestsTableView({
   const [hasInitialSelection, setHasInitialSelection] = useState(false);
   const [isConfirmingReview, setIsConfirmingReview] = useState(false);
   const isConfirmingRef = useRef(false);
-
-  // Local state to track immediate test updates before parent prop updates
   const [localTestUpdates, setLocalTestUpdates] = useState<
     Record<string, TestResultDetail>
   >({});
 
-  // Merge local updates with tests prop for immediate UI updates
-  const mergedTests = React.useMemo(() => {
+  const mergedTests = useMemo(() => {
     if (Object.keys(localTestUpdates).length === 0) {
       return tests;
     }
-    const merged = tests.map(test => {
-      const updated = localTestUpdates[test.id];
-      return updated || test;
-    });
-    return merged;
+    return tests.map(test => localTestUpdates[test.id] || test);
   }, [tests, localTestUpdates]);
 
-  // Clear local updates when tests prop changes AND includes our local updates
-  React.useEffect(() => {
-    if (Object.keys(localTestUpdates).length > 0) {
-      // Check if any of our local updates are now in the tests prop
-      const allUpdatesIncluded = Object.keys(localTestUpdates).every(testId => {
-        const propTest = tests.find(t => t.id === testId);
-        const localTest = localTestUpdates[testId];
-        // Check if the prop test has the same last_review as our local update
-        return (
-          propTest?.last_review?.review_id === localTest?.last_review?.review_id
-        );
-      });
+  useEffect(() => {
+    if (Object.keys(localTestUpdates).length === 0) return;
 
-      if (allUpdatesIncluded) {
-        setLocalTestUpdates({});
-      }
-    }
-  }, [tests, localTestUpdates]);
-
-  // Handle initial selection when initialSelectedTestId is provided
-  React.useEffect(() => {
-    if (
-      initialSelectedTestId &&
-      mergedTests.length > 0 &&
-      !hasInitialSelection
-    ) {
-      const testIndex = mergedTests.findIndex(
-        t => t.id === initialSelectedTestId
+    const allUpdatesIncluded = Object.keys(localTestUpdates).every(testId => {
+      const propTest = tests.find(t => t.id === testId);
+      const localTest = localTestUpdates[testId];
+      return (
+        propTest?.last_review?.review_id === localTest?.last_review?.review_id
       );
-      if (testIndex !== -1) {
-        // Calculate which page the test is on
-        const testPage = Math.floor(testIndex / rowsPerPage);
-        const rowIndexInPage = testIndex % rowsPerPage;
+    });
 
-        setPage(testPage);
-        setSelectedTest(mergedTests[testIndex]);
-        setSelectedRowIndex(rowIndexInPage);
-        setDrawerOpen(true);
-        setHasInitialSelection(true);
-      }
+    if (allUpdatesIncluded) {
+      setLocalTestUpdates({});
     }
-  }, [initialSelectedTestId, mergedTests, rowsPerPage, hasInitialSelection]);
+  }, [tests, localTestUpdates]);
 
-  // Sync selectedTest with tests array when tests are updated (e.g., after review changes)
-  React.useEffect(() => {
+  useEffect(() => {
+    if (
+      !initialSelectedTestId ||
+      mergedTests.length === 0 ||
+      hasInitialSelection
+    ) {
+      return;
+    }
+
+    const testIndex = mergedTests.findIndex(
+      t => t.id === initialSelectedTestId
+    );
+    if (testIndex === -1) return;
+
+    const page = Math.floor(testIndex / paginationModel.pageSize);
+    setPaginationModel(prev => ({ ...prev, page }));
+    setSelectedTest(mergedTests[testIndex]);
+    setDrawerOpen(true);
+    setHasInitialSelection(true);
+  }, [
+    initialSelectedTestId,
+    mergedTests,
+    paginationModel.pageSize,
+    hasInitialSelection,
+  ]);
+
+  useEffect(() => {
     setSelectedTest(prev => {
       if (!prev) return prev;
       const updated = mergedTests.find(t => t.id === prev.id);
@@ -168,48 +170,24 @@ export default function TestsTableView({
     });
   }, [mergedTests]);
 
-  // Reset to page 0 only when the current page is out of range for the (filtered) tests list.
-  // This avoids overriding the deep-link page set by the initialSelectedTestId effect on mount.
-  React.useEffect(() => {
-    const maxPage = Math.max(0, Math.ceil(tests.length / rowsPerPage) - 1);
-    if (page > maxPage) {
-      setPage(0);
+  useEffect(() => {
+    const maxPage = Math.max(
+      0,
+      Math.ceil(mergedTests.length / paginationModel.pageSize) - 1
+    );
+    if (paginationModel.page > maxPage) {
+      setPaginationModel(prev => ({ ...prev, page: 0 }));
     }
-  }, [tests.length, page, rowsPerPage]);
-
-  const handleChangePage = (_event: unknown, newPage: number) => {
-    setPage(newPage);
-  };
-
-  const handleChangeRowsPerPage = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    setRowsPerPage(parseInt(event.target.value, 10));
-    setPage(0);
-  };
-
-  const handleRowClick = (
-    test: TestResultDetail,
-    index: number,
-    tabIndex: number = 0
-  ) => {
-    setSelectedTest(test);
-    setSelectedRowIndex(index);
-    setInitialTab(tabIndex);
-    setDrawerOpen(true);
-  };
+  }, [mergedTests.length, paginationModel.page, paginationModel.pageSize]);
 
   const handleCloseDrawer = () => {
     setDrawerOpen(false);
   };
 
-  // Handle test result updates from the drawer (e.g., when reviews are added/deleted)
   const handleTestResultUpdateInDrawer = (updatedTest: TestResultDetail) => {
-    // Update local selected test state if it's the same test
     if (selectedTest && selectedTest.id === updatedTest.id) {
       setSelectedTest(updatedTest);
     }
-    // Propagate to parent component to update the tests array
     onTestResultUpdate(updatedTest);
   };
 
@@ -224,12 +202,9 @@ export default function TestsTableView({
 
   const handleOverruleSave = async (testId: string) => {
     try {
-      // Fetch the updated test result from the backend
       const clientFactory = new ApiClientFactory(sessionToken);
       const testResultsClient = clientFactory.getTestResultsClient();
       const updatedTest = await testResultsClient.getTestResult(testId);
-
-      // Update the test in the parent component
       onTestResultUpdate(updatedTest);
     } catch (error) {
       console.error('Failed to save overrule judgement:', error);
@@ -241,8 +216,6 @@ export default function TestsTableView({
     test: TestResultDetail
   ) => {
     event.stopPropagation();
-
-    // Atomic check-and-set to prevent duplicate submissions
     if (isConfirmingRef.current) return;
     isConfirmingRef.current = true;
 
@@ -252,14 +225,10 @@ export default function TestsTableView({
       const clientFactory = new ApiClientFactory(sessionToken);
       const testResultsClient = clientFactory.getTestResultsClient();
       const statusClient = clientFactory.getStatusClient();
-
-      // Get available statuses for TestResult
       const statuses = await statusClient.getStatuses({
         entity_type: 'TestResult',
       });
 
-      // Determine the current automated status
-      // Use test_metrics for all test types when available
       const metrics = test.test_metrics?.metrics || {};
       const metricValues = Object.values(metrics);
       const totalMetrics = metricValues.length;
@@ -268,22 +237,16 @@ export default function TestsTableView({
         const passedMetrics = metricValues.filter(m => m.is_successful).length;
         automatedPassed = passedMetrics === totalMetrics;
       } else if (isMultiTurn && test.test_output?.goal_evaluation) {
-        // Fallback for multi-turn without test_metrics
         automatedPassed =
           test.test_output.goal_evaluation.all_criteria_met || false;
       }
 
-      // Find appropriate status ID using centralized utility
       const targetStatus = findStatusByCategory(
         statuses,
         automatedPassed ? 'passed' : 'failed'
       );
+      if (!targetStatus) return;
 
-      if (!targetStatus) {
-        return;
-      }
-
-      // Create a review that matches the automated result
       await testResultsClient.createReview(
         test.id,
         targetStatus.id,
@@ -291,40 +254,29 @@ export default function TestsTableView({
         { type: REVIEW_TARGET_TYPES.TEST_RESULT, reference: null }
       );
 
-      // Poll for the updated test result with exponential backoff
-      // Use a timestamp to ensure we only use the most recent response
-      const _requestTimestamp = Date.now();
       let updatedTest: TestResultDetail | null = null;
-      const delays = [100, 200, 400, 800]; // Exponential backoff delays
+      const delays = [100, 200, 400, 800];
 
       for (const delay of delays) {
         await new Promise(resolve => setTimeout(resolve, delay));
         const fetchedTest = await testResultsClient.getTestResult(test.id);
-
-        // Check if last_review property is now present
         if (fetchedTest.last_review) {
           updatedTest = fetchedTest;
           break;
         }
       }
 
-      // Final fetch to get the most recent state
-      // This ensures we get the latest data regardless of previous poll results
-      const finalTest = await testResultsClient.getTestResult(test.id);
-      updatedTest = finalTest;
+      updatedTest = await testResultsClient.getTestResult(test.id);
 
-      // IMMEDIATELY update local state for instant UI feedback
       setLocalTestUpdates(prev => ({
         ...prev,
         [updatedTest.id]: updatedTest,
       }));
 
-      // Update local selected test if this is the currently selected test
       if (selectedTest && selectedTest.id === test.id) {
         setSelectedTest(updatedTest);
       }
 
-      // Propagate to parent component
       onTestResultUpdate(updatedTest);
     } catch (error) {
       console.error('Failed to confirm review:', error);
@@ -334,697 +286,399 @@ export default function TestsTableView({
     }
   };
 
-  // Calculate test result status (considering reviews from backend)
-  const getTestStatus = (test: TestResultDetail) => {
-    // For multi-turn tests, use test_metrics when available, fall back to goal_evaluation
-    if (isMultiTurn && test.test_output?.goal_evaluation) {
-      const allMetrics = test.test_metrics?.metrics || {};
-      const allMetricValues = Object.values(allMetrics);
-      const hasTestMetrics = allMetricValues.length > 0;
+  const openTestDrawer = useCallback((test: TestResultDetail, tabIndex = 0) => {
+    setSelectedTest(test);
+    setInitialTab(tabIndex);
+    setDrawerOpen(true);
+  }, []);
 
-      // Determine pass/fail from all metrics when available
-      const allCriteriaMet = hasTestMetrics
-        ? allMetricValues.every(m => m.is_successful)
-        : test.test_output.goal_evaluation.all_criteria_met;
+  const columns = useMemo<GridColDef<TestResultDetail>[]>(() => {
+    const cellTextSx = {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      display: '-webkit-box',
+      WebkitLineClamp: 2,
+      WebkitBoxOrient: 'vertical' as const,
+    };
 
-      const totalCriteria = hasTestMetrics
-        ? allMetricValues.length
-        : test.test_output.goal_evaluation.criteria_evaluations?.length || 0;
-      const metCriteria = hasTestMetrics
-        ? allMetricValues.filter(m => m.is_successful).length
-        : test.test_output.goal_evaluation.criteria_evaluations?.filter(
-            c => c.met
-          )?.length || 0;
-
-      const originalPassed = allCriteriaMet === true;
-      const lastReview = test.last_review;
-
-      // Check for human review FIRST (reviews override automated results)
-      if (lastReview && lastReview.status?.name) {
-        const reviewPassed = isPassedStatusName(lastReview.status.name);
-
-        // Calculate conflict ourselves (don't trust backend's matches_review)
-        // A conflict exists if the review decision differs from the automated decision
-        const hasConflict = reviewPassed !== originalPassed;
-
-        const result = {
-          passed: reviewPassed,
-          label: reviewPassed ? 'Passed' : 'Failed',
-          count: `${metCriteria}/${totalCriteria}`,
-          isOverruled: true,
-          hasConflict,
-          automatedPassed: originalPassed,
-          hasExecutionError: false,
-          reviewData: {
-            reviewer: lastReview.user?.name || 'Unknown',
-            comments: lastReview.comments,
-            updated_at: lastReview.updated_at,
-            newStatus: reviewPassed ? 'passed' : 'failed',
-          },
-        };
-
-        return result;
-      }
-
-      // No review, check for execution errors/failures
-      const hasExecutionError = test.test_output.status === 'error';
-      const hasExecutionFailure = test.test_output.status === 'failure';
-
-      if (hasExecutionError) {
-        return {
-          passed: false,
-          label: 'Error',
-          count: `${metCriteria}/${totalCriteria}`,
-          isOverruled: false,
-          hasConflict: false,
-          hasExecutionError: true,
-        };
-      }
-
-      if (hasExecutionFailure) {
-        return {
-          passed: false,
-          label: 'Failed',
-          count: `${metCriteria}/${totalCriteria}`,
-          isOverruled: false,
-          hasConflict: false,
-          hasExecutionError: false,
-        };
-      }
-
-      return {
-        passed: originalPassed,
-        label: originalPassed ? 'Passed' : 'Failed',
-        count: `${metCriteria}/${totalCriteria}`,
-        isOverruled: false,
-        hasConflict: false,
-        automatedPassed: originalPassed,
-        hasExecutionError: false,
-      };
-    }
-
-    // For single-turn tests, use metrics (original logic)
-    const metrics = test.test_metrics?.metrics || {};
-    const metricValues = Object.values(metrics);
-    const totalMetrics = metricValues.length;
-    const passedMetrics = metricValues.filter(m => m.is_successful).length;
-
-    // Check for execution error (no metrics or empty metrics)
-    const hasExecutionError = !test.test_metrics || totalMetrics === 0;
-
-    if (hasExecutionError) {
-      return {
-        passed: false,
-        label: 'Error',
-        count: '0/0',
-        isOverruled: false,
-        hasConflict: false,
-        hasExecutionError: true,
-      };
-    }
-
-    const originalPassed = passedMetrics === totalMetrics;
-    const lastReview = test.last_review;
-
-    // If there's a review, use the review status
-    if (lastReview && lastReview.status?.name) {
-      const reviewPassed = isPassedStatusName(lastReview.status.name);
-
-      // Calculate conflict ourselves (don't trust backend's matches_review)
-      // A conflict exists if the review decision differs from the automated decision
-      const hasConflict = reviewPassed !== originalPassed;
-
-      return {
-        passed: reviewPassed,
-        label: reviewPassed ? 'Passed' : 'Failed',
-        count: `${passedMetrics}/${totalMetrics}`,
-        isOverruled: true,
-        hasConflict,
-        automatedPassed: originalPassed, // Keep original automated result
-        hasExecutionError: false,
-        reviewData: {
-          reviewer: lastReview.user?.name || 'Unknown',
-          comments: lastReview.comments,
-          updated_at: lastReview.updated_at,
-          newStatus: reviewPassed ? 'passed' : 'failed',
+    return [
+      {
+        field: 'goal',
+        headerName: isMultiTurn ? 'Goal' : 'Prompt',
+        flex: 1,
+        minWidth: 240,
+        sortable: false,
+        disableColumnMenu: true,
+        valueGetter: (_, row) => getGoalContent(row, prompts, isMultiTurn),
+        renderCell: params => (
+          <Tooltip title={String(params.value ?? '')} enterDelay={500}>
+            <Typography variant="body2" sx={cellTextSx}>
+              {truncateText(String(params.value ?? ''), 150)}
+            </Typography>
+          </Tooltip>
+        ),
+      },
+      {
+        field: 'result',
+        headerName: 'Result',
+        width: 110,
+        sortable: false,
+        disableColumnMenu: true,
+        align: 'center',
+        headerAlign: 'center',
+        valueGetter: (_, row) =>
+          getTestResultDisplayStatus(row, isMultiTurn).label,
+        renderCell: params => {
+          const status = getTestResultDisplayStatus(params.row, isMultiTurn);
+          return (
+            <GridBadge
+              label={status.label}
+              sx={{
+                bgcolor: status.hasExecutionError
+                  ? alpha(theme.palette.warning.main, 0.12)
+                  : status.passed
+                    ? alpha(theme.palette.success.main, 0.12)
+                    : alpha(theme.palette.error.main, 0.12),
+                color: status.hasExecutionError
+                  ? 'warning.dark'
+                  : status.passed
+                    ? 'success.dark'
+                    : 'error.dark',
+              }}
+            />
+          );
         },
-      };
-    }
+      },
+      {
+        field: 'evaluation',
+        headerName: 'Evaluation',
+        flex: 1,
+        minWidth: 260,
+        sortable: false,
+        disableColumnMenu: true,
+        valueGetter: (_, row) => getEvaluationContent(row),
+        renderCell: params => (
+          <Tooltip title={String(params.value ?? '')} enterDelay={500}>
+            <Typography variant="body2" sx={cellTextSx}>
+              {truncateText(String(params.value ?? ''), 150)}
+            </Typography>
+          </Tooltip>
+        ),
+      },
+      {
+        field: 'review',
+        headerName: 'Review',
+        width: 120,
+        sortable: false,
+        disableColumnMenu: true,
+        align: 'center',
+        headerAlign: 'center',
+        renderHeader: () => (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 0.5,
+              width: '100%',
+            }}
+          >
+            Review
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.25 }}>
+              <SmartToyOutlinedIcon sx={{ fontSize: 16 }} />
+              <Typography variant="caption" color="text.secondary">
+                /
+              </Typography>
+              <PersonOutlineIcon sx={{ fontSize: 16 }} />
+            </Box>
+          </Box>
+        ),
+        renderCell: params => {
+          const test = params.row;
+          const status = getTestResultDisplayStatus(test, isMultiTurn);
+          const failedMetrics = getFailedMetricNames(test);
 
-    return {
-      passed: originalPassed,
-      label: originalPassed ? 'Passed' : 'Failed',
-      count: `${passedMetrics}/${totalMetrics}`,
-      isOverruled: false,
-      hasConflict: false,
-      automatedPassed: originalPassed, // Same as passed when no review
-      hasExecutionError: false,
-    };
-  };
-
-  // Get failed metrics names
-  const getFailedMetrics = (test: TestResultDetail): string[] => {
-    const metrics = test.test_metrics?.metrics || {};
-    return Object.entries(metrics)
-      .filter(([_, metric]) => !metric.is_successful)
-      .map(([name]) => name);
-  };
-
-  // Paginated tests
-  const paginatedTests = useMemo(() => {
-    return mergedTests.slice(
-      page * rowsPerPage,
-      page * rowsPerPage + rowsPerPage
-    );
-  }, [mergedTests, page, rowsPerPage]);
-
-  // Keyboard navigation
-  React.useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      // Only handle if drawer is not open
-      if (drawerOpen || overruleDrawerOpen) return;
-      if (paginatedTests.length === 0) return;
-
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
-        const newIndex =
-          selectedRowIndex === null
-            ? 0
-            : Math.min(selectedRowIndex + 1, paginatedTests.length - 1);
-        setSelectedRowIndex(newIndex);
-        setSelectedTest(paginatedTests[newIndex]);
-      } else if (event.key === 'ArrowUp') {
-        event.preventDefault();
-        const newIndex =
-          selectedRowIndex === null
-            ? paginatedTests.length - 1
-            : Math.max(selectedRowIndex - 1, 0);
-        setSelectedRowIndex(newIndex);
-        setSelectedTest(paginatedTests[newIndex]);
-      } else if (event.key === 'Enter') {
-        if (selectedRowIndex !== null && paginatedTests[selectedRowIndex]) {
-          event.preventDefault();
-          setDrawerOpen(true);
-        }
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [paginatedTests, selectedRowIndex, drawerOpen, overruleDrawerOpen]);
-
-  // Reset selected row when page changes
-  React.useEffect(() => {
-    setSelectedRowIndex(null);
-    setSelectedTest(null);
-  }, [page]);
-
-  // Truncate text helper
-  const truncateText = (text: string, maxLength: number) => {
-    if (text.length <= maxLength) return text;
-    return text.substring(0, maxLength) + '...';
-  };
-
-  return (
-    <Box>
-      <TableContainer
-        component={Paper}
-        elevation={2}
-        sx={{
-          maxHeight: 'calc(100vh - 250px)',
-          minHeight: 800,
-        }}
-      >
-        <Table stickyHeader>
-          <TableHead>
-            <TableRow>
-              <TableCell
-                sx={{
-                  backgroundColor: theme.palette.background.paper,
-                  fontWeight: 600,
-                  width: '22%',
-                }}
+          return (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 1.5,
+                width: '100%',
+              }}
+            >
+              <Tooltip
+                title={
+                  status.hasExecutionError
+                    ? 'Execution Error: Test could not be executed'
+                    : `Automated: ${
+                        status.automatedPassed ? 'Passed' : 'Failed'
+                      } (${status.count})${
+                        failedMetrics.length > 0
+                          ? ` - Failed: ${failedMetrics.join(', ')}`
+                          : ''
+                      }`
+                }
               >
-                {isMultiTurn ? 'Goal' : 'Prompt'}
-              </TableCell>
-              <TableCell
-                sx={{
-                  backgroundColor: theme.palette.background.paper,
-                  fontWeight: 600,
-                  width: '10%',
-                  textAlign: 'center',
-                }}
-              >
-                Result
-              </TableCell>
-              <TableCell
-                sx={{
-                  backgroundColor: theme.palette.background.paper,
-                  fontWeight: 600,
-                  width: '30%',
-                }}
-              >
-                {isMultiTurn ? 'Evaluation Reasoning' : 'Response'}
-              </TableCell>
-              <TableCell
-                sx={{
-                  backgroundColor: theme.palette.background.paper,
-                  fontWeight: 600,
-                  width: '13%',
-                  textAlign: 'center',
-                }}
-              >
-                <Box
-                  sx={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    gap: 0.5,
-                  }}
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                  {status.hasExecutionError ? (
+                    <ErrorOutlineIcon
+                      sx={{ fontSize: 20, color: 'warning.main' }}
+                    />
+                  ) : status.automatedPassed ? (
+                    <CheckIcon
+                      sx={{
+                        fontSize: 20,
+                        color: status.hasConflict
+                          ? 'warning.main'
+                          : 'success.main',
+                      }}
+                    />
+                  ) : (
+                    <CloseIcon
+                      sx={{
+                        fontSize: 20,
+                        color: status.hasConflict
+                          ? 'warning.main'
+                          : 'error.main',
+                      }}
+                    />
+                  )}
+                </Box>
+              </Tooltip>
+
+              {status.isOverruled ? (
+                <Tooltip
+                  title={
+                    status.reviewData
+                      ? `Human review by ${status.reviewData.reviewer}: ${
+                          status.reviewData.newStatus === 'passed'
+                            ? 'Passed'
+                            : 'Failed'
+                        } - ${status.reviewData.comments}`
+                      : 'Manually reviewed'
+                  }
                 >
-                  Review
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    {status.reviewData?.newStatus === 'passed' ? (
+                      <CheckIcon
+                        sx={{
+                          fontSize: 20,
+                          color: status.hasConflict
+                            ? 'warning.main'
+                            : 'success.main',
+                        }}
+                      />
+                    ) : (
+                      <CloseIcon
+                        sx={{
+                          fontSize: 20,
+                          color: status.hasConflict
+                            ? 'warning.main'
+                            : 'error.main',
+                        }}
+                      />
+                    )}
+                  </Box>
+                </Tooltip>
+              ) : (
+                <Tooltip title="No manual review yet">
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <CircleOutlinedIcon
+                      sx={{
+                        fontSize: 20,
+                        color: 'action.disabled',
+                        opacity: 0.3,
+                      }}
+                    />
+                  </Box>
+                </Tooltip>
+              )}
+            </Box>
+          );
+        },
+      },
+      {
+        field: 'activity',
+        headerName: 'Activity',
+        width: 100,
+        sortable: false,
+        disableColumnMenu: true,
+        align: 'center',
+        headerAlign: 'center',
+        renderCell: params => {
+          const test = params.row;
+
+          return (
+            <Box
+              sx={{
+                display: 'flex',
+                gap: 1,
+                justifyContent: 'center',
+                alignItems: 'center',
+                width: '100%',
+              }}
+            >
+              {test.counts && test.counts.comments > 0 && (
+                <Tooltip
+                  title={`${test.counts.comments} comment(s) - Click to view`}
+                >
                   <Box
+                    onClick={e => {
+                      e.stopPropagation();
+                      openTestDrawer(test, 4);
+                    }}
                     sx={{
                       display: 'flex',
                       alignItems: 'center',
-                      gap: 0.25,
-                      ml: 0.5,
+                      gap: 0.5,
+                      cursor: 'pointer',
+                      px: 0.5,
+                      borderRadius: 1,
+                      '&:hover': { bgcolor: 'action.hover' },
                     }}
                   >
-                    <SmartToyOutlinedIcon
-                      fontSize="small"
-                      sx={{ fontSize: 16 }}
+                    <CommentOutlinedIcon
+                      sx={{ fontSize: 18, color: 'action.active' }}
                     />
                     <Typography variant="caption" color="text.secondary">
-                      /
+                      {test.counts.comments}
                     </Typography>
-                    <PersonOutlineIcon fontSize="small" sx={{ fontSize: 16 }} />
                   </Box>
-                </Box>
-              </TableCell>
-              <TableCell
-                sx={{
-                  backgroundColor: theme.palette.background.paper,
-                  fontWeight: 600,
-                  width: '12%',
-                  textAlign: 'center',
-                }}
-              >
-                Activity
-              </TableCell>
-              <TableCell
-                sx={{
-                  backgroundColor: theme.palette.background.paper,
-                  fontWeight: 600,
-                  width: '13%',
-                  textAlign: 'center',
-                }}
-              >
-                Actions
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {loading ? (
-              <TableRow>
-                <TableCell colSpan={6} align="center" sx={{ py: 8 }}>
-                  <Typography color="text.secondary">
-                    Loading tests...
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            ) : paginatedTests.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={6} align="center" sx={{ py: 8 }}>
-                  <Typography color="text.secondary">
-                    No tests to display
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            ) : (
-              paginatedTests.map((test, index) => {
-                const status = getTestStatus(test);
-                const failedMetrics = getFailedMetrics(test);
+                </Tooltip>
+              )}
 
-                // Get prompt/goal content based on test type
-                const promptContent = isMultiTurn
-                  ? test.test_output?.test_configuration?.goal || 'N/A'
-                  : test.prompt_id && prompts[test.prompt_id]
-                    ? prompts[test.prompt_id].content
-                    : test.test?.prompt?.content || 'N/A';
-
-                // Get response/evaluation content based on test type
-                const responseContent = isMultiTurn
-                  ? test.test_output?.goal_evaluation?.reason || 'N/A'
-                  : test.test_output?.output || 'N/A';
-
-                const isRowSelected = selectedRowIndex === index;
-
-                return (
-                  <TableRow
-                    key={test.id}
-                    hover
-                    onClick={() => handleRowClick(test, index)}
+              {test.counts && test.counts.tasks > 0 && (
+                <Tooltip title={`${test.counts.tasks} task(s) - Click to view`}>
+                  <Box
+                    onClick={e => {
+                      e.stopPropagation();
+                      openTestDrawer(test, 4);
+                    }}
                     sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.5,
                       cursor: 'pointer',
-                      '&:hover': {
-                        backgroundColor: alpha(
-                          theme.palette.primary.main,
-                          0.04
-                        ),
-                      },
-                      ...(isRowSelected && {
-                        backgroundColor: alpha(
-                          theme.palette.primary.main,
-                          0.08
-                        ),
-                        outline: `2px solid ${theme.palette.primary.main}`,
-                        outlineOffset: '-2px',
-                      }),
+                      px: 0.5,
+                      borderRadius: 1,
+                      '&:hover': { bgcolor: 'action.hover' },
                     }}
                   >
-                    {/* Prompt Column */}
-                    <TableCell>
-                      <Tooltip title={promptContent} enterDelay={500}>
-                        <Typography variant="body2">
-                          {truncateText(promptContent, 150)}
-                        </Typography>
-                      </Tooltip>
-                    </TableCell>
+                    <TaskAltOutlinedIcon
+                      sx={{ fontSize: 18, color: 'action.active' }}
+                    />
+                    <Typography variant="caption" color="text.secondary">
+                      {test.counts.tasks}
+                    </Typography>
+                  </Box>
+                </Tooltip>
+              )}
 
-                    {/* Result Column */}
-                    <TableCell align="center">
-                      <Chip
-                        label={status.label}
-                        size="small"
-                        sx={{
-                          backgroundColor: status.hasExecutionError
-                            ? alpha(theme.palette.warning.main, 0.1)
-                            : status.passed
-                              ? alpha(theme.palette.success.main, 0.1)
-                              : alpha(theme.palette.error.main, 0.1),
-                          color: status.hasExecutionError
-                            ? 'warning.main'
-                            : status.passed
-                              ? 'success.main'
-                              : 'error.main',
-                          fontWeight: 600,
-                          minWidth: 70,
-                        }}
-                      />
-                    </TableCell>
+              {(!test.counts ||
+                (test.counts.comments === 0 && test.counts.tasks === 0)) && (
+                <Typography variant="caption" color="text.disabled">
+                  —
+                </Typography>
+              )}
+            </Box>
+          );
+        },
+      },
+      {
+        field: 'actions',
+        headerName: '',
+        width: 96,
+        sortable: false,
+        disableColumnMenu: true,
+        align: 'center',
+        headerAlign: 'center',
+        renderCell: params => {
+          const test = params.row;
 
-                    {/* Response Column */}
-                    <TableCell>
-                      <Tooltip title={responseContent} enterDelay={500}>
-                        <Typography variant="body2" color="text.secondary">
-                          {truncateText(responseContent, 150)}
-                        </Typography>
-                      </Tooltip>
-                    </TableCell>
+          return (
+            <Box
+              className="test-row-actions"
+              sx={{
+                display: 'flex',
+                gap: '10px',
+                justifyContent: 'center',
+                alignItems: 'center',
+                width: '100%',
+              }}
+            >
+              {!test.last_review && (
+                <Tooltip title="Confirm Review">
+                  <span>
+                    <IconButton
+                      size="small"
+                      onClick={e => handleConfirmReview(e, test)}
+                      disabled={isConfirmingReview}
+                      sx={{
+                        p: 0.5,
+                        color: 'primary.main',
+                        '&:hover': {
+                          bgcolor: alpha(theme.palette.primary.main, 0.08),
+                        },
+                      }}
+                    >
+                      <CheckIcon sx={{ fontSize: 20 }} />
+                    </IconButton>
+                  </span>
+                </Tooltip>
+              )}
 
-                    {/* Review Column */}
-                    <TableCell align="center">
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          gap: 1.5,
-                        }}
-                      >
-                        {/* Machine Evaluation Icon */}
-                        <Tooltip
-                          title={
-                            status.hasExecutionError
-                              ? 'Execution Error: Test could not be executed'
-                              : `Automated: ${
-                                  status.automatedPassed ? 'Passed' : 'Failed'
-                                } (${status.count})${
-                                  failedMetrics.length > 0
-                                    ? ` - Failed: ${failedMetrics.join(', ')}`
-                                    : ''
-                                }`
-                          }
-                        >
-                          <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                            {status.hasExecutionError ? (
-                              <ErrorOutlineIcon
-                                sx={{
-                                  fontSize: 20,
-                                  color: 'warning.main',
-                                }}
-                              />
-                            ) : status.automatedPassed ? (
-                              <CheckIcon
-                                sx={{
-                                  fontSize: 20,
-                                  color: status.hasConflict
-                                    ? 'warning.main'
-                                    : 'success.main',
-                                }}
-                              />
-                            ) : (
-                              <CloseIcon
-                                sx={{
-                                  fontSize: 20,
-                                  color: status.hasConflict
-                                    ? 'warning.main'
-                                    : 'error.main',
-                                }}
-                              />
-                            )}
-                          </Box>
-                        </Tooltip>
+              <Tooltip title="Provide Review">
+                <IconButton
+                  size="small"
+                  onClick={e => handleOverruleJudgement(e, test)}
+                  sx={{
+                    p: 0.5,
+                    color: 'primary.main',
+                    '&:hover': {
+                      bgcolor: alpha(theme.palette.primary.main, 0.08),
+                    },
+                  }}
+                >
+                  <RateReviewOutlinedIcon sx={{ fontSize: 20 }} />
+                </IconButton>
+              </Tooltip>
+            </Box>
+          );
+        },
+      },
+    ];
+  }, [isMultiTurn, prompts, theme, isConfirmingReview, openTestDrawer]);
 
-                        {/* Human Review Icon */}
-                        {status.isOverruled ? (
-                          <Tooltip
-                            title={
-                              'reviewData' in status && status.reviewData
-                                ? `Human review by ${status.reviewData.reviewer}: ${
-                                    status.reviewData.newStatus === 'passed'
-                                      ? 'Passed'
-                                      : 'Failed'
-                                  } - ${status.reviewData.comments}`
-                                : 'Manually reviewed'
-                            }
-                          >
-                            <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                              {'reviewData' in status &&
-                              status.reviewData?.newStatus === 'passed' ? (
-                                <CheckIcon
-                                  sx={{
-                                    fontSize: 20,
-                                    color: status.hasConflict
-                                      ? 'warning.main'
-                                      : 'success.main',
-                                  }}
-                                />
-                              ) : (
-                                <CloseIcon
-                                  sx={{
-                                    fontSize: 20,
-                                    color: status.hasConflict
-                                      ? 'warning.main'
-                                      : 'error.main',
-                                  }}
-                                />
-                              )}
-                            </Box>
-                          </Tooltip>
-                        ) : (
-                          <Tooltip title="No manual review yet">
-                            <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                              <CircleOutlinedIcon
-                                sx={{
-                                  fontSize: 20,
-                                  color: 'action.disabled',
-                                  opacity: 0.3,
-                                }}
-                              />
-                            </Box>
-                          </Tooltip>
-                        )}
-                      </Box>
-                    </TableCell>
+  return (
+    <Box sx={{ width: '100%', minWidth: 0 }}>
+      <BaseDataGrid
+        rows={mergedTests}
+        columns={columns}
+        loading={loading}
+        getRowId={row => row.id}
+        paginationModel={paginationModel}
+        onPaginationModelChange={setPaginationModel}
+        pageSizeOptions={[10, 25, 50, 100]}
+        onRowClick={(params: GridRowParams<TestResultDetail>) => {
+          openTestDrawer(params.row);
+        }}
+        disablePaperWrapper={embedded}
+        showToolbar={false}
+        sx={{
+          '& .test-row-actions': {
+            opacity: 0,
+            pointerEvents: 'none',
+            transition: 'opacity 0.15s ease',
+          },
+          '& .MuiDataGrid-row:hover .test-row-actions': {
+            opacity: 1,
+            pointerEvents: 'auto',
+          },
+        }}
+      />
 
-                    {/* Activity Column */}
-                    <TableCell align="center">
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          gap: 1,
-                          justifyContent: 'center',
-                          alignItems: 'center',
-                        }}
-                      >
-                        {/* Comments Count */}
-                        {test.counts && test.counts.comments > 0 && (
-                          <Tooltip
-                            title={`${test.counts.comments} comment(s) - Click to view`}
-                          >
-                            <Box
-                              onClick={e => {
-                                e.stopPropagation();
-                                handleRowClick(test, index, 4); // Tab index 4 is Tasks & Comments
-                              }}
-                              sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: 0.5,
-                                cursor: 'pointer',
-                                padding: theme.spacing(0.25, 0.5),
-                                borderRadius: theme.shape.borderRadius / 8,
-                                '&:hover': {
-                                  backgroundColor: theme.palette.action.hover,
-                                },
-                              }}
-                            >
-                              <CommentOutlinedIcon
-                                sx={{ fontSize: 18, color: 'action.active' }}
-                              />
-                              <Typography
-                                variant="caption"
-                                color="text.secondary"
-                              >
-                                {test.counts.comments}
-                              </Typography>
-                            </Box>
-                          </Tooltip>
-                        )}
-
-                        {/* Tasks Count */}
-                        {test.counts && test.counts.tasks > 0 && (
-                          <Tooltip
-                            title={`${test.counts.tasks} task(s) - Click to view`}
-                          >
-                            <Box
-                              onClick={e => {
-                                e.stopPropagation();
-                                handleRowClick(test, index, 4); // Tab index 4 is Tasks & Comments
-                              }}
-                              sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: 0.5,
-                                cursor: 'pointer',
-                                padding: theme.spacing(0.25, 0.5),
-                                borderRadius: theme.shape.borderRadius / 8,
-                                '&:hover': {
-                                  backgroundColor: theme.palette.action.hover,
-                                },
-                              }}
-                            >
-                              <TaskAltOutlinedIcon
-                                sx={{ fontSize: 18, color: 'action.active' }}
-                              />
-                              <Typography
-                                variant="caption"
-                                color="text.secondary"
-                              >
-                                {test.counts.tasks}
-                              </Typography>
-                            </Box>
-                          </Tooltip>
-                        )}
-
-                        {/* Show dash if no activity */}
-                        {(!test.counts ||
-                          (test.counts.comments === 0 &&
-                            test.counts.tasks === 0)) && (
-                          <Typography variant="caption" color="text.disabled">
-                            —
-                          </Typography>
-                        )}
-                      </Box>
-                    </TableCell>
-
-                    {/* Actions Column */}
-                    <TableCell align="center">
-                      <Box
-                        sx={{
-                          display: 'flex',
-                          gap: 0.5,
-                          justifyContent: 'center',
-                          alignItems: 'center',
-                        }}
-                      >
-                        {/* Show Confirm Review button only if not already reviewed */}
-                        {!test.last_review && (
-                          <Tooltip title="Confirm Review">
-                            <span>
-                              <IconButton
-                                size="small"
-                                onClick={e => handleConfirmReview(e, test)}
-                                disabled={isConfirmingReview}
-                                sx={{
-                                  '&:hover': {
-                                    backgroundColor: alpha(
-                                      theme.palette.success.main,
-                                      0.1
-                                    ),
-                                  },
-                                  '&:disabled': {
-                                    color: 'action.disabled',
-                                  },
-                                }}
-                              >
-                                <CheckIcon
-                                  sx={{ fontSize: 18, color: 'action.active' }}
-                                />
-                              </IconButton>
-                            </span>
-                          </Tooltip>
-                        )}
-
-                        <Tooltip title="Provide Review">
-                          <IconButton
-                            size="small"
-                            onClick={e => handleOverruleJudgement(e, test)}
-                            sx={{
-                              '&:hover': {
-                                backgroundColor: alpha(
-                                  theme.palette.primary.main,
-                                  0.1
-                                ),
-                              },
-                            }}
-                          >
-                            <RateReviewOutlinedIcon
-                              sx={{ fontSize: 18, color: 'action.active' }}
-                            />
-                          </IconButton>
-                        </Tooltip>
-                      </Box>
-                    </TableCell>
-                  </TableRow>
-                );
-              })
-            )}
-          </TableBody>
-        </Table>
-      </TableContainer>
-
-      {/* Pagination */}
-      <Paper elevation={2}>
-        <TablePagination
-          rowsPerPageOptions={[10, 25, 50, 100]}
-          component="div"
-          count={mergedTests.length}
-          rowsPerPage={rowsPerPage}
-          page={page}
-          onPageChange={handleChangePage}
-          onRowsPerPageChange={handleChangeRowsPerPage}
-          sx={{
-            borderTop: 1,
-            borderColor: 'divider',
-            backgroundColor: theme.palette.background.paper,
-          }}
-        />
-      </Paper>
-
-      {/* Test Result Drawer */}
       <TestResultDrawer
         open={drawerOpen}
         onClose={handleCloseDrawer}
@@ -1045,7 +699,6 @@ export default function TestsTableView({
         metricsSource={metricsSource}
       />
 
-      {/* Review Judgement Drawer */}
       <ReviewJudgementDrawer
         open={overruleDrawerOpen}
         onClose={() => setOverruleDrawerOpen(false)}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/__tests__/TestsTableView.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/__tests__/TestsTableView.test.tsx
@@ -18,6 +18,47 @@ jest.mock('../ReviewJudgementDrawer', () => ({
   default: () => null,
 }));
 
+jest.mock('@/components/common/BaseDataGrid', () => {
+  return function MockBaseDataGrid({
+    rows,
+    paginationModel,
+    onPaginationModelChange,
+  }: {
+    rows: unknown[];
+    paginationModel: { page: number; pageSize: number };
+    onPaginationModelChange: (model: {
+      page: number;
+      pageSize: number;
+    }) => void;
+  }) {
+    const { page, pageSize } = paginationModel;
+    const count = rows.length;
+    const from = count === 0 ? 0 : page * pageSize + 1;
+    const to = Math.min((page + 1) * pageSize, count);
+    const maxPage = Math.max(0, Math.ceil(count / pageSize) - 1);
+
+    return (
+      <div>
+        <div>
+          {from}–{to} of {count}
+        </div>
+        <button
+          type="button"
+          aria-label="Next page"
+          disabled={page >= maxPage}
+          onClick={() => onPaginationModelChange({ page: page + 1, pageSize })}
+        />
+        <button
+          type="button"
+          aria-label="Previous page"
+          disabled={page <= 0}
+          onClick={() => onPaginationModelChange({ page: page - 1, pageSize })}
+        />
+      </div>
+    );
+  };
+});
+
 // ---- API client: only used in event handlers, not needed for render-path tests ----
 
 jest.mock('@/utils/api-client/client-factory', () => ({

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/test-run-results-grid-utils.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/test-run-results-grid-utils.ts
@@ -1,0 +1,190 @@
+import {
+  TestResultDetail,
+  MetricResult,
+} from '@/utils/api-client/interfaces/test-results';
+import {
+  getTestEvaluationSummary,
+  isPassedStatusName,
+} from '@/utils/test-result-status';
+
+export type TestResultDisplayStatus = {
+  passed: boolean;
+  label: string;
+  count: string;
+  isOverruled: boolean;
+  hasConflict: boolean;
+  automatedPassed?: boolean;
+  hasExecutionError: boolean;
+  reviewData?: {
+    reviewer: string;
+    comments: string;
+    updated_at?: string;
+    newStatus: string;
+  };
+};
+
+function truncateText(text: string, maxLength: number) {
+  if (text.length <= maxLength) return text;
+  return `${text.substring(0, maxLength)}...`;
+}
+
+export function getGoalContent(
+  test: TestResultDetail,
+  prompts: Record<string, { content: string; name?: string }>,
+  isMultiTurn: boolean
+): string {
+  if (isMultiTurn) {
+    return test.test_output?.test_configuration?.goal || 'N/A';
+  }
+  if (test.prompt_id && prompts[test.prompt_id]) {
+    return prompts[test.prompt_id].content;
+  }
+  return test.test?.prompt?.content || 'N/A';
+}
+
+export function getEvaluationContent(test: TestResultDetail): string {
+  return getTestEvaluationSummary(test) || '—';
+}
+
+export function getFailedMetricNames(test: TestResultDetail): string[] {
+  const metrics = test.test_metrics?.metrics || {};
+  return Object.entries(metrics)
+    .filter(([_, metric]) => !metric.is_successful)
+    .map(([name]) => name);
+}
+
+export function getTestResultDisplayStatus(
+  test: TestResultDetail,
+  isMultiTurn: boolean
+): TestResultDisplayStatus {
+  if (isMultiTurn && test.test_output?.goal_evaluation) {
+    const allMetrics = test.test_metrics?.metrics || {};
+    const allMetricValues = Object.values(allMetrics);
+    const hasTestMetrics = allMetricValues.length > 0;
+
+    const allCriteriaMet = hasTestMetrics
+      ? allMetricValues.every((m: MetricResult) => m.is_successful)
+      : test.test_output.goal_evaluation.all_criteria_met;
+
+    const totalCriteria = hasTestMetrics
+      ? allMetricValues.length
+      : test.test_output.goal_evaluation.criteria_evaluations?.length || 0;
+    const metCriteria = hasTestMetrics
+      ? allMetricValues.filter((m: MetricResult) => m.is_successful).length
+      : test.test_output.goal_evaluation.criteria_evaluations?.filter(
+          c => c.met
+        )?.length || 0;
+
+    const originalPassed = allCriteriaMet === true;
+    const lastReview = test.last_review;
+
+    if (lastReview && lastReview.status?.name) {
+      const reviewPassed = isPassedStatusName(lastReview.status.name);
+      const hasConflict = reviewPassed !== originalPassed;
+
+      return {
+        passed: reviewPassed,
+        label: reviewPassed ? 'Passed' : 'Failed',
+        count: `${metCriteria}/${totalCriteria}`,
+        isOverruled: true,
+        hasConflict,
+        automatedPassed: originalPassed,
+        hasExecutionError: false,
+        reviewData: {
+          reviewer: lastReview.user?.name || 'Unknown',
+          comments: lastReview.comments,
+          updated_at: lastReview.updated_at,
+          newStatus: reviewPassed ? 'passed' : 'failed',
+        },
+      };
+    }
+
+    const hasExecutionError = test.test_output.status === 'error';
+    const hasExecutionFailure = test.test_output.status === 'failure';
+
+    if (hasExecutionError) {
+      return {
+        passed: false,
+        label: 'Error',
+        count: `${metCriteria}/${totalCriteria}`,
+        isOverruled: false,
+        hasConflict: false,
+        hasExecutionError: true,
+      };
+    }
+
+    if (hasExecutionFailure) {
+      return {
+        passed: false,
+        label: 'Failed',
+        count: `${metCriteria}/${totalCriteria}`,
+        isOverruled: false,
+        hasConflict: false,
+        hasExecutionError: false,
+      };
+    }
+
+    return {
+      passed: originalPassed,
+      label: originalPassed ? 'Passed' : 'Failed',
+      count: `${metCriteria}/${totalCriteria}`,
+      isOverruled: false,
+      hasConflict: false,
+      automatedPassed: originalPassed,
+      hasExecutionError: false,
+    };
+  }
+
+  const metrics = test.test_metrics?.metrics || {};
+  const metricValues = Object.values(metrics);
+  const totalMetrics = metricValues.length;
+  const passedMetrics = metricValues.filter(m => m.is_successful).length;
+  const hasExecutionError = !test.test_metrics || totalMetrics === 0;
+
+  if (hasExecutionError) {
+    return {
+      passed: false,
+      label: 'Error',
+      count: '0/0',
+      isOverruled: false,
+      hasConflict: false,
+      hasExecutionError: true,
+    };
+  }
+
+  const originalPassed = passedMetrics === totalMetrics;
+  const lastReview = test.last_review;
+
+  if (lastReview && lastReview.status?.name) {
+    const reviewPassed = isPassedStatusName(lastReview.status.name);
+    const hasConflict = reviewPassed !== originalPassed;
+
+    return {
+      passed: reviewPassed,
+      label: reviewPassed ? 'Passed' : 'Failed',
+      count: `${passedMetrics}/${totalMetrics}`,
+      isOverruled: true,
+      hasConflict,
+      automatedPassed: originalPassed,
+      hasExecutionError: false,
+      reviewData: {
+        reviewer: lastReview.user?.name || 'Unknown',
+        comments: lastReview.comments,
+        updated_at: lastReview.updated_at,
+        newStatus: reviewPassed ? 'passed' : 'failed',
+      },
+    };
+  }
+
+  return {
+    passed: originalPassed,
+    label: originalPassed ? 'Passed' : 'Failed',
+    count: `${passedMetrics}/${totalMetrics}`,
+    isOverruled: false,
+    hasConflict: false,
+    automatedPassed: originalPassed,
+    hasExecutionError: false,
+  };
+}
+
+export { truncateText };

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/test-run-summary-utils.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/test-run-summary-utils.ts
@@ -1,0 +1,86 @@
+import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+import { getEffectiveTestResultStatus } from '@/utils/test-result-status';
+
+export type ReviewBand = 'ok' | 'watch' | 'review';
+
+export interface ReviewBandInfo {
+  band: ReviewBand;
+  label: string;
+  colorKey: 'success' | 'warning' | 'error';
+}
+
+export function getReviewBand(passRate: number): ReviewBandInfo {
+  if (passRate >= 100) {
+    return { band: 'ok', label: 'OK', colorKey: 'success' };
+  }
+  if (passRate >= 70) {
+    return { band: 'watch', label: 'Watch', colorKey: 'warning' };
+  }
+  return { band: 'review', label: 'Needs Review', colorKey: 'error' };
+}
+
+export interface BehaviorStat {
+  name: string;
+  total: number;
+  passed: number;
+  failed: number;
+  passRate: number;
+}
+
+export interface MetricStat {
+  name: string;
+  total: number;
+  passed: number;
+  failed: number;
+  failRate: number;
+}
+
+export function aggregateBehaviorStats(
+  testResults: TestResultDetail[]
+): BehaviorStat[] {
+  const map = new Map<string, { passed: number; total: number }>();
+
+  for (const result of testResults) {
+    const name =
+      result.test?.behavior?.name ||
+      (result.test as { behavior?: { name?: string } } | undefined)?.behavior
+        ?.name;
+    if (!name) continue;
+    const entry = map.get(name) ?? { passed: 0, total: 0 };
+    entry.total += 1;
+    if (getEffectiveTestResultStatus(result) === 'Pass') entry.passed += 1;
+    map.set(name, entry);
+  }
+
+  return Array.from(map.entries()).map(([name, { passed, total }]) => ({
+    name,
+    total,
+    passed,
+    failed: total - passed,
+    passRate: total > 0 ? (passed / total) * 100 : 0,
+  }));
+}
+
+export function aggregateMetricStats(
+  testResults: TestResultDetail[]
+): MetricStat[] {
+  const map = new Map<string, { passed: number; total: number }>();
+
+  for (const result of testResults) {
+    const metrics = result.test_metrics?.metrics ?? {};
+    for (const [name, m] of Object.entries(metrics)) {
+      const entry = map.get(name) ?? { passed: 0, total: 0 };
+      entry.total += 1;
+      if (m.is_successful) entry.passed += 1;
+      map.set(name, entry);
+    }
+  }
+
+  return Array.from(map.entries()).map(([name, { passed, total }]) => ({
+    name,
+    total,
+    passed,
+    failed: total - passed,
+    failRate: total > 0 ? ((total - passed) / total) * 100 : 0,
+  }));
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunDetailData.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunDetailData.ts
@@ -1,0 +1,196 @@
+import { useEffect, useState } from 'react';
+import { UUID } from 'crypto';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+import { Prompt } from '@/utils/api-client/interfaces/prompt';
+
+export interface BehaviorWithMetrics {
+  id: string;
+  name: string;
+  description?: string;
+  metrics: Array<{ name: string; description?: string }>;
+}
+
+interface UseTestRunDetailDataOptions {
+  testRunId: string;
+  sessionToken: string;
+  enabled?: boolean;
+}
+
+interface UseTestRunDetailDataReturn {
+  testResults: TestResultDetail[];
+  prompts: Record<string, Prompt>;
+  behaviors: BehaviorWithMetrics[];
+  availableMetrics: string[];
+  loading: boolean;
+  error: string | null;
+}
+
+async function fetchAllTestResults(
+  testRunId: string,
+  sessionToken: string
+): Promise<TestResultDetail[]> {
+  const testResultsClient = new ApiClientFactory(
+    sessionToken
+  ).getTestResultsClient();
+
+  let testResults: TestResultDetail[] = [];
+  let skip = 0;
+  const batchSize = 100;
+  let hasMore = true;
+
+  while (hasMore) {
+    const response = await testResultsClient.getTestResults({
+      filter: `test_run_id eq '${testRunId}'`,
+      limit: batchSize,
+      skip,
+      sort_by: 'created_at',
+      sort_order: 'desc',
+    });
+
+    testResults = [...testResults, ...response.data];
+    const totalCount = response.pagination?.totalCount || 0;
+    hasMore = testResults.length < totalCount;
+    skip += batchSize;
+
+    if (skip > 10000) break;
+  }
+
+  return testResults;
+}
+
+function buildPromptsMap(
+  testResults: TestResultDetail[]
+): Record<string, Prompt> {
+  return testResults.reduce(
+    (acc, testResult) => {
+      if (testResult.test?.prompt) {
+        acc[testResult.test.prompt.id] = {
+          id: testResult.test.prompt.id,
+          content: testResult.test.prompt.content,
+          expected_response: testResult.test.prompt.expected_response,
+          nano_id: testResult.test.prompt.nano_id,
+          counts: testResult.test.prompt.counts,
+        } as Prompt;
+      }
+      return acc;
+    },
+    {} as Record<string, Prompt>
+  );
+}
+
+async function fetchBehaviorsWithMetrics(
+  testRunId: string,
+  sessionToken: string
+): Promise<{
+  behaviors: BehaviorWithMetrics[];
+  availableMetrics: string[];
+}> {
+  const apiFactory = new ApiClientFactory(sessionToken);
+  const testRunsClient = apiFactory.getTestRunsClient();
+  const behaviorClient = apiFactory.getBehaviorClient();
+
+  const [behaviorsData, metricsData] = await Promise.all([
+    testRunsClient.getTestRunBehaviors(testRunId),
+    testRunsClient.getTestRunMetrics(testRunId),
+  ]);
+
+  const behaviorsWithMetrics = await Promise.all(
+    behaviorsData.map(async behavior => {
+      try {
+        const behaviorMetrics = await behaviorClient.getBehaviorMetrics(
+          behavior.id as UUID
+        );
+        return {
+          id: behavior.id as string,
+          name: behavior.name,
+          description: behavior.description ?? undefined,
+          metrics: behaviorMetrics.map(m => ({
+            name: m.name,
+            description: m.description ?? undefined,
+          })),
+        };
+      } catch {
+        return {
+          id: behavior.id as string,
+          name: behavior.name,
+          description: behavior.description ?? undefined,
+          metrics: [] as Array<{ name: string; description?: string }>,
+        };
+      }
+    })
+  );
+
+  return {
+    behaviors: behaviorsWithMetrics,
+    availableMetrics: metricsData,
+  };
+}
+
+export function useTestRunDetailData({
+  testRunId,
+  sessionToken,
+  enabled = true,
+}: UseTestRunDetailDataOptions): UseTestRunDetailDataReturn {
+  const [testResults, setTestResults] = useState<TestResultDetail[]>([]);
+  const [prompts, setPrompts] = useState<Record<string, Prompt>>({});
+  const [behaviors, setBehaviors] = useState<BehaviorWithMetrics[]>([]);
+  const [availableMetrics, setAvailableMetrics] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !sessionToken || !testRunId) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const [results, behaviorData] = await Promise.all([
+          fetchAllTestResults(testRunId, sessionToken),
+          fetchBehaviorsWithMetrics(testRunId, sessionToken),
+        ]);
+
+        if (cancelled) return;
+
+        setTestResults(results);
+        setPrompts(buildPromptsMap(results));
+        setBehaviors(behaviorData.behaviors);
+        setAvailableMetrics(behaviorData.availableMetrics);
+      } catch {
+        if (!cancelled) {
+          setError('Failed to load test run data');
+          setTestResults([]);
+          setPrompts({});
+          setBehaviors([]);
+          setAvailableMetrics([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [testRunId, sessionToken, enabled]);
+
+  return {
+    testResults,
+    prompts,
+    behaviors,
+    availableMetrics,
+    loading,
+    error,
+  };
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
@@ -1,11 +1,9 @@
-import { Box } from '@mui/material';
 import { Metadata } from 'next';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { notFound } from 'next/navigation';
 import { auth } from '@/auth';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
-import { UUID } from 'crypto';
+import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 import TestRunMainView from './components/TestRunMainViewClient';
 
 interface _PageProps {
@@ -38,7 +36,6 @@ export default async function TestRunPage({
   params: Promise<{ identifier: string }>;
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
-  // Ensure params and searchParams are properly awaited
   const resolvedParams = await Promise.resolve(params);
   const resolvedSearchParams = await Promise.resolve(searchParams);
   const identifier = resolvedParams.identifier;
@@ -46,167 +43,54 @@ export default async function TestRunPage({
 
   const session = await auth();
 
-  // If no session, throw error - will be caught by error boundary
   if (!session?.session_token) {
     throw new Error('Authentication required');
   }
 
-  const apiFactory = new ApiClientFactory(session.session_token);
-  const testRunsClient = apiFactory.getTestRunsClient();
-  const testResultsClient = apiFactory.getTestResultsClient();
-  const behaviorClient = apiFactory.getBehaviorClient();
+  const testRunsClient = new ApiClientFactory(
+    session.session_token
+  ).getTestRunsClient();
 
-  // Fetch test run details — notFound() on any API error (404, 422, etc.)
-  // so Next.js returns a 404 response instead of a 500.
-  const testRun = await testRunsClient
-    .getTestRun(identifier)
-    .catch(() => notFound());
-
-  // Fetch all test results for this test run in batches (API limit is 100)
-  // The backend now includes nested prompt and behavior objects, eliminating the need for separate API calls
-  let testResults: TestResultDetail[] = [];
-  let skip = 0;
-  const batchSize = 100;
-  let hasMore = true;
-
-  while (hasMore) {
-    const testResultsResponse = await testResultsClient.getTestResults({
-      filter: `test_run_id eq '${identifier}'`,
-      limit: batchSize,
-      skip: skip,
-      sort_by: 'created_at',
-      sort_order: 'desc',
-    });
-
-    testResults = [...testResults, ...testResultsResponse.data];
-
-    // Check if there are more results
-    const totalCount = testResultsResponse.pagination?.totalCount || 0;
-    hasMore = testResults.length < totalCount;
-    skip += batchSize;
-
-    // Safety check to prevent infinite loops
-    if (skip > 10000) break;
-  }
-
-  // Build prompts map from nested data in test results (optimized - no separate API calls needed!)
-  const promptsMap = testResults.reduce(
-    (acc, testResult) => {
-      // Use nested prompt data if available
-      if (testResult.test?.prompt) {
-        acc[testResult.test.prompt.id] = {
-          id: testResult.test.prompt.id,
-          content: testResult.test.prompt.content,
-          expected_response: testResult.test.prompt.expected_response,
-          nano_id: testResult.test.prompt.nano_id,
-          counts: testResult.test.prompt.counts,
-        };
-      }
-      // Fallback: if prompt_id exists but nested data is not available (backward compatibility)
-      else if (testResult.prompt_id && !acc[testResult.prompt_id]) {
-      }
-      return acc;
-    },
-    {} as Record<
-      string,
-      {
-        id: string;
-        content: string;
-        expected_response?: string;
-        nano_id?: string;
-        counts?: unknown;
-      }
-    >
-  );
-
-  // Fetch behaviors (with their associated metrics for behavior-level filtering)
-  // and the distinct metric names actually evaluated in this test run, in parallel
-  let behaviors: Array<{
-    id: string;
-    name: string;
-    description?: string;
-    metrics: Array<{ name: string; description?: string }>;
-  }> = [];
-  let availableMetrics: string[] = [];
+  let testRun;
   try {
-    const [behaviorsData, metricsData] = await Promise.all([
-      testRunsClient.getTestRunBehaviors(identifier),
-      testRunsClient.getTestRunMetrics(identifier),
-    ]);
-
-    availableMetrics = metricsData;
-
-    const behaviorsWithMetrics = await Promise.all(
-      behaviorsData.map(async behavior => {
-        try {
-          const behaviorMetrics = await behaviorClient.getBehaviorMetrics(
-            behavior.id as UUID
-          );
-          return {
-            id: behavior.id as string,
-            name: behavior.name,
-            description: behavior.description ?? undefined,
-            metrics: behaviorMetrics.map(m => ({
-              name: m.name,
-              description: m.description ?? undefined,
-            })),
-          };
-        } catch (_error) {
-          return {
-            id: behavior.id as string,
-            name: behavior.name,
-            description: behavior.description ?? undefined,
-            metrics: [] as Array<{ name: string; description?: string }>,
-          };
-        }
-      })
-    );
-
-    behaviors = behaviorsWithMetrics;
-  } catch (_error) {
-    behaviors = [];
-    availableMetrics = [];
+    testRun = await testRunsClient.getTestRun(identifier);
+  } catch (error) {
+    if (isNotFoundApiError(error)) {
+      notFound();
+    }
+    throw error;
   }
 
-  // Define title and breadcrumbs for PageContainer
   const title = testRun.name || `Test Run ${identifier}`;
   const breadcrumbs = [
     { label: 'Test Runs', href: '/test-runs' },
     { label: title, href: `/test-runs/${identifier}` },
   ];
 
-  // All errors (404 not found, 410 deleted, etc.) are caught by the global error.tsx
   return (
     <PageLayout title="" breadcrumbs={breadcrumbs}>
-      <Box sx={{ flexGrow: 1 }}>
-        {/* Main Split View */}
-        <TestRunMainView
-          testRunId={identifier}
-          testRunData={{
-            id: testRun.id,
-            name: testRun.name,
-            created_at:
-              (typeof testRun.attributes?.started_at === 'string'
-                ? testRun.attributes.started_at
-                : null) ||
-              testRun.created_at ||
-              '',
-            test_configuration_id: testRun.test_configuration_id,
-          }}
-          testRun={testRun}
-          sessionToken={session.session_token}
-          testResults={testResults}
-          prompts={promptsMap}
-          behaviors={behaviors}
-          availableMetrics={availableMetrics}
-          currentUserId={session.user?.id || ''}
-          currentUserName={session.user?.name || ''}
-          currentUserPicture={session.user?.picture || undefined}
-          initialSelectedTestId={
-            typeof selectedResult === 'string' ? selectedResult : undefined
-          }
-        />
-      </Box>
+      <TestRunMainView
+        testRunId={identifier}
+        testRunData={{
+          id: testRun.id,
+          name: testRun.name,
+          created_at:
+            (typeof testRun.attributes?.started_at === 'string'
+              ? testRun.attributes.started_at
+              : null) ||
+            testRun.created_at ||
+            '',
+          test_configuration_id: testRun.test_configuration_id,
+        }}
+        testRun={testRun}
+        sessionToken={session.session_token}
+        currentUserId={session.user?.id || ''}
+        currentUserName={session.user?.name || ''}
+        currentUserPicture={session.user?.picture || undefined}
+        initialSelectedTestId={
+          typeof selectedResult === 'string' ? selectedResult : undefined
+        }
+      />
     </PageLayout>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -59,12 +59,10 @@ type RunKindFilter = 'all' | 'tests' | 'experiments';
 
 const STATUS_TABS = [
   { label: 'All', value: 'all' },
-  { label: 'Queued', value: 'Queued' },
   { label: 'In Progress', value: 'Progress' },
   { label: 'Completed', value: 'Completed' },
   { label: 'Partial', value: 'Partial' },
   { label: 'Failed', value: 'Failed' },
-  { label: 'Cancelled', value: 'Cancelled' },
 ];
 
 // ── Toolbar context ──────────────────────────────────────────────────────────

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -356,6 +356,46 @@ function TestRunsGrid({
         },
       },
       {
+        field: 'pass_rate',
+        headerName: 'Pass Rate',
+        width: 110,
+        minWidth: 90,
+        resizable: true,
+        align: 'right',
+        headerAlign: 'right',
+        sortable: false,
+        filterable: false,
+        valueGetter: (_, row) => {
+          const stats = row.stats;
+          if (!stats || !stats.total) return null;
+          return (stats.passed / stats.total) * 100;
+        },
+        renderCell: params => {
+          const value = params.value as number | null;
+          if (value === null || value === undefined) {
+            return (
+              <Typography variant="body2" color="text.secondary">
+                —
+              </Typography>
+            );
+          }
+          return <Typography variant="body2">{value.toFixed(1)}%</Typography>;
+        },
+      },
+      {
+        field: 'status',
+        headerName: 'Status',
+        width: 120,
+        minWidth: 90,
+        resizable: true,
+        renderCell: params => {
+          const status = params.row.status?.name;
+          if (!status) return null;
+
+          return <GridBadge label={status} />;
+        },
+      },
+      {
         field: 'test_set_type',
         headerName: 'Type',
         width: 120,
@@ -374,19 +414,6 @@ function TestRunsGrid({
           if (!testSetType) return null;
 
           return <GridBadge label={testSetType} />;
-        },
-      },
-      {
-        field: 'status',
-        headerName: 'Status',
-        width: 120,
-        minWidth: 90,
-        resizable: true,
-        renderCell: params => {
-          const status = params.row.status?.name;
-          if (!status) return null;
-
-          return <GridBadge label={status} />;
         },
       },
       {

--- a/apps/frontend/src/app/(protected)/test-runs/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/page.tsx
@@ -4,10 +4,9 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import AddIcon from '@mui/icons-material/Add';
 import { useSession } from 'next-auth/react';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { PlayArrowIcon } from '@/components/icons';
 import TestRunsGrid from './components/TestRunsGrid';
@@ -82,7 +81,7 @@ export default function TestRunsPage() {
         actions={
           <FabGroup>
             <Fab
-              icon={<AddIcon />}
+              icon={<FabAddIcon />}
               tooltip="New Test Run"
               onClick={() => setCreateDrawerOpen(true)}
             />

--- a/apps/frontend/src/app/(protected)/test-sets/TestSetsNewAction.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/TestSetsNewAction.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { Fab } from '@/components/common/Fab';
+import { Fab, FabAddIcon } from '@/components/common/Fab';
 import TestSetDrawer from './components/TestSetDrawer';
 
 /**

--- a/apps/frontend/src/app/(protected)/test-sets/TestSetsNewAction.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/TestSetsNewAction.tsx
@@ -3,7 +3,6 @@
 import React, { useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import AddIcon from '@mui/icons-material/Add';
 import { Fab } from '@/components/common/Fab';
 import TestSetDrawer from './components/TestSetDrawer';
 
@@ -22,7 +21,7 @@ export function TestSetsNewAction() {
   return (
     <>
       <Fab
-        icon={<AddIcon />}
+        icon={<FabAddIcon />}
         tooltip="New Test Set"
         onClick={() => setOpen(true)}
         disabled={!sessionToken}

--- a/apps/frontend/src/app/(protected)/test-sets/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/page.tsx
@@ -5,12 +5,11 @@ import { useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import AddIcon from '@mui/icons-material/Add';
 import FileUploadIcon from '@mui/icons-material/FileUploadOutlined';
 import SecurityIcon from '@mui/icons-material/SecurityOutlined';
 import { useSession } from 'next-auth/react';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { HorizontalSplitIcon } from '@/components/icons';
 import TestSetsGrid from './components/TestSetsGrid';
@@ -131,7 +130,7 @@ export default function TestSetsPage() {
               onClick={() => setGarakImportDialogOpen(true)}
             />
             <Fab
-              icon={<AddIcon />}
+              icon={<FabAddIcon />}
               tooltip="New Test Set"
               onClick={() => setCreateDrawerOpen(true)}
             />

--- a/apps/frontend/src/app/(protected)/tests/new-manual/components/ManualTestWriter.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-manual/components/ManualTestWriter.tsx
@@ -26,7 +26,6 @@ import {
   ToggleButtonGroup,
 } from '@mui/material';
 import {
-  Add as AddIcon,
   Delete as DeleteIcon,
   Save as SaveIcon,
   Download as DownloadIcon,
@@ -36,7 +35,7 @@ import {
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -640,7 +639,7 @@ export default function ManualTestWriter() {
                 disabled={loading || testCases.length === 0}
               />
               <Fab
-                icon={<AddIcon />}
+                icon={<FabAddIcon />}
                 tooltip="Add test case"
                 onClick={addNewRow}
                 disabled={loading}

--- a/apps/frontend/src/app/(protected)/tokens/components/TokensPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokensPageClient.tsx
@@ -13,7 +13,6 @@ import {
   IconButton,
   Alert,
 } from '@mui/material';
-import AddIcon from '@mui/icons-material/Add';
 import GridToolbar, {
   ToolbarPillTabs,
   directoryToolbarSx,
@@ -32,7 +31,7 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { Token, TokenResponse } from '@/utils/api-client/interfaces/token';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { VpnKeyIcon } from '@/components/icons';
 
@@ -224,7 +223,7 @@ export default function TokensPageClient({
       actions={
         <FabGroup>
           <Fab
-            icon={<AddIcon />}
+            icon={<FabAddIcon />}
             tooltip="Create API token"
             aria-label="Create API token"
             onClick={handleOpenCreateModal}

--- a/apps/frontend/src/app/(protected)/traces/components/ConversationTraceView.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/ConversationTraceView.tsx
@@ -14,6 +14,7 @@ import {
   OverrideMarker,
   Review,
 } from '@/utils/api-client/interfaces/test-results';
+import { reconstructConversationFromSpans } from '@/utils/conversation-from-spans';
 import type { FileResponse } from '@/utils/api-client/interfaces/file';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import ConversationHistory from '@/components/common/ConversationHistory';
@@ -29,31 +30,6 @@ interface ConversationTraceViewProps {
 interface TurnOverrideEntry {
   success: boolean;
   override: OverrideMarker;
-}
-
-/**
- * Compute automated turn success from turn_metrics.metrics
- * (before any human per-turn overrides).
- */
-function getAutomatedTurnSuccess(rootSpans: SpanNode[]): boolean | undefined {
-  const traceMetrics = rootSpans.find(s => s.trace_metrics)?.trace_metrics as
-    | Record<string, unknown>
-    | undefined;
-  if (!traceMetrics) return undefined;
-
-  const turnSection = traceMetrics.turn_metrics as
-    | Record<string, unknown>
-    | undefined;
-  if (!turnSection) return undefined;
-
-  const metrics = turnSection.metrics as
-    | Record<string, { is_successful?: boolean }>
-    | undefined;
-  if (metrics && Object.keys(metrics).length > 0) {
-    return Object.values(metrics).every(m => m?.is_successful);
-  }
-
-  return undefined;
 }
 
 /**
@@ -88,36 +64,6 @@ function getPerTurnOverrides(
     }
   }
   return result;
-}
-
-/**
- * Reconstruct conversation turns from span attributes when no test result
- * is available (e.g. direct SDK/endpoint multi-turn invocations).
- */
-function reconstructConversationFromSpans(
-  rootSpans: SpanNode[]
-): ConversationTurn[] {
-  const automatedSuccess = getAutomatedTurnSuccess(rootSpans);
-
-  return rootSpans
-    .filter(
-      span =>
-        span.attributes['rhesis.conversation.input'] ||
-        span.attributes['rhesis.conversation.output']
-    )
-    .map((span, i) => ({
-      turn: i + 1,
-      timestamp: span.start_time,
-      penelope_message: String(
-        span.attributes['rhesis.conversation.input'] || ''
-      ),
-      target_response: String(
-        span.attributes['rhesis.conversation.output'] || ''
-      ),
-      penelope_reasoning: '',
-      session_id: span.span_id,
-      success: automatedSuccess ?? span.status_code !== 'ERROR',
-    }));
 }
 
 export default function ConversationTraceView({

--- a/apps/frontend/src/app/(protected)/traces/components/SpanDetailsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/SpanDetailsPanel.tsx
@@ -1155,7 +1155,6 @@ export default function SpanDetailsPanel({
               currentUserId={currentUserId}
               currentUserName={currentUserName}
               currentUserPicture={currentUserPicture}
-              elevation={0}
             />
           </TabPanel>
         )}

--- a/apps/frontend/src/app/(protected)/traces/components/TraceFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceFilterDrawer.tsx
@@ -21,6 +21,7 @@ import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import { TRACE_METRICS_STATUS } from '@/utils/api-client/interfaces/telemetry';
 import {
   EMPTY_TRACE_DRAWER_FILTERS,
+  sanitizeTraceDrawerFiltersForTestRunScope,
   type TraceDrawerFilters,
   type TraceTimeRange,
 } from './trace-filter-params';
@@ -71,6 +72,7 @@ interface TraceFilterDrawerProps {
   filters: TraceDrawerFilters;
   onApply: (filters: TraceDrawerFilters) => void;
   sessionToken: string;
+  fixedTestRunId?: string;
 }
 
 export default function TraceFilterDrawer({
@@ -79,11 +81,25 @@ export default function TraceFilterDrawer({
   filters,
   onApply,
   sessionToken,
+  fixedTestRunId,
 }: TraceFilterDrawerProps) {
+  const isTestRunScope = Boolean(fixedTestRunId);
+
+  const resetFilters = React.useMemo(
+    () =>
+      fixedTestRunId
+        ? sanitizeTraceDrawerFiltersForTestRunScope(
+            EMPTY_TRACE_DRAWER_FILTERS,
+            fixedTestRunId
+          )
+        : EMPTY_TRACE_DRAWER_FILTERS,
+    [fixedTestRunId]
+  );
+
   const { draft, setDraft, handleReset, handleApply } = useFilterDrawerDraft(
     open,
     filters,
-    EMPTY_TRACE_DRAWER_FILTERS,
+    resetFilters,
     onApply,
     onClose
   );
@@ -118,10 +134,10 @@ export default function TraceFilterDrawer({
       }
     };
 
-    if (open && sessionToken) {
+    if (open && sessionToken && !isTestRunScope) {
       fetchData();
     }
-  }, [open, sessionToken]);
+  }, [open, sessionToken, isTestRunScope]);
 
   const filteredEndpoints = draft.projectId
     ? endpoints.filter(e => e.project_id === draft.projectId)
@@ -145,180 +161,188 @@ export default function TraceFilterDrawer({
       onApply={handleApply}
       title="Filter"
     >
-      <FilterSection title="Project">
-        <FormControl fullWidth size="small">
-          <InputLabel>Project</InputLabel>
-          <Select
-            value={draft.projectId || ''}
-            label="Project"
-            onChange={e => {
-              const projectId = e.target.value || undefined;
-              setDraft(prev => {
-                const next = { ...prev, projectId };
-                if (prev.endpointId && projectId) {
-                  const ep = endpoints.find(x => x.id === prev.endpointId);
-                  if (ep && ep.project_id !== projectId) {
-                    next.endpointId = undefined;
-                  }
+      {!isTestRunScope && (
+        <>
+          <FilterSection title="Project">
+            <FormControl fullWidth size="small">
+              <InputLabel>Project</InputLabel>
+              <Select
+                value={draft.projectId || ''}
+                label="Project"
+                onChange={e => {
+                  const projectId = e.target.value || undefined;
+                  setDraft(prev => {
+                    const next = { ...prev, projectId };
+                    if (prev.endpointId && projectId) {
+                      const ep = endpoints.find(x => x.id === prev.endpointId);
+                      if (ep && ep.project_id !== projectId) {
+                        next.endpointId = undefined;
+                      }
+                    }
+                    return next;
+                  });
+                }}
+              >
+                <MenuItem value="">All projects</MenuItem>
+                {projects.map(project => (
+                  <MenuItem key={project.id} value={project.id}>
+                    {project.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </FilterSection>
+
+          <FilterSection title="Endpoint">
+            <FormControl
+              fullWidth
+              size="small"
+              disabled={filteredEndpoints.length === 0 && !!draft.projectId}
+            >
+              <InputLabel>Endpoint</InputLabel>
+              <Select
+                value={draft.endpointId || ''}
+                label="Endpoint"
+                onChange={e =>
+                  setDraft(prev => ({
+                    ...prev,
+                    endpointId: e.target.value || undefined,
+                  }))
                 }
-                return next;
-              });
-            }}
-          >
-            <MenuItem value="">All projects</MenuItem>
-            {projects.map(project => (
-              <MenuItem key={project.id} value={project.id}>
-                {project.name}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </FilterSection>
+              >
+                <MenuItem value="">
+                  {draft.projectId && filteredEndpoints.length === 0
+                    ? 'No endpoints in project'
+                    : 'All endpoints'}
+                </MenuItem>
+                {filteredEndpoints.map(endpoint => (
+                  <MenuItem key={endpoint.id} value={endpoint.id}>
+                    {endpoint.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </FilterSection>
 
-      <FilterSection title="Endpoint">
-        <FormControl
-          fullWidth
-          size="small"
-          disabled={filteredEndpoints.length === 0 && !!draft.projectId}
-        >
-          <InputLabel>Endpoint</InputLabel>
-          <Select
-            value={draft.endpointId || ''}
-            label="Endpoint"
-            onChange={e =>
-              setDraft(prev => ({
-                ...prev,
-                endpointId: e.target.value || undefined,
-              }))
-            }
-          >
-            <MenuItem value="">
-              {draft.projectId && filteredEndpoints.length === 0
-                ? 'No endpoints in project'
-                : 'All endpoints'}
-            </MenuItem>
-            {filteredEndpoints.map(endpoint => (
-              <MenuItem key={endpoint.id} value={endpoint.id}>
-                {endpoint.name}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-      </FilterSection>
-
-      <FilterSection title="Environment">
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-          {ENV_OPTIONS.map(opt => (
-            <Box
-              key={opt.value}
-              component="button"
-              type="button"
-              onClick={() =>
-                setDraft(prev => ({
-                  ...prev,
-                  environment:
-                    prev.environment === opt.value ? undefined : opt.value,
-                }))
-              }
-              sx={filterChipSx(draft.environment === opt.value)}
-            >
-              {opt.label}
+          <FilterSection title="Environment">
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+              {ENV_OPTIONS.map(opt => (
+                <Box
+                  key={opt.value}
+                  component="button"
+                  type="button"
+                  onClick={() =>
+                    setDraft(prev => ({
+                      ...prev,
+                      environment:
+                        prev.environment === opt.value ? undefined : opt.value,
+                    }))
+                  }
+                  sx={filterChipSx(draft.environment === opt.value)}
+                >
+                  {opt.label}
+                </Box>
+              ))}
             </Box>
-          ))}
-        </Box>
-      </FilterSection>
+          </FilterSection>
 
-      <FilterSection title="Time range">
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 2 }}>
-          {TIME_RANGE_OPTIONS.map(opt => (
-            <Box
-              key={opt.value}
-              component="button"
-              type="button"
-              onClick={() => setTimeRange(opt.value)}
-              sx={filterChipSx(draft.timeRange === opt.value)}
-            >
-              {opt.label}
+          <FilterSection title="Time range">
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap', mb: 2 }}>
+              {TIME_RANGE_OPTIONS.map(opt => (
+                <Box
+                  key={opt.value}
+                  component="button"
+                  type="button"
+                  onClick={() => setTimeRange(opt.value)}
+                  sx={filterChipSx(draft.timeRange === opt.value)}
+                >
+                  {opt.label}
+                </Box>
+              ))}
+              <Box
+                component="button"
+                type="button"
+                onClick={() => setTimeRange('custom')}
+                sx={filterChipSx(draft.timeRange === 'custom')}
+              >
+                Custom
+              </Box>
             </Box>
-          ))}
-          <Box
-            component="button"
-            type="button"
-            onClick={() => setTimeRange('custom')}
-            sx={filterChipSx(draft.timeRange === 'custom')}
-          >
-            Custom
-          </Box>
-        </Box>
-        {draft.timeRange === 'custom' && (
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-            <TextField
-              fullWidth
-              size="small"
-              label="Start time after"
-              type="datetime-local"
-              value={
-                draft.startTimeAfter
-                  ? new Date(draft.startTimeAfter).toISOString().slice(0, 16)
-                  : ''
-              }
-              onChange={e =>
-                setDraft(prev => ({
-                  ...prev,
-                  startTimeAfter: e.target.value
-                    ? new Date(e.target.value).toISOString()
-                    : undefined,
-                }))
-              }
-              InputLabelProps={{ shrink: true }}
-              sx={textFieldSx}
-            />
-            <TextField
-              fullWidth
-              size="small"
-              label="Start time before"
-              type="datetime-local"
-              value={
-                draft.startTimeBefore
-                  ? new Date(draft.startTimeBefore).toISOString().slice(0, 16)
-                  : ''
-              }
-              onChange={e =>
-                setDraft(prev => ({
-                  ...prev,
-                  startTimeBefore: e.target.value
-                    ? new Date(e.target.value).toISOString()
-                    : undefined,
-                }))
-              }
-              InputLabelProps={{ shrink: true }}
-              sx={textFieldSx}
-            />
-          </Box>
-        )}
-      </FilterSection>
+            {draft.timeRange === 'custom' && (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                <TextField
+                  fullWidth
+                  size="small"
+                  label="Start time after"
+                  type="datetime-local"
+                  value={
+                    draft.startTimeAfter
+                      ? new Date(draft.startTimeAfter)
+                          .toISOString()
+                          .slice(0, 16)
+                      : ''
+                  }
+                  onChange={e =>
+                    setDraft(prev => ({
+                      ...prev,
+                      startTimeAfter: e.target.value
+                        ? new Date(e.target.value).toISOString()
+                        : undefined,
+                    }))
+                  }
+                  InputLabelProps={{ shrink: true }}
+                  sx={textFieldSx}
+                />
+                <TextField
+                  fullWidth
+                  size="small"
+                  label="Start time before"
+                  type="datetime-local"
+                  value={
+                    draft.startTimeBefore
+                      ? new Date(draft.startTimeBefore)
+                          .toISOString()
+                          .slice(0, 16)
+                      : ''
+                  }
+                  onChange={e =>
+                    setDraft(prev => ({
+                      ...prev,
+                      startTimeBefore: e.target.value
+                        ? new Date(e.target.value).toISOString()
+                        : undefined,
+                    }))
+                  }
+                  InputLabelProps={{ shrink: true }}
+                  sx={textFieldSx}
+                />
+              </Box>
+            )}
+          </FilterSection>
 
-      <FilterSection title="Source">
-        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-          {SOURCE_OPTIONS.map(opt => (
-            <Box
-              key={opt.value}
-              component="button"
-              type="button"
-              onClick={() =>
-                setDraft(prev => ({
-                  ...prev,
-                  traceSource:
-                    prev.traceSource === opt.value ? undefined : opt.value,
-                }))
-              }
-              sx={filterChipSx(draft.traceSource === opt.value)}
-            >
-              {opt.label}
+          <FilterSection title="Source">
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+              {SOURCE_OPTIONS.map(opt => (
+                <Box
+                  key={opt.value}
+                  component="button"
+                  type="button"
+                  onClick={() =>
+                    setDraft(prev => ({
+                      ...prev,
+                      traceSource:
+                        prev.traceSource === opt.value ? undefined : opt.value,
+                    }))
+                  }
+                  sx={filterChipSx(draft.traceSource === opt.value)}
+                >
+                  {opt.label}
+                </Box>
+              ))}
             </Box>
-          ))}
-        </Box>
-      </FilterSection>
+          </FilterSection>
+        </>
+      )}
 
       <FilterSection title="Evaluation">
         <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
@@ -344,20 +368,22 @@ export default function TraceFilterDrawer({
         </Box>
       </FilterSection>
 
-      <FilterSection title="Test association">
+      <FilterSection title={isTestRunScope ? 'Test case' : 'Test association'}>
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          <TextField
-            fullWidth
-            placeholder="Test run ID"
-            value={draft.testRunId || ''}
-            onChange={e =>
-              setDraft(prev => ({
-                ...prev,
-                testRunId: e.target.value || undefined,
-              }))
-            }
-            sx={textFieldSx}
-          />
+          {!isTestRunScope && (
+            <TextField
+              fullWidth
+              placeholder="Test run ID"
+              value={draft.testRunId || ''}
+              onChange={e =>
+                setDraft(prev => ({
+                  ...prev,
+                  testRunId: e.target.value || undefined,
+                }))
+              }
+              sx={textFieldSx}
+            />
+          )}
           <TextField
             fullWidth
             placeholder="Test result ID"

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
@@ -15,6 +15,7 @@ import {
   buildTraceQueryParams,
   EMPTY_TRACE_DRAWER_FILTERS,
   hasActiveTraceDrawerFilters,
+  sanitizeTraceDrawerFiltersForTestRunScope,
   type TraceDrawerFilters,
 } from './trace-filter-params';
 
@@ -31,6 +32,7 @@ interface TracesClientProps {
   currentUserPicture?: string;
   initialTraceId?: string | null;
   initialProjectId?: string | null;
+  fixedTestRunId?: string;
   refreshKey?: number;
   onRefresh?: () => void;
   onUnfilteredEmpty?: (empty: boolean) => void;
@@ -43,6 +45,7 @@ export default function TracesClient({
   currentUserPicture,
   initialTraceId = null,
   initialProjectId = null,
+  fixedTestRunId,
   refreshKey: externalRefreshKey = 0,
   onRefresh,
   onUnfilteredEmpty,
@@ -67,11 +70,16 @@ export default function TracesClient({
 
   const [searchQuery, setSearchQuery] = useState('');
   const [typeFilter, setTypeFilter] = useState('all');
-  const [drawerFilters, setDrawerFilters] = useState<TraceDrawerFilters>(
-    () => ({
-      ...EMPTY_TRACE_DRAWER_FILTERS,
-      ...(initialProjectId ? { projectId: initialProjectId } : {}),
-    })
+  const [drawerFilters, setDrawerFilters] = useState<TraceDrawerFilters>(() =>
+    fixedTestRunId
+      ? sanitizeTraceDrawerFiltersForTestRunScope(
+          EMPTY_TRACE_DRAWER_FILTERS,
+          fixedTestRunId
+        )
+      : {
+          ...EMPTY_TRACE_DRAWER_FILTERS,
+          ...(initialProjectId ? { projectId: initialProjectId } : {}),
+        }
   );
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [limit, setLimit] = useState(50);
@@ -142,7 +150,10 @@ export default function TracesClient({
     const unfiltered =
       typeFilter === 'all' &&
       !searchQuery.trim() &&
-      !hasActiveTraceDrawerFilters(drawerFilters);
+      !hasActiveTraceDrawerFilters(drawerFilters, {
+        testRunScope: Boolean(fixedTestRunId),
+        excludeTestRunId: Boolean(fixedTestRunId),
+      });
     onUnfilteredEmpty?.(!loading && totalCount === 0 && unfiltered);
   }, [
     loading,
@@ -150,6 +161,7 @@ export default function TracesClient({
     typeFilter,
     searchQuery,
     drawerFilters,
+    fixedTestRunId,
     onUnfilteredEmpty,
   ]);
 
@@ -181,6 +193,19 @@ export default function TracesClient({
     setOffset(0);
   };
 
+  const handleApplyDrawerFilters = useCallback(
+    (filters: TraceDrawerFilters) => {
+      if (fixedTestRunId) {
+        setDrawerFilters(
+          sanitizeTraceDrawerFiltersForTestRunScope(filters, fixedTestRunId)
+        );
+        return;
+      }
+      setDrawerFilters(filters);
+    },
+    [fixedTestRunId]
+  );
+
   const handleRefresh = () => {
     onRefresh?.();
   };
@@ -209,11 +234,12 @@ export default function TracesClient({
         typeFilter={typeFilter}
         onTypeFilterChange={setTypeFilter}
         drawerFilters={drawerFilters}
-        onApplyDrawerFilters={setDrawerFilters}
+        onApplyDrawerFilters={handleApplyDrawerFilters}
         filterDrawerOpen={filterDrawerOpen}
         onFilterDrawerOpen={() => setFilterDrawerOpen(true)}
         onFilterDrawerClose={() => setFilterDrawerOpen(false)}
         sessionToken={sessionToken}
+        fixedTestRunId={fixedTestRunId}
       />
 
       {showFilteredEmpty && (

--- a/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
@@ -50,7 +50,11 @@ const TracesToolbarContext = React.createContext<TracesToolbarState>({
   hasActiveDrawerFilters: false,
 });
 
-function TracesUnifiedToolbar() {
+function TracesUnifiedToolbar({
+  hideTypeFilter,
+}: {
+  hideTypeFilter?: boolean;
+}) {
   const {
     searchQuery,
     setSearchQuery,
@@ -68,11 +72,13 @@ function TracesUnifiedToolbar() {
       onFilterClick={openFilterDrawer}
       hasActiveFilters={hasActiveDrawerFilters}
       middleContent={
-        <ToolbarPillTabs
-          tabs={PILL_TABS}
-          activeValue={typeFilter}
-          onChange={setTypeFilter}
-        />
+        hideTypeFilter ? undefined : (
+          <ToolbarPillTabs
+            tabs={PILL_TABS}
+            activeValue={typeFilter}
+            onChange={setTypeFilter}
+          />
+        )
       }
       rightContent={
         <>
@@ -104,6 +110,7 @@ interface TracesTableProps {
   onFilterDrawerOpen: () => void;
   onFilterDrawerClose: () => void;
   sessionToken: string;
+  fixedTestRunId?: string;
 }
 
 export default function TracesTable({
@@ -125,8 +132,12 @@ export default function TracesTable({
   onFilterDrawerOpen,
   onFilterDrawerClose,
   sessionToken,
+  fixedTestRunId,
 }: TracesTableProps) {
-  const hasActiveDrawerFilters = hasActiveTraceDrawerFilters(drawerFilters);
+  const hasActiveDrawerFilters = hasActiveTraceDrawerFilters(drawerFilters, {
+    testRunScope: Boolean(fixedTestRunId),
+    excludeTestRunId: Boolean(fixedTestRunId),
+  });
 
   const columns: GridColDef[] = useMemo(
     () => [
@@ -400,7 +411,9 @@ export default function TracesTable({
         pageSizeOptions={[25, 50, 100]}
         disablePaperWrapper
         showToolbar
-        toolbarSlot={TracesUnifiedToolbar}
+        toolbarSlot={() => (
+          <TracesUnifiedToolbar hideTypeFilter={Boolean(fixedTestRunId)} />
+        )}
         persistState
         storageKey="traces-grid"
         sx={{
@@ -420,6 +433,7 @@ export default function TracesTable({
         filters={drawerFilters}
         onApply={onApplyDrawerFilters}
         sessionToken={sessionToken}
+        fixedTestRunId={fixedTestRunId}
       />
     </TracesToolbarContext.Provider>
   );

--- a/apps/frontend/src/app/(protected)/traces/components/__tests__/trace-filter-params.test.ts
+++ b/apps/frontend/src/app/(protected)/traces/components/__tests__/trace-filter-params.test.ts
@@ -57,6 +57,29 @@ describe('trace-filter-params', () => {
     ).toBe(true);
   });
 
+  it('detects active drawer filters in test run scope', () => {
+    expect(
+      hasActiveTraceDrawerFilters(
+        {
+          ...EMPTY_TRACE_DRAWER_FILTERS,
+          testRunId: 'run-1',
+          projectId: 'proj-1',
+        },
+        { testRunScope: true }
+      )
+    ).toBe(false);
+    expect(
+      hasActiveTraceDrawerFilters(
+        {
+          ...EMPTY_TRACE_DRAWER_FILTERS,
+          testRunId: 'run-1',
+          traceMetricsStatus: 'pass',
+        },
+        { testRunScope: true }
+      )
+    ).toBe(true);
+  });
+
   it('maps preset time ranges to ISO timestamps', () => {
     const after = timeRangeToStartTimeAfter('24h');
     expect(after).toBeDefined();

--- a/apps/frontend/src/app/(protected)/traces/components/trace-filter-params.ts
+++ b/apps/frontend/src/app/(protected)/traces/components/trace-filter-params.ts
@@ -25,20 +25,44 @@ export const EMPTY_TRACE_DRAWER_FILTERS: TraceDrawerFilters = {
   timeRange: 'all',
 };
 
-export function hasActiveTraceDrawerFilters(f: TraceDrawerFilters): boolean {
+export function hasActiveTraceDrawerFilters(
+  f: TraceDrawerFilters,
+  options?: { excludeTestRunId?: boolean; testRunScope?: boolean }
+): boolean {
+  if (options?.testRunScope) {
+    return !!(f.traceMetricsStatus || f.testResultId || f.testId);
+  }
+
+  const filters = options?.excludeTestRunId
+    ? { ...f, testRunId: undefined }
+    : f;
   return !!(
-    f.projectId ||
-    f.endpointId ||
-    f.environment ||
-    f.traceSource ||
-    f.traceMetricsStatus ||
-    f.testRunId ||
-    f.testResultId ||
-    f.testId ||
-    f.startTimeBefore ||
-    (f.timeRange !== 'all' && f.timeRange !== 'custom') ||
-    (f.timeRange === 'custom' && f.startTimeAfter)
+    filters.projectId ||
+    filters.endpointId ||
+    filters.environment ||
+    filters.traceSource ||
+    filters.traceMetricsStatus ||
+    filters.testRunId ||
+    filters.testResultId ||
+    filters.testId ||
+    filters.startTimeBefore ||
+    (filters.timeRange !== 'all' && filters.timeRange !== 'custom') ||
+    (filters.timeRange === 'custom' && filters.startTimeAfter)
   );
+}
+
+/** Keep only filters meaningful when traces are scoped to a single test run. */
+export function sanitizeTraceDrawerFiltersForTestRunScope(
+  filters: TraceDrawerFilters,
+  testRunId: string
+): TraceDrawerFilters {
+  return {
+    timeRange: 'all',
+    testRunId,
+    traceMetricsStatus: filters.traceMetricsStatus,
+    testResultId: filters.testResultId,
+    testId: filters.testId,
+  };
 }
 
 export function timeRangeToStartTimeAfter(

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Metadata } from 'next';
+import { cookies } from 'next/headers';
 import ThemeAwareLogo from '../components/common/ThemeAwareLogo';
 import '../styles/fonts.css';
 // Side-effect import: registers EE features into core's extension
@@ -252,6 +253,8 @@ const AUTHENTICATION: AuthenticationProps = {
 
 export default async function RootLayout(props: { children: React.ReactNode }) {
   const session = await auth().catch(() => null);
+  const themeCookie = (await cookies()).get('theme-mode')?.value;
+  const initialThemeMode = themeCookie === 'dark' ? 'dark' : 'light';
 
   // Get navigation with dynamic organization name
   const { items: navigation, organizationName } =
@@ -264,33 +267,12 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
   };
 
   return (
-    <html lang="en" suppressHydrationWarning>
-      <head>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `
-              (function() {
-                try {
-                  var THEME_MODE_KEY = 'theme-mode';
-                  var storedMode = localStorage.getItem(THEME_MODE_KEY);
-                  var mode;
-
-                  if (storedMode) {
-                    mode = storedMode;
-                  } else {
-                    var darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
-                    mode = darkModeQuery.matches ? 'dark' : 'light';
-                  }
-
-                  document.documentElement.setAttribute('data-theme-mode', mode);
-                } catch (e) {}
-              })();
-            `,
-          }}
-        />
-      </head>
+    <html lang="en" suppressHydrationWarning data-theme-mode={initialThemeMode}>
       <body suppressHydrationWarning>
-        <ThemeContextProvider disableTransitionOnChange>
+        <ThemeContextProvider
+          disableTransitionOnChange
+          initialMode={initialThemeMode}
+        >
           <LayoutContent
             session={session}
             navigation={navigation}

--- a/apps/frontend/src/components/comments/CommentItem.tsx
+++ b/apps/frontend/src/components/comments/CommentItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import {
   Box,
   Typography,
@@ -9,14 +9,12 @@ import {
   Button,
   TextField,
   Tooltip,
-  useTheme,
-  Chip,
+  type Theme,
 } from '@mui/material';
 import {
   EditIcon,
   DeleteIcon,
   EmojiIcon,
-  AssignmentIcon,
   AddTaskIcon,
 } from '@/components/icons';
 import { formatDistanceToNow, format } from 'date-fns';
@@ -25,8 +23,6 @@ import { Comment } from '@/types/comments';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import { UserAvatar } from '@/components/common/UserAvatar';
 import { createReactionTooltipText } from '@/utils/comment-utils';
-import { useTasks } from '@/hooks/useTasks';
-import { Task } from '@/utils/api-client/interfaces/task';
 
 interface CommentItemProps {
   comment: Comment;
@@ -35,8 +31,8 @@ interface CommentItemProps {
   onReact: (commentId: string, emoji: string) => Promise<void>;
   onCreateTask?: (commentId: string) => void;
   currentUserId: string;
-  entityType?: string; // Add entityType to determine if Create Task button should show
-  isHighlighted?: boolean; // Add highlighting prop
+  entityType?: string;
+  isHighlighted?: boolean;
 }
 
 export function CommentItem({
@@ -49,41 +45,17 @@ export function CommentItem({
   entityType,
   isHighlighted = false,
 }: CommentItemProps) {
-  const theme = useTheme();
   const [isEditing, setIsEditing] = useState(false);
   const [editText, setEditText] = useState(comment.content);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [emojiAnchorEl, setEmojiAnchorEl] = useState<HTMLElement | null>(null);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [associatedTasks, setAssociatedTasks] = useState<Task[]>([]);
-  const [_isLoadingTasks, setIsLoadingTasks] = useState(false);
-
-  const { fetchTasksByCommentId } = useTasks({ autoFetch: false });
 
   const isOwner = comment.user_id === currentUserId;
-  const canEdit = isOwner;
-  const canDelete = isOwner;
-
-  // Fetch associated tasks when component mounts
-  useEffect(() => {
-    const loadAssociatedTasks = async () => {
-      setIsLoadingTasks(true);
-      try {
-        const tasks = await fetchTasksByCommentId(comment.id);
-        setAssociatedTasks(tasks);
-      } catch (_error) {
-      } finally {
-        setIsLoadingTasks(false);
-      }
-    };
-
-    loadAssociatedTasks();
-  }, [comment.id, fetchTasksByCommentId]);
 
   const handleSaveEdit = async () => {
     if (!editText.trim()) return;
-
     setIsSubmitting(true);
     try {
       await onEdit(comment.id, editText.trim());
@@ -99,10 +71,6 @@ export function CommentItem({
     setIsEditing(false);
   };
 
-  const handleDeleteClick = () => {
-    setShowDeleteModal(true);
-  };
-
   const handleConfirmDelete = async () => {
     setIsDeleting(true);
     try {
@@ -114,41 +82,27 @@ export function CommentItem({
     }
   };
 
-  const handleCancelDelete = () => {
-    setShowDeleteModal(false);
-  };
-
   const handleEmojiClick = (emojiData: { emoji: string }) => {
     onReact(comment.id, emojiData.emoji);
     setEmojiAnchorEl(null);
   };
 
-  const openEmojiPicker = (event: React.MouseEvent<HTMLElement>) => {
-    setEmojiAnchorEl(event.currentTarget);
-  };
-
-  const closeEmojiPicker = () => {
-    setEmojiAnchorEl(null);
-  };
-
   const formatDate = (dateString: string) => {
-    // Backend sends timestamps without timezone info, so we need to treat them as UTC
-    // Add 'Z' suffix to ensure UTC parsing
     const date = new Date(dateString + 'Z');
-    const now = new Date();
-    const diffInHours = (now.getTime() - date.getTime()) / (1000 * 60 * 60);
-
-    // If less than 24 hours, use relative time
+    const diffInHours =
+      (new Date().getTime() - date.getTime()) / (1000 * 60 * 60);
     if (diffInHours < 24) {
       return formatDistanceToNow(date, { addSuffix: true }).toUpperCase();
-    } else {
-      // If more than 24 hours, use absolute date
-      return format(date, 'dd MMM yyyy HH:mm').toUpperCase();
     }
+    return format(date, 'dd MMM yyyy HH:mm').toUpperCase();
   };
 
-  // Get task count for this comment (placeholder - would need API call in real implementation)
-  const taskCount: number = 0; // TODO: Implement API call to get task count by comment ID
+  const actionIconSx = {
+    p: 0,
+    '& .MuiSvgIcon-root': {
+      color: (theme: Theme) => `${theme.palette.primary.main} !important`,
+    },
+  };
 
   return (
     <>
@@ -156,339 +110,215 @@ export function CommentItem({
         id={`comment-${comment.id}`}
         sx={{
           display: 'flex',
-          gap: 2,
-          mb: 3,
-          alignItems: 'flex-start',
-          // Highlighting styles
+          flexDirection: 'column',
+          gap: '10px',
           ...(isHighlighted && {
-            backgroundColor: 'primary.light',
-            border: '2px solid',
-            borderColor: 'primary.main',
-            borderRadius: theme.shape.borderRadius,
-            p: 2,
-            mb: 3,
+            outline: theme => `2px solid ${theme.palette.primary.main}`,
+            borderRadius: 1,
+            p: 1,
           }),
         }}
       >
-        {/* User Avatar */}
-        <UserAvatar
-          userName={comment.user?.name}
-          userPicture={comment.user?.picture}
-          size={32}
-        />
+        {/* ── Header row ── */}
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+          <UserAvatar
+            userName={comment.user?.name}
+            userPicture={comment.user?.picture}
+            sx={{ width: 32, height: 32, flexShrink: 0 }}
+          />
 
-        {/* Comment Content */}
-        <Box sx={{ flex: 1, minWidth: 0 }}>
-          {/* Header with user info and action buttons */}
-          <Box
+          <Typography
             sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'flex-start',
-              mb: 1,
+              fontWeight: 700,
+              fontSize: 14,
+              lineHeight: '22px',
+              color: 'text.primary',
+              whiteSpace: 'nowrap',
             }}
           >
-            <Box sx={{ display: 'flex', alignItems: 'baseline', gap: 1 }}>
-              <Typography
-                variant="subtitle2"
-                fontWeight={600}
-                sx={{ lineHeight: 1.2 }}
-              >
-                {comment.user?.name || 'UNKNOWN USER'}
-              </Typography>
-              <Typography
-                variant="caption"
-                color="text.secondary"
-                sx={{
-                  lineHeight: 1.2,
-                  fontSize: theme.typography.chartLabel.fontSize,
-                }}
-              >
-                {formatDate(comment.created_at)}
-              </Typography>
-            </Box>
+            {comment.user?.name || 'Unknown User'}
+          </Typography>
 
-            {/* Action Buttons and Task Counter */}
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              {/* Task Counter */}
-              {taskCount > 0 && (
-                <Tooltip
-                  title={`${taskCount} task${taskCount === 1 ? '' : 's'} created from this comment`}
-                >
-                  <Chip
-                    icon={<AddTaskIcon />}
-                    label={taskCount}
-                    size="small"
-                    color="primary"
-                    variant="outlined"
-                    sx={{
-                      height: 24,
-                      fontSize: theme.typography.caption.fontSize,
-                      '& .MuiChip-icon': {
-                        fontSize: theme.typography.helperText.fontSize,
-                      },
-                    }}
-                  />
-                </Tooltip>
-              )}
-
-              {/* Create Task Button */}
-              {onCreateTask && entityType !== 'Task' && (
-                <Tooltip title="Create Task from Comment">
-                  <IconButton
-                    size="small"
-                    onClick={() => onCreateTask(comment.id)}
-                    sx={{
-                      color: 'text.secondary',
-                      '&:hover': { color: 'warning.main' },
-                    }}
-                  >
-                    <AssignmentIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-              )}
-
-              {/* Edit/Delete Icons (only for comment owner) */}
-              {canEdit && (
-                <Tooltip title="Edit comment">
-                  <IconButton
-                    size="small"
-                    onClick={() => setIsEditing(true)}
-                    sx={{
-                      color: 'text.secondary',
-                      '&:hover': { color: 'primary.main' },
-                    }}
-                  >
-                    <EditIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-              )}
-
-              {canDelete && (
-                <Tooltip title="Delete comment">
-                  <IconButton
-                    size="small"
-                    onClick={handleDeleteClick}
-                    sx={{
-                      color: 'text.secondary',
-                      '&:hover': { color: 'error.main' },
-                    }}
-                  >
-                    <DeleteIcon fontSize="small" />
-                  </IconButton>
-                </Tooltip>
-              )}
-            </Box>
-          </Box>
-
-          {/* Gray card wrapping comment body, reactions, and associated tasks */}
-          <Box
+          <Typography
             sx={{
-              bgcolor: 'background.default',
-              borderRadius: 1,
-              p: 2,
-              mt: 1,
+              flex: 1,
+              fontSize: 12,
+              lineHeight: '18px',
+              letterSpacing: '0.48px',
+              textTransform: 'uppercase',
+              color: 'text.secondary',
             }}
           >
-            {isEditing ? (
-              <Box>
-                <TextField
-                  value={editText}
-                  onChange={e => setEditText(e.target.value)}
-                  multiline
-                  rows={3}
-                  fullWidth
-                  variant="outlined"
+            {formatDate(comment.created_at)}
+          </Typography>
+
+          {/* Action icons */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+            {onCreateTask && entityType !== 'Task' && (
+              <Tooltip title="Create task from comment">
+                <IconButton
                   size="small"
-                  sx={{ mb: 1 }}
-                />
-                <Box
-                  sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}
+                  onClick={() => onCreateTask(comment.id)}
+                  sx={actionIconSx}
                 >
-                  <Button
-                    size="small"
-                    onClick={handleCancelEdit}
-                    sx={{ textTransform: 'none', borderRadius: '16px' }}
-                  >
-                    Cancel
-                  </Button>
-                  <Button
-                    size="small"
-                    variant="contained"
-                    onClick={handleSaveEdit}
-                    disabled={isSubmitting || !editText.trim()}
-                    sx={{ textTransform: 'none', borderRadius: '16px' }}
-                  >
-                    {isSubmitting ? 'Saving...' : 'Save'}
-                  </Button>
-                </Box>
-              </Box>
-            ) : (
-              <Typography
-                variant="body2"
-                sx={{
-                  lineHeight: 1.6,
-                  whiteSpace: 'pre-wrap',
-                  color: 'text.primary',
-                }}
-              >
-                {comment.content}
-              </Typography>
+                  <AddTaskIcon sx={{ fontSize: 20 }} />
+                </IconButton>
+              </Tooltip>
             )}
-
-            {/* Emoji Picker Button and Reactions */}
-            <Box
-              sx={{ display: 'flex', alignItems: 'center', gap: 1, mt: 1.5 }}
-            >
-              {Object.keys(comment.emojis || {}).length > 0 && (
-                <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-                  {Object.entries(comment.emojis).map(([emoji, reactions]) => {
-                    const hasReacted = reactions.some(
-                      reaction => reaction.user_id === currentUserId
-                    );
-                    const reactionCount = reactions.length;
-                    const tooltipText = createReactionTooltipText(
-                      reactions,
-                      emoji
-                    );
-
-                    return (
-                      <Tooltip
-                        key={emoji}
-                        title={tooltipText}
-                        arrow
-                        placement="top"
-                      >
-                        <Box
-                          onClick={() => onReact(comment.id, emoji)}
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: 0.5,
-                            bgcolor: 'background.paper',
-                            color: 'text.primary',
-                            border: '1px solid',
-                            borderColor: hasReacted
-                              ? 'primary.main'
-                              : 'divider',
-                            borderRadius: theme => theme.shape.borderRadius * 4,
-                            px: 1.5,
-                            py: 0.75,
-                            cursor: 'pointer',
-                            '&:hover': {
-                              bgcolor: 'action.hover',
-                              borderColor: hasReacted
-                                ? 'primary.main'
-                                : 'text.primary',
-                            },
-                          }}
-                        >
-                          <Typography variant="subtitle1">{emoji}</Typography>
-                          <Typography variant="body2" fontWeight={600}>
-                            {reactionCount}
-                          </Typography>
-                        </Box>
-                      </Tooltip>
-                    );
-                  })}
-                </Box>
-              )}
-
-              <IconButton
-                size="small"
-                onClick={openEmojiPicker}
-                sx={{
-                  color: 'text.secondary',
-                  '&:hover': { color: 'primary.main' },
-                }}
-              >
-                <EmojiIcon fontSize="small" />
-              </IconButton>
-            </Box>
-
-            {/* Associated Tasks */}
-            {associatedTasks.length > 0 && (
-              <Box
-                sx={{
-                  mt: 2,
-                  pt: 2,
-                  borderTop: '1px solid',
-                  borderColor: 'divider',
-                }}
-              >
-                <Typography
-                  variant="caption"
-                  color="text.secondary"
-                  sx={{ mb: 1, display: 'block' }}
+            {isOwner && (
+              <Tooltip title="Edit comment">
+                <IconButton
+                  size="small"
+                  onClick={() => setIsEditing(true)}
+                  sx={actionIconSx}
                 >
-                  Associated Tasks:
-                </Typography>
-                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-                  {associatedTasks.map(task => (
-                    <Box
-                      key={task.id}
-                      onClick={() => window.open(`/tasks/${task.id}`, '_blank')}
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 0.5,
-                        bgcolor: 'background.paper',
-                        color: 'text.primary',
-                        border: '1px solid',
-                        borderColor: 'divider',
-                        borderRadius: theme.shape.borderRadius,
-                        px: 1.5,
-                        py: 0.75,
-                        cursor: 'pointer',
-                        '&:hover': {
-                          bgcolor: 'action.hover',
-                          borderColor: 'text.primary',
-                        },
-                      }}
-                    >
-                      <AddTaskIcon
-                        sx={{ fontSize: '1rem', color: 'text.secondary' }}
-                      />
-                      <Typography
-                        variant="body2"
-                        fontWeight={600}
-                        sx={{
-                          color: 'text.primary',
-                          fontSize: theme.typography.caption.fontSize,
-                        }}
-                      >
-                        {task.title}
-                      </Typography>
-                    </Box>
-                  ))}
-                </Box>
-              </Box>
+                  <EditIcon sx={{ fontSize: 20 }} />
+                </IconButton>
+              </Tooltip>
+            )}
+            {isOwner && (
+              <Tooltip title="Delete comment">
+                <IconButton
+                  size="small"
+                  onClick={() => setShowDeleteModal(true)}
+                  sx={actionIconSx}
+                >
+                  <DeleteIcon sx={{ fontSize: 20 }} />
+                </IconButton>
+              </Tooltip>
             )}
           </Box>
         </Box>
 
-        {/* Emoji Picker Popover */}
-        <Popover
-          open={Boolean(emojiAnchorEl)}
-          anchorEl={emojiAnchorEl}
-          onClose={closeEmojiPicker}
-          anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'left',
-          }}
-          transformOrigin={{
-            vertical: 'top',
-            horizontal: 'left',
+        {/* ── Content box ── */}
+        <Box
+          sx={{
+            bgcolor: '#f9f9fa',
+            borderRadius: '4px',
+            p: '16px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '20px',
           }}
         >
-          <EmojiPicker onEmojiClick={handleEmojiClick} />
-        </Popover>
+          {isEditing ? (
+            <Box>
+              <TextField
+                value={editText}
+                onChange={e => setEditText(e.target.value)}
+                multiline
+                rows={3}
+                fullWidth
+                variant="outlined"
+                size="small"
+                sx={{ mb: 1 }}
+              />
+              <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: 1 }}>
+                <Button size="small" onClick={handleCancelEdit}>
+                  Cancel
+                </Button>
+                <Button
+                  size="small"
+                  variant="contained"
+                  onClick={handleSaveEdit}
+                  disabled={isSubmitting || !editText.trim()}
+                >
+                  {isSubmitting ? 'Saving…' : 'Save'}
+                </Button>
+              </Box>
+            </Box>
+          ) : (
+            <Typography
+              sx={{
+                fontSize: 16,
+                lineHeight: '24px',
+                color: 'text.secondary',
+                whiteSpace: 'pre-wrap',
+              }}
+            >
+              {comment.content}
+            </Typography>
+          )}
+
+          {/* Reactions + emoji trigger */}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '10px',
+              flexWrap: 'wrap',
+            }}
+          >
+            {Object.entries(comment.emojis || {}).map(([emoji, reactions]) => {
+              const hasReacted = reactions.some(
+                r => r.user_id === currentUserId
+              );
+              return (
+                <Tooltip
+                  key={emoji}
+                  title={createReactionTooltipText(reactions, emoji)}
+                  arrow
+                  placement="top"
+                >
+                  <Box
+                    onClick={() => onReact(comment.id, emoji)}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '4px',
+                      border: '1px solid',
+                      borderColor: hasReacted ? 'primary.main' : '#b6bdc9',
+                      borderRadius: '999px',
+                      px: '10px',
+                      py: '2px',
+                      cursor: 'pointer',
+                      userSelect: 'none',
+                      '&:hover': { borderColor: 'text.primary' },
+                    }}
+                  >
+                    <Typography sx={{ fontSize: 14, lineHeight: '22px' }}>
+                      {emoji}
+                    </Typography>
+                    <Typography
+                      sx={{
+                        fontSize: 14,
+                        lineHeight: '22px',
+                        color: '#2a2e36',
+                      }}
+                    >
+                      {reactions.length}
+                    </Typography>
+                  </Box>
+                </Tooltip>
+              );
+            })}
+
+            <Tooltip title="Add reaction">
+              <IconButton
+                size="small"
+                onClick={e => setEmojiAnchorEl(e.currentTarget)}
+                sx={actionIconSx}
+              >
+                <EmojiIcon sx={{ fontSize: 20 }} />
+              </IconButton>
+            </Tooltip>
+          </Box>
+        </Box>
       </Box>
 
-      {/* Delete Confirmation Modal */}
+      <Popover
+        open={Boolean(emojiAnchorEl)}
+        anchorEl={emojiAnchorEl}
+        onClose={() => setEmojiAnchorEl(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+      >
+        <EmojiPicker onEmojiClick={handleEmojiClick} />
+      </Popover>
+
       <DeleteModal
         open={showDeleteModal}
-        onClose={handleCancelDelete}
+        onClose={() => setShowDeleteModal(false)}
         onConfirm={handleConfirmDelete}
         isLoading={isDeleting}
         itemType="comment"

--- a/apps/frontend/src/components/comments/CommentsSection.tsx
+++ b/apps/frontend/src/components/comments/CommentsSection.tsx
@@ -12,7 +12,8 @@ import {
 import { SendIcon } from '@/components/icons';
 import { Comment, EntityType } from '@/types/comments';
 import { CommentItem } from './CommentItem';
-
+import { SectionCard } from '@/components/common/SectionCard';
+import { UserAvatar } from '@/components/common/UserAvatar';
 interface CommentsSectionProps {
   entityType: EntityType;
   entityId: string;
@@ -40,8 +41,8 @@ export function CommentsSection({
   onCreateTask,
   onCreateTaskFromEntity: _onCreateTaskFromEntity,
   currentUserId,
-  currentUserName: _currentUserName,
-  currentUserPicture: _currentUserPicture,
+  currentUserName,
+  currentUserPicture,
   isLoading = false,
 }: CommentsSectionProps) {
   const [highlightedCommentId, setHighlightedCommentId] = useState<
@@ -147,15 +148,7 @@ export function CommentsSection({
   );
 
   return (
-    <Box>
-      {/* Header */}
-      <Typography
-        variant="h6"
-        sx={{ fontWeight: 600, color: 'primary.main', mb: 2 }}
-      >
-        Comments ({comments.length})
-      </Typography>
-
+    <SectionCard title={`Comments (${comments.length})`}>
       {/* Comments List */}
       {isLoading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
@@ -163,7 +156,14 @@ export function CommentsSection({
         </Box>
       ) : (
         comments.length > 0 && (
-          <Box sx={{ mb: 3 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '30px',
+              mb: 3,
+            }}
+          >
             {sortedComments.map(comment => (
               <CommentItem
                 key={comment.id}
@@ -182,17 +182,25 @@ export function CommentsSection({
       )}
 
       {/* Comment Form */}
-      <Box component="form" onSubmit={handleSubmit}>
-        <Box sx={{ flex: 1, minWidth: 0, position: 'relative' }}>
+      <Box
+        component="form"
+        onSubmit={handleSubmit}
+        sx={{ display: 'flex', alignItems: 'flex-start', gap: '30px' }}
+      >
+        <UserAvatar
+          userName={currentUserName}
+          userPicture={currentUserPicture}
+          sx={{ width: 48, height: 48, flexShrink: 0 }}
+        />
+        <Box sx={{ flex: 1, minWidth: 0 }}>
           <TextField
             value={newComment}
             onChange={e => setNewComment(e.target.value)}
             placeholder="Add comment"
             multiline
-            rows={3}
+            minRows={1}
             fullWidth
             variant="outlined"
-            size="small"
             onKeyDown={e => {
               if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault();
@@ -236,6 +244,6 @@ export function CommentsSection({
           )}
         </Box>
       </Box>
-    </Box>
+    </SectionCard>
   );
 }

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -183,6 +183,52 @@ interface BaseDataGridProps {
   hideRowsPerPageBelow?: number;
 }
 
+/**
+ * Reconcile a persisted column order with the current column definitions.
+ *
+ * Without this, a column added to `columns` after a user already has a
+ * persisted `orderedFields` is appended at the end by MUI (it isn't in the
+ * saved order). This keeps the user's relative ordering for known fields while
+ * slotting any brand-new field next to the neighbour it's defined after.
+ */
+function reconcileOrderedFields(
+  persistedOrder: string[],
+  columnFields: string[]
+): string[] {
+  const result = [...persistedOrder];
+  const present = new Set(persistedOrder);
+
+  columnFields.forEach((field, idx) => {
+    if (present.has(field)) return;
+
+    // Find the nearest preceding defined column that's already in the order.
+    let insertAfter: string | null = null;
+    for (let i = idx - 1; i >= 0; i--) {
+      if (present.has(columnFields[i])) {
+        insertAfter = columnFields[i];
+        break;
+      }
+    }
+
+    let insertIndex: number;
+    if (insertAfter !== null) {
+      insertIndex = result.indexOf(insertAfter) + 1;
+    } else {
+      // No preceding defined column yet — insert before the first one present
+      // (keeps it after special leading fields like the selection checkbox).
+      const firstPresentColField = columnFields.find(f => present.has(f));
+      insertIndex = firstPresentColField
+        ? result.indexOf(firstPresentColField)
+        : result.length;
+    }
+
+    result.splice(insertIndex, 0, field);
+    present.add(field);
+  });
+
+  return result;
+}
+
 // Create a styled version of DataGrid with Figma-aligned borders and headers
 const StyledDataGrid = styled(DataGrid)(({ theme }) => ({
   border: 'none',
@@ -455,9 +501,14 @@ export default function BaseDataGrid({
           ...initialState.columns?.columnVisibilityModel,
           ...persistedState.columns?.columnVisibilityModel,
         },
-        // Deep merge orderedFields only if persisted (user reordered columns)
+        // Deep merge orderedFields only if persisted (user reordered columns).
+        // Reconcile against the current columns so a newly added column lands
+        // next to its defined neighbour instead of being appended at the end.
         ...(persistedState.columns?.orderedFields && {
-          orderedFields: persistedState.columns.orderedFields,
+          orderedFields: reconcileOrderedFields(
+            persistedState.columns.orderedFields,
+            columns.map(col => col.field)
+          ),
         }),
         // Deep merge dimensions only if persisted (user resized columns)
         ...(persistedState.columns?.dimensions && {
@@ -482,7 +533,7 @@ export default function BaseDataGrid({
       // Density: persisted overrides initial
       ...(persistedState.density && { density: persistedState.density }),
     };
-  }, [persistState, persistedState, initialState]);
+  }, [persistState, persistedState, initialState, columns]);
 
   // Save state callback - memoized to avoid unnecessary re-subscriptions
   const handleStateChange = useCallback(() => {

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -176,6 +176,11 @@ interface BaseDataGridProps {
   persistState?: boolean;
   storageKey?: string;
   hideFooter?: boolean;
+  /**
+   * Hide rows-per-page selector when total row count is below this value.
+   * Set to 0 to always show the selector. Default: 10.
+   */
+  hideRowsPerPageBelow?: number;
 }
 
 // Create a styled version of DataGrid with Figma-aligned borders and headers
@@ -236,6 +241,11 @@ function SortOnlyColumnMenu(props: GridColumnMenuProps) {
 // Context to pass pageSizeOptions into the DataGrid footer slot
 const PaginationSizeContext = React.createContext<number[]>([10, 25, 50]);
 
+/** When row count is below this value, hide the rows-per-page selector in the footer. */
+const HideRowsPerPageBelowContext = React.createContext<number | undefined>(
+  undefined
+);
+
 function FigmaPaginationFooter() {
   const theme = useTheme();
   const textColor = theme.palette.greyscale.body;
@@ -245,12 +255,15 @@ function FigmaPaginationFooter() {
   const paginationModel = useGridSelector(apiRef, gridPaginationModelSelector);
   const rowCount = useGridSelector(apiRef, gridRowCountSelector);
   const pageSizeOptions = React.useContext(PaginationSizeContext);
+  const hideRowsPerPageBelow = React.useContext(HideRowsPerPageBelowContext);
 
   const { page, pageSize } = paginationModel;
   const from = rowCount === 0 ? 0 : page * pageSize + 1;
   const to = Math.min((page + 1) * pageSize, rowCount);
   const isFirst = page === 0;
   const isLast = rowCount === 0 || to >= rowCount;
+  const showRowsPerPage =
+    hideRowsPerPageBelow <= 0 || rowCount >= hideRowsPerPageBelow;
 
   const navBtnSx = (active: boolean): SxProps<Theme> => ({
     border: '2px solid',
@@ -277,47 +290,48 @@ function FigmaPaginationFooter() {
       sx={{
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'space-between',
+        justifyContent: showRowsPerPage ? 'space-between' : 'flex-end',
         px: '30px',
         py: '16px',
       }}
     >
-      {/* Rows per page */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: '15px' }}>
-        <Typography
-          sx={{
-            fontSize: 12,
-            fontWeight: 600,
-            color: textColor,
-            whiteSpace: 'nowrap',
-          }}
-        >
-          Rows per page:
-        </Typography>
-        <Select
-          value={pageSize}
-          onChange={e =>
-            apiRef.current.setPaginationModel({
-              page: 0,
-              pageSize: Number(e.target.value),
-            })
-          }
-          variant="standard"
-          disableUnderline
-          sx={{
-            fontSize: 14,
-            fontWeight: 700,
-            color: textColor,
-            '& .MuiSelect-icon': { color: textColor },
-          }}
-        >
-          {pageSizeOptions.map(opt => (
-            <MenuItem key={opt} value={opt} sx={{ fontSize: 14 }}>
-              {opt}
-            </MenuItem>
-          ))}
-        </Select>
-      </Box>
+      {showRowsPerPage ? (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: '15px' }}>
+          <Typography
+            sx={{
+              fontSize: 12,
+              fontWeight: 600,
+              color: textColor,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            Rows per page:
+          </Typography>
+          <Select
+            value={pageSize}
+            onChange={e =>
+              apiRef.current.setPaginationModel({
+                page: 0,
+                pageSize: Number(e.target.value),
+              })
+            }
+            variant="standard"
+            disableUnderline
+            sx={{
+              fontSize: 14,
+              fontWeight: 700,
+              color: textColor,
+              '& .MuiSelect-icon': { color: textColor },
+            }}
+          >
+            {pageSizeOptions.map(opt => (
+              <MenuItem key={opt} value={opt} sx={{ fontSize: 14 }}>
+                {opt}
+              </MenuItem>
+            ))}
+          </Select>
+        </Box>
+      ) : null}
 
       {/* Prev / range / Next */}
       <Box sx={{ display: 'flex', alignItems: 'center', gap: '30px' }}>
@@ -326,6 +340,7 @@ function FigmaPaginationFooter() {
             apiRef.current.setPaginationModel({ page: page - 1, pageSize })
           }
           disabled={isFirst}
+          aria-label="Previous page"
           sx={navBtnSx(!isFirst)}
         >
           <ArrowBackIosNewIcon />
@@ -347,6 +362,7 @@ function FigmaPaginationFooter() {
             apiRef.current.setPaginationModel({ page: page + 1, pageSize })
           }
           disabled={isLast}
+          aria-label="Next page"
           sx={navBtnSx(!isLast)}
         >
           <ArrowForwardIosIcon />
@@ -403,6 +419,7 @@ export default function BaseDataGrid({
   persistState = false,
   storageKey,
   hideFooter = false,
+  hideRowsPerPageBelow = 10,
 }: BaseDataGridProps) {
   const _theme = useTheme();
   const router = useRouter();
@@ -1013,74 +1030,7 @@ export default function BaseDataGrid({
       </Box>
 
       {disablePaperWrapper ? (
-        <PaginationSizeContext.Provider value={pageSizeOptions}>
-          <StyledDataGrid
-            apiRef={apiRef}
-            rows={serverSidePagination ? rows : filteredRows}
-            columns={columns}
-            getRowId={getRowId}
-            autoHeight
-            pagination
-            hideFooter={hideFooter}
-            paginationMode={serverSidePagination ? 'server' : 'client'}
-            rowCount={serverSidePagination ? totalRows : undefined}
-            paginationModel={paginationModel}
-            onPaginationModelChange={onPaginationModelChange}
-            pageSizeOptions={pageSizeOptions}
-            checkboxSelection={checkboxSelection}
-            disableVirtualization={false}
-            loading={loading}
-            slots={resolvedSlots}
-            sx={dataGridSx}
-            onRowClick={
-              enableEditing
-                ? undefined
-                : linkPath || onRowClick
-                  ? handleRowClickWithLink
-                  : undefined
-            }
-            disableMultipleRowSelection={disableMultipleRowSelection}
-            {...(density && { density })}
-            {...(mergedInitialState && { initialState: mergedInitialState })}
-            {...(serverSideFiltering && {
-              filterMode: 'server',
-              filterModel,
-              onFilterModelChange,
-            })}
-            {...(sortingMode === 'server' && {
-              sortingMode: 'server',
-              sortModel,
-              onSortModelChange,
-            })}
-            {...(enableEditing && {
-              editMode,
-              processRowUpdate,
-              onProcessRowUpdateError,
-              isCellEditable,
-            })}
-            {...(onRowSelectionModelChange && {
-              onRowSelectionModelChange,
-            })}
-            {...(rowSelectionModel !== undefined && {
-              rowSelectionModel,
-            })}
-            {...(isRowSelectable && { isRowSelectable })}
-            {...(disableRowSelectionOnClick && {
-              disableRowSelectionOnClick,
-            })}
-          />
-        </PaginationSizeContext.Provider>
-      ) : (
-        <Paper
-          elevation={0}
-          sx={{
-            width: '100%',
-            borderRadius: BORDER_RADIUS.md,
-            border: theme => `1px solid ${theme.palette.greyscale.border}`,
-            boxShadow: ELEVATION.xs,
-            overflow: 'hidden',
-          }}
-        >
+        <HideRowsPerPageBelowContext.Provider value={hideRowsPerPageBelow}>
           <PaginationSizeContext.Provider value={pageSizeOptions}>
             <StyledDataGrid
               apiRef={apiRef}
@@ -1132,11 +1082,84 @@ export default function BaseDataGrid({
               {...(rowSelectionModel !== undefined && {
                 rowSelectionModel,
               })}
+              {...(isRowSelectable && { isRowSelectable })}
               {...(disableRowSelectionOnClick && {
                 disableRowSelectionOnClick,
               })}
             />
           </PaginationSizeContext.Provider>
+        </HideRowsPerPageBelowContext.Provider>
+      ) : (
+        <Paper
+          elevation={0}
+          sx={{
+            width: '100%',
+            borderRadius: BORDER_RADIUS.md,
+            border: theme => `1px solid ${theme.palette.greyscale.border}`,
+            boxShadow: ELEVATION.xs,
+            overflow: 'hidden',
+          }}
+        >
+          <HideRowsPerPageBelowContext.Provider value={hideRowsPerPageBelow}>
+            <PaginationSizeContext.Provider value={pageSizeOptions}>
+              <StyledDataGrid
+                apiRef={apiRef}
+                rows={serverSidePagination ? rows : filteredRows}
+                columns={columns}
+                getRowId={getRowId}
+                autoHeight
+                pagination
+                hideFooter={hideFooter}
+                paginationMode={serverSidePagination ? 'server' : 'client'}
+                rowCount={serverSidePagination ? totalRows : undefined}
+                paginationModel={paginationModel}
+                onPaginationModelChange={onPaginationModelChange}
+                pageSizeOptions={pageSizeOptions}
+                checkboxSelection={checkboxSelection}
+                disableVirtualization={false}
+                loading={loading}
+                slots={resolvedSlots}
+                sx={dataGridSx}
+                onRowClick={
+                  enableEditing
+                    ? undefined
+                    : linkPath || onRowClick
+                      ? handleRowClickWithLink
+                      : undefined
+                }
+                disableMultipleRowSelection={disableMultipleRowSelection}
+                {...(density && { density })}
+                {...(mergedInitialState && {
+                  initialState: mergedInitialState,
+                })}
+                {...(serverSideFiltering && {
+                  filterMode: 'server',
+                  filterModel,
+                  onFilterModelChange,
+                })}
+                {...(sortingMode === 'server' && {
+                  sortingMode: 'server',
+                  sortModel,
+                  onSortModelChange,
+                })}
+                {...(enableEditing && {
+                  editMode,
+                  processRowUpdate,
+                  onProcessRowUpdateError,
+                  isCellEditable,
+                })}
+                {...(onRowSelectionModelChange && {
+                  onRowSelectionModelChange,
+                })}
+                {...(rowSelectionModel !== undefined && {
+                  rowSelectionModel,
+                })}
+                {...(disableRowSelectionOnClick && {
+                  disableRowSelectionOnClick,
+                })}
+              />
+            </PaginationSizeContext.Provider>
+          </HideRowsPerPageBelowContext.Provider>
         </Paper>
       )}
     </>

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -309,7 +309,7 @@ function FigmaPaginationFooter() {
   const isFirst = page === 0;
   const isLast = rowCount === 0 || to >= rowCount;
   const showRowsPerPage =
-    hideRowsPerPageBelow <= 0 || rowCount >= hideRowsPerPageBelow;
+    (hideRowsPerPageBelow ?? 0) <= 0 || rowCount >= (hideRowsPerPageBelow ?? 0);
 
   const navBtnSx = (active: boolean): SxProps<Theme> => ({
     border: '2px solid',

--- a/apps/frontend/src/components/common/BaseDrawer.tsx
+++ b/apps/frontend/src/components/common/BaseDrawer.tsx
@@ -73,6 +73,8 @@ export default function BaseDrawer({
   showHeader = true,
   anchor = 'right',
 }: BaseDrawerProps) {
+  const hasFooter = !!(closeButtonText || onSave || error);
+
   return (
     <Drawer
       anchor={anchor}
@@ -131,62 +133,66 @@ export default function BaseDrawer({
         {children}
       </Box>
 
-      {/* Bottom toolbar — right-aligned Cancel + Save, no border */}
-      <Box sx={{ flexShrink: 0 }}>
-        {error && (
-          <Typography color="error" variant="body2" sx={{ mb: 1.5 }}>
-            {error}
-          </Typography>
-        )}
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
-          {closeButtonText && (
-            <Button
-              variant="outlined"
-              onClick={onClose}
-              disabled={loading}
-              sx={{
-                borderWidth: 2,
-                borderColor: 'primary.main',
-                color: 'primary.main',
-                fontWeight: 700,
-                fontSize: 14,
-                borderRadius: BORDER_RADIUS.sm,
-                px: '16px',
-                py: '8px',
-                '&:hover': { borderWidth: 2 },
-              }}
-            >
-              {closeButtonText}
-            </Button>
+      {/* Bottom toolbar — only rendered when there is something to show */}
+      {hasFooter && (
+        <Box sx={{ flexShrink: 0 }}>
+          {error && (
+            <Typography color="error" variant="body2" sx={{ mb: 1.5 }}>
+              {error}
+            </Typography>
           )}
-          {onSave && (
-            <Button
-              variant="contained"
-              onClick={onSave}
-              disabled={loading || saveDisabled}
-              {...(saveDataTour ? { 'data-tour': saveDataTour } : {})}
-              startIcon={
-                loading ? (
-                  <CircularProgress size={16} color="inherit" />
-                ) : undefined
-              }
-              sx={{
-                borderRadius: BORDER_RADIUS.sm,
-                px: '16px',
-                py: '8px',
-                fontWeight: 700,
-                fontSize: 14,
-                '&.Mui-disabled': {
-                  bgcolor: theme => theme.palette.greyscale.border,
-                  color: '#fff',
-                },
-              }}
-            >
-              {loading ? 'Executing...' : saveButtonText}
-            </Button>
-          )}
+          <Box
+            sx={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}
+          >
+            {closeButtonText && (
+              <Button
+                variant="outlined"
+                onClick={onClose}
+                disabled={loading}
+                sx={{
+                  borderWidth: 2,
+                  borderColor: 'primary.main',
+                  color: 'primary.main',
+                  fontWeight: 700,
+                  fontSize: 14,
+                  borderRadius: BORDER_RADIUS.sm,
+                  px: '16px',
+                  py: '8px',
+                  '&:hover': { borderWidth: 2 },
+                }}
+              >
+                {closeButtonText}
+              </Button>
+            )}
+            {onSave && (
+              <Button
+                variant="contained"
+                onClick={onSave}
+                disabled={loading || saveDisabled}
+                {...(saveDataTour ? { 'data-tour': saveDataTour } : {})}
+                startIcon={
+                  loading ? (
+                    <CircularProgress size={16} color="inherit" />
+                  ) : undefined
+                }
+                sx={{
+                  borderRadius: BORDER_RADIUS.sm,
+                  px: '16px',
+                  py: '8px',
+                  fontWeight: 700,
+                  fontSize: 14,
+                  '&.Mui-disabled': {
+                    bgcolor: theme => theme.palette.greyscale.border,
+                    color: '#fff',
+                  },
+                }}
+              >
+                {loading ? 'Executing...' : saveButtonText}
+              </Button>
+            )}
+          </Box>
         </Box>
-      </Box>
+      )}
     </Drawer>
   );
 }

--- a/apps/frontend/src/components/common/Fab.tsx
+++ b/apps/frontend/src/components/common/Fab.tsx
@@ -7,13 +7,34 @@ import type { FabProps as MuiFabProps } from '@mui/material/Fab';
 import { ELEVATION, FAB_GROUP_GAP } from '@/styles/theme';
 
 export { FAB_GROUP_GAP };
+export { default as FabAddIcon } from './FabAddIcon';
 
-/** Shared FAB surface styles (56px circle, primary fill, elevation) */
+/** Figma FAB icon slot — 32×32 with 24×24 glyph (12.5% inset) */
+const fabIconSlotSx = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: 32,
+  height: 32,
+  flexShrink: 0,
+  lineHeight: 0,
+  '& > .MuiSvgIcon-root': {
+    width: 24,
+    height: 24,
+    fontSize: 24,
+  },
+} as const;
+
+/** Shared FAB surface styles (56px circle, 12px padding, primary fill, elevation) */
 export const fabButtonSx = {
   bgcolor: 'primary.main',
   color: 'primary.contrastText',
   width: 56,
   height: 56,
+  minWidth: 56,
+  minHeight: 56,
+  padding: '12px',
+  boxSizing: 'border-box',
   boxShadow: ELEVATION.xs,
   '&:hover': {
     bgcolor: 'primary.dark',
@@ -33,11 +54,9 @@ export interface FabProps extends Omit<MuiFabProps, 'children'> {
 }
 
 /**
- * Figma-aligned FAB component.
+ * Figma-aligned FAB component (node 1639:10079).
  *
- * Wraps MUI `Fab` with Rhesis styling:
- *   - Teal/primary.main fill, white icon, 56px circular
- *   - Accepts an optional `tooltip` for accessibility
+ * 56px circle, 12px padding, 32px icon slot, primary fill, elevation XS.
  */
 export function Fab({
   icon,
@@ -60,7 +79,13 @@ export function Fab({
       }}
       {...props}
     >
-      {loading ? <CircularProgress size={24} sx={{ color: '#fff' }} /> : icon}
+      {loading ? (
+        <CircularProgress size={24} sx={{ color: '#fff' }} />
+      ) : (
+        <Box component="span" sx={fabIconSlotSx}>
+          {icon}
+        </Box>
+      )}
     </MuiFab>
   );
 

--- a/apps/frontend/src/components/common/FabAddIcon.tsx
+++ b/apps/frontend/src/components/common/FabAddIcon.tsx
@@ -1,0 +1,17 @@
+import { forwardRef } from 'react';
+import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon';
+
+// Figma Frontend node 1639:10079 — Icons/Weight 400/add_2 (18×18 viewBox)
+const FAB_ADD_ICON_PATH = 'M8 18V10H0V8H8V0H10V8H18V10H10V18H8Z';
+
+const FabAddIcon = forwardRef<SVGSVGElement, SvgIconProps>(
+  function FabAddIcon(props, ref) {
+    return (
+      <SvgIcon ref={ref} viewBox="0 0 18 18" {...props}>
+        <path d={FAB_ADD_ICON_PATH} fill="currentColor" />
+      </SvgIcon>
+    );
+  }
+);
+
+export default FabAddIcon;

--- a/apps/frontend/src/components/common/FormSectionDivider.tsx
+++ b/apps/frontend/src/components/common/FormSectionDivider.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+export interface FormSectionDividerProps {
+  headline: string;
+  descriptiveText?: string;
+}
+
+/**
+ * In-card section heading matching Figma Form Section Divider (node 1228:5851).
+ */
+export default function FormSectionDivider({
+  headline,
+  descriptiveText,
+}: FormSectionDividerProps) {
+  return (
+    <Box>
+      <Typography
+        sx={{
+          fontSize: 18,
+          lineHeight: '25px',
+          fontWeight: 700,
+          color: theme => theme.palette.greyscale.title,
+        }}
+      >
+        {headline}
+      </Typography>
+      {descriptiveText ? (
+        <Typography
+          sx={{
+            fontSize: 12,
+            lineHeight: '18px',
+            color: theme => theme.palette.greyscale.subtitle,
+          }}
+        >
+          {descriptiveText}
+        </Typography>
+      ) : null}
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/common/GridToolbar.tsx
+++ b/apps/frontend/src/components/common/GridToolbar.tsx
@@ -12,6 +12,7 @@ import { BORDER_RADIUS } from '@/styles/theme';
 export interface ToolbarPillTab {
   label: string;
   value: string;
+  icon?: React.ReactNode;
 }
 
 export interface GridToolbarProps {
@@ -19,7 +20,7 @@ export interface GridToolbarProps {
   onSearchChange: (value: string) => void;
   searchPlaceholder?: string;
   searchWidth?: number;
-  onFilterClick?: () => void;
+  onFilterClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   hasActiveFilters?: boolean;
   middleContent?: React.ReactNode;
   rightContent?: React.ReactNode;
@@ -120,7 +121,7 @@ export function PrimarySegmentedPills({
 }: PrimarySegmentedPillsProps) {
   return (
     <Box sx={{ flex: 1, display: 'flex', justifyContent: 'center' }}>
-      {tabs.map(({ value, label }, idx, arr) => {
+      {tabs.map(({ value, label, icon }, idx, arr) => {
         const isSelected =
           mode === 'single'
             ? activeValue === value
@@ -153,6 +154,7 @@ export function PrimarySegmentedPills({
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
+              gap: '4px',
               px: '16px',
               py: '8px',
               fontSize: 14,
@@ -177,8 +179,12 @@ export function PrimarySegmentedPills({
                   : theme => `${theme.palette.primary.main}0f`,
               },
               whiteSpace: 'nowrap',
+              '& svg': {
+                fontSize: 20,
+              },
             }}
           >
+            {icon}
             {label}
           </Box>
         );

--- a/apps/frontend/src/components/common/ModelSelector.tsx
+++ b/apps/frontend/src/components/common/ModelSelector.tsx
@@ -11,6 +11,7 @@ import {
   Typography,
   useTheme,
 } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
 import SettingsSuggestIcon from '@mui/icons-material/SettingsSuggest';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -27,6 +28,10 @@ interface ModelSelectorProps {
   purpose?: ModelPurpose;
   disabled?: boolean;
   helperText?: string;
+  hideHelperText?: boolean;
+  /** Plain text in the closed select — matches Figma drawer dropdowns. */
+  compact?: boolean;
+  fieldSx?: SxProps<Theme>;
 }
 
 function ProviderIcon({ icon }: { icon?: string }) {
@@ -65,6 +70,9 @@ export default function ModelSelector({
   purpose,
   disabled = false,
   helperText,
+  hideHelperText = false,
+  compact = false,
+  fieldSx,
 }: ModelSelectorProps) {
   const theme = useTheme();
   const [models, setModels] = useState<Model[]>([]);
@@ -126,7 +134,7 @@ export default function ModelSelector({
 
   return (
     <Box>
-      <FormControl fullWidth disabled={disabled}>
+      <FormControl fullWidth disabled={disabled} sx={fieldSx}>
         <InputLabel shrink>{label}</InputLabel>
         <Select
           value={value}
@@ -134,6 +142,14 @@ export default function ModelSelector({
           onChange={e => onChange(e.target.value as string)}
           displayEmpty
           renderValue={selectedValue => {
+            if (compact) {
+              if (selectedValue === '') {
+                return defaultModelName ?? 'Default model';
+              }
+              const model = models.find(m => m.id === selectedValue);
+              return model?.name ?? String(selectedValue);
+            }
+
             if (selectedValue === '') {
               return (
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
@@ -192,7 +208,7 @@ export default function ModelSelector({
           )}
         </Select>
       </FormControl>
-      {effectiveHelperText && (
+      {effectiveHelperText && !hideHelperText && (
         <Typography
           variant="caption"
           color="text.secondary"

--- a/apps/frontend/src/components/common/RerunTestRunDrawer.tsx
+++ b/apps/frontend/src/components/common/RerunTestRunDrawer.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import RunDrawer, { type RerunConfig } from '@/components/common/RunDrawer';
+
+export type { RerunConfig };
+
+interface RerunTestRunDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  sessionToken: string;
+  data: RerunConfig;
+  onSuccess?: () => void;
+}
+
+export default function RerunTestRunDrawer({
+  open,
+  onClose,
+  sessionToken,
+  data,
+  onSuccess,
+}: RerunTestRunDrawerProps) {
+  return (
+    <RunDrawer
+      mode="rerunTestRun"
+      open={open}
+      onClose={onClose}
+      sessionToken={sessionToken}
+      data={data}
+      onSuccess={onSuccess}
+    />
+  );
+}

--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -43,6 +43,12 @@ import Switch from '@mui/material/Switch';
 import Link from 'next/link';
 import BaseDrawer from '@/components/common/BaseDrawer';
 import BaseTag from '@/components/common/BaseTag';
+import FormSectionDivider from '@/components/common/FormSectionDivider';
+import {
+  drawerDisabledFieldSx,
+  drawerOutlinedFieldSx,
+  drawerTagFieldSx,
+} from '@/components/common/drawerFormFieldSx';
 import ModelSelector from '@/components/common/ModelSelector';
 import { PreflightDialog } from '@/components/common/PreflightDialog';
 import SelectExperimentsDialog from '@/components/common/SelectExperimentsDialog';
@@ -67,6 +73,7 @@ import {
 } from '@/utils/test-run-batch';
 import { BiotechIcon } from '@/components/icons';
 import tagStyles from '@/styles/BaseTag.module.css';
+import { BORDER_RADIUS } from '@/styles/theme';
 import type { UUID } from 'crypto';
 
 // ---------------------------------------------------------------------------
@@ -199,8 +206,8 @@ const MODE_CONFIGS: Record<RunDrawerProps['mode'], ModeConfig> = {
     showMetrics: true,
   },
   rerunTestRun: {
-    title: 'Re-run Test',
-    saveButtonText: 'Re-run Test',
+    title: 'Re-run Tests',
+    saveButtonText: 'Re-run Tests',
     projectEditable: false,
     endpointEditable: false,
     testSetMode: 'hidden',
@@ -219,6 +226,35 @@ const MODE_CONFIGS: Record<RunDrawerProps['mode'], ModeConfig> = {
     showMetrics: true,
   },
 };
+
+const RERUN_SECTION_SX = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '40px',
+} as const;
+
+const RERUN_FIELDS_SX = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '30px',
+} as const;
+
+const RERUN_OUTLINE_BUTTON_SX = {
+  borderWidth: 2,
+  borderColor: 'primary.main',
+  color: 'primary.main',
+  fontWeight: 700,
+  fontSize: 14,
+  lineHeight: '22px',
+  borderRadius: BORDER_RADIUS.sm,
+  px: '16px',
+  py: '8px',
+  textTransform: 'none',
+  '&:hover': { borderWidth: 2 },
+} as const;
+
+const EXPERIMENT_SECTION_DESCRIPTION =
+  "Each selected experiment triggers its own test run with that experiment's parameters pinned. Leave empty to run without an experiment.";
 
 // ---------------------------------------------------------------------------
 // Component
@@ -988,6 +1024,8 @@ export default function RunDrawer(props: RunDrawerProps) {
             value={rerunConfig?.projectName ?? ''}
             disabled
             fullWidth
+            InputLabelProps={{ shrink: true }}
+            sx={drawerDisabledFieldSx}
           />
         );
       }
@@ -1057,6 +1095,8 @@ export default function RunDrawer(props: RunDrawerProps) {
             value={rerunConfig?.endpointName ?? ''}
             disabled
             fullWidth
+            InputLabelProps={{ shrink: true }}
+            sx={drawerDisabledFieldSx}
           />
         );
       }
@@ -1136,6 +1176,8 @@ export default function RunDrawer(props: RunDrawerProps) {
             value={rerunConfig?.testSetName ?? ''}
             disabled
             fullWidth
+            InputLabelProps={{ shrink: true }}
+            sx={drawerDisabledFieldSx}
           />
         );
       }
@@ -1252,98 +1294,108 @@ export default function RunDrawer(props: RunDrawerProps) {
     );
   };
 
+  const renderSelectedExperimentGroups = () => {
+    if (selectedExperiments.length === 0) return null;
+
+    const grouped = new Map<
+      string,
+      { name: string; versions: SelectedExperiment[] }
+    >();
+    for (const exp of selectedExperiments) {
+      const key = String(exp.experiment_id);
+      const group = grouped.get(key) ?? {
+        name: exp.experiment_name,
+        versions: [],
+      };
+      group.versions.push(exp);
+      grouped.set(key, group);
+    }
+
+    return (
+      <Stack spacing={1}>
+        {Array.from(grouped.entries()).map(([expId, group]) => (
+          <Box
+            key={expId}
+            sx={{
+              p: 1.5,
+              border: 1,
+              borderColor: 'divider',
+              borderRadius: theme => theme.spacing(1),
+            }}
+          >
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                mb: 1,
+              }}
+            >
+              <BiotechIcon fontSize="small" color="primary" />
+              <Typography variant="body2" noWrap>
+                {group.name}
+              </Typography>
+            </Box>
+            <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
+              {group.versions.map(exp => (
+                <Chip
+                  key={exp.version}
+                  label={shortVersion(exp.version)}
+                  size="small"
+                  variant="outlined"
+                  sx={{ fontFamily: 'monospace' }}
+                  onDelete={() =>
+                    setSelectedExperiments(prev =>
+                      prev.filter(
+                        row =>
+                          row.experiment_id !== exp.experiment_id ||
+                          row.version !== exp.version
+                      )
+                    )
+                  }
+                />
+              ))}
+            </Stack>
+          </Box>
+        ))}
+      </Stack>
+    );
+  };
+
   const renderExperimentsSection = () => {
     if (!cfg.experimentsEditable) return null;
     if (!effectiveProjectId) return null;
 
+    if (mode === 'rerunTestRun') {
+      return (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+          <FormSectionDivider
+            headline="Experiment"
+            descriptiveText={EXPERIMENT_SECTION_DESCRIPTION}
+          />
+          {renderSelectedExperimentGroups()}
+          <Button
+            variant="outlined"
+            fullWidth
+            startIcon={<AddIcon />}
+            onClick={() => setExperimentsDialogOpen(true)}
+            sx={RERUN_OUTLINE_BUTTON_SX}
+          >
+            Add experiment
+          </Button>
+        </Box>
+      );
+    }
+
+    const experimentGroups = renderSelectedExperimentGroups();
+
     return (
       <Box>
-        {mode === 'rerunTestRun' && (
-          <Typography
-            variant="h6"
-            color="text.primary"
-            fontWeight={600}
-            sx={{ mb: 1 }}
-          >
-            Experiment
-          </Typography>
-        )}
         <Alert severity="info" sx={{ mb: 2 }}>
-          Each selected experiment triggers its own test run with that
-          experiment&apos;s parameters pinned. Leave empty to run without an
-          experiment.
+          {EXPERIMENT_SECTION_DESCRIPTION}
         </Alert>
 
-        {selectedExperiments.length > 0 &&
-          (() => {
-            const grouped = new Map<
-              string,
-              { name: string; versions: SelectedExperiment[] }
-            >();
-            for (const exp of selectedExperiments) {
-              const key = String(exp.experiment_id);
-              const group = grouped.get(key) ?? {
-                name: exp.experiment_name,
-                versions: [],
-              };
-              group.versions.push(exp);
-              grouped.set(key, group);
-            }
-            return (
-              <Stack spacing={1} sx={{ mb: 2 }}>
-                {Array.from(grouped.entries()).map(([expId, group]) => (
-                  <Box
-                    key={expId}
-                    sx={{
-                      p: 1.5,
-                      border: 1,
-                      borderColor: 'divider',
-                      borderRadius: theme => theme.spacing(1),
-                    }}
-                  >
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: 1,
-                        mb: 1,
-                      }}
-                    >
-                      <BiotechIcon fontSize="small" color="primary" />
-                      <Typography variant="body2" noWrap>
-                        {group.name}
-                      </Typography>
-                    </Box>
-                    <Stack
-                      direction="row"
-                      spacing={0.5}
-                      flexWrap="wrap"
-                      useFlexGap
-                    >
-                      {group.versions.map(exp => (
-                        <Chip
-                          key={exp.version}
-                          label={shortVersion(exp.version)}
-                          size="small"
-                          variant="outlined"
-                          sx={{ fontFamily: 'monospace' }}
-                          onDelete={() =>
-                            setSelectedExperiments(prev =>
-                              prev.filter(
-                                row =>
-                                  row.experiment_id !== exp.experiment_id ||
-                                  row.version !== exp.version
-                              )
-                            )
-                          }
-                        />
-                      ))}
-                    </Stack>
-                  </Box>
-                ))}
-              </Stack>
-            );
-          })()}
+        {experimentGroups && <Box sx={{ mb: 2 }}>{experimentGroups}</Box>}
 
         <Button
           variant="outlined"
@@ -1592,6 +1644,202 @@ export default function RunDrawer(props: RunDrawerProps) {
   };
 
   // -----------------------------------------------------------------------
+  // RerunTestRunDrawer layout (Figma 1641:16598)
+  // -----------------------------------------------------------------------
+
+  const renderRerunTestRunContent = () => (
+    <>
+      <Box sx={RERUN_SECTION_SX}>
+        <FormSectionDivider headline="Execution Target" />
+        <Box sx={RERUN_FIELDS_SX}>
+          {renderTestSetField()}
+          {renderProjectField()}
+          {renderEndpointField()}
+        </Box>
+      </Box>
+
+      {renderExperimentsSection()}
+
+      <Box sx={RERUN_SECTION_SX}>
+        <FormSectionDivider headline="Configuration" />
+        <Box sx={RERUN_FIELDS_SX}>
+          <FormControl fullWidth sx={drawerOutlinedFieldSx}>
+            <InputLabel shrink>Execution Mode</InputLabel>
+            <Select
+              value={executionMode}
+              onChange={e => setExecutionMode(e.target.value)}
+              label="Execution Mode"
+            >
+              <MenuItem value="Parallel">Parallel</MenuItem>
+              <MenuItem value="Sequential">Sequential</MenuItem>
+            </Select>
+          </FormControl>
+
+          <FormControl fullWidth sx={drawerOutlinedFieldSx}>
+            <InputLabel shrink>Scoring Target</InputLabel>
+            <Select
+              value={scoringTarget}
+              onChange={e => setScoringTarget(e.target.value as ScoringTarget)}
+              label="Scoring Target"
+            >
+              <MenuItem value="fresh">Fresh Outputs</MenuItem>
+              <MenuItem value="reuse">Reuse Outputs</MenuItem>
+            </Select>
+          </FormControl>
+
+          <FormControl fullWidth sx={drawerOutlinedFieldSx}>
+            <InputLabel shrink>Metric Source</InputLabel>
+            <Select
+              value={metricMode}
+              onChange={e => {
+                setMetricMode(e.target.value as MetricMode);
+                if (e.target.value !== 'define_custom') setSelectedMetrics([]);
+              }}
+              label="Metric Source"
+            >
+              {testSetMetrics.length > 0 && (
+                <MenuItem value="use_test_set">Test Set Metrics</MenuItem>
+              )}
+              <MenuItem value="use_behavior">Behavior Metrics</MenuItem>
+              <MenuItem value="define_custom">Custom Metrics</MenuItem>
+            </Select>
+          </FormControl>
+
+          {metricMode === 'define_custom' && (
+            <Box>
+              {selectedMetrics.length > 0 && (
+                <Stack spacing={1} sx={{ mb: 2 }}>
+                  {selectedMetrics.map(metric => (
+                    <Box
+                      key={metric.id}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        p: 1,
+                        border: 1,
+                        borderColor: 'divider',
+                        borderRadius: theme => theme.spacing(1),
+                      }}
+                    >
+                      <Box
+                        sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
+                      >
+                        <AutoGraphIcon fontSize="small" color="primary" />
+                        <Typography variant="body2">{metric.name}</Typography>
+                      </Box>
+                      <IconButton
+                        size="small"
+                        onClick={() => handleRemoveMetric(metric.id)}
+                      >
+                        <CloseIcon fontSize="small" />
+                      </IconButton>
+                    </Box>
+                  ))}
+                </Stack>
+              )}
+
+              <Button
+                variant="outlined"
+                fullWidth
+                startIcon={<AddIcon />}
+                onClick={() => setMetricsDialogOpen(true)}
+                sx={RERUN_OUTLINE_BUTTON_SX}
+              >
+                Add metric
+              </Button>
+
+              <SelectMetricsDialog
+                open={metricsDialogOpen}
+                onClose={() => setMetricsDialogOpen(false)}
+                onSelect={handleAddMetric}
+                sessionToken={sessionToken}
+                excludeMetricIds={selectedMetrics.map(m => m.id)}
+                title="Add Metric to Execution"
+                subtitle="Select a metric to use for this test run"
+                scopeFilter={metricScopeFilter}
+              />
+            </Box>
+          )}
+        </Box>
+      </Box>
+
+      <Box sx={RERUN_SECTION_SX}>
+        <FormSectionDivider headline="Model Settings" />
+        <Box sx={RERUN_FIELDS_SX}>
+          <ModelSelector
+            sessionToken={sessionToken}
+            value={selectedEvaluationModelId}
+            onChange={setSelectedEvaluationModelId}
+            label="Evaluation Model"
+            purpose="evaluation"
+            hideHelperText
+            compact
+            fieldSx={drawerOutlinedFieldSx}
+          />
+
+          {effectiveTestSetType === 'Multi-Turn' && (
+            <ModelSelector
+              sessionToken={sessionToken}
+              value={selectedExecutionModelId}
+              onChange={setSelectedExecutionModelId}
+              label="Execution Model"
+              purpose="execution"
+              hideHelperText
+              compact
+              fieldSx={drawerOutlinedFieldSx}
+            />
+          )}
+
+          <Box
+            sx={{
+              borderTop: 1,
+              borderColor: theme => theme.palette.greyscale.border,
+              pt: '20px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+            }}
+          >
+            <Typography
+              sx={{
+                fontSize: 16,
+                lineHeight: '24px',
+                color: theme => theme.palette.greyscale.title,
+              }}
+            >
+              Run Preflight Checks
+            </Typography>
+            <Switch
+              checked={preflightEnabled}
+              onChange={e => setPreflightEnabled(e.target.checked)}
+              size="small"
+            />
+          </Box>
+        </Box>
+      </Box>
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+        <FormSectionDivider headline="Tags" />
+        <BaseTag
+          value={tags}
+          onChange={setTags}
+          label="Tags"
+          placeholder="Add tags (press Enter or comma to add)"
+          chipColor="default"
+          addOnBlur
+          delimiters={[',', 'Enter']}
+          size="small"
+          margin="none"
+          fullWidth
+          chipClassName={tagStyles.modalTag}
+          sx={drawerTagFieldSx}
+        />
+      </Box>
+    </>
+  );
+
+  // -----------------------------------------------------------------------
   // Dynamic title for createFromGrid
   // -----------------------------------------------------------------------
 
@@ -1628,6 +1876,8 @@ export default function RunDrawer(props: RunDrawerProps) {
         <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>
           <CircularProgress />
         </Box>
+      ) : mode === 'rerunTestRun' ? (
+        renderRerunTestRunContent()
       ) : (
         <Stack spacing={3}>
           {/* Experiment versions (runExperiment only) */}
@@ -1642,11 +1892,7 @@ export default function RunDrawer(props: RunDrawerProps) {
           )}
 
           {/* Execution Target */}
-          <Typography
-            variant={mode === 'rerunTestRun' ? 'h6' : 'subtitle2'}
-            color={mode === 'rerunTestRun' ? 'text.primary' : 'text.secondary'}
-            fontWeight={mode === 'rerunTestRun' ? 600 : 400}
-          >
+          <Typography variant="subtitle2" color="text.secondary">
             Execution Target
           </Typography>
 
@@ -1654,20 +1900,6 @@ export default function RunDrawer(props: RunDrawerProps) {
           {renderProjectField()}
           {renderEndpointField()}
           {renderExperimentsSection()}
-
-          {/* Experiments dialog (editable modes only) */}
-          {cfg.experimentsEditable && (
-            <SelectExperimentsDialog
-              open={experimentsDialogOpen}
-              onClose={() => setExperimentsDialogOpen(false)}
-              onConfirm={setSelectedExperiments}
-              sessionToken={sessionToken}
-              projectId={effectiveProjectId}
-              initialSelection={selectedExperiments}
-              title={`Experiments for this ${mode === 'rerunTestRun' ? 're-run' : 'run'}`}
-              subtitle="Selecting multiple experiments queues one run per experiment."
-            />
-          )}
 
           {/* Run count summary (runExperiment) */}
           {mode === 'runExperiment' &&
@@ -1691,11 +1923,7 @@ export default function RunDrawer(props: RunDrawerProps) {
           <Divider />
 
           {/* Configuration Options */}
-          <Typography
-            variant={mode === 'rerunTestRun' ? 'h6' : 'subtitle2'}
-            color={mode === 'rerunTestRun' ? 'text.primary' : 'text.secondary'}
-            fontWeight={mode === 'rerunTestRun' ? 600 : 400}
-          >
+          <Typography variant="subtitle2" color="text.secondary">
             Configuration Options
           </Typography>
 
@@ -1706,11 +1934,7 @@ export default function RunDrawer(props: RunDrawerProps) {
           <Divider />
 
           {/* Model Settings */}
-          <Typography
-            variant={mode === 'rerunTestRun' ? 'h6' : 'subtitle2'}
-            color={mode === 'rerunTestRun' ? 'text.primary' : 'text.secondary'}
-            fontWeight={mode === 'rerunTestRun' ? 600 : 400}
-          >
+          <Typography variant="subtitle2" color="text.secondary">
             Model Settings
           </Typography>
 
@@ -1767,12 +1991,8 @@ export default function RunDrawer(props: RunDrawerProps) {
           <Divider />
 
           {/* Tags */}
-          <Typography
-            variant={mode === 'rerunTestRun' ? 'h6' : 'subtitle2'}
-            color={mode === 'rerunTestRun' ? 'text.primary' : 'text.secondary'}
-            fontWeight={mode === 'rerunTestRun' ? 600 : 400}
-          >
-            Test Run Tags
+          <Typography variant="subtitle2" color="text.secondary">
+            Tags
           </Typography>
           <BaseTag
             value={tags}
@@ -1788,6 +2008,18 @@ export default function RunDrawer(props: RunDrawerProps) {
             chipClassName={tagStyles.modalTag}
           />
         </Stack>
+      )}
+      {cfg.experimentsEditable && effectiveProjectId && (
+        <SelectExperimentsDialog
+          open={experimentsDialogOpen}
+          onClose={() => setExperimentsDialogOpen(false)}
+          onConfirm={setSelectedExperiments}
+          sessionToken={sessionToken}
+          projectId={effectiveProjectId}
+          initialSelection={selectedExperiments}
+          title={`Experiments for this ${mode === 'rerunTestRun' ? 're-run' : 'run'}`}
+          subtitle="Selecting multiple experiments queues one run per experiment."
+        />
       )}
       {preflightDialogOpen && (
         <PreflightDialog

--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -1258,6 +1258,16 @@ export default function RunDrawer(props: RunDrawerProps) {
 
     return (
       <Box>
+        {mode === 'rerunTestRun' && (
+          <Typography
+            variant="h6"
+            color="text.primary"
+            fontWeight={600}
+            sx={{ mb: 1 }}
+          >
+            Experiment
+          </Typography>
+        )}
         <Alert severity="info" sx={{ mb: 2 }}>
           Each selected experiment triggers its own test run with that
           experiment&apos;s parameters pinned. Leave empty to run without an
@@ -1461,7 +1471,11 @@ export default function RunDrawer(props: RunDrawerProps) {
     return (
       <>
         <Divider />
-        <Typography variant="subtitle2" color="text.secondary">
+        <Typography
+          variant={mode === 'rerunTestRun' ? 'h6' : 'subtitle2'}
+          color={mode === 'rerunTestRun' ? 'text.primary' : 'text.secondary'}
+          fontWeight={mode === 'rerunTestRun' ? 600 : 400}
+        >
           Test Run Metrics
         </Typography>
 
@@ -1628,7 +1642,11 @@ export default function RunDrawer(props: RunDrawerProps) {
           )}
 
           {/* Execution Target */}
-          <Typography variant="subtitle2" color="text.secondary">
+          <Typography
+            variant={mode === 'rerunTestRun' ? 'h6' : 'subtitle2'}
+            color={mode === 'rerunTestRun' ? 'text.primary' : 'text.secondary'}
+            fontWeight={mode === 'rerunTestRun' ? 600 : 400}
+          >
             Execution Target
           </Typography>
 
@@ -1673,7 +1691,11 @@ export default function RunDrawer(props: RunDrawerProps) {
           <Divider />
 
           {/* Configuration Options */}
-          <Typography variant="subtitle2" color="text.secondary">
+          <Typography
+            variant={mode === 'rerunTestRun' ? 'h6' : 'subtitle2'}
+            color={mode === 'rerunTestRun' ? 'text.primary' : 'text.secondary'}
+            fontWeight={mode === 'rerunTestRun' ? 600 : 400}
+          >
             Configuration Options
           </Typography>
 
@@ -1684,7 +1706,11 @@ export default function RunDrawer(props: RunDrawerProps) {
           <Divider />
 
           {/* Model Settings */}
-          <Typography variant="subtitle2" color="text.secondary">
+          <Typography
+            variant={mode === 'rerunTestRun' ? 'h6' : 'subtitle2'}
+            color={mode === 'rerunTestRun' ? 'text.primary' : 'text.secondary'}
+            fontWeight={mode === 'rerunTestRun' ? 600 : 400}
+          >
             Model Settings
           </Typography>
 
@@ -1711,8 +1737,6 @@ export default function RunDrawer(props: RunDrawerProps) {
               }
             />
           )}
-
-          <Divider />
 
           <FormControlLabel
             control={
@@ -1743,7 +1767,11 @@ export default function RunDrawer(props: RunDrawerProps) {
           <Divider />
 
           {/* Tags */}
-          <Typography variant="subtitle2" color="text.secondary">
+          <Typography
+            variant={mode === 'rerunTestRun' ? 'h6' : 'subtitle2'}
+            color={mode === 'rerunTestRun' ? 'text.primary' : 'text.secondary'}
+            fontWeight={mode === 'rerunTestRun' ? 600 : 400}
+          >
             Test Run Tags
           </Typography>
           <BaseTag

--- a/apps/frontend/src/components/common/SectionCard.tsx
+++ b/apps/frontend/src/components/common/SectionCard.tsx
@@ -8,7 +8,8 @@ import { ELEVATION, BORDER_RADIUS } from '@/styles/theme';
 export type SectionCardVariant = 'default' | 'danger';
 
 export interface SectionCardProps {
-  title: string;
+  /** When omitted (along with subtitle and actions), the header row is skipped entirely */
+  title?: string;
   /** Optional subtitle below the title (Body S, secondary) */
   subtitle?: string;
   /** Header actions (e.g. Edit button, FAB) */
@@ -57,37 +58,45 @@ export function SectionCard({
   children,
 }: SectionCardProps) {
   const titleColor = variant === 'danger' ? 'error.main' : 'primary.main';
+  const hasHeader = Boolean(title || subtitle || actions);
 
   return (
     <Paper elevation={0} sx={cardSx(variant)}>
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          gap: 2,
-          mb: subtitle || actions ? 3 : 3,
-        }}
-      >
-        <Box sx={{ flex: 1, minWidth: 0 }}>
-          <Typography variant="h6" sx={{ fontWeight: 600, color: titleColor }}>
-            {title}
-          </Typography>
-          {subtitle && (
-            <Typography
-              variant="body2"
-              sx={{ mt: 0.5, color: 'text.secondary' }}
-            >
-              {subtitle}
-            </Typography>
+      {hasHeader && (
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            gap: 2,
+            mb: 3,
+          }}
+        >
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            {title && (
+              <Typography
+                variant="h6"
+                sx={{ fontWeight: 600, color: titleColor }}
+              >
+                {title}
+              </Typography>
+            )}
+            {subtitle && (
+              <Typography
+                variant="body2"
+                sx={{ mt: 0.5, color: 'text.secondary' }}
+              >
+                {subtitle}
+              </Typography>
+            )}
+          </Box>
+          {actions && (
+            <Box sx={{ display: 'flex', flexShrink: 0, alignItems: 'center' }}>
+              {actions}
+            </Box>
           )}
         </Box>
-        {actions && (
-          <Box sx={{ display: 'flex', flexShrink: 0, alignItems: 'center' }}>
-            {actions}
-          </Box>
-        )}
-      </Box>
+      )}
       {children}
     </Paper>
   );

--- a/apps/frontend/src/components/common/ViewField.tsx
+++ b/apps/frontend/src/components/common/ViewField.tsx
@@ -60,7 +60,6 @@ export default function ViewField({
           pl: '16px',
           pr: '12px',
           py: '16px',
-          minHeight: multiline ? 120 : undefined,
           alignItems: multiline ? 'flex-start' : 'center',
         }}
       >

--- a/apps/frontend/src/components/common/drawerFormFieldSx.ts
+++ b/apps/frontend/src/components/common/drawerFormFieldSx.ts
@@ -1,0 +1,72 @@
+import type { SxProps, Theme } from '@mui/material/styles';
+import { BORDER_RADIUS } from '@/styles/theme';
+
+/**
+ * Figma outlined drawer field (node 1642:16790).
+ * 56px control height: 16px vertical padding + 24px line-height content.
+ */
+export const drawerOutlinedFieldSx: SxProps<Theme> = {
+  '& .MuiOutlinedInput-root': {
+    borderRadius: BORDER_RADIUS.xs,
+    minHeight: 56,
+  },
+  '& .MuiOutlinedInput-notchedOutline': {
+    borderColor: theme => theme.palette.greyscale.border,
+  },
+  '& .MuiInputLabel-root': {
+    fontSize: 12,
+    lineHeight: '18px',
+    color: theme => theme.palette.greyscale.subtitle,
+  },
+  '& .MuiOutlinedInput-input': {
+    padding: '16px 12px 16px 16px !important',
+    minHeight: '24px',
+    fontSize: 16,
+    lineHeight: '24px',
+    boxSizing: 'border-box',
+  },
+  '& .MuiSelect-select': {
+    padding: '16px 32px 16px 16px !important',
+    minHeight: '24px !important',
+    fontSize: 16,
+    lineHeight: '24px',
+    display: 'flex',
+    alignItems: 'center',
+    boxSizing: 'border-box',
+  },
+};
+
+export const drawerDisabledFieldSx: SxProps<Theme> = {
+  ...drawerOutlinedFieldSx,
+  '& .MuiOutlinedInput-root.Mui-disabled': {
+    minHeight: 56,
+  },
+  '& .MuiOutlinedInput-input.Mui-disabled': {
+    padding: '16px 12px 16px 16px !important',
+    minHeight: '24px',
+    WebkitTextFillColor: theme => theme.palette.greyscale.border,
+    color: theme => theme.palette.greyscale.border,
+    opacity: 1,
+  },
+};
+
+export const drawerTagFieldSx: SxProps<Theme> = {
+  ...drawerOutlinedFieldSx,
+  '& .MuiOutlinedInput-root': {
+    borderRadius: BORDER_RADIUS.xs,
+    alignItems: 'center',
+    gap: '10px',
+    py: '16px',
+    pl: '16px',
+    pr: '12px',
+  },
+  '& .MuiOutlinedInput-input': {
+    padding: 0,
+    minHeight: '24px',
+    fontSize: 16,
+    lineHeight: '24px',
+  },
+  '& .MuiChip-root': {
+    fontWeight: 400,
+  },
+};

--- a/apps/frontend/src/components/common/drawerFormFieldSx.ts
+++ b/apps/frontend/src/components/common/drawerFormFieldSx.ts
@@ -13,7 +13,7 @@ export const drawerOutlinedFieldSx: SxProps<Theme> = {
   '& .MuiOutlinedInput-notchedOutline': {
     borderColor: theme => theme.palette.greyscale.border,
   },
-  '& .MuiInputLabel-root': {
+  '& .MuiInputLabel-root.MuiInputLabel-shrink': {
     fontSize: 12,
     lineHeight: '18px',
     color: theme => theme.palette.greyscale.subtitle,

--- a/apps/frontend/src/components/providers/ThemeProvider.tsx
+++ b/apps/frontend/src/components/providers/ThemeProvider.tsx
@@ -8,7 +8,6 @@ import {
 import { getDesignTokens } from '../../styles/theme';
 import CssBaseline from '@mui/material/CssBaseline';
 
-// Create a context for theme mode
 export const ColorModeContext = React.createContext({
   toggleColorMode: () => {},
   mode: 'light' as 'light' | 'dark',
@@ -17,57 +16,75 @@ export const ColorModeContext = React.createContext({
 interface ThemeContextProviderProps {
   children: React.ReactNode;
   disableTransitionOnChange?: boolean;
+  initialMode?: 'light' | 'dark';
 }
 
 const THEME_MODE_KEY = 'theme-mode';
+const THEME_MODE_COOKIE = 'theme-mode';
+
+function persistThemeMode(mode: 'light' | 'dark') {
+  localStorage.setItem(THEME_MODE_KEY, mode);
+  document.documentElement.setAttribute('data-theme-mode', mode);
+  document.cookie = `${THEME_MODE_COOKIE}=${mode};path=/;max-age=31536000;SameSite=Lax`;
+}
 
 export default function ThemeContextProvider({
   children,
   disableTransitionOnChange = false,
+  initialMode = 'light',
 }: ThemeContextProviderProps) {
-  const [mode, setMode] = React.useState<'light' | 'dark'>('light');
-  const [mounted, setMounted] = React.useState(false);
+  const [mode, setMode] = React.useState<'light' | 'dark'>(initialMode);
 
   React.useLayoutEffect(() => {
     const attr = document.documentElement.getAttribute('data-theme-mode');
     if (attr === 'light' || attr === 'dark') {
       setMode(attr);
+      return;
     }
-    setMounted(true);
+
+    const storedMode = localStorage.getItem(THEME_MODE_KEY);
+    if (storedMode === 'light' || storedMode === 'dark') {
+      setMode(storedMode);
+      document.documentElement.setAttribute('data-theme-mode', storedMode);
+      return;
+    }
+
+    const systemMode = window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? 'dark'
+      : 'light';
+    setMode(systemMode);
+    document.documentElement.setAttribute('data-theme-mode', systemMode);
   }, []);
 
   React.useEffect(() => {
     const storedMode = localStorage.getItem(THEME_MODE_KEY);
-    if (!storedMode) {
-      const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
-      const handler = (e: MediaQueryListEvent) => {
-        const newMode = e.matches ? 'dark' : 'light';
-        setMode(newMode);
-        document.documentElement.setAttribute('data-theme-mode', newMode);
-      };
-      darkModeQuery.addEventListener('change', handler);
-      return () => darkModeQuery.removeEventListener('change', handler);
-    }
+    if (storedMode) return;
+
+    const darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const handler = (e: MediaQueryListEvent) => {
+      const newMode = e.matches ? 'dark' : 'light';
+      setMode(newMode);
+      document.documentElement.setAttribute('data-theme-mode', newMode);
+    };
+    darkModeQuery.addEventListener('change', handler);
+    return () => darkModeQuery.removeEventListener('change', handler);
   }, []);
 
   const colorMode = React.useMemo(
     () => ({
       toggleColorMode: () => {
         if (disableTransitionOnChange) {
-          // Disable all transitions temporarily
           document.documentElement.style.setProperty('transition', 'none');
           document.body.style.setProperty('transition', 'none');
         }
 
         setMode(prevMode => {
           const newMode = prevMode === 'light' ? 'dark' : 'light';
-          localStorage.setItem(THEME_MODE_KEY, newMode);
-          document.documentElement.setAttribute('data-theme-mode', newMode);
+          persistThemeMode(newMode);
           return newMode;
         });
 
         if (disableTransitionOnChange) {
-          // Re-enable transitions after the theme change
           requestAnimationFrame(() => {
             document.documentElement.style.removeProperty('transition');
             document.body.style.removeProperty('transition');
@@ -88,14 +105,7 @@ export default function ThemeContextProvider({
         disableTransitionOnChange={disableTransitionOnChange}
       >
         <CssBaseline />
-        <div
-          style={{
-            visibility: mounted ? 'visible' : 'hidden',
-          }}
-          suppressHydrationWarning
-        >
-          {children}
-        </div>
+        {children}
       </MuiThemeProvider>
     </ColorModeContext.Provider>
   );

--- a/apps/frontend/src/components/providers/__tests__/ThemeProvider.test.tsx
+++ b/apps/frontend/src/components/providers/__tests__/ThemeProvider.test.tsx
@@ -105,20 +105,4 @@ describe('ThemeContextProvider', () => {
       'dark'
     );
   });
-
-  it('hides children until mounted (visibility hidden then visible)', async () => {
-    const { container } = render(
-      <ThemeContextProvider>
-        <span data-testid="child">content</span>
-      </ThemeContextProvider>
-    );
-    // After all layout effects run (jsdom runs them synchronously), the div should be visible
-    const wrapper = container.querySelector(
-      'div[suppresshydrationwarning]'
-    ) as HTMLElement;
-    if (wrapper) {
-      // After mount, visibility is 'visible'
-      expect(wrapper.style.visibility).toBe('visible');
-    }
-  });
 });

--- a/apps/frontend/src/components/tasks/TaskCreationDrawer.tsx
+++ b/apps/frontend/src/components/tasks/TaskCreationDrawer.tsx
@@ -18,6 +18,7 @@ import { User } from '@/utils/api-client/interfaces/user';
 import { Priority, Status } from '@/utils/api-client/interfaces/task';
 import { useSession } from 'next-auth/react';
 import BaseDrawer from '@/components/common/BaseDrawer';
+import { drawerOutlinedFieldSx } from '@/components/common/drawerFormFieldSx';
 
 interface TaskCreationDrawerProps {
   open: boolean;
@@ -155,10 +156,11 @@ export function TaskCreationDrawer({
           fullWidth
           variant="outlined"
           disabled={isLoading}
+          sx={drawerOutlinedFieldSx}
         />
 
         {/* Status */}
-        <FormControl fullWidth>
+        <FormControl fullWidth sx={drawerOutlinedFieldSx}>
           <InputLabel>Status</InputLabel>
           <Select
             value={statusId}
@@ -175,7 +177,7 @@ export function TaskCreationDrawer({
         </FormControl>
 
         {/* Priority */}
-        <FormControl fullWidth>
+        <FormControl fullWidth sx={drawerOutlinedFieldSx}>
           <InputLabel>Priority</InputLabel>
           <Select
             value={priorityId}
@@ -195,7 +197,7 @@ export function TaskCreationDrawer({
         </FormControl>
 
         {/* Assignee */}
-        <FormControl fullWidth>
+        <FormControl fullWidth sx={drawerOutlinedFieldSx}>
           <InputLabel>Assignee</InputLabel>
           <Select
             value={assigneeId}
@@ -224,6 +226,7 @@ export function TaskCreationDrawer({
           rows={4}
           variant="outlined"
           disabled={isLoading}
+          sx={drawerOutlinedFieldSx}
         />
       </Box>
     </BaseDrawer>

--- a/apps/frontend/src/components/tasks/TaskCreationDrawer.tsx
+++ b/apps/frontend/src/components/tasks/TaskCreationDrawer.tsx
@@ -11,11 +11,11 @@ import {
   Typography,
 } from '@mui/material';
 import { EntityType } from '@/types/tasks';
-import { getPriorities } from '@/utils/task-lookup';
+import { getPriorities, getStatuses } from '@/utils/task-lookup';
 import { getEntityDisplayName } from '@/utils/entity-helpers';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { User } from '@/utils/api-client/interfaces/user';
-import { Priority } from '@/utils/api-client/interfaces/task';
+import { Priority, Status } from '@/utils/api-client/interfaces/task';
 import { useSession } from 'next-auth/react';
 import BaseDrawer from '@/components/common/BaseDrawer';
 
@@ -45,8 +45,10 @@ export function TaskCreationDrawer({
   const { data: session } = useSession();
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
+  const [statusId, setStatusId] = useState<string>('');
   const [priorityId, setPriorityId] = useState<string>('');
   const [assigneeId, setAssigneeId] = useState('');
+  const [statuses, setStatuses] = useState<Status[]>([]);
   const [priorities, setPriorities] = useState<Priority[]>([]);
   const [users, setUsers] = useState<User[]>([]);
   const [isLoadingData, setIsLoadingData] = useState(false);
@@ -59,18 +61,27 @@ export function TaskCreationDrawer({
 
       setIsLoadingData(true);
       try {
-        const [fetchedPriorities, fetchedUsers] = await Promise.all([
-          getPriorities(sessionToken),
-          (async () => {
-            const clientFactory = new ApiClientFactory(sessionToken);
-            const usersClient = clientFactory.getUsersClient();
-            const response = await usersClient.getUsers();
-            return response.data;
-          })(),
-        ]);
+        const [fetchedStatuses, fetchedPriorities, fetchedUsers] =
+          await Promise.all([
+            getStatuses(sessionToken),
+            getPriorities(sessionToken),
+            (async () => {
+              const clientFactory = new ApiClientFactory(sessionToken);
+              const usersClient = clientFactory.getUsersClient();
+              const response = await usersClient.getUsers();
+              return response.data;
+            })(),
+          ]);
 
+        setStatuses(fetchedStatuses);
         setPriorities(fetchedPriorities);
         setUsers(fetchedUsers);
+
+        // Default to "Open" status
+        const openStatus = fetchedStatuses.find(s => s.name === 'Open');
+        if (openStatus) {
+          setStatusId(openStatus.id);
+        }
       } catch (_error) {
       } finally {
         setIsLoadingData(false);
@@ -86,6 +97,7 @@ export function TaskCreationDrawer({
     await onSubmit({
       title: title.trim(),
       description: description.trim(),
+      status_id: statusId,
       priority_id: priorityId || null,
       assignee_id: assigneeId || null,
       entity_type: entityType,
@@ -96,6 +108,7 @@ export function TaskCreationDrawer({
     // Reset form
     setTitle('');
     setDescription('');
+    setStatusId('');
     setPriorityId('');
     setAssigneeId('');
   };
@@ -104,6 +117,7 @@ export function TaskCreationDrawer({
     if (!isLoading) {
       setTitle('');
       setDescription('');
+      setStatusId('');
       setPriorityId('');
       setAssigneeId('');
       onClose();
@@ -114,14 +128,16 @@ export function TaskCreationDrawer({
     <BaseDrawer
       open={open}
       onClose={handleClose}
-      title="Create New Task"
+      title="Create task"
       loading={isLoading}
       onSave={handleSubmit}
-      saveButtonText={isLoading ? 'Creating...' : 'Create Task'}
-      width={600}
+      saveButtonText="Save"
+      closeButtonText="Close"
+      saveDisabled={!title.trim()}
+      width={578}
     >
       <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-        {/* Comment context info */}
+        {/* Comment context note */}
         {commentId && (
           <Box sx={{ p: 2, bgcolor: 'background.default', borderRadius: 1 }}>
             <Typography variant="body2" color="text.secondary">
@@ -131,17 +147,72 @@ export function TaskCreationDrawer({
           </Box>
         )}
 
-        {/* Title */}
+        {/* Task Title */}
         <TextField
-          label="Task Title"
+          label="Task Title*"
           value={title}
           onChange={e => setTitle(e.target.value)}
           fullWidth
-          required
           variant="outlined"
-          placeholder="Enter a brief description of the task"
           disabled={isLoading}
         />
+
+        {/* Status */}
+        <FormControl fullWidth>
+          <InputLabel>Status</InputLabel>
+          <Select
+            value={statusId}
+            onChange={e => setStatusId(e.target.value)}
+            label="Status"
+            disabled={isLoadingData || isLoading}
+          >
+            {statuses.map(statusOption => (
+              <MenuItem key={statusOption.id} value={statusOption.id}>
+                {statusOption.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        {/* Priority */}
+        <FormControl fullWidth>
+          <InputLabel>Priority</InputLabel>
+          <Select
+            value={priorityId}
+            onChange={e => setPriorityId(e.target.value)}
+            label="Priority"
+            disabled={isLoadingData || isLoading}
+          >
+            <MenuItem value="">
+              <em>None</em>
+            </MenuItem>
+            {priorities.map(priorityOption => (
+              <MenuItem key={priorityOption.id} value={priorityOption.id}>
+                {priorityOption.type_value || priorityOption.id}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        {/* Assignee */}
+        <FormControl fullWidth>
+          <InputLabel>Assignee</InputLabel>
+          <Select
+            value={assigneeId}
+            onChange={e => setAssigneeId(e.target.value)}
+            label="Assignee"
+            disabled={isLoadingData || isLoading}
+          >
+            <MenuItem value="">
+              <em>Unassigned</em>
+            </MenuItem>
+            {users.map(user => (
+              <MenuItem key={user.id} value={user.id}>
+                {user.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
 
         {/* Description */}
         <TextField
@@ -152,62 +223,8 @@ export function TaskCreationDrawer({
           multiline
           rows={4}
           variant="outlined"
-          placeholder="Provide detailed information about what needs to be done"
           disabled={isLoading}
         />
-
-        {/* Priority and Assignee Row */}
-        <Box sx={{ display: 'flex', gap: 2 }}>
-          {/* Priority */}
-          <FormControl fullWidth>
-            <InputLabel>Priority</InputLabel>
-            <Select
-              value={priorityId}
-              onChange={e => setPriorityId(e.target.value)}
-              label="Priority"
-              disabled={isLoadingData || isLoading}
-            >
-              {priorities.map(priorityOption => (
-                <MenuItem key={priorityOption.id} value={priorityOption.id}>
-                  {priorityOption.type_value || priorityOption.id}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-
-          {/* Assignee */}
-          <FormControl fullWidth>
-            <InputLabel>Assignee</InputLabel>
-            <Select
-              value={assigneeId}
-              onChange={e => setAssigneeId(e.target.value)}
-              label="Assignee"
-              disabled={isLoadingData || isLoading}
-            >
-              <MenuItem value="">
-                <em>Unassigned</em>
-              </MenuItem>
-              {users.map(user => (
-                <MenuItem key={user.id} value={user.id}>
-                  {user.name}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </Box>
-
-        {/* Entity Info */}
-        <Box sx={{ p: 2, bgcolor: 'background.default', borderRadius: 1 }}>
-          <Typography variant="body2" color="text.secondary">
-            <strong>Related to:</strong> {getEntityDisplayName(entityType)}
-          </Typography>
-          {commentId && (
-            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
-              <strong>From comment:</strong> This task was created from a
-              comment
-            </Typography>
-          )}
-        </Box>
       </Box>
     </BaseDrawer>
   );

--- a/apps/frontend/src/components/tasks/TasksAndCommentsWrapper.tsx
+++ b/apps/frontend/src/components/tasks/TasksAndCommentsWrapper.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback, useState } from 'react';
-import { Paper } from '@mui/material';
+import { Box } from '@mui/material';
 import { EntityType } from '@/types/tasks';
 import type { TaskCreate } from '@/utils/api-client/interfaces/task';
 import { useTasks } from '@/hooks/useTasks';
@@ -16,7 +16,6 @@ interface TasksAndCommentsWrapperProps {
   currentUserId: string;
   currentUserName: string;
   currentUserPicture?: string;
-  elevation?: number;
   onCountsChange?: () => void;
   additionalMetadata?: Record<string, unknown>;
 }
@@ -28,7 +27,6 @@ export function TasksAndCommentsWrapper({
   currentUserId,
   currentUserName,
   currentUserPicture,
-  elevation = 1,
   onCountsChange,
   additionalMetadata,
 }: TasksAndCommentsWrapperProps) {
@@ -103,25 +101,19 @@ export function TasksAndCommentsWrapper({
 
   return (
     <>
-      <Paper
-        elevation={elevation}
-        sx={{ p: 3, mb: 3 }}
-        suppressHydrationWarning
-      >
-        <TasksSection
-          entityType={entityType}
-          entityId={entityId}
-          sessionToken={sessionToken}
-          onCreateTask={handleCreateTask}
-          onEditTask={handleEditTask}
-          onDeleteTask={handleDeleteTask}
-          onOpenCreateDrawer={handleOpenCreateDrawer}
-          currentUserId={currentUserId}
-          currentUserName={currentUserName}
-        />
-      </Paper>
+      <TasksSection
+        entityType={entityType}
+        entityId={entityId}
+        sessionToken={sessionToken}
+        onCreateTask={handleCreateTask}
+        onEditTask={handleEditTask}
+        onDeleteTask={handleDeleteTask}
+        onOpenCreateDrawer={handleOpenCreateDrawer}
+        currentUserId={currentUserId}
+        currentUserName={currentUserName}
+      />
 
-      <Paper elevation={elevation} sx={{ p: 3 }} suppressHydrationWarning>
+      <Box sx={{ mt: '16px' }}>
         <CommentsWrapper
           entityType={entityType}
           entityId={entityId}
@@ -133,7 +125,7 @@ export function TasksAndCommentsWrapper({
           onCreateTaskFromEntity={() => handleOpenCreateDrawer()}
           onCountsChange={onCountsChange}
         />
-      </Paper>
+      </Box>
 
       <TaskCreationDrawer
         open={createDrawerOpen}

--- a/apps/frontend/src/components/tasks/TasksSection.tsx
+++ b/apps/frontend/src/components/tasks/TasksSection.tsx
@@ -3,10 +3,11 @@
 import React, { useState, useCallback } from 'react';
 import { Box, Typography, Button, Chip, Avatar } from '@mui/material';
 import { AddIcon } from '@/components/icons';
-import RouteOutlinedIcon from '@mui/icons-material/RouteOutlined';
+import TasksIcon from '@/components/TasksIcon';
 import { Task, EntityType } from '@/types/tasks';
 import { getEntityDisplayName } from '@/utils/entity-helpers';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
+import { SectionCard } from '@/components/common/SectionCard';
 import {
   GridColDef,
   GridPaginationModel,
@@ -251,38 +252,25 @@ export function TasksSection({
     },
   ];
 
-  return (
-    <TaskErrorBoundary>
-      <Box>
-        {/* Header */}
-        <Box
-          sx={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            mb: 2,
-          }}
-        >
-          <Typography variant="h6" component="h2">
-            Tasks ({tasks.length})
-          </Typography>
-          <Button
-            variant="contained"
-            startIcon={<AddIcon />}
-            onClick={handleCreateTask}
-            sx={{
-              color: 'white',
-              '& .MuiButton-startIcon': {
-                color: 'white',
-              },
-            }}
-          >
-            Create Task
-          </Button>
-        </Box>
+  const createButton = (
+    <Button
+      variant="outlined"
+      startIcon={
+        <AddIcon
+          sx={{ color: theme => `${theme.palette.primary.main} !important` }}
+        />
+      }
+      onClick={handleCreateTask}
+      size="small"
+    >
+      Create
+    </Button>
+  );
 
-        {/* Tasks Table */}
-        {error ? (
+  if (error) {
+    return (
+      <TaskErrorBoundary>
+        <SectionCard title={`Tasks (${totalCount})`} actions={createButton}>
           <Typography
             variant="body2"
             color="error"
@@ -290,7 +278,15 @@ export function TasksSection({
           >
             {error}
           </Typography>
-        ) : !loading && tasks.length === 0 ? (
+        </SectionCard>
+      </TaskErrorBoundary>
+    );
+  }
+
+  if (!loading && tasks.length === 0) {
+    return (
+      <TaskErrorBoundary>
+        <SectionCard>
           <Box
             sx={{
               display: 'flex',
@@ -301,7 +297,12 @@ export function TasksSection({
               textAlign: 'center',
             }}
           >
-            <RouteOutlinedIcon sx={{ fontSize: 32, color: 'primary.main' }} />
+            <TasksIcon
+              sx={{
+                fontSize: 32,
+                color: theme => `${theme.palette.primary.main} !important`,
+              }}
+            />
             <Typography
               variant="h6"
               sx={{ fontWeight: 600, color: 'primary.main' }}
@@ -314,40 +315,43 @@ export function TasksSection({
             </Typography>
             <Button
               variant="contained"
-              startIcon={<AddIcon />}
+              startIcon={<AddIcon sx={{ color: 'white !important' }} />}
               onClick={handleCreateTask}
-              sx={{
-                color: 'white',
-                '& .MuiButton-startIcon': { color: 'white' },
-              }}
+              sx={{ color: 'white' }}
             >
               Create task
             </Button>
           </Box>
-        ) : (
-          <BaseDataGrid
-            rows={tasks}
-            columns={columns}
-            loading={loading}
-            onRowClick={handleRowClick}
-            disableRowSelectionOnClick
-            pageSizeOptions={[5, 10, 25]}
-            paginationModel={paginationModel}
-            onPaginationModelChange={handlePaginationModelChange}
-            getRowId={row => row.id}
-            showToolbar={true}
-            disablePaperWrapper={true}
-            serverSidePagination={true}
-            totalRows={totalCount}
-            sx={{
-              '& .MuiDataGrid-row': {
-                cursor: 'pointer',
-              },
-              minHeight: Math.min(tasks.length * 52 + 120, 400), // Dynamic height
-            }}
-          />
-        )}
-      </Box>
+        </SectionCard>
+      </TaskErrorBoundary>
+    );
+  }
+
+  return (
+    <TaskErrorBoundary>
+      <SectionCard title={`Tasks (${totalCount})`} actions={createButton}>
+        <BaseDataGrid
+          rows={tasks}
+          columns={columns}
+          loading={loading}
+          onRowClick={handleRowClick}
+          disableRowSelectionOnClick
+          pageSizeOptions={[5, 10, 25]}
+          paginationModel={paginationModel}
+          onPaginationModelChange={handlePaginationModelChange}
+          getRowId={row => row.id}
+          showToolbar={true}
+          disablePaperWrapper={true}
+          serverSidePagination={true}
+          totalRows={totalCount}
+          sx={{
+            '& .MuiDataGrid-row': {
+              cursor: 'pointer',
+            },
+            minHeight: Math.min(tasks.length * 52 + 120, 400),
+          }}
+        />
+      </SectionCard>
     </TaskErrorBoundary>
   );
 }

--- a/apps/frontend/src/hooks/__tests__/useGridStateStorage.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useGridStateStorage.test.ts
@@ -44,7 +44,9 @@ describe('useGridStateStorage', () => {
         columns: { columnVisibilityModel: { name: false } },
         sorting: { sortModel: [{ field: 'name', sort: 'asc' as const }] },
       };
-      getItemSpy.mockReturnValue(JSON.stringify(savedState));
+      getItemSpy.mockReturnValue(
+        JSON.stringify({ version: 2, state: savedState })
+      );
 
       const { result } = renderHook(() => useGridStateStorage());
 
@@ -53,6 +55,41 @@ describe('useGridStateStorage', () => {
       });
 
       expect(result.current.initialState).toEqual(savedState);
+    });
+
+    it('discards legacy (unversioned) persisted state', async () => {
+      const legacyState = {
+        columns: { orderedFields: ['name', 'status'] },
+      };
+      getItemSpy.mockReturnValue(JSON.stringify(legacyState));
+
+      const { result } = renderHook(() => useGridStateStorage());
+
+      await waitFor(() => {
+        expect(result.current.isLoaded).toBe(true);
+      });
+
+      expect(result.current.initialState).toBeUndefined();
+      expect(removeItemSpy).toHaveBeenCalledWith(
+        expect.stringContaining(STORAGE_KEY_PREFIX)
+      );
+    });
+
+    it('discards persisted state with an outdated version', async () => {
+      getItemSpy.mockReturnValue(
+        JSON.stringify({
+          version: 1,
+          state: { columns: { orderedFields: ['name'] } },
+        })
+      );
+
+      const { result } = renderHook(() => useGridStateStorage());
+
+      await waitFor(() => {
+        expect(result.current.isLoaded).toBe(true);
+      });
+
+      expect(result.current.initialState).toBeUndefined();
     });
 
     it('handles corrupted localStorage data gracefully', async () => {
@@ -135,10 +172,11 @@ describe('useGridStateStorage', () => {
         expect.stringContaining('"pageSize":25')
       );
 
-      // Pagination page should always be reset to 0
+      // Saved payload is versioned; pagination page should always reset to 0
       const savedArg = setItemSpy.mock.calls[0][1];
       const parsed = JSON.parse(savedArg);
-      expect(parsed.pagination.paginationModel.page).toBe(0);
+      expect(parsed.version).toBe(2);
+      expect(parsed.state.pagination.paginationModel.page).toBe(0);
 
       jest.useRealTimers();
     });

--- a/apps/frontend/src/hooks/useGridStateStorage.ts
+++ b/apps/frontend/src/hooks/useGridStateStorage.ts
@@ -5,6 +5,19 @@ import type { GridApi, GridInitialState } from '@mui/x-data-grid';
 const STORAGE_KEY_PREFIX = 'rhesis_grid_state_';
 
 /**
+ * Version of the persisted grid-state schema. Bump this whenever grid columns
+ * change in a way that a stale saved layout (column order / visibility) would
+ * mask — e.g. adding or removing a column. On load, any persisted state with a
+ * different version is discarded so the code-defined column layout wins.
+ */
+const GRID_STATE_VERSION = 2;
+
+interface VersionedGridState {
+  version: number;
+  state: GridInitialState;
+}
+
+/**
  * Sanitize pathname to create a valid localStorage key
  */
 function sanitizePathname(pathname: string): string {
@@ -23,7 +36,14 @@ function loadState(storageKey: string): GridInitialState | null {
   try {
     const stored = localStorage.getItem(storageKey);
     if (stored) {
-      return JSON.parse(stored);
+      const parsed = JSON.parse(stored) as Partial<VersionedGridState>;
+      // Discard legacy (unversioned) or outdated state so that column schema
+      // changes (e.g. a newly added column) aren't masked by a stale layout.
+      if (parsed?.version !== GRID_STATE_VERSION || !parsed.state) {
+        localStorage.removeItem(storageKey);
+        return null;
+      }
+      return parsed.state;
     }
   } catch (error) {
     console.error('Failed to load grid state:', error);
@@ -39,7 +59,11 @@ function saveState(storageKey: string, state: GridInitialState): void {
   if (typeof window === 'undefined') return;
 
   try {
-    localStorage.setItem(storageKey, JSON.stringify(state));
+    const versioned: VersionedGridState = {
+      version: GRID_STATE_VERSION,
+      state,
+    };
+    localStorage.setItem(storageKey, JSON.stringify(versioned));
   } catch (error) {
     console.error('Failed to save grid state:', error);
   }

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -461,6 +461,16 @@ const getDesignTokens = (mode: PaletteMode) => {
           },
         },
       },
+      MuiTooltip: {
+        styleOverrides: {
+          tooltip: {
+            fontFamily: '"Be Vietnam Pro", sans-serif',
+            fontSize: '0.75rem', // 12px
+            lineHeight: 1.4,
+            padding: '6px 10px',
+          },
+        },
+      },
       MuiCard: {
         styleOverrides: {
           root: {

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -296,6 +296,10 @@ const getDesignTokens = (mode: PaletteMode) => {
             '& .MuiSvgIcon-root': {
               color: mode === 'light' ? gs.body : '#FFFFFF',
             },
+            '& .MuiButton-icon .MuiSvgIcon-root, & .MuiButton-startIcon .MuiSvgIcon-root, & .MuiButton-endIcon .MuiSvgIcon-root':
+              {
+                color: 'inherit',
+              },
             '& .MuiListItemButton-root.Mui-selected': {
               backgroundColor: '#0080AF',
               '& .MuiSvgIcon-root': { color: '#FFFFFF' },

--- a/apps/frontend/src/utils/__tests__/test-result-status.test.ts
+++ b/apps/frontend/src/utils/__tests__/test-result-status.test.ts
@@ -421,7 +421,7 @@ describe('testResultStatus', () => {
             evidence: [],
             criteria_evaluations: [],
           },
-        } as TestResultDetail['test_output'],
+        } as unknown as TestResultDetail['test_output'],
         test_metrics: {
           metrics: {
             'Goal Evaluation': createMetricResult(false),
@@ -445,7 +445,7 @@ describe('testResultStatus', () => {
             evidence: [],
             criteria_evaluations: [],
           },
-        } as TestResultDetail['test_output'],
+        } as unknown as TestResultDetail['test_output'],
         test_metrics: {
           metrics: {
             'Goal Achievement': {

--- a/apps/frontend/src/utils/__tests__/test-result-status.test.ts
+++ b/apps/frontend/src/utils/__tests__/test-result-status.test.ts
@@ -6,6 +6,7 @@ import {
   getTestResultLabelWithReview,
   hasConflictingReview,
   hasExecutionError,
+  getTestEvaluationSummary,
 } from '../test-result-status';
 import {
   TestResultDetail,
@@ -405,6 +406,78 @@ describe('testResultStatus', () => {
       };
       expect(getTestResultStatusWithReview(test as TestResultDetail)).toBe(
         'Pass'
+      );
+    });
+  });
+
+  describe('getTestEvaluationSummary', () => {
+    it('prefers goal_evaluation reason', () => {
+      const test: Partial<TestResultDetail> = {
+        test_output: {
+          goal_evaluation: {
+            all_criteria_met: false,
+            confidence: 0.5,
+            reason: 'Goal not met due to missing confirmation.',
+            evidence: [],
+            criteria_evaluations: [],
+          },
+        } as TestResultDetail['test_output'],
+        test_metrics: {
+          metrics: {
+            'Goal Evaluation': createMetricResult(false),
+          },
+          execution_time: 1,
+        },
+      };
+
+      expect(getTestEvaluationSummary(test as TestResultDetail)).toBe(
+        'Goal not met due to missing confirmation.'
+      );
+    });
+
+    it('falls back to goal metric reason when goal_evaluation reason is empty', () => {
+      const test: Partial<TestResultDetail> = {
+        test_output: {
+          goal_evaluation: {
+            all_criteria_met: false,
+            confidence: 0.5,
+            reason: '',
+            evidence: [],
+            criteria_evaluations: [],
+          },
+        } as TestResultDetail['test_output'],
+        test_metrics: {
+          metrics: {
+            'Goal Achievement': {
+              ...createMetricResult(false),
+              reason: 'The assistant never confirmed the booking.',
+            },
+          },
+          execution_time: 1,
+        },
+      };
+
+      expect(getTestEvaluationSummary(test as TestResultDetail)).toBe(
+        'The assistant never confirmed the booking.'
+      );
+    });
+
+    it('uses failed metric reasons for single-turn tests', () => {
+      const test: Partial<TestResultDetail> = {
+        test_metrics: {
+          metrics: {
+            relevance: {
+              ...createMetricResult(false),
+              reason: 'Response was off-topic.',
+            },
+            safety: createMetricResult(true),
+          },
+          execution_time: 1,
+        },
+      };
+
+      expect(getTestEvaluationSummary(test as TestResultDetail)).toBe(
+        'Response was off-topic.'
       );
     });
   });

--- a/apps/frontend/src/utils/__tests__/test-run-utils.test.ts
+++ b/apps/frontend/src/utils/__tests__/test-run-utils.test.ts
@@ -1,4 +1,4 @@
-import { pollForTestRun } from '../test-run-utils';
+import { pollForTestRun, getTestRunDisplayTimestamp } from '../test-run-utils';
 
 type MockTestRunsClient = {
   getTestRunsByTestConfiguration: jest.Mock;
@@ -7,6 +7,36 @@ type MockTestRunsClient = {
 function makeMockClient(): MockTestRunsClient {
   return { getTestRunsByTestConfiguration: jest.fn() };
 }
+
+describe('getTestRunDisplayTimestamp', () => {
+  it('prefers attributes.started_at over created_at', () => {
+    expect(
+      getTestRunDisplayTimestamp({
+        attributes: { started_at: '2024-06-01T10:00:00Z' },
+        created_at: '2024-05-01T10:00:00Z',
+        updated_at: '2024-07-01T10:00:00Z',
+      })
+    ).toBe('2024-06-01T10:00:00Z');
+  });
+
+  it('falls back to created_at then updated_at', () => {
+    expect(
+      getTestRunDisplayTimestamp({
+        attributes: {},
+        created_at: '2024-05-01T10:00:00Z',
+        updated_at: '2024-07-01T10:00:00Z',
+      })
+    ).toBe('2024-05-01T10:00:00Z');
+
+    expect(
+      getTestRunDisplayTimestamp({
+        attributes: {},
+        created_at: '',
+        updated_at: '2024-07-01T10:00:00Z',
+      })
+    ).toBe('2024-07-01T10:00:00Z');
+  });
+});
 
 describe('pollForTestRun', () => {
   beforeEach(() => {

--- a/apps/frontend/src/utils/api-client/interfaces/test-run.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/test-run.ts
@@ -49,4 +49,10 @@ export interface TestRunDetail extends TestRun {
     comments: number;
     tasks: number;
   };
+  stats?: {
+    total: number;
+    passed: number;
+    failed: number;
+    errors: number;
+  };
 }

--- a/apps/frontend/src/utils/api-client/is-not-found-error.ts
+++ b/apps/frontend/src/utils/api-client/is-not-found-error.ts
@@ -1,0 +1,8 @@
+export function isNotFoundApiError(error: unknown): boolean {
+  if (!(error instanceof Error) || !('status' in error)) {
+    return false;
+  }
+
+  const status = (error as Error & { status?: number }).status;
+  return status === 404 || status === 410;
+}

--- a/apps/frontend/src/utils/conversation-from-spans.ts
+++ b/apps/frontend/src/utils/conversation-from-spans.ts
@@ -1,0 +1,97 @@
+import type { FileResponse } from '@/utils/api-client/interfaces/file';
+import type { SpanNode } from '@/utils/api-client/interfaces/telemetry';
+import type {
+  ConversationTurn,
+  TestResultDetail,
+} from '@/utils/api-client/interfaces/test-results';
+
+function getAutomatedTurnSuccess(rootSpans: SpanNode[]): boolean | undefined {
+  const traceMetrics = rootSpans.find(s => s.trace_metrics)?.trace_metrics as
+    | Record<string, unknown>
+    | undefined;
+  if (!traceMetrics) return undefined;
+
+  const turnSection = traceMetrics.turn_metrics as
+    | Record<string, unknown>
+    | undefined;
+  if (!turnSection) return undefined;
+
+  const metrics = turnSection.metrics as
+    | Record<string, { is_successful?: boolean }>
+    | undefined;
+  if (metrics && Object.keys(metrics).length > 0) {
+    return Object.values(metrics).every(m => m?.is_successful);
+  }
+
+  return undefined;
+}
+
+/**
+ * Whether this test result is a multi-turn conversation (test-set type or
+ * per-result output shape).
+ */
+export function isMultiTurnTestResult(
+  test: TestResultDetail,
+  testSetType?: string
+): boolean {
+  if (testSetType?.toLowerCase().includes('multi-turn')) return true;
+  if ((test.test_output?.conversation_summary?.length ?? 0) > 0) return true;
+  if (test.test_output?.goal_evaluation) return true;
+  if (test.test_output?.test_configuration?.goal) return true;
+  return false;
+}
+
+/**
+ * Reconstruct conversation turns from trace span attributes when
+ * test_output.conversation_summary is missing (same fallback as traces UI).
+ */
+export function reconstructConversationFromSpans(
+  rootSpans: SpanNode[]
+): ConversationTurn[] {
+  const automatedSuccess = getAutomatedTurnSuccess(rootSpans);
+
+  return rootSpans
+    .filter(
+      span =>
+        span.attributes['rhesis.conversation.input'] ||
+        span.attributes['rhesis.conversation.output']
+    )
+    .map((span, i) => ({
+      turn: i + 1,
+      timestamp: span.start_time,
+      penelope_message: String(
+        span.attributes['rhesis.conversation.input'] || ''
+      ),
+      target_response: String(
+        span.attributes['rhesis.conversation.output'] || ''
+      ),
+      penelope_reasoning: '',
+      session_id: span.span_id,
+      success: automatedSuccess ?? span.status_code !== 'ERROR',
+    }));
+}
+
+export function mergeSpanFilesIntoConversation(
+  conversation: ConversationTurn[],
+  spanFiles: FileResponse[][]
+): ConversationTurn[] {
+  if (spanFiles.length === 0) return conversation;
+  return conversation.map((turn, i) => ({
+    ...turn,
+    penelope_files: spanFiles[i] ?? [],
+  }));
+}
+
+/**
+ * Resolve conversation turns for a test result: prefer stored summary, else spans.
+ */
+export function resolveConversationSummary(
+  test: TestResultDetail,
+  rootSpans: SpanNode[],
+  spanFiles: FileResponse[][]
+): ConversationTurn[] {
+  const stored = test.test_output?.conversation_summary ?? [];
+  const base =
+    stored.length > 0 ? stored : reconstructConversationFromSpans(rootSpans);
+  return mergeSpanFilesIntoConversation(base, spanFiles);
+}

--- a/apps/frontend/src/utils/task-lookup.ts
+++ b/apps/frontend/src/utils/task-lookup.ts
@@ -54,12 +54,7 @@ export async function getStatuses(sessionToken?: string): Promise<Status[]> {
     const apiStatuses = await statusClient.getStatuses({ entity_type: 'Task' });
 
     // Convert API statuses to task statuses and filter for specific options
-    const allowedStatusNames = [
-      'Open',
-      'In Progress',
-      'Completed',
-      'Cancelled',
-    ];
+    const allowedStatusNames = ['Open', 'In Progress', 'Completed'];
     const statuses: Status[] = apiStatuses
       .filter((status: ApiStatus) => allowedStatusNames.includes(status.name))
       .map((status: ApiStatus) => ({
@@ -67,7 +62,12 @@ export async function getStatuses(sessionToken?: string): Promise<Status[]> {
         name: status.name,
         description: status.description,
         entity_type_id: status.entity_type,
-      }));
+      }))
+      .sort(
+        (a, b) =>
+          allowedStatusNames.indexOf(a.name) -
+          allowedStatusNames.indexOf(b.name)
+      );
 
     taskDataCache.set(cacheKey, statuses);
     return statuses;
@@ -90,12 +90,6 @@ export async function getStatuses(sessionToken?: string): Promise<Status[]> {
         id: '550e8400-e29b-41d4-a716-446655440003',
         name: 'Completed',
         description: 'Task is completed',
-        entity_type_id: 'Task',
-      },
-      {
-        id: '550e8400-e29b-41d4-a716-446655440004',
-        name: 'Cancelled',
-        description: 'Task is cancelled',
         entity_type_id: 'Task',
       },
     ];
@@ -138,7 +132,12 @@ export async function getPriorities(
         type_name: priority.type_name,
         type_value: priority.type_value,
         description: priority.description,
-      }));
+      }))
+      .sort(
+        (a, b) =>
+          allowedPriorityValues.indexOf(a.type_value) -
+          allowedPriorityValues.indexOf(b.type_value)
+      );
 
     taskDataCache.set(cacheKey, priorities);
     return priorities;

--- a/apps/frontend/src/utils/test-result-status.ts
+++ b/apps/frontend/src/utils/test-result-status.ts
@@ -265,3 +265,65 @@ export function isPassedStatusName(statusName: string): boolean {
     name.includes('completed')
   );
 }
+
+function isGoalMetricName(name: string): boolean {
+  const lower = name.toLowerCase();
+  return (
+    lower.includes('goal') &&
+    (lower.includes('achievement') || lower.includes('evaluation'))
+  );
+}
+
+/**
+ * Summary text for the Evaluation column in test run result tables.
+ * Prefers goal evaluation / metric reasons over raw model output.
+ */
+export function getTestEvaluationSummary(test: TestResultDetail): string {
+  const metrics = test.test_metrics?.metrics ?? {};
+  const goalEvaluation = test.test_output?.goal_evaluation;
+
+  const goalReason = goalEvaluation?.reason?.trim();
+  if (goalReason) {
+    return goalReason;
+  }
+
+  const goalMetric = Object.entries(metrics).find(([name]) =>
+    isGoalMetricName(name)
+  )?.[1];
+  const goalMetricReason = goalMetric?.reason?.trim();
+  if (goalMetricReason) {
+    return goalMetricReason;
+  }
+
+  const criteriaReasons =
+    goalEvaluation?.criteria_evaluations
+      ?.map(criterion => criterion.reasoning?.trim())
+      .filter(Boolean) ?? [];
+  if (criteriaReasons.length > 0) {
+    return criteriaReasons.join(' · ');
+  }
+
+  const failedMetricReasons = Object.values(metrics)
+    .filter(metric => !metric.is_successful)
+    .map(metric => metric.reason?.trim())
+    .filter(Boolean);
+  if (failedMetricReasons.length > 0) {
+    return failedMetricReasons.join(' · ');
+  }
+
+  const metricReasons = Object.values(metrics)
+    .map(metric => metric.reason?.trim())
+    .filter(Boolean);
+  if (metricReasons.length > 0) {
+    return metricReasons.join(' · ');
+  }
+
+  const evidence = goalEvaluation?.evidence
+    ?.map(item => item.trim())
+    .filter(Boolean);
+  if (evidence && evidence.length > 0) {
+    return evidence.join(' · ');
+  }
+
+  return '';
+}

--- a/apps/frontend/src/utils/test-run-utils.ts
+++ b/apps/frontend/src/utils/test-run-utils.ts
@@ -1,6 +1,23 @@
 import { TestRunsClient } from '@/utils/api-client/test-runs-client';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 
+/** Prefer execution start time; fall back to record timestamps. */
+export function getTestRunDisplayTimestamp(
+  testRun: Pick<TestRunDetail, 'created_at' | 'updated_at' | 'attributes'>
+): string | undefined {
+  const startedAt = testRun.attributes?.started_at;
+  if (typeof startedAt === 'string' && startedAt) {
+    return startedAt;
+  }
+  if (testRun.created_at) {
+    return testRun.created_at;
+  }
+  if (testRun.updated_at) {
+    return testRun.updated_at;
+  }
+  return undefined;
+}
+
 interface PollForTestRunOptions {
   /** Maximum number of polling attempts (default: 10) */
   maxAttempts?: number;

--- a/apps/frontend/tests/e2e/pages/TestRunDetailPage.ts
+++ b/apps/frontend/tests/e2e/pages/TestRunDetailPage.ts
@@ -35,7 +35,16 @@ export class TestRunDetailPage extends BasePage {
    * Assert the test results grid or an empty/error state is visible.
    * The test run detail always renders either a populated grid or a message.
    */
+  async goToLinkedEntitiesTab() {
+    const tab = this.page.getByRole('tab', { name: /linked entities/i });
+    if (await tab.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await tab.click();
+      await this.page.waitForLoadState('networkidle');
+    }
+  }
+
   async expectResultsAreaVisible() {
+    await this.goToLinkedEntitiesTab();
     await this.page.waitForLoadState('networkidle');
     const grid = this.page.locator('[role="grid"]');
     const mainContent = this.page.locator('main, [role="main"]').first();

--- a/apps/frontend/tests/e2e/pages/TestRunDetailPage.ts
+++ b/apps/frontend/tests/e2e/pages/TestRunDetailPage.ts
@@ -36,7 +36,7 @@ export class TestRunDetailPage extends BasePage {
    * The test run detail always renders either a populated grid or a message.
    */
   async goToLinkedEntitiesTab() {
-    const tab = this.page.getByRole('tab', { name: /linked entities/i });
+    const tab = this.page.getByRole('tab', { name: /test cases/i });
     if (await tab.isVisible({ timeout: 5_000 }).catch(() => false)) {
       await tab.click();
       await this.page.waitForLoadState('networkidle');

--- a/apps/frontend/tests/e2e/tests/test-run-comparison.spec.ts
+++ b/apps/frontend/tests/e2e/tests/test-run-comparison.spec.ts
@@ -28,8 +28,9 @@ test.describe('Test Runs — comparison mode @interaction', () => {
     await runsPage.expectDetailPageLoaded();
     await page.waitForLoadState('networkidle');
 
-    // Look for the "Compare" button
-    const compareBtn = page.getByRole('button', { name: /compare/i }).first();
+    const compareBtn = page
+      .getByRole('button', { name: /compare runs/i })
+      .first();
     const hasCompare = await compareBtn
       .isVisible({ timeout: 10_000 })
       .catch(() => false);
@@ -38,12 +39,15 @@ test.describe('Test Runs — comparison mode @interaction', () => {
       return;
     }
 
-    await compareBtn.click();
-    await page.waitForLoadState('networkidle');
-
-    await expect(page.locator('body')).not.toContainText(
+    const [comparePage] = await Promise.all([
+      page.context().waitForEvent('page'),
+      compareBtn.click(),
+    ]);
+    await comparePage.waitForLoadState('domcontentloaded');
+    await expect(comparePage.locator('body')).not.toContainText(
       'Internal Server Error'
     );
+    await comparePage.close();
   });
 
   test('can select a baseline from the comparison dropdown', async ({
@@ -68,7 +72,9 @@ test.describe('Test Runs — comparison mode @interaction', () => {
     await runsPage.expectDetailPageLoaded();
     await page.waitForLoadState('networkidle');
 
-    const compareBtn = page.getByRole('button', { name: /compare/i }).first();
+    const compareBtn = page
+      .getByRole('button', { name: /compare runs/i })
+      .first();
     const hasCompare = await compareBtn
       .isVisible({ timeout: 10_000 })
       .catch(() => false);
@@ -76,44 +82,31 @@ test.describe('Test Runs — comparison mode @interaction', () => {
       test.skip(true, '"Compare" button not found — skipping');
       return;
     }
-    await compareBtn.click();
-    await page.waitForLoadState('networkidle');
 
-    // A baseline dropdown should appear
-    const baselineSelect = page
-      .getByRole('combobox', { name: /baseline|compare/i })
-      .or(page.locator('[aria-haspopup="listbox"]'))
+    const [comparePage] = await Promise.all([
+      page.context().waitForEvent('page'),
+      compareBtn.click(),
+    ]);
+    await comparePage.waitForLoadState('domcontentloaded');
+
+    const baselineCard = comparePage.getByText(/select a baseline run/i);
+    const baselinePicker = comparePage
+      .locator('[class*="MuiCardActionArea"]')
       .first();
-    const hasSelect = await baselineSelect
-      .isVisible({ timeout: 8_000 })
-      .catch(() => false);
-    if (!hasSelect) {
-      test.skip(
-        true,
-        'Baseline dropdown not found after clicking Compare — skipping'
-      );
+    const hasPicker =
+      (await baselineCard.isVisible({ timeout: 8_000 }).catch(() => false)) &&
+      (await baselinePicker.isVisible({ timeout: 3_000 }).catch(() => false));
+    if (!hasPicker) {
+      await comparePage.close();
+      test.skip(true, 'Baseline picker not found — skipping');
       return;
     }
-
-    await baselineSelect.click();
-    const firstOption = page.getByRole('option').first();
-    const hasOption = await firstOption
-      .isVisible({ timeout: 8_000 })
-      .catch(() => false);
-    if (!hasOption) {
-      await page.keyboard.press('Escape');
-      test.skip(
-        true,
-        'No baseline options available — need at least 2 test runs'
-      );
-      return;
-    }
-    await firstOption.click();
-
-    await page.waitForLoadState('networkidle');
-    await expect(page.locator('body')).not.toContainText(
+    await baselinePicker.click();
+    await comparePage.waitForLoadState('networkidle');
+    await expect(comparePage.locator('body')).not.toContainText(
       'Internal Server Error'
     );
+    await comparePage.close();
   });
 
   test('comparison mode shows Improved, Regressed, and Unchanged stat cards', async ({
@@ -138,39 +131,36 @@ test.describe('Test Runs — comparison mode @interaction', () => {
     await runsPage.expectDetailPageLoaded();
     await page.waitForLoadState('networkidle');
 
-    const compareBtn = page.getByRole('button', { name: /compare/i }).first();
+    const compareBtn = page
+      .getByRole('button', { name: /compare runs/i })
+      .first();
     if (!(await compareBtn.isVisible({ timeout: 10_000 }).catch(() => false))) {
       test.skip(true, '"Compare" button not found — skipping');
       return;
     }
-    await compareBtn.click();
 
-    // Select a baseline
-    const baselineSelect = page
-      .getByRole('combobox', { name: /baseline|compare/i })
-      .or(page.locator('[aria-haspopup="listbox"]'))
+    const [comparePage] = await Promise.all([
+      page.context().waitForEvent('page'),
+      compareBtn.click(),
+    ]);
+    await comparePage.waitForLoadState('domcontentloaded');
+
+    const baselinePicker = comparePage
+      .locator('[class*="MuiCardActionArea"]')
       .first();
-    if (await baselineSelect.isVisible({ timeout: 5_000 }).catch(() => false)) {
-      await baselineSelect.click();
-      const firstOption = page.getByRole('option').first();
-      if (await firstOption.isVisible({ timeout: 5_000 }).catch(() => false)) {
-        await firstOption.click();
-      } else {
-        await page.keyboard.press('Escape');
-        test.skip(
-          true,
-          'No baseline runs available — skipping stat cards test'
-        );
-        return;
-      }
+    if (
+      !(await baselinePicker.isVisible({ timeout: 8_000 }).catch(() => false))
+    ) {
+      await comparePage.close();
+      test.skip(true, 'No baseline runs available — skipping stat cards test');
+      return;
     }
+    await baselinePicker.click();
+    await comparePage.waitForLoadState('networkidle');
 
-    await page.waitForLoadState('networkidle');
-
-    // The comparison stat cards (Improved / Regressed / Unchanged) should appear
-    const improved = page.getByText(/improved/i).first();
-    const regressed = page.getByText(/regressed/i).first();
-    const unchanged = page.getByText(/unchanged/i).first();
+    const improved = comparePage.getByText(/improved/i).first();
+    const regressed = comparePage.getByText(/regressed/i).first();
+    const unchanged = comparePage.getByText(/unchanged/i).first();
 
     const hasImproved = await improved
       .isVisible({ timeout: 10_000 })
@@ -209,45 +199,47 @@ test.describe('Test Runs — comparison mode @interaction', () => {
     await runsPage.clickFirstRow();
     await runsPage.expectDetailPageLoaded();
 
-    const compareBtn = page.getByRole('button', { name: /compare/i }).first();
+    const compareBtn = page
+      .getByRole('button', { name: /compare runs/i })
+      .first();
     if (!(await compareBtn.isVisible({ timeout: 10_000 }).catch(() => false))) {
       test.skip(true, '"Compare" button not found — skipping');
       return;
     }
-    await compareBtn.click();
 
-    const baselineSelect = page
-      .getByRole('combobox', { name: /baseline|compare/i })
-      .or(page.locator('[aria-haspopup="listbox"]'))
+    const [comparePage] = await Promise.all([
+      page.context().waitForEvent('page'),
+      compareBtn.click(),
+    ]);
+    await comparePage.waitForLoadState('domcontentloaded');
+
+    const baselinePicker = comparePage
+      .locator('[class*="MuiCardActionArea"]')
       .first();
-    if (await baselineSelect.isVisible({ timeout: 5_000 }).catch(() => false)) {
-      await baselineSelect.click();
-      const opt = page.getByRole('option').first();
-      if (await opt.isVisible({ timeout: 5_000 }).catch(() => false))
-        await opt.click();
-      else {
-        await page.keyboard.press('Escape');
-        test.skip(true, 'No baseline runs — skipping');
-        return;
-      }
+    if (
+      !(await baselinePicker.isVisible({ timeout: 8_000 }).catch(() => false))
+    ) {
+      test.skip(true, 'No baseline runs — skipping');
+      return;
     }
+    await baselinePicker.click();
+    await comparePage.waitForLoadState('networkidle');
 
-    await page.waitForLoadState('networkidle');
-
-    // Click "Improved" filter button if present
-    const improvedBtn = page.getByRole('button', { name: /improved/i }).first();
+    const improvedBtn = comparePage
+      .getByRole('button', { name: /improved/i })
+      .first();
     if (await improvedBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
       await improvedBtn.click();
-      await page.waitForLoadState('networkidle');
-      await expect(page.locator('body')).not.toContainText(
+      await comparePage.waitForLoadState('networkidle');
+      await expect(comparePage.locator('body')).not.toContainText(
         'Internal Server Error'
       );
     }
 
-    // Click "All" to reset
-    const allBtn = page.getByRole('button', { name: /^all$/i }).first();
+    const allBtn = comparePage.getByRole('button', { name: /^all$/i }).first();
     if (await allBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
       await allBtn.click();
     }
+    await comparePage.close();
   });
 });


### PR DESCRIPTION
## Purpose

Redesign the test run detail page and the individual test result drawer to match the updated Figma designs, improving information hierarchy, visual consistency, and usability.

## What Changed

**Test Run Detail Page**
- Redesigned the full test run detail page layout per Figma
- Added `TestRunDetailHeader`, `TestRunConfigurationTab`, `TestRunLinkedEntitiesTab`, `TestRunStatsTab`, and `TestRunTracesTab` components
- Added `TestRunDetailFilterDrawer` for filtering test results
- Extracted `useTestRunDetailData` hook to consolidate data-fetching logic
- Refactored `TestRunFilterBar` and `TestsTableView` for clarity and performance
- Added pass rate column to the test runs grid

**Comparison View**
- Refactored `ComparisonView` for readability and Figma alignment
- Added `ComparePageClient` and dedicated compare page route
- Added test detail overlay to the comparison view

**Test Result Drawer — Tab Bar**
- Removed all tab icons; switched to text-only tabs (18px bold, `textTransform: none`)
- Active tab uses dark-text underline indicator (2px, `text.primary` colour)
- Inactive tabs use `text.disabled`; hover uses `text.secondary`

**Test Result Drawer — Overview Tab**
- Replaced flat layout with a single bordered card (`BORDER_RADIUS.md` + `ELEVATION.xs`)
- Status header row: "Status" label + `StatusChip` + optional "Confirmed" chip
- Single-turn: Prompt (full width) → Response / Expected Response (side-by-side) → Context (always-expanded bullet list) → Tags — all inside the card
- Multi-turn: Goal → Instructions → Restrictions → Scenario → Reasoning with collapsible Evidence → Tags — all inside the card
- Metadata / Files / Output Files remain as collapsible sections below the card

**Test Result Drawer — Reviews Tab**
- Polished review judgement flow: fixed pass/fail toggle, corrected icon colours, auto-show all reviews once current user has reviewed
- Replaced single-turn flat layout with `ConversationHistory` component
- Styled conflict chip as filled red pill; applied `fieldSurface` background to comment boxes
- Removed Go-to-Test / Close footer from all drawer tabs
- Widened drawer from 60% to 75% to match Figma

## Additional Context

- Designs: Figma file `RCN0J2AjA0UlStdPpdjUCu` nodes `1640-13827`, `1640-16732`, `1640-22988`
- Frontend-only change; no backend, SDK, or database migrations affected

## Testing

1. Navigate to any test run detail page and verify the redesigned layout.
2. Open the result drawer for a **single-turn** test result and check:
   - Tab bar: text-only, bold, underline indicator on active tab
   - Overview tab: bordered card with status header, side-by-side response fields, context bullets
3. Open the result drawer for a **multi-turn** test result and check Goal / Instructions / Reasoning fields in the card.
4. Switch to the Conversation and Reviews tabs and confirm they still work correctly.
5. Verify the pass rate column appears in the test runs grid.