### PR TITLE
fix(worker): add missing API_BASE_URL to k8s deployment

### DIFF
--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -326,6 +326,7 @@ jobs:
             --from-literal=LOCAL_STORAGE_PATH="${{ secrets.LOCAL_STORAGE_PATH }}" \
             --from-literal=RHESIS_CONNECTOR_DISABLED="${{ secrets.RHESIS_CONNECTOR_DISABLED }}" \
             --from-literal=DEFAULT_POLYPHEMUS_URL="${{ secrets.DEFAULT_POLYPHEMUS_URL }}" \
+            --from-literal=API_BASE_URL="${{ secrets.API_BASE_URL }}" \
             --dry-run=client -o yaml | kubectl apply -f -
 
           # Clean up temporary files

--- a/apps/worker/k8s/deployment.yaml
+++ b/apps/worker/k8s/deployment.yaml
@@ -258,6 +258,11 @@ spec:
             secretKeyRef:
               name: rhesis-worker-secrets
               key: DEFAULT_POLYPHEMUS_URL
+        - name: API_BASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: rhesis-worker-secrets
+              key: API_BASE_URL
         - name: GIT_BRANCH
           value: "GIT_BRANCH_PLACEHOLDER"
         - name: GIT_COMMIT


### PR DESCRIPTION
## Purpose
Fix worker crash on startup: `ValidationError: 1 validation error for ApplicationSettings API_BASE_URL Field required`.

## What Changed
- **`apps/worker/k8s/deployment.yaml`**: Added `API_BASE_URL` env var sourced from `rhesis-worker-secrets`
- **`.github/workflows/worker.yml`**: Added `API_BASE_URL` to the `kubectl create secret` step so it's included when the secret is created/updated during deploy

## Additional Context
The `API_BASE_URL` secret (`secrets.API_BASE_URL`) must be set in each GitHub environment (dev, stg, prd) for the deploy to work. It's already configured for the backend Cloud Run deploys.

## Testing
Deployment-only change — no code logic affected.