### PR TITLE
Fix: allow confirming automated test reviews

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ReviewJudgementDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ReviewJudgementDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   Box,
   ToggleButton,
@@ -10,16 +10,10 @@ import {
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
 import CancelOutlinedIcon from '@mui/icons-material/CancelOutlined';
 import BaseDrawer from '@/components/common/BaseDrawer';
-import {
-  TestResultDetail,
-  REVIEW_TARGET_TYPES,
-} from '@/utils/api-client/interfaces/test-results';
+import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { Status } from '@/utils/api-client/interfaces/status';
-import {
-  findStatusByCategory,
-  isPassedStatusName,
-} from '@/utils/test-result-status';
+import { findStatusByCategory } from '@/utils/test-result-status';
 import MentionTextInput, {
   MentionOption,
   inferReviewTarget,
@@ -110,42 +104,6 @@ export default function ReviewJudgementDrawer({
     if (matching) setSelectedStatusId(String(matching.id));
   }, [open, statuses, initialStatus, selectedStatusId]);
 
-  // Automated status of the review target (used for conflict validation)
-  const getOriginalStatus = useCallback((): 'passed' | 'failed' => {
-    if (!test) return 'failed';
-
-    if (
-      inferredTarget.type === REVIEW_TARGET_TYPES.METRIC &&
-      inferredTarget.reference
-    ) {
-      const metrics = test.test_metrics?.metrics || {};
-      const entry = Object.entries(metrics).find(
-        ([name]) => name === inferredTarget.reference
-      );
-      return entry?.[1]?.is_successful ? 'passed' : 'failed';
-    }
-
-    if (
-      inferredTarget.type === REVIEW_TARGET_TYPES.TURN &&
-      inferredTarget.reference
-    ) {
-      const turns = test.test_output?.conversation_summary || [];
-      const turnNum = parseInt(inferredTarget.reference.replace(/\D/g, ''), 10);
-      const turn = turns.find((t: { turn: number }) => t.turn === turnNum);
-      return turn?.success ? 'passed' : 'failed';
-    }
-
-    const metrics = test.test_metrics?.metrics || {};
-    const metricValues = Object.values(metrics);
-    const totalMetrics = metricValues.length;
-    const passedMetrics = metricValues.filter(m => m.is_successful).length;
-    return totalMetrics > 0 && passedMetrics === totalMetrics
-      ? 'passed'
-      : 'failed';
-  }, [test, inferredTarget]);
-
-  const originalStatus = getOriginalStatus();
-
   const handleSave = async () => {
     if (!reason.trim()) {
       setError('Please provide a comment for your review.');
@@ -163,27 +121,6 @@ export default function ReviewJudgementDrawer({
     }
 
     if (!test || !sessionToken) return;
-
-    const selectedStatus = statuses.find(
-      s => String(s.id) === selectedStatusId
-    );
-
-    // For test_result-level first reviews, block matching the automated outcome
-    if (inferredTarget.type === REVIEW_TARGET_TYPES.TEST_RESULT) {
-      const hasExistingReview = !!test.last_review;
-      if (
-        !hasExistingReview &&
-        selectedStatus &&
-        isPassedStatusName(selectedStatus.name) ===
-          (originalStatus === 'passed')
-      ) {
-        setError(
-          'The selected status matches the automated result. ' +
-            'Please select a different status, or add a comment confirming your agreement.'
-        );
-        return;
-      }
-    }
 
     try {
       setSubmitting(true);


### PR DESCRIPTION
## Purpose
Human reviewers could not submit a review that agrees with the automated pass/fail result via the Create Review drawer. The UI showed an error even when a detailed comment was provided, despite the message suggesting a comment should allow confirmation.

## What Changed
- Removed client-side validation in `ReviewJudgementDrawer` that blocked saving when the selected status matched the automated outcome
- A comment (minimum 10 characters) and status selection remain required before save

## Additional Context
The backend already accepts matching-status reviews; only the frontend was blocking submission. The separate one-click "Confirm" flow in the conversation tab was unaffected.

## Testing
- Open a test result with no existing review
- Open Create Review, select the same pass/fail status as the automated result, add a comment (10+ chars), and save
- Verify the review is created and the result shows as confirmed (`matches_review: true`)