### PR TITLE
Align /tokens page to Figma design system

### DIFF
--- a/apps/frontend/src/app/(protected)/tokens/components/TokenDisplay.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokenDisplay.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Box, TextField, Typography, IconButton } from '@mui/material';
+import { alpha } from '@mui/material/styles';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CelebrationIcon from '@mui/icons-material/Celebration';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
@@ -13,12 +14,14 @@ interface TokenDisplayProps {
   open: boolean;
   onClose: () => void;
   token: TokenResponse | null;
+  title?: string;
 }
 
 export default function TokenDisplay({
   open,
   onClose,
   token,
+  title = 'Your New API Token',
 }: TokenDisplayProps) {
   const notifications = useNotifications();
 
@@ -41,7 +44,7 @@ export default function TokenDisplay({
     <BaseDrawer
       open={open}
       onClose={onClose}
-      title="Your New API Token"
+      title={title}
       titleIcon={<CelebrationIcon color="primary" />}
       closeButtonText="Close"
     >
@@ -72,7 +75,7 @@ export default function TokenDisplay({
             sx={{
               display: 'flex',
               alignItems: 'flex-start',
-              bgcolor: '#e5f2ff',
+              bgcolor: theme => alpha(theme.palette.primary.main, 0.1),
               borderRadius: BORDER_RADIUS.xs,
               px: '30px',
               py: '12px',

--- a/apps/frontend/src/app/(protected)/tokens/components/TokenDisplay.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokenDisplay.tsx
@@ -1,20 +1,13 @@
 'use client';
 
-import {
-  Box,
-  Button,
-  TextField,
-  Typography,
-  IconButton,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-} from '@mui/material';
+import { Box, TextField, Typography, IconButton } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CelebrationIcon from '@mui/icons-material/Celebration';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { TokenResponse } from '@/utils/api-client/interfaces/token';
 import { useNotifications } from '@/components/common/NotificationContext';
+import BaseDrawer from '@/components/common/BaseDrawer';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
 
 interface TokenDisplayProps {
   open: boolean;
@@ -45,46 +38,90 @@ export default function TokenDisplay({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
-      <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-        <CelebrationIcon color="primary" />
-        Your New API Token
-      </DialogTitle>
-      <DialogContent>
-        {token && (
-          <>
-            <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'bold' }}>
-              Token Name: {token.name}
+    <BaseDrawer
+      open={open}
+      onClose={onClose}
+      title="Your New API Token"
+      titleIcon={<CelebrationIcon color="primary" />}
+      closeButtonText="Close"
+    >
+      {token && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+              Token Name
             </Typography>
-            <Typography variant="subtitle2" sx={{ mb: 2 }}>
-              Expires:{' '}
+            <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+              {token.name}
+            </Typography>
+          </Box>
+
+          <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+              Expires
+            </Typography>
+            <Typography variant="body1">
               {token.expires_at
                 ? new Date(token.expires_at).toLocaleDateString()
                 : 'Never'}
             </Typography>
-            <Typography color="warning.main" sx={{ mb: 2 }}>
-              Store this token securely - it won&apos;t be shown again. If you
-              lose it, you&apos;ll need to generate a new one.
+          </Box>
+
+          {/* Figma Info Alert — node 1299:16000 (blue variant) */}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              bgcolor: '#e5f2ff',
+              borderRadius: BORDER_RADIUS.xs,
+              px: '30px',
+              py: '12px',
+              overflow: 'hidden',
+            }}
+          >
+            <Box sx={{ flexShrink: 0, pt: '7px', pr: '12px' }}>
+              <InfoOutlinedIcon sx={{ fontSize: 22, color: 'primary.main' }} />
+            </Box>
+            <Box sx={{ flex: 1, py: '8px' }}>
+              <Typography
+                sx={{
+                  fontSize: 16,
+                  fontWeight: 400,
+                  lineHeight: '24px',
+                  color: 'primary.main',
+                }}
+              >
+                Store this token securely — it won&apos;t be shown again. If you
+                lose it, you&apos;ll need to generate a new one.
+              </Typography>
+            </Box>
+          </Box>
+
+          <Box>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              Access Token
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
               <TextField
                 fullWidth
                 value={token.access_token}
                 variant="outlined"
-                InputProps={{
-                  readOnly: true,
+                InputProps={{ readOnly: true }}
+                inputProps={{
+                  style: { fontFamily: 'monospace', fontSize: 13 },
                 }}
               />
-              <IconButton onClick={handleCopyToken} color="primary">
+              <IconButton
+                onClick={handleCopyToken}
+                color="primary"
+                aria-label="Copy token"
+              >
                 <ContentCopyIcon />
               </IconButton>
             </Box>
-          </>
-        )}
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose}>Close</Button>
-      </DialogActions>
-    </Dialog>
+          </Box>
+        </Box>
+      )}
+    </BaseDrawer>
   );
 }

--- a/apps/frontend/src/app/(protected)/tokens/components/TokensGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokensGrid.tsx
@@ -133,7 +133,7 @@ export default function TokensGrid({
       headerName: 'Name',
       flex: 1,
       renderCell: (params: GridRenderCellParams) => (
-        <span style={{ fontWeight: 'medium' }}>{params.row.name}</span>
+        <span style={{ fontWeight: 500 }}>{params.row.name}</span>
       ),
     },
     {

--- a/apps/frontend/src/app/(protected)/tokens/components/TokensGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokensGrid.tsx
@@ -1,19 +1,17 @@
 'use client';
 
-import React, { useState } from 'react';
-import {
-  Box,
-  IconButton,
-  Tooltip,
-  Paper,
-  CircularProgress,
-} from '@mui/material';
+import React, { useContext, useState } from 'react';
+import { Box, Tooltip, IconButton } from '@mui/material';
 import {
   GridPaginationModel,
   type GridRenderCellParams,
   type GridColDef,
+  GridToolbarColumnsButton,
+  GridToolbarDensitySelector,
+  GridToolbarExport,
 } from '@mui/x-data-grid';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
+import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
 import { Token } from '@/utils/api-client/interfaces/token';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { DeleteIcon } from '@/components/icons';
@@ -24,6 +22,77 @@ import {
   ROW_ACTIONS_CLASS,
   rowActionsHoverSx,
 } from '@/components/common/createRowActionsColumn';
+
+// ── Toolbar status filter options ────────────────────────────────────────────
+
+export type TokenStatusFilter = 'all' | 'active' | 'expired';
+
+export const STATUS_OPTIONS: { value: TokenStatusFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'active', label: 'Active' },
+  { value: 'expired', label: 'Expired' },
+];
+
+// ── Toolbar context (passes search/filter state into the DataGrid slot) ──────
+
+export interface TokensToolbarState {
+  searchQuery: string;
+  setSearchQuery: (v: string) => void;
+  statusFilter: TokenStatusFilter;
+  setStatusFilter: (v: TokenStatusFilter) => void;
+  openFilterDrawer: () => void;
+  hasActiveDrawerFilters: boolean;
+  activeFilterCount: number;
+}
+
+export const TokensToolbarContext = React.createContext<TokensToolbarState>({
+  searchQuery: '',
+  setSearchQuery: () => {},
+  statusFilter: 'all',
+  setStatusFilter: () => {},
+  openFilterDrawer: () => {},
+  hasActiveDrawerFilters: false,
+  activeFilterCount: 0,
+});
+
+function TokensUnifiedToolbar() {
+  const {
+    searchQuery,
+    setSearchQuery,
+    statusFilter,
+    setStatusFilter,
+    openFilterDrawer,
+    hasActiveDrawerFilters,
+    activeFilterCount,
+  } = useContext(TokensToolbarContext);
+
+  return (
+    <GridToolbar
+      searchQuery={searchQuery}
+      onSearchChange={setSearchQuery}
+      searchPlaceholder="Search tokens…"
+      onFilterClick={openFilterDrawer}
+      hasActiveFilters={hasActiveDrawerFilters}
+      activeFilterCount={activeFilterCount}
+      middleContent={
+        <ToolbarPillTabs
+          tabs={STATUS_OPTIONS}
+          activeValue={statusFilter}
+          onChange={v => setStatusFilter(v as TokenStatusFilter)}
+        />
+      }
+      rightContent={
+        <>
+          <GridToolbarColumnsButton />
+          <GridToolbarDensitySelector />
+          <GridToolbarExport />
+        </>
+      }
+    />
+  );
+}
+
+// ── Grid component ────────────────────────────────────────────────────────────
 
 interface TokensGridProps {
   tokens: Token[];
@@ -58,7 +127,7 @@ export default function TokensGrid({
     setRefreshModalOpen(true);
   };
 
-  const columns = [
+  const columns: GridColDef[] = [
     {
       field: 'name',
       headerName: 'Name',
@@ -156,46 +225,25 @@ export default function TokensGrid({
     } as GridColDef,
   ];
 
-  // Initial load spinner — only when we don't have any rows yet.
-  if (loading && tokens.length === 0) {
-    return (
-      <Paper
-        elevation={2}
-        sx={{
-          width: '100%',
-          mb: 2,
-          py: 8,
-          px: 3,
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
-        <CircularProgress />
-      </Paper>
-    );
-  }
-
   return (
     <>
-      <Paper sx={{ width: '100%', mb: 2, overflow: 'hidden' }}>
-        <Box sx={{ p: 2 }}>
-          <BaseDataGrid
-            columns={columns}
-            rows={tokens}
-            loading={loading}
-            getRowId={row => (row as Token).id}
-            density="standard"
-            paginationModel={paginationModel}
-            onPaginationModelChange={onPaginationModelChange}
-            serverSidePagination={false}
-            totalRows={totalCount}
-            pageSizeOptions={[10, 25, 50]}
-            disablePaperWrapper={true}
-            sx={rowActionsHoverSx}
-          />
-        </Box>
-      </Paper>
+      <BaseDataGrid
+        columns={columns}
+        rows={tokens}
+        loading={loading}
+        getRowId={row => (row as Token).id}
+        density="standard"
+        paginationModel={paginationModel}
+        onPaginationModelChange={onPaginationModelChange}
+        serverSidePagination={false}
+        totalRows={totalCount}
+        pageSizeOptions={[10, 25, 50]}
+        disablePaperWrapper={true}
+        toolbarSlot={TokensUnifiedToolbar}
+        persistState
+        storageKey="tokens-grid"
+        sx={rowActionsHoverSx}
+      />
       <RefreshTokenModal
         open={refreshModalOpen}
         onClose={() => setRefreshModalOpen(false)}

--- a/apps/frontend/src/app/(protected)/tokens/components/TokensPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokensPageClient.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import {
   Box,
   Button,
+  Paper,
   Typography,
   Dialog,
   DialogTitle,
@@ -13,17 +14,16 @@ import {
   IconButton,
   Alert,
 } from '@mui/material';
-import GridToolbar, {
-  ToolbarPillTabs,
-  directoryToolbarSx,
-} from '@/components/common/GridToolbar';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-import TokensGrid from './TokensGrid';
+import TokensGrid, {
+  TokensToolbarContext,
+  type TokenStatusFilter,
+  type TokensToolbarState,
+} from './TokensGrid';
 import CreateTokenDrawer from './CreateTokenDrawer';
 import TokenDisplay from './TokenDisplay';
 import TokenFilterDrawer, {
   type TokenFilters,
-  type TokenStatusFilter,
   EMPTY_TOKEN_FILTERS,
   hasActiveTokenFilters,
   countActiveTokenFilters,
@@ -35,12 +35,7 @@ import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { VpnKeyIcon } from '@/components/icons';
-
-const STATUS_OPTIONS: { value: TokenStatusFilter; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: 'active', label: 'Active' },
-  { value: 'expired', label: 'Expired' },
-];
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 
 interface TokensPageClientProps {
   sessionToken: string;
@@ -214,6 +209,27 @@ export default function TokensPageClient({
     }
   }, [filteredTokens.length, paginationModel.page, paginationModel.pageSize]);
 
+  // ── Toolbar context value ────────────────────────────────────────────────────
+
+  const toolbarContextValue: TokensToolbarState = useMemo(
+    () => ({
+      searchQuery: search,
+      setSearchQuery: (v: string) => {
+        setSearch(v);
+        setPaginationModel(prev => ({ ...prev, page: 0 }));
+      },
+      statusFilter,
+      setStatusFilter: (v: TokenStatusFilter) => {
+        setStatusFilter(v);
+        setPaginationModel(prev => ({ ...prev, page: 0 }));
+      },
+      openFilterDrawer: () => setFilterDrawerOpen(true),
+      hasActiveDrawerFilters: hasActiveTokenFilters(drawerFilters),
+      activeFilterCount: countActiveTokenFilters(drawerFilters),
+    }),
+    [search, statusFilter, drawerFilters]
+  );
+
   // ── Render ──────────────────────────────────────────────────────────────────
 
   return (
@@ -232,29 +248,6 @@ export default function TokensPageClient({
         </FabGroup>
       }
     >
-      <GridToolbar
-        searchQuery={search}
-        onSearchChange={v => {
-          setSearch(v);
-          setPaginationModel(prev => ({ ...prev, page: 0 }));
-        }}
-        searchPlaceholder="Search tokens…"
-        onFilterClick={() => setFilterDrawerOpen(true)}
-        hasActiveFilters={hasActiveTokenFilters(drawerFilters)}
-        activeFilterCount={countActiveTokenFilters(drawerFilters)}
-        sx={directoryToolbarSx}
-        middleContent={
-          <ToolbarPillTabs
-            tabs={STATUS_OPTIONS}
-            activeValue={statusFilter}
-            onChange={v => {
-              setStatusFilter(v as TokenStatusFilter);
-              setPaginationModel(prev => ({ ...prev, page: 0 }));
-            }}
-          />
-        }
-      />
-
       {/* Error state */}
       {error && (
         <Alert severity="error" sx={{ mb: 2 }}>
@@ -265,6 +258,7 @@ export default function TokensPageClient({
       {/* Empty state vs grid */}
       {!loading && tokens.length === 0 ? (
         <EntityEmptyState
+          card
           icon={VpnKeyIcon}
           title="No API tokens yet"
           description="Create your first API token to start interacting with the Rhesis API. Tokens allow you to authenticate your applications and build powerful integrations."
@@ -273,6 +267,8 @@ export default function TokensPageClient({
         />
       ) : !loading && filteredTokens.length === 0 && hasActiveFilters ? (
         <EntityEmptyState
+          card
+          showAddIcon={false}
           icon={VpnKeyIcon}
           title="No tokens match your filters"
           description="Try adjusting your search or filters to find the tokens you're looking for."
@@ -284,15 +280,28 @@ export default function TokensPageClient({
           }}
         />
       ) : (
-        <TokensGrid
-          tokens={filteredTokens}
-          onRefreshToken={handleRefreshToken}
-          onDeleteToken={handleDeleteToken}
-          loading={loading}
-          totalCount={filteredTokens.length}
-          paginationModel={paginationModel}
-          onPaginationModelChange={setPaginationModel}
-        />
+        <Paper
+          elevation={0}
+          sx={{
+            width: '100%',
+            borderRadius: BORDER_RADIUS.md,
+            boxShadow: ELEVATION.xs,
+            border: theme => `1px solid ${theme.palette.greyscale.border}`,
+            overflow: 'hidden',
+          }}
+        >
+          <TokensToolbarContext.Provider value={toolbarContextValue}>
+            <TokensGrid
+              tokens={filteredTokens}
+              onRefreshToken={handleRefreshToken}
+              onDeleteToken={handleDeleteToken}
+              loading={loading}
+              totalCount={filteredTokens.length}
+              paginationModel={paginationModel}
+              onPaginationModelChange={setPaginationModel}
+            />
+          </TokensToolbarContext.Provider>
+        </Paper>
       )}
 
       {/* Modals & dialogs */}

--- a/apps/frontend/src/app/(protected)/tokens/components/TokensPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/TokensPageClient.tsx
@@ -1,20 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import {
-  Box,
-  Button,
-  Paper,
-  Typography,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  TextField,
-  IconButton,
-  Alert,
-} from '@mui/material';
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import { Paper, Alert } from '@mui/material';
 import TokensGrid, {
   TokensToolbarContext,
   type TokenStatusFilter,
@@ -317,52 +304,12 @@ export default function TokensPageClient({
         token={newToken}
       />
 
-      <Dialog
+      <TokenDisplay
+        title="Your Refreshed API Token"
         open={refreshedToken !== null}
         onClose={() => setRefreshedToken(null)}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle>Your Refreshed API Token</DialogTitle>
-        <DialogContent>
-          <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: 'bold' }}>
-            Token Name: {refreshedToken?.name}
-          </Typography>
-          <Typography variant="subtitle2" sx={{ mb: 2 }}>
-            Expires:{' '}
-            {refreshedToken?.expires_at
-              ? new Date(refreshedToken.expires_at).toLocaleDateString()
-              : 'Never'}
-          </Typography>
-          <Typography color="warning.main" sx={{ mb: 2 }}>
-            Store this token securely - it won&apos;t be shown again. If you
-            lose it, you&apos;ll need to generate a new one.
-          </Typography>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <TextField
-              fullWidth
-              value={refreshedToken?.access_token || ''}
-              variant="outlined"
-              InputProps={{ readOnly: true }}
-            />
-            <IconButton
-              onClick={async () => {
-                if (refreshedToken) {
-                  await navigator.clipboard.writeText(
-                    refreshedToken.access_token
-                  );
-                }
-              }}
-              color="primary"
-            >
-              <ContentCopyIcon />
-            </IconButton>
-          </Box>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setRefreshedToken(null)}>Close</Button>
-        </DialogActions>
-      </Dialog>
+        token={refreshedToken}
+      />
 
       <DeleteModal
         open={deleteTokenId !== null}

--- a/apps/frontend/src/app/(protected)/tokens/components/__tests__/TokensGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/__tests__/TokensGrid.test.tsx
@@ -52,6 +52,11 @@ jest.mock('@/components/common/BaseDataGrid', () => ({
   ),
 }));
 
+jest.mock('@/components/common/GridBadge', () => ({
+  __esModule: true,
+  default: ({ label }: { label: string }) => <span>{label}</span>,
+}));
+
 jest.mock('../RefreshTokenModal', () => ({
   __esModule: true,
   default: ({ open, onClose }: { open: boolean; onClose: () => void }) =>
@@ -84,7 +89,7 @@ describe('TokensGrid', () => {
     jest.clearAllMocks();
   });
 
-  it('shows a loading spinner when loading=true and no tokens', () => {
+  it('renders the grid (via BaseDataGrid) even when loading=true and no tokens', () => {
     render(
       <TokensGrid
         tokens={[]}
@@ -94,9 +99,9 @@ describe('TokensGrid', () => {
         totalCount={0}
       />
     );
-    expect(
-      document.querySelector('.MuiCircularProgress-root')
-    ).toBeInTheDocument();
+    // BaseDataGrid is mocked to render a <table>; loading state is handled
+    // internally by BaseDataGrid (not by a standalone spinner in TokensGrid).
+    expect(document.querySelector('table')).toBeInTheDocument();
   });
 
   it('renders token names in the data grid', () => {


### PR DESCRIPTION
## Purpose
Bring the `/tokens` page in line with the Figma design system — specifically the "Overview Table" unified-card pattern already used by Tests and Test Sets — and update the new-token display flow.

## What Changed
- **Unified-card grid layout** — `TokensGrid` now uses `toolbarSlot` + `disablePaperWrapper` so the toolbar, grid, and pagination live inside a single `Paper` card (matching Figma node 841-38312). Removed the inner `Paper`/`Box` and standalone loading spinner.
- **Unified toolbar** — new `TokensUnifiedToolbar` wires search, status pill-tabs, and the standard Columns / Density / Export controls into `GridToolbar` (matches the reference toolbar used by Tests/Test Sets).
- **Design-system card wrapper** — `TokensPageClient` wraps the grid in a `Paper` with `BORDER_RADIUS.md`, `ELEVATION.xs`, and `greyscale.border`.
- **Empty states** — both `EntityEmptyState` usages updated to the `card` variant (Figma node 1435-45062); the "no results" state also sets `showAddIcon={false}`.
- **Token display drawer** — `TokenDisplay` converted from `Dialog` to `BaseDrawer` with a title and `CelebrationIcon`.
- **Info alert** — "Store this token securely" note styled as the Figma blue info alert (node 1299-16000): `#e5f2ff` background, `InfoOutlinedIcon`, `primary.main` text.
- **Tests** — `TokensGrid.test.tsx` updated: loading assertion targets the mocked `BaseDataGrid` table; `GridBadge` mocked to avoid theme access outside `ThemeProvider`.

## Additional Context
- Follows the same pattern as `Tests` and `Test Sets` overview pages.
- No backend changes; purely frontend styling/refactor.

## Testing
1. Navigate to `/tokens` — grid should render inside a single card with search, pill-tabs, and Columns/Density/Export controls.
2. Delete all tokens — empty state should show the card variant with the illustrated icon.
3. Create a token — drawer opens instead of modal; security note shows as a blue info box.
4. Run `cd apps/frontend && npx jest --testPathPatterns tokens` — all tests green.