### PR TITLE
Align invite drawer with Figma design system

### DIFF
--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteDrawer.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import * as React from 'react';
-import { Typography } from '@mui/material';
 import BaseDrawer from '@/components/common/BaseDrawer';
 import TeamInviteForm from './TeamInviteForm';
 
@@ -43,12 +42,6 @@ export default function TeamInviteDrawer({
       loading={isSubmitting}
       saveDisabled={disableDuringTour}
     >
-      <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-        Send invitations to colleagues to join your organization. You can invite
-        up to 10 members at once. Select which projects they should have access
-        to — users without a project assigned will see a no-access screen until
-        an admin adds them.
-      </Typography>
       <TeamInviteForm
         ref={formRef}
         embedded

--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteForm.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteForm.tsx
@@ -10,21 +10,22 @@ import {
   Button,
   IconButton,
   CircularProgress,
-  FormControl,
-  InputLabel,
   List,
   ListItemButton,
-  MenuItem,
-  Select,
-  Stack,
   Tooltip,
   Typography,
 } from '@mui/material';
 import CheckIcon from '@mui/icons-material/Check';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import SearchIcon from '@mui/icons-material/Search';
+import FormSectionDivider from '@/components/common/FormSectionDivider';
 import { getProjectIcon } from '@/components/common/ProjectIcons';
-import { BORDER_RADIUS } from '@/styles/theme';
+import {
+  drawerFieldsSx,
+  drawerOutlinedFieldSx,
+  drawerOutlineButtonSx,
+  drawerSectionSx,
+} from '@/components/common/drawerFormFieldSx';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
 import SendIcon from '@mui/icons-material/Send';
@@ -418,15 +419,25 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
     };
 
     return (
-      <Box component="form" ref={ref} onSubmit={handleSubmit}>
-        <Stack spacing={2} sx={{ mb: embedded ? 0 : 3 }}>
-          {formData.invites.map((invite, index) => {
-            return (
+      <Box
+        component="form"
+        ref={ref}
+        onSubmit={handleSubmit}
+        sx={drawerSectionSx}
+      >
+        {/* Section A: Team members */}
+        <Box sx={drawerSectionSx}>
+          <FormSectionDivider
+            headline="Team members"
+            descriptiveText={`Invite up to ${MAX_TEAM_MEMBERS} colleagues to join your organization. Members without a project assigned see a no-access screen until an admin adds them.`}
+          />
+          <Box sx={drawerFieldsSx}>
+            {formData.invites.map((invite, index) => (
               <Box
                 key={invite.id}
                 display="flex"
                 alignItems="flex-start"
-                gap={2}
+                gap={1.5}
               >
                 <TextField
                   fullWidth
@@ -438,52 +449,43 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
                   helperText={errors[invite.id]?.message || ''}
                   placeholder="colleague@company.com"
                   variant="outlined"
-                  size="small"
+                  sx={drawerOutlinedFieldSx}
                   data-tour={index === 0 ? 'invite-email-input' : undefined}
                 />
                 {formData.invites.length > 1 && (
                   <IconButton
                     onClick={() => removeEmailField(invite)}
                     color="error"
-                    size="small"
+                    sx={{ mt: '8px' }}
                   >
                     <DeleteIcon />
                   </IconButton>
                 )}
               </Box>
-            );
-          })}
+            ))}
 
-          <Box display="flex" justifyContent="flex-start">
             <Button
               startIcon={<AddIcon />}
               onClick={addEmailField}
               variant="outlined"
-              size="small"
+              fullWidth
               disabled={formData.invites.length >= MAX_TEAM_MEMBERS}
+              sx={drawerOutlineButtonSx}
             >
               {formData.invites.length >= MAX_TEAM_MEMBERS
                 ? `Maximum ${MAX_TEAM_MEMBERS} invites reached`
                 : 'Add Another Email'}
             </Button>
           </Box>
+        </Box>
 
+        {/* Section B: Project access */}
+        <Box sx={drawerSectionSx}>
+          <FormSectionDivider
+            headline="Project access"
+            descriptiveText="Invited users will only have access to the projects you select. Leave empty to invite without any project access — an admin can add them later."
+          />
           <Box>
-            <Typography
-              variant="subtitle2"
-              sx={{ mb: 0.5, color: 'text.primary' }}
-            >
-              Project access
-            </Typography>
-            <Typography
-              variant="body2"
-              sx={{ mb: 1.5, color: 'text.secondary' }}
-            >
-              Invited users will only have access to the projects you select.
-              Leave empty to invite without any project access — an admin can
-              add them later.
-            </Typography>
-
             {availableProjects.length === 0 ? (
               <Typography variant="body2" color="text.disabled">
                 No projects available
@@ -494,14 +496,8 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
                   value={projectSearch}
                   onChange={e => setProjectSearch(e.target.value)}
                   placeholder="Search projects…"
-                  size="small"
                   fullWidth
-                  sx={{
-                    mb: 1,
-                    '& .MuiOutlinedInput-root': {
-                      borderRadius: BORDER_RADIUS.sm,
-                    },
-                  }}
+                  sx={{ ...drawerOutlinedFieldSx, mb: 1 }}
                   slotProps={{
                     input: {
                       startAdornment: (
@@ -545,7 +541,7 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
                             )
                           }
                           sx={{
-                            borderRadius: BORDER_RADIUS.md,
+                            borderRadius: '12px',
                             px: 1.5,
                             py: 1.25,
                             gap: theme => theme.spacing(1.5),
@@ -679,7 +675,7 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
               </Box>
             )}
           </Box>
-        </Stack>
+        </Box>
 
         {!embedded && (
           <Box display="flex" justifyContent="flex-end">

--- a/apps/frontend/src/components/common/drawerFormFieldSx.ts
+++ b/apps/frontend/src/components/common/drawerFormFieldSx.ts
@@ -1,6 +1,38 @@
 import type { SxProps, Theme } from '@mui/material/styles';
 import { BORDER_RADIUS } from '@/styles/theme';
 
+/** 40px gap between top-level drawer sections (Figma "Drawer Create" Section spacing). */
+export const drawerSectionSx: SxProps<Theme> = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '40px',
+};
+
+/** 30px gap between fields within a section. */
+export const drawerFieldsSx: SxProps<Theme> = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '30px',
+};
+
+/**
+ * Full-width outlined "Add …" button — border-2 primary, radius sm, 14px/700.
+ * Matches the Figma "Button / Outlined / Medium" used inside drawer sections.
+ */
+export const drawerOutlineButtonSx: SxProps<Theme> = {
+  borderWidth: 2,
+  borderColor: 'primary.main',
+  color: 'primary.main',
+  fontWeight: 700,
+  fontSize: 14,
+  lineHeight: '22px',
+  borderRadius: BORDER_RADIUS.sm,
+  px: '16px',
+  py: '8px',
+  textTransform: 'none',
+  '&:hover': { borderWidth: 2 },
+};
+
 /**
  * Figma outlined drawer field (node 1642:16790).
  * 56px control height: 16px vertical padding + 24px line-height content.

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -296,6 +296,9 @@ const getDesignTokens = (mode: PaletteMode) => {
             '& .MuiSvgIcon-root': {
               color: mode === 'light' ? gs.body : '#FFFFFF',
             },
+            '& .MuiAvatar-root .MuiSvgIcon-root': {
+              color: 'inherit',
+            },
             '& .MuiButton-icon .MuiSvgIcon-root, & .MuiButton-startIcon .MuiSvgIcon-root, & .MuiButton-endIcon .MuiSvgIcon-root':
               {
                 color: 'inherit',


### PR DESCRIPTION
## Purpose

The "Invite team members" drawer was using a compact, ad-hoc layout that didn't match the Figma design system. This aligns it with the canonical \"Drawer Create\" template already used by RunDrawer, and fixes a theme bug that made project icons render as black inside coloured Avatars in light mode.

## What Changed

- **`drawerFormFieldSx.ts`** — exports three new shared constants: `drawerSectionSx` (40px section gap), `drawerFieldsSx` (30px field gap), and `drawerOutlineButtonSx` (border-2 primary full-width outlined button). These match the Figma spacing spec and are shared with RunDrawer.
- **`TeamInviteForm.tsx`** — restructured from a flat `Stack spacing={2}` into two `FormSectionDivider` sections ("Team members" and "Project access"). Email fields upgraded to full 56px `drawerOutlinedFieldSx`. "Add Another Email" is now full-width outlined. Intro copy folded into section subtitles.
- **`TeamInviteDrawer.tsx`** — removed the redundant standalone intro `<Typography>` (content now lives in the section subtitle).
- **`theme.ts`** — added `'& .MuiAvatar-root .MuiSvgIcon-root': { color: 'inherit' }` carve-out in `MuiDrawer` styleOverrides. The existing rule forced all SVG icons in drawers to the body text colour in light mode, overriding the white colour that `Avatar colorDefault` provides for icons inside coloured Avatars (e.g. project icons in the invite drawer).

## Additional Context

- All `data-tour` attributes (`invite-email-input`, `send-invites-button`) are preserved for the onboarding tour.
- ESLint passes on all changed files.

## Testing

1. Open `/organizations/team` and click the invite FAB.
2. Confirm: 40px gap between the two sections, 30px between email fields, full-size 56px fields, full-width outlined "Add Another Email" button, bold 18px section headings.
3. Add a second email and confirm the delete icon appears.
4. Confirm project icons in the list are white (not black) in light mode.
5. Run `?tour=invite` and confirm the onboarding tour still works end-to-end.