### PR TITLE
Add chatbot image to GHCR publish workflow

### DIFF
--- a/.github/workflows/publish-ghcr-images.yml
+++ b/.github/workflows/publish-ghcr-images.yml
@@ -152,6 +152,61 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  chatbot:
+    name: Build chatbot (${{ matrix.platform.arch }})
+    runs-on: ${{ matrix.platform.runner }}
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - arch: amd64
+            os: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            os: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build chatbot by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./apps/chatbot/Dockerfile
+          target: runtime
+          platforms: ${{ matrix.platform.os }}
+          provenance: false
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/chatbot,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v7
+        with:
+          name: digests-chatbot-${{ matrix.platform.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
   merge:
     name: Merge ${{ matrix.image }} manifest
     runs-on: ubuntu-latest
@@ -159,6 +214,7 @@ jobs:
     needs:
       - backend
       - frontend
+      - chatbot
 
     strategy:
       fail-fast: false
@@ -167,6 +223,7 @@ jobs:
           - backend
           - worker
           - frontend
+          - chatbot
 
     steps:
       - name: Download digests


### PR DESCRIPTION
## Summary
- Add a `chatbot` job to `publish-ghcr-images.yml` that builds `apps/chatbot/Dockerfile` for amd64 and arm64
- Push per-arch digests to `ghcr.io/rhesis-ai/chatbot` and merge them into a multi-arch `latest` manifest

## Test plan
- [ ] Trigger `[Build] Docker GitHub Container Registry` workflow via workflow_dispatch
- [ ] Confirm `chatbot` job completes for both amd64 and arm64
- [ ] Confirm merge job publishes `ghcr.io/rhesis-ai/chatbot:latest`