### PR TITLE
Speed up test run detail page by cutting redundant API calls

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -2614,6 +2614,7 @@ def get_test_results(
         sort_by,
         sort_order,
         filter,
+        nested_relationships={"test": ["prompt", "behavior", "topic"]},
         organization_id=organization_id,
         user_id=user_id,
     )

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ReviewJudgementDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ReviewJudgementDrawer.tsx
@@ -65,10 +65,10 @@ export default function ReviewJudgementDrawer({
     [statuses]
   );
 
-  // Fetch statuses for TestResult entity type on mount
+  // Fetch statuses for TestResult entity type when first opened
   useEffect(() => {
     const fetchStatuses = async () => {
-      if (!sessionToken || statuses.length > 0) return;
+      if (!open || !sessionToken || statuses.length > 0) return;
       try {
         setLoadingStatuses(true);
         const clientFactory = new ApiClientFactory(sessionToken);
@@ -84,7 +84,7 @@ export default function ReviewJudgementDrawer({
       }
     };
     fetchStatuses();
-  }, [sessionToken, statuses.length]);
+  }, [open, sessionToken, statuses.length]);
 
   // Reset form when drawer opens (intentionally excludes initialComment/initialStatus
   // from deps so parent state resets don't clear a form the user is actively filling)

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunDetailData.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunDetailData.ts
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { UUID } from 'crypto';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { Prompt } from '@/utils/api-client/interfaces/prompt';
@@ -79,51 +78,45 @@ function buildPromptsMap(
   );
 }
 
