### PR TITLE
Introduce per-(provider, action) routing for MCP/REST actions

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/tools.py
+++ b/apps/backend/src/rhesis/backend/app/routers/tools.py
@@ -20,8 +20,18 @@ from rhesis.backend.app.schemas.services import (
     TestToolConnectionRequest,
     TestToolConnectionResponse,
 )
+from rhesis.backend.app.services.tool.actions import (
+    ToolAction,
+    Transport,
+    resolve_provider,
+    route,
+)
 from rhesis.backend.app.services.tool.exceptions import ToolConfigurationError
-from rhesis.backend.app.services.tool.mcp import handle_mcp_exception
+from rhesis.backend.app.services.tool.mcp import (
+    handle_mcp_exception,
+    mcp_extract,
+    mcp_health_check,
+)
 from rhesis.backend.app.services.tool.rest import (
     create_jira_ticket_from_task,
     get_rest_client,
@@ -200,25 +210,33 @@ async def extract_tool_item(
     """
     Extract content from a tool item as markdown.
 
-    Supports Notion and GitHub tools via direct REST API calls.
+    The transport (deterministic REST call vs. MCP agent) is chosen per provider for
+    the extract action — invisible to the caller.
     Set include_children=True to recursively fetch child pages / subdirectory files.
     Either ``id`` or ``url`` (or both) must be provided in the request body.
     """
     try:
         organization_id, user_id = tenant_context
-        client = get_rest_client(
-            db=db,
-            tool_id=str(tool_id),
-            organization_id=organization_id,
-            user_id=user_id,
-        )
-        if not hasattr(client, "fetch_all"):
-            raise HTTPException(
-                status_code=400,
-                detail="Extract is not supported for this tool provider.",
-            )
+        provider = resolve_provider(db, organization_id, tool_id=str(tool_id), user_id=user_id)
         identifier = request.url or request.id
-        docs = await client.fetch_all(identifier, include_children=request.include_children)
+        if route(provider, ToolAction.EXTRACT) is Transport.REST:
+            client = get_rest_client(
+                db=db,
+                tool_id=str(tool_id),
+                organization_id=organization_id,
+                user_id=user_id,
+            )
+            if not hasattr(client, "fetch_all"):
+                raise ToolConfigurationError("Extract is not supported for this tool provider.")
+            docs = await client.fetch_all(identifier, include_children=request.include_children)
+        else:
+            docs = await mcp_extract(
+                tool_id=str(tool_id),
+                identifier=identifier,
+                organization_id=organization_id,
+                user_id=user_id,
+                include_children=request.include_children,
+            )
         return ExtractToolResponse(
             sources=[
                 {"id": d.id, "title": d.title, "content": d.content, "url": d.url} for d in docs
@@ -240,18 +258,32 @@ async def test_tool_connection(
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
 ):
-    """Test a tool's credentials via a lightweight REST health check."""
+    """Test a tool's credentials via a lightweight connection check."""
     try:
         organization_id, user_id = tenant_context
-        result = await run_rest_health_check(
-            db=db,
+        provider = resolve_provider(
+            db,
+            organization_id,
+            tool_id=request.tool_id,
+            provider_type_id=request.provider_type_id,
+            user_id=user_id,
+        )
+        if route(provider, ToolAction.TEST_CONNECTION) is Transport.REST:
+            return await run_rest_health_check(
+                db=db,
+                organization_id=organization_id,
+                tool_id=request.tool_id,
+                provider_type_id=request.provider_type_id,
+                credentials=request.credentials,
+                user_id=user_id,
+            )
+        return await mcp_health_check(
             organization_id=organization_id,
+            user_id=user_id,
             tool_id=request.tool_id,
             provider_type_id=request.provider_type_id,
             credentials=request.credentials,
-            user_id=user_id,
         )
-        return result
     except (ToolConfigurationError, ValueError) as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
@@ -277,14 +309,16 @@ async def create_jira_ticket_from_task_endpoint(
     """
     try:
         organization_id, user_id = tenant_context
-        result = await create_jira_ticket_from_task(
+        provider = resolve_provider(db, organization_id, tool_id=request.tool_id, user_id=user_id)
+        # Validate the provider supports ticket creation (raises if not).
+        route(provider, ToolAction.CREATE_TICKET)
+        return await create_jira_ticket_from_task(
             task_id=request.task_id,
             tool_id=request.tool_id,
             db=db,
             organization_id=organization_id,
             user_id=user_id,
         )
-        return result
     except ToolConfigurationError as e:
         raise HTTPException(status_code=404, detail=str(e))
     except ValueError as e:

--- a/apps/backend/src/rhesis/backend/app/routers/tools.py
+++ b/apps/backend/src/rhesis/backend/app/routers/tools.py
@@ -219,17 +219,15 @@ async def extract_tool_item(
         organization_id, user_id = tenant_context
         provider = resolve_provider(db, organization_id, tool_id=str(tool_id), user_id=user_id)
         identifier = request.url or request.id
-        if route(provider, ToolAction.EXTRACT) is Transport.REST:
-            client = get_rest_client(
+        transport = route(provider, ToolAction.EXTRACT)
+        if transport is Transport.REST:
+            docs = await get_rest_client(
                 db=db,
                 tool_id=str(tool_id),
                 organization_id=organization_id,
                 user_id=user_id,
-            )
-            if not hasattr(client, "fetch_all"):
-                raise ToolConfigurationError("Extract is not supported for this tool provider.")
-            docs = await client.fetch_all(identifier, include_children=request.include_children)
-        else:
+            ).fetch_all(identifier, include_children=request.include_children)
+        elif transport is Transport.MCP:
             docs = await mcp_extract(
                 tool_id=str(tool_id),
                 identifier=identifier,
@@ -268,7 +266,8 @@ async def test_tool_connection(
             provider_type_id=request.provider_type_id,
             user_id=user_id,
         )
-        if route(provider, ToolAction.TEST_CONNECTION) is Transport.REST:
+        transport = route(provider, ToolAction.TEST_CONNECTION)
+        if transport is Transport.REST:
             return await run_rest_health_check(
                 db=db,
                 organization_id=organization_id,
@@ -277,13 +276,14 @@ async def test_tool_connection(
                 credentials=request.credentials,
                 user_id=user_id,
             )
-        return await mcp_health_check(
-            organization_id=organization_id,
-            user_id=user_id,
-            tool_id=request.tool_id,
-            provider_type_id=request.provider_type_id,
-            credentials=request.credentials,
-        )
+        elif transport is Transport.MCP:
+            return await mcp_health_check(
+                organization_id=organization_id,
+                user_id=user_id,
+                tool_id=request.tool_id,
+                provider_type_id=request.provider_type_id,
+                credentials=request.credentials,
+            )
     except (ToolConfigurationError, ValueError) as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:

--- a/apps/backend/src/rhesis/backend/app/services/tool/actions.py
+++ b/apps/backend/src/rhesis/backend/app/services/tool/actions.py
@@ -48,6 +48,7 @@ _ROUTES: Dict[Tuple[str, ToolAction], Transport] = {
     ("github", ToolAction.TEST_CONNECTION): Transport.REST,
     ("jira", ToolAction.TEST_CONNECTION): Transport.REST,
     ("jira", ToolAction.CREATE_TICKET): Transport.REST,
+    ("confluence", ToolAction.TEST_CONNECTION): Transport.REST,
 }
 
 

--- a/apps/backend/src/rhesis/backend/app/services/tool/actions.py
+++ b/apps/backend/src/rhesis/backend/app/services/tool/actions.py
@@ -1,0 +1,95 @@
+"""Per-(provider, action) transport routing for tool operations.
+
+A tool operation (extract content, test connection, create a ticket) can be served by
+a deterministic REST call or an LLM-driven MCP agent. The choice is made **per action,
+per provider** — not per provider — so the same provider can serve one action over REST
+and another over MCP.
+
+``_ROUTES`` is the declarative table: which transport handles each cell. A missing cell
+means the provider does not support that action. When a provider eventually needs both
+transports for the *same* action, change that cell's value to carry both plus a
+selection policy in :func:`route` — callers are unaffected, they only ask for
+``route(provider, action)``.
+"""
+
+import uuid
+from enum import Enum
+from typing import Dict, Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import crud
+from rhesis.backend.app.services.tool.exceptions import ToolConfigurationError
+from rhesis.backend.app.utils.database_exceptions import ItemDeletedException
+
+
+class ToolAction(str, Enum):
+    """A user-facing operation a tool can perform."""
+
+    TEST_CONNECTION = "test_connection"
+    EXTRACT = "extract"
+    CREATE_TICKET = "create_ticket"
+
+
+class Transport(str, Enum):
+    """How an action is carried out."""
+
+    REST = "rest"
+    MCP = "mcp"
+
+
+# (provider, action) -> transport. REST wherever a client exists. Actions a provider
+# can only serve through the MCP agent (Transport.MCP) are registered the same way —
+# that is how MCP-based providers (e.g. GitLab, Shortcut, Asana) plug in.
+_ROUTES: Dict[Tuple[str, ToolAction], Transport] = {
+    ("notion", ToolAction.EXTRACT): Transport.REST,
+    ("notion", ToolAction.TEST_CONNECTION): Transport.REST,
+    ("github", ToolAction.EXTRACT): Transport.REST,
+    ("github", ToolAction.TEST_CONNECTION): Transport.REST,
+    ("jira", ToolAction.TEST_CONNECTION): Transport.REST,
+    ("jira", ToolAction.CREATE_TICKET): Transport.REST,
+}
+
+
+def route(provider: str, action: ToolAction) -> Transport:
+    """Return the transport for *provider*/*action*.
+
+    Raises:
+        ToolConfigurationError: If the provider does not support the action.
+    """
+    transport = _ROUTES.get((provider, action))
+    if transport is None:
+        raise ToolConfigurationError(
+            f"Provider '{provider}' does not support action '{action.value}'."
+        )
+    return transport
+
+
+def resolve_provider(
+    db: Session,
+    organization_id: str,
+    *,
+    tool_id: Optional[str] = None,
+    provider_type_id: Optional[uuid.UUID] = None,
+    user_id: Optional[str] = None,
+) -> str:
+    """Resolve the provider ``type_value`` from a saved tool or a provider type.
+
+    Raises:
+        ToolConfigurationError: If the tool/provider type cannot be found.
+    """
+    if tool_id is not None:
+        try:
+            tool = crud.get_tool(db, uuid.UUID(tool_id), organization_id, user_id)
+        except ItemDeletedException:
+            raise ToolConfigurationError(
+                f"Tool '{tool_id}' has been deleted. Please re-import the source."
+            )
+        if not tool:
+            raise ToolConfigurationError(f"Tool '{tool_id}' not found.")
+        return tool.tool_provider_type.type_value
+
+    provider_type = crud.get_type_lookup(db, provider_type_id, organization_id, user_id)
+    if not provider_type:
+        raise ToolConfigurationError(f"Provider type '{provider_type_id}' not found.")
+    return provider_type.type_value

--- a/apps/backend/src/rhesis/backend/app/services/tool/mcp/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/services/tool/mcp/__init__.py
@@ -6,7 +6,11 @@ from rhesis.backend.app.services.tool.mcp.config import (
     _get_mcp_tool_config,
 )
 from rhesis.backend.app.services.tool.mcp.exceptions import handle_mcp_exception
-from rhesis.backend.app.services.tool.mcp.operations import query_mcp
+from rhesis.backend.app.services.tool.mcp.operations import (
+    mcp_extract,
+    mcp_health_check,
+    query_mcp,
+)
 from rhesis.backend.app.services.tool.mcp.templates import jinja_env
 
 __all__ = [
@@ -15,5 +19,7 @@ __all__ = [
     "_get_mcp_tool_config",
     "handle_mcp_exception",
     "jinja_env",
+    "mcp_extract",
+    "mcp_health_check",
     "query_mcp",
 ]

--- a/apps/backend/src/rhesis/backend/app/services/tool/mcp/operations.py
+++ b/apps/backend/src/rhesis/backend/app/services/tool/mcp/operations.py
@@ -1,15 +1,67 @@
+import json
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
+from rhesis.backend.app import crud
 from rhesis.backend.app.config.settings import get_model_settings
+from rhesis.backend.app.database import get_db_with_tenant_variables
+from rhesis.backend.app.services.tool.exceptions import ToolConfigurationError
+from rhesis.backend.app.services.tool.rest.schemas import FetchedSource
 from rhesis.sdk.agents.mcp import MCPAgent
 from rhesis.sdk.context import EndpointContext
 
 from .agents import get_agent_event_handlers
-from .config import _get_mcp_tool_config
+from .config import _get_mcp_client_from_params, _get_mcp_tool_config
 from .templates import jinja_env
 
 logger = logging.getLogger(__name__)
+
+
+async def _run_agent(
+    client: Any,
+    query: str,
+    system_prompt: str,
+    max_iterations: int,
+    agent_name: str,
+) -> Dict[str, Any]:
+    """Run an MCP agent turn and return its serialized result."""
+    model = get_model_settings().generation_model
+    agent = MCPAgent(
+        model=model,
+        mcp_client=client,
+        system_prompt=system_prompt,
+        max_iterations=max_iterations,
+        verbose=False,
+        event_handlers=get_agent_event_handlers(
+            model_name=getattr(model, "model_name", None) or str(model),
+            agent_name=agent_name,
+        ),
+    )
+    result = await agent.run_async(query)
+    return result.model_dump()
+
+
+def _resolve_tool_client(organization_id: str, user_id: str, tool_id: str) -> Tuple[Any, str]:
+    """Build an MCP client + provider name for a saved tool."""
+    with get_db_with_tenant_variables(organization_id, user_id) as db:
+        return _get_mcp_tool_config(db, tool_id, organization_id, user_id)
+
+
+def _resolve_params_client(
+    organization_id: str,
+    user_id: str,
+    provider_type_id: Any,
+    credentials: Dict[str, str],
+) -> Tuple[Any, str]:
+    """Build an MCP client + provider name from unsaved credentials."""
+    with get_db_with_tenant_variables(organization_id, user_id) as db:
+        provider_type = crud.get_type_lookup(db, provider_type_id, organization_id, user_id)
+        if not provider_type:
+            raise ToolConfigurationError(f"Provider type '{provider_type_id}' not found.")
+        client = _get_mcp_client_from_params(
+            provider_type_id, credentials, db, organization_id, user_id
+        )
+        return client, provider_type.type_value
 
 
 async def query_mcp(
@@ -39,19 +91,124 @@ async def query_mcp(
             provider=provider
         )
 
-    model = get_model_settings().generation_model
-    agent = MCPAgent(
-        model=model,
-        mcp_client=client,
-        system_prompt=system_prompt,
-        max_iterations=max_iterations,
-        verbose=False,
-        event_handlers=get_agent_event_handlers(
-            model_name=getattr(model, "model_name", None) or str(model),
-            agent_name="mcp-query",
-        ),
+    return await _run_agent(client, query, system_prompt, max_iterations, "mcp-query")
+
+
+def _strip_code_fence(text: str) -> str:
+    """Strip a leading/trailing markdown code fence and an optional ``json`` tag."""
+    text = text.strip()
+    if not text.startswith("```"):
+        return text
+    lines = text.splitlines()
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].strip().startswith("```"):
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
+def _parse_fetched_sources(answer: str) -> List[FetchedSource]:
+    """Parse an agent's JSON answer into typed sources.
+
+    Expects a JSON array of ``{id, title, content, url}`` objects — the same shape
+    the REST extract path produces — so the router maps either path identically.
+
+    Raises:
+        ValueError: If the answer is not a JSON array of objects.
+    """
+    data = json.loads(_strip_code_fence(answer))
+    if not isinstance(data, list):
+        raise ValueError("Expected a JSON array of sources.")
+    sources: List[FetchedSource] = []
+    for item in data:
+        if not isinstance(item, dict):
+            raise ValueError("Each source must be a JSON object.")
+        sources.append(
+            FetchedSource(
+                id=str(item.get("id", "")),
+                title=item.get("title", ""),
+                content=item.get("content", ""),
+                url=item.get("url"),
+            )
+        )
+    return sources
+
+
+async def mcp_extract(
+    tool_id: str,
+    identifier: str,
+    organization_id: str,
+    user_id: str,
+    include_children: bool = False,
+    max_iterations: int = 10,
+) -> List[FetchedSource]:
+    """Extract content from an MCP-backed tool as structured sources.
+
+    Drives the MCP agent with the ``mcp_extract_prompt`` template, which requires a
+    JSON array reply, then parses it into ``FetchedSource`` objects. On a malformed
+    reply, retries once with the template's repair variant before giving up.
+
+    Raises:
+        ValueError: If user_id is missing or the agent never returns valid JSON.
+    """
+    if not user_id:
+        raise ValueError("user_id is required")
+
+    client, provider = _resolve_tool_client(organization_id, user_id, tool_id)
+    query = f"Extract the full content of: {identifier}"
+    template = jinja_env.get_template("mcp_extract_prompt.jinja2")
+
+    last_error: Optional[Exception] = None
+    for repair in (False, True):
+        system_prompt = template.render(
+            provider=provider, include_children=include_children, repair=repair
+        )
+        result = await _run_agent(client, query, system_prompt, max_iterations, "mcp-extract")
+        try:
+            return _parse_fetched_sources(result.get("final_answer", ""))
+        except (json.JSONDecodeError, ValueError, TypeError) as e:
+            last_error = e
+            if not repair:
+                logger.warning("MCP extract returned non-JSON; retrying with repair prompt.")
+
+    raise ValueError(f"MCP extract did not return valid JSON: {last_error}")
+
+
+async def mcp_health_check(
+    organization_id: str,
+    user_id: str,
+    tool_id: Optional[str] = None,
+    provider_type_id: Optional[Any] = None,
+    credentials: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
+    """Test MCP credentials via a minimal read-only agent auth ping.
+
+    Accepts either a saved ``tool_id`` or, for connections not yet saved,
+    ``provider_type_id`` + ``credentials``.
+
+    Raises:
+        ToolConfigurationError: If neither a tool_id nor provider_type_id+credentials
+            is provided.
+    """
+    if not user_id:
+        raise ValueError("user_id is required")
+
+    if tool_id:
+        client, provider = _resolve_tool_client(organization_id, user_id, tool_id)
+    elif provider_type_id is not None and credentials is not None:
+        client, provider = _resolve_params_client(
+            organization_id, user_id, provider_type_id, credentials
+        )
+    else:
+        raise ToolConfigurationError(
+            "A saved tool_id or provider_type_id + credentials is required to test the connection."
+        )
+
+    system_prompt = jinja_env.get_template("mcp_test_auth_prompt.jinja2").render(provider=provider)
+    result = await _run_agent(
+        client, "Verify authentication and report the result.", system_prompt, 3, "mcp-health"
     )
-
-    result = await agent.run_async(query)
-
-    return result.model_dump()
+    if result.get("success"):
+        message = (result.get("final_answer") or "Connected").strip()[:200]
+        return {"is_authenticated": "Yes", "message": message}
+    return {"is_authenticated": "No", "message": "Authentication failed."}

--- a/apps/backend/src/rhesis/backend/app/services/tool/mcp/operations.py
+++ b/apps/backend/src/rhesis/backend/app/services/tool/mcp/operations.py
@@ -102,6 +102,8 @@ def _strip_code_fence(text: str) -> str:
     lines = text.splitlines()
     if lines and lines[0].startswith("```"):
         lines = lines[1:]
+    if lines and lines[0].strip() == "json":
+        lines = lines[1:]
     if lines and lines[-1].strip().startswith("```"):
         lines = lines[:-1]
     return "\n".join(lines).strip()
@@ -123,12 +125,13 @@ def _parse_fetched_sources(answer: str) -> List[FetchedSource]:
     for item in data:
         if not isinstance(item, dict):
             raise ValueError("Each source must be a JSON object.")
+        raw_url = item.get("url")
         sources.append(
             FetchedSource(
                 id=str(item.get("id", "")),
-                title=item.get("title", ""),
-                content=item.get("content", ""),
-                url=item.get("url"),
+                title=str(item.get("title") or ""),
+                content=str(item.get("content") or ""),
+                url=str(raw_url) if raw_url is not None else None,
             )
         )
     return sources

--- a/apps/backend/src/rhesis/backend/app/services/tool/mcp/templates.py
+++ b/apps/backend/src/rhesis/backend/app/services/tool/mcp/templates.py
@@ -4,7 +4,9 @@ from pathlib import Path
 
 import jinja2
 
-TEMPLATE_DIR = Path(__file__).parent.parent.parent / "templates"
+# templates.py lives at app/services/tool/mcp/; the templates dir is app/templates/.
+# parents[3] == app/ (mcp -> tool -> services -> app).
+TEMPLATE_DIR = Path(__file__).parents[3] / "templates"
 jinja_env = jinja2.Environment(
     loader=jinja2.FileSystemLoader(str(TEMPLATE_DIR)),
     autoescape=jinja2.select_autoescape(),

--- a/apps/backend/src/rhesis/backend/app/templates/mcp_extract_prompt.jinja2
+++ b/apps/backend/src/rhesis/backend/app/templates/mcp_extract_prompt.jinja2
@@ -1,0 +1,28 @@
+{% if repair %}
+Your previous reply was not valid JSON. Reply with ONLY the JSON array described
+below — no prose, no explanation, no code fences.
+
+{% endif %}
+Extract the full content of the requested item using the available tools.
+
+{# Add provider-specific extraction guidance here, e.g.
+   {% if provider == "<name>" %}...{% endif %} #}
+{% if include_children %}
+Also extract every child page / nested item and return each as a separate entry.
+{% endif %}
+
+Return ONLY a JSON array. Each element is an object with these fields:
+- id: a stable identifier for the item (page id, file path, issue key, ...)
+- title: the item's title or name
+- content: the full content rendered as markdown
+- url: the canonical URL of the item, or null if unavailable
+
+Example:
+[{"id": "abc123", "title": "Onboarding", "content": "# Onboarding\n...", "url": "https://..."}]
+
+Rules:
+- Your entire response must be a valid JSON array and nothing else.
+- No prose, no explanation, no markdown code fences (no ```json or ```).
+- Render content as markdown inside the JSON string value.
+- Return one object per item; return [] if nothing could be extracted.
+- If you encounter recoverable errors (rate limits, temporary failures), you may retry.

--- a/apps/backend/src/rhesis/backend/app/templates/mcp_test_auth_prompt.jinja2
+++ b/apps/backend/src/rhesis/backend/app/templates/mcp_test_auth_prompt.jinja2
@@ -1,0 +1,6 @@
+Verify that the configured credentials can authenticate against the {{ provider }} API.
+
+{# Add provider-specific auth-check guidance here, e.g.
+   {% if provider == "<name>" %}...{% endif %} #}
+Use a single read-only call. Do not create, modify, or delete anything.
+Report whether authentication succeeded and, if possible, the authenticated identity.

--- a/tests/backend/services/test_tool_actions.py
+++ b/tests/backend/services/test_tool_actions.py
@@ -22,12 +22,6 @@ class TestRouteTable:
         assert route("jira", ToolAction.CREATE_TICKET) is Transport.REST
         assert route("jira", ToolAction.TEST_CONNECTION) is Transport.REST
 
-    def test_confluence_supports_only_connection_test(self):
-        # Per-action: Confluence has a REST connection test but no extract route.
-        assert route("confluence", ToolAction.TEST_CONNECTION) is Transport.REST
-        with pytest.raises(ToolConfigurationError, match="does not support"):
-            route("confluence", ToolAction.EXTRACT)
-
     def test_jira_has_no_extract(self):
         with pytest.raises(ToolConfigurationError, match="does not support"):
             route("jira", ToolAction.EXTRACT)

--- a/tests/backend/services/test_tool_actions.py
+++ b/tests/backend/services/test_tool_actions.py
@@ -1,0 +1,149 @@
+"""Unit tests for the (provider, action) routing table and MCP extract fallback."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from rhesis.backend.app.services.tool.actions import ToolAction, Transport, route
+from rhesis.backend.app.services.tool.exceptions import ToolConfigurationError
+from rhesis.backend.app.services.tool.mcp.operations import (
+    _parse_fetched_sources,
+    _strip_code_fence,
+    mcp_extract,
+    mcp_health_check,
+)
+
+
+class TestRouteTable:
+    def test_rest_providers_route_to_rest(self):
+        assert route("notion", ToolAction.EXTRACT) is Transport.REST
+        assert route("github", ToolAction.EXTRACT) is Transport.REST
+        assert route("notion", ToolAction.TEST_CONNECTION) is Transport.REST
+        assert route("jira", ToolAction.CREATE_TICKET) is Transport.REST
+        assert route("jira", ToolAction.TEST_CONNECTION) is Transport.REST
+
+    def test_confluence_supports_only_connection_test(self):
+        # Per-action: Confluence has a REST connection test but no extract route.
+        assert route("confluence", ToolAction.TEST_CONNECTION) is Transport.REST
+        with pytest.raises(ToolConfigurationError, match="does not support"):
+            route("confluence", ToolAction.EXTRACT)
+
+    def test_jira_has_no_extract(self):
+        with pytest.raises(ToolConfigurationError, match="does not support"):
+            route("jira", ToolAction.EXTRACT)
+
+    def test_unregistered_provider_raises(self):
+        with pytest.raises(ToolConfigurationError, match="does not support"):
+            route("gitlab", ToolAction.EXTRACT)
+
+
+class TestParsing:
+    def test_strip_plain_json(self):
+        assert _strip_code_fence('[{"id": "1"}]') == '[{"id": "1"}]'
+
+    def test_strip_json_fence(self):
+        fenced = '```json\n[{"id": "1"}]\n```'
+        assert _strip_code_fence(fenced) == '[{"id": "1"}]'
+
+    def test_strip_bare_fence(self):
+        assert _strip_code_fence("```\nhello\n```") == "hello"
+
+    def test_parse_valid_array(self):
+        raw = '[{"id": "a", "title": "T", "content": "# md", "url": "https://x"}]'
+        sources = _parse_fetched_sources(raw)
+        assert len(sources) == 1
+        assert sources[0].id == "a"
+        assert sources[0].title == "T"
+        assert sources[0].content == "# md"
+        assert sources[0].url == "https://x"
+
+    def test_parse_coerces_missing_fields(self):
+        sources = _parse_fetched_sources('[{"content": "body only"}]')
+        assert sources[0].id == ""
+        assert sources[0].url is None
+        assert sources[0].content == "body only"
+
+    def test_parse_non_array_raises(self):
+        with pytest.raises(ValueError, match="JSON array"):
+            _parse_fetched_sources('{"id": "1"}')
+
+    def test_parse_non_object_element_raises(self):
+        with pytest.raises(ValueError, match="JSON object"):
+            _parse_fetched_sources('["just a string"]')
+
+
+_OPS = "rhesis.backend.app.services.tool.mcp.operations"
+
+
+@pytest.mark.asyncio
+class TestMcpExtract:
+    _ARGS = dict(
+        tool_id="11111111-1111-1111-1111-111111111111",
+        identifier="https://example.com/page",
+        organization_id="org",
+        user_id="user",
+    )
+
+    async def test_parses_first_try(self):
+        good = {"final_answer": '[{"id": "p1", "title": "Page", "content": "body"}]'}
+        with (
+            patch(f"{_OPS}._resolve_tool_client", return_value=(object(), "gitlab")),
+            patch(f"{_OPS}._run_agent", new=AsyncMock(return_value=good)) as run,
+        ):
+            sources = await mcp_extract(**self._ARGS)
+        assert [s.id for s in sources] == ["p1"]
+        assert run.await_count == 1
+
+    async def test_repairs_then_parses(self):
+        bad = {"final_answer": "Sure! Here is the content..."}
+        good = {"final_answer": '[{"id": "p1", "content": "body"}]'}
+        with (
+            patch(f"{_OPS}._resolve_tool_client", return_value=(object(), "gitlab")),
+            patch(f"{_OPS}._run_agent", new=AsyncMock(side_effect=[bad, good])) as run,
+        ):
+            sources = await mcp_extract(**self._ARGS)
+        assert [s.id for s in sources] == ["p1"]
+        assert run.await_count == 2  # one repair retry
+
+    async def test_repair_exhausted_raises(self):
+        bad = {"final_answer": "still not json"}
+        with (
+            patch(f"{_OPS}._resolve_tool_client", return_value=(object(), "gitlab")),
+            patch(f"{_OPS}._run_agent", new=AsyncMock(return_value=bad)),
+        ):
+            with pytest.raises(ValueError, match="did not return valid JSON"):
+                await mcp_extract(**self._ARGS)
+
+
+@pytest.mark.asyncio
+class TestMcpHealthCheck:
+    async def test_requires_tool_or_params(self):
+        with pytest.raises(ToolConfigurationError, match="required to test the connection"):
+            await mcp_health_check(organization_id="org", user_id="user")
+
+    async def test_authenticated_saved_tool(self):
+        ok = {"success": True, "final_answer": "Connected as alice"}
+        with (
+            patch(f"{_OPS}._resolve_tool_client", return_value=(object(), "github")),
+            patch(f"{_OPS}._run_agent", new=AsyncMock(return_value=ok)),
+        ):
+            result = await mcp_health_check(
+                organization_id="org", user_id="user", tool_id="t1"
+            )
+        assert result["is_authenticated"] == "Yes"
+        assert "alice" in result["message"]
+
+    async def test_authenticated_unsaved_credentials(self):
+        ok = {"success": True, "final_answer": "Connected"}
+        with (
+            patch(f"{_OPS}._resolve_params_client", return_value=(object(), "github")) as rp,
+            patch(f"{_OPS}._run_agent", new=AsyncMock(return_value=ok)),
+        ):
+            result = await mcp_health_check(
+                organization_id="org",
+                user_id="user",
+                provider_type_id="pt1",
+                credentials={"TOKEN": "x"},
+            )
+        assert result["is_authenticated"] == "Yes"
+        assert rp.call_count == 1  # the unsaved-credentials path was used

--- a/tests/backend/services/test_tool_actions.py
+++ b/tests/backend/services/test_tool_actions.py
@@ -21,6 +21,7 @@ class TestRouteTable:
         assert route("notion", ToolAction.TEST_CONNECTION) is Transport.REST
         assert route("jira", ToolAction.CREATE_TICKET) is Transport.REST
         assert route("jira", ToolAction.TEST_CONNECTION) is Transport.REST
+        assert route("confluence", ToolAction.TEST_CONNECTION) is Transport.REST
 
     def test_jira_has_no_extract(self):
         with pytest.raises(ToolConfigurationError, match="does not support"):


### PR DESCRIPTION
**Purpose**

#1853 introduced deterministic REST clients for Notion/GitHub/Jira/Confluence and removed the MCP agent path from the tool endpoints. This left the MCP service layer intact but unreachable, and made it impossible to add providers introduced by [Ayush7614](https://github.com/Ayush7614): GitLab #1976, Shortcut #1974, Asana #1975, that don't have a hand-written REST client.

This PR restores the MCP path as a first-class transport and introduces a lightweight routing layer so the choice of REST vs. MCP is made **per action, per provider** keeping the deterministic REST path for existing providers while unblocking MCP-based ones.

**What Changed**

- `services/tool/actions.py` — `_ROUTES` table mapping `(provider, action) → Transport` (REST or MCP); `route()` lookup and `resolve_provider()` helper
- `services/tool/mcp/operations.py` — `mcp_extract()` (JSON output + one repair retry), `mcp_health_check()` (suh saved tools and unsaved credentials via `_get_mcp_client_from_params`), shared `_run_agent()` helper
- `services/tool/mcp/templates.py` — fix template dir path (broke when mcp moved under `tool/` in #1853)
- `routers/tools.py` — extract / test-connection / create-ticket endpoints dispatch through `route()`
- `templates/mcp_extract_prompt.jinja2` — restored and rewritten: generic, JSON-output contract, `include_children` and `repair` flags, provider hook comment for contributors
- `templates/mcp_test_autpt.jinja2` — new minimal auth-ping prompt with same provider hook pattern

**Additional Context**

- Adding an MCP-only provider now means: a row in `_ROUTES`, an SDK provider template, `{% if provider == "..." %}` hints in the two jinja templates, and frontend icon/fields — no backend service code.
- The old `services/mcp/` pycache leftover from #1853 has been removed.
