### PR TITLE
fix(ci): add always() guard to k8s deploy job conditions

### DIFF
--- a/.github/workflows/backend-k8s.yml
+++ b/.github/workflows/backend-k8s.yml
@@ -89,7 +89,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      (github.event_name == 'push' || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/chatbot-k8s.yml
+++ b/.github/workflows/chatbot-k8s.yml
@@ -85,7 +85,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      (github.event_name == 'push' || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/docs-k8s.yml
+++ b/.github/workflows/docs-k8s.yml
@@ -86,7 +86,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      (github.event_name == 'push' || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/frontend-k8s.yml
+++ b/.github/workflows/frontend-k8s.yml
@@ -86,7 +86,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      (github.event_name == 'push' || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/otel-collector-k8s.yml
+++ b/.github/workflows/otel-collector-k8s.yml
@@ -85,7 +85,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      (github.event_name == 'push' || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/polyphemus-k8s.yml
+++ b/.github/workflows/polyphemus-k8s.yml
@@ -86,7 +86,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      (github.event_name == 'push' || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/telemetry-processor-k8s.yml
+++ b/.github/workflows/telemetry-processor-k8s.yml
@@ -85,7 +85,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      (github.event_name == 'push' || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/worker-k8s.yml
+++ b/.github/workflows/worker-k8s.yml
@@ -89,7 +89,10 @@ jobs:
     # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
     # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
     # reusable workflow, so it cannot distinguish a direct run from a called one.
-    if: github.event_name == 'push' || inputs.deploy
+    if: |
+      always() &&
+      needs.build.result == 'success' &&
+      (github.event_name == 'push' || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}


### PR DESCRIPTION
## Purpose
Fix deploy jobs being silently skipped on push-triggered runs across all k8s workflows.

## What Changed
- Added `always()` + explicit `needs.build.result == 'success'` guard to the `deploy` job `if:` condition in all 8 k8s workflows: `backend`, `chatbot`, `docs`, `frontend`, `otel-collector`, `polyphemus`, `telemetry-processor`, `worker`

## Additional Context
Without `always()`, GitHub wraps the condition with an implicit `success()` that evaluates over the **full** dependency chain — not just the direct `needs: build`. Because `gate` (a transitive dependency) is skipped on `push` events, `success()` returns `false` and the entire deploy condition short-circuits, even when `build` succeeded.

The `build` job already works around this correctly with `always()` + explicit result checks. This PR applies the same pattern to `deploy`.

Effective condition before:
```
success() && (github.event_name == 'push' || inputs.deploy)
# ↑ evaluates over full chain including skipped `gate` → false
```

Effective condition after:
```
always() && needs.build.result == 'success' && (github.event_name == 'push' || inputs.deploy)
```

## Testing
Push to main and verify all 8 deploy jobs run instead of being skipped.