### PR TITLE
Fix unauthentication error testing endpoint mappings

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/routers/endpoint.py
@@ -248,17 +248,13 @@ async def test_endpoint_mapping(
     frontend test unsaved mapping edits without the auth token ever reaching the browser.
     """
     organization_id, user_id = tenant_context
-    endpoint = db.query(models.Endpoint).filter(
-        models.Endpoint.id == endpoint_id
-    ).first()
+    endpoint = crud.get_endpoint(
+        db, endpoint_id=endpoint_id, organization_id=organization_id, user_id=user_id
+    )
     if not endpoint:
         raise HTTPException(status_code=404, detail="Endpoint not found")
 
-    response_format = (
-        test_request.response_format.value
-        if test_request.response_format
-        else None
-    )
+    response_format = test_request.response_format.value if test_request.response_format else None
 
     return await endpoint_service.test_endpoint_mapping(
         db=db,

--- a/apps/backend/src/rhesis/backend/app/routers/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/routers/endpoint.py
@@ -15,7 +15,11 @@ from rhesis.backend.app.dependencies import (
     get_tenant_db_session,
 )
 from rhesis.backend.app.models.user import User
-from rhesis.backend.app.schemas.endpoint import AutoConfigureRequest, AutoConfigureResult
+from rhesis.backend.app.schemas.endpoint import (
+    AutoConfigureRequest,
+    AutoConfigureResult,
+    EndpointMappingTestRequest,
+)
 from rhesis.backend.app.schemas.services import ExploreEndpointRequest, ExploreEndpointResponse
 from rhesis.backend.app.services.endpoint import EndpointService
 from rhesis.backend.app.services.endpoint.auto_configure import AutoConfigureService
@@ -227,6 +231,45 @@ def get_endpoint_schema(endpoint_service: EndpointService = Depends(get_endpoint
 
 
 # --- Routes with path parameters must come AFTER static routes ---
+
+
+@router.post("/{endpoint_id}/test")
+async def test_endpoint_mapping(
+    endpoint_id: uuid.UUID,
+    test_request: EndpointMappingTestRequest,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    endpoint_service: EndpointService = Depends(get_endpoint_service),
+):
+    """Test draft mappings against a stored endpoint using its stored credentials.
+
+    Fetches the endpoint from the database (including its auth token) and invokes it
+    with the provided request/response mapping overrides and input data. This lets the
+    frontend test unsaved mapping edits without the auth token ever reaching the browser.
+    """
+    organization_id, user_id = tenant_context
+    endpoint = db.query(models.Endpoint).filter(
+        models.Endpoint.id == endpoint_id
+    ).first()
+    if not endpoint:
+        raise HTTPException(status_code=404, detail="Endpoint not found")
+
+    response_format = (
+        test_request.response_format.value
+        if test_request.response_format
+        else None
+    )
+
+    return await endpoint_service.test_endpoint_mapping(
+        db=db,
+        endpoint=endpoint,
+        request_mapping=test_request.request_mapping,
+        response_mapping=test_request.response_mapping,
+        input_data=test_request.input_data,
+        organization_id=str(organization_id),
+        user_id=str(user_id),
+        response_format=response_format,
+    )
 
 
 @router.get("/{endpoint_id}", response_model=EndpointDetailSchema)

--- a/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
@@ -173,6 +173,19 @@ class EndpointTestRequest(Base):
         return v
 
 
+class EndpointMappingTestRequest(Base):
+    """Test draft mappings against a stored endpoint using its stored credentials.
+
+    The endpoint's URL, method, headers, and auth are taken from the database.
+    Only the mappings and input data are supplied by the caller.
+    """
+
+    request_mapping: Dict[str, Any]
+    response_mapping: Dict[str, str]
+    input_data: Dict[str, Any]
+    response_format: Optional[EndpointResponseFormat] = None
+
+
 class Endpoint(Base):
     """Response schema - excludes sensitive write-only fields"""
 

--- a/apps/backend/src/rhesis/backend/app/services/endpoint/service.py
+++ b/apps/backend/src/rhesis/backend/app/services/endpoint/service.py
@@ -27,6 +27,7 @@ from .files import (
     inject_file_content_into_input,
 )
 from .testing import test_endpoint as _test_endpoint
+from .testing import test_endpoint_mapping as _test_endpoint_mapping
 
 logger = logging.getLogger(__name__)
 
@@ -415,6 +416,29 @@ class EndpointService:
             test_config=test_config,
             organization_id=organization_id,
             user_id=user_id,
+        )
+
+    async def test_endpoint_mapping(
+        self,
+        db: Session,
+        endpoint: Endpoint,
+        request_mapping: Dict[str, Any],
+        response_mapping: Dict[str, Any],
+        input_data: Dict[str, Any],
+        organization_id: str = None,
+        user_id: str = None,
+        response_format: str = None,
+    ) -> Dict[str, Any]:
+        """Test draft mappings against a stored endpoint using its stored credentials."""
+        return await _test_endpoint_mapping(
+            db=db,
+            endpoint=endpoint,
+            request_mapping=request_mapping,
+            response_mapping=response_mapping,
+            input_data=input_data,
+            organization_id=organization_id,
+            user_id=user_id,
+            response_format=response_format,
         )
 
     async def sync_sdk_endpoints(

--- a/apps/backend/src/rhesis/backend/app/services/endpoint/testing.py
+++ b/apps/backend/src/rhesis/backend/app/services/endpoint/testing.py
@@ -131,3 +131,79 @@ async def test_endpoint(
     except Exception as exc:
         logger.error("Exception testing endpoint: %s", exc, exc_info=True)
         raise HTTPException(status_code=500, detail=str(exc))
+
+
+async def test_endpoint_mapping(
+    db: Session,
+    endpoint: Endpoint,
+    request_mapping: dict,
+    response_mapping: dict,
+    input_data: dict,
+    organization_id: str = None,
+    user_id: str = None,
+    response_format: str = None,
+) -> Dict[str, Any]:
+    """Invoke a stored endpoint with draft request/response mappings.
+
+    Uses the endpoint's stored URL, method, headers, and auth credentials, but
+    substitutes the caller-supplied draft mappings instead of the saved ones.
+    This lets the frontend test unsaved mapping changes without exposing the
+    stored auth token to the browser.
+    """
+    temp_endpoint = Endpoint(
+        name=endpoint.name,
+        connection_type=endpoint.connection_type,
+        url=endpoint.url,
+        method=endpoint.method,
+        endpoint_path=endpoint.endpoint_path,
+        request_headers=endpoint.request_headers,
+        query_params=endpoint.query_params,
+        request_mapping=request_mapping,
+        response_mapping=response_mapping,
+        response_format=response_format or endpoint.response_format,
+        auth_type=endpoint.auth_type,
+        auth_token=endpoint.auth_token,
+        client_id=endpoint.client_id,
+        client_secret=endpoint.client_secret,
+        token_url=endpoint.token_url,
+        scopes=endpoint.scopes,
+        audience=endpoint.audience,
+        extra_payload=endpoint.extra_payload,
+        last_token=endpoint.last_token,
+        last_token_expires_at=endpoint.last_token_expires_at,
+        environment=endpoint.environment,
+        config_source=endpoint.config_source,
+        disable_tracing=True,
+    )
+
+    try:
+        enriched_input_data = input_data.copy()
+        if organization_id:
+            enriched_input_data["organization_id"] = organization_id
+        if user_id:
+            enriched_input_data["user_id"] = user_id
+
+        if (
+            ConversationTracker.detect_stateless_mode(temp_endpoint)
+            and "messages" not in enriched_input_data
+        ):
+            messages: list = []
+            system_prompt = ConversationTracker.extract_system_prompt(temp_endpoint)
+            if system_prompt:
+                messages.append({"role": "system", "content": system_prompt})
+            user_input = enriched_input_data.get("input", "")
+            if user_input:
+                messages.append({"role": "user", "content": user_input})
+            enriched_input_data["messages"] = messages
+            enriched_input_data.pop("conversation_id", None)
+
+        context = InvocationContext(db=db, endpoint=temp_endpoint, input_data=enriched_input_data)
+        result = await create_invoker(context).invoke()
+        logger.debug("Endpoint mapping test completed")
+        return result
+    except ValueError as exc:
+        logger.error("ValueError testing endpoint mapping: %s", exc)
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        logger.error("Exception testing endpoint mapping: %s", exc, exc_info=True)
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/apps/frontend/src/actions/endpoints/index.ts
+++ b/apps/frontend/src/actions/endpoints/index.ts
@@ -1,3 +1,4 @@
 export * from './create';
 export * from './update';
 export * from './invoke';
+export * from './test-mapping';

--- a/apps/frontend/src/actions/endpoints/test-mapping.ts
+++ b/apps/frontend/src/actions/endpoints/test-mapping.ts
@@ -1,0 +1,40 @@
+'use server';
+
+import { auth } from '@/auth';
+import { createServerApiFactory } from '@/utils/api-client/server-factory';
+
+export interface TestEndpointMappingResult {
+  success: boolean;
+  data?: Record<string, unknown>;
+  error?: string;
+}
+
+export async function testEndpointMapping(
+  endpointId: string,
+  inputData: Record<string, unknown>,
+  requestMapping: Record<string, unknown>,
+  responseMapping: Record<string, string>
+): Promise<TestEndpointMappingResult> {
+  try {
+    const session = await auth();
+    if (!session?.session_token) {
+      throw new Error('No session token available');
+    }
+
+    const apiFactory = await createServerApiFactory(session.session_token);
+    const endpointsClient = apiFactory.getEndpointsClient();
+    const response = await endpointsClient.testEndpointMapping(endpointId, {
+      request_mapping: requestMapping,
+      response_mapping: responseMapping,
+      input_data: inputData,
+    });
+
+    return { success: true, data: response };
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : 'An unknown error occurred',
+    };
+  }
+}

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointMappingTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointMappingTab.tsx
@@ -172,6 +172,37 @@ export default function EndpointMappingTab() {
 
       <EditableSection
         title="Manual Mapping"
+        subtitle={
+          <>
+            Define the request format, run a test call, then click the response
+            field that holds your model&apos;s reply.{' '}
+            <Link
+              href="https://docs.rhesis.ai/docs/endpoints/mapping-examples"
+              target="_blank"
+              rel="noopener"
+            >
+              See examples ↗
+            </Link>
+          </>
+        }
+        headerActions={
+          <IconButton
+            aria-label={
+              manualExpanded
+                ? 'Collapse manual mapping'
+                : 'Expand manual mapping'
+            }
+            size="small"
+            onClick={() => setManualExpanded(e => !e)}
+            sx={{ color: 'primary.main' }}
+          >
+            {manualExpanded ? (
+              <KeyboardArrowUpIcon />
+            ) : (
+              <KeyboardArrowDownIcon />
+            )}
+          </IconButton>
+        }
         initialValue={mappingInitial}
         onSave={async draft => {
           let responseMapping: Record<string, string>;
@@ -192,117 +223,81 @@ export default function EndpointMappingTab() {
         }}
       >
         {({ draft, setDraft, isEditing }) => (
-          <SectionCard
-            title="Manual Mapping"
-            subtitle={
-              <>
-                Define the request format, run a test call, then click the
-                response field that holds your model&apos;s reply.{' '}
-                <Link
-                  href="https://docs.rhesis.ai/docs/endpoints/mapping-examples"
-                  target="_blank"
-                  rel="noopener"
-                  onClick={e => e.stopPropagation()}
-                >
-                  See examples ↗
-                </Link>
-              </>
-            }
-            actions={
-              <IconButton
-                aria-label={
-                  manualExpanded
-                    ? 'Collapse manual mapping'
-                    : 'Expand manual mapping'
+          <Collapse in={manualExpanded}>
+            {isEditing ? (
+              <TestAndMap
+                requestTemplate={draft.reqBody}
+                responseMapping={(() => {
+                  try {
+                    return JSON.parse(draft.resBody);
+                  } catch {
+                    return {};
+                  }
+                })()}
+                onRequestTemplateChange={t =>
+                  setDraft(prev => ({ ...prev, reqBody: t }))
                 }
-                size="small"
-                sx={{ color: 'primary.main', pointerEvents: 'none' }}
-              >
-                {manualExpanded ? (
-                  <KeyboardArrowUpIcon />
-                ) : (
-                  <KeyboardArrowDownIcon />
-                )}
-              </IconButton>
-            }
-            onHeaderClick={() => setManualExpanded(e => !e)}
-          >
-            <Collapse in={manualExpanded}>
-              {isEditing ? (
-                <TestAndMap
-                  requestTemplate={draft.reqBody}
-                  responseMapping={(() => {
-                    try {
-                      return JSON.parse(draft.resBody);
-                    } catch {
-                      return {};
-                    }
-                  })()}
-                  onRequestTemplateChange={t =>
-                    setDraft(prev => ({ ...prev, reqBody: t }))
-                  }
-                  onResponseMappingChange={m =>
-                    setDraft(prev => ({
-                      ...prev,
-                      resBody: JSON.stringify(m, null, 2),
-                    }))
-                  }
-                  onTest={inputData =>
-                    handleRunTest(inputData, draft.reqBody, draft.resBody)
-                  }
-                  testResponse={testResponse}
-                  isTestingEndpoint={isTestingEndpoint}
-                />
-              ) : (
-                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-                  <Box>
-                    <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                      Request mapping
-                    </Typography>
-                    <Typography
-                      component="pre"
-                      variant="body2"
-                      sx={{
-                        m: 0,
-                        p: 2,
-                        bgcolor: 'action.hover',
-                        borderRadius: 1,
-                        overflow: 'auto',
-                        fontFamily: 'monospace',
-                        fontSize: 13,
-                        whiteSpace: 'pre-wrap',
-                        wordBreak: 'break-word',
-                      }}
-                    >
-                      {draft.reqBody || '{}'}
-                    </Typography>
-                  </Box>
-                  <Box>
-                    <Typography variant="subtitle2" sx={{ mb: 1 }}>
-                      Response mapping
-                    </Typography>
-                    <Typography
-                      component="pre"
-                      variant="body2"
-                      sx={{
-                        m: 0,
-                        p: 2,
-                        bgcolor: 'action.hover',
-                        borderRadius: 1,
-                        overflow: 'auto',
-                        fontFamily: 'monospace',
-                        fontSize: 13,
-                        whiteSpace: 'pre-wrap',
-                        wordBreak: 'break-word',
-                      }}
-                    >
-                      {draft.resBody || '{}'}
-                    </Typography>
-                  </Box>
+                onResponseMappingChange={m =>
+                  setDraft(prev => ({
+                    ...prev,
+                    resBody: JSON.stringify(m, null, 2),
+                  }))
+                }
+                onTest={inputData =>
+                  handleRunTest(inputData, draft.reqBody, draft.resBody)
+                }
+                testResponse={testResponse}
+                isTestingEndpoint={isTestingEndpoint}
+              />
+            ) : (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+                <Box>
+                  <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                    Request mapping
+                  </Typography>
+                  <Typography
+                    component="pre"
+                    variant="body2"
+                    sx={{
+                      m: 0,
+                      p: 2,
+                      bgcolor: 'action.hover',
+                      borderRadius: 1,
+                      overflow: 'auto',
+                      fontFamily: 'monospace',
+                      fontSize: 13,
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                    }}
+                  >
+                    {draft.reqBody || '{}'}
+                  </Typography>
                 </Box>
-              )}
-            </Collapse>
-          </SectionCard>
+                <Box>
+                  <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                    Response mapping
+                  </Typography>
+                  <Typography
+                    component="pre"
+                    variant="body2"
+                    sx={{
+                      m: 0,
+                      p: 2,
+                      bgcolor: 'action.hover',
+                      borderRadius: 1,
+                      overflow: 'auto',
+                      fontFamily: 'monospace',
+                      fontSize: 13,
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                    }}
+                  >
+                    {draft.resBody || '{}'}
+                  </Typography>
+                </Box>
+              </Box>
+            )}
+          </Collapse>
         )}
       </EditableSection>
 

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointMappingTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointMappingTab.tsx
@@ -9,7 +9,6 @@ import {
   Link,
   Typography,
 } from '@mui/material';
-import { useSession } from 'next-auth/react';
 import {
   AutoFixHighIcon,
   KeyboardArrowDownIcon,
@@ -18,8 +17,8 @@ import {
 import EditableSection from '@/components/common/EditableSection';
 import { SectionCard } from '@/components/common/SectionCard';
 import { useNotifications } from '@/components/common/NotificationContext';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { AutoConfigureResult } from '@/utils/api-client/interfaces/endpoint';
+import { testEndpointMapping } from '@/actions/endpoints';
 import TestAndMap from '../../components/TestAndMap';
 import AutoConfigureDrawer from '../../components/AutoConfigureDrawer';
 import {
@@ -46,7 +45,6 @@ function mappingFromEndpoint(endpoint: {
 
 export default function EndpointMappingTab() {
   const { endpoint, saveFields } = useEndpointDetailContext();
-  const { data: session } = useSession();
   const notifications = useNotifications();
   const [autoConfigureOpen, setAutoConfigureOpen] = useState(false);
   const [manualExpanded, setManualExpanded] = useState(true);
@@ -117,46 +115,22 @@ export default function EndpointMappingTab() {
     setIsTestingEndpoint(true);
     setTestResult(null);
     try {
-      if (!endpoint.url) {
-        throw new Error('Endpoint URL is required');
-      }
-      if (!session?.session_token) {
-        throw new Error('Session token not available');
-      }
-
-      const requestHeaders = (endpoint.request_headers ?? {}) as Record<
-        string,
-        string
-      >;
-
       let responseMapping: Record<string, string> = {};
       try {
         responseMapping = JSON.parse(resBody);
       } catch {
         throw new Error('Invalid response mapping JSON');
       }
-
-      const client = new ApiClientFactory(
-        session.session_token
-      ).getEndpointsClient();
-      const result = await client.testEndpoint({
-        connection_type: 'REST',
-        url: endpoint.url,
-        method: endpoint.method || 'POST',
-        request_headers: requestHeaders,
-        request_mapping: bodyToRequestMapping(reqBody),
-        response_mapping: responseMapping,
-        auth_type: 'bearer_token',
-        auth_token: '',
-        input_data: inputData,
-        endpoint_path: endpoint.endpoint_path || undefined,
-        response_format: (endpoint.response_format || 'json') as
-          | 'json'
-          | 'xml'
-          | 'text',
-      });
-
-      const r = result as Record<string, unknown>;
+      const result = await testEndpointMapping(
+        endpoint.id,
+        inputData,
+        bodyToRequestMapping(reqBody) as Record<string, unknown>,
+        responseMapping
+      );
+      if (!result.success) {
+        throw new Error(result.error ?? 'Test failed');
+      }
+      const r = result.data as Record<string, unknown>;
       const success = r.success !== false && !r.error;
       setTestResult({ success: Boolean(success), response: r });
     } catch (err) {

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
@@ -46,13 +46,13 @@ function maskHeaders(headers: Record<string, string>): Record<string, string> {
 
 function cleanUnresolved(val: unknown): unknown {
   if (Array.isArray(val)) {
-    return val.map(cleanUnresolved).filter(v => v !== null && v !== '');
+    return val.map(cleanUnresolved).filter(v => v !== null);
   }
   if (val && typeof val === 'object') {
     return Object.fromEntries(
       Object.entries(val as Record<string, unknown>)
         .map(([k, v]) => [k, cleanUnresolved(v)])
-        .filter(([, v]) => v !== null && v !== '')
+        .filter(([, v]) => v !== null)
     );
   }
   return val;
@@ -72,15 +72,15 @@ function substituteVars(
       return values[base] !== undefined ? JSON.stringify(values[base]) : 'null';
     }
   );
-  // Unquoted template vars: {{ ... }} → value or ""
+  // Unquoted template vars: {{ ... }} → value or null (so JSON stays valid)
   result = result.replace(
     /\{\{\s*([\w.]+)(?:\s*\|[^}]*)?\s*\}\}/g,
     (_match, name) => {
       const base = name.split('.')[0];
-      return values[base] !== undefined ? String(values[base]) : '';
+      return values[base] !== undefined ? String(values[base]) : 'null';
     }
   );
-  // Remove nulls and empty strings left by unresolved vars
+  // Remove nulls left by unresolved vars
   try {
     return JSON.stringify(cleanUnresolved(JSON.parse(result)), null, 2);
   } catch {

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
@@ -8,109 +8,13 @@ import { useEndpointDetailContext } from './EndpointDetailContext';
 import { invokeEndpoint } from '@/actions/endpoints';
 import EndpointTestWorkbench from '../../components/EndpointTestWorkbench';
 import { responseMappingToPathToVar } from '../../components/JsonPreview';
-
-function extractVars(template: string): string[] {
-  const vars = new Set<string>();
-  for (const m of template.matchAll(/\{\{\s*([\w.]+)(?:\s*\|[^}]*)?\s*\}\}/g)) {
-    vars.add(m[1].split('.')[0]);
-  }
-  return [...vars];
-}
-
-function applyJsonPath(obj: unknown, path: string): unknown {
-  const cleaned = path.replace(/^\$\.?/, '');
-  if (!cleaned) return obj;
-  const parts: string[] = [];
-  const re = /([^.[]+)|\[(\d+)\]/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(cleaned)) !== null) parts.push(m[1] ?? m[2]);
-  let cur: unknown = obj;
-  for (const p of parts) {
-    if (cur == null || typeof cur !== 'object') return undefined;
-    cur = (cur as Record<string, unknown>)[p];
-  }
-  return cur;
-}
-
-const SENSITIVE_HEADERS = new Set(['authorization', 'x-api-key', 'api-key']);
-
-function maskHeaders(headers: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(headers).map(([k, v]) => {
-      if (!SENSITIVE_HEADERS.has(k.toLowerCase())) return [k, v];
-      const prefix = v.match(/^(Bearer\s+)/i)?.[1] ?? '';
-      return [k, `${prefix}[hidden]`];
-    })
-  );
-}
-
-function cleanUnresolved(val: unknown): unknown {
-  if (Array.isArray(val)) {
-    return val.map(cleanUnresolved).filter(v => v !== null);
-  }
-  if (val && typeof val === 'object') {
-    return Object.fromEntries(
-      Object.entries(val as Record<string, unknown>)
-        .map(([k, v]) => [k, cleanUnresolved(v)])
-        .filter(([, v]) => v !== null)
-    );
-  }
-  return val;
-}
-
-function substituteVars(
-  template: string,
-  values: Record<string, string>
-): string {
-  // Quoted template vars: "{{ ... }}" → value or null (so JSON stays valid)
-  let result = template.replace(
-    /"(\{\{\s*[\w.]+(?:\s*\|[^}]*)?\s*\}\})"/g,
-    match => {
-      const nameMatch = match.match(/\{\{\s*([\w.]+)/);
-      if (!nameMatch) return 'null';
-      const base = nameMatch[1].split('.')[0];
-      return values[base] !== undefined ? JSON.stringify(values[base]) : 'null';
-    }
-  );
-  // Unquoted template vars: {{ ... }} → value or null (so JSON stays valid)
-  result = result.replace(
-    /\{\{\s*([\w.]+)(?:\s*\|[^}]*)?\s*\}\}/g,
-    (_match, name) => {
-      const base = name.split('.')[0];
-      return values[base] !== undefined ? String(values[base]) : 'null';
-    }
-  );
-  // Remove nulls left by unresolved vars
-  try {
-    return JSON.stringify(cleanUnresolved(JSON.parse(result)), null, 2);
-  } catch {
-    return result;
-  }
-}
-
-function buildCurl(
-  method: string,
-  url: string,
-  headers: Record<string, string>,
-  body: string
-): string {
-  const lines: string[] = [`curl -X ${method} '${url}'`];
-  for (const [k, v] of Object.entries(maskHeaders(headers))) {
-    lines.push(`  -H '${k}: ${v}'`);
-  }
-  const trimmed = body.trim();
-  if (trimmed && trimmed !== '{}') {
-    const pretty = (() => {
-      try {
-        return JSON.stringify(JSON.parse(trimmed), null, 2);
-      } catch {
-        return trimmed;
-      }
-    })();
-    lines.push(`  -d '${pretty.replace(/'/g, "\\'")}'`);
-  }
-  return lines.join(' \\\n');
-}
+import {
+  extractVars,
+  applyJsonPath,
+  maskHeaders,
+  substituteVars,
+  buildCurl,
+} from '../../components/endpoint-template-utils';
 
 export default function EndpointTestTab() {
   const { endpoint } = useEndpointDetailContext();

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
@@ -44,27 +44,48 @@ function maskHeaders(headers: Record<string, string>): Record<string, string> {
   );
 }
 
+function cleanUnresolved(val: unknown): unknown {
+  if (Array.isArray(val)) {
+    return val.map(cleanUnresolved).filter(v => v !== null && v !== '');
+  }
+  if (val && typeof val === 'object') {
+    return Object.fromEntries(
+      Object.entries(val as Record<string, unknown>)
+        .map(([k, v]) => [k, cleanUnresolved(v)])
+        .filter(([, v]) => v !== null && v !== '')
+    );
+  }
+  return val;
+}
+
 function substituteVars(
   template: string,
   values: Record<string, string>
 ): string {
+  // Quoted template vars: "{{ ... }}" → value or null (so JSON stays valid)
   let result = template.replace(
     /"(\{\{\s*[\w.]+(?:\s*\|[^}]*)?\s*\}\})"/g,
     match => {
       const nameMatch = match.match(/\{\{\s*([\w.]+)/);
-      if (!nameMatch) return match;
+      if (!nameMatch) return 'null';
       const base = nameMatch[1].split('.')[0];
-      return values[base] !== undefined ? JSON.stringify(values[base]) : match;
+      return values[base] !== undefined ? JSON.stringify(values[base]) : 'null';
     }
   );
+  // Unquoted template vars: {{ ... }} → value or ""
   result = result.replace(
     /\{\{\s*([\w.]+)(?:\s*\|[^}]*)?\s*\}\}/g,
     (_match, name) => {
       const base = name.split('.')[0];
-      return values[base] !== undefined ? String(values[base]) : _match;
+      return values[base] !== undefined ? String(values[base]) : '';
     }
   );
-  return result;
+  // Remove nulls and empty strings left by unresolved vars
+  try {
+    return JSON.stringify(cleanUnresolved(JSON.parse(result)), null, 2);
+  } catch {
+    return result;
+  }
 }
 
 function buildCurl(

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/endpoint-detail-shared.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/endpoint-detail-shared.tsx
@@ -1,36 +1,9 @@
 'use client';
 
-import React from 'react';
-import {
-  SmartToyIcon,
-  DevicesIcon,
-  WebIcon,
-  StorageIcon,
-  CodeIcon,
-  DataObjectIcon,
-  CloudIcon,
-  AnalyticsIcon,
-  ShoppingCartIcon,
-  TerminalIcon,
-  VideogameAssetIcon,
-  ChatIcon,
-  PsychologyIcon,
-  DashboardIcon,
-  SearchIcon,
-  AutoFixHighIcon,
-  PhoneIphoneIcon,
-  SchoolIcon,
-  ScienceIcon,
-  AccountTreeIcon,
-} from '@/components/icons';
-import { Project } from '@/utils/api-client/interfaces/project';
-
-export const ENVIRONMENTS = [
-  'production',
-  'staging',
-  'development',
-  'local',
-] as const;
+export {
+  ENVIRONMENTS,
+  getProjectIcon,
+} from '../../components/endpoint-icon-utils';
 
 export const METHODS = ['POST'] as const;
 
@@ -47,37 +20,6 @@ export type EndpointTabKey = (typeof TAB_KEYS)[number];
 export const LEGACY_TAB_MAP: Record<string, EndpointTabKey> = {
   mappings: 'connection-test',
 };
-
-const ICON_MAP: Record<string, React.ComponentType> = {
-  SmartToy: SmartToyIcon,
-  Devices: DevicesIcon,
-  Web: WebIcon,
-  Storage: StorageIcon,
-  Code: CodeIcon,
-  DataObject: DataObjectIcon,
-  Cloud: CloudIcon,
-  Analytics: AnalyticsIcon,
-  ShoppingCart: ShoppingCartIcon,
-  Terminal: TerminalIcon,
-  VideogameAsset: VideogameAssetIcon,
-  Chat: ChatIcon,
-  Psychology: PsychologyIcon,
-  Dashboard: DashboardIcon,
-  Search: SearchIcon,
-  AutoFixHigh: AutoFixHighIcon,
-  PhoneIphone: PhoneIphoneIcon,
-  School: SchoolIcon,
-  Science: ScienceIcon,
-  AccountTree: AccountTreeIcon,
-};
-
-export function getProjectIcon(project: Project) {
-  if (project?.icon && ICON_MAP[project.icon]) {
-    const IconComponent = ICON_MAP[project.icon];
-    return <IconComponent />;
-  }
-  return <SmartToyIcon />;
-}
 
 export function getEnvironmentChipColor():
   | 'default'

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointHeadersFields.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointHeadersFields.tsx
@@ -64,6 +64,7 @@ export default function EndpointHeadersFields({
       <Chip
         label="{{ auth_token }}"
         size="small"
+        component="span"
         sx={{
           ...variableChipSx,
           height: 18,

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointTestWorkbench.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointTestWorkbench.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import {
   Box,
   Typography,
@@ -12,8 +12,11 @@ import {
   Grid,
 } from '@mui/material';
 import FormSectionDivider from '@/components/common/FormSectionDivider';
-import ViewField from '@/components/common/ViewField';
-import { variableChipSx, testPreviewSx } from './endpoint-styles';
+import {
+  variableChipSx,
+  testPreviewSx,
+  fieldSurfaceBoxSx,
+} from './endpoint-styles';
 import { JsonPreview, TemplatePreview } from './JsonPreview';
 import {
   FileUploadIcon,
@@ -81,259 +84,290 @@ export default function EndpointTestWorkbench({
 
   const isSuccess = statusCode.startsWith('2');
 
+  const varRow = (
+    key: string,
+    chip: React.ReactNode,
+    content: React.ReactNode
+  ) => (
+    <Box key={key} sx={{ display: 'flex', alignItems: 'flex-start', gap: 1.5 }}>
+      <Box sx={{ flexShrink: 0, pt: '7px' }}>{chip}</Box>
+      <Box sx={{ flex: 1, minWidth: 0 }}>{content}</Box>
+    </Box>
+  );
+
   return (
     <Grid container spacing={4}>
-      {/* Left column: Request */}
+      {/* Row 1: Input variables | Mapped output */}
       <Grid size={{ xs: 12, md: 6 }}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-          <Box>
-            <FormSectionDivider
-              headline="Request preview"
-              descriptiveText={`${method || 'POST'} ${url || '—'}`}
-            />
-            <Box
-              sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 2 }}
-            >
-              <Box>
-                <Button
-                  size="small"
-                  variant="text"
-                  onClick={() => setCurlExpanded(v => !v)}
-                  endIcon={
-                    curlExpanded ? (
-                      <KeyboardArrowUpIcon />
-                    ) : (
-                      <KeyboardArrowDownIcon />
-                    )
-                  }
-                  sx={{ mb: 1, color: 'text.secondary', textTransform: 'none' }}
-                >
-                  cURL command
-                </Button>
-                <Collapse in={curlExpanded}>
-                  <Box component="pre" sx={testPreviewSx}>
-                    {curlText}
-                  </Box>
-                </Collapse>
-              </Box>
-              <ViewField label="Request body template">
-                <Box
-                  component="pre"
-                  sx={{ ...testPreviewSx, p: 0, minHeight: 'unset' }}
-                >
-                  <TemplatePreview template={requestTemplate || '{}'} />
-                </Box>
-              </ViewField>
-            </Box>
-          </Box>
-
-          <Box>
-            <FormSectionDivider
-              headline="Input variables"
-              descriptiveText="Values Rhesis substitutes into the request before sending."
-            />
-            <Box
-              sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1.5 }}
-            >
-              {inputVars.length === 0 ? (
-                <Typography variant="body2" sx={{ color: 'text.disabled' }}>
-                  No template variables in request body.
-                </Typography>
-              ) : (
-                inputVars.map(v => (
-                  <Box
-                    key={v}
-                    sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}
-                  >
-                    <Chip
-                      label={`{{ ${v} }}`}
-                      size="small"
-                      sx={{ ...variableChipSx, flexShrink: 0, mt: 0.5 }}
+        <FormSectionDivider
+          headline="Mapped Input"
+          descriptiveText="Values Rhesis substitutes into the request before sending."
+        />
+        <Box sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 1.5 }}>
+          {inputVars.length === 0 ? (
+            <Typography variant="body2" sx={{ color: 'text.disabled' }}>
+              No template variables in request body.
+            </Typography>
+          ) : (
+            inputVars.map(v =>
+              varRow(
+                v,
+                <Chip label={`{{ ${v} }}`} size="small" sx={variableChipSx} />,
+                FILE_VAR_RE.test(v) ? (
+                  <>
+                    <input
+                      type="file"
+                      multiple
+                      ref={el => {
+                        fileInputRefs.current[v] = el;
+                      }}
+                      style={{ display: 'none' }}
+                      onChange={e =>
+                        onFileValuesChange({
+                          ...fileValues,
+                          [v]: Array.from(e.target.files ?? []),
+                        })
+                      }
                     />
-                    {FILE_VAR_RE.test(v) ? (
-                      <>
-                        <input
-                          type="file"
-                          multiple
-                          ref={el => {
-                            fileInputRefs.current[v] = el;
-                          }}
-                          style={{ display: 'none' }}
-                          onChange={e =>
-                            onFileValuesChange({
-                              ...fileValues,
-                              [v]: Array.from(e.target.files ?? []),
-                            })
-                          }
-                        />
-                        <Button
-                          variant="outlined"
-                          size="small"
-                          startIcon={<FileUploadIcon />}
-                          onClick={() => fileInputRefs.current[v]?.click()}
-                        >
-                          {(fileValues[v]?.length ?? 0) > 0
-                            ? fileValues[v].map(f => f.name).join(', ')
-                            : 'Upload'}
-                        </Button>
-                      </>
-                    ) : (
-                      <TextField
-                        size="small"
-                        fullWidth
-                        multiline={v === 'input' || v === 'system_prompt'}
-                        maxRows={4}
-                        placeholder={
-                          v === 'conversation_id'
-                            ? 'Auto-filled from last response'
-                            : ''
-                        }
-                        value={varValues[v] ?? ''}
-                        onChange={e =>
-                          onVarValuesChange({
-                            ...varValues,
-                            [v]: e.target.value,
-                          })
-                        }
-                      />
-                    )}
-                  </Box>
-                ))
-              )}
-            </Box>
-          </Box>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      startIcon={<FileUploadIcon />}
+                      onClick={() => fileInputRefs.current[v]?.click()}
+                    >
+                      {(fileValues[v]?.length ?? 0) > 0
+                        ? fileValues[v].map(f => f.name).join(', ')
+                        : 'Upload'}
+                    </Button>
+                  </>
+                ) : (
+                  <TextField
+                    key={v}
+                    size="small"
+                    fullWidth
+                    multiline={v === 'input' || v === 'system_prompt'}
+                    maxRows={4}
+                    placeholder={
+                      v === 'conversation_id'
+                        ? 'Auto-filled from last response'
+                        : ''
+                    }
+                    value={varValues[v] ?? ''}
+                    onChange={e =>
+                      onVarValuesChange({ ...varValues, [v]: e.target.value })
+                    }
+                  />
+                )
+              )
+            )
+          )}
         </Box>
       </Grid>
 
-      {/* Right column: Response */}
       <Grid size={{ xs: 12, md: 6 }}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-          <Box>
-            <FormSectionDivider
-              headline="Response"
-              descriptiveText={
-                isTestingEndpoint
-                  ? 'Waiting for response…'
-                  : statusCode
-                    ? `Status: ${statusCode}`
-                    : 'Run a test to see the response.'
-              }
-            />
-            <Box
-              sx={{ mt: 2, display: 'flex', flexDirection: 'column', gap: 2 }}
+        <FormSectionDivider
+          headline="Mapped Output"
+          descriptiveText="Values Rhesis extracts using your response mapping."
+        />
+        <Box
+          sx={{
+            mt: 2,
+            display: 'grid',
+            gridTemplateColumns: 'max-content 1fr',
+            gap: '12px 12px',
+            alignItems: 'start',
+          }}
+        >
+          {Object.keys(responseMapping).length === 0 ? (
+            <Typography
+              variant="body2"
+              sx={{ color: 'text.disabled', gridColumn: '1 / -1' }}
             >
-              {statusCode ? (
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <Box
-                    sx={{
-                      width: 8,
-                      height: 8,
-                      borderRadius: '50%',
-                      bgcolor: isSuccess ? 'success.main' : 'error.main',
-                    }}
-                  />
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      fontFamily: 'monospace',
-                      fontWeight: 700,
-                      color: isSuccess ? 'success.main' : 'error.main',
-                    }}
-                  >
-                    {statusCode}
-                  </Typography>
-                  {rawResponse != null && (
-                    <Button
+              No response mapping configured yet.
+            </Typography>
+          ) : (
+            Object.entries(responseMapping).map(([varName, path]) => {
+              const display = formatMappedValue(mappedValues[varName]);
+              return (
+                <React.Fragment key={varName}>
+                  <Box sx={{ pt: '5px' }}>
+                    <Chip
+                      label={`{{ ${varName} }}`}
                       size="small"
-                      variant="text"
-                      onClick={() => setRawExpanded(v => !v)}
-                      endIcon={
-                        rawExpanded ? (
-                          <KeyboardArrowUpIcon />
-                        ) : (
-                          <KeyboardArrowDownIcon />
-                        )
-                      }
-                      sx={{
-                        ml: 'auto',
-                        color: 'text.secondary',
-                        textTransform: 'none',
-                      }}
-                    >
-                      Raw response
-                    </Button>
-                  )}
-                </Box>
-              ) : null}
-              {rawResponse != null && (
-                <Collapse in={rawExpanded}>
-                  <Box component="pre" sx={testPreviewSx}>
-                    {rawResponseText}
+                      sx={variableChipSx}
+                    />
                   </Box>
-                </Collapse>
-              )}
-              <ViewField label="Mapped response preview">
-                {rawResponse != null ? (
-                  <Box
-                    component="pre"
-                    sx={{ ...testPreviewSx, p: 0, minHeight: 'unset' }}
-                  >
-                    <JsonPreview value={rawResponse} pathToVar={pathToVar} />
-                  </Box>
-                ) : (
-                  <Typography
-                    sx={{
-                      fontSize: 12,
-                      lineHeight: '24px',
-                      color: theme => theme.palette.greyscale.subtitle,
-                      fontFamily: 'monospace',
-                    }}
-                  >
-                    Run a test to see the response
-                  </Typography>
-                )}
-              </ViewField>
-            </Box>
-          </Box>
-
-          <Box>
-            <FormSectionDivider
-              headline="Mapped output"
-              descriptiveText="Values Rhesis extracts using your response mapping."
-            />
-            <Box sx={{ mt: 2 }}>
-              {Object.keys(responseMapping).length === 0 ? (
-                <Typography variant="body2" sx={{ color: 'text.disabled' }}>
-                  No response mapping configured yet.
-                </Typography>
-              ) : (
-                <Grid container spacing={2}>
-                  {Object.entries(responseMapping).map(([varName, path]) => {
-                    const val = mappedValues[varName];
-                    const display = formatMappedValue(val);
-                    return (
-                      <Grid
-                        key={varName}
-                        size={{
-                          xs: 12,
-                          md: Object.keys(responseMapping).length > 1 ? 6 : 12,
+                  <Box>
+                    <Box sx={fieldSurfaceBoxSx}>
+                      <Typography
+                        sx={{
+                          fontSize: 12,
+                          lineHeight: '20px',
+                          color: theme => theme.palette.greyscale.body,
+                          fontFamily: 'monospace',
+                          whiteSpace: 'pre-wrap',
+                          wordBreak: 'break-word',
                         }}
                       >
-                        <ViewField
-                          label={`{{ ${varName} }}`}
-                          value={display || undefined}
-                          helperText={rawResponse ? undefined : path}
-                          multiline
-                          inputSx={{ fontFamily: 'monospace', fontSize: 12 }}
-                        />
-                      </Grid>
-                    );
-                  })}
-                </Grid>
-              )}
-            </Box>
-          </Box>
+                        {display || '—'}
+                      </Typography>
+                    </Box>
+                    {!rawResponse && path && (
+                      <Typography
+                        sx={{
+                          fontSize: 11,
+                          color: theme => theme.palette.greyscale.subtitle,
+                          fontFamily: 'monospace',
+                          pt: '3px',
+                        }}
+                      >
+                        {path}
+                      </Typography>
+                    )}
+                  </Box>
+                </React.Fragment>
+              );
+            })
+          )}
+        </Box>
+      </Grid>
 
+      {/* Row 2a: section headings */}
+      <Grid size={{ xs: 12, md: 6 }}>
+        <FormSectionDivider headline="Request" />
+      </Grid>
+      <Grid size={{ xs: 12, md: 6 }}>
+        <FormSectionDivider
+          headline="Response"
+          descriptiveText={
+            isTestingEndpoint ? 'Waiting for response…' : undefined
+          }
+        />
+      </Grid>
+
+      {/* Row 2b: URL | empty — same CSS grid row keeps them equal height */}
+      <Grid size={{ xs: 12, md: 6 }}>
+        <Typography
+          variant="body2"
+          sx={{
+            fontFamily: 'monospace',
+            fontSize: 12,
+            color: 'text.secondary',
+          }}
+        >
+          {method || 'POST'} {url || '—'}
+        </Typography>
+      </Grid>
+      <Grid size={{ xs: 12, md: 6 }}>
+        {statusCode && (
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Box
+              sx={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                bgcolor: isSuccess ? 'success.main' : 'error.main',
+              }}
+            />
+            <Typography
+              variant="body2"
+              sx={{
+                fontFamily: 'monospace',
+                fontWeight: 700,
+                color: isSuccess ? 'success.main' : 'error.main',
+              }}
+            >
+              {statusCode}
+            </Typography>
+          </Box>
+        )}
+      </Grid>
+
+      {/* Row 2c: JSON blocks — aligned */}
+      <Grid size={{ xs: 12, md: 6 }}>
+        <Box component="pre" sx={{ ...testPreviewSx, minHeight: 'unset' }}>
+          <TemplatePreview template={requestTemplate || '{}'} />
+        </Box>
+      </Grid>
+      <Grid size={{ xs: 12, md: 6 }}>
+        {rawResponse != null ? (
+          <Box component="pre" sx={{ ...testPreviewSx, minHeight: 'unset' }}>
+            <JsonPreview value={rawResponse} pathToVar={pathToVar} />
+          </Box>
+        ) : (
+          <Typography
+            sx={{
+              fontSize: 12,
+              lineHeight: '24px',
+              color: theme => theme.palette.greyscale.subtitle,
+              fontFamily: 'monospace',
+            }}
+          >
+            Run a test to see the response
+          </Typography>
+        )}
+      </Grid>
+
+      {/* Row 2d: secondary controls */}
+      <Grid size={{ xs: 12, md: 6 }}>
+        {(rawResponse != null || !!statusCode) && (
+          <Box>
+            <Button
+              size="small"
+              variant="text"
+              onClick={() => setCurlExpanded(v => !v)}
+              endIcon={
+                curlExpanded ? (
+                  <KeyboardArrowUpIcon />
+                ) : (
+                  <KeyboardArrowDownIcon />
+                )
+              }
+              sx={{ mb: 1, color: 'text.secondary', textTransform: 'none' }}
+            >
+              cURL command
+            </Button>
+            <Collapse in={curlExpanded}>
+              <Box component="pre" sx={testPreviewSx}>
+                {curlText}
+              </Box>
+            </Collapse>
+          </Box>
+        )}
+      </Grid>
+      <Grid size={{ xs: 12, md: 6 }}>
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'flex-start',
+            gap: 2,
+          }}
+        >
+          {rawResponse != null && (
+            <Button
+              size="small"
+              variant="text"
+              onClick={() => setRawExpanded(v => !v)}
+              endIcon={
+                rawExpanded ? (
+                  <KeyboardArrowUpIcon />
+                ) : (
+                  <KeyboardArrowDownIcon />
+                )
+              }
+              sx={{ color: 'text.secondary', textTransform: 'none' }}
+            >
+              Raw response
+            </Button>
+          )}
+          {rawResponse != null && (
+            <Collapse in={rawExpanded}>
+              <Box component="pre" sx={testPreviewSx}>
+                {rawResponseText}
+              </Box>
+            </Collapse>
+          )}
           {error && <Alert severity="error">{error}</Alert>}
         </Box>
       </Grid>

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -22,13 +22,6 @@ import {
 import BaseDataGrid from '@/components/common/BaseDataGrid';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import { Project } from '@/utils/api-client/interfaces/project';
-import {
-  SmartToyIcon,
-  DevicesIcon,
-  WebIcon,
-  StorageIcon,
-  CodeIcon,
-} from '@/components/icons';
 import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { DeleteModal } from '@/components/common/DeleteModal';
@@ -44,55 +37,7 @@ import {
   createRowActionsColumn,
   rowActionsHoverSx,
 } from '@/components/common/createRowActionsColumn';
-import DataObjectIcon from '@mui/icons-material/DataObject';
-import CloudIcon from '@mui/icons-material/Cloud';
-import AnalyticsIcon from '@mui/icons-material/Analytics';
-import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
-import TerminalIcon from '@mui/icons-material/Terminal';
-import VideogameAssetIcon from '@mui/icons-material/VideogameAsset';
-import ChatIcon from '@mui/icons-material/Chat';
-import PsychologyIcon from '@mui/icons-material/Psychology';
-import DashboardIcon from '@mui/icons-material/Dashboard';
-import SearchIcon from '@mui/icons-material/Search';
-import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
-import PhoneIphoneIcon from '@mui/icons-material/PhoneIphone';
-import SchoolIcon from '@mui/icons-material/School';
-import ScienceIcon from '@mui/icons-material/Science';
-import AccountTreeIcon from '@mui/icons-material/AccountTree';
-
-const ICON_MAP: Record<string, React.ComponentType> = {
-  SmartToy: SmartToyIcon,
-  Devices: DevicesIcon,
-  Web: WebIcon,
-  Storage: StorageIcon,
-  Code: CodeIcon,
-  DataObject: DataObjectIcon,
-  Cloud: CloudIcon,
-  Analytics: AnalyticsIcon,
-  ShoppingCart: ShoppingCartIcon,
-  Terminal: TerminalIcon,
-  VideogameAsset: VideogameAssetIcon,
-  Chat: ChatIcon,
-  Psychology: PsychologyIcon,
-  Dashboard: DashboardIcon,
-  Search: SearchIcon,
-  AutoFixHigh: AutoFixHighIcon,
-  PhoneIphone: PhoneIphoneIcon,
-  School: SchoolIcon,
-  Science: ScienceIcon,
-  AccountTree: AccountTreeIcon,
-};
-
-const getProjectIcon = (project: Project | undefined) => {
-  if (!project) {
-    return <SmartToyIcon />;
-  }
-  if (project.icon && ICON_MAP[project.icon]) {
-    const IconComponent = ICON_MAP[project.icon];
-    return <IconComponent />;
-  }
-  return <SmartToyIcon />;
-};
+import { getProjectIcon } from './endpoint-icon-utils';
 
 interface EndpointsGridProps {
   sessionToken?: string;

--- a/apps/frontend/src/app/(protected)/endpoints/components/SwaggerEndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/SwaggerEndpointForm.tsx
@@ -32,65 +32,7 @@ import { useOnboarding } from '@/contexts/OnboardingContext';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { readActiveProjectId } from '@/utils/active-project';
 
-// Import icons for project icon rendering
-import SmartToyIcon from '@mui/icons-material/SmartToy';
-import DevicesIcon from '@mui/icons-material/Devices';
-import WebIcon from '@mui/icons-material/Web';
-import StorageIcon from '@mui/icons-material/Storage';
-import CodeIcon from '@mui/icons-material/Code';
-import DataObjectIcon from '@mui/icons-material/DataObject';
-import CloudIcon from '@mui/icons-material/Cloud';
-import AnalyticsIcon from '@mui/icons-material/Analytics';
-import ShoppingCartIcon from '@mui/icons-material/ShoppingCart';
-import TerminalIcon from '@mui/icons-material/Terminal';
-import VideogameAssetIcon from '@mui/icons-material/VideogameAsset';
-import ChatIcon from '@mui/icons-material/Chat';
-import PsychologyIcon from '@mui/icons-material/Psychology';
-import DashboardIcon from '@mui/icons-material/Dashboard';
-import SearchIcon from '@mui/icons-material/Search';
-import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
-import PhoneIphoneIcon from '@mui/icons-material/PhoneIphone';
-import SchoolIcon from '@mui/icons-material/School';
-import ScienceIcon from '@mui/icons-material/Science';
-import AccountTreeIcon from '@mui/icons-material/AccountTree';
-
-// Map of icon names to components for easy lookup
-const ICON_MAP: Record<string, React.ComponentType> = {
-  SmartToy: SmartToyIcon,
-  Devices: DevicesIcon,
-  Web: WebIcon,
-  Storage: StorageIcon,
-  Code: CodeIcon,
-  DataObject: DataObjectIcon,
-  Cloud: CloudIcon,
-  Analytics: AnalyticsIcon,
-  ShoppingCart: ShoppingCartIcon,
-  Terminal: TerminalIcon,
-  VideogameAsset: VideogameAssetIcon,
-  Chat: ChatIcon,
-  Psychology: PsychologyIcon,
-  Dashboard: DashboardIcon,
-  Search: SearchIcon,
-  AutoFixHigh: AutoFixHighIcon,
-  PhoneIphone: PhoneIphoneIcon,
-  School: SchoolIcon,
-  Science: ScienceIcon,
-  AccountTree: AccountTreeIcon,
-};
-
-const ENVIRONMENTS = ['production', 'staging', 'development', 'local'];
-
-// Get appropriate icon based on project type or use case
-const getProjectIcon = (project: Project) => {
-  // Check if a specific project icon was selected during creation
-  if (project?.icon && ICON_MAP[project.icon]) {
-    const IconComponent = ICON_MAP[project.icon];
-    return <IconComponent />;
-  }
-
-  // Fall back to a default icon
-  return <SmartToyIcon />;
-};
+import { getProjectIcon, ENVIRONMENTS } from './endpoint-icon-utils';
 
 export default function SwaggerEndpointForm() {
   const router = useRouter();

--- a/apps/frontend/src/app/(protected)/endpoints/components/TestAndMap.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/TestAndMap.tsx
@@ -20,6 +20,7 @@ import { LoadingButton } from '@mui/lab';
 import { PlayArrowIcon } from '@/components/icons';
 import RequestBodyEditor from './RequestBodyEditor';
 import FormSectionDivider from '@/components/common/FormSectionDivider';
+import { sectionContainedButtonSx } from '@/components/common/SectionCardActions';
 import { alpha, type Theme } from '@mui/material/styles';
 import { testPreviewSx } from './endpoint-styles';
 import VariableChip from './VariableChip';
@@ -581,14 +582,13 @@ export default function TestAndMap({
           />
           <LoadingButton
             variant="contained"
-            size="small"
             onClick={handleQuickTest}
             loading={isTestingEndpoint}
             loadingPosition="start"
             startIcon={<PlayArrowIcon />}
-            sx={{ flexShrink: 0, mt: 0.5 }}
+            sx={{ ...sectionContainedButtonSx, flexShrink: 0, mt: 0.5 }}
           >
-            Test
+            Run test
           </LoadingButton>
         </Box>
         <RequestBodyEditor

--- a/apps/frontend/src/app/(protected)/endpoints/components/endpoint-icon-utils.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/endpoint-icon-utils.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import {
+  SmartToyIcon,
+  DevicesIcon,
+  WebIcon,
+  StorageIcon,
+  CodeIcon,
+  DataObjectIcon,
+  CloudIcon,
+  AnalyticsIcon,
+  ShoppingCartIcon,
+  TerminalIcon,
+  VideogameAssetIcon,
+  ChatIcon,
+  PsychologyIcon,
+  DashboardIcon,
+  SearchIcon,
+  AutoFixHighIcon,
+  PhoneIphoneIcon,
+  SchoolIcon,
+  ScienceIcon,
+  AccountTreeIcon,
+} from '@/components/icons';
+import { Project } from '@/utils/api-client/interfaces/project';
+
+export const ENVIRONMENTS = [
+  'production',
+  'staging',
+  'development',
+  'local',
+] as const;
+
+const ICON_MAP: Record<string, React.ComponentType> = {
+  SmartToy: SmartToyIcon,
+  Devices: DevicesIcon,
+  Web: WebIcon,
+  Storage: StorageIcon,
+  Code: CodeIcon,
+  DataObject: DataObjectIcon,
+  Cloud: CloudIcon,
+  Analytics: AnalyticsIcon,
+  ShoppingCart: ShoppingCartIcon,
+  Terminal: TerminalIcon,
+  VideogameAsset: VideogameAssetIcon,
+  Chat: ChatIcon,
+  Psychology: PsychologyIcon,
+  Dashboard: DashboardIcon,
+  Search: SearchIcon,
+  AutoFixHigh: AutoFixHighIcon,
+  PhoneIphone: PhoneIphoneIcon,
+  School: SchoolIcon,
+  Science: ScienceIcon,
+  AccountTree: AccountTreeIcon,
+};
+
+export function getProjectIcon(project: Project | undefined) {
+  if (project?.icon && ICON_MAP[project.icon]) {
+    const IconComponent = ICON_MAP[project.icon];
+    return <IconComponent />;
+  }
+  return <SmartToyIcon />;
+}

--- a/apps/frontend/src/app/(protected)/endpoints/components/endpoint-template-utils.ts
+++ b/apps/frontend/src/app/(protected)/endpoints/components/endpoint-template-utils.ts
@@ -1,0 +1,104 @@
+export function extractVars(template: string): string[] {
+  const vars = new Set<string>();
+  for (const m of template.matchAll(/\{\{\s*([\w.]+)(?:\s*\|[^}]*)?\s*\}\}/g)) {
+    vars.add(m[1].split('.')[0]);
+  }
+  return [...vars];
+}
+
+export function applyJsonPath(obj: unknown, path: string): unknown {
+  const cleaned = path.replace(/^\$\.?/, '');
+  if (!cleaned) return obj;
+  const parts: string[] = [];
+  const re = /([^.[]+)|\[(\d+)\]/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(cleaned)) !== null) parts.push(m[1] ?? m[2]);
+  let cur: unknown = obj;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== 'object') return undefined;
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return cur;
+}
+
+const SENSITIVE_HEADERS = new Set(['authorization', 'x-api-key', 'api-key']);
+
+export function maskHeaders(
+  headers: Record<string, string>
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).map(([k, v]) => {
+      if (!SENSITIVE_HEADERS.has(k.toLowerCase())) return [k, v];
+      const prefix = v.match(/^(Bearer\s+)/i)?.[1] ?? '';
+      return [k, `${prefix}[hidden]`];
+    })
+  );
+}
+
+function cleanUnresolved(val: unknown): unknown {
+  if (Array.isArray(val)) {
+    return val.map(cleanUnresolved).filter(v => v !== null);
+  }
+  if (val && typeof val === 'object') {
+    return Object.fromEntries(
+      Object.entries(val as Record<string, unknown>)
+        .map(([k, v]) => [k, cleanUnresolved(v)])
+        .filter(([, v]) => v !== null)
+    );
+  }
+  return val;
+}
+
+export function substituteVars(
+  template: string,
+  values: Record<string, string>
+): string {
+  // Quoted template vars: "{{ ... }}" → value or null (so JSON stays valid)
+  let result = template.replace(
+    /"(\{\{\s*[\w.]+(?:\s*\|[^}]*)?\s*\}\})"/g,
+    match => {
+      const nameMatch = match.match(/\{\{\s*([\w.]+)/);
+      if (!nameMatch) return 'null';
+      const base = nameMatch[1].split('.')[0];
+      return values[base] !== undefined ? JSON.stringify(values[base]) : 'null';
+    }
+  );
+  // Unquoted template vars: {{ ... }} → value or null (so JSON stays valid)
+  result = result.replace(
+    /\{\{\s*([\w.]+)(?:\s*\|[^}]*)?\s*\}\}/g,
+    (_match, name) => {
+      const base = name.split('.')[0];
+      return values[base] !== undefined ? String(values[base]) : 'null';
+    }
+  );
+  // Strip nulls left by unresolved vars; preserve intentional empty strings
+  try {
+    return JSON.stringify(cleanUnresolved(JSON.parse(result)), null, 2);
+  } catch {
+    return result;
+  }
+}
+
+export function buildCurl(
+  method: string,
+  url: string,
+  headers: Record<string, string>,
+  body: string
+): string {
+  const lines: string[] = [`curl -X ${method} '${url}'`];
+  for (const [k, v] of Object.entries(maskHeaders(headers))) {
+    lines.push(`  -H '${k}: ${v}'`);
+  }
+  const trimmed = body.trim();
+  if (trimmed && trimmed !== '{}') {
+    const pretty = (() => {
+      try {
+        return JSON.stringify(JSON.parse(trimmed), null, 2);
+      } catch {
+        return trimmed;
+      }
+    })();
+    lines.push(`  -d '${pretty.replace(/'/g, "\\'")}'`);
+  }
+  return lines.join(' \\\n');
+}

--- a/apps/frontend/src/app/(protected)/endpoints/components/tabs/TabTest.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/tabs/TabTest.tsx
@@ -6,88 +6,12 @@ import { PlayArrowIcon } from '@/components/icons';
 import { SectionCard } from '@/components/common/SectionCard';
 import EndpointTestWorkbench from '../EndpointTestWorkbench';
 import { responseMappingToPathToVar } from '../JsonPreview';
-
-function extractVars(template: string): string[] {
-  const vars = new Set<string>();
-  for (const m of template.matchAll(/\{\{\s*([\w.]+)(?:\s*\|[^}]*)?\s*\}\}/g)) {
-    vars.add(m[1].split('.')[0]);
-  }
-  return [...vars];
-}
-
-function applyJsonPath(obj: unknown, path: string): unknown {
-  const cleaned = path.replace(/^\$\.?/, '');
-  if (!cleaned) return obj;
-  const parts: string[] = [];
-  const re = /([^.[]+)|\[(\d+)\]/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(cleaned)) !== null) parts.push(m[1] ?? m[2]);
-  let cur: unknown = obj;
-  for (const p of parts) {
-    if (cur == null || typeof cur !== 'object') return undefined;
-    cur = (cur as Record<string, unknown>)[p];
-  }
-  return cur;
-}
-
-const SENSITIVE_HEADERS = new Set(['authorization', 'x-api-key', 'api-key']);
-
-function maskHeaders(headers: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(headers).map(([k, v]) => {
-      if (!SENSITIVE_HEADERS.has(k.toLowerCase())) return [k, v];
-      const prefix = v.match(/^(Bearer\s+)/i)?.[1] ?? '';
-      return [k, `${prefix}[hidden]`];
-    })
-  );
-}
-
-function substituteVars(
-  template: string,
-  values: Record<string, string>
-): string {
-  let result = template.replace(
-    /"(\{\{\s*[\w.]+(?:\s*\|[^}]*)?\s*\}\})"/g,
-    match => {
-      const nameMatch = match.match(/\{\{\s*([\w.]+)/);
-      if (!nameMatch) return match;
-      const base = nameMatch[1].split('.')[0];
-      return values[base] !== undefined ? JSON.stringify(values[base]) : match;
-    }
-  );
-  result = result.replace(
-    /\{\{\s*([\w.]+)(?:\s*\|[^}]*)?\s*\}\}/g,
-    (_match, name) => {
-      const base = name.split('.')[0];
-      return values[base] !== undefined ? String(values[base]) : _match;
-    }
-  );
-  return result;
-}
-
-function buildCurl(
-  method: string,
-  url: string,
-  headers: Record<string, string>,
-  body: string
-): string {
-  const lines: string[] = [`curl -X ${method} '${url}'`];
-  for (const [k, v] of Object.entries(maskHeaders(headers))) {
-    lines.push(`  -H '${k}: ${v}'`);
-  }
-  const trimmed = body.trim();
-  if (trimmed && trimmed !== '{}') {
-    const pretty = (() => {
-      try {
-        return JSON.stringify(JSON.parse(trimmed), null, 2);
-      } catch {
-        return trimmed;
-      }
-    })();
-    lines.push(`  -d '${pretty.replace(/'/g, "\\'")}'`);
-  }
-  return lines.join(' \\\n');
-}
+import {
+  extractVars,
+  applyJsonPath,
+  substituteVars,
+  buildCurl,
+} from '../endpoint-template-utils';
 
 interface TestResult {
   success: boolean;

--- a/apps/frontend/src/components/common/EditableSection.tsx
+++ b/apps/frontend/src/components/common/EditableSection.tsx
@@ -9,6 +9,8 @@ import {
 
 interface EditableSectionProps<T> {
   title: string;
+  subtitle?: React.ReactNode;
+  headerActions?: React.ReactNode;
   initialValue: T;
   onSave: (draft: T) => Promise<boolean | void>;
   isDirty?: (draft: T, initial: T) => boolean;
@@ -25,6 +27,8 @@ function defaultIsDirty<T>(draft: T, initial: T): boolean {
 
 export function EditableSection<T>({
   title,
+  subtitle,
+  headerActions,
   initialValue,
   onSave,
   isDirty = defaultIsDirty,
@@ -77,7 +81,18 @@ export function EditableSection<T>({
   );
 
   return (
-    <SectionCard title={title} actions={actionButtons}>
+    <SectionCard
+      title={title}
+      subtitle={subtitle}
+      actions={
+        headerActions || actionButtons ? (
+          <>
+            {headerActions}
+            {actionButtons}
+          </>
+        ) : undefined
+      }
+    >
       {children({ draft, setDraft, isEditing })}
     </SectionCard>
   );

--- a/apps/frontend/src/utils/api-client/endpoints-client.ts
+++ b/apps/frontend/src/utils/api-client/endpoints-client.ts
@@ -90,6 +90,26 @@ export class EndpointsClient extends BaseApiClient {
     );
   }
 
+  async testEndpointMapping(
+    id: string,
+    payload: {
+      request_mapping: Record<string, unknown>;
+      response_mapping: Record<string, string>;
+      input_data: Record<string, unknown>;
+    }
+  ): Promise<Record<string, unknown>> {
+    return this.fetch<Record<string, unknown>>(
+      `${API_ENDPOINTS.endpoints}/${id}/test`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      }
+    );
+  }
+
   async executeTestSet(
     endpointId: string,
     testSetId: string


### PR DESCRIPTION
## Purpose

Three issues addressed:

1. **403 errors when testing mappings** — `auth_token` is write-only on the backend, so sending it as `""` from the browser caused every test to arrive unauthenticated.
2. **Unresolved template variables** left raw `{{ var }}` placeholders or invalid JSON in the request preview.
3. **Duplicated utility code** — `extractVars`, `substituteVars`, `buildCurl`, `ICON_MAP`, `getProjectIcon`, and `ENVIRONMENTS` were each defined 2-3 times across the endpoint components.

Also reorganized the layout of the Connection Test tab:

<img width="1308" height="807" alt="Screenshot 2026-06-12 alle 16 52 58" src="https://github.com/user-attachments/assets/b20edd71-f2f8-4ea4-b7be-e8844e04279d" />

## What Changed

- **`POST /endpoints/{id}/test`** — new backend route that fetches the stored endpoint server-side (including the encrypted auth token) and merges in caller-supplied draft mappings before invoking. Auth always comes from the database.
- **`testEndpointMapping` server action** — calls the new route, keeping the auth token entirely server-side. `EndpointMappingTab` now uses this instead of the browser-side `testEndpoint`.
- **Template substitution fix** — unresolved quoted and unquoted vars both emit `null` (valid JSON). `cleanUnresolved()` strips those from the JSON tree so the preview stays clean, while preserving intentionally-empty strings.
- **`EndpointTestWorkbench` redesign** — reorganised into a symmetric 2-column grid: Mapped Input | Mapped Output on top, Request | Response below. Mapped output values now render inline with variable chips.
- **`endpoint-template-utils.ts`** — new shared module for `extractVars`, `applyJsonPath`, `maskHeaders`, `substituteVars`, `buildCurl`. Both `EndpointTestTab` and `TabTest` now import from here instead of each defining their own copies.
- **`endpoint-icon-utils.tsx`** — new shared module for `ICON_MAP`, `getProjectIcon`, and `ENVIRONMENTS`. `EndpointsGrid`, `SwaggerEndpointForm`, and `endpoint-detail-shared` now all import from one place.

## Testing

1. Open an endpoint that requires an API key (e.g. Gemini), go to Mapping tab, click Edit, run a test — should return a valid response instead of a 403.
2. Verify the Connection Test tab still works.
3. Leave a template variable empty and confirm the request preview shows valid JSON with that key omitted.