### PR TITLE
Update GHCR builds to use native ARM runners

### DIFF
--- a/.github/workflows/backend-ghcr.yml
+++ b/.github/workflows/backend-ghcr.yml
@@ -7,27 +7,29 @@ permissions:
   contents: read
   packages: write
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: rhesis-ai
+
 jobs:
   backend:
-    runs-on: ubuntu-latest
+    name: Build backend + worker (${{ matrix.platform.arch }})
+    runs-on: ${{ matrix.platform.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - arch: amd64
+            os: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            os: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
-
-      - name: Set up Docker
-        uses: docker/setup-docker-action@v5
-        with:
-          daemon-config: |
-            {
-              "debug": true,
-              "features": {
-                "containerd-snapshotter": true
-              }
-            }
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -35,34 +37,73 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push backend image
+      # Backend builds first; the shared base-build/build-backend/base-runtime
+      # stages it produces stay warm in the local BuildKit cache so the worker
+      # build below reuses them instead of rebuilding from scratch.
+      - name: Build backend by digest
+        id: build-backend
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./apps/backend/Dockerfile
           target: backend
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform.os }}
           provenance: false
-          tags: ghcr.io/rhesis-ai/backend:latest
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/backend,push-by-digest=true,name-canonical=true,push=true
 
-      - name: Build and push worker image
+      - name: Build worker by digest
+        id: build-worker
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./apps/backend/Dockerfile
           target: worker
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform.os }}
           provenance: false
-          tags: ghcr.io/rhesis-ai/worker:latest
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/worker,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digests
+        run: |
+          mkdir -p "${{ runner.temp }}/digests/backend" "${{ runner.temp }}/digests/worker"
+          backend_digest="${{ steps.build-backend.outputs.digest }}"
+          worker_digest="${{ steps.build-worker.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/backend/${backend_digest#sha256:}"
+          touch "${{ runner.temp }}/digests/worker/${worker_digest#sha256:}"
+
+      - name: Upload backend digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-backend-${{ matrix.platform.arch }}
+          path: ${{ runner.temp }}/digests/backend/*
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Upload worker digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-worker-${{ matrix.platform.arch }}
+          path: ${{ runner.temp }}/digests/worker/*
+          if-no-files-found: error
+          retention-days: 1
 
   frontend:
-    runs-on: ubuntu-latest
+    name: Build frontend (${{ matrix.platform.arch }})
+    runs-on: ${{ matrix.platform.runner }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - arch: amd64
+            os: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            os: linux/arm64
+            runner: ubuntu-24.04-arm
 
     env:
       FRONTEND_ENV: local
@@ -72,19 +113,67 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Set up Docker
-        uses: docker/setup-docker-action@v5
-        with:
-          daemon-config: |
-            {
-              "debug": true,
-              "features": {
-                "containerd-snapshotter": true
-              }
-            }
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build frontend by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/frontend/Dockerfile
+          platforms: ${{ matrix.platform.os }}
+          provenance: false
+          build-args: |
+            FRONTEND_ENV=${{ env.FRONTEND_ENV }}
+            NEXT_PUBLIC_API_BASE_URL=${{ env.NEXT_PUBLIC_API_BASE_URL }}
+            GIT_BRANCH=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.sha }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/frontend,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-frontend-${{ matrix.platform.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge ${{ matrix.image }} manifest
+    runs-on: ubuntu-latest
+    needs:
+      - backend
+      - frontend
+
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - backend
+          - worker
+          - frontend
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-${{ matrix.image }}-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -92,21 +181,18 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push frontend image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./apps/frontend/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          build-args: |
-            FRONTEND_ENV=${{ env.FRONTEND_ENV }}
-            NEXT_PUBLIC_API_BASE_URL=${{ env.NEXT_PUBLIC_API_BASE_URL }}
-            GIT_BRANCH=${{ github.ref_name }}
-            GIT_COMMIT=${{ github.sha }}
-          push: true
-          provenance: false
-          tags: ghcr.io/rhesis-ai/frontend:latest
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            -t ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:latest \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:latest

--- a/.github/workflows/publish-ghcr-images.yml
+++ b/.github/workflows/publish-ghcr-images.yml
@@ -15,6 +15,7 @@ jobs:
   backend:
     name: Build backend + worker (${{ matrix.platform.arch }})
     runs-on: ${{ matrix.platform.runner }}
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -93,6 +94,7 @@ jobs:
   frontend:
     name: Build frontend (${{ matrix.platform.arch }})
     runs-on: ${{ matrix.platform.runner }}
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -155,6 +157,7 @@ jobs:
   merge:
     name: Merge ${{ matrix.image }} manifest
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs:
       - backend
       - frontend


### PR DESCRIPTION
## Purpose
Move GHCR multi-arch image builds off QEMU emulation so arm64 images build on native GitHub-hosted ARM runners.

## What Changed
- Split backend, worker, and frontend builds by architecture using `ubuntu-latest` for amd64 and `ubuntu-24.04-arm` for arm64.
- Kept backend and worker builds sequential within each architecture so shared Dockerfile layers stay warm in the local BuildKit cache.
- Push platform-specific images by digest, upload those digests as artifacts, and merge them into multi-arch `:latest` manifests.

## Additional Context
- The workflow still publishes `ghcr.io/rhesis-ai/backend:latest`, `ghcr.io/rhesis-ai/worker:latest`, and `ghcr.io/rhesis-ai/frontend:latest`.
- This assumes the repository has access to GitHub-hosted `ubuntu-24.04-arm` runners.

## Testing
- Validated the workflow YAML parses successfully with PyYAML.