### PR TITLE
Refactor Quick Start status ownership

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -121,6 +121,7 @@ class ProvidersResponse(BaseModel):
 
     providers: List[ProviderInfo]
     password_policy: PasswordPolicyResponse
+    quick_start: bool = False
 
 
 class VerifyEmailRequest(BaseModel):
@@ -297,6 +298,7 @@ def _resolve_org_by_id_or_slug(db: Session, org: str):
 
 @router.get("/providers", response_model=ProvidersResponse)
 async def get_providers(
+    request: Request,
     org: Optional[str] = None,
     db: Session = Depends(get_db_session),
 ):
@@ -336,6 +338,10 @@ async def get_providers(
             min_length=policy.min_length,
             max_length=policy.max_length,
             min_strength_score=policy.min_strength_score,
+        ),
+        quick_start=is_quick_start_enabled(
+            hostname=request.url.hostname,
+            headers=dict(request.headers),
         ),
     )
 

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -56,14 +56,13 @@ ENV GIT_COMMIT=${GIT_COMMIT}
 ENV NEXT_PUBLIC_GIT_BRANCH=${GIT_BRANCH}
 ENV NEXT_PUBLIC_GIT_COMMIT=${GIT_COMMIT}
 
-# NEXT_PUBLIC_API_BASE_URL and NEXT_PUBLIC_QUICK_START are fixed placeholders;
-# replace-runtime-env.sh substitutes the real values at container start.
+# NEXT_PUBLIC_API_BASE_URL is a fixed placeholder;
+# replace-runtime-env.sh substitutes the real value at container start.
 
 # Create a temporary .env file using build arguments for NEXT_PUBLIC_ and direct placeholders for the rest
 RUN echo "NEXTAUTH_SECRET=temporary-build-secret-not-for-production" > apps/frontend/.env && \
     echo "NEXT_PUBLIC_API_BASE_URL=__NEXT_PUBLIC_API_BASE_URL__" >> apps/frontend/.env && \
     echo "BACKEND_URL=${BACKEND_URL}" >> apps/frontend/.env && \
-    echo "NEXT_PUBLIC_QUICK_START=__NEXT_PUBLIC_QUICK_START__" >> apps/frontend/.env && \
     echo "GOOGLE_CLIENT_ID=placeholder-client-id" >> apps/frontend/.env && \
     echo "GOOGLE_CLIENT_SECRET=placeholder-client-secret" >> apps/frontend/.env && \
     echo "AUTH_SECRET=placeholder-auth-secret" >> apps/frontend/.env

--- a/apps/frontend/Makefile
+++ b/apps/frontend/Makefile
@@ -104,7 +104,6 @@ docker-clean:
 # E2E tests (starts docker automatically)
 # Runs @sanity smoke tests on both Chromium and Firefox, plus @crud interaction tests on Chromium only
 test-e2e: docker-up
-	NEXT_PUBLIC_QUICK_START=true \
 	NEXT_PUBLIC_API_BASE_URL=http://localhost:$(BACKEND_E2E_PORT) \
 	BACKEND_URL=http://localhost:$(BACKEND_E2E_PORT) \
 	NEXTAUTH_SECRET=test-secret-for-e2e-tests-only \
@@ -113,7 +112,6 @@ test-e2e: docker-up
 
 # Run only @sanity smoke tests (faster, cross-browser)
 test-e2e-smoke: docker-up
-	NEXT_PUBLIC_QUICK_START=true \
 	NEXT_PUBLIC_API_BASE_URL=http://localhost:$(BACKEND_E2E_PORT) \
 	BACKEND_URL=http://localhost:$(BACKEND_E2E_PORT) \
 	NEXTAUTH_SECRET=test-secret-for-e2e-tests-only \

