### PR TITLE
fix(endpoints): pass auth token in mapping tab test request

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointMappingTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointMappingTab.tsx
@@ -147,7 +147,7 @@ export default function EndpointMappingTab() {
         request_mapping: bodyToRequestMapping(reqBody),
         response_mapping: responseMapping,
         auth_type: 'bearer_token',
-        auth_token: '',
+        auth_token: endpoint.auth_token || '',
         input_data: inputData,
         endpoint_path: endpoint.endpoint_path || undefined,
         response_format: (endpoint.response_format || 'json') as


### PR DESCRIPTION
## Purpose
Fix 403 errors when running a test from the Mapping tab on endpoints
that use `{{ auth_token }}` in their request headers.

## What Changed
- Pass `endpoint.auth_token` instead of hardcoded `''` when calling
  `testEndpoint` from the mapping tab (`EndpointMappingTab.tsx`)
