### PR TITLE
Add update_endpoint MCP tool and forward project scope

### DIFF
--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -506,6 +506,65 @@ tools:
       audience:
         description: "OAuth audience (client_credentials flow)."
 
+  - name: update_endpoint
+    label: Updating endpoint
+    method: PUT
+    path: /endpoints/{endpoint_id}
+    requires_confirmation: true
+    description: >
+      Update an existing endpoint's configuration. Resolve the endpoint
+      FIRST with list_endpoints to obtain its id, then pass that id as
+      endpoint_id. Send ONLY the fields you want to change — every field is
+      optional and omitted fields keep their current values. Do NOT send
+      server-managed fields (id, user_id, organization_id, status_id,
+      created_at, updated_at). After updating, you can verify reachability
+      with check_endpoint.
+    parameters:
+      endpoint_id:
+        description: "REQUIRED. UUID of the endpoint to update (path parameter)."
+      name:
+        description: "New endpoint name, unique within the project (string)."
+      description:
+        description: "What the endpoint does (string)."
+      url:
+        description: "Full endpoint URL, e.g. https://api.example.com/chat."
+      method:
+        description: 'HTTP method for REST endpoints, e.g. "POST" or "GET".'
+      environment:
+        description: '"production", "staging", "development", or "local".'
+      request_headers:
+        description: >
+          Object of HTTP headers sent with each request, e.g.
+          {"Content-Type": "application/json"}.
+      request_mapping:
+        description: >
+          Object mapping the request body, using {{ input }} for the user
+          message. e.g. {"message": "{{ input }}"}.
+      response_mapping:
+        description: >
+          Object mapping the response, using JSONPath to extract the output
+          field. e.g. {"output": "$.response"}.
+      query_params:
+        description: "Optional object of query-string parameters."
+      response_format:
+        description: '"json", "xml", or "text".'
+      auth_type:
+        description: >
+          Authentication scheme: "bearer_token", "client_credentials", or
+          "api_key".
+      auth_token:
+        description: "Bearer token / API key (write-only, stored encrypted)."
+      client_id:
+        description: "OAuth client id (client_credentials flow)."
+      client_secret:
+        description: "OAuth client secret (write-only, stored encrypted)."
+      token_url:
+        description: "OAuth token endpoint URL (client_credentials flow)."
+      scopes:
+        description: "List of OAuth scope strings (client_credentials flow)."
+      audience:
+        description: "OAuth audience (client_credentials flow)."
+
   - name: check_endpoint
     label: Checking endpoint connectivity
     method: POST

--- a/apps/backend/src/rhesis/backend/app/mcp_server/server.py
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/server.py
@@ -115,6 +115,13 @@ def _create_mcp_server(fastapi_app: Any) -> MCPServer:
                 auth_value = request.headers.get("authorization", "")
                 if auth_value:
                     headers["Authorization"] = auth_value
+                # Forward project scope so project-isolated resources
+                # (endpoints, etc.) resolve under the correct RLS project.
+                # Without this, app.current_project is empty and any write
+                # carrying a project_id violates the project_isolation policy.
+                project_value = request.headers.get("x-project-id", "")
+                if project_value:
+                    headers["X-Project-Id"] = project_value
         except LookupError:
             pass
 

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/system_prompt.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/system_prompt.j2
@@ -41,6 +41,16 @@ When the user mentions an endpoint (by name, or says "test my endpoint", "test m
 
 If the explore_endpoint tool requires an endpoint_id parameter, pass the ID you resolved in step 1.
 
+### Registering a new endpoint
+If the user wants to test an endpoint that does not exist yet on the platform (e.g. "register my chatbot at https://…", or the name resolution in step 1 returns no match and they describe a fresh API), offer to register it with `create_endpoint`. Before calling it:
+- Gather what the endpoint needs: a `name`, the `url`, the HTTP `method` (usually `POST`), how the request body is shaped (`request_mapping`, using `{{ input }}` for the user's message), and how to extract the answer from the response (`response_mapping`, a JSONPath like `{"output": "$.choices[0].message.content"}`). Ask for any of these you cannot infer.
+- A `project_id` is required — resolve the user's project by name with `list_projects`, or ask which project the endpoint belongs to if it is ambiguous.
+- Follow "Confirm before acting": present the proposed configuration (name, url, method, request/response mapping) and wait for the user to approve before calling `create_endpoint`.
+- After registering, verify reachability with `check_endpoint`, then continue into exploration as usual.
+
+### Updating an existing endpoint
+When the user asks to change an existing endpoint's configuration (its URL, auth, request/response mapping, headers, environment, etc.), resolve it by name with `list_endpoints`, then call `update_endpoint` with the endpoint's id and ONLY the fields that change — omitted fields keep their current values. Present the proposed changes and wait for confirmation first.
+
 ### Compiled observations
 After exploring, synthesize the findings into structured observations. Do NOT dump raw tool output. Present your findings organized by:
 - **Domain and purpose**: What the endpoint does and which domain it operates in
@@ -356,6 +366,8 @@ Not every request requires the full phased workflow. If the user asks you to per
 - "Update metric X to include user management scenarios" → use list_metrics to find X by name, then call improve_metric with the user's instructions
 - "Add a description to behavior Y" → use list_behaviors to find Y, then call update_behavior
 - "Link metric A to behavior B" → resolve both by name, then call add_behavior_to_metric
+- "Register my chatbot at https://… as 'Support Bot'" → gather the required config (see "Registering a new endpoint"), confirm, then call create_endpoint
+- "Change endpoint Z's URL / auth token / response mapping" → use list_endpoints to find Z, present the change, then call update_endpoint with only the changed fields
 
 Only enter the phased workflow when the user asks you to design or create a test suite from scratch.
 


### PR DESCRIPTION
## Purpose
Agents need a way to update existing endpoint configuration (URL, auth, mappings, etc.) without recreating endpoints. MCP calls that write project-scoped resources also need the active project forwarded so RLS policies resolve correctly.

## What Changed
- Add `update_endpoint` MCP tool (PUT `/endpoints/{endpoint_id}`) with partial-update semantics and confirmation required
- Forward `X-Project-Id` from incoming MCP requests through the proxy so endpoint writes land in the correct project
- Extend the architect agent system prompt with guidance for registering new endpoints and updating existing ones

## Additional Context
- Follows up on `create_endpoint` (#2006) for the full register → verify → explore workflow
- Without project header forwarding, writes carrying `project_id` can violate the `project_isolation` RLS policy

## Testing
- [ ] Call `update_endpoint` via MCP with a resolved endpoint id and a single changed field
- [ ] Confirm omitted fields retain their current values
- [ ] Verify MCP writes succeed when `X-Project-Id` is set on the client request
- [ ] Confirm architect agent offers `create_endpoint` / `update_endpoint` flows with user confirmation