### PR TITLE
Update GitHub Actions setup-python and setup-uv versions

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -41,7 +41,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Cache uv dependencies
         uses: actions/cache@v4

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv for SDK
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
             version: latest
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Install uv
       if: steps.filter.outputs.sdk == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.penelope == 'true' || github.event_name == 'workflow_dispatch'
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         version: latest
         enable-cache: true

--- a/.github/workflows/penelope-test.yml
+++ b/.github/workflows/penelope-test.yml
@@ -21,12 +21,12 @@ jobs:
         fetch-depth: 0  # Needed for git diff
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         version: latest
         enable-cache: true

--- a/.github/workflows/polyphemus-vertex-ai.yml
+++ b/.github/workflows/polyphemus-vertex-ai.yml
@@ -96,12 +96,12 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Install dependencies
         working-directory: apps/polyphemus

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -56,7 +56,7 @@ jobs:
           python-version: '3.11'
 
       - name: Install uv for SDK
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
             version: latest
 

--- a/.github/workflows/sdk-test.yml
+++ b/.github/workflows/sdk-test.yml
@@ -23,12 +23,12 @@ jobs:
         fetch-depth: 0  # Needed for git diff
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.10"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         version: latest
         enable-cache: true

--- a/docs/content/guides/ci-cd-integration.mdx
+++ b/docs/content/guides/ci-cd-integration.mdx
@@ -122,7 +122,7 @@ Create `.github/workflows/rhesis-tests.yml` in your repository. The workflow inc
 
 <CodeBlock filename="rhesis-tests.yml" language="yaml">
 {`- name: Set up Python
-  uses: actions/setup-python@v5
+  uses: actions/setup-python@v6
   with:
     python-version: '3.11'
 

--- a/examples/ci-cd/rhesis-tests.yml
+++ b/examples/ci-cd/rhesis-tests.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v6
       
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'


### PR DESCRIPTION
## Purpose
Keep CI workflows on current, pinned versions of `actions/setup-python` and `astral-sh/setup-uv` for security and reproducibility.

## What Changed
- Bump `actions/setup-python` from v5 to v6 in SDK, Penelope, Polyphemus, docs, and example workflows
- Pin `astral-sh/setup-uv` to v8.1.0 (`08807647e7069bb48b6ef5acd8ec9567f424441b`) across all workflows (replacing `@v3` and `@v6` tags)

## Additional Context
- Follows the same SHA-pinning pattern used elsewhere in the repo for GitHub Actions

## Testing
- CI workflows will validate on merge (backend-test, sdk-test, penelope-test, lint, release workflows)