### PR TITLE
Add project-scoped token auto-resolution for project_id

### DIFF
--- a/apps/backend/src/rhesis/backend/app/dependencies.py
+++ b/apps/backend/src/rhesis/backend/app/dependencies.py
@@ -80,6 +80,10 @@ def get_project_context(
          (stored on ``request.state.api_token_project_id`` by the auth layer)
       3. ``None`` — request is not scoped to a specific project
 
+    When both an explicit header and a project-scoped token are present, the
+    values must match — a project-scoped token cannot be used to access a
+    different project (403).
+
     When a project_id is resolved the dependency validates that the authenticated
     user is a member of that project.  Non-members receive **403**.
 
@@ -89,11 +93,21 @@ def get_project_context(
         only -- project-scoped rows are not visible.
     """
     # 1. Prefer explicit header (FastAPI already parsed it via the Header() annotation)
-    project_id_str = x_project_id or request.headers.get("X-Project-Id")
+    explicit_project_id = x_project_id or request.headers.get("X-Project-Id")
+    token_project_id = getattr(request.state, "api_token_project_id", None)
+
+    # If the token is project-scoped, an explicit project_id must match
+    if explicit_project_id and token_project_id and explicit_project_id != token_project_id:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                f"Project-scoped token is bound to project {token_project_id}; "
+                f"cannot override with {explicit_project_id}"
+            ),
+        )
 
     # 2. Fall back to the project bound to the API token
-    if not project_id_str:
-        project_id_str = getattr(request.state, REQUEST_STATE_API_TOKEN_PROJECT_ID, None)
+    project_id_str = explicit_project_id or token_project_id
 
     if not project_id_str:
         return None

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -13,7 +13,11 @@ from sqlalchemy.orm.attributes import flag_modified
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.constants import EnrichedDataKeys, EntityType, TestResultStatus
-from rhesis.backend.app.dependencies import get_tenant_context, get_tenant_db_session
+from rhesis.backend.app.dependencies import (
+    get_project_context,
+    get_tenant_context,
+    get_tenant_db_session,
+)
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.schemas.telemetry import (
     OTELTraceBatch,
@@ -51,6 +55,7 @@ def ingest_trace(
     trace_batch: OTELTraceBatch,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
+    scope_project_id: str | None = Depends(get_project_context),
 ) -> TraceResponse:
     """
     Ingest OpenTelemetry traces from SDK.
@@ -78,13 +83,21 @@ def ingest_trace(
     """
     organization_id, user_id = tenant_context
 
-    # Extract metadata
-    project_id = trace_batch.spans[0].project_id if trace_batch.spans else None
-
-    if not project_id:
+    # Resolve project_id: prefer span value, fall back to token/header scope
+    span_project_id = trace_batch.spans[0].project_id if trace_batch.spans else None
+    if span_project_id and span_project_id != "unknown":
+        project_id = span_project_id
+    elif scope_project_id:
+        project_id = scope_project_id
+        for span in trace_batch.spans:
+            span.project_id = scope_project_id
+    else:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Trace batch must contain at least one span with project_id",
+            detail=(
+                "No project_id could be resolved. Use a project-scoped token, "
+                "set RHESIS_PROJECT_ID, or pass X-Project-Id header."
+            ),
         )
 
     # Log ingestion (summary only)

--- a/apps/backend/src/rhesis/backend/app/routers/token.py
+++ b/apps/backend/src/rhesis/backend/app/routers/token.py
@@ -22,6 +22,7 @@ from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.token import (
     TokenCreate,
     TokenCreateResponse,
+    TokenInfoResponse,
     TokenRead,
     TokenUpdate,
 )
@@ -176,6 +177,21 @@ def _validate_token_scopes(scopes: list[str], principal: "Principal", db: Sessio
             status_code=422,
             detail=(f"Requested scopes exceed your effective permissions: {sorted(out_of_bounds)}"),
         )
+
+
+@router.get("/current", response_model=TokenInfoResponse)
+def current_token_info(
+    request: Request,
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Return project_id and organization_id for the calling API token."""
+    token_project_id = getattr(request.state, "api_token_project_id", None)
+    organization_id = str(current_user.organization_id) if current_user.organization_id else None
+
+    return TokenInfoResponse(
+        project_id=token_project_id,
+        organization_id=organization_id,
+    )
 
 
 @router.get("/", response_model=List[TokenRead])

--- a/apps/backend/src/rhesis/backend/app/schemas/token.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/token.py
@@ -71,6 +71,13 @@ class Token(TokenBase):
     updated_at: datetime
 
 
+class TokenInfoResponse(Base):
+    """Lightweight introspection response for the calling token."""
+
+    project_id: Optional[UUID4] = None
+    organization_id: Optional[UUID4] = None
+
+
 # Special response schema for token creation that includes the actual token value
 class TokenCreateResponse(Base):
     id: UUID4  # Add ID field for consistency

--- a/packages/rhesis/src/rhesis/telemetry/exporter.py
+++ b/packages/rhesis/src/rhesis/telemetry/exporter.py
@@ -40,7 +40,7 @@ class RhesisOTLPExporter(OTLPSpanExporter):
         self,
         api_key: str,
         base_url: str,
-        project_id: str,
+        project_id: Optional[str],
         environment: str,
         timeout: int = 10,
         max_attempts: int = 3,

--- a/packages/rhesis/src/rhesis/telemetry/provider.py
+++ b/packages/rhesis/src/rhesis/telemetry/provider.py
@@ -19,7 +19,7 @@ def get_tracer_provider(
     service_name: str,
     api_key: str,
     base_url: str,
-    project_id: str,
+    project_id: Optional[str],
     environment: str,
 ) -> TracerProvider:
     """

--- a/sdk/src/rhesis/sdk/clients/rhesis.py
+++ b/sdk/src/rhesis/sdk/clients/rhesis.py
@@ -138,6 +138,10 @@ class RhesisClient:
         self.project_id = project_id or os.getenv("RHESIS_PROJECT_ID")
         self.environment = environment or os.getenv("RHESIS_ENVIRONMENT", "development")
 
+        # Resolve project_id from token when not explicitly provided
+        if not self.project_id and self.api_key:
+            self._resolve_project_from_token()
+
         # Lazy connector (not initialized yet)
         self._connector_manager = None
 
@@ -149,6 +153,32 @@ class RhesisClient:
 
         # Automatically register as default client for decorators
         self._register_as_default()
+
+    def _resolve_project_from_token(self) -> None:
+        """Resolve project_id by introspecting the API token."""
+        import logging
+
+        logger = logging.getLogger(__name__)
+        try:
+            import requests
+
+            resp = requests.get(
+                f"{self._base_url.rstrip('/')}/tokens/current",
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                timeout=5,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                token_project_id = data.get("project_id")
+                if token_project_id:
+                    self.project_id = token_project_id
+                    logger.info(f"Resolved project_id from token: {token_project_id}")
+            else:
+                logger.debug(
+                    f"Token introspection returned {resp.status_code}, project_id not resolved"
+                )
+        except Exception as e:
+            logger.debug(f"Token introspection failed: {e}")
 
     @classmethod
     def from_environment(cls) -> Union["RhesisClient", DisabledClient]:
@@ -203,7 +233,7 @@ class RhesisClient:
                 service_name="rhesis-sdk",
                 api_key=self.api_key,
                 base_url=self._base_url,
-                project_id=self.project_id or "unknown",
+                project_id=self.project_id,
                 environment=self.environment,
             )
 
@@ -214,7 +244,7 @@ class RhesisClient:
             # Log successful initialization
             logger.info(
                 f"✅ Telemetry initialized successfully\n"
-                f"   Project: {self.project_id or 'unknown'}\n"
+                f"   Project: {self.project_id or 'not set (will use token scope)'}\n"
                 f"   Environment: {self.environment}\n"
                 f"   Endpoint: {self._base_url}/telemetry/traces\n"
                 f"   Note: Traces are batched and exported every 5 seconds"
@@ -250,7 +280,7 @@ class RhesisClient:
 
         self._tracer = Tracer(
             api_key=self.api_key,
-            project_id=self.project_id or "unknown",
+            project_id=self.project_id,
             environment=self.environment,
             base_url=self._base_url,
         )

--- a/sdk/src/rhesis/sdk/connector/manager.py
+++ b/sdk/src/rhesis/sdk/connector/manager.py
@@ -67,7 +67,7 @@ class ConnectorManager:
         self._executor = TestExecutor()
         self._tracer = Tracer(
             api_key=api_key,
-            project_id=project_id or "",
+            project_id=project_id,
             environment=environment,
             base_url=base_url,
         )

--- a/sdk/src/rhesis/sdk/telemetry/tracer.py
+++ b/sdk/src/rhesis/sdk/telemetry/tracer.py
@@ -69,7 +69,7 @@ class Tracer:
     def __init__(
         self,
         api_key: str,
-        project_id: str,
+        project_id: Optional[str],
         environment: str,
         base_url: str,
     ):


### PR DESCRIPTION
## Purpose
Enable project-scoped API tokens to automatically supply the `project_id` context without requiring callers to set `RHESIS_PROJECT_ID` or pass `X-Project-Id` headers explicitly. This makes SDK-based integrations simpler and safer — a project-scoped token is self-describing.

## What Changed
- **`GET /tokens/current`** — new endpoint that returns `project_id` and `organization_id` for the calling token (`TokenInfoResponse` schema)
- **`dependencies.py`** — enforce that an explicit `X-Project-Id` header must match a project-scoped token's bound project; mismatches now return 403
- **`routers/telemetry.py`** — telemetry ingest resolves `project_id` from the token/header scope when a span carries no `project_id` or carries `"unknown"`; clearer error message when no project can be resolved
- **`schemas/token.py`** — new `TokenInfoResponse` lightweight schema
- **`sdk/clients/rhesis.py`** — `RhesisClient.__init__` calls `/tokens/current` to resolve `project_id` automatically when `RHESIS_PROJECT_ID` is not set
- **`telemetry/exporter.py`, `provider.py`, `sdk/telemetry/tracer.py`, `sdk/connector/manager.py`** — allow `project_id` to be `Optional[str]` throughout the telemetry stack; remove the `or "unknown"` fallbacks that silently masked missing configuration

## Additional Context
- Follows up on `fix(mcp): forward project scope from token and stamp project_id on token creation`
- No breaking changes — callers that already set `RHESIS_PROJECT_ID` or pass `X-Project-Id` are unaffected; the new `/tokens/current` call is a best-effort no-op on failure

## Testing
1. Create a project-scoped API token via the UI
2. Instantiate `RhesisClient(api_key=<token>)` without setting `RHESIS_PROJECT_ID` — verify `client.project_id` is populated
3. Send a telemetry trace with a span that has no `project_id` — verify it is stored under the correct project
4. Call `GET /tokens/current` with a project-scoped token — verify `project_id` and `organization_id` are returned
5. Pass a mismatched `X-Project-Id` header with a project-scoped token — verify 403 is returned