### PR TITLE
Add Google ADK integration (auto-instrumentation + Penelope Target)

### DIFF
--- a/penelope/pyproject.toml
+++ b/penelope/pyproject.toml
@@ -58,11 +58,15 @@ langgraph = [
     "langchain-core>=1.3.3",
     "langchain-google-genai>=2.0.0",
 ]
+google-adk = [
+    "google-adk>=0.1.0",
+]
 all = [
     "langchain>=1.0.0",
     "langchain-core>=1.3.3",
     "langchain-google-genai>=2.0.0",
     "langgraph>=0.2.0",
+    "google-adk>=0.1.0",
 ]
 
 [dependency-groups]

--- a/penelope/src/rhesis/penelope/targets/__init__.py
+++ b/penelope/src/rhesis/penelope/targets/__init__.py
@@ -13,6 +13,7 @@ Future targets may include:
 """
 
 from rhesis.penelope.targets.endpoint import EndpointTarget
+from rhesis.penelope.targets.google_adk import GoogleADKTarget
 from rhesis.penelope.targets.langchain import LangChainTarget
 from rhesis.penelope.targets.langgraph import LangGraphTarget
 from rhesis.sdk.targets import Target, TargetResponse
@@ -21,6 +22,7 @@ __all__ = [
     "Target",
     "TargetResponse",
     "EndpointTarget",
+    "GoogleADKTarget",
     "LangChainTarget",
     "LangGraphTarget",
 ]

--- a/penelope/src/rhesis/penelope/targets/google_adk.py
+++ b/penelope/src/rhesis/penelope/targets/google_adk.py
@@ -5,10 +5,10 @@ Wraps a Google ADK Runner (or Agent) so Penelope can run multi-turn conversation
 tests against ADK-based agents.
 """
 
-import asyncio
 import inspect
 from typing import Any, List, Optional
 
+from rhesis.sdk.async_utils import run_sync
 from rhesis.sdk.targets import Target, TargetResponse
 
 
@@ -152,7 +152,7 @@ class GoogleADKTarget(Target):
         session_id = conversation_id or "default"
         try:
             if inspect.iscoroutinefunction(self.runner.run):
