### PR TITLE
Redesign linked entities grids on metric & behavior detail pages

### DIFF
--- a/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorDetailTabs.tsx
@@ -8,6 +8,7 @@ import {
   GridRowModel,
 } from '@mui/x-data-grid';
 import GridBadge from '@/components/common/GridBadge';
+import { useNotifications } from '@/components/common/NotificationContext';
 import { createRowActionsColumn } from '@/components/common/createRowActionsColumn';
 import LinkedEntitiesGrid from '@/components/common/LinkedEntitiesGrid';
 import AssignEntityDrawer from '@/components/common/AssignEntityDrawer';
@@ -285,6 +286,7 @@ function BehaviorLinkedMetrics({
   sessionToken: string;
 }) {
   const router = useRouter();
+  const notifications = useNotifications();
   const [metrics, setMetrics] = useState<MetricWithRelationships[]>(
     behavior.metrics ?? []
   );
@@ -339,12 +341,21 @@ function BehaviorLinkedMetrics({
           metricId as UUID,
           behavior.id as UUID
         );
-        setMetrics(prev => prev.filter(m => m.id !== metricId));
-      } catch {
-        // ignore
+        setMetrics(prev => prev.filter(m => String(m.id) !== metricId));
+        notifications.show('Metric unassigned', {
+          severity: 'success',
+          autoHideDuration: 4000,
+        });
+      } catch (error) {
+        notifications.show(
+          error instanceof Error
+            ? `Failed to unassign metric: ${error.message}`
+            : 'Failed to unassign metric',
+          { severity: 'error', autoHideDuration: 6000 }
+        );
       }
     },
-    [behavior.id, sessionToken]
+    [behavior.id, sessionToken, notifications]
   );
 
   // Linked metrics columns (with unassign action)

