### PR TITLE
Polish test-runs UI

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunConfigurationTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunConfigurationTab.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import { Box, Chip, Grid, Paper, Switch, Typography } from '@mui/material';
 import type { Theme } from '@mui/material/styles';
+import Link from 'next/link';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import FormSectionDivider from '@/components/common/FormSectionDivider';
 import ViewField from '@/components/common/ViewField';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
@@ -70,7 +72,45 @@ export default function TestRunConfigurationTab({
         <Box sx={fieldsSx}>
           <Grid container spacing="30px">
             <Grid size={{ xs: 12, sm: 6 }}>
-              <ViewField label="Test Set" value={config?.test_set?.name} />
+              {config?.test_set?.id ? (
+                <ViewField label="Test Set">
+                  <Link
+                    href={`/test-sets/${config.test_set.id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ textDecoration: 'none' }}
+                  >
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 0.5,
+                        '&:hover .field-link-text': {
+                          color: 'primary.main',
+                          textDecoration: 'underline',
+                        },
+                      }}
+                    >
+                      <Typography
+                        className="field-link-text"
+                        sx={{
+                          fontSize: 16,
+                          lineHeight: '24px',
+                          color: theme => theme.palette.greyscale.body,
+                          transition: 'color 0.2s',
+                        }}
+                      >
+                        {config.test_set.name || '—'}
+                      </Typography>
+                      <OpenInNewIcon
+                        sx={{ fontSize: 14, color: 'text.disabled' }}
+                      />
+                    </Box>
+                  </Link>
+                </ViewField>
+              ) : (
+                <ViewField label="Test Set" value={config?.test_set?.name} />
+              )}
             </Grid>
             <Grid size={{ xs: 12, sm: 6 }}>
               <ViewField
@@ -79,7 +119,45 @@ export default function TestRunConfigurationTab({
               />
             </Grid>
             <Grid size={{ xs: 12 }}>
-              <ViewField label="Endpoint" value={config?.endpoint?.name} />
+              {config?.endpoint?.id ? (
+                <ViewField label="Endpoint">
+                  <Link
+                    href={`/endpoints/${config.endpoint.id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{ textDecoration: 'none' }}
+                  >
+                    <Box
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 0.5,
+                        '&:hover .field-link-text': {
+                          color: 'primary.main',
+                          textDecoration: 'underline',
+                        },
+                      }}
+                    >
+                      <Typography
+                        className="field-link-text"
+                        sx={{
+                          fontSize: 16,
+                          lineHeight: '24px',
+                          color: theme => theme.palette.greyscale.body,
+                          transition: 'color 0.2s',
+                        }}
+                      >
+                        {config.endpoint.name || '—'}
+                      </Typography>
+                      <OpenInNewIcon
+                        sx={{ fontSize: 14, color: 'text.disabled' }}
+                      />
+                    </Box>
+                  </Link>
+                </ViewField>
+              ) : (
+                <ViewField label="Endpoint" value={config?.endpoint?.name} />
+              )}
             </Grid>
           </Grid>
         </Box>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunHeader.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunHeader.tsx
@@ -505,7 +505,6 @@ export default function TestRunHeader({
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'space-between',
-                  mb: 2,
                 }}
               >
                 <Typography
@@ -537,118 +536,6 @@ export default function TestRunHeader({
                   sx={{ fontWeight: 600 }}
                 />
               </Box>
-
-              {testRun.test_configuration?.test_set?.id ? (
-                <Link
-                  href={`/test-sets/${testRun.test_configuration.test_set.id}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ textDecoration: 'none' }}
-                >
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 0.5,
-                      '&:hover': {
-                        '& .test-set-name': {
-                          color: theme.palette.primary.main,
-                          textDecoration: 'underline',
-                        },
-                      },
-                    }}
-                  >
-                    <Typography
-                      variant="subtitle1"
-                      className="test-set-name"
-                      sx={{
-                        transition: 'color 0.2s',
-                        color: 'text.secondary',
-                        fontWeight: 500,
-                      }}
-                    >
-                      {testRun.test_configuration.test_set.name ||
-                        'Unknown Test Set'}
-                    </Typography>
-                    <OpenInNewIcon
-                      sx={{
-                        fontSize: 14,
-                        color: 'text.disabled',
-                      }}
-                    />
-                  </Box>
-                </Link>
-              ) : (
-                <Typography
-                  variant="subtitle1"
-                  color="text.secondary"
-                  fontWeight={500}
-                >
-                  {testRun.test_configuration?.test_set?.name ||
-                    'Unknown Test Set'}
-                </Typography>
-              )}
-
-              {testRun.test_configuration?.endpoint?.id ? (
-                <Link
-                  href={`/endpoints/${testRun.test_configuration.endpoint.id}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  style={{ textDecoration: 'none' }}
-                >
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      gap: 0.5,
-                      mt: 1,
-                      '&:hover': {
-                        '& .endpoint-name': {
-                          color: theme.palette.primary.main,
-                          textDecoration: 'underline',
-                        },
-                      },
-                    }}
-                  >
-                    <Typography
-                      variant="body2"
-                      className="endpoint-name"
-                      sx={{
-                        transition: 'color 0.2s',
-                        color: 'text.secondary',
-                        fontWeight: 200,
-                      }}
-                    >
-                      Endpoint:{' '}
-                      {testRun.test_configuration?.endpoint?.name ||
-                        (typeof testRun.attributes?.environment === 'string'
-                          ? testRun.attributes.environment
-                          : null) ||
-                        'development'}
-                    </Typography>
-                    <OpenInNewIcon
-                      sx={{
-                        fontSize: 12,
-                        color: 'text.disabled',
-                      }}
-                    />
-                  </Box>
-                </Link>
-              ) : (
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  fontWeight={500}
-                  sx={{ display: 'block', mt: 1 }}
-                >
-                  Endpoint:{' '}
-                  {testRun.test_configuration?.endpoint?.name ||
-                    (typeof testRun.attributes?.environment === 'string'
-                      ? testRun.attributes.environment
-                      : null) ||
-                    'development'}
-                </Typography>
-              )}
             </CardContent>
           </Card>
         </Grid>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunStatsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunStatsTab.tsx
@@ -19,20 +19,9 @@ import {
   TableSortLabel,
   Tooltip,
   Typography,
-  useTheme,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Cell,
-  ResponsiveContainer,
-  Tooltip as RechartsTooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import {
   TestResultDetail,
@@ -248,72 +237,13 @@ function BehaviorPerformanceSection({
   behaviors?: BehaviorWithMetrics[];
   onViewBehavior?: (behaviorId: string) => void;
 }) {
-  const theme = useTheme();
-
-  const chartData = useMemo(
-    () => [...stats].sort((a, b) => a.passRate - b.passRate),
-    [stats]
-  );
-
-  const chartHeight = Math.max(200, chartData.length * 52 + 40);
-
-  const getBandColor = (passRate: number) =>
-    theme.palette[getReviewBand(passRate).colorKey].main;
-
   return (
     <SectionCard title="Behavior Performance">
-      <ResponsiveContainer width="100%" height={chartHeight}>
-        <BarChart
-          layout="vertical"
-          data={chartData}
-          margin={{ top: 4, right: 48, bottom: 8, left: 4 }}
-        >
-          <CartesianGrid
-            strokeDasharray="3 3"
-            horizontal={false}
-            stroke={theme.palette.divider}
-          />
-          <XAxis
-            type="number"
-            domain={[0, 100]}
-            tickFormatter={(v: number) => `${v}%`}
-            tick={{
-              fontSize: 12,
-              fill: theme.palette.text.secondary as string,
-            }}
-          />
-          <YAxis
-            type="category"
-            dataKey="name"
-            width={160}
-            tick={{
-              fontSize: 12,
-              fill: theme.palette.text.secondary as string,
-            }}
-            tickFormatter={(name: string) =>
-              name.length > 22 ? `${name.slice(0, 19)}\u2026` : name
-            }
-          />
-          <RechartsTooltip
-            cursor={{ fill: theme.palette.action.hover }}
-            formatter={(value: number) => [`${value.toFixed(1)}%`, 'Pass Rate']}
-            labelStyle={{ fontWeight: 600 }}
-          />
-          <Bar dataKey="passRate" radius={[0, 4, 4, 0]} maxBarSize={30}>
-            {chartData.map(entry => (
-              <Cell key={entry.name} fill={getBandColor(entry.passRate)} />
-            ))}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
-
-      <Box sx={{ mt: 3 }}>
-        <BehaviorTable
-          stats={stats}
-          behaviors={behaviors}
-          onViewBehavior={onViewBehavior}
-        />
-      </Box>
+      <BehaviorTable
+        stats={stats}
+        behaviors={behaviors}
+        onViewBehavior={onViewBehavior}
+      />
     </SectionCard>
   );
 }
@@ -466,68 +396,9 @@ function MetricPerformanceSection({
   stats: MetricStat[];
   onViewMetric?: (metricName: string) => void;
 }) {
-  const theme = useTheme();
-
-  const chartData = useMemo(
-    () => [...stats].sort((a, b) => b.failRate - a.failRate),
-    [stats]
-  );
-
-  const chartHeight = Math.max(200, chartData.length * 52 + 40);
-
-  const getBandColor = (failRate: number) =>
-    theme.palette[getReviewBand(100 - failRate).colorKey].main;
-
   return (
     <SectionCard title="Metric Performance">
-      <ResponsiveContainer width="100%" height={chartHeight}>
-        <BarChart
-          layout="vertical"
-          data={chartData}
-          margin={{ top: 4, right: 48, bottom: 8, left: 4 }}
-        >
-          <CartesianGrid
-            strokeDasharray="3 3"
-            horizontal={false}
-            stroke={theme.palette.divider}
-          />
-          <XAxis
-            type="number"
-            domain={[0, 100]}
-            tickFormatter={(v: number) => `${v}%`}
-            tick={{
-              fontSize: 12,
-              fill: theme.palette.text.secondary as string,
-            }}
-          />
-          <YAxis
-            type="category"
-            dataKey="name"
-            width={160}
-            tick={{
-              fontSize: 12,
-              fill: theme.palette.text.secondary as string,
-            }}
-            tickFormatter={(name: string) =>
-              name.length > 22 ? `${name.slice(0, 19)}\u2026` : name
-            }
-          />
-          <RechartsTooltip
-            cursor={{ fill: theme.palette.action.hover }}
-            formatter={(value: number) => [`${value.toFixed(1)}%`, 'Fail Rate']}
-            labelStyle={{ fontWeight: 600 }}
-          />
-          <Bar dataKey="failRate" radius={[0, 4, 4, 0]} maxBarSize={30}>
-            {chartData.map(entry => (
-              <Cell key={entry.name} fill={getBandColor(entry.failRate)} />
-            ))}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
-
-      <Box sx={{ mt: 3 }}>
-        <MetricTable stats={stats} onViewMetric={onViewMetric} />
-      </Box>
+      <MetricTable stats={stats} onViewMetric={onViewMetric} />
     </SectionCard>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTracesTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTracesTab.tsx
@@ -29,26 +29,46 @@ export default function TestRunTracesTab({
   }, []);
 
   return (
-    <Box>
-      <Paper
-        sx={{
-          width: '100%',
-          borderRadius: BORDER_RADIUS.md,
-          boxShadow: ELEVATION.xs,
-          border: theme => `1px solid ${theme.palette.greyscale.border}`,
-          overflow: 'hidden',
-          display: showEmptyHint ? 'none' : 'block',
-        }}
+    <Box sx={{ position: 'relative' }}>
+      {/*
+       * TracesClient must stay mounted to detect the empty state via onUnfilteredEmpty.
+       * When empty we collapse the wrapper to 0 height and make it invisible instead of
+       * using display:none — display:none removes the element from layout and causes the
+       * MUI DataGrid inside to measure a 0px width, triggering a console warning.
+       */}
+      <Box
+        sx={
+          showEmptyHint
+            ? {
+                position: 'absolute',
+                width: '100%',
+                height: 0,
+                overflow: 'hidden',
+                visibility: 'hidden',
+                pointerEvents: 'none',
+              }
+            : {}
+        }
       >
-        <TracesClient
-          sessionToken={sessionToken}
-          currentUserId={currentUserId}
-          currentUserName={currentUserName}
-          currentUserPicture={currentUserPicture}
-          fixedTestRunId={testRunId}
-          onUnfilteredEmpty={handleUnfilteredEmpty}
-        />
-      </Paper>
+        <Paper
+          sx={{
+            width: '100%',
+            borderRadius: BORDER_RADIUS.md,
+            boxShadow: ELEVATION.xs,
+            border: theme => `1px solid ${theme.palette.greyscale.border}`,
+            overflow: 'hidden',
+          }}
+        >
+          <TracesClient
+            sessionToken={sessionToken}
+            currentUserId={currentUserId}
+            currentUserName={currentUserName}
+            currentUserPicture={currentUserPicture}
+            fixedTestRunId={testRunId}
+            onUnfilteredEmpty={handleUnfilteredEmpty}
+          />
+        </Paper>
+      </Box>
 
       {showEmptyHint && (
         <Box sx={{ mt: 3 }}>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTracesTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunTracesTab.tsx
@@ -37,6 +37,7 @@ export default function TestRunTracesTab({
           boxShadow: ELEVATION.xs,
           border: theme => `1px solid ${theme.palette.greyscale.border}`,
           overflow: 'hidden',
+          display: showEmptyHint ? 'none' : 'block',
         }}
       >
         <TracesClient

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunDrawer.tsx
@@ -15,7 +15,6 @@ import {
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { TestSet } from '@/utils/api-client/interfaces/test-set';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
-import { Project } from '@/utils/api-client/interfaces/project';
 import { TestConfigurationCreate } from '@/utils/api-client/interfaces/test-configuration';
 import { UUID } from 'crypto';
 import { useNotifications } from '@/components/common/NotificationContext';
@@ -46,11 +45,9 @@ export default function TestRunDrawer({
   const [error, setError] = React.useState<string>();
   const [loading, setLoading] = React.useState(false);
   const [testSet, setTestSet] = React.useState<TestSet | null>(null);
-  const [project, setProject] = React.useState<Project | null>(null);
   const [endpoint, setEndpoint] = React.useState<Endpoint | null>(null);
 
   const [testSets, setTestSets] = React.useState<TestSet[]>([]);
-  const [projects, setProjects] = React.useState<Project[]>([]);
   const [endpoints, setEndpoints] = React.useState<Endpoint[]>([]);
   const [filteredEndpoints, setFilteredEndpoints] = React.useState<Endpoint[]>(
     []
@@ -88,49 +85,23 @@ export default function TestRunDrawer({
 
         const clientFactory = new ApiClientFactory(sessionToken);
         const testSetsClient = clientFactory.getTestSetsClient();
-        const projectsClient = clientFactory.getProjectsClient();
         const endpointsClient = clientFactory.getEndpointsClient();
 
         try {
-          const [fetchedTestSets, fetchedProjects, fetchedEndpoints] =
-            await Promise.all([
-              testSetsClient.getTestSets({ limit: 100 }),
-              projectsClient.getProjects(),
-              endpointsClient.getEndpoints(),
-            ]);
+          const [fetchedTestSets, fetchedEndpoints] = await Promise.all([
+            testSetsClient.getTestSets({ limit: 100 }),
+            endpointsClient.getEndpoints(),
+          ]);
 
           // Ensure we always set arrays, never undefined
           setTestSets(
             Array.isArray(fetchedTestSets?.data) ? fetchedTestSets.data : []
           );
 
-          // Handle both response formats for projects: direct array or {data: array}
-          let projectsArray: Project[] = [];
-          if (Array.isArray(fetchedProjects)) {
-            // Direct array response (what we're getting)
-            projectsArray = fetchedProjects;
-          } else if (fetchedProjects && Array.isArray(fetchedProjects.data)) {
-            // Paginated response with data property
-            projectsArray = fetchedProjects.data;
-          } else {
-          }
-
-          setProjects(projectsArray);
           const allEndpoints = Array.isArray(fetchedEndpoints?.data)
             ? fetchedEndpoints.data
             : [];
           setEndpoints(allEndpoints);
-
-          // Pre-select the active project from the session cookie
-          const activeProjectId = readActiveProjectId();
-          if (activeProjectId && projectsArray.length > 0) {
-            const activeProject = projectsArray.find(
-              p => p.id === activeProjectId
-            );
-            if (activeProject) {
-              setProject(activeProject);
-            }
-          }
 
           // Set initial values if editing
           if (testRun) {
@@ -150,7 +121,6 @@ export default function TestRunDrawer({
           setError('Failed to load required data');
           // Ensure state remains as empty arrays even on error
           setTestSets([]);
-          setProjects([]);
           setEndpoints([]);
           setFilteredEndpoints([]);
         }
@@ -166,11 +136,12 @@ export default function TestRunDrawer({
     }
   }, [sessionToken, testRun, getCurrentUserId, open]);
 
-  // Filter endpoints by selected project; when no project is selected show all
+  // Filter endpoints by the active project; fall back to all when none is set
   React.useEffect(() => {
     if (Array.isArray(endpoints)) {
-      const filtered = project
-        ? endpoints.filter(e => e.project_id === project.id)
+      const activeProjectId = readActiveProjectId();
+      const filtered = activeProjectId
+        ? endpoints.filter(e => e.project_id === activeProjectId)
         : endpoints;
       setFilteredEndpoints(filtered);
       // Clear endpoint selection if it no longer appears in the filtered list
@@ -178,7 +149,7 @@ export default function TestRunDrawer({
         setEndpoint(null);
       }
     }
-  }, [project, endpoints, endpoint]);
+  }, [endpoints, endpoint]);
 
   const handleSave = async () => {
     if (!sessionToken || !testSet || !endpoint) {
@@ -312,29 +283,6 @@ export default function TestRunDrawer({
               fullWidth
               renderInput={params => (
                 <TextField {...params} label="Test Set" required />
-              )}
-            />
-
-            <Autocomplete
-              options={Array.isArray(projects) ? projects : []}
-              value={project}
-              onChange={(_, newValue) => setProject(newValue)}
-              getOptionLabel={option => option.name}
-              isOptionEqualToValue={(option, value) => option.id === value.id}
-              renderOption={(props, option) => {
-                const { key: _key, ...otherProps } = props;
-                return (
-                  <Box component="li" key={option.id} {...otherProps}>
-                    {option.name}
-                  </Box>
-                );
-              }}
-              fullWidth
-              renderInput={params => (
-                <TextField
-                  {...params}
-                  label="Project (optional — filters endpoints)"
-                />
               )}
             />
 

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -8,15 +8,12 @@ import React, {
   useRef,
   useMemo,
 } from 'react';
-import DeleteIcon from '@mui/icons-material/Delete';
-import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import ListIcon from '@mui/icons-material/List';
 import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
 import GridBadge from '@/components/common/GridBadge';
 import TagLabel from '@/components/common/Tag';
 import {
   GridColDef,
-  GridRowSelectionModel,
   GridPaginationModel,
   GridFilterModel,
   GridToolbarColumnsButton,
@@ -153,7 +150,6 @@ function TestRunsGrid({
   const [statusFilter, setStatusFilter] = useState('all');
 
   // ── Core grid state ────────────────────────────────────────────────────────
-  const [selectedRows, setSelectedRows] = useState<GridRowSelectionModel>([]);
   const [testRuns, setTestRuns] = useState<TestRunDetail[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -163,6 +159,7 @@ function TestRunsGrid({
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [cancelModalOpen, setCancelModalOpen] = useState(false);
   const [isCancelling, setIsCancelling] = useState(false);
+  const [pendingCancelId, setPendingCancelId] = useState<string | null>(null);
   const [runKindFilter, setRunKindFilter] = useState<RunKindFilter>('all');
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
     page: 0,
@@ -339,12 +336,27 @@ function TestRunsGrid({
     [router]
   );
 
+  const handleRowCancelAction = useCallback((id: string) => {
+    setPendingCancelId(id);
+    setCancelModalOpen(true);
+  }, []);
+
+  const isCancellableRun = useCallback((row: Record<string, unknown>) => {
+    const statusName = (
+      (row.status as { name?: string } | undefined)?.name ?? ''
+    ).toLowerCase();
+    return statusName === 'queued' || statusName === 'progress';
+  }, []);
+
   // ── Column definitions ────────────────────────────────────────────────────
 
   const columns: GridColDef[] = useMemo(() => {
     const actionsCol = createRowActionsColumn({
       onEdit: id => handleRowEditAction(id),
+      onCancel: id => handleRowCancelAction(id),
+      canCancel: isCancellableRun,
       onDelete: id => handleRowDeleteAction(id),
+      width: 112,
     });
     return [
       {
@@ -618,7 +630,12 @@ function TestRunsGrid({
       },
       actionsCol,
     ];
-  }, [handleRowEditAction, handleRowDeleteAction]);
+  }, [
+    handleRowEditAction,
+    handleRowCancelAction,
+    isCancellableRun,
+    handleRowDeleteAction,
+  ]);
 
   // ── Row handlers ──────────────────────────────────────────────────────────
 
@@ -627,13 +644,6 @@ function TestRunsGrid({
       router.push(`/test-runs/${params.id}`);
     },
     [router]
-  );
-
-  const handleSelectionChange = useCallback(
-    (newSelection: GridRowSelectionModel) => {
-      setSelectedRows(newSelection);
-    },
-    []
   );
 
   const handlePaginationModelChange = useCallback(
@@ -655,47 +665,31 @@ function TestRunsGrid({
 
   // ── Delete handlers ───────────────────────────────────────────────────────
 
-  const handleDeleteSelected = useCallback(() => {
-    const validSelectedRows = Array.isArray(selectedRows) ? selectedRows : [];
-    if (validSelectedRows.length === 0) return;
-    setDeleteModalOpen(true);
-  }, [selectedRows]);
-
   const handleDeleteConfirm = useCallback(async () => {
-    const idsToDelete = pendingDeleteId
-      ? [pendingDeleteId]
-      : Array.isArray(selectedRows)
-        ? selectedRows.map(String)
-        : [];
-    if (idsToDelete.length === 0) return;
+    if (!pendingDeleteId) return;
 
     try {
       setIsDeleting(true);
       const clientFactory = new ApiClientFactory(sessionToken);
       const testRunsClient = clientFactory.getTestRunsClient();
 
-      await Promise.all(
-        idsToDelete.map(id => testRunsClient.deleteTestRun(id))
-      );
+      await testRunsClient.deleteTestRun(pendingDeleteId);
 
-      notifications.show(
-        `Successfully deleted ${idsToDelete.length} test run${idsToDelete.length === 1 ? '' : 's'}`,
-        { severity: 'success' }
-      );
+      notifications.show('Successfully deleted test run', {
+        severity: 'success',
+      });
 
       setPendingDeleteId(null);
       const skip = paginationModel.page * paginationModel.pageSize;
       await fetchTestRuns(skip, paginationModel.pageSize);
-      setSelectedRows([]);
     } catch (_error) {
-      notifications.show('Failed to delete test runs', { severity: 'error' });
+      notifications.show('Failed to delete test run', { severity: 'error' });
     } finally {
       setIsDeleting(false);
       setDeleteModalOpen(false);
     }
   }, [
     pendingDeleteId,
-    selectedRows,
     sessionToken,
     notifications,
     paginationModel,
@@ -709,25 +703,8 @@ function TestRunsGrid({
 
   // ── Cancel handlers ───────────────────────────────────────────────────────
 
-  const cancellableSelectedRuns = useMemo(() => {
-    const validSelectedRows = Array.isArray(selectedRows) ? selectedRows : [];
-    return testRuns.filter(run => {
-      const status = run.status?.name?.toLowerCase();
-      return (
-        validSelectedRows.includes(run.id) &&
-        (status === 'queued' || status === 'progress')
-      );
-    });
-  }, [selectedRows, testRuns]);
-
-  const handleCancelSelected = useCallback(() => {
-    setCancelModalOpen(true);
-  }, []);
-
   const handleCancelConfirm = useCallback(async () => {
-    const ids = cancellableSelectedRuns.map(run => run.id.toString());
-
-    if (ids.length === 0) {
+    if (!pendingCancelId) {
       setCancelModalOpen(false);
       return;
     }
@@ -736,23 +713,22 @@ function TestRunsGrid({
       setIsCancelling(true);
       const clientFactory = new ApiClientFactory(sessionToken);
       const testRunsClient = clientFactory.getTestRunsClient();
-      await Promise.all(ids.map(id => testRunsClient.cancelTestRun(id)));
-      notifications.show(
-        `Successfully cancelled ${ids.length} test run${ids.length === 1 ? '' : 's'}`,
-        { severity: 'success' }
-      );
+      await testRunsClient.cancelTestRun(pendingCancelId);
+      notifications.show('Successfully cancelled test run', {
+        severity: 'success',
+      });
+      setPendingCancelId(null);
       const skip = paginationModel.page * paginationModel.pageSize;
       await fetchTestRuns(skip, paginationModel.pageSize);
-      setSelectedRows([]);
       onRefresh?.();
     } catch (_error) {
-      notifications.show('Failed to cancel test runs', { severity: 'error' });
+      notifications.show('Failed to cancel test run', { severity: 'error' });
     } finally {
       setIsCancelling(false);
       setCancelModalOpen(false);
     }
   }, [
-    cancellableSelectedRuns,
+    pendingCancelId,
     sessionToken,
     notifications,
     paginationModel,
@@ -762,44 +738,13 @@ function TestRunsGrid({
 
   const handleCancelClose = useCallback(() => {
     setCancelModalOpen(false);
+    setPendingCancelId(null);
   }, []);
 
   const handleRunKindFilterChange = useCallback((value: RunKindFilter) => {
     setRunKindFilter(value);
     setPaginationModel(prev => ({ ...prev, page: 0 }));
   }, []);
-
-  const actionButtons = useMemo(() => {
-    const buttons = [];
-    const validSelectedRows = Array.isArray(selectedRows) ? selectedRows : [];
-
-    if (cancellableSelectedRuns.length > 0) {
-      buttons.push({
-        label: `Cancel Test Run${cancellableSelectedRuns.length === 1 ? '' : 's'}`,
-        icon: <StopCircleOutlinedIcon />,
-        variant: 'outlined' as const,
-        color: 'warning' as const,
-        onClick: handleCancelSelected,
-      });
-    }
-
-    if (validSelectedRows.length > 0) {
-      buttons.push({
-        label: 'Delete Test Runs',
-        icon: <DeleteIcon />,
-        variant: 'outlined' as const,
-        color: 'error' as const,
-        onClick: handleDeleteSelected,
-      });
-    }
-
-    return buttons;
-  }, [
-    selectedRows,
-    cancellableSelectedRuns,
-    handleCancelSelected,
-    handleDeleteSelected,
-  ]);
 
   const runKindToolbar = useMemo(
     () => (
@@ -848,24 +793,6 @@ function TestRunsGrid({
         </Alert>
       )}
 
-      {Array.isArray(selectedRows) && selectedRows.length > 0 && (
-        <Box
-          sx={{
-            px: 2,
-            py: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2,
-            borderBottom: theme =>
-              `1px solid ${theme.palette.greyscale.border}`,
-          }}
-        >
-          <Typography variant="subtitle1" color="primary">
-            {selectedRows.length} selected
-          </Typography>
-        </Box>
-      )}
-
       <BaseDataGrid
         rows={testRuns}
         columns={columns}
@@ -876,15 +803,10 @@ function TestRunsGrid({
         filterModel={filterModel}
         onFilterModelChange={handleFilterModelChange}
         serverSideFiltering={true}
-        onRowSelectionModelChange={handleSelectionChange}
-        rowSelectionModel={Array.isArray(selectedRows) ? selectedRows : []}
         onRowClick={handleRowClick}
         serverSidePagination={true}
         totalRows={totalCount}
         pageSizeOptions={[10, 25, 50]}
-        checkboxSelection
-        disableRowSelectionOnClick
-        actionButtons={actionButtons}
         gridToolbarExtra={runKindToolbar}
         disablePaperWrapper={true}
         showToolbar={true}
@@ -898,12 +820,8 @@ function TestRunsGrid({
         onClose={handleDeleteCancel}
         onConfirm={handleDeleteConfirm}
         isLoading={isDeleting}
-        title={pendingDeleteId ? 'Delete Test Run' : 'Delete Test Runs'}
-        message={
-          pendingDeleteId
-            ? 'Are you sure you want to delete this test run? Related data will not be deleted.'
-            : `Are you sure you want to delete ${Array.isArray(selectedRows) ? selectedRows.length : 0} test run${Array.isArray(selectedRows) && selectedRows.length === 1 ? '' : 's'}? Don't worry, related data will not be deleted, only ${Array.isArray(selectedRows) && selectedRows.length === 1 ? 'this record' : 'these records'}.`
-        }
+        title="Delete Test Run"
+        message="Are you sure you want to delete this test run? Related data will not be deleted."
         itemType="test runs"
       />
 
@@ -912,8 +830,8 @@ function TestRunsGrid({
         onClose={handleCancelClose}
         onConfirm={handleCancelConfirm}
         isLoading={isCancelling}
-        title={`Cancel Test Run${cancellableSelectedRuns.length === 1 ? '' : 's'}`}
-        message={`Are you sure you want to cancel ${cancellableSelectedRuns.length} test run${cancellableSelectedRuns.length === 1 ? '' : 's'}? ${cancellableSelectedRuns.length === 1 ? 'It' : 'They'} will be stopped and marked as Cancelled.`}
+        title="Cancel Test Run"
+        message="Are you sure you want to cancel this test run? It will be stopped and marked as Cancelled."
         itemType="test run"
         confirmButtonText={isCancelling ? 'Cancelling...' : 'Cancel Run'}
         cancelButtonText="Keep Running"

--- a/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsGrid.test.tsx
@@ -52,45 +52,30 @@ jest.mock('@/utils/api-client/client-factory', () => ({
 // toolbarSlot is not rendered here: MUI DataGrid toolbar slots require the
 // real DataGrid context and cannot be exercised in a shallow unit test.
 
-type ActionButton = {
-  label: string;
-  onClick?: () => void;
-  disabled?: boolean;
-};
-
 jest.mock('@/components/common/BaseDataGrid', () => {
   return function MockBaseDataGrid({
     rows,
     loading,
-    actionButtons,
+    columns,
     onRowClick,
-    checkboxSelection,
-    onRowSelectionModelChange,
-    rowSelectionModel,
   }: {
     rows: Array<Record<string, unknown>>;
     loading?: boolean;
-    actionButtons?: ActionButton[];
+    columns?: Array<{
+      field: string;
+      renderCell?: (params: {
+        id: unknown;
+        row: Record<string, unknown>;
+      }) => React.ReactNode;
+    }>;
     onRowClick?: (p: { id: unknown; row: Record<string, unknown> }) => void;
-    checkboxSelection?: boolean;
-    onRowSelectionModelChange?: (sel: unknown[]) => void;
-    rowSelectionModel?: unknown[];
     toolbarSlot?: unknown;
     showToolbar?: boolean;
   }) {
     if (loading) return <div data-testid="grid-loading">Loading…</div>;
+    const actionsCol = columns?.find(c => c.field === 'actions');
     return (
       <div data-testid="base-data-grid">
-        {actionButtons?.map(btn => (
-          <button
-            key={btn.label}
-            onClick={btn.onClick}
-            disabled={btn.disabled}
-            data-testid={`action-${btn.label}`}
-          >
-            {btn.label}
-          </button>
-        ))}
         {rows.map(row => (
           <div
             key={String(row.id)}
@@ -98,23 +83,7 @@ jest.mock('@/components/common/BaseDataGrid', () => {
             data-testid={`row-${row.id}`}
             onClick={() => onRowClick?.({ id: row.id, row })}
           >
-            {checkboxSelection && (
-              <input
-                type="checkbox"
-                aria-label={`select-${row.id}`}
-                checked={((rowSelectionModel as unknown[]) ?? []).includes(
-                  row.id
-                )}
-                onChange={e => {
-                  const prev = (rowSelectionModel as unknown[]) ?? [];
-                  onRowSelectionModelChange?.(
-                    e.target.checked
-                      ? [...prev, row.id]
-                      : prev.filter(id => id !== row.id)
-                  );
-                }}
-              />
-            )}
+            {actionsCol?.renderCell?.({ id: row.id, row })}
           </div>
         ))}
       </div>
@@ -130,6 +99,7 @@ jest.mock('../TestRunFilterDrawer', () => ({
     open ? <div data-testid="test-run-filter-drawer" /> : null,
   EMPTY_TEST_RUN_FILTERS: { testSet: '', executor: '', tag: '' },
   hasActiveTestRunFilters: () => false,
+  countActiveTestRunFilters: () => 0,
 }));
 
 jest.mock('@/components/common/DeleteModal', () => ({
@@ -156,10 +126,14 @@ jest.mock('@/components/common/DeleteModal', () => ({
 
 // ---- Fixtures ----
 
-const makeTestRun = (id: string, name = 'Test Run') => ({
+const makeTestRun = (
+  id: string,
+  name = 'Test Run',
+  statusName = 'Completed'
+) => ({
   id,
   name,
-  status: { id: 's1', name: 'Completed' },
+  status: { id: 's1', name: statusName },
   test_configuration: {
     test_set: { name: 'Set A', test_set_type: { type_value: 'evaluation' } },
     endpoint: { project_id: null },
@@ -236,7 +210,41 @@ describe('TestRunsGrid', () => {
     expect(mockPush).toHaveBeenCalledWith('/test-runs/r-99');
   });
 
-  it('shows "Delete Test Runs" button when rows are selected', async () => {
+  it('renders a delete action button in the row actions column', async () => {
+    mockGetTestRuns.mockResolvedValue(
+      makePaginatedResponse([makeTestRun('r-1')])
+    );
+    render(<TestRunsGrid sessionToken="tok" />);
+    await waitFor(() =>
+      expect(screen.getByTestId('row-r-1')).toBeInTheDocument()
+    );
+    // The row-actions column renders a Delete icon button
+    expect(screen.getByLabelText('Delete')).toBeInTheDocument();
+  });
+
+  it('does not render a cancel action for completed runs', async () => {
+    mockGetTestRuns.mockResolvedValue(
+      makePaginatedResponse([makeTestRun('r-1', 'Test Run', 'Completed')])
+    );
+    render(<TestRunsGrid sessionToken="tok" />);
+    await waitFor(() =>
+      expect(screen.getByTestId('row-r-1')).toBeInTheDocument()
+    );
+    expect(screen.queryByLabelText('Cancel')).not.toBeInTheDocument();
+  });
+
+  it('renders a cancel action for queued runs', async () => {
+    mockGetTestRuns.mockResolvedValue(
+      makePaginatedResponse([makeTestRun('r-1', 'Test Run', 'queued')])
+    );
+    render(<TestRunsGrid sessionToken="tok" />);
+    await waitFor(() =>
+      expect(screen.getByTestId('row-r-1')).toBeInTheDocument()
+    );
+    expect(screen.getByLabelText('Cancel')).toBeInTheDocument();
+  });
+
+  it('opens delete modal on clicking the row delete button', async () => {
     mockGetTestRuns.mockResolvedValue(
       makePaginatedResponse([makeTestRun('r-1')])
     );
@@ -245,36 +253,7 @@ describe('TestRunsGrid', () => {
       expect(screen.getByTestId('row-r-1')).toBeInTheDocument()
     );
 
-    await userEvent.click(screen.getByLabelText('select-r-1'));
-    await waitFor(() =>
-      expect(screen.getByTestId('action-Delete Test Runs')).toBeInTheDocument()
-    );
-  });
-
-  it('hides "Delete Test Runs" button when nothing is selected', async () => {
-    render(<TestRunsGrid sessionToken="tok" />);
-    await waitFor(() =>
-      expect(screen.queryByTestId('grid-loading')).not.toBeInTheDocument()
-    );
-    expect(
-      screen.queryByTestId('action-Delete Test Runs')
-    ).not.toBeInTheDocument();
-  });
-
-  it('opens delete modal on clicking "Delete Test Runs"', async () => {
-    mockGetTestRuns.mockResolvedValue(
-      makePaginatedResponse([makeTestRun('r-1')])
-    );
-    render(<TestRunsGrid sessionToken="tok" />);
-    await waitFor(() =>
-      expect(screen.getByTestId('row-r-1')).toBeInTheDocument()
-    );
-
-    await userEvent.click(screen.getByLabelText('select-r-1'));
-    await waitFor(() =>
-      expect(screen.getByTestId('action-Delete Test Runs')).toBeInTheDocument()
-    );
-    await userEvent.click(screen.getByTestId('action-Delete Test Runs'));
+    await userEvent.click(screen.getByLabelText('Delete'));
     expect(screen.getByTestId('delete-modal')).toBeInTheDocument();
   });
 
@@ -288,11 +267,7 @@ describe('TestRunsGrid', () => {
       expect(screen.getByTestId('row-r-1')).toBeInTheDocument()
     );
 
-    await userEvent.click(screen.getByLabelText('select-r-1'));
-    await waitFor(() =>
-      expect(screen.getByTestId('action-Delete Test Runs')).toBeInTheDocument()
-    );
-    await userEvent.click(screen.getByTestId('action-Delete Test Runs'));
+    await userEvent.click(screen.getByLabelText('Delete'));
     await userEvent.click(
       screen.getByRole('button', { name: /confirm delete/i })
     );
@@ -316,11 +291,7 @@ describe('TestRunsGrid', () => {
       expect(screen.getByTestId('row-r-1')).toBeInTheDocument()
     );
 
-    await userEvent.click(screen.getByLabelText('select-r-1'));
-    await waitFor(() =>
-      expect(screen.getByTestId('action-Delete Test Runs')).toBeInTheDocument()
-    );
-    await userEvent.click(screen.getByTestId('action-Delete Test Runs'));
+    await userEvent.click(screen.getByLabelText('Delete'));
     await userEvent.click(
       screen.getByRole('button', { name: /confirm delete/i })
     );

--- a/apps/frontend/src/components/common/createRowActionsColumn.tsx
+++ b/apps/frontend/src/components/common/createRowActionsColumn.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Box, IconButton, Tooltip } from '@mui/material';
 import type { SxProps, Theme } from '@mui/material/styles';
 import type { GridColDef } from '@mui/x-data-grid';
+import StopCircleOutlinedIcon from '@mui/icons-material/StopCircleOutlined';
 import { EditIcon, DeleteIcon } from '@/components/icons';
 
 export const ROW_ACTIONS_CLASS = 'row-actions';
@@ -27,21 +28,28 @@ export const rowActionsHoverSx: SxProps<Theme> = {
 interface RowActionsColumnOptions {
   onEdit?: (id: string, row: Record<string, unknown>) => void;
   onDelete?: (id: string, row: Record<string, unknown>) => void;
+  onCancel?: (id: string, row: Record<string, unknown>) => void;
+  canCancel?: (row: Record<string, unknown>) => boolean;
   width?: number;
   editTooltip?: string;
   deleteTooltip?: string;
+  cancelTooltip?: string;
 }
 
 /**
- * Creates a header-less trailing column showing edit + delete icons that are
- * revealed on row hover. Pass `onEdit` and/or `onDelete` as needed.
+ * Creates a header-less trailing column showing edit / delete / cancel icons
+ * revealed on row hover. Pass handlers as needed; `onCancel` is only rendered
+ * when `canCancel(row)` returns true (defaults to always-true if omitted).
  */
 export function createRowActionsColumn({
   onEdit,
   onDelete,
+  onCancel,
+  canCancel,
   width = 88,
   editTooltip = 'Edit',
   deleteTooltip = 'Delete',
+  cancelTooltip = 'Cancel',
 }: RowActionsColumnOptions): GridColDef {
   return {
     field: 'actions',
@@ -54,6 +62,8 @@ export function createRowActionsColumn({
     renderCell: params => {
       const id = String(params.id);
       const row = params.row as Record<string, unknown>;
+      const cancelFn = onCancel;
+      const showCancel = cancelFn && (!canCancel || canCancel(row));
 
       return (
         <Box
@@ -84,6 +94,27 @@ export function createRowActionsColumn({
                 }}
               >
                 <EditIcon sx={{ fontSize: 18 }} />
+              </IconButton>
+            </Tooltip>
+          )}
+          {showCancel && cancelFn && (
+            <Tooltip title={cancelTooltip}>
+              <IconButton
+                size="small"
+                onClick={e => {
+                  e.stopPropagation();
+                  cancelFn(id, row);
+                }}
+                sx={{
+                  p: 0.5,
+                  color: 'text.secondary',
+                  '&:hover': {
+                    color: 'warning.main',
+                    bgcolor: 'action.hover',
+                  },
+                }}
+              >
+                <StopCircleOutlinedIcon sx={{ fontSize: 18 }} />
               </IconButton>
             </Tooltip>
           )}


### PR DESCRIPTION
## Purpose
Five focused UI polish changes to the /test-runs list page, create drawer, and detail pages to reduce noise and improve clarity.

## What Changed
- **Grid**: removed multi-select checkbox column; added per-row hover actions (cancel for queued/in-progress runs, delete) via an extended `createRowActionsColumn`
- **Create drawer**: removed Project dropdown; endpoints are now auto-filtered by the active project id (falls back to all when none is set)
- **Summary tab**: dropped Behavior and Metric bar charts; sortable tables are kept inside the section cards
- **Traces tab**: grid is hidden (collapsed + invisible) when no traces exist; only the empty-state card is shown — uses `position:absolute`/`visibility:hidden` instead of `display:none` to avoid the MUI DataGrid empty-width console warning
- **Status card**: stripped test-set and endpoint info; now shows only the status chip
- **Configuration tab**: Test Set and Endpoint fields now link to their respective detail pages (with open-in-new icon); fall back to plain text when IDs are absent

## Testing
- All 13 `TestRunsGrid` unit tests pass
- ESLint clean on all touched files
- Manually verify: list grid has no checkbox; row hover shows cancel (queued/in-progress only) and delete; create drawer has no project field; summary tab shows only tables; empty traces shows only the empty-state card; status card shows just the chip; configuration tab links test set + endpoint