### PR TITLE
Fix SSO get_providers unit tests after Request param added

### DIFF
--- a/tests/backend/ee/sso/test_sso_slug_resolution.py
+++ b/tests/backend/ee/sso/test_sso_slug_resolution.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
+from starlette.datastructures import Headers
 
 # ---------------------------------------------------------------------------
 # _get_org_or_404
@@ -34,6 +35,15 @@ class _FakeQuery:
 
     def first(self):
         return self._result
+
+
+def _make_mock_request(host: str = "localhost", port: int = 8080) -> MagicMock:
+    """Minimal Starlette Request stand-in for direct get_providers() calls."""
+    request = MagicMock()
+    request.url = MagicMock()
+    request.url.hostname = host
+    request.headers = Headers({"host": f"{host}:{port}"})
+    return request
 
 
 class TestGetOrgOr404:
@@ -124,7 +134,9 @@ class TestAuthProvidersOrgParam:
 
         from rhesis.backend.app.routers.auth import get_providers
 
-        result = asyncio.get_event_loop().run_until_complete(get_providers(org=str(org_id), db=db))
+        result = asyncio.get_event_loop().run_until_complete(
+            get_providers(request=_make_mock_request(), org=str(org_id), db=db)
+        )
 
         sso_providers = [p for p in result.providers if p.name == "sso"]
         assert len(sso_providers) == 1
@@ -141,7 +153,9 @@ class TestAuthProvidersOrgParam:
 
         from rhesis.backend.app.routers.auth import get_providers
 
-        result = asyncio.get_event_loop().run_until_complete(get_providers(org="acme-corp", db=db))
+        result = asyncio.get_event_loop().run_until_complete(
+            get_providers(request=_make_mock_request(), org="acme-corp", db=db)
+        )
 
         sso_providers = [p for p in result.providers if p.name == "sso"]
         assert len(sso_providers) == 1
@@ -159,7 +173,9 @@ class TestAuthProvidersOrgParam:
 
         from rhesis.backend.app.routers.auth import get_providers
 
-        result = asyncio.get_event_loop().run_until_complete(get_providers(org=str(org_id), db=db))
+        result = asyncio.get_event_loop().run_until_complete(
+            get_providers(request=_make_mock_request(), org=str(org_id), db=db)
+        )
 
         sso_providers = [p for p in result.providers if p.name == "sso"]
         assert len(sso_providers) == 1
@@ -173,7 +189,9 @@ class TestAuthProvidersOrgParam:
 
         from rhesis.backend.app.routers.auth import get_providers
 
-        result = asyncio.get_event_loop().run_until_complete(get_providers(org=None, db=db))
+        result = asyncio.get_event_loop().run_until_complete(
+            get_providers(request=_make_mock_request(), org=None, db=db)
+        )
 
         sso_providers = [p for p in result.providers if p.name == "sso"]
         assert len(sso_providers) == 0


### PR DESCRIPTION
## Purpose
`get_providers` now takes a `Request` argument for `quick_start` detection. Unit tests that call the handler directly were failing because they bypass FastAPI dependency injection.

## What Changed
- Add `_make_mock_request` helper in `test_sso_slug_resolution.py`
- Pass mock `request` in all four `TestAuthProvidersOrgParam` direct `get_providers()` calls

## Additional Context
Fixes failures like:
`TypeError: get_providers() missing 1 required positional argument: 'request'`

HTTP-level tests (`TestClient`) were unaffected — FastAPI injects `Request` automatically on route calls.

## Testing
```bash
cd apps/backend
uv run pytest ../../tests/backend/ee/sso/test_sso_slug_resolution.py::TestAuthProvidersOrgParam -v
```