### PR TITLE
Fix release staging deploy missing environment input

### DIFF
--- a/.github/workflows/deploy-all-k8s.yml
+++ b/.github/workflows/deploy-all-k8s.yml
@@ -41,13 +41,13 @@ jobs:
     steps:
       - name: Approve build and push all K8s services
         run: |
-          echo "Building and pushing all K8s service images to ${{ github.event.inputs.environment }}"
-          echo "Tag override: ${{ github.event.inputs.tag || '(short git SHA)' }}"
+          echo "Building and pushing all K8s service images to ${{ inputs.environment }}"
+          echo "Tag override: ${{ inputs.tag || '(short git SHA)' }}"
 
       - id: resolve-tag
         name: Resolve image tag
         run: |
-          TAG="${{ github.event.inputs.tag }}"
+          TAG="${{ inputs.tag }}"
           if [ -z "$TAG" ]; then
             TAG=$(echo "${{ github.sha }}" | cut -c1-8)
           fi
@@ -62,7 +62,7 @@ jobs:
     needs: gate
     uses: ./.github/workflows/backend-k8s.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
+      environment: ${{ inputs.environment }}
       tag: ${{ needs.gate.outputs.tag }}
       deploy: false
     secrets: inherit
@@ -71,7 +71,7 @@ jobs:
     needs: gate
     uses: ./.github/workflows/worker-k8s.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
+      environment: ${{ inputs.environment }}
       tag: ${{ needs.gate.outputs.tag }}
       deploy: false
     secrets: inherit
@@ -80,7 +80,7 @@ jobs:
     needs: gate
     uses: ./.github/workflows/frontend-k8s.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
+      environment: ${{ inputs.environment }}
       tag: ${{ needs.gate.outputs.tag }}
       deploy: false
     secrets: inherit
@@ -89,7 +89,7 @@ jobs:
     needs: gate
     uses: ./.github/workflows/docs-k8s.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
+      environment: ${{ inputs.environment }}
       tag: ${{ needs.gate.outputs.tag }}
       deploy: false
     secrets: inherit
@@ -98,7 +98,7 @@ jobs:
     needs: gate
     uses: ./.github/workflows/polyphemus-k8s.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
+      environment: ${{ inputs.environment }}
       tag: ${{ needs.gate.outputs.tag }}
       deploy: false
     secrets: inherit
@@ -107,7 +107,7 @@ jobs:
     needs: gate
     uses: ./.github/workflows/otel-collector-k8s.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
+      environment: ${{ inputs.environment }}
       tag: ${{ needs.gate.outputs.tag }}
       deploy: false
     secrets: inherit
@@ -116,7 +116,7 @@ jobs:
     needs: gate
     uses: ./.github/workflows/telemetry-processor-k8s.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
+      environment: ${{ inputs.environment }}
       tag: ${{ needs.gate.outputs.tag }}
       deploy: false
     secrets: inherit
@@ -135,7 +135,7 @@ jobs:
       - telemetry-processor-build
     uses: ./.github/workflows/k8s-deploy.yml
     with:
-      environment: ${{ github.event.inputs.environment }}
+      environment: ${{ inputs.environment }}
       tag: ${{ needs.gate.outputs.tag }}
       # service left empty → deploy-all helm-set list in k8s-deploy.yml
     secrets: inherit


### PR DESCRIPTION
## Purpose
Release pushes to `release/*` trigger `[Release] Deploy all to staging`, which calls `deploy-all-k8s.yml` with `environment: stg`. The workflow was reading `github.event.inputs.environment`, which is empty for `workflow_call` triggers, causing all K8s image builds to fail with `ERROR: ENVIRONMENT is not set`.

## What Changed
- Use `inputs.environment` and `inputs.tag` throughout `deploy-all-k8s.yml` instead of `github.event.inputs`
- Applies to gate logging, tag resolution, all service build jobs, and the final deploy-all job

## Additional Context
- Failed run: https://github.com/rhesis-ai/rhesis/actions/runs/27415356041
- Per-service workflows (`backend-k8s.yml`, etc.) already forward `inputs.environment` correctly; the bug was only in the orchestrator workflow

## Testing
- Re-run or push to `release/v0.10.0` after merge; `[Release] Deploy all to staging` should pass the GCP credentials step with `ENVIRONMENT=stg`