### PR TITLE
Clean up verbose backend logging

### DIFF
--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -12,8 +12,8 @@ lint:
 	uvx ruff format $(ALL_FILES) --check
 
 format:
+	# uvx ruff check --fix $(ALL_FILES)
 	uvx ruff format $(ALL_FILES)
-	uvx ruff check --fix $(ALL_FILES)
 
 
 lint_diff:

--- a/apps/backend/src/rhesis/backend/app/database.py
+++ b/apps/backend/src/rhesis/backend/app/database.py
@@ -79,9 +79,6 @@ def _set_session_variables(
     # Persist in session.info so after_begin can re-apply after each commit.
     db.info[_TENANT_VARS_KEY] = params
     _execute_set_config(db, params)
-    logger.debug(
-        f"Session variables set: org={organization_id}, user={user_id}, project={project_id}"
-    )
 
 
 def _apply_scope_variables(db: Session, scope) -> None:
@@ -269,8 +266,6 @@ def reset_session_context(db: Session):
 
         # Also clear context vars for backward compatibility
         clear_tenant_context()
-
-        logger.debug("Successfully reset session variables to empty strings")
 
     except Exception as e:
         logger.debug(f"Error resetting RLS session context: {e}")

--- a/apps/backend/src/rhesis/backend/app/models/scope_events.py
+++ b/apps/backend/src/rhesis/backend/app/models/scope_events.py
@@ -212,11 +212,6 @@ def setup_scope_listeners():
                     query = _inject_filter(query, entity.project_id.is_(None))
 
         query._scope_filter_applied = True
-        logger.debug(
-            "scope auto-filter: org=%s project=%s",
-            scope.organization_id,
-            scope.project_id,
-        )
         return query
 
     # ------------------------------------------------------------------

--- a/apps/backend/src/rhesis/backend/app/services/test.py
+++ b/apps/backend/src/rhesis/backend/app/services/test.py
@@ -536,23 +536,10 @@ def prepare_test_data(
     else:
         data = test_data.copy()
 
-    # Debug: Log original data
-    uuid_fields_before = {k: v for k, v in data.items() if k.endswith("_id")}
-    logger.debug(f"prepare_test_data - UUID fields before sanitization: {uuid_fields_before}")
-
     # Sanitize UUID fields - convert empty strings to None
     for key, value in list(data.items()):
         if key.endswith("_id"):
-            original_value = value
             data[key] = sanitize_uuid_field(value)
-            if original_value != data[key]:
-                logger.debug(
-                    f"prepare_test_data - Sanitized {key}: '{original_value}' -> '{data[key]}'"
-                )
-
-    # Debug: Log sanitized data
-    uuid_fields_after = {k: v for k, v in data.items() if k.endswith("_id")}
-    logger.debug(f"prepare_test_data - UUID fields after sanitization: {uuid_fields_after}")
 
     return data
 
@@ -672,11 +659,7 @@ def bulk_create_tests(
         )
 
         for i, test_data in enumerate(tests_data):
-            logger.debug(f"bulk_create_tests - Processing test {i + 1}/{len(tests_data)}")
             test_data_dict = prepare_test_data(test_data, defaults)
-            logger.debug(
-                f"bulk_create_tests - test_data_dict after prepare_test_data: {test_data_dict}"
-            )
 
             # Determine test type for this specific test
             # Priority: 1. Individual test's test_type, 2. Auto-detect from config,
@@ -758,22 +741,8 @@ def bulk_create_tests(
             )
 
             # Create test with improved owner_id handling
-            original_assignee_id = test_data_dict.get("assignee_id", None)
-            original_owner_id = test_data_dict.get("owner_id", None)
-            logger.debug(
-                f"bulk_create_tests - Original UUID values: "
-                f"assignee_id='{original_assignee_id}', "
-                f"owner_id='{original_owner_id}'"
-            )
-
             assignee_id = sanitize_uuid_field(test_data_dict.pop("assignee_id", None))
             owner_id = ensure_owner_id(test_data_dict.pop("owner_id", None), user_id)
-
-            logger.debug(
-                f"bulk_create_tests - Sanitized UUID values: "
-                f"assignee_id='{assignee_id}', "
-                f"owner_id='{owner_id}'"
-            )
 
             # Extract source_id from metadata if present
             # Note: SDK uses "metadata" but DB uses "test_metadata"
@@ -826,27 +795,13 @@ def bulk_create_tests(
             }
 
             # Clean any remaining UUID fields from the test data dict
-            logger.debug(
-                f"bulk_create_tests - Remaining test_data_dict before cleaning: {test_data_dict}"
-            )
             for key, value in list(test_data_dict.items()):
                 if key.endswith("_id"):
-                    original_value = value
                     test_data_dict[key] = sanitize_uuid_field(value)
-                    if original_value != test_data_dict[key]:
-                        logger.debug(
-                            f"bulk_create_tests - Cleaned remaining field {key}: "
-                            f"'{original_value}' -> '{test_data_dict[key]}'"
-                        )
             # Add any remaining fields from test_data_dict that weren't explicitly handled
             remaining_fields = {k: v for k, v in test_data_dict.items() if k not in test_params}
-            logger.debug(f"bulk_create_tests - Remaining fields to add: {remaining_fields}")
             test_params.update(remaining_fields)
 
-            # Log final test parameters for debugging UUID issues
-            uuid_params = {k: v for k, v in test_params.items() if k.endswith("_id")}
-            logger.debug(f"bulk_create_tests - Final UUID parameters: {uuid_params}")
-            logger.debug(f"bulk_create_tests - All test parameters: {test_params}")
             # Map "metadata" to "test_metadata" (SDK uses "metadata" but DB uses "test_metadata")
             if "metadata" in test_params and "test_metadata" not in test_params:
                 test_params["test_metadata"] = test_params.pop("metadata")
@@ -855,17 +810,13 @@ def bulk_create_tests(
                 test = models.Test(**test_params)
                 db.add(test)
                 _pending_tests.append(test)
-                logger.debug(
-                    f"bulk_create_tests - Successfully created Test model for test {i + 1}"
-                )
             except Exception as model_error:
                 logger.error(
-                    f"bulk_create_tests - Failed to create Test model "
-                    f"for test {i + 1}: {model_error}"
+                    "bulk_create_tests - Failed to create Test model for test %s: %s",
+                    i + 1,
+                    model_error,
                 )
-                logger.error(
-                    f"bulk_create_tests - Test parameters that caused error: {test_params}"
-                )
+                logger.error("bulk_create_tests - Test parameters that caused error: %s", test_params)
                 raise
 
             # Flush+expunge cycle: every flush_interval tests, flush to
@@ -876,11 +827,6 @@ def bulk_create_tests(
                 for t in _pending_tests:
                     created_test_ids.append(str(t.id))
                     db.expunge(t)
-                logger.debug(
-                    f"bulk_create_tests - Flushed and expunged "
-                    f"{len(_pending_tests)} tests "
-                    f"(total so far: {len(created_test_ids)})"
-                )
                 _pending_tests.clear()
 
         # Flush any remaining tests in the last partial batch
@@ -889,11 +835,6 @@ def bulk_create_tests(
             for t in _pending_tests:
                 created_test_ids.append(str(t.id))
                 db.expunge(t)
-            logger.debug(
-                f"bulk_create_tests - Flushed final batch of "
-                f"{len(_pending_tests)} tests "
-                f"(total: {len(created_test_ids)})"
-            )
             _pending_tests.clear()
 
         # Create test set associations AFTER all tests are created

--- a/apps/backend/src/rhesis/backend/app/services/test.py
+++ b/apps/backend/src/rhesis/backend/app/services/test.py
@@ -816,7 +816,9 @@ def bulk_create_tests(
                     i + 1,
                     model_error,
                 )
-                logger.error("bulk_create_tests - Test parameters that caused error: %s", test_params)
+                logger.error(
+                    "bulk_create_tests - Test parameters that caused error: %s", test_params
+                )
                 raise
 
             # Flush+expunge cycle: every flush_interval tests, flush to

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -974,10 +974,6 @@ def get_or_create_type_lookup(
     description: str = None,
 ) -> TypeLookup:
     """Get or create a type lookup with the specified type_name and type_value."""
-    logger.debug(
-        f"get_or_create_type_lookup - Looking for type_name='{type_name}', "
-        f"type_value='{type_value}'"
-    )
 
     # Try to find existing type lookup
     query = (
@@ -991,18 +987,15 @@ def get_or_create_type_lookup(
         )
     )
 
-    logger.debug("get_or_create_type_lookup - About to execute query for existing type")
     try:
         existing_type = query.first()
         if existing_type:
-            logger.debug(f"get_or_create_type_lookup - Found existing type: {existing_type}")
             return existing_type
     except Exception as query_error:
-        logger.error(f"get_or_create_type_lookup - Error querying existing type: {query_error}")
+        logger.error("get_or_create_type_lookup - Error querying existing type: %s", query_error)
         raise
 
     # Create new type lookup
-    logger.debug("get_or_create_type_lookup - Creating new type lookup")
     try:
         item_data = {"type_name": type_name, "type_value": type_value}
         if description is not None:
@@ -1016,10 +1009,9 @@ def get_or_create_type_lookup(
             user_id=user_id,
             commit=commit,
         )
-        logger.debug(f"get_or_create_type_lookup - Created new type: {result}")
         return result
     except Exception as create_error:
-        logger.error(f"get_or_create_type_lookup - Error creating new type: {create_error}")
+        logger.error("get_or_create_type_lookup - Error creating new type: %s", create_error)
         raise
 
 

--- a/apps/backend/src/rhesis/backend/app/utils/encryption.py
+++ b/apps/backend/src/rhesis/backend/app/utils/encryption.py
@@ -316,7 +316,6 @@ class EncryptedString(TypeDecorator):
         # Try to decrypt
         try:
             decrypted = decrypt(value)
-            logger.debug("Successfully decrypted value from database")
             return decrypted
         except DecryptionError:
             # BACKWARD COMPATIBILITY: During migration, some values may still be plaintext

--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -56,7 +56,7 @@ def get_generation_model_with_override(
         Either a string (provider name) or a configured BaseLLM instance
     """
     if model_id:
-        logger.info(f"[LLM_UTILS] Using per-request model override: model_id={model_id}")
+        logger.debug("Using per-request generation model override: model_id=%s", model_id)
         return _fetch_and_configure_model(
             db=db,
             model_id=str(model_id),
@@ -145,7 +145,7 @@ def get_execution_model_with_override(
         Either a string (provider name) or a configured BaseLLM instance
     """
     if model_id:
-        logger.info(f"[LLM_UTILS] Using per-request execution model override: model_id={model_id}")
+        logger.debug("Using per-request execution model override: model_id=%s", model_id)
         return _fetch_and_configure_model(
             db=db,
             model_id=str(model_id),
@@ -175,7 +175,7 @@ def get_evaluation_model_with_override(
         Either a string (provider name) or a configured BaseLLM instance
     """
     if model_id:
-        logger.info(f"[LLM_UTILS] Using per-request evaluation model override: model_id={model_id}")
+        logger.debug("Using per-request evaluation model override: model_id=%s", model_id)
         return _fetch_and_configure_model(
             db=db,
             model_id=str(model_id),
@@ -224,8 +224,9 @@ def validate_user_evaluation_model(db: Session, user: User) -> None:
                    with a specific error message about the configuration issue
     """
     logger.info(
-        f"[LLM_UTILS] Validating evaluation model for user_id={user.id}, "
-        f"email={user.email}, org_id={user.organization_id}"
+        "Validating evaluation model for user_id=%s, org_id=%s",
+        user.id,
+        user.organization_id,
     )
 
     # Get the evaluation model settings
@@ -234,11 +235,9 @@ def validate_user_evaluation_model(db: Session, user: User) -> None:
 
     # If no model configured, default model will be used (always valid)
     if not model_id:
-        logger.info("[LLM_UTILS] No custom evaluation model configured, default will be used")
         return
 
     # Try to fetch and configure the model to validate it
-    logger.info("[LLM_UTILS] Validating user's configured evaluation model...")
     try:
         _fetch_and_configure_model(
             db=db,
@@ -247,7 +246,6 @@ def validate_user_evaluation_model(db: Session, user: User) -> None:
             default_model=_default_evaluation_model(),
             user=user,
         )
-        logger.info("[LLM_UTILS] ✓ Evaluation model validation successful")
     except ValueError:
         # Re-raise ValueError as-is (it already has a user-friendly message)
         raise
@@ -270,8 +268,9 @@ def validate_user_generation_model(db: Session, user: User) -> None:
                    with a specific error message about the configuration issue
     """
     logger.info(
-        f"[LLM_UTILS] Validating generation model for user_id={user.id}, "
-        f"email={user.email}, org_id={user.organization_id}"
+        "Validating generation model for user_id=%s, org_id=%s",
+        user.id,
+        user.organization_id,
     )
 
     # Get the generation model settings
@@ -280,11 +279,9 @@ def validate_user_generation_model(db: Session, user: User) -> None:
 
     # If no model configured, default model will be used (always valid)
     if not model_id:
-        logger.info("[LLM_UTILS] No custom generation model configured, default will be used")
         return
 
     # Try to fetch and configure the model to validate it
-    logger.info("[LLM_UTILS] Validating user's configured generation model...")
     try:
         _fetch_and_configure_model(
             db=db,
@@ -293,7 +290,6 @@ def validate_user_generation_model(db: Session, user: User) -> None:
             default_model=_default_generation_model(),
             user=user,
         )
-        logger.info("[LLM_UTILS] ✓ Generation model validation successful")
     except ValueError:
         # Re-raise ValueError as-is (it already has a user-friendly message)
         raise
@@ -316,18 +312,17 @@ def validate_user_execution_model(db: Session, user: User) -> None:
                    with a specific error message about the configuration issue
     """
     logger.info(
-        f"[LLM_UTILS] Validating execution model for user_id={user.id}, "
-        f"email={user.email}, org_id={user.organization_id}"
+        "Validating execution model for user_id=%s, org_id=%s",
+        user.id,
+        user.organization_id,
     )
 
     model_settings = getattr(user.settings.models, "execution")
     model_id = model_settings.model_id
 
     if not model_id:
-        logger.info("[LLM_UTILS] No custom execution model configured, default will be used")
         return
 
-    logger.info("[LLM_UTILS] Validating user's configured execution model...")
     try:
         _fetch_and_configure_model(
             db=db,
@@ -336,7 +331,6 @@ def validate_user_execution_model(db: Session, user: User) -> None:
             default_model=_default_execution_model(),
             user=user,
         )
-        logger.info("[LLM_UTILS] ✓ Execution model validation successful")
     except ValueError:
         raise
 
@@ -380,19 +374,15 @@ def _call_polyphemus_with_delegation(user: User, model_name: str, **kwargs):
 
     # Verify user is active and verified before creating delegation token
     if not user.is_active:
-        logger.error(f"[LLM_UTILS] Cannot create delegation token: user {user.email} is inactive")
+        logger.error("Cannot create delegation token: user %s is inactive", user.email)
         raise ValueError("User account is inactive")
 
     if not user.is_verified:
-        logger.error(
-            f"[LLM_UTILS] Cannot create delegation token: user {user.email} is not verified"
-        )
+        logger.error("Cannot create delegation token: user %s is not verified", user.email)
         raise ValueError("User account is not verified")
 
     delegation_token = create_service_delegation_token(user, "polyphemus")
     polyphemus_url = os.environ.get("DEFAULT_POLYPHEMUS_URL", "https://polyphemus.rhesis.ai")
-
-    logger.info(f"[LLM_UTILS] Creating Polyphemus client with delegation for user: {user.email}")
 
     return PolyphemusLLM(
         model_name=model_name,
@@ -426,66 +416,41 @@ def _fetch_and_configure_model(
     model = crud.get_model(db=db, model_id=model_id, organization_id=organization_id)
 
     if not model or not model.provider_type:
-        logger.warning(f"[LLM_UTILS] Model with id={model_id} not found or has no provider_type")
+        logger.warning("Model with id=%s not found or has no provider_type", model_id)
         return default_model
 
     # Get provider configuration
     provider = model.provider_type.type_value
     model_name = model.model_name
     api_key = model.key
-    api_key_preview = f"{model.key[:8]}..." if model.key else "None"
-
-    logger.info(
-        f"[LLM_UTILS] Found configured model: name={model.name}, provider={provider}, "
-        f"model_name={model_name}, api_key={api_key_preview}"
-    )
 
     # Special handling for Rhesis system models
     if _is_rhesis_system_model(provider, api_key):
-        logger.info(
-            "[LLM_UTILS] Rhesis system model detected - "
-            "using backend's default model infrastructure"
-        )
-        logger.info(f"[LLM_UTILS] ✓ Falling back to default model: {default_model}")
         return default_model
 
     # Special handling for Polyphemus models without API keys (use delegation tokens)
     if provider == "polyphemus" and not api_key and user:
-        logger.info(
-            "[LLM_UTILS] Polyphemus system model detected - "
-            "using delegation token for authentication"
-        )
-        configured_model = _call_polyphemus_with_delegation(user, model_name)
-        model_type_name = type(configured_model).__name__
-        logger.info(
-            f"[LLM_UTILS] ✓ Returning Polyphemus instance with delegation: {model_type_name}"
-        )
-        return configured_model
+        return _call_polyphemus_with_delegation(user, model_name)
 
     # Use SDK's get_model to create configured instance with error handling
     try:
         extra_params = {}
         if model.endpoint and model.endpoint.strip():
             extra_params["api_base"] = model.endpoint.strip()
-        configured_model = get_model(
+        return get_model(
             provider=provider,
             model_name=model_name,
             api_key=api_key,
             model_type="language",
             **extra_params,
         )
-        logger.info(
-            f"[LLM_UTILS] ✓ Returning configured BaseLLM instance: "
-            f"{type(configured_model).__name__}"
-        )
-        return configured_model
     except ValueError as e:
         error_msg = str(e)
         error_msg_lower = error_msg.lower()
 
         # Provide specific error messages based on the type of configuration issue
         if "api_key" in error_msg_lower or "not set" in error_msg_lower:
-            logger.error(f"[LLM_UTILS] User model API key not configured: {error_msg}")
+            logger.error("User model API key not configured: %s", error_msg)
             raise ModelConfigurationError(
                 f"Your configured model '{model.name}' ({provider}/{model_name}) requires "
                 f"an API key that is missing or invalid. "
@@ -493,7 +458,7 @@ def _fetch_and_configure_model(
                 original_error=e,
             )
         elif "provider" in error_msg_lower or "not supported" in error_msg_lower:
-            logger.error(f"[LLM_UTILS] Invalid provider for user model: {error_msg}")
+            logger.error("Invalid provider for user model: %s", error_msg)
             raise ModelConfigurationError(
                 f"Your configured model '{model.name}' uses an unsupported provider ({provider}). "
                 f"Please select a different model in the Models settings.",
@@ -502,7 +467,7 @@ def _fetch_and_configure_model(
         elif "model" in error_msg_lower and (
             "not found" in error_msg_lower or "invalid" in error_msg_lower
         ):
-            logger.error(f"[LLM_UTILS] Invalid model name for user model: {error_msg}")
+            logger.error("Invalid model name for user model: %s", error_msg)
             raise ModelConfigurationError(
                 f"Your configured model '{model.name}' has an invalid model name ({model_name}). "
                 f"Please select a valid model in the Models settings.",
@@ -510,7 +475,7 @@ def _fetch_and_configure_model(
             )
         else:
             # Generic configuration error
-            logger.error(f"[LLM_UTILS] Failed to configure user model: {error_msg}")
+            logger.error("Failed to configure user model: %s", error_msg)
             raise ModelConfigurationError(
                 f"Failed to initialize your configured model '{model.name}': {error_msg}",
                 original_error=e,
@@ -542,24 +507,13 @@ def _get_user_model(
         Always uses user.organization_id for model lookup to prevent privilege escalation.
         Never accepts organization_id as a parameter that could be manipulated.
     """
-    logger.info(
-        f"[LLM_UTILS] Getting {purpose} model for user_id={user.id}, "
-        f"email={user.email}, org_id={user.organization_id}"
-    )
-
     # Get the appropriate model settings based on type
     model_settings = getattr(user.settings.models, purpose)
     model_id = model_settings.model_id
 
-    logger.info(f"[LLM_UTILS] User settings: model_id={model_id}")
-
     if not model_id:
-        logger.info("[LLM_UTILS] No configured model found in user settings")
-        logger.info(f"[LLM_UTILS] ✓ Falling back to default model: {default_model}")
         return default_model
 
-    # Fetch and configure the user's model
-    logger.info("[LLM_UTILS] User has configured model, fetching from database...")
     return _fetch_and_configure_model(
         db=db,
         model_id=str(model_id),
@@ -589,27 +543,16 @@ def _fetch_and_configure_embedder(
     model = crud.get_model(db=db, model_id=model_id, organization_id=organization_id)
 
     if not model or not model.provider_type:
-        logger.warning(f"[LLM_UTILS] Model with id={model_id} not found or has no provider_type")
+        logger.warning("Model with id=%s not found or has no provider_type", model_id)
         return default_model
 
     # Get provider configuration
     provider = model.provider_type.type_value
     model_name = model.model_name
     api_key = model.key
-    api_key_preview = f"{model.key[:8]}..." if model.key else "None"
-
-    logger.info(
-        f"[LLM_UTILS] Found configured embedder: name={model.name}, provider={provider}, "
-        f"model_name={model_name}, api_key={api_key_preview}"
-    )
 
     # Special handling for Rhesis system models
     if _is_rhesis_system_model(provider, api_key):
-        logger.info(
-            "[LLM_UTILS] Rhesis system model detected - "
-            "using backend's default embedder infrastructure"
-        )
-        logger.info(f"[LLM_UTILS] ✓ Falling back to default embedder: {default_model}")
         return default_model
 
     # Use SDK's get_model to create configured instance with error handling
@@ -617,25 +560,20 @@ def _fetch_and_configure_embedder(
         extra_params = {}
         if model.endpoint and model.endpoint.strip():
             extra_params["api_base"] = model.endpoint.strip()
-        configured_embedder = get_model(
+        return get_model(
             provider=provider,
             model_name=model_name,
             api_key=api_key,
             model_type="embedding",
             **extra_params,
         )
-        logger.info(
-            f"[LLM_UTILS] ✓ Returning configured BaseEmbedder instance: "
-            f"{type(configured_embedder).__name__}"
-        )
-        return configured_embedder
     except ValueError as e:
         error_msg = str(e)
         error_msg_lower = error_msg.lower()
 
         # Provide specific error messages based on the type of configuration issue
         if "api_key" in error_msg_lower or "not set" in error_msg_lower:
-            logger.error(f"[LLM_UTILS] Embedder API key not configured: {error_msg}")
+            logger.error("Embedder API key not configured: %s", error_msg)
             raise ModelConfigurationError(
                 f"Your configured embedding model '{model.name}' ({provider}/{model_name}) "
                 f"requires an API key that is missing or invalid. "
@@ -643,14 +581,14 @@ def _fetch_and_configure_embedder(
                 original_error=e,
             )
         elif "provider" in error_msg_lower or "not supported" in error_msg_lower:
-            logger.error(f"[LLM_UTILS] Invalid provider for embedder: {error_msg}")
+            logger.error("Invalid provider for embedder: %s", error_msg)
             raise ModelConfigurationError(
                 f"Your configured embedding model '{model.name}' uses an unsupported "
                 f"provider ({provider}). Please select a different model in the Models settings.",
                 original_error=e,
             )
         else:
-            logger.error(f"[LLM_UTILS] Failed to configure embedder: {error_msg}")
+            logger.error("Failed to configure embedder: %s", error_msg)
             raise ModelConfigurationError(
                 f"Failed to configure your embedding model '{model.name}': {error_msg}. "
                 f"Please check your model configuration in the Models settings.",
@@ -678,25 +616,13 @@ def _get_user_embedding_model_with_settings(db: Session, user: User):
     Security:
         Always uses user.organization_id for model lookup to prevent privilege escalation.
     """
-    logger.info(
-        f"[LLM_UTILS] Getting embedding model for user_id={user.id}, "
-        f"email={user.email}, org_id={user.organization_id}"
-    )
-
     # Get embedding model settings
     model_settings = user.settings.models.embedding
     model_id = model_settings.model_id
 
-    logger.info(f"[LLM_UTILS] User settings: model_id={model_id}")
-
     if not model_id:
-        default_embedding_model = _default_embedding_model()
-        logger.info("[LLM_UTILS] No configured embedding model found in user settings")
-        logger.info(f"[LLM_UTILS] ✓ Falling back to default embedder: {default_embedding_model}")
-        return default_embedding_model
+        return _default_embedding_model()
 
-    # Fetch and configure the user's embedder
-    logger.info("[LLM_UTILS] User has configured embedding model, fetching from database...")
     return _fetch_and_configure_embedder(
         db=db,
         model_id=str(model_id),

--- a/apps/backend/src/rhesis/backend/app/utils/uuid_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/uuid_utils.py
@@ -38,10 +38,7 @@ def sanitize_uuid_field(value: Any) -> Optional[str]:
         None if value is None, empty string, or invalid UUID format,
         otherwise returns the value as string
     """
-    logger.debug(f"sanitize_uuid_field - Input: value='{value}', type={type(value)}")
-
     if value is None or value == "" or (isinstance(value, str) and value.strip() == ""):
-        logger.debug(f"sanitize_uuid_field - Returning None for empty/None value: '{value}'")
         return None
 
     # Validate UUID format
@@ -49,10 +46,9 @@ def sanitize_uuid_field(value: Any) -> Optional[str]:
         # Try to convert to UUID to validate format
         UUID(str(value))
         result = str(value)
-        logger.debug(f"sanitize_uuid_field - Valid UUID, returning: '{result}'")
         return result
     except (ValueError, TypeError) as e:
-        logger.debug(f"sanitize_uuid_field - Invalid UUID format provided: {value}, error: {e}")
+        logger.error(f"sanitize_uuid_field - Invalid UUID format provided: {value}, error: {e}")
         return None
 
 
@@ -106,6 +102,5 @@ def ensure_owner_id(owner_id: Optional[str], user_id: str) -> str:
     """
     sanitized_owner_id = sanitize_uuid_field(owner_id)
     if sanitized_owner_id is None:
-        logger.debug(f"Setting owner_id to user_id: {user_id}")
         return user_id
     return sanitized_owner_id

--- a/apps/backend/src/rhesis/backend/celery/signals.py
+++ b/apps/backend/src/rhesis/backend/celery/signals.py
@@ -1,6 +1,11 @@
 import logging
 
-from celery.signals import task_failure, task_revoked, worker_shutdown
+from celery.signals import (
+    after_setup_logger,
+    task_failure,
+    task_revoked,
+    worker_shutdown,
+)
 
 import rhesis.backend.tasks.architect.monitor  # noqa: F401
 from rhesis.backend.tasks.enums import RunStatus
@@ -42,6 +47,23 @@ def _update_test_run_status(task_id: str, new_status: RunStatus, error_message: 
                 )
     except Exception as e:
         logger.error(f"Failed to update test run status for task {task_id}: {e}", exc_info=True)
+
+
+@after_setup_logger.connect
+def quiet_celery_internal_loggers(logger=None, **kw):
+    """Silence low-signal Celery internal DEBUG chatter (e.g. pidbox
+    'enable_events()' control-mailbox heartbeats) without lowering the
+    worker's overall log level.
+
+    Runs after Celery configures its loggers at worker boot, so these
+    levels stick (an import-time setLevel would be reset by Celery).
+    """
+    for name in (
+        "celery.utils.functional",
+        "celery.app.trace",
+        "kombu.pidbox",
+    ):
+        logging.getLogger(name).setLevel(logging.WARNING)
 
 
 @task_failure.connect

--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -267,5 +267,6 @@ def set_logger():
     for name in (
         "celery.utils.functional",
         "celery.app.trace",
+        "kombu.pidbox",
     ):
         logging.getLogger(name).setLevel(logging.WARNING)

--- a/apps/backend/src/rhesis/backend/tasks/base.py
+++ b/apps/backend/src/rhesis/backend/tasks/base.py
@@ -160,7 +160,10 @@ class BaseTask(Task):
     def on_success(self, retval, task_id, args, kwargs):
         """Log successful task completion with context information."""
         self.log_with_context(
-            "info", "Task completed successfully", task_result_type=type(retval).__name__
+            "info",
+            "Task completed successfully",
+            task_result_type=type(retval).__name__,
+            execution_time=self._get_execution_time() or "Unknown",
         )
 
         # Send email notification for successful completion if enabled
@@ -209,6 +212,7 @@ class BaseTask(Task):
                 f"Task permanently failed after {retries} attempts",
                 error=str(exc),
                 exception_type=type(exc).__name__,
+                execution_time=self._get_execution_time() or "Unknown",
             )
             # Send email notification for permanent failure if enabled
             if self.send_email_notification_flag:
@@ -230,6 +234,7 @@ class BaseTask(Task):
                 f"Task failed (will retry, attempt {retries}/{self.max_retries})",
                 error=str(exc),
                 exception_type=type(exc).__name__,
+                execution_time=self._get_execution_time() or "Unknown",
             )
 
         return super().on_failure(exc, task_id, args, kwargs, einfo)
@@ -264,6 +269,24 @@ class BaseTask(Task):
         self.validate_params(args, kwargs)
 
         return super().before_start(task_id, args, kwargs)
+
+    def _get_execution_time(self) -> Optional[str]:
+        """Return formatted task execution duration, if start time is available."""
+        from rhesis.backend.tasks.utils import format_execution_time
+
+        if hasattr(self.request, "custom_start_time") and self.request.custom_start_time:
+            try:
+                duration = (datetime.utcnow() - self.request.custom_start_time).total_seconds()
+                return format_execution_time(duration)
+            except Exception:
+                pass
+        elif hasattr(self.request, "time_start") and self.request.time_start:
+            try:
+                duration = datetime.utcnow().timestamp() - self.request.time_start
+                return format_execution_time(duration)
+            except Exception:
+                pass
+        return None
 
     def _get_user_info(
         self, user_id: str, organization_id: str = None
@@ -328,27 +351,7 @@ class BaseTask(Task):
             if "placeholder.rhesis.ai" in user_email:
                 return
 
-            # Calculate execution time using our custom start time or Celery's time_start
-            execution_time = None
-
-            # Try our custom start time first (most reliable)
-            if hasattr(self.request, "custom_start_time") and self.request.custom_start_time:
-                try:
-                    duration = (datetime.utcnow() - self.request.custom_start_time).total_seconds()
-                    from rhesis.backend.tasks.utils import format_execution_time
-
-                    execution_time = format_execution_time(duration)
-                except Exception:
-                    pass
-            # Fallback to Celery's time_start if available
-            elif hasattr(self.request, "time_start") and self.request.time_start:
-                try:
-                    duration = datetime.utcnow().timestamp() - self.request.time_start
-                    from rhesis.backend.tasks.utils import format_execution_time
-
-                    execution_time = format_execution_time(duration)
-                except Exception:
-                    pass
+            execution_time = self._get_execution_time()
 
             # Get frontend URL for links
             frontend_url = get_frontend_settings().url

--- a/apps/backend/src/rhesis/backend/tasks/base.py
+++ b/apps/backend/src/rhesis/backend/tasks/base.py
@@ -191,8 +191,6 @@ class BaseTask(Task):
                     error=str(e),
                     exception_type=type(e).__name__,
                 )
-        else:
-            self.log_with_context("debug", "Email notification disabled for this task type")
 
         return super().on_success(retval, task_id, args, kwargs)
 
@@ -316,33 +314,18 @@ class BaseTask(Task):
             # Get user context
             organization_id, user_id, _ = self.get_tenant_context()
 
-            self.log_with_context(
-                "debug",
-                "Email notification process started",
-                status=status,
-                organization_id=organization_id,
-                user_id=user_id,
-            )
-
             if not user_id:
-                self.log_with_context("debug", "No user context available for email notification")
                 return
 
             # Get user information
-            self.log_with_context("debug", f"Looking up user information for user_id: {user_id}")
             user_email, user_name = self._get_user_info(user_id, organization_id)
 
             if not user_email:
                 self.log_with_context("warning", f"No email found for user {user_id}")
                 return
 
-            self.log_with_context("debug", f"Found user email: {user_email}, name: {user_name}")
-
             # Skip placeholder emails (these are internal users without real emails)
             if "placeholder.rhesis.ai" in user_email:
-                self.log_with_context(
-                    "debug", f"Skipping notification for placeholder email: {user_email}"
-                )
                 return
 
             # Calculate execution time using our custom start time or Celery's time_start
@@ -355,15 +338,8 @@ class BaseTask(Task):
                     from rhesis.backend.tasks.utils import format_execution_time
 
                     execution_time = format_execution_time(duration)
-                    self.log_with_context(
-                        "debug", f"Calculated execution time from custom timing: {execution_time}"
-                    )
-                except Exception as e:
-                    self.log_with_context(
-                        "warning",
-                        "Failed to calculate execution time from custom timing",
-                        error=str(e),
-                    )
+                except Exception:
+                    pass
             # Fallback to Celery's time_start if available
             elif hasattr(self.request, "time_start") and self.request.time_start:
                 try:
@@ -371,37 +347,13 @@ class BaseTask(Task):
                     from rhesis.backend.tasks.utils import format_execution_time
 
                     execution_time = format_execution_time(duration)
-                    self.log_with_context(
-                        "debug", f"Calculated execution time from Celery timing: {execution_time}"
-                    )
-                except Exception as e:
-                    self.log_with_context(
-                        "warning",
-                        "Failed to calculate execution time from Celery timing",
-                        error=str(e),
-                    )
-            else:
-                self.log_with_context(
-                    "debug",
-                    "No start time available for execution time calculation",
-                )
-
-            # Log final execution time
-            self.log_with_context("debug", f"Final calculated execution time: {execution_time}")
+                except Exception:
+                    pass
 
             # Get frontend URL for links
             frontend_url = get_frontend_settings().url
-            self.log_with_context("debug", f"Using frontend URL: {frontend_url}")
-
-            # Check if email service is configured
-            self.log_with_context(
-                "debug", f"Email service configured: {email_service.is_configured}"
-            )
 
             if not email_service.is_configured:
-                self.log_with_context(
-                    "warning", "Email service not configured - skipping email notification"
-                )
                 return
 
             # Get template and subject from decorator or use defaults
@@ -429,7 +381,6 @@ class BaseTask(Task):
             # Special handling for execution_time - ensure we have a reasonable fallback
             if template_variables.get("execution_time") is None:
                 template_variables["execution_time"] = "Unknown"
-                self.log_with_context("debug", "Using fallback execution time: Unknown")
 
             # Build subject
             if subject_template:
@@ -446,8 +397,6 @@ class BaseTask(Task):
             else:
                 subject = f"Task Completed: {self.get_display_name()} - {status.title()}"
 
-            # Send the email using centralized approach
-            self.log_with_context("info", f"Sending {status} email notification to {user_email}")
             success = email_service.send_email(
                 template=template,
                 recipient_email=user_email,
@@ -458,10 +407,16 @@ class BaseTask(Task):
 
             if success:
                 self.log_with_context(
-                    "info", f"Email notification sent successfully to {user_email}"
+                    "info",
+                    f"Task completion email sent ({status})",
+                    recipient_email=user_email,
                 )
             else:
-                self.log_with_context("error", f"Email notification failed to send to {user_email}")
+                self.log_with_context(
+                    "error",
+                    f"Task completion email failed ({status})",
+                    recipient_email=user_email,
+                )
 
         except Exception as e:
             # Don't fail the task if email sending fails - just log the error
@@ -519,3 +474,7 @@ class SilentTask(BaseTask):
     """Base task class with email notifications disabled (for background/parallel tasks)."""
 
     send_email_notification_flag = False
+
+    def on_success(self, retval, task_id, args, kwargs):
+        """Skip generic completion logging; callers log task-specific outcomes."""
+        return super(BaseTask, self).on_success(retval, task_id, args, kwargs)

--- a/apps/backend/src/rhesis/backend/tasks/embedding/generate.py
+++ b/apps/backend/src/rhesis/backend/tasks/embedding/generate.py
@@ -51,10 +51,4 @@ def generate_embedding_task(
             searchable_text=searchable_text,
         )
 
-    self.log_with_context(
-        "info",
-        "Embedding task finished",
-        status=result["status"],
-        embedding_id=result.get("embedding_id"),
-    )
     return result


### PR DESCRIPTION
## Purpose
Reduce noisy and low-signal log output in the backend so production and worker logs are easier to read and search.

## What Changed
- Remove verbose `debug` logging from tenant/session setup, scope auto-filter, bulk test creation, CRUD helpers, and UUID sanitization paths
- Promote invalid UUID format messages from `debug` to `error` in `uuid_utils`
- Quiet Celery internal loggers (`celery.utils.functional`, `celery.app.trace`, `kombu.pidbox`) via `after_setup_logger` on workers and in the shared logging config
- Trim email-notification debug chatter in `BaseTask`; keep concise info/error logs with structured `recipient_email`
- Add `SilentTask.on_success` override to skip generic completion logging for background tasks
- Remove redundant embedding task completion info log

## Additional Context
- Focused logging cleanup only; no behavior changes to business logic

## Testing
- [ ] Run backend locally and confirm log volume is reduced during normal API and Celery worker activity
- [ ] Verify task completion emails still send and log success/failure at info/error level
- [ ] Confirm invalid UUID inputs still surface as errors in logs