### PR TITLE
Fix missing FRONTEND_URL in frontend E2E compose

### DIFF
--- a/tests/docker-compose.frontend.yml
+++ b/tests/docker-compose.frontend.yml
@@ -20,6 +20,7 @@ x-frontend-redis-config: &frontend-redis-config
   CELERY_RESULT_BACKEND: redis://:rhesis-redis-pass@frontend-test-redis:6379/1
 
 x-frontend-backend-config: &frontend-backend-config
+  FRONTEND_URL: "http://localhost:3000"
   JWT_SECRET_KEY: test-jwt-secret-key-for-e2e-tests
   SESSION_SECRET_KEY: test-session-secret-key-for-e2e
   JWT_ALGORITHM: HS256


### PR DESCRIPTION
## Purpose
The backend requires `FRONTEND_URL` at startup. The frontend E2E Docker Compose setup was missing it, which could cause the test backend to fail validation on boot.

## What Changed
- Added `FRONTEND_URL: "http://localhost:3000"` to the shared backend config in `tests/docker-compose.frontend.yml`, matching `tests/docker-compose.test.yml`

## Additional Context
- Aligns with the required `FrontendSettings.url` field in backend settings

## Testing
- Frontend E2E CI workflow should start the backend container without settings validation errors