### PR TITLE
Fix MCP tool schema rejection from $-prefixed param names

### DIFF
--- a/apps/backend/src/rhesis/backend/app/mcp_server/local_tools.py
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/local_tools.py
@@ -114,11 +114,13 @@ class LocalToolProvider(MCPTool):
                     str(arguments.pop(param["name"])),
                 )
 
-        # Query params
+        # Query params (agent sees sanitized names, e.g. "filter" for the
+        # "$filter" alias — see build_input_schema)
         query: Dict[str, Any] = {}
         for param in op["parameters"]:
-            if param.get("in") == "query" and param["name"] in arguments:
-                query[param["name"]] = arguments.pop(param["name"])
+            client_name = param["name"].lstrip("$")
+            if param.get("in") == "query" and client_name in arguments:
+                query[param["name"]] = arguments.pop(client_name)
 
         # Apply default_query and page_size peek-ahead.
         query, current_skip, page_size = apply_query_overrides(query, op)

--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -665,7 +665,10 @@ tools:
       NEVER fetch source content — pass IDs directly to generate_test_set
       and the backend handles content injection.
     parameters:
-      $filter:
+      filter:
+        description: >
+          OData filter expression to search by title or description, e.g.
+          $filter=contains(tolower(title), 'keyword').
 
   # ── Background Jobs ─────────────────────────────────────
   - name: get_job_status

--- a/apps/backend/src/rhesis/backend/app/mcp_server/schema.py
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/schema.py
@@ -62,22 +62,27 @@ def build_input_schema(
             continue
 
         name = param["name"]
+        # OData params are declared with aliases like "$filter"/"$select".
+        # "$" is not allowed in tool-schema property names by the Anthropic
+        # API (^[a-zA-Z0-9_.-]{1,64}$), so expose a sanitized key. The
+        # dispatcher maps it back to the real param name when forwarding.
+        prop_name = name.lstrip("$")
         param_schema = resolve_schema_references(
             param.get("schema", {"type": "string"}), openapi_schema
         )
         prop: Dict[str, Any] = dict(param_schema)
 
-        # Use OpenAPI description, allow YAML override
+        # Use OpenAPI description, allow YAML override (keyed by sanitized name)
         description = param.get("description", "")
-        if name in yaml_param_overrides:
-            description = yaml_param_overrides[name].get("description", description)
+        if prop_name in yaml_param_overrides:
+            description = yaml_param_overrides[prop_name].get("description", description)
         if description:
             prop["description"] = description
 
-        properties[name] = prop
+        properties[prop_name] = prop
 
         if param.get("required", param_in == "path"):
-            required.append(name)
+            required.append(prop_name)
 
     # Request body fields (flattened into top-level properties)
     request_body = operation.get("requestBody", {})

--- a/apps/backend/src/rhesis/backend/app/mcp_server/server.py
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/server.py
@@ -127,11 +127,13 @@ def _create_mcp_server(fastapi_app: Any) -> MCPServer:
                     str(arguments.pop(param["name"])),
                 )
 
-        # 2. Query params: pop from arguments
+        # 2. Query params: pop from arguments (agent sees sanitized names,
+        #    e.g. "filter" for the "$filter" alias — see build_input_schema)
         query: Dict[str, Any] = {}
         for param in op["parameters"]:
-            if param.get("in") == "query" and param["name"] in arguments:
-                query[param["name"]] = arguments.pop(param["name"])
+            client_name = param["name"].lstrip("$")
+            if param.get("in") == "query" and client_name in arguments:
+                query[param["name"]] = arguments.pop(client_name)
 
         # Apply default_query and page_size peek-ahead. Both are declared in
         # mcp_tools.yaml and enforced here regardless of what the agent passed.

--- a/tests/backend/services/test_mcp_tools_yaml.py
+++ b/tests/backend/services/test_mcp_tools_yaml.py
@@ -43,3 +43,42 @@ class TestExploreEndpointInMcpTools:
         params = cfg.get("parameters", {})
         assert "strategy" in params, "strategy parameter missing from explore_endpoint"
         assert "goal" in params, "goal parameter missing from explore_endpoint"
+
+
+@pytest.mark.unit
+class TestInputSchemaPropertyNames:
+    """Generated tool-schema property names must satisfy the Anthropic API.
+
+    Property keys must match ``^[a-zA-Z0-9_.-]{1,64}$``; OData aliases like
+    ``$filter``/``$select`` would otherwise get the whole tool list rejected.
+    """
+
+    def test_dollar_prefixed_params_are_sanitized(self):
+        from rhesis.backend.app.mcp_server.schema import build_input_schema
+
+        operation = {
+            "parameters": [
+                {"name": "$filter", "in": "query", "schema": {"type": "string"}},
+                {"name": "$select", "in": "query", "schema": {"type": "string"}},
+                {"name": "source_id", "in": "path", "required": True},
+            ]
+        }
+        schema = build_input_schema(operation, {}, {})
+
+        props = schema["properties"]
+        assert "filter" in props and "$filter" not in props
+        assert "select" in props and "$select" not in props
+        assert "source_id" in props
+        assert schema["required"] == ["source_id"]
+
+    def test_yaml_override_keyed_by_sanitized_name_applies(self):
+        from rhesis.backend.app.mcp_server.schema import build_input_schema
+
+        operation = {
+            "parameters": [
+                {"name": "$filter", "in": "query", "schema": {"type": "string"}},
+            ]
+        }
+        schema = build_input_schema(operation, {}, {"filter": {"description": "search by title"}})
+
+        assert schema["properties"]["filter"]["description"] == "search by title"


### PR DESCRIPTION
## Purpose

Connecting the rhesis MCP server failed with the Anthropic API rejecting the tool definitions:

> `tools.N.custom.input_schema.properties` — property name does not match `^[a-zA-Z0-9_.-]{1,64}$`

The whole tool array is rejected on the first offending tool, so **no** rhesis tools load (chatbot creation, listing, etc. all blocked).

## Root Cause

Backend list endpoints declare OData params via FastAPI aliases (`Query(None, alias="$filter")`, `alias="$select"`) on 35 and 13 endpoints respectively. These aliases become the OpenAPI parameter `name`, and `build_input_schema` copied them verbatim into `inputSchema.properties` — producing illegal `$`-prefixed property keys on every `list_*` tool. `list_sources` also had an explicit `$filter:` key in the YAML.

## What Changed

- `schema.py` — `build_input_schema` sanitizes the agent-facing property key (`$filter` → `filter`, `$select` → `select`); path params and `required`/YAML-override lookups use the sanitized name.
- `server.py` & `local_tools.py` — query-param dispatch looks up the sanitized name in agent arguments but forwards under the real OpenAPI name (`$filter`), so FastAPI still receives the correct OData param.
- `mcp_tools.yaml` — `list_sources` override key `$filter:` → `filter:` (with description).
- `test_mcp_tools_yaml.py` — regression tests asserting `$`-aliases are sanitized and YAML overrides apply by sanitized key.

`default_query` values (e.g. `$select: "id,..."`) stay `$`-prefixed — those go straight onto the wire and are correct as-is.

## Testing

- New unit tests in `tests/backend/services/test_mcp_tools_yaml.py` cover sanitization, path-param passthrough, `required`, and YAML override-by-sanitized-name.
- Verified `build_input_schema` output contains no `$`-prefixed property names; ruff clean on all changed files.

Run: `cd apps/backend && uv run pytest ../../tests/backend/services/test_mcp_tools_yaml.py` (requires the backend test DB up).