### PR TITLE
Use mirror.gcr.io for uv in Docker builds

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -12,7 +12,7 @@
 # base-build: shared Python builder + Rust + uv + monorepo libs
 # =============================================================================
 FROM mirror.gcr.io/library/python:3.12.8-slim AS base-build
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=mirror.gcr.io/astral/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
@@ -97,7 +97,7 @@ COPY apps/backend/src ./src
 # base-runtime: shared slim runtime + uv + rhesis-user + full backend payload
 # =============================================================================
 FROM mirror.gcr.io/library/python:3.12.8-slim AS base-runtime
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=mirror.gcr.io/astral/uv:latest /uv /uvx /bin/
 
 WORKDIR /app/apps/backend
 
@@ -137,7 +137,7 @@ EXPOSE 8080
 # migrate: core-only venv + Alembic (Cloud Run migration job)
 # =============================================================================
 FROM mirror.gcr.io/library/python:3.12.8-slim AS migrate
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=mirror.gcr.io/astral/uv:latest /uv /uvx /bin/
 
 WORKDIR /app/apps/backend
 

--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -13,7 +13,7 @@
 # STAGE 1: Builder - Install dependencies and build artifacts
 # ============================================================================
 FROM mirror.gcr.io/library/python:3.12.8-slim AS builder
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=mirror.gcr.io/astral/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # STAGE 2: Runtime - Create minimal runtime image
 # ============================================================================
 FROM mirror.gcr.io/library/python:3.12.8-slim AS runtime
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=mirror.gcr.io/astral/uv:latest /uv /uvx /bin/
 # Copy Bun from official image (lighter than Node.js, required for bunx to run MCP servers)
 COPY --from=oven/bun:latest /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=oven/bun:latest /usr/local/bin/bunx /usr/local/bin/bunx

--- a/apps/polyphemus/Dockerfile
+++ b/apps/polyphemus/Dockerfile
@@ -15,7 +15,7 @@
 # ============================================================================
 FROM python:3.12.8-slim AS builder
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=mirror.gcr.io/astral/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 


### PR DESCRIPTION
## Purpose
Local Docker builds failed with `403 Forbidden` when pulling `ghcr.io/astral-sh/uv:latest`, even though the image is public (stale GHCR credentials or registry access issues).

## What Changed
- Replaced `COPY --from=ghcr.io/astral-sh/uv:latest` with `COPY --from=mirror.gcr.io/astral/uv:latest` in backend and polyphemus Dockerfiles (prod, dev, migrate stages).

## Testing
- [ ] `docker compose build` (or backend/worker target) succeeds without GHCR auth errors