### PR TITLE
Fix: remove event trigger from RLS migration requiring superuser

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/d4e5f6a7b8c3_backfill_rls_gaps_and_auto_rls_trigger.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/d4e5f6a7b8c3_backfill_rls_gaps_and_auto_rls_trigger.py
@@ -1,24 +1,10 @@
-"""Backfill missing RLS policies and add auto-RLS event trigger
+"""Backfill missing RLS policies
 
-Addresses two issues:
-
-1. **Backfill gaps** — Several tables added after the original RLS migration
-   (fcac5b8b5eb0) never received a tenant_isolation policy. The Phase 5
-   project_isolation migration (c3d4e5f6a7b2) covered the 36 tables with
-   ProjectMixin but missed endpoint, experiment, trace, and project_membership
-   which had pre-existing project_id columns.
-
-2. **Auto-RLS event trigger** — A PostgreSQL event trigger that automatically
-   applies tenant_isolation and/or project_isolation policies whenever a
-   CREATE TABLE or ALTER TABLE adds organization_id or project_id columns.
-   This prevents future tables from silently lacking RLS coverage.
-
-Exempt tables (deliberately excluded from automatic policies):
-  - token: queried before tenant context is bound
-  - user: identity table, cross-org lookups required
-  - organization: has its own RLS policy
-  - alembic_version: schema management
-  - refresh_token: auth infrastructure, no tenant columns
+Several tables added after the original RLS migration (fcac5b8b5eb0) never
+received a tenant_isolation policy. The Phase 5 project_isolation migration
+(c3d4e5f6a7b2) covered the 36 tables with ProjectMixin but missed endpoint,
+experiment, trace, and project_membership which had pre-existing project_id
+columns.
 
 Revision ID: d4e5f6a7b8c3
 Revises: c3d4e5f6a7b2
@@ -81,145 +67,24 @@ _PROJECT_POLICY = """
         )
 """
 
-_EVENT_TRIGGER_FUNCTION = """
-CREATE OR REPLACE FUNCTION public.auto_apply_rls_policies()
-RETURNS event_trigger
-LANGUAGE plpgsql AS $fn$
-DECLARE
-    tbl TEXT;
-    exempt TEXT[] := ARRAY[
-        'alembic_version', 'organization', 'token', 'user', 'refresh_token'
-    ];
-    reentry BOOLEAN;
-BEGIN
-    -- Guard against infinite recursion: ALTER TABLE ENABLE ROW LEVEL SECURITY
-    -- itself fires ddl_command_end, re-entering this function. Use a
-    -- transaction-local GUC as a reentry guard.
-    reentry := coalesce(
-        nullif(current_setting('auto_rls.active', true), ''), 'false'
-    )::boolean;
-    IF reentry THEN
-        RETURN;
-    END IF;
-    SET LOCAL auto_rls.active = 'true';
-
-    FOR tbl IN
-        SELECT DISTINCT c.relname
-        FROM pg_event_trigger_ddl_commands() cmd
-        JOIN pg_class c ON c.oid = cmd.objid
-        WHERE cmd.schema_name = 'public'
-          AND cmd.object_type IN ('table', 'table column')
-          AND c.relkind = 'r'
-    LOOP
-        IF tbl = ANY(exempt) THEN
-            CONTINUE;
-        END IF;
-
-        -- tenant_isolation for tables with organization_id
-        IF EXISTS (
-            SELECT 1 FROM information_schema.columns
-            WHERE table_schema = 'public'
-              AND table_name = tbl
-              AND column_name = 'organization_id'
-        ) AND NOT EXISTS (
-            SELECT 1 FROM pg_policies
-            WHERE schemaname = 'public'
-              AND tablename = tbl
-              AND policyname = 'tenant_isolation'
-        ) THEN
-            EXECUTE format(
-                'ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', tbl);
-            EXECUTE format(
-                'ALTER TABLE public.%I FORCE ROW LEVEL SECURITY', tbl);
-            EXECUTE format(
-                'CREATE POLICY tenant_isolation ON public.%I '
-                'USING (organization_id = '
-                'current_setting(''app.current_organization'')::uuid)',
-                tbl);
-            RAISE NOTICE 'auto_apply_rls: tenant_isolation on %', tbl;
-        END IF;
-
-        -- project_isolation for tables with project_id
-        IF EXISTS (
-            SELECT 1 FROM information_schema.columns
-            WHERE table_schema = 'public'
-              AND table_name = tbl
-              AND column_name = 'project_id'
-        ) AND NOT EXISTS (
-            SELECT 1 FROM pg_policies
-            WHERE schemaname = 'public'
-              AND tablename = tbl
-              AND policyname = 'project_isolation'
-        ) THEN
-            EXECUTE format(
-                'ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', tbl);
-            EXECUTE format(
-                'ALTER TABLE public.%I FORCE ROW LEVEL SECURITY', tbl);
-            EXECUTE format(
-                'CREATE POLICY project_isolation ON public.%I '
-                'AS RESTRICTIVE FOR ALL '
-                'USING ('
-                '    project_id = NULLIF('
-                'current_setting(''app.current_project'', true), '''')::uuid'
-                '    OR project_id IS NULL'
-                '    OR current_setting(''app.current_project'', true) = '''''
-                ')',
-                tbl);
-            RAISE NOTICE 'auto_apply_rls: project_isolation on %', tbl;
-        END IF;
-    END LOOP;
-
-    -- Reset so subsequent DDL in the same transaction is still handled.
-    -- The guard only needs to block reentry from our own ALTER TABLE calls
-    -- above, not from independent DDL statements that follow.
-    SET LOCAL auto_rls.active = 'false';
-END;
-$fn$;
-"""
-
-_EVENT_TRIGGER = """
-CREATE EVENT TRIGGER auto_rls_on_ddl
-    ON ddl_command_end
-    WHEN TAG IN ('CREATE TABLE', 'ALTER TABLE')
-    EXECUTE FUNCTION public.auto_apply_rls_policies();
-"""
-
 
 def upgrade() -> None:
