### PR TITLE
Fix: Permission Denied Home Runner

### DIFF
--- a/kubernetes/clusters/dev/arc/arc-runner-set-application.yaml
+++ b/kubernetes/clusters/dev/arc/arc-runner-set-application.yaml
@@ -31,6 +31,11 @@ spec:
         maxRunners: 3
         template:
           spec:
+            # The runner runs as uid 1001 (member of group 123); the work-volume
+            # PVC mounts root-owned. fsGroup 123 makes it group-writable, else the
+            # job fails with "Access to the path '/home/runner/_work/_tool' is denied".
+            securityContext:
+              fsGroup: 123
             containers:
               - name: runner
                 # image/command must be repeated: Helm replaces the whole

--- a/kubernetes/clusters/prd/arc/arc-runner-set-application.yaml
+++ b/kubernetes/clusters/prd/arc/arc-runner-set-application.yaml
@@ -25,6 +25,11 @@ spec:
         maxRunners: 5
         template:
           spec:
+            # The runner runs as uid 1001 (member of group 123); the work-volume
+            # PVC mounts root-owned. fsGroup 123 makes it group-writable, else the
+            # job fails with "Access to the path '/home/runner/_work/_tool' is denied".
+            securityContext:
+              fsGroup: 123
             containers:
               - name: runner
                 # image/command must be repeated: Helm replaces the whole

--- a/kubernetes/clusters/stg/arc/arc-runner-set-application.yaml
+++ b/kubernetes/clusters/stg/arc/arc-runner-set-application.yaml
@@ -25,6 +25,11 @@ spec:
         maxRunners: 3
         template:
           spec:
+            # The runner runs as uid 1001 (member of group 123); the work-volume
+            # PVC mounts root-owned. fsGroup 123 makes it group-writable, else the
+            # job fails with "Access to the path '/home/runner/_work/_tool' is denied".
+            securityContext:
+              fsGroup: 123
             containers:
               - name: runner
                 # image/command must be repeated: Helm replaces the whole


### PR DESCRIPTION
This PR introduces changes from the `fix/permission-denied-home-runner` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->


## 📁 Files Changed (       3 files)

```
kubernetes/clusters/dev/arc/arc-runner-set-application.yaml
kubernetes/clusters/prd/arc/arc-runner-set-application.yaml
kubernetes/clusters/stg/arc/arc-runner-set-application.yaml
```

## 📋 Commit Details

```
255e35621 - fix(arc): set fsGroup on runner pods for work volume access (Md Asaduzzaman Miah, 2026-06-10 21:08)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->