### PR TITLE
Add vLLM LLM provider support

### DIFF
--- a/apps/frontend/src/app/(protected)/models/components/ConnectionForm.tsx
+++ b/apps/frontend/src/app/(protected)/models/components/ConnectionForm.tsx
@@ -39,6 +39,7 @@ import {
   DEFAULT_ENDPOINTS,
   LOCAL_PROVIDERS,
   PROVIDERS_WITH_OPTIONAL_API_KEY,
+  providerSupportsModelListing,
 } from '@/config/model-providers';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 
@@ -240,6 +241,14 @@ export const ConnectionForm = forwardRef<
       const currentProvider =
         isEditMode && model?.provider_type ? model.provider_type : provider;
       if (!currentProvider || !session?.session_token) return;
+
+      if (
+        !providerSupportsModelListing(currentProvider.type_value, modelType)
+      ) {
+        setAvailableModels([]);
+        setLoadingModels(false);
+        return;
+      }
 
       setLoadingModels(true);
       try {

--- a/apps/frontend/src/config/model-providers.tsx
+++ b/apps/frontend/src/config/model-providers.tsx
@@ -31,6 +31,7 @@ export const SUPPORTED_PROVIDERS = [
   'gemini',
   'vertex_ai',
   'ollama',
+  'vllm',
   'anthropic',
   'groq',
   'mistral',
@@ -51,6 +52,44 @@ export const SUPPORTED_PROVIDERS = [
 export const LOCAL_PROVIDERS = ['huggingface', 'lmformatenforcer', 'ollama'];
 
 export const EMBEDDING_PROVIDERS = ['openai', 'gemini', 'vertex_ai'];
+
+// Providers that support GET /models/provider/{name} model listing.
+// Keep aligned with _LISTABLE_LLM_PROVIDERS and _LISTABLE_EMBEDDING_PROVIDERS in
+// sdk/src/rhesis/sdk/models/factory.py
+export const LANGUAGE_MODEL_LISTABLE_PROVIDERS = [
+  'anthropic',
+  'azure',
+  'azure_ai',
+  'cohere',
+  'gemini',
+  'groq',
+  'meta_llama',
+  'mistral',
+  'ollama',
+  'openai',
+  'openrouter',
+  'perplexity',
+  'replicate',
+  'together_ai',
+  'vertex_ai',
+] as const;
+
+export const EMBEDDING_MODEL_LISTABLE_PROVIDERS = [
+  'openai',
+  'gemini',
+  'vertex_ai',
+] as const;
+
+export function providerSupportsModelListing(
+  provider: string,
+  modelType: 'language' | 'embedding'
+): boolean {
+  const listable =
+    modelType === 'embedding'
+      ? EMBEDDING_MODEL_LISTABLE_PROVIDERS
+      : LANGUAGE_MODEL_LISTABLE_PROVIDERS;
+  return (listable as readonly string[]).includes(provider);
+}
 
 // Providers that require custom endpoint URLs (self-hosted or local)
 export const PROVIDERS_REQUIRING_ENDPOINT = [

--- a/sdk/src/rhesis/sdk/models/factory.py
+++ b/sdk/src/rhesis/sdk/models/factory.py
@@ -215,6 +215,9 @@ UNIFIED_MODEL_REGISTRY: Dict[str, Dict[ModelType, Union[_ProviderSpec, Callable]
             pass_api_key=False,
         ),
     },
+    "vllm": {
+        ModelType.LANGUAGE: _ProviderSpec(f"{_PROVIDERS_MODULE}.vllm", "VllmLLM"),
+    },
     "openrouter": {
         ModelType.LANGUAGE: _ProviderSpec(f"{_PROVIDERS_MODULE}.openrouter", "OpenRouterLLM"),
     },

--- a/sdk/src/rhesis/sdk/models/providers/vllm.py
+++ b/sdk/src/rhesis/sdk/models/providers/vllm.py
@@ -53,9 +53,7 @@ class VllmLLM(LiteLLM):
         """
         if not model_name or not isinstance(model_name, str) or model_name.strip() == "":
             raise ValueError(NO_MODEL_NAME_PROVIDED)
-        resolved_api_base = (
-            api_base or os.getenv("HOSTED_VLLM_API_BASE") or DEFAULT_API_BASE
-        )
+        resolved_api_base = api_base or os.getenv("HOSTED_VLLM_API_BASE") or DEFAULT_API_BASE
         resolved_api_key = api_key or os.getenv("HOSTED_VLLM_API_KEY")
         super().__init__(
             self.PROVIDER + "/" + model_name,

--- a/sdk/src/rhesis/sdk/models/providers/vllm.py
+++ b/sdk/src/rhesis/sdk/models/providers/vllm.py
@@ -1,0 +1,64 @@
+import os
+from typing import Optional
+
+from rhesis.sdk.errors import NO_MODEL_NAME_PROVIDED
+from rhesis.sdk.models.providers.litellm import LiteLLM
+
+"""
+LiteLLM routes OpenAI-compatible vLLM servers through the hosted_vllm provider.
+https://docs.litellm.ai/docs/providers/vllm
+"""
+
+DEFAULT_API_BASE = "http://localhost:8000"
+
+
+class VllmLLM(LiteLLM):
+    PROVIDER = "hosted_vllm"
+
+    def __init__(
+        self,
+        model_name: str,
+        api_base: Optional[str] = None,
+        api_key: Optional[str] = None,
+        **kwargs,
+    ):
+        """
+        VllmLLM: vLLM LLM Provider
+
+        This class provides an interface to models served by a vLLM OpenAI-compatible
+        inference server via LiteLLM.
+
+        In order to use this class, you need a running vLLM server exposing
+        /v1/chat/completions. See https://docs.vllm.ai/ for setup instructions.
+
+        Args:
+            model_name: The model name as served by your vLLM instance
+                (e.g. "meta-llama/Llama-2-7b-chat-hf").
+            api_base: Base URL of the vLLM server (without /v1).
+                Defaults to HOSTED_VLLM_API_BASE env var or http://localhost:8000.
+            api_key: Optional API key when the vLLM server requires authentication.
+                Defaults to HOSTED_VLLM_API_KEY env var.
+            **kwargs: Additional parameters passed to the underlying LiteLLM completion call.
+
+        Usage:
+            >>> llm = VllmLLM(
+            ...     model_name="meta-llama/Llama-2-7b-chat-hf",
+            ...     api_base="http://localhost:8000",
+            ... )
+            >>> result = llm.generate("Tell me a joke.")
+            >>> print(result)
+
+        If a Pydantic schema is provided to `generate`, the response will be validated and
+        returned as a dict.
+        """
+        if not model_name or not isinstance(model_name, str) or model_name.strip() == "":
+            raise ValueError(NO_MODEL_NAME_PROVIDED)
+        resolved_api_base = (
+            api_base or os.getenv("HOSTED_VLLM_API_BASE") or DEFAULT_API_BASE
+        )
+        resolved_api_key = api_key or os.getenv("HOSTED_VLLM_API_KEY")
+        super().__init__(
+            self.PROVIDER + "/" + model_name,
+            api_key=resolved_api_key,
+            api_base=resolved_api_base,
+        )

--- a/tests/sdk/models/providers/test_vllm.py
+++ b/tests/sdk/models/providers/test_vllm.py
@@ -1,0 +1,79 @@
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+from rhesis.sdk.models.providers.vllm import DEFAULT_API_BASE, VllmLLM
+
+
+class TestVllmLLM:
+    def test_provider_constant(self):
+        assert VllmLLM.PROVIDER == "hosted_vllm"
+
+    def test_init_sets_litellm_model_name(self):
+        llm = VllmLLM(model_name="meta-llama/Llama-2-7b-chat-hf")
+        assert llm.model_name == "hosted_vllm/meta-llama/Llama-2-7b-chat-hf"
+        assert llm.api_base == DEFAULT_API_BASE
+        assert llm.api_key is None
+
+    def test_init_with_api_base_and_api_key(self):
+        llm = VllmLLM(
+            model_name="facebook/opt-125m",
+            api_base="https://vllm.example.com",
+            api_key="secret",
+        )
+        assert llm.model_name == "hosted_vllm/facebook/opt-125m"
+        assert llm.api_base == "https://vllm.example.com"
+        assert llm.api_key == "secret"
+
+    def test_init_uses_env_vars(self, monkeypatch):
+        monkeypatch.setenv("HOSTED_VLLM_API_BASE", "http://vllm.local:8000")
+        monkeypatch.setenv("HOSTED_VLLM_API_KEY", "env-key")
+
+        llm = VllmLLM(model_name="qwen")
+
+        assert llm.api_base == "http://vllm.local:8000"
+        assert llm.api_key == "env-key"
+
+    def test_init_without_name(self):
+        with pytest.raises(ValueError):
+            VllmLLM("")
+
+    @patch("rhesis.sdk.models.providers.litellm.acompletion")
+    def test_generate_calls_litellm_with_api_base(self, mock_completion):
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "ok"
+        mock_completion.return_value = mock_response
+
+        llm = VllmLLM(
+            model_name="facebook/opt-125m",
+            api_base="http://localhost:8000",
+        )
+        result = llm.generate("ping")
+
+        assert result == "ok"
+        mock_completion.assert_called_once_with(
+            model="hosted_vllm/facebook/opt-125m",
+            messages=[{"role": "user", "content": "ping"}],
+            response_format=None,
+            api_key=None,
+            api_base="http://localhost:8000",
+            api_version=None,
+        )
+
+    @patch("rhesis.sdk.models.factory._create_from_spec")
+    def test_get_model_registry_wires_vllm(self, mock_create):
+        from rhesis.sdk.models.factory import get_model
+
+        get_model("vllm", "my-model", api_base="http://localhost:8000")
+
+        mock_create.assert_called_once()
+        spec, model_type, model_name, api_key, dimensions = mock_create.call_args[0]
+        kwargs = mock_create.call_args[1]
+        assert spec.module.endswith(".vllm")
+        assert spec.class_name == "VllmLLM"
+        assert model_type.value == "language"
+        assert model_name == "my-model"
+        assert api_key is None
+        assert kwargs == {"api_base": "http://localhost:8000"}

--- a/tests/sdk/models/test_model_factory.py
+++ b/tests/sdk/models/test_model_factory.py
@@ -450,6 +450,24 @@ class TestAdditionalProviders:
         with pytest.raises(ValueError, match="does not support model type 'embedding'"):
             get_model("azure", "text-embedding-ada-002", model_type="embedding")
 
+    @patch("rhesis.sdk.models.providers.vllm.VllmLLM")
+    def test_vllm_llm_creation(self, mock_cls):
+        """vLLM LLM is created with correct args via shorthand."""
+        mock_instance = Mock(spec=BaseLLM)
+        mock_cls.return_value = mock_instance
+
+        result = get_model(
+            "vllm/meta-llama/Llama-2-7b-chat-hf",
+            api_base="http://localhost:8000",
+        )
+
+        mock_cls.assert_called_once_with(
+            model_name="meta-llama/Llama-2-7b-chat-hf",
+            api_key=None,
+            api_base="http://localhost:8000",
+        )
+        assert result == mock_instance
+
 
 class TestModelTypeClassification:
     """Test ModelType enum and classification logic."""


### PR DESCRIPTION
## Purpose
Enable users to connect self-hosted vLLM inference servers as language models in Rhesis, using the OpenAI-compatible API that vLLM exposes.

## What Changed
- Added `VllmLLM` SDK provider that routes through LiteLLM's `hosted_vllm` integration
- Registered `vllm` in the model factory for language-model creation
- Added `vllm` to supported frontend providers with default endpoint configuration
- Skipped model-listing API calls for providers that do not support `GET /models/provider/{name}` (including vLLM)
- Added unit tests for the provider and factory wiring

## Additional Context
- vLLM uses `HOSTED_VLLM_API_BASE` / `HOSTED_VLLM_API_KEY` env vars when not passed explicitly
- Default API base is `http://localhost:8000` (frontend default: `http://host.docker.internal:8000`)

## Testing
- [x] `uv run pytest ../tests/sdk/models/providers/test_vllm.py` (7 tests)
- [x] `uv run pytest ../tests/sdk/models/test_model_factory.py::TestAdditionalProviders::test_vllm_llm_creation`