### PR TITLE
Add create_endpoint MCP tool for agent endpoint registration

### DIFF
--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -444,6 +444,68 @@ tools:
       tested (chat APIs, completion APIs, etc.). Use $select to request
       only the fields you need (e.g. $select=name,id,url,description).
 
+  - name: create_endpoint
+    label: Creating endpoint
+    method: POST
+    path: /endpoints/
+    requires_confirmation: true
+    description: >
+      Register a new REST API endpoint (an AI system to be tested — a chat
+      API, completion API, or chatbot). Resolve the target project FIRST with
+      list_projects and pass its id as project_id (REQUIRED — the endpoint
+      cannot be created without it). Do NOT send server-managed fields
+      (id, user_id, organization_id, status_id, created_at, updated_at).
+      After creating, you can verify reachability with check_endpoint.
+    parameters:
+      name:
+        description: "REQUIRED. Endpoint name, unique within the project (string)."
+      project_id:
+        description: >
+          REQUIRED. UUID of the project this endpoint belongs to. Resolve it
+          via list_projects (use the user's project, or ask if ambiguous).
+      connection_type:
+        description: 'Connection protocol. Use "REST" for HTTP APIs (default for chatbots).'
+      url:
+        description: "REQUIRED for REST. Full endpoint URL, e.g. https://api.example.com/chat."
+      method:
+        description: 'HTTP method for REST endpoints, e.g. "POST" or "GET".'
+      description:
+        description: "What the endpoint does (string)."
+      environment:
+        description: '"production", "staging", "development", or "local". Default: "development".'
+      request_headers:
+        description: >
+          Object of HTTP headers sent with each request, e.g.
+          {"Content-Type": "application/json"}.
+      request_mapping:
+        description: >
+          Object mapping the request body, using {{ input }} for the user
+          message. e.g. {"message": "{{ input }}"}.
+      response_mapping:
+        description: >
+          Object mapping the response, using JSONPath to extract the output
+          field. e.g. {"output": "$.response"}.
+      query_params:
+        description: "Optional object of query-string parameters."
+      response_format:
+        description: '"json", "xml", or "text". Default: "json".'
+      auth_type:
+        description: >
+          Authentication scheme: "bearer_token", "client_credentials", or
+          "api_key". Omit for unauthenticated endpoints.
+      auth_token:
+        description: "Bearer token / API key (write-only, stored encrypted)."
+      client_id:
+        description: "OAuth client id (client_credentials flow)."
+      client_secret:
+        description: "OAuth client secret (write-only, stored encrypted)."
+      token_url:
+        description: "OAuth token endpoint URL (client_credentials flow)."
+      scopes:
+        description: "List of OAuth scope strings (client_credentials flow)."
+      audience:
+        description: "OAuth audience (client_credentials flow)."
+
   - name: check_endpoint
     label: Checking endpoint connectivity
     method: POST

--- a/skills/rhesis/SKILL.md
+++ b/skills/rhesis/SKILL.md
@@ -38,7 +38,7 @@ When a user refers to any entity by name, look it up using the appropriate `list
 
 When a user mentions an endpoint or says "test my chatbot / test my AI":
 
-1. Resolve the endpoint by name using `list_endpoints` with `$select=name,id,url,description`.
+1. Resolve the endpoint by name using `list_endpoints` with `$select=name,id,url,description`. If the endpoint isn't registered yet, create it with `create_endpoint` — resolve the target project via `list_projects` first and pass its id as `project_id` (required). Then continue.
 2. Check connectivity via `check_endpoint` before doing anything else. If it fails, report the error before proceeding.
 3. Ask which exploration mode the user prefers before running:
    - **Quick** — domain probing only. Fast; good for familiar endpoints or when the user wants to start quickly.

--- a/skills/rhesis/references/tool-catalog.md
+++ b/skills/rhesis/references/tool-catalog.md
@@ -18,6 +18,34 @@ List configured endpoints (the AI systems under test).
 
 ---
 
+### `create_endpoint`
+Register a new REST API endpoint (the AI system to be tested — a chat API, completion API, or chatbot).
+
+Resolve the target project **first** with `list_projects` and pass its id — the endpoint cannot be created without a `project_id`. After creating, verify reachability with `check_endpoint`.
+
+**Key parameters:**
+- `name` (required) — endpoint name, unique within the project
+- `project_id` (required) — UUID of the owning project; resolve via `list_projects`
+- `connection_type` — `"REST"` for HTTP APIs (default for chatbots)
+- `url` (required for REST) — full endpoint URL, e.g. `https://api.example.com/chat`
+- `method` — HTTP method, e.g. `"POST"` or `"GET"`
+- `description` — what the endpoint does
+- `environment` — `"production"`, `"staging"`, `"development"`, or `"local"` (default `"development"`)
+- `request_headers` — object of HTTP headers, e.g. `{"Content-Type": "application/json"}`
+- `request_mapping` — object mapping the request body, using `{{ input }}` for the user message, e.g. `{"message": "{{ input }}"}`
+- `response_mapping` — object mapping the response via JSONPath, e.g. `{"output": "$.response"}`
+- `query_params` — optional object of query-string parameters
+- `response_format` — `"json"` (default), `"xml"`, or `"text"`
+
+**Auth (optional):**
+- `auth_type` — `"bearer_token"`, `"client_credentials"`, or `"api_key"`; omit for unauthenticated endpoints
+- `auth_token` — bearer token / API key (write-only, stored encrypted)
+- `client_id`, `client_secret`, `token_url`, `scopes`, `audience` — OAuth client-credentials fields (`client_secret` is write-only, stored encrypted)
+
+**Common mistakes:** Omitting `project_id` — the create fails because it is a required relationship. Always resolve the project with `list_projects` first. Do NOT send server-managed fields (`id`, `user_id`, `organization_id`, `status_id`, `created_at`, `updated_at`) — `status_id` is auto-assigned to "Active".
+
+---
+
 ### `check_endpoint`
 Send a test message to an endpoint to verify it is reachable and responding.
 


### PR DESCRIPTION
## Purpose
Agents testing chatbots or AI APIs need to register endpoints in Rhesis before running connectivity checks and test suites. The backend already supports `POST /endpoints/`, but the MCP tool catalog and Rhesis skill did not expose or document this flow.

## What Changed
- Added `create_endpoint` MCP tool mapping to `POST /endpoints/` with parameter guidance (required `project_id`, REST mapping fields, optional auth)
- Updated the Rhesis skill workflow to create endpoints via `create_endpoint` when they are not yet registered
- Documented `create_endpoint` in the skill tool catalog, including common mistakes (missing `project_id`, sending server-managed fields)

## Additional Context
- Requires confirmation before execution (`requires_confirmation: true`)
- Agents should resolve the target project with `list_projects` before creating an endpoint

## Testing
- Verify `create_endpoint` appears in the MCP tool list
- Register a REST endpoint via MCP and confirm it is created with the correct `project_id`
- Run `check_endpoint` on the newly created endpoint to verify connectivity