--- a/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorDetailTabs.tsx
@@ -678,6 +678,8 @@ function BehaviorLinkedMetrics({
         onFilterClick={() => setAssignFilterOpen(true)}
         hasActiveFilters={hasActiveLinkedFilters(assignFilters)}
         activeFilterCount={countActiveLinkedFilters(assignFilters)}
+        onCreateNew={() => router.push('/metrics/new')}
+        createNewLabel="Create new metric"
       />
 
       <LinkedEntitiesFilterDrawer

--- a/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorDetailTabs.tsx
@@ -11,6 +11,14 @@ import GridBadge from '@/components/common/GridBadge';
 import { createRowActionsColumn } from '@/components/common/createRowActionsColumn';
 import LinkedEntitiesGrid from '@/components/common/LinkedEntitiesGrid';
 import AssignEntityDrawer from '@/components/common/AssignEntityDrawer';
+import LinkedEntitiesFilterDrawer, {
+  type LinkedFilterSectionConfig,
+  type LinkedFilterValues,
+  emptyLinkedFilters,
+  hasActiveLinkedFilters,
+  countActiveLinkedFilters,
+} from '@/components/common/LinkedEntitiesFilterDrawer';
+import type { ToolbarPillTab } from '@/components/common/GridToolbar';
 import { useDetailTabNav } from '@/hooks/useDetailTabNav';
 import DetailTabNav from '@/components/common/DetailTabNav';
 import DetailTabPanel from '@/components/common/DetailTabPanel';
@@ -25,6 +33,7 @@ import type {
   MetricWithRelationships,
 } from '@/utils/api-client/interfaces/behavior';
 import type { MetricDetail } from '@/utils/api-client/interfaces/metric';
+import type { Status } from '@/utils/api-client/interfaces/status';
 import { EntityType, type Tag } from '@/utils/api-client/interfaces/tag';
 import { BehaviorClient } from '@/utils/api-client/behavior-client';
 import { MetricsClient } from '@/utils/api-client/metrics-client';
@@ -286,6 +295,15 @@ function BehaviorLinkedMetrics({
   const [available, setAvailable] = useState<MetricDetail[]>([]);
   const [loadingAvailable, setLoadingAvailable] = useState(false);
 
+  // Toolbar filter state
+  const [scorePill, setScorePill] = useState('all');
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [appliedFilters, setAppliedFilters] = useState<LinkedFilterValues>({
+    backend: [],
+    score_type: [],
+    status: [],
+  });
+
   const fetchLinked = useCallback(async () => {
     setLoading(true);
     try {
@@ -446,6 +464,90 @@ function BehaviorLinkedMetrics({
     [behavior.id, sessionToken, fetchLinked]
   );
 
+  // Score Type pill tabs
+  const pillTabs: ToolbarPillTab[] = useMemo(
+    () => [
+      { label: 'All', value: 'all' },
+      { label: 'Numeric', value: 'numeric' },
+      { label: 'Categorical', value: 'categorical' },
+    ],
+    []
+  );
+
+  // Filter drawer sections: Backend, Score Type, Status (derived from rows)
+  const filterSections: LinkedFilterSectionConfig[] = useMemo(() => {
+    const backends = Array.from(
+      new Set(
+        metrics
+          .map(m => m.backend_type?.type_value)
+          .filter((value): value is string => !!value)
+      )
+    ).sort();
+    const scoreTypes = Array.from(
+      new Set(
+        metrics
+          .map(m => m.score_type)
+          .filter((value): value is string => !!value)
+      )
+    ).sort();
+    const statusNames = Array.from(
+      new Set(
+        metrics
+          .map(m => m.status?.name)
+          .filter((name): name is string => !!name)
+      )
+    ).sort();
+
+    return [
+      {
+        key: 'backend',
+        title: 'Backend',
+        options: backends.map(value => ({ value, label: value })),
+      },
+      {
+        key: 'score_type',
+        title: 'Score Type',
+        options: scoreTypes.map(value => ({
+          value,
+          label: value.charAt(0).toUpperCase() + value.slice(1),
+        })),
+      },
+      {
+        key: 'status',
+        title: 'Status',
+        options: statusNames.map(value => ({ value, label: value })),
+      },
+    ];
+  }, [metrics]);
+
+  const rowFilter = useCallback(
+    (row: GridRowModel) => {
+      const scoreType =
+        typeof row.score_type === 'string' ? row.score_type : '';
+      if (scorePill !== 'all' && scoreType !== scorePill) return false;
+
+      const backends = appliedFilters.backend ?? [];
+      if (backends.length > 0) {
+        const bt = row.backend_type as { type_value?: string } | null;
+        if (!backends.includes(bt?.type_value ?? '')) return false;
+      }
+
+      const scoreTypes = appliedFilters.score_type ?? [];
+      if (scoreTypes.length > 0 && !scoreTypes.includes(scoreType))
+        return false;
+
+      const statuses = appliedFilters.status ?? [];
+      if (statuses.length > 0) {
+        const statusName =
+          (row.status as Status | null | undefined)?.name ?? '';
+        if (!statuses.includes(statusName)) return false;
+      }
+
+      return true;
+    },
+    [scorePill, appliedFilters]
+  );
+
   return (
     <>
       <LinkedEntitiesGrid
@@ -456,6 +558,14 @@ function BehaviorLinkedMetrics({
         getRowId={row => String(row.id)}
         onRowClick={params => router.push(`/metrics/${String(params.id)}`)}
         onAssignClick={handleAssignClick}
+        searchPlaceholder="Search metrics…"
+        rowFilter={rowFilter}
+        onFilterClick={() => setFilterOpen(true)}
+        hasActiveFilters={hasActiveLinkedFilters(appliedFilters)}
+        activeFilterCount={countActiveLinkedFilters(appliedFilters)}
+        pillTabs={pillTabs}
+        activePill={scorePill}
+        onPillChange={setScorePill}
         emptyState={
           <Box
             sx={{
@@ -491,6 +601,16 @@ function BehaviorLinkedMetrics({
         loading={loadingAvailable}
         getRowId={row => String(row.id)}
         onAssign={handleAssign}
+      />
+
+      <LinkedEntitiesFilterDrawer
+        open={filterOpen}
+        onClose={() => setFilterOpen(false)}
+        sections={filterSections}
+        filters={appliedFilters}
+        onApply={next =>
+          setAppliedFilters(next ?? emptyLinkedFilters(filterSections))
+        }
       />
     </>
   );

--- a/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorDetailTabs.tsx
@@ -1,14 +1,16 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Box, Chip, Stack, Paper, Typography } from '@mui/material';
-import { GridColDef } from '@mui/x-data-grid';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
-import GridBadge from '@/components/common/GridBadge';
+import { Box, Chip, Stack, Typography } from '@mui/material';
 import {
-  createRowActionsColumn,
-  rowActionsHoverSx,
-} from '@/components/common/createRowActionsColumn';
+  GridColDef,
+  GridRenderCellParams,
+  GridRowModel,
+} from '@mui/x-data-grid';
+import GridBadge from '@/components/common/GridBadge';
+import { createRowActionsColumn } from '@/components/common/createRowActionsColumn';
+import LinkedEntitiesGrid from '@/components/common/LinkedEntitiesGrid';
+import AssignEntityDrawer from '@/components/common/AssignEntityDrawer';
 import { useDetailTabNav } from '@/hooks/useDetailTabNav';
 import DetailTabNav from '@/components/common/DetailTabNav';
 import DetailTabPanel from '@/components/common/DetailTabPanel';
@@ -22,6 +24,7 @@ import type {
   BehaviorWithMetrics,
   MetricWithRelationships,
 } from '@/utils/api-client/interfaces/behavior';
+import type { MetricDetail } from '@/utils/api-client/interfaces/metric';
 import { EntityType, type Tag } from '@/utils/api-client/interfaces/tag';
 import { BehaviorClient } from '@/utils/api-client/behavior-client';
 import { MetricsClient } from '@/utils/api-client/metrics-client';
@@ -278,20 +281,27 @@ function BehaviorLinkedMetrics({
   );
   const [loading, setLoading] = useState(false);
 
+  // Assign drawer state
+  const [assignOpen, setAssignOpen] = useState(false);
+  const [available, setAvailable] = useState<MetricDetail[]>([]);
+  const [loadingAvailable, setLoadingAvailable] = useState(false);
+
+  const fetchLinked = useCallback(async () => {
+    setLoading(true);
+    try {
+      const client = new BehaviorClient(sessionToken);
+      const result = await client.getBehaviorWithMetrics(behavior.id as UUID);
+      setMetrics(result.metrics ?? []);
+    } catch {
+      // keep existing
+    } finally {
+      setLoading(false);
+    }
+  }, [behavior.id, sessionToken]);
+
   useEffect(() => {
-    const fetchMetrics = async () => {
-      try {
-        setLoading(true);
-        const client = new BehaviorClient(sessionToken);
-        const result = await client.getBehaviorWithMetrics(behavior.id as UUID);
-        setMetrics(result.metrics ?? []);
-      } catch {
-        // keep existing
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchMetrics();
+    fetchLinked();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only on mount / id change
   }, [behavior.id, sessionToken]);
 
   const handleUnassign = useCallback(
@@ -310,7 +320,8 @@ function BehaviorLinkedMetrics({
     [behavior.id, sessionToken]
   );
 
-  const columns: GridColDef<MetricWithRelationships>[] = useMemo(
+  // Linked metrics columns (with unassign action)
+  const linkedColumns = useMemo<GridColDef[]>(
     () => [
       { field: 'name', headerName: 'Name', flex: 1, minWidth: 160 },
       {
@@ -318,16 +329,16 @@ function BehaviorLinkedMetrics({
         headerName: 'Description',
         flex: 2,
         minWidth: 200,
-        renderCell: params => (
+        renderCell: (params: GridRenderCellParams) => (
           <Box
-            title={params.value ?? ''}
+            title={typeof params.value === 'string' ? params.value : ''}
             sx={{
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
             }}
           >
-            {params.value || '—'}
+            {typeof params.value === 'string' ? params.value : '—'}
           </Box>
         ),
       },
@@ -335,9 +346,12 @@ function BehaviorLinkedMetrics({
         field: 'backend',
         headerName: 'Backend',
         width: 130,
-        valueGetter: (_value, row) => row.backend_type?.type_value ?? '',
-        renderCell: params =>
-          params.value ? (
+        valueGetter: (_value: unknown, row: GridRowModel) => {
+          const bt = row.backend_type as { type_value?: string } | null;
+          return bt?.type_value ?? '';
+        },
+        renderCell: (params: GridRenderCellParams) =>
+          typeof params.value === 'string' && params.value ? (
             <GridBadge size="detail" label={params.value} />
           ) : null,
       },
@@ -345,8 +359,8 @@ function BehaviorLinkedMetrics({
         field: 'score_type',
         headerName: 'Score Type',
         width: 130,
-        renderCell: params =>
-          params.value ? (
+        renderCell: (params: GridRenderCellParams) =>
+          typeof params.value === 'string' && params.value ? (
             <GridBadge size="detail" label={params.value} />
           ) : null,
       },
@@ -358,12 +372,91 @@ function BehaviorLinkedMetrics({
     [handleUnassign]
   );
 
-  const isEmpty = !loading && metrics.length === 0;
+  // Assign drawer columns (name + description + badges, no action)
+  const drawerColumns = useMemo<GridColDef[]>(
+    () => [
+      { field: 'name', headerName: 'Name', flex: 1, minWidth: 160 },
+      {
+        field: 'description',
+        headerName: 'Description',
+        flex: 2,
+        minWidth: 200,
+      },
+      {
+        field: 'backend',
+        headerName: 'Backend',
+        width: 130,
+        valueGetter: (_value: unknown, row: GridRowModel) => {
+          const bt = row.backend_type as { type_value?: string } | null;
+          return bt?.type_value ?? '';
+        },
+        renderCell: (params: GridRenderCellParams) =>
+          typeof params.value === 'string' && params.value ? (
+            <GridBadge size="detail" label={params.value} />
+          ) : null,
+      },
+      {
+        field: 'score_type',
+        headerName: 'Score Type',
+        width: 130,
+        renderCell: (params: GridRenderCellParams) =>
+          typeof params.value === 'string' && params.value ? (
+            <GridBadge size="detail" label={params.value} />
+          ) : null,
+      },
+    ],
+    []
+  );
+
+  const linkedIds = useMemo(
+    () => new Set(metrics.map(m => String(m.id))),
+    [metrics]
+  );
+
+  const availableFiltered: GridRowModel[] = useMemo(
+    () => available.filter(m => !linkedIds.has(String(m.id))),
+    [available, linkedIds]
+  );
+
+  const handleAssignClick = useCallback(async () => {
+    setLoadingAvailable(true);
+    setAssignOpen(true);
+    try {
+      const client = new MetricsClient(sessionToken);
+      const result = await client.getAllMetrics();
+      setAvailable(result);
+    } catch {
+      setAvailable([]);
+    } finally {
+      setLoadingAvailable(false);
+    }
+  }, [sessionToken]);
+
+  const handleAssign = useCallback(
+    async (selectedIds: string[]) => {
+      const client = new MetricsClient(sessionToken);
+      await Promise.all(
+        selectedIds.map(id =>
+          client.addBehaviorToMetric(id as UUID, behavior.id as UUID)
+        )
+      );
+      await fetchLinked();
+      setAssignOpen(false);
+    },
+    [behavior.id, sessionToken, fetchLinked]
+  );
 
   return (
     <>
-      {isEmpty ? (
-        <Paper elevation={1} sx={{ p: 3 }}>
+      <LinkedEntitiesGrid
+        title="Linked Metrics"
+        rows={metrics as GridRowModel[]}
+        columns={linkedColumns}
+        loading={loading}
+        getRowId={row => String(row.id)}
+        onRowClick={params => router.push(`/metrics/${String(params.id)}`)}
+        onAssignClick={handleAssignClick}
+        emptyState={
           <Box
             sx={{
               display: 'flex',
@@ -382,41 +475,23 @@ function BehaviorLinkedMetrics({
               No metrics assigned yet
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              No metrics have been assigned to this behavior yet. Navigate to
-              Metrics to assign a metric to start measuring this behavior.
+              No metrics have been assigned to this behavior yet. Click Assign
+              to link a metric and start measuring this behavior.
             </Typography>
           </Box>
-        </Paper>
-      ) : (
-        <Paper elevation={1} sx={{ p: 3 }}>
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              mb: 2,
-            }}
-          >
-            <Typography
-              variant="h6"
-              sx={{ fontWeight: 600, color: 'primary.main' }}
-            >
-              Linked Metrics ({metrics.length})
-            </Typography>
-          </Box>
-          <BaseDataGrid
-            rows={metrics}
-            columns={columns}
-            loading={loading}
-            getRowId={row => row.id}
-            onRowClick={params => router.push(`/metrics/${String(params.id)}`)}
-            pageSizeOptions={[5, 10, 25]}
-            disableRowSelectionOnClick
-            disablePaperWrapper={true}
-            sx={rowActionsHoverSx}
-          />
-        </Paper>
-      )}
+        }
+      />
+
+      <AssignEntityDrawer
+        open={assignOpen}
+        onClose={() => setAssignOpen(false)}
+        title="Assign Metric"
+        rows={availableFiltered}
+        columns={drawerColumns}
+        loading={loadingAvailable}
+        getRowId={row => String(row.id)}
+        onAssign={handleAssign}
+      />
     </>
   );
 }

--- a/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorDetailTabs.tsx
@@ -304,6 +304,15 @@ function BehaviorLinkedMetrics({
     status: [],
   });
 
+  // Assign-drawer toolbar filter state (independent of the linked-grid filters)
+  const [assignScorePill, setAssignScorePill] = useState('all');
+  const [assignFilterOpen, setAssignFilterOpen] = useState(false);
+  const [assignFilters, setAssignFilters] = useState<LinkedFilterValues>({
+    backend: [],
+    score_type: [],
+    status: [],
+  });
+
   const fetchLinked = useCallback(async () => {
     setLoading(true);
     try {
@@ -439,6 +448,8 @@ function BehaviorLinkedMetrics({
   const handleAssignClick = useCallback(async () => {
     setLoadingAvailable(true);
     setAssignOpen(true);
+    setAssignScorePill('all');
+    setAssignFilters({ backend: [], score_type: [], status: [] });
     try {
       const client = new MetricsClient(sessionToken);
       const result = await client.getAllMetrics();
@@ -520,23 +531,23 @@ function BehaviorLinkedMetrics({
     ];
   }, [metrics]);
 
-  const rowFilter = useCallback(
-    (row: GridRowModel) => {
+  const makeRowFilter = useCallback(
+    (pill: string, filters: LinkedFilterValues) => (row: GridRowModel) => {
       const scoreType =
         typeof row.score_type === 'string' ? row.score_type : '';
-      if (scorePill !== 'all' && scoreType !== scorePill) return false;
+      if (pill !== 'all' && scoreType !== pill) return false;
 
-      const backends = appliedFilters.backend ?? [];
+      const backends = filters.backend ?? [];
       if (backends.length > 0) {
         const bt = row.backend_type as { type_value?: string } | null;
         if (!backends.includes(bt?.type_value ?? '')) return false;
       }
 
-      const scoreTypes = appliedFilters.score_type ?? [];
+      const scoreTypes = filters.score_type ?? [];
       if (scoreTypes.length > 0 && !scoreTypes.includes(scoreType))
         return false;
 
-      const statuses = appliedFilters.status ?? [];
+      const statuses = filters.status ?? [];
       if (statuses.length > 0) {
         const statusName =
           (row.status as Status | null | undefined)?.name ?? '';
@@ -545,8 +556,66 @@ function BehaviorLinkedMetrics({
 
       return true;
     },
-    [scorePill, appliedFilters]
+    []
   );
+
+  const rowFilter = useMemo(
+    () => makeRowFilter(scorePill, appliedFilters),
+    [makeRowFilter, scorePill, appliedFilters]
+  );
+
+  const assignRowFilter = useMemo(
+    () => makeRowFilter(assignScorePill, assignFilters),
+    [makeRowFilter, assignScorePill, assignFilters]
+  );
+
+  // Assign-drawer filter sections derived from the available (unlinked) metrics
+  const assignFilterSections: LinkedFilterSectionConfig[] = useMemo(() => {
+    const backends = Array.from(
+      new Set(
+        availableFiltered
+          .map(
+            m => (m.backend_type as { type_value?: string } | null)?.type_value
+          )
+          .filter((value): value is string => !!value)
+      )
+    ).sort();
+    const scoreTypes = Array.from(
+      new Set(
+        availableFiltered
+          .map(m => (typeof m.score_type === 'string' ? m.score_type : ''))
+          .filter((value): value is string => !!value)
+      )
+    ).sort();
+    const statusNames = Array.from(
+      new Set(
+        availableFiltered
+          .map(m => (m.status as Status | null | undefined)?.name)
+          .filter((name): name is string => !!name)
+      )
+    ).sort();
+
+    return [
+      {
+        key: 'backend',
+        title: 'Backend',
+        options: backends.map(value => ({ value, label: value })),
+      },
+      {
+        key: 'score_type',
+        title: 'Score Type',
+        options: scoreTypes.map(value => ({
+          value,
+          label: value.charAt(0).toUpperCase() + value.slice(1),
+        })),
+      },
+      {
+        key: 'status',
+        title: 'Status',
+        options: statusNames.map(value => ({ value, label: value })),
+      },
+    ];
+  }, [availableFiltered]);
 
   return (
     <>
@@ -601,6 +670,14 @@ function BehaviorLinkedMetrics({
         loading={loadingAvailable}
         getRowId={row => String(row.id)}
         onAssign={handleAssign}
+        searchPlaceholder="Search metrics…"
+        rowFilter={assignRowFilter}
+        pillTabs={pillTabs}
+        activePill={assignScorePill}
+        onPillChange={setAssignScorePill}
+        onFilterClick={() => setAssignFilterOpen(true)}
+        hasActiveFilters={hasActiveLinkedFilters(assignFilters)}
+        activeFilterCount={countActiveLinkedFilters(assignFilters)}
       />
 
       <LinkedEntitiesFilterDrawer
@@ -610,6 +687,16 @@ function BehaviorLinkedMetrics({
         filters={appliedFilters}
         onApply={next =>
           setAppliedFilters(next ?? emptyLinkedFilters(filterSections))
+        }
+      />
+
+      <LinkedEntitiesFilterDrawer
+        open={assignFilterOpen}
+        onClose={() => setAssignFilterOpen(false)}
+        sections={assignFilterSections}
+        filters={assignFilters}
+        onApply={next =>
+          setAssignFilters(next ?? emptyLinkedFilters(assignFilterSections))
         }
       />
     </>

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
@@ -14,6 +14,13 @@ import DetailTabNav from '@/components/common/DetailTabNav';
 import { createRowActionsColumn } from '@/components/common/createRowActionsColumn';
 import LinkedEntitiesGrid from '@/components/common/LinkedEntitiesGrid';
 import AssignEntityDrawer from '@/components/common/AssignEntityDrawer';
+import LinkedEntitiesFilterDrawer, {
+  type LinkedFilterSectionConfig,
+  type LinkedFilterValues,
+  emptyLinkedFilters,
+  hasActiveLinkedFilters,
+  countActiveLinkedFilters,
+} from '@/components/common/LinkedEntitiesFilterDrawer';
 import { RouteIcon } from '@/components/icons';
 import { MetricDetailView } from './MetricDetailView';
 import { MetricsClient } from '@/utils/api-client/metrics-client';
@@ -22,7 +29,11 @@ import type {
   BehaviorReference,
   BehaviorWithMetrics,
 } from '@/utils/api-client/interfaces/behavior';
+import type { Status } from '@/utils/api-client/interfaces/status';
 import type { UUID } from 'crypto';
+
+/** Linked behaviors come back with the status relationship at runtime. */
+type LinkedBehaviorRow = BehaviorReference & { status?: Status | null };
 
 const TAB_KEYS = ['basic', 'linked-behaviors'] as const;
 
@@ -81,13 +92,19 @@ function MetricLinkedBehaviors({
   sessionToken: string;
 }) {
   const router = useRouter();
-  const [behaviors, setBehaviors] = useState<BehaviorReference[]>([]);
+  const [behaviors, setBehaviors] = useState<LinkedBehaviorRow[]>([]);
   const [loading, setLoading] = useState(true);
 
   // Assign drawer state
   const [assignOpen, setAssignOpen] = useState(false);
   const [available, setAvailable] = useState<BehaviorWithMetrics[]>([]);
   const [loadingAvailable, setLoadingAvailable] = useState(false);
+
+  // Filter drawer state
+  const [filterOpen, setFilterOpen] = useState(false);
+  const [appliedFilters, setAppliedFilters] = useState<LinkedFilterValues>({
+    status: [],
+  });
 
   const fetchLinked = useCallback(async () => {
     if (!sessionToken) return;
@@ -96,7 +113,7 @@ function MetricLinkedBehaviors({
       const client = new MetricsClient(sessionToken);
       const result = await client.getMetricBehaviors(metricId as UUID);
       const data =
-        (result as unknown as { data: BehaviorReference[] }).data ?? [];
+        (result as unknown as { data: LinkedBehaviorRow[] }).data ?? [];
       setBehaviors(data);
     } catch {
       setBehaviors([]);
@@ -208,6 +225,34 @@ function MetricLinkedBehaviors({
     [metricId, sessionToken, fetchLinked]
   );
 
+  // Filter drawer: Status only (linked behaviors have no other filterable field)
+  const filterSections: LinkedFilterSectionConfig[] = useMemo(() => {
+    const statusNames = Array.from(
+      new Set(
+        behaviors
+          .map(b => b.status?.name)
+          .filter((name): name is string => !!name)
+      )
+    ).sort();
+    return [
+      {
+        key: 'status',
+        title: 'Status',
+        options: statusNames.map(name => ({ value: name, label: name })),
+      },
+    ];
+  }, [behaviors]);
+
+  const rowFilter = useCallback(
+    (row: GridRowModel) => {
+      const statuses = appliedFilters.status ?? [];
+      if (statuses.length === 0) return true;
+      const statusName = (row.status as Status | null | undefined)?.name ?? '';
+      return statuses.includes(statusName);
+    },
+    [appliedFilters]
+  );
+
   return (
     <>
       <LinkedEntitiesGrid
@@ -218,6 +263,11 @@ function MetricLinkedBehaviors({
         getRowId={row => String(row.id)}
         onRowClick={params => router.push(`/behaviors/${String(params.id)}`)}
         onAssignClick={handleAssignClick}
+        searchPlaceholder="Search behaviors…"
+        rowFilter={rowFilter}
+        onFilterClick={() => setFilterOpen(true)}
+        hasActiveFilters={hasActiveLinkedFilters(appliedFilters)}
+        activeFilterCount={countActiveLinkedFilters(appliedFilters)}
         emptyState={
           <Box
             sx={{
@@ -253,6 +303,16 @@ function MetricLinkedBehaviors({
         loading={loadingAvailable}
         getRowId={row => String(row.id)}
         onAssign={handleAssign}
+      />
+
+      <LinkedEntitiesFilterDrawer
+        open={filterOpen}
+        onClose={() => setFilterOpen(false)}
+        sections={filterSections}
+        filters={appliedFilters}
+        onApply={next =>
+          setAppliedFilters(next ?? emptyLinkedFilters(filterSections))
+        }
       />
     </>
   );

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mui/x-data-grid';
 import { useDetailTabNav } from '@/hooks/useDetailTabNav';
 import DetailTabNav from '@/components/common/DetailTabNav';
+import { useNotifications } from '@/components/common/NotificationContext';
 import { createRowActionsColumn } from '@/components/common/createRowActionsColumn';
 import LinkedEntitiesGrid from '@/components/common/LinkedEntitiesGrid';
 import AssignEntityDrawer from '@/components/common/AssignEntityDrawer';
@@ -92,6 +93,7 @@ function MetricLinkedBehaviors({
   sessionToken: string;
 }) {
   const router = useRouter();
+  const notifications = useNotifications();
   const [behaviors, setBehaviors] = useState<LinkedBehaviorRow[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -141,12 +143,21 @@ function MetricLinkedBehaviors({
           metricId as UUID,
           behaviorId as UUID
         );
-        setBehaviors(prev => prev.filter(b => b.id !== behaviorId));
-      } catch {
-        // ignore
+        setBehaviors(prev => prev.filter(b => String(b.id) !== behaviorId));
+        notifications.show('Behavior unassigned', {
+          severity: 'success',
+          autoHideDuration: 4000,
+        });
+      } catch (error) {
+        notifications.show(
+          error instanceof Error
+            ? `Failed to unassign behavior: ${error.message}`
+            : 'Failed to unassign behavior',
+          { severity: 'error', autoHideDuration: 6000 }
+        );
       }
     },
-    [metricId, sessionToken]
+    [metricId, sessionToken, notifications]
   );
 
   // Linked behaviors columns

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
@@ -343,6 +343,8 @@ function MetricLinkedBehaviors({
         onFilterClick={() => setAssignFilterOpen(true)}
         hasActiveFilters={hasActiveLinkedFilters(assignFilters)}
         activeFilterCount={countActiveLinkedFilters(assignFilters)}
+        onCreateNew={() => router.push('/behaviors')}
+        createNewLabel="Create new behavior"
       />
 
       <LinkedEntitiesFilterDrawer

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
@@ -2,20 +2,26 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { Box, Paper, Typography } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { useSession } from 'next-auth/react';
-import { GridColDef } from '@mui/x-data-grid';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
+import {
+  GridColDef,
+  GridRenderCellParams,
+  GridRowModel,
+} from '@mui/x-data-grid';
 import { useDetailTabNav } from '@/hooks/useDetailTabNav';
 import DetailTabNav from '@/components/common/DetailTabNav';
-import {
-  createRowActionsColumn,
-  rowActionsHoverSx,
-} from '@/components/common/createRowActionsColumn';
+import { createRowActionsColumn } from '@/components/common/createRowActionsColumn';
+import LinkedEntitiesGrid from '@/components/common/LinkedEntitiesGrid';
+import AssignEntityDrawer from '@/components/common/AssignEntityDrawer';
 import { RouteIcon } from '@/components/icons';
 import { MetricDetailView } from './MetricDetailView';
 import { MetricsClient } from '@/utils/api-client/metrics-client';
-import type { BehaviorReference } from '@/utils/api-client/interfaces/behavior';
+import { BehaviorClient } from '@/utils/api-client/behavior-client';
+import type {
+  BehaviorReference,
+  BehaviorWithMetrics,
+} from '@/utils/api-client/interfaces/behavior';
 import type { UUID } from 'crypto';
 
 const TAB_KEYS = ['basic', 'linked-behaviors'] as const;
@@ -78,23 +84,30 @@ function MetricLinkedBehaviors({
   const [behaviors, setBehaviors] = useState<BehaviorReference[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
+  // Assign drawer state
+  const [assignOpen, setAssignOpen] = useState(false);
+  const [available, setAvailable] = useState<BehaviorWithMetrics[]>([]);
+  const [loadingAvailable, setLoadingAvailable] = useState(false);
+
+  const fetchLinked = useCallback(async () => {
     if (!sessionToken) return;
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-        const client = new MetricsClient(sessionToken);
-        const result = await client.getMetricBehaviors(metricId as UUID);
-        const data =
-          (result as unknown as { data: BehaviorReference[] }).data ?? [];
-        setBehaviors(data);
-      } catch {
-        setBehaviors([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchData();
+    setLoading(true);
+    try {
+      const client = new MetricsClient(sessionToken);
+      const result = await client.getMetricBehaviors(metricId as UUID);
+      const data =
+        (result as unknown as { data: BehaviorReference[] }).data ?? [];
+      setBehaviors(data);
+    } catch {
+      setBehaviors([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [metricId, sessionToken]);
+
+  useEffect(() => {
+    fetchLinked();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only on mount / id change
   }, [metricId, sessionToken]);
 
   const handleUnassign = useCallback(
@@ -113,7 +126,8 @@ function MetricLinkedBehaviors({
     [metricId, sessionToken]
   );
 
-  const columns: GridColDef<BehaviorReference>[] = useMemo(
+  // Linked behaviors columns
+  const linkedColumns = useMemo<GridColDef[]>(
     () => [
       { field: 'name', headerName: 'Name', flex: 1, minWidth: 160 },
       {
@@ -121,16 +135,16 @@ function MetricLinkedBehaviors({
         headerName: 'Description',
         flex: 2,
         minWidth: 200,
-        renderCell: params => (
+        renderCell: (params: GridRenderCellParams) => (
           <Box
-            title={params.value ?? ''}
+            title={typeof params.value === 'string' ? params.value : ''}
             sx={{
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
             }}
           >
-            {params.value || '—'}
+            {typeof params.value === 'string' ? params.value : '—'}
           </Box>
         ),
       },
@@ -142,12 +156,69 @@ function MetricLinkedBehaviors({
     [handleUnassign]
   );
 
-  const isEmpty = !loading && behaviors.length === 0;
+  // Assign drawer columns (no actions)
+  const drawerColumns = useMemo<GridColDef[]>(
+    () => [
+      { field: 'name', headerName: 'Name', flex: 1, minWidth: 160 },
+      {
+        field: 'description',
+        headerName: 'Description',
+        flex: 2,
+        minWidth: 200,
+      },
+    ],
+    []
+  );
+
+  const linkedIds = useMemo(
+    () => new Set(behaviors.map(b => String(b.id))),
+    [behaviors]
+  );
+
+  const availableFiltered: GridRowModel[] = useMemo(
+    () => available.filter(b => !linkedIds.has(String(b.id))),
+    [available, linkedIds]
+  );
+
+  const handleAssignClick = useCallback(async () => {
+    setLoadingAvailable(true);
+    setAssignOpen(true);
+    try {
+      const client = new BehaviorClient(sessionToken);
+      const result = await client.getBehaviors({ skip: 0, limit: 200 });
+      setAvailable(result);
+    } catch {
+      setAvailable([]);
+    } finally {
+      setLoadingAvailable(false);
+    }
+  }, [sessionToken]);
+
+  const handleAssign = useCallback(
+    async (selectedIds: string[]) => {
+      const client = new MetricsClient(sessionToken);
+      await Promise.all(
+        selectedIds.map(id =>
+          client.addBehaviorToMetric(metricId as UUID, id as UUID)
+        )
+      );
+      await fetchLinked();
+      setAssignOpen(false);
+    },
+    [metricId, sessionToken, fetchLinked]
+  );
 
   return (
     <>
-      {isEmpty ? (
-        <Paper elevation={1} sx={{ p: 3 }}>
+      <LinkedEntitiesGrid
+        title="Linked Behaviors"
+        rows={behaviors as GridRowModel[]}
+        columns={linkedColumns}
+        loading={loading}
+        getRowId={row => String(row.id)}
+        onRowClick={params => router.push(`/behaviors/${String(params.id)}`)}
+        onAssignClick={handleAssignClick}
+        emptyState={
           <Box
             sx={{
               display: 'flex',
@@ -166,43 +237,23 @@ function MetricLinkedBehaviors({
               No behaviors assigned yet
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              No behaviors have been assigned to this metric yet. Navigate to
-              Behaviors to assign a behavior to start linking it to this metric.
+              No behaviors have been assigned to this metric yet. Click Assign
+              to link a behavior.
             </Typography>
           </Box>
-        </Paper>
-      ) : (
-        <Paper elevation={1} sx={{ p: 3 }}>
-          <Box
-            sx={{
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-              mb: 2,
-            }}
-          >
-            <Typography
-              variant="h6"
-              sx={{ fontWeight: 600, color: 'primary.main' }}
-            >
-              Linked Behaviors ({behaviors.length})
-            </Typography>
-          </Box>
-          <BaseDataGrid
-            rows={behaviors}
-            columns={columns}
-            loading={loading}
-            getRowId={row => row.id}
-            onRowClick={params =>
-              router.push(`/behaviors/${String(params.id)}`)
-            }
-            pageSizeOptions={[5, 10, 25]}
-            disableRowSelectionOnClick
-            disablePaperWrapper={true}
-            sx={rowActionsHoverSx}
-          />
-        </Paper>
-      )}
+        }
+      />
+
+      <AssignEntityDrawer
+        open={assignOpen}
+        onClose={() => setAssignOpen(false)}
+        title="Assign Behavior"
+        rows={availableFiltered}
+        columns={drawerColumns}
+        loading={loadingAvailable}
+        getRowId={row => String(row.id)}
+        onAssign={handleAssign}
+      />
     </>
   );
 }

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
@@ -209,7 +209,7 @@ function MetricLinkedBehaviors({
     setAssignFilters({ status: [] });
     try {
       const client = new BehaviorClient(sessionToken);
-      const result = await client.getBehaviors({ skip: 0, limit: 200 });
+      const result = await client.getBehaviors({ skip: 0, limit: 100 });
       setAvailable(result);
     } catch {
       setAvailable([]);

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailPageTabs.tsx
@@ -106,6 +106,12 @@ function MetricLinkedBehaviors({
     status: [],
   });
 
+  // Assign-drawer filter state (independent of the linked-grid filters)
+  const [assignFilterOpen, setAssignFilterOpen] = useState(false);
+  const [assignFilters, setAssignFilters] = useState<LinkedFilterValues>({
+    status: [],
+  });
+
   const fetchLinked = useCallback(async () => {
     if (!sessionToken) return;
     setLoading(true);
@@ -200,6 +206,7 @@ function MetricLinkedBehaviors({
   const handleAssignClick = useCallback(async () => {
     setLoadingAvailable(true);
     setAssignOpen(true);
+    setAssignFilters({ status: [] });
     try {
       const client = new BehaviorClient(sessionToken);
       const result = await client.getBehaviors({ skip: 0, limit: 200 });
@@ -253,6 +260,34 @@ function MetricLinkedBehaviors({
     [appliedFilters]
   );
 
+  // Assign-drawer filter sections derived from available (unlinked) behaviors
+  const assignFilterSections: LinkedFilterSectionConfig[] = useMemo(() => {
+    const statusNames = Array.from(
+      new Set(
+        availableFiltered
+          .map(b => (b.status as Status | null | undefined)?.name)
+          .filter((name): name is string => !!name)
+      )
+    ).sort();
+    return [
+      {
+        key: 'status',
+        title: 'Status',
+        options: statusNames.map(name => ({ value: name, label: name })),
+      },
+    ];
+  }, [availableFiltered]);
+
+  const assignRowFilter = useCallback(
+    (row: GridRowModel) => {
+      const statuses = assignFilters.status ?? [];
+      if (statuses.length === 0) return true;
+      const statusName = (row.status as Status | null | undefined)?.name ?? '';
+      return statuses.includes(statusName);
+    },
+    [assignFilters]
+  );
+
   return (
     <>
       <LinkedEntitiesGrid
@@ -303,6 +338,11 @@ function MetricLinkedBehaviors({
         loading={loadingAvailable}
         getRowId={row => String(row.id)}
         onAssign={handleAssign}
+        searchPlaceholder="Search behaviors…"
+        rowFilter={assignRowFilter}
+        onFilterClick={() => setAssignFilterOpen(true)}
+        hasActiveFilters={hasActiveLinkedFilters(assignFilters)}
+        activeFilterCount={countActiveLinkedFilters(assignFilters)}
       />
 
       <LinkedEntitiesFilterDrawer
@@ -312,6 +352,16 @@ function MetricLinkedBehaviors({
         filters={appliedFilters}
         onApply={next =>
           setAppliedFilters(next ?? emptyLinkedFilters(filterSections))
+        }
+      />
+
+      <LinkedEntitiesFilterDrawer
+        open={assignFilterOpen}
+        onClose={() => setAssignFilterOpen(false)}
+        sections={assignFilterSections}
+        filters={assignFilters}
+        onApply={next =>
+          setAssignFilters(next ?? emptyLinkedFilters(assignFilterSections))
         }
       />
     </>

--- a/apps/frontend/src/components/common/AssignEntityDrawer.tsx
+++ b/apps/frontend/src/components/common/AssignEntityDrawer.tsx
@@ -104,9 +104,12 @@ export default function AssignEntityDrawer({
 
   const hasSelection = Array.isArray(selected) && selected.length > 0;
 
-  // Inset the first/last column content to 30px so it lines up with the
+  // Fill the card's remaining height (rows scroll internally, footer pinned)
+  // and inset the first/last column content to 30px so it lines up with the
   // toolbar and footer (which already use 30px horizontal padding).
   const gridSx = {
+    flex: 1,
+    minHeight: 0,
     '& .MuiDataGrid-columnHeader:first-of-type, & .MuiDataGrid-cell:first-of-type':
       { paddingLeft: '30px' },
     '& .MuiDataGrid-columnHeader:last-of-type, & .MuiDataGrid-cell:last-of-type':
@@ -128,6 +131,10 @@ export default function AssignEntityDrawer({
         elevation={0}
         sx={{
           width: '100%',
+          flex: 1,
+          minHeight: 0,
+          display: 'flex',
+          flexDirection: 'column',
           borderRadius: BORDER_RADIUS.md,
           border: (theme: Theme) =>
             `1px solid ${theme.palette.greyscale.border}`,
@@ -135,7 +142,7 @@ export default function AssignEntityDrawer({
           overflow: 'hidden',
         }}
       >
-        <Box sx={{ px: '30px', pt: '30px', pb: '30px' }}>
+        <Box sx={{ px: '30px', pt: '30px', pb: '30px', flexShrink: 0 }}>
           <GridToolbar
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}
@@ -192,6 +199,7 @@ export default function AssignEntityDrawer({
           checkboxSelection
           disableRowSelectionOnClick
           disableColumnResize
+          autoHeight={false}
           onRowSelectionModelChange={setSelected}
           rowSelectionModel={selected}
           disablePaperWrapper

--- a/apps/frontend/src/components/common/AssignEntityDrawer.tsx
+++ b/apps/frontend/src/components/common/AssignEntityDrawer.tsx
@@ -9,7 +9,11 @@ import {
 } from '@mui/x-data-grid';
 import BaseDrawer from '@/components/common/BaseDrawer';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
-import { SearchPill } from '@/components/common/SearchPill';
+import {
+  GridToolbar,
+  PrimarySegmentedPills,
+  type ToolbarPillTab,
+} from '@/components/common/GridToolbar';
 
 export interface AssignEntityDrawerProps {
   open: boolean;
@@ -21,6 +25,17 @@ export interface AssignEntityDrawerProps {
   getRowId: (row: GridRowModel) => string;
   onAssign: (selectedIds: string[]) => Promise<void>;
   saveButtonText?: string;
+  searchPlaceholder?: string;
+  /** Parent-supplied predicate for pill/drawer filtering (search is handled internally). */
+  rowFilter?: (row: GridRowModel) => boolean;
+  // Filter (tune) button
+  onFilterClick?: () => void;
+  hasActiveFilters?: boolean;
+  activeFilterCount?: number;
+  // Centered segmented quick-filter pills
+  pillTabs?: ToolbarPillTab[];
+  activePill?: string;
+  onPillChange?: (value: string) => void;
 }
 
 export default function AssignEntityDrawer({
@@ -33,6 +48,14 @@ export default function AssignEntityDrawer({
   getRowId,
   onAssign,
   saveButtonText = 'Assign',
+  searchPlaceholder = 'Search…',
+  rowFilter,
+  onFilterClick,
+  hasActiveFilters,
+  activeFilterCount,
+  pillTabs,
+  activePill,
+  onPillChange,
 }: AssignEntityDrawerProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [selected, setSelected] = useState<GridRowSelectionModel>([]);
@@ -46,17 +69,21 @@ export default function AssignEntityDrawer({
   }, [open]);
 
   const filteredRows = useMemo(() => {
-    if (!searchQuery.trim()) return rows;
-    const q = searchQuery.toLowerCase();
-    return rows.filter(row => {
-      const name = typeof row.name === 'string' ? row.name : '';
-      const description =
-        typeof row.description === 'string' ? row.description : '';
-      return (
-        name.toLowerCase().includes(q) || description.toLowerCase().includes(q)
-      );
-    });
-  }, [rows, searchQuery]);
+    let result = rowFilter ? rows.filter(rowFilter) : rows;
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(row => {
+        const name = typeof row.name === 'string' ? row.name : '';
+        const description =
+          typeof row.description === 'string' ? row.description : '';
+        return (
+          name.toLowerCase().includes(q) ||
+          description.toLowerCase().includes(q)
+        );
+      });
+    }
+    return result;
+  }, [rows, rowFilter, searchQuery]);
 
   const handleAssign = async () => {
     setSaving(true);
@@ -78,14 +105,28 @@ export default function AssignEntityDrawer({
       onSave={handleAssign}
       saveDisabled={!hasSelection}
       saveButtonText={saveButtonText}
-      width={960}
+      width="min(1186px, 95vw)"
     >
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <SearchPill
-          value={searchQuery}
-          onChange={setSearchQuery}
-          placeholder="Search…"
-          width="100%"
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '30px' }}>
+        <GridToolbar
+          searchQuery={searchQuery}
+          onSearchChange={setSearchQuery}
+          searchPlaceholder={searchPlaceholder}
+          searchWidth={288}
+          onFilterClick={onFilterClick ? () => onFilterClick() : undefined}
+          hasActiveFilters={hasActiveFilters}
+          activeFilterCount={activeFilterCount}
+          sx={{ px: 0, py: 0, gap: '20px', minHeight: 'auto' }}
+          middleContent={
+            pillTabs && pillTabs.length > 0 ? (
+              <PrimarySegmentedPills
+                tabs={pillTabs}
+                mode="single"
+                activeValue={activePill ?? pillTabs[0]?.value ?? ''}
+                onSingleChange={value => onPillChange?.(value)}
+              />
+            ) : undefined
+          }
         />
         <BaseDataGrid
           rows={filteredRows}
@@ -94,6 +135,7 @@ export default function AssignEntityDrawer({
           getRowId={getRowId}
           checkboxSelection
           disableRowSelectionOnClick
+          disableColumnResize
           onRowSelectionModelChange={setSelected}
           rowSelectionModel={selected}
           disablePaperWrapper

--- a/apps/frontend/src/components/common/AssignEntityDrawer.tsx
+++ b/apps/frontend/src/components/common/AssignEntityDrawer.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { Box } from '@mui/material';
+import { Box, Paper } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
 import {
   GridColDef,
   GridRowModel,
@@ -14,6 +15,7 @@ import {
   PrimarySegmentedPills,
   type ToolbarPillTab,
 } from '@/components/common/GridToolbar';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 
 export interface AssignEntityDrawerProps {
   open: boolean;
@@ -96,6 +98,15 @@ export default function AssignEntityDrawer({
 
   const hasSelection = Array.isArray(selected) && selected.length > 0;
 
+  // Inset the first/last column content to 30px so it lines up with the
+  // toolbar and footer (which already use 30px horizontal padding).
+  const gridSx = {
+    '& .MuiDataGrid-columnHeader:first-of-type, & .MuiDataGrid-cell:first-of-type':
+      { paddingLeft: '30px' },
+    '& .MuiDataGrid-columnHeader:last-of-type, & .MuiDataGrid-cell:last-of-type':
+      { paddingRight: '30px' },
+  } as SxProps<Theme>;
+
   return (
     <BaseDrawer
       open={open}
@@ -107,27 +118,39 @@ export default function AssignEntityDrawer({
       saveButtonText={saveButtonText}
       width="min(1186px, 95vw)"
     >
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '30px' }}>
-        <GridToolbar
-          searchQuery={searchQuery}
-          onSearchChange={setSearchQuery}
-          searchPlaceholder={searchPlaceholder}
-          searchWidth={288}
-          onFilterClick={onFilterClick ? () => onFilterClick() : undefined}
-          hasActiveFilters={hasActiveFilters}
-          activeFilterCount={activeFilterCount}
-          sx={{ px: 0, py: 0, gap: '20px', minHeight: 'auto' }}
-          middleContent={
-            pillTabs && pillTabs.length > 0 ? (
-              <PrimarySegmentedPills
-                tabs={pillTabs}
-                mode="single"
-                activeValue={activePill ?? pillTabs[0]?.value ?? ''}
-                onSingleChange={value => onPillChange?.(value)}
-              />
-            ) : undefined
-          }
-        />
+      <Paper
+        elevation={0}
+        sx={{
+          width: '100%',
+          borderRadius: BORDER_RADIUS.md,
+          border: (theme: Theme) =>
+            `1px solid ${theme.palette.greyscale.border}`,
+          boxShadow: ELEVATION.xs,
+          overflow: 'hidden',
+        }}
+      >
+        <Box sx={{ px: '30px', pt: '30px', pb: '30px' }}>
+          <GridToolbar
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            searchPlaceholder={searchPlaceholder}
+            searchWidth={288}
+            onFilterClick={onFilterClick ? () => onFilterClick() : undefined}
+            hasActiveFilters={hasActiveFilters}
+            activeFilterCount={activeFilterCount}
+            sx={{ px: 0, py: 0, gap: '20px', minHeight: 'auto' }}
+            middleContent={
+              pillTabs && pillTabs.length > 0 ? (
+                <PrimarySegmentedPills
+                  tabs={pillTabs}
+                  mode="single"
+                  activeValue={activePill ?? pillTabs[0]?.value ?? ''}
+                  onSingleChange={value => onPillChange?.(value)}
+                />
+              ) : undefined
+            }
+          />
+        </Box>
         <BaseDataGrid
           rows={filteredRows}
           columns={columns}
@@ -144,8 +167,9 @@ export default function AssignEntityDrawer({
             pagination: { paginationModel: { page: 0, pageSize: 10 } },
           }}
           hideRowsPerPageBelow={0}
+          sx={gridSx}
         />
-      </Box>
+      </Paper>
     </BaseDrawer>
   );
 }

--- a/apps/frontend/src/components/common/AssignEntityDrawer.tsx
+++ b/apps/frontend/src/components/common/AssignEntityDrawer.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { Box } from '@mui/material';
+import {
+  GridColDef,
+  GridRowModel,
+  GridRowSelectionModel,
+} from '@mui/x-data-grid';
+import BaseDrawer from '@/components/common/BaseDrawer';
+import BaseDataGrid from '@/components/common/BaseDataGrid';
+import { SearchPill } from '@/components/common/SearchPill';
+
+export interface AssignEntityDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  rows: GridRowModel[];
+  columns: GridColDef[];
+  loading?: boolean;
+  getRowId: (row: GridRowModel) => string;
+  onAssign: (selectedIds: string[]) => Promise<void>;
+  saveButtonText?: string;
+}
+
+export default function AssignEntityDrawer({
+  open,
+  onClose,
+  title,
+  rows,
+  columns,
+  loading = false,
+  getRowId,
+  onAssign,
+  saveButtonText = 'Assign',
+}: AssignEntityDrawerProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selected, setSelected] = useState<GridRowSelectionModel>([]);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setSearchQuery('');
+      setSelected([]);
+    }
+  }, [open]);
+
+  const filteredRows = useMemo(() => {
+    if (!searchQuery.trim()) return rows;
+    const q = searchQuery.toLowerCase();
+    return rows.filter(row => {
+      const name = typeof row.name === 'string' ? row.name : '';
+      const description =
+        typeof row.description === 'string' ? row.description : '';
+      return (
+        name.toLowerCase().includes(q) || description.toLowerCase().includes(q)
+      );
+    });
+  }, [rows, searchQuery]);
+
+  const handleAssign = async () => {
+    setSaving(true);
+    try {
+      await onAssign(selected as string[]);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const hasSelection = Array.isArray(selected) && selected.length > 0;
+
+  return (
+    <BaseDrawer
+      open={open}
+      onClose={onClose}
+      title={title}
+      loading={saving}
+      onSave={handleAssign}
+      saveDisabled={!hasSelection}
+      saveButtonText={saveButtonText}
+      width={960}
+    >
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <SearchPill
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder="Search…"
+          width="100%"
+        />
+        <BaseDataGrid
+          rows={filteredRows}
+          columns={columns}
+          loading={loading}
+          getRowId={getRowId}
+          checkboxSelection
+          disableRowSelectionOnClick
+          onRowSelectionModelChange={setSelected}
+          rowSelectionModel={selected}
+          disablePaperWrapper
+          pageSizeOptions={[10, 25]}
+          hideRowsPerPageBelow={0}
+        />
+      </Box>
+    </BaseDrawer>
+  );
+}

--- a/apps/frontend/src/components/common/AssignEntityDrawer.tsx
+++ b/apps/frontend/src/components/common/AssignEntityDrawer.tsx
@@ -97,7 +97,10 @@ export default function AssignEntityDrawer({
           onRowSelectionModelChange={setSelected}
           rowSelectionModel={selected}
           disablePaperWrapper
-          pageSizeOptions={[10, 25]}
+          pageSizeOptions={[10, 25, 50]}
+          initialState={{
+            pagination: { paginationModel: { page: 0, pageSize: 10 } },
+          }}
           hideRowsPerPageBelow={0}
         />
       </Box>

--- a/apps/frontend/src/components/common/AssignEntityDrawer.tsx
+++ b/apps/frontend/src/components/common/AssignEntityDrawer.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { Box, Paper } from '@mui/material';
+import { Box, Button, Paper } from '@mui/material';
+import NorthEastIcon from '@mui/icons-material/NorthEast';
 import type { SxProps, Theme } from '@mui/material/styles';
 import {
   GridColDef,
@@ -38,6 +39,9 @@ export interface AssignEntityDrawerProps {
   pillTabs?: ToolbarPillTab[];
   activePill?: string;
   onPillChange?: (value: string) => void;
+  // Jump-off action (top-right) to create a brand-new entity elsewhere
+  onCreateNew?: () => void;
+  createNewLabel?: string;
 }
 
 export default function AssignEntityDrawer({
@@ -58,6 +62,8 @@ export default function AssignEntityDrawer({
   pillTabs,
   activePill,
   onPillChange,
+  onCreateNew,
+  createNewLabel = 'Create new',
 }: AssignEntityDrawerProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [selected, setSelected] = useState<GridRowSelectionModel>([]);
@@ -147,6 +153,33 @@ export default function AssignEntityDrawer({
                   activeValue={activePill ?? pillTabs[0]?.value ?? ''}
                   onSingleChange={value => onPillChange?.(value)}
                 />
+              ) : undefined
+            }
+            rightContent={
+              onCreateNew ? (
+                <Button
+                  variant="text"
+                  startIcon={<NorthEastIcon />}
+                  onClick={onCreateNew}
+                  sx={{
+                    fontWeight: 400,
+                    fontSize: 14,
+                    lineHeight: '22px',
+                    color: 'primary.main',
+                    px: '16px',
+                    py: '8px',
+                    whiteSpace: 'nowrap',
+                    '& .MuiButton-startIcon': {
+                      marginRight: '4px',
+                      marginLeft: 0,
+                    },
+                    '& .MuiButton-startIcon > *:nth-of-type(1)': {
+                      fontSize: 20,
+                    },
+                  }}
+                >
+                  {createNewLabel}
+                </Button>
               ) : undefined
             }
           />

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -170,6 +170,12 @@ interface BaseDataGridProps {
   disablePaperWrapper?: boolean;
   /** Hide column resize handles (enabled by default). */
   disableColumnResize?: boolean;
+  /**
+   * Grow the grid to fit all rows (no internal vertical scroll). Default true.
+   * Set false to give the grid a fixed/flex height so its rows scroll
+   * internally and the header + pagination footer stay pinned.
+   */
+  autoHeight?: boolean;
   // Initial state props
   initialState?: GridInitialState;
   // State persistence props
@@ -461,6 +467,7 @@ export default function BaseDataGrid({
   toolbarSlot,
   disablePaperWrapper = false,
   disableColumnResize = false,
+  autoHeight = true,
   initialState,
   persistState = false,
   storageKey,
@@ -1100,7 +1107,7 @@ export default function BaseDataGrid({
               rows={serverSidePagination ? rows : filteredRows}
               columns={columns}
               getRowId={getRowId}
-              autoHeight
+              {...(autoHeight && { autoHeight: true })}
               pagination
               hideFooter={hideFooter}
               paginationMode={serverSidePagination ? 'server' : 'client'}
@@ -1170,7 +1177,7 @@ export default function BaseDataGrid({
                 rows={serverSidePagination ? rows : filteredRows}
                 columns={columns}
                 getRowId={getRowId}
-                autoHeight
+                {...(autoHeight && { autoHeight: true })}
                 pagination
                 hideFooter={hideFooter}
                 paginationMode={serverSidePagination ? 'server' : 'client'}

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -917,168 +917,180 @@ export default function BaseDataGrid({
     _sx,
   ].filter(Boolean) as SxProps<Theme>;
 
+  const hasHeaderContent = !!(
+    title ||
+    (filters && filters.length > 0) ||
+    (actionButtons && actionButtons.length > 0) ||
+    customToolbarContent
+  );
+
   return (
     <>
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'flex-start',
-          alignItems: 'center',
-          mb: 2,
-          gap: 2,
-        }}
-      >
-        {title && (
-          <Typography variant="h6" component="h1">
-            {title}
-          </Typography>
-        )}
+      {hasHeaderContent && (
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'flex-start',
+            alignItems: 'center',
+            mb: 2,
+            gap: 2,
+          }}
+        >
+          {title && (
+            <Typography variant="h6" component="h1">
+              {title}
+            </Typography>
+          )}
 
-        {filters && filters.length > 0 && (
-          <Box sx={{ display: 'flex', gap: 2 }}>
-            {filters.map(filter => (
-              <FormControl
-                key={filter.name}
-                variant="outlined"
-                size="small"
-                sx={{ minWidth: 150 }}
-              >
-                <InputLabel id={`${filter.name}-label`}>
-                  {filter.label}
-                </InputLabel>
-                <Select
-                  labelId={`${filter.name}-label`}
-                  id={filter.name}
-                  value={filterValues[filter.name] || filter.defaultValue}
-                  onChange={handleFilterChange(filter.name)}
-                  label={filter.label}
+          {filters && filters.length > 0 && (
+            <Box sx={{ display: 'flex', gap: 2 }}>
+              {filters.map(filter => (
+                <FormControl
+                  key={filter.name}
+                  variant="outlined"
+                  size="small"
+                  sx={{ minWidth: 150 }}
                 >
-                  {filter.options.map(option => (
-                    <MenuItem key={option.value} value={option.value}>
-                      {option.label}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            ))}
-          </Box>
-        )}
+                  <InputLabel id={`${filter.name}-label`}>
+                    {filter.label}
+                  </InputLabel>
+                  <Select
+                    labelId={`${filter.name}-label`}
+                    id={filter.name}
+                    value={filterValues[filter.name] || filter.defaultValue}
+                    onChange={handleFilterChange(filter.name)}
+                    label={filter.label}
+                  >
+                    {filter.options.map(option => (
+                      <MenuItem key={option.value} value={option.value}>
+                        {option.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              ))}
+            </Box>
+          )}
 
-        {actionButtons && actionButtons.length > 0 && (
-          <Box sx={{ display: 'flex', gap: 1 }}>
-            {actionButtons.map((button, index) => {
-              if (button.splitButton) {
-                const options = button.splitButton.options; // Extract options to satisfy TypeScript
-                return (
-                  <React.Fragment key={button.label}>
-                    <ButtonGroup
+          {actionButtons && actionButtons.length > 0 && (
+            <Box sx={{ display: 'flex', gap: 1 }}>
+              {actionButtons.map((button, index) => {
+                if (button.splitButton) {
+                  const options = button.splitButton.options; // Extract options to satisfy TypeScript
+                  return (
+                    <React.Fragment key={button.label}>
+                      <ButtonGroup
+                        variant={button.variant || 'contained'}
+                        color={button.color || 'primary'}
+                        ref={buttonRefs.current[index]}
+                        aria-label="split button"
+                        disabled={button.disabled}
+                      >
+                        <Button
+                          onClick={button.onClick}
+                          startIcon={button.icon}
+                          disabled={button.disabled}
+                        >
+                          {button.label}
+                        </Button>
+                        <Button
+                          size="small"
+                          aria-controls={
+                            openStates[index] ? 'split-button-menu' : undefined
+                          }
+                          aria-expanded={openStates[index] ? 'true' : undefined}
+                          aria-label="select option"
+                          aria-haspopup="menu"
+                          onClick={() => handleToggle(index)}
+                          disabled={button.disabled}
+                        >
+                          <ArrowDropDownIcon />
+                        </Button>
+                      </ButtonGroup>
+                      <Popper
+                        sx={{
+                          zIndex: 1,
+                        }}
+                        open={openStates[index]}
+                        anchorEl={buttonRefs.current[index].current}
+                        role={undefined}
+                        transition
+                        disablePortal
+                      >
+                        {({ TransitionProps, placement }) => (
+                          <Grow
+                            {...TransitionProps}
+                            style={{
+                              transformOrigin:
+                                placement === 'bottom'
+                                  ? 'center top'
+                                  : 'center bottom',
+                            }}
+                          >
+                            <Paper>
+                              <ClickAwayListener
+                                onClickAway={event => handleClose(event, index)}
+                              >
+                                <MenuList id="split-button-menu" autoFocusItem>
+                                  {options.map(option => (
+                                    <MenuItem
+                                      key={option.label}
+                                      disabled={option.disabled}
+                                      onClick={() =>
+                                        handleMenuItemClick(
+                                          option.onClick,
+                                          index
+                                        )
+                                      }
+                                    >
+                                      {option.label}
+                                    </MenuItem>
+                                  ))}
+                                </MenuList>
+                              </ClickAwayListener>
+                            </Paper>
+                          </Grow>
+                        )}
+                      </Popper>
+                    </React.Fragment>
+                  );
+                }
+
+                return button.href ? (
+                  <Link
+                    key={button.label}
+                    href={button.href}
+                    style={{ textDecoration: 'none' }}
+                  >
+                    <Button
                       variant={button.variant || 'contained'}
                       color={button.color || 'primary'}
-                      ref={buttonRefs.current[index]}
-                      aria-label="split button"
+                      startIcon={button.icon}
+                      data-tour={button.dataTour}
                       disabled={button.disabled}
                     >
-                      <Button
-                        onClick={button.onClick}
-                        startIcon={button.icon}
-                        disabled={button.disabled}
-                      >
-                        {button.label}
-                      </Button>
-                      <Button
-                        size="small"
-                        aria-controls={
-                          openStates[index] ? 'split-button-menu' : undefined
-                        }
-                        aria-expanded={openStates[index] ? 'true' : undefined}
-                        aria-label="select option"
-                        aria-haspopup="menu"
-                        onClick={() => handleToggle(index)}
-                        disabled={button.disabled}
-                      >
-                        <ArrowDropDownIcon />
-                      </Button>
-                    </ButtonGroup>
-                    <Popper
-                      sx={{
-                        zIndex: 1,
-                      }}
-                      open={openStates[index]}
-                      anchorEl={buttonRefs.current[index].current}
-                      role={undefined}
-                      transition
-                      disablePortal
-                    >
-                      {({ TransitionProps, placement }) => (
-                        <Grow
-                          {...TransitionProps}
-                          style={{
-                            transformOrigin:
-                              placement === 'bottom'
-                                ? 'center top'
-                                : 'center bottom',
-                          }}
-                        >
-                          <Paper>
-                            <ClickAwayListener
-                              onClickAway={event => handleClose(event, index)}
-                            >
-                              <MenuList id="split-button-menu" autoFocusItem>
-                                {options.map(option => (
-                                  <MenuItem
-                                    key={option.label}
-                                    disabled={option.disabled}
-                                    onClick={() =>
-                                      handleMenuItemClick(option.onClick, index)
-                                    }
-                                  >
-                                    {option.label}
-                                  </MenuItem>
-                                ))}
-                              </MenuList>
-                            </ClickAwayListener>
-                          </Paper>
-                        </Grow>
-                      )}
-                    </Popper>
-                  </React.Fragment>
-                );
-              }
-
-              return button.href ? (
-                <Link
-                  key={button.label}
-                  href={button.href}
-                  style={{ textDecoration: 'none' }}
-                >
+                      {button.label}
+                    </Button>
+                  </Link>
+                ) : (
                   <Button
+                    key={button.label}
                     variant={button.variant || 'contained'}
                     color={button.color || 'primary'}
+                    onClick={button.onClick}
                     startIcon={button.icon}
                     data-tour={button.dataTour}
                     disabled={button.disabled}
                   >
                     {button.label}
                   </Button>
-                </Link>
-              ) : (
-                <Button
-                  key={button.label}
-                  variant={button.variant || 'contained'}
-                  color={button.color || 'primary'}
-                  onClick={button.onClick}
-                  startIcon={button.icon}
-                  data-tour={button.dataTour}
-                  disabled={button.disabled}
-                >
-                  {button.label}
-                </Button>
-              );
-            })}
-          </Box>
-        )}
-        {customToolbarContent}
-      </Box>
+                );
+              })}
+            </Box>
+          )}
+          {customToolbarContent}
+        </Box>
+      )}
 
       {disablePaperWrapper ? (
         <HideRowsPerPageBelowContext.Provider value={hideRowsPerPageBelow}>

--- a/apps/frontend/src/components/common/BaseDrawer.tsx
+++ b/apps/frontend/src/components/common/BaseDrawer.tsx
@@ -123,6 +123,7 @@ export default function BaseDrawer({
       <Box
         sx={{
           flex: 1,
+          minHeight: 0,
           overflowY: 'auto',
           display: 'flex',
           flexDirection: 'column',

--- a/apps/frontend/src/components/common/FilterButton.tsx
+++ b/apps/frontend/src/components/common/FilterButton.tsx
@@ -46,6 +46,9 @@ export function FilterButton({
         height: 36,
         flexShrink: 0,
         '&:hover': { bgcolor: 'primary.dark' },
+        // The MuiDrawer theme override force-colors `.MuiSvgIcon-root` dark in
+        // light mode; keep this button's icon on its (white) contrast text.
+        '& .MuiSvgIcon-root': { color: 'primary.contrastText' },
         ...sx,
       }}
       {...props}

--- a/apps/frontend/src/components/common/LinkedEntitiesFilterDrawer.tsx
+++ b/apps/frontend/src/components/common/LinkedEntitiesFilterDrawer.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import * as React from 'react';
+import { Box } from '@mui/material';
+import {
+  FilterDrawerShell,
+  FilterSection,
+  filterChipSx,
+  useFilterDrawerDraft,
+} from '@/components/common/FilterDrawer';
+
+export interface LinkedFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface LinkedFilterSectionConfig {
+  key: string;
+  title: string;
+  options: LinkedFilterOption[];
+}
+
+export type LinkedFilterValues = Record<string, string[]>;
+
+export function emptyLinkedFilters(
+  sections: LinkedFilterSectionConfig[]
+): LinkedFilterValues {
+  return sections.reduce<LinkedFilterValues>((acc, section) => {
+    acc[section.key] = [];
+    return acc;
+  }, {});
+}
+
+export function hasActiveLinkedFilters(filters: LinkedFilterValues): boolean {
+  return Object.values(filters).some(values => values.length > 0);
+}
+
+export function countActiveLinkedFilters(filters: LinkedFilterValues): number {
+  return Object.values(filters).reduce(
+    (total, values) => total + values.length,
+    0
+  );
+}
+
+interface LinkedEntitiesFilterDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  sections: LinkedFilterSectionConfig[];
+  filters: LinkedFilterValues;
+  onApply: (filters: LinkedFilterValues) => void;
+}
+
+/**
+ * Client-side filter drawer for linked-entity grids. Renders one chip section
+ * per provided config and returns the selected values map on apply.
+ */
+export default function LinkedEntitiesFilterDrawer({
+  open,
+  onClose,
+  sections,
+  filters,
+  onApply,
+}: LinkedEntitiesFilterDrawerProps) {
+  const empty = React.useMemo(() => emptyLinkedFilters(sections), [sections]);
+
+  const { draft, setDraft, handleReset, handleApply } = useFilterDrawerDraft(
+    open,
+    filters,
+    empty,
+    onApply,
+    onClose
+  );
+
+  const toggle = (key: string, value: string) => {
+    setDraft(prev => {
+      const arr = prev[key] ?? [];
+      return {
+        ...prev,
+        [key]: arr.includes(value)
+          ? arr.filter(v => v !== value)
+          : [...arr, value],
+      };
+    });
+  };
+
+  return (
+    <FilterDrawerShell
+      open={open}
+      onClose={onClose}
+      onReset={handleReset}
+      onApply={handleApply}
+    >
+      {sections
+        .filter(section => section.options.length > 0)
+        .map(section => (
+          <FilterSection key={section.key} title={section.title}>
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+              {section.options.map(option => (
+                <Box
+                  key={option.value}
+                  component="button"
+                  onClick={() => toggle(section.key, option.value)}
+                  sx={filterChipSx(
+                    (draft[section.key] ?? []).includes(option.value)
+                  )}
+                >
+                  {option.label}
+                </Box>
+              ))}
+            </Box>
+          </FilterSection>
+        ))}
+    </FilterDrawerShell>
+  );
+}

--- a/apps/frontend/src/components/common/LinkedEntitiesGrid.tsx
+++ b/apps/frontend/src/components/common/LinkedEntitiesGrid.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import React, { createContext, useContext, useMemo, useState } from 'react';
+import { Box, Button, Paper, Typography } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import {
+  GridColDef,
+  GridRowModel,
+  GridRowParams,
+  GridToolbarColumnsButton,
+  GridToolbarDensitySelector,
+  GridToolbarExport,
+} from '@mui/x-data-grid';
+import type { SxProps, Theme } from '@mui/material/styles';
+import BaseDataGrid from '@/components/common/BaseDataGrid';
+import { GridToolbar } from '@/components/common/GridToolbar';
+import { rowActionsHoverSx } from '@/components/common/createRowActionsColumn';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
+
+// --- Context for sharing search state with the toolbar slot ---
+
+interface LinkedEntitiesContextValue {
+  searchQuery: string;
+  setSearchQuery: (value: string) => void;
+}
+
+const LinkedEntitiesContext = createContext<LinkedEntitiesContextValue>({
+  searchQuery: '',
+  setSearchQuery: () => {},
+});
+
+function LinkedEntitiesToolbar() {
+  const { searchQuery, setSearchQuery } = useContext(LinkedEntitiesContext);
+  return (
+    <GridToolbar
+      searchQuery={searchQuery}
+      onSearchChange={setSearchQuery}
+      searchPlaceholder="Search…"
+      rightContent={
+        <>
+          <GridToolbarColumnsButton />
+          <GridToolbarDensitySelector />
+          <GridToolbarExport />
+        </>
+      }
+    />
+  );
+}
+
+// --- Component props ---
+
+export interface LinkedEntitiesGridProps {
+  title: string;
+  rows: GridRowModel[];
+  columns: GridColDef[];
+  loading?: boolean;
+  getRowId: (row: GridRowModel) => string;
+  onRowClick?: (params: GridRowParams) => void;
+  onAssignClick?: () => void;
+  pageSizeOptions?: number[];
+  sx?: SxProps<Theme>;
+  emptyState?: React.ReactNode;
+}
+
+export default function LinkedEntitiesGrid({
+  title,
+  rows,
+  columns,
+  loading = false,
+  getRowId,
+  onRowClick,
+  onAssignClick,
+  pageSizeOptions = [5, 10, 25],
+  sx,
+  emptyState,
+}: LinkedEntitiesGridProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filteredRows = useMemo(() => {
+    if (!searchQuery.trim()) return rows;
+    const q = searchQuery.toLowerCase();
+    return rows.filter(row => {
+      const name = typeof row.name === 'string' ? row.name : '';
+      const description =
+        typeof row.description === 'string' ? row.description : '';
+      return (
+        name.toLowerCase().includes(q) || description.toLowerCase().includes(q)
+      );
+    });
+  }, [rows, searchQuery]);
+
+  const showEmptyState = !loading && rows.length === 0 && !!emptyState;
+
+  return (
+    <LinkedEntitiesContext.Provider value={{ searchQuery, setSearchQuery }}>
+      <Paper
+        elevation={0}
+        sx={[
+          {
+            width: '100%',
+            borderRadius: BORDER_RADIUS.md,
+            border: (theme: Theme) =>
+              `1px solid ${theme.palette.greyscale.border}`,
+            boxShadow: ELEVATION.xs,
+            overflow: 'hidden',
+          },
+          ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+        ]}
+      >
+        {/* Card header */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            px: 2,
+            pt: 2.5,
+            pb: showEmptyState ? 2.5 : 0,
+          }}
+        >
+          <Typography
+            sx={{
+              fontSize: 20,
+              fontWeight: 600,
+              lineHeight: '24px',
+              color: 'primary.main',
+            }}
+          >
+            {title} ({rows.length})
+          </Typography>
+          {onAssignClick && (
+            <Button
+              variant="outlined"
+              startIcon={<AddIcon />}
+              onClick={onAssignClick}
+              sx={{
+                borderWidth: 2,
+                fontWeight: 700,
+                fontSize: 14,
+                borderRadius: BORDER_RADIUS.sm,
+                px: '16px',
+                py: '8px',
+                '&:hover': { borderWidth: 2 },
+              }}
+            >
+              Assign
+            </Button>
+          )}
+        </Box>
+
+        {/* Empty state or grid */}
+        {showEmptyState ? (
+          <Box sx={{ px: 2, pb: 2.5 }}>{emptyState}</Box>
+        ) : (
+          <BaseDataGrid
+            rows={filteredRows}
+            columns={columns}
+            loading={loading}
+            getRowId={getRowId}
+            onRowClick={onRowClick}
+            toolbarSlot={LinkedEntitiesToolbar}
+            disablePaperWrapper
+            pageSizeOptions={pageSizeOptions}
+            disableRowSelectionOnClick
+            sx={rowActionsHoverSx}
+          />
+        )}
+      </Paper>
+    </LinkedEntitiesContext.Provider>
+  );
+}

--- a/apps/frontend/src/components/common/LinkedEntitiesGrid.tsx
+++ b/apps/frontend/src/components/common/LinkedEntitiesGrid.tsx
@@ -220,9 +220,12 @@ export default function LinkedEntitiesGrid({
                 borderWidth: 2,
                 fontWeight: 700,
                 fontSize: 14,
+                lineHeight: '22px',
                 borderRadius: BORDER_RADIUS.sm,
                 px: '16px',
                 py: '8px',
+                '& .MuiButton-startIcon': { marginRight: '4px', marginLeft: 0 },
+                '& .MuiButton-startIcon > *:nth-of-type(1)': { fontSize: 20 },
                 '&:hover': { borderWidth: 2 },
               }}
             >

--- a/apps/frontend/src/components/common/LinkedEntitiesGrid.tsx
+++ b/apps/frontend/src/components/common/LinkedEntitiesGrid.tsx
@@ -62,6 +62,7 @@ function LinkedEntitiesToolbar() {
       onFilterClick={onFilterClick ? () => onFilterClick() : undefined}
       hasActiveFilters={hasActiveFilters}
       activeFilterCount={activeFilterCount}
+      sx={{ px: '30px', pt: 0, pb: '30px', minHeight: 'auto' }}
       middleContent={
         pillTabs && pillTabs.length > 0 ? (
           <PrimarySegmentedPills
@@ -151,6 +152,16 @@ export default function LinkedEntitiesGrid({
   // Empty state is based on the total linked rows, not the filtered subset.
   const showEmptyState = !loading && rows.length === 0 && !!emptyState;
 
+  // Inset the first/last column content to 30px so it lines up with the
+  // header, toolbar and footer (which already use 30px horizontal padding).
+  const gridSx = {
+    ...(rowActionsHoverSx as Record<string, unknown>),
+    '& .MuiDataGrid-columnHeader:first-of-type, & .MuiDataGrid-cell:first-of-type':
+      { paddingLeft: '30px' },
+    '& .MuiDataGrid-columnHeader:last-of-type, & .MuiDataGrid-cell:last-of-type':
+      { paddingRight: '30px' },
+  } as SxProps<Theme>;
+
   const contextValue: LinkedEntitiesContextValue = {
     searchQuery,
     setSearchQuery,
@@ -185,9 +196,9 @@ export default function LinkedEntitiesGrid({
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'space-between',
-            px: 2,
-            pt: 2.5,
-            pb: showEmptyState ? 2.5 : 0,
+            px: '30px',
+            pt: '30px',
+            pb: '30px',
           }}
         >
           <Typography
@@ -222,7 +233,7 @@ export default function LinkedEntitiesGrid({
 
         {/* Empty state or grid */}
         {showEmptyState ? (
-          <Box sx={{ px: 2, pb: 2.5 }}>{emptyState}</Box>
+          <Box sx={{ px: '30px', pb: '30px' }}>{emptyState}</Box>
         ) : (
           <BaseDataGrid
             rows={displayedRows}
@@ -245,7 +256,7 @@ export default function LinkedEntitiesGrid({
             }}
             disableRowSelectionOnClick
             hideRowsPerPageBelow={0}
-            sx={rowActionsHoverSx}
+            sx={gridSx}
           />
         )}
       </Paper>

--- a/apps/frontend/src/components/common/LinkedEntitiesGrid.tsx
+++ b/apps/frontend/src/components/common/LinkedEntitiesGrid.tsx
@@ -13,29 +13,65 @@ import {
 } from '@mui/x-data-grid';
 import type { SxProps, Theme } from '@mui/material/styles';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
-import { GridToolbar } from '@/components/common/GridToolbar';
+import {
+  GridToolbar,
+  PrimarySegmentedPills,
+  type ToolbarPillTab,
+} from '@/components/common/GridToolbar';
 import { rowActionsHoverSx } from '@/components/common/createRowActionsColumn';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 
-// --- Context for sharing search state with the toolbar slot ---
+// --- Context for sharing toolbar state with the toolbar slot ---
 
 interface LinkedEntitiesContextValue {
   searchQuery: string;
   setSearchQuery: (value: string) => void;
+  searchPlaceholder: string;
+  onFilterClick?: () => void;
+  hasActiveFilters?: boolean;
+  activeFilterCount?: number;
+  pillTabs?: ToolbarPillTab[];
+  activePill?: string;
+  onPillChange?: (value: string) => void;
 }
 
 const LinkedEntitiesContext = createContext<LinkedEntitiesContextValue>({
   searchQuery: '',
   setSearchQuery: () => {},
+  searchPlaceholder: 'Search…',
 });
 
 function LinkedEntitiesToolbar() {
-  const { searchQuery, setSearchQuery } = useContext(LinkedEntitiesContext);
+  const {
+    searchQuery,
+    setSearchQuery,
+    searchPlaceholder,
+    onFilterClick,
+    hasActiveFilters,
+    activeFilterCount,
+    pillTabs,
+    activePill,
+    onPillChange,
+  } = useContext(LinkedEntitiesContext);
+
   return (
     <GridToolbar
       searchQuery={searchQuery}
       onSearchChange={setSearchQuery}
-      searchPlaceholder="Search…"
+      searchPlaceholder={searchPlaceholder}
+      onFilterClick={onFilterClick ? () => onFilterClick() : undefined}
+      hasActiveFilters={hasActiveFilters}
+      activeFilterCount={activeFilterCount}
+      middleContent={
+        pillTabs && pillTabs.length > 0 ? (
+          <PrimarySegmentedPills
+            tabs={pillTabs}
+            mode="single"
+            activeValue={activePill ?? pillTabs[0]?.value ?? ''}
+            onSingleChange={value => onPillChange?.(value)}
+          />
+        ) : undefined
+      }
       rightContent={
         <>
           <GridToolbarColumnsButton />
@@ -60,6 +96,17 @@ export interface LinkedEntitiesGridProps {
   pageSizeOptions?: number[];
   sx?: SxProps<Theme>;
   emptyState?: React.ReactNode;
+  searchPlaceholder?: string;
+  /** Parent-supplied predicate for pill/drawer filtering (search is handled internally). */
+  rowFilter?: (row: GridRowModel) => boolean;
+  // Filter (tune) button
+  onFilterClick?: () => void;
+  hasActiveFilters?: boolean;
+  activeFilterCount?: number;
+  // Centered segmented pill tabs
+  pillTabs?: ToolbarPillTab[];
+  activePill?: string;
+  onPillChange?: (value: string) => void;
 }
 
 export default function LinkedEntitiesGrid({
@@ -73,26 +120,51 @@ export default function LinkedEntitiesGrid({
   pageSizeOptions = [5, 10, 25],
   sx,
   emptyState,
+  searchPlaceholder = 'Search…',
+  rowFilter,
+  onFilterClick,
+  hasActiveFilters,
+  activeFilterCount,
+  pillTabs,
+  activePill,
+  onPillChange,
 }: LinkedEntitiesGridProps) {
   const [searchQuery, setSearchQuery] = useState('');
 
-  const filteredRows = useMemo(() => {
-    if (!searchQuery.trim()) return rows;
-    const q = searchQuery.toLowerCase();
-    return rows.filter(row => {
-      const name = typeof row.name === 'string' ? row.name : '';
-      const description =
-        typeof row.description === 'string' ? row.description : '';
-      return (
-        name.toLowerCase().includes(q) || description.toLowerCase().includes(q)
-      );
-    });
-  }, [rows, searchQuery]);
+  const displayedRows = useMemo(() => {
+    let result = rowFilter ? rows.filter(rowFilter) : rows;
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      result = result.filter(row => {
+        const name = typeof row.name === 'string' ? row.name : '';
+        const description =
+          typeof row.description === 'string' ? row.description : '';
+        return (
+          name.toLowerCase().includes(q) ||
+          description.toLowerCase().includes(q)
+        );
+      });
+    }
+    return result;
+  }, [rows, rowFilter, searchQuery]);
 
+  // Empty state is based on the total linked rows, not the filtered subset.
   const showEmptyState = !loading && rows.length === 0 && !!emptyState;
 
+  const contextValue: LinkedEntitiesContextValue = {
+    searchQuery,
+    setSearchQuery,
+    searchPlaceholder,
+    onFilterClick,
+    hasActiveFilters,
+    activeFilterCount,
+    pillTabs,
+    activePill,
+    onPillChange,
+  };
+
   return (
-    <LinkedEntitiesContext.Provider value={{ searchQuery, setSearchQuery }}>
+    <LinkedEntitiesContext.Provider value={contextValue}>
       <Paper
         elevation={0}
         sx={[
@@ -153,7 +225,7 @@ export default function LinkedEntitiesGrid({
           <Box sx={{ px: 2, pb: 2.5 }}>{emptyState}</Box>
         ) : (
           <BaseDataGrid
-            rows={filteredRows}
+            rows={displayedRows}
             columns={columns}
             loading={loading}
             getRowId={getRowId}
@@ -161,7 +233,18 @@ export default function LinkedEntitiesGrid({
             toolbarSlot={LinkedEntitiesToolbar}
             disablePaperWrapper
             pageSizeOptions={pageSizeOptions}
+            initialState={{
+              pagination: {
+                paginationModel: {
+                  page: 0,
+                  pageSize: pageSizeOptions.includes(10)
+                    ? 10
+                    : (pageSizeOptions[0] ?? 10),
+                },
+              },
+            }}
             disableRowSelectionOnClick
+            hideRowsPerPageBelow={0}
             sx={rowActionsHoverSx}
           />
         )}

--- a/apps/frontend/src/components/common/SearchPill.tsx
+++ b/apps/frontend/src/components/common/SearchPill.tsx
@@ -75,7 +75,9 @@ export function SearchPill({
           flexShrink: 0,
           cursor: 'pointer',
           '&:hover': { bgcolor: 'primary.dark' },
-          '& svg': { fontSize: 18 },
+          // The MuiDrawer theme override force-colors `.MuiSvgIcon-root` dark in
+          // light mode; keep this icon on its (white) contrast text.
+          '& .MuiSvgIcon-root': { fontSize: 18, color: 'primary.contrastText' },
         }}
       >
         <SearchIcon fontSize="small" />


### PR DESCRIPTION
## Purpose

The linked-entities grids (Linked Behaviors on the metric detail page, Linked Metrics on the behavior detail page) did not match the Figma design and behaved inconsistently with the `/tests` and `/test-sets` overview pages. This PR brings them in line with the design system and makes the assign/unassign flows fully functional.

## What Changed

- **Redesigned linked grids** into the card-style layout used on the overview pages, via a new shared `LinkedEntitiesGrid` component (header, count, Assign button, search, columns/density/export, filter button, and segmented pill tabs).
- **New `AssignEntityDrawer`** for assigning metrics/behaviors: wider responsive drawer, custom toolbar (narrower search, filter button, quick-filter pills), a "Create new" jump-off action, a card frame, and internally scrolling grid (header + pagination stay pinned).
- **New `LinkedEntitiesFilterDrawer`** for client-side filtering (Backend / Score Type / Status for metrics; Status for behaviors).
- **`BaseDataGrid`**: added an `autoHeight` prop to allow internal grid scrolling, and made the header render conditionally to avoid stray spacing.
- **Fixes**: white filter/search icons inside drawers, capped assign fetch at the backend's `limit <= 100`, 30px spacing to match Figma, tightened Assign button sizing.
- **Reliable unassign**: surfaced success/error notifications and used a string-safe id comparison so rows are removed on success instead of silently failing.

## Testing

- Lint passes on the changed files; pre-commit hooks (formatting, lint, secret scan) pass.
- Manual: verify both detail pages (empty + populated), assign drawer (search/filter/pills/create-new/scroll), and unassign (success toast removes row, error toast surfaces failures).

## Additional Context

Implements the Figma designs for the linked-entities grids and assign drawer.