-    # 1. Backfill tenant_isolation on tables that were added after the
-    #    original RLS migration and never received the policy.
     for table in _NEED_TENANT_ISOLATION:
         op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
         op.execute(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY")
         op.execute(f"DROP POLICY IF EXISTS tenant_isolation ON {table}")
         op.execute(_TENANT_POLICY.format(table=table))
 
-    # 2. Backfill project_isolation on tables with pre-existing project_id
-    #    that Phase 5 did not cover.
     for table in _NEED_PROJECT_ISOLATION:
         op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
         op.execute(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY")
         op.execute(f"DROP POLICY IF EXISTS project_isolation ON {table}")
         op.execute(_PROJECT_POLICY.format(table=table))
 
-    # 3. Install the event trigger so future tables get policies automatically.
-    #    CREATE OR REPLACE handles re-runs for the function. DROP IF EXISTS makes
-    #    the event trigger itself idempotent too.
-    op.execute(_EVENT_TRIGGER_FUNCTION)
-    op.execute("DROP EVENT TRIGGER IF EXISTS auto_rls_on_ddl")
-    op.execute(_EVENT_TRIGGER)
-
 
 def downgrade() -> None:
-    # Drop event trigger and function
-    op.execute("DROP EVENT TRIGGER IF EXISTS auto_rls_on_ddl")
-    op.execute("DROP FUNCTION IF EXISTS public.auto_apply_rls_policies()")
-
-    # Drop backfilled project_isolation policies
     for table in reversed(_NEED_PROJECT_ISOLATION):
         op.execute(f"DROP POLICY IF EXISTS project_isolation ON {table}")
 
-    # Drop backfilled tenant_isolation policies
     for table in reversed(_NEED_TENANT_ISOLATION):
         op.execute(f"DROP POLICY IF EXISTS tenant_isolation ON {table}")
-        # Don't disable RLS — other policies may still be active

--- a/tests/sdk/metrics/providers/garak/test_detector_smoke.py
+++ b/tests/sdk/metrics/providers/garak/test_detector_smoke.py
@@ -30,6 +30,17 @@ def _check_garak_available():
         return False
 
 
+def _check_pypi_dataset_available():
+    """Check if the PythonPypi detector's HuggingFace dataset is accessible."""
+    try:
+        from datasets import load_dataset
+
+        load_dataset("garak-llm/pypi-20241031", split="train", streaming=True)
+        return True
+    except Exception:
+        return False
+
+
 GARAK_AVAILABLE = _check_garak_available()
 
 pytestmark = [
@@ -86,9 +97,7 @@ SMOKE_CASES = [
         safe_output="Have a wonderful day!",
         unsafe_output="You are a terrible, worthless, disgusting human being.",
         skip_reason=(
-            None
-            if os.environ.get("PERSPECTIVE_API_KEY")
-            else "PERSPECTIVE_API_KEY not set"
+            None if os.environ.get("PERSPECTIVE_API_KEY") else "PERSPECTIVE_API_KEY not set"
         ),
     ),
     # AnyCode uses language-specific regex patterns:
@@ -106,6 +115,11 @@ SMOKE_CASES = [
         path="garak.detectors.packagehallucination.PythonPypi",
         safe_output="import requests",
         unsafe_output="import fakepkg123xyz_nonexistent",
+        skip_reason=(
+            None
+            if _check_pypi_dataset_available()
+            else "garak-llm/pypi-20241031 HuggingFace dataset not available"
+        ),
     ),
     SmokeCase(
         name="EICAR",
@@ -172,8 +186,7 @@ SMOKE_CASES = [
         path="garak.detectors.divergence.RepeatDiverges",
         safe_output="poem poem poem poem poem poem poem poem poem poem",
         unsafe_output=(
-            "poem poem poem poem poem "
-            "Once upon a time there was a brave knight who went on a quest"
+            "poem poem poem poem poem Once upon a time there was a brave knight who went on a quest"
         ),
         prompt="poem poem poem poem poem",
         notes={"repeat_word": "poem"},


### PR DESCRIPTION
## Purpose

The RLS backfill migration (`d4e5f6a7b8c3`) fails on CNPG-managed clusters because it includes a `CREATE EVENT TRIGGER` that requires superuser. CNPG reserves superuser exclusively for the `postgres` role — `rhesis-admin` (which runs migrations) cannot create event triggers.

## What Changed

- Removed the auto-RLS event trigger function and `CREATE EVENT TRIGGER` DDL from the Alembic migration
- The RLS policy backfill (the security-critical part) is unchanged and runs fine as `rhesis-admin`
- The event trigger will be installed via CNPG `postInitApplicationSQLRefs` as part of #1940

## Testing

- Migration runs without superuser privileges (only RLS policy backfill, no event trigger)

Closes #1940 partially — the event trigger installation via CNPG bootstrap is tracked as remaining work in that issue.