### PR TITLE
Fix E2E and SDK integration test

### DIFF
--- a/tests/docker-compose.frontend.yml
+++ b/tests/docker-compose.frontend.yml
@@ -26,10 +26,10 @@ x-frontend-backend-config: &frontend-backend-config
   JWT_ALGORITHM: HS256
   JWT_ACCESS_TOKEN_EXPIRE_MINUTES: 10080
   LOG_LEVEL: INFO
-  ENVIRONMENT: test
   BACKEND_ENV: local
   QUICK_START: true
   RHESIS_CONNECTOR_DISABLED: true
+  API_BASE_URL: "http://localhost:14003"
 
 services:
   frontend-test-postgres:

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -23,13 +23,13 @@ x-sdk-redis-config: &sdk-redis-config
   CELERY_RESULT_BACKEND: redis://:rhesis-redis-pass@sdk-test-redis:6379/1
 
 x-sdk-backend-config: &sdk-backend-config
-  ENVIRONMENT: test
   BACKEND_ENV: test
   FRONTEND_URL: "http://localhost:3000"
   JWT_SECRET_KEY: your-jwt-secret-key
   SESSION_SECRET_KEY: test-session-secret-key
   LOG_LEVEL: DEBUG
   RHESIS_CONNECTOR_DISABLED: true
+  API_BASE_URL: "http://localhost:10003"
 
 services:
   # ==========================================================================


### PR DESCRIPTION
## Purpose
Fix E2E and SDK integration test backends crashing on startup after `API_BASE_URL` was made a required `ApplicationSettings` field in #1933.

## What Changed
- Added `API_BASE_URL` to `x-frontend-backend-config` in `docker-compose.frontend.yml` and `x-sdk-backend-config` in `docker-compose.test.yml`
- Removed `ENVIRONMENT: test` from both files — it was never read by the backend (no matching pydantic field or `os.getenv` call)

## Additional Context
The backend container was crashing at import time with `pydantic_core.ValidationError: API_BASE_URL Field required`, causing all 3 E2E shards to exit before running any tests and the `merge-reports` job to fail downstream.
