### PR TITLE
Fix MCP project scope forwarding and token project stamping

### DIFF
--- a/apps/backend/src/rhesis/backend/app/mcp_server/server.py
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/server.py
@@ -122,9 +122,9 @@ def _create_mcp_server(fastapi_app: Any) -> MCPServer:
                 # request.state).  Without this, MCP clients that
                 # authenticate with a project-scoped token (e.g. Cursor)
                 # would see no project filtering on list endpoints.
-                project_value = request.headers.get(
-                    "x-project-id", ""
-                ) or getattr(request.state, "api_token_project_id", "")
+                project_value = request.headers.get("x-project-id", "") or getattr(
+                    request.state, "api_token_project_id", ""
+                )
                 if project_value:
                     headers["X-Project-Id"] = project_value
         except LookupError:

--- a/apps/backend/src/rhesis/backend/app/mcp_server/server.py
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/server.py
@@ -117,9 +117,14 @@ def _create_mcp_server(fastapi_app: Any) -> MCPServer:
                     headers["Authorization"] = auth_value
                 # Forward project scope so project-isolated resources
                 # (endpoints, etc.) resolve under the correct RLS project.
-                # Without this, app.current_project is empty and any write
-                # carrying a project_id violates the project_isolation policy.
-                project_value = request.headers.get("x-project-id", "")
+                # Prefer the explicit header; fall back to the project_id
+                # bound to the API token (set by the auth layer on
+                # request.state).  Without this, MCP clients that
+                # authenticate with a project-scoped token (e.g. Cursor)
+                # would see no project filtering on list endpoints.
+                project_value = request.headers.get(
+                    "x-project-id", ""
+                ) or getattr(request.state, "api_token_project_id", "")
                 if project_value:
                     headers["X-Project-Id"] = project_value
         except LookupError:

--- a/apps/backend/src/rhesis/backend/app/routers/token.py
+++ b/apps/backend/src/rhesis/backend/app/routers/token.py
@@ -10,6 +10,7 @@ from rhesis.backend.app import crud
 from rhesis.backend.app.auth.token_utils import generate_api_token
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import (
+    get_project_context,
     get_tenant_context,
     get_tenant_db_session,
 )
@@ -40,6 +41,7 @@ def create_token(
     data: dict = Body(...),
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
+    project_id: str | None = Depends(get_project_context),
     current_user: User = Depends(require_current_user_or_token),
 ):
     """Create a new API token."""
@@ -64,6 +66,7 @@ def create_token(
         ),
         "user_id": user_id,
         "organization_id": organization_id,
+        "project_id": project_id,
     }
 
     token_create = TokenCreate(**token_data)
@@ -71,7 +74,6 @@ def create_token(
         db=db, token=token_create, organization_id=organization_id, user_id=user_id
     )
 
-    # Return the special response that includes the actual token value
     return TokenCreateResponse(
         id=created_token.id,
         access_token=created_token.token,
@@ -79,6 +81,7 @@ def create_token(
         token_type=created_token.token_type,
         expires_at=created_token.expires_at,
         name=created_token.name,
+        project_id=created_token.project_id,
     )
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/token.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/token.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional
+from typing import ClassVar, Optional, Set
 
 from pydantic import UUID4
 
@@ -12,6 +12,7 @@ class TokenBase(Base):
     expires_at: Optional[datetime] = None
     user_id: UUID4
     organization_id: Optional[UUID4] = None
+    project_id: Optional[UUID4] = None
 
 
 class TokenCreate(TokenBase):
@@ -20,9 +21,12 @@ class TokenCreate(TokenBase):
     token_obfuscated: str
     user_id: UUID4
     organization_id: Optional[UUID4] = None
+    project_id: Optional[UUID4] = None
 
 
 class TokenUpdate(TokenBase):
+    _IMMUTABLE_FIELDS: ClassVar[Set[str]] = {"project_id"}
+
     name: Optional[str] = None
     token: Optional[str] = None
     token_hash: Optional[str] = None
@@ -33,6 +37,12 @@ class TokenUpdate(TokenBase):
     last_refreshed_at: Optional[datetime] = None
     user_id: Optional[UUID4] = None
     organization_id: Optional[UUID4] = None
+
+    def model_dump(self, **kwargs) -> dict:
+        data = super().model_dump(**kwargs)
+        for field in self._IMMUTABLE_FIELDS:
+            data.pop(field, None)
+        return data
 
 
 # For list and detail views - excludes the actual token value
@@ -63,4 +73,5 @@ class TokenCreateResponse(Base):
     token_type: str
     expires_at: Optional[datetime]
     name: str
+    project_id: Optional[UUID4] = None
     last_refreshed_at: Optional[datetime] = None  # For refresh operations

--- a/apps/frontend/src/utils/api-client/interfaces/token.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/token.ts
@@ -19,4 +19,5 @@ export interface TokenResponse {
   token_type: string;
   expires_at: string;
   name?: string;
+  project_id?: string;
 }

--- a/apps/frontend/src/utils/api-client/interfaces/token.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/token.ts
@@ -8,6 +8,7 @@ export interface Token {
   last_refreshed_at?: string;
   user_id: string;
   organization_id?: string;
+  project_id?: string;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- **MCP project forwarding**: MCP clients (e.g. Cursor) authenticate with API tokens but don't send `X-Project-Id` headers. The MCP dispatcher now falls back to the token's bound `project_id` (stored on `request.state` by the auth layer), so all MCP tool calls—list, create, update, delete—respect project isolation.
- **Token project stamping**: Token creation now stamps the active project context onto new tokens via `get_project_context`. Previously, tokens were always minted with `project_id = NULL` because the Token model is in `EXEMPT_TABLES` (needed for auth lookups) and auto-stamp doesn't fire for exempt tables.
- **Immutable project_id**: `TokenUpdate.model_dump()` strips `project_id` so it cannot be reassigned after minting.

## Test plan
- [x] Verified MCP `list_endpoints` returns project-scoped results when using a project-scoped token (no explicit `X-Project-Id` header)
- [x] Verified token creation stamps `project_id` when `X-Project-Id` header is present
- [x] Verified `TokenUpdate` strips `project_id` from serialization (tested with explicit and omitted values)
- [x] Verified test tokens cleaned up after manual testing