### PR TITLE
Fix traces page empty state and project-scoped fetch race

### DIFF
--- a/apps/frontend/src/app/(protected)/traces/components/SpanDetailsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/SpanDetailsPanel.tsx
@@ -15,13 +15,10 @@ import {
   TableBody,
   TableRow,
   TableCell,
-  Tabs,
-  Tab,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import GridBadge from '@/components/common/GridBadge';
-import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
-import AssessmentOutlinedIcon from '@mui/icons-material/AssessmentOutlined';
+import DetailTabNav from '@/components/common/DetailTabNav';
 import {
   SpanNode,
   TraceDetailResponse,
@@ -36,8 +33,6 @@ import { formatDuration } from '@/utils/format-duration';
 import TestResultTab from './TestResultTab';
 import TraceMetricsTab from './TraceMetricsTab';
 import TraceReviewsTab from './TraceReviewsTab';
-import RateReviewIcon from '@mui/icons-material/RateReview';
-import ForumOutlinedIcon from '@mui/icons-material/ForumOutlined';
 import { TasksAndCommentsWrapper } from '@/components/tasks/TasksAndCommentsWrapper';
 
 interface SpanDetailsPanelProps {
@@ -97,19 +92,68 @@ export default function SpanDetailsPanel({
   traceMetricsStatus = null,
   selectedTurnNumber = null,
 }: SpanDetailsPanelProps) {
-  const [activeTab, setActiveTab] = useState<number | string>('details');
+  const [activeTabIndex, setActiveTabIndex] = useState(0);
   const [spanFiles, setSpanFiles] = useState<FileResponse[]>([]);
   const [spanFilesLoading, setSpanFilesLoading] = useState(false);
 
   // Determine if Test Result tab should be shown
   const showTestResultTab = trace?.test_result != null;
 
+  const spanDetailTabs = useMemo(() => {
+    const tabs: {
+      key: string;
+      label: string;
+      id: string;
+      'aria-controls': string;
+    }[] = [
+      {
+        key: 'details',
+        label: 'Span Details',
+        id: 'span-detail-tab-details',
+        'aria-controls': 'span-detail-tabpanel-details',
+      },
+    ];
+    if (showTestResultTab) {
+      tabs.push({
+        key: 'tests',
+        label: 'Test Results',
+        id: 'span-detail-tab-tests',
+        'aria-controls': 'span-detail-tabpanel-tests',
+      });
+    }
+    if (hasTraceMetrics) {
+      tabs.push(
+        {
+          key: 'metrics',
+          label: 'Trace Metrics',
+          id: 'span-detail-tab-metrics',
+          'aria-controls': 'span-detail-tabpanel-metrics',
+        },
+        {
+          key: 'reviews',
+          label: 'Reviews',
+          id: 'span-detail-tab-reviews',
+          'aria-controls': 'span-detail-tabpanel-reviews',
+        }
+      );
+    }
+    tabs.push({
+      key: 'tasks',
+      label: 'Tasks & Comments',
+      id: 'span-detail-tab-tasks',
+      'aria-controls': 'span-detail-tabpanel-tasks',
+    });
+    return tabs;
+  }, [showTestResultTab, hasTraceMetrics]);
+
+  const activeTabKey = spanDetailTabs[activeTabIndex]?.key ?? 'details';
+
   // Reset to details tab when Test Result tab becomes unavailable
   useEffect(() => {
-    if (!showTestResultTab && activeTab === 'tests') {
-      setActiveTab('details');
+    if (!showTestResultTab && activeTabKey === 'tests') {
+      setActiveTabIndex(0);
     }
-  }, [showTestResultTab, activeTab]);
+  }, [showTestResultTab, activeTabKey]);
 
   // Fetch files attached to the selected span
   useEffect(() => {
@@ -279,111 +323,21 @@ export default function SpanDetailsPanel({
 
   return (
     <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      {/* Tabs Header */}
-      <Box
-        sx={{
-          borderBottom: 1,
-          borderColor: 'divider',
-          px: theme => theme.spacing(2),
-          pt: theme => theme.spacing(2),
-          pb: theme => theme.spacing(2),
-          mb: theme => theme.spacing(1),
-        }}
-      >
-        <Tabs
-          value={activeTab}
-          onChange={(_, newValue) => setActiveTab(newValue)}
+      <Box sx={{ flexShrink: 0, px: '30px', pt: '30px' }}>
+        <DetailTabNav
+          tabs={spanDetailTabs}
+          activeIndex={activeTabIndex}
+          onChange={setActiveTabIndex}
           aria-label="span detail tabs"
-          variant="scrollable"
-          scrollButtons="auto"
-          sx={{
-            minHeight: 'auto',
-            '& .MuiTab-root': {
-              minHeight: 'auto',
-              fontSize: theme => theme.typography.subtitle2.fontSize,
-              fontWeight: theme => theme.typography.subtitle2.fontWeight,
-              textTransform: 'none',
-              py: theme => theme.spacing(1.25),
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'flex-start',
-              backgroundColor: 'transparent !important',
-              color: theme => theme.palette.text.secondary,
-              '& .MuiSvgIcon-root': {
-                color: 'inherit',
-              },
-              '&.Mui-selected': {
-                backgroundColor: 'transparent !important',
-                color: theme => theme.palette.text.primary,
-                '& .MuiSvgIcon-root': {
-                  color: theme => theme.palette.text.primary,
-                },
-              },
-              '&:hover': {
-                backgroundColor: 'transparent !important',
-              },
-            },
-            '& .MuiTabs-indicator': {
-              display: 'none',
-            },
-            '& .MuiTabs-flexContainer': {
-              backgroundColor: 'transparent',
-            },
-          }}
-        >
-          <Tab
-            value="details"
-            icon={<InfoOutlinedIcon fontSize="small" />}
-            iconPosition="start"
-            label="Span Details"
-            id="span-detail-tab-details"
-            aria-controls="span-detail-tabpanel-details"
-          />
-          {showTestResultTab && (
-            <Tab
-              value="tests"
-              icon={<AssessmentOutlinedIcon fontSize="small" />}
-              iconPosition="start"
-              label="Test Results"
-              id="span-detail-tab-tests"
-              aria-controls="span-detail-tabpanel-tests"
-            />
-          )}
-          {hasTraceMetrics && (
-            <Tab
-              value="metrics"
-              icon={<AssessmentOutlinedIcon fontSize="small" />}
-              iconPosition="start"
-              label="Trace Metrics"
-              id="span-detail-tab-metrics"
-              aria-controls="span-detail-tabpanel-metrics"
-            />
-          )}
-          {hasTraceMetrics && (
-            <Tab
-              value="reviews"
-              icon={<RateReviewIcon fontSize="small" />}
-              iconPosition="start"
-              label="Reviews"
-              id="span-detail-tab-reviews"
-              aria-controls="span-detail-tabpanel-reviews"
-            />
-          )}
-          <Tab
-            value="tasks"
-            icon={<ForumOutlinedIcon fontSize="small" />}
-            iconPosition="start"
-            label="Tasks & Comments"
-            id="span-detail-tab-tasks"
-            aria-controls="span-detail-tabpanel-tasks"
-          />
-        </Tabs>
+          tabGap="20px"
+          scrollable
+        />
       </Box>
 
       {/* Tab Content */}
-      <Box sx={{ flex: 1, overflow: 'auto' }}>
+      <Box sx={{ flex: 1, overflow: 'auto', minHeight: 0 }}>
         {/* Span Details Tab */}
-        <TabPanel value={activeTab} index="details">
+        <TabPanel value={activeTabKey} index="details">
           <Box sx={{ p: theme => theme.spacing(2) }}>
             {/* Overview Card */}
             <Card
@@ -1113,13 +1067,13 @@ export default function SpanDetailsPanel({
 
         {/* Test Result Tab */}
         {showTestResultTab && (
-          <TabPanel value={activeTab} index="tests">
+          <TabPanel value={activeTabKey} index="tests">
             <TestResultTab trace={trace} sessionToken={sessionToken} />
           </TabPanel>
         )}
 
         {hasTraceMetrics && (
-          <TabPanel value={activeTab} index="metrics">
+          <TabPanel value={activeTabKey} index="metrics">
             <TraceMetricsTab
               selectedSpan={span}
               isConversationTrace={isConversationTrace}
@@ -1133,7 +1087,7 @@ export default function SpanDetailsPanel({
         )}
 
         {hasTraceMetrics && trace && (
-          <TabPanel value={activeTab} index="reviews">
+          <TabPanel value={activeTabKey} index="reviews">
             <TraceReviewsTab
               selectedSpan={span}
               trace={trace}
@@ -1147,15 +1101,17 @@ export default function SpanDetailsPanel({
         )}
 
         {trace?.root_spans?.[0]?.id && (
-          <TabPanel value={activeTab} index="tasks">
-            <TasksAndCommentsWrapper
-              entityType="Trace"
-              entityId={trace.root_spans[0].id}
-              sessionToken={sessionToken}
-              currentUserId={currentUserId}
-              currentUserName={currentUserName}
-              currentUserPicture={currentUserPicture}
-            />
+          <TabPanel value={activeTabKey} index="tasks">
+            <Box sx={{ p: '30px' }}>
+              <TasksAndCommentsWrapper
+                entityType="Trace"
+                entityId={trace.root_spans[0].id}
+                sessionToken={sessionToken}
+                currentUserId={currentUserId}
+                currentUserName={currentUserName}
+                currentUserPicture={currentUserPicture}
+              />
+            </Box>
           </TabPanel>
         )}
       </Box>

--- a/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
@@ -1,26 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
-import {
-  Box,
-  Typography,
-  CircularProgress,
-  Alert,
-  IconButton,
-  Chip,
-  Stack,
-  Tabs,
-  Tab,
-} from '@mui/material';
-import CloseIcon from '@mui/icons-material/Close';
-import FolderIcon from '@mui/icons-material/Folder';
-import ApiIcon from '@mui/icons-material/Api';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
-import AssignmentIcon from '@mui/icons-material/Assignment';
-import AccountTreeIcon from '@mui/icons-material/AccountTree';
-import TimelineIcon from '@mui/icons-material/Timeline';
-import HubIcon from '@mui/icons-material/Hub';
-import ForumIcon from '@mui/icons-material/Forum';
+import { Box, Typography, CircularProgress, Alert, Paper } from '@mui/material';
 import Link from 'next/link';
 import SpanTreeView from './SpanTreeView';
 import SpanSequenceView from './SpanSequenceView';
@@ -30,6 +11,8 @@ import ConversationTraceView from './ConversationTraceView';
 import TraceReviewDrawer from './TraceReviewDrawer';
 import ErrorBoundary from '@/components/common/ErrorBoundary';
 import BaseDrawer from '@/components/common/BaseDrawer';
+import DetailTabNav from '@/components/common/DetailTabNav';
+import { GridBadge } from '@/components/common/GridBadge';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import {
   TraceDetailResponse,
@@ -41,9 +24,9 @@ import {
   toMentionId,
 } from '@/components/common/MentionTextInput';
 import { formatDuration } from '@/utils/format-duration';
-import ScienceIcon from '@mui/icons-material/Science';
 import { shortVersion } from '@/utils/api-client/interfaces/parameters';
 import { experimentHref } from '@/utils/experiment-links';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 
 interface TraceDrawerProps {
   open: boolean;
@@ -56,6 +39,61 @@ interface TraceDrawerProps {
   currentUserName?: string;
   currentUserPicture?: string;
   onTraceUpdated?: () => void;
+}
+
+function TraceMetadataRow({
+  label,
+  href,
+  children,
+}: {
+  label: string;
+  href?: string;
+  children: React.ReactNode;
+}) {
+  const pillSx = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    px: '10px',
+    py: '2px',
+    borderRadius: BORDER_RADIUS.pill,
+    border: '1px solid',
+    borderColor: 'greyscale.border',
+    fontSize: 12,
+    lineHeight: '18px',
+    color: 'greyscale.body',
+    textDecoration: 'none',
+    whiteSpace: 'nowrap',
+    ...(href
+      ? {
+          '&:hover': {
+            borderColor: 'primary.main',
+            color: 'primary.main',
+          },
+        }
+      : {}),
+  } as const;
+
+  return (
+    <Box sx={{ display: 'flex', gap: '10px', alignItems: 'center' }}>
+      <Typography
+        sx={{
+          fontSize: 12,
+          lineHeight: '18px',
+          color: 'greyscale.body',
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {label}
+      </Typography>
+      {href ? (
+        <Box component={Link} href={href} target="_blank" sx={pillSx}>
+          {children}
+        </Box>
+      ) : (
+        <Box sx={pillSx}>{children}</Box>
+      )}
+    </Box>
+  );
 }
 
 export default function TraceDrawer({
@@ -82,7 +120,7 @@ export default function TraceDrawer({
   const [viewTab, setViewTab] = useState<number>(0);
 
   // Resizable drawer width state
-  const [drawerWidth, setDrawerWidth] = useState(60); // viewport percentage
+  const [drawerWidth, setDrawerWidth] = useState(85); // viewport percentage
   const [isResizingDrawer, setIsResizingDrawer] = useState(false);
 
   // Tab index computation for optional conversation tab
@@ -92,14 +130,46 @@ export default function TraceDrawer({
     trace?.root_spans?.some(
       s => s.trace_metrics && Object.keys(s.trace_metrics).length > 0
     ) ?? false;
-  const tabIndices = useMemo(() => {
-    const offset = showConversationTab ? 1 : 0;
-    return {
-      tree: 0 + offset,
-      sequence: 1 + offset,
-      graph: 2 + offset,
-    };
+
+  const viewTabs = useMemo(() => {
+    const tabs: {
+      key: string;
+      label: string;
+      id: string;
+      'aria-controls': string;
+    }[] = [];
+    if (showConversationTab) {
+      tabs.push({
+        key: 'conversation',
+        label: 'Conversation',
+        id: 'span-hierarchy-tab-conversation',
+        'aria-controls': 'span-hierarchy-tabpanel-conversation',
+      });
+    }
+    tabs.push(
+      {
+        key: 'tree',
+        label: 'Tree',
+        id: 'span-hierarchy-tab-tree',
+        'aria-controls': 'span-hierarchy-tabpanel-tree',
+      },
+      {
+        key: 'sequence',
+        label: 'Sequence',
+        id: 'span-hierarchy-tab-sequence',
+        'aria-controls': 'span-hierarchy-tabpanel-sequence',
+      },
+      {
+        key: 'graph',
+        label: 'Graph',
+        id: 'span-hierarchy-tab-graph',
+        'aria-controls': 'span-hierarchy-tabpanel-graph',
+      }
+    );
+    return tabs;
   }, [showConversationTab]);
+
+  const activeViewKey = viewTabs[viewTab]?.key ?? 'tree';
 
   // Resizable split pane state
   const [leftPanelWidth, setLeftPanelWidth] = useState(60); // percentage
@@ -128,8 +198,7 @@ export default function TraceDrawer({
         setSelectedSpan(data.root_spans[spanIndex]);
 
         if (initialTurnIndex !== undefined) {
-          const offset = data.conversation_id ? 1 : 0;
-          setViewTab(0 + offset);
+          setViewTab(data.conversation_id ? 1 : 0);
         }
       }
     } catch (err: unknown) {
@@ -464,160 +533,103 @@ export default function TraceDrawer({
           height: '100%',
           display: 'flex',
           flexDirection: 'column',
+          gap: '40px',
           overflow: 'hidden',
+          minHeight: 0,
         }}
       >
-        {/* Header */}
         <Box
           sx={{
-            p: 2,
-            borderBottom: 1,
-            borderColor: 'divider',
             display: 'flex',
             flexDirection: 'column',
-            gap: 1,
+            gap: '20px',
+            flexShrink: 0,
           }}
         >
           <Box
             sx={{
               display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-            }}
-          >
-            <Typography variant="h6">Trace Details</Typography>
-            <IconButton onClick={onClose}>
-              <CloseIcon />
-            </IconButton>
-          </Box>
-
-          {/* Context Information */}
-          <Box
-            sx={{
-              display: 'flex',
               flexWrap: 'wrap',
-              gap: 1,
+              gap: '30px',
               alignItems: 'center',
             }}
           >
-            {/* Project */}
             {trace.project && (
-              <Chip
-                icon={<FolderIcon />}
-                label={`Project: ${trace.project.name}`}
-                component={Link}
+              <TraceMetadataRow
+                label="Project:"
                 href={`/projects/${trace.project.id}`}
-                target="_blank"
-                clickable
-                size="small"
-                variant="outlined"
-              />
+              >
+                {trace.project.name}
+              </TraceMetadataRow>
             )}
-
-            {/* Endpoint (if available) */}
             {trace.endpoint && (
-              <Chip
-                icon={<ApiIcon />}
-                label={`Endpoint: ${trace.endpoint.name}`}
-                component={Link}
+              <TraceMetadataRow
+                label="Endpoint:"
                 href={`/endpoints/${trace.endpoint.id}`}
-                target="_blank"
-                clickable
-                size="small"
-                variant="outlined"
-              />
+              >
+                {trace.endpoint.name}
+              </TraceMetadataRow>
             )}
-
-            {/* Test Run (if from test execution) */}
             {trace.test_run && (
-              <Chip
-                icon={<PlayArrowIcon />}
-                label={`Test Run: ${trace.test_run.name || trace.test_run.nano_id || trace.test_run.id}`}
-                component={Link}
+              <TraceMetadataRow
+                label="Test Run:"
                 href={`/test-runs/${trace.test_run.id}`}
-                target="_blank"
-                clickable
-                size="small"
-                variant="outlined"
-              />
+              >
+                {trace.test_run.name ||
+                  trace.test_run.nano_id ||
+                  trace.test_run.id}
+              </TraceMetadataRow>
             )}
-
-            {/* Test (if from test execution) */}
             {trace.test && (
-              <Chip
-                icon={<AssignmentIcon />}
-                label={`Test: ${trace.test.nano_id || trace.test.id}`}
-                component={Link}
-                href={`/tests/${trace.test.id}`}
-                target="_blank"
-                clickable
-                size="small"
-                variant="outlined"
-              />
+              <TraceMetadataRow label="Test:" href={`/tests/${trace.test.id}`}>
+                {trace.test.nano_id || trace.test.id}
+              </TraceMetadataRow>
             )}
-
-            {/* Experiment (if test run had pinned parameters) */}
             {experimentInfo && (
-              <>
-                <Chip
-                  icon={<ScienceIcon />}
-                  label={experimentInfo.name}
-                  component={Link}
-                  href={experimentHref(
-                    experimentInfo.id,
-                    experimentInfo.version
-                  )}
-                  target="_blank"
-                  clickable
-                  size="small"
-                  variant="outlined"
-                />
-                {experimentInfo.version && (
-                  <Chip
-                    label={shortVersion(experimentInfo.version)}
-                    size="small"
-                    variant="outlined"
-                  />
-                )}
-              </>
+              <TraceMetadataRow
+                label="Experiment:"
+                href={experimentHref(experimentInfo.id, experimentInfo.version)}
+              >
+                {experimentInfo.name}
+                {experimentInfo.version
+                  ? ` (${shortVersion(experimentInfo.version)})`
+                  : ''}
+              </TraceMetadataRow>
             )}
           </Box>
 
-          {/* Trace Metrics */}
-          <Stack direction="row" spacing={1}>
-            <Chip
-              label={`${trace.span_count} spans`}
-              size="small"
-              variant="outlined"
-            />
-            <Chip
-              label={formatDuration(trace.duration_ms)}
-              size="small"
-              variant="outlined"
-            />
-            <Chip
-              label={trace.environment}
-              size="small"
-              variant="outlined"
-              color="default"
-            />
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+            <GridBadge label={`${trace.span_count} spans`} size="grid" />
+            <GridBadge label={formatDuration(trace.duration_ms)} size="grid" />
+            <GridBadge label={trace.environment} size="grid" />
             {trace.error_count > 0 && (
-              <Chip
+              <GridBadge
                 label={`${trace.error_count} errors`}
-                size="small"
-                color="error"
-                variant="outlined"
+                size="grid"
+                sx={{
+                  bgcolor: 'error.main',
+                  color: 'error.contrastText',
+                }}
               />
             )}
-          </Stack>
+          </Box>
         </Box>
 
-        {/* Content - Split Layout */}
-        <Box
+        <Paper
           ref={containerRef}
-          sx={{ flex: 1, display: 'flex', overflow: 'hidden' }}
+          elevation={0}
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            display: 'flex',
+            overflow: 'hidden',
+            borderRadius: BORDER_RADIUS.md,
+            boxShadow: theme =>
+              theme.palette.mode === 'light' ? ELEVATION.xs : 'none',
+            border: theme => `1px solid ${theme.palette.greyscale.border}`,
+            bgcolor: 'background.paper',
+          }}
         >
-          {/* Left: Span Tree */}
           <Box
             sx={{
               width: `${leftPanelWidth}%`,
@@ -627,124 +639,42 @@ export default function TraceDrawer({
               flexShrink: 0,
             }}
           >
-            {/* Tabs Header */}
-            <Box
-              sx={{
-                borderBottom: 1,
-                borderColor: 'divider',
-                px: theme => theme.spacing(2),
-                pt: theme => theme.spacing(2),
-                pb: theme => theme.spacing(2),
-                mb: theme => theme.spacing(1),
-              }}
-            >
-              <Tabs
-                value={viewTab}
-                onChange={(_, newValue) => setViewTab(newValue)}
+            <Box sx={{ flexShrink: 0, px: '30px', pt: '30px' }}>
+              <DetailTabNav
+                tabs={viewTabs}
+                activeIndex={viewTab}
+                onChange={setViewTab}
                 aria-label="span hierarchy tabs"
-                variant="scrollable"
-                scrollButtons="auto"
-                sx={{
-                  minHeight: 'auto',
-                  '& .MuiTab-root': {
-                    minHeight: 'auto',
-                    fontSize: theme => theme.typography.subtitle2.fontSize,
-                    fontWeight: theme => theme.typography.subtitle2.fontWeight,
-                    textTransform: 'none',
-                    py: theme => theme.spacing(1.25),
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'flex-start',
-                    backgroundColor: 'transparent !important',
-                    color: theme => theme.palette.text.secondary,
-                    '& .MuiSvgIcon-root': {
-                      color: 'inherit',
-                    },
-                    '&.Mui-selected': {
-                      backgroundColor: 'transparent !important',
-                      color: theme => theme.palette.text.primary,
-                      '& .MuiSvgIcon-root': {
-                        color: theme => theme.palette.text.primary,
-                      },
-                    },
-                    '&:hover': {
-                      backgroundColor: 'transparent !important',
-                    },
-                  },
-                  '& .MuiTabs-indicator': {
-                    display: 'none',
-                  },
-                  '& .MuiTabs-flexContainer': {
-                    backgroundColor: 'transparent',
-                  },
-                }}
-              >
-                {showConversationTab && (
-                  <Tab
-                    icon={<ForumIcon fontSize="small" />}
-                    iconPosition="start"
-                    label="Conversation"
-                    id="span-hierarchy-tab-conversation"
-                    aria-controls="span-hierarchy-tabpanel-conversation"
-                  />
-                )}
-                <Tab
-                  icon={<AccountTreeIcon fontSize="small" />}
-                  iconPosition="start"
-                  label="Tree View"
-                  id="span-hierarchy-tab-tree"
-                  aria-controls="span-hierarchy-tabpanel-tree"
-                />
-                <Tab
-                  icon={<TimelineIcon fontSize="small" />}
-                  iconPosition="start"
-                  label="Sequence View"
-                  id="span-hierarchy-tab-sequence"
-                  aria-controls="span-hierarchy-tabpanel-sequence"
-                />
-                <Tab
-                  icon={<HubIcon fontSize="small" />}
-                  iconPosition="start"
-                  label="Graph View"
-                  id="span-hierarchy-tab-graph"
-                  aria-controls="span-hierarchy-tabpanel-graph"
-                />
-              </Tabs>
+                tabGap="20px"
+                scrollable
+              />
             </Box>
 
-            {/* Tab Content - wrapped in error boundary for resilience */}
             <ErrorBoundary>
               <Box
                 sx={{
                   flex: 1,
                   overflow:
-                    viewTab === tabIndices.tree ||
-                    (showConversationTab && viewTab === 0)
+                    activeViewKey === 'tree' || activeViewKey === 'conversation'
                       ? 'auto'
                       : 'hidden',
-                  p:
-                    viewTab === tabIndices.tree ? theme => theme.spacing(2) : 0,
+                  px: activeViewKey === 'tree' ? '30px' : 0,
+                  pb: '30px',
+                  minHeight: 0,
                 }}
               >
-                {showConversationTab && (
-                  <Box
-                    sx={{
-                      display: viewTab === 0 ? 'block' : 'none',
-                      height: '100%',
-                    }}
-                  >
-                    <ConversationTraceView
-                      trace={trace}
-                      sessionToken={sessionToken}
-                      onSpanSelect={handleSpanSelect}
-                      rootSpans={trace.root_spans}
-                      onReviewTurn={
-                        hasTraceMetrics ? handleReviewTurn : undefined
-                      }
-                    />
-                  </Box>
+                {activeViewKey === 'conversation' && (
+                  <ConversationTraceView
+                    trace={trace}
+                    sessionToken={sessionToken}
+                    onSpanSelect={handleSpanSelect}
+                    rootSpans={trace.root_spans}
+                    onReviewTurn={
+                      hasTraceMetrics ? handleReviewTurn : undefined
+                    }
+                  />
                 )}
-                {viewTab === tabIndices.tree && (
+                {activeViewKey === 'tree' && (
                   <SpanTreeView
                     spans={trace.root_spans}
                     selectedSpan={selectedSpan}
@@ -752,7 +682,7 @@ export default function TraceDrawer({
                     isConversationTrace={isConversationTrace}
                   />
                 )}
-                {viewTab === tabIndices.sequence && (
+                {activeViewKey === 'sequence' && (
                   <SpanSequenceView
                     spans={trace.root_spans}
                     selectedSpan={selectedSpan}
@@ -761,7 +691,7 @@ export default function TraceDrawer({
                     rootSpans={trace.root_spans}
                   />
                 )}
-                {viewTab === tabIndices.graph && (
+                {activeViewKey === 'graph' && (
                   <SpanGraphView
                     spans={trace.root_spans}
                     selectedSpan={selectedSpan}
@@ -774,7 +704,6 @@ export default function TraceDrawer({
             </ErrorBoundary>
           </Box>
 
-          {/* Draggable Divider */}
           <Box
             onMouseDown={handleMouseDown}
             sx={{
@@ -802,12 +731,13 @@ export default function TraceDrawer({
             }}
           />
 
-          {/* Right: Span Details */}
           <Box
             sx={{
               flex: 1,
-              overflow: 'auto',
+              overflow: 'hidden',
               minWidth: 0,
+              display: 'flex',
+              flexDirection: 'column',
             }}
           >
             <SpanDetailsPanel
@@ -829,7 +759,7 @@ export default function TraceDrawer({
               selectedTurnNumber={selectedTurnNumber}
             />
           </Box>
-        </Box>
+        </Paper>
       </Box>
     );
   };
@@ -841,8 +771,17 @@ export default function TraceDrawer({
       width={`${drawerWidth}%`}
       showHeader={false}
       closeButtonText="Close"
+      contentLayout="fill"
     >
-      <Box sx={{ position: 'relative', height: '100%' }}>
+      <Box
+        sx={{
+          position: 'relative',
+          height: '100%',
+          minHeight: 0,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
         {/* Drawer width resize handle */}
         <Box
           onMouseDown={handleDrawerResizeStart}

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClient.tsx
@@ -11,6 +11,8 @@ import {
   TraceQueryParams,
 } from '@/utils/api-client/interfaces/telemetry';
 import { useNotifications } from '@/components/common/NotificationContext';
+import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { readActiveProjectId } from '@/utils/active-project';
 import {
   buildTraceQueryParams,
   EMPTY_TRACE_DRAWER_FILTERS,
@@ -53,8 +55,13 @@ export default function TracesClient({
   const router = useRouter();
   const pathname = usePathname();
   const notifications = useNotifications();
+  const { activeProject, loading: projectLoading } = useActiveProject();
+  const scopedProjectId = activeProject?.id
+    ? String(activeProject.id)
+    : readActiveProjectId();
   const [traces, setTraces] = useState<TraceSummary[]>([]);
   const [loading, setLoading] = useState(false);
+  const [hasFetchedOnce, setHasFetchedOnce] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [totalCount, setTotalCount] = useState(0);
 
@@ -99,17 +106,33 @@ export default function TracesClient({
     [drawerFilters, searchQuery, typeFilter, pageSize, offset]
   );
 
+  const listLoading = loading || projectLoading;
+
   useEffect(() => {
     let cancelled = false;
 
     const fetchTraces = async () => {
-      if (!sessionToken) return;
+      if (!sessionToken || projectLoading) return;
 
+      // Traces are project-scoped (fail-closed RLS). Wait for active project
+      // resolution before fetching — the cookie may not exist on first paint.
+      if (!scopedProjectId) {
+        setTraces([]);
+        setTotalCount(0);
+        setHasFetchedOnce(false);
+        setLoading(false);
+        return;
+      }
+
+      setHasFetchedOnce(false);
       setLoading(true);
       setError(null);
 
       try {
-        const clientFactory = new ApiClientFactory(sessionToken);
+        const clientFactory = new ApiClientFactory(
+          sessionToken,
+          scopedProjectId
+        );
         const client = clientFactory.getTelemetryClient();
         const response = await client.listTraces(queryParams);
         if (cancelled) return;
@@ -125,7 +148,10 @@ export default function TracesClient({
         setTraces([]);
         setTotalCount(0);
       } finally {
-        if (!cancelled) setLoading(false);
+        if (!cancelled) {
+          setHasFetchedOnce(true);
+          setLoading(false);
+        }
       }
     };
 
@@ -138,6 +164,8 @@ export default function TracesClient({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     sessionToken,
+    projectLoading,
+    scopedProjectId,
     externalRefreshKey,
     drawerFilters,
     searchQuery,
@@ -154,9 +182,17 @@ export default function TracesClient({
         testRunScope: Boolean(fixedTestRunId),
         excludeTestRunId: Boolean(fixedTestRunId),
       });
-    onUnfilteredEmpty?.(!loading && totalCount === 0 && unfiltered);
+    onUnfilteredEmpty?.(
+      hasFetchedOnce &&
+        !listLoading &&
+        !!scopedProjectId &&
+        totalCount === 0 &&
+        unfiltered
+    );
   }, [
-    loading,
+    hasFetchedOnce,
+    listLoading,
+    scopedProjectId,
     totalCount,
     typeFilter,
     searchQuery,
@@ -210,7 +246,8 @@ export default function TracesClient({
     onRefresh?.();
   };
 
-  const showFilteredEmpty = !loading && traces.length === 0 && totalCount === 0;
+  const showFilteredEmpty =
+    !listLoading && traces.length === 0 && totalCount === 0;
 
   return (
     <>
@@ -222,7 +259,7 @@ export default function TracesClient({
 
       <TracesTable
         traces={traces}
-        loading={loading}
+        loading={listLoading}
         onRowClick={handleRowClick}
         totalCount={totalCount}
         page={Math.floor(offset / pageSize)}

--- a/apps/frontend/src/app/(protected)/traces/components/TracesClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesClientWrapper.tsx
@@ -76,8 +76,26 @@ export default function TracesClientWrapper({
         </FabGroup>
       }
     >
-      <Box sx={{ mt: 2, mb: 2 }}>
-        {!showEmptyHint && (
+      <Box sx={{ mt: 2, mb: 2, position: 'relative' }}>
+        {/*
+         * Keep TracesClient mounted so a completed fetch can clear the empty hint.
+         * Unmounting on the first empty response trapped the page even when later
+         * requests returned traces (visible in Network but not in the UI).
+         */}
+        <Box
+          sx={
+            showEmptyHint
+              ? {
+                  position: 'absolute',
+                  width: '100%',
+                  height: 0,
+                  overflow: 'hidden',
+                  visibility: 'hidden',
+                  pointerEvents: 'none',
+                }
+              : {}
+          }
+        >
           <Paper
             sx={{
               width: '100%',
@@ -99,7 +117,7 @@ export default function TracesClientWrapper({
               onUnfilteredEmpty={handleUnfilteredEmpty}
             />
           </Paper>
-        )}
+        </Box>
         {showEmptyHint && (
           <EntityEmptyState
             card

--- a/apps/frontend/src/components/common/BaseDrawer.tsx
+++ b/apps/frontend/src/components/common/BaseDrawer.tsx
@@ -38,6 +38,8 @@ export interface BaseDrawerProps {
   width?: number | string;
   showHeader?: boolean;
   anchor?: 'left' | 'right';
+  /** `form` — scrollable stacked sections; `fill` — full-height workspace (traces, test results). */
+  contentLayout?: 'form' | 'fill';
 }
 
 // Utility function to filter out duplicates and invalid entries
@@ -84,8 +86,10 @@ export default function BaseDrawer({
   width = DRAWER_WIDTH,
   showHeader = true,
   anchor = 'right',
+  contentLayout = 'form',
 }: BaseDrawerProps) {
   const hasFooter = !!(closeButtonText || onSave || onDelete || error);
+  const isFillLayout = contentLayout === 'fill';
 
   return (
     <Drawer
@@ -136,11 +140,11 @@ export default function BaseDrawer({
         sx={{
           flex: 1,
           minHeight: 0,
-          overflowY: 'auto',
+          overflowY: isFillLayout ? 'hidden' : 'auto',
           display: 'flex',
           flexDirection: 'column',
-          gap: '40px',
-          pt: '10px',
+          gap: isFillLayout ? 0 : '40px',
+          pt: isFillLayout ? 0 : '10px',
         }}
       >
         {children}

--- a/apps/frontend/src/components/common/DetailTabNav.tsx
+++ b/apps/frontend/src/components/common/DetailTabNav.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { Box, Typography } from '@mui/material';
+import type { SxProps, Theme } from '@mui/material/styles';
 
 export interface DetailTabNavItem {
   key: string;
@@ -15,6 +16,11 @@ export interface DetailTabNavProps {
   activeIndex: number;
   onChange: (index: number) => void;
   'aria-label'?: string;
+  /** Horizontal space between tabs. Default 50px (full-width detail pages). */
+  tabGap?: string | number;
+  /** Keep tabs on one row with horizontal scroll when they overflow. */
+  scrollable?: boolean;
+  sx?: SxProps<Theme>;
 }
 
 /**
@@ -27,6 +33,9 @@ export function DetailTabNav({
   activeIndex,
   onChange,
   'aria-label': ariaLabel = 'Detail page tabs',
+  tabGap = '50px',
+  scrollable = false,
+  sx,
 }: DetailTabNavProps) {
   const tabRefs = React.useRef<(HTMLButtonElement | null)[]>([]);
 
@@ -49,12 +58,23 @@ export function DetailTabNav({
     <Box
       role="tablist"
       aria-label={ariaLabel}
-      sx={{
-        display: 'flex',
-        gap: '50px',
-        alignItems: 'flex-start',
-        flexWrap: 'wrap',
-      }}
+      sx={[
+        {
+          display: 'flex',
+          gap: tabGap,
+          alignItems: 'flex-start',
+          flexWrap: scrollable ? 'nowrap' : 'wrap',
+          ...(scrollable
+            ? {
+                overflowX: 'auto',
+                overflowY: 'hidden',
+                pb: '2px',
+                scrollbarWidth: 'thin',
+              }
+            : {}),
+        },
+        ...(Array.isArray(sx) ? sx : sx ? [sx] : []),
+      ]}
     >
       {tabs.map((tab, index) => {
         const selected = activeIndex === index;
@@ -85,6 +105,7 @@ export function DetailTabNav({
               cursor: 'pointer',
               outline: 'none',
               minWidth: 0,
+              flexShrink: scrollable ? 0 : 1,
               '&:focus-visible': {
                 outline: '2px solid',
                 outlineColor: 'primary.main',

--- a/apps/frontend/src/components/tasks/TasksAndCommentsWrapper.tsx
+++ b/apps/frontend/src/components/tasks/TasksAndCommentsWrapper.tsx
@@ -104,20 +104,27 @@ export function TasksAndCommentsWrapper({
 
   return (
     <>
-      <TasksSection
-        entityType={entityType}
-        entityId={entityId}
-        sessionToken={sessionToken}
-        onCreateTask={handleCreateTask}
-        onEditTask={handleEditTask}
-        onDeleteTask={handleDeleteTask}
-        onOpenCreateDrawer={handleOpenCreateDrawer}
-        currentUserId={currentUserId}
-        currentUserName={currentUserName}
-        refreshKey={tasksRefreshKey}
-      />
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '30px',
+          '& .MuiPaper-root': { mb: 0 },
+        }}
+      >
+        <TasksSection
+          entityType={entityType}
+          entityId={entityId}
+          sessionToken={sessionToken}
+          onCreateTask={handleCreateTask}
+          onEditTask={handleEditTask}
+          onDeleteTask={handleDeleteTask}
+          onOpenCreateDrawer={handleOpenCreateDrawer}
+          currentUserId={currentUserId}
+          currentUserName={currentUserName}
+          refreshKey={tasksRefreshKey}
+        />
 
-      <Box sx={{ mt: '16px' }}>
         <CommentsWrapper
           entityType={entityType}
           entityId={entityId}


### PR DESCRIPTION
## Purpose

The Traces page could incorrectly show the empty state even when traces existed, and could fail to load traces on first visit because requests were sent before the active project was known.

## Problem

Two related bugs caused the Traces page to appear empty while the Network tab showed successful trace responses:

1. **Project scope race on first fetch** — Traces are project-scoped (fail-closed RLS). `TracesClient` fetched immediately on mount using only the session token. On first paint the active-project cookie/context may not be resolved yet, so `ApiClientFactory` was called without a project ID. That request returned no traces (or was rejected), and the UI treated the result as a real empty project.

2. **Empty hint unmounted the list** — `TracesClientWrapper` conditionally unmounted `TracesClient` when `showEmptyHint` was true. If the first fetch completed empty (from the race above), the empty-state card replaced the list component entirely. Later fetches that returned traces still succeeded in the Network tab, but the list was no longer mounted to render them — leaving the page stuck on the empty hint.

## What Changed

- Wait for `ActiveProjectContext` to finish loading before fetching traces; pass the resolved project ID into `ApiClientFactory`.
- Track `hasFetchedOnce` so the unfiltered empty hint only appears after a completed fetch with a known project.
- Keep `TracesClient` mounted in `TracesClientWrapper` and hide it visually while the empty hint is shown, so a subsequent successful fetch can clear the empty state.

## Additional Context

Hotfix for `release/v0.9.0`.

## Testing

- [ ] Open Traces on a project that has traces (hard refresh / first visit) — list should load instead of empty hint.
- [ ] Switch projects — traces should refresh for the selected project.
- [ ] Project with no traces — empty hint should still appear after fetch completes.
- [ ] Apply filters with no matches — filtered empty state should still work.