### PR TITLE
Add Asana MCP tool integration

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/e8f9a0b1c2d3_add_asana_tool_provider_type.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/e8f9a0b1c2d3_add_asana_tool_provider_type.py
@@ -1,0 +1,41 @@
+"""Add Asana ToolProviderType
+
+Revision ID: e8f9a0b1c2d3
+Revises: d7e8f9a0b1c2
+Create Date: 2026-06-17
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+from rhesis.backend.alembic.utils.template_loader import (
+    load_cleanup_type_lookup_template,
+    load_type_lookup_template,
+)
+
+revision: str = "e8f9a0b1c2d3"
+down_revision: Union[str, None] = "d7e8f9a0b1c2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    provider_type_values = """
+        ('ToolProviderType', 'asana', 'Asana integration')
+    """
+    op.execute(load_type_lookup_template(provider_type_values))
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DELETE FROM tool
+        WHERE tool_provider_type_id IN (
+            SELECT id FROM type_lookup
+            WHERE type_name = 'ToolProviderType' AND type_value = 'asana'
+        );
+        """
+    )
+    op.execute(load_cleanup_type_lookup_template("ToolProviderType", "'asana'"))

--- a/apps/backend/src/rhesis/backend/app/routers/tools.py
+++ b/apps/backend/src/rhesis/backend/app/routers/tools.py
@@ -119,6 +119,26 @@ def _validate_shortcut_credentials(credentials: dict[str, str] | None) -> None:
         )
 
 
