### PR TITLE
fix(ci): compute deploy flag in shell step to fix push-triggered skip

### DIFF
--- a/.github/workflows/backend-k8s.yml
+++ b/.github/workflows/backend-k8s.yml
@@ -50,6 +50,8 @@ on:
 jobs:
   validate-inputs:
     runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.deploy_flag.outputs.should_deploy }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -58,6 +60,15 @@ jobs:
         uses: ./.github/actions/validate-environment
         with:
           environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+
+      - name: Set deploy flag
+        id: deploy_flag
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ inputs.deploy }}" == "true" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+          fi
 
   gate:
     needs: validate-inputs
@@ -84,12 +95,8 @@ jobs:
     secrets: inherit
 
   deploy:
-    needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    needs: [build, validate-inputs]
+    if: needs.validate-inputs.outputs.should_deploy == 'true'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/chatbot-k8s.yml
+++ b/.github/workflows/chatbot-k8s.yml
@@ -47,6 +47,8 @@ on:
 jobs:
   validate-inputs:
     runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.deploy_flag.outputs.should_deploy }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -55,6 +57,15 @@ jobs:
         uses: ./.github/actions/validate-environment
         with:
           environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+
+      - name: Set deploy flag
+        id: deploy_flag
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ inputs.deploy }}" == "true" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+          fi
 
   gate:
     needs: validate-inputs
@@ -80,12 +91,8 @@ jobs:
     secrets: inherit
 
   deploy:
-    needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    needs: [build, validate-inputs]
+    if: needs.validate-inputs.outputs.should_deploy == 'true'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/docs-k8s.yml
+++ b/.github/workflows/docs-k8s.yml
@@ -48,6 +48,8 @@ on:
 jobs:
   validate-inputs:
     runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.deploy_flag.outputs.should_deploy }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -56,6 +58,15 @@ jobs:
         uses: ./.github/actions/validate-environment
         with:
           environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+
+      - name: Set deploy flag
+        id: deploy_flag
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ inputs.deploy }}" == "true" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+          fi
 
   gate:
     needs: validate-inputs
@@ -81,12 +92,8 @@ jobs:
     secrets: inherit
 
   deploy:
-    needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    needs: [build, validate-inputs]
+    if: needs.validate-inputs.outputs.should_deploy == 'true'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/frontend-k8s.yml
+++ b/.github/workflows/frontend-k8s.yml
@@ -48,6 +48,8 @@ on:
 jobs:
   validate-inputs:
     runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.deploy_flag.outputs.should_deploy }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -56,6 +58,15 @@ jobs:
         uses: ./.github/actions/validate-environment
         with:
           environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+
+      - name: Set deploy flag
+        id: deploy_flag
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ inputs.deploy }}" == "true" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+          fi
 
   gate:
     needs: validate-inputs
@@ -81,12 +92,8 @@ jobs:
     secrets: inherit
 
   deploy:
-    needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    needs: [build, validate-inputs]
+    if: needs.validate-inputs.outputs.should_deploy == 'true'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/otel-collector-k8s.yml
+++ b/.github/workflows/otel-collector-k8s.yml
@@ -47,6 +47,8 @@ on:
 jobs:
   validate-inputs:
     runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.deploy_flag.outputs.should_deploy }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -55,6 +57,15 @@ jobs:
         uses: ./.github/actions/validate-environment
         with:
           environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+
+      - name: Set deploy flag
+        id: deploy_flag
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ inputs.deploy }}" == "true" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+          fi
 
   gate:
     needs: validate-inputs
@@ -80,12 +91,8 @@ jobs:
     secrets: inherit
 
   deploy:
-    needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    needs: [build, validate-inputs]
+    if: needs.validate-inputs.outputs.should_deploy == 'true'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/polyphemus-k8s.yml
+++ b/.github/workflows/polyphemus-k8s.yml
@@ -48,6 +48,8 @@ on:
 jobs:
   validate-inputs:
     runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.deploy_flag.outputs.should_deploy }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -56,6 +58,15 @@ jobs:
         uses: ./.github/actions/validate-environment
         with:
           environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+
+      - name: Set deploy flag
+        id: deploy_flag
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ inputs.deploy }}" == "true" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+          fi
 
   gate:
     needs: validate-inputs
@@ -81,12 +92,8 @@ jobs:
     secrets: inherit
 
   deploy:
-    needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    needs: [build, validate-inputs]
+    if: needs.validate-inputs.outputs.should_deploy == 'true'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/telemetry-processor-k8s.yml
+++ b/.github/workflows/telemetry-processor-k8s.yml
@@ -47,6 +47,8 @@ on:
 jobs:
   validate-inputs:
     runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.deploy_flag.outputs.should_deploy }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -55,6 +57,15 @@ jobs:
         uses: ./.github/actions/validate-environment
         with:
           environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+
+      - name: Set deploy flag
+        id: deploy_flag
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ inputs.deploy }}" == "true" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+          fi
 
   gate:
     needs: validate-inputs
@@ -80,12 +91,8 @@ jobs:
     secrets: inherit
 
   deploy:
-    needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    needs: [build, validate-inputs]
+    if: needs.validate-inputs.outputs.should_deploy == 'true'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/worker-k8s.yml
+++ b/.github/workflows/worker-k8s.yml
@@ -50,6 +50,8 @@ on:
 jobs:
   validate-inputs:
     runs-on: ubuntu-latest
+    outputs:
+      should_deploy: ${{ steps.deploy_flag.outputs.should_deploy }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -58,6 +60,15 @@ jobs:
         uses: ./.github/actions/validate-environment
         with:
           environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+
+      - name: Set deploy flag
+        id: deploy_flag
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ inputs.deploy }}" == "true" ]]; then
+            echo "should_deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_deploy=false" >> $GITHUB_OUTPUT
+          fi
 
   gate:
     needs: validate-inputs
@@ -84,12 +95,8 @@ jobs:
     secrets: inherit
 
   deploy:
-    needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    needs: [build, validate-inputs]
+    if: needs.validate-inputs.outputs.should_deploy == 'true'
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}


### PR DESCRIPTION
## Purpose
Fixes deploy job still being skipped on push even after the operand swap in #1968.

## Root Cause
`github.event_name` in an `if:` condition on a job using `uses:` (reusable workflow call) is evaluated in the **called** workflow's context, where the event is always `workflow_call` — never `push`. So `github.event_name == 'push'` is always `false` in that position, regardless of operand order.

## What Changed
Instead of relying on `github.event_name` in the `deploy` job's `if:`, compute a `should_deploy` flag in a regular shell step inside `validate-inputs` (where `github.event_name` is the caller's actual event):

```yaml
validate-inputs:
  outputs:
    should_deploy: ${{ steps.deploy_flag.outputs.should_deploy }}
  steps:
    ...
    - name: Set deploy flag
      id: deploy_flag
      run: |
        if [[ "${{ github.event_name }}" == "push" ]] || [[ "${{ inputs.deploy }}" == "true" ]]; then
          echo "should_deploy=true" >> $GITHUB_OUTPUT
        else
          echo "should_deploy=false" >> $GITHUB_OUTPUT
        fi

deploy:
  needs: [build, validate-inputs]
  if: needs.validate-inputs.outputs.should_deploy == 'true'
```

## All three cases remain correct
- **push** → shell sees `github.event_name == push` → `should_deploy=true` → deploy runs ✓
- **workflow_dispatch direct** (deploy defaults to `true`) → `inputs.deploy == true` → `should_deploy=true` → deploy runs ✓
- **workflow_call from deploy-all-k8s with `deploy: false`** → neither condition true → `should_deploy=false` → deploy skipped ✓