-                return asyncio.run(self._async_send_message(message, session_id, **kwargs))
+                return run_sync(self._async_send_message(message, session_id, **kwargs))
             result = self.runner.run(
                 user_id=self.user_id,
                 session_id=session_id,

--- a/penelope/src/rhesis/penelope/targets/google_adk.py
+++ b/penelope/src/rhesis/penelope/targets/google_adk.py
@@ -1,0 +1,183 @@
+"""
+Google ADK target implementation for Penelope.
+
+Wraps a Google ADK Runner (or Agent) so Penelope can run multi-turn conversation
+tests against ADK-based agents.
+"""
+
+import asyncio
+import inspect
+from typing import Any, List, Optional
+
+from rhesis.sdk.targets import Target, TargetResponse
+
+
+class GoogleADKTarget(Target):
+    """
+    Target for Google ADK Runner or Agent instances.
+
+    Usage:
+        >>> from google.adk.runners import Runner
+        >>> runner = Runner(agent=my_agent, app_name="my-app", session_service=service)
+        >>> target = GoogleADKTarget(runner, "adk-bot", user_id="penelope")
+        >>> response = target.send_message("Hello!")
+    """
+
+    def __init__(
+        self,
+        runner: Any = None,
+        target_id: str = "",
+        description: Optional[str] = None,
+        agent: Any = None,
+        app_name: str = "penelope",
+        user_id: str = "penelope-user",
+        session_service: Any = None,
+    ):
+        self.runner = runner
+        self.agent = agent
+        self.app_name = app_name
+        self.user_id = user_id
+        self.session_service = session_service
+        self._target_id = target_id
+        self._description = description or self._default_description()
+
+        if self.runner is None and self.agent is not None:
+            self.runner = self._build_runner_from_agent()
+
+        is_valid, error = self.validate_configuration()
+        if not is_valid:
+            raise ValueError(f"Invalid Google ADK target: {error}")
+
+    def _default_description(self) -> str:
+        if self.runner is not None:
+            return f"Google ADK Runner: {self._target_id or self.app_name}"
+        return f"Google ADK Agent: {self._target_id or getattr(self.agent, 'name', 'agent')}"
+
+    def _build_runner_from_agent(self) -> Any:
+        from google.adk.runners import Runner
+
+        if self.session_service is None:
+            from google.adk.sessions.in_memory_session_service import InMemorySessionService
+
+            self.session_service = InMemorySessionService()
+
+        return Runner(
+            agent=self.agent,
+            app_name=self.app_name,
+            session_service=self.session_service,
+        )
+
+    @property
+    def target_type(self) -> str:
+        return "google_adk"
+
+    @property
+    def target_id(self) -> str:
+        return self._target_id
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    def validate_configuration(self) -> tuple[bool, Optional[str]]:
+        if self.runner is None:
+            return False, "Runner or agent must be provided"
+        if not self._target_id:
+            return False, "target_id cannot be empty"
+        if not hasattr(self.runner, "run"):
+            return False, "Runner must have run() method"
+        return True, None
+
+    def _build_user_content(self, message: str) -> Any:
+        try:
+            from google.genai import types
+
+            return types.Content(role="user", parts=[types.Part(text=message)])
+        except ImportError:
+            return {"role": "user", "parts": [{"text": message}]}
+
+    def _extract_content(self, result: Any) -> str:
+        if isinstance(result, str):
+            return result
+        content = getattr(result, "content", None)
+        if content is not None:
+            if hasattr(content, "parts") and content.parts:
+                part = content.parts[0]
+                text = getattr(part, "text", None)
+                if text:
+                    return str(text)
+            return str(content)
+        if isinstance(result, dict):
+            parts = result.get("parts") or []
+            if parts and isinstance(parts[0], dict) and "text" in parts[0]:
+                return str(parts[0]["text"])
+        return str(result)
+
+    async def _async_send_message(
+        self,
+        message: str,
+        session_id: str,
+        **kwargs: Any,
+    ) -> TargetResponse:
+        user_content = self._build_user_content(message)
+        run_kwargs = {
+            "user_id": self.user_id,
+            "session_id": session_id,
+            "new_message": user_content,
+            **kwargs,
+        }
+        result = await self.runner.run(**run_kwargs)
+        content = self._extract_content(result)
+        return TargetResponse(
+            success=True,
+            content=content,
+            conversation_id=session_id,
+            metadata={
+                "input_sent": message,
+                "raw_response": result if isinstance(result, (str, dict)) else str(result),
+                "app_name": self.app_name,
+            },
+        )
+
+    def send_message(
+        self,
+        message: str,
+        conversation_id: Optional[str] = None,
+        files: Optional[List] = None,
+        **kwargs: Any,
+    ) -> TargetResponse:
+        if not message.strip():
+            return TargetResponse(success=False, content="", error="Empty message")
+
+        session_id = conversation_id or "default"
+        try:
+            if inspect.iscoroutinefunction(self.runner.run):
+                return asyncio.run(self._async_send_message(message, session_id, **kwargs))
+            result = self.runner.run(
+                user_id=self.user_id,
+                session_id=session_id,
+                new_message=self._build_user_content(message),
+                **kwargs,
+            )
+            return TargetResponse(
+                success=True,
+                content=self._extract_content(result),
+                conversation_id=session_id,
+                metadata={"input_sent": message, "raw_response": str(result)},
+            )
+        except Exception as exc:
+            return TargetResponse(
+                success=False,
+                content="",
+                error=f"Google ADK error: {exc}",
+            )
+
+    def get_tool_documentation(self) -> str:
+        return f"""
+Target: {self._description}
+Type: Google ADK Runner
+Memory: Yes (ADK session_id / conversation_id)
+
+Send messages using send_message_to_target(message, conversation_id).
+Maintain conversation_id to preserve ADK session context across turns.
+"""

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -104,12 +104,17 @@ autogen = [
     "pyautogen>=0.2.0",
 ]
 
+google-adk = [
+    "google-adk>=0.1.0",
+]
+
 all-integrations = [
     "langchain>=0.1.0",
     "langchain-core>=1.3.3",
     "langgraph>=0.0.26",
     "langgraph-checkpoint>=3.0.0",
     "pyautogen>=0.2.0",
+    "google-adk>=0.1.0",
 ]
 
 all = [
@@ -122,6 +127,7 @@ all = [
     "langgraph>=0.0.26",
     "langgraph-checkpoint>=3.0.0",
     "pyautogen>=0.2.0",
+    "google-adk>=0.1.0",
 ]
 [dependency-groups]
 dev = [

--- a/sdk/src/rhesis/sdk/telemetry/integrations/__init__.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/__init__.py
@@ -1,6 +1,7 @@
 """Framework integrations for automatic observability."""
 
 from rhesis.sdk.telemetry.integrations.autogen import get_integration as _get_autogen
+from rhesis.sdk.telemetry.integrations.google_adk import get_integration as _get_google_adk
 from rhesis.sdk.telemetry.integrations.langchain import get_integration as _get_langchain
 from rhesis.sdk.telemetry.integrations.langgraph import get_integration as _get_langgraph
 
@@ -8,11 +9,13 @@ from rhesis.sdk.telemetry.integrations.langgraph import get_integration as _get_
 langchain = _get_langchain()
 langgraph = _get_langgraph()
 autogen = _get_autogen()
+google_adk = _get_google_adk()
 
 __all__ = [
     "langchain",
     "langgraph",
     "autogen",
+    "google_adk",
     "get_all_integrations",
 ]
 
@@ -28,4 +31,5 @@ def get_all_integrations():
         "langchain": langchain,
         "langgraph": langgraph,
         "autogen": autogen,
+        "google_adk": google_adk,
     }

--- a/sdk/src/rhesis/sdk/telemetry/integrations/google_adk.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/google_adk.py
@@ -1,0 +1,194 @@
+"""Google Agent Development Kit (ADK) framework integration."""
+
+import logging
+from typing import Any, Callable, Optional
+
+from rhesis.sdk.telemetry.attributes import AIAttributes
+from rhesis.sdk.telemetry.integrations.base import BaseIntegration
+from rhesis.sdk.telemetry.integrations.tracing_helpers import (
+    add_agent_io_events,
+    observe_framework_call,
+    set_agent_attributes,
+    set_token_attributes,
+)
+
+logger = logging.getLogger(__name__)
+
+RHESIS_PLUGIN_NAME = "rhesis_telemetry"
+
+_original_runner_init: Optional[Callable] = None
+_original_runner_run: Optional[Callable] = None
+_patching_done = False
+_rhesis_plugin: Any = None
+
+
+class GoogleADKPatchState:
+    """Accessor for Google ADK patching state (used in tests)."""
+
+    @staticmethod
+    def is_done() -> bool:
+        return _patching_done
+
+    @staticmethod
+    def reset() -> None:
+        global _original_runner_init, _original_runner_run, _patching_done, _rhesis_plugin
+        if _patching_done:
+            try:
+                from google.adk.runners import Runner
+
+                if _original_runner_init is not None:
+                    Runner.__init__ = _original_runner_init
+                if _original_runner_run is not None and hasattr(Runner, "run"):
+                    Runner.run = _original_runner_run
+            except ImportError:
+                pass
+        _original_runner_init = None
+        _original_runner_run = None
+        _patching_done = False
+        _rhesis_plugin = None
+
+
+def _extract_usage_from_llm_response(llm_response: Any) -> Any:
+    usage = getattr(llm_response, "usage_metadata", None)
+    if usage is not None:
+        return usage
+    if isinstance(llm_response, dict):
+        return llm_response.get("usage_metadata") or llm_response.get("usage")
+    return None
+
+
+def _create_rhesis_plugin() -> Any:
+    from google.adk.plugins.base_plugin import BasePlugin
+    from opentelemetry import context as otel_context
+    from opentelemetry import trace
+
+    class RhesisADKPlugin(BasePlugin):
+        """Global ADK plugin that emits Rhesis telemetry spans."""
+
+        def __init__(self) -> None:
+            super().__init__(name=RHESIS_PLUGIN_NAME)
+            self._tracer = trace.get_tracer("rhesis.sdk.integrations.google_adk")
+
+        async def before_agent_callback(self, *, agent, callback_context):
+            agent_name = getattr(agent, "name", type(agent).__name__)
+            model = getattr(agent, "model", None)
+            span = self._tracer.start_span(f"google_adk.agent {agent_name}")
+            set_agent_attributes(span, agent_name=agent_name, model=model)
+            token = otel_context.attach(trace.set_span_in_context(span))
+            callback_context.state["_rhesis_span"] = span
+            callback_context.state["_rhesis_span_token"] = token
+            return None
+
+        async def after_agent_callback(self, *, agent, callback_context):
+            span = callback_context.state.pop("_rhesis_span", None)
+            token = callback_context.state.pop("_rhesis_span_token", None)
+            if span is not None:
+                span.end()
+            if token is not None:
+                otel_context.detach(token)
+            return None
+
+        async def after_model_callback(self, *, callback_context, llm_response):
+            span = callback_context.state.get("_rhesis_span")
+            if span is not None:
+                set_token_attributes(span, _extract_usage_from_llm_response(llm_response))
+            return llm_response
+
+    return RhesisADKPlugin()
+
+
+def _wrap_runner_run(original: Callable) -> Callable:
+    async def wrapped(self, *args, **kwargs):
+        session_id = kwargs.get("session_id")
+        if session_id is None and len(args) >= 2:
+            session_id = args[1]
+        new_message = kwargs.get("new_message")
+        if new_message is None and len(args) >= 3:
+            new_message = args[2]
+
+        with observe_framework_call(
+            f"google_adk.runner.run {getattr(self, 'app_name', 'adk')}",
+            framework="google_adk",
+            attributes={AIAttributes.SESSION_ID: session_id} if session_id else None,
+        ) as span:
+            add_agent_io_events(span, new_message, None)
+            result = await original(self, *args, **kwargs)
+            add_agent_io_events(span, new_message, result)
+            return result
+
+    return wrapped
+
+
+def _patch_runner() -> Any:
+    global _original_runner_init, _original_runner_run, _patching_done, _rhesis_plugin
+    if _patching_done:
+        return _rhesis_plugin
+
+    from google.adk.runners import Runner
+
+    plugin = _create_rhesis_plugin()
+    _rhesis_plugin = plugin
+
+    _original_runner_init = Runner.__init__
+
+    def patched_init(self, *args, **kwargs):
+        plugins = list(kwargs.pop("plugins", None) or [])
+        if not any(getattr(item, "name", "") == RHESIS_PLUGIN_NAME for item in plugins):
+            plugins.append(plugin)
+        kwargs["plugins"] = plugins
+        return _original_runner_init(self, *args, **kwargs)
+
+    Runner.__init__ = patched_init
+
+    if hasattr(Runner, "run"):
+        _original_runner_run = Runner.run
+        Runner.run = _wrap_runner_run(_original_runner_run)
+
+    _patching_done = True
+    return plugin
+
+
+class GoogleADKIntegration(BaseIntegration):
+    """Google ADK framework integration."""
+
+    @property
+    def framework_name(self) -> str:
+        return "google_adk"
+
+    def is_installed(self) -> bool:
+        try:
+            import google.adk  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    def _create_callback(self):
+        return _patch_runner()
+
+    def enable(self) -> bool:
+        if self._enabled:
+            return True
+        if not self.is_installed():
+            return False
+        try:
+            self._callback = self._create_callback()
+            self._enabled = True
+            logger.info("✓ Observing google_adk")
+            return True
+        except Exception as exc:
+            logger.warning(f"Failed to enable google_adk: {exc}")
+            return False
+
+    def disable(self) -> None:
+        if self._enabled:
+            GoogleADKPatchState.reset()
+        super().disable()
+
+
+_google_adk_integration = GoogleADKIntegration()
+
+
+def get_integration() -> GoogleADKIntegration:
+    """Get the singleton Google ADK integration instance."""
+    return _google_adk_integration

--- a/sdk/src/rhesis/sdk/telemetry/integrations/google_adk.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/google_adk.py
@@ -113,7 +113,7 @@ def _wrap_runner_run(original: Callable) -> Callable:
         ) as span:
             add_agent_io_events(span, new_message, None)
             result = await original(self, *args, **kwargs)
-            add_agent_io_events(span, new_message, result)
+            add_agent_io_events(span, None, result)
             return result
 
     return wrapped

--- a/sdk/src/rhesis/sdk/telemetry/integrations/tracing_helpers.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/tracing_helpers.py
@@ -1,0 +1,105 @@
+"""Shared helpers for framework telemetry integrations."""
+
+import time
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+from opentelemetry import trace
+from opentelemetry.trace import SpanKind, Status, StatusCode
+
+from rhesis.sdk.telemetry.attributes import AIAttributes, AIEvents
+from rhesis.sdk.telemetry.context import is_tracing_disabled
+from rhesis.sdk.telemetry.utils.token_extraction import extract_token_usage
+
+MAX_CONTENT_LENGTH = 4000
+
+
+def truncate_content(value: Any) -> str:
+    """Truncate serialized content for span events."""
+    return str(value)[:MAX_CONTENT_LENGTH]
+
+
+def infer_model_provider(model_name: str) -> Optional[str]:
+    """Infer provider name from a model identifier."""
+    lowered = model_name.lower()
+    if "gpt" in lowered or lowered.startswith("o1") or lowered.startswith("o3"):
+        return "openai"
+    if "claude" in lowered:
+        return "anthropic"
+    if "gemini" in lowered:
+        return "google"
+    return None
+
+
+def set_agent_attributes(span: trace.Span, *, agent_name: str, model: Optional[str] = None) -> None:
+    """Set common agent invocation attributes on a span."""
+    span.set_attribute(AIAttributes.OPERATION_TYPE, AIAttributes.OPERATION_AGENT_INVOKE)
+    span.set_attribute(AIAttributes.AGENT_NAME, agent_name)
+    if model:
+        span.set_attribute(AIAttributes.MODEL_NAME, model)
+        provider = infer_model_provider(model)
+        if provider:
+            span.set_attribute(AIAttributes.MODEL_PROVIDER, provider)
+
+
+def set_token_attributes(span: trace.Span, usage: Any) -> None:
+    """Extract token usage from a provider response and set span attributes."""
+    if usage is None:
+        return
+    try:
+        prompt, completion, total = extract_token_usage(usage)
+        if prompt:
+            span.set_attribute(AIAttributes.LLM_TOKENS_INPUT, prompt)
+        if completion:
+            span.set_attribute(AIAttributes.LLM_TOKENS_OUTPUT, completion)
+        if total:
+            span.set_attribute(AIAttributes.LLM_TOKENS_TOTAL, total)
+    except Exception:
+        return
+
+
+@contextmanager
+def observe_framework_call(
+    span_name: str,
+    *,
+    framework: str,
+    operation_type: str = AIAttributes.OPERATION_AGENT_INVOKE,
+    attributes: Optional[dict[str, Any]] = None,
+) -> Iterator[trace.Span]:
+    """Create a span for a framework operation with latency and error handling."""
+    if is_tracing_disabled():
+        yield trace.get_current_span()
+        return
+
+    tracer = trace.get_tracer(f"rhesis.sdk.integrations.{framework}")
+    start = time.perf_counter()
+    with tracer.start_as_current_span(span_name, kind=SpanKind.CLIENT) as span:
+        span.set_attribute(AIAttributes.OPERATION_TYPE, operation_type)
+        span.set_attribute(AIAttributes.SYSTEM, framework)
+        if attributes:
+            for key, value in attributes.items():
+                if value is not None:
+                    span.set_attribute(key, value)
+        try:
+            yield span
+        except Exception as exc:
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            raise
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000
+            span.set_attribute("ai.operation.duration_ms", duration_ms)
+
+
+def add_agent_io_events(span: trace.Span, input_data: Any, output_data: Any) -> None:
+    """Record agent input/output as span events."""
+    if input_data is not None:
+        span.add_event(
+            AIEvents.AGENT_INPUT,
+            {AIAttributes.AGENT_INPUT_CONTENT: truncate_content(input_data)},
+        )
+    if output_data is not None:
+        span.add_event(
+            AIEvents.AGENT_OUTPUT,
+            {AIAttributes.AGENT_OUTPUT_CONTENT: truncate_content(output_data)},
+        )

--- a/tests/penelope/targets/test_google_adk.py
+++ b/tests/penelope/targets/test_google_adk.py
@@ -1,0 +1,53 @@
+"""Tests for GoogleADKTarget."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from rhesis.penelope.targets.google_adk import GoogleADKTarget
+
+
+@pytest.fixture
+def mock_runner():
+    runner = MagicMock()
+    runner.run = MagicMock(return_value={"parts": [{"text": "ADK reply"}]})
+    return runner
+
+
+def test_google_adk_target_initialization(mock_runner):
+    target = GoogleADKTarget(runner=mock_runner, target_id="adk-1", description="ADK bot")
+    assert target.target_type == "google_adk"
+    assert target.target_id == "adk-1"
+
+
+def test_google_adk_target_rejects_missing_run():
+    runner = MagicMock(spec=[])
+    with pytest.raises(ValueError, match="run\\(\\)"):
+        GoogleADKTarget(runner=runner, target_id="adk-1")
+
+
+def test_send_message_success(mock_runner):
+    target = GoogleADKTarget(runner=mock_runner, target_id="adk-1")
+    response = target.send_message("Hello", conversation_id="session-1")
+
+    assert response.success is True
+    assert response.content == "ADK reply"
+    assert response.conversation_id == "session-1"
+    mock_runner.run.assert_called_once()
+
+
+def test_send_message_async_runner():
+    runner = MagicMock()
+    runner.run = AsyncMock(return_value="async reply")
+    target = GoogleADKTarget(runner=runner, target_id="adk-1")
+    response = target.send_message("Hello", conversation_id="session-2")
+
+    assert response.success is True
+    assert response.content == "async reply"
+
+
+def test_send_message_empty(mock_runner):
+    target = GoogleADKTarget(runner=mock_runner, target_id="adk-1")
+    response = target.send_message(" ")
+    assert response.success is False
+    mock_runner.run.assert_not_called()

--- a/tests/penelope/targets/test_google_adk.py
+++ b/tests/penelope/targets/test_google_adk.py
@@ -46,6 +46,18 @@ def test_send_message_async_runner():
     assert response.content == "async reply"
 
 
+@pytest.mark.asyncio
+async def test_send_message_async_runner_under_running_loop():
+    runner = MagicMock()
+    runner.run = AsyncMock(return_value="async reply")
+    target = GoogleADKTarget(runner=runner, target_id="adk-1")
+    response = target.send_message("Hello", conversation_id="session-3")
+
+    assert response.success is True
+    assert response.content == "async reply"
+    runner.run.assert_awaited_once()
+
+
 def test_send_message_empty(mock_runner):
     target = GoogleADKTarget(runner=mock_runner, target_id="adk-1")
     response = target.send_message(" ")

--- a/tests/sdk/telemetry/integrations/test_google_adk_integration.py
+++ b/tests/sdk/telemetry/integrations/test_google_adk_integration.py
@@ -1,0 +1,97 @@
+"""Tests for Google ADK auto-instrumentation integration."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rhesis.sdk.telemetry.integrations.google_adk import (
+    GoogleADKIntegration,
+    GoogleADKPatchState,
+    RHESIS_PLUGIN_NAME,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_patch_state():
+    GoogleADKPatchState.reset()
+    yield
+    GoogleADKPatchState.reset()
+
+
+class FakeBasePlugin:
+    def __init__(self, name: str = "plugin"):
+        self.name = name
+
+
+class FakeCallbackContext:
+    def __init__(self):
+        self.state = {}
+
+
+def test_enable_injects_plugin_into_runner(monkeypatch):
+    class FakeRunner:
+        def __init__(self, *args, **kwargs):
+            self.plugins = kwargs.get("plugins", [])
+
+        async def run(self, *args, **kwargs):
+            return "ok"
+
+    fake_plugin_module = MagicMock()
+    fake_plugin_module.BasePlugin = FakeBasePlugin
+    fake_runners = MagicMock()
+    fake_runners.Runner = FakeRunner
+    fake_google = MagicMock()
+    fake_google.adk = MagicMock()
+    fake_google.adk.plugins = MagicMock()
+    fake_google.adk.plugins.base_plugin = fake_plugin_module
+    fake_google.adk.runners = fake_runners
+
+    monkeypatch.setitem(__import__("sys").modules, "google", fake_google)
+    monkeypatch.setitem(__import__("sys").modules, "google.adk", fake_google.adk)
+    monkeypatch.setitem(__import__("sys").modules, "google.adk.plugins", fake_google.adk.plugins)
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "google.adk.plugins.base_plugin",
+        fake_plugin_module,
+    )
+    monkeypatch.setitem(__import__("sys").modules, "google.adk.runners", fake_runners)
+
+    integration = GoogleADKIntegration()
+    assert integration.enable() is True
+    assert GoogleADKPatchState.is_done() is True
+
+    runner = FakeRunner(plugins=[])
+    assert any(getattr(plugin, "name", "") == RHESIS_PLUGIN_NAME for plugin in runner.plugins)
+
+
+def test_disable_resets_runner_patch(monkeypatch):
+    class FakeRunner:
+        def __init__(self, *args, **kwargs):
+            self.plugins = kwargs.get("plugins", [])
+
+    fake_plugin_module = MagicMock()
+    fake_plugin_module.BasePlugin = FakeBasePlugin
+    fake_runners = MagicMock()
+    fake_runners.Runner = FakeRunner
+    fake_google = MagicMock()
+    fake_google.adk = MagicMock()
+    fake_google.adk.plugins = MagicMock()
+    fake_google.adk.plugins.base_plugin = fake_plugin_module
+    fake_google.adk.runners = fake_runners
+
+    monkeypatch.setitem(__import__("sys").modules, "google", fake_google)
+    monkeypatch.setitem(__import__("sys").modules, "google.adk", fake_google.adk)
+    monkeypatch.setitem(__import__("sys").modules, "google.adk.plugins", fake_google.adk.plugins)
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "google.adk.plugins.base_plugin",
+        fake_plugin_module,
+    )
+    monkeypatch.setitem(__import__("sys").modules, "google.adk.runners", fake_runners)
+
+    integration = GoogleADKIntegration()
+    integration.enable()
+    integration.disable()
+
+    assert integration.enabled is False
+    assert GoogleADKPatchState.is_done() is False


### PR DESCRIPTION
## Purpose
Add Google ADK auto-instrumentation and a Penelope target for multi-turn agent testing with session continuity.

Closes #1868

## What Changed
- Implemented `GoogleADKIntegration` injecting a global `RhesisADKPlugin` into ADK `Runner` instances
- Patched `Runner.run` for latency and I/O spans with `session_id` attributes
- Added `GoogleADKTarget` supporting Runner or Agent (auto-builds Runner + in-memory sessions)
- Registered integration in `get_all_integrations()` and added `google-adk` optional deps
- Added SDK and Penelope unit tests

## Testing
- `cd sdk && uv run pytest ../tests/sdk/telemetry/integrations/test_google_adk_integration.py ../tests/sdk/telemetry/integrations/test_langgraph_integration.py -q`
- `cd penelope && uv run pytest ../tests/penelope/targets/test_google_adk.py -q`