### PR TITLE
Allow BACKEND_ENV=test in backend settings

### DIFF
--- a/apps/backend/src/rhesis/backend/app/config/settings.py
+++ b/apps/backend/src/rhesis/backend/app/config/settings.py
@@ -92,7 +92,7 @@ class ApplicationSettings(BaseSettings):
     model_config = SettingsConfigDict(env_ignore_empty=True)
 
     quick_start: bool = Field(default=False, alias="QUICK_START")
-    backend_env: Literal["production", "development", "staging", "local"] = Field(
+    backend_env: Literal["production", "development", "staging", "local", "test"] = Field(
         default="development", alias="BACKEND_ENV"
     )
     # Google Cloud-specific environment variables set by Google Cloud runtimes.

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -24,6 +24,7 @@ x-sdk-redis-config: &sdk-redis-config
 
 x-sdk-backend-config: &sdk-backend-config
   ENVIRONMENT: test
+  BACKEND_ENV: test
   FRONTEND_URL: "http://localhost:3000"
   JWT_SECRET_KEY: your-jwt-secret-key
   SESSION_SECRET_KEY: test-session-secret-key


### PR DESCRIPTION
## Summary
- Add `test` to `BACKEND_ENV` allowed values
- Set `BACKEND_ENV=test` in SDK test docker-compose

## Test plan
- [ ] SDK integration tests pass