### PR TITLE
ci(k8s): add push to main triggers to all k8s deploy workflows

### DIFF
--- a/.github/workflows/backend-k8s.yml
+++ b/.github/workflows/backend-k8s.yml
@@ -1,6 +1,14 @@
 name: "[Build & Deploy] Backend (K8s)"
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'apps/backend/**'
+      - 'ee/backend/**'
+      - 'sdk/**'
+      - 'penelope/**'
+      - '.github/workflows/backend-k8s.yml'
   workflow_dispatch:
     inputs:
       environment:
@@ -49,7 +57,7 @@ jobs:
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
         with:
-          environment: ${{ inputs.environment || github.event.inputs.environment }}
+          environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
 
   gate:
     needs: validate-inputs
@@ -71,7 +79,7 @@ jobs:
       dockerfile: apps/backend/Dockerfile
       context: .
       target: backend
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ inputs.tag || github.event.inputs.tag }}
     secrets: inherit
 
@@ -81,10 +89,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy
+    if: inputs.deploy || github.event_name == 'push'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ needs.build.outputs.tag }}
       service: backend
     secrets: inherit

--- a/.github/workflows/chatbot-k8s.yml
+++ b/.github/workflows/chatbot-k8s.yml
@@ -1,6 +1,11 @@
 name: "[Build & Deploy] Chatbot (K8s)"
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'apps/chatbot/**'
+      - '.github/workflows/chatbot-k8s.yml'
   workflow_dispatch:
     inputs:
       environment:
@@ -49,7 +54,7 @@ jobs:
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
         with:
-          environment: ${{ inputs.environment || github.event.inputs.environment }}
+          environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
 
   gate:
     needs: validate-inputs
@@ -70,7 +75,7 @@ jobs:
       image: rhesis-chatbot
       dockerfile: apps/chatbot/Dockerfile
       context: .
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ inputs.tag || github.event.inputs.tag }}
     secrets: inherit
 
@@ -80,10 +85,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy
+    if: inputs.deploy || github.event_name == 'push'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ needs.build.outputs.tag }}
       service: chatbot
     secrets: inherit

