### PR TITLE
Pin uv to 0.11.19 in Docker service images

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -12,7 +12,7 @@
 # base-build: shared Python builder + Rust + uv + monorepo libs
 # =============================================================================
 FROM mirror.gcr.io/library/python:3.12.8-slim AS base-build
-COPY --from=mirror.gcr.io/astral/uv:latest /uv /uvx /bin/
+COPY --from=mirror.gcr.io/astral/uv:0.11.19 /uv /uvx /bin/
 
 WORKDIR /app
 
@@ -97,7 +97,7 @@ COPY apps/backend/src ./src
 # base-runtime: shared slim runtime + uv + rhesis-user + full backend payload
 # =============================================================================
 FROM mirror.gcr.io/library/python:3.12.8-slim AS base-runtime
-COPY --from=mirror.gcr.io/astral/uv:latest /uv /uvx /bin/
+COPY --from=mirror.gcr.io/astral/uv:0.11.19 /uv /uvx /bin/
 
 WORKDIR /app/apps/backend
 
@@ -137,7 +137,7 @@ EXPOSE 8080
 # migrate: core-only venv + Alembic (Cloud Run migration job)
 # =============================================================================
 FROM mirror.gcr.io/library/python:3.12.8-slim AS migrate
-COPY --from=mirror.gcr.io/astral/uv:latest /uv /uvx /bin/
+COPY --from=mirror.gcr.io/astral/uv:0.11.19 /uv /uvx /bin/
 
 WORKDIR /app/apps/backend
 

--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -13,7 +13,7 @@
 # STAGE 1: Builder - Install dependencies and build artifacts
 # ============================================================================
 FROM mirror.gcr.io/library/python:3.12.8-slim AS builder
-COPY --from=mirror.gcr.io/astral/uv:latest /uv /uvx /bin/
+COPY --from=mirror.gcr.io/astral/uv:0.11.19 /uv /uvx /bin/
 
 WORKDIR /app
 
@@ -70,7 +70,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # STAGE 2: Runtime - Create minimal runtime image
 # ============================================================================
 FROM mirror.gcr.io/library/python:3.12.8-slim AS runtime
-COPY --from=mirror.gcr.io/astral/uv:latest /uv /uvx /bin/
+COPY --from=mirror.gcr.io/astral/uv:0.11.19 /uv /uvx /bin/
 # Copy Bun from official image (lighter than Node.js, required for bunx to run MCP servers)
 COPY --from=oven/bun:latest /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=oven/bun:latest /usr/local/bin/bunx /usr/local/bin/bunx

--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -4,10 +4,11 @@
 # Single stage build for simplicity
 # IMPORTANT: The python version must match the version in the .python-version file.
 FROM mirror.gcr.io/library/python:3.12-slim
+COPY --from=mirror.gcr.io/astral/uv:0.11.19 /uv /uvx /bin/
 
 WORKDIR /app
 
-# Install OS-level dependencies and uv with retry logic
+# Install OS-level dependencies with retry logic
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     --allow-unauthenticated \
@@ -17,7 +18,6 @@ RUN apt-get update && \
     build-essential \
     curl \
     git \
-    && pip install --no-cache-dir uv \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy only the dependency files for chatbot

--- a/apps/polyphemus/Dockerfile
+++ b/apps/polyphemus/Dockerfile
@@ -15,7 +15,7 @@
 # ============================================================================
 FROM python:3.12.8-slim AS builder
 
-COPY --from=mirror.gcr.io/astral/uv:latest /uv /uvx /bin/
+COPY --from=mirror.gcr.io/astral/uv:0.11.19 /uv /uvx /bin/
 
 WORKDIR /app
 

--- a/apps/telemetry-processor/Dockerfile
+++ b/apps/telemetry-processor/Dockerfile
@@ -1,4 +1,5 @@
 FROM mirror.gcr.io/library/python:3.11-slim
+COPY --from=mirror.gcr.io/astral/uv:0.11.19 /uv /uvx /bin/
 
 WORKDIR /app
 
@@ -15,9 +16,6 @@ RUN apt-get update && \
 
 # Copy requirements
 COPY pyproject.toml .
-
-# Install uv for faster installs
-RUN pip install --no-cache-dir uv
 
 # Install dependencies
 RUN uv pip install --system -e .


### PR DESCRIPTION
## Purpose
Docker builds were copying `mirror.gcr.io/astral/uv:latest` (or installing uv via pip), which can change between builds and break reproducibility. This pins uv to a known version and uses the same mirror-based COPY pattern everywhere.

## What Changed
- Pin `COPY --from=mirror.gcr.io/astral/uv:0.11.19` in backend, backend dev, polyphemus, chatbot, and telemetry-processor Dockerfiles
- Replace `pip install uv` in chatbot and telemetry-processor with the mirrored uv binary copy (consistent with other services)

## Additional Context
Follow-up to #1879, which moved uv pulls to `mirror.gcr.io`.

## Testing
- [ ] Rebuild affected images locally or in CI and confirm `uv --version` reports 0.11.19
- [ ] Verify backend, chatbot, and telemetry-processor images still install dependencies successfully