### PR TITLE
Pass model endpoint as api_base to SDK

### DIFF
--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -464,8 +464,15 @@ def _fetch_and_configure_model(
 
     # Use SDK's get_model to create configured instance with error handling
     try:
+        extra_params = {}
+        if model.endpoint and model.endpoint.strip():
+            extra_params["api_base"] = model.endpoint.strip()
         configured_model = get_model(
-            provider=provider, model_name=model_name, api_key=api_key, model_type="language"
+            provider=provider,
+            model_name=model_name,
+            api_key=api_key,
+            model_type="language",
+            **extra_params,
         )
         logger.info(
             f"[LLM_UTILS] ✓ Returning configured BaseLLM instance: "
@@ -607,8 +614,15 @@ def _fetch_and_configure_embedder(
 
     # Use SDK's get_model to create configured instance with error handling
     try:
+        extra_params = {}
+        if model.endpoint and model.endpoint.strip():
+            extra_params["api_base"] = model.endpoint.strip()
         configured_embedder = get_model(
-            provider=provider, model_name=model_name, api_key=api_key, model_type="embedding"
+            provider=provider,
+            model_name=model_name,
+            api_key=api_key,
+            model_type="embedding",
+            **extra_params,
         )
         logger.info(
             f"[LLM_UTILS] ✓ Returning configured BaseEmbedder instance: "

--- a/apps/backend/src/rhesis/backend/metrics/strategies/local.py
+++ b/apps/backend/src/rhesis/backend/metrics/strategies/local.py
@@ -662,10 +662,14 @@ def _resolve_metric_model(
         )
 
         if model_record and model_record.provider_type:
+            extra_params = {}
+            if model_record.endpoint and model_record.endpoint.strip():
+                extra_params["api_base"] = model_record.endpoint.strip()
             llm = get_model(
                 provider=model_record.provider_type.type_value,
                 model_name=model_record.model_name,
                 api_key=model_record.key,
+                **extra_params,
             )
             logger.info(
                 f"[METRIC_MODEL] Using metric-specific model for "

--- a/sdk/src/rhesis/sdk/models/providers/litellm_proxy.py
+++ b/sdk/src/rhesis/sdk/models/providers/litellm_proxy.py
@@ -14,7 +14,7 @@ from rhesis.sdk.models.utils import validate_llm_response
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_API_BASE = "http://0.0.0.0:4000"
+DEFAULT_API_BASE = "http://localhost:4000"
 DEFAULT_REQUEST_TIMEOUT = int(os.getenv("LITELLM_PROXY_TIMEOUT", "300"))
 
 
@@ -28,7 +28,7 @@ class LiteLLMProxy(BaseLLM):
     Args:
         model_name: The model name as configured in the proxy (e.g. "gemini").
         api_base: Base URL of the LiteLLM Proxy server.
-            Defaults to LITELLM_PROXY_BASE_URL env var or http://0.0.0.0:4000.
+            Defaults to LITELLM_PROXY_BASE_URL env var or http://localhost:4000.
         api_key: Optional API key for the proxy.
             Defaults to LITELLM_PROXY_API_KEY env var.
 

--- a/tests/backend/utils/test_llm_delegation.py
+++ b/tests/backend/utils/test_llm_delegation.py
@@ -200,3 +200,105 @@ class TestPolyphemusModelConfiguration:
         assert len(call_kwargs["api_key"]) > 0
         # JWT tokens don't start with rh-
         assert not call_kwargs["api_key"].startswith("rh-")
+
+
+class TestModelEndpointConfiguration:
+    """Test that stored model endpoint URLs are passed to the SDK."""
+
+    @pytest.fixture
+    def mock_db_model(self):
+        from rhesis.backend.app.models.model import Model
+
+        model = Mock(spec=Model)
+        model.id = "model-789"
+        model.name = "Local LiteLLM Proxy"
+        model.model_name = "gemini"
+        model.key = "test-key"
+        model.endpoint = "http://host.docker.internal:4000"
+        model.provider_type = Mock()
+        model.provider_type.type_value = "litellm_proxy"
+        return model
+
+    @patch("rhesis.backend.app.utils.user_model_utils.get_model")
+    @patch("rhesis.backend.app.utils.user_model_utils.crud.get_model")
+    def test_fetch_and_configure_model_passes_endpoint(
+        self, mock_get_model, mock_sdk_get_model, mock_db_model
+    ):
+        from sqlalchemy.orm import Session
+
+        from rhesis.backend.app.utils.user_model_utils import _fetch_and_configure_model
+
+        mock_db = Mock(spec=Session)
+        mock_get_model.return_value = mock_db_model
+        mock_sdk_get_model.return_value = Mock()
+
+        _fetch_and_configure_model(
+            db=mock_db,
+            model_id="model-789",
+            organization_id="org-456",
+            default_model="gpt-4",
+        )
+
+        mock_sdk_get_model.assert_called_once_with(
+            provider="litellm_proxy",
+            model_name="gemini",
+            api_key="test-key",
+            model_type="language",
+            api_base="http://host.docker.internal:4000",
+        )
+
+    @patch("rhesis.backend.app.utils.user_model_utils.get_model")
+    @patch("rhesis.backend.app.utils.user_model_utils.crud.get_model")
+    def test_fetch_and_configure_embedder_passes_endpoint(
+        self, mock_get_model, mock_sdk_get_model, mock_db_model
+    ):
+        from sqlalchemy.orm import Session
+
+        from rhesis.backend.app.utils.user_model_utils import _fetch_and_configure_embedder
+
+        mock_db = Mock(spec=Session)
+        mock_get_model.return_value = mock_db_model
+        mock_sdk_get_model.return_value = Mock()
+
+        _fetch_and_configure_embedder(
+            db=mock_db,
+            model_id="model-789",
+            organization_id="org-456",
+            default_model="openai",
+        )
+
+        mock_sdk_get_model.assert_called_once_with(
+            provider="litellm_proxy",
+            model_name="gemini",
+            api_key="test-key",
+            model_type="embedding",
+            api_base="http://host.docker.internal:4000",
+        )
+
+    @patch("rhesis.backend.app.utils.user_model_utils.get_model")
+    @patch("rhesis.backend.app.utils.user_model_utils.crud.get_model")
+    def test_fetch_and_configure_model_omits_empty_endpoint(
+        self, mock_get_model, mock_sdk_get_model, mock_db_model
+    ):
+        from sqlalchemy.orm import Session
+
+        from rhesis.backend.app.utils.user_model_utils import _fetch_and_configure_model
+
+        mock_db_model.endpoint = None
+        mock_db = Mock(spec=Session)
+        mock_get_model.return_value = mock_db_model
+        mock_sdk_get_model.return_value = Mock()
+
+        _fetch_and_configure_model(
+            db=mock_db,
+            model_id="model-789",
+            organization_id="org-456",
+            default_model="gpt-4",
+        )
+
+        mock_sdk_get_model.assert_called_once_with(
+            provider="litellm_proxy",
+            model_name="gemini",
+            api_key="test-key",
+            model_type="language",
+        )


### PR DESCRIPTION
## Purpose
Models stored in the database can have a custom endpoint URL (e.g. a LiteLLM proxy at `http://host.docker.internal:4000`), but the backend was not forwarding that value when constructing SDK model instances. This caused requests to fall back to provider defaults instead of the configured endpoint.

## What Changed
- Pass `model.endpoint` as `api_base` when configuring language and embedding models in `user_model_utils`
- Pass `model_record.endpoint` as `api_base` when resolving metric-specific models in the local metrics strategy
- Change LiteLLM proxy default API base from `http://0.0.0.0:4000` to `http://localhost:4000`
- Add unit tests verifying endpoint forwarding and omission when endpoint is empty

## Additional Context
- Fixes custom endpoint configuration for LiteLLM proxy and other providers that accept `api_base`

## Testing
- [x] `cd apps/backend && uv run pytest ../../tests/backend/utils/test_llm_delegation.py -v`