### PR TITLE
Fix: Endpoint UI improvements

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointOverviewTab.tsx
@@ -25,7 +25,6 @@ import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import { useEndpointDetailContext } from './EndpointDetailContext';
 import { ENVIRONMENTS } from './endpoint-detail-shared';
 import {
-  connectionTarget,
   detailGridSpacing,
   formatConfigSource,
   formatEnvironment,
@@ -59,7 +58,6 @@ export default function EndpointOverviewTab() {
   const { endpoint, projects, loadingProjects, saveFields } =
     useEndpointDetailContext();
   const projectList = useMemo(() => Object.values(projects), [projects]);
-  const target = connectionTarget(endpoint);
 
   const detailsInitial = useMemo(
     () => detailsFromEndpoint(endpoint),
@@ -192,29 +190,6 @@ export default function EndpointOverviewTab() {
                   multiline
                 />
               )}
-            </Grid>
-
-            <Grid size={{ xs: 12, sm: 3, md: 2 }}>
-              {endpoint.connection_type === 'REST' && endpoint.method ? (
-                <ViewField label="Method">
-                  <GridBadge size="detail" label={endpoint.method} />
-                </ViewField>
-              ) : (
-                <ViewField label="Method" value="—" />
-              )}
-            </Grid>
-            <Grid size={{ xs: 12, sm: 9, md: 10 }}>
-              <ViewField
-                label="Target"
-                value={target}
-                inputSx={{
-                  fontFamily:
-                    endpoint.connection_type === 'SDK'
-                      ? 'monospace'
-                      : 'inherit',
-                  wordBreak: 'break-all',
-                }}
-              />
             </Grid>
 
             <Grid size={{ xs: 12, md: 6 }}>

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/endpoint-overview-utils.ts
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/endpoint-overview-utils.ts
@@ -1,13 +1,3 @@
-import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
-
-export function connectionTarget(endpoint: Endpoint): string {
-  if (endpoint.connection_type === 'SDK') {
-    const fn = endpoint.endpoint_metadata?.sdk_connection?.function_name;
-    return fn ? String(fn) : 'SDK function (not registered)';
-  }
-  return endpoint.url || 'No URL configured';
-}
-
 export function formatConfigSource(value: string): string {
   return value.replace(/_/g, ' ');
 }

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointTestWorkbench.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointTestWorkbench.tsx
@@ -198,7 +198,13 @@ export default function EndpointTestWorkbench({
                     />
                   </Box>
                   <Box>
-                    <Box sx={fieldSurfaceBoxSx}>
+                    <Box
+                      sx={{
+                        ...fieldSurfaceBoxSx,
+                        maxHeight: 200,
+                        overflowY: 'auto',
+                      }}
+                    >
                       <Typography
                         sx={{
                           fontSize: 12,
@@ -286,7 +292,15 @@ export default function EndpointTestWorkbench({
       {/* Row 2c: JSON blocks — aligned */}
       <Grid size={{ xs: 12, md: 6 }}>
         <Box component="pre" sx={{ ...testPreviewSx, minHeight: 'unset' }}>
-          <TemplatePreview template={requestTemplate || '{}'} />
+          {(() => {
+            try {
+              return (
+                <JsonPreview value={JSON.parse(requestTemplate || '{}')} />
+              );
+            } catch {
+              return <TemplatePreview template={requestTemplate || '{}'} />;
+            }
+          })()}
         </Box>
       </Grid>
       <Grid size={{ xs: 12, md: 6 }}>

--- a/apps/frontend/src/app/(protected)/endpoints/components/JsonPreview.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/JsonPreview.tsx
@@ -130,7 +130,16 @@ export function JsonPreview({
         {tail}
       </>
     );
-  if (typeof value === 'string')
+  if (typeof value === 'string') {
+    if (/^\{\{[^}]+\}\}$/.test(value))
+      return (
+        <>
+          <Box component="span" sx={varChipSx}>
+            {value}
+          </Box>
+          {tail}
+        </>
+      );
     return (
       <>
         <Box component="span" sx={{ color: T.str }}>
@@ -139,6 +148,7 @@ export function JsonPreview({
         {tail}
       </>
     );
+  }
 
   if (Array.isArray(value)) {
     if (!value.length)


### PR DESCRIPTION
## Purpose
Clean up inconsistencies in the endpoint detail UI.

## What Changed
- Removed Method and Target fields from the Overview tab — they belong in Connection
- Request body in the Test tab now uses the same JSON syntax highlighting as the response (keys, strings, numbers, `{{ var }}` chips)
- Mapped Output values in the Test tab now scroll per-variable (max 200px) instead of expanding unbounded

## Testing
1. Open any endpoint → Overview tab → click Edit: Method/Target no longer appear
2. Open Test tab: request body shows syntax-highlighted JSON matching the response style
3. Run a test with a long output value: the mapped output box scrolls independently
