### PR TITLE
Fix test set generation model resolution with project scope

### DIFF
--- a/apps/backend/src/rhesis/backend/tasks/test_set.py
+++ b/apps/backend/src/rhesis/backend/tasks/test_set.py
@@ -2,17 +2,19 @@ import logging
 from typing import Any, List, Optional, Union
 
 from rhesis.backend.app import crud
-from rhesis.backend.app.config.settings import get_model_settings
 from rhesis.backend.app.constants import TestSetType
 from rhesis.backend.app.database import get_db_with_tenant_variables
 from rhesis.backend.app.models.test_set import TestSet
 from rhesis.backend.app.schemas.services import GenerationConfig, SourceData
+from rhesis.backend.app.services.test import bulk_create_tests
 from rhesis.backend.app.services.test_set import (
     bulk_create_test_set,
     generate_test_set_attributes,
     load_defaults,
 )
-from rhesis.backend.app.services.test import bulk_create_tests
+from rhesis.backend.app.utils.user_model_utils import (
+    get_generation_model_with_override,
+)
 from rhesis.backend.celery.core import app
 from rhesis.backend.notifications.email.template_service import EmailTemplate
 from rhesis.backend.tasks.base import BaseTask, EmailEnabledTask, email_notification
@@ -183,72 +185,27 @@ def _save_test_set_to_database(
     return db_test_set
 
 
-def _get_model_for_user(self, org_id: str, user_id: str) -> Union[str, Any]:
-    """
-    Fetch user's configured generation model from database.
+def _resolve_generation_model(
+    self, org_id: str, user_id: str, project_id: str = "", model_id: Optional[str] = None
+) -> Union[str, Any]:
+    """Fetch the generation model for this task run.
 
-    Args:
-        org_id: Organization ID
-        user_id: User ID
-
-    Returns:
-        Either the user's configured BaseLLM instance or the system generation model string
+    Uses model_id as an explicit override when provided; otherwise returns the
+    user's configured default. project_id is required so project-scoped models
+    are visible to the ORM auto-filter.
     """
-    self.log_with_context("info", "Fetching user's configured generation model")
-    with get_db_with_tenant_variables(org_id, user_id) as db:
+    with get_db_with_tenant_variables(org_id, user_id, project_id) as db:
         user = crud.get_user(db, user_id=user_id)
-        if user:
-            from rhesis.backend.app.utils.user_model_utils import get_user_generation_model
+        if not user:
+            raise ValueError(f"User not found: {user_id}")
 
-            model = get_user_generation_model(db, user)
-            self.log_with_context(
-                "info",
-                "Using user's configured model",
-                model_type=type(model).__name__ if not isinstance(model, str) else "string",
-            )
-            return model
-        else:
-            # Fallback to default if user not found
-            default_model = get_model_settings().generation_model
-            self.log_with_context(
-                "warning", "User not found, using default model", model=default_model
-            )
-            return default_model
-
-
-def _get_override_model(self, org_id: str, user_id: str, model_id: str) -> Union[str, Any]:
-    """
-    Fetch a specific model by ID for per-request override.
-
-    Args:
-        org_id: Organization ID
-        user_id: User ID
-        model_id: Model UUID to fetch
-
-    Returns:
-        Either a configured BaseLLM instance or the system generation model string
-    """
-    self.log_with_context("info", "Fetching per-request override model", model_id=model_id)
-    with get_db_with_tenant_variables(org_id, user_id) as db:
-        user = crud.get_user(db, user_id=user_id)
-        if user:
-            from rhesis.backend.app.utils.user_model_utils import (
-                get_generation_model_with_override,
-            )
-
-            model = get_generation_model_with_override(db, user, model_id=model_id)
-            self.log_with_context(
-                "info",
-                "Using per-request override model",
-                model_type=type(model).__name__ if not isinstance(model, str) else "string",
-            )
-            return model
-        else:
-            default_model = get_model_settings().generation_model
-            self.log_with_context(
-                "warning", "User not found, using default model", model=default_model
-            )
-            return default_model
+        model = get_generation_model_with_override(db, user, model_id=model_id)
+        self.log_with_context(
+            "info",
+            "Resolved generation model",
+            model_type=type(model).__name__ if not isinstance(model, str) else "string",
+        )
+        return model
 
 
 def _build_task_result(
@@ -474,7 +431,7 @@ def generate_and_save_test_set(
     Returns:
         dict: Information about the generated and saved test set including ID and metadata
     """
-    org_id, user_id, _ = self.get_tenant_context()
+    org_id, user_id, project_id = self.get_tenant_context()
 
     # Parse config
     generation_config = GenerationConfig(**config)
@@ -496,11 +453,7 @@ def generate_and_save_test_set(
                 user_id=user_id,
             )
 
-    # Get model: use per-request override if provided, otherwise user's default
-    if model_id:
-        model = _get_override_model(self, org_id, user_id, model_id)
-    else:
-        model = _get_model_for_user(self, org_id, user_id)
+    model = _resolve_generation_model(self, org_id, user_id, project_id or "", model_id)
 
     # Determine model info for logging
     model_info = model if isinstance(model, str) else f"{type(model).__name__} instance"

--- a/tests/backend/tasks/test_test_set_model_override.py
+++ b/tests/backend/tasks/test_test_set_model_override.py
@@ -1,16 +1,16 @@
 """
-Unit tests for the model_id override helpers used by generate_and_save_test_set.
+Unit tests for _resolve_generation_model used by generate_and_save_test_set.
 
 Verifies that:
-- _get_model_for_user calls get_user_generation_model (user default path)
-- _get_override_model calls get_generation_model_with_override (per-request override)
+- With no model_id, the user's default is resolved
+  (get_generation_model_with_override called with model_id=None)
+- With a model_id, that override is passed through
+- A missing user raises ValueError (no silent fallback to the default model)
 """
 
 from unittest.mock import MagicMock, patch
 
 import pytest
-
-from rhesis.backend.app.config.settings import get_model_settings
 
 
 def _make_mock_task():
@@ -20,87 +20,87 @@ def _make_mock_task():
     return task
 
 
-@pytest.mark.unit
-class TestGetModelForUser:
-    """Tests for _get_model_for_user (the user-default path)."""
-
-    @patch("rhesis.backend.app.utils.user_model_utils.get_user_generation_model")
-    @patch("rhesis.backend.app.crud.get_user")
-    @patch("rhesis.backend.tasks.test_set.get_db_with_tenant_variables")
-    def test_calls_get_user_generation_model(
-        self, mock_get_db, mock_get_user, mock_gen_model
-    ):
-        from rhesis.backend.tasks.test_set import _get_model_for_user
-
-        task = _make_mock_task()
-        mock_user = MagicMock()
-        mock_get_user.return_value = mock_user
-        mock_db = MagicMock()
-        mock_get_db.return_value.__enter__ = MagicMock(return_value=mock_db)
-        mock_get_db.return_value.__exit__ = MagicMock(return_value=False)
-        mock_gen_model.return_value = "user-default-model"
-
-        result = _get_model_for_user(task, "org-1", "user-1")
-
-        mock_gen_model.assert_called_once_with(mock_db, mock_user)
-        assert result == "user-default-model"
-
-    @patch("rhesis.backend.app.crud.get_user")
-    @patch("rhesis.backend.tasks.test_set.get_db_with_tenant_variables")
-    def test_falls_back_when_user_not_found(self, mock_get_db, mock_get_user):
-        from rhesis.backend.tasks.test_set import _get_model_for_user
-
-        task = _make_mock_task()
-        mock_get_user.return_value = None
-        mock_db = MagicMock()
-        mock_get_db.return_value.__enter__ = MagicMock(return_value=mock_db)
-        mock_get_db.return_value.__exit__ = MagicMock(return_value=False)
-
-        result = _get_model_for_user(task, "org-1", "user-1")
-
-        assert result == get_model_settings().generation_model
+def _mock_db_session(mock_get_db, mock_db):
+    """Wire the get_db_with_tenant_variables context manager to yield mock_db."""
+    mock_get_db.return_value.__enter__ = MagicMock(return_value=mock_db)
+    mock_get_db.return_value.__exit__ = MagicMock(return_value=False)
 
 
 @pytest.mark.unit
-class TestGetOverrideModel:
-    """Tests for _get_override_model (the per-request override path)."""
+class TestResolveGenerationModel:
+    """Tests for _resolve_generation_model."""
 
-    @patch(
-        "rhesis.backend.app.utils.user_model_utils.get_generation_model_with_override"
-    )
+    @patch("rhesis.backend.tasks.test_set.get_generation_model_with_override")
     @patch("rhesis.backend.app.crud.get_user")
     @patch("rhesis.backend.tasks.test_set.get_db_with_tenant_variables")
-    def test_calls_get_generation_model_with_override(
+    def test_resolves_user_default_when_no_model_id(
         self, mock_get_db, mock_get_user, mock_override
     ):
-        from rhesis.backend.tasks.test_set import _get_override_model
+        from rhesis.backend.tasks.test_set import _resolve_generation_model
 
         task = _make_mock_task()
         mock_user = MagicMock()
         mock_get_user.return_value = mock_user
         mock_db = MagicMock()
-        mock_get_db.return_value.__enter__ = MagicMock(return_value=mock_db)
-        mock_get_db.return_value.__exit__ = MagicMock(return_value=False)
+        _mock_db_session(mock_get_db, mock_db)
+        mock_override.return_value = "user-default-model"
+
+        result = _resolve_generation_model(task, "org-1", "user-1", "project-1")
+
+        mock_override.assert_called_once_with(mock_db, mock_user, model_id=None)
+        assert result == "user-default-model"
+
+    @patch("rhesis.backend.tasks.test_set.get_generation_model_with_override")
+    @patch("rhesis.backend.app.crud.get_user")
+    @patch("rhesis.backend.tasks.test_set.get_db_with_tenant_variables")
+    def test_passes_through_override_model_id(
+        self, mock_get_db, mock_get_user, mock_override
+    ):
+        from rhesis.backend.tasks.test_set import _resolve_generation_model
+
+        task = _make_mock_task()
+        mock_user = MagicMock()
+        mock_get_user.return_value = mock_user
+        mock_db = MagicMock()
+        _mock_db_session(mock_get_db, mock_db)
         mock_override.return_value = "override-model"
 
-        result = _get_override_model(task, "org-1", "user-1", "model-uuid-789")
+        result = _resolve_generation_model(
+            task, "org-1", "user-1", "project-1", "model-uuid-789"
+        )
 
         mock_override.assert_called_once_with(
             mock_db, mock_user, model_id="model-uuid-789"
         )
         assert result == "override-model"
 
+    @patch("rhesis.backend.tasks.test_set.get_generation_model_with_override")
     @patch("rhesis.backend.app.crud.get_user")
     @patch("rhesis.backend.tasks.test_set.get_db_with_tenant_variables")
-    def test_falls_back_when_user_not_found(self, mock_get_db, mock_get_user):
-        from rhesis.backend.tasks.test_set import _get_override_model
+    def test_passes_project_id_to_session(
+        self, mock_get_db, mock_get_user, mock_override
+    ):
+        from rhesis.backend.tasks.test_set import _resolve_generation_model
+
+        task = _make_mock_task()
+        mock_get_user.return_value = MagicMock()
+        mock_db = MagicMock()
+        _mock_db_session(mock_get_db, mock_db)
+        mock_override.return_value = "user-default-model"
+
+        _resolve_generation_model(task, "org-1", "user-1", "project-1")
+
+        mock_get_db.assert_called_once_with("org-1", "user-1", "project-1")
+
+    @patch("rhesis.backend.app.crud.get_user")
+    @patch("rhesis.backend.tasks.test_set.get_db_with_tenant_variables")
+    def test_raises_when_user_not_found(self, mock_get_db, mock_get_user):
+        from rhesis.backend.tasks.test_set import _resolve_generation_model
 
         task = _make_mock_task()
         mock_get_user.return_value = None
         mock_db = MagicMock()
-        mock_get_db.return_value.__enter__ = MagicMock(return_value=mock_db)
-        mock_get_db.return_value.__exit__ = MagicMock(return_value=False)
+        _mock_db_session(mock_get_db, mock_db)
 
-        result = _get_override_model(task, "org-1", "user-1", "model-uuid-789")
-
-        assert result == get_model_settings().generation_model
+        with pytest.raises(ValueError, match="User not found"):
+            _resolve_generation_model(task, "org-1", "user-1", "project-1")


### PR DESCRIPTION
## Purpose
Test set generation could fail to resolve project-scoped models because model lookup did not pass `project_id` into the tenant session. This consolidates model resolution and ensures the correct scope is applied.

## What Changed
- Replaced `_get_model_for_user` and `_get_override_model` with a single `_resolve_generation_model` helper
- Pass `project_id` from tenant context into `get_db_with_tenant_variables` so project-scoped models are visible to the ORM auto-filter
- Route both default and override paths through `get_generation_model_with_override`
- Raise `ValueError` when the user is missing instead of silently falling back to the system default model
- Updated unit tests for the new helper

## Additional Context
- Fixes incorrect or missing model resolution when users configure project-scoped generation models

## Testing
- `cd apps/backend && uv run pytest ../../tests/backend/tasks/test_test_set_model_override.py -v` (4 passed)