### PR TITLE
Refactor environment checks to use ApplicationSettings properties

### DIFF
--- a/apps/backend/src/rhesis/backend/app/config/settings.py
+++ b/apps/backend/src/rhesis/backend/app/config/settings.py
@@ -115,6 +115,10 @@ class ApplicationSettings(BaseSettings):
         return not self.is_production
 
     @property
+    def is_local(self) -> bool:
+        return self.backend_env.lower() == "local"
+
+    @property
     def is_google_cloud(self) -> bool:
         return bool(self.cloud_run_service or self.cloud_run_revision)
 

--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -209,7 +209,7 @@ def is_running_locally() -> bool:
 
     # Signal 3: BACKEND_ENV explicitly set to local
     settings = get_application_settings()
-    if settings.backend_env == "local":
+    if settings.is_local:
         return True
 
     return False

--- a/apps/backend/src/rhesis/backend/app/utils/git_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/git_utils.py
@@ -48,7 +48,7 @@ def should_show_git_info() -> bool:
     settings = get_application_settings()
 
     # Don't show git info in production
-    return settings.backend_env != "production"
+    return settings.is_development
 
 
 def get_version_info() -> dict:

--- a/ee/backend/src/rhesis/backend/ee/__init__.py
+++ b/ee/backend/src/rhesis/backend/ee/__init__.py
@@ -92,9 +92,7 @@ def bootstrap(app: "FastAPI") -> None:
     # forensic capability; refuse to bootstrap rather than ship an
     # un-correlatable audit stream.
     settings = get_application_settings()
