### PR TITLE
fix(arc): restore runner image/command in resources override

### DIFF
--- a/kubernetes/clusters/dev/arc/arc-runner-set-application.yaml
+++ b/kubernetes/clusters/dev/arc/arc-runner-set-application.yaml
@@ -33,6 +33,11 @@ spec:
           spec:
             containers:
               - name: runner
+                # image/command must be repeated: Helm replaces the whole
+                # containers array, so omitting them drops the chart defaults
+                # and the runner pod fails with "spec.containers[0].image: Required".
+                image: ghcr.io/actions/actions-runner:latest
+                command: ["/home/runner/run.sh"]
                 resources:
                   requests:
                     cpu: 250m

--- a/kubernetes/clusters/prd/arc/arc-runner-set-application.yaml
+++ b/kubernetes/clusters/prd/arc/arc-runner-set-application.yaml
@@ -27,6 +27,11 @@ spec:
           spec:
             containers:
               - name: runner
+                # image/command must be repeated: Helm replaces the whole
+                # containers array, so omitting them drops the chart defaults
+                # and the runner pod fails with "spec.containers[0].image: Required".
+                image: ghcr.io/actions/actions-runner:latest
+                command: ["/home/runner/run.sh"]
                 resources:
                   requests:
                     cpu: 500m

--- a/kubernetes/clusters/stg/arc/arc-runner-set-application.yaml
+++ b/kubernetes/clusters/stg/arc/arc-runner-set-application.yaml
@@ -27,6 +27,11 @@ spec:
           spec:
             containers:
               - name: runner
+                # image/command must be repeated: Helm replaces the whole
+                # containers array, so omitting them drops the chart defaults
+                # and the runner pod fails with "spec.containers[0].image: Required".
+                image: ghcr.io/actions/actions-runner:latest
+                command: ["/home/runner/run.sh"]
                 resources:
                   requests:
                     cpu: 250m


### PR DESCRIPTION
Overriding template.spec.containers to set resources replaced the whole containers array (Helm does not deep-merge lists), dropping the chart's default image and command. Runner pods then failed with "spec.containers[0].image: Required value". Re-specify the actions-runner image and run.sh command alongside the resources in all environments.