### PR TITLE
Fix sidebar: left-align project name and remove email from user info

### DIFF
--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -545,20 +545,6 @@ export function Sidebar() {
               >
                 {user?.name ?? 'User'}
               </Typography>
-              <Typography
-                sx={{
-                  display: 'block',
-                  fontSize: 12,
-                  fontWeight: 400,
-                  lineHeight: '18px',
-                  color: theme => theme.palette.greyscale.subtitle,
-                  whiteSpace: 'nowrap',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                }}
-              >
-                {user?.email ?? ''}
-              </Typography>
             </Box>
           )}
         </ButtonBase>

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -265,6 +265,7 @@ export function Sidebar() {
                       whiteSpace: 'nowrap',
                       overflow: 'hidden',
                       textOverflow: 'ellipsis',
+                      textAlign: 'left',
                     }}
                   >
                     {activeProject.name}


### PR DESCRIPTION
## Purpose
Fix two minor UI inconsistencies in the sidebar navbar.

## What Changed
- Left-align project name in the brand block — MUI `ButtonBase` inherits `text-align: center`, the org name `Typography` already overrode this with `textAlign: 'left'` but the project name was missing the same override
- Remove the user email `Typography` from the user info section at the bottom of the sidebar

## Additional Context
- Both changes are in `apps/frontend/src/components/navigation/Sidebar.tsx`

## Testing
Open the app and verify:
1. Project name in the top-left brand block is left-aligned (matching the org name below it)
2. Only the user's display name is shown in the bottom user section — no email