### PR TITLE
Fix/arc crd exceed limit

### DIFF
--- a/kubernetes/clusters/dev/arc/arc-runner-set-application.yaml
+++ b/kubernetes/clusters/dev/arc/arc-runner-set-application.yaml
@@ -21,6 +21,11 @@ spec:
       valuesObject:
         githubConfigUrl: https://github.com/rhesis-ai/rhesis
         githubConfigSecret: arc-github-app-secret
+        # ArgoCD renders charts with `helm template` (no cluster lookup), so the
+        # chart cannot auto-discover the controller ServiceAccount. Set it explicitly.
+        controllerServiceAccount:
+          namespace: arc-systems
+          name: arc-controller-gha-rs-controller
         runnerScaleSetName: arc-runner-dev
         minRunners: 0
         maxRunners: 3

--- a/kubernetes/clusters/prd/arc/arc-runner-set-application.yaml
+++ b/kubernetes/clusters/prd/arc/arc-runner-set-application.yaml
@@ -15,6 +15,11 @@ spec:
       valuesObject:
         githubConfigUrl: https://github.com/rhesis-ai/rhesis
         githubConfigSecret: arc-github-app-secret
+        # ArgoCD renders charts with `helm template` (no cluster lookup), so the
+        # chart cannot auto-discover the controller ServiceAccount. Set it explicitly.
+        controllerServiceAccount:
+          namespace: arc-systems
+          name: arc-controller-gha-rs-controller
         runnerScaleSetName: arc-runner-prd
         minRunners: 0
         maxRunners: 5

--- a/kubernetes/clusters/stg/arc/arc-runner-set-application.yaml
+++ b/kubernetes/clusters/stg/arc/arc-runner-set-application.yaml
@@ -15,6 +15,11 @@ spec:
       valuesObject:
         githubConfigUrl: https://github.com/rhesis-ai/rhesis
         githubConfigSecret: arc-github-app-secret
+        # ArgoCD renders charts with `helm template` (no cluster lookup), so the
+        # chart cannot auto-discover the controller ServiceAccount. Set it explicitly.
+        controllerServiceAccount:
+          namespace: arc-systems
+          name: arc-controller-gha-rs-controller
         runnerScaleSetName: arc-runner-stg
         minRunners: 0
         maxRunners: 3


### PR DESCRIPTION
ArgoCD renders Helm charts with `helm template`, which has no cluster access, so the gha-runner-scale-set chart's lookup-based discovery of the controller ServiceAccount (label app.kubernetes.io/part-of=gha-rs-controller) always returns empty and the template fails. Pin controllerServiceAccount to arc-controller-gha-rs-controller in arc-systems for all environments.