### PR TITLE
Pin Node.js version in frontend E2E workflow

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -44,7 +44,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Cache uv dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/uv
           key: ${{ runner.os }}-uv-backend-${{ hashFiles('apps/backend/uv.lock') }}

--- a/.github/workflows/check-hardcoded-styles.yml
+++ b/.github/workflows/check-hardcoded-styles.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -66,7 +66,7 @@ jobs:
           uv lock --project ./apps/backend
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24.15
+          node-version: '24.15'
           cache: 'npm'
           cache-dependency-path: apps/frontend/package-lock.json
 

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: 24.15
           cache: 'npm'
           cache-dependency-path: apps/frontend/package-lock.json
 

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24.15
           cache: 'npm'
@@ -58,7 +58,7 @@ jobs:
         working-directory: apps/frontend
 
       - name: Upload blob report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: blob-report-${{ matrix.shard }}
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -87,7 +87,7 @@ jobs:
         working-directory: apps/frontend
 
       - name: Download blob reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: apps/frontend/all-blob-reports
           pattern: blob-report-*
@@ -98,7 +98,7 @@ jobs:
         working-directory: apps/frontend
 
       - name: Upload merged Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: apps/frontend/playwright-report/

--- a/.github/workflows/frontend-test.yml
+++ b/.github/workflows/frontend-test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
 

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -151,7 +151,7 @@ jobs:
           echo "sa_key_path=$(realpath ${{ env.SA_KEY_PATH }})" >> $GITHUB_OUTPUT
       
       - name: Upload setup artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: setup-artifacts
           path: |
@@ -172,7 +172,7 @@ jobs:
         uses: actions/checkout@v6
       
       - name: Download setup artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: setup-artifacts
           path: .
@@ -323,7 +323,7 @@ jobs:
           fi
       
       - name: Upload Terraform Plan
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: terraform-plan-${{ github.event.inputs.environment }}
           path: infrastructure/environments/${{ github.event.inputs.environment }}/terraform-${{ github.event.inputs.environment }}-plan
@@ -341,7 +341,7 @@ jobs:
         uses: actions/checkout@v6
       
       - name: Download setup artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: setup-artifacts
           path: .
@@ -368,7 +368,7 @@ jobs:
           echo "Current GCP project: $CURRENT_PROJECT"
       
       - name: Download Terraform Plan
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: terraform-plan-${{ github.event.inputs.environment }}
           path: infrastructure/environments/${{ github.event.inputs.environment }}
@@ -464,7 +464,7 @@ jobs:
         uses: actions/checkout@v6
       
       - name: Download setup artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: setup-artifacts
           path: .
@@ -491,7 +491,7 @@ jobs:
           echo "Current GCP project: $CURRENT_PROJECT"
       
       - name: Download Terraform Plan
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: terraform-plan-${{ github.event.inputs.environment }}
           path: infrastructure/environments/${{ github.event.inputs.environment }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -76,7 +76,7 @@ jobs:
     # Frontend & Docs Linting (both use Node.js)
     - name: Set up Node.js for Frontend/Docs
       if: steps.filter.outputs.frontend == 'true' || steps.filter.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
           node-version: '24'
 

--- a/.github/workflows/publish-ghcr-images.yml
+++ b/.github/workflows/publish-ghcr-images.yml
@@ -76,7 +76,7 @@ jobs:
           touch "${{ runner.temp }}/digests/worker/${worker_digest#sha256:}"
 
       - name: Upload backend digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-backend-${{ matrix.platform.arch }}
           path: ${{ runner.temp }}/digests/backend/*
@@ -84,7 +84,7 @@ jobs:
           retention-days: 1
 
       - name: Upload worker digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-worker-${{ matrix.platform.arch }}
           path: ${{ runner.temp }}/digests/worker/*
@@ -145,7 +145,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-frontend-${{ matrix.platform.arch }}
           path: ${{ runner.temp }}/digests/*
@@ -170,7 +170,7 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-${{ matrix.image }}-*

--- a/.github/workflows/terraform-infrastructure.yml
+++ b/.github/workflows/terraform-infrastructure.yml
@@ -115,7 +115,7 @@ jobs:
               body: `<details><summary>Terraform Plan — <code>${{ steps.ctx.outputs.target_env }}</code></summary>\n\n\`\`\`\n${body}\n\`\`\`\n</details>`
             });
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: tfplan-${{ steps.ctx.outputs.target_env }}
           path: terraform/infrastructure/envs/${{ steps.ctx.outputs.target_env }}/tfplan
@@ -179,7 +179,7 @@ jobs:
         with:
           terraform_version: ${{ env.TF_VERSION }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: tfplan-${{ needs.plan.outputs.target_env }}
           path: terraform/infrastructure/envs/${{ needs.plan.outputs.target_env }}

--- a/examples/ci-cd/rhesis-tests.yml
+++ b/examples/ci-cd/rhesis-tests.yml
@@ -36,7 +36,7 @@ jobs:
       
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rhesis-test-results
           path: test-results.json


### PR DESCRIPTION
## Purpose
Pin Node.js to 24.15 in the frontend E2E workflow to fix reported errors when installing Playwright browsers.

## What Changed
- Set `node-version` to `24.15` (was `'24'`) in the E2E job setup step

## Testing
- CI will validate on this PR