-async function fetchBehaviorsWithMetrics(
-  testRunId: string,
-  sessionToken: string
-): Promise<{
+function extractBehaviorsWithMetrics(results: TestResultDetail[]): {
   behaviors: BehaviorWithMetrics[];
   availableMetrics: string[];
-}> {
-  const apiFactory = new ApiClientFactory(sessionToken);
-  const testRunsClient = apiFactory.getTestRunsClient();
-  const behaviorClient = apiFactory.getBehaviorClient();
+} {
+  const behaviorMap = new Map<string, BehaviorWithMetrics>();
 
-  const [behaviorsData, metricsData] = await Promise.all([
-    testRunsClient.getTestRunBehaviors(testRunId),
-    testRunsClient.getTestRunMetrics(testRunId),
-  ]);
+  for (const result of results) {
+    const behavior = result.test?.behavior;
+    const metrics = result.test_metrics?.metrics ?? {};
 
-  const behaviorsWithMetrics = await Promise.all(
-    behaviorsData.map(async behavior => {
-      try {
-        const behaviorMetrics = await behaviorClient.getBehaviorMetrics(
-          behavior.id as UUID
-        );
-        return {
-          id: behavior.id as string,
-          name: behavior.name,
-          description: behavior.description ?? undefined,
-          metrics: behaviorMetrics.map(m => ({
-            name: m.name,
-            description: m.description ?? undefined,
-          })),
-        };
-      } catch {
-        return {
-          id: behavior.id as string,
-          name: behavior.name,
-          description: behavior.description ?? undefined,
-          metrics: [] as Array<{ name: string; description?: string }>,
-        };
+    if (behavior && !behaviorMap.has(behavior.id as string)) {
+      behaviorMap.set(behavior.id as string, {
+        id: behavior.id as string,
+        name: behavior.name,
+        description: behavior.description || undefined,
+        metrics: [],
+      });
+    }
+
+    if (behavior) {
+      const entry = behaviorMap.get(behavior.id as string)!;
+      for (const [name, data] of Object.entries(metrics)) {
+        if (!entry.metrics.some(m => m.name === name)) {
+          entry.metrics.push({
+            name,
+            description: data.description || undefined,
+          });
+        }
       }
-    })
-  );
+    }
+  }
 
   return {
-    behaviors: behaviorsWithMetrics,
-    availableMetrics: metricsData,
+    behaviors: Array.from(behaviorMap.values()),
+    availableMetrics: [
+      ...new Set(
+        results.flatMap(r => Object.keys(r.test_metrics?.metrics ?? {}))
+      ),
+    ],
   };
 }
 
@@ -152,17 +145,17 @@ export function useTestRunDetailData({
       setError(null);
 
       try {
-        const [results, behaviorData] = await Promise.all([
-          fetchAllTestResults(testRunId, sessionToken),
-          fetchBehaviorsWithMetrics(testRunId, sessionToken),
-        ]);
+        const results = await fetchAllTestResults(testRunId, sessionToken);
 
         if (cancelled) return;
 
+        const { behaviors, availableMetrics } =
+          extractBehaviorsWithMetrics(results);
+
         setTestResults(results);
         setPrompts(buildPromptsMap(results));
-        setBehaviors(behaviorData.behaviors);
-        setAvailableMetrics(behaviorData.availableMetrics);
+        setBehaviors(behaviors);
+        setAvailableMetrics(availableMetrics);
       } catch {
         if (!cancelled) {
           setError('Failed to load test run data');

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunDetailData.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/hooks/useTestRunDetailData.ts
@@ -110,14 +110,22 @@ function extractBehaviorsWithMetrics(results: TestResultDetail[]): {
     }
   }
 
-  return {
-    behaviors: Array.from(behaviorMap.values()),
-    availableMetrics: [
-      ...new Set(
-        results.flatMap(r => Object.keys(r.test_metrics?.metrics ?? {}))
+  const behaviors = Array.from(behaviorMap.values())
+    .map(behavior => ({
+      ...behavior,
+      metrics: [...behavior.metrics].sort((a, b) =>
+        a.name.localeCompare(b.name)
       ),
-    ],
-  };
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const availableMetrics = [
+    ...new Set(
+      results.flatMap(r => Object.keys(r.test_metrics?.metrics ?? {}))
+    ),
+  ].sort();
+
+  return { behaviors, availableMetrics };
 }
 
 export function useTestRunDetailData({

--- a/apps/frontend/src/utils/api-client/base-client.ts
+++ b/apps/frontend/src/utils/api-client/base-client.ts
@@ -439,8 +439,9 @@ export class BaseApiClient {
       }
     });
 
-    const path =
+    const rawPath =
       API_ENDPOINTS[endpoint as keyof typeof API_ENDPOINTS] || endpoint;
+    const path = rawPath.endsWith('/') ? rawPath : `${rawPath}/`;
     const queryString = queryParams.toString();
     const url = joinUrl(
       this.baseUrl,


### PR DESCRIPTION
## Purpose

The test run detail page (`/test-runs/[id]`) was slow on load because it fired **6+ API calls** and the main `test_results` response triggered **~300 lazy SQL queries** on the backend for 100 rows. Most of that work was redundant — the data was already in the first response.

This PR removes the unnecessary round-trips and fixes the backend N+1 so the page loads with a single API call and far fewer database queries.

## What Changed

**Frontend — fewer requests on page load**
- Derive behaviors and metrics from the `test_results` response instead of calling `getTestRunBehaviors`, `getTestRunMetrics`, and `getBehaviorMetrics` per behavior
- Defer the `statuses` fetch in `ReviewJudgementDrawer` until the drawer is actually opened
- Append trailing slashes to API paths to avoid 307 redirects (and their extra CORS preflights)

**Backend — fix N+1 on `GET /test_results`**
- Eager-load nested `test.prompt`, `test.behavior`, and `test.topic` relationships in `get_test_results`, matching what the response schema already promises

## Impact

| Before | After |
|--------|-------|
| 6+ API calls on load (+ N per behavior) | **1 API call** (`test_results`) |
| ~300 extra SQL queries per 100 results (lazy loads) | **Eager-loaded in the main query** |
| Statuses fetched even when drawer is closed | Fetched only when user opens the drawer |
| 307 redirects doubling some requests | Direct hits with trailing slashes |


## Testing

- [ ] Open `/test-runs/[id]?tab=linked_entities` and confirm only `GET test_results/` fires on load (no behaviors, metrics, or statuses calls)
- [ ] Verify behaviors and metric columns still render correctly in the table
- [ ] Open the review drawer and confirm statuses load on first open
- [ ] Check network tab: no 307 redirects on API paths