### PR TITLE
Fix TraceDrawer project scope for deep-link fetches

### DIFF
--- a/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
@@ -115,7 +115,7 @@ export default function TraceDrawer({
     setSelectedSpan(null);
 
     try {
-      const clientFactory = new ApiClientFactory(sessionToken);
+      const clientFactory = new ApiClientFactory(sessionToken, projectId);
       const client = clientFactory.getTelemetryClient();
       const data = await client.getTrace(traceId, projectId);
       setTrace(data);
@@ -146,7 +146,7 @@ export default function TraceDrawer({
     if (!traceId || !projectId) return;
 
     try {
-      const clientFactory = new ApiClientFactory(sessionToken);
+      const clientFactory = new ApiClientFactory(sessionToken, projectId);
       const client = clientFactory.getTelemetryClient();
       const data = await client.getTrace(traceId, projectId);
       setTrace(data);
@@ -292,12 +292,12 @@ export default function TraceDrawer({
   // Fetch experiment info from test run attributes
   useEffect(() => {
     const fetchExperimentInfo = async () => {
-      if (!trace?.test_run?.id || !sessionToken) {
+      if (!trace?.test_run?.id || !sessionToken || !projectId) {
         setExperimentInfo(null);
         return;
       }
       try {
-        const clientFactory = new ApiClientFactory(sessionToken);
+        const clientFactory = new ApiClientFactory(sessionToken, projectId);
         const testRunsClient = clientFactory.getTestRunsClient();
         const testRun = await testRunsClient.getTestRun(trace.test_run.id);
         if (testRun?.experiment_id) {
@@ -317,7 +317,7 @@ export default function TraceDrawer({
       }
     };
     fetchExperimentInfo();
-  }, [trace?.test_run?.id, sessionToken]);
+  }, [trace?.test_run?.id, sessionToken, projectId]);
 
   // Add keyboard shortcut for ESC key
   useEffect(() => {


### PR DESCRIPTION
## Purpose
TraceDrawer fetches traces with `?project_id=` but without `X-Project-Id`. Backend RLS fail-closes project-scoped rows when the active-project cookie is not set yet (deep links, first paint).

## What Changed
- Pass `projectId` to `ApiClientFactory` in `fetchTrace` and `refreshTrace`
- Apply the same scope to the test-run experiment metadata fetch

## Additional Context
- Follow-up to #1952 review feedback (merged before this fix landed)

## Testing
- Open a trace via deep link (`?open_trace=...&project_id=...`) before the project switcher resolves
- Confirm trace details load instead of 404/empty state
- Refresh trace in drawer and verify span data updates