### PR TITLE
Fix project_id not flowing through architect and Penelope execution

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -75,10 +75,16 @@ def get_session_variables(db: Session):
 
 # Endpoint CRUD
 def get_endpoint(
-    db: Session, endpoint_id: uuid.UUID, organization_id: str, user_id: str
+    db: Session,
+    endpoint_id: uuid.UUID,
+    organization_id: str,
+    user_id: str,
+    project_id: str = None,
 ) -> Optional[models.Endpoint]:
     """Get endpoint with relationships eagerly loaded."""
-    return get_item_detail(db, models.Endpoint, endpoint_id, organization_id, user_id)
+    return get_item_detail(
+        db, models.Endpoint, endpoint_id, organization_id, user_id, project_id=project_id
+    )
 
 
 def get_endpoints(

--- a/apps/backend/src/rhesis/backend/app/mcp_server/local_tools.py
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/local_tools.py
@@ -38,10 +38,16 @@ class LocalToolProvider(MCPTool):
     goes straight through httpx ASGITransport.
     """
 
-    def __init__(self, fastapi_app: Any, auth_token: str):
+    def __init__(
+        self,
+        fastapi_app: Any,
+        auth_token: str,
+        project_id: str | None = None,
+    ):
         # Skip MCPTool.__init__ — we don't have an MCP client.
         self._app = fastapi_app
         self._auth_header = f"Bearer {auth_token}"
+        self._project_id = project_id
         self._tool_defs: List[Dict[str, Any]] = []
         self._operation_map: Dict[str, dict] = {}
         self._confirmation_map: Dict[str, bool] = {}
@@ -96,6 +102,8 @@ class LocalToolProvider(MCPTool):
 
         arguments = dict(kwargs)
         headers = {"Authorization": self._auth_header}
+        if self._project_id:
+            headers["X-Project-Id"] = self._project_id
 
         # Path params
         path = op["path"]

--- a/apps/backend/src/rhesis/backend/app/services/architect/runner.py
+++ b/apps/backend/src/rhesis/backend/app/services/architect/runner.py
@@ -156,7 +156,7 @@ async def build_agent(
         pending_tasks=agent_state.get("pending_tasks") or [],
     )
 
-    tool_provider = LocalToolProvider(fastapi_app, delegation_token)
+    tool_provider = LocalToolProvider(fastapi_app, delegation_token, project_id=project_id)
     explore_tool = ExploreEndpointTool(
         target_factory=_make_target_factory(organization_id, user_id, project_id),
         model=model,

--- a/apps/backend/src/rhesis/backend/app/services/architect/runner.py
+++ b/apps/backend/src/rhesis/backend/app/services/architect/runner.py
@@ -308,6 +308,7 @@ def _make_target_factory(org_id: str, user_id: str, project_id: Optional[str] = 
                     input_data,
                     organization_id=org_id,
                     user_id=str(user_id),
+                    project_id=project_id,
                 )
             )
 
@@ -318,7 +319,9 @@ def _make_target_factory(org_id: str, user_id: str, project_id: Optional[str] = 
             from rhesis.backend.app import crud
 
             with get_db_with_tenant_variables(org_id or "", user_id or "", project_id or "") as db:
-                ep = crud.get_endpoint(db, endpoint_id, organization_id=org_id, user_id=user_id)
+                ep = crud.get_endpoint(
+                    db, endpoint_id, organization_id=org_id, user_id=user_id, project_id=project_id
+                )
                 if ep:
                     name = ep.name or endpoint_id
                     description = ep.description or ""

--- a/apps/backend/src/rhesis/backend/app/services/endpoint/service.py
+++ b/apps/backend/src/rhesis/backend/app/services/endpoint/service.py
@@ -60,6 +60,7 @@ class EndpointService:
         endpoint: Optional[Endpoint] = None,
         deferred_trace: bool = False,
         trace_id: Optional[str] = None,
+        project_id: str = None,
     ) -> Dict[str, Any]:
         """Invoke an endpoint with the given input data.
 
@@ -75,6 +76,7 @@ class EndpointService:
             deferred_trace: When True, trace data is collected in-memory and
                 returned in the result dict under ``_deferred_trace``.
             trace_id: Optional trace_id to reuse (for in-memory multi-turn tracking).
+            project_id: Project ID for explicit filtering (defense-in-depth).
 
         Returns:
             Dict containing the mapped response from the endpoint.
@@ -83,7 +85,7 @@ class EndpointService:
             HTTPException: If endpoint is not found or invocation fails.
         """
         if endpoint is None:
-            endpoint = self._get_endpoint(db, endpoint_id, organization_id)
+            endpoint = self._get_endpoint(db, endpoint_id, organization_id, project_id)
         logger.debug(f"Invoking endpoint {endpoint.name} ({endpoint.connection_type})")
 
         try:
@@ -382,13 +384,28 @@ class EndpointService:
                 organization_id=organization_id,
             )
 
-    def _get_endpoint(self, db: Session, endpoint_id: str, organization_id: str = None) -> Endpoint:
-        """Fetch an endpoint by ID, applying organization-level security filtering."""
+    def _get_endpoint(
+        self,
+        db: Session,
+        endpoint_id: str,
+        organization_id: str = None,
+        project_id: str = None,
+    ) -> Endpoint:
+        """Fetch an endpoint by ID, applying organization and project security filtering."""
+        from uuid import UUID
+
+        from sqlalchemy import or_
+
         query = db.query(Endpoint).filter(Endpoint.id == endpoint_id)
         if organization_id:
-            from uuid import UUID
-
             query = query.filter(Endpoint.organization_id == UUID(organization_id))
+        if project_id:
+            query = query.filter(
+                or_(
+                    Endpoint.project_id == UUID(project_id),
+                    Endpoint.project_id.is_(None),
+                )
+            )
         endpoint = query.first()
         if not endpoint:
             raise HTTPException(status_code=404, detail="Endpoint not found or not accessible")

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -335,6 +335,7 @@ def get_item_detail(
     organization_id: str = None,
     user_id: str = None,
     include_deleted: bool = False,
+    project_id: str = None,
 ) -> Optional[T]:
     """
     Get a single item with all first-level relationships eagerly loaded.
@@ -348,6 +349,10 @@ def get_item_detail(
         organization_id: Organization ID for filtering
         user_id: User ID for filtering
         include_deleted: If True, include soft-deleted records (default: False)
+        project_id: Project ID for filtering (defense-in-depth alongside
+            the session auto-filter).  When provided the predicate is
+            ``project_id = :pid OR project_id IS NULL`` so org-level rows
+            remain visible.  ``None`` skips the filter.
 
     Returns:
         Item with relationships loaded or None if not found
@@ -361,6 +366,7 @@ def get_item_detail(
         .with_deleted()  # Always include deleted to check status
         .with_optimized_loads(skip_one_to_many=True)
         .with_organization_filter(organization_id)
+        .with_project_filter(project_id)
         .with_visibility_filter()
         .filter_by_id(item_id)
     )

--- a/apps/backend/src/rhesis/backend/celery/signals.py
+++ b/apps/backend/src/rhesis/backend/celery/signals.py
@@ -2,7 +2,7 @@ import logging
 
 from celery.signals import task_failure, task_revoked, worker_shutdown
 
-import rhesis.backend.tasks.architect_monitor  # noqa: F401
+import rhesis.backend.tasks.architect.monitor  # noqa: F401
 from rhesis.backend.tasks.enums import RunStatus
 
 logger = logging.getLogger("celery.signals")

--- a/apps/backend/src/rhesis/backend/tasks/architect/__init__.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/__init__.py
@@ -1,0 +1,27 @@
+"""Architect agent task package.
+
+Re-exports the public API so existing import paths continue to work:
+
+    from rhesis.backend.tasks.architect import architect_chat_task
+    from rhesis.backend.tasks.architect import register_awaiting_tasks
+"""
+
+from rhesis.backend.tasks.architect.chat import architect_chat_task
+from rhesis.backend.tasks.architect.monitor import register_awaiting_tasks
+from rhesis.backend.tasks.architect.progress import (
+    lookup_session_for_task,
+    publish_task_progress,
+)
+from rhesis.backend.tasks.architect.telemetry import (
+    _conversation_telemetry_context,
+    _load_session_trace_id,
+)
+
+__all__ = [
+    "architect_chat_task",
+    "register_awaiting_tasks",
+    "lookup_session_for_task",
+    "publish_task_progress",
+    "_conversation_telemetry_context",
+    "_load_session_trace_id",
+]

--- a/apps/backend/src/rhesis/backend/tasks/architect/chat.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/chat.py
@@ -47,7 +47,10 @@ def architect_chat_task(
     4. Persist response + updated state to DB
     5. Publish final ARCHITECT_RESPONSE event
     """
-    org_id, user_id, project_id = self.get_tenant_context()
+    _org_id, _user_id, _project_id = self.get_tenant_context()
+    org_id = _org_id or ""
+    user_id = _user_id or ""
+    project_id = _project_id or ""
     channel = f"architect:{session_id}"
     target = ChannelTarget(channel=channel)
 
@@ -69,9 +72,9 @@ def architect_chat_task(
 
         prior_trace_id = _load_session_trace_id(session_id, org_id, user_id, project_id)
         ctx = EndpointContext(
-            organization_id=org_id or "",
-            user_id=user_id or "",
-            project_id=project_id or "",
+            organization_id=org_id,
+            user_id=user_id,
+            project_id=project_id,
             _db_factory=get_db_with_tenant_variables,
         )
 
@@ -121,10 +124,10 @@ def architect_chat_task(
             register_awaiting_tasks(
                 session_id=session_id,
                 task_ids=[t["task_id"] for t in result.pending_tasks],
-                org_id=org_id or "",
-                user_id=user_id or "",
+                org_id=org_id,
+                user_id=user_id,
                 auto_approve=result.auto_approve_all,
-                project_id=project_id or "",
+                project_id=project_id,
             )
 
         publish_event(

--- a/apps/backend/src/rhesis/backend/tasks/architect/chat.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/chat.py
@@ -5,9 +5,7 @@ via Redis pub/sub, and persists the final response + updated state.
 """
 
 import logging
-from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Dict, Optional
-from uuid import UUID
+from typing import Any, Dict, Optional
 
 from rhesis.backend.app.schemas.websocket import (
     ChannelTarget,
@@ -15,83 +13,14 @@ from rhesis.backend.app.schemas.websocket import (
     WebSocketMessage,
 )
 from rhesis.backend.app.services.websocket.publisher import publish_event
+from rhesis.backend.tasks.architect.telemetry import (
+    _conversation_telemetry_context,
+    _load_session_trace_id,
+)
 from rhesis.backend.tasks.base import SilentTask
 from rhesis.backend.worker import app
 
 logger = logging.getLogger(__name__)
-
-
-@asynccontextmanager
-async def _conversation_telemetry_context(
-    conversation_id: Optional[str],
-    conversation_trace_id: Optional[str],
-    mapped_input: Optional[str],
-) -> AsyncIterator[None]:
-    """Bind the SDK conversation telemetry ContextVars for one turn.
-
-    The SDK tracer reuses ``conversation_trace_id`` (if set) as the
-    trace_id for the root span this turn opens, so subsequent turns of
-    the same architect session render as one coherent trace in the
-    viewer instead of one trace per turn.  All four ContextVars are
-    cleared on exit so they do not leak into surrounding scopes that
-    share the same asyncio task.
-    """
-    from rhesis.sdk.telemetry.context import (
-        set_conversation_id,
-        set_conversation_mapped_input,
-        set_conversation_trace_id,
-        set_root_trace_id,
-    )
-
-    if conversation_id:
-        set_conversation_id(conversation_id)
-    if conversation_trace_id:
-        set_conversation_trace_id(conversation_trace_id)
-    if mapped_input:
-        set_conversation_mapped_input(mapped_input)
-    set_root_trace_id(None)
-    try:
-        yield
-    finally:
-        set_conversation_id(None)
-        set_conversation_trace_id(None)
-        set_conversation_mapped_input(None)
-        set_root_trace_id(None)
-
-
-def _load_session_trace_id(
-    session_id: str,
-    organization_id: Optional[str],
-    user_id: Optional[str],
-    project_id: Optional[str] = None,
-) -> Optional[str]:
-    """Return the conversation root trace_id stamped by a prior turn.
-
-    ``persist_state`` stores the SDK tracer's root trace_id under
-    ``agent_state["conversation_trace_id"]`` on every turn.  Returns
-    ``None`` for the first turn of a session and on any DB lookup
-    failure -- tracing is best-effort and must not break the chat.
-    """
-    if not session_id or not organization_id:
-        return None
-    try:
-        from rhesis.backend.app import crud
-        from rhesis.backend.app.database import get_db_with_tenant_variables
-
-        with get_db_with_tenant_variables(organization_id, user_id or "", project_id or "") as db:
-            session_row = crud.get_architect_session(
-                db,
-                session_id=UUID(session_id),
-                organization_id=organization_id,
-                user_id=user_id or "",
-            )
-            if session_row is None:
-                return None
-            agent_state = session_row.agent_state or {}
-            return agent_state.get("conversation_trace_id")
-    except Exception as exc:
-        logger.warning("Failed to load conversation_trace_id for %s: %s", session_id, exc)
-        return None
 
 
 @app.task(
@@ -142,6 +71,7 @@ def architect_chat_task(
         ctx = EndpointContext(
             organization_id=org_id or "",
             user_id=user_id or "",
+            project_id=project_id or "",
             _db_factory=get_db_with_tenant_variables,
         )
 
@@ -163,8 +93,6 @@ def architect_chat_task(
 
         result: ArchitectChatResult = asyncio.run(_run())
 
-        # Park the conversation output so the telemetry ingest pipeline
-        # can stamp ``rhesis.conversation.output`` on the root span.
         if result.content:
             try:
                 from rhesis.backend.app.services.telemetry.conversation_linking import (
@@ -178,12 +106,17 @@ def architect_chat_task(
                         trace_id=turn_trace_id,
                         mapped_output=result.content,
                     )
-                    logger.debug("Parked conversation output for trace_id=%s", turn_trace_id)
+                    logger.debug(
+                        "Parked conversation output for trace_id=%s",
+                        turn_trace_id,
+                    )
             except Exception as exc:
                 logger.warning("Failed to park conversation output: %s", exc)
 
         if result.pending_tasks:
-            from rhesis.backend.tasks.architect_monitor import register_awaiting_tasks
+            from rhesis.backend.tasks.architect.monitor import (
+                register_awaiting_tasks,
+            )
 
             register_awaiting_tasks(
                 session_id=session_id,
@@ -191,6 +124,7 @@ def architect_chat_task(
                 org_id=org_id or "",
                 user_id=user_id or "",
                 auto_approve=result.auto_approve_all,
+                project_id=project_id or "",
             )
 
         publish_event(
@@ -236,16 +170,3 @@ def architect_chat_task(
             target,
         )
         raise
-
-
-def _process_attachments(
-    attachments: Optional[Dict[str, Any]],
-) -> Optional[Dict[str, Any]]:
-    """Thin shim preserved for callers outside this module.
-
-    Delegates to the canonical implementation in
-    :mod:`rhesis.backend.app.services.architect.attachments`.
-    """
-    from rhesis.backend.app.services.architect.attachments import process_attachments
-
-    return process_attachments(attachments)

--- a/apps/backend/src/rhesis/backend/tasks/architect/monitor.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/monitor.py
@@ -263,8 +263,8 @@ def _resume_architect(
             "auto_approve": context.get("auto_approve"),
         },
         headers={
-            "organization_id": context.get("org_id", ""),
-            "user_id": context.get("user_id", ""),
-            "project_id": context.get("project_id", ""),
+            "organization_id": context.get("org_id") or "",
+            "user_id": context.get("user_id") or "",
+            "project_id": context.get("project_id") or "",
         },
     )

--- a/apps/backend/src/rhesis/backend/tasks/architect/monitor.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/monitor.py
@@ -44,7 +44,7 @@ def _get_redis() -> _redis_lib.Redis:
 
 
 # ------------------------------------------------------------------
-# Public API — called from architect.py
+# Public API — called from chat.py
 # ------------------------------------------------------------------
 
 
@@ -54,6 +54,7 @@ def register_awaiting_tasks(
     org_id: str,
     user_id: str,
     auto_approve: bool = False,
+    project_id: str | None = None,
 ) -> None:
     """Store the set of task IDs the Architect is waiting for."""
     r = _get_redis()
@@ -65,6 +66,7 @@ def register_awaiting_tasks(
             "org_id": org_id,
             "user_id": user_id,
             "auto_approve": auto_approve,
+            "project_id": project_id,
         }
     )
 
@@ -84,7 +86,7 @@ def register_awaiting_tasks(
 
 
 # ------------------------------------------------------------------
-# Result summarisation (reused from previous implementation)
+# Result summarisation
 # ------------------------------------------------------------------
 
 
@@ -252,7 +254,7 @@ def _resume_architect(
         session_id,
     )
 
-    from rhesis.backend.tasks.architect import architect_chat_task
+    from rhesis.backend.tasks.architect.chat import architect_chat_task
 
     architect_chat_task.apply_async(
         kwargs={
@@ -263,5 +265,6 @@ def _resume_architect(
         headers={
             "organization_id": context.get("org_id", ""),
             "user_id": context.get("user_id", ""),
+            "project_id": context.get("project_id", ""),
         },
     )

--- a/apps/backend/src/rhesis/backend/tasks/architect/progress.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/progress.py
@@ -25,7 +25,7 @@ from rhesis.backend.app.schemas.websocket import (
     WebSocketMessage,
 )
 from rhesis.backend.app.services.websocket.publisher import publish_event
-from rhesis.backend.tasks.architect_monitor import _get_redis
+from rhesis.backend.tasks.architect.monitor import _get_redis
 
 logger = logging.getLogger(__name__)
 

--- a/apps/backend/src/rhesis/backend/tasks/architect/telemetry.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/telemetry.py
@@ -1,0 +1,89 @@
+"""Conversation telemetry helpers for the Architect agent.
+
+Binds SDK telemetry ContextVars around each chat turn so multi-turn
+sessions render as one coherent trace in the viewer.
+"""
+
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Optional
+from uuid import UUID
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _conversation_telemetry_context(
+    conversation_id: Optional[str],
+    conversation_trace_id: Optional[str],
+    mapped_input: Optional[str],
+) -> AsyncIterator[None]:
+    """Bind the SDK conversation telemetry ContextVars for one turn.
+
+    The SDK tracer reuses ``conversation_trace_id`` (if set) as the
+    trace_id for the root span this turn opens, so subsequent turns of
+    the same architect session render as one coherent trace in the
+    viewer instead of one trace per turn.  All four ContextVars are
+    cleared on exit so they do not leak into surrounding scopes that
+    share the same asyncio task.
+    """
+    from rhesis.sdk.telemetry.context import (
+        set_conversation_id,
+        set_conversation_mapped_input,
+        set_conversation_trace_id,
+        set_root_trace_id,
+    )
+
+    if conversation_id:
+        set_conversation_id(conversation_id)
+    if conversation_trace_id:
+        set_conversation_trace_id(conversation_trace_id)
+    if mapped_input:
+        set_conversation_mapped_input(mapped_input)
+    set_root_trace_id(None)
+    try:
+        yield
+    finally:
+        set_conversation_id(None)
+        set_conversation_trace_id(None)
+        set_conversation_mapped_input(None)
+        set_root_trace_id(None)
+
+
+def _load_session_trace_id(
+    session_id: str,
+    organization_id: Optional[str],
+    user_id: Optional[str],
+    project_id: Optional[str] = None,
+) -> Optional[str]:
+    """Return the conversation root trace_id stamped by a prior turn.
+
+    ``persist_state`` stores the SDK tracer's root trace_id under
+    ``agent_state["conversation_trace_id"]`` on every turn.  Returns
+    ``None`` for the first turn of a session and on any DB lookup
+    failure -- tracing is best-effort and must not break the chat.
+    """
+    if not session_id or not organization_id:
+        return None
+    try:
+        from rhesis.backend.app import crud
+        from rhesis.backend.app.database import get_db_with_tenant_variables
+
+        with get_db_with_tenant_variables(organization_id, user_id or "", project_id or "") as db:
+            session_row = crud.get_architect_session(
+                db,
+                session_id=UUID(session_id),
+                organization_id=organization_id,
+                user_id=user_id or "",
+            )
+            if session_row is None:
+                return None
+            agent_state = session_row.agent_state or {}
+            return agent_state.get("conversation_trace_id")
+    except Exception as exc:
+        logger.warning(
+            "Failed to load conversation_trace_id for %s: %s",
+            session_id,
+            exc,
+        )
+        return None

--- a/apps/backend/src/rhesis/backend/tasks/endpoint/explore.py
+++ b/apps/backend/src/rhesis/backend/tasks/endpoint/explore.py
@@ -18,7 +18,7 @@ from rhesis.backend.app import crud
 from rhesis.backend.app.database import get_db_with_tenant_variables
 from rhesis.backend.app.utils.user_model_utils import get_user_generation_model
 from rhesis.backend.celery.core import app
-from rhesis.backend.tasks.architect_progress import publish_task_progress
+from rhesis.backend.tasks.architect.progress import publish_task_progress
 from rhesis.backend.tasks.base import SilentTask
 from rhesis.backend.tasks.endpoint.target import make_target_factory
 
@@ -148,7 +148,9 @@ def run_exploration_task(
     start = time.monotonic()
 
     with get_db_with_tenant_variables(org_id or "", user_id or "", project_id or "") as db:
-        target_factory = make_target_factory(org_id=org_id, user_id=user_id, db=db)
+        target_factory = make_target_factory(
+            org_id=org_id, user_id=user_id, db=db, project_id=project_id
+        )
 
         tool = ExploreEndpointTool(
             target_factory=target_factory,

--- a/apps/backend/src/rhesis/backend/tasks/endpoint/target.py
+++ b/apps/backend/src/rhesis/backend/tasks/endpoint/target.py
@@ -27,6 +27,7 @@ def make_target_factory(
     org_id: str,
     user_id: str,
     db: "Session",
+    project_id: str | None = None,
 ) -> Callable[[str], "BackendEndpointTarget"]:
     """Return a factory that creates ``BackendEndpointTarget`` instances.
 
@@ -36,6 +37,7 @@ def make_target_factory(
         db: An open SQLAlchemy session.  The caller must keep this session
             alive for the entire duration of the exploration (i.e. until
             all ``send_message`` calls on the returned targets complete).
+        project_id: Project UUID string for tenant isolation.
 
     Returns:
         A callable ``(endpoint_id: str) -> BackendEndpointTarget``.
@@ -48,6 +50,7 @@ def make_target_factory(
             endpoint_id=endpoint_id,
             organization_id=org_id,
             user_id=str(user_id),
+            project_id=project_id,
         )
 
     return factory

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/invocation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/invocation.py
@@ -108,6 +108,7 @@ async def _run_multi_turn(
         endpoint_id=str(ctx.endpoint.id),
         organization_id=ctx.organization_id,
         user_id=ctx.user_id,
+        project_id=ctx.project_id,
         test_execution_context=test_execution_context,
         endpoint=ctx.endpoint,
         invoke_max_attempts=ctx.invoke_max_attempts,

--- a/apps/backend/src/rhesis/backend/tasks/execution/penelope_target.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/penelope_target.py
@@ -133,6 +133,7 @@ class BackendEndpointTarget(Target):
                 UUID(self.endpoint_id),
                 organization_id=self.organization_id,
                 user_id=self.user_id,
+                project_id=self.project_id,
             )
             if endpoint:
                 self._endpoint_name = endpoint.name
@@ -181,6 +182,7 @@ class BackendEndpointTarget(Target):
                 UUID(self.endpoint_id),
                 organization_id=self.organization_id,
                 user_id=self.user_id,
+                project_id=self.project_id,
             )
             if not endpoint:
                 return False, f"Endpoint {self.endpoint_id} not found or not accessible"
@@ -271,6 +273,7 @@ class BackendEndpointTarget(Target):
                     organization_id=self.organization_id,
                     user_id=self.user_id,
                     test_execution_context=self.test_execution_context,
+                    project_id=self.project_id,
                 )
             )
 
@@ -394,6 +397,7 @@ class BackendEndpointTarget(Target):
                     endpoint=self._endpoint,
                     deferred_trace=True,
                     trace_id=self._current_trace_id,
+                    project_id=self.project_id,
                 )
 
             response_data = await invoke_with_retry(

--- a/apps/backend/src/rhesis/backend/tasks/execution/penelope_target.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/penelope_target.py
@@ -67,6 +67,7 @@ class BackendEndpointTarget(Target):
         endpoint_id: str = "",
         organization_id: Optional[str] = None,
         user_id: Optional[str] = None,
+        project_id: Optional[str] = None,
         test_execution_context: Optional[dict[str, str]] = None,
         endpoint: Optional[Endpoint] = None,
         invoke_max_attempts: int = 4,
@@ -96,6 +97,7 @@ class BackendEndpointTarget(Target):
         self.endpoint_id = endpoint_id or (str(endpoint.id) if endpoint else "")
         self.organization_id = organization_id
         self.user_id = user_id
+        self.project_id = project_id
         self.test_execution_context = test_execution_context
         self.endpoint_service = get_endpoint_service()
         self._invoke_max_attempts = invoke_max_attempts

--- a/sdk/src/rhesis/sdk/connector/manager.py
+++ b/sdk/src/rhesis/sdk/connector/manager.py
@@ -129,6 +129,7 @@ class ConnectorManager:
         return EndpointContext(
             organization_id=self._organization_id,
             user_id=self._user_id,
+            project_id=self.project_id or "",
         )
 
     def _ensure_connection(self) -> None:

--- a/sdk/src/rhesis/sdk/context.py
+++ b/sdk/src/rhesis/sdk/context.py
@@ -43,13 +43,11 @@ class EndpointContext:
             with ctx.get_db() as db:
                 rows = db.query(Model).all()
 
-        A ``_db_factory`` **must** be supplied at construction time.
-        Platform-side code (Celery tasks, HTTP routes, and the internal
-        SDK connector) always provides one.  Calling this method on a
-        context created without a factory raises :exc:`RuntimeError`.
-
-        External SDK users writing ``@endpoint`` functions that do not
-        declare a ``ctx: EndpointContext`` parameter are unaffected.
+        When ``_db_factory`` is provided, it is called with
+        ``(organization_id, user_id, project_id)``.  Otherwise, falls
+        back to the backend's ``get_db_with_tenant_variables`` (when
+        running inside the backend process).  Raises
+        :exc:`RuntimeError` outside the backend if no factory is set.
         """
         if self._db_factory is not None:
             return self._db_factory(self.organization_id, self.user_id, self.project_id)

--- a/sdk/src/rhesis/sdk/context.py
+++ b/sdk/src/rhesis/sdk/context.py
@@ -30,6 +30,7 @@ class EndpointContext:
 
     organization_id: str
     user_id: str
+    project_id: str = ""
     _db_factory: Optional[Callable[..., ContextManager[Any]]] = field(
         default=None, repr=False, compare=False
     )
@@ -51,7 +52,7 @@ class EndpointContext:
         declare a ``ctx: EndpointContext`` parameter are unaffected.
         """
         if self._db_factory is not None:
-            return self._db_factory(self.organization_id, self.user_id)
+            return self._db_factory(self.organization_id, self.user_id, self.project_id)
 
         # Try the backend module as a fallback so the internal connector
         # (which runs inside the backend process) works without needing to
@@ -61,7 +62,7 @@ class EndpointContext:
         try:
             from rhesis.backend.app.database import get_db_with_tenant_variables
 
-            return get_db_with_tenant_variables(self.organization_id, self.user_id)
+            return get_db_with_tenant_variables(self.organization_id, self.user_id, self.project_id)
         except ImportError:
             raise RuntimeError(
                 "EndpointContext.get_db() requires a _db_factory when called "

--- a/tests/backend/services/test_mcp_service.py
+++ b/tests/backend/services/test_mcp_service.py
@@ -52,7 +52,7 @@ def _make_ctx(org_id="test-org-id", user_id="test-user-id", db=None):
         return EndpointContext(
             organization_id=org_id,
             user_id=user_id,
-            _db_factory=lambda o, u: _FakeCtxMgr(),
+            _db_factory=lambda o, u, p="": _FakeCtxMgr(),
         )
     return EndpointContext(organization_id=org_id, user_id=user_id)
 

--- a/tests/backend/tasks/architect/test_chat.py
+++ b/tests/backend/tasks/architect/test_chat.py
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from rhesis.backend.app.services.architect.runner import persist_state
-from rhesis.backend.tasks.architect import (
+from rhesis.backend.tasks.architect.telemetry import (
     _conversation_telemetry_context,
     _load_session_trace_id,
 )
@@ -57,6 +57,16 @@ class TestLoadSessionTraceId:
         result = _load_session_trace_id(_VALID_SESSION_ID, "org", "user")
 
         assert result == "abc123"
+
+    @patch("rhesis.backend.app.database.get_db_with_tenant_variables")
+    @patch("rhesis.backend.app.crud.get_architect_session")
+    def test_forwards_project_id_to_db_factory(self, mock_get_session, mock_db_ctx):
+        mock_db_ctx.return_value.__enter__.return_value = MagicMock()
+        mock_get_session.return_value = _make_session_row({"conversation_trace_id": "x"})
+
+        _load_session_trace_id(_VALID_SESSION_ID, "org", "user", project_id="proj-1")
+
+        mock_db_ctx.assert_called_once_with("org", "user", "proj-1")
 
     @patch("rhesis.backend.app.database.get_db_with_tenant_variables")
     @patch("rhesis.backend.app.crud.get_architect_session")
@@ -308,7 +318,7 @@ def test_task_parks_conversation_output_when_trace_id_available():
         patch(
             "rhesis.backend.app.services.telemetry.conversation_linking.register_pending_output"
         ) as mock_register,
-        patch("rhesis.backend.tasks.architect.architect_chat_task.run"),
+        patch("rhesis.backend.tasks.architect.chat.architect_chat_task.run"),
     ):
         # Simulate the parking logic directly (isolated from Celery infra).
         from rhesis.backend.app.services.telemetry.conversation_linking import (

--- a/tests/backend/tasks/architect/test_event_handler.py
+++ b/tests/backend/tasks/architect/test_event_handler.py
@@ -16,9 +16,6 @@ from rhesis.backend.app.services.architect.event_handler import (
     _tool_description,
 )
 
-# Keep the legacy name used by older callers / the CHANGELOG shim.
-_process_attachments = process_attachments
-
 _HANDLER_MODULE = "rhesis.backend.app.services.architect.event_handler"
 
 # ---------------------------------------------------------------------------
@@ -335,8 +332,8 @@ class TestProcessAttachments:
     _EXTRACT_PATH = "rhesis.sdk.services.extractor.extract_with_vision_fallback"
 
     def test_returns_none_for_empty_input(self):
-        assert _process_attachments(None) is None
-        assert _process_attachments({}) is None
+        assert process_attachments(None) is None
+        assert process_attachments({}) is None
 
     def test_files_produce_extracted_text_key(self):
         b64_data = base64.b64encode(b"%PDF-fake").decode("ascii")
@@ -351,16 +348,14 @@ class TestProcessAttachments:
         }
 
         with patch(self._EXTRACT_PATH, return_value="3 microservices"):
-            result = _process_attachments(attachments)
+            result = process_attachments(attachments)
 
         assert result is not None
         assert "files" in result
         f = result["files"][0]
         assert f["filename"] == "deck.pdf"
         assert f["content_type"] == "application/pdf"
-        # Canonical key shared with the rest of the pipeline.
         assert f["extracted_text"] == "3 microservices"
-        # Legacy key must not be emitted any more.
         assert "content" not in f
 
     def test_extraction_failure_falls_back_to_marker_in_extracted_text(self):
@@ -372,7 +367,7 @@ class TestProcessAttachments:
         }
 
         with patch(self._EXTRACT_PATH, side_effect=RuntimeError("LLM down")):
-            result = _process_attachments(attachments)
+            result = process_attachments(attachments)
 
         f = result["files"][0]
         assert "could not extract" in f["extracted_text"].lower()
@@ -380,5 +375,5 @@ class TestProcessAttachments:
 
     def test_mentions_pass_through(self):
         attachments = {"mentions": [{"type": "test", "id": "t-1", "display": "a"}]}
-        result = _process_attachments(attachments)
+        result = process_attachments(attachments)
         assert result == {"mentions": attachments["mentions"]}

--- a/tests/backend/tasks/architect/test_monitor.py
+++ b/tests/backend/tasks/architect/test_monitor.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from rhesis.backend.tasks.architect_monitor import (
+from rhesis.backend.tasks.architect.monitor import (
     _on_task_done,
     _resolve_awaiting_key,
     _resume_architect,
@@ -13,7 +13,7 @@ from rhesis.backend.tasks.architect_monitor import (
     register_awaiting_tasks,
 )
 
-_CHAT_TASK_PATH = "rhesis.backend.tasks.architect.architect_chat_task"
+_CHAT_TASK_PATH = "rhesis.backend.tasks.architect.chat.architect_chat_task"
 
 
 # ---------------------------------------------------------------------------
@@ -29,7 +29,7 @@ def mock_redis():
     r.exists.return_value = False
     r.scan_iter.return_value = []
     with patch(
-        "rhesis.backend.tasks.architect_monitor._get_redis",
+        "rhesis.backend.tasks.architect.monitor._get_redis",
         return_value=r,
     ):
         yield r
@@ -139,6 +139,33 @@ class TestRegisterAwaitingTasks:
         assert ctx["user_id"] == "user-2"
         assert ctx["auto_approve"] is False
 
+    def test_context_includes_project_id(self, mock_redis):
+        register_awaiting_tasks(
+            session_id="sess-3",
+            task_ids=["tid-d"],
+            org_id="org-3",
+            user_id="user-3",
+            project_id="proj-1",
+        )
+
+        pipe = mock_redis.pipeline.return_value
+        set_calls = [c for c in pipe.method_calls if c[0] == "set"]
+        ctx = json.loads(set_calls[0][1][1])
+        assert ctx["project_id"] == "proj-1"
+
+    def test_context_project_id_defaults_to_none(self, mock_redis):
+        register_awaiting_tasks(
+            session_id="sess-4",
+            task_ids=["tid-e"],
+            org_id="org-4",
+            user_id="user-4",
+        )
+
+        pipe = mock_redis.pipeline.return_value
+        set_calls = [c for c in pipe.method_calls if c[0] == "set"]
+        ctx = json.loads(set_calls[0][1][1])
+        assert ctx["project_id"] is None
+
 
 # ---------------------------------------------------------------------------
 # _resolve_awaiting_key
@@ -236,7 +263,7 @@ class TestOnTaskDone:
         assert result_key == "arch:result:sess-1:tid-a"
         mock_redis.decr.assert_called_once_with("arch:count:sess-1")
 
-    @patch("rhesis.backend.tasks.architect_monitor._resume_architect")
+    @patch("rhesis.backend.tasks.architect.monitor._resume_architect")
     def test_matches_via_test_run_id_in_result(
         self, mock_resume, mock_redis
     ):
@@ -270,7 +297,7 @@ class TestOnTaskDone:
         mock_redis.decr.assert_called_once_with("arch:count:sess-1")
         mock_resume.assert_called_once()
 
-    @patch("rhesis.backend.tasks.architect_monitor._resume_architect")
+    @patch("rhesis.backend.tasks.architect.monitor._resume_architect")
     def test_resumes_when_counter_hits_zero(self, mock_resume, mock_redis):
         ctx = json.dumps({
             "session_id": "sess-1",
@@ -289,7 +316,7 @@ class TestOnTaskDone:
         assert call_args[0][0] == "sess-1"
         assert call_args[0][1]["auto_approve"] is True
 
-    @patch("rhesis.backend.tasks.architect_monitor._resume_architect")
+    @patch("rhesis.backend.tasks.architect.monitor._resume_architect")
     def test_does_not_resume_while_tasks_remain(self, mock_resume, mock_redis):
         ctx = json.dumps({
             "session_id": "sess-1",
@@ -387,3 +414,44 @@ class TestResumeArchitect:
         deleted_keys = [c[1][0] for c in delete_calls]
         assert b"arch:result:sess-2:tid-x" in deleted_keys
         assert "arch:count:sess-2" in deleted_keys
+
+    @patch(_CHAT_TASK_PATH)
+    def test_forwards_project_id_in_headers(self, mock_chat_task, mock_redis):
+        mock_redis.scan_iter.return_value = [b"arch:result:sess-3:tid-y"]
+        mock_redis.get.return_value = json.dumps({
+            "task_id": "tid-y",
+            "state": "SUCCESS",
+            "result": {},
+        }).encode()
+
+        context = {
+            "session_id": "sess-3",
+            "org_id": "org-1",
+            "user_id": "user-1",
+            "project_id": "proj-1",
+        }
+
+        _resume_architect("sess-3", context, mock_redis)
+
+        kw = mock_chat_task.apply_async.call_args.kwargs
+        assert kw["headers"]["project_id"] == "proj-1"
+
+    @patch(_CHAT_TASK_PATH)
+    def test_project_id_defaults_to_empty_string(self, mock_chat_task, mock_redis):
+        mock_redis.scan_iter.return_value = [b"arch:result:sess-4:tid-z"]
+        mock_redis.get.return_value = json.dumps({
+            "task_id": "tid-z",
+            "state": "SUCCESS",
+            "result": {},
+        }).encode()
+
+        context = {
+            "session_id": "sess-4",
+            "org_id": "org-1",
+            "user_id": "user-1",
+        }
+
+        _resume_architect("sess-4", context, mock_redis)
+
+        kw = mock_chat_task.apply_async.call_args.kwargs
+        assert kw["headers"]["project_id"] == ""

--- a/tests/backend/tasks/architect/test_progress.py
+++ b/tests/backend/tasks/architect/test_progress.py
@@ -11,16 +11,15 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # lookup_session_for_task
 # ---------------------------------------------------------------------------
 
 
 class TestLookupSessionForTask:
-    @patch("rhesis.backend.tasks.architect_progress._get_redis")
+    @patch("rhesis.backend.tasks.architect.progress._get_redis")
     def test_returns_session_id_when_key_present(self, mock_get_redis):
-        from rhesis.backend.tasks.architect_progress import lookup_session_for_task
+        from rhesis.backend.tasks.architect.progress import lookup_session_for_task
 
         mock_redis = MagicMock()
         mock_redis.get.return_value = json.dumps(
@@ -31,9 +30,9 @@ class TestLookupSessionForTask:
         assert lookup_session_for_task("task-abc") == "sess-123"
         mock_redis.get.assert_called_once_with("arch:task:task-abc")
 
-    @patch("rhesis.backend.tasks.architect_progress._get_redis")
+    @patch("rhesis.backend.tasks.architect.progress._get_redis")
     def test_returns_none_when_key_missing(self, mock_get_redis):
-        from rhesis.backend.tasks.architect_progress import lookup_session_for_task
+        from rhesis.backend.tasks.architect.progress import lookup_session_for_task
 
         mock_redis = MagicMock()
         mock_redis.get.return_value = None
@@ -41,9 +40,9 @@ class TestLookupSessionForTask:
 
         assert lookup_session_for_task("task-missing") is None
 
-    @patch("rhesis.backend.tasks.architect_progress._get_redis")
+    @patch("rhesis.backend.tasks.architect.progress._get_redis")
     def test_returns_none_on_invalid_json(self, mock_get_redis):
-        from rhesis.backend.tasks.architect_progress import lookup_session_for_task
+        from rhesis.backend.tasks.architect.progress import lookup_session_for_task
 
         mock_redis = MagicMock()
         mock_redis.get.return_value = b"not-valid-json"
@@ -51,9 +50,9 @@ class TestLookupSessionForTask:
 
         assert lookup_session_for_task("task-bad") is None
 
-    @patch("rhesis.backend.tasks.architect_progress._get_redis")
+    @patch("rhesis.backend.tasks.architect.progress._get_redis")
     def test_returns_none_when_session_id_missing(self, mock_get_redis):
-        from rhesis.backend.tasks.architect_progress import lookup_session_for_task
+        from rhesis.backend.tasks.architect.progress import lookup_session_for_task
 
         mock_redis = MagicMock()
         mock_redis.get.return_value = json.dumps({"org_id": "org-1"})
@@ -61,11 +60,9 @@ class TestLookupSessionForTask:
 
         assert lookup_session_for_task("task-no-sid") is None
 
-    @patch("rhesis.backend.tasks.architect_progress._get_redis")
+    @patch("rhesis.backend.tasks.architect.progress._get_redis")
     def test_returns_none_on_redis_failure(self, mock_get_redis):
-        # Redis unavailable / connection error must never propagate —
-        # background workers should keep running for non-architect callers.
-        from rhesis.backend.tasks.architect_progress import lookup_session_for_task
+        from rhesis.backend.tasks.architect.progress import lookup_session_for_task
 
         mock_get_redis.side_effect = RuntimeError("redis down")
 
@@ -78,16 +75,14 @@ class TestLookupSessionForTask:
 
 
 class TestPublishTaskProgress:
-    @patch("rhesis.backend.tasks.architect_progress.publish_event")
-    @patch("rhesis.backend.tasks.architect_progress.lookup_session_for_task")
-    def test_publishes_to_session_channel(
-        self, mock_lookup, mock_publish
-    ):
+    @patch("rhesis.backend.tasks.architect.progress.publish_event")
+    @patch("rhesis.backend.tasks.architect.progress.lookup_session_for_task")
+    def test_publishes_to_session_channel(self, mock_lookup, mock_publish):
         from rhesis.backend.app.schemas.websocket import (
             ChannelTarget,
             EventType,
         )
-        from rhesis.backend.tasks.architect_progress import publish_task_progress
+        from rhesis.backend.tasks.architect.progress import publish_task_progress
 
         mock_lookup.return_value = "sess-1"
 
@@ -109,12 +104,10 @@ class TestPublishTaskProgress:
         assert isinstance(target, ChannelTarget)
         assert target.channel == "architect:sess-1"
 
-    @patch("rhesis.backend.tasks.architect_progress.publish_event")
-    @patch("rhesis.backend.tasks.architect_progress.lookup_session_for_task")
-    def test_includes_optional_fields_when_provided(
-        self, mock_lookup, mock_publish
-    ):
-        from rhesis.backend.tasks.architect_progress import publish_task_progress
+    @patch("rhesis.backend.tasks.architect.progress.publish_event")
+    @patch("rhesis.backend.tasks.architect.progress.lookup_session_for_task")
+    def test_includes_optional_fields_when_provided(self, mock_lookup, mock_publish):
+        from rhesis.backend.tasks.architect.progress import publish_task_progress
 
         mock_lookup.return_value = "sess-1"
         publish_task_progress(
@@ -131,12 +124,10 @@ class TestPublishTaskProgress:
         assert payload["total"] == 8
         assert payload["duration_ms"] == 1234
 
-    @patch("rhesis.backend.tasks.architect_progress.publish_event")
-    @patch("rhesis.backend.tasks.architect_progress.lookup_session_for_task")
-    def test_skips_optional_fields_when_omitted(
-        self, mock_lookup, mock_publish
-    ):
-        from rhesis.backend.tasks.architect_progress import publish_task_progress
+    @patch("rhesis.backend.tasks.architect.progress.publish_event")
+    @patch("rhesis.backend.tasks.architect.progress.lookup_session_for_task")
+    def test_skips_optional_fields_when_omitted(self, mock_lookup, mock_publish):
+        from rhesis.backend.tasks.architect.progress import publish_task_progress
 
         mock_lookup.return_value = "sess-1"
         publish_task_progress(task_id="t", status="started", label="Hi")
@@ -145,10 +136,10 @@ class TestPublishTaskProgress:
         for key in ("step", "total", "duration_ms"):
             assert key not in payload, f"{key} should not be set when not provided"
 
-    @patch("rhesis.backend.tasks.architect_progress.publish_event")
-    @patch("rhesis.backend.tasks.architect_progress.lookup_session_for_task")
+    @patch("rhesis.backend.tasks.architect.progress.publish_event")
+    @patch("rhesis.backend.tasks.architect.progress.lookup_session_for_task")
     def test_silent_noop_when_no_session(self, mock_lookup, mock_publish):
-        from rhesis.backend.tasks.architect_progress import publish_task_progress
+        from rhesis.backend.tasks.architect.progress import publish_task_progress
 
         mock_lookup.return_value = None
         publish_task_progress(
@@ -158,14 +149,10 @@ class TestPublishTaskProgress:
         )
         mock_publish.assert_not_called()
 
-    @patch("rhesis.backend.tasks.architect_progress.publish_event")
-    @patch("rhesis.backend.tasks.architect_progress.lookup_session_for_task")
-    def test_skips_lookup_when_session_id_provided(
-        self, mock_lookup, mock_publish
-    ):
-        # Workers that already know the session_id (e.g. cached at task
-        # start) shouldn't pay the Redis read on every event.
-        from rhesis.backend.tasks.architect_progress import publish_task_progress
+    @patch("rhesis.backend.tasks.architect.progress.publish_event")
+    @patch("rhesis.backend.tasks.architect.progress.lookup_session_for_task")
+    def test_skips_lookup_when_session_id_provided(self, mock_lookup, mock_publish):
+        from rhesis.backend.tasks.architect.progress import publish_task_progress
 
         publish_task_progress(
             task_id="task-1",
@@ -177,17 +164,14 @@ class TestPublishTaskProgress:
         assert mock_publish.call_count == 1
         assert mock_publish.call_args.args[0].payload["session_id"] == "sess-cached"
 
-    @patch("rhesis.backend.tasks.architect_progress.publish_event")
-    @patch("rhesis.backend.tasks.architect_progress.lookup_session_for_task")
+    @patch("rhesis.backend.tasks.architect.progress.publish_event")
+    @patch("rhesis.backend.tasks.architect.progress.lookup_session_for_task")
     def test_swallows_publisher_failures(self, mock_lookup, mock_publish):
-        # A Redis publish failure must never raise into the worker —
-        # progress events are best-effort, not load-bearing.
-        from rhesis.backend.tasks.architect_progress import publish_task_progress
+        from rhesis.backend.tasks.architect.progress import publish_task_progress
 
         mock_lookup.return_value = "sess-1"
         mock_publish.side_effect = ConnectionError("redis cluster down")
 
-        # Must not raise.
         publish_task_progress(task_id="t", status="started", label="L")
 
 
@@ -235,8 +219,6 @@ class TestExplorationEmitsProgress:
         result_mock.error = None
         mock_asyncio_run.return_value = result_mock
 
-        # Direct .run() leaves self.request.id empty, so the helper would
-        # short-circuit on ``not task_id``. Stub a synthetic id.
         with (
             patch.object(
                 run_exploration_task,
@@ -251,26 +233,14 @@ class TestExplorationEmitsProgress:
                 create=True,
             ),
         ):
-            run_exploration_task.run(
-                endpoint_id="ep-uuid", strategy="domain_probing"
-            )
+            run_exploration_task.run(endpoint_id="ep-uuid", strategy="domain_probing")
 
         statuses = [call.kwargs.get("status") for call in mock_publish.call_args_list]
         assert "started" in statuses
         assert "progress" in statuses
         assert "completed" in statuses
-        # No session_id is passed — the helper does the Redis lookup
-        # lazily on every call so a late-registered task still gets
-        # picked up mid-run.
-        assert all(
-            "session_id" not in call.kwargs
-            for call in mock_publish.call_args_list
-        )
-        # Every event carries the running task id.
-        assert all(
-            call.kwargs.get("task_id") == "task-abc"
-            for call in mock_publish.call_args_list
-        )
+        assert all("session_id" not in call.kwargs for call in mock_publish.call_args_list)
+        assert all(call.kwargs.get("task_id") == "task-abc" for call in mock_publish.call_args_list)
 
     @patch("rhesis.backend.tasks.endpoint.explore.publish_task_progress")
     @patch("rhesis.backend.tasks.endpoint.explore.asyncio.run")
@@ -289,10 +259,6 @@ class TestExplorationEmitsProgress:
         mock_asyncio_run,
         mock_publish,
     ):
-        # When invoked outside a real Celery context (e.g. a unit
-        # test that calls ``.run()`` directly), ``self.request.id`` is
-        # empty. We bail out cheaply rather than spamming the helper
-        # with empty-key lookups that can never succeed.
         from rhesis.backend.tasks.endpoint.explore import run_exploration_task
 
         mock_crud.get_user.return_value = MagicMock()
@@ -313,9 +279,7 @@ class TestExplorationEmitsProgress:
             ),
             patch.object(run_exploration_task, "update_state"),
         ):
-            run_exploration_task.run(
-                endpoint_id="ep-uuid", strategy="domain_probing"
-            )
+            run_exploration_task.run(endpoint_id="ep-uuid", strategy="domain_probing")
 
         mock_publish.assert_not_called()
 
@@ -363,9 +327,7 @@ class TestExplorationEmitsProgress:
             ),
         ):
             with pytest.raises(RuntimeError):
-                run_exploration_task.run(
-                    endpoint_id="ep-uuid", strategy="domain_probing"
-                )
+                run_exploration_task.run(endpoint_id="ep-uuid", strategy="domain_probing")
 
         statuses = [call.kwargs.get("status") for call in mock_publish.call_args_list]
         assert "failed" in statuses
@@ -409,12 +371,8 @@ class TestPenelopeProgressHandler:
         emitted: list = []
         handler = _PenelopeProgressHandler(lambda *a, **kw: emitted.append((a, kw)))
 
-        await handler.on_tool_start(
-            tool_name="analyze_response", arguments={}
-        )
-        await handler.on_tool_start(
-            tool_name="record_finding", arguments={"text": "..."}
-        )
+        await handler.on_tool_start(tool_name="analyze_response", arguments={})
+        await handler.on_tool_start(tool_name="record_finding", arguments={"text": "..."})
 
         assert emitted == [], "internal Penelope tools should not surface as progress"
 
@@ -434,8 +392,6 @@ class TestPenelopeProgressHandler:
             arguments={"message": long_message},
         )
 
-        # Label should be much shorter than the original message —
-        # otherwise the bubble fills with one giant progress entry.
         assert len(emitted[0]) < len(long_message) / 2
 
     @pytest.mark.asyncio
@@ -451,3 +407,64 @@ class TestPenelopeProgressHandler:
         )
 
         assert emitted == []
+
+
+# ---------------------------------------------------------------------------
+# project_id flow through exploration task
+# ---------------------------------------------------------------------------
+
+
+class TestExplorationProjectIdFlow:
+    """Verify that project_id from tenant context flows to make_target_factory."""
+
+    @patch("rhesis.backend.tasks.endpoint.explore.publish_task_progress")
+    @patch("rhesis.backend.tasks.endpoint.explore.asyncio.run")
+    @patch("rhesis.sdk.agents.tools.ExploreEndpointTool")
+    @patch("rhesis.backend.tasks.endpoint.explore.make_target_factory")
+    @patch("rhesis.backend.tasks.endpoint.explore.get_db_with_tenant_variables")
+    @patch("rhesis.backend.tasks.endpoint.explore.get_user_generation_model")
+    @patch("rhesis.backend.tasks.endpoint.explore.crud")
+    def test_passes_project_id_to_target_factory(
+        self,
+        mock_crud,
+        mock_get_model,
+        mock_db_ctx,
+        mock_make_factory,
+        mock_tool_cls,
+        mock_asyncio_run,
+        mock_publish,
+    ):
+        from rhesis.backend.tasks.endpoint.explore import run_exploration_task
+
+        mock_crud.get_user.return_value = MagicMock()
+        mock_get_model.return_value = "vertex_ai/gemini-2.0-flash"
+        mock_db_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_db_ctx.return_value.__exit__ = MagicMock(return_value=False)
+        result_mock = MagicMock()
+        result_mock.success = True
+        result_mock.content = json.dumps({"findings": {}, "conversation": []})
+        result_mock.error = None
+        mock_asyncio_run.return_value = result_mock
+
+        with (
+            patch.object(
+                run_exploration_task,
+                "get_tenant_context",
+                return_value=("org-1", "user-1", "proj-1"),
+            ),
+            patch.object(run_exploration_task, "update_state"),
+            patch.object(
+                run_exploration_task.request,
+                "id",
+                "task-abc",
+                create=True,
+            ),
+        ):
+            run_exploration_task.run(endpoint_id="ep-uuid", strategy="domain_probing")
+
+        mock_make_factory.assert_called_once_with(
+            org_id="org-1",
+            user_id="user-1",
+            db=mock_db_ctx.return_value.__enter__.return_value,
+            project_id="proj-1",
+        )

--- a/tests/backend/tasks/test_explore.py
+++ b/tests/backend/tasks/test_explore.py
@@ -175,4 +175,5 @@ class TestMakeTargetFactory:
                 endpoint_id="ep-uuid",
                 organization_id="org-1",
                 user_id="user-1",
+                project_id=None,
             )

--- a/tests/backend/tasks/test_penelope_target.py
+++ b/tests/backend/tasks/test_penelope_target.py
@@ -148,3 +148,80 @@ class TestBackendEndpointTargetResponseMetadata:
 
         assert result.success is True
         assert "endpoint_metadata" not in result.metadata
+
+
+class TestBackendEndpointTargetProjectId:
+    """Verify project_id flows through BackendEndpointTarget."""
+
+    def test_stores_project_id(self):
+        db = MagicMock(spec=Session)
+        with (
+            patch.object(
+                BackendEndpointTarget, "validate_configuration", return_value=(True, None)
+            ),
+            patch.object(BackendEndpointTarget, "_load_endpoint_metadata"),
+        ):
+            target = BackendEndpointTarget(
+                db=db,
+                endpoint_id="00000000-0000-0000-0000-000000000001",
+                organization_id="org-1",
+                user_id="user-1",
+                project_id="proj-1",
+            )
+        assert target.project_id == "proj-1"
+
+    def test_project_id_defaults_to_none(self):
+        db = MagicMock(spec=Session)
+        with (
+            patch.object(
+                BackendEndpointTarget, "validate_configuration", return_value=(True, None)
+            ),
+            patch.object(BackendEndpointTarget, "_load_endpoint_metadata"),
+        ):
+            target = BackendEndpointTarget(
+                db=db,
+                endpoint_id="00000000-0000-0000-0000-000000000001",
+                organization_id="org-1",
+                user_id="user-1",
+            )
+        assert target.project_id is None
+
+
+class TestMakeTargetFactory:
+    """Verify make_target_factory forwards project_id."""
+
+    def test_factory_passes_project_id(self):
+        from rhesis.backend.tasks.endpoint.target import make_target_factory
+
+        db = MagicMock(spec=Session)
+        factory = make_target_factory(
+            org_id="org-1", user_id="user-1", db=db, project_id="proj-1"
+        )
+
+        with (
+            patch.object(
+                BackendEndpointTarget, "validate_configuration", return_value=(True, None)
+            ),
+            patch.object(BackendEndpointTarget, "_load_endpoint_metadata"),
+        ):
+            target = factory("00000000-0000-0000-0000-000000000001")
+
+        assert target.project_id == "proj-1"
+        assert target.organization_id == "org-1"
+        assert target.user_id == "user-1"
+
+    def test_factory_defaults_project_id_to_none(self):
+        from rhesis.backend.tasks.endpoint.target import make_target_factory
+
+        db = MagicMock(spec=Session)
+        factory = make_target_factory(org_id="org-1", user_id="user-1", db=db)
+
+        with (
+            patch.object(
+                BackendEndpointTarget, "validate_configuration", return_value=(True, None)
+            ),
+            patch.object(BackendEndpointTarget, "_load_endpoint_metadata"),
+        ):
+            target = factory("00000000-0000-0000-0000-000000000001")
+
+        assert target.project_id is None

--- a/tests/sdk/connector/test_executor_context.py
+++ b/tests/sdk/connector/test_executor_context.py
@@ -1,10 +1,10 @@
 """Tests for executor handling of test execution context and EndpointContext injection."""
 
 import pytest
+from rhesis.telemetry.constants import TestExecutionContext as TestContextConstants
 
 from rhesis.sdk.connector.executor import TestExecutor
 from rhesis.sdk.context import EndpointContext
-from rhesis.telemetry.constants import TestExecutionContext as TestContextConstants
 from rhesis.sdk.telemetry.context import get_test_execution_context
 
 
@@ -160,7 +160,9 @@ async def test_endpoint_context_injected_by_type_annotation(executor):
 
     ctx = EndpointContext(organization_id="org-1", user_id="user-1")
     result = await executor.execute(
-        func_with_ctx, "func_with_ctx", {"message": "hi"},
+        func_with_ctx,
+        "func_with_ctx",
+        {"message": "hi"},
         endpoint_context=ctx,
     )
 
@@ -177,12 +179,15 @@ async def test_endpoint_context_not_injected_when_none(executor):
     or accept the missing arg."""
 
     def func_with_optional_ctx(
-        message: str, ctx: EndpointContext = None,
+        message: str,
+        ctx: EndpointContext = None,
     ) -> str:
         return f"{message}:{ctx}"
 
     result = await executor.execute(
-        func_with_optional_ctx, "func", {"message": "hi"},
+        func_with_optional_ctx,
+        "func",
+        {"message": "hi"},
         endpoint_context=None,
     )
 
@@ -201,12 +206,8 @@ async def test_endpoint_context_wire_input_blocked_when_context_provided(executo
     def func(ctx: EndpointContext) -> dict:
         return {"org": ctx.organization_id, "user": ctx.user_id}
 
-    malicious_inputs = {
-        "ctx": {"organization_id": "attacker-org", "user_id": "attacker-user"}
-    }
-    result = await executor.execute(
-        func, "func", malicious_inputs, endpoint_context=injected
-    )
+    malicious_inputs = {"ctx": {"organization_id": "attacker-org", "user_id": "attacker-user"}}
+    result = await executor.execute(func, "func", malicious_inputs, endpoint_context=injected)
 
     assert result["status"] == "success"
     assert result["output"]["org"] == "trusted-org"
@@ -230,9 +231,7 @@ async def test_endpoint_context_wire_input_blocked_when_context_none(executor):
         "message": "hello",
         "ctx": {"organization_id": "attacker-org", "user_id": "attacker-user"},
     }
-    result = await executor.execute(
-        func, "func", malicious_inputs, endpoint_context=None
-    )
+    result = await executor.execute(func, "func", malicious_inputs, endpoint_context=None)
 
     assert result["status"] == "success"
     assert result["output"] == "safe:hello"
@@ -253,7 +252,9 @@ async def test_endpoint_context_not_leaked_to_kwargs(executor):
 
     ctx = EndpointContext(organization_id="org-2", user_id="user-2")
     result = await executor.execute(
-        func_with_kwargs, "func", {"x": 1},
+        func_with_kwargs,
+        "func",
+        {"x": 1},
         endpoint_context=ctx,
     )
 
@@ -272,7 +273,9 @@ async def test_endpoint_context_skipped_for_non_annotated_param(executor):
 
     ctx = EndpointContext(organization_id="org", user_id="user")
     result = await executor.execute(
-        func_with_plain_ctx, "func", {"ctx": "plain-value"},
+        func_with_plain_ctx,
+        "func",
+        {"ctx": "plain-value"},
         endpoint_context=ctx,
     )
 
@@ -284,6 +287,7 @@ async def test_endpoint_context_skipped_for_non_annotated_param(executor):
 # EndpointContext.get_db() behaviour
 # ---------------------------------------------------------------------------
 
+
 def test_endpoint_context_get_db_uses_factory():
     """When a _db_factory is provided, get_db() delegates to it."""
     from contextlib import contextmanager
@@ -291,9 +295,10 @@ def test_endpoint_context_get_db_uses_factory():
     sentinel = object()
 
     @contextmanager
-    def fake_factory(org_id, user_id):
+    def fake_factory(org_id, user_id, project_id=""):
         assert org_id == "org"
         assert user_id == "user"
+        assert project_id == ""
         yield sentinel
 
     ctx = EndpointContext(
@@ -319,3 +324,27 @@ def test_endpoint_context_get_db_raises_without_factory(monkeypatch):
     with pytest.raises((RuntimeError, ImportError)):
         with ctx.get_db():
             pass
+
+
+def test_endpoint_context_passes_project_id_to_db_factory():
+    """get_db() must forward project_id to the db_factory so that the
+    returned session is project-scoped, not just org-scoped."""
+    from unittest.mock import MagicMock
+
+    mock_factory = MagicMock()
+    ctx = EndpointContext(
+        organization_id="org-1",
+        user_id="user-1",
+        project_id="proj-1",
+        _db_factory=mock_factory,
+    )
+
+    ctx.get_db()
+
+    mock_factory.assert_called_once_with("org-1", "user-1", "proj-1")
+
+
+def test_endpoint_context_project_id_defaults_to_empty():
+    """project_id should default to empty string for backward compatibility."""
+    ctx = EndpointContext(organization_id="org-1", user_id="user-1")
+    assert ctx.project_id == ""


### PR DESCRIPTION
## Summary

- **Fix architect returning no endpoints**: `LocalToolProvider` was not sending the `X-Project-Id` header, so FastAPI resolved `project_id=None` and returned only org-level rows when the architect listed endpoints.
- **Refactor architect tasks into package**: Moved flat `architect.py`, `architect_monitor.py`, `architect_progress.py` into a `tasks/architect/` package with backward-compatible re-exports. Extracted telemetry helpers into their own module.
- **Thread project_id through all execution paths**: `EndpointContext` lacked a `project_id` field, causing silent data isolation gaps across architect chat, SDK connector, endpoint exploration, and batch test execution. Added `project_id` to `EndpointContext`, `make_target_factory`, `BackendEndpointTarget`, and all construction sites.

## What Changed

### Bug fix (LocalToolProvider)
- `LocalToolProvider` now accepts `project_id` and sends `X-Project-Id` header on every ASGI request
- `run_architect_turn` forwards `project_id` to `LocalToolProvider`

### Architect package refactor
- `tasks/architect.py` → `tasks/architect/chat.py`
- `tasks/architect_monitor.py` → `tasks/architect/monitor.py`
- `tasks/architect_progress.py` → `tasks/architect/progress.py`
- New `tasks/architect/telemetry.py` (extracted from old `architect.py`)
- New `tasks/architect/__init__.py` with re-exports for backward compatibility
- `monitor.py` now stores and forwards `project_id` in Redis context for resumed turns

### EndpointContext + execution path fixes
- Added `project_id: str = ""` field to `EndpointContext` (SDK)
- Updated `EndpointContext.get_db()` to pass `project_id` to session factory
- Updated `ConnectorManager._build_endpoint_context()` to include `project_id`
- Added `project_id` parameter to `make_target_factory` and `BackendEndpointTarget`
- Wired `project_id` through `explore.py` → `make_target_factory` and `batch/invocation.py` → `BackendEndpointTarget`

## Testing

- All 93 architect tests pass (moved to `tests/backend/tasks/architect/`)
- 8 new regression tests for project_id flow:
  - `EndpointContext.get_db()` forwards project_id
  - `make_target_factory` forwards/defaults project_id
  - `BackendEndpointTarget` stores/defaults project_id
  - `_load_session_trace_id` forwards project_id to DB factory
  - Exploration task passes project_id to target factory
- Full backend suite: 2343 passed (pre-existing failures in auth/utils unrelated)
- Full SDK suite: 2120 passed