### PR TITLE
Cherry-pick: endpoints hotfix and open nav for all users (#1946)

### DIFF
--- a/apps/frontend/src/__tests__/components/navigation/Sidebar.test.tsx
+++ b/apps/frontend/src/__tests__/components/navigation/Sidebar.test.tsx
@@ -53,7 +53,6 @@ import type { NavigationItem } from '@/types/navigation';
 // ── helper ────────────────────────────────────────────────────────────────
 function setupMocks({
   navigation = [] as NavigationItem[],
-  isSuperuser = false,
   pathname = '/insights',
 } = {}) {
   (usePathname as jest.Mock).mockReturnValue(pathname);
@@ -62,7 +61,6 @@ function setupMocks({
       user: {
         name: 'Test User',
         email: 'test@example.com',
-        is_superuser: isSuperuser,
       },
     },
   });
@@ -100,39 +98,17 @@ describe('Sidebar', () => {
     expect(screen.getByText('Tests')).toBeInTheDocument();
   });
 
-  // ── Fix 3 regression: requireSuperuser filtering ───────────────────────
-  describe('requireSuperuser filtering', () => {
+  it('shows all nav items regardless of user role', () => {
     const navigation: NavigationItem[] = [
       { kind: 'page', segment: 'insights', title: 'Insights' },
-      {
-        kind: 'page',
-        segment: 'metrics',
-        title: 'Metrics',
-        requireSuperuser: true,
-      },
-      {
-        kind: 'page',
-        segment: 'models',
-        title: 'Models',
-        requireSuperuser: true,
-      },
+      { kind: 'page', segment: 'metrics', title: 'Metrics' },
+      { kind: 'page', segment: 'models', title: 'Models' },
     ];
-
-    it('hides requireSuperuser items for non-superusers', () => {
-      setupMocks({ navigation, isSuperuser: false });
-      render(<Sidebar />);
-      expect(screen.getByText('Insights')).toBeInTheDocument();
-      expect(screen.queryByText('Metrics')).not.toBeInTheDocument();
-      expect(screen.queryByText('Models')).not.toBeInTheDocument();
-    });
-
-    it('shows requireSuperuser items for superusers', () => {
-      setupMocks({ navigation, isSuperuser: true });
-      render(<Sidebar />);
-      expect(screen.getByText('Insights')).toBeInTheDocument();
-      expect(screen.getByText('Metrics')).toBeInTheDocument();
-      expect(screen.getByText('Models')).toBeInTheDocument();
-    });
+    setupMocks({ navigation });
+    render(<Sidebar />);
+    expect(screen.getByText('Insights')).toBeInTheDocument();
+    expect(screen.getByText('Metrics')).toBeInTheDocument();
+    expect(screen.getByText('Models')).toBeInTheDocument();
   });
 
   // ── Fix 1 regression: full path accumulation ───────────────────────────

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointCreateDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointCreateDrawer.tsx
@@ -45,6 +45,7 @@ export default function EndpointCreateDrawer({
           ref={formRef}
           projectId={projectId}
           hideActionBar
+          hideProjectSelect
           onCancel={onClose}
           onCreated={handleCreated}
           onSubmitStateChange={setSubmitState}

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointFilterDrawer.tsx
@@ -11,21 +11,17 @@ import {
 } from '@/components/common/FilterDrawer';
 import { BORDER_RADIUS } from '@/styles/theme';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { Project } from '@/utils/api-client/interfaces/project';
 import { Status } from '@/utils/api-client/interfaces/status';
-import { readActiveProjectId } from '@/utils/active-project';
 
 export interface EndpointFilters {
   connectionType: string;
   environment: string;
-  projectId: string;
   status: string;
 }
 
 export const EMPTY_ENDPOINT_FILTERS: EndpointFilters = {
   connectionType: '',
   environment: '',
-  projectId: '',
   status: '',
 };
 
@@ -39,7 +35,7 @@ export function countActiveEndpointFilters(f: EndpointFilters): number {
 
 const CONNECTION_TYPE_OPTIONS = [
   { label: 'REST', value: 'REST' },
-  { label: 'WebSocket', value: 'WEBSOCKET' },
+  { label: 'WebSocket', value: 'WebSocket' },
   { label: 'gRPC', value: 'GRPC' },
   { label: 'SDK', value: 'SDK' },
 ] as const;
@@ -64,8 +60,6 @@ interface EndpointFilterDrawerProps {
   onClose: () => void;
   filters: EndpointFilters;
   onApply: (filters: EndpointFilters) => void;
-  /** Hide project filter when the grid is already scoped to a project */
-  hideProjectFilter?: boolean;
 }
 
 export default function EndpointFilterDrawer({
@@ -73,7 +67,6 @@ export default function EndpointFilterDrawer({
   onClose,
   filters,
   onApply,
-  hideProjectFilter = false,
 }: EndpointFilterDrawerProps) {
   const { data: session } = useSession();
   const { draft, setDraft, handleReset, handleApply } = useFilterDrawerDraft(
@@ -83,7 +76,6 @@ export default function EndpointFilterDrawer({
     onApply,
     onClose
   );
-  const [projects, setProjects] = React.useState<Project[]>([]);
   const [statuses, setStatuses] = React.useState<Status[]>([]);
   const [loadingOptions, setLoadingOptions] = React.useState(false);
 
@@ -95,44 +87,17 @@ export default function EndpointFilterDrawer({
       setLoadingOptions(true);
       try {
         const factory = new ApiClientFactory(sessionToken);
-        const [projectsResponse, statusesResponse] = await Promise.all([
-          hideProjectFilter
-            ? Promise.resolve(null)
-            : factory.getProjectsClient().getProjects(),
-          factory.getStatusClient().getStatuses({
-            entity_type: 'General',
-            sort_by: 'name',
-            sort_order: 'asc',
-          }),
-        ]);
-
-        if (!hideProjectFilter && projectsResponse) {
-          const projectsArray = Array.isArray(projectsResponse)
-            ? projectsResponse
-            : projectsResponse?.data || [];
-          const filtered = projectsArray.filter(
-            (p: Project) => p?.id && p?.name
-          );
-          setProjects(filtered);
-
-          // Pre-select active project when no project filter is already set
-          if (!draft.projectId) {
-            const activeId = readActiveProjectId();
-            if (
-              activeId &&
-              filtered.some((p: Project) => String(p.id) === activeId)
-            ) {
-              setDraft(prev => ({ ...prev, projectId: activeId }));
-            }
-          }
-        }
+        const statusesResponse = await factory.getStatusClient().getStatuses({
+          entity_type: 'General',
+          sort_by: 'name',
+          sort_order: 'asc',
+        });
 
         const uniqueStatuses = statusesResponse.filter(
           (s, i, arr) => s?.name && arr.findIndex(x => x.name === s.name) === i
         );
         setStatuses(uniqueStatuses);
       } catch {
-        if (!hideProjectFilter) setProjects([]);
         setStatuses([]);
       } finally {
         setLoadingOptions(false);
@@ -140,7 +105,7 @@ export default function EndpointFilterDrawer({
     };
 
     loadOptions();
-  }, [open, session?.session_token, hideProjectFilter]);
+  }, [open, session?.session_token]);
 
   return (
     <FilterDrawerShell
@@ -190,32 +155,6 @@ export default function EndpointFilterDrawer({
           ))}
         </Box>
       </FilterSection>
-
-      {!hideProjectFilter && (
-        <FilterSection title="Project">
-          <FormControl fullWidth size="small" disabled={loadingOptions}>
-            <InputLabel id="endpoint-filter-project-label">Project</InputLabel>
-            <Select
-              labelId="endpoint-filter-project-label"
-              label="Project"
-              value={draft.projectId}
-              onChange={e =>
-                setDraft(prev => ({ ...prev, projectId: e.target.value }))
-              }
-              sx={selectSx}
-            >
-              <MenuItem value="">
-                <em>All projects</em>
-              </MenuItem>
-              {projects.map(project => (
-                <MenuItem key={project.id} value={project.id}>
-                  {project.name}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </FilterSection>
-      )}
 
       <FilterSection title="Status">
         <FormControl fullWidth size="small" disabled={loadingOptions}>

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
@@ -82,6 +82,8 @@ export interface EndpointFormProps {
   onCancel?: () => void;
   onCreated?: () => void;
   hideActionBar?: boolean;
+  /** Hide project picker — project is inferred from active project scope */
+  hideProjectSelect?: boolean;
   onSubmitStateChange?: (state: EndpointFormSubmitState) => void;
 }
 
@@ -96,6 +98,7 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
       onCancel,
       onCreated,
       hideActionBar = false,
+      hideProjectSelect = false,
       onSubmitStateChange,
     },
     ref
@@ -162,6 +165,11 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
     }, [projectIdFromUrl]);
 
     useEffect(() => {
+      if (hideProjectSelect) {
+        setLoadingProjects(false);
+        return;
+      }
+
       const fetchProjects = async () => {
         if (!session?.session_token) {
           setLoadingProjects(false);
@@ -182,7 +190,7 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
         }
       };
       fetchProjects();
-    }, [session]);
+    }, [session, hideProjectSelect]);
 
     const handleChange = (field: keyof FormData, value: unknown) => {
       setFormData(prev => ({ ...prev, [field]: value }));
@@ -448,6 +456,7 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
               onChange={handleChange}
               projects={projects}
               loadingProjects={loadingProjects}
+              hideProjectSelect={hideProjectSelect}
             />
           </DetailTabPanel>
 

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -14,7 +14,6 @@ import GridToolbar from '@/components/common/GridToolbar';
 import {
   GridColDef,
   GridPaginationModel,
-  GridRowSelectionModel,
   GridFilterModel,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
@@ -24,8 +23,6 @@ import BaseDataGrid from '@/components/common/BaseDataGrid';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import { Project } from '@/utils/api-client/interfaces/project';
 import {
-  DeleteIcon,
-  ContentCopyIcon,
   SmartToyIcon,
   DevicesIcon,
   WebIcon,
@@ -35,7 +32,6 @@ import {
 import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { DeleteModal } from '@/components/common/DeleteModal';
-import { createEndpoint } from '@/actions/endpoints';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { buildEndpointListFilter } from '@/utils/odata-filter';
 import EndpointFilterDrawer, {
@@ -116,7 +112,6 @@ interface EndpointsToolbarState {
 const DRAWER_FILTER_FIELDS = [
   'connectionType',
   'environment',
-  'projectId',
   'status',
 ] as const;
 
@@ -183,11 +178,9 @@ export default function EndpointsGrid({
   });
   const [projects, setProjects] = useState<Record<string, Project>>({});
   const [loadingProjects, setLoadingProjects] = useState(true);
-  const [selectedRows, setSelectedRows] = useState<GridRowSelectionModel>([]);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const [duplicating, setDuplicating] = useState(false);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [drawerFilters, setDrawerFilters] = useState<EndpointFilters>(
     EMPTY_ENDPOINT_FILTERS
@@ -213,12 +206,27 @@ export default function EndpointsGrid({
       setTotalCount(response.pagination.totalCount);
       setError(null);
     } catch {
-      setError('Failed to load endpoints');
-      setEndpoints([]);
+      const hasActiveFilters =
+        hasActiveEndpointFilters(drawerFilters) || searchQuery.trim() !== '';
+      if (hasActiveFilters) {
+        setEndpoints([]);
+        setTotalCount(0);
+        setError(null);
+      } else {
+        setError('Failed to load endpoints');
+        setEndpoints([]);
+      }
     } finally {
       setLoading(false);
     }
-  }, [sessionToken, paginationModel, filterModel, projectId]);
+  }, [
+    sessionToken,
+    paginationModel,
+    filterModel,
+    projectId,
+    drawerFilters,
+    searchQuery,
+  ]);
 
   useEffect(() => {
     fetchEndpoints();
@@ -271,13 +279,6 @@ export default function EndpointsGrid({
           value: drawerFilters.environment,
         });
       }
-      if (drawerFilters.projectId && !projectId) {
-        drawerItems.push({
-          field: 'projectId',
-          operator: 'equals',
-          value: drawerFilters.projectId,
-        });
-      }
       if (drawerFilters.status) {
         drawerItems.push({
           field: 'status',
@@ -324,12 +325,6 @@ export default function EndpointsGrid({
     }
   }, [sessionToken]);
 
-  const handleRowSelectionModelChange = (
-    newSelection: GridRowSelectionModel
-  ) => {
-    setSelectedRows(newSelection);
-  };
-
   const handleFilterModelChange = useCallback((model: GridFilterModel) => {
     setFilterModel(model);
     setPaginationModel(prev => ({ ...prev, page: 0 }));
@@ -348,10 +343,8 @@ export default function EndpointsGrid({
   }, [fetchEndpoints, onRefresh]);
 
   const handleDeleteEndpoints = async () => {
-    const idsToDelete = pendingDeleteId
-      ? [pendingDeleteId]
-      : (selectedRows as string[]);
-    if (!sessionToken || idsToDelete.length === 0) return;
+    if (!sessionToken || !pendingDeleteId) return;
+    const idsToDelete = [pendingDeleteId];
 
     try {
       setDeleting(true);
@@ -364,7 +357,6 @@ export default function EndpointsGrid({
       );
 
       setPendingDeleteId(null);
-      setSelectedRows([]);
       setDeleteDialogOpen(false);
       handleRefresh();
     } catch {
@@ -378,92 +370,6 @@ export default function EndpointsGrid({
     setPendingDeleteId(id);
     setDeleteDialogOpen(true);
   }, []);
-
-  const handleDuplicateEndpoints = useCallback(async () => {
-    if (selectedRows.length === 0) return;
-
-    try {
-      setDuplicating(true);
-      let successCount = 0;
-
-      for (const rowId of selectedRows) {
-        const source = endpoints.find(ep => ep.id === rowId);
-        if (!source) continue;
-
-        const {
-          id: _id,
-          status: _status,
-          status_id: _statusId,
-          user_id: _userId,
-          organization_id: _orgId,
-          nano_id: _nanoId,
-          created_at: _createdAt,
-          updated_at: _updatedAt,
-          ...rest
-        } = source as Endpoint & Record<string, unknown>;
-
-        const copyMatch = source.name.match(
-          /^(.*?)\s*\(Copy(?:\s+(\d+))?\)\s*$/
-        );
-        let newName: string;
-        if (copyMatch) {
-          const base = copyMatch[1];
-          const currentNum = copyMatch[2] ? parseInt(copyMatch[2], 10) : 1;
-          newName = `${base} (Copy ${currentNum + 1})`;
-        } else {
-          newName = `${source.name} (Copy)`;
-        }
-
-        const result = await createEndpoint({
-          ...rest,
-          name: newName,
-        } as Omit<Endpoint, 'id'>);
-
-        if (result.success) {
-          successCount++;
-        }
-      }
-
-      if (successCount > 0) {
-        notifications.show(
-          `${successCount} endpoint${successCount > 1 ? 's' : ''} duplicated`,
-          { severity: 'success' }
-        );
-        setSelectedRows([]);
-        handleRefresh();
-      }
-    } catch {
-      notifications.show('Failed to duplicate endpoints', {
-        severity: 'error',
-      });
-    } finally {
-      setDuplicating(false);
-    }
-  }, [selectedRows, endpoints, notifications, handleRefresh]);
-
-  const getActionButtons = useCallback(() => {
-    if (selectedRows.length === 0) return [];
-
-    return [
-      {
-        label: duplicating
-          ? 'Duplicating...'
-          : `Duplicate ${selectedRows.length} endpoint${selectedRows.length > 1 ? 's' : ''}`,
-        icon: <ContentCopyIcon />,
-        variant: 'outlined' as const,
-        onClick: handleDuplicateEndpoints,
-        disabled: duplicating,
-      },
-      {
-        label: `Delete ${selectedRows.length} endpoint${selectedRows.length > 1 ? 's' : ''}`,
-        icon: <DeleteIcon />,
-        variant: 'outlined' as const,
-        color: 'error' as const,
-        onClick: () => setDeleteDialogOpen(true),
-        disabled: deleting,
-      },
-    ];
-  }, [selectedRows.length, duplicating, deleting, handleDuplicateEndpoints]);
 
   const columns: GridColDef[] = useMemo(() => {
     const actionsCol = createRowActionsColumn({
@@ -557,24 +463,6 @@ export default function EndpointsGrid({
   return (
     <EndpointsToolbarContext.Provider value={toolbarContextValue}>
       <Box sx={{ position: 'relative' }}>
-        {selectedRows.length > 0 && (
-          <Box
-            sx={{
-              px: 2,
-              py: 1,
-              display: 'flex',
-              alignItems: 'center',
-              gap: 2,
-              borderBottom: theme =>
-                `1px solid ${theme.palette.greyscale.border}`,
-            }}
-          >
-            <Typography variant="subtitle1" color="primary">
-              {selectedRows.length} selected
-            </Typography>
-          </Box>
-        )}
-
         <BaseDataGrid
           rows={endpoints}
           columns={columns}
@@ -589,15 +477,10 @@ export default function EndpointsGrid({
           paginationModel={paginationModel}
           onPaginationModelChange={handlePaginationModelChange}
           pageSizeOptions={[10, 25, 50]}
-          checkboxSelection
-          disableRowSelectionOnClick
-          rowSelectionModel={selectedRows}
-          onRowSelectionModelChange={handleRowSelectionModelChange}
           serverSideFiltering={true}
           filterModel={filterModel}
           onFilterModelChange={handleFilterModelChange}
           toolbarSlot={EndpointsUnifiedToolbar}
-          actionButtons={getActionButtons()}
           showToolbar={true}
           disablePaperWrapper={true}
           persistState
@@ -612,16 +495,8 @@ export default function EndpointsGrid({
           }}
           onConfirm={handleDeleteEndpoints}
           isLoading={deleting}
-          title={
-            pendingDeleteId
-              ? 'Delete Endpoint'
-              : `Delete Endpoint${selectedRows.length > 1 ? 's' : ''}`
-          }
-          message={
-            pendingDeleteId
-              ? 'Are you sure you want to delete this endpoint? Related data will not be deleted.'
-              : `Are you sure you want to delete ${selectedRows.length} endpoint${selectedRows.length > 1 ? 's' : ''}? Don't worry, related data will not be deleted, only ${selectedRows.length === 1 ? 'this record' : 'these records'}.`
-          }
+          title="Delete Endpoint"
+          message="Are you sure you want to delete this endpoint? Related data will not be deleted."
           itemType="endpoints"
         />
       </Box>
@@ -631,7 +506,6 @@ export default function EndpointsGrid({
         onClose={() => setFilterDrawerOpen(false)}
         filters={drawerFilters}
         onApply={setDrawerFilters}
-        hideProjectFilter={!!projectId}
       />
     </EndpointsToolbarContext.Provider>
   );

--- a/apps/frontend/src/app/(protected)/endpoints/components/__tests__/TabBasics.test.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/__tests__/TabBasics.test.tsx
@@ -51,6 +51,22 @@ describe('TabBasics', () => {
     ).toBeInTheDocument();
   });
 
+  it('hides the project dropdown when hideProjectSelect is true', () => {
+    render(
+      <TabBasics
+        formData={defaultFormData}
+        onChange={jest.fn()}
+        projects={projects}
+        loadingProjects={false}
+        hideProjectSelect
+      />
+    );
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('textbox', { name: /endpoint name/i })
+    ).toBeInTheDocument();
+  });
+
   it('disables the project dropdown while projects are loading', () => {
     render(
       <TabBasics

--- a/apps/frontend/src/app/(protected)/endpoints/components/tabs/TabBasics.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/tabs/TabBasics.tsx
@@ -35,6 +35,8 @@ interface TabBasicsProps {
   onChange: (field: keyof FormData, value: unknown) => void;
   projects: Project[];
   loadingProjects: boolean;
+  /** Hide project picker — project is inferred from the active project scope */
+  hideProjectSelect?: boolean;
 }
 
 function ProjectSelect({
@@ -113,6 +115,7 @@ export default function TabBasics({
   onChange,
   projects,
   loadingProjects,
+  hideProjectSelect = false,
 }: TabBasicsProps) {
   const validateUrl = (url: string) => {
     try {
@@ -127,14 +130,20 @@ export default function TabBasics({
     <Box>
       <SectionCard
         title="Overview"
-        subtitle="Choose a project, name your endpoint, and configure how Rhesis connects to it."
+        subtitle={
+          hideProjectSelect
+            ? 'Name your endpoint and configure how Rhesis connects to it.'
+            : 'Choose a project, name your endpoint, and configure how Rhesis connects to it.'
+        }
       >
-        <ProjectSelect
-          formData={formData}
-          onChange={onChange}
-          projects={projects}
-          loadingProjects={loadingProjects}
-        />
+        {!hideProjectSelect && (
+          <ProjectSelect
+            formData={formData}
+            onChange={onChange}
+            projects={projects}
+            loadingProjects={loadingProjects}
+          />
+        )}
 
         <TextField
           fullWidth

--- a/apps/frontend/src/app/(protected)/endpoints/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/page.tsx
@@ -9,7 +9,7 @@ import { useSession } from 'next-auth/react';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
-import { ApiIcon } from '@/components/icons';
+import EndpointsIcon from '@/components/EndpointsIcon';
 import EndpointsGrid from './components/EndpointsGrid';
 import EndpointCreateDrawer from './components/EndpointCreateDrawer';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
@@ -115,7 +115,8 @@ export default function EndpointsPage() {
         <Box sx={{ mt: 2, mb: 2 }}>
           {endpointCount === 0 ? (
             <EntityEmptyState
-              icon={ApiIcon}
+              card
+              icon={EndpointsIcon}
               title="No endpoints yet"
               description="Create your first endpoint to connect your application under test and start running tests and evaluations."
               actionLabel="Create endpoint"

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -107,7 +107,6 @@ async function getNavigationItems(
       segment: 'metrics',
       title: 'Metrics',
       icon: <AutoGraphIcon key="metrics-icon" />,
-      requireSuperuser: true,
     },
     // GENERATE section — creation and exploration tools
     {
@@ -191,7 +190,6 @@ async function getNavigationItems(
       segment: 'models',
       title: 'Models',
       icon: <SmartToyIcon key="models-icon" />,
-      requireSuperuser: true,
     },
     {
       kind: 'page',

--- a/apps/frontend/src/components/common/EntityEmptyState.tsx
+++ b/apps/frontend/src/components/common/EntityEmptyState.tsx
@@ -2,13 +2,13 @@
 
 import React from 'react';
 import { Box, Button, Paper, Typography } from '@mui/material';
+import type { SvgIconProps } from '@mui/material/SvgIcon';
 import AddIcon from '@mui/icons-material/Add';
-import type { SvgIconComponent } from '@mui/icons-material';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
 
 export interface EntityEmptyStateProps {
-  /** MUI SvgIcon component class (not an element). */
-  icon: SvgIconComponent;
+  /** SvgIcon component class (not an element). */
+  icon: React.ComponentType<SvgIconProps>;
   title: string;
   description?: string;
   actionLabel?: string;
@@ -113,7 +113,7 @@ export default function EntityEmptyState({
 
       {actionLabel && onAction && (
         <Button
-          variant="contained"
+          variant={card ? 'outlined' : 'contained'}
           startIcon={resolvedShowAddIcon ? <AddIcon /> : undefined}
           onClick={onAction}
           disabled={actionDisabled}
@@ -127,6 +127,10 @@ export default function EntityEmptyState({
                   textTransform: 'none',
                   px: '20px',
                   py: '12px',
+                  borderWidth: 2,
+                  '&:hover': {
+                    borderWidth: 2,
+                  },
                 }
               : { mt: 1, fontWeight: 700 }
           }

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -34,7 +34,6 @@ import {
   type StandaloneGroup,
   type SectionGroup,
   type FooterLinksGroup,
-  filterNavItems,
   groupNavItems,
   collapsedNavGroupSx,
   COLLAPSED_NAV_ITEM_SIZE,
@@ -101,9 +100,7 @@ export function Sidebar() {
   const [supportOpen, setSupportOpen] = useState(false);
 
   const orgName = branding?.title ?? 'Rhesis AI';
-  const isSuperuser = user?.is_superuser === true;
-  const filteredNavigation = filterNavItems(navigation, isSuperuser);
-  const groups = groupNavItems(filteredNavigation);
+  const groups = groupNavItems(navigation);
 
   const mainGroups = groups.filter(g => g.type !== 'footer-links') as (
     | StandaloneGroup

--- a/apps/frontend/src/components/navigation/sidebar-utils.ts
+++ b/apps/frontend/src/components/navigation/sidebar-utils.ts
@@ -33,7 +33,6 @@ export interface ExtendedUser {
   name?: string | null;
   email?: string | null;
   image?: string | null;
-  is_superuser?: boolean;
 }
 
 // ── Active-path helper ────────────────────────────────────────────────────────
@@ -41,29 +40,6 @@ export interface ExtendedUser {
 export function isActive(pathname: string | null, fullPath: string): boolean {
   if (!pathname) return false;
   return pathname === fullPath || pathname.startsWith(`${fullPath}/`);
-}
-
-// ── Navigation filtering ──────────────────────────────────────────────────────
-
-export function filterNavItems(
-  items: NavigationItem[],
-  isSuperuser: boolean
-): NavigationItem[] {
-  return items.reduce<NavigationItem[]>((acc, item) => {
-    const needsSuperuser =
-      'requireSuperuser' in item &&
-      (item as { requireSuperuser?: boolean }).requireSuperuser;
-    if (needsSuperuser && !isSuperuser) return acc;
-    if (item.kind === 'page' && item.children && item.children.length > 0) {
-      acc.push({
-        ...item,
-        children: filterNavItems(item.children, isSuperuser),
-      } as NavigationPageItem);
-    } else {
-      acc.push(item);
-    }
-    return acc;
-  }, []);
 }
 
 // ── Navigation grouping ───────────────────────────────────────────────────────

--- a/apps/frontend/src/lib/extension-registries/admin-nav.ts
+++ b/apps/frontend/src/lib/extension-registries/admin-nav.ts
@@ -49,8 +49,6 @@ export interface AdminNavItem {
   feature?: FeatureName;
   /** Sort order. Lower numbers render earlier. */
   order?: number;
-  /** Whether the item requires superuser. Default false. */
-  requireSuperuser?: boolean;
 }
 
 const _items: AdminNavItem[] = [];

--- a/apps/frontend/src/types/navigation.ts
+++ b/apps/frontend/src/types/navigation.ts
@@ -10,7 +10,6 @@ export interface NavigationPageItem {
   icon?: React.ReactNode;
   action?: React.ReactNode;
   children?: NavigationPageItem[];
-  requireSuperuser?: boolean;
 }
 
 export interface NavigationHeaderItem {
@@ -30,7 +29,6 @@ export interface NavigationLinkItem {
   href: string;
   icon?: React.ReactNode;
   external?: boolean;
-  requireSuperuser?: boolean;
 }
 
 export interface NavigationActionItem {
@@ -38,7 +36,6 @@ export interface NavigationActionItem {
   title: string;
   icon?: React.ReactNode;
   action: string; // Action identifier to handle in the UI
-  requireSuperuser?: boolean;
 }
 
 export type NavigationItem =

--- a/apps/frontend/tests/e2e/helpers/seed-auth.ts
+++ b/apps/frontend/tests/e2e/helpers/seed-auth.ts
@@ -25,7 +25,7 @@ function createE2ESessionToken(): string {
       email: E2E_USER.email,
       name: E2E_USER.name,
       picture: null,
-      is_superuser: true,
+      is_superuser: false,
       is_email_verified: true,
       organization_id: E2E_USER.organization_id,
     },

--- a/apps/frontend/tests/e2e/mock-backend.mjs
+++ b/apps/frontend/tests/e2e/mock-backend.mjs
@@ -74,7 +74,7 @@ const listByResource = {
 
 const e2eUser = {
   ...loadJson('e2e-user.json'),
-  is_superuser: true,
+  is_superuser: false,
   is_email_verified: true,
 };
 

--- a/apps/frontend/tests/e2e/pages/MetricsPage.ts
+++ b/apps/frontend/tests/e2e/pages/MetricsPage.ts
@@ -3,7 +3,6 @@ import { BasePage } from './BasePage';
 
 /**
  * Page Object for the Metrics page (/metrics).
- * Only accessible to superusers.
  */
 export class MetricsPage extends BasePage {
   readonly dataGrid = this.page.locator('[role="grid"]');
@@ -21,10 +20,7 @@ export class MetricsPage extends BasePage {
     await this.expectNoErrors();
   }
 
-  /**
-   * Returns true when the page renders metric cards or any main content.
-   * The page may redirect to /dashboard for non-superusers.
-   */
+  /** Returns true when the page renders metric cards or any main content. */
   async expectContentOrRedirect(): Promise<boolean> {
     await this.page.waitForLoadState('networkidle');
     const url = this.page.url();

--- a/apps/frontend/tests/e2e/tests/metrics-crud.spec.ts
+++ b/apps/frontend/tests/e2e/tests/metrics-crud.spec.ts
@@ -8,9 +8,6 @@ import { MetricsPage } from '../pages/MetricsPage';
  * A4.5 (fill and submit metric form), A4.6 (edit metric from detail page),
  * A4.7 (assign metric to behavior from metric list card).
  *
- * The Metrics page is only visible to superusers; tests gracefully skip
- * when redirected away from /metrics (non-superuser session).
- *
  * All tests run against the real backend in Quick Start mode.
  */
 test.describe('Metrics — CRUD @crud', () => {
@@ -18,12 +15,6 @@ test.describe('Metrics — CRUD @crud', () => {
     const metricsPage = new MetricsPage(page);
     await metricsPage.goto();
     await page.waitForLoadState('networkidle');
-
-    if (!page.url().includes('/metrics')) {
-      test.skip(true, 'Not a superuser — skipping New Metric dialog test');
-      return;
-    }
-
     await metricsPage.expectLoaded();
 
     // "New Metric" FAB lives in PageLayout actions
@@ -64,14 +55,6 @@ test.describe('Metrics — CRUD @crud', () => {
     const metricsPage = new MetricsPage(page);
     await metricsPage.goto();
     await page.waitForLoadState('networkidle');
-
-    if (!page.url().includes('/metrics')) {
-      test.skip(
-        true,
-        'Not a superuser — skipping metric creation navigation test'
-      );
-      return;
-    }
 
     await metricsPage.expectLoaded();
 
@@ -129,13 +112,7 @@ test.describe('Metrics — CRUD @crud', () => {
     await page.goto('/metrics/new?type=custom-prompt');
     await page.waitForLoadState('networkidle');
 
-    if (!page.url().includes('/metrics/new')) {
-      test.skip(
-        true,
-        'Not a superuser or redirected — skipping metric creation test'
-      );
-      return;
-    }
+    await expect(page).toHaveURL(/\/metrics\/new/);
 
     const UNIQUE_NAME = `e2e-metric-${Date.now()}`;
 
@@ -251,11 +228,6 @@ test.describe('Metrics — CRUD @crud', () => {
     await metricsPage.goto();
     await page.waitForLoadState('networkidle');
 
-    if (!page.url().includes('/metrics')) {
-      test.skip(true, 'Not a superuser — skipping metric edit test');
-      return;
-    }
-
     await metricsPage.expectLoaded();
 
     const cardCount = await metricsPage.getCardCount();
@@ -340,11 +312,6 @@ test.describe('Metrics — CRUD @crud', () => {
     const metricsPage = new MetricsPage(page);
     await metricsPage.goto();
     await page.waitForLoadState('networkidle');
-
-    if (!page.url().includes('/metrics')) {
-      test.skip(true, 'Not a superuser — skipping assign-to-behavior test');
-      return;
-    }
 
     await metricsPage.expectLoaded();
 

--- a/apps/frontend/tests/e2e/tests/metrics-page.spec.ts
+++ b/apps/frontend/tests/e2e/tests/metrics-page.spec.ts
@@ -2,28 +2,16 @@ import { test, expect } from '@playwright/test';
 import { MetricsPage } from '../pages/MetricsPage';
 
 /**
- * Metrics page tests — superuser only.
+ * Metrics page tests.
  *
  * Covers: A4.1 (page loads, both Language and Embedding sections),
  * A4.2 (search filter, backend filter buttons: All / Custom / DeepEval etc.).
- *
- * If the current session user is not a superuser the page redirects to /dashboard,
- * in which case all tests gracefully skip.
  */
 test.describe('Metrics page — load and filters @interaction', () => {
   test('metrics page loads without error', async ({ page }) => {
     const metricsPage = new MetricsPage(page);
     await metricsPage.goto();
     await page.waitForLoadState('networkidle');
-
-    const isOnMetrics = page.url().includes('/metrics');
-    if (!isOnMetrics) {
-      test.skip(
-        true,
-        'Redirected away from /metrics — user is not a superuser, skipping'
-      );
-      return;
-    }
 
     await metricsPage.expectLoaded();
     await expect(page.locator('body')).not.toContainText(
@@ -38,11 +26,6 @@ test.describe('Metrics page — load and filters @interaction', () => {
     const metricsPage = new MetricsPage(page);
     await metricsPage.goto();
     await page.waitForLoadState('networkidle');
-
-    if (!page.url().includes('/metrics')) {
-      test.skip(true, 'Not a superuser — skipping metrics content test');
-      return;
-    }
 
     await metricsPage.expectLoaded();
 
@@ -66,11 +49,6 @@ test.describe('Metrics page — load and filters @interaction', () => {
     const metricsPage = new MetricsPage(page);
     await metricsPage.goto();
     await page.waitForLoadState('networkidle');
-
-    if (!page.url().includes('/metrics')) {
-      test.skip(true, 'Not a superuser — skipping search filter test');
-      return;
-    }
 
     await metricsPage.expectLoaded();
 
@@ -104,11 +82,6 @@ test.describe('Metrics page — load and filters @interaction', () => {
     const metricsPage = new MetricsPage(page);
     await metricsPage.goto();
     await page.waitForLoadState('networkidle');
-
-    if (!page.url().includes('/metrics')) {
-      test.skip(true, 'Not a superuser — skipping backend filter test');
-      return;
-    }
 
     await metricsPage.expectLoaded();
 
@@ -144,11 +117,6 @@ test.describe('Metrics page — load and filters @interaction', () => {
     const metricsPage = new MetricsPage(page);
     await metricsPage.goto();
     await page.waitForLoadState('networkidle');
-
-    if (!page.url().includes('/metrics')) {
-      test.skip(true, 'Not a superuser — skipping filters popover test');
-      return;
-    }
 
     await metricsPage.expectLoaded();
 


### PR DESCRIPTION
## Summary
Cherry-pick of #1946 from `release/v0.9.0` into `main`.

- Remove endpoint grid multi-select column and bulk duplicate/delete actions
- Show empty grid (not error) when filters return no results
- Remove project filter from endpoint grid and project picker from create drawer
- Align endpoints empty state with Figma card design
- Remove frontend superuser gating so Metrics and Models appear in sidebar for all users (#1943)

## Test plan
- [ ] `npm test -- --testPathPatterns="Sidebar|TabBasics|EntityEmptyState"` passes
- [ ] Metrics and Models visible in sidebar for non-superuser