### PR TITLE
Persist default project on switch

### DIFF
--- a/apps/frontend/src/contexts/ActiveProjectContext.tsx
+++ b/apps/frontend/src/contexts/ActiveProjectContext.tsx
@@ -115,25 +115,44 @@ export function ActiveProjectProvider({
     fetchProjects();
   }, [fetchProjects]);
 
-  const setActiveProject = useCallback((project: Project | null) => {
-    const previousId = readActiveProjectId();
-    const nextId = project ? String(project.id) : null;
+  const setActiveProject = useCallback(
+    async (project: Project | null) => {
+      const previousId = readActiveProjectId();
+      const nextId = project ? String(project.id) : null;
 
-    if (project) {
-      writeActiveProjectId(nextId as string);
-    } else {
-      clearActiveProjectId();
-    }
-    setActiveProjectState(project);
+      if (project) {
+        writeActiveProjectId(nextId as string);
 
-    // Project scope is sent as the X-Project-Id header, read from the cookie at
-    // request time. Most data views are client components that fetch once on mount,
-    // so router.refresh() (server-only) would not refetch them. A full reload is the
-    // reliable way to make every project-scoped view pick up the new project.
-    if (previousId !== nextId && typeof window !== 'undefined') {
-      window.location.reload();
-    }
-  }, []);
+        // Persist as default_project so the selection survives logout/login.
+        const token = session?.session_token;
+        if (token) {
+          try {
+            const factory = new ApiClientFactory(token);
+            await factory.getUsersClient().updateUserSettings({
+              default_project: {
+                project_id: String(project.id),
+                name: project.name,
+              },
+            });
+          } catch {
+            // Cookie still scopes the current session; ignore persistence failure.
+          }
+        }
+      } else {
+        clearActiveProjectId();
+      }
+      setActiveProjectState(project);
+
+      // Project scope is sent as the X-Project-Id header, read from the cookie at
+      // request time. Most data views are client components that fetch once on mount,
+      // so router.refresh() (server-only) would not refetch them. A full reload is the
+      // reliable way to make every project-scoped view pick up the new project.
+      if (previousId !== nextId && typeof window !== 'undefined') {
+        window.location.reload();
+      }
+    },
+    [session?.session_token]
+  );
 
   return (
     <ActiveProjectContext.Provider

--- a/apps/frontend/src/contexts/ActiveProjectContext.tsx
+++ b/apps/frontend/src/contexts/ActiveProjectContext.tsx
@@ -15,6 +15,7 @@ import {
   readActiveProjectId,
   writeActiveProjectId,
 } from '@/utils/active-project';
+import { UUID } from 'crypto';
 import { Project } from '@/utils/api-client/interfaces/project';
 
 interface ActiveProjectContextValue {
@@ -130,7 +131,7 @@ export function ActiveProjectProvider({
             const factory = new ApiClientFactory(token);
             await factory.getUsersClient().updateUserSettings({
               default_project: {
-                project_id: String(project.id),
+                project_id: project.id as UUID,
                 name: project.name,
               },
             });


### PR DESCRIPTION
## Purpose
Users who switch projects and then log out expect to return to the project they last selected. Previously, only a browser cookie tracked the active project, which is cleared on logout, so login fell back to the stale `default_project` stored in user settings.

## What Changed
- Update `setActiveProject` to persist the selected project to `user_settings.default_project` via `PATCH /users/settings` before the page reload
- Await the settings update so the request completes before navigation

## Additional Context
- The backend already stores and reads `default_project`; the frontend read it on login but never wrote it on project switch
- Cookie-based active project selection still applies for the current session; this change makes that selection survive logout/login

## Testing
- [ ] Switch to a different project in the project switcher
- [ ] Log out and log back in
- [ ] Confirm the app restores the project you switched to, not the original default