### PR TITLE
Fix: use correct ragas env var to disable telemetry

### DIFF
--- a/sdk/src/rhesis/sdk/metrics/providers/ragas/__init__.py
+++ b/sdk/src/rhesis/sdk/metrics/providers/ragas/__init__.py
@@ -3,7 +3,7 @@
 import os
 
 # Disable ragas telemetry
-os.environ.setdefault("RAGAS_TELEMETRY_DISABLED", "true")
+os.environ.setdefault("RAGAS_DO_NOT_TRACK", "true")
 
 from .factory import RagasMetricFactory
 from .metric_base import RagasMetricBase


### PR DESCRIPTION
## Purpose
Fix ragas telemetry opt-out by using the correct environment variable name.

## What Changed
- Changed `RAGAS_TELEMETRY_DISABLED` to `RAGAS_DO_NOT_TRACK` in the ragas metrics provider `__init__.py`

## Additional Context
- `RAGAS_DO_NOT_TRACK` is the env var that ragas actually checks; the previous variable had no effect

## Testing
No functional change to SDK behavior — ragas telemetry will now be correctly disabled on import.