### PR TITLE
fix(ci): swap deploy condition operands to fix push-triggered deploy skip

### DIFF
--- a/.github/workflows/backend-k8s.yml
+++ b/.github/workflows/backend-k8s.yml
@@ -89,7 +89,7 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy || github.event_name == 'push'
+    if: github.event_name == 'push' || inputs.deploy
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/chatbot-k8s.yml
+++ b/.github/workflows/chatbot-k8s.yml
@@ -85,7 +85,7 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy || github.event_name == 'push'
+    if: github.event_name == 'push' || inputs.deploy
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/docs-k8s.yml
+++ b/.github/workflows/docs-k8s.yml
@@ -86,7 +86,7 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy || github.event_name == 'push'
+    if: github.event_name == 'push' || inputs.deploy
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/frontend-k8s.yml
+++ b/.github/workflows/frontend-k8s.yml
@@ -86,7 +86,7 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy || github.event_name == 'push'
+    if: github.event_name == 'push' || inputs.deploy
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/otel-collector-k8s.yml
+++ b/.github/workflows/otel-collector-k8s.yml
@@ -85,7 +85,7 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy || github.event_name == 'push'
+    if: github.event_name == 'push' || inputs.deploy
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/polyphemus-k8s.yml
+++ b/.github/workflows/polyphemus-k8s.yml
@@ -86,7 +86,7 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy || github.event_name == 'push'
+    if: github.event_name == 'push' || inputs.deploy
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/telemetry-processor-k8s.yml
+++ b/.github/workflows/telemetry-processor-k8s.yml
@@ -85,7 +85,7 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy || github.event_name == 'push'
+    if: github.event_name == 'push' || inputs.deploy
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/worker-k8s.yml
+++ b/.github/workflows/worker-k8s.yml
@@ -89,7 +89,7 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: inputs.deploy || github.event_name == 'push'
+    if: github.event_name == 'push' || inputs.deploy
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}


### PR DESCRIPTION
## Purpose
Fixes deploy job being skipped on push-triggered k8s workflow runs (observed in https://github.com/rhesis-ai/rhesis/actions/runs/27421503346).

## What Changed
Swapped operands in the `deploy` job `if` condition across all 8 component k8s workflows:

```yaml
# before (broken on push)
if: inputs.deploy || github.event_name == 'push'

# after
if: github.event_name == 'push' || inputs.deploy
```

## Root Cause
On push events, `inputs.deploy` is `undefined`/`null` (inputs context is empty for non-dispatch events). GitHub Actions fails to short-circuit `||` correctly when the left operand accesses an undefined `inputs` key, causing the entire expression to resolve to `false` before reaching the `github.event_name == 'push'` check.

Placing `github.event_name == 'push'` on the left ensures it evaluates to `true` on push and short-circuits immediately without touching `inputs.deploy`.

## All three cases remain correct
- **push** → `true || …` short-circuits, deploy runs ✓
- **workflow_dispatch direct** (deploy defaults to `true`) → `false || true` = `true` ✓
- **workflow_call from deploy-all-k8s with `deploy: false`** → `false || false` = `false`, deploy skipped ✓