### PR TITLE
Enable knowledge import from MCP extract providers and scope tools by projects

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/tools.py
+++ b/apps/backend/src/rhesis/backend/app/routers/tools.py
@@ -381,7 +381,8 @@ async def extract_tool_item(
 
     The transport (deterministic REST call vs. MCP agent) is chosen per provider for
     the extract action — invisible to the caller.
-    Set include_children=True to recursively fetch child pages / subdirectory files.
+    Set include_children=True to recursively fetch child pages / subdirectory files
+    (REST providers only).
     Either ``id`` or ``url`` (or both) must be provided in the request body.
     """
     try:
@@ -402,7 +403,6 @@ async def extract_tool_item(
                 identifier=identifier,
                 organization_id=organization_id,
                 user_id=user_id,
-                include_children=request.include_children,
                 project_id=project_id,
             )
         return ExtractToolResponse(

--- a/apps/backend/src/rhesis/backend/app/routers/tools.py
+++ b/apps/backend/src/rhesis/backend/app/routers/tools.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import uuid
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from rhesis.backend.app.routers.base import RhesisRouter
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import (
+    get_project_context,
     get_tenant_context,
     get_tenant_db_session,
 )
@@ -372,6 +373,7 @@ async def extract_tool_item(
     request: ExtractToolRequest,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
+    project_id: Optional[str] = Depends(get_project_context),
     current_user: User = Depends(require_current_user_or_token),
 ):
     """
@@ -401,6 +403,7 @@ async def extract_tool_item(
                 organization_id=organization_id,
                 user_id=user_id,
                 include_children=request.include_children,
+                project_id=project_id,
             )
         return ExtractToolResponse(
             sources=[
@@ -421,6 +424,7 @@ async def test_tool_connection(
     request: TestToolConnectionRequest,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
+    project_id: Optional[str] = Depends(get_project_context),
     current_user: User = Depends(require_current_user_or_token),
 ):
     """Test a tool's credentials via a lightweight connection check."""
@@ -455,6 +459,7 @@ async def test_tool_connection(
                 provider_type_id=request.provider_type_id,
                 credentials=request.credentials,
                 tool_metadata=request.tool_metadata,
+                project_id=project_id,
             )
     except (ToolConfigurationError, ValueError) as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/apps/backend/src/rhesis/backend/app/schemas/services.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/services.py
@@ -311,7 +311,8 @@ class ExtractToolRequest(BaseModel):
     """Request to extract content from a tool item.
 
     Either 'id' or 'url' (or both) must be provided.
-    Set include_children=True to recursively extract child pages/files.
+    Set include_children=True to recursively extract child pages/files
+    (REST providers only — ignored for MCP-backed tools).
     """
 
     id: Optional[str] = None

--- a/apps/backend/src/rhesis/backend/app/services/tool/mcp/operations.py
+++ b/apps/backend/src/rhesis/backend/app/services/tool/mcp/operations.py
@@ -200,7 +200,6 @@ async def mcp_extract(
     identifier: str,
     organization_id: str,
     user_id: str,
-    include_children: bool = False,
     max_iterations: int = 10,
     project_id: Optional[str] = None,
 ) -> List[FetchedSource]:
@@ -226,7 +225,6 @@ async def mcp_extract(
     for repair in (False, True):
         system_prompt = template.render(
             provider=provider,
-            include_children=include_children,
             repair=repair,
             **_mcp_template_scope_kwargs(provider, scope_context),
         )

--- a/apps/backend/src/rhesis/backend/app/services/tool/mcp/operations.py
+++ b/apps/backend/src/rhesis/backend/app/services/tool/mcp/operations.py
@@ -90,9 +90,10 @@ def _resolve_tool_client(
     user_id: str,
     tool_id: str,
     tool_metadata: Optional[Dict[str, Any]] = None,
+    project_id: Optional[str] = None,
 ) -> Tuple[Any, str, Optional[Dict[str, str]]]:
     """Build an MCP client, provider name, and optional scope context for a saved tool."""
-    with get_db_with_tenant_variables(organization_id, user_id) as db:
+    with get_db_with_tenant_variables(organization_id, user_id, project_id or "") as db:
         return _get_mcp_tool_config(
             db, tool_id, organization_id, user_id, tool_metadata_override=tool_metadata
         )
@@ -104,9 +105,10 @@ def _resolve_params_client(
     provider_type_id: Any,
     credentials: Dict[str, str],
     tool_metadata: Optional[Dict[str, Any]] = None,
+    project_id: Optional[str] = None,
 ) -> Tuple[Any, str, Optional[Dict[str, str]]]:
     """Build an MCP client from unsaved credentials."""
-    with get_db_with_tenant_variables(organization_id, user_id) as db:
+    with get_db_with_tenant_variables(organization_id, user_id, project_id or "") as db:
         return _get_mcp_client_from_params(
             provider_type_id,
             credentials,
@@ -200,6 +202,7 @@ async def mcp_extract(
     user_id: str,
     include_children: bool = False,
     max_iterations: int = 10,
+    project_id: Optional[str] = None,
 ) -> List[FetchedSource]:
     """Extract content from an MCP-backed tool as structured sources.
 
@@ -213,7 +216,9 @@ async def mcp_extract(
     if not user_id:
         raise ValueError("user_id is required")
 
-    client, provider, scope_context = _resolve_tool_client(organization_id, user_id, tool_id)
+    client, provider, scope_context = _resolve_tool_client(
+        organization_id, user_id, tool_id, project_id=project_id
+    )
     query = f"Extract the full content of: {identifier}"
     template = jinja_env.get_template("mcp_extract_prompt.jinja2")
 
@@ -243,6 +248,7 @@ async def mcp_health_check(
     provider_type_id: Optional[Any] = None,
     credentials: Optional[Dict[str, str]] = None,
     tool_metadata: Optional[Dict[str, Any]] = None,
+    project_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Test MCP credentials via a minimal read-only agent auth ping.
 
@@ -258,7 +264,11 @@ async def mcp_health_check(
 
     if tool_id:
         client, provider, scope_context = _resolve_tool_client(
-            organization_id, user_id, tool_id, tool_metadata=tool_metadata
+            organization_id,
+            user_id,
+            tool_id,
+            tool_metadata=tool_metadata,
+            project_id=project_id,
         )
     elif provider_type_id is not None and credentials is not None:
         client, provider, scope_context = _resolve_params_client(
@@ -267,6 +277,7 @@ async def mcp_health_check(
             provider_type_id,
             credentials,
             tool_metadata=tool_metadata,
+            project_id=project_id,
         )
     else:
         raise ToolConfigurationError(

--- a/apps/backend/src/rhesis/backend/app/templates/mcp_extract_prompt.jinja2
+++ b/apps/backend/src/rhesis/backend/app/templates/mcp_extract_prompt.jinja2
@@ -30,10 +30,6 @@ You are restricted to the following Asana workspace:
 Scope all Asana tool calls to workspace GID "{{ workspace_context.workspace_gid }}".
 {% endif %}
 {% endif %}
-{% if include_children %}
-Also extract every child page / nested item and return each as a separate entry.
-{% endif %}
-
 Return ONLY a JSON array. Each element is an object with these fields:
 - id: a stable identifier for the item (page id, file path, issue key, ...)
 - title: the item's title or name

--- a/apps/frontend/src/app/(protected)/knowledge/components/ToolImportDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/ToolImportDrawer.tsx
@@ -16,7 +16,10 @@ import SmartToyIcon from '@mui/icons-material/SmartToy';
 import BaseDrawer from '@/components/common/BaseDrawer';
 import { Tool } from '@/utils/api-client/interfaces/tool';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { TOOL_PROVIDER_ICONS, REST_PROVIDERS } from '@/config/tool-providers';
+import {
+  TOOL_PROVIDER_ICONS,
+  EXTRACT_PROVIDERS,
+} from '@/config/tool-providers';
 import { drawerOutlinedFieldSx } from '@/components/common/drawerFormFieldSx';
 import ToolImportPanel, {
   ToolImportPanelHandle,
@@ -57,7 +60,7 @@ export default function ToolImportDrawer({
         .getToolsClient()
         .getTools({ limit: 100 });
       const supported = (response.data || []).filter(t =>
-        REST_PROVIDERS.includes(t.tool_provider_type?.type_value ?? '')
+        EXTRACT_PROVIDERS.includes(t.tool_provider_type?.type_value ?? '')
       );
       setTools(supported);
       if (supported.length === 1) {
@@ -116,7 +119,7 @@ export default function ToolImportDrawer({
         </Box>
       ) : tools.length === 0 ? (
         <Alert severity="info">
-          No tools configured. Connect a Notion or GitHub tool in{' '}
+          No tools configured. Connect a tool in{' '}
           <Link href="/tools" underline="hover">
             Settings &rsaquo; Tools
           </Link>{' '}

--- a/apps/frontend/src/app/(protected)/knowledge/components/ToolImportPanel.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/ToolImportPanel.tsx
@@ -93,19 +93,19 @@ function getProviderLabel(provider: string): {
   }
   if (provider === 'gitlab') {
     return {
-      checkbox: 'Include linked items',
+      checkbox: '',
       placeholder: 'Paste GitLab issue or merge request URL...',
     };
   }
   if (provider === 'shortcut') {
     return {
-      checkbox: 'Include linked items',
+      checkbox: '',
       placeholder: 'Paste Shortcut story or epic URL...',
     };
   }
   if (provider === 'asana') {
     return {
-      checkbox: 'Include subtasks',
+      checkbox: '',
       placeholder: 'Paste Asana task or project URL...',
     };
   }
@@ -398,13 +398,7 @@ const ToolImportPanel = forwardRef<ToolImportPanelHandle, ToolImportPanelProps>(
 
     const provider = tool?.tool_provider_type?.type_value ?? 'resource';
     const providerLabels = getProviderLabel(provider);
-    const showChildrenOption = [
-      'notion',
-      'github',
-      'gitlab',
-      'shortcut',
-      'asana',
-    ].includes(provider);
+    const showChildrenOption = provider === 'notion' || provider === 'github';
 
     if (!open) return null;
 

--- a/apps/frontend/src/app/(protected)/knowledge/components/ToolImportPanel.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/ToolImportPanel.tsx
@@ -91,6 +91,24 @@ function getProviderLabel(provider: string): {
       placeholder: 'Paste GitHub file or directory URL...',
     };
   }
+  if (provider === 'gitlab') {
+    return {
+      checkbox: 'Include linked items',
+      placeholder: 'Paste GitLab issue or merge request URL...',
+    };
+  }
+  if (provider === 'shortcut') {
+    return {
+      checkbox: 'Include linked items',
+      placeholder: 'Paste Shortcut story or epic URL...',
+    };
+  }
+  if (provider === 'asana') {
+    return {
+      checkbox: 'Include subtasks',
+      placeholder: 'Paste Asana task or project URL...',
+    };
+  }
   return {
     checkbox: 'Include linked items',
     placeholder: 'Paste URL...',
@@ -380,7 +398,13 @@ const ToolImportPanel = forwardRef<ToolImportPanelHandle, ToolImportPanelProps>(
 
     const provider = tool?.tool_provider_type?.type_value ?? 'resource';
     const providerLabels = getProviderLabel(provider);
-    const showChildrenOption = provider === 'notion' || provider === 'github';
+    const showChildrenOption = [
+      'notion',
+      'github',
+      'gitlab',
+      'shortcut',
+      'asana',
+    ].includes(provider);
 
     if (!open) return null;
 

--- a/apps/frontend/src/config/tool-providers.tsx
+++ b/apps/frontend/src/config/tool-providers.tsx
@@ -15,9 +15,18 @@ import {
  * - Provider icons and branding
  */
 
-// Providers supported via the deterministic REST extract path.
-// Must match ToolProviderType values defined in the backend.
-export const REST_PROVIDERS = ['notion', 'github'];
+// Providers that support the extract action (REST or MCP — backend picks transport).
+// Must stay in sync with _ROUTES in apps/backend/.../services/tool/actions.py.
+export const EXTRACT_PROVIDERS = [
+  'notion',
+  'github',
+  'gitlab',
+  'shortcut',
+  'asana',
+];
+
+/** @deprecated Use EXTRACT_PROVIDERS */
+export const REST_PROVIDERS = EXTRACT_PROVIDERS;
 
 // Short description of what each provider is used for in Rhesis
 export const TOOL_PROVIDER_DESCRIPTIONS: Record<string, string> = {

--- a/tests/backend/services/test_tool_actions.py
+++ b/tests/backend/services/test_tool_actions.py
@@ -83,6 +83,32 @@ class TestParsing:
 _OPS = "rhesis.backend.app.services.tool.mcp.operations"
 
 
+class TestResolveToolClient:
+    def test_passes_project_id_to_tenant_session(self):
+        from unittest.mock import Mock
+
+        from rhesis.backend.app.services.tool.mcp.operations import _resolve_tool_client
+
+        with (
+            patch(f"{_OPS}.get_db_with_tenant_variables") as gdb,
+            patch(f"{_OPS}._get_mcp_tool_config", return_value=(object(), "gitlab", None)),
+        ):
+            gdb.return_value.__enter__ = Mock(return_value=Mock())
+            gdb.return_value.__exit__ = Mock(return_value=False)
+            _resolve_tool_client(
+                "org",
+                "user",
+                "tool-id",
+                project_id="b7302a7a-1290-4a9e-9d9a-4bb8cc044057",
+            )
+
+        gdb.assert_called_once_with(
+            "org",
+            "user",
+            "b7302a7a-1290-4a9e-9d9a-4bb8cc044057",
+        )
+
+
 @pytest.mark.asyncio
 class TestMcpExtract:
     _ARGS = dict(


### PR DESCRIPTION
## Summary
- Pass `project_id` through MCP extract and test-connection paths so tool lookups respect project scope
- Expose GitLab, Shortcut and Asana in the Knowledge import drawer
- Rename `REST_PROVIDERS` → `EXTRACT_PROVIDERS` (REST alias kept for compatibility)
- Remove `include_children` support for MCP extract operations.

## Test plan
- [ ] Connect a GitLab / Shortcut / Asana tool in Settings → Tools
- [ ] Open Knowledge → Import; confirm configured extract tools appear in the source picker
- [ ] Import a URL with and without "include children/linked items" checked
- [ ] Confirm Notion and GitHub import still works (regression)
- [ ] `cd apps/backend && uv run pytest ../../tests/backend/services/test_tool_actions.py::TestResolveToolClient -v`
