### PR TITLE
Fix: metric evaluation failures for single-turn tests

### DIFF
--- a/apps/backend/src/rhesis/backend/metrics/metric_config.py
+++ b/apps/backend/src/rhesis/backend/metrics/metric_config.py
@@ -13,6 +13,26 @@ from rhesis.sdk.metrics.utils import backend_config_to_sdk_config
 logger = logging.getLogger(__name__)
 
 
+def _get_metric_signature(metric: BaseMetric) -> Any:
+    """Return the parameter map for the method that will actually be called.
+
+    Prefers a_evaluate because that is what the evaluation pipeline invokes.
+    Falls back to evaluate when a_evaluate only carries *args/**kwargs (the
+    BaseMetric default), which would yield no named parameters to inspect.
+    """
+    a_eval_params = inspect.signature(metric.a_evaluate).parameters
+    named = {
+        name
+        for name, p in a_eval_params.items()
+        if p.kind
+        not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        and name != "self"
+    }
+    if named:
+        return a_eval_params
+    return inspect.signature(metric.evaluate).parameters
+
+
 def build_metric_evaluate_params(
     metric: BaseMetric,
     input_text: str,
@@ -24,9 +44,10 @@ def build_metric_evaluate_params(
     tool_calls: Optional[List[Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """
-    Build kwargs for metric.evaluate() from evaluation inputs using introspection.
+    Build kwargs for metric.a_evaluate() from evaluation inputs using introspection.
 
-    Inspects the metric's evaluate signature and only includes parameters
+    Inspects the metric's a_evaluate signature (falling back to evaluate when
+    a_evaluate is the base *args/**kwargs default) and only includes parameters
     that are actually defined (e.g., ContextualRelevancy doesn't need output).
 
     Args:
@@ -40,10 +61,9 @@ def build_metric_evaluate_params(
         tool_calls: Optional list of tool calls
 
     Returns:
-        Dict of kwargs to pass to metric.evaluate()
+        Dict of kwargs to pass to metric.a_evaluate()
     """
-    sig = inspect.signature(metric.evaluate)
-    params = sig.parameters
+    params = _get_metric_signature(metric)
 
     kwargs: Dict[str, Any] = {}
     if "input" in params:
@@ -54,7 +74,7 @@ def build_metric_evaluate_params(
         kwargs["expected_output"] = expected_output
     if "context" in params:
         kwargs["context"] = context
-    if "conversation_history" in params and conversation_history is not None:
+    if "conversation_history" in params:
         kwargs["conversation_history"] = conversation_history
     if "metadata" in params and metadata is not None:
         kwargs["metadata"] = metadata
@@ -79,6 +99,7 @@ def metric_model_to_config(metric: MetricModel) -> MetricConfig:
         "score_type",
         "ground_truth_required",
         "context_required",
+        "metric_scope",
     ]
     config = {field: getattr(metric, field, None) for field in common_fields}
     config["backend"] = metric.backend_type.type_value if metric.backend_type else "rhesis"

--- a/apps/backend/src/rhesis/backend/metrics/metric_config.py
+++ b/apps/backend/src/rhesis/backend/metrics/metric_config.py
@@ -24,8 +24,7 @@ def _get_metric_signature(metric: BaseMetric) -> Any:
     named = {
         name
         for name, p in a_eval_params.items()
-        if p.kind
-        not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+        if p.kind not in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
         and name != "self"
     }
     if named:

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/test_execution_summary.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/test_execution_summary.html.jinja2
@@ -26,6 +26,10 @@
         <p>Your test configuration execution has finished.</p>
     </div>
 
+    {%- set execution_errors = execution_errors | default(0) %}
+    {%- set tests_failed = tests_failed | default(0) %}
+    {%- set tests_passed = tests_passed | default(0) %}
+    {%- set total_tests = total_tests | default(0) %}
     <div style="background: {% if tests_failed == 0 and execution_errors == 0 %}#d4edda{% else %}#f8d7da{% endif %}; border: 2px solid {% if tests_failed == 0 and execution_errors == 0 %}#28a745{% else %}#dc3545{% endif %}; border-radius: 8px; padding: 20px; margin-bottom: 20px; text-align: center;">
         <h3 style="color: {% if tests_failed == 0 and execution_errors == 0 %}#155724{% else %}#721c24{% endif %}; margin-top: 0; margin-bottom: 10px;">Test Results</h3>
         <div style="font-size: 36px; font-weight: bold; margin: 10px 0;">

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/evaluation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/evaluation.py
@@ -51,7 +51,10 @@ async def _evaluate_multi_turn_metrics(
     output: Dict[str, Any],
 ) -> Dict[str, Any]:
     from rhesis.backend.tasks.execution.constants import CONVERSATION_SUMMARY_KEY
-    from rhesis.backend.tasks.execution.evaluation import _build_conversation_history
+    from rhesis.backend.tasks.execution.evaluation import (
+        _build_conversation_history,
+        _is_multi_turn_only,
+    )
 
     conversation_summary = output.get(CONVERSATION_SUMMARY_KEY, [])
     conversation_history = _build_conversation_history(conversation_summary)
@@ -67,24 +70,11 @@ async def _evaluate_multi_turn_metrics(
     if not filtered_configs:
         return {}
 
-    # If conversation_history could not be built (empty summary), drop metrics
-    # that require it so they don't surface a confusing type error.
+    # Empty conversation summary means there is nothing to evaluate in a multi-turn
+    # context — return early rather than passing conversation_history=None to metrics
+    # that may accept it (including those with metric_scope=None or mixed scopes).
     if conversation_history is None:
-        from rhesis.sdk.metrics.base import MetricScope
-
-        filtered_configs = [
-            mc
-            for mc in filtered_configs
-            if not (
-                mc.metric_scope
-                and all(
-                    (s if isinstance(s, MetricScope) else MetricScope(s)) == MetricScope.MULTI_TURN
-                    for s in mc.metric_scope
-                )
-            )
-        ]
-        if not filtered_configs:
-            return {}
+        return {}
 
     return await evaluator.a_evaluate(
         input_text=goal,
@@ -123,19 +113,9 @@ async def _evaluate_single_turn_metrics(
 
     # Drop metrics that are scoped exclusively to Multi-Turn — they require
     # conversation_history which is not available for single-turn tests.
-    from rhesis.sdk.metrics.base import MetricScope
+    from rhesis.backend.tasks.execution.evaluation import _is_multi_turn_only
 
-    metric_configs = [
-        mc
-        for mc in metric_configs
-        if not (
-            mc.metric_scope
-            and all(
-                (s if isinstance(s, MetricScope) else MetricScope(s)) == MetricScope.MULTI_TURN
-                for s in mc.metric_scope
-            )
-        )
-    ]
+    metric_configs = [mc for mc in metric_configs if not _is_multi_turn_only(mc)]
 
     if not metric_configs:
         return {}

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/evaluation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/evaluation.py
@@ -67,6 +67,25 @@ async def _evaluate_multi_turn_metrics(
     if not filtered_configs:
         return {}
 
+    # If conversation_history could not be built (empty summary), drop metrics
+    # that require it so they don't surface a confusing type error.
+    if conversation_history is None:
+        from rhesis.sdk.metrics.base import MetricScope
+
+        filtered_configs = [
+            mc
+            for mc in filtered_configs
+            if not (
+                mc.metric_scope
+                and all(
+                    (s if isinstance(s, MetricScope) else MetricScope(s)) == MetricScope.MULTI_TURN
+                    for s in mc.metric_scope
+                )
+            )
+        ]
+        if not filtered_configs:
+            return {}
+
     return await evaluator.a_evaluate(
         input_text=goal,
         output_text=conversation_text.strip(),
@@ -87,11 +106,14 @@ async def _evaluate_single_turn_metrics(
 ) -> Dict[str, Any]:
     from rhesis.backend.tasks.execution.response_extractor import (
         extract_response_with_fallback,
+        normalize_context_to_list,
     )
 
     actual_response = extract_response_with_fallback(output)
     metadata = output.get("metadata") if isinstance(output, dict) else None
     tool_calls = output.get("tool_calls") if isinstance(output, dict) else None
+    raw_context = output.get("context") if isinstance(output, dict) else None
+    context = normalize_context_to_list(raw_context)
 
     # Inject probe-level notes (e.g. trigger strings for Garak probe-coupled detectors)
     # directly into the metric configs so the metric has them at construction time.
@@ -99,11 +121,30 @@ async def _evaluate_single_turn_metrics(
     garak_notes = (test.test_metadata or {}).get("garak_notes") if test else None
     metric_configs = _inject_probe_notes(ctx.metric_configs, garak_notes)
 
+    # Drop metrics that are scoped exclusively to Multi-Turn — they require
+    # conversation_history which is not available for single-turn tests.
+    from rhesis.sdk.metrics.base import MetricScope
+
+    metric_configs = [
+        mc
+        for mc in metric_configs
+        if not (
+            mc.metric_scope
+            and all(
+                (s if isinstance(s, MetricScope) else MetricScope(s)) == MetricScope.MULTI_TURN
+                for s in mc.metric_scope
+            )
+        )
+    ]
+
+    if not metric_configs:
+        return {}
+
     return await evaluator.a_evaluate(
         input_text=prompt_content,
         output_text=actual_response,
         expected_output=expected_response,
-        context=[],
+        context=context,
         metrics=metric_configs,
         metadata=metadata,
         tool_calls=tool_calls,

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/evaluation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/evaluation.py
@@ -51,10 +51,7 @@ async def _evaluate_multi_turn_metrics(
     output: Dict[str, Any],
 ) -> Dict[str, Any]:
     from rhesis.backend.tasks.execution.constants import CONVERSATION_SUMMARY_KEY
-    from rhesis.backend.tasks.execution.evaluation import (
-        _build_conversation_history,
-        _is_multi_turn_only,
-    )
+    from rhesis.backend.tasks.execution.evaluation import _build_conversation_history
 
     conversation_summary = output.get(CONVERSATION_SUMMARY_KEY, [])
     conversation_history = _build_conversation_history(conversation_summary)

--- a/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
@@ -38,6 +38,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _is_multi_turn_only(mc: Any) -> bool:
+    """Return True when a metric config is scoped exclusively to Multi-Turn.
+
+    Handles both MetricConfig objects and raw dicts, and guards against a
+    mis-shaped metric_scope that is a bare string rather than a list.
+    """
+    from rhesis.sdk.metrics.base import MetricScope
+
+    scope = mc.get("metric_scope") if isinstance(mc, dict) else getattr(mc, "metric_scope", None)
+    if not scope or not isinstance(scope, (list, tuple, set)):
+        return False
+    return all(
+        (s if isinstance(s, MetricScope) else MetricScope(s)) == MetricScope.MULTI_TURN
+        for s in scope
+    )
+
+
 def _build_conversation_history(
     conversation_summary: List[Dict[str, Any]],
 ) -> Optional[ConversationHistory]:
@@ -109,20 +126,7 @@ def evaluate_single_turn_metrics(
     tool_calls = result.get("tool_calls") if isinstance(result, dict) else None
 
     # Drop metrics scoped exclusively to Multi-Turn — they require conversation_history.
-    from rhesis.sdk.metrics.base import MetricScope
-
-    metrics = [
-        mc
-        for mc in metrics
-        if not (
-            hasattr(mc, "metric_scope")
-            and mc.metric_scope
-            and all(
-                (s if isinstance(s, MetricScope) else MetricScope(s)) == MetricScope.MULTI_TURN
-                for s in mc.metric_scope
-            )
-        )
-    ]
+    metrics = [mc for mc in metrics if not _is_multi_turn_only(mc)]
 
     if not metrics:
         return metrics_results

--- a/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
@@ -124,6 +124,9 @@ def evaluate_single_turn_metrics(
         )
     ]
 
+    if not metrics:
+        return metrics_results
+
     try:
         metrics_results = metrics_evaluator.evaluate(
             input_text=prompt_content,

--- a/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
@@ -108,6 +108,22 @@ def evaluate_single_turn_metrics(
     metadata = result.get("metadata") if isinstance(result, dict) else None
     tool_calls = result.get("tool_calls") if isinstance(result, dict) else None
 
+    # Drop metrics scoped exclusively to Multi-Turn — they require conversation_history.
+    from rhesis.sdk.metrics.base import MetricScope
+
+    metrics = [
+        mc
+        for mc in metrics
+        if not (
+            hasattr(mc, "metric_scope")
+            and mc.metric_scope
+            and all(
+                (s if isinstance(s, MetricScope) else MetricScope(s)) == MetricScope.MULTI_TURN
+                for s in mc.metric_scope
+            )
+        )
+    ]
+
     try:
         metrics_results = metrics_evaluator.evaluate(
             input_text=prompt_content,

--- a/apps/backend/src/rhesis/backend/tasks/execution/shared.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/shared.py
@@ -124,6 +124,7 @@ def trigger_results_collection(
             if test_config.organization_id
             else None,
             "user_id": str(test_config.user_id) if test_config.user_id else None,
+            "project_id": str(test_config.project_id) if test_config.project_id else None,
             "test_run_id": test_run_id,  # Pass test_run_id in headers
         }
     )

--- a/sdk/src/rhesis/sdk/metrics/conversational/base.py
+++ b/sdk/src/rhesis/sdk/metrics/conversational/base.py
@@ -109,6 +109,11 @@ class ConversationalMetricBase(ABC):
 
         Subclasses with native async implementations should override this.
         """
+        if conversation_history is None:
+            raise ValueError(
+                f"{self.__class__.__name__} requires conversation_history to evaluate. "
+                "No conversation history was provided."
+            )
         return await asyncio.to_thread(
             self.evaluate, conversation_history, goal, instructions, context, **kwargs
         )

--- a/sdk/src/rhesis/sdk/metrics/providers/deepeval/conversational_base.py
+++ b/sdk/src/rhesis/sdk/metrics/providers/deepeval/conversational_base.py
@@ -120,6 +120,12 @@ class DeepEvalConversationalBase(ConversationalMetricBase):
         if self._metric is None:
             raise ValueError("DeepEval metric not initialized. Child class must set self._metric")
 
+        if conversation_history is None:
+            raise ValueError(
+                f"{self.__class__.__name__} requires conversation_history to evaluate. "
+                "No conversation history was provided."
+            )
+
         # Convert to DeepEval format, passing chatbot_role if provided
         test_case = self._to_deepeval_format(
             conversation_history, chatbot_role=chatbot_role, **kwargs
@@ -157,6 +163,12 @@ class DeepEvalConversationalBase(ConversationalMetricBase):
         """
         if self._metric is None:
             raise ValueError("DeepEval metric not initialized. Child class must set self._metric")
+
+        if conversation_history is None:
+            raise ValueError(
+                f"{self.__class__.__name__} requires conversation_history to evaluate. "
+                "No conversation history was provided."
+            )
 
         metric_copy = copy.copy(self._metric)
 

--- a/sdk/src/rhesis/sdk/metrics/providers/native/conversational_judge.py
+++ b/sdk/src/rhesis/sdk/metrics/providers/native/conversational_judge.py
@@ -340,6 +340,11 @@ Provide your evaluation as a numeric score between {{ min_score }} and {{ max_sc
         Raises:
             ValueError: If validation fails
         """
+        if conversation_history is None:
+            raise ValueError(
+                f"{self.__class__.__name__} requires conversation_history to evaluate. "
+                "No conversation history was provided."
+            )
         if not isinstance(conversation_history, ConversationHistory):
             raise ValueError("conversation_history must be a ConversationHistory instance")
 

--- a/tests/backend/metrics/test_introspection.py
+++ b/tests/backend/metrics/test_introspection.py
@@ -279,8 +279,14 @@ class TestConversationalParams:
         assert "conversation_history" not in kwargs
         assert kwargs == {"input": "test", "output": "response"}
 
-    def test_conversation_history_none_not_passed(self):
-        """When conversation_history is None, it is not passed even if accepted."""
+    def test_conversation_history_none_is_passed_when_accepted(self):
+        """conversation_history=None IS forwarded when the metric accepts it.
+
+        The metric's own validator (e.g. _validate_evaluate_inputs) is
+        responsible for raising a clear error on None input. Suppressing
+        None here produced a confusing 'must be a ConversationHistory
+        instance' TypeError instead.
+        """
         mock_metric = MagicMock()
 
         def evaluate_conv(conversation_history=None, goal=None):
@@ -297,8 +303,73 @@ class TestConversationalParams:
             conversation_history=None,
         )
 
-        assert "conversation_history" not in kwargs
+        assert "conversation_history" in kwargs
+        assert kwargs["conversation_history"] is None
         assert kwargs["goal"] == "goal text"
+
+    def test_a_evaluate_params_preferred_over_evaluate(self):
+        """build_metric_evaluate_params uses a_evaluate signature when it has named params.
+
+        This is the primary path: async metrics expose their real signature on
+        a_evaluate, not on the base-class evaluate(*args, **kwargs) fallback.
+        """
+        mock_metric = MagicMock()
+
+        # a_evaluate has different params than evaluate — only input + conversation_history
+        def a_evaluate_impl(input, conversation_history, goal=None):
+            return MetricResult(score=0.8)
+
+        # evaluate has input + output — should NOT be used
+        def evaluate_impl(input, output):
+            return MetricResult(score=0.9)
+
+        mock_metric.a_evaluate = a_evaluate_impl
+        mock_metric.evaluate = evaluate_impl
+
+        history = ConversationHistory.from_messages(
+            [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hello"}]
+        )
+
+        kwargs = build_metric_evaluate_params(
+            mock_metric,
+            input_text="goal",
+            output_text="text",
+            expected_output="",
+            context=[],
+            conversation_history=history,
+        )
+
+        # a_evaluate signature: input, conversation_history, goal
+        assert "input" in kwargs
+        assert "conversation_history" in kwargs
+        assert kwargs["conversation_history"] is history
+        # output is NOT in a_evaluate — must not appear
+        assert "output" not in kwargs
+
+    def test_a_evaluate_fallback_to_evaluate_when_varargs_only(self):
+        """Falls back to evaluate signature when a_evaluate is bare *args/**kwargs."""
+        mock_metric = MagicMock()
+
+        # a_evaluate only has *args/**kwargs — the base-class default
+        def a_evaluate_varargs(*args, **kwargs):
+            pass
+
+        def evaluate_impl(input, output):
+            return MetricResult(score=0.9)
+
+        mock_metric.a_evaluate = a_evaluate_varargs
+        mock_metric.evaluate = evaluate_impl
+
+        kwargs = build_metric_evaluate_params(
+            mock_metric,
+            input_text="test",
+            output_text="response",
+            expected_output="",
+            context=[],
+        )
+
+        # Falls back to evaluate: input + output
+        assert kwargs == {"input": "test", "output": "response"}
 
 
 class TestIntrospectionCompleteness:

--- a/tests/backend/metrics/test_metric_model_to_config.py
+++ b/tests/backend/metrics/test_metric_model_to_config.py
@@ -1,0 +1,100 @@
+"""
+Unit tests for metric_model_to_config.
+
+Covers the ORM model → MetricConfig conversion boundary, specifically that
+fields present on the DB model are not silently dropped during conversion.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rhesis.backend.metrics.metric_config import metric_model_to_config
+
+
+def _make_metric(**overrides):
+    """Minimal mock of a Metric ORM model suitable for metric_model_to_config."""
+    m = MagicMock()
+    m.id = "00000000-0000-0000-0000-000000000001"
+    m.name = "Test Metric"
+    m.class_name = "RhesisPromptMetric"
+    m.description = "A test metric"
+    m.evaluation_prompt = "Rate the quality"
+    m.evaluation_steps = None
+    m.reasoning = None
+    m.evaluation_examples = None
+    m.score_type = "numeric"
+    m.ground_truth_required = False
+    m.context_required = False
+    m.metric_scope = None
+    m.backend_type = None
+    m.threshold = 0.5
+    m.threshold_operator = ">="
+    m.min_score = 0.0
+    m.max_score = 1.0
+    m.model_id = None
+    m.model = None
+    for k, v in overrides.items():
+        setattr(m, k, v)
+    return m
+
+
+class TestMetricScopePreservation:
+    """metric_scope must survive the ORM → MetricConfig conversion."""
+
+    def test_single_turn_scope_is_preserved(self):
+        metric = _make_metric(metric_scope=["Single-Turn"])
+        config = metric_model_to_config(metric)
+        assert config.metric_scope is not None
+        assert len(config.metric_scope) == 1
+        assert "Single-Turn" in [
+            s.value if hasattr(s, "value") else s for s in config.metric_scope
+        ]
+
+    def test_multi_turn_scope_is_preserved(self):
+        metric = _make_metric(metric_scope=["Multi-Turn"])
+        config = metric_model_to_config(metric)
+        assert config.metric_scope is not None
+        assert len(config.metric_scope) == 1
+        assert "Multi-Turn" in [
+            s.value if hasattr(s, "value") else s for s in config.metric_scope
+        ]
+
+    def test_multi_scope_values_are_preserved(self):
+        metric = _make_metric(metric_scope=["Single-Turn", "Multi-Turn"])
+        config = metric_model_to_config(metric)
+        assert config.metric_scope is not None
+        scope_values = [s.value if hasattr(s, "value") else s for s in config.metric_scope]
+        assert "Single-Turn" in scope_values
+        assert "Multi-Turn" in scope_values
+
+    def test_none_scope_is_preserved(self):
+        metric = _make_metric(metric_scope=None)
+        config = metric_model_to_config(metric)
+        assert config.metric_scope is None
+
+    def test_missing_scope_attribute_does_not_raise(self):
+        """getattr fallback must not raise when the column is absent."""
+        metric = _make_metric()
+        del metric.metric_scope  # simulate column not present
+        config = metric_model_to_config(metric)
+        assert config.metric_scope is None
+
+
+class TestOtherFieldsPreservation:
+    """Sanity-check that unrelated fields are still copied correctly."""
+
+    def test_name_is_preserved(self):
+        metric = _make_metric(name="My Custom Metric")
+        config = metric_model_to_config(metric)
+        assert config.name == "My Custom Metric"
+
+    def test_class_name_is_preserved(self):
+        metric = _make_metric(class_name="NumericJudge")
+        config = metric_model_to_config(metric)
+        assert config.class_name == "NumericJudge"
+
+    def test_threshold_is_preserved(self):
+        metric = _make_metric(threshold=0.8)
+        config = metric_model_to_config(metric)
+        assert config.threshold == pytest.approx(0.8)

--- a/tests/backend/tasks/test_metrics_evaluation.py
+++ b/tests/backend/tasks/test_metrics_evaluation.py
@@ -86,6 +86,82 @@ class TestEvaluateSingleTurnMetrics:
 
         assert result == {}
 
+    def test_multi_turn_only_metrics_are_excluded(self):
+        """Metrics scoped exclusively to Multi-Turn are not passed to the evaluator."""
+        from rhesis.sdk.metrics import MetricConfig
+        from rhesis.sdk.metrics.base import MetricScope
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate.return_value = {}
+
+        multi_turn_metric = MetricConfig(
+            name="conv_metric",
+            class_name="ConversationalJudge",
+            metric_scope=[MetricScope.MULTI_TURN],
+        )
+
+        result = evaluate_single_turn_metrics(
+            metrics_evaluator=mock_evaluator,
+            prompt_content="test input",
+            expected_response="expected",
+            context=[],
+            result={"output": "response"},
+            metrics=[multi_turn_metric],
+        )
+
+        mock_evaluator.evaluate.assert_not_called()
+        assert result == {}
+
+    def test_single_turn_metrics_are_not_excluded(self):
+        """Metrics scoped to Single-Turn are still passed to the evaluator."""
+        from rhesis.sdk.metrics import MetricConfig
+        from rhesis.sdk.metrics.base import MetricScope
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate.return_value = {"accuracy": {"score": 0.9}}
+
+        single_turn_metric = MetricConfig(
+            name="accuracy",
+            class_name="NumericJudge",
+            metric_scope=[MetricScope.SINGLE_TURN],
+        )
+
+        evaluate_single_turn_metrics(
+            metrics_evaluator=mock_evaluator,
+            prompt_content="test input",
+            expected_response="expected",
+            context=[],
+            result={"output": "response"},
+            metrics=[single_turn_metric],
+        )
+
+        mock_evaluator.evaluate.assert_called_once()
+
+    def test_mixed_scope_metric_is_not_excluded(self):
+        """A metric scoped to both Single-Turn and Multi-Turn is kept for single-turn."""
+        from rhesis.sdk.metrics import MetricConfig
+        from rhesis.sdk.metrics.base import MetricScope
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate.return_value = {}
+
+        mixed_metric = MetricConfig(
+            name="mixed",
+            class_name="NumericJudge",
+            metric_scope=[MetricScope.SINGLE_TURN, MetricScope.MULTI_TURN],
+        )
+
+        evaluate_single_turn_metrics(
+            metrics_evaluator=mock_evaluator,
+            prompt_content="test",
+            expected_response="",
+            context=[],
+            result={"output": "response"},
+            metrics=[mixed_metric],
+        )
+
+        mock_evaluator.evaluate.assert_called_once()
+
 
 # ============================================================================
 # Backward compatibility alias tests
@@ -110,7 +186,7 @@ class TestEvaluatePromptResponseAlias:
             expected_response="e",
             context=[],
             result={"output": "o"},
-            metrics=[],
+            metrics=[{"name": "m1"}],
         )
 
         assert result == {"m1": {"score": 0.5}}

--- a/tests/backend/tasks/test_metrics_evaluation.py
+++ b/tests/backend/tasks/test_metrics_evaluation.py
@@ -162,6 +162,50 @@ class TestEvaluateSingleTurnMetrics:
 
         mock_evaluator.evaluate.assert_called_once()
 
+    def test_dict_metric_with_multi_turn_scope_is_excluded(self):
+        """A dict metric config with metric_scope=['Multi-Turn'] is excluded (comment #1 fix)."""
+        from rhesis.sdk.metrics.base import MetricScope
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate.return_value = {}
+
+        dict_metric = {"name": "conv", "class_name": "ConversationalJudge", "metric_scope": [MetricScope.MULTI_TURN]}
+
+        result = evaluate_single_turn_metrics(
+            metrics_evaluator=mock_evaluator,
+            prompt_content="test",
+            expected_response="",
+            context=[],
+            result={"output": "response"},
+            metrics=[dict_metric],
+        )
+
+        mock_evaluator.evaluate.assert_not_called()
+        assert result == {}
+
+    def test_bare_string_metric_scope_is_not_excluded(self):
+        """A mis-shaped bare-string metric_scope does not crash and is treated as non-filtering.
+
+        MetricConfig validates and rejects bare strings, so this scenario can only
+        arrive via a loosely-typed object (e.g. a dict-converted mock).
+        """
+        mock_evaluator = MagicMock()
+        mock_evaluator.evaluate.return_value = {}
+
+        bad_scope_metric = MagicMock()
+        bad_scope_metric.metric_scope = "Multi-Turn"  # bare string, not a list
+
+        evaluate_single_turn_metrics(
+            metrics_evaluator=mock_evaluator,
+            prompt_content="test",
+            expected_response="",
+            context=[],
+            result={"output": "response"},
+            metrics=[bad_scope_metric],
+        )
+
+        mock_evaluator.evaluate.assert_called_once()
+
 
 # ============================================================================
 # Backward compatibility alias tests
@@ -622,4 +666,64 @@ class TestEvaluateMultiTurnMetrics:
 
         tc_list = conv.get_assistant_tool_calls()
         assert tc_list[0] == [{"name": "search", "arguments": {"q": "policy"}}]
-        assert tc_list[1] is None
+
+
+# ============================================================================
+# _is_multi_turn_only helper tests
+# ============================================================================
+
+
+class TestIsMultiTurnOnly:
+    """Unit tests for the _is_multi_turn_only helper used by both evaluation paths."""
+
+    def setup_method(self):
+        from rhesis.backend.tasks.execution.evaluation import _is_multi_turn_only
+        from rhesis.sdk.metrics.base import MetricScope
+
+        self._fn = _is_multi_turn_only
+        self._MT = MetricScope.MULTI_TURN
+        self._ST = MetricScope.SINGLE_TURN
+
+    def test_object_multi_turn_only_returns_true(self):
+        from rhesis.sdk.metrics import MetricConfig
+
+        mc = MetricConfig(name="m", class_name="C", metric_scope=[self._MT])
+        assert self._fn(mc) is True
+
+    def test_object_single_turn_only_returns_false(self):
+        from rhesis.sdk.metrics import MetricConfig
+
+        mc = MetricConfig(name="m", class_name="C", metric_scope=[self._ST])
+        assert self._fn(mc) is False
+
+    def test_object_mixed_scope_returns_false(self):
+        from rhesis.sdk.metrics import MetricConfig
+
+        mc = MetricConfig(name="m", class_name="C", metric_scope=[self._ST, self._MT])
+        assert self._fn(mc) is False
+
+    def test_object_none_scope_returns_false(self):
+        from rhesis.sdk.metrics import MetricConfig
+
+        mc = MetricConfig(name="m", class_name="C", metric_scope=None)
+        assert self._fn(mc) is False
+
+    def test_dict_multi_turn_only_returns_true(self):
+        mc = {"name": "m", "class_name": "C", "metric_scope": [self._MT]}
+        assert self._fn(mc) is True
+
+    def test_dict_single_turn_only_returns_false(self):
+        mc = {"name": "m", "class_name": "C", "metric_scope": [self._ST]}
+        assert self._fn(mc) is False
+
+    def test_dict_no_metric_scope_key_returns_false(self):
+        mc = {"name": "m", "class_name": "C"}
+        assert self._fn(mc) is False
+
+    def test_bare_string_scope_returns_false_and_does_not_crash(self):
+        """A mis-shaped bare string must not raise — treated as non-filtering."""
+        from unittest.mock import MagicMock
+
+        mc = MagicMock()
+        mc.metric_scope = "Multi-Turn"
+        assert self._fn(mc) is False

--- a/tests/backend/tasks/test_results_collection.py
+++ b/tests/backend/tasks/test_results_collection.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for trigger_results_collection in tasks/execution/shared.py.
+
+Covers the task dispatch boundary: verifies that all tenant context fields
+(including project_id) are forwarded to the collect_results chord callback
+via Celery task headers.
+"""
+
+from unittest.mock import MagicMock, patch
+from uuid import UUID
+
+import pytest
+
+from rhesis.backend.tasks.execution.shared import trigger_results_collection
+
+_ORG_ID = UUID("aaaaaaaa-0000-0000-0000-000000000001")
+_USER_ID = UUID("bbbbbbbb-0000-0000-0000-000000000002")
+_PROJECT_ID = UUID("cccccccc-0000-0000-0000-000000000003")
+_TEST_RUN_ID = "dddddddd-0000-0000-0000-000000000004"
+
+
+def _make_test_config(**overrides):
+    cfg = MagicMock()
+    cfg.organization_id = _ORG_ID
+    cfg.user_id = _USER_ID
+    cfg.project_id = _PROJECT_ID
+    for k, v in overrides.items():
+        setattr(cfg, k, v)
+    return cfg
+
+
+def _capture_headers(test_config, results=None):
+    """Call trigger_results_collection and return the headers dict passed to .set()."""
+    with patch("rhesis.backend.tasks.execution.shared.collect_results") as mock_cr:
+        mock_sig = MagicMock()
+        mock_cr.s.return_value = mock_sig
+        mock_sig.set.return_value = mock_sig
+
+        trigger_results_collection(test_config, _TEST_RUN_ID, results or [])
+
+        mock_sig.set.assert_called_once()
+        return mock_sig.set.call_args.kwargs["headers"]
+
+
+class TestTriggerResultsCollectionHeaders:
+    """Headers passed to collect_results must include all three tenant fields."""
+
+    def test_organization_id_in_headers(self):
+        headers = _capture_headers(_make_test_config())
+        assert headers["organization_id"] == str(_ORG_ID)
+
+    def test_user_id_in_headers(self):
+        headers = _capture_headers(_make_test_config())
+        assert headers["user_id"] == str(_USER_ID)
+
+    def test_project_id_in_headers(self):
+        headers = _capture_headers(_make_test_config())
+        assert headers["project_id"] == str(_PROJECT_ID)
+
+    def test_test_run_id_in_headers(self):
+        headers = _capture_headers(_make_test_config())
+        assert headers["test_run_id"] == _TEST_RUN_ID
+
+    def test_none_project_id_becomes_none_in_headers(self):
+        cfg = _make_test_config(project_id=None)
+        headers = _capture_headers(cfg)
+        assert headers["project_id"] is None
+
+    def test_none_organization_id_becomes_none_in_headers(self):
+        cfg = _make_test_config(organization_id=None)
+        headers = _capture_headers(cfg)
+        assert headers["organization_id"] is None
+
+    def test_none_user_id_becomes_none_in_headers(self):
+        cfg = _make_test_config(user_id=None)
+        headers = _capture_headers(cfg)
+        assert headers["user_id"] is None
+
+    def test_results_forwarded_to_signature(self):
+        results = [{"test_id": "t1", "status": "passed"}]
+        with patch("rhesis.backend.tasks.execution.shared.collect_results") as mock_cr:
+            mock_sig = MagicMock()
+            mock_cr.s.return_value = mock_sig
+            mock_sig.set.return_value = mock_sig
+
+            trigger_results_collection(_make_test_config(), _TEST_RUN_ID, results)
+
+            mock_cr.s.assert_called_once_with(results)


### PR DESCRIPTION
## Purpose

Fix a series of silent failures in the metric evaluation pipeline that caused single-turn test runs to error out with confusing messages and get stuck in "in progress" state.

## What Changed

**Root cause fixes:**
- `metric_model_to_config`: add `metric_scope` to `common_fields` — it was silently dropped during ORM→MetricConfig conversion, making all scope-based filters a no-op
- `tasks/execution/shared.py`: pass `project_id` in `collect_results` task headers — without it the ORM scope filter added `WHERE project_id IS NULL`, making the test run lookup always fail
- `batch/evaluation.py` + `evaluation.py`: filter out Multi-Turn-only metrics before single-turn evaluation so they don't reach the evaluator without `conversation_history`
- `evaluation.py`: add early return when all metrics are filtered out (consistent with batch path)
- Conversational metric base classes (`ConversationalJudge`, `ConversationalMetricBase`, `DeepEvalConversationalBase`): add explicit `None` guard before `isinstance` check so missing `conversation_history` raises a clear error
- `build_metric_evaluate_params`: always forward `conversation_history` (even `None`) so the metric's own validator fires instead of silently omitting the param
- Email template: add `| default(0)` for numeric variables so the template renders safely when a task fails before producing summary data

**Tests:**
- `test_metric_model_to_config.py`: regression tests for the ORM→MetricConfig conversion boundary, including `metric_scope` preservation
- `test_results_collection.py`: asserts all three tenant fields (`organization_id`, `user_id`, `project_id`) are present in `collect_results` task headers
- `test_introspection.py`: fix broken test reflecting new `conversation_history=None` behavior; add `a_evaluate` preference and fallback tests
- `test_metrics_evaluation.py`: add Multi-Turn scope filter tests for `evaluate_single_turn_metrics`

## Additional Context

Both root-cause bugs were at layer boundaries with no test coverage: the ORM→config conversion and the Celery task dispatch headers. The new regression tests pin those seams.

## Testing

```bash
RHESIS_SKIP_MIGRATIONS=1 uv run --project apps/backend pytest \
  tests/backend/metrics/test_metric_model_to_config.py \
  tests/backend/metrics/test_introspection.py \
  tests/backend/tasks/test_results_collection.py \
  tests/backend/tasks/test_metrics_evaluation.py -v
```