### PR TITLE
Enforce user ownership in visibility filter and remove public TestSet visibility

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/b1c2d3e4f5a6_remove_public_from_test_set_visibility.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/b1c2d3e4f5a6_remove_public_from_test_set_visibility.py
@@ -1,0 +1,40 @@
+"""Remove 'public' from test_set visibility CHECK constraint
+
+The TestSet visibility CHECK constraint allowed 'public', 'organization', and
+'user'.  The 'public' value was dead — nothing writes it, and cross-org sharing
+is hard-blocked by RLS + ORM auto-filter.  Remove it so the schema honestly
+reflects what is supported.  Any stale 'public' rows are migrated to
+'organization' as a defensive measure.
+
+Revision ID: b1c2d3e4f5a6
+Revises: a0b1c2d3e4f5
+Create Date: 2026-06-24
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, None] = "a0b1c2d3e4f5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE test_set SET visibility = 'organization' WHERE visibility = 'public'")
+    op.execute("ALTER TABLE test_set DROP CONSTRAINT IF EXISTS test_set_visibility_check")
+    op.create_check_constraint(
+        "test_set_visibility_check",
+        "test_set",
+        "visibility IN ('organization', 'user')",
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE test_set DROP CONSTRAINT IF EXISTS test_set_visibility_check")
+    op.create_check_constraint(
+        "test_set_visibility_check",
+        "test_set",
+        "visibility IN ('public', 'organization', 'user')",
+    )

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -505,7 +505,7 @@ def get_test_set(
     return (
         QueryBuilder(db, models.TestSet)
         .with_organization_filter(organization_id)  # Add organization filtering
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .with_custom_filter(lambda q: q.filter(models.TestSet.id == test_set_id))
         .first()
     )
@@ -543,7 +543,7 @@ def get_test_sets(
             "organization",
         )
         .with_organization_filter(organization_id)  # Apply organization filtering
-        .with_visibility_filter()  # This already handles public visibility correctly
+        .with_visibility_filter(user_id)
         .with_odata_filter(filter)
         .with_pagination(skip, limit)
         .with_sorting(sort_by, sort_order)
@@ -644,7 +644,7 @@ def get_test_set_by_nano_id_or_slug(
             "organization",
         )
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .with_custom_filter(
             lambda q: q.filter(
                 (models.TestSet.nano_id == identifier) | (models.TestSet.slug == identifier)
@@ -721,7 +721,7 @@ def get_test_sets_for_test(
             "organization",
         )
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .with_custom_filter(
             lambda q: q.join(models.test.test_test_set_association).filter(
                 and_(
@@ -942,7 +942,7 @@ def get_status(
         .with_deleted()
         .with_optimized_loads(skip_one_to_many=True)
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .filter_by_id(status_id)
     )
     return _check_and_raise_if_deleted(item, models.Status, status_id, False)
@@ -2103,7 +2103,7 @@ def get_projects(
             QueryBuilder(db, models.Project)
             .with_optimized_loads(skip_many_to_many=False, skip_one_to_many=True)
             .with_organization_filter(organization_id)
-            .with_visibility_filter()
+            .with_visibility_filter(user_id)
             .with_odata_filter(filter)
         )
 
@@ -2137,7 +2137,7 @@ def count_projects(
         builder = (
             QueryBuilder(db, models.Project)
             .with_organization_filter(organization_id)
-            .with_visibility_filter()
+            .with_visibility_filter(user_id)
             .with_odata_filter(filter)
         )
         if user_id:
@@ -2378,7 +2378,7 @@ def get_test_run(
         )
         .with_custom_filter(_defer_endpoint_last_token)
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .filter_by_id(test_run_id)
     )
 
@@ -2421,7 +2421,7 @@ def get_test_runs(
         .with_custom_filter(_defer_endpoint_last_token)
         .with_custom_filter(experiment_filter)
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .with_odata_filter(filter)
         .with_pagination(skip, limit)
         .with_sorting(sort_by, sort_order)
@@ -2878,7 +2878,7 @@ def get_metric(
         .with_joined(*_METRIC_M2O_RELATIONSHIPS)
         .with_selectin(*_METRIC_M2M_RELATIONSHIPS)
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .with_custom_filter(lambda q: q.filter(models.Metric.id == metric_id))
         .first()
     )
@@ -2900,7 +2900,7 @@ def get_metrics(
         .with_joined(*_METRIC_M2O_RELATIONSHIPS)
         .with_selectin(*_METRIC_M2M_RELATIONSHIPS)
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .with_odata_filter(filter)
         .with_pagination(skip, limit)
         .with_sorting(sort_by, sort_order)

--- a/apps/backend/src/rhesis/backend/app/models/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/models/test_set.py
@@ -76,9 +76,7 @@ class TestSet(
     priority = Column(Integer, default=0)
 
     __table_args__ = (
-        CheckConstraint(
-            "visibility IN ('public', 'organization', 'user')", name="test_set_visibility_check"
-        ),
+        CheckConstraint("visibility IN ('organization', 'user')", name="test_set_visibility_check"),
     )
 
     # Relationship to subscriptions

--- a/apps/backend/src/rhesis/backend/app/routers/experiments.py
+++ b/apps/backend/src/rhesis/backend/app/routers/experiments.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
-from rhesis.backend.app.routers.base import RhesisRouter
+from fastapi import Depends, HTTPException, Query, Response, status
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud
@@ -28,6 +27,7 @@ from rhesis.backend.app.dependencies import (
 )
 from rhesis.backend.app.models.experiment import Experiment
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.parameters import (
     ExperimentDetail,
     ExperimentRead,
@@ -85,14 +85,17 @@ def list_experiments(
         organization_id=organization_id,
         user_id=user_id,
     )
-    visible = [
-        r
-        for r in rows
-        if r.visibility != "private"
-        or (user_id is not None and str(r.owner_user_id) == str(user_id))
-    ]
-    response.headers["X-Total-Count"] = str(len(visible))
-    return [to_read(r) for r in visible]
+    from rhesis.backend.app.utils.crud_utils import count_items
+
+    total = count_items(
+        db,
+        Experiment,
+        filter=filter,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    response.headers["X-Total-Count"] = str(total)
+    return [to_read(r) for r in rows]
 
 
 @router.get("/{experiment_id}", response_model=ExperimentDetail)

--- a/apps/backend/src/rhesis/backend/app/routers/recycle.py
+++ b/apps/backend/src/rhesis/backend/app/routers/recycle.py
@@ -11,17 +11,17 @@ import logging
 from typing import Dict, List
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query
-from rhesis.backend.app.routers.base import RhesisRouter
-from rhesis.backend.app.auth.capabilities import Permission, capability
+from fastapi import Depends, HTTPException, Query
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import UnmappedClassError
 
 from rhesis.backend.app import models
+from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import get_tenant_context, get_tenant_db_session
 from rhesis.backend.app.models.base import Base
+from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.services import recycle as recycle_service
 from rhesis.backend.app.utils.crud_utils import (
     get_deleted_items,
@@ -244,7 +244,7 @@ def empty_recycle_bin_for_model(
         QueryBuilder(db, model)
         .only_deleted()
         .with_organization_filter(org_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .all()
     )
 
@@ -358,7 +358,7 @@ def get_recycle_bin_counts(
                 QueryBuilder(db, model)
                 .only_deleted()
                 .with_organization_filter(org_id)
-                .with_visibility_filter()
+                .with_visibility_filter(user_id)
                 .count()
             )
 

--- a/apps/backend/src/rhesis/backend/app/services/experiment.py
+++ b/apps/backend/src/rhesis/backend/app/services/experiment.py
@@ -89,13 +89,6 @@ def get_visible_experiment(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Experiment not found",
         )
-    if db_experiment.visibility == "private" and (
-        user_id is None or str(db_experiment.owner_user_id) != str(user_id)
-    ):
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Experiment not found",
-        )
     return db_experiment
 
 

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -327,7 +327,7 @@ def get_item(
         QueryBuilder(db, model)
         .with_deleted()  # Always include deleted to check status
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .filter_by_id(item_id)
     )
 
@@ -374,7 +374,7 @@ def get_item_detail(
         .with_optimized_loads(skip_one_to_many=True)
         .with_organization_filter(organization_id)
         .with_project_filter(project_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .filter_by_id(item_id)
     )
 
@@ -419,7 +419,7 @@ def get_item_with_deferred(
         .with_deleted()  # Always include deleted to check status
         .with_optimized_loads()
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
     )
 
     # Add undefer options for deferred fields BEFORE query execution
@@ -451,7 +451,7 @@ def get_items(
     return (
         QueryBuilder(db, model)
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .with_odata_filter(filter)
         .with_pagination(skip, limit)
         .with_sorting(sort_by, sort_order)
@@ -496,7 +496,7 @@ def get_items_detail(
         builder = builder.with_selectin_chain(*chain)
     return (
         builder.with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .with_odata_filter(filter)
         .with_pagination(skip, limit)
         .with_sorting(
@@ -706,7 +706,7 @@ def get_deleted_items(
         QueryBuilder(db, model)
         .only_deleted()
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .with_pagination(skip, limit)
         .with_sorting(sort_by, sort_order)
         .all()
@@ -802,7 +802,7 @@ def count_items(
     return (
         QueryBuilder(db, model)
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .with_odata_filter(filter)
         .count()
     )
@@ -885,7 +885,9 @@ def get_or_create_entity(
 
     # Build base query with direct tenant context
     query = (
-        QueryBuilder(db, model).with_organization_filter(organization_id).with_visibility_filter()
+        QueryBuilder(db, model)
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
     )
 
     # Try to find by ID first if provided
@@ -943,7 +945,7 @@ def get_or_create_status(
     query = (
         QueryBuilder(db, Status)
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .with_custom_filter(
             lambda q: q.filter(Status.name == name, Status.entity_type_id == entity_type_lookup.id)
         )
@@ -986,7 +988,7 @@ def get_or_create_type_lookup(
     query = (
         QueryBuilder(db, TypeLookup)
         .with_organization_filter(organization_id)
-        .with_visibility_filter()
+        .with_visibility_filter(user_id)
         .with_custom_filter(
             lambda q: q.filter(
                 TypeLookup.type_name == type_name, TypeLookup.type_value == type_value

--- a/apps/backend/src/rhesis/backend/app/utils/query_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/query_utils.py
@@ -2,7 +2,7 @@ import logging
 from typing import Callable, Dict, List, Optional, Type, TypeVar
 from uuid import UUID
 
-from sqlalchemy import desc, inspect
+from sqlalchemy import desc, inspect, or_
 from sqlalchemy.orm import Query, RelationshipProperty, Session, joinedload, selectinload
 
 # Removed unused imports - legacy tenant functions no longer needed
@@ -281,8 +281,6 @@ class QueryBuilder:
         e.g. in admin paths that operate outside the normal request scope.
         """
         if project_id and has_project_id(self.model):
