### PR TITLE
Fix: bind tenant scope in enrich_trace_async task

### DIFF
--- a/apps/backend/src/rhesis/backend/tasks/telemetry/enrich.py
+++ b/apps/backend/src/rhesis/backend/tasks/telemetry/enrich.py
@@ -4,7 +4,7 @@ import logging
 
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app.database import SessionLocal
+from rhesis.backend.app.database import SessionLocal, bind_scope_to_session
 from rhesis.backend.app.services.telemetry.enrichment.processor import TraceEnricher
 from rhesis.backend.celery.core import app
 
@@ -30,6 +30,8 @@ def enrich_trace_async(self, trace_id: str, project_id: str, organization_id: st
     db: Session = SessionLocal()
 
     try:
+        bind_scope_to_session(db, organization_id, "", project_id)
+
         logger.info(f"Starting async enrichment for trace {trace_id}")
 
         # Use same enricher as sync path (code reuse!)


### PR DESCRIPTION
## Summary
- `enrich_trace_async` was the only Celery telemetry task that opened a `SessionLocal()` without calling `bind_scope_to_session()`, causing `invalid input syntax for type uuid: ""` errors when project-wide RLS casts blank GUCs

## What Changed
- Added `bind_scope_to_session(db, organization_id, "", project_id)` to `enrich_trace_async`, matching the pattern used by `post_ingest_link`, `evaluate_turn_trace_metrics`, and `evaluate_conversation_trace_metrics`

## Audit
All 6 `SessionLocal()` call sites in the backend were audited — this was the only one missing scope binding.

## Test plan
- [ ] Ingest telemetry spans and verify `enrich_trace_async` completes without UUID cast errors
- [ ] Confirm enriched trace data appears in the UI
- [ ] Verify no `invalid input syntax for type uuid: ""` in Celery worker logs

Closes #1944