### PR TITLE
Fix multi-turn synthesizer turn bounds validation

### DIFF
--- a/apps/developer-tools/mock_llm/main.py
+++ b/apps/developer-tools/mock_llm/main.py
@@ -25,6 +25,44 @@ class ChatCompletionRequest(BaseModel):
     response_format: Optional[dict[str, Any]] = None
 
 
+TURN_FIELD_PAIRS = (
+    ("test_configuration_min_turns", "test_configuration_max_turns"),
+    ("min_turns", "max_turns"),
+)
+TURN_MIN = 1
+TURN_MAX = 50
+
+
+def _clamp_turn(value: Any) -> int:
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        number = TURN_MIN
+    return max(TURN_MIN, min(TURN_MAX, number))
+
+
+def _fix_turn_bounds_in_dict(data: dict[str, Any]) -> None:
+    for min_key, max_key in TURN_FIELD_PAIRS:
+        if min_key not in data or max_key not in data:
+            continue
+        lo = _clamp_turn(data[min_key])
+        hi = _clamp_turn(data[max_key])
+        if lo > hi:
+            lo, hi = hi, lo
+        data[min_key] = lo
+        data[max_key] = hi
+
+
+def _fix_schema_constraints(value: Any) -> Any:
+    if isinstance(value, dict):
+        fixed = {k: _fix_schema_constraints(v) for k, v in value.items()}
+        _fix_turn_bounds_in_dict(fixed)
+        return fixed
+    if isinstance(value, list):
+        return [_fix_schema_constraints(item) for item in value]
+    return value
+
+
 def _no_empty_strings(value: Any) -> Any:
     if isinstance(value, str):
         return value or "mock"
@@ -47,7 +85,8 @@ def _build_content(text: str, response_format: Optional[dict[str, Any]]) -> str:
     if fmt_type == "json_schema":
         schema = (response_format.get("json_schema") or {}).get("schema") or {}
         if schema:
-            return json.dumps(_no_empty_strings(JSF(schema).generate()), default=str)
+            generated = _no_empty_strings(JSF(schema).generate())
+            return json.dumps(_fix_schema_constraints(generated), default=str)
 
     if fmt_type == "json_object":
         return json.dumps({"response": text})

--- a/sdk/src/rhesis/sdk/synthesizers/multi_turn/base.py
+++ b/sdk/src/rhesis/sdk/synthesizers/multi_turn/base.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional, Union
 
 from jinja2 import Environment, FileSystemLoader, Template
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from rhesis.sdk.entities.test import TestConfiguration
 from rhesis.sdk.entities.test_set import TestSet
@@ -40,8 +40,8 @@ class FlatTest(BaseModel):
     test_configuration_instructions: str
     test_configuration_restrictions: str
     test_configuration_scenario: str
-    test_configuration_min_turns: int
-    test_configuration_max_turns: int
+    test_configuration_min_turns: int = Field(ge=1, le=50)
+    test_configuration_max_turns: int = Field(ge=1, le=50)
     behavior: str
     category: str
     topic: str


### PR DESCRIPTION
## Purpose
Multi-turn test generation can produce invalid `min_turns` / `max_turns` values (out of range or inverted), which then fail backend validation. This aligns SDK schema constraints with the backend and makes the local mock LLM generate valid turn pairs during dev.

## What Changed
- Add Pydantic `Field(ge=1, le=50)` constraints on `FlatTest.test_configuration_min_turns` and `test_configuration_max_turns` in the SDK synthesizer schema
- Update mock LLM JSON schema generation to clamp turn fields to 1–50 and swap when min > max

## Additional Context
- Backend `MultiTurnTestConfig` already enforces `ge=1, le=50` for both turn fields
- Mock LLM fix helps local dev when using structured output for multi-turn test generation

## Testing
- `cd sdk && uv run pytest ../tests/sdk/synthesizers/test_multi_turn_synthesizer.py -v` (20 passed)