### PR TITLE
Add cloud-only enriched entity empty states

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -214,6 +214,30 @@ RHESIS_CONNECTOR_DISABLED=true
 # Project ID for SDK connector (if RHESIS_CONNECTOR_DISABLED is set to false)
 RHESIS_PROJECT_ID=your-project-id
 
+# =============================================================================
+# ☁️ CLOUD ONLY — Empty state enrichment (optional; self-hosted: leave unset)
+# =============================================================================
+# Per entity: 1 YouTube URL + up to 4 comma-separated docs URLs.
+# Unset = basic empty state for that entity.
+#
+# NEXT_PUBLIC_TESTS_EMPTY_STATE_VIDEO_URL=https://www.youtube.com/watch?v=VIDEO_ID
+# NEXT_PUBLIC_TESTS_EMPTY_STATE_ARTICLE_URLS=https://docs.rhesis.ai/docs/tests,...
+#
+# NEXT_PUBLIC_PROJECTS_EMPTY_STATE_VIDEO_URL=
+# NEXT_PUBLIC_PROJECTS_EMPTY_STATE_ARTICLE_URLS=
+# NEXT_PUBLIC_TEST_SETS_EMPTY_STATE_VIDEO_URL=
+# NEXT_PUBLIC_TEST_SETS_EMPTY_STATE_ARTICLE_URLS=
+# NEXT_PUBLIC_TEST_RUNS_EMPTY_STATE_VIDEO_URL=
+# NEXT_PUBLIC_TEST_RUNS_EMPTY_STATE_ARTICLE_URLS=
+# NEXT_PUBLIC_ENDPOINTS_EMPTY_STATE_VIDEO_URL=
+# NEXT_PUBLIC_ENDPOINTS_EMPTY_STATE_ARTICLE_URLS=
+# NEXT_PUBLIC_BEHAVIORS_EMPTY_STATE_VIDEO_URL=
+# NEXT_PUBLIC_BEHAVIORS_EMPTY_STATE_ARTICLE_URLS=
+# NEXT_PUBLIC_METRICS_EMPTY_STATE_VIDEO_URL=
+# NEXT_PUBLIC_METRICS_EMPTY_STATE_ARTICLE_URLS=
+# NEXT_PUBLIC_EXPERIMENTS_EMPTY_STATE_VIDEO_URL=
+# NEXT_PUBLIC_EXPERIMENTS_EMPTY_STATE_ARTICLE_URLS=
+
 #####################################################################################
 # 📚 QUICK START GUIDE
 #####################################################################################

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -21,6 +21,7 @@ import BehaviorDrawer from './BehaviorDrawer';
 import BehaviorMetricsViewer from './BehaviorMetricsViewer';
 import { generateCopyName } from '@/utils/entity-helpers';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import { PsychologyIcon } from '@/components/icons';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
