### PR TITLE
Fix 'Event loop is closed' in sequential test execution

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/invokers/rest_invoker.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/rest_invoker.py
@@ -46,6 +46,11 @@ def _get_http_client() -> httpx.AsyncClient:
     stored_loop = getattr(_tls, "http_client_loop", None)
 
     if client is None or client.is_closed or stored_loop is not current_loop:
+        if client is not None and not client.is_closed and current_loop is not None:
+            try:
+                current_loop.create_task(client.aclose())
+            except Exception:
+                pass
         client = httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
         _tls.http_client = client
         _tls.http_client_loop = current_loop
@@ -72,6 +77,7 @@ def _close_thread_local_client() -> None:
             pass
         finally:
             _tls.http_client = None
+            _tls.http_client_loop = None
 
 
 class RestEndpointInvoker(BaseEndpointInvoker):

--- a/apps/backend/src/rhesis/backend/app/services/invokers/rest_invoker.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/rest_invoker.py
@@ -35,10 +35,20 @@ _HTTP_TIMEOUT = 30.0
 
 def _get_http_client() -> httpx.AsyncClient:
     """Return the thread-local AsyncClient, creating it on first access."""
+    import asyncio as _asyncio
+
     client: httpx.AsyncClient | None = getattr(_tls, "http_client", None)
-    if client is None or client.is_closed:
+    try:
+        current_loop = _asyncio.get_running_loop()
+    except RuntimeError:
+        current_loop = None
+
+    stored_loop = getattr(_tls, "http_client_loop", None)
+
+    if client is None or client.is_closed or stored_loop is not current_loop:
         client = httpx.AsyncClient(timeout=_HTTP_TIMEOUT)
         _tls.http_client = client
+        _tls.http_client_loop = current_loop
     return client
 
 


### PR DESCRIPTION
## Purpose
Fix `Unexpected error: Event loop is closed` errors in sequential test execution against REST endpoints.

## What Changed
- `_get_http_client()` now tracks which event loop the `httpx.AsyncClient` was created on and recreates the client when the loop changes

## Additional Context
Sequential mode calls `asyncio.run()` per test, which creates and destroys a new event loop each time. The thread-local HTTP client was being reused across these loop lifetimes, but `httpx.AsyncClient` is bound to the loop it was first created on — using it after that loop is closed raises `Event loop is closed`. The existing `client.is_closed` check doesn't catch this because httpx doesn't know the loop was externally destroyed.

Batch mode is unaffected: each worker thread keeps one long-lived loop, so the client is always reused correctly.
