### PR TITLE
Fix DeepEval wrapper schema conversion fallback

### DIFF
--- a/sdk/src/rhesis/sdk/metrics/providers/deepeval/model.py
+++ b/sdk/src/rhesis/sdk/metrics/providers/deepeval/model.py
@@ -1,5 +1,3 @@
-# Import DeepEvalBaseLLM for proper custom model implementation
-
 import logging
 from typing import Any, Optional, Union
 
@@ -18,45 +16,25 @@ class DeepEvalModelWrapper(DeepEvalBaseLLM):
     def load_model(self, *args, **kwargs):  # type: ignore[override]
         return self._model.load_model(*args, **kwargs)
 
-    def _convert_to_schema(self, result: dict, schema: Any) -> Any:
-        """Convert dict result to Pydantic schema instance."""
-        # When schema is provided, model always returns a dict
+    def _convert_to_schema(self, result: Any, schema: Any) -> Any:
+        # Raise TypeError on failure so DeepEval's unstructured fallback triggers.
+        if isinstance(result, schema):
+            return result
         try:
-            schema_instance = schema(**result)
-            logger.debug(f"Instantiated {schema.__name__} with keys: {list(result.keys())}")
-            return schema_instance
-        except (TypeError, ValueError) as e:
-            logger.warning(f"Failed to instantiate {schema.__name__}: {e}")
-            return result  # Return dict as fallback
+            if isinstance(result, dict) and hasattr(schema, "model_validate"):
+                return schema.model_validate(result)
+            return schema(**result)
+        except Exception as e:
+            schema_name = getattr(schema, "__name__", str(schema))
+            logger.warning(f"Failed to convert to {schema_name}: {e}")
+            raise TypeError(f"Cannot convert to {schema_name}: {e}") from e
 
     def generate(self, prompt: str, schema: Optional[Any] = None, **kwargs) -> Union[str, Any]:
-        """
-        Generate response from the model with optional structured output.
-
-        Args:
-            prompt: The prompt to generate from
-            schema: Optional Pydantic schema for structured output
-            **kwargs: Additional generation parameters
-
-        Returns:
-            Generated response (str or schema instance if schema provided)
-        """
         return run_sync(self.a_generate(prompt=prompt, schema=schema, **kwargs))
 
     async def a_generate(
         self, prompt: str, schema: Optional[Any] = None, **kwargs
     ) -> Union[str, Any]:
-        """
-        Async generate response from the model with optional structured output.
-
-        Args:
-            prompt: The prompt to generate from
-            schema: Optional Pydantic schema for structured output
-            **kwargs: Additional generation parameters
-
-        Returns:
-            Generated response (str or schema instance if schema provided)
-        """
         result = await self._model.a_generate(prompt, schema=schema, **kwargs)
         return self._convert_to_schema(result, schema) if schema else result
 

--- a/tests/sdk/metrics/providers/deepeval/test_model_wrapper.py
+++ b/tests/sdk/metrics/providers/deepeval/test_model_wrapper.py
@@ -1,0 +1,86 @@
+"""Tests for DeepEvalModelWrapper._convert_to_schema."""
+
+from typing import List, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import BaseModel, Field
+
+from rhesis.sdk.metrics.providers.deepeval.model import DeepEvalModelWrapper
+from rhesis.sdk.models.base import BaseLLM
+
+
+class FakeVerdict(BaseModel):
+    statement: str
+    verdict: str
+    reason: Optional[str] = Field(default=None)
+
+
+class FakeVerdicts(BaseModel):
+    verdicts: List[FakeVerdict]
+
+
+@pytest.fixture
+def mock_base_llm():
+    mock = MagicMock(spec=BaseLLM)
+    mock.get_model_name.return_value = "mock-model"
+    return mock
+
+
+@pytest.fixture
+def wrapper(mock_base_llm):
+    return DeepEvalModelWrapper(mock_base_llm)
+
+
+class TestConvertToSchema:
+    def test_returns_instance_when_result_is_already_correct_type(self, wrapper):
+        instance = FakeVerdicts(verdicts=[FakeVerdict(statement="s", verdict="yes")])
+        result = wrapper._convert_to_schema(instance, FakeVerdicts)
+        assert result is instance
+
+    def test_converts_valid_dict_to_schema_instance(self, wrapper):
+        data = {"verdicts": [{"statement": "s", "verdict": "yes", "reason": None}]}
+        result = wrapper._convert_to_schema(data, FakeVerdicts)
+        assert isinstance(result, FakeVerdicts)
+        assert len(result.verdicts) == 1
+        assert result.verdicts[0].statement == "s"
+
+    def test_raises_type_error_for_invalid_dict(self, wrapper):
+        """When schema instantiation fails, TypeError is raised (not silent dict return)."""
+        bad_data = {"wrong_key": "wrong_value"}
+        with pytest.raises(TypeError):
+            wrapper._convert_to_schema(bad_data, FakeVerdicts)
+
+    def test_raises_type_error_for_non_dict(self, wrapper):
+        with pytest.raises(TypeError):
+            wrapper._convert_to_schema("not a dict", FakeVerdicts)
+
+    def test_raises_type_error_for_empty_dict(self, wrapper):
+        with pytest.raises(TypeError):
+            wrapper._convert_to_schema({}, FakeVerdicts)
+
+
+class TestAGenerate:
+    @pytest.mark.asyncio
+    async def test_returns_schema_instance_when_model_returns_valid_dict(
+        self, wrapper, mock_base_llm
+    ):
+        valid_dict = {"verdicts": [{"statement": "s", "verdict": "yes", "reason": None}]}
+        mock_base_llm.a_generate = AsyncMock(return_value=valid_dict)
+        result = await wrapper.a_generate("prompt", schema=FakeVerdicts)
+        assert isinstance(result, FakeVerdicts)
+
+    @pytest.mark.asyncio
+    async def test_raises_type_error_when_model_returns_wrong_dict(
+        self, wrapper, mock_base_llm
+    ):
+        """TypeError allows deepeval's fallback (unstructured generation) to trigger."""
+        mock_base_llm.a_generate = AsyncMock(return_value={"wrong": "data"})
+        with pytest.raises(TypeError):
+            await wrapper.a_generate("prompt", schema=FakeVerdicts)
+
+    @pytest.mark.asyncio
+    async def test_returns_string_when_no_schema(self, wrapper, mock_base_llm):
+        mock_base_llm.a_generate = AsyncMock(return_value="raw response")
+        result = await wrapper.a_generate("prompt")
+        assert result == "raw response"


### PR DESCRIPTION
## Purpose
The `DeepEvalModelWrapper._convert_to_schema` method silently returned raw dicts when Pydantic schema instantiation failed. DeepEval metrics expect Pydantic model instances — receiving a dict caused downstream `AttributeError`s (e.g., accessing `.verdicts` on a dict).

## What Changed
- `_convert_to_schema` now raises `TypeError` on conversion failure, which triggers DeepEval's built-in unstructured fallback path (re-calls generate without schema, parses JSON string, constructs Pydantic instance manually)
- Widen `result` type from `dict` to `Any` with early `isinstance` return for already-correct types
- Use `model_validate` (Pydantic v2) for more robust dict-to-model conversion
- Add unit tests covering happy path, error cases, and async integration

## Testing
```bash
cd sdk
uv run pytest ../tests/sdk/metrics/providers/deepeval/test_model_wrapper.py -v
```