### PR TITLE
Fix traces empty state: hide grid and use card style

### DIFF
--- a/apps/frontend/src/app/(protected)/traces/components/TracesClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClientWrapper.tsx
@@ -77,35 +77,36 @@ export default function TracesClientWrapper({
       }
     >
       <Box sx={{ mt: 2, mb: 2 }}>
-        <Paper
-          sx={{
-            width: '100%',
-            borderRadius: BORDER_RADIUS.md,
-            boxShadow: ELEVATION.xs,
-            border: theme => `1px solid ${theme.palette.greyscale.border}`,
-            overflow: 'hidden',
-          }}
-        >
-          <TracesClient
-            sessionToken={sessionToken}
-            currentUserId={currentUserId}
-            currentUserName={currentUserName}
-            currentUserPicture={currentUserPicture}
-            initialTraceId={initialTraceId}
-            initialProjectId={initialProjectId}
-            refreshKey={refreshKey}
-            onRefresh={handleRefresh}
-            onUnfilteredEmpty={handleUnfilteredEmpty}
-          />
-        </Paper>
-        {showEmptyHint && (
-          <Box sx={{ mt: 3 }}>
-            <EntityEmptyState
-              icon={TimelineOutlinedIcon}
-              title="No traces yet"
-              description="Traces appear after test runs or live endpoint invocations. Run a test set or call an instrumented endpoint to get started."
+        {!showEmptyHint && (
+          <Paper
+            sx={{
+              width: '100%',
+              borderRadius: BORDER_RADIUS.md,
+              boxShadow: ELEVATION.xs,
+              border: theme => `1px solid ${theme.palette.greyscale.border}`,
+              overflow: 'hidden',
+            }}
+          >
+            <TracesClient
+              sessionToken={sessionToken}
+              currentUserId={currentUserId}
+              currentUserName={currentUserName}
+              currentUserPicture={currentUserPicture}
+              initialTraceId={initialTraceId}
+              initialProjectId={initialProjectId}
+              refreshKey={refreshKey}
+              onRefresh={handleRefresh}
+              onUnfilteredEmpty={handleUnfilteredEmpty}
             />
-          </Box>
+          </Paper>
+        )}
+        {showEmptyHint && (
+          <EntityEmptyState
+            card
+            icon={TimelineOutlinedIcon}
+            title="No traces yet"
+            description="Traces appear after test runs or live endpoint invocations. Run a test set or call an instrumented endpoint to get started."
+          />
         )}
       </Box>
     </PageLayout>


### PR DESCRIPTION
## Purpose
When no traces exist and no filters are active, the DataGrid was still rendered showing an empty \"No rows\" state, alongside a separate \"No traces yet\" empty state below it — causing a visually confusing duplicate empty UI.

## What Changed
- Hide the traces grid `Paper` when there are no traces and no active filters (`showEmptyHint = true`)
- Render the `EntityEmptyState` with `card=true` so it uses the Figma-aligned bordered Paper card (matching the design at Figma node 1669:38642)
- Remove the extra `Box` wrapper (unnecessary `mt: 3` spacing) around the empty state

## Testing
1. Navigate to the Traces page with no traces
2. Verify the grid is not shown — only the \"No traces yet\" card is displayed
3. Apply any filter or search — the grid should reappear with the \"No traces found\" inline message