### PR TITLE
fix(ci): scope k8s deploy push trigger to main branch

### DIFF
--- a/.github/workflows/backend-k8s.yml
+++ b/.github/workflows/backend-k8s.yml
@@ -85,14 +85,15 @@ jobs:
 
   deploy:
     needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
+    # Auto-deploy on a direct push to main (CI to dev) or when a caller sets
+    # deploy: true. The main-ref guard matters: on a release push (release/*)
+    # deploy-all-k8s calls this with deploy: false, but github.event_name is
+    # inherited as 'push', so without the ref check the per-service deploy would
+    # fire and race the centralized k8s-deploy.
     if: |
       always() &&
       needs.build.result == 'success' &&
-      (github.event_name == 'push' || inputs.deploy)
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/chatbot-k8s.yml
+++ b/.github/workflows/chatbot-k8s.yml
@@ -81,14 +81,15 @@ jobs:
 
   deploy:
     needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
+    # Auto-deploy on a direct push to main (CI to dev) or when a caller sets
+    # deploy: true. The main-ref guard matters: on a release push (release/*)
+    # deploy-all-k8s calls this with deploy: false, but github.event_name is
+    # inherited as 'push', so without the ref check the per-service deploy would
+    # fire and race the centralized k8s-deploy.
     if: |
       always() &&
       needs.build.result == 'success' &&
-      (github.event_name == 'push' || inputs.deploy)
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/docs-k8s.yml
+++ b/.github/workflows/docs-k8s.yml
@@ -82,14 +82,15 @@ jobs:
 
   deploy:
     needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
+    # Auto-deploy on a direct push to main (CI to dev) or when a caller sets
+    # deploy: true. The main-ref guard matters: on a release push (release/*)
+    # deploy-all-k8s calls this with deploy: false, but github.event_name is
+    # inherited as 'push', so without the ref check the per-service deploy would
+    # fire and race the centralized k8s-deploy.
     if: |
       always() &&
       needs.build.result == 'success' &&
-      (github.event_name == 'push' || inputs.deploy)
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/frontend-k8s.yml
+++ b/.github/workflows/frontend-k8s.yml
@@ -82,14 +82,15 @@ jobs:
 
   deploy:
     needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
+    # Auto-deploy on a direct push to main (CI to dev) or when a caller sets
+    # deploy: true. The main-ref guard matters: on a release push (release/*)
+    # deploy-all-k8s calls this with deploy: false, but github.event_name is
+    # inherited as 'push', so without the ref check the per-service deploy would
+    # fire and race the centralized k8s-deploy.
     if: |
       always() &&
       needs.build.result == 'success' &&
-      (github.event_name == 'push' || inputs.deploy)
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/otel-collector-k8s.yml
+++ b/.github/workflows/otel-collector-k8s.yml
@@ -81,14 +81,15 @@ jobs:
 
   deploy:
     needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
+    # Auto-deploy on a direct push to main (CI to dev) or when a caller sets
+    # deploy: true. The main-ref guard matters: on a release push (release/*)
+    # deploy-all-k8s calls this with deploy: false, but github.event_name is
+    # inherited as 'push', so without the ref check the per-service deploy would
+    # fire and race the centralized k8s-deploy.
     if: |
       always() &&
       needs.build.result == 'success' &&
-      (github.event_name == 'push' || inputs.deploy)
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/polyphemus-k8s.yml
+++ b/.github/workflows/polyphemus-k8s.yml
@@ -82,14 +82,15 @@ jobs:
 
   deploy:
     needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
+    # Auto-deploy on a direct push to main (CI to dev) or when a caller sets
+    # deploy: true. The main-ref guard matters: on a release push (release/*)
+    # deploy-all-k8s calls this with deploy: false, but github.event_name is
+    # inherited as 'push', so without the ref check the per-service deploy would
+    # fire and race the centralized k8s-deploy.
     if: |
       always() &&
       needs.build.result == 'success' &&
-      (github.event_name == 'push' || inputs.deploy)
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/telemetry-processor-k8s.yml
+++ b/.github/workflows/telemetry-processor-k8s.yml
@@ -81,14 +81,15 @@ jobs:
 
   deploy:
     needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
+    # Auto-deploy on a direct push to main (CI to dev) or when a caller sets
+    # deploy: true. The main-ref guard matters: on a release push (release/*)
+    # deploy-all-k8s calls this with deploy: false, but github.event_name is
+    # inherited as 'push', so without the ref check the per-service deploy would
+    # fire and race the centralized k8s-deploy.
     if: |
       always() &&
       needs.build.result == 'success' &&
-      (github.event_name == 'push' || inputs.deploy)
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}

--- a/.github/workflows/worker-k8s.yml
+++ b/.github/workflows/worker-k8s.yml
@@ -85,14 +85,15 @@ jobs:
 
   deploy:
     needs: build
-    # Run on a direct manual dispatch (deploy defaults to true) and skip when a
-    # parent workflow (e.g. deploy-all-k8s) passes deploy: false. github.event_name
-    # is NOT used here: it inherits the caller's event (workflow_dispatch) inside a
-    # reusable workflow, so it cannot distinguish a direct run from a called one.
+    # Auto-deploy on a direct push to main (CI to dev) or when a caller sets
+    # deploy: true. The main-ref guard matters: on a release push (release/*)
+    # deploy-all-k8s calls this with deploy: false, but github.event_name is
+    # inherited as 'push', so without the ref check the per-service deploy would
+    # fire and race the centralized k8s-deploy.
     if: |
       always() &&
       needs.build.result == 'success' &&
-      (github.event_name == 'push' || inputs.deploy)
+      ((github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.deploy)
     uses: ./.github/workflows/k8s-deploy.yml
     with:
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}


### PR DESCRIPTION
## Purpose
Prevent per-service k8s deploy jobs from firing (and racing the centralized deploy) during release deploys.

## What Changed
- Added a `github.ref == 'refs/heads/main'` guard to the `deploy` job condition in all 8 k8s service workflows: `backend`, `chatbot`, `docs`, `frontend`, `otel-collector`, `polyphemus`, `telemetry-processor`, `worker`

## Additional Context
Follow-up to #1970. The release flow is:

`release.yml` (push to `release/*`) → `deploy-all-k8s.yml` → calls each `*-k8s.yml` with **`deploy: false`** → deployment happens centrally via the `deploy-all` job → `k8s-deploy.yml`.

Inside a reusable workflow, `github.event_name` is **inherited** from the root event. On a release push it is `'push'`, so the old condition:

```
(github.event_name == 'push' || inputs.deploy)
```

evaluated `true` via the push clause — overriding the `deploy: false` that `deploy-all-k8s` passed. The per-service deploy fired and raced the centralized deploy.

New condition scopes the push auto-deploy to genuine `main` pushes:

```yaml
if: |
  always() &&
  needs.build.result == 'success' &&
  ((github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.deploy)
```

Behavior matrix:
- Push to `main` → `event_name=push`, `ref=main` → deploys (CI to dev)
- Push to `release/*` (via deploy-all-k8s, `deploy: false`) → ref isn't main, `inputs.deploy=false` → per-service deploy skipped, central deploy handles it
- Manual dispatch with `deploy: true` → deploys

## Testing
Push to a `release/*` branch and confirm the per-service deploy jobs are skipped while the centralized `deploy-all` job runs. Push to `main` and confirm per-service deploy still runs.