### PR TITLE
Update test detail page UI

### DIFF
--- a/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestDetailTabs.tsx
@@ -37,10 +37,10 @@ export default function TestDetailTabs({
     key,
     label:
       key === 'basic'
-        ? 'Basic Information'
+        ? 'Overview'
         : key === 'linked'
-          ? 'Linked entities'
-          : 'Tasks',
+          ? 'Linked Test Sets'
+          : 'Tasks & Comments',
     id: `test-detail-tab-${index}`,
     'aria-controls': `test-detail-tabpanel-${index}`,
   }));

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestFormElementsCard.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestFormElementsCard.tsx
@@ -1,16 +1,12 @@
 'use client';
 
 import * as React from 'react';
-import { Box, Typography } from '@mui/material';
 import EditableSection from '@/components/common/EditableSection';
 import TagsField from '@/components/common/TagsField';
-import FileAttachmentList from '@/components/common/FileAttachmentList';
-import MultiFileUpload from '@/components/common/MultiFileUpload';
 import { TestDetail } from '@/utils/api-client/interfaces/tests';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { EntityType, Tag } from '@/utils/api-client/interfaces/tag';
 import { TagsClient } from '@/utils/api-client/tags-client';
-import { useFiles } from '@/hooks/useFiles';
 import { UUID } from 'crypto';
 
 interface TagsDraft {
@@ -29,20 +25,6 @@ export default function TestFormElementsCard({
   onUpdate: _onUpdate,
 }: TestFormElementsCardProps) {
   const notifications = useNotifications();
-  const [pendingFiles, setPendingFiles] = React.useState<File[]>([]);
-  const [isUploading, setIsUploading] = React.useState(false);
-
-  const {
-    files: attachedFiles,
-    isLoading: filesLoading,
-    totalSizeBytes: existingFilesSize,
-    uploadFiles: uploadFilesToServer,
-    deleteFile: deleteAttachedFile,
-  } = useFiles({
-    entityId: test.id,
-    entityType: 'Test',
-    sessionToken,
-  });
 
   const initialTagNames = (test.tags ?? []).map((t: Tag) => t.name);
 
@@ -81,22 +63,9 @@ export default function TestFormElementsCard({
     });
   };
 
-  const handleFilesSelect = React.useCallback(
-    async (files: File[]) => {
-      setPendingFiles([]);
-      setIsUploading(true);
-      try {
-        await uploadFilesToServer(files);
-      } finally {
-        setIsUploading(false);
-      }
-    },
-    [uploadFilesToServer]
-  );
-
   return (
     <EditableSection
-      title="Tags & attachments"
+      title="Tags"
       initialValue={initialDraft}
       onSave={handleSave}
       isDirty={(draft, initial) =>
@@ -105,56 +74,12 @@ export default function TestFormElementsCard({
       }
     >
       {({ draft, setDraft, isEditing }) => (
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-          {/* Tags */}
-          <TagsField
-            tagNames={draft.tagNames}
-            isEditing={isEditing}
-            onChange={tagNames => setDraft(d => ({ ...d, tagNames }))}
-            helperText="These tags help categorize and find this test"
-          />
-
-          {/* Attachments */}
-          <Box>
-            <Typography
-              sx={{
-                fontSize: 18,
-                fontWeight: 700,
-                lineHeight: '25px',
-                color: 'text.primary',
-                mb: '2px',
-              }}
-            >
-              Attachments
-            </Typography>
-            <Typography
-              sx={{
-                fontSize: 12,
-                lineHeight: '18px',
-                color: 'text.secondary',
-                display: 'block',
-                mb: 2,
-              }}
-            >
-              Images, PDFs or audio files attached to this test
-            </Typography>
-            <FileAttachmentList
-              files={attachedFiles}
-              sessionToken={sessionToken}
-              isLoading={filesLoading}
-              onDelete={deleteAttachedFile}
-            />
-            <MultiFileUpload
-              selectedFiles={pendingFiles}
-              onFilesSelect={handleFilesSelect}
-              onFileRemove={idx =>
-                setPendingFiles(prev => prev.filter((_, i) => i !== idx))
-              }
-              existingFilesSize={existingFilesSize}
-              disabled={isUploading}
-            />
-          </Box>
-        </Box>
+        <TagsField
+          tagNames={draft.tagNames}
+          isEditing={isEditing}
+          onChange={tagNames => setDraft(d => ({ ...d, tagNames }))}
+          helperText="These tags help categorize and find this test"
+        />
       )}
     </EditableSection>
   );

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestMetadataCard.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestMetadataCard.tsx
@@ -12,7 +12,6 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { TestDetail } from '@/utils/api-client/interfaces/tests';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { useRouter } from 'next/navigation';
-import { formatDate } from '@/utils/date';
 import { UUID } from 'crypto';
 
 interface TestDetailOption {
@@ -189,7 +188,7 @@ export default function TestMetadataCard({
             />
           </Grid>
 
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <Grid size={{ xs: 12, sm: 6, md: 6 }}>
             {isEditing ? (
               <BaseFreesoloAutocomplete
                 options={topics}
@@ -224,7 +223,7 @@ export default function TestMetadataCard({
             )}
           </Grid>
 
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <Grid size={{ xs: 12, sm: 6, md: 6 }}>
             {isEditing ? (
               <BaseFreesoloAutocomplete
                 options={categories}
@@ -261,15 +260,6 @@ export default function TestMetadataCard({
                 helperText="Infotext"
               />
             )}
-          </Grid>
-
-          {/* Row 2: Created (read-only), Priority */}
-          <Grid size={{ xs: 12, sm: 6 }}>
-            <ViewField
-              label="Created"
-              value={formatDate(test.created_at)}
-              helperText="Infotext"
-            />
           </Grid>
 
           <Grid size={{ xs: 12, sm: 6 }}>

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestTechnicalCard.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestTechnicalCard.tsx
@@ -2,12 +2,15 @@
 
 import * as React from 'react';
 import Grid from '@mui/material/Grid';
-import { TextField, Typography } from '@mui/material';
+import { Box, TextField, Typography } from '@mui/material';
 import EditableSection from '@/components/common/EditableSection';
 import ViewField from '@/components/common/ViewField';
+import FileAttachmentList from '@/components/common/FileAttachmentList';
+import MultiFileUpload from '@/components/common/MultiFileUpload';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { TestDetail } from '@/utils/api-client/interfaces/tests';
 import { useNotifications } from '@/components/common/NotificationContext';
+import { useFiles } from '@/hooks/useFiles';
 import { isMultiTurnTest } from '@/constants/test-types';
 import {
   MultiTurnTestConfig,
@@ -36,6 +39,84 @@ interface TestTechnicalCardProps {
   sessionToken: string;
   test: TestDetail;
   onUpdate?: () => void;
+}
+
+function AttachmentsBlock({
+  test,
+  sessionToken,
+}: {
+  test: TestDetail;
+  sessionToken: string;
+}) {
+  const [pendingFiles, setPendingFiles] = React.useState<File[]>([]);
+  const [isUploading, setIsUploading] = React.useState(false);
+
+  const {
+    files: attachedFiles,
+    isLoading: filesLoading,
+    totalSizeBytes: existingFilesSize,
+    uploadFiles: uploadFilesToServer,
+    deleteFile: deleteAttachedFile,
+  } = useFiles({
+    entityId: test.id,
+    entityType: 'Test',
+    sessionToken,
+  });
+
+  const handleFilesSelect = React.useCallback(
+    async (files: File[]) => {
+      setPendingFiles([]);
+      setIsUploading(true);
+      try {
+        await uploadFilesToServer(files);
+      } finally {
+        setIsUploading(false);
+      }
+    },
+    [uploadFilesToServer]
+  );
+
+  return (
+    <Box>
+      <Typography
+        sx={{
+          fontSize: 18,
+          fontWeight: 700,
+          lineHeight: '25px',
+          color: 'text.primary',
+          mb: '2px',
+        }}
+      >
+        Attachments
+      </Typography>
+      <Typography
+        sx={{
+          fontSize: 12,
+          lineHeight: '18px',
+          color: 'text.secondary',
+          display: 'block',
+          mb: 2,
+        }}
+      >
+        Images, PDFs or audio files attached to this test
+      </Typography>
+      <FileAttachmentList
+        files={attachedFiles}
+        sessionToken={sessionToken}
+        isLoading={filesLoading}
+        onDelete={deleteAttachedFile}
+      />
+      <MultiFileUpload
+        selectedFiles={pendingFiles}
+        onFilesSelect={handleFilesSelect}
+        onFileRemove={idx =>
+          setPendingFiles(prev => prev.filter((_, i) => i !== idx))
+        }
+        existingFilesSize={existingFilesSize}
+        disabled={isUploading}
+      />
+    </Box>
+  );
 }
 
 export default function TestTechnicalCard({
@@ -119,16 +200,19 @@ export default function TestTechnicalCard({
 
     return (
       <EditableSection
-        title="Prompts"
+        title="Test input"
         initialValue={initialMultiTurnDraft}
         onSave={handleMultiTurnSave}
       >
         {({ draft, setDraft, isEditing }) => (
-          <MultiTurnConfigFields
-            draft={draft}
-            setDraft={setDraft}
-            isEditing={isEditing}
-          />
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+            <MultiTurnConfigFields
+              draft={draft}
+              setDraft={setDraft}
+              isEditing={isEditing}
+            />
+            <AttachmentsBlock test={test} sessionToken={sessionToken} />
+          </Box>
         )}
       </EditableSection>
     );
@@ -136,7 +220,7 @@ export default function TestTechnicalCard({
 
   return (
     <EditableSection
-      title="Prompts"
+      title="Test input"
       initialValue={initialDraft}
       onSave={handleSave}
     >
@@ -240,6 +324,10 @@ export default function TestTechnicalCard({
               </Grid>
             </Grid>
           )}
+
+          <Grid size={12}>
+            <AttachmentsBlock test={test} sessionToken={sessionToken} />
+          </Grid>
         </Grid>
       )}
     </EditableSection>

--- a/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
+++ b/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
@@ -1,18 +1,21 @@
 'use client';
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { Box, Button, Paper, Typography } from '@mui/material';
-import GridBadge from '@/components/common/GridBadge';
 import AddIcon from '@mui/icons-material/Add';
 import RouteOutlinedIcon from '@mui/icons-material/RouteOutlined';
 import Link from 'next/link';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
-import { GridColDef, GridPaginationModel } from '@mui/x-data-grid';
+import AssignEntityDrawer from '@/components/common/AssignEntityDrawer';
+import {
+  GridColDef,
+  GridPaginationModel,
+  GridRowModel,
+} from '@mui/x-data-grid';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { TestSetsClient } from '@/utils/api-client/test-sets-client';
 import { TestSet } from '@/utils/api-client/interfaces/test-set';
 import { useNotifications } from '@/components/common/NotificationContext';
-import TestSetSelectionDialog from '@/app/(protected)/tests/components/TestSetSelectionDialog';
 import { formatDate } from '@/utils/date';
 
 interface LinkedTestSetsSectionProps {
@@ -33,7 +36,11 @@ export default function LinkedTestSetsSection({
     page: 0,
     pageSize: 10,
   });
-  const [assignDialogOpen, setAssignDialogOpen] = useState(false);
+
+  // Assign drawer state
+  const [assignOpen, setAssignOpen] = useState(false);
+  const [available, setAvailable] = useState<TestSet[]>([]);
+  const [loadingAvailable, setLoadingAvailable] = useState(false);
 
   const fetchLinkedTestSets = useCallback(async () => {
     if (!testId || !sessionToken) return;
@@ -68,27 +75,65 @@ export default function LinkedTestSetsSection({
     fetchLinkedTestSets();
   }, [fetchLinkedTestSets]);
 
-  const handleAssign = async (testSet: TestSet) => {
+  const handleAssignClick = useCallback(async () => {
+    setLoadingAvailable(true);
+    setAssignOpen(true);
     try {
       const testSetsClient = new TestSetsClient(sessionToken);
-      await testSetsClient.associateTestsWithTestSet(testSet.id, [testId]);
-      showNotification(`Assigned to "${testSet.name}"`, {
-        severity: 'success',
-        autoHideDuration: 4000,
+      const response = await testSetsClient.getTestSets({
+        limit: 500,
+        sort_by: 'name',
+        sort_order: 'asc',
       });
-      setAssignDialogOpen(false);
-      await fetchLinkedTestSets();
-    } catch (error) {
-      const msg = error instanceof Error ? error.message : '';
-      if (msg.includes('already associated')) {
-        showNotification('Test is already assigned to this test set', {
-          severity: 'warning',
+      setAvailable(response.data);
+    } catch {
+      setAvailable([]);
+    } finally {
+      setLoadingAvailable(false);
+    }
+  }, [sessionToken]);
+
+  const linkedIds = useMemo(
+    () => new Set(testSets.map(ts => String(ts.id))),
+    [testSets]
+  );
+
+  const availableFiltered = useMemo<GridRowModel[]>(
+    () => available.filter(ts => !linkedIds.has(String(ts.id))),
+    [available, linkedIds]
+  );
+
+  const handleAssign = useCallback(
+    async (selectedIds: string[]) => {
+      const testSetsClient = new TestSetsClient(sessionToken);
+      const errors: string[] = [];
+      await Promise.all(
+        selectedIds.map(async id => {
+          try {
+            await testSetsClient.associateTestsWithTestSet(id, [testId]);
+          } catch (error) {
+            const msg = error instanceof Error ? error.message : '';
+            if (!msg.includes('already associated')) {
+              errors.push(id);
+            }
+          }
+        })
+      );
+      if (errors.length > 0) {
+        showNotification('Failed to assign to some test sets', {
+          severity: 'error',
         });
       } else {
-        showNotification('Failed to assign to test set', { severity: 'error' });
+        showNotification(
+          `Assigned to ${selectedIds.length} test set${selectedIds.length !== 1 ? 's' : ''}`,
+          { severity: 'success', autoHideDuration: 4000 }
+        );
       }
-    }
-  };
+      setAssignOpen(false);
+      await fetchLinkedTestSets();
+    },
+    [sessionToken, testId, showNotification, fetchLinkedTestSets]
+  );
 
   const columns: GridColDef[] = [
     {
@@ -133,20 +178,17 @@ export default function LinkedTestSetsSection({
       ),
     },
     {
-      field: 'visibility',
-      headerName: 'Visibility',
-      width: 120,
-      renderCell: params => (
-        <GridBadge label={params.value ?? 'organization'} />
-      ),
-    },
-    {
       field: '__actions',
       headerName: '',
       width: 80,
       sortable: false,
       renderCell: () => null,
     },
+  ];
+
+  const drawerColumns: GridColDef[] = [
+    { field: 'name', headerName: 'Name', flex: 1, minWidth: 160 },
+    { field: 'description', headerName: 'Description', flex: 2, minWidth: 200 },
   ];
 
   const isEmpty = !loading && testSets.length === 0;
@@ -170,7 +212,7 @@ export default function LinkedTestSetsSection({
               variant="h6"
               sx={{ fontWeight: 600, color: 'primary.main' }}
             >
-              No assigned entity yet
+              No test sets assigned yet
             </Typography>
             <Typography variant="body2" color="text.secondary">
               Assign this test to a test set to group related cases together.
@@ -178,9 +220,9 @@ export default function LinkedTestSetsSection({
             <Button
               variant="contained"
               startIcon={<AddIcon />}
-              onClick={() => setAssignDialogOpen(true)}
+              onClick={handleAssignClick}
             >
-              Assign entity
+              Assign to test set
             </Button>
           </Box>
         </Paper>
@@ -198,12 +240,12 @@ export default function LinkedTestSetsSection({
               variant="h6"
               sx={{ fontWeight: 600, color: 'primary.main' }}
             >
-              Linked entities ({totalCount})
+              Linked Test Sets ({totalCount})
             </Typography>
             <Button
               variant="outlined"
               startIcon={<AddIcon />}
-              onClick={() => setAssignDialogOpen(true)}
+              onClick={handleAssignClick}
             >
               Assign
             </Button>
@@ -226,11 +268,16 @@ export default function LinkedTestSetsSection({
         </Paper>
       )}
 
-      <TestSetSelectionDialog
-        open={assignDialogOpen}
-        onClose={() => setAssignDialogOpen(false)}
-        onSelect={handleAssign}
-        sessionToken={sessionToken}
+      <AssignEntityDrawer
+        open={assignOpen}
+        onClose={() => setAssignOpen(false)}
+        title="Assign Test Set"
+        rows={availableFiltered}
+        columns={drawerColumns}
+        loading={loadingAvailable}
+        getRowId={row => String(row.id)}
+        onAssign={handleAssign}
+        searchPlaceholder="Search test sets…"
       />
     </>
   );


### PR DESCRIPTION
## Purpose
Polish the test detail page (`/tests/[identifier]`) with several UI improvements for clarity and consistency.

## What Changed
- Rename tabs: **Basic Information** → Overview, **Linked entities** → Linked Test Sets, **Tasks** → Tasks & Comments
- Remove the Visibility column from the Linked Test Sets grid
- Replace the Select Test Set dialog (single Autocomplete) with `AssignEntityDrawer` (right-side drawer, multi-select checkbox grid) — matches the metric→behavior assign pattern
- Move the Attachments block into the renamed **Test input** card (was "Prompts"); rename the remaining card to **Tags**
- Remove the duplicate **Created** field from the Test details card (already shown in the page header); widen the Topic field to span half the row

## Additional Context
- The bulk assign-to-test-set flow on the tests list grid is unchanged and keeps using `TestSetSelectionDialog`
- No backend changes

## Testing
Navigate to any test detail page and verify:
- Tab labels are updated
- Linked Test Sets tab has no Visibility column; Assign button opens a drawer with search + multi-select
- Overview tab: "Test input" card contains prompt fields + attachments; "Tags" card contains only tags; Test details card has no Created field and a wider Topic