### PR TITLE
Align task detail page with Figma design

### DIFF
--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailTabs.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import React from 'react';
+import { Box } from '@mui/material';
+import DetailTabNav from '@/components/common/DetailTabNav';
+import DetailTabPanel from '@/components/common/DetailTabPanel';
+import CommentsWrapper from '@/components/comments/CommentsWrapper';
+import { useDetailTabNav } from '@/hooks/useDetailTabNav';
+import { Priority, Status, Task, TaskUpdate, User } from '@/types/tasks';
+import TaskDetailsCard from './TaskDetailsCard';
+import TaskLinkedEntityTab from './TaskLinkedEntityTab';
+
+const TAB_KEYS = ['basic', 'linked', 'comments'] as const;
+
+const TAB_LABELS: Record<(typeof TAB_KEYS)[number], string> = {
+  basic: 'Basic Information',
+  linked: 'Linked entities',
+  comments: 'Comments',
+};
+
+interface TaskDetailTabsProps {
+  task: Task;
+  statuses: Status[];
+  priorities: Priority[];
+  users: User[];
+  sessionToken: string;
+  currentUserId: string;
+  currentUserName: string;
+  currentUserPicture?: string;
+  onTaskUpdated: (task: Task) => void;
+  updateTask: (id: string, data: TaskUpdate) => Promise<Task | undefined>;
+}
+
+export default function TaskDetailTabs({
+  task,
+  statuses,
+  priorities,
+  users,
+  sessionToken,
+  currentUserId,
+  currentUserName,
+  currentUserPicture,
+  onTaskUpdated,
+  updateTask,
+}: TaskDetailTabsProps) {
+  const { activeTab, handleTabChange } = useDetailTabNav(TAB_KEYS);
+
+  const navTabs = TAB_KEYS.map((key, index) => ({
+    key,
+    label: TAB_LABELS[key],
+    id: `task-detail-tab-${index}`,
+    'aria-controls': `task-detail-tabpanel-${index}`,
+  }));
+
+  const handleSave = async (update: TaskUpdate) => updateTask(task.id, update);
+
+  return (
+    <Box>
+      <DetailTabNav
+        tabs={navTabs}
+        activeIndex={activeTab}
+        onChange={handleTabChange}
+        aria-label="Task detail tabs"
+      />
+
+      <DetailTabPanel value={activeTab} index={0} prefix="task-detail">
+        <TaskDetailsCard
+          task={task}
+          statuses={statuses}
+          priorities={priorities}
+          users={users}
+          onSave={handleSave}
+          onTaskUpdated={onTaskUpdated}
+        />
+      </DetailTabPanel>
+
+      <DetailTabPanel value={activeTab} index={1} prefix="task-detail">
+        <TaskLinkedEntityTab task={task} />
+      </DetailTabPanel>
+
+      <DetailTabPanel value={activeTab} index={2} prefix="task-detail">
+        <CommentsWrapper
+          entityType="Task"
+          entityId={task.id}
+          sessionToken={sessionToken}
+          currentUserId={currentUserId}
+          currentUserName={currentUserName}
+          currentUserPicture={currentUserPicture}
+        />
+      </DetailTabPanel>
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailTabs.tsx
@@ -6,7 +6,8 @@ import DetailTabNav from '@/components/common/DetailTabNav';
 import DetailTabPanel from '@/components/common/DetailTabPanel';
 import CommentsWrapper from '@/components/comments/CommentsWrapper';
 import { useDetailTabNav } from '@/hooks/useDetailTabNav';
-import { Priority, Status, Task, TaskUpdate, User } from '@/types/tasks';
+import { Priority, Status, Task, TaskUpdate } from '@/types/tasks';
+import type { User } from '@/utils/api-client/interfaces/user';
 import TaskDetailsCard from './TaskDetailsCard';
 import TaskLinkedEntityTab from './TaskLinkedEntityTab';
 
@@ -28,7 +29,10 @@ interface TaskDetailTabsProps {
   currentUserName: string;
   currentUserPicture?: string;
   onTaskUpdated: (task: Task) => void;
-  updateTask: (id: string, data: TaskUpdate) => Promise<Task | undefined>;
+  updateTask: (
+    id: string,
+    data: TaskUpdate
+  ) => Promise<Task | null | undefined>;
 }
 
 export default function TaskDetailTabs({

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailsCard.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailsCard.tsx
@@ -15,8 +15,14 @@ import {
 import EditableSection from '@/components/common/EditableSection';
 import ViewField from '@/components/common/ViewField';
 import { AVATAR_SIZES } from '@/constants/avatar-sizes';
-import { Priority, Status, Task, TaskUpdate, User } from '@/types/tasks';
+import { Priority, Status, Task, TaskUpdate } from '@/types/tasks';
+import type { User } from '@/utils/api-client/interfaces/user';
 import { useNotifications } from '@/components/common/NotificationContext';
+
+interface AssigneeDisplay {
+  name?: string;
+  picture?: string;
+}
 
 interface TaskDetailsDraft {
   title: string;
@@ -31,7 +37,7 @@ interface TaskDetailsCardProps {
   statuses: Status[];
   priorities: Priority[];
   users: User[];
-  onSave: (update: TaskUpdate) => Promise<Task | undefined>;
+  onSave: (update: TaskUpdate) => Promise<Task | null | undefined>;
   onTaskUpdated: (task: Task) => void;
 }
 
@@ -39,7 +45,7 @@ function UserFieldContent({
   user,
   fallback,
 }: {
-  user?: User | null;
+  user?: AssigneeDisplay | null;
   fallback: string;
 }) {
   if (!user?.name) {
@@ -135,8 +141,13 @@ export default function TaskDetailsCard({
     return Boolean(updatedTask);
   };
 
-  const assigneeForDraft = (assigneeId: string) =>
-    users.find(user => user.id === assigneeId) ?? task.assignee;
+  const assigneeForDraft = (
+    assigneeId: string
+  ): AssigneeDisplay | undefined => {
+    const fromList = users.find(user => user.id === assigneeId);
+    if (fromList) return fromList;
+    return task.assignee;
+  };
 
   return (
     <EditableSection

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailsCard.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailsCard.tsx
@@ -144,8 +144,15 @@ export default function TaskDetailsCard({
   const assigneeForDraft = (
     assigneeId: string
   ): AssigneeDisplay | undefined => {
+    if (!assigneeId) {
+      return undefined;
+    }
+
     const fromList = users.find(user => user.id === assigneeId);
-    if (fromList) return fromList;
+    if (fromList) {
+      return fromList;
+    }
+
     return task.assignee;
   };
 

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailsCard.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailsCard.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import React from 'react';
+import {
+  Avatar,
+  Box,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography,
+} from '@mui/material';
+import EditableSection from '@/components/common/EditableSection';
+import ViewField from '@/components/common/ViewField';
+import { AVATAR_SIZES } from '@/constants/avatar-sizes';
+import { Priority, Status, Task, TaskUpdate, User } from '@/types/tasks';
+import { useNotifications } from '@/components/common/NotificationContext';
+
+interface TaskDetailsDraft {
+  title: string;
+  description: string;
+  status_id: string;
+  priority_id: string;
+  assignee_id: string;
+}
+
+interface TaskDetailsCardProps {
+  task: Task;
+  statuses: Status[];
+  priorities: Priority[];
+  users: User[];
+  onSave: (update: TaskUpdate) => Promise<Task | undefined>;
+  onTaskUpdated: (task: Task) => void;
+}
+
+function UserFieldContent({
+  user,
+  fallback,
+}: {
+  user?: User | null;
+  fallback: string;
+}) {
+  if (!user?.name) {
+    return (
+      <Typography
+        sx={{
+          fontSize: 16,
+          lineHeight: '24px',
+          color: theme => theme.palette.greyscale.body,
+        }}
+      >
+        {fallback}
+      </Typography>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      <Avatar
+        src={user.picture}
+        alt={user.name}
+        sx={{
+          width: AVATAR_SIZES.SMALL,
+          height: AVATAR_SIZES.SMALL,
+          bgcolor: 'primary.main',
+        }}
+      >
+        {user.name.charAt(0)}
+      </Avatar>
+      <Typography
+        sx={{
+          fontSize: 16,
+          lineHeight: '24px',
+          color: theme => theme.palette.greyscale.body,
+        }}
+      >
+        {user.name}
+      </Typography>
+    </Box>
+  );
+}
+
+function toDraft(task: Task): TaskDetailsDraft {
+  return {
+    title: task.title || '',
+    description: task.description || '',
+    status_id: task.status_id || '',
+    priority_id: task.priority_id || '',
+    assignee_id: task.assignee_id || '',
+  };
+}
+
+function statusLabel(statuses: Status[], statusId: string): string {
+  return statuses.find(status => status.id === statusId)?.name ?? '—';
+}
+
+function priorityLabel(priorities: Priority[], priorityId: string): string {
+  return (
+    priorities.find(priority => priority.id === priorityId)?.type_value ?? '—'
+  );
+}
+
+export default function TaskDetailsCard({
+  task,
+  statuses,
+  priorities,
+  users,
+  onSave,
+  onTaskUpdated,
+}: TaskDetailsCardProps) {
+  const { show } = useNotifications();
+  const initialDraft = React.useMemo(() => toDraft(task), [task]);
+
+  const handleSave = async (draft: TaskDetailsDraft) => {
+    if (!draft.title.trim()) {
+      show('Task title cannot be empty', { severity: 'error' });
+      return false;
+    }
+
+    const updatedTask = await onSave({
+      title: draft.title.trim(),
+      description: draft.description,
+      status_id: draft.status_id,
+      priority_id: draft.priority_id || null,
+      assignee_id: draft.assignee_id || null,
+    });
+
+    if (updatedTask) {
+      onTaskUpdated(updatedTask);
+      show('Task updated successfully', { severity: 'success' });
+    }
+
+    return Boolean(updatedTask);
+  };
+
+  const assigneeForDraft = (assigneeId: string) =>
+    users.find(user => user.id === assigneeId) ?? task.assignee;
+
+  return (
+    <EditableSection
+      title="Task details"
+      initialValue={initialDraft}
+      onSave={handleSave}
+    >
+      {({ draft, setDraft, isEditing }) => (
+        <Grid
+          container
+          columnSpacing={isEditing ? 2 : '30px'}
+          rowSpacing={isEditing ? 2 : '50px'}
+        >
+          <Grid size={12}>
+            {isEditing ? (
+              <TextField
+                fullWidth
+                label="Title"
+                value={draft.title}
+                onChange={event =>
+                  setDraft(current => ({
+                    ...current,
+                    title: event.target.value,
+                  }))
+                }
+                variant="outlined"
+                helperText="Task title"
+                error={!draft.title.trim()}
+              />
+            ) : (
+              <ViewField
+                label="Title"
+                value={draft.title}
+                helperText="Task title"
+              />
+            )}
+          </Grid>
+
+          <Grid size={12}>
+            {isEditing ? (
+              <TextField
+                fullWidth
+                multiline
+                minRows={3}
+                label="Description"
+                value={draft.description}
+                onChange={event =>
+                  setDraft(current => ({
+                    ...current,
+                    description: event.target.value,
+                  }))
+                }
+                variant="outlined"
+                helperText="Additional context for this task"
+              />
+            ) : (
+              <ViewField
+                label="Description"
+                value={draft.description}
+                helperText="Additional context for this task"
+                multiline
+              />
+            )}
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 6 }}>
+            {isEditing ? (
+              <FormControl fullWidth>
+                <InputLabel>Status</InputLabel>
+                <Select
+                  value={draft.status_id}
+                  label="Status"
+                  onChange={event =>
+                    setDraft(current => ({
+                      ...current,
+                      status_id: event.target.value,
+                    }))
+                  }
+                >
+                  {statuses.map(status => (
+                    <MenuItem key={status.id} value={status.id}>
+                      {status.name}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            ) : (
+              <ViewField
+                label="Status"
+                value={statusLabel(statuses, draft.status_id)}
+                helperText="Current workflow status"
+              />
+            )}
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 6 }}>
+            {isEditing ? (
+              <FormControl fullWidth>
+                <InputLabel>Priority</InputLabel>
+                <Select
+                  value={draft.priority_id}
+                  label="Priority"
+                  onChange={event =>
+                    setDraft(current => ({
+                      ...current,
+                      priority_id: event.target.value,
+                    }))
+                  }
+                >
+                  {priorities.map(priority => (
+                    <MenuItem key={priority.id} value={priority.id}>
+                      {priority.type_value}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            ) : (
+              <ViewField
+                label="Priority"
+                value={priorityLabel(priorities, draft.priority_id)}
+                helperText="Task urgency level"
+              />
+            )}
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 6 }}>
+            <ViewField label="Creator" helperText="User who created this task">
+              <UserFieldContent user={task.user} fallback="Unknown" />
+            </ViewField>
+          </Grid>
+
+          <Grid size={{ xs: 12, sm: 6 }}>
+            {isEditing ? (
+              <FormControl fullWidth>
+                <InputLabel shrink>Assignee</InputLabel>
+                <Select
+                  value={draft.assignee_id}
+                  label="Assignee"
+                  displayEmpty
+                  onChange={event =>
+                    setDraft(current => ({
+                      ...current,
+                      assignee_id: event.target.value,
+                    }))
+                  }
+                  sx={{
+                    '& .MuiSelect-select': {
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 1,
+                      py: 2,
+                    },
+                  }}
+                  renderValue={value => {
+                    const selectedUser = assigneeForDraft(String(value));
+                    return (
+                      <UserFieldContent
+                        user={selectedUser}
+                        fallback="Unassigned"
+                      />
+                    );
+                  }}
+                >
+                  <MenuItem value="">
+                    <UserFieldContent user={null} fallback="Unassigned" />
+                  </MenuItem>
+                  {users
+                    .filter(user => user.id && user.name)
+                    .map(user => (
+                      <MenuItem key={user.id} value={user.id}>
+                        <UserFieldContent user={user} fallback="Unassigned" />
+                      </MenuItem>
+                    ))}
+                </Select>
+              </FormControl>
+            ) : (
+              <ViewField
+                label="Assignee"
+                helperText="User responsible for this task"
+              >
+                <UserFieldContent
+                  user={assigneeForDraft(draft.assignee_id)}
+                  fallback="Unassigned"
+                />
+              </ViewField>
+            )}
+          </Grid>
+        </Grid>
+      )}
+    </EditableSection>
+  );
+}

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailsCard.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskDetailsCard.tsx
@@ -263,12 +263,6 @@ export default function TaskDetailsCard({
           </Grid>
 
           <Grid size={{ xs: 12, sm: 6 }}>
-            <ViewField label="Creator" helperText="User who created this task">
-              <UserFieldContent user={task.user} fallback="Unknown" />
-            </ViewField>
-          </Grid>
-
-          <Grid size={{ xs: 12, sm: 6 }}>
             {isEditing ? (
               <FormControl fullWidth>
                 <InputLabel shrink>Assignee</InputLabel>

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskLinkedEntityTab.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskLinkedEntityTab.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import React from 'react';
+import { Box, Button, Typography } from '@mui/material';
+import LinkIcon from '@mui/icons-material/Link';
+import ArrowOutwardIcon from '@mui/icons-material/ArrowOutward';
+import { useRouter } from 'next/navigation';
+import { SectionCard } from '@/components/common/SectionCard';
+import SectionEmptyState from '@/components/common/SectionEmptyState';
+import ViewField from '@/components/common/ViewField';
+import { Task } from '@/types/tasks';
+import {
+  buildLinkedEntityUrl,
+  getEntityDisplayName,
+} from '@/utils/entity-helpers';
+
+interface TaskLinkedEntityTabProps {
+  task: Task;
+}
+
+export default function TaskLinkedEntityTab({
+  task,
+}: TaskLinkedEntityTabProps) {
+  const router = useRouter();
+  const linkedUrl = buildLinkedEntityUrl(task);
+
+  if (!task.entity_type || !task.entity_id || !linkedUrl) {
+    return (
+      <SectionCard>
+        <SectionEmptyState
+          icon={LinkIcon}
+          title="No linked entity"
+          description="This task is not linked to another record in Rhesis."
+        />
+      </SectionCard>
+    );
+  }
+
+  const entityLabel = getEntityDisplayName(
+    task.entity_type as Parameters<typeof getEntityDisplayName>[0]
+  );
+  const navigationLabel = task.task_metadata?.comment_id
+    ? 'Go to associated comment'
+    : `Go to ${entityLabel}`;
+
+  return (
+    <SectionCard title="Linked entity">
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+        <Typography variant="body2" color="text.secondary">
+          This task was created from or is associated with another record.
+        </Typography>
+
+        <Box
+          sx={{
+            display: 'grid',
+            gridTemplateColumns: { xs: '1fr', sm: '1fr 1fr' },
+            gap: '30px',
+          }}
+        >
+          <ViewField label="Entity type" value={entityLabel} />
+          <ViewField label="Entity ID" value={task.entity_id} />
+        </Box>
+
+        <Box>
+          <Button
+            variant="outlined"
+            endIcon={<ArrowOutwardIcon />}
+            onClick={() => router.push(linkedUrl)}
+            sx={{ textTransform: 'none' }}
+          >
+            {navigationLabel}
+          </Button>
+        </Box>
+      </Box>
+    </SectionCard>
+  );
+}

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskLinkedEntityTab.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/components/TaskLinkedEntityTab.tsx
@@ -12,6 +12,7 @@ import { Task } from '@/types/tasks';
 import {
   buildLinkedEntityUrl,
   getEntityDisplayName,
+  isValidEntityType,
 } from '@/utils/entity-helpers';
 
 interface TaskLinkedEntityTabProps {
@@ -36,9 +37,9 @@ export default function TaskLinkedEntityTab({
     );
   }
 
-  const entityLabel = getEntityDisplayName(
-    task.entity_type as Parameters<typeof getEntityDisplayName>[0]
-  );
+  const entityLabel = isValidEntityType(task.entity_type)
+    ? getEntityDisplayName(task.entity_type)
+    : task.entity_type;
   const navigationLabel = task.task_metadata?.comment_id
     ? 'Go to associated comment'
     : `Go to ${entityLabel}`;

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
@@ -5,39 +5,223 @@ import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import {
   Box,
-  Paper,
   Typography,
-  TextField,
   Button,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  Grid,
   Alert,
   CircularProgress,
-  Avatar,
-  useTheme,
-  IconButton,
-  Divider,
-  Tooltip,
 } from '@mui/material';
-import { ArrowOutwardIcon, EditIcon } from '@/components/icons';
+import { format } from 'date-fns';
 import { PageLayout } from '@/components/layout/PageLayout';
+import DetailMetadataStrip from '@/components/common/DetailMetadataStrip';
 import { useTasks } from '@/hooks/useTasks';
 import { Task, TaskUpdate } from '@/types/tasks';
 import { getStatusesForTask, getPrioritiesForTask } from '@/utils/task-lookup';
 import type { Status, Priority } from '@/utils/api-client/interfaces/task';
-import { getEntityUrlMap } from '@/utils/entity-helpers';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { User } from '@/utils/api-client/interfaces/user';
 import { useNotifications } from '@/components/common/NotificationContext';
-import CommentsWrapper from '@/components/comments/CommentsWrapper';
-import { AVATAR_SIZES } from '@/constants/avatar-sizes';
 import CreateJiraIssueButton from '../components/CreateJiraIssueButton';
+import TaskDetailTabs from './components/TaskDetailTabs';
 
 interface PageProps {
   params: Promise<{ identifier: string }>;
+}
+
+function TaskDetailLoadingState({
+  taskId,
+  loadingTimeout,
+  onBack,
+  onRetry,
+}: {
+  taskId: string;
+  loadingTimeout: boolean;
+  onBack: () => void;
+  onRetry: () => void;
+}) {
+  return (
+    <PageLayout
+      title={loadingTimeout ? 'Taking longer than expected...' : 'Loading...'}
+      breadcrumbs={[
+        { label: 'Tasks', href: '/tasks' },
+        {
+          label: loadingTimeout ? 'Slow Connection' : 'Loading...',
+          href: `/tasks/${taskId}`,
+        },
+      ]}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: '50vh',
+          gap: 3,
+        }}
+      >
+        <CircularProgress />
+
+        {loadingTimeout && (
+          <Box sx={{ textAlign: 'center', maxWidth: 400 }}>
+            <Alert severity="warning" sx={{ mb: 2 }}>
+              <Typography variant="h6" sx={{ mb: 1 }}>
+                This is taking longer than usual
+              </Typography>
+              <Typography variant="body2" sx={{ mb: 2 }}>
+                The server might be experiencing high load or there could be a
+                network issue. We&apos;re still trying to load your task.
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Task ID: {taskId}
+              </Typography>
+            </Alert>
+
+            <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center' }}>
+              <Button variant="contained" onClick={onBack}>
+                Back to Tasks
+              </Button>
+              <Button variant="outlined" onClick={onRetry}>
+                Try Again
+              </Button>
+            </Box>
+          </Box>
+        )}
+      </Box>
+    </PageLayout>
+  );
+}
+
+function TaskDetailErrorState({
+  taskId,
+  error,
+  isRetrying,
+  onBack,
+  onRetry,
+}: {
+  taskId: string;
+  error: string;
+  isRetrying: boolean;
+  onBack: () => void;
+  onRetry: () => void;
+}) {
+  return (
+    <PageLayout
+      title="Error"
+      breadcrumbs={[
+        { label: 'Tasks', href: '/tasks' },
+        { label: 'Error', href: `/tasks/${taskId}` },
+      ]}
+    >
+      <Box sx={{ flexGrow: 1, pt: 3 }}>
+        <Alert
+          severity="error"
+          sx={{ mb: 3 }}
+          action={
+            <Button
+              color="inherit"
+              size="small"
+              onClick={onRetry}
+              disabled={isRetrying}
+            >
+              {isRetrying ? (
+                <>
+                  <CircularProgress color="inherit" size={16} sx={{ mr: 1 }} />
+                  Retrying...
+                </>
+              ) : (
+                'Retry'
+              )}
+            </Button>
+          }
+        >
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            Sorry, we couldn&apos;t load this task
+          </Typography>
+          <Typography variant="body2" sx={{ mb: 1 }}>
+            We encountered an issue while trying to load the task details. This
+            might be due to a temporary network issue or server problem.
+          </Typography>
+          <Box
+            sx={{
+              fontSize: theme => theme.typography.helperText.fontSize,
+              fontFamily: 'monospace',
+              color: 'text.secondary',
+              mt: 1,
+            }}
+          >
+            Error: {error}
+          </Box>
+        </Alert>
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Button variant="contained" onClick={onBack}>
+            Back to Tasks
+          </Button>
+          <Button variant="outlined" onClick={onRetry} disabled={isRetrying}>
+            {isRetrying ? (
+              <>
+                <CircularProgress color="inherit" size={16} sx={{ mr: 1 }} />
+                Retrying...
+              </>
+            ) : (
+              'Try Again'
+            )}
+          </Button>
+        </Box>
+      </Box>
+    </PageLayout>
+  );
+}
+
+function TaskDetailNotFoundState({
+  taskId,
+  isRetrying,
+  onBack,
+  onRetry,
+}: {
+  taskId: string;
+  isRetrying: boolean;
+  onBack: () => void;
+  onRetry: () => void;
+}) {
+  return (
+    <PageLayout
+      title="Task Not Found"
+      breadcrumbs={[
+        { label: 'Tasks', href: '/tasks' },
+        { label: 'Not Found', href: `/tasks/${taskId}` },
+      ]}
+    >
+      <Box sx={{ flexGrow: 1, pt: 3 }}>
+        <Alert severity="warning" sx={{ mb: 3 }}>
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            Sorry, we couldn&apos;t load this task
+          </Typography>
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            The task you&apos;re looking for might have been deleted, moved, or
+            you may not have permission to view it.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Task ID: {taskId}
+          </Typography>
+        </Alert>
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Button variant="contained" onClick={onBack}>
+            Back to Tasks
+          </Button>
+          <Button variant="outlined" onClick={onRetry} disabled={isRetrying}>
+            {isRetrying ? (
+              <>
+                <CircularProgress color="inherit" size={16} sx={{ mr: 1 }} />
+                Retrying...
+              </>
+            ) : (
+              'Try Again'
+            )}
+          </Button>
+        </Box>
+      </Box>
+    </PageLayout>
+  );
 }
 
 export default function TaskDetailPage({ params }: PageProps) {
@@ -46,19 +230,23 @@ export default function TaskDetailPage({ params }: PageProps) {
   const { getTask, updateTask } = useTasks({ autoFetch: false });
   const { show } = useNotifications();
 
-  const theme = useTheme();
   const [isLoading, setIsLoading] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [hasInitialLoad, setHasInitialLoad] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
   const [loadingTimeout, setLoadingTimeout] = useState(false);
 
-  // Use refs to track state without causing dependency cycles
   const isLoadingRef = useRef(false);
   const hasInitialLoadRef = useRef(false);
 
-  // Update refs when state changes
+  const [statuses, setStatuses] = useState<Status[]>([]);
+  const [priorities, setPriorities] = useState<Priority[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
+  const [task, setTask] = useState<Task | null>(null);
+
+  const resolvedParams = use(params);
+  const taskId = resolvedParams.identifier;
+
   useEffect(() => {
     isLoadingRef.current = isLoading;
   }, [isLoading]);
@@ -67,32 +255,11 @@ export default function TaskDetailPage({ params }: PageProps) {
     hasInitialLoadRef.current = hasInitialLoad;
   }, [hasInitialLoad]);
 
-  const [statuses, setStatuses] = useState<Status[]>([]);
-  const [priorities, setPriorities] = useState<Priority[]>([]);
-  const [users, setUsers] = useState<User[]>([]);
-  const [editedTask, setEditedTask] = useState<Task | null>(null);
-  const [isEditingDescription, setIsEditingDescription] = useState(false);
-  const [editDescription, setEditDescription] = useState('');
-  const [isEditingTitle, setIsEditingTitle] = useState(false);
-  const [editTitle, setEditTitle] = useState('');
-
-  const resolvedParams = use(params);
-  const taskId = resolvedParams.identifier;
-
-  // Initialize edit description and title when task loads
-  useEffect(() => {
-    if (editedTask) {
-      setEditDescription(editedTask.description || '');
-      setEditTitle(editedTask.title || '');
-    }
-  }, [editedTask]);
-
-  // Create a stable reference for the load function
   const loadInitialData = useCallback(
     async (isRetry = false) => {
-      // Prevent multiple concurrent requests using refs to avoid dependency cycles
-      if (!isRetry && (isLoadingRef.current || hasInitialLoadRef.current))
+      if (!isRetry && (isLoadingRef.current || hasInitialLoadRef.current)) {
         return;
+      }
 
       try {
         if (isRetry) {
@@ -110,20 +277,16 @@ export default function TaskDetailPage({ params }: PageProps) {
           throw new Error('No session token available');
         }
 
-        // Load task data first to get existing status/priority IDs
         const taskData = await getTask(taskId);
-
         if (!taskData) {
           throw new Error('Task not found');
         }
 
-        // Load statuses, priorities, and users in parallel, including existing task's status/priority
         const [fetchedStatuses, fetchedPriorities, fetchedUsers] =
           await Promise.all([
             getStatusesForTask(session.session_token, taskData.status_id),
             getPrioritiesForTask(session.session_token, taskData.priority_id),
             (async () => {
-              if (!session?.session_token) return [];
               const clientFactory = new ApiClientFactory(session.session_token);
               const usersClient = clientFactory.getUsersClient();
               const response = await usersClient.getUsers();
@@ -134,19 +297,17 @@ export default function TaskDetailPage({ params }: PageProps) {
         setStatuses(fetchedStatuses || []);
         setPriorities(fetchedPriorities || []);
         setUsers(fetchedUsers);
-        setEditedTask(taskData);
+        setTask(taskData);
         setHasInitialLoad(true);
       } catch (err) {
         const errorMessage =
           err instanceof Error ? err.message : 'Failed to load task data';
         setError(errorMessage);
 
-        // Only show notification on initial load or retry
         if (!hasInitialLoad || isRetry) {
           show(errorMessage, { severity: 'error' });
         }
 
-        // Set hasInitialLoad to true even on error to prevent infinite retries
         setHasInitialLoad(true);
       } finally {
         setIsLoading(false);
@@ -156,19 +317,16 @@ export default function TaskDetailPage({ params }: PageProps) {
     [taskId, getTask, session?.session_token, show, hasInitialLoad]
   );
 
-  // Initial load effect - only depends on essential values
   useEffect(() => {
     if (taskId && session?.session_token) {
       loadInitialData();
     }
   }, [taskId, session?.session_token, loadInitialData]);
 
-  // Timeout effect - show timeout message if loading takes too long
   useEffect(() => {
     let timeoutId: NodeJS.Timeout;
 
     if (isLoading || (!hasInitialLoad && taskId && session?.session_token)) {
-      // Set timeout for 10 seconds
       timeoutId = setTimeout(() => {
         setLoadingTimeout(true);
       }, 10000);
@@ -183,438 +341,93 @@ export default function TaskDetailPage({ params }: PageProps) {
     };
   }, [isLoading, hasInitialLoad, taskId, session?.session_token]);
 
-  // Show loading state while loading or if we haven't loaded yet
+  const handleRetry = () => {
+    setLoadingTimeout(false);
+    setHasInitialLoad(false);
+    loadInitialData(true);
+  };
+
   if (isLoading || (!hasInitialLoad && taskId && session?.session_token)) {
     return (
-      <PageLayout
-        title={loadingTimeout ? 'Taking longer than expected...' : 'Loading...'}
-        breadcrumbs={[
-          { label: 'Tasks', href: '/tasks' },
-          {
-            label: loadingTimeout ? 'Slow Connection' : 'Loading...',
-            href: `/tasks/${taskId}`,
-          },
-        ]}
-      >
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'center',
-            alignItems: 'center',
-            minHeight: '50vh',
-            gap: 3,
-          }}
-        >
-          <CircularProgress />
-
-          {loadingTimeout && (
-            <Box sx={{ textAlign: 'center', maxWidth: 400 }}>
-              <Alert severity="warning" sx={{ mb: 2 }}>
-                <Typography variant="h6" sx={{ mb: 1 }}>
-                  This is taking longer than usual
-                </Typography>
-                <Typography variant="body2" sx={{ mb: 2 }}>
-                  The server might be experiencing high load or there could be a
-                  network issue. We&apos;re still trying to load your task.
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Task ID: {taskId}
-                </Typography>
-              </Alert>
-
-              <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center' }}>
-                <Button
-                  variant="contained"
-                  onClick={() => router.push('/tasks')}
-                >
-                  Back to Tasks
-                </Button>
-                <Button
-                  variant="outlined"
-                  onClick={() => {
-                    setLoadingTimeout(false);
-                    setHasInitialLoad(false);
-                    loadInitialData(true);
-                  }}
-                >
-                  Try Again
-                </Button>
-              </Box>
-            </Box>
-          )}
-        </Box>
-      </PageLayout>
+      <TaskDetailLoadingState
+        taskId={taskId}
+        loadingTimeout={loadingTimeout}
+        onBack={() => router.push('/tasks')}
+        onRetry={handleRetry}
+      />
     );
   }
 
-  if (error && !editedTask) {
+  if (error && !task) {
     return (
-      <PageLayout
-        title="Error"
-        breadcrumbs={[
-          { label: 'Tasks', href: '/tasks' },
-          { label: 'Error', href: `/tasks/${taskId}` },
-        ]}
-      >
-        <Box sx={{ flexGrow: 1, pt: 3 }}>
-          <Alert
-            severity="error"
-            sx={{ mb: 3 }}
-            action={
-              <Button
-                color="inherit"
-                size="small"
-                onClick={() => loadInitialData(true)}
-                disabled={isRetrying}
-              >
-                {isRetrying ? (
-                  <>
-                    <CircularProgress
-                      color="inherit"
-                      size={16}
-                      sx={{ mr: 1 }}
-                    />
-                    Retrying...
-                  </>
-                ) : (
-                  'Retry'
-                )}
-              </Button>
-            }
-          >
-            <Typography variant="h6" sx={{ mb: 1 }}>
-              Sorry, we couldn&apos;t load this task
-            </Typography>
-            <Typography variant="body2" sx={{ mb: 1 }}>
-              We encountered an issue while trying to load the task details.
-              This might be due to a temporary network issue or server problem.
-            </Typography>
-            <Box
-              sx={{
-                fontSize: theme => theme.typography.helperText.fontSize,
-                fontFamily: 'monospace',
-                color: 'text.secondary',
-                mt: 1,
-              }}
-            >
-              Error: {error}
-            </Box>
-          </Alert>
-          <Box sx={{ display: 'flex', gap: 2 }}>
-            <Button variant="contained" onClick={() => router.push('/tasks')}>
-              Back to Tasks
-            </Button>
-            <Button
-              variant="outlined"
-              onClick={() => loadInitialData(true)}
-              disabled={isRetrying}
-            >
-              {isRetrying ? (
-                <>
-                  <CircularProgress color="inherit" size={16} sx={{ mr: 1 }} />
-                  Retrying...
-                </>
-              ) : (
-                'Try Again'
-              )}
-            </Button>
-          </Box>
-        </Box>
-      </PageLayout>
+      <TaskDetailErrorState
+        taskId={taskId}
+        error={error}
+        isRetrying={isRetrying}
+        onBack={() => router.push('/tasks')}
+        onRetry={handleRetry}
+      />
     );
   }
 
-  if (!editedTask) {
+  if (!task) {
     return (
-      <PageLayout
-        title="Task Not Found"
-        breadcrumbs={[
-          { label: 'Tasks', href: '/tasks' },
-          { label: 'Not Found', href: `/tasks/${taskId}` },
-        ]}
-      >
-        <Box sx={{ flexGrow: 1, pt: 3 }}>
-          <Alert severity="warning" sx={{ mb: 3 }}>
-            <Typography variant="h6" sx={{ mb: 1 }}>
-              Sorry, we couldn&apos;t load this task
-            </Typography>
-            <Typography variant="body2" sx={{ mb: 2 }}>
-              The task you&apos;re looking for might have been deleted, moved,
-              or you may not have permission to view it.
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
-              Task ID: {taskId}
-            </Typography>
-          </Alert>
-          <Box sx={{ display: 'flex', gap: 2 }}>
-            <Button variant="contained" onClick={() => router.push('/tasks')}>
-              Back to Tasks
-            </Button>
-            <Button
-              variant="outlined"
-              onClick={() => loadInitialData(true)}
-              disabled={isRetrying}
-            >
-              {isRetrying ? (
-                <>
-                  <CircularProgress color="inherit" size={16} sx={{ mr: 1 }} />
-                  Retrying...
-                </>
-              ) : (
-                'Try Again'
-              )}
-            </Button>
-          </Box>
-        </Box>
-      </PageLayout>
+      <TaskDetailNotFoundState
+        taskId={taskId}
+        isRetrying={isRetrying}
+        onBack={() => router.push('/tasks')}
+        onRetry={handleRetry}
+      />
     );
   }
 
-  const task = editedTask;
+  const metadataStrip = (
+    <DetailMetadataStrip
+      items={[
+        { label: 'created by:', value: task.user?.name || '—' },
+        {
+          label: 'created on:',
+          value: task.created_at
+            ? format(new Date(task.created_at), 'dd/MM/yyyy')
+            : '—',
+        },
+      ]}
+    />
+  );
 
-  const handleSaveDescription = async () => {
-    if (!taskId || !editedTask) return;
-
-    setIsSaving(true);
-    const originalDescription = editedTask.description;
-
-    try {
-      const updateData: TaskUpdate = {
-        title: editedTask.title,
-        description: editDescription,
-        status_id: editedTask.status_id,
-        priority_id: editedTask.priority_id,
-        assignee_id: editedTask.assignee_id || null,
-      };
-
-      const updatedTask = await updateTask(taskId, updateData);
-
-      // Update local state with the response from server
-      if (updatedTask) {
-        setEditedTask(updatedTask);
-      }
-
-      show('Description updated successfully', { severity: 'success' });
-      setIsEditingDescription(false);
-    } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'Failed to update description';
-      show(errorMessage, { severity: 'error' });
-
-      // Revert description on error
-      setEditDescription(originalDescription || '');
-    } finally {
-      setIsSaving(false);
-    }
+  const handleTaskUpdated = (updatedTask: Task) => {
+    setTask(updatedTask);
   };
 
-  const handleSave = async (taskToSave?: Task) => {
-    if (!taskId) return;
-
-    const taskData = taskToSave || task;
-    setIsSaving(true);
-
-    try {
-      const updateData: TaskUpdate = {
-        title: taskData.title,
-        description: taskData.description,
-        status_id: taskData.status_id,
-        priority_id: taskData.priority_id,
-        assignee_id: taskData.assignee_id || null,
-      };
-
-      const updatedTask = await updateTask(taskId, updateData);
-
-      // Update local state with the response from server
-      if (updatedTask) {
-        setEditedTask(updatedTask);
-      }
-
-      show('Task updated successfully', { severity: 'success' });
-    } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : 'Failed to update task';
-      show(errorMessage, { severity: 'error' });
-
-      // Revert local changes on error if we have original data
-      if (editedTask && taskToSave) {
-        setEditedTask(editedTask);
-      }
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  const handleChange =
-    (field: keyof Task) => (event: { target: { value: string } }) => {
-      if (!editedTask) return;
-
-      const value = event.target.value;
-      const updatedTask = { ...editedTask, [field]: value };
-      setEditedTask(updatedTask);
-
-      // Auto-save for non-description fields
-      if (field !== 'description') {
-        handleSave(updatedTask);
-      }
-    };
-
-  const handleSaveTitle = async () => {
-    if (!editTitle.trim()) {
-      show('Task title cannot be empty', { severity: 'error' });
-      return;
-    }
-
-    if (!editedTask) return;
-
-    setIsSaving(true);
-    const updatedTask = { ...editedTask, title: editTitle.trim() };
-    setEditedTask(updatedTask);
-    setIsEditingTitle(false);
-
-    try {
-      await handleSave(updatedTask);
-    } catch (_error) {
-      // Revert on error
-      setEditTitle(editedTask.title || '');
-      setIsEditingTitle(true);
-    } finally {
-      setIsSaving(false);
-    }
-  };
+  const handleUpdateTask = async (id: string, update: TaskUpdate) =>
+    updateTask(id, update);
 
   return (
     <PageLayout
+      title={task.title}
       breadcrumbs={[
         { label: 'Tasks', href: '/tasks' },
-        { label: editedTask?.title || task.title, href: `/tasks/${taskId}` },
+        { label: task.title, href: `/tasks/${taskId}` },
       ]}
+      metadata={metadataStrip}
+      actions={
+        <CreateJiraIssueButton
+          task={task}
+          onIssueCreated={() => loadInitialData(true)}
+        />
+      }
     >
-      {/* Title and Navigation Button in same row */}
-      <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, mb: 3 }}>
-        <Typography variant="h4" component="h1" sx={{ fontWeight: 500 }}>
-          {editedTask?.title || task.title}
-        </Typography>
-        {task.entity_type && task.entity_id && (
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={() => {
-              // Always navigate to the entity, optionally with comment hash
-              if (task.entity_type && task.entity_id) {
-                try {
-                  // Special handling for TestResult entities - navigate to test run page
-                  if (
-                    task.entity_type === 'TestResult' &&
-                    task.task_metadata?.test_run_id
-                  ) {
-                    const queryParams = new URLSearchParams();
-                    queryParams.append('selectedresult', task.entity_id);
-                    const queryString = queryParams.toString();
-                    const commentHash = task.task_metadata?.comment_id
-                      ? `#comment-${task.task_metadata.comment_id}`
-                      : '';
-                    const finalUrl = `/test-runs/${task.task_metadata.test_run_id}?${queryString}${commentHash}`;
-                    router.push(finalUrl);
-                    return;
-                  }
-
-                  // Map entity types to correct URL paths (plural)
-                  const entityUrlMap = getEntityUrlMap();
-                  const entityPath =
-                    entityUrlMap[task.entity_type] ||
-                    task.entity_type.toLowerCase();
-                  const baseUrl = `/${entityPath}/${task.entity_id}`;
-
-                  // Add query parameters if available (e.g., selectedresult for test runs)
-                  const queryParams = new URLSearchParams();
-                  if (task.task_metadata?.test_result_id) {
-                    queryParams.append(
-                      'selectedresult',
-                      String(task.task_metadata.test_result_id)
-                    );
-                  }
-                  const queryString = queryParams.toString()
-                    ? `?${queryParams.toString()}`
-                    : '';
-
-                  // Add hash for comments if available
-                  const commentHash = task.task_metadata?.comment_id
-                    ? `#comment-${task.task_metadata.comment_id}`
-                    : '';
-
-                  const finalUrl = `${baseUrl}${queryString}${commentHash}`;
-                  router.push(finalUrl);
-                } catch (error) {
-                  console.error('Failed to navigate to linked entity:', error);
-                }
-              }
-            }}
-            sx={{
-              borderRadius: theme.shape.borderRadius,
-              backgroundColor: 'background.paper',
-              color: 'text.secondary',
-              border: '1px solid',
-              borderColor: 'divider',
-              px: 2,
-              py: 1,
-              '&:hover': {
-                backgroundColor: 'action.hover',
-                color: 'text.primary',
-                borderColor: 'primary.main',
-              },
-            }}
-            endIcon={
-              <Box
-                sx={{
-                  width: 20,
-                  height: 20,
-                  borderRadius: theme.shape.circular,
-                  backgroundColor: 'text.secondary',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-              >
-                <ArrowOutwardIcon
-                  sx={{ fontSize: '12px', color: 'background.paper' }}
-                />
-              </Box>
-            }
-          >
-            {task.task_metadata?.comment_id
-              ? 'Go to associated comment'
-              : `Go to ${task.entity_type}`}
-          </Button>
-        )}
-      </Box>
-      <Box sx={{ flexGrow: 1, pt: 3 }}>
-        {/* Show warning if there's an error but we have cached data */}
-        {error && editedTask && (
-          <Alert severity="warning" sx={{ mb: 2 }}>
-            <Typography variant="body2" sx={{ mb: 1 }}>
-              <strong>Connection Issue:</strong> We&apos;re having trouble
-              connecting to the server, but we&apos;re showing you the last
-              saved version of this task.
-            </Typography>
-            <Box
-              sx={{
-                fontSize: theme => theme.typography.helperText.fontSize,
-                fontFamily: 'monospace',
-                color: 'text.secondary',
-                mb: 1,
-              }}
-            >
-              {error}
-            </Box>
+      {error && (
+        <Alert
+          severity="warning"
+          sx={{ mb: 3 }}
+          action={
             <Button
               color="inherit"
               size="small"
-              onClick={() => loadInitialData(true)}
+              onClick={handleRetry}
               disabled={isRetrying}
               variant="outlined"
-              sx={{ mt: 1 }}
             >
               {isRetrying ? (
                 <>
@@ -625,458 +438,28 @@ export default function TaskDetailPage({ params }: PageProps) {
                 'Try to Reconnect'
               )}
             </Button>
-          </Alert>
-        )}
+          }
+        >
+          <Typography variant="body2">
+            <strong>Connection Issue:</strong> We&apos;re having trouble
+            connecting to the server, but we&apos;re showing you the last saved
+            version of this task.
+          </Typography>
+        </Alert>
+      )}
 
-        <Grid container spacing={3}>
-          <Grid size={12}>
-            <Paper sx={{ p: 4 }}>
-              {/* Task Details Section Header */}
-              <Box
-                sx={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'flex-start',
-                  mb: 4,
-                }}
-              >
-                <Box>
-                  <Typography
-                    variant="h6"
-                    component="h2"
-                    sx={{ fontWeight: 'bold', mb: 1 }}
-                  >
-                    Task Details
-                  </Typography>
-                  <Typography variant="body2" color="text.secondary">
-                    Key information about this task.
-                  </Typography>
-                </Box>
-                <CreateJiraIssueButton
-                  task={editedTask || task}
-                  onIssueCreated={() => loadInitialData(true)}
-                />
-              </Box>
-
-              {/* Title */}
-              <Box sx={{ mb: 4 }}>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    mb: 1,
-                  }}
-                >
-                  <Typography variant="body2" color="text.secondary">
-                    Title
-                  </Typography>
-                  {!isEditingTitle ? (
-                    <Tooltip title="Edit title">
-                      <IconButton
-                        onClick={() => setIsEditingTitle(true)}
-                        size="small"
-                        sx={{
-                          color: 'text.secondary',
-                          '&:hover': {
-                            color: 'primary.main',
-                          },
-                        }}
-                      >
-                        <EditIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                  ) : null}
-                </Box>
-                {isEditingTitle ? (
-                  <Box sx={{ mb: 2 }}>
-                    <TextField
-                      value={editTitle}
-                      onChange={e => setEditTitle(e.target.value)}
-                      fullWidth
-                      variant="outlined"
-                      size="small"
-                      placeholder="Enter task title..."
-                      error={!editTitle.trim()}
-                      helperText={
-                        !editTitle.trim() ? 'Title cannot be empty' : ''
-                      }
-                      sx={{ mb: 1 }}
-                    />
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        justifyContent: 'flex-end',
-                        gap: 1,
-                      }}
-                    >
-                      <Button
-                        size="small"
-                        onClick={() => {
-                          setIsEditingTitle(false);
-                          setEditTitle(task.title || '');
-                        }}
-                        disabled={isSaving}
-                        sx={{ textTransform: 'none', borderRadius: '16px' }}
-                      >
-                        Cancel
-                      </Button>
-                      <Button
-                        size="small"
-                        variant="contained"
-                        onClick={handleSaveTitle}
-                        disabled={isSaving || !editTitle.trim()}
-                        sx={{ textTransform: 'none', borderRadius: '16px' }}
-                      >
-                        {isSaving ? 'Saving...' : 'Save'}
-                      </Button>
-                    </Box>
-                  </Box>
-                ) : (
-                  <Typography
-                    variant="body1"
-                    sx={{
-                      minHeight: '24px',
-                      color:
-                        editedTask?.title || task.title
-                          ? 'text.primary'
-                          : 'text.secondary',
-                      fontStyle:
-                        editedTask?.title || task.title ? 'normal' : 'italic',
-                    }}
-                  >
-                    {editedTask?.title || task.title || 'No title set'}
-                  </Typography>
-                )}
-              </Box>
-
-              {/* Description */}
-              <Box sx={{ mb: 4 }}>
-                <Box
-                  sx={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    mb: 1,
-                  }}
-                >
-                  <Typography variant="body2" color="text.secondary">
-                    Description
-                  </Typography>
-                  {!isEditingDescription ? (
-                    <Tooltip title="Edit description">
-                      <IconButton
-                        onClick={() => setIsEditingDescription(true)}
-                        size="small"
-                        sx={{
-                          color: 'text.secondary',
-                          '&:hover': {
-                            color: 'primary.main',
-                          },
-                        }}
-                      >
-                        <EditIcon fontSize="small" />
-                      </IconButton>
-                    </Tooltip>
-                  ) : null}
-                </Box>
-                {isEditingDescription ? (
-                  <Box sx={{ mb: 2 }}>
-                    <TextField
-                      value={editDescription}
-                      onChange={e => setEditDescription(e.target.value)}
-                      multiline
-                      rows={3}
-                      fullWidth
-                      variant="outlined"
-                      size="small"
-                      sx={{ mb: 1 }}
-                    />
-                    <Box
-                      sx={{
-                        display: 'flex',
-                        justifyContent: 'flex-end',
-                        gap: 1,
-                      }}
-                    >
-                      <Button
-                        size="small"
-                        onClick={() => {
-                          setIsEditingDescription(false);
-                          setEditDescription(task.description || '');
-                        }}
-                        sx={{ textTransform: 'none', borderRadius: '16px' }}
-                      >
-                        Cancel
-                      </Button>
-                      <Button
-                        size="small"
-                        variant="contained"
-                        onClick={handleSaveDescription}
-                        disabled={isSaving || !editDescription.trim()}
-                        sx={{ textTransform: 'none', borderRadius: '16px' }}
-                      >
-                        {isSaving ? 'Saving...' : 'Save'}
-                      </Button>
-                    </Box>
-                  </Box>
-                ) : (
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      mb: 2,
-                      lineHeight: 1.6,
-                      whiteSpace: 'pre-wrap',
-                      color: 'text.primary',
-                    }}
-                  >
-                    {task.description || 'No description provided'}
-                  </Typography>
-                )}
-              </Box>
-
-              {/* Status and Priority Row */}
-              <Grid container spacing={3} sx={{ mb: 4 }}>
-                <Grid size={6}>
-                  <FormControl fullWidth disabled={isSaving}>
-                    <InputLabel>Status</InputLabel>
-                    <Select
-                      value={task.status_id || ''}
-                      onChange={handleChange('status_id')}
-                      label="Status"
-                    >
-                      {statuses.map(status => (
-                        <MenuItem key={status.id} value={status.id}>
-                          {status.name}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                </Grid>
-                <Grid size={6}>
-                  <FormControl fullWidth disabled={isSaving}>
-                    <InputLabel>Priority</InputLabel>
-                    <Select
-                      value={task.priority_id || ''}
-                      onChange={handleChange('priority_id')}
-                      label="Priority"
-                    >
-                      {priorities.map(priority => (
-                        <MenuItem key={priority.id} value={priority.id}>
-                          {priority.type_value}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                </Grid>
-              </Grid>
-
-              {/* Creator and Assignee Row */}
-              <Grid container spacing={3} sx={{ mb: 4 }}>
-                <Grid size={6}>
-                  <FormControl fullWidth disabled>
-                    <InputLabel>Creator</InputLabel>
-                    <Select
-                      value={task.user?.id || ''}
-                      label="Creator"
-                      displayEmpty
-                      sx={{
-                        '& .MuiSelect-select': {
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 1,
-                        },
-                      }}
-                      renderValue={_value => {
-                        return (
-                          <Box
-                            sx={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: 1,
-                            }}
-                          >
-                            <Avatar
-                              src={task.user?.picture}
-                              alt={task.user?.name || 'Unknown'}
-                              sx={{
-                                width: AVATAR_SIZES.SMALL,
-                                height: AVATAR_SIZES.SMALL,
-                                bgcolor: 'primary.main',
-                              }}
-                            >
-                              {task.user?.name?.charAt(0) || 'U'}
-                            </Avatar>
-                            <Typography variant="body1">
-                              {task.user?.name || 'Unknown'}
-                            </Typography>
-                          </Box>
-                        );
-                      }}
-                    >
-                      <MenuItem value={task.user?.id || ''}>
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                        >
-                          <Avatar
-                            src={task.user?.picture}
-                            alt={task.user?.name || 'Unknown'}
-                            sx={{
-                              width: AVATAR_SIZES.SMALL,
-                              height: AVATAR_SIZES.SMALL,
-                              bgcolor: 'primary.main',
-                            }}
-                          >
-                            {task.user?.name?.charAt(0) || 'U'}
-                          </Avatar>
-                          <Typography variant="body1">
-                            {task.user?.name || 'Unknown'}
-                          </Typography>
-                        </Box>
-                      </MenuItem>
-                    </Select>
-                  </FormControl>
-                </Grid>
-                <Grid size={6}>
-                  <FormControl fullWidth disabled={isSaving}>
-                    <InputLabel shrink>Assignee</InputLabel>
-                    <Select
-                      value={task.assignee_id || ''}
-                      onChange={handleChange('assignee_id')}
-                      label="Assignee"
-                      displayEmpty
-                      sx={{
-                        '& .MuiSelect-select': {
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 1,
-                          paddingTop: theme.spacing(2),
-                          paddingBottom: theme.spacing(2),
-                        },
-                      }}
-                      renderValue={value => {
-                        const selectedUser = users.find(
-                          user => user.id === value
-                        );
-                        if (!selectedUser) {
-                          // Handle "Unassigned" case
-                          return (
-                            <Box
-                              sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: 1,
-                              }}
-                            >
-                              <Avatar
-                                sx={{
-                                  width: AVATAR_SIZES.SMALL,
-                                  height: AVATAR_SIZES.SMALL,
-                                  bgcolor: 'grey.300',
-                                }}
-                              >
-                                U
-                              </Avatar>
-                              <Typography variant="body1">
-                                Unassigned
-                              </Typography>
-                            </Box>
-                          );
-                        }
-                        return (
-                          <Box
-                            sx={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              gap: 1,
-                            }}
-                          >
-                            <Avatar
-                              src={selectedUser.picture}
-                              alt={selectedUser.name || 'User'}
-                              sx={{
-                                width: AVATAR_SIZES.SMALL,
-                                height: AVATAR_SIZES.SMALL,
-                                bgcolor: 'primary.main',
-                              }}
-                            >
-                              {selectedUser.name?.charAt(0) || 'U'}
-                            </Avatar>
-                            <Typography variant="body1">
-                              {selectedUser.name}
-                            </Typography>
-                          </Box>
-                        );
-                      }}
-                    >
-                      <MenuItem value="">
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                        >
-                          <Avatar
-                            sx={{
-                              width: AVATAR_SIZES.SMALL,
-                              height: AVATAR_SIZES.SMALL,
-                              bgcolor: 'grey.300',
-                            }}
-                          >
-                            U
-                          </Avatar>
-                          <Typography variant="body1">Unassigned</Typography>
-                        </Box>
-                      </MenuItem>
-                      {users
-                        .filter(user => user.id && user.name)
-                        .map(user => (
-                          <MenuItem key={user.id} value={user.id}>
-                            <Box
-                              sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: 1,
-                              }}
-                            >
-                              <Avatar
-                                src={user.picture}
-                                alt={user.name || 'User'}
-                                sx={{
-                                  width: AVATAR_SIZES.SMALL,
-                                  height: AVATAR_SIZES.SMALL,
-                                  bgcolor: 'primary.main',
-                                }}
-                              >
-                                {user.name?.charAt(0) || 'U'}
-                              </Avatar>
-                              <Typography variant="body1">
-                                {user.name}
-                              </Typography>
-                            </Box>
-                          </MenuItem>
-                        ))}
-                    </Select>
-                  </FormControl>
-                </Grid>
-              </Grid>
-
-              {/* Divider between task details and comments */}
-              <Divider sx={{ my: 4 }} />
-
-              {/* Comments Section */}
-              <Box>
-                <CommentsWrapper
-                  entityType="Task"
-                  entityId={taskId}
-                  sessionToken={session?.session_token || ''}
-                  currentUserId={session?.user?.id || ''}
-                  currentUserName={session?.user?.name || 'Unknown User'}
-                  currentUserPicture={session?.user?.picture || undefined}
-                  onCreateTask={undefined} // No task creation from task comments
-                />
-              </Box>
-            </Paper>
-          </Grid>
-        </Grid>
-      </Box>
+      <TaskDetailTabs
+        task={task}
+        statuses={statuses}
+        priorities={priorities}
+        users={users}
+        sessionToken={session?.session_token || ''}
+        currentUserId={session?.user?.id || ''}
+        currentUserName={session?.user?.name || 'Unknown User'}
+        currentUserPicture={session?.user?.picture || undefined}
+        onTaskUpdated={handleTaskUpdated}
+        updateTask={handleUpdateTask}
+      />
     </PageLayout>
   );
 }

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
@@ -342,6 +342,8 @@ export default function TaskDetailPage({ params }: PageProps) {
     };
   }, [isLoading, hasInitialLoad, taskId, session?.session_token]);
 
+  // Keep the last loaded task visible while retrying so transient failures
+  // still show cached data instead of flashing back to the loading state.
   const handleRetry = () => {
     setLoadingTimeout(false);
     setHasInitialLoad(false);

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
@@ -277,6 +277,7 @@ export default function TaskDetailPage({ params }: PageProps) {
           throw new Error('No session token available');
         }
 
+        const sessionToken = session.session_token;
         const taskData = await getTask(taskId);
         if (!taskData) {
           throw new Error('Task not found');
@@ -284,10 +285,10 @@ export default function TaskDetailPage({ params }: PageProps) {
 
         const [fetchedStatuses, fetchedPriorities, fetchedUsers] =
           await Promise.all([
-            getStatusesForTask(session.session_token, taskData.status_id),
-            getPrioritiesForTask(session.session_token, taskData.priority_id),
+            getStatusesForTask(sessionToken, taskData.status_id),
+            getPrioritiesForTask(sessionToken, taskData.priority_id),
             (async () => {
-              const clientFactory = new ApiClientFactory(session.session_token);
+              const clientFactory = new ApiClientFactory(sessionToken);
               const usersClient = clientFactory.getUsersClient();
               const response = await usersClient.getUsers();
               return response.data || [];

--- a/apps/frontend/src/app/(protected)/tasks/components/CreateJiraIssueButton.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/CreateJiraIssueButton.tsx
@@ -2,23 +2,15 @@
 
 import React, { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
-import {
-  Button,
-  CircularProgress,
-  Menu,
-  MenuItem,
-  Typography,
-  Tooltip,
-} from '@mui/material';
+import { Menu, MenuItem, Typography } from '@mui/material';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { Tool } from '@/utils/api-client/interfaces/tool';
 import { Task } from '@/types/tasks';
 import { useNotifications } from '@/components/common/NotificationContext';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import SvgIcon, { type SvgIconProps } from '@mui/material/SvgIcon';
+import { Fab, FabGroup } from '@/components/common/Fab';
 
-// Jira icon component
 const JiraIcon = (props: SvgIconProps) => (
   <SvgIcon {...props} viewBox="0 0 24 24">
     <path d="M11.571 11.513H0a5.218 5.218 0 0 0 5.232 5.215h2.13v2.057A5.215 5.215 0 0 0 12.575 24V12.518a1.005 1.005 0 0 0-1.004-1.005zm5.723-5.756H5.736a5.215 5.215 0 0 0 5.215 5.214h2.129v2.058a5.218 5.218 0 0 0 5.215 5.214V6.758a1.001 1.001 0 0 0-1.001-1.001zM23.013 0H11.455a5.215 5.215 0 0 0 5.215 5.215h2.129v2.057A5.215 5.215 0 0 0 24 12.483V1.005A1.001 1.001 0 0 0 23.013 0z" />
@@ -42,7 +34,6 @@ export default function CreateJiraIssueButton({
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
-  // Check if task already has a Jira issue
   const hasJiraIssue = Boolean(task.task_metadata?.jira_issue);
   const jiraIssue = task.task_metadata?.jira_issue as
     | {
@@ -60,11 +51,9 @@ export default function CreateJiraIssueButton({
         const clientFactory = new ApiClientFactory(session.session_token);
         const toolsClient = clientFactory.getToolsClient();
 
-        // Fetch all tools and filter by Jira provider
         const response = await toolsClient.getTools({});
         const tools = response.data || [];
 
-        // Filter for Jira tools that have space_key configured
         const jiraToolsList = tools.filter(
           tool =>
             tool.tool_provider_type?.type_value === 'jira' &&
@@ -83,10 +72,8 @@ export default function CreateJiraIssueButton({
   }, [session?.session_token]);
 
   const handleCreateIssue = async (toolId?: string) => {
-    // Close menu if open
     setAnchorEl(null);
 
-    // Use the first tool if no toolId provided
     const selectedToolId = toolId || jiraTools[0]?.id;
     if (!selectedToolId) return;
 
@@ -109,7 +96,6 @@ export default function CreateJiraIssueButton({
         severity: 'success',
       });
 
-      // Notify parent to refetch task
       if (onIssueCreated) {
         onIssueCreated();
       }
@@ -130,10 +116,8 @@ export default function CreateJiraIssueButton({
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     if (jiraTools.length === 1) {
-      // If only one tool, create issue directly
       handleCreateIssue(jiraTools[0].id);
     } else {
-      // Show menu to select project
       setAnchorEl(event.currentTarget);
     }
   };
@@ -142,73 +126,46 @@ export default function CreateJiraIssueButton({
     setAnchorEl(null);
   };
 
-  // If task already has a Jira issue, show "View in Jira" button
   if (hasJiraIssue && jiraIssue) {
     return (
-      <Button
-        variant="outlined"
-        size="small"
-        onClick={handleOpenJiraIssue}
-        startIcon={<OpenInNewIcon />}
-        sx={{
-          textTransform: 'none',
-        }}
-      >
-        View in Jira
-      </Button>
+      <FabGroup>
+        <Fab
+          icon={<OpenInNewIcon />}
+          tooltip={
+            jiraIssue.issue_key
+              ? `View ${jiraIssue.issue_key} in Jira`
+              : 'View in Jira'
+          }
+          aria-label="View in Jira"
+          onClick={handleOpenJiraIssue}
+        />
+      </FabGroup>
     );
   }
 
-  // If no Jira tools available, show disabled button with tooltip
   const hasNoJiraTools = !loading && jiraTools.length === 0;
 
-  // Show "Create Jira Issue" button
+  const tooltip = hasNoJiraTools
+    ? 'Connect Jira in Connect → MCP to create issues from this task'
+    : loading
+      ? 'Loading Jira tools…'
+      : isCreating
+        ? 'Creating Jira issue…'
+        : 'Create Jira Issue';
+
   return (
     <>
-      <Tooltip
-        title={
-          hasNoJiraTools ? 'Go to MCP -> Add Jira tool to create issues' : ''
-        }
-        arrow
-      >
-        <span>
-          <Button
-            variant="outlined"
-            size="small"
-            onClick={handleClick}
-            disabled={isCreating || loading || hasNoJiraTools}
-            startIcon={
-              loading ? (
-                <CircularProgress size={16} />
-              ) : isCreating ? (
-                <CircularProgress size={16} />
-              ) : (
-                <JiraIcon />
-              )
-            }
-            endIcon={
-              !hasNoJiraTools && jiraTools.length > 1 ? (
-                <ArrowDropDownIcon />
-              ) : undefined
-            }
-            sx={{
-              textTransform: 'none',
-              '&.Mui-disabled': {
-                color: 'text.secondary',
-                borderColor: 'divider',
-              },
-            }}
-          >
-            {loading
-              ? 'Loading...'
-              : isCreating
-                ? 'Creating...'
-                : 'Create Jira Issue'}
-          </Button>
-        </span>
-      </Tooltip>
+      <FabGroup>
+        <Fab
+          icon={<JiraIcon />}
+          tooltip={tooltip}
+          aria-label="Create Jira Issue"
+          onClick={handleClick}
+          disabled={hasNoJiraTools}
+          loading={loading || isCreating}
+        />
+      </FabGroup>
 
-      {/* Dropdown menu for multiple tools */}
       {jiraTools.length > 1 && (
         <Menu
           anchorEl={anchorEl}

--- a/apps/frontend/src/utils/__tests__/entity-helpers.test.ts
+++ b/apps/frontend/src/utils/__tests__/entity-helpers.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildLinkedEntityUrl,
   getEntityDisplayName,
   getEntityPath,
   getEntityUrlMap,
@@ -64,6 +65,37 @@ describe('getEntityIconName', () => {
   it('falls back to Assignment for unknown types', () => {
     // @ts-expect-error testing unknown type
     expect(getEntityIconName('Unknown')).toBe('Assignment');
+  });
+});
+
+describe('buildLinkedEntityUrl', () => {
+  it('returns null when entity is missing', () => {
+    expect(buildLinkedEntityUrl({})).toBeNull();
+    expect(
+      buildLinkedEntityUrl({ entity_type: 'Test', entity_id: undefined })
+    ).toBeNull();
+  });
+
+  it('builds a standard entity URL', () => {
+    expect(
+      buildLinkedEntityUrl({
+        entity_type: 'Test',
+        entity_id: 'test-id',
+      })
+    ).toBe('/tests/test-id');
+  });
+
+  it('builds a test run URL for test results', () => {
+    expect(
+      buildLinkedEntityUrl({
+        entity_type: 'TestResult',
+        entity_id: 'result-id',
+        task_metadata: {
+          test_run_id: 'run-id',
+          comment_id: 'comment-id',
+        },
+      })
+    ).toBe('/test-runs/run-id?selectedresult=result-id#comment-comment-id');
   });
 });
 

--- a/apps/frontend/src/utils/entity-helpers.ts
+++ b/apps/frontend/src/utils/entity-helpers.ts
@@ -92,12 +92,6 @@ export const isValidEntityType = (
 };
 
 /**
- * Generate a duplicate name with an incrementing "(Copy N)" suffix.
- * - "Foo"          → "Foo (Copy)"
- * - "Foo (Copy)"   → "Foo (Copy 2)"
- * - "Foo (Copy 2)" → "Foo (Copy 3)"
- */
-/**
  * Build a navigation URL for a task's linked entity (comment, test result, etc.).
  */
 export const buildLinkedEntityUrl = (task: {
@@ -141,6 +135,12 @@ export const buildLinkedEntityUrl = (task: {
   return `${baseUrl}${queryString}${commentHash}`;
 };
 
+/**
+ * Generate a duplicate name with an incrementing "(Copy N)" suffix.
+ * - "Foo"          → "Foo (Copy)"
+ * - "Foo (Copy)"   → "Foo (Copy 2)"
+ * - "Foo (Copy 2)" → "Foo (Copy 3)"
+ */
 export const generateCopyName = (name: string): string => {
   const copyPattern = /^(.*) \(Copy(?: (\d+))?\)$/;
   const match = name.match(copyPattern);

--- a/apps/frontend/src/utils/entity-helpers.ts
+++ b/apps/frontend/src/utils/entity-helpers.ts
@@ -1,4 +1,5 @@
-import { EntityType, type TaskMetadata } from '@/types/tasks';
+import { EntityType } from '@/types/tasks';
+import type { TaskMetadata } from '@/utils/api-client/interfaces/task';
 
 /**
  * Get the display name for an entity type

--- a/apps/frontend/src/utils/entity-helpers.ts
+++ b/apps/frontend/src/utils/entity-helpers.ts
@@ -1,4 +1,4 @@
-import { EntityType } from '@/types/tasks';
+import { EntityType, type TaskMetadata } from '@/types/tasks';
 
 /**
  * Get the display name for an entity type
@@ -96,6 +96,50 @@ export const isValidEntityType = (
  * - "Foo (Copy)"   → "Foo (Copy 2)"
  * - "Foo (Copy 2)" → "Foo (Copy 3)"
  */
+/**
+ * Build a navigation URL for a task's linked entity (comment, test result, etc.).
+ */
+export const buildLinkedEntityUrl = (task: {
+  entity_type?: string;
+  entity_id?: string;
+  task_metadata?: TaskMetadata;
+}): string | null => {
+  if (!task.entity_type || !task.entity_id) {
+    return null;
+  }
+
+  if (task.entity_type === 'TestResult' && task.task_metadata?.test_run_id) {
+    const queryParams = new URLSearchParams();
+    queryParams.append('selectedresult', task.entity_id);
+    const queryString = queryParams.toString();
+    const commentHash = task.task_metadata?.comment_id
+      ? `#comment-${task.task_metadata.comment_id}`
+      : '';
+    return `/test-runs/${task.task_metadata.test_run_id}?${queryString}${commentHash}`;
+  }
+
+  const entityUrlMap = getEntityUrlMap();
+  const entityPath =
+    entityUrlMap[task.entity_type] || task.entity_type.toLowerCase();
+  const baseUrl = `/${entityPath}/${task.entity_id}`;
+
+  const queryParams = new URLSearchParams();
+  if (task.task_metadata?.test_result_id) {
+    queryParams.append(
+      'selectedresult',
+      String(task.task_metadata.test_result_id)
+    );
+  }
+  const queryString = queryParams.toString()
+    ? `?${queryParams.toString()}`
+    : '';
+  const commentHash = task.task_metadata?.comment_id
+    ? `#comment-${task.task_metadata.comment_id}`
+    : '';
+
+  return `${baseUrl}${queryString}${commentHash}`;
+};
+
 export const generateCopyName = (name: string): string => {
   const copyPattern = /^(.*) \(Copy(?: (\d+))?\)$/;
   const match = name.match(copyPattern);


### PR DESCRIPTION
## Purpose
Task detail pages did not follow the shared Figma detail-page pattern used elsewhere in the app (tests, behaviors, experiments). This brings the layout in line with those designs.

## What Changed
- Refactored task detail to use `PageLayout`, metadata strip, and tab navigation (`Basic Information`, `Linked entities`, `Comments`)
- Added editable section cards with `ViewField` read-only display for task fields
- Moved Jira issue creation to a header FAB with clearer disabled-state tooltip
- Removed duplicate Creator field from the details card (creator remains in page metadata)
- Added `buildLinkedEntityUrl` helper and unit tests

## Additional Context
- Figma references: Frontend file nodes `1417:12693` and `1413:8082`
- Status/priority/assignee changes now require clicking **Edit** on the section card, consistent with other detail pages

## Testing
- [ ] Open a task detail page and verify header (title, breadcrumbs, created by/on metadata)
- [ ] Confirm tabs switch between Basic Information, Linked entities, and Comments
- [ ] Edit task fields via section **Edit** button and save
- [ ] Verify Jira FAB tooltip and behavior when Jira is not connected
- [ ] Run `npm test -- --testPathPatterns=entity-helpers` in `apps/frontend`