--- a/apps/frontend/playwright.config.ts
+++ b/apps/frontend/playwright.config.ts
@@ -3,8 +3,8 @@ import { defineConfig, devices } from '@playwright/test';
 /**
  * Playwright configuration for Rhesis frontend E2E tests.
  *
- * Uses Quick Start mode for authentication (NEXT_PUBLIC_QUICK_START=true)
- * to bypass OAuth and enable local-login flow during tests.
+ * Uses backend Quick Start mode to bypass OAuth and enable local-login flow
+ * during tests.
  */
 export default defineConfig({
   testDir: './tests/e2e',
@@ -105,7 +105,6 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,
     env: {
-      NEXT_PUBLIC_QUICK_START: 'true',
       NEXT_PUBLIC_API_BASE_URL:
         process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:8080',
       BACKEND_URL: process.env.BACKEND_URL || 'http://localhost:8080',

--- a/apps/frontend/scripts/replace-runtime-env.sh
+++ b/apps/frontend/scripts/replace-runtime-env.sh
@@ -4,7 +4,6 @@
 #
 # Placeholders baked into the bundle at build time:
 #   __NEXT_PUBLIC_API_BASE_URL__  -> API_BASE_URL | BACKEND_URL | localhost:8080
-#   __NEXT_PUBLIC_QUICK_START__   -> QUICK_START | false
 #
 # This allows a single Docker image to be used for all deployment modes.
 
@@ -46,11 +45,5 @@ fi
 replace_placeholder '__NEXT_PUBLIC_API_BASE_URL__' "$API_URL_VALUE"
 printf '[entrypoint] using NEXT_PUBLIC_API_BASE_URL=%s (set at runtime)\n' "$API_URL_VALUE"
 export NEXT_PUBLIC_API_BASE_URL="$API_URL_VALUE"
-
-# Quick Start mode - read from QUICK_START (single source of truth)
-QUICK_START_VALUE="${QUICK_START:-false}"
-replace_placeholder '__NEXT_PUBLIC_QUICK_START__' "$QUICK_START_VALUE"
-printf '[entrypoint] using NEXT_PUBLIC_QUICK_START=%s (set at runtime)\n' "$QUICK_START_VALUE"
-export NEXT_PUBLIC_QUICK_START="$QUICK_START_VALUE"
 
 exec "$@"

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -9,6 +9,7 @@ import LoginSection from '../components/auth/LoginSection';
 import AuthPageShell from '../components/auth/AuthPageShell';
 import { getClientApiBaseUrl } from '../utils/url-resolver';
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunchOutlined';
+import { fetchQuickStartEnabled } from '@/utils/quick_start';
 
 export default function LandingPage() {
   const { data: session, status } = useSession();
@@ -18,60 +19,64 @@ export default function LandingPage() {
     boolean | null
   >(null);
   const [autoLoggingIn, setAutoLoggingIn] = useState(false);
-  const [mounted, setMounted] = useState(false);
   const [isQuickStartMode, setIsQuickStartMode] = useState(false);
+  const [quickStartLoaded, setQuickStartLoaded] = useState(false);
 
   useEffect(() => {
-    setMounted(true);
+    let cancelled = false;
+
+    fetchQuickStartEnabled().then(enabled => {
+      if (!cancelled) {
+        setIsQuickStartMode(enabled);
+        setQuickStartLoaded(true);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
-    if (!mounted) return;
-    import('@/utils/quick_start').then(({ isQuickStartEnabled }) => {
-      setIsQuickStartMode(isQuickStartEnabled());
-    });
-  }, [mounted]);
+    if (
+      quickStartLoaded &&
+      isQuickStartMode &&
+      status === 'unauthenticated' &&
+      !autoLoggingIn
+    ) {
+      const urlParams = new URLSearchParams(window.location.search);
+      const isSessionExpired = urlParams.get('session_expired') === 'true';
+      const isForcedLogout = urlParams.get('force_logout') === 'true';
 
-  useEffect(() => {
-    if (!mounted) return;
-    import('@/utils/quick_start').then(({ isQuickStartEnabled }) => {
-      const quickStartEnabled = isQuickStartEnabled();
+      if (!isSessionExpired && !isForcedLogout) {
+        setAutoLoggingIn(true);
 
-      if (quickStartEnabled && status === 'unauthenticated' && !autoLoggingIn) {
-        const urlParams = new URLSearchParams(window.location.search);
-        const isSessionExpired = urlParams.get('session_expired') === 'true';
-        const isForcedLogout = urlParams.get('force_logout') === 'true';
-
-        if (!isSessionExpired && !isForcedLogout) {
-          setAutoLoggingIn(true);
-
-          fetch(`${getClientApiBaseUrl()}/auth/local-login`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-          })
-            .then(async response => {
-              if (response.ok) {
-                const data = await response.json();
-                const { signIn } = await import('next-auth/react');
-                await signIn('credentials', {
-                  session_token: data.session_token,
-                  refresh_token: data.refresh_token || '',
-                  redirect: true,
-                  callbackUrl: '/architect',
-                });
-              } else {
-                console.error('Local auto-login failed');
-                setAutoLoggingIn(false);
-              }
-            })
-            .catch(error => {
-              console.error('Local auto-login error:', error);
+        fetch(`${getClientApiBaseUrl()}/auth/local-login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        })
+          .then(async response => {
+            if (response.ok) {
+              const data = await response.json();
+              const { signIn } = await import('next-auth/react');
+              await signIn('credentials', {
+                session_token: data.session_token,
+                refresh_token: data.refresh_token || '',
+                redirect: true,
+                callbackUrl: '/architect',
+              });
+            } else {
+              console.error('Local auto-login failed');
               setAutoLoggingIn(false);
-            });
-        }
+            }
+          })
+          .catch(error => {
+            console.error('Local auto-login error:', error);
+            setAutoLoggingIn(false);
+          });
       }
-    });
-  }, [mounted, status, autoLoggingIn]);
+    }
+  }, [quickStartLoaded, isQuickStartMode, status, autoLoggingIn]);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);

--- a/apps/frontend/src/components/layout/LayoutContent.tsx
+++ b/apps/frontend/src/components/layout/LayoutContent.tsx
@@ -12,6 +12,7 @@ import { OnboardingProvider } from '@/contexts/OnboardingContext';
 import OnboardingChecklist from '../onboarding/OnboardingChecklist';
 import { type NavigationItem, type LayoutProps } from '../../types/navigation';
 import { ActiveProjectProvider } from '@/contexts/ActiveProjectContext';
+import { fetchQuickStartEnabled } from '@/utils/quick_start';
 // Side-effect import: pulls ee_bootstrap into the *client* bundle so
 // EE feature registrations land in the client-side registry as well as
 // the server-side one. Layout.tsx imports the same module for the
@@ -60,10 +61,17 @@ export function LayoutContent({
 
   // Check Quick Start mode after mount (client-side only)
   React.useEffect(() => {
-    // Dynamic import for client-side only code
-    import('@/utils/quick_start').then(({ isQuickStartEnabled }) => {
-      setIsQuickStartMode(isQuickStartEnabled());
+    let cancelled = false;
+
+    fetchQuickStartEnabled().then(enabled => {
+      if (!cancelled) {
+        setIsQuickStartMode(enabled);
+      }
     });
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Build sx prop conditionally

--- a/apps/frontend/src/utils/__tests__/quick_start.test.ts
+++ b/apps/frontend/src/utils/__tests__/quick_start.test.ts
@@ -1,241 +1,54 @@
-import { isQuickStartEnabled } from '../quick_start';
+import { fetchQuickStartEnabled } from '../quick_start';
+
+function makeResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
 
 describe('quick_start', () => {
-  describe('isQuickStartEnabled', () => {
-    const originalEnv = process.env;
-    let savedLocation: Location;
-
-    beforeAll(() => {
-      // Save the initial window.location set by jest.setup
-      savedLocation = window.location;
-    });
+  describe('fetchQuickStartEnabled', () => {
+    let fetchMock: jest.Mock;
 
     beforeEach(() => {
-      // Reset process.env before each test
-      jest.resetModules();
-      process.env = { ...originalEnv };
-      // Restore window.location to the initial state
-      // @ts-expect-error - jsdom location reassignment
-      window.location = savedLocation;
+      fetchMock = jest.fn();
+      global.fetch = fetchMock;
     });
 
-    afterAll(() => {
-      // Restore original process.env after all tests
-      process.env = originalEnv;
-      // Restore original window.location
-      // @ts-expect-error - jsdom location reassignment
-      window.location = savedLocation;
+    afterEach(() => {
+      jest.restoreAllMocks();
     });
 
-    describe('Environment variable validation', () => {
-      it('should return false when NEXT_PUBLIC_QUICK_START is not set', () => {
-        delete process.env.NEXT_PUBLIC_QUICK_START;
+    it('returns true when the backend enables Quick Start', async () => {
+      fetchMock.mockResolvedValue(makeResponse({ quick_start: true }));
 
-        const result = isQuickStartEnabled();
-
-        expect(result).toBe(false);
-      });
-
-      it('should return false when NEXT_PUBLIC_QUICK_START is false', () => {
-        process.env.NEXT_PUBLIC_QUICK_START = 'false';
-
-        const result = isQuickStartEnabled();
-
-        expect(result).toBe(false);
-      });
-
-      it('should return false when NEXT_PUBLIC_QUICK_START is empty', () => {
-        process.env.NEXT_PUBLIC_QUICK_START = '';
-
-        const result = isQuickStartEnabled();
-
-        expect(result).toBe(false);
-      });
-
-      it('should return true when NEXT_PUBLIC_QUICK_START is true and no cloud signals', () => {
-        process.env.NEXT_PUBLIC_QUICK_START = 'true';
-
-        const result = isQuickStartEnabled('localhost');
-
-        expect(result).toBe(true);
-      });
-
-      it('should accept value with surrounding whitespace', () => {
-        process.env.NEXT_PUBLIC_QUICK_START = '  true  ';
-
-        const result = isQuickStartEnabled('localhost');
-
-        expect(result).toBe(true);
-      });
-
-      it('should be case-insensitive for the env value', () => {
-        process.env.NEXT_PUBLIC_QUICK_START = 'TRUE';
-
-        const result = isQuickStartEnabled('localhost');
-
-        expect(result).toBe(true);
-      });
+      await expect(fetchQuickStartEnabled()).resolves.toBe(true);
+      expect(fetchMock).toHaveBeenCalledWith('/api/auth-config');
     });
 
-    describe('Hostname pattern matching', () => {
-      beforeEach(() => {
-        process.env.NEXT_PUBLIC_QUICK_START = 'true';
-      });
+    it('returns false when the backend disables Quick Start', async () => {
+      fetchMock.mockResolvedValue(makeResponse({ quick_start: false }));
 
-      it.each([
-        'example-app.rhesis.ai',
-        'test-dev.rhesis.ai',
-        'sample-stg.rhesis.ai',
-        'demo-api.rhesis.ai',
-        'test-dev-api.rhesis.ai',
-        'sample-stg-api.rhesis.ai',
-        'rhesis.ai',
-        'subdomain.rhesis.ai',
-        'any.rhesis.ai',
-        'test-app.rhesis.ai',
-      ])('should return false for rhesis.ai domain: %s', hostname => {
-        const result = isQuickStartEnabled(hostname);
-
-        expect(result).toBe(false);
-      });
-
-      it.each([
-        'localhost',
-        '127.0.0.1',
-        '192.168.1.1',
-        'local.rhesis.local',
-        'test.local',
-        'example.com',
-        'myapp.com',
-      ])('should return true for local/non-cloud domain: %s', hostname => {
-        const result = isQuickStartEnabled(hostname);
-
-        expect(result).toBe(true);
-      });
-
-      it.each([
-        'my-service.run.app',
-        'app.cloudrun.dev',
-        'service.appspot.com',
-        'subdomain.run.app',
-      ])('should return false for Cloud Run domain: %s', hostname => {
-        const result = isQuickStartEnabled(hostname);
-
-        expect(result).toBe(false);
-      });
-
-      it('should be case-insensitive for hostname matching', () => {
-        const result = isQuickStartEnabled('APP.RHESIS.AI');
-
-        expect(result).toBe(false);
-      });
-
-      it('should use window.location.hostname when hostname not provided', () => {
-        // @ts-expect-error - jsdom location replacement
-        delete window.location;
-        // @ts-expect-error - jsdom location replacement
-        window.location = { hostname: 'localhost' } as Location;
-
-        const result = isQuickStartEnabled();
-
-        expect(result).toBe(true);
-      });
-
-      it('should detect rhesis.ai from window.location.hostname', () => {
-        // For this test, just pass the hostname directly instead of mocking window.location
-        // since mocking window.location is problematic in newer jsdom versions
-        const result = isQuickStartEnabled('example-app.rhesis.ai');
-
-        expect(result).toBe(false);
-      });
-
-      it('should handle undefined window (SSR)', () => {
-        const originalWindow = global.window;
-        // @ts-expect-error - intentionally removing window for SSR test
-        delete global.window;
-
-        const result = isQuickStartEnabled('localhost');
-
-        expect(result).toBe(true);
-
-        global.window = originalWindow;
-      });
+      await expect(fetchQuickStartEnabled()).resolves.toBe(false);
     });
 
-    describe('Edge cases', () => {
-      beforeEach(() => {
-        process.env.NEXT_PUBLIC_QUICK_START = 'true';
-      });
+    it('returns false when the backend omits Quick Start status', async () => {
+      fetchMock.mockResolvedValue(makeResponse({}));
 
-      it('should handle empty hostname string', () => {
-        // Empty string should fall back to window.location.hostname
-        // For this test, we'll test with empty string but ensure window.location is set correctly
-        // @ts-expect-error - jsdom location replacement
-        delete window.location;
-        // @ts-expect-error - jsdom location replacement
-        window.location = { hostname: 'localhost' } as Location;
-
-        const result = isQuickStartEnabled('');
-
-        expect(result).toBe(true);
-      });
-
-      it('should handle hostname with port', () => {
-        const result = isQuickStartEnabled('localhost:3000');
-
-        expect(result).toBe(true);
-      });
-
-      it('should detect rhesis.ai even with port', () => {
-        const result = isQuickStartEnabled('example-app.rhesis.ai:443');
-
-        expect(result).toBe(false);
-      });
-
-      it('should not have false positive for substring match', () => {
-        // Should not match "rhesis.ai" in "my-rhesis-ai-app.com"
-        const result = isQuickStartEnabled('my-rhesis-ai-app.com');
-
-        expect(result).toBe(true);
-      });
-
-      it('should detect rhesis.ai as part of larger domain', () => {
-        const result = isQuickStartEnabled('subdomain.example-app.rhesis.ai');
-
-        expect(result).toBe(false);
-      });
-
-      it('should handle whitespace in hostname', () => {
-        const result = isQuickStartEnabled('  localhost  ');
-
-        expect(result).toBe(true);
-      });
+      await expect(fetchQuickStartEnabled()).resolves.toBe(false);
     });
 
-    describe('Fail-secure behavior', () => {
-      it('should return false if environment is true but hostname is cloud', () => {
-        process.env.NEXT_PUBLIC_QUICK_START = 'true';
+    it('returns false when the auth config request fails', async () => {
+      fetchMock.mockResolvedValue(makeResponse({}, false));
 
-        const result = isQuickStartEnabled('example-app.rhesis.ai');
+      await expect(fetchQuickStartEnabled()).resolves.toBe(false);
+    });
 
-        expect(result).toBe(false);
-      });
+    it('returns false when fetching auth config throws', async () => {
+      fetchMock.mockRejectedValue(new Error('network unavailable'));
 
-      it('should return false if environment is true but hostname is Cloud Run', () => {
-        process.env.NEXT_PUBLIC_QUICK_START = 'true';
-
-        const result = isQuickStartEnabled('my-service.run.app');
-
-        expect(result).toBe(false);
-      });
-
-      it('should return true only when all checks pass', () => {
-        process.env.NEXT_PUBLIC_QUICK_START = 'true';
-
-        const result = isQuickStartEnabled('localhost');
-
-        expect(result).toBe(true);
-      });
+      await expect(fetchQuickStartEnabled()).resolves.toBe(false);
     });
   });
 });

--- a/apps/frontend/src/utils/quick_start.ts
+++ b/apps/frontend/src/utils/quick_start.ts
@@ -1,73 +1,17 @@
-/**
- * Quick Start mode detection utility for frontend.
- *
- * Quick Start is ONLY enabled when QUICK_START=true AND all signals confirm QUICK START MODE.
- */
+interface AuthConfigResponse {
+  quick_start?: boolean;
+}
 
-/**
- * Determine if QUICK START MODE should be enabled.
- *
- * Quick Start is ONLY enabled when ALL of the following conditions are met:
- * 1. QUICK_START environment variable is explicitly set to 'true'
- * 2. Hostname/domain does NOT indicate cloud deployment
- * 3. Google Cloud Run domains are NOT detected
- *
- * This is a fail-secure function: if ANY signal indicates cloud deployment,
- * it returns false. Default is false for safety.
- *
- * @param hostname - Optional hostname to check (defaults to window.location.hostname)
- * @returns True ONLY if all signals confirm QUICK START MODE, False otherwise
- *
- * @example
- * ```typescript
- * if (isQuickStartEnabled()) {
- *   // Show Quick Start login button
- * }
- * ```
- */
-export function isQuickStartEnabled(hostname?: string): boolean {
-  // 1. Check QUICK_START environment variable (default: false for safety).
-  //
-  // The value is captured into a string variable before comparison so the
-  // build-time placeholder (`__NEXT_PUBLIC_QUICK_START__`) survives SWC
-  // constant folding and can be substituted at container start by
-  // scripts/replace-runtime-env.sh. Direct `=== 'true'` comparison gets
-  // folded to a static `false` and removes the placeholder from the bundle.
-  const raw = process.env.NEXT_PUBLIC_QUICK_START ?? '';
-  const quickStartEnv = String(raw).trim().toLowerCase() === 'true';
-
-  if (!quickStartEnv) {
-    return false;
-  }
-
-  // 2. HOSTNAME/DOMAIN CHECKS - Fail if cloud domain detected
-  const checkHostname =
-    hostname || (typeof window !== 'undefined' ? window.location.hostname : '');
-  if (checkHostname) {
-    const hostnameLower = checkHostname.toLowerCase();
-
-    // Check for Rhesis cloud domains (any domain containing rhesis.ai)
-    if (hostnameLower.includes('rhesis.ai')) {
-      console.warn(
-        ` QUICK START MODE disabled: Cloud hostname detected (${checkHostname})`
-      );
+export async function fetchQuickStartEnabled(): Promise<boolean> {
+  try {
+    const response = await fetch('/api/auth-config');
+    if (!response.ok) {
       return false;
     }
 
-    // Google Cloud Run domains
-    const cloudRunDomains = ['.run.app', '.cloudrun.dev', '.appspot.com'];
-
-    // Check for Cloud Run domains
-    for (const cloudDomain of cloudRunDomains) {
-      if (hostnameLower.includes(cloudDomain)) {
-        console.warn(
-          ` QUICK START MODE disabled: Cloud Run domain detected (${checkHostname})`
-        );
-        return false;
-      }
-    }
+    const data = (await response.json()) as AuthConfigResponse;
+    return data.quick_start === true;
+  } catch (_error) {
+    return false;
   }
-
-  // All checks passed - QUICK START MODE is enabled
-  return true;
 }

--- a/apps/frontend/tests/e2e/auth.setup.ts
+++ b/apps/frontend/tests/e2e/auth.setup.ts
@@ -5,9 +5,9 @@ import { LoginPage } from './pages/LoginPage';
 /**
  * Authentication setup — runs once before all tests.
  *
- * Relies on Quick Start mode (NEXT_PUBLIC_QUICK_START=true) which
- * auto-logs in via the /auth/local-login endpoint and redirects
- * to /architect. The resulting browser state (cookies, localStorage)
+ * Relies on backend Quick Start mode, which auto-logs in via the
+ * /auth/local-login endpoint and redirects to /architect. The resulting
+ * browser state (cookies, localStorage)
  * is persisted to tests/e2e/.auth/user.json so every test project that
  * depends on "setup" starts already authenticated.
  */

--- a/charts/rhesis/templates/configmap.yaml
+++ b/charts/rhesis/templates/configmap.yaml
@@ -39,7 +39,6 @@ data:
   NEXTAUTH_URL: {{ .Values.config.nextauthUrl | quote }}
   NEXT_PUBLIC_AUTH0_CLIENT_ID: {{ .Values.config.nextPublicAuth0ClientId | quote }}
   NEXT_PUBLIC_AUTH0_DOMAIN: {{ .Values.config.nextPublicAuth0Domain | quote }}
-  NEXT_PUBLIC_QUICK_START: {{ .Values.config.nextPublicQuickStart | quote }}
 
   # -------------------------------------------------------------------------
   # Backend

--- a/charts/rhesis/values.yaml
+++ b/charts/rhesis/values.yaml
@@ -67,7 +67,6 @@ config:
   nextTelemetryDisabled: "1"
   nextPublicAuth0ClientId: ""
   nextPublicAuth0Domain: "dev-rhesis.eu.auth0.com"
-  nextPublicQuickStart: "false"
 
   # Backend
   rhesisBaseUrl: ""

--- a/docs/content/contribute/environment-variables.mdx
+++ b/docs/content/contribute/environment-variables.mdx
@@ -76,7 +76,6 @@ For a full production file (many more keys), teams often load secrets from Googl
 <Table
   headers={['Variable', 'Description']}
   rows={[
-    ['`NEXT_PUBLIC_QUICK_START`', 'Mirrors backend quick-start; **disable in production** (`false`).'],
     ['`NEXT_PUBLIC_API_BASE_URL`', 'Backend API URL exposed to the browser, e.g. `http://localhost:8080`.'],
     ['`BACKEND_URL`', 'Backend URL for server-side requests, e.g. `http://localhost:8080`.'],
     ['`NEXTAUTH_URL`', 'Must match how users open the app (same origin as the frontend).'],

--- a/rh
+++ b/rh
@@ -215,7 +215,6 @@ create_frontend_env() {
     cat > "$env_file" << EOF
 $DEV_ENV_MARKER on $timestamp
 
-NEXT_PUBLIC_QUICK_START=true
 NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
 FRONTEND_ENV=local
 BACKEND_URL=http://localhost:8080


### PR DESCRIPTION
## Purpose

This PR is built on top of the previous PR #1897 (`refactor/quick-start-env-gate`). It moves Quick Start enablement decisions fully behind the backend contract so the frontend no longer duplicates environment or hostname checks.

## What Changed
- Expose `quick_start` from `GET /auth/providers` using the backend `is_quick_start_enabled()` check.
- Update frontend Quick Start consumers to read backend status via `/api/auth-config`.
- Remove obsolete `NEXT_PUBLIC_QUICK_START` frontend runtime/env plumbing from Docker, Helm, local dev setup, E2E config, and docs.

## Testing
- `npx eslint "src/utils/quick_start.ts" "src/app/page.tsx" "src/components/layout/LayoutContent.tsx" "src/utils/__tests__/quick_start.test.ts" "tests/e2e/auth.setup.ts" "playwright.config.ts"`
- `cd apps/backend && uv run pytest ../../tests/backend/routes/test_auth.py -v` could not start because local Postgres on `localhost:12001` was not running.
- Focused Jest quick-start test command was attempted but blocked by command review before execution.