### PR TITLE
Stop TruffleHog self-updates on commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         - id: trufflehog
           name: TruffleHog
           description: Detect secrets in your data.
-          entry: bash -c 'trufflehog git file://. --branch HEAD'
+          entry: bash -c 'trufflehog git file://. --branch HEAD --no-update'
           language: system
           stages: ["pre-commit", "pre-push"]
 


### PR DESCRIPTION
## Purpose
Stop TruffleHog from attempting self-updates on every commit.

## What Changed
- Added `--no-update` to the TruffleHog pre-commit hook entry

## Additional Context
The hook occasionally fails with `"error occurred with trufflehog updater: cannot move binary (exit status 1)"`. This did not happen because secrets were found, but because after scanning, TruffleHog sometimes tries to self-update when a new version is available. 

The binary at `/opt/homebrew/bin/trufflehog` is read-only (Homebrew-managed), so the update always fails. Use `brew upgrade trufflehog` to update instead.