### PR TITLE
Align support drawer to Figma design system

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,11 @@ SMTP_PORT=465
 SMTP_USER=your-smtp-username
 SMTP_PASSWORD=your-smtp-password
 FROM_EMAIL=noreply@yourdomain.com
+# Sender used for welcome / onboarding emails (RFC822 format or plain address)
+WELCOME_FROM_EMAIL="Nicolai from Rhesis AI" <hello@rhesis.ai>
+
+# Support contact address shown in the UI (must match the address in WELCOME_FROM_EMAIL)
+NEXT_PUBLIC_SUPPORT_EMAIL=hello@rhesis.ai
 
 # SendGrid API Key (for Dynamic Templates and scheduling)
 SENDGRID_API_KEY=your-sendgrid-api-key

--- a/apps/frontend/src/components/common/FilterDrawer.tsx
+++ b/apps/frontend/src/components/common/FilterDrawer.tsx
@@ -122,10 +122,10 @@ export function FilterDrawerShell({
       >
         <Typography
           sx={{
-            fontSize: 22,
+            fontSize: 23,
             fontWeight: 700,
             color: theme => theme.palette.greyscale.title,
-            lineHeight: 1.1,
+            lineHeight: '27.6px',
           }}
         >
           {title}

--- a/apps/frontend/src/components/navigation/SupportDrawer.tsx
+++ b/apps/frontend/src/components/navigation/SupportDrawer.tsx
@@ -27,11 +27,9 @@ function SupportSection({ title, description, children }: SectionProps) {
   return (
     <Box
       sx={{
-        borderTop: theme => `1px solid ${theme.palette.divider}`,
-        pt: '20px',
         display: 'flex',
         flexDirection: 'column',
-        gap: '16px',
+        gap: '20px',
       }}
     >
       <Box>
@@ -131,79 +129,81 @@ export default function SupportDrawer({ open, onClose }: SupportDrawerProps) {
       title="Support"
       anchor="right"
     >
-      <SupportSection
-        title="Docs"
-        description="Explore guides, API references, and examples to get the most out of Rhesis."
-      >
-        <Button
-          component="a"
-          href="https://docs.rhesis.ai"
-          target="_blank"
-          rel="noopener noreferrer"
-          variant="outlined"
-          startIcon={<MenuBookIcon />}
-          fullWidth
-          sx={{
-            borderWidth: 2,
-            borderColor: 'primary.main',
-            color: 'primary.main',
-            fontWeight: 700,
-            fontSize: 14,
-            borderRadius: BORDER_RADIUS.sm,
-            px: '16px',
-            py: '8px',
-            justifyContent: 'flex-start',
-            '&:hover': { borderWidth: 2 },
-          }}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '40px' }}>
+        <SupportSection
+          title="Docs"
+          description="Explore guides, API references, and examples to get the most out of Rhesis."
         >
-          View documentation
-        </Button>
-      </SupportSection>
+          <Button
+            component="a"
+            href="https://docs.rhesis.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            variant="outlined"
+            startIcon={<MenuBookIcon />}
+            fullWidth
+            sx={{
+              borderWidth: 2,
+              borderColor: 'primary.main',
+              color: 'primary.main',
+              fontWeight: 700,
+              fontSize: 14,
+              borderRadius: BORDER_RADIUS.sm,
+              px: '16px',
+              py: '8px',
+              justifyContent: 'flex-start',
+              '&:hover': { borderWidth: 2 },
+            }}
+          >
+            View documentation
+          </Button>
+        </SupportSection>
 
-      <SupportSection
-        title="Email a Support Engineer"
-        description="Still stuck? Our support team is happy to help you get unblocked."
-      >
-        <Button
-          component="a"
-          href="mailto:hello@rhesis.ai"
-          variant="outlined"
-          startIcon={<EmailOutlinedIcon />}
-          fullWidth
-          sx={{
-            borderWidth: 2,
-            borderColor: 'primary.main',
-            color: 'primary.main',
-            fontWeight: 700,
-            fontSize: 14,
-            borderRadius: BORDER_RADIUS.sm,
-            px: '16px',
-            py: '8px',
-            justifyContent: 'flex-start',
-            '&:hover': { borderWidth: 2 },
-          }}
+        <SupportSection
+          title="Email a Support Engineer"
+          description="Still stuck? Our support team is happy to help you get unblocked."
         >
-          Email a Support Engineer
-        </Button>
-      </SupportSection>
+          <Button
+            component="a"
+            href="mailto:hello@rhesis.ai"
+            variant="outlined"
+            startIcon={<EmailOutlinedIcon />}
+            fullWidth
+            sx={{
+              borderWidth: 2,
+              borderColor: 'primary.main',
+              color: 'primary.main',
+              fontWeight: 700,
+              fontSize: 14,
+              borderRadius: BORDER_RADIUS.sm,
+              px: '16px',
+              py: '8px',
+              justifyContent: 'flex-start',
+              '&:hover': { borderWidth: 2 },
+            }}
+          >
+            Email a Support Engineer
+          </Button>
+        </SupportSection>
 
-      <SupportSection
-        title="Community & Resources"
-        description="Join the conversation and connect with the Rhesis community."
-      >
-        <Box sx={{ display: 'flex', flexDirection: 'column' }}>
-          <CommunityLink
-            icon={<GitHubIcon />}
-            label="GitHub"
-            href="https://github.com/rhesis-ai/rhesis"
-          />
-          <CommunityLink
-            icon={<DiscordIcon />}
-            label="Discord"
-            href="https://discord.rhesis.ai"
-          />
-        </Box>
-      </SupportSection>
+        <SupportSection
+          title="Community & Resources"
+          description="Join the conversation and connect with the Rhesis community."
+        >
+          <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+            <CommunityLink
+              icon={<GitHubIcon />}
+              label="GitHub"
+              href="https://github.com/rhesis-ai/rhesis"
+            />
+            <CommunityLink
+              icon={<DiscordIcon />}
+              label="Discord"
+              href="https://discord.rhesis.ai"
+            />
+          </Box>
+        </SupportSection>
+      </Box>
     </FilterDrawerShell>
   );
 }

--- a/apps/frontend/src/components/navigation/SupportDrawer.tsx
+++ b/apps/frontend/src/components/navigation/SupportDrawer.tsx
@@ -165,7 +165,7 @@ export default function SupportDrawer({ open, onClose }: SupportDrawerProps) {
         >
           <Button
             component="a"
-            href="mailto:hello@rhesis.ai"
+            href={`mailto:${process.env.NEXT_PUBLIC_SUPPORT_EMAIL ?? 'hello@rhesis.ai'}`}
             variant="outlined"
             startIcon={<EmailOutlinedIcon />}
             fullWidth


### PR DESCRIPTION
## Purpose

Follow-up to #1902 — aligns the support drawer more closely with the Figma drawer chrome spec (node 1641:16598) and removes a hardcoded email address.

## What Changed

- **Remove section dividers**: replaced `borderTop` rule between `SupportSection` items with pure whitespace separation (40 px gap), matching the Figma pattern where sections use gap rather than horizontal rules
- **Fix inter-section gap**: sections are now wrapped in a single `Box` with `gap: 40px` (up from the FilterDrawerShell default of 30 px) to match Figma's `gap-[40px]` rhythm
- **Fix intra-section gap**: gap between the title/description block and the action button/links tightened to 20 px (was 16 px), matching Figma's `FormSectionDivider → content` spacing
- **Fix drawer title typography**: `FilterDrawerShell` title updated from 22 px / `lineHeight: 1.1` to **23 px / 27.6 px** (exact Figma H5/Bold values — affects all drawers)
- **Replace hardcoded support email**: `mailto:hello@rhesis.ai` → `process.env.NEXT_PUBLIC_SUPPORT_EMAIL` with `hello@rhesis.ai` fallback; variable documented in `.env.example` next to `WELCOME_FROM_EMAIL` with a note that both should carry the same address

## Additional Context

- Figma reference: [node 1641:16598](https://www.figma.com/design/RCN0J2AjA0UlStdPpdjUCu/Frontend?node-id=1641-16598)
- Follows up on #1902 (support drawer) and addresses typography/spacing feedback

## Testing

1. Open the app and click **Support** in the sidebar
2. Verify no horizontal dividers appear between the three sections
3. Verify sections have comfortable spacing (~40 px gap)
4. Verify the drawer title font size looks slightly larger than before
5. Set `NEXT_PUBLIC_SUPPORT_EMAIL=test@example.com` locally and confirm the mailto href updates accordingly