### PR TITLE
Add AutoGen integration (auto-instrumentation + Penelope Target)

### DIFF
--- a/penelope/pyproject.toml
+++ b/penelope/pyproject.toml
@@ -66,6 +66,7 @@ all = [
     "langchain-core>=1.3.3",
     "langchain-google-genai>=2.0.0",
     "langgraph>=0.2.0",
+    "pyautogen>=0.2.0",
 ]
 
 [dependency-groups]

--- a/penelope/pyproject.toml
+++ b/penelope/pyproject.toml
@@ -58,6 +58,9 @@ langgraph = [
     "langchain-core>=1.3.3",
     "langchain-google-genai>=2.0.0",
 ]
+autogen = [
+    "pyautogen>=0.2.0",
+]
 all = [
     "langchain>=1.0.0",
     "langchain-core>=1.3.3",

--- a/penelope/src/rhesis/penelope/targets/__init__.py
+++ b/penelope/src/rhesis/penelope/targets/__init__.py
@@ -12,6 +12,7 @@ Future targets may include:
 - Custom targets: User-defined
 """
 
+from rhesis.penelope.targets.autogen import AutoGenTarget
 from rhesis.penelope.targets.endpoint import EndpointTarget
 from rhesis.penelope.targets.langchain import LangChainTarget
 from rhesis.penelope.targets.langgraph import LangGraphTarget
@@ -21,6 +22,7 @@ __all__ = [
     "Target",
     "TargetResponse",
     "EndpointTarget",
+    "AutoGenTarget",
     "LangChainTarget",
     "LangGraphTarget",
 ]

--- a/penelope/src/rhesis/penelope/targets/autogen.py
+++ b/penelope/src/rhesis/penelope/targets/autogen.py
@@ -84,6 +84,15 @@ class AutoGenTarget(Target):
             return TargetResponse(success=False, content="", error="Empty message")
 
         session_key = conversation_id or "default"
+
+        if files:
+            return TargetResponse(
+                success=False,
+                content="",
+                error="AutoGenTarget does not support file attachments",
+                conversation_id=session_key,
+            )
+
         history = self._session_histories.setdefault(session_key, [])
         history.append({"role": "user", "content": message})
 
@@ -104,10 +113,13 @@ class AutoGenTarget(Target):
                 },
             )
         except Exception as exc:
+            if history and history[-1].get("role") == "user":
+                history.pop()
             return TargetResponse(
                 success=False,
                 content="",
                 error=f"AutoGen error: {exc}",
+                conversation_id=session_key,
             )
 
     def get_tool_documentation(self) -> str:

--- a/penelope/src/rhesis/penelope/targets/autogen.py
+++ b/penelope/src/rhesis/penelope/targets/autogen.py
@@ -1,0 +1,126 @@
+"""
+AutoGen target implementation for Penelope.
+
+Wraps an AutoGen ConversableAgent or AssistantAgent so Penelope can run
+multi-turn conversation tests against AutoGen-based agents.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from rhesis.sdk.targets import Target, TargetResponse
+
+
+class AutoGenTarget(Target):
+    """
+    Target for AutoGen ConversableAgent / AssistantAgent instances.
+
+    Maintains per-conversation message history and calls generate_reply()
+    for each Penelope turn.
+
+    Usage:
+        >>> from autogen import AssistantAgent
+        >>> agent = AssistantAgent(name="assistant", llm_config={"config_list": [...]})
+        >>> target = AutoGenTarget(agent, "support-bot", "Customer support agent")
+        >>> response = target.send_message("Hello!")
+    """
+
+    def __init__(
+        self,
+        agent: Any,
+        target_id: str,
+        description: Optional[str] = None,
+    ):
+        self.agent = agent
+        self._target_id = target_id
+        self._description = description or (
+            f"AutoGen {type(agent).__name__}: {getattr(agent, 'name', target_id)}"
+        )
+        self._session_histories: Dict[str, List[dict[str, str]]] = {}
+
+        is_valid, error = self.validate_configuration()
+        if not is_valid:
+            raise ValueError(f"Invalid AutoGen target: {error}")
+
+    @property
+    def target_type(self) -> str:
+        return "autogen"
+
+    @property
+    def target_id(self) -> str:
+        return self._target_id
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    def validate_configuration(self) -> tuple[bool, Optional[str]]:
+        if self.agent is None:
+            return False, "Agent cannot be None"
+        if not self._target_id:
+            return False, "target_id cannot be empty"
+        if not hasattr(self.agent, "generate_reply"):
+            return False, "Agent must have generate_reply() method"
+        return True, None
+
+    def _extract_content(self, reply: Any) -> str:
+        if isinstance(reply, str):
+            return reply
+        if isinstance(reply, dict):
+            content = reply.get("content")
+            if isinstance(content, str):
+                return content
+        if hasattr(reply, "content"):
+            return str(reply.content)
+        return str(reply)
+
+    def send_message(
+        self,
+        message: str,
+        conversation_id: Optional[str] = None,
+        files: Optional[List] = None,
+        **kwargs: Any,
+    ) -> TargetResponse:
+        if not message.strip():
+            return TargetResponse(success=False, content="", error="Empty message")
+
+        session_key = conversation_id or "default"
+        history = self._session_histories.setdefault(session_key, [])
+        history.append({"role": "user", "content": message})
+
+        try:
+            reply = self.agent.generate_reply(messages=list(history), **kwargs)
+            content = self._extract_content(reply)
+            history.append({"role": "assistant", "content": content})
+
+            return TargetResponse(
+                success=True,
+                content=content,
+                conversation_id=session_key,
+                metadata={
+                    "input_sent": message,
+                    "raw_response": reply if isinstance(reply, (str, dict)) else str(reply),
+                    "agent_name": getattr(self.agent, "name", type(self.agent).__name__),
+                    "session_messages_count": len(history),
+                },
+            )
+        except Exception as exc:
+            return TargetResponse(
+                success=False,
+                content="",
+                error=f"AutoGen error: {exc}",
+            )
+
+    def get_tool_documentation(self) -> str:
+        agent_name = getattr(self.agent, "name", type(self.agent).__name__)
+        return f"""
+Target: {self._description}
+Type: AutoGen {type(self.agent).__name__} ({agent_name})
+Memory: Yes (conversation history per conversation_id)
+
+Send messages using send_message_to_target(message, conversation_id).
+Maintain conversation_id for multi-turn continuity across agent turns.
+"""
+
+    def clear_session(self, session_id: str) -> None:
+        """Clear conversation history for a specific session."""
+        self._session_histories.pop(session_id, None)

--- a/sdk/src/rhesis/sdk/telemetry/integrations/autogen.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/autogen.py
@@ -1,26 +1,132 @@
 """Microsoft AutoGen framework integration."""
 
 import logging
+from typing import Any, Callable, Optional
 
 from rhesis.sdk.telemetry.integrations.base import BaseIntegration
+from rhesis.sdk.telemetry.integrations.tracing_helpers import (
+    add_agent_io_events,
+    observe_framework_call,
+    set_agent_attributes,
+    set_token_attributes,
+)
 
 logger = logging.getLogger(__name__)
 
+_original_generate_reply: Optional[Callable] = None
+_original_a_generate_reply: Optional[Callable] = None
+_patching_done = False
+
+
+class AutoGenPatchState:
+    """Accessor for AutoGen patching state (used in tests)."""
+
+    @staticmethod
+    def is_done() -> bool:
+        return _patching_done
+
+    @staticmethod
+    def reset() -> None:
+        global _original_generate_reply, _original_a_generate_reply, _patching_done
+        if _patching_done and _original_generate_reply is not None:
+            try:
+                from autogen import ConversableAgent
+
+                ConversableAgent.generate_reply = _original_generate_reply
+                if _original_a_generate_reply is not None:
+                    ConversableAgent.a_generate_reply = _original_a_generate_reply
+            except ImportError:
+                pass
+        _original_generate_reply = None
+        _original_a_generate_reply = None
+        _patching_done = False
+
+
+def _extract_model_from_agent(agent: Any) -> Optional[str]:
+    llm_config = getattr(agent, "llm_config", None) or {}
+    if not isinstance(llm_config, dict):
+        return None
+    config_list = llm_config.get("config_list") or []
+    if config_list and isinstance(config_list[0], dict):
+        model = config_list[0].get("model")
+        if isinstance(model, str):
+            return model
+    return None
+
+
+def _extract_usage_from_reply(reply: Any) -> Any:
+    if isinstance(reply, dict):
+        return reply.get("usage") or reply.get("token_usage")
+    return getattr(reply, "usage", None)
+
+
+def _wrap_generate_reply(original: Callable) -> Callable:
+    def wrapped(self, *args, **kwargs):
+        agent_name = getattr(self, "name", type(self).__name__)
+        model = _extract_model_from_agent(self)
+        messages = kwargs.get("messages")
+        if messages is None and args:
+            messages = args[0]
+
+        with observe_framework_call(
+            f"autogen.generate_reply {agent_name}",
+            framework="autogen",
+        ) as span:
+            set_agent_attributes(span, agent_name=agent_name, model=model)
+            result = original(self, *args, **kwargs)
+            add_agent_io_events(span, messages, result)
+            set_token_attributes(span, _extract_usage_from_reply(result))
+            return result
+
+    return wrapped
+
+
+def _wrap_a_generate_reply(original: Callable) -> Callable:
+    async def wrapped(self, *args, **kwargs):
+        agent_name = getattr(self, "name", type(self).__name__)
+        model = _extract_model_from_agent(self)
+        messages = kwargs.get("messages")
+        if messages is None and args:
+            messages = args[0]
+
+        with observe_framework_call(
+            f"autogen.a_generate_reply {agent_name}",
+            framework="autogen",
+        ) as span:
+            set_agent_attributes(span, agent_name=agent_name, model=model)
+            result = await original(self, *args, **kwargs)
+            add_agent_io_events(span, messages, result)
+            set_token_attributes(span, _extract_usage_from_reply(result))
+            return result
+
+    return wrapped
+
+
+def _patch_autogen() -> None:
+    global _original_generate_reply, _original_a_generate_reply, _patching_done
+    if _patching_done:
+        return
+
+    from autogen import ConversableAgent
+
+    _original_generate_reply = ConversableAgent.generate_reply
+    ConversableAgent.generate_reply = _wrap_generate_reply(_original_generate_reply)
+
+    if hasattr(ConversableAgent, "a_generate_reply"):
+        _original_a_generate_reply = ConversableAgent.a_generate_reply
+        ConversableAgent.a_generate_reply = _wrap_a_generate_reply(_original_a_generate_reply)
+
+    _patching_done = True
+
 
 class AutoGenIntegration(BaseIntegration):
-    """
-    Microsoft AutoGen framework integration.
-
-    TODO: Research AutoGen's instrumentation patterns.
-    May require different approach than callbacks.
-    """
+    """Microsoft AutoGen framework integration."""
 
     @property
     def framework_name(self) -> str:
         return "autogen"
 
     def is_installed(self) -> bool:
-        """Check if AutoGen is installed."""
         try:
             import autogen  # noqa: F401
 
@@ -29,16 +135,34 @@ class AutoGenIntegration(BaseIntegration):
             return False
 
     def _create_callback(self):
-        """
-        Create AutoGen instrumentation.
+        """Patch AutoGen agent entry points for automatic tracing."""
+        _patch_autogen()
+        return "autogen_patched"
 
-        Not yet implemented - placeholder for future work.
-        """
-        logger.warning("AutoGen integration not yet implemented")
-        return None
+    def enable(self) -> bool:
+        if self._enabled:
+            logger.debug("autogen observation already enabled")
+            return True
+
+        if not self.is_installed():
+            logger.debug("autogen not installed")
+            return False
+
+        try:
+            self._callback = self._create_callback()
+            self._enabled = True
+            logger.info("✓ Observing autogen")
+            return True
+        except Exception as exc:
+            logger.warning(f"Failed to enable autogen: {exc}")
+            return False
+
+    def disable(self) -> None:
+        if self._enabled:
+            AutoGenPatchState.reset()
+        super().disable()
 
 
-# Singleton instance
 _autogen_integration = AutoGenIntegration()
 
 

--- a/sdk/src/rhesis/sdk/telemetry/integrations/tracing_helpers.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/tracing_helpers.py
@@ -48,12 +48,9 @@ def set_token_attributes(span: trace.Span, usage: Any) -> None:
         return
     try:
         prompt, completion, total = extract_token_usage(usage)
-        if prompt:
-            span.set_attribute(AIAttributes.LLM_TOKENS_INPUT, prompt)
-        if completion:
-            span.set_attribute(AIAttributes.LLM_TOKENS_OUTPUT, completion)
-        if total:
-            span.set_attribute(AIAttributes.LLM_TOKENS_TOTAL, total)
+        span.set_attribute(AIAttributes.LLM_TOKENS_INPUT, prompt)
+        span.set_attribute(AIAttributes.LLM_TOKENS_OUTPUT, completion)
+        span.set_attribute(AIAttributes.LLM_TOKENS_TOTAL, total)
     except Exception:
         return
 

--- a/sdk/src/rhesis/sdk/telemetry/integrations/tracing_helpers.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/tracing_helpers.py
@@ -1,0 +1,105 @@
+"""Shared helpers for framework telemetry integrations."""
+
+import time
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind, Status, StatusCode
+
+from rhesis.sdk.telemetry.attributes import AIAttributes, AIEvents
+from rhesis.sdk.telemetry.context import is_tracing_disabled
+from rhesis.sdk.telemetry.utils.token_extraction import extract_token_usage
+
+MAX_CONTENT_LENGTH = 4000
+
+
+def truncate_content(value: Any) -> str:
+    """Truncate serialized content for span events."""
+    return str(value)[:MAX_CONTENT_LENGTH]
+
+
+def infer_model_provider(model_name: str) -> Optional[str]:
+    """Infer provider name from a model identifier."""
+    lowered = model_name.lower()
+    if "gpt" in lowered or lowered.startswith("o1") or lowered.startswith("o3"):
+        return "openai"
+    if "claude" in lowered:
+        return "anthropic"
+    if "gemini" in lowered:
+        return "google"
+    return None
+
+
+def set_agent_attributes(span: trace.Span, *, agent_name: str, model: Optional[str] = None) -> None:
+    """Set common agent invocation attributes on a span."""
+    span.set_attribute(AIAttributes.OPERATION_TYPE, AIAttributes.OPERATION_AGENT_INVOKE)
+    span.set_attribute(AIAttributes.AGENT_NAME, agent_name)
+    if model:
+        span.set_attribute(AIAttributes.MODEL_NAME, model)
+        provider = infer_model_provider(model)
+        if provider:
+            span.set_attribute(AIAttributes.MODEL_PROVIDER, provider)
+
+
+def set_token_attributes(span: trace.Span, usage: Any) -> None:
+    """Extract token usage from a provider response and set span attributes."""
+    if usage is None:
+        return
+    try:
+        prompt, completion, total = extract_token_usage(usage)
+        if prompt:
+            span.set_attribute(AIAttributes.LLM_TOKENS_INPUT, prompt)
+        if completion:
+            span.set_attribute(AIAttributes.LLM_TOKENS_OUTPUT, completion)
+        if total:
+            span.set_attribute(AIAttributes.LLM_TOKENS_TOTAL, total)
+    except Exception:
+        return
+
+
+@contextmanager
+def observe_framework_call(
+    span_name: str,
+    *,
+    framework: str,
+    operation_type: str = AIAttributes.OPERATION_AGENT_INVOKE,
+    attributes: Optional[dict[str, Any]] = None,
+) -> Iterator[trace.Span]:
+    """Create a span for a framework operation with latency and error handling."""
+    if is_tracing_disabled():
+        yield trace.get_current_span()
+        return
+
+    tracer = trace.get_tracer(f"rhesis.sdk.integrations.{framework}")
+    start = time.perf_counter()
+    with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+        span.set_attribute(AIAttributes.OPERATION_TYPE, operation_type)
+        span.set_attribute(AIAttributes.SYSTEM, framework)
+        if attributes:
+            for key, value in attributes.items():
+                if value is not None:
+                    span.set_attribute(key, value)
+        try:
+            yield span
+        except Exception as exc:
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            raise
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000
+            span.set_attribute("ai.operation.duration_ms", duration_ms)
+
+
+def add_agent_io_events(span: trace.Span, input_data: Any, output_data: Any) -> None:
+    """Record agent input/output as span events."""
+    if input_data is not None:
+        span.add_event(
+            AIEvents.AGENT_INPUT,
+            {AIAttributes.AGENT_INPUT_CONTENT: truncate_content(input_data)},
+        )
+    if output_data is not None:
+        span.add_event(
+            AIEvents.AGENT_OUTPUT,
+            {AIAttributes.AGENT_OUTPUT_CONTENT: truncate_content(output_data)},
+        )

--- a/tests/penelope/targets/test_autogen.py
+++ b/tests/penelope/targets/test_autogen.py
@@ -66,10 +66,22 @@ def test_send_message_multi_turn(mock_agent):
 def test_send_message_handles_exception(mock_agent):
     mock_agent.generate_reply.side_effect = RuntimeError("boom")
     target = AutoGenTarget(mock_agent, "bot-1")
-    response = target.send_message("Hello")
+    response = target.send_message("Hello", conversation_id="session-err")
 
     assert response.success is False
     assert "AutoGen error" in (response.error or "")
+    assert response.conversation_id == "session-err"
+    assert target._session_histories.get("session-err", []) == []
+
+
+def test_send_message_rejects_files(mock_agent):
+    target = AutoGenTarget(mock_agent, "bot-1")
+    response = target.send_message("Hello", files=[{"name": "doc.pdf"}])
+
+    assert response.success is False
+    assert "file attachments" in (response.error or "").lower()
+    assert response.conversation_id == "default"
+    mock_agent.generate_reply.assert_not_called()
 
 
 def test_clear_session(mock_agent):

--- a/tests/penelope/targets/test_autogen.py
+++ b/tests/penelope/targets/test_autogen.py
@@ -1,0 +1,86 @@
+"""Tests for AutoGenTarget."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rhesis.penelope.targets.autogen import AutoGenTarget
+
+
+@pytest.fixture
+def mock_agent():
+    agent = MagicMock()
+    agent.name = "assistant"
+    agent.generate_reply.side_effect = lambda messages, **kwargs: f"Reply to: {messages[-1]['content']}"
+    return agent
+
+
+def test_autogen_target_initialization(mock_agent):
+    target = AutoGenTarget(mock_agent, "bot-1", "Test bot")
+    assert target.target_type == "autogen"
+    assert target.target_id == "bot-1"
+    assert target.agent == mock_agent
+
+
+def test_autogen_target_rejects_missing_generate_reply():
+    agent = MagicMock(spec=[])
+    with pytest.raises(ValueError, match="generate_reply"):
+        AutoGenTarget(agent, "bot-1")
+
+
+def test_send_message_success(mock_agent):
+    target = AutoGenTarget(mock_agent, "bot-1")
+    response = target.send_message("Hello")
+
+    assert response.success is True
+    assert "Hello" in response.content
+    assert response.conversation_id == "default"
+    mock_agent.generate_reply.assert_called_once()
+
+
+def test_send_message_empty():
+    agent = MagicMock()
+    agent.generate_reply = MagicMock()
+    target = AutoGenTarget(agent, "bot-1")
+    response = target.send_message("   ")
+
+    assert response.success is False
+    assert response.error == "Empty message"
+    agent.generate_reply.assert_not_called()
+
+
+def test_send_message_multi_turn(mock_agent):
+    target = AutoGenTarget(mock_agent, "bot-1")
+    first = target.send_message("Hello", conversation_id="session-1")
+    second = target.send_message("Follow up", conversation_id="session-1")
+
+    assert first.success is True
+    assert second.success is True
+    assert second.conversation_id == "session-1"
+    assert mock_agent.generate_reply.call_count == 2
+
+    second_call_messages = mock_agent.generate_reply.call_args_list[1].kwargs["messages"]
+    assert len(second_call_messages) >= 3
+
+
+def test_send_message_handles_exception(mock_agent):
+    mock_agent.generate_reply.side_effect = RuntimeError("boom")
+    target = AutoGenTarget(mock_agent, "bot-1")
+    response = target.send_message("Hello")
+
+    assert response.success is False
+    assert "AutoGen error" in (response.error or "")
+
+
+def test_clear_session(mock_agent):
+    target = AutoGenTarget(mock_agent, "bot-1")
+    target.send_message("Hello", conversation_id="session-1")
+    target.clear_session("session-1")
+    target.send_message("Again", conversation_id="session-1")
+
+    first_messages = mock_agent.generate_reply.call_args_list[0].kwargs["messages"]
+    second_messages = mock_agent.generate_reply.call_args_list[1].kwargs["messages"]
+    assert len(first_messages) == 1
+    assert len(second_messages) == 1
+    assert first_messages[0]["content"] == "Hello"
+    assert second_messages[0]["content"] == "Again"

--- a/tests/sdk/telemetry/integrations/test_autogen_integration.py
+++ b/tests/sdk/telemetry/integrations/test_autogen_integration.py
@@ -1,0 +1,87 @@
+"""Tests for AutoGen auto-instrumentation integration."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rhesis.sdk.telemetry.integrations.autogen import (
+    AutoGenIntegration,
+    AutoGenPatchState,
+    _extract_model_from_agent,
+    _wrap_generate_reply,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_patch_state():
+    """Reset AutoGen patching state before each test."""
+    AutoGenPatchState.reset()
+    yield
+    AutoGenPatchState.reset()
+
+
+@pytest.fixture
+def integration():
+    return AutoGenIntegration()
+
+
+def test_extract_model_from_agent():
+    agent = MagicMock()
+    agent.llm_config = {"config_list": [{"model": "gpt-4o-mini"}]}
+    assert _extract_model_from_agent(agent) == "gpt-4o-mini"
+
+
+def test_wrap_generate_reply_traces_call():
+    original = MagicMock(return_value="assistant reply")
+    agent = MagicMock()
+    agent.name = "assistant"
+    agent.llm_config = {"config_list": [{"model": "gpt-4o"}]}
+
+    wrapped = _wrap_generate_reply(original)
+    result = wrapped(agent, messages=[{"role": "user", "content": "hi"}])
+
+    assert result == "assistant reply"
+    original.assert_called_once()
+
+
+def test_enable_patches_conversable_agent(monkeypatch):
+    class FakeConversableAgent:
+        def generate_reply(self, *args, **kwargs):
+            return "ok"
+
+    fake_autogen = MagicMock()
+    fake_autogen.ConversableAgent = FakeConversableAgent
+    monkeypatch.setitem(__import__("sys").modules, "autogen", fake_autogen)
+
+    integration = AutoGenIntegration()
+    assert integration.enable() is True
+    assert integration.enabled is True
+    assert AutoGenPatchState.is_done() is True
+
+
+def test_disable_restores_original(monkeypatch):
+    class FakeConversableAgent:
+        original_called = False
+
+        def generate_reply(self, *args, **kwargs):
+            self.original_called = True
+            return "original"
+
+    fake_autogen = MagicMock()
+    fake_autogen.ConversableAgent = FakeConversableAgent
+    monkeypatch.setitem(__import__("sys").modules, "autogen", fake_autogen)
+
+    integration = AutoGenIntegration()
+    integration.enable()
+    integration.disable()
+
+    assert integration.enabled is False
+    assert AutoGenPatchState.is_done() is False
+
+
+def test_enable_when_not_installed():
+    class NotInstalledIntegration(AutoGenIntegration):
+        def is_installed(self) -> bool:
+            return False
+
+    assert NotInstalledIntegration().enable() is False

--- a/tests/sdk/telemetry/integrations/test_autogen_integration.py
+++ b/tests/sdk/telemetry/integrations/test_autogen_integration.py
@@ -85,3 +85,24 @@ def test_enable_when_not_installed():
             return False
 
     assert NotInstalledIntegration().enable() is False
+
+
+def test_set_token_attributes_records_zero_counts():
+    from opentelemetry.sdk.trace import TracerProvider
+
+    from rhesis.sdk.telemetry.attributes import AIAttributes
+    from rhesis.sdk.telemetry.integrations.tracing_helpers import set_token_attributes
+
+    provider = TracerProvider()
+    tracer = provider.get_tracer("test")
+    span = tracer.start_span("test")
+    set_token_attributes(
+        span,
+        {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+    )
+    attrs = dict(span.attributes or {})
+    span.end()
+
+    assert attrs[AIAttributes.LLM_TOKENS_INPUT] == 0
+    assert attrs[AIAttributes.LLM_TOKENS_OUTPUT] == 0
+    assert attrs[AIAttributes.LLM_TOKENS_TOTAL] == 0


### PR DESCRIPTION
## Purpose
Complete AutoGen SDK auto-instrumentation and add a Penelope target so users can observe and test AutoGen agents automatically.

Closes #1866

## What Changed
- Implemented `AutoGenIntegration` with `generate_reply` / `a_generate_reply` patching and OTel spans (model, tokens, latency, I/O)
- Added shared `tracing_helpers.py` for framework integration span utilities
- Added `AutoGenTarget` wrapping `ConversableAgent` with per-`conversation_id` history
- Exported `AutoGenTarget` from Penelope targets and added `autogen` optional dependency
- Added SDK and Penelope unit tests

## Testing
- `cd sdk && uv run pytest ../tests/sdk/telemetry/integrations/test_autogen_integration.py ../tests/sdk/telemetry/integrations/test_langgraph_integration.py -q`
- `cd penelope && uv run pytest ../tests/penelope/targets/test_autogen.py -q`