### PR TITLE
fix: resolve circular import in architect task package

### DIFF
--- a/apps/backend/src/rhesis/backend/celery/config.py
+++ b/apps/backend/src/rhesis/backend/celery/config.py
@@ -97,7 +97,7 @@ CELERY_CONFIG = {
         "rhesis.backend.tasks.test_set",
         "rhesis.backend.tasks.execution.results",
         "rhesis.backend.tasks.telemetry.enrich",
-        "rhesis.backend.tasks.architect",
+        "rhesis.backend.tasks.architect.chat",
         "rhesis.backend.tasks.telemetry.evaluate",
         "rhesis.backend.tasks.telemetry.post_ingest",
     ],

--- a/apps/backend/src/rhesis/backend/tasks/architect/__init__.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/__init__.py
@@ -1,27 +1,32 @@
 """Architect agent task package.
 
-Re-exports the public API so existing import paths continue to work:
+Submodules are imported lazily to avoid a circular import:
 
-    from rhesis.backend.tasks.architect import architect_chat_task
-    from rhesis.backend.tasks.architect import register_awaiting_tasks
+    worker → tasks → tasks.endpoint.explore → tasks.architect.progress
+    → (this __init__) → tasks.architect.chat → worker  (boom)
+
+Direct submodule imports still work and are preferred::
+
+    from rhesis.backend.tasks.architect.chat import architect_chat_task
+    from rhesis.backend.tasks.architect.progress import publish_task_progress
 """
 
-from rhesis.backend.tasks.architect.chat import architect_chat_task
-from rhesis.backend.tasks.architect.monitor import register_awaiting_tasks
-from rhesis.backend.tasks.architect.progress import (
-    lookup_session_for_task,
-    publish_task_progress,
-)
-from rhesis.backend.tasks.architect.telemetry import (
-    _conversation_telemetry_context,
-    _load_session_trace_id,
-)
+import importlib as _importlib
 
-__all__ = [
-    "architect_chat_task",
-    "register_awaiting_tasks",
-    "lookup_session_for_task",
-    "publish_task_progress",
-    "_conversation_telemetry_context",
-    "_load_session_trace_id",
-]
+_LAZY_MAP = {
+    "architect_chat_task": "rhesis.backend.tasks.architect.chat",
+    "register_awaiting_tasks": "rhesis.backend.tasks.architect.monitor",
+    "lookup_session_for_task": "rhesis.backend.tasks.architect.progress",
+    "publish_task_progress": "rhesis.backend.tasks.architect.progress",
+    "_conversation_telemetry_context": "rhesis.backend.tasks.architect.telemetry",
+    "_load_session_trace_id": "rhesis.backend.tasks.architect.telemetry",
+}
+
+__all__ = list(_LAZY_MAP)
+
+
+def __getattr__(name: str):
+    if name in _LAZY_MAP:
+        mod = _importlib.import_module(_LAZY_MAP[name])
+        return getattr(mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Purpose
Fix a worker crash caused by a circular import introduced when the architect tasks were refactored into a package in #1979.

## What Changed
- **`tasks/architect/__init__.py`**: Replaced eager top-level imports with lazy `__getattr__`-based imports. The package can now be imported without triggering the full `worker → tasks → endpoint.explore → architect.progress → architect.__init__ → architect.chat → worker` cycle.
- **`celery/config.py`**: Changed the `include` entry from `rhesis.backend.tasks.architect` to `rhesis.backend.tasks.architect.chat` so Celery discovers the `@app.task`-decorated function directly rather than relying on the package `__init__`.

## Testing
- All 100 architect + explore tests pass
- `ruff check` clean