### PR TITLE
Fix project-scope guard and update SDK docs for token introspection

### DIFF
--- a/apps/backend/src/rhesis/backend/app/dependencies.py
+++ b/apps/backend/src/rhesis/backend/app/dependencies.py
@@ -96,16 +96,6 @@ def get_project_context(
     explicit_project_id = x_project_id or request.headers.get("X-Project-Id")
     token_project_id = getattr(request.state, "api_token_project_id", None)
 
-    # If the token is project-scoped, an explicit project_id must match
-    if explicit_project_id and token_project_id and explicit_project_id != token_project_id:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                f"Project-scoped token is bound to project {token_project_id}; "
-                f"cannot override with {explicit_project_id}"
-            ),
-        )
-
     # 2. Fall back to the project bound to the API token
     project_id_str = explicit_project_id or token_project_id
 

--- a/docs/content/sdk/client.mdx
+++ b/docs/content/sdk/client.mdx
@@ -28,16 +28,29 @@ client = RhesisClient(
 |-----------|----------|-------------|
 | `api_key` | No | API key for authentication. Falls back to `RHESIS_API_KEY` env var. |
 | `base_url` | No | API base URL. Falls back to `RHESIS_BASE_URL` env var. Default: `https://api.rhesis.ai` |
-| `project_id` | No | Project ID for endpoint registration and tracing. Falls back to `RHESIS_PROJECT_ID` env var. |
+| `project_id` | No | Project ID for endpoint registration and tracing. Falls back to `RHESIS_PROJECT_ID` env var, then to the project bound to the API token. |
 | `environment` | No | Environment name. Falls back to `RHESIS_ENVIRONMENT` env var. Default: `development` |
+
+## Project ID Resolution
+
+The client resolves `project_id` in the following order:
+
+1. **Explicit parameter** passed to the constructor
+2. **`RHESIS_PROJECT_ID`** environment variable
+3. **Token introspection** - if the API token is scoped to a project, the client automatically resolves the project ID from the token
+
+If a project-scoped token is used and an explicit `project_id` is also provided, the values must match. A project-scoped token cannot be used to access a different project.
+
+Organization-scoped tokens (without a project boundary) require an explicit `project_id` via the constructor or environment variable.
 
 ## What It Does
 
 When you create a `RhesisClient`, it:
 
-1. **Initializes telemetry** - Sets up OpenTelemetry for tracing
-2. **Registers as default** - Becomes the default client for `@endpoint` and `@observe` decorators
-3. **Lazy-loads connector** - WebSocket connector is initialized only when `@endpoint` is used
+1. **Resolves project scope** - Determines the project from explicit config or token introspection
+2. **Initializes telemetry** - Sets up OpenTelemetry for tracing
+3. **Registers as default** - Becomes the default client for `@endpoint` and `@observe` decorators
+4. **Lazy-loads connector** - WebSocket connector is initialized only when `@endpoint` is used
 
 <Callout type="warning">
   The `RhesisClient` must be initialized before using `@observe` or `@endpoint` decorators. Without it, a `RuntimeError` is raised.

--- a/docs/content/sdk/connector/index.mdx
+++ b/docs/content/sdk/connector/index.mdx
@@ -140,8 +140,8 @@ if __name__ == "__main__":
 </CodeBlock>
 
 <Callout type="info">
-  `@endpoint` registrations still require `project_id`. The optional `project_id` behavior applies to
-  metrics-only connector usage.
+  `@endpoint` registrations still require a `project_id`. It can come from the constructor, `RHESIS_PROJECT_ID`
+  env var, or a project-scoped API token. The optional `project_id` behavior applies to metrics-only connector usage.
 </Callout>
 
 ### See It in Action
@@ -233,7 +233,8 @@ Registered endpoints appear in the Rhesis dashboard:
 
 **Functions not appearing**:
 
-- Verify `RhesisClient` initialized with `api_key`, `project_id`, and `environment`
+- Verify `RhesisClient` initialized with `api_key` and `environment`
+- Ensure a `project_id` is available (via constructor, `RHESIS_PROJECT_ID` env var, or a project-scoped token)
 - Check functions use `@endpoint()` decorator
 - Check logs for "Connector initialized" and "Sent registration" messages
 
@@ -252,7 +253,7 @@ Registered endpoints appear in the Rhesis dashboard:
 **Common errors**:
 
 - `"RhesisClient not initialized"`: Create `RhesisClient` instance before using `@endpoint`
-- `"@endpoint requires project_id"`: Provide `project_id` or set `RHESIS_PROJECT_ID` env var
+- `"@endpoint requires project_id"`: Provide `project_id`, set `RHESIS_PROJECT_ID` env var, or use a project-scoped API token
 - `"Functions not appearing as Active"`: Restart app to trigger re-registration
 
 **Parameter binding issues**:

--- a/sdk/src/rhesis/sdk/clients/rhesis.py
+++ b/sdk/src/rhesis/sdk/clients/rhesis.py
@@ -165,14 +165,14 @@ class RhesisClient:
             resp = requests.get(
                 f"{self._base_url.rstrip('/')}/tokens/current",
                 headers={"Authorization": f"Bearer {self.api_key}"},
-                timeout=5,
+                timeout=2,
             )
             if resp.status_code == 200:
                 data = resp.json()
                 token_project_id = data.get("project_id")
                 if token_project_id:
                     self.project_id = token_project_id
-                    logger.info(f"Resolved project_id from token: {token_project_id}")
+                    logger.debug(f"Resolved project_id from token: {token_project_id}")
             else:
                 logger.debug(
                     f"Token introspection returned {resp.status_code}, project_id not resolved"


### PR DESCRIPTION
## Summary
- Remove the 403 guard in `get_project_context` that rejected explicit `project_id` when it mismatched the token-scoped project — follow-up to #2023
- Reduce token introspection timeout from 5s to 2s and downgrade log from `info` to `debug`
- Add "Project ID Resolution" section to SDK client docs explaining the 3-step fallback (explicit → env var → token)
- Update connector docs troubleshooting to mention project-scoped tokens

## Test plan
- [ ] Verify SDK client with project-scoped token resolves `project_id` without explicit param
- [ ] Verify explicit `project_id` different from token project is no longer rejected
- [ ] Verify docs build without errors