### PR TITLE
Fix/arc crd exceed limit

### DIFF
--- a/kubernetes/base/arc/arc-controller-application.yaml
+++ b/kubernetes/base/arc/arc-controller-application.yaml
@@ -10,6 +10,10 @@ metadata:
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
+    # The ARC CRDs are ~1 MB; the apiserver fills in schema/conversion defaults
+    # that client-side diff reports as perpetual drift (OutOfSync forever).
+    # Server-side diff compares against the apiserver's merge result instead.
+    argocd.argoproj.io/compare-options: ServerSideDiff=true
 spec:
   project: arc-runners
   source:

--- a/kubernetes/base/arc/arc-controller-application.yaml
+++ b/kubernetes/base/arc/arc-controller-application.yaml
@@ -25,3 +25,7 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      # ARC CRDs (e.g. autoscalingrunnersets) exceed the 262144-byte annotation
+      # limit of client-side apply's last-applied-configuration. Server-side
+      # apply avoids writing that annotation.
+      - ServerSideApply=true


### PR DESCRIPTION
ARC CRDs (e.g. autoscalingrunnersets) exceed the 262144-byte annotation limit of client-side apply's last-applied-configuration. Server-side apply avoids writing that annotation.