### PR TITLE
Add @nicolai-rhesis as frontend codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,5 @@
 #
 # See CONTRIBUTING.md for the full contributor policy.
 
+apps/frontend/ @nicolai-rhesis
 ee/ @rhesis-ai/maintainers


### PR DESCRIPTION
## Purpose
Require review from the frontend maintainer on changes under `apps/frontend/`.

## What Changed
- Added `apps/frontend/ @nicolai-rhesis` to `.github/CODEOWNERS`

## Additional Context
- Mirrors the existing `ee/ @rhesis-ai/maintainers` pattern for scoped ownership

## Testing
- N/A — CODEOWNERS-only change; GitHub will auto-request review on matching PRs after merge