### PR TITLE
Fix empty test set dropdown in Run Experiment drawer

### DIFF
--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -508,11 +508,11 @@ export default function RunDrawer(props: RunDrawerProps) {
   }, [open, sessionToken, mode]);
 
   // -----------------------------------------------------------------------
-  // Load test sets (newTestRun mode)
+  // Load test sets (newTestRun & runExperiment modes)
   // -----------------------------------------------------------------------
 
   useEffect(() => {
-    if (!open || mode !== 'newTestRun') return;
+    if (!open || (mode !== 'newTestRun' && mode !== 'runExperiment')) return;
     let mounted = true;
     const load = async () => {
       try {


### PR DESCRIPTION
## Purpose
The Run Experiment drawer always showed "No options" in the Test Set dropdown even when test sets existed in the project.

## What Changed
- Load test sets for `runExperiment` mode in `RunDrawer`, not only for `newTestRun`
- Update the loader comment to reflect both modes

## Additional Context
After the Experiments UX redesign (#1893), `runExperiment` was switched from `multi-search` to `single` test set mode, but the fetch effect still only populated `testSets` for `newTestRun`. The drawer UI reads from `testSets`, so the dropdown stayed empty.

## Testing
- [ ] Open an experiment detail page
- [ ] Click "Run Experiment"
- [ ] Confirm the Test Set dropdown lists available test sets