--- a/.github/workflows/docs-k8s.yml
+++ b/.github/workflows/docs-k8s.yml
@@ -1,6 +1,12 @@
 name: "[Build & Deploy] Docs (K8s)"
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/src/**'
+      - 'docs/content/**'
+      - '.github/workflows/docs-k8s.yml'
   workflow_dispatch:
     inputs:
       environment:
@@ -49,7 +55,7 @@ jobs:
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
         with:
-          environment: ${{ inputs.environment || github.event.inputs.environment }}
+          environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
 
   gate:
     needs: validate-inputs
@@ -70,7 +76,7 @@ jobs:
       image: rhesis-docs
       dockerfile: docs/src/Dockerfile
       context: docs/
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ inputs.tag || github.event.inputs.tag }}
     secrets: inherit
 
@@ -80,10 +86,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy
+    if: inputs.deploy || github.event_name == 'push'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ needs.build.outputs.tag }}
       service: docs
     secrets: inherit

--- a/.github/workflows/frontend-k8s.yml
+++ b/.github/workflows/frontend-k8s.yml
@@ -1,6 +1,12 @@
 name: "[Build & Deploy] Frontend (K8s)"
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'apps/frontend/**'
+      - 'ee/frontend/**'
+      - '.github/workflows/frontend-k8s.yml'
   workflow_dispatch:
     inputs:
       environment:
@@ -49,7 +55,7 @@ jobs:
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
         with:
-          environment: ${{ inputs.environment || github.event.inputs.environment }}
+          environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
 
   gate:
     needs: validate-inputs
@@ -70,7 +76,7 @@ jobs:
       image: rhesis-frontend
       dockerfile: apps/frontend/Dockerfile
       context: .
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ inputs.tag || github.event.inputs.tag }}
     secrets: inherit
 
@@ -80,10 +86,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy
+    if: inputs.deploy || github.event_name == 'push'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ needs.build.outputs.tag }}
       service: frontend
     secrets: inherit

--- a/.github/workflows/otel-collector-k8s.yml
+++ b/.github/workflows/otel-collector-k8s.yml
@@ -1,6 +1,11 @@
 name: "[Build & Deploy] OTEL Collector (K8s)"
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'apps/otel-collector/**'
+      - '.github/workflows/otel-collector-k8s.yml'
   workflow_dispatch:
     inputs:
       environment:
@@ -49,7 +54,7 @@ jobs:
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
         with:
-          environment: ${{ inputs.environment || github.event.inputs.environment }}
+          environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
 
   gate:
     needs: validate-inputs
@@ -70,7 +75,7 @@ jobs:
       image: rhesis-otel-collector
       dockerfile: apps/otel-collector/Dockerfile
       context: apps/otel-collector/
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ inputs.tag || github.event.inputs.tag }}
     secrets: inherit
 
@@ -80,10 +85,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy
+    if: inputs.deploy || github.event_name == 'push'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ needs.build.outputs.tag }}
       service: otelCollector
     secrets: inherit

--- a/.github/workflows/polyphemus-k8s.yml
+++ b/.github/workflows/polyphemus-k8s.yml
@@ -1,6 +1,12 @@
 name: "[Build & Deploy] Polyphemus (K8s)"
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'apps/polyphemus/**'
+      - 'sdk/**'
+      - '.github/workflows/polyphemus-k8s.yml'
   workflow_dispatch:
     inputs:
       environment:
@@ -49,7 +55,7 @@ jobs:
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
         with:
-          environment: ${{ inputs.environment || github.event.inputs.environment }}
+          environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
 
   gate:
     needs: validate-inputs
@@ -70,7 +76,7 @@ jobs:
       image: rhesis-polyphemus
       dockerfile: apps/polyphemus/Dockerfile
       context: .
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ inputs.tag || github.event.inputs.tag }}
     secrets: inherit
 
@@ -80,10 +86,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy
+    if: inputs.deploy || github.event_name == 'push'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ needs.build.outputs.tag }}
       service: polyphemus
     secrets: inherit

--- a/.github/workflows/telemetry-processor-k8s.yml
+++ b/.github/workflows/telemetry-processor-k8s.yml
@@ -1,6 +1,11 @@
 name: "[Build & Deploy] Telemetry Processor (K8s)"
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'apps/telemetry-processor/**'
+      - '.github/workflows/telemetry-processor-k8s.yml'
   workflow_dispatch:
     inputs:
       environment:
@@ -49,7 +54,7 @@ jobs:
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
         with:
-          environment: ${{ inputs.environment || github.event.inputs.environment }}
+          environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
 
   gate:
     needs: validate-inputs
@@ -70,7 +75,7 @@ jobs:
       image: rhesis-telemetry-processor
       dockerfile: apps/telemetry-processor/Dockerfile
       context: apps/telemetry-processor/
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ inputs.tag || github.event.inputs.tag }}
     secrets: inherit
 
@@ -80,10 +85,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy
+    if: inputs.deploy || github.event_name == 'push'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ needs.build.outputs.tag }}
       service: telemetryProcessor
     secrets: inherit

--- a/.github/workflows/worker-k8s.yml
+++ b/.github/workflows/worker-k8s.yml
@@ -1,6 +1,14 @@
 name: "[Build & Deploy] Worker (K8s)"
 
 on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'apps/worker/**'
+      - 'apps/backend/**'
+      - 'sdk/**'
+      - 'penelope/**'
+      - '.github/workflows/worker-k8s.yml'
   workflow_dispatch:
     inputs:
       environment:
@@ -49,7 +57,7 @@ jobs:
       - name: Validate environment parameter
         uses: ./.github/actions/validate-environment
         with:
-          environment: ${{ inputs.environment || github.event.inputs.environment }}
+          environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
 
   gate:
     needs: validate-inputs
@@ -71,7 +79,7 @@ jobs:
       dockerfile: apps/backend/Dockerfile
       context: .
       target: worker
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ inputs.tag || github.event.inputs.tag }}
     secrets: inherit
 
@@ -81,10 +89,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy
+    if: inputs.deploy || github.event_name == 'push'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
-      environment: ${{ inputs.environment || github.event.inputs.environment }}
+      environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ needs.build.outputs.tag }}
       service: workers
     secrets: inherit


### PR DESCRIPTION
## Purpose
K8s deploy workflows only triggered on `workflow_dispatch` and `workflow_call`, so merges to `main` never auto-deployed via the K8s path. This mirrors the push triggers from each Cloud Run workflow to its k8s counterpart.

## What Changed
- Added `push: branches: [main]` trigger to all 8 component k8s workflows (`backend`, `frontend`, `worker`, `chatbot`, `docs`, `telemetry-processor`, `polyphemus`, `otel-collector`) with the same path filters as the Cloud Run siblings (workflow self-reference updated to the `-k8s` filename)
- Added `|| 'dev'` fallback to all `environment` expressions — push events carry no inputs so the value was previously empty, which caused `k8s-build-push.yml` to fail with `ENVIRONMENT is not set`
- Extended `deploy` job condition from `if: inputs.deploy` to `if: inputs.deploy || github.event_name == 'push'` — `inputs.deploy` is falsy on push, so deploy was skipped entirely; safe because `deploy-all-k8s.yml` calls with `deploy: false` never run as a `push` event

## Additional Context
- `deploy-all-k8s.yml`, Cloud Run workflows, and reusable `k8s-build-push.yml`/`k8s-deploy.yml` are unchanged
- Both Cloud Run and k8s workflows now fire on the same push (additive, no removals)
- `penelope/**` added to `backend-k8s.yml` push paths (consistent with `worker-k8s.yml`)

## Testing
- YAML validated locally with PyYAML — all 8 files parse cleanly with `on-keys=['push', 'workflow_dispatch', 'workflow_call']`
- Post-merge: push a change touching any component path and confirm the corresponding `*-k8s.yml` run starts, `gate` is skipped, `build` runs against `dev`, and `deploy` runs