-    dev_environments = ("local", "development", "staging")
-    is_dev = settings.backend_env in dev_environments
-    if not is_dev:
+    if not settings.is_development:
         if not os.getenv("AUDIT_HASH_KEY"):
             raise RuntimeError(
                 "AUDIT_HASH_KEY must be set in non-dev environments; "

--- a/ee/backend/src/rhesis/backend/ee/api_clients/audit.py
+++ b/ee/backend/src/rhesis/backend/ee/api_clients/audit.py
@@ -71,19 +71,6 @@ class TokenExchangeEvent(str, Enum):
 # ---------------------------------------------------------------------------
 
 
-def _is_dev_environment() -> bool:
-    """Mirror :func:`rhesis.backend.ee.sso.http_client.is_dev_environment`.
-
-    Duplicated here rather than imported so this audit module has zero
-    runtime dependency on the SSO subpackage; otherwise importing
-    ``audit`` would transitively pull in ``httpx`` even in test setups
-    that do not exercise SSO.
-    """
-    settings = get_application_settings()
-    dev_environments = ("local", "development", "staging")
-    return settings.backend_env in dev_environments
-
-
 def _get_audit_hash_key() -> Optional[bytes]:
     """Return the configured AUDIT_HASH_KEY as bytes, or ``None``.
 
@@ -94,7 +81,7 @@ def _get_audit_hash_key() -> Optional[bytes]:
     """
     raw = os.getenv("AUDIT_HASH_KEY")
     if not raw:
-        if not _is_dev_environment():
+        if not get_application_settings().is_development:
             # Should never reach here in production because EE bootstrap
             # asserts the key is set before registering API_CLIENTS.
             # Logged once so operators see it if the assertion is

--- a/ee/backend/src/rhesis/backend/ee/sso/http_client.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/http_client.py
@@ -21,17 +21,7 @@ from rhesis.backend.app.config.settings import get_application_settings
 
 logger = logging.getLogger(__name__)
 
-_DEV_ENVIRONMENTS = ("local", "development", "staging")
 _LOCALHOST_NAMES = {"localhost", "127.0.0.1", "::1"}
-
-
-def is_dev_environment() -> bool:
-    """True when BACKEND_ENV is local, development, or staging.
-
-    Used by SSO modules to relax localhost/HTTPS restrictions that are only
-    appropriate for production deployments.
-    """
-    return get_application_settings().backend_env in _DEV_ENVIRONMENTS
 
 _BLOCKED_NETWORKS = [
     # RFC 1918 private address space -- VPCs, Kubernetes pods, Docker networks,
@@ -107,7 +97,8 @@ def _resolve_and_validate(hostname: str) -> List[Tuple]:
         raise SSRFError(f"Blocked hostname: {hostname}")
 
     skip_blocklist = (
-        is_dev_environment() and hostname.lower() in _LOCALHOST_NAMES
+        get_application_settings().is_development
+        and hostname.lower() in _LOCALHOST_NAMES
     )
 
     try:
@@ -266,7 +257,10 @@ class SSOHttpClient:
         addr_infos = _resolve_and_validate(hostname)
 
         is_https = parsed.scheme == "https"
-        is_localhost_dev = is_dev_environment() and hostname.lower() in _LOCALHOST_NAMES
+        is_localhost_dev = (
+            get_application_settings().is_development
+            and hostname.lower() in _LOCALHOST_NAMES
+        )
 
         if is_https:
             # Keep hostname URL intact so httpx presents the correct SNI and

--- a/ee/backend/src/rhesis/backend/ee/sso/router.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/router.py
@@ -25,7 +25,11 @@ from rhesis.backend.app.auth.session_invalidation import clear_user_logout
 from rhesis.backend.app.auth.session_utils import regenerate_session
 from rhesis.backend.app.auth.token_utils import create_session_token
 from rhesis.backend.app.auth.url_utils import build_redirect_url
-from rhesis.backend.app.config.settings import get_frontend_settings, get_rhesis_settings
+from rhesis.backend.app.config.settings import (
+    get_application_settings,
+    get_frontend_settings,
+    get_rhesis_settings,
+)
 from rhesis.backend.app.dependencies import get_db_session
 from rhesis.backend.app.features import FeatureName, FeatureRegistry
 from rhesis.backend.app.models.organization import Organization
@@ -33,7 +37,7 @@ from rhesis.backend.app.schemas.organization import SLUG_RE as _SLUG_RE
 from rhesis.backend.app.utils.rate_limit import limiter
 from rhesis.backend.ee.sso.audit import SSOAuditEvent, audit_log
 from rhesis.backend.ee.sso.encryption import sso_decrypt, sso_encrypt
-from rhesis.backend.ee.sso.http_client import SSOHttpClient, SSRFError, is_dev_environment
+from rhesis.backend.ee.sso.http_client import SSOHttpClient, SSRFError
 from rhesis.backend.ee.sso.oidc import (
     OIDCProvider,
     verify_signed_state,
@@ -84,7 +88,7 @@ def _get_sso_config(organization: Organization) -> Optional[SSOConfig]:
             try:
                 config_data["client_secret"] = sso_decrypt(config_data["client_secret"])
             except Exception:
-                if is_dev_environment():
+                if get_application_settings().is_development:
                     logger.warning(
                         "SSO client_secret decryption failed for org %s; "
                         "allowing plaintext fallback in local/test",

--- a/ee/backend/src/rhesis/backend/ee/sso/schemas.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/schemas.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from pydantic import BaseModel, SecretStr, field_validator
 
-from rhesis.backend.ee.sso.http_client import is_dev_environment
+from rhesis.backend.app.config.settings import get_application_settings
 
 _BLOCKED_NETWORKS = [
     ipaddress.ip_network("10.0.0.0/8"),
@@ -42,7 +42,7 @@ class SSOConfig(BaseModel):
     def issuer_must_be_https_and_not_internal(cls, v: str) -> str:
         """Validate issuer URL: HTTPS required, no internal/private destinations."""
         if not v.startswith("https://"):
-            if not (is_dev_environment() and "localhost" in v):
+            if not (get_application_settings().is_development and "localhost" in v):
                 raise ValueError("issuer_url must use HTTPS")
 
         parsed = urlparse(v)
@@ -64,7 +64,7 @@ class SSOConfig(BaseModel):
             # hostname is not an IP literal -- DNS resolution
             # is validated at connect time by SSOHttpClient
 
-        if not is_dev_environment():
+        if not get_application_settings().is_development:
             port = parsed.port
             if port is not None and port != 443:
                 raise ValueError("issuer_url must use port 443 in production")

--- a/tests/backend/routes/test_auth.py
+++ b/tests/backend/routes/test_auth.py
@@ -38,7 +38,12 @@ def _mock_rhesis_settings(base_url: str):
 
 
 def _mock_application_settings(backend_env: str = "development"):
-    return lambda: Mock(backend_env=backend_env)
+    env = backend_env.lower()
+    settings = Mock(backend_env=env)
+    settings.is_local = env == "local"
+    settings.is_development = env != "production"
+    settings.is_production = env == "production"
+    return lambda: settings
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Add `is_local` on `ApplicationSettings` and use it in auth local-detection instead of comparing `backend_env` directly
- Replace ad-hoc dev-environment tuples (`local`, `development`, `staging`) and `_is_dev_environment()` / `is_dev_environment()` helpers with `settings.is_development` across community backend, EE bootstrap, audit client, and SSO
- Use `is_development` for git version info visibility instead of `backend_env != "production"`

## Test plan
- [ ] Confirm `BACKEND_ENV=local` still enables local auth flows (`is_running_locally`)
- [ ] Verify git/version metadata is hidden when `BACKEND_ENV=production`
- [ ] EE bootstrap still requires `AUDIT_HASH_KEY` in production
- [ ] SSO issuer validation still allows localhost HTTP in dev and enforces HTTPS/port 443 in production
- [ ] Run backend tests: `cd apps/backend && uv run pytest ../../tests/backend/ -v` (if SSO/audit covered)