-            from sqlalchemy import or_
-
             self.query = self.query.filter(
                 or_(
                     self.model.project_id == project_id,
@@ -291,11 +289,38 @@ class QueryBuilder:
             )
         return self
 
-    def with_visibility_filter(self) -> "QueryBuilder":
-        """Apply visibility filter if the model supports it"""
-        # Note: Visibility filtering is now handled through direct parameter passing
-        # rather than session variables. This method is kept for compatibility
-        # but no longer applies automatic filters.
+    def with_visibility_filter(self, user_id: Optional[str] = None) -> "QueryBuilder":
+        """Hide owner-only rows from non-owners.
+
+        Models that declare a ``visibility`` column alongside an owner column
+        (``user_id`` or ``owner_user_id``) are filtered so that rows whose
+        visibility marks them as private (``'user'`` for TestSet,
+        ``'private'`` for Experiment) are visible only to their owner.
+        Models without these columns are returned unfiltered.
+        """
+        columns = inspect(self.model).columns.keys()
+        if "visibility" not in columns:
+            return self
+
+        if "user_id" in columns:
+            owner_col = self.model.user_id
+        elif "owner_user_id" in columns:
+            owner_col = self.model.owner_user_id
+        else:
+            return self
+
+        private_values = ("user", "private")
+
+        if user_id:
+            self.query = self.query.filter(
+                or_(
+                    ~self.model.visibility.in_(private_values),
+                    owner_col == user_id,
+                )
+            )
+        else:
+            self.query = self.query.filter(~self.model.visibility.in_(private_values))
+
         return self
 
     def with_odata_filter(self, filter_str: Optional[str]) -> "QueryBuilder":
@@ -444,10 +469,14 @@ def has_project_id(model: Type[T]) -> bool:
 
 
 def has_visibility(model: Type[T]) -> bool:
-    """Check if model supports visibility filtering (has visibility, organization_id and user_id
-    fields)"""
+    """Check if model supports visibility filtering.
+
+    Requires a ``visibility`` column and an owner column (``user_id`` or
+    ``owner_user_id``).
+    """
     columns = inspect(model).columns.keys()
-    return "visibility" in columns and "organization_id" in columns and "user_id" in columns
+    has_owner = "user_id" in columns or "owner_user_id" in columns
+    return "visibility" in columns and has_owner
 
 
 def get_model_relationships(

--- a/apps/backend/src/rhesis/backend/app/utils/query_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/query_utils.py
@@ -297,11 +297,18 @@ class QueryBuilder:
         visibility marks them as private (``'user'`` for TestSet,
         ``'private'`` for Experiment) are visible only to their owner.
         Models without these columns are returned unfiltered.
+
+        Owner column priority: ``user_id`` > ``owner_user_id``.  Some
+        models (e.g. TestSet) also carry an ``owner_id`` column, but
+        ``user_id`` is the canonical field used by capability / ``:own``
+        checks and creation paths.  ``owner_id`` is intentionally
+        ignored here to stay aligned with the auth layer.
         """
         columns = inspect(self.model).columns.keys()
         if "visibility" not in columns:
             return self
 
+        # owner_id is intentionally not checked — see docstring.
         if "user_id" in columns:
             owner_col = self.model.user_id
         elif "owner_user_id" in columns:

--- a/apps/backend/src/rhesis/backend/app/utils/query_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/query_utils.py
@@ -318,15 +318,19 @@ class QueryBuilder:
 
         private_values = ("user", "private")
 
+        vis = self.model.visibility
         if user_id:
             self.query = self.query.filter(
                 or_(
-                    ~self.model.visibility.in_(private_values),
+                    vis.is_(None),
+                    ~vis.in_(private_values),
                     owner_col == user_id,
                 )
             )
         else:
-            self.query = self.query.filter(~self.model.visibility.in_(private_values))
+            self.query = self.query.filter(
+                or_(vis.is_(None), ~vis.in_(private_values))
+            )
 
         return self
 

--- a/apps/backend/src/rhesis/backend/app/utils/query_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/query_utils.py
@@ -328,9 +328,7 @@ class QueryBuilder:
                 )
             )
         else:
-            self.query = self.query.filter(
-                or_(vis.is_(None), ~vis.in_(private_values))
-            )
+            self.query = self.query.filter(or_(vis.is_(None), ~vis.in_(private_values)))
 
         return self
 

--- a/apps/backend/src/rhesis/backend/tasks/test_set.py
+++ b/apps/backend/src/rhesis/backend/tasks/test_set.py
@@ -59,8 +59,10 @@ def count_test_sets(self):
             self.log_with_context("info", "Total test sets counted", total_count=total_count)
 
             # Get counts by visibility
-            public_count = db.query(TestSet).filter(TestSet.visibility == "public").count()
-            private_count = db.query(TestSet).filter(TestSet.visibility == "private").count()
+            org_visible_count = (
+                db.query(TestSet).filter(TestSet.visibility == "organization").count()
+            )
+            user_only_count = db.query(TestSet).filter(TestSet.visibility == "user").count()
 
             published_count = db.query(TestSet).filter(TestSet.is_published).count()
             unpublished_count = db.query(TestSet).filter(~TestSet.is_published).count()
@@ -68,8 +70,8 @@ def count_test_sets(self):
         self.log_with_context(
             "info",
             "Visibility counts retrieved",
-            public_count=public_count,
-            private_count=private_count,
+            organization_count=org_visible_count,
+            user_only_count=user_only_count,
         )
         self.log_with_context(
             "info",
@@ -80,7 +82,7 @@ def count_test_sets(self):
 
         result = {
             "total_count": total_count,
-            "by_visibility": {"public": public_count, "private": private_count},
+            "by_visibility": {"organization": org_visible_count, "user": user_only_count},
             "by_status": {"published": published_count, "unpublished": unpublished_count},
             "organization_id": org_id,
             "user_id": user_id,
@@ -90,8 +92,8 @@ def count_test_sets(self):
             "info",
             "Task completed successfully",
             total_count=total_count,
-            public_count=public_count,
-            private_count=private_count,
+            org_visible_count=org_visible_count,
+            user_only_count=user_only_count,
         )
         return result
 

--- a/docs/content/contribute/backend/authorization.mdx
+++ b/docs/content/contribute/backend/authorization.mdx
@@ -203,8 +203,14 @@ permissions, so a token can only ever narrow access, never widen it:
   scope on a downgraded user's token cannot re-grant a removed permission.
 - The community provider ignores scopes entirely.
 
-Note: M2M / token-exchange JWT clients do not yet populate `principal.scopes`;
-RBAC scope enforcement currently covers `rh-*` tokens only.
+**M2M / token-exchange JWT clients** are narrowed by their **service user's
+role**, not by capability scopes. Their JWT branch does not populate
+`principal.scopes`, so the intersection is not applied. This is by design
+(Decision A, locked): assign the service user a low-privilege role (Viewer or a
+custom role) to restrict M2M access. Per-token capability narrowing below the
+service user's role is available for `rh-*` tokens only. If a concrete
+requirement for sub-role M2M narrowing appears, the hybrid option (optional
+`rbac_scopes` on `AuthClient`) can be added without changing the PDP.
 
 ## Non-HTTP enforcement surfaces
 

--- a/tests/backend/security/test_visibility_filter.py
+++ b/tests/backend/security/test_visibility_filter.py
@@ -1,0 +1,288 @@
+"""Deny-first tests for the visibility filter.
+
+Verifies that ``QueryBuilder.with_visibility_filter()`` correctly hides
+owner-only rows (TestSet ``visibility='user'``, Experiment
+``visibility='private'``) from non-owners, while keeping shared rows
+visible to all org members.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.utils.query_utils import QueryBuilder, has_visibility
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_OWNER_ID = str(uuid.uuid4())
+_OTHER_USER_ID = str(uuid.uuid4())
+_ORG_ID = str(uuid.uuid4())
+
+
+def _insert_test_set(
+    db: Session,
+    *,
+    visibility: str = "organization",
+    user_id: str = _OWNER_ID,
+    organization_id: str = _ORG_ID,
+) -> uuid.UUID:
+    """Insert a minimal test_set row and return its id."""
+    ts_id = uuid.uuid4()
+    db.execute(
+        text(
+            """
+            INSERT INTO test_set
+                (id, name, visibility, user_id, organization_id,
+                 created_at, updated_at)
+            VALUES (:id, :name, :vis, :uid, :oid, now(), now())
+            """
+        ),
+        {
+            "id": str(ts_id),
+            "name": f"ts-{ts_id.hex[:8]}",
+            "vis": visibility,
+            "uid": user_id,
+            "oid": organization_id,
+        },
+    )
+    db.flush()
+    return ts_id
+
+
+def _ensure_project(db: Session, project_id: str, organization_id: str) -> None:
+    """Create a project row if it doesn't exist (for FK satisfaction)."""
+    exists = db.execute(
+        text("SELECT 1 FROM project WHERE id = :pid"),
+        {"pid": project_id},
+    ).scalar()
+    if not exists:
+        db.execute(
+            text(
+                "INSERT INTO project (id, name, organization_id, created_at, updated_at) "
+                "VALUES (:pid, :name, :oid, now(), now())"
+            ),
+            {"pid": project_id, "name": f"proj-{project_id[:8]}", "oid": organization_id},
+        )
+        db.flush()
+
+
+def _insert_experiment(
+    db: Session,
+    *,
+    visibility: str = "private",
+    owner_user_id: str = _OWNER_ID,
+    organization_id: str = _ORG_ID,
+    project_id: str | None = None,
+) -> uuid.UUID:
+    """Insert a minimal experiment row and return its id."""
+    exp_id = uuid.uuid4()
+    pid = project_id or str(uuid.uuid4())
+    _ensure_project(db, pid, organization_id)
+    db.execute(
+        text(
+            """
+            INSERT INTO experiment
+                (id, name, visibility, owner_user_id, organization_id, project_id,
+                 versions, update_count, created_at, updated_at)
+            VALUES (:id, :name, :vis, :uid, :oid, :pid,
+                    '[]'::jsonb, 0, now(), now())
+            """
+        ),
+        {
+            "id": str(exp_id),
+            "name": f"exp-{exp_id.hex[:8]}",
+            "vis": visibility,
+            "uid": owner_user_id,
+            "oid": organization_id,
+            "pid": pid,
+        },
+    )
+    db.flush()
+    return exp_id
+
+
+# ---------------------------------------------------------------------------
+# has_visibility probe
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestHasVisibility:
+    def test_test_set_has_visibility(self):
+        assert has_visibility(models.TestSet) is True
+
+    def test_experiment_has_visibility(self):
+        assert has_visibility(models.Experiment) is True
+
+    def test_project_no_visibility(self):
+        assert has_visibility(models.Project) is False
+
+
+# ---------------------------------------------------------------------------
+# TestSet visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestTestSetVisibility:
+    """TestSet visibility='user' must be hidden from non-owners."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db: Session, test_org_id, authenticated_user_id):
+        self.db = test_db
+        self.org_id = test_org_id
+        self.user_id = authenticated_user_id
+        self.other_user_id = _OTHER_USER_ID
+
+    def test_org_visible_to_all(self):
+        ts_id = _insert_test_set(
+            self.db,
+            visibility="organization",
+            user_id=self.user_id,
+            organization_id=self.org_id,
+        )
+        rows = (
+            QueryBuilder(self.db, models.TestSet).with_visibility_filter(self.other_user_id).all()
+        )
+        assert any(r.id == ts_id for r in rows)
+
+    def test_user_visible_to_owner(self):
+        ts_id = _insert_test_set(
+            self.db,
+            visibility="user",
+            user_id=self.user_id,
+            organization_id=self.org_id,
+        )
+        rows = QueryBuilder(self.db, models.TestSet).with_visibility_filter(self.user_id).all()
+        assert any(r.id == ts_id for r in rows)
+
+    def test_user_hidden_from_non_owner(self):
+        ts_id = _insert_test_set(
+            self.db,
+            visibility="user",
+            user_id=self.user_id,
+            organization_id=self.org_id,
+        )
+        rows = (
+            QueryBuilder(self.db, models.TestSet).with_visibility_filter(self.other_user_id).all()
+        )
+        assert not any(r.id == ts_id for r in rows)
+
+    def test_user_hidden_when_no_user_id(self):
+        ts_id = _insert_test_set(
+            self.db,
+            visibility="user",
+            user_id=self.user_id,
+            organization_id=self.org_id,
+        )
+        rows = QueryBuilder(self.db, models.TestSet).with_visibility_filter().all()
+        assert not any(r.id == ts_id for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Experiment visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestExperimentVisibility:
+    """Experiment visibility='private' must be hidden from non-owners."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db: Session, test_org_id, authenticated_user_id):
+        self.db = test_db
+        self.org_id = test_org_id
+        self.user_id = authenticated_user_id
+        self.other_user_id = _OTHER_USER_ID
+
+    def test_shared_visible_to_all(self):
+        exp_id = _insert_experiment(
+            self.db,
+            visibility="shared",
+            owner_user_id=self.user_id,
+            organization_id=self.org_id,
+        )
+        rows = (
+            QueryBuilder(self.db, models.Experiment)
+            .with_visibility_filter(self.other_user_id)
+            .all()
+        )
+        assert any(r.id == exp_id for r in rows)
+
+    def test_private_visible_to_owner(self):
+        exp_id = _insert_experiment(
+            self.db,
+            visibility="private",
+            owner_user_id=self.user_id,
+            organization_id=self.org_id,
+        )
+        rows = QueryBuilder(self.db, models.Experiment).with_visibility_filter(self.user_id).all()
+        assert any(r.id == exp_id for r in rows)
+
+    def test_private_hidden_from_non_owner(self):
+        exp_id = _insert_experiment(
+            self.db,
+            visibility="private",
+            owner_user_id=self.user_id,
+            organization_id=self.org_id,
+        )
+        rows = (
+            QueryBuilder(self.db, models.Experiment)
+            .with_visibility_filter(self.other_user_id)
+            .all()
+        )
+        assert not any(r.id == exp_id for r in rows)
+
+    def test_private_hidden_when_no_user_id(self):
+        exp_id = _insert_experiment(
+            self.db,
+            visibility="private",
+            owner_user_id=self.user_id,
+            organization_id=self.org_id,
+        )
+        rows = QueryBuilder(self.db, models.Experiment).with_visibility_filter().all()
+        assert not any(r.id == exp_id for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Models without visibility are unaffected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestNoVisibilityModel:
+    """Models without a visibility column pass through unfiltered."""
+
+    def test_filter_is_noop_for_project(self, test_db: Session):
+        qb = QueryBuilder(test_db, models.Project)
+        before = str(qb.query)
+        qb.with_visibility_filter(_OTHER_USER_ID)
+        after = str(qb.query)
+        assert before == after
+
+
+# ---------------------------------------------------------------------------
+# CHECK constraint: 'public' is rejected
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+class TestPublicRemoved:
+    """The migration should have removed 'public' from the CHECK constraint."""
+
+    def test_public_rejected_by_db(self, test_db: Session):
+        with pytest.raises(Exception):
+            _insert_test_set(
+                test_db,
+                visibility="public",
+                user_id=_OWNER_ID,
+                organization_id=_ORG_ID,
+            )
+        test_db.rollback()

--- a/tests/backend/security/test_visibility_filter.py
+++ b/tests/backend/security/test_visibility_filter.py
@@ -277,12 +277,12 @@ class TestNoVisibilityModel:
 class TestPublicRemoved:
     """The migration should have removed 'public' from the CHECK constraint."""
 
-    def test_public_rejected_by_db(self, test_db: Session):
+    def test_public_rejected_by_db(self, test_db: Session, test_org_id, authenticated_user_id):
         with pytest.raises(Exception):
             _insert_test_set(
                 test_db,
                 visibility="public",
-                user_id=_OWNER_ID,
-                organization_id=_ORG_ID,
+                user_id=authenticated_user_id,
+                organization_id=test_org_id,
             )
         test_db.rollback()

--- a/tests/backend/test_secret_equality.py
+++ b/tests/backend/test_secret_equality.py
@@ -67,8 +67,8 @@ SENSITIVE_MARKERS = (
 ALLOWED_SITES: frozenset[tuple[str, int]] = frozenset(
     {
         # content_hash is a SHA-based fingerprint for version dedup, not a secret
-        ("apps/backend/src/rhesis/backend/app/services/experiment.py", 155),
-        ("apps/backend/src/rhesis/backend/app/services/experiment.py", 211),
+        ("apps/backend/src/rhesis/backend/app/services/experiment.py", 148),
+        ("apps/backend/src/rhesis/backend/app/services/experiment.py", 204),
         # auth_token_project_id is a UUID project reference, not a secret token;
         # comparing it to another project UUID is safe (no timing oracle risk)
         ("apps/backend/src/rhesis/backend/app/services/connector/manager.py", 1005),


### PR DESCRIPTION
## Purpose
Centralise visibility enforcement in `QueryBuilder.with_visibility_filter()` so that owner-only rows are automatically hidden from non-owners at the query layer, rather than being checked ad-hoc across routers and services.

## What Changed
- **`query_utils.py`**: `with_visibility_filter()` now accepts an optional `user_id`. When present, rows with `visibility IN ('user', 'private')` are shown only to their owner (`user_id` / `owner_user_id`). Previously the method was a no-op.
- **`crud.py` / `crud_utils.py`**: All `QueryBuilder` call sites now pass `user_id` to `with_visibility_filter()`.
- **`routers/recycle.py`**: Passes `user_id` to `with_visibility_filter()` for recycle-bin queries.
- **`models/test_set.py`**: Removed `'public'` from the `visibility` check constraint — only `'organization'` and `'user'` are valid values going forward.
- **`alembic/.../b1c2d3e4f5a6_remove_public_from_test_set_visibility.py`**: Migration that drops the old constraint and adds the updated one.
- **`routers/experiments.py`**: Fixed `X-Total-Count` header to use `count_items()` instead of Python-side post-filtering (which was double-counting).
- **`services/experiment.py`**: Removed redundant manual `visibility == 'private'` guard now handled by the query layer.
- **`tasks/test_set.py`**: Updated visibility count logging to use `'organization'` / `'user'` bucket names.
- **`tests/backend/security/test_visibility_filter.py`**: Unit tests covering the new filter logic.
- **`docs/content/contribute/backend/authorization.mdx`**: Clarified M2M / token-exchange JWT client scope behaviour.

## Additional Context
- The `has_visibility()` helper is updated to accept models with `owner_user_id` (e.g. `Experiment`) in addition to `user_id` (e.g. `TestSet`).
- No changes to the public API contract; visibility semantics are tightened, not loosened.

## Testing
```bash
cd apps/backend
uv run pytest ../../tests/backend/security/test_visibility_filter.py -v
```