### PR TITLE
Fix: Invoker token management

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/invokers/rest_invoker.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/rest_invoker.py
@@ -265,12 +265,12 @@ class RestEndpointInvoker(BaseEndpointInvoker):
                     mapped_response[conversation_field] = conversation_id
                     logger.debug(f"Added {conversation_field} to response: {conversation_id}")
 
-            # Preserve important unmapped fields from original response (error info, message, etc.)
-            important_fields = ["error", "status", "message"]
-            for field in important_fields:
-                if field in response_data and field not in mapped_response:
-                    mapped_response[field] = response_data[field]
-                    logger.debug(f"Preserved unmapped field '{field}': {response_data[field]}")
+            # Keep the full API response for display
+            try:
+                raw_copy = json.loads(json.dumps(response_data))
+                mapped_response["raw_response"] = raw_copy
+            except (TypeError, ValueError):
+                mapped_response["raw_response"] = None
 
             return mapped_response
         except json.JSONDecodeError as json_error:
@@ -313,8 +313,13 @@ class RestEndpointInvoker(BaseEndpointInvoker):
         if endpoint.auth_type or endpoint.auth_token:
             auth_token = self._get_valid_token(db, endpoint)
 
-            # Automatically add Authorization header if not explicitly set
-            if "Authorization" not in headers and auth_token:
+            # Automatically add Authorization header only if the token is not
+            # already referenced in any custom header (e.g. x-goog-api-key).
+            token_already_placed = any(
+                "auth_token" in str(v) or (auth_token and auth_token in str(v))
+                for v in headers.values()
+            )
+            if "Authorization" not in headers and not token_already_placed and auth_token:
                 headers["Authorization"] = f"Bearer {auth_token}"
         else:
             auth_token = ""

--- a/apps/backend/src/rhesis/backend/app/services/invokers/rest_invoker.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/rest_invoker.py
@@ -272,6 +272,10 @@ class RestEndpointInvoker(BaseEndpointInvoker):
             except (TypeError, ValueError):
                 mapped_response["raw_response"] = None
 
+            for field in ("error", "status", "message"):
+                if field in response_data and field not in mapped_response:
+                    mapped_response[field] = response_data[field]
+
             return mapped_response
         except json.JSONDecodeError as json_error:
             logger.error(f"JSON parsing error from {url}: {str(json_error)}")

--- a/apps/backend/src/rhesis/backend/app/services/invokers/templating/filters.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/templating/filters.py
@@ -72,8 +72,50 @@ def to_gemini(
     return parts
 
 
+def gemini_parts(
+    files: Optional[List[Dict[str, Any]]],
+    input_text: str = "",
+) -> List[Dict[str, Any]]:
+    """Build a Gemini parts array merging a text part with file inline_data parts.
+
+    Usage: {{ files | gemini_parts(input) | tojson }}
+    """
+    parts: List[Dict[str, Any]] = [{"text": input_text}]
+    parts.extend(to_gemini(files))
+    return parts
+
+
+def openai_content(
+    files: Optional[List[Dict[str, Any]]],
+    input_text: str = "",
+) -> List[Dict[str, Any]]:
+    """Build an OpenAI content array merging a text block with image_url blocks.
+
+    Usage: {{ files | openai_content(input) | tojson }}
+    """
+    content: List[Dict[str, Any]] = [{"type": "text", "text": input_text}]
+    content.extend(to_openai(files))
+    return content
+
+
+def anthropic_content(
+    files: Optional[List[Dict[str, Any]]],
+    input_text: str = "",
+) -> List[Dict[str, Any]]:
+    """Build an Anthropic content array merging a text block with image/document blocks.
+
+    Usage: {{ files | anthropic_content(input) | tojson }}
+    """
+    content: List[Dict[str, Any]] = [{"type": "text", "text": input_text}]
+    content.extend(to_anthropic(files))
+    return content
+
+
 FILE_FILTERS = {
     "to_anthropic": to_anthropic,
     "to_openai": to_openai,
     "to_gemini": to_gemini,
+    "gemini_parts": gemini_parts,
+    "openai_content": openai_content,
+    "anthropic_content": anthropic_content,
 }

--- a/apps/backend/src/rhesis/backend/app/services/invokers/templating/renderer.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/templating/renderer.py
@@ -126,7 +126,12 @@ class TemplateRenderer:
         elif isinstance(template_data, list):
             result = []
             for item in template_data:
-                result.append(self._render_recursive(item, render_context))
+                rendered_item = self._render_recursive(item, render_context)
+                # Spread rendered lists into the parent array
+                if isinstance(item, str) and isinstance(rendered_item, list):
+                    result.extend(rendered_item)
+                else:
+                    result.append(rendered_item)
             return result
         else:
             # For other types (int, float, bool, None, etc.), return as-is


### PR DESCRIPTION
## Purpose
Fix two bugs in `RestEndpointInvoker`, add a new `raw_response` field, and introduce convenience Jinja2 filters for multimodal prompt templates.

## What Changed

### Bug fixes

- **Auth token double-injection**: skip the automatic `Authorization: Bearer` header when the token is already referenced in a custom header (e.g. `x-goog-api-key: {{auth_token}}`), avoiding duplicate credentials.
- **Another bug:** The intended usage pattern - having a separate `{"text": "{{ input }}"}` element alongside `{{ files | to_gemini | tojson }}` in a parts array - was broken by the renderer. When a template string inside a JSON array renders to a JSON array, the renderer was nesting it (`[[...]]`) rather than spreading it (`[...]`). This made templates like the one below fail with a 400:
 ```json
 "parts": [
   {"text": "{{ input }}"},
   {{ files | to_gemini | tojson }}
 ]
 ```
Fixed in the renderer (`_render_recursive`): a string element that renders to a list is now spread into the parent array.

### Features

- **Raw response envelope**: in addition to the narrow 3-field pass-through (`error`, `status`, `message`), we now include a full `raw_response` copy of the original API payload, so users can debug unexpected API responses without guessing.

- **Combined content filters**: Added gemini_parts, openai_content, and anthropic_content filters that build the entire parts/content array in a single expression (text + files merged).

## Additional Context

- `raw_response` is additive: downstream consumers that only read mapped fields (`output`, `conversation_id`) are unaffected.
- The new template filters are purely additive — no existing templates break.