+def _validate_asana_workspace_gid(tool_metadata: dict | None) -> None:
+    if not tool_metadata or "workspace_gid" not in tool_metadata:
+        return
+    workspace_gid = tool_metadata["workspace_gid"]
+    if not isinstance(workspace_gid, str) or not workspace_gid.strip():
+        raise HTTPException(
+            status_code=400,
+            detail="Asana 'workspace_gid' must be a non-empty string",
+        )
+
+
+def _validate_asana_credentials(credentials: dict[str, str] | None) -> None:
+    token = (credentials or {}).get("ASANA_ACCESS_TOKEN", "")
+    if not isinstance(token, str) or not token.strip():
+        raise HTTPException(
+            status_code=400,
+            detail="Asana integrations require 'ASANA_ACCESS_TOKEN'",
+        )
+
+
 def _validate_mcp_test_connection_request(
     provider: str,
     credentials: dict[str, str] | None,
@@ -133,6 +153,9 @@ def _validate_mcp_test_connection_request(
         _validate_gitlab_project(tool_metadata)
     elif provider == "shortcut":
         _validate_shortcut_credentials(credentials)
+    elif provider == "asana":
+        _validate_asana_credentials(credentials)
+        _validate_asana_workspace_gid(tool_metadata)
 
 
 def _validate_provider_type_switch(
@@ -170,6 +193,9 @@ def _validate_provider_type_switch(
         _validate_gitlab_project(tool.tool_metadata)
     elif provider_type.type_value == "shortcut":
         _validate_shortcut_credentials(tool.credentials)
+    elif provider_type.type_value == "asana":
+        _validate_asana_credentials(tool.credentials)
+        _validate_asana_workspace_gid(tool.tool_metadata)
 
 
 @router.post("/", response_model=schemas.Tool)
@@ -206,6 +232,9 @@ def create_tool(
             _validate_gitlab_project(tool.tool_metadata)
         elif provider_type.type_value == "shortcut":
             _validate_shortcut_credentials(tool.credentials)
+        elif provider_type.type_value == "asana":
+            _validate_asana_credentials(tool.credentials)
+            _validate_asana_workspace_gid(tool.tool_metadata)
 
     return crud.create_tool(db=db, tool=tool, organization_id=organization_id, user_id=user_id)
 
@@ -303,6 +332,8 @@ def update_tool(
                 raise HTTPException(status_code=400, detail="Jira 'space_key' must be non-empty")
         elif provider_type.type_value == "gitlab":
             _validate_gitlab_project(tool.tool_metadata)
+        elif provider_type.type_value == "asana":
+            _validate_asana_workspace_gid(tool.tool_metadata)
 
     if tool.credentials is not None and provider_type:
         if provider_type.type_value == "jira" and "JIRA_URL" in tool.credentials:
@@ -324,6 +355,8 @@ def update_tool(
             tool = tool.model_copy(update={"credentials": merged_credentials})
         elif provider_type.type_value == "shortcut":
             _validate_shortcut_credentials(tool.credentials)
+        elif provider_type.type_value == "asana":
+            _validate_asana_credentials(tool.credentials)
 
     db_tool = crud.update_tool(
         db=db, tool_id=tool_id, tool=tool, organization_id=organization_id, user_id=user_id

--- a/apps/backend/src/rhesis/backend/app/services/initial_data.json
+++ b/apps/backend/src/rhesis/backend/app/services/initial_data.json
@@ -593,6 +593,11 @@
             "description": "Shortcut integration"
         },
         {
+            "type_name": "ToolProviderType",
+            "type_value": "asana",
+            "description": "Asana integration"
+        },
+        {
             "type_name": "EmbeddingDimension",
             "type_value": "384",
             "description": "384-dimensional embeddings"

--- a/apps/backend/src/rhesis/backend/app/services/tool/actions.py
+++ b/apps/backend/src/rhesis/backend/app/services/tool/actions.py
@@ -53,6 +53,8 @@ _ROUTES: Dict[Tuple[str, ToolAction], Transport] = {
     ("gitlab", ToolAction.TEST_CONNECTION): Transport.MCP,
     ("shortcut", ToolAction.EXTRACT): Transport.MCP,
     ("shortcut", ToolAction.TEST_CONNECTION): Transport.MCP,
+    ("asana", ToolAction.EXTRACT): Transport.MCP,
+    ("asana", ToolAction.TEST_CONNECTION): Transport.MCP,
 }
 
 

--- a/apps/backend/src/rhesis/backend/app/services/tool/mcp/config.py
+++ b/apps/backend/src/rhesis/backend/app/services/tool/mcp/config.py
@@ -29,6 +29,16 @@ def _scope_context_from_metadata(
             )
         return {"namespace": namespace.strip()}
 
+    if provider == "asana":
+        if "workspace_gid" not in tool_metadata:
+            return None
+        workspace_gid = tool_metadata["workspace_gid"]
+        if not isinstance(workspace_gid, str) or not workspace_gid.strip():
+            raise ToolConfigurationError(
+                "Asana tool has invalid workspace_gid metadata; must be a non-empty string"
+            )
+        return {"workspace_gid": workspace_gid.strip()}
+
     return None
 
 

--- a/apps/backend/src/rhesis/backend/app/templates/mcp_default_query_prompt.jinja2
+++ b/apps/backend/src/rhesis/backend/app/templates/mcp_default_query_prompt.jinja2
@@ -10,3 +10,7 @@ When using GitLab tools, scope all operations to project namespace:
 
 Do not access any other GitLab projects.
 {% endif %}
+{% if provider == "asana" and workspace_context and workspace_context.workspace_gid %}
+IMPORTANT RESTRICTION: Scope all Asana operations to workspace GID
+"{{ workspace_context.workspace_gid }}".
+{% endif %}

--- a/apps/backend/src/rhesis/backend/app/templates/mcp_extract_prompt.jinja2
+++ b/apps/backend/src/rhesis/backend/app/templates/mcp_extract_prompt.jinja2
@@ -20,6 +20,16 @@ Do not access content outside this project!
 Use Shortcut tools to retrieve the full story or epic content, including description,
 acceptance criteria, tasks, and comments when available.
 {% endif %}
+{% if provider == "asana" %}
+Use Asana tools to retrieve the full task or project content, including description,
+notes, and custom fields when available.
+{% if workspace_context and workspace_context.workspace_gid %}
+You are restricted to the following Asana workspace:
+- Workspace GID: {{ workspace_context.workspace_gid }}
+
+Scope all Asana tool calls to workspace GID "{{ workspace_context.workspace_gid }}".
+{% endif %}
+{% endif %}
 {% if include_children %}
 Also extract every child page / nested item and return each as a separate entry.
 {% endif %}

--- a/apps/backend/src/rhesis/backend/app/templates/mcp_test_auth_prompt.jinja2
+++ b/apps/backend/src/rhesis/backend/app/templates/mcp_test_auth_prompt.jinja2
@@ -10,6 +10,11 @@ Perform a read-only project-scoped call for namespace "{{ project_context.namesp
 (for example, fetch project details). Set authenticated to false if the project is
 not accessible with these credentials.
 {% endif %}
+{% if provider == "asana" and workspace_context and workspace_context.workspace_gid %}
+Scope the read-only auth check to Asana workspace GID
+"{{ workspace_context.workspace_gid }}". Set authenticated to false if the workspace
+is not accessible with these credentials.
+{% endif %}
 Use a single read-only call. Do not create, modify, or delete anything.
 
 Return ONLY a JSON object with these fields:

--- a/apps/frontend/src/app/(protected)/tools/components/ToolConnectionDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tools/components/ToolConnectionDrawer.tsx
@@ -46,6 +46,8 @@ function getCredentialKey(providerType: string | undefined): string {
       return 'GITLAB_PERSONAL_ACCESS_TOKEN';
     case 'shortcut':
       return 'SHORTCUT_API_TOKEN';
+    case 'asana':
+      return 'ASANA_ACCESS_TOKEN';
     case 'jira':
       return 'JIRA_API_TOKEN';
     case 'confluence':
@@ -123,6 +125,7 @@ export function ToolConnectionDrawer({
   const [initialProjectNamespace, setInitialProjectNamespace] = useState('');
   const [initialGitlabApiUrl, setInitialGitlabApiUrl] = useState('');
   const [initialSpaceKey, setInitialSpaceKey] = useState('');
+  const [initialWorkspaceGid, setInitialWorkspaceGid] = useState('');
 
   // GitHub repository fields
   const [repositoryUrl, setRepositoryUrl] = useState('');
@@ -130,6 +133,9 @@ export function ToolConnectionDrawer({
   // GitLab project fields
   const [projectNamespace, setProjectNamespace] = useState('');
   const [gitlabApiUrl, setGitlabApiUrl] = useState('');
+
+  // Asana workspace scope
+  const [workspaceGid, setWorkspaceGid] = useState('');
 
   // Jira and Confluence fields
   const [instanceUrl, setInstanceUrl] = useState('');
@@ -207,6 +213,17 @@ export function ToolConnectionDrawer({
         setGitlabApiUrl('');
         setInitialGitlabApiUrl('');
 
+        if (
+          currentProviderType === 'asana' &&
+          typeof tool.tool_metadata?.workspace_gid === 'string'
+        ) {
+          setWorkspaceGid(tool.tool_metadata.workspace_gid);
+          setInitialWorkspaceGid(tool.tool_metadata.workspace_gid);
+        } else {
+          setWorkspaceGid('');
+          setInitialWorkspaceGid('');
+        }
+
         // Note: Jira/Confluence URL and username are stored in encrypted credentials
         // We cannot display them in edit mode as they're encrypted
         // Show placeholder to indicate existing values
@@ -239,6 +256,7 @@ export function ToolConnectionDrawer({
         setRepositoryUrl('');
         setProjectNamespace('');
         setGitlabApiUrl('');
+        setWorkspaceGid('');
         setInstanceUrl('');
         // Pre-fill email with logged-in user's email for Jira/Confluence
         const isAtlassian =
@@ -277,7 +295,8 @@ export function ToolConnectionDrawer({
       const scopeMetadataChanged =
         repositoryUrl !== initialRepositoryUrl ||
         projectNamespace !== initialProjectNamespace ||
-        selectedSpaceKey !== initialSpaceKey;
+        selectedSpaceKey !== initialSpaceKey ||
+        workspaceGid !== initialWorkspaceGid;
       const gitlabApiUrlChanged = gitlabApiUrl !== initialGitlabApiUrl;
       const credentialsChanged =
         tokenChanged || urlChanged || usernameChanged || gitlabApiUrlChanged;
@@ -299,9 +318,11 @@ export function ToolConnectionDrawer({
     projectNamespace,
     selectedSpaceKey,
     gitlabApiUrl,
+    workspaceGid,
     initialRepositoryUrl,
     initialProjectNamespace,
     initialSpaceKey,
+    initialWorkspaceGid,
     initialGitlabApiUrl,
   ]);
 
@@ -385,6 +406,13 @@ export function ToolConnectionDrawer({
     return credentials;
   };
 
+  const buildAsanaMetadata = (
+    workspace: string
+  ): Record<string, unknown> | undefined => {
+    const trimmed = workspace.trim();
+    return trimmed ? { workspace_gid: trimmed } : undefined;
+  };
+
   const buildScopeMetadataFromForm = (
     currentProviderType: string | undefined
   ): Record<string, unknown> | undefined => {
@@ -404,6 +432,10 @@ export function ToolConnectionDrawer({
 
     if (currentProviderType === 'jira' && selectedSpaceKey) {
       return { space_key: selectedSpaceKey };
+    }
+
+    if (currentProviderType === 'asana') {
+      return buildAsanaMetadata(workspaceGid);
     }
 
     return undefined;
@@ -841,6 +873,16 @@ export function ToolConnectionDrawer({
           };
         }
 
+        if (providerType === 'asana') {
+          metadataToUpdate = {
+            ...(metadataToUpdate || tool.tool_metadata || {}),
+            ...(buildAsanaMetadata(workspaceGid) || {}),
+          };
+          if (!workspaceGid.trim() && metadataToUpdate.workspace_gid) {
+            delete metadataToUpdate.workspace_gid;
+          }
+        }
+
         if (metadataToUpdate) {
           updates.tool_metadata = metadataToUpdate;
         }
@@ -980,6 +1022,13 @@ export function ToolConnectionDrawer({
             };
           }
 
+          if (providerType === 'asana') {
+            parsedMetadata = {
+              ...(parsedMetadata || {}),
+              ...(buildAsanaMetadata(workspaceGid) || {}),
+            };
+          }
+
           const toolData: ToolCreate = {
             name,
             description: description || undefined,
@@ -1017,6 +1066,7 @@ export function ToolConnectionDrawer({
       description !== initialDescription ||
       repositoryUrl !== initialRepositoryUrl ||
       projectNamespace !== initialProjectNamespace ||
+      workspaceGid !== initialWorkspaceGid ||
       selectedSpaceKey !== initialSpaceKey);
 
   const saveDisabled =
@@ -1237,6 +1287,17 @@ export function ToolConnectionDrawer({
                   helperText="Leave blank for gitlab.com; use for self-managed instances"
                 />
               </>
+            )}
+
+            {providerType === 'asana' && (
+              <TextField
+                label="Workspace GID (optional)"
+                fullWidth
+                value={workspaceGid}
+                onChange={e => setWorkspaceGid(e.target.value)}
+                placeholder="1234567890"
+                helperText="Optional Asana workspace scope for search and import"
+              />
             )}
 
             <Box>

--- a/apps/frontend/src/app/(protected)/tools/components/ToolConnectionDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tools/components/ToolConnectionDrawer.tsx
@@ -520,9 +520,18 @@ export function ToolConnectionDrawer({
           return;
         }
 
+        // When the Asana workspace field is cleared, buildScopeMetadataFromForm
+        // returns undefined and JSON would drop the key, so the backend would
+        // test against the stored workspace_gid. Send an explicit empty object
+        // so the test reflects the cleared scope.
+        const scopeMetadata =
+          currentProviderType === 'asana' && !workspaceGid.trim()
+            ? {}
+            : parsedMetadata;
+
         testRequest = {
           tool_id: tool.id,
-          tool_metadata: parsedMetadata,
+          tool_metadata: scopeMetadata,
         };
       } else if (isEditMode && tool?.id && credentialsModified) {
         // Edit mode with changed credentials — test new credentials directly

--- a/apps/frontend/src/config/tool-providers.tsx
+++ b/apps/frontend/src/config/tool-providers.tsx
@@ -26,7 +26,24 @@ export const TOOL_PROVIDER_DESCRIPTIONS: Record<string, string> = {
   jira: 'Create Jira issues directly from Rhesis tasks',
   gitlab: 'Import issues, merge requests, and wiki pages from GitLab projects',
   shortcut: 'Import stories and epics from Shortcut into your knowledge base',
+  asana: 'Import tasks and projects from Asana into your knowledge base',
 };
+
+function AsanaIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      role="img"
+      aria-label="Asana"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="12" cy="6" r="3.5" fill="#F06A6A" />
+      <circle cx="5.5" cy="16" r="3.5" fill="#F06A6A" />
+      <circle cx="18.5" cy="16" r="3.5" fill="#F06A6A" />
+    </svg>
+  );
+}
 
 // Provider icon mapping
 export const TOOL_PROVIDER_ICONS: Record<string, React.ReactNode> = {
@@ -35,4 +52,5 @@ export const TOOL_PROVIDER_ICONS: Record<string, React.ReactNode> = {
   jira: <SiJira className="h-8 w-8" />,
   gitlab: <SiGitlab className="h-8 w-8" />,
   shortcut: <SiShortcut className="h-8 w-8" />,
+  asana: <AsanaIcon className="h-8 w-8" />,
 };

--- a/apps/frontend/src/utils/api-client/interfaces/tool.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/tool.ts
@@ -32,6 +32,7 @@ export interface ToolMetadata {
     [key: string]: unknown;
   };
   space_key?: string;
+  workspace_gid?: string;
   [key: string]: unknown;
 }
 

--- a/sdk/src/rhesis/sdk/agents/mcp/provider_templates/asana.json.j2
+++ b/sdk/src/rhesis/sdk/agents/mcp/provider_templates/asana.json.j2
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "asana": {
+      "transport": "stdio",
+      "command": "npx",
+      "args": ["-y", "@roychri/mcp-server-asana"],
+      "env": {
+        "ASANA_ACCESS_TOKEN": {{ ASANA_ACCESS_TOKEN | tojson }}
+      }
+    }
+  }
+}

--- a/tests/backend/routes/test_tools_asana.py
+++ b/tests/backend/routes/test_tools_asana.py
@@ -1,0 +1,28 @@
+import pytest
+from fastapi import HTTPException
+
+from rhesis.backend.app.routers.tools import (
+    _validate_asana_credentials,
+    _validate_asana_workspace_gid,
+)
+
+
+def test_validate_asana_credentials_requires_token():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_asana_credentials({})
+
+    assert exc_info.value.status_code == 400
+    assert "ASANA_ACCESS_TOKEN" in exc_info.value.detail
+
+
+def test_validate_asana_workspace_gid_rejects_empty_string():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_asana_workspace_gid({"workspace_gid": "   "})
+
+    assert exc_info.value.status_code == 400
+    assert "workspace_gid" in exc_info.value.detail
+
+
+def test_validate_asana_workspace_gid_allows_missing_key():
+    _validate_asana_workspace_gid({})
+    _validate_asana_workspace_gid(None)

--- a/tests/backend/routes/test_tools_test_connection.py
+++ b/tests/backend/routes/test_tools_test_connection.py
@@ -4,6 +4,26 @@ from fastapi import HTTPException
 from rhesis.backend.app.routers.tools import _validate_mcp_test_connection_request
 
 
+def test_mcp_test_connection_validates_asana_credentials():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_mcp_test_connection_request("asana", {}, None)
+
+    assert exc_info.value.status_code == 400
+    assert "ASANA_ACCESS_TOKEN" in exc_info.value.detail
+
+
+def test_mcp_test_connection_validates_asana_workspace_gid():
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_mcp_test_connection_request(
+            "asana",
+            {"ASANA_ACCESS_TOKEN": "token"},
+            {"workspace_gid": "   "},
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "workspace_gid" in exc_info.value.detail
+
+
 def test_mcp_test_connection_validates_shortcut_credentials():
     with pytest.raises(HTTPException) as exc_info:
         _validate_mcp_test_connection_request("shortcut", {}, None)
@@ -13,4 +33,5 @@ def test_mcp_test_connection_validates_shortcut_credentials():
 
 
 def test_mcp_test_connection_skips_when_credentials_omitted():
+    _validate_mcp_test_connection_request("asana", None, None)
     _validate_mcp_test_connection_request("shortcut", None, None)

--- a/tests/backend/services/test_tool_actions.py
+++ b/tests/backend/services/test_tool_actions.py
@@ -36,6 +36,10 @@ class TestRouteTable:
         assert route("shortcut", ToolAction.EXTRACT) is Transport.MCP
         assert route("shortcut", ToolAction.TEST_CONNECTION) is Transport.MCP
 
+    def test_asana_routes_to_mcp(self):
+        assert route("asana", ToolAction.EXTRACT) is Transport.MCP
+        assert route("asana", ToolAction.TEST_CONNECTION) is Transport.MCP
+
     def test_unregistered_provider_raises(self):
         with pytest.raises(ToolConfigurationError, match="does not support"):
             route("unknown", ToolAction.EXTRACT)

--- a/tests/sdk/agents/mcp/test_asana_provider_template.py
+++ b/tests/sdk/agents/mcp/test_asana_provider_template.py
@@ -11,7 +11,7 @@ def test_asana_provider_template_renders_valid_config():
     assert factory.config_dict is not None
     server = factory.config_dict["mcpServers"]["asana"]
     assert server["command"] == "npx"
-    assert "@roychri/mcp-server-asana" in server["args"]
+    assert server["args"][1] == "@roychri/mcp-server-asana"
     assert "@latest" not in " ".join(server["args"])
     assert server["env"]["ASANA_ACCESS_TOKEN"] == "asana_test_token_123"
 

--- a/tests/sdk/agents/mcp/test_asana_provider_template.py
+++ b/tests/sdk/agents/mcp/test_asana_provider_template.py
@@ -1,0 +1,19 @@
+import json
+
+from rhesis.sdk.agents.mcp.client import MCPClientFactory
+
+
+def test_asana_provider_template_renders_valid_config():
+    credentials = {"ASANA_ACCESS_TOKEN": "asana_test_token_123"}
+
+    factory = MCPClientFactory.from_provider("asana", credentials)
+
+    assert factory.config_dict is not None
+    server = factory.config_dict["mcpServers"]["asana"]
+    assert server["command"] == "npx"
+    assert "@roychri/mcp-server-asana" in server["args"]
+    assert "@latest" not in " ".join(server["args"])
+    assert server["env"]["ASANA_ACCESS_TOKEN"] == "asana_test_token_123"
+
+    rendered = json.dumps(factory.config_dict)
+    assert "asana_test_token_123" in rendered


### PR DESCRIPTION
## Purpose
Add Asana as a supported MCP tool provider so teams can import tasks, project briefs, and acceptance criteria into Rhesis for test generation and Architect grounding.

Closes #1873

## What Changed
- Backend: Alembic migration `e8f9a0b1c2d3` (after Shortcut `d7e8f9a0b1c2`) seeds `ToolProviderType=asana`; credential validation for `ASANA_ACCESS_TOKEN` and optional `workspace_gid`
- SDK: `@roychri/mcp-server-asana` stdio provider template
- Frontend: Asana in `tool-providers.tsx`, `ToolConnectionDrawer` (token + optional workspace GID)
- MCP: Asana registered in `services/tool/actions.py` for `EXTRACT` and `TEST_CONNECTION`; workspace scoping in extract/default-query/test-auth prompts
- **test-connection**: validate unsaved MCP credentials (Asana/Shortcut/GitLab) before `mcp_health_check` — returns `400` instead of opaque MCP failure
- Tests: SDK template, Asana validation helpers, `test_tools_test_connection.py`

## Stacked on #1974
This branch is rebased on `ayush6` so migrations chain correctly: `f1a2b3c4d5e0` → `d7e8f9a0b1c2` (Shortcut) → `e8f9a0b1c2d3` (Asana). Merge **#1974 first**, then this PR diff against `main` is Asana-only.

## Test plan
- [ ] Run migrations and confirm `ToolProviderType=asana` appears
- [ ] Create Asana tool connection with `ASANA_ACCESS_TOKEN`; optional workspace GID
- [ ] Test connection with empty token returns 400
- [ ] `cd sdk && uv run pytest ../tests/sdk/agents/mcp/test_asana_provider_template.py`
- [ ] `cd apps/backend && uv run pytest ../../tests/backend/routes/test_tools_asana.py ../../tests/backend/routes/test_tools_test_connection.py`