@@ -580,11 +581,13 @@ export default function BehaviorsClient({
           />
         ) : (
           <EntityEmptyState
+            card
             icon={PsychologyIcon}
             title="No behavior yet"
             description="Create your first behavior to define atomic expectations for your AI applications. Behaviors are measured through metrics to ensure your requirements are met."
             actionLabel="Create behavior"
             onAction={handleAddNewBehavior}
+            enrichment={getEntityEmptyStateEnrichment('behaviors')}
           />
         )
       ) : (

--- a/apps/frontend/src/app/(protected)/endpoints/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/page.tsx
@@ -9,6 +9,7 @@ import { useSession } from 'next-auth/react';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import EndpointsIcon from '@/components/EndpointsIcon';
 import EndpointsGrid from './components/EndpointsGrid';
 import EndpointCreateDrawer from './components/EndpointCreateDrawer';
@@ -121,6 +122,7 @@ export default function EndpointsPage() {
               description="Create your first endpoint to connect your application under test and start running tests and evaluations."
               actionLabel="Create endpoint"
               onAction={handleCreate}
+              enrichment={getEntityEmptyStateEnrichment('endpoints')}
             />
           ) : (
             <Paper

--- a/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
@@ -8,7 +8,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Box, Button, Chip, Paper, Typography } from '@mui/material';
+import { Box, Chip, Paper, Typography } from '@mui/material';
 import {
   GridColDef,
   GridFilterModel,
@@ -19,6 +19,8 @@ import {
 } from '@mui/x-data-grid';
 import { useRouter } from 'next/navigation';
 import { PageLayout } from '@/components/layout/PageLayout';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
@@ -39,7 +41,7 @@ import {
   ExperimentRead,
   shortVersion,
 } from '@/utils/api-client/interfaces/parameters';
-import { AddIcon, BiotechIcon } from '@/components/icons';
+import { BiotechIcon } from '@/components/icons';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { combineExperimentFiltersToOData } from '@/utils/odata-filter';
@@ -398,47 +400,16 @@ export default function ExperimentsClientWrapper({
       experiments.length === 0 &&
       !searchQuery.trim() &&
       !visibilityFilter ? (
-        <Paper
-          elevation={0}
-          sx={{
-            borderRadius: BORDER_RADIUS.md,
-            border: theme => `1px solid ${theme.palette.greyscale.border}`,
-            boxShadow: ELEVATION.xs,
-            p: theme => theme.spacing(6),
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            textAlign: 'center',
-          }}
-        >
-          <BiotechIcon
-            sx={{
-              fontSize: theme => theme.spacing(8),
-              color: 'text.disabled',
-              mb: 2,
-            }}
-          />
-          <Typography variant="h6" gutterBottom>
-            No experiments yet
-          </Typography>
-          <Typography
-            variant="body2"
-            color="text.secondary"
-            sx={{ maxWidth: theme => theme.spacing(58), mb: 3 }}
-          >
-            Experiments let you bundle parameter values into versioned
-            configurations. Create one to start tracking how different settings
-            affect your test results.
-          </Typography>
-          <Button
-            variant="contained"
-            startIcon={<AddIcon />}
-            onClick={() => setCreateOpen(true)}
-            disabled={!activeProject}
-          >
-            New Experiment
-          </Button>
-        </Paper>
+        <EntityEmptyState
+          card
+          icon={BiotechIcon}
+          title="No experiments yet"
+          description="Experiments let you bundle parameter values into versioned configurations. Create one to start tracking how different settings affect your test results."
+          actionLabel="New Experiment"
+          onAction={() => setCreateOpen(true)}
+          actionDisabled={!activeProject}
+          enrichment={getEntityEmptyStateEnrichment('experiments')}
+        />
       ) : (
         <ExperimentsToolbarContext.Provider
           value={{

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
@@ -15,7 +15,10 @@ import { DeleteModal } from '@/components/common/DeleteModal';
 import SelectBehaviorsDialog from '@/components/common/SelectBehaviorsDialog';
 import MetricFilterDrawer from './MetricFilterDrawer';
 import { PageLayout } from '@/components/layout/PageLayout';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
+import { InsertChartIcon } from '@/components/icons';
 import MetricCard from './MetricCard';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
@@ -148,6 +151,12 @@ export default function MetricsDirectoryTab({
     filters.scoreType.length +
     filters.metricScope.length +
     (behaviorStr.trim() !== '' ? 1 : 0);
+
+  const isTrueEmpty =
+    metrics.length === 0 &&
+    !filters.search &&
+    filters.backend.length === 0 &&
+    activeAdvancedFilterCount === 0;
 
   // Filter metrics based on search and filter criteria
   const getFilteredMetrics = () => {
@@ -526,164 +535,181 @@ export default function MetricsDirectoryTab({
         </FabGroup>
       }
     >
-      <GridToolbar
-        searchQuery={filters.search}
-        onSearchChange={value => handleFilterChange('search', value)}
-        searchPlaceholder="Search metrics..."
-        onFilterClick={() => setFilterDrawerOpen(true)}
-        hasActiveFilters={activeAdvancedFilterCount > 0}
-        activeFilterCount={activeAdvancedFilterCount}
-        {...directoryToolbarProps}
-        middleContent={
-          <PrimarySegmentedPills
-            mode="multi"
-            tabs={[
-              { value: '', label: 'All' },
-              ...filterOptions.backend.map(o => ({
-                value: o.type_value.toLowerCase(),
-                label: o.type_value,
-              })),
-            ]}
-            selectedValues={filters.backend}
-            onMultiChange={values => handleFilterChange('backend', values)}
-            clearValue=""
-          />
-        }
-      />
-
-      {/* Advanced Filters Drawer */}
-      <MetricFilterDrawer
-        open={filterDrawerOpen}
-        onClose={() => setFilterDrawerOpen(false)}
-        filters={{
-          type: filters.type,
-          scoreType: filters.scoreType,
-          metricScope: filters.metricScope,
-          behavior:
-            typeof filters.behavior === 'string' ? filters.behavior : '',
-        }}
-        filterOptions={{
-          type: filterOptions.type,
-          scoreType: filterOptions.scoreType,
-          metricScope: filterOptions.metricScope,
-          behavior: filterOptions.behavior,
-        }}
-        onApply={drawerFilters => {
-          setFilters(prev => ({
-            ...prev,
-            type: drawerFilters.type,
-            scoreType: drawerFilters.scoreType,
-            metricScope: drawerFilters.metricScope,
-            behavior: drawerFilters.behavior,
-          }));
-          setPage(0);
-        }}
-      />
-
-      {/* Metrics grid */}
-      <Box
-        sx={{
-          display: 'grid',
-          gridTemplateColumns: {
-            xs: '1fr',
-            sm: '1fr 1fr',
-            md: 'repeat(3, 1fr)',
-          },
-          gap: '24px',
-          mb: 4,
-        }}
-      >
-        {filteredMetrics
-          .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-          .map(metric => {
-            const assignedBehaviors = activeBehaviors.filter(b => {
-              if (!Array.isArray(metric.behaviors)) return false;
-              // Check if behaviors is an array of strings (UUIDs) or BehaviorReference objects
-              const behaviorIds = metric.behaviors.map(behavior =>
-                typeof behavior === 'string' ? behavior : behavior.id
-              );
-              return behaviorIds.includes(b.id as string);
-            });
-            const behaviorNames = assignedBehaviors.map(
-              b => b.name || 'Unnamed Behavior'
-            );
-
-            const isCustomMetric =
-              metric.backend_type?.type_value?.toLowerCase() === 'custom';
-
-            return (
-              <MetricCard
-                key={metric.id}
-                type={
-                  isValidMetricType(metric.metric_type?.type_value)
-                    ? metric.metric_type.type_value
-                    : undefined
-                }
-                title={metric.name}
-                description={metric.description}
-                backend={metric.backend_type?.type_value}
-                metricType={metric.metric_type?.type_value}
-                scoreType={metric.score_type}
-                metricScope={metric.metric_scope}
-                usedIn={behaviorNames}
-                showUsage={true}
-                onClick={
-                  assignMode
-                    ? () => {
-                        setSelectedMetric(metric);
-                        setAssignDialogOpen(true);
-                      }
-                    : isCustomMetric
-                      ? () => router.push(`/metrics/${metric.id}`)
-                      : undefined
-                }
-                onDelete={
-                  assignedBehaviors.length === 0 &&
-                  metric.backend_type?.type_value?.toLowerCase() === 'custom'
-                    ? () => handleDeleteMetric(metric.id, metric.name)
-                    : undefined
-                }
-              />
-            );
-          })}
-      </Box>
-      {filteredMetrics.length > 0 && (
-        <TablePagination
-          component="div"
-          count={filteredMetrics.length}
-          page={page}
-          onPageChange={(_event, newPage) => setPage(newPage)}
-          rowsPerPage={rowsPerPage}
-          onRowsPerPageChange={event => {
-            setRowsPerPage(parseInt(event.target.value, 10));
-            setPage(0);
-          }}
-          rowsPerPageOptions={[25, 50, 100]}
-          labelRowsPerPage="Metrics per page:"
-          sx={{ mb: 2 }}
+      {isTrueEmpty ? (
+        <EntityEmptyState
+          card
+          icon={InsertChartIcon}
+          title="No metrics yet"
+          description="Create your first metric to measure behaviors and evaluate whether your AI applications meet requirements."
+          actionLabel="Create metric"
+          onAction={() => router.push('/metrics/new?type=custom-prompt')}
+          enrichment={getEntityEmptyStateEnrichment('metrics')}
         />
+      ) : (
+        <>
+          <GridToolbar
+            searchQuery={filters.search}
+            onSearchChange={value => handleFilterChange('search', value)}
+            searchPlaceholder="Search metrics..."
+            onFilterClick={() => setFilterDrawerOpen(true)}
+            hasActiveFilters={activeAdvancedFilterCount > 0}
+            activeFilterCount={activeAdvancedFilterCount}
+            {...directoryToolbarProps}
+            middleContent={
+              <PrimarySegmentedPills
+                mode="multi"
+                tabs={[
+                  { value: '', label: 'All' },
+                  ...filterOptions.backend.map(o => ({
+                    value: o.type_value.toLowerCase(),
+                    label: o.type_value,
+                  })),
+                ]}
+                selectedValues={filters.backend}
+                onMultiChange={values => handleFilterChange('backend', values)}
+                clearValue=""
+              />
+            }
+          />
+
+          {/* Advanced Filters Drawer */}
+          <MetricFilterDrawer
+            open={filterDrawerOpen}
+            onClose={() => setFilterDrawerOpen(false)}
+            filters={{
+              type: filters.type,
+              scoreType: filters.scoreType,
+              metricScope: filters.metricScope,
+              behavior:
+                typeof filters.behavior === 'string' ? filters.behavior : '',
+            }}
+            filterOptions={{
+              type: filterOptions.type,
+              scoreType: filterOptions.scoreType,
+              metricScope: filterOptions.metricScope,
+              behavior: filterOptions.behavior,
+            }}
+            onApply={drawerFilters => {
+              setFilters(prev => ({
+                ...prev,
+                type: drawerFilters.type,
+                scoreType: drawerFilters.scoreType,
+                metricScope: drawerFilters.metricScope,
+                behavior: drawerFilters.behavior,
+              }));
+              setPage(0);
+            }}
+          />
+
+          {/* Metrics grid */}
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: {
+                xs: '1fr',
+                sm: '1fr 1fr',
+                md: 'repeat(3, 1fr)',
+              },
+              gap: '24px',
+              mb: 4,
+            }}
+          >
+            {filteredMetrics
+              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              .map(metric => {
+                const assignedBehaviors = activeBehaviors.filter(b => {
+                  if (!Array.isArray(metric.behaviors)) return false;
+                  // Check if behaviors is an array of strings (UUIDs) or BehaviorReference objects
+                  const behaviorIds = metric.behaviors.map(behavior =>
+                    typeof behavior === 'string' ? behavior : behavior.id
+                  );
+                  return behaviorIds.includes(b.id as string);
+                });
+                const behaviorNames = assignedBehaviors.map(
+                  b => b.name || 'Unnamed Behavior'
+                );
+
+                const isCustomMetric =
+                  metric.backend_type?.type_value?.toLowerCase() === 'custom';
+
+                return (
+                  <MetricCard
+                    key={metric.id}
+                    type={
+                      isValidMetricType(metric.metric_type?.type_value)
+                        ? metric.metric_type.type_value
+                        : undefined
+                    }
+                    title={metric.name}
+                    description={metric.description}
+                    backend={metric.backend_type?.type_value}
+                    metricType={metric.metric_type?.type_value}
+                    scoreType={metric.score_type}
+                    metricScope={metric.metric_scope}
+                    usedIn={behaviorNames}
+                    showUsage={true}
+                    onClick={
+                      assignMode
+                        ? () => {
+                            setSelectedMetric(metric);
+                            setAssignDialogOpen(true);
+                          }
+                        : isCustomMetric
+                          ? () => router.push(`/metrics/${metric.id}`)
+                          : undefined
+                    }
+                    onDelete={
+                      assignedBehaviors.length === 0 &&
+                      metric.backend_type?.type_value?.toLowerCase() ===
+                        'custom'
+                        ? () => handleDeleteMetric(metric.id, metric.name)
+                        : undefined
+                    }
+                  />
+                );
+              })}
+          </Box>
+          {filteredMetrics.length > 0 && (
+            <TablePagination
+              component="div"
+              count={filteredMetrics.length}
+              page={page}
+              onPageChange={(_event, newPage) => setPage(newPage)}
+              rowsPerPage={rowsPerPage}
+              onRowsPerPageChange={event => {
+                setRowsPerPage(parseInt(event.target.value, 10));
+                setPage(0);
+              }}
+              rowsPerPageOptions={[25, 50, 100]}
+              labelRowsPerPage="Metrics per page:"
+              sx={{ mb: 2 }}
+            />
+          )}
+          {/* Dialogs */}
+          <DeleteModal
+            open={deleteMetricDialogOpen}
+            onClose={handleCancelDeleteMetric}
+            onConfirm={handleConfirmDeleteMetric}
+            isLoading={isDeletingMetric}
+            itemType="metric"
+            itemName={metricToDeleteCompletely?.name}
+          />
+          <SelectBehaviorsDialog
+            open={assignDialogOpen}
+            onClose={() => {
+              setAssignDialogOpen(false);
+              setSelectedMetric(null);
+            }}
+            onSelect={handleAssignMetric}
+            sessionToken={sessionToken}
+            excludeBehaviorIds={(selectedMetric?.behaviors || [])
+              .filter(b => typeof b !== 'string' && b.id)
+              .map(b =>
+                typeof b !== 'string' ? b.id : (b as unknown as UUID)
+              )}
+          />
+        </>
       )}
-      {/* Dialogs */}
-      <DeleteModal
-        open={deleteMetricDialogOpen}
-        onClose={handleCancelDeleteMetric}
-        onConfirm={handleConfirmDeleteMetric}
-        isLoading={isDeletingMetric}
-        itemType="metric"
-        itemName={metricToDeleteCompletely?.name}
-      />
-      <SelectBehaviorsDialog
-        open={assignDialogOpen}
-        onClose={() => {
-          setAssignDialogOpen(false);
-          setSelectedMetric(null);
-        }}
-        onSelect={handleAssignMetric}
-        sessionToken={sessionToken}
-        excludeBehaviorIds={(selectedMetric?.behaviors || [])
-          .filter(b => typeof b !== 'string' && b.id)
-          .map(b => (typeof b !== 'string' ? b.id : (b as unknown as UUID)))}
-      />
     </PageLayout>
   );
 }

--- a/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/components/ProjectsClientWrapper.tsx
@@ -24,6 +24,7 @@ import GridToolbar, {
   directoryToolbarProps,
 } from '@/components/common/GridToolbar';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import { AppsIcon } from '@/components/icons';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { useOnboardingTour } from '@/hooks/useOnboardingTour';
@@ -273,12 +274,14 @@ export default function ProjectsClientWrapper({
               />
             ) : (
               <EntityEmptyState
+                card
                 icon={AppsIcon}
                 title="No project yet"
                 description="Create your first project to start organizing your AI applications. Projects help you group endpoints, tests, and results so you can collaborate with your team."
                 actionLabel="Create project"
                 onAction={() => setCreateDrawerOpen(true)}
                 actionDisabled={isProjectButtonDisabled}
+                enrichment={getEntityEmptyStateEnrichment('projects')}
               />
             )
           ) : (

--- a/apps/frontend/src/app/(protected)/test-runs/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/page.tsx
@@ -8,6 +8,7 @@ import { useSession } from 'next-auth/react';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import { PlayArrowIcon } from '@/components/icons';
 import TestRunsGrid from './components/TestRunsGrid';
 import RunDrawer from '@/components/common/RunDrawer';
@@ -91,11 +92,13 @@ export default function TestRunsPage() {
         <Box sx={{ mt: 2, mb: 2 }}>
           {testRunCount === 0 ? (
             <EntityEmptyState
+              card
               icon={PlayArrowIcon}
               title="No test runs yet"
               description="Execute a test set against an AI endpoint to start your first test run. Test runs measure quality, safety, and reliability of your AI endpoints."
               actionLabel="Create test run"
               onAction={() => setCreateDrawerOpen(true)}
+              enrichment={getEntityEmptyStateEnrichment('test-runs')}
             />
           ) : (
             <Paper

--- a/apps/frontend/src/app/(protected)/test-sets/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/page.tsx
@@ -12,6 +12,7 @@ import { useSession } from 'next-auth/react';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import { HorizontalSplitIcon } from '@/components/icons';
 import TestSetsGrid from './components/TestSetsGrid';
 import TestSetDrawer from './components/TestSetDrawer';
@@ -148,11 +149,13 @@ export default function TestSetsPage() {
         <Box sx={{ mt: 2, mb: 2 }}>
           {testSetCount === 0 ? (
             <EntityEmptyState
+              card
               icon={HorizontalSplitIcon}
               title="No test sets yet"
               description="Group related tests into a test set to version, share, and run them together."
               actionLabel="Create test set"
               onAction={() => setCreateDrawerOpen(true)}
+              enrichment={getEntityEmptyStateEnrichment('test-sets')}
             />
           ) : (
             <Paper

--- a/apps/frontend/src/app/(protected)/tests/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/page.tsx
@@ -11,6 +11,7 @@ import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabGroup } from '@/components/common/Fab';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 import { ScienceIcon } from '@/components/icons';
 import TestsGrid from './components/TestsGrid';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
@@ -133,12 +134,14 @@ export default function TestsPage() {
       <Box sx={{ mt: 2, mb: 2 }}>
         {testCount === 0 ? (
           <EntityEmptyState
+            card
             icon={ScienceIcon}
             title="No test yet"
             description="Create your first test to start evaluating your AI endpoints. Tests let you measure quality, safety, and reliability across single-turn and multi-turn interactions."
             actionLabel="Create test"
             onAction={handleCreateManual}
             actionDisabled={shouldDisableAddButton}
+            enrichment={getEntityEmptyStateEnrichment('tests')}
           />
         ) : (
           <Paper

--- a/apps/frontend/src/app/api/og-metadata/__tests__/og-metadata-utils.test.ts
+++ b/apps/frontend/src/app/api/og-metadata/__tests__/og-metadata-utils.test.ts
@@ -1,0 +1,39 @@
+import {
+  isAllowedOgMetadataUrl,
+  resolveRedirectUrl,
+} from '@/app/api/og-metadata/og-metadata-utils';
+
+describe('og-metadata-utils', () => {
+  it('allows docs hostnames over http/https', () => {
+    expect(
+      isAllowedOgMetadataUrl(new URL('https://docs.rhesis.ai/docs/tests'))
+    ).toBe(true);
+    expect(
+      isAllowedOgMetadataUrl(new URL('https://www.docs.rhesis.ai/docs/tests'))
+    ).toBe(true);
+  });
+
+  it('rejects non-allowlisted hosts and schemes', () => {
+    expect(isAllowedOgMetadataUrl(new URL('https://evil.example/docs'))).toBe(
+      false
+    );
+    expect(isAllowedOgMetadataUrl(new URL('file://docs.rhesis.ai/docs'))).toBe(
+      false
+    );
+  });
+
+  it('allows same-host redirects and rejects off-host redirects', () => {
+    const base = new URL('https://docs.rhesis.ai/docs/tests');
+
+    expect(resolveRedirectUrl('/docs/other', base)?.toString()).toBe(
+      'https://docs.rhesis.ai/docs/other'
+    );
+
+    expect(
+      resolveRedirectUrl('https://www.docs.rhesis.ai/docs/other', base)
+        ?.hostname
+    ).toBe('www.docs.rhesis.ai');
+
+    expect(resolveRedirectUrl('https://evil.example/steal', base)).toBeNull();
+  });
+});

--- a/apps/frontend/src/app/api/og-metadata/og-metadata-utils.ts
+++ b/apps/frontend/src/app/api/og-metadata/og-metadata-utils.ts
@@ -1,0 +1,55 @@
+const ALLOWED_HOSTS = new Set(['docs.rhesis.ai', 'www.docs.rhesis.ai']);
+const MAX_REDIRECTS = 3;
+
+export function isAllowedOgMetadataUrl(url: URL): boolean {
+  return (
+    (url.protocol === 'https:' || url.protocol === 'http:') &&
+    ALLOWED_HOSTS.has(url.hostname)
+  );
+}
+
+export function resolveRedirectUrl(location: string, baseUrl: URL): URL | null {
+  try {
+    const nextUrl = new URL(location, baseUrl);
+    return isAllowedOgMetadataUrl(nextUrl) ? nextUrl : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchAllowedPage(
+  startUrl: URL
+): Promise<Response | null> {
+  let currentUrl = startUrl;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop += 1) {
+    if (!isAllowedOgMetadataUrl(currentUrl)) {
+      return null;
+    }
+
+    const response = await fetch(currentUrl.toString(), {
+      headers: { 'User-Agent': 'RhesisOgMetadata/1.0' },
+      redirect: 'manual',
+      next: { revalidate: 86400 },
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) {
+        return null;
+      }
+
+      const nextUrl = resolveRedirectUrl(location, currentUrl);
+      if (!nextUrl) {
+        return null;
+      }
+
+      currentUrl = nextUrl;
+      continue;
+    }
+
+    return response;
+  }
+
+  return null;
+}

--- a/apps/frontend/src/app/api/og-metadata/route.ts
+++ b/apps/frontend/src/app/api/og-metadata/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-const ALLOWED_HOSTS = new Set(['docs.rhesis.ai', 'www.docs.rhesis.ai']);
+import {
+  fetchAllowedPage,
+  isAllowedOgMetadataUrl,
+} from '@/app/api/og-metadata/og-metadata-utils';
 
 function extractMetaContent(
   html: string,
@@ -46,17 +48,14 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: 'invalid url' }, { status: 400 });
   }
 
-  if (!ALLOWED_HOSTS.has(parsed.hostname)) {
+  if (!isAllowedOgMetadataUrl(parsed)) {
     return NextResponse.json({ error: 'host not allowed' }, { status: 403 });
   }
 
   try {
-    const response = await fetch(parsed.toString(), {
-      headers: { 'User-Agent': 'RhesisOgMetadata/1.0' },
-      next: { revalidate: 86400 },
-    });
+    const response = await fetchAllowedPage(parsed);
 
-    if (!response.ok) {
+    if (!response?.ok) {
       return NextResponse.json(
         { error: 'failed to fetch page' },
         { status: 502 }

--- a/apps/frontend/src/app/api/og-metadata/route.ts
+++ b/apps/frontend/src/app/api/og-metadata/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const ALLOWED_HOSTS = new Set(['docs.rhesis.ai', 'www.docs.rhesis.ai']);
+
+function extractMetaContent(
+  html: string,
+  attr: 'property' | 'name',
+  key: string
+) {
+  const patterns = [
+    new RegExp(
+      `<meta[^>]+${attr}=["']${key}["'][^>]+content=["']([^"']+)["']`,
+      'i'
+    ),
+    new RegExp(
+      `<meta[^>]+content=["']([^"']+)["'][^>]+${attr}=["']${key}["']`,
+      'i'
+    ),
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    if (match?.[1]) {
+      return match[1].trim();
+    }
+  }
+
+  return null;
+}
+
+function extractTitle(html: string): string | null {
+  const match = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+  return match?.[1]?.trim() ?? null;
+}
+
+export async function GET(req: NextRequest) {
+  const rawUrl = req.nextUrl.searchParams.get('url')?.trim();
+  if (!rawUrl) {
+    return NextResponse.json({ error: 'url is required' }, { status: 400 });
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return NextResponse.json({ error: 'invalid url' }, { status: 400 });
+  }
+
+  if (!ALLOWED_HOSTS.has(parsed.hostname)) {
+    return NextResponse.json({ error: 'host not allowed' }, { status: 403 });
+  }
+
+  try {
+    const response = await fetch(parsed.toString(), {
+      headers: { 'User-Agent': 'RhesisOgMetadata/1.0' },
+      next: { revalidate: 86400 },
+    });
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: 'failed to fetch page' },
+        { status: 502 }
+      );
+    }
+
+    const html = await response.text();
+    const title =
+      extractMetaContent(html, 'property', 'og:title') ?? extractTitle(html);
+    const description =
+      extractMetaContent(html, 'property', 'og:description') ??
+      extractMetaContent(html, 'name', 'description');
+    const imageUrl = extractMetaContent(html, 'property', 'og:image');
+
+    return NextResponse.json(
+      { title, description, imageUrl },
+      {
+        headers: {
+          'Cache-Control': 'public, max-age=86400, stale-while-revalidate=3600',
+        },
+      }
+    );
+  } catch {
+    return NextResponse.json({ error: 'fetch failed' }, { status: 502 });
+  }
+}

--- a/apps/frontend/src/components/common/EntityEmptyState.tsx
+++ b/apps/frontend/src/components/common/EntityEmptyState.tsx
@@ -1,10 +1,20 @@
 'use client';
 
 import React from 'react';
-import { Box, Button, Paper, Typography } from '@mui/material';
+import { Box, Button, Typography } from '@mui/material';
 import type { SvgIconProps } from '@mui/material/SvgIcon';
 import AddIcon from '@mui/icons-material/Add';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
+import type { EntityEmptyStateEnrichment } from '@/constants/entity-empty-state-types';
+import { hasEnrichmentContent } from '@/constants/entity-empty-state-env';
+import {
+  EnrichmentCardExtras,
+  EnrichmentPrimaryAction,
+  EntityEmptyStateCardShell,
+  EntityEmptyStateEnrichmentSections,
+} from '@/components/common/EntityEmptyStateEnrichmentParts';
+
+export type { EntityEmptyStateEnrichment } from '@/constants/entity-empty-state-types';
 
 export interface EntityEmptyStateProps {
   /** SvgIcon component class (not an element). */
@@ -33,6 +43,8 @@ export interface EntityEmptyStateProps {
    * when `card` is true.
    */
   showAddIcon?: boolean;
+  /** Cloud-only enrichment (video, help articles, community). Unset = basic. */
+  enrichment?: EntityEmptyStateEnrichment;
 }
 
 /**
@@ -41,6 +53,8 @@ export interface EntityEmptyStateProps {
  * - **Default** (`card=false`): large icon, centered text, optional CTA button.
  * - **Card** (`card=true`): bordered Paper card for section / linked-entity tabs
  *   (Figma node 1435:49277).
+ * - **Enriched** (cloud env vars): v2 layout with media and help sections
+ *   (Figma node 1858:51148).
  */
 export default function EntityEmptyState({
   icon: Icon,
@@ -52,11 +66,137 @@ export default function EntityEmptyState({
   card = false,
   iconSize,
   showAddIcon,
+  enrichment,
 }: EntityEmptyStateProps) {
-  const resolvedIconSize = iconSize ?? (card ? 32 : 64);
-  const resolvedShowAddIcon = showAddIcon ?? card;
+  const isEnriched = hasEnrichmentContent(enrichment);
+  const useCardShell = card || isEnriched;
+  const resolvedIconSize = iconSize ?? (useCardShell ? 32 : 64);
+  const resolvedShowAddIcon = showAddIcon ?? useCardShell;
 
-  const content = (
+  const headerBlock = (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: useCardShell ? '10px' : 0,
+      }}
+    >
+      <Icon
+        sx={{
+          fontSize: resolvedIconSize,
+          color: 'primary.main',
+          opacity: useCardShell ? 1 : 0.6,
+        }}
+      />
+
+      <Typography
+        variant="h6"
+        sx={{
+          fontWeight: useCardShell ? 600 : 700,
+          fontSize: useCardShell ? 20 : undefined,
+          lineHeight: useCardShell ? '24px' : undefined,
+          color: useCardShell ? 'primary.main' : 'text.primary',
+        }}
+      >
+        {title}
+      </Typography>
+    </Box>
+  );
+
+  const descriptionBlock = description && (
+    <Typography
+      variant="body2"
+      sx={{
+        color: 'text.secondary',
+        maxWidth: isEnriched ? 734 : 480,
+        lineHeight: useCardShell ? '22px' : undefined,
+      }}
+    >
+      {description}
+    </Typography>
+  );
+
+  const basicAction =
+    actionLabel && onAction ? (
+      <Button
+        variant={useCardShell ? 'outlined' : 'contained'}
+        startIcon={resolvedShowAddIcon ? <AddIcon /> : undefined}
+        onClick={onAction}
+        disabled={actionDisabled}
+        sx={
+          useCardShell
+            ? {
+                fontWeight: 700,
+                fontSize: 18,
+                lineHeight: '25px',
+                borderRadius: BORDER_RADIUS.md,
+                textTransform: 'none',
+                px: '20px',
+                py: '12px',
+                borderWidth: 2,
+                '&:hover': {
+                  borderWidth: 2,
+                },
+              }
+            : { mt: 1, fontWeight: 700 }
+        }
+      >
+        {actionLabel}
+      </Button>
+    ) : null;
+
+  const enrichedActions =
+    isEnriched && enrichment ? (
+      <Box
+        sx={{
+          display: 'flex',
+          gap: '10px',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexWrap: 'wrap',
+        }}
+      >
+        {enrichment.secondaryAction && (
+          <Button
+            component={enrichment.secondaryAction.href ? 'a' : 'button'}
+            href={enrichment.secondaryAction.href}
+            target={enrichment.secondaryAction.href ? '_blank' : undefined}
+            rel={
+              enrichment.secondaryAction.href
+                ? 'noopener noreferrer'
+                : undefined
+            }
+            variant="outlined"
+            disabled={enrichment.secondaryAction.disabled}
+            onClick={enrichment.secondaryAction.onAction}
+            sx={{
+              fontWeight: 700,
+              fontSize: 14,
+              lineHeight: '22px',
+              borderRadius: BORDER_RADIUS.sm,
+              textTransform: 'none',
+              px: '16px',
+              py: '8px',
+              borderWidth: 2,
+              '&:hover': { borderWidth: 2 },
+            }}
+          >
+            {enrichment.secondaryAction.label}
+          </Button>
+        )}
+        {actionLabel && onAction && (
+          <EnrichmentPrimaryAction
+            actionLabel={actionLabel}
+            onAction={onAction}
+            actionDisabled={actionDisabled}
+            showAddIcon={resolvedShowAddIcon}
+          />
+        )}
+      </Box>
+    ) : null;
+
+  const cardContent = (
     <Box
       sx={{
         display: 'flex',
@@ -64,9 +204,9 @@ export default function EntityEmptyState({
         alignItems: 'center',
         justifyContent: 'center',
         textAlign: 'center',
-        py: card ? 0 : 10,
-        px: card ? { xs: 2, md: '200px' } : 4,
-        gap: card ? '20px' : 2,
+        py: useCardShell ? 0 : 10,
+        px: useCardShell ? { xs: 2, md: '200px' } : 4,
+        gap: isEnriched ? '50px' : useCardShell ? '20px' : 2,
       }}
     >
       <Box
@@ -74,87 +214,51 @@ export default function EntityEmptyState({
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
-          gap: card ? '10px' : 0,
+          gap: isEnriched ? '30px' : useCardShell ? '20px' : 0,
+          width: isEnriched ? '100%' : undefined,
+          maxWidth: isEnriched ? 734 : undefined,
         }}
       >
-        <Icon
-          sx={{
-            fontSize: resolvedIconSize,
-            color: 'primary.main',
-            opacity: card ? 1 : 0.6,
-          }}
-        />
-
-        <Typography
-          variant="h6"
-          sx={{
-            fontWeight: card ? 600 : 700,
-            fontSize: card ? 20 : undefined,
-            lineHeight: card ? '24px' : undefined,
-            color: card ? 'primary.main' : 'text.primary',
-          }}
-        >
-          {title}
-        </Typography>
+        {headerBlock}
+        {descriptionBlock}
+        {isEnriched ? enrichedActions : basicAction}
       </Box>
 
-      {description && (
-        <Typography
-          variant="body2"
-          sx={{
-            color: 'text.secondary',
-            maxWidth: 480,
-            lineHeight: card ? '22px' : undefined,
-          }}
-        >
-          {description}
-        </Typography>
-      )}
-
-      {actionLabel && onAction && (
-        <Button
-          variant={card ? 'outlined' : 'contained'}
-          startIcon={resolvedShowAddIcon ? <AddIcon /> : undefined}
-          onClick={onAction}
-          disabled={actionDisabled}
-          sx={
-            card
-              ? {
-                  fontWeight: 700,
-                  fontSize: 18,
-                  lineHeight: '25px',
-                  borderRadius: BORDER_RADIUS.md,
-                  textTransform: 'none',
-                  px: '20px',
-                  py: '12px',
-                  borderWidth: 2,
-                  '&:hover': {
-                    borderWidth: 2,
-                  },
-                }
-              : { mt: 1, fontWeight: 700 }
-          }
-        >
-          {actionLabel}
-        </Button>
+      {isEnriched && enrichment && (
+        <EnrichmentCardExtras enrichment={enrichment} />
       )}
     </Box>
   );
 
-  if (!card) return content;
-
-  return (
-    <Paper
-      elevation={0}
+  const standaloneContent = (
+    <Box
       sx={{
-        border: theme => `1px solid ${theme.palette.greyscale.border}`,
-        borderRadius: BORDER_RADIUS.md,
-        boxShadow: ELEVATION.xs,
-        px: '30px',
-        py: '40px',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        py: 10,
+        px: 4,
+        gap: 2,
       }}
     >
-      {content}
-    </Paper>
+      {headerBlock}
+      {descriptionBlock}
+      {basicAction}
+    </Box>
+  );
+
+  if (!useCardShell) {
+    return standaloneContent;
+  }
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <EntityEmptyStateCardShell>{cardContent}</EntityEmptyStateCardShell>
+      {isEnriched && enrichment && (
+        <EntityEmptyStateEnrichmentSections enrichment={enrichment} />
+      )}
+    </Box>
   );
 }

--- a/apps/frontend/src/components/common/EntityEmptyStateEnrichmentParts.tsx
+++ b/apps/frontend/src/components/common/EntityEmptyStateEnrichmentParts.tsx
@@ -148,7 +148,7 @@ function EmptyStateMedia({
         display: 'block',
         width: '100%',
         maxWidth: 734,
-        borderRadius: '13px',
+        borderRadius: BORDER_RADIUS.md,
         overflow: 'hidden',
         textDecoration: 'none',
       }}
@@ -166,7 +166,7 @@ function EmptyStateMedia({
           display: 'block',
           width: '100%',
           height: 'auto',
-          borderRadius: '13px',
+          borderRadius: BORDER_RADIUS.md,
         }}
       />
     </Box>
@@ -262,7 +262,7 @@ function EmptyStateLinkCard({ card }: { card: EmptyStateLinkCard }) {
       elevation={0}
       sx={{
         border: theme => `1px solid ${theme.palette.greyscale.border}`,
-        borderRadius: '10px',
+        borderRadius: BORDER_RADIUS.sm,
         boxShadow: '0px 3px 5px rgba(0, 0, 0, 0.09)',
         p: '30px',
         width: '100%',

--- a/apps/frontend/src/components/common/EntityEmptyStateEnrichmentParts.tsx
+++ b/apps/frontend/src/components/common/EntityEmptyStateEnrichmentParts.tsx
@@ -1,0 +1,483 @@
+'use client';
+
+import React from 'react';
+import { Box, Button, Paper, Skeleton, Typography } from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import { ArrowOutwardIcon } from '@/components/icons';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
+import type {
+  EmptyStateAction,
+  EmptyStateArticle,
+  EmptyStateLinkCard,
+  EntityEmptyStateEnrichment,
+} from '@/constants/entity-empty-state-types';
+import {
+  getYouTubeThumbnailUrl,
+  getYouTubeWatchUrl,
+} from '@/utils/onboarding-video';
+
+interface OgMetadata {
+  title: string | null;
+  description: string | null;
+  imageUrl: string | null;
+}
+
+function useOgMetadata(url: string | undefined, enabled: boolean) {
+  const [metadata, setMetadata] = React.useState<OgMetadata | null>(null);
+  const [loading, setLoading] = React.useState(enabled);
+
+  React.useEffect(() => {
+    if (!enabled || !url) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+
+    fetch(`/api/og-metadata?url=${encodeURIComponent(url)}`)
+      .then(async response => {
+        if (!response.ok) return null;
+        return response.json() as Promise<OgMetadata>;
+      })
+      .then(data => {
+        if (!cancelled) {
+          setMetadata(data);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setMetadata(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [url, enabled]);
+
+  return { metadata, loading };
+}
+
+function EnrichmentActionButton({
+  action,
+  variant,
+  showAddIcon = false,
+  enriched = false,
+}: {
+  action: EmptyStateAction;
+  variant: 'outlined' | 'contained';
+  showAddIcon?: boolean;
+  enriched?: boolean;
+}) {
+  const commonSx = enriched
+    ? {
+        fontWeight: 700,
+        fontSize: 14,
+        lineHeight: '22px',
+        borderRadius: BORDER_RADIUS.sm,
+        textTransform: 'none' as const,
+        px: '16px',
+        py: '8px',
+        ...(variant === 'outlined'
+          ? { borderWidth: 2, '&:hover': { borderWidth: 2 } }
+          : {}),
+      }
+    : undefined;
+
+  if (action.href) {
+    return (
+      <Button
+        component="a"
+        href={action.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        variant={variant}
+        startIcon={showAddIcon ? <AddIcon /> : undefined}
+        disabled={action.disabled}
+        sx={commonSx}
+      >
+        {action.label}
+      </Button>
+    );
+  }
+
+  if (!action.onAction) return null;
+
+  return (
+    <Button
+      variant={variant}
+      startIcon={showAddIcon ? <AddIcon /> : undefined}
+      onClick={action.onAction}
+      disabled={action.disabled}
+      sx={commonSx}
+    >
+      {action.label}
+    </Button>
+  );
+}
+
+function EmptyStateMedia({
+  youtubeSource,
+  alt,
+}: {
+  youtubeSource: string;
+  alt?: string;
+}) {
+  const [quality, setQuality] = React.useState<'maxresdefault' | 'hqdefault'>(
+    'maxresdefault'
+  );
+  const thumbnailUrl = getYouTubeThumbnailUrl(youtubeSource, quality);
+  const watchUrl = getYouTubeWatchUrl(youtubeSource) ?? youtubeSource;
+
+  if (!thumbnailUrl) return null;
+
+  return (
+    <Box
+      component="a"
+      href={watchUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={alt ?? 'Watch product demo video'}
+      sx={{
+        display: 'block',
+        width: '100%',
+        maxWidth: 734,
+        borderRadius: '13px',
+        overflow: 'hidden',
+        textDecoration: 'none',
+      }}
+    >
+      <Box
+        component="img"
+        src={thumbnailUrl}
+        alt={alt ?? 'Product demo video thumbnail'}
+        onError={() => {
+          if (quality === 'maxresdefault') {
+            setQuality('hqdefault');
+          }
+        }}
+        sx={{
+          display: 'block',
+          width: '100%',
+          height: 'auto',
+          borderRadius: '13px',
+        }}
+      />
+    </Box>
+  );
+}
+
+function EmptyStateArticleCard({ article }: { article: EmptyStateArticle }) {
+  const shouldFetch =
+    !article.title && !article.description && !article.imageUrl;
+  const { metadata, loading } = useOgMetadata(article.href, shouldFetch);
+
+  const title = article.title ?? metadata?.title ?? article.href;
+  const description = article.description ?? metadata?.description ?? '';
+  const imageUrl = article.imageUrl ?? metadata?.imageUrl ?? null;
+
+  const content = (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '14px',
+        alignItems: 'flex-start',
+        width: '100%',
+      }}
+    >
+      {loading ? (
+        <Skeleton variant="rounded" width="100%" height={148} />
+      ) : (
+        imageUrl && (
+          <Box
+            component="img"
+            src={imageUrl}
+            alt=""
+            sx={{
+              width: '100%',
+              height: 148,
+              objectFit: 'cover',
+              borderRadius: BORDER_RADIUS.sm,
+            }}
+          />
+        )
+      )}
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+        <Typography
+          sx={{
+            fontWeight: 700,
+            fontSize: 14,
+            lineHeight: '22px',
+            color: theme => theme.palette.greyscale.title,
+          }}
+        >
+          {loading ? <Skeleton width="80%" /> : title}
+        </Typography>
+        {(loading || description) && (
+          <Typography
+            sx={{
+              fontSize: 12,
+              lineHeight: '18px',
+              color: theme => theme.palette.greyscale.body,
+            }}
+          >
+            {loading ? <Skeleton width="100%" /> : description}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+
+  if (article.href) {
+    return (
+      <Box
+        component="a"
+        href={article.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        sx={{
+          textDecoration: 'none',
+          color: 'inherit',
+          width: '100%',
+        }}
+      >
+        {content}
+      </Box>
+    );
+  }
+
+  return content;
+}
+
+function EmptyStateLinkCard({ card }: { card: EmptyStateLinkCard }) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        border: theme => `1px solid ${theme.palette.greyscale.border}`,
+        borderRadius: '10px',
+        boxShadow: '0px 3px 5px rgba(0, 0, 0, 0.09)',
+        p: '30px',
+        width: '100%',
+        maxWidth: 358,
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '12px',
+          textAlign: 'center',
+        }}
+      >
+        <Typography
+          sx={{
+            fontWeight: 700,
+            fontSize: 16,
+            lineHeight: '24px',
+            color: theme => theme.palette.greyscale.title,
+          }}
+        >
+          {card.title}
+        </Typography>
+        <Typography
+          sx={{
+            fontSize: 14,
+            lineHeight: '22px',
+            color: theme => theme.palette.greyscale.body,
+          }}
+        >
+          {card.description}
+        </Typography>
+        {card.href && (
+          <Box
+            component="a"
+            href={card.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            sx={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: '3px',
+              textDecoration: 'none',
+              color: 'primary.main',
+            }}
+          >
+            <ArrowOutwardIcon sx={{ fontSize: 22 }} />
+            <Typography sx={{ fontSize: 14, lineHeight: '22px' }}>
+              {card.linkLabel}
+            </Typography>
+          </Box>
+        )}
+      </Box>
+    </Paper>
+  );
+}
+
+export function EntityEmptyStateEnrichmentSections({
+  enrichment,
+}: {
+  enrichment: EntityEmptyStateEnrichment;
+}) {
+  const hasHelpArticles = (enrichment.helpArticles?.items.length ?? 0) > 0;
+  const communityItems =
+    enrichment.communityLinks?.items.filter(card => card.href) ?? [];
+
+  if (!hasHelpArticles && communityItems.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '40px',
+        pt: '40px',
+        pb: '50px',
+        width: '100%',
+      }}
+    >
+      {hasHelpArticles && enrichment.helpArticles && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+          <Typography
+            sx={{
+              fontWeight: 700,
+              fontSize: 16,
+              lineHeight: '24px',
+              color: 'primary.main',
+            }}
+          >
+            {enrichment.helpArticles.title}
+          </Typography>
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: {
+                xs: '1fr',
+                sm: 'repeat(2, 1fr)',
+                lg: 'repeat(4, 1fr)',
+              },
+              gap: '26px',
+            }}
+          >
+            {enrichment.helpArticles.items.map(article => (
+              <EmptyStateArticleCard key={article.href} article={article} />
+            ))}
+          </Box>
+        </Box>
+      )}
+
+      {communityItems.length > 0 && enrichment.communityLinks && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+          <Typography
+            sx={{
+              fontWeight: 700,
+              fontSize: 16,
+              lineHeight: '24px',
+              color: 'primary.main',
+            }}
+          >
+            {enrichment.communityLinks.title}
+          </Typography>
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: {
+                xs: '1fr',
+                md: 'repeat(3, 1fr)',
+              },
+              gap: '14px',
+            }}
+          >
+            {communityItems.map(card => (
+              <EmptyStateLinkCard key={card.title} card={card} />
+            ))}
+          </Box>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export function EnrichmentCardExtras({
+  enrichment,
+}: {
+  enrichment: EntityEmptyStateEnrichment;
+}) {
+  const youtubeSource =
+    enrichment.media?.youtubeUrl ?? enrichment.media?.youtubeVideoId;
+
+  if (!youtubeSource) return null;
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        width: '100%',
+        maxWidth: 734,
+      }}
+    >
+      <EmptyStateMedia
+        youtubeSource={youtubeSource}
+        alt={enrichment.media?.alt}
+      />
+    </Box>
+  );
+}
+
+export function EnrichmentPrimaryAction({
+  actionLabel,
+  onAction,
+  actionDisabled,
+  showAddIcon,
+}: {
+  actionLabel: string;
+  onAction: () => void;
+  actionDisabled?: boolean;
+  showAddIcon?: boolean;
+}) {
+  return (
+    <EnrichmentActionButton
+      action={{
+        label: actionLabel,
+        onAction,
+        disabled: actionDisabled,
+      }}
+      variant="contained"
+      showAddIcon={showAddIcon}
+      enriched
+    />
+  );
+}
+
+export function EntityEmptyStateCardShell({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        border: theme => `1px solid ${theme.palette.greyscale.border}`,
+        borderRadius: BORDER_RADIUS.md,
+        boxShadow: ELEVATION.xs,
+        px: '30px',
+        py: '40px',
+      }}
+    >
+      {children}
+    </Paper>
+  );
+}

--- a/apps/frontend/src/components/common/__tests__/EntityEmptyState.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/EntityEmptyState.test.tsx
@@ -61,4 +61,55 @@ describe('EntityEmptyState', () => {
 
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
+
+  it('renders enriched layout with secondary CTA and help section', () => {
+    renderEmptyState({
+      card: true,
+      icon: RouteIcon,
+      title: 'Get started with tests',
+      description: 'Create your first test.',
+      actionLabel: 'Create test',
+      onAction: jest.fn(),
+      enrichment: {
+        secondaryAction: {
+          label: 'Learn more',
+          href: 'https://docs.rhesis.ai/docs/tests',
+        },
+        media: {
+          youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        },
+        helpArticles: {
+          title: 'Top Help Articles',
+          items: [
+            {
+              href: 'https://docs.rhesis.ai/docs/tests',
+              title: 'Tests guide',
+              description: 'Learn how to create tests',
+            },
+          ],
+        },
+        communityLinks: {
+          title: 'Community & Support',
+          items: [
+            {
+              title: 'Documentation',
+              description: 'Guides and API references',
+              linkLabel: 'Browse docs',
+              href: 'https://docs.rhesis.ai',
+            },
+          ],
+        },
+      },
+    });
+
+    expect(screen.getByRole('link', { name: /learn more/i })).toHaveAttribute(
+      'href',
+      'https://docs.rhesis.ai/docs/tests'
+    );
+    expect(screen.getByText('Top Help Articles')).toBeInTheDocument();
+    expect(screen.getByText('Community & Support')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /product demo video/i })
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/constants/__tests__/entity-empty-state-env.test.ts
+++ b/apps/frontend/src/constants/__tests__/entity-empty-state-env.test.ts
@@ -1,0 +1,38 @@
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
+
+describe('entity-empty-state-env', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns undefined when env vars are unset', () => {
+    delete process.env.NEXT_PUBLIC_TESTS_EMPTY_STATE_VIDEO_URL;
+    delete process.env.NEXT_PUBLIC_TESTS_EMPTY_STATE_ARTICLE_URLS;
+
+    expect(getEntityEmptyStateEnrichment('tests')).toBeUndefined();
+  });
+
+  it('builds enrichment from cloud env vars', () => {
+    process.env.NEXT_PUBLIC_TESTS_EMPTY_STATE_VIDEO_URL =
+      'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
+    process.env.NEXT_PUBLIC_TESTS_EMPTY_STATE_ARTICLE_URLS =
+      'https://docs.rhesis.ai/docs/tests,https://docs.rhesis.ai/docs/metrics';
+
+    const enrichment = getEntityEmptyStateEnrichment('tests');
+
+    expect(enrichment?.media?.youtubeUrl).toBe(
+      'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+    );
+    expect(enrichment?.helpArticles?.items).toHaveLength(2);
+    expect(enrichment?.secondaryAction?.href).toBe(
+      'https://docs.rhesis.ai/docs/tests'
+    );
+    expect(enrichment?.communityLinks?.items.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/frontend/src/constants/entity-empty-state-env.ts
+++ b/apps/frontend/src/constants/entity-empty-state-env.ts
@@ -1,0 +1,122 @@
+import type {
+  EntityEmptyStateEnrichment,
+  EntityEmptyStateKey,
+  EmptyStateLinkCard,
+} from '@/constants/entity-empty-state-types';
+import { getYouTubeWatchUrl } from '@/utils/onboarding-video';
+
+const ENV_PREFIX: Record<EntityEmptyStateKey, string> = {
+  projects: 'PROJECTS',
+  tests: 'TESTS',
+  'test-sets': 'TEST_SETS',
+  'test-runs': 'TEST_RUNS',
+  endpoints: 'ENDPOINTS',
+  behaviors: 'BEHAVIORS',
+  metrics: 'METRICS',
+  experiments: 'EXPERIMENTS',
+};
+
+const COMMUNITY_LINK_CARDS: EmptyStateLinkCard[] = [
+  {
+    title: 'Documentation',
+    description: 'Comprehensive guides and API references',
+    linkLabel: 'Browse docs',
+    href: 'https://docs.rhesis.ai',
+  },
+  {
+    title: 'Community',
+    description: 'Ask questions and share feedback with other users',
+    linkLabel: 'GitHub Discussions',
+    href: 'https://github.com/rhesis-ai/rhesis/discussions',
+  },
+  {
+    title: 'Issues',
+    description: 'Report bugs and request features',
+    linkLabel: 'GitHub Issues',
+    href: 'https://github.com/rhesis-ai/rhesis/issues',
+  },
+];
+
+function parseCommaSeparatedUrls(value: string | undefined): string[] {
+  if (!value?.trim()) return [];
+  return value
+    .split(',')
+    .map(url => url.trim())
+    .filter(Boolean)
+    .slice(0, 4);
+}
+
+function readEnv(
+  key: EntityEmptyStateKey,
+  suffix: 'VIDEO_URL' | 'ARTICLE_URLS'
+) {
+  const prefix = ENV_PREFIX[key];
+  return process.env[`NEXT_PUBLIC_${prefix}_EMPTY_STATE_${suffix}`]?.trim();
+}
+
+function buildEnrichment({
+  videoUrl,
+  articleUrls,
+}: {
+  videoUrl?: string;
+  articleUrls: string[];
+}): EntityEmptyStateEnrichment {
+  const enrichment: EntityEmptyStateEnrichment = {
+    communityLinks: {
+      title: 'Community & Support',
+      items: COMMUNITY_LINK_CARDS,
+    },
+  };
+
+  if (videoUrl) {
+    enrichment.media = {
+      youtubeUrl: videoUrl,
+      alt: 'Product demo video',
+    };
+  }
+
+  if (articleUrls.length > 0) {
+    enrichment.helpArticles = {
+      title: 'Top Help Articles',
+      items: articleUrls.map(href => ({ href })),
+    };
+    enrichment.secondaryAction = {
+      label: 'Learn more',
+      href: articleUrls[0],
+    };
+  } else if (videoUrl) {
+    enrichment.secondaryAction = {
+      label: 'Learn more',
+      href: getYouTubeWatchUrl(videoUrl) ?? videoUrl,
+    };
+  }
+
+  return enrichment;
+}
+
+export function hasEnrichmentContent(
+  enrichment: EntityEmptyStateEnrichment | undefined
+): boolean {
+  if (!enrichment) return false;
+  return Boolean(
+    enrichment.media?.youtubeUrl ||
+    enrichment.media?.youtubeVideoId ||
+    (enrichment.helpArticles?.items.length ?? 0) > 0 ||
+    enrichment.secondaryAction?.href ||
+    enrichment.secondaryAction?.onAction
+  );
+}
+
+/** Cloud-only: returns enrichment when NEXT_PUBLIC_* env vars are set. */
+export function getEntityEmptyStateEnrichment(
+  key: EntityEmptyStateKey
+): EntityEmptyStateEnrichment | undefined {
+  const videoUrl = readEnv(key, 'VIDEO_URL');
+  const articleUrls = parseCommaSeparatedUrls(readEnv(key, 'ARTICLE_URLS'));
+
+  if (!videoUrl && articleUrls.length === 0) {
+    return undefined;
+  }
+
+  return buildEnrichment({ videoUrl, articleUrls });
+}

--- a/apps/frontend/src/constants/entity-empty-state-env.ts
+++ b/apps/frontend/src/constants/entity-empty-state-env.ts
@@ -5,17 +5,6 @@ import type {
 } from '@/constants/entity-empty-state-types';
 import { getYouTubeWatchUrl } from '@/utils/onboarding-video';
 
-const ENV_PREFIX: Record<EntityEmptyStateKey, string> = {
-  projects: 'PROJECTS',
-  tests: 'TESTS',
-  'test-sets': 'TEST_SETS',
-  'test-runs': 'TEST_RUNS',
-  endpoints: 'ENDPOINTS',
-  behaviors: 'BEHAVIORS',
-  metrics: 'METRICS',
-  experiments: 'EXPERIMENTS',
-};
-
 const COMMUNITY_LINK_CARDS: EmptyStateLinkCard[] = [
   {
     title: 'Documentation',
@@ -37,6 +26,76 @@ const COMMUNITY_LINK_CARDS: EmptyStateLinkCard[] = [
   },
 ];
 
+/**
+ * Static process.env access per entity so Next.js inlines NEXT_PUBLIC_* at build time.
+ * Dynamic/bracket access is not replaced in client bundles.
+ */
+function readEntityEnvSources(key: EntityEmptyStateKey): {
+  videoUrl?: string;
+  articleUrls?: string;
+} {
+  switch (key) {
+    case 'projects':
+      return {
+        videoUrl:
+          process.env.NEXT_PUBLIC_PROJECTS_EMPTY_STATE_VIDEO_URL?.trim(),
+        articleUrls:
+          process.env.NEXT_PUBLIC_PROJECTS_EMPTY_STATE_ARTICLE_URLS?.trim(),
+      };
+    case 'tests':
+      return {
+        videoUrl: process.env.NEXT_PUBLIC_TESTS_EMPTY_STATE_VIDEO_URL?.trim(),
+        articleUrls:
+          process.env.NEXT_PUBLIC_TESTS_EMPTY_STATE_ARTICLE_URLS?.trim(),
+      };
+    case 'test-sets':
+      return {
+        videoUrl:
+          process.env.NEXT_PUBLIC_TEST_SETS_EMPTY_STATE_VIDEO_URL?.trim(),
+        articleUrls:
+          process.env.NEXT_PUBLIC_TEST_SETS_EMPTY_STATE_ARTICLE_URLS?.trim(),
+      };
+    case 'test-runs':
+      return {
+        videoUrl:
+          process.env.NEXT_PUBLIC_TEST_RUNS_EMPTY_STATE_VIDEO_URL?.trim(),
+        articleUrls:
+          process.env.NEXT_PUBLIC_TEST_RUNS_EMPTY_STATE_ARTICLE_URLS?.trim(),
+      };
+    case 'endpoints':
+      return {
+        videoUrl:
+          process.env.NEXT_PUBLIC_ENDPOINTS_EMPTY_STATE_VIDEO_URL?.trim(),
+        articleUrls:
+          process.env.NEXT_PUBLIC_ENDPOINTS_EMPTY_STATE_ARTICLE_URLS?.trim(),
+      };
+    case 'behaviors':
+      return {
+        videoUrl:
+          process.env.NEXT_PUBLIC_BEHAVIORS_EMPTY_STATE_VIDEO_URL?.trim(),
+        articleUrls:
+          process.env.NEXT_PUBLIC_BEHAVIORS_EMPTY_STATE_ARTICLE_URLS?.trim(),
+      };
+    case 'metrics':
+      return {
+        videoUrl: process.env.NEXT_PUBLIC_METRICS_EMPTY_STATE_VIDEO_URL?.trim(),
+        articleUrls:
+          process.env.NEXT_PUBLIC_METRICS_EMPTY_STATE_ARTICLE_URLS?.trim(),
+      };
+    case 'experiments':
+      return {
+        videoUrl:
+          process.env.NEXT_PUBLIC_EXPERIMENTS_EMPTY_STATE_VIDEO_URL?.trim(),
+        articleUrls:
+          process.env.NEXT_PUBLIC_EXPERIMENTS_EMPTY_STATE_ARTICLE_URLS?.trim(),
+      };
+    default: {
+      const _exhaustive: never = key;
+      return _exhaustive;
+    }
+  }
+}
+
 function parseCommaSeparatedUrls(value: string | undefined): string[] {
   if (!value?.trim()) return [];
   return value
@@ -44,14 +103,6 @@ function parseCommaSeparatedUrls(value: string | undefined): string[] {
     .map(url => url.trim())
     .filter(Boolean)
     .slice(0, 4);
-}
-
-function readEnv(
-  key: EntityEmptyStateKey,
-  suffix: 'VIDEO_URL' | 'ARTICLE_URLS'
-) {
-  const prefix = ENV_PREFIX[key];
-  return process.env[`NEXT_PUBLIC_${prefix}_EMPTY_STATE_${suffix}`]?.trim();
 }
 
 function buildEnrichment({
@@ -111,8 +162,8 @@ export function hasEnrichmentContent(
 export function getEntityEmptyStateEnrichment(
   key: EntityEmptyStateKey
 ): EntityEmptyStateEnrichment | undefined {
-  const videoUrl = readEnv(key, 'VIDEO_URL');
-  const articleUrls = parseCommaSeparatedUrls(readEnv(key, 'ARTICLE_URLS'));
+  const { videoUrl, articleUrls: articleUrlsRaw } = readEntityEnvSources(key);
+  const articleUrls = parseCommaSeparatedUrls(articleUrlsRaw);
 
   if (!videoUrl && articleUrls.length === 0) {
     return undefined;

--- a/apps/frontend/src/constants/entity-empty-state-types.ts
+++ b/apps/frontend/src/constants/entity-empty-state-types.ts
@@ -1,0 +1,41 @@
+export interface EmptyStateAction {
+  label: string;
+  href?: string;
+  onAction?: () => void;
+  disabled?: boolean;
+}
+
+export interface EmptyStateArticle {
+  href: string;
+  title?: string;
+  description?: string;
+  imageUrl?: string;
+}
+
+export interface EmptyStateLinkCard {
+  title: string;
+  description: string;
+  linkLabel: string;
+  href?: string;
+}
+
+export interface EntityEmptyStateEnrichment {
+  secondaryAction?: EmptyStateAction;
+  media?: {
+    youtubeVideoId?: string;
+    youtubeUrl?: string;
+    alt?: string;
+  };
+  helpArticles?: { title: string; items: EmptyStateArticle[] };
+  communityLinks?: { title: string; items: EmptyStateLinkCard[] };
+}
+
+export type EntityEmptyStateKey =
+  | 'projects'
+  | 'tests'
+  | 'test-sets'
+  | 'test-runs'
+  | 'endpoints'
+  | 'behaviors'
+  | 'metrics'
+  | 'experiments';

--- a/apps/frontend/src/utils/__tests__/onboarding-video.test.ts
+++ b/apps/frontend/src/utils/__tests__/onboarding-video.test.ts
@@ -45,6 +45,21 @@ describe('onboarding-video utils', () => {
   it('builds YouTube thumbnail URLs', () => {
     expect(
       getYouTubeThumbnailUrl('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+    ).toBe('https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg');
+  });
+
+  it('builds hqdefault thumbnails when requested', () => {
+    expect(
+      getYouTubeThumbnailUrl(
+        'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        'hqdefault'
+      )
     ).toBe('https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg');
+  });
+
+  it('parses raw YouTube video IDs', () => {
+    expect(getYouTubeThumbnailUrl('dQw4w9WgXcQ')).toBe(
+      'https://img.youtube.com/vi/dQw4w9WgXcQ/maxresdefault.jpg'
+    );
   });
 });

--- a/apps/frontend/src/utils/onboarding-video.ts
+++ b/apps/frontend/src/utils/onboarding-video.ts
@@ -62,17 +62,37 @@ function isValidVideoId(videoId: string): boolean {
   return /^[\w-]{11}$/.test(videoId);
 }
 
-/**
- * YouTube thumbnail for a watch/short URL (maxresdefault with hqdefault fallback).
- */
-export function getYouTubeThumbnailUrl(raw: string): string | null {
-  const embedUrl = getOnboardingVideoEmbedUrl(raw);
+/** Extract a YouTube video ID from a raw ID or watch/short/embed URL. */
+export function parseYouTubeVideoId(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (isValidVideoId(trimmed)) return trimmed;
+
+  const embedUrl = getOnboardingVideoEmbedUrl(trimmed);
   if (!embedUrl) return null;
 
   const match = embedUrl.match(/\/embed\/([^?&/]+)/);
-  if (!match?.[1]) return null;
+  return match?.[1] ?? null;
+}
 
-  return `https://img.youtube.com/vi/${match[1]}/hqdefault.jpg`;
+/**
+ * YouTube thumbnail for a watch/short URL or raw video ID.
+ * Defaults to maxresdefault; use hqdefault as fallback in the UI on error.
+ */
+export function getYouTubeThumbnailUrl(
+  raw: string,
+  quality: 'maxresdefault' | 'hqdefault' = 'maxresdefault'
+): string | null {
+  const videoId = parseYouTubeVideoId(raw);
+  if (!videoId) return null;
+
+  return `https://img.youtube.com/vi/${videoId}/${quality}.jpg`;
+}
+
+export function getYouTubeWatchUrl(raw: string): string | null {
+  const videoId = parseYouTubeVideoId(raw);
+  if (!videoId) return null;
+  return `https://www.youtube.com/watch?v=${videoId}`;
 }
 
 export function getOnboardingVideoUrl(): string | undefined {


### PR DESCRIPTION
## Purpose
Enrich high-level entity list empty states on cloud deployments with demo video, help articles, and community links—while self-hosted installs continue to see the basic card.

## What Changed
- Extended `EntityEmptyState` with optional v2 layout (dual CTAs, YouTube thumbnail, help article grid, community cards)
- Added cloud-only env resolver (`getEntityEmptyStateEnrichment`) reading `NEXT_PUBLIC_{ENTITY}_EMPTY_STATE_*` vars
- Added `/api/og-metadata` route to resolve docs page title, description, and image from OG tags
- Wired enrichment on projects, tests, test sets, test runs, endpoints, behaviors, metrics, and experiments list pages
- Migrated experiments and metrics to shared `EntityEmptyState`
- Documented optional cloud env vars in `.env.example`

## Additional Context
- Self-hosted: leave env vars unset → basic empty state (no YouTube/docs enrichment)
- Cloud: set per-entity `VIDEO_URL` + `ARTICLE_URLS` (comma-separated, max 4 docs URLs)
- Figma v1 basic: node 1201:28292; v2 enriched: node 1858:51148

## Testing
- `cd apps/frontend && npm test -- --testPathPatterns="EntityEmptyState|entity-empty-state-env|onboarding-video"`
- `cd apps/frontend && npx tsc --noEmit`
- Manually: visit `/tests` with zero tests on cloud env with vars set vs unset