### PR TITLE
Update playground UI to align with design system

### DIFF
--- a/apps/frontend/src/app/(protected)/playground/components/CreateTestFromConversationDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/CreateTestFromConversationDrawer.tsx
@@ -10,6 +10,7 @@ import {
   CircularProgress,
   Divider,
 } from '@mui/material';
+import SubsectionHeader from '@/components/common/SubsectionHeader';
 import BaseFreesoloAutocomplete, {
   AutocompleteOption,
 } from '@/components/common/BaseFreesoloAutocomplete';
@@ -282,9 +283,7 @@ export default function CreateTestFromConversationDrawer({
       ) : (
         <Stack spacing={3}>
           {/* Test details section */}
-          <Typography variant="subtitle2" color="text.secondary">
-            Test Details
-          </Typography>
+          <SubsectionHeader headline="Test Details" />
 
           <BaseFreesoloAutocomplete
             options={behaviors}
@@ -313,9 +312,7 @@ export default function CreateTestFromConversationDrawer({
           <Divider />
 
           {/* Content section */}
-          <Typography variant="subtitle2" color="text.secondary">
-            Content
-          </Typography>
+          <SubsectionHeader headline="Content" />
 
           {testType === TEST_TYPES.SINGLE_TURN ? (
             <>

--- a/apps/frontend/src/app/(protected)/playground/components/MessageBubble.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/MessageBubble.tsx
@@ -22,6 +22,7 @@ import DownloadIcon from '@mui/icons-material/Download';
 import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
 import { ChatMessage } from '@/hooks/usePlaygroundChat';
 import MarkdownContent from '@/components/common/MarkdownContent';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
 
 interface MessageBubbleProps {
   /** The chat message to display */
@@ -35,8 +36,9 @@ interface MessageBubbleProps {
 /**
  * MessageBubble Component
  *
- * Displays a single chat message in a bubble format.
- * User messages appear on the right, assistant messages on the left.
+ * User messages are left-aligned with a teal left-border accent.
+ * Assistant messages are right-aligned with a neutral right-border accent,
+ * mirroring the Penelope/Target layout used in ConversationHistory.
  */
 export default function MessageBubble({
   message,
@@ -59,12 +61,8 @@ export default function MessageBubble({
     }
   };
 
-  const formatTime = (date: Date) => {
-    return date.toLocaleTimeString([], {
-      hour: '2-digit',
-      minute: '2-digit',
-    });
-  };
+  const formatTime = (date: Date) =>
+    date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
   const handleDownloadFile = (
     filename: string,
@@ -82,18 +80,19 @@ export default function MessageBubble({
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        alignItems: isUser ? 'flex-end' : 'flex-start',
-        mb: 2,
+        // user → left edge; assistant → right edge
+        alignItems: isUser ? 'flex-start' : 'flex-end',
+        mb: 2.5,
       }}
     >
-      {/* Message Content */}
+      {/* Row: avatar + card (reversed for assistant so avatar stays outside) */}
       <Box
         sx={{
           display: 'flex',
           alignItems: 'flex-start',
-          gap: 1,
-          maxWidth: '80%',
-          flexDirection: isUser ? 'row-reverse' : 'row',
+          flexDirection: isUser ? 'row' : 'row-reverse',
+          gap: 1.5,
+          maxWidth: '85%',
         }}
       >
         {/* Avatar */}
@@ -109,13 +108,14 @@ export default function MessageBubble({
               ? 'primary.main'
               : message.isError
                 ? 'error.light'
-                : 'action.hover',
+                : theme => theme.palette.greyscale.surface2,
             color: isUser
               ? 'primary.contrastText'
               : message.isError
                 ? 'error.contrastText'
-                : 'text.secondary',
+                : theme => theme.palette.greyscale.body,
             flexShrink: 0,
+            mt: 0.25,
           }}
         >
           {isUser ? (
@@ -127,7 +127,7 @@ export default function MessageBubble({
           )}
         </Box>
 
-        {/* Bubble */}
+        {/* Card — user gets teal left accent, assistant gets neutral right accent */}
         <Tooltip
           title={hasTrace ? 'Click to view trace details' : ''}
           placement="top"
@@ -142,19 +142,25 @@ export default function MessageBubble({
             }
             sx={{
               p: 2,
-              borderRadius: theme => theme.shape.borderRadius * 0.5,
-              bgcolor: isUser
-                ? 'primary.main'
-                : message.isError
-                  ? 'error.light'
-                  : 'action.hover',
-              color: isUser
-                ? 'primary.contrastText'
-                : message.isError
-                  ? 'error.contrastText'
-                  : 'text.primary',
-              borderTopRightRadius: isUser ? 0 : 2,
-              borderTopLeftRadius: isUser ? 2 : 0,
+              borderRadius: BORDER_RADIUS.sm,
+              bgcolor: message.isError
+                ? 'error.light'
+                : isUser
+                  ? 'background.paper'
+                  : theme => theme.palette.greyscale.surface1,
+              color: message.isError
+                ? 'error.contrastText'
+                : theme => theme.palette.greyscale.body,
+              border: theme => `1px solid ${theme.palette.greyscale.border}`,
+              ...(isUser
+                ? {
+                    borderLeft: theme =>
+                      `3px solid ${message.isError ? theme.palette.error.main : theme.palette.primary.main}`,
+                  }
+                : {
+                    borderRight: theme =>
+                      `3px solid ${message.isError ? theme.palette.error.main : theme.palette.greyscale.border}`,
+                  }),
               ...(hasTrace && {
                 cursor: 'pointer',
                 transition: theme =>
@@ -162,111 +168,29 @@ export default function MessageBubble({
                     duration: theme.transitions.duration.short,
                   }),
                 '&:hover': {
-                  bgcolor: 'action.selected',
+                  bgcolor: theme => theme.palette.greyscale.surface2,
                   boxShadow: 1,
                 },
               }),
             }}
           >
-            <Box
-              sx={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 1,
-              }}
-            >
-              <Box sx={{ flex: 1, minWidth: 0 }}>
-                {isUser ? (
-                  // User messages: plain text with pre-wrap
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      whiteSpace: 'pre-wrap',
-                      wordBreak: 'break-word',
-                    }}
-                  >
-                    {message.content}
-                  </Typography>
-                ) : (
-                  // Assistant messages: render markdown with same variant as user text
-                  <MarkdownContent content={message.content} variant="body2" />
-                )}
-              </Box>
-
-              {/* Action icons */}
-              <Box
+            {/* Message text */}
+            {isUser ? (
+              <Typography
+                variant="body2"
                 sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 0.5,
-                  flexShrink: 0,
-                  ml: 1,
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-word',
+                  color: theme => theme.palette.greyscale.body,
                 }}
               >
-                {/* Create single-turn test button (user messages only) */}
-                {isUser && (
-                  <Tooltip title="Create single-turn test from this message">
-                    <IconButton
-                      size="small"
-                      onClick={e => {
-                        e.stopPropagation();
-                        onCreateSingleTurnTest?.(message.id);
-                      }}
-                      sx={{
-                        p: 0.5,
-                        color: 'primary.contrastText',
-                        opacity: 0.7,
-                        '&:hover': {
-                          opacity: 1,
-                          bgcolor: 'primary.dark',
-                        },
-                      }}
-                    >
-                      <ScienceOutlinedIcon sx={{ fontSize: 16 }} />
-                    </IconButton>
-                  </Tooltip>
-                )}
+                {message.content}
+              </Typography>
+            ) : (
+              <MarkdownContent content={message.content} variant="body2" />
+            )}
 
-                {/* Copy button (assistant messages only) */}
-                {!isUser && (
-                  <Tooltip title={copied ? 'Copied!' : 'Copy message'}>
-                    <IconButton
-                      size="small"
-                      onClick={handleCopy}
-                      sx={{
-                        p: 0.5,
-                        color: 'action.active',
-                        opacity: 0.7,
-                        '&:hover': {
-                          opacity: 1,
-                          bgcolor: 'action.hover',
-                        },
-                      }}
-                    >
-                      {copied ? (
-                        <CheckIcon sx={{ fontSize: 16 }} />
-                      ) : (
-                        <ContentCopyIcon sx={{ fontSize: 16 }} />
-                      )}
-                    </IconButton>
-                  </Tooltip>
-                )}
-
-                {/* Trace Icon indicator (for assistant messages with traces) */}
-                {hasTrace && (
-                  <Tooltip title="View trace">
-                    <TimelineIcon
-                      sx={{
-                        fontSize: 18,
-                        color: 'action.active',
-                      }}
-                    />
-                  </Tooltip>
-                )}
-              </Box>
-            </Box>
-
-            {/* User message: show attached file names (clickable for download) */}
+            {/* User: attached file chips */}
             {isUser && message.files && message.files.length > 0 && (
               <Box
                 sx={{
@@ -292,20 +216,12 @@ export default function MessageBubble({
                         file.data
                       );
                     }}
-                    sx={{
-                      color: 'primary.contrastText',
-                      borderColor: 'primary.contrastText',
-                      '& .MuiChip-icon': {
-                        color: 'primary.contrastText',
-                      },
-                      opacity: 0.85,
-                    }}
                   />
                 ))}
               </Box>
             )}
 
-            {/* Assistant message: show output files */}
+            {/* Assistant: output files */}
             {!isUser &&
               message.outputFiles &&
               message.outputFiles.length > 0 && (
@@ -343,7 +259,9 @@ export default function MessageBubble({
                         </Tooltip>
                         <Typography
                           variant="caption"
-                          color="text.secondary"
+                          sx={{
+                            color: theme => theme.palette.greyscale.subtitle,
+                          }}
                           display="block"
                         >
                           {file.filename}
@@ -371,17 +289,87 @@ export default function MessageBubble({
                   )}
                 </Box>
               )}
+
+            {/* Action icons — bottom-right of card */}
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                alignItems: 'center',
+                gap: 0.5,
+                mt: 1,
+              }}
+            >
+              {/* Create single-turn test (user messages) */}
+              {isUser && (
+                <Tooltip title="Create single-turn test from this message">
+                  <IconButton
+                    size="small"
+                    onClick={e => {
+                      e.stopPropagation();
+                      onCreateSingleTurnTest?.(message.id);
+                    }}
+                    sx={{
+                      p: 0.5,
+                      color: theme => theme.palette.greyscale.label,
+                      '&:hover': {
+                        color: 'primary.main',
+                        bgcolor: theme => theme.palette.background.light1,
+                      },
+                    }}
+                  >
+                    <ScienceOutlinedIcon sx={{ fontSize: 16 }} />
+                  </IconButton>
+                </Tooltip>
+              )}
+
+              {/* Copy (assistant messages) */}
+              {!isUser && !message.isError && (
+                <Tooltip title={copied ? 'Copied!' : 'Copy message'}>
+                  <IconButton
+                    size="small"
+                    onClick={handleCopy}
+                    sx={{
+                      p: 0.5,
+                      color: theme => theme.palette.greyscale.label,
+                      '&:hover': {
+                        color: 'primary.main',
+                        bgcolor: theme => theme.palette.greyscale.surface2,
+                      },
+                    }}
+                  >
+                    {copied ? (
+                      <CheckIcon sx={{ fontSize: 16 }} />
+                    ) : (
+                      <ContentCopyIcon sx={{ fontSize: 16 }} />
+                    )}
+                  </IconButton>
+                </Tooltip>
+              )}
+
+              {/* Trace link (assistant messages with trace) */}
+              {hasTrace && (
+                <Tooltip title="View trace">
+                  <TimelineIcon
+                    sx={{
+                      fontSize: 18,
+                      color: theme => theme.palette.greyscale.label,
+                    }}
+                  />
+                </Tooltip>
+              )}
+            </Box>
           </Paper>
         </Tooltip>
       </Box>
 
-      {/* Timestamp */}
+      {/* Timestamp — stays under the card on the correct side */}
       <Typography
         variant="caption"
-        color="text.disabled"
         sx={{
           mt: 0.5,
-          mx: 5,
+          ...(isUser ? { ml: 5.5 } : { mr: 5.5 }),
+          color: theme => theme.palette.greyscale.subtitle,
         }}
       >
         {formatTime(message.timestamp)}
@@ -391,35 +379,36 @@ export default function MessageBubble({
 }
 
 /**
- * Loading skeleton for message bubble.
+ * Loading skeleton for the assistant's pending response (right-aligned).
  */
 export function MessageBubbleSkeleton() {
   return (
     <Box
       sx={{
         display: 'flex',
+        justifyContent: 'flex-end',
         alignItems: 'flex-start',
-        gap: 1,
-        mb: 2,
+        gap: 1.5,
+        mb: 2.5,
       }}
     >
-      <Skeleton
-        variant="circular"
-        sx={{
-          width: theme => theme.spacing(4),
-          height: theme => theme.spacing(4),
-        }}
-      />
       <Box sx={{ flex: 1, maxWidth: '60%' }}>
         <Skeleton
           variant="rounded"
           sx={{
             height: theme => theme.spacing(7.5),
-            borderRadius: theme => theme.shape.borderRadius * 0.5,
-            borderTopLeftRadius: 0,
+            borderRadius: BORDER_RADIUS.sm,
           }}
         />
       </Box>
+      <Skeleton
+        variant="circular"
+        sx={{
+          width: theme => theme.spacing(4),
+          height: theme => theme.spacing(4),
+          flexShrink: 0,
+        }}
+      />
     </Box>
   );
 }

--- a/apps/frontend/src/app/(protected)/playground/components/PlaygroundChat.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/PlaygroundChat.tsx
@@ -242,16 +242,15 @@ export default function PlaygroundChat({
             justifyContent: label ? 'space-between' : 'flex-end',
             px: 1.5,
             minHeight: theme => theme.spacing(4),
-            bgcolor: 'action.hover',
+            bgcolor: theme => theme.palette.greyscale.surface1,
             borderBottom: 1,
-            borderColor: 'divider',
+            borderColor: theme => theme.palette.greyscale.border,
           }}
         >
           {label && (
             <Typography
-              variant="caption"
-              color="text.secondary"
-              fontWeight="medium"
+              variant="captionBold"
+              sx={{ color: theme => theme.palette.greyscale.label }}
             >
               {label}
             </Typography>
@@ -270,7 +269,10 @@ export default function PlaygroundChat({
                   size="small"
                   onClick={handleCreateMultiTurnTest}
                   disabled={messages.length < 2 || isLoading}
-                  sx={{ color: 'text.secondary', p: 0.25 }}
+                  sx={{
+                    color: theme => theme.palette.greyscale.label,
+                    p: 0.25,
+                  }}
                 >
                   <ScienceOutlinedIcon fontSize="small" />
                 </IconButton>
@@ -280,7 +282,7 @@ export default function PlaygroundChat({
               <IconButton
                 size="small"
                 onClick={onClose}
-                sx={{ color: 'text.secondary', p: 0.25 }}
+                sx={{ color: theme => theme.palette.greyscale.label, p: 0.25 }}
               >
                 <CloseIcon fontSize="inherit" />
               </IconButton>
@@ -290,7 +292,10 @@ export default function PlaygroundChat({
                 <IconButton
                   size="small"
                   onClick={onSplit}
-                  sx={{ color: 'text.secondary', p: 0.25 }}
+                  sx={{
+                    color: theme => theme.palette.greyscale.label,
+                    p: 0.25,
+                  }}
                 >
                   <AddIcon fontSize="small" />
                 </IconButton>
@@ -317,7 +322,10 @@ export default function PlaygroundChat({
                 justifyContent: 'center',
               }}
             >
-              <Typography variant="body2" color="text.secondary">
+              <Typography
+                variant="body2"
+                sx={{ color: theme => theme.palette.greyscale.subtitle }}
+              >
                 Send a message to start the conversation
               </Typography>
             </Box>
@@ -360,7 +368,7 @@ export default function PlaygroundChat({
           sx={{
             p: 2,
             borderTop: 1,
-            borderColor: 'divider',
+            borderColor: theme => theme.palette.greyscale.border,
             bgcolor: 'background.paper',
           }}
         >

--- a/apps/frontend/src/app/(protected)/playground/components/PlaygroundClient.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/PlaygroundClient.tsx
@@ -16,9 +16,11 @@ import {
   Tooltip,
 } from '@mui/material';
 import { PageLayout } from '@/components/layout/PageLayout';
+import { Fab } from '@/components/common/Fab';
 import AddIcon from '@mui/icons-material/Add';
 import CloseIcon from '@mui/icons-material/Close';
-import ChatBubbleOutlineIcon from '@mui/icons-material/ChatBubbleOutline';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import PlaygroundIcon from '@/components/PlaygroundIcon';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -66,16 +68,15 @@ function ChatPlaceholder({
             justifyContent: label ? 'space-between' : 'flex-end',
             px: 1.5,
             minHeight: theme => theme.spacing(4),
-            bgcolor: 'action.hover',
+            bgcolor: theme => theme.palette.greyscale.surface1,
             borderBottom: 1,
-            borderColor: 'divider',
+            borderColor: theme => theme.palette.greyscale.border,
           }}
         >
           {label && (
             <Typography
-              variant="caption"
-              color="text.secondary"
-              fontWeight="medium"
+              variant="captionBold"
+              sx={{ color: theme => theme.palette.greyscale.label }}
             >
               {label}
             </Typography>
@@ -84,7 +85,7 @@ function ChatPlaceholder({
             <IconButton
               size="small"
               onClick={onClose}
-              sx={{ color: 'text.secondary', p: 0.25 }}
+              sx={{ color: theme => theme.palette.greyscale.label, p: 0.25 }}
             >
               <CloseIcon fontSize="inherit" />
             </IconButton>
@@ -94,7 +95,7 @@ function ChatPlaceholder({
               <IconButton
                 size="small"
                 onClick={onSplit}
-                sx={{ color: 'text.secondary', p: 0.25 }}
+                sx={{ color: theme => theme.palette.greyscale.label, p: 0.25 }}
               >
                 <AddIcon fontSize="small" />
               </IconButton>
@@ -111,17 +112,17 @@ function ChatPlaceholder({
         }}
       >
         <Stack spacing={1} alignItems="center">
-          <ChatBubbleOutlineIcon
+          <PlaygroundIcon
             sx={{
               fontSize: theme => theme.typography.h3.fontSize,
-              color: 'text.disabled',
+              color: 'primary.main',
             }}
           />
-          <Typography variant="h6" color="text.secondary">
+          <Typography
+            variant="h6"
+            sx={{ color: 'primary.main', fontWeight: 600 }}
+          >
             Select an endpoint to start chatting
-          </Typography>
-          <Typography variant="body2" color="text.disabled">
-            Choose an endpoint from the dropdown above
           </Typography>
         </Stack>
       </Box>
@@ -238,6 +239,12 @@ export default function PlaygroundClient() {
     loadEndpoints();
   }, [loadEndpoints]);
 
+  const handleReset = useCallback(() => {
+    setSelectedEndpointId(null);
+    setSelectedProjectId(null);
+    setIsSplit(false);
+  }, []);
+
   const handleEndpointChange = (
     event: React.ChangeEvent<HTMLInputElement> | { target: { value: string } }
   ) => {
@@ -272,11 +279,21 @@ export default function PlaygroundClient() {
     }
   };
 
+  const hasActiveSession = !!(selectedEndpointId || isSplit);
+
   return (
     <PageLayout
       title="Playground"
       description="Chat with your endpoints interactively to test their responses and generate test cases from your conversations."
       breadcrumbs={[]}
+      actions={
+        <Fab
+          icon={<RestartAltIcon />}
+          tooltip="Reset playground"
+          onClick={handleReset}
+          disabled={!hasActiveSession}
+        />
+      }
     >
       {/* Endpoint Selector */}
       <Paper elevation={0} sx={{ ...playgroundPanelSx, p: 2, mb: 2 }}>
@@ -320,7 +337,13 @@ export default function PlaygroundClient() {
                       width: '100%',
                     }}
                   >
-                    <Typography variant="body2" sx={{ flexGrow: 1 }}>
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        flexGrow: 1,
+                        color: theme => theme.palette.greyscale.body,
+                      }}
+                    >
                       {option.projectName} › {option.endpointName}
                     </Typography>
                     <Typography
@@ -329,10 +352,10 @@ export default function PlaygroundClient() {
                         ml: 2,
                         px: 1,
                         py: 0.25,
-                        borderRadius: BORDER_RADIUS.xs,
-                        bgcolor: 'action.hover',
+                        borderRadius: BORDER_RADIUS.pill,
+                        bgcolor: theme => theme.palette.greyscale.surface2,
                         color: getEnvironmentColor(option.environment),
-                        fontWeight: 'medium',
+                        fontWeight: 600,
                       }}
                     >
                       {formatEnvironment(option.environment)}

--- a/apps/frontend/src/app/(protected)/playground/components/__tests__/PlaygroundChat.test.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/__tests__/PlaygroundChat.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import lightTheme from '@/styles/theme';
 import PlaygroundChat from '../PlaygroundChat';
 
 // jsdom does not implement scrollIntoView — save and restore to avoid leaking into other suites
@@ -90,7 +92,11 @@ function renderChat(
   props: Partial<React.ComponentProps<typeof PlaygroundChat>> = {}
 ) {
   const defaults = { endpointId: 'endpoint-1', projectId: 'project-1' };
-  return render(<PlaygroundChat {...defaults} {...props} />);
+  return render(
+    <ThemeProvider theme={lightTheme}>
+      <PlaygroundChat {...defaults} {...props} />
+    </ThemeProvider>
+  );
 }
 
 beforeEach(() => {

--- a/apps/frontend/src/app/(protected)/playground/components/playgroundPanelSx.ts
+++ b/apps/frontend/src/app/(protected)/playground/components/playgroundPanelSx.ts
@@ -1,9 +1,9 @@
 import type { SxProps, Theme } from '@mui/material/styles';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
 
-/** Bordered panel style aligned with list-page content areas (8px corners). */
+/** Bordered panel style aligned with list-page content areas (12px corners). */
 export const playgroundPanelSx: SxProps<Theme> = {
-  borderRadius: BORDER_RADIUS.sm,
+  borderRadius: BORDER_RADIUS.md,
   border: theme => `1px solid ${theme.palette.greyscale.border}`,
   boxShadow: ELEVATION.xs,
   overflow: 'hidden',


### PR DESCRIPTION
## Purpose
The playground page was built before the design system was updated. This PR brings it in line with the current visual language — rounded cards, greyscale tokens, teal accents, and consistent typography — without requiring new designer deliverables.

## What Changed
- **Panel radius**: bumped from `sm` (8 px) to `md` (12 px) via `playgroundPanelSx`
- **Pane headers**: background → `greyscale.surface1`, border → `greyscale.border`, label → `captionBold` + `greyscale.label` colour
- **Empty state**: replaced `ChatBubbleOutlineIcon` with the navigation `PlaygroundIcon`; title uses `primary.main`; removed the redundant "Choose an endpoint…" hint
- **Reset FAB**: added `RestartAltIcon` FAB in the `PageLayout` actions slot; clears selected endpoint, project, and split state; disabled when no session is active
- **Endpoint badge**: restyled to pill shape (`BORDER_RADIUS.pill`) with `greyscale.surface2` background
- **Message bubbles**: full card-style redesign — user messages left-aligned with teal `borderLeft` accent; assistant messages right-aligned with neutral `borderRight` accent (mirrors `ConversationHistory` layout); removed solid blue bubble
- **Loading skeleton**: right-aligned to match the assistant message position
- **Drawer section labels**: replaced ad-hoc `Typography` with `SubsectionHeader` in `CreateTestFromConversationDrawer`
- **Input border**: `greyscale.border` token instead of `divider`
- **Tests**: wrapped `PlaygroundChat` tests in `ThemeProvider` to prevent theme-palette errors

## Additional Context
- No new dependencies introduced
- All existing playground unit tests pass (42/42)

## Testing
1. Navigate to `/playground`
2. Verify empty state shows the playground icon and no "Choose an endpoint" text
3. Select an endpoint and send a message — user message should appear left with teal left border; assistant response should appear right with neutral right border
4. While waiting for a response the skeleton should appear on the right
5. Click the reset FAB — state should clear
6. Open a trace from a message and confirm the drawer matches the one at `/traces`