### PR TITLE
Fix release workflow to call reusable K8s deploy

### DIFF
--- a/.github/workflows/deploy-all-k8s.yml
+++ b/.github/workflows/deploy-all-k8s.yml
@@ -17,9 +17,20 @@ on:
         required: false
         default: ''
         type: string
+  workflow_call:
+    inputs:
+      environment:
+        description: 'Environment to build and push to'
+        required: true
+        type: string
+      tag:
+        description: 'Image tag override (default: short git SHA)'
+        required: false
+        default: ''
+        type: string
 
 concurrency:
-  group: k8s-deploy-all-${{ github.event.inputs.environment }}
+  group: k8s-deploy-all-${{ inputs.environment }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy-all-to-staging:
-    uses: ./.github/workflows/deploy_all.yml
+    uses: ./.github/workflows/deploy-all-k8s.yml
     with:
       environment: stg
     secrets: inherit


### PR DESCRIPTION
## Purpose
Release branches (`release/*`) should trigger a staging deploy when pushed, but `release.yml` referenced a non-existent workflow (`deploy_all.yml`). This wires it to the correct reusable K8s deploy workflow.

## What Changed
- Point `release.yml` at `deploy-all-k8s.yml` instead of `deploy_all.yml`
- Add `workflow_call` inputs to `deploy-all-k8s.yml` so it can be invoked as a reusable workflow
- Use `inputs.environment` in the concurrency group so it works for both `workflow_dispatch` and `workflow_call`

## Additional Context
- `deploy-all-k8s.yml` previously only supported manual `workflow_dispatch` triggers

## Testing
- [ ] Push to a `release/*` branch and confirm the staging deploy workflow runs
- [ ] Manually dispatch `deploy-all-k8s.yml` and confirm concurrency grouping still works