### PR TITLE
Disable RLS during alembic migrations

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/env.py
+++ b/apps/backend/src/rhesis/backend/alembic/env.py
@@ -2,6 +2,7 @@ from logging.config import fileConfig
 
 from alembic import context
 from dotenv import load_dotenv
+import sqlalchemy as sa
 from sqlalchemy import create_engine
 
 from rhesis.backend.app.config.settings import get_database_settings
@@ -95,6 +96,8 @@ def run_migrations_online():
         )
 
         with context.begin_transaction():
+            # Disable RLS for migrations — admin credentials already grant full access.
+            connection.execute(sa.text("SET LOCAL row_security = off"))
             context.run_migrations()
 
 


### PR DESCRIPTION
## Purpose
Alembic migrations crash on any database where RLS was enabled by https://github.com/rhesis-ai/rhesis/pull/1849 because the migration connection never sets `app.current_organization` — the session variable RLS policies depend on.

The error:

```
psycopg2.errors.UndefinedObject: unrecognized configuration parameter "app.current_organization"
```

## What Changed
Added `SET LOCAL row_security = off` at the start of the migration transaction in `env.py`. `SET LOCAL` scopes the change to the migration transaction only — no other connections are affected.

This is safe: whoever runs migrations already holds admin credentials with full database access; RLS provides no additional protection in that context.

## Testing
Deploy to an environment with RLS enabled and run `alembic upgrade head`.
