### PR TITLE
Speed up test run summary tab

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunHeader.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunHeader.tsx
@@ -24,7 +24,10 @@ import TrendingDownIcon from '@mui/icons-material/TrendingDown';
 import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 import WarningAmberOutlinedIcon from '@mui/icons-material/WarningAmberOutlined';
 import Link from 'next/link';
-import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+import {
+  PassFailStats,
+  TestResultDetail,
+} from '@/utils/api-client/interfaces/test-results';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 import { formatDate } from '@/utils/date';
 import { getEffectiveTestResultStatus } from '@/utils/test-result-status';
@@ -35,6 +38,7 @@ import { BiotechIcon } from '@/components/icons';
 interface TestRunHeaderProps {
   testRun: TestRunDetail;
   testResults: TestResultDetail[];
+  overallStats?: PassFailStats;
   loading?: boolean;
   onRefresh?: () => void;
 }
@@ -140,6 +144,7 @@ function SummaryCard({
 export default function TestRunHeader({
   testRun,
   testResults,
+  overallStats,
   loading: _loading = false,
   onRefresh,
 }: TestRunHeaderProps) {
@@ -153,40 +158,45 @@ export default function TestRunHeader({
 
   // Calculate statistics
   const stats = useMemo(() => {
-    const total = testResults.length;
-
-    // Count passed, failed, and execution errors
-    let passed = 0;
-    let failed = 0;
-    let executionErrors = 0;
+    let total: number;
+    let passed: number;
+    let failed: number;
+    let executionErrors: number;
     let totalTurns = 0;
     let testsWithTurnData = 0;
 
-    testResults.forEach(result => {
-      // Use unified status determination for both single-turn and multi-turn tests
-      // This checks test_metrics.metrics[].is_successful which is set by backend
-      // for both single-turn (SDK metrics) and multi-turn (Penelope metrics)
-      const status = getEffectiveTestResultStatus(result);
+    if (overallStats) {
+      total = overallStats.total;
+      passed = overallStats.passed;
+      failed = overallStats.failed;
+      executionErrors = total - passed - failed;
+    } else {
+      total = testResults.length;
+      passed = 0;
+      failed = 0;
+      executionErrors = 0;
 
-      if (status === 'Error') {
-        executionErrors++;
-      } else if (status === 'Pass') {
-        passed++;
-      } else if (status === 'Fail') {
-        failed++;
-      }
-
-      // For multi-turn tests, track turn depth
-      if (isMultiTurn && result.test_output) {
-        const turns =
-          result.test_output.turns_used ||
-          result.test_output.stats?.total_turns;
-        if (turns) {
-          totalTurns += turns;
-          testsWithTurnData++;
+      testResults.forEach(result => {
+        const status = getEffectiveTestResultStatus(result);
+        if (status === 'Error') {
+          executionErrors++;
+        } else if (status === 'Pass') {
+          passed++;
+        } else if (status === 'Fail') {
+          failed++;
         }
-      }
-    });
+
+        if (isMultiTurn && result.test_output) {
+          const turns =
+            result.test_output.turns_used ||
+            result.test_output.stats?.total_turns;
+          if (turns) {
+            totalTurns += turns;
+            testsWithTurnData++;
+          }
+        }
+      });
+    }
 
     const passRate = total > 0 ? ((passed / total) * 100).toFixed(1) : '0.0';
     const avgTurnDepth =

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunHeader.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunHeader.tsx
@@ -302,7 +302,7 @@ export default function TestRunHeader({
       statusColor,
       statusLabel,
     };
-  }, [testResults, testRun, isMultiTurn]);
+  }, [testResults, testRun, isMultiTurn, overallStats]);
 
   const totalExpected =
     testRun.test_configuration?.test_set?.attributes?.metadata?.total_tests;

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -101,6 +101,21 @@ export default function TestRunMainView({
   const router = useRouter();
   const searchParams = useSearchParams();
 
+  const preferLinkedEntities = Boolean(initialSelectedTestId);
+  const activeTab = tabIndexFromKey(
+    searchParams.get('tab'),
+    preferLinkedEntities && !searchParams.get('tab')
+  );
+
+  // Only fetch raw test results once the Test Cases tab is opened.
+  // A ref ensures the fetch starts and stays enabled after the first visit.
+  const testCasesVisited = React.useRef(
+    activeTab === TAB_KEYS.indexOf('linked_entities')
+  );
+  if (activeTab === TAB_KEYS.indexOf('linked_entities')) {
+    testCasesVisited.current = true;
+  }
+
   const {
     testResults: loadedTestResults,
     prompts,
@@ -111,13 +126,8 @@ export default function TestRunMainView({
   } = useTestRunDetailData({
     testRunId,
     sessionToken,
+    enabled: testCasesVisited.current,
   });
-
-  const preferLinkedEntities = Boolean(initialSelectedTestId);
-  const activeTab = tabIndexFromKey(
-    searchParams.get('tab'),
-    preferLinkedEntities && !searchParams.get('tab')
-  );
 
   const handleTabChange = useCallback(
     (newValue: number) => {

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunStatsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunStatsTab.tsx
@@ -563,7 +563,7 @@ export default function TestRunStatsTab({
     isMounted.current = true;
 
     const fetchStats = async () => {
-      if (!sessionToken) return;
+      if (!sessionToken) return setStatsLoading(false);
       try {
         setStatsLoading(true);
         const client = new ApiClientFactory(

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunStatsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunStatsTab.tsx
@@ -24,16 +24,16 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import {
+  CategoryPassRates,
   TestResultDetail,
   TestResultsStats,
+  TopicPassRates,
 } from '@/utils/api-client/interfaces/test-results';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 import { BehaviorWithMetrics } from '../hooks/useTestRunDetailData';
 import TestRunHeader from './TestRunHeader';
 import TestRunTags from './TestRunTags';
 import {
-  aggregateBehaviorStats,
-  aggregateMetricStats,
   BehaviorStat,
   getReviewBand,
   MetricStat,
@@ -463,61 +463,29 @@ function DimensionList({ items }: { items: DimensionItem[] }) {
 }
 
 function MoreBreakdownsSection({
-  testRunId,
-  sessionToken,
+  categoryPassRates,
+  topicPassRates,
+  isLoading,
 }: {
-  testRunId: string;
-  sessionToken: string;
+  categoryPassRates?: CategoryPassRates;
+  topicPassRates?: TopicPassRates;
+  isLoading: boolean;
 }) {
-  const isMounted = useRef(false);
-  const [data, setData] = useState<TestResultsStats | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
   const [expanded, setExpanded] = useState(false);
 
-  useEffect(() => {
-    isMounted.current = true;
-
-    const fetchData = async () => {
-      if (!sessionToken) return;
-      try {
-        setIsLoading(true);
-        const client = new ApiClientFactory(
-          sessionToken
-        ).getTestResultsClient();
-        const result = await client.getComprehensiveTestResultsStats({
-          test_run_ids: [testRunId],
-          mode: 'all',
-        });
-        if (isMounted.current) {
-          setData(result);
-          setIsLoading(false);
-        }
-      } catch {
-        if (isMounted.current) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    void fetchData();
-    return () => {
-      isMounted.current = false;
-    };
-  }, [testRunId, sessionToken]);
-
   const categoryStats = useMemo((): DimensionItem[] => {
-    if (!data?.category_pass_rates) return [];
-    return Object.entries(data.category_pass_rates)
+    if (!categoryPassRates) return [];
+    return Object.entries(categoryPassRates)
       .map(([name, s]) => ({ name, ...s }))
       .sort((a, b) => a.pass_rate - b.pass_rate);
-  }, [data]);
+  }, [categoryPassRates]);
 
   const topicStats = useMemo((): DimensionItem[] => {
-    if (!data?.topic_pass_rates) return [];
-    return Object.entries(data.topic_pass_rates)
+    if (!topicPassRates) return [];
+    return Object.entries(topicPassRates)
       .map(([name, s]) => ({ name, ...s }))
       .sort((a, b) => a.pass_rate - b.pass_rate);
-  }, [data]);
+  }, [topicPassRates]);
 
   const hasData = categoryStats.length > 0 || topicStats.length > 0;
 
@@ -587,15 +555,62 @@ export default function TestRunStatsTab({
   onViewBehavior,
   onViewMetric,
 }: TestRunStatsTabProps) {
-  const behaviorStats = useMemo(
-    () => aggregateBehaviorStats(testResults),
-    [testResults]
-  );
+  const isMounted = useRef(false);
+  const [stats, setStats] = useState<TestResultsStats | null>(null);
+  const [statsLoading, setStatsLoading] = useState(true);
 
-  const metricStats = useMemo(
-    () => aggregateMetricStats(testResults),
-    [testResults]
-  );
+  useEffect(() => {
+    isMounted.current = true;
+
+    const fetchStats = async () => {
+      if (!sessionToken) return;
+      try {
+        setStatsLoading(true);
+        const client = new ApiClientFactory(
+          sessionToken
+        ).getTestResultsClient();
+        const result = await client.getComprehensiveTestResultsStats({
+          test_run_ids: [testRunId],
+          mode: 'all',
+        });
+        if (isMounted.current) {
+          setStats(result);
+          setStatsLoading(false);
+        }
+      } catch {
+        if (isMounted.current) {
+          setStatsLoading(false);
+        }
+      }
+    };
+
+    void fetchStats();
+    return () => {
+      isMounted.current = false;
+    };
+  }, [testRunId, sessionToken]);
+
+  const behaviorStats = useMemo((): BehaviorStat[] => {
+    if (!stats?.behavior_pass_rates) return [];
+    return Object.entries(stats.behavior_pass_rates).map(([name, s]) => ({
+      name,
+      total: s.total,
+      passed: s.passed,
+      failed: s.failed,
+      passRate: s.pass_rate,
+    }));
+  }, [stats]);
+
+  const metricStats = useMemo((): MetricStat[] => {
+    if (!stats?.metric_pass_rates) return [];
+    return Object.entries(stats.metric_pass_rates).map(([name, s]) => ({
+      name,
+      total: s.total,
+      passed: s.passed,
+      failed: s.failed,
+      failRate: s.total > 0 ? ((s.total - s.passed) / s.total) * 100 : 0,
+    }));
+  }, [stats]);
 
   const hasInsights = behaviorStats.length > 0 || metricStats.length > 0;
 
@@ -604,12 +619,13 @@ export default function TestRunStatsTab({
       <TestRunHeader
         testRun={testRun}
         testResults={testResults}
-        loading={loading}
+        overallStats={stats?.overall_pass_rates}
+        loading={statsLoading}
         onRefresh={onRefresh}
       />
 
       <Stack spacing={3} sx={{ mt: 3 }}>
-        {loading && testResults.length === 0 ? (
+        {statsLoading ? (
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
             <CircularProgress />
           </Box>
@@ -635,8 +651,9 @@ export default function TestRunStatsTab({
               />
             )}
             <MoreBreakdownsSection
-              testRunId={testRunId}
-              sessionToken={sessionToken}
+              categoryPassRates={stats?.category_pass_rates}
+              topicPassRates={stats?.topic_pass_rates}
+              isLoading={statsLoading}
             />
           </>
         )}


### PR DESCRIPTION
## Purpose
Speed up the test run summary tab, which was slow due to downloading all raw test results on page load before rendering any stats.

## What Changed
- Stats tab now fetches a single pre-aggregated `GET /test_results/stats` response instead of looping over raw results client-side
- Removed `aggregateBehaviorStats` / `aggregateMetricStats` — behavior and metric pass rates come directly from the API
- Consolidated two independent stats API calls (parent + child component) into one
- Raw test results are now lazy-loaded — the download only starts when the user opens the Test Cases tab, not on page open
- `TestRunHeader` can now consume pre-aggregated overall stats so the summary header renders immediately

## What's Not Included (that was mentioned in #1984)
Backend computation of metric stats (`_metric_stats`) still uses a Python loop over JSONB blobs rather than a SQL aggregation. This was intentionally left out — the current stats infrastructure is a stepping stone toward a broader analytics overhaul. The plan is to move away from on-the-fly computation entirely, towards an OLAP-style architecture with materialized views (or similar, see #1985), a semantic layer bridging the raw schema and query definitions, and a standardized analytics query contract. Patching the Python loop now would be optimizing something we intend to replace.

## Testing
- Open a run with many results — summary tab should render immediately
- Verify behavior/metric/category/topic pass rates match expected values
- Navigate to Test Cases tab — results table should load as before
- Direct-linking to `?tab=linked_entities` should still load results eagerly