### PR TITLE
Add MCP inspection tools and Telemachus relation guidance

### DIFF
--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -203,7 +203,7 @@ tools:
       manually. Response includes test_run_id and task_id.
     parameters:
       test_set_identifier:
-        description: "REQUIRED. The UUID of the test set to execute (path parameter)."
+        description: "REQUIRED. Test set UUID, nano_id, or slug (path parameter)."
       endpoint_id:
         description: "REQUIRED. The UUID of the target endpoint (path parameter)."
 

--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -25,9 +25,49 @@ tools:
     path: /test_sets/
     page_size: 20
     description: >
-      List test sets in the organization. Test sets group related tests
-      that share a common behavior, category, or theme. Use $select to
-      request only the fields you need (e.g. $select=name,id,description).
+      List test sets in the organization. ENTITY: TestSet.
+      PREREQUISITES: none. CHAIN: resolve by name here, then
+      get_test_set for full metadata or list_test_set_tests for
+      contained tests; pass id to execute_test_set. Use $select
+      (e.g. $select=name,id,description) to keep payloads small.
+
+  - name: get_test_set
+    label: Retrieving test set
+    method: GET
+    path: /test_sets/{test_set_identifier}
+    description: >
+      Get one test set by UUID, nano_id, or slug. ENTITY: TestSet.
+      PREREQUISITES: test_set_identifier from list_test_sets or
+      get_job_status after generate_test_set. CHAIN: after generation
+      completes, call this for set metadata, then list_test_set_tests
+      to verify prompts before execute_test_set. NEVER: use org-wide
+      list_tests when you already have the test set ID.
+    parameters:
+      test_set_identifier:
+        description: "REQUIRED. Test set UUID, nano_id, or slug."
+
+  - name: update_test_set
+    label: Updating test set
+    method: PUT
+    path: /test_sets/{test_set_id}
+    requires_confirmation: true
+    description: >
+      Update test set metadata (name, description, etc.). ENTITY: TestSet.
+      PREREQUISITES: test_set_id from list_test_sets or get_test_set.
+      CHAIN: resolve with list_test_sets first; use get_test_set to
+      confirm current values. Send ONLY fields to change. Does NOT
+      regenerate or replace tests — use generate_test_set for new content.
+      Do NOT send server-managed fields (id, user_id, organization_id,
+      created_at, updated_at).
+    parameters:
+      test_set_id:
+        description: "REQUIRED. UUID of the test set to update."
+      name:
+        description: "New test set name (string). Omit to keep unchanged."
+      description:
+        description: "New description (string). Omit to keep unchanged."
+      short_description:
+        description: "Brief summary, one line (string). Omit to keep unchanged."
 
   - name: create_test_set_bulk
     label: Creating test set
@@ -79,7 +119,10 @@ tools:
       you provide. The tests are persisted to the database automatically.
       This runs as a background task — the response includes a task_id.
       Poll get_job_status with that task_id until status is "SUCCESS",
-      then extract test_set_id from the result.
+      then extract test_set_id from the result. CHAIN: after SUCCESS →
+      get_test_set + list_test_set_tests to verify content → offer
+      execute_test_set. For grounded tests, pass source IDs from
+      list_sources or create_source in the sources parameter.
       Supports both single-turn and multi-turn test generation via the
       test_type parameter.
       PRECONDITION: when a saved plan is in effect, every behavior,
@@ -136,17 +179,37 @@ tools:
     path: /test_sets/{test_set_identifier}/execute/{endpoint_id}
     requires_confirmation: false
     description: >
-      Run a complete test set against an endpoint. The backend
-      automatically creates the internal test configuration and queues
-      a test run — you do NOT need to create these manually. The
-      response includes a test_run_id you can use with get_test_run
-      to monitor progress and list_test_results to fetch results once
-      the run completes.
+      Run a complete test set against an endpoint. ENTITY: TestSet +
+      Endpoint → TestRun. PREREQUISITES: test_set_identifier from
+      list_test_sets or get_job_status; endpoint_id from list_endpoints
+      or get_endpoint. CHAIN: after response use get_test_run for
+      totals, then get_test_result_stats(mode=all) and
+      list_test_results filtered by test_run_id. The backend auto-creates
+      the internal test configuration — do NOT create test configurations
+      manually. Response includes test_run_id and task_id.
     parameters:
       test_set_identifier:
         description: "REQUIRED. The UUID of the test set to execute (path parameter)."
       endpoint_id:
         description: "REQUIRED. The UUID of the target endpoint (path parameter)."
+
+  - name: list_test_set_tests
+    label: Listing tests in test set
+    method: GET
+    path: /test_sets/{test_set_identifier}/tests
+    page_size: 20
+    default_query:
+      $select: "id,prompt,behavior,category,topic"
+    description: >
+      List tests that belong to one test set. ENTITY: Test (scoped to
+      TestSet). PREREQUISITES: test_set_identifier from list_test_sets
+      or get_job_status after generate_test_set. CHAIN: after
+      generate_test_set completes, call get_test_set then this tool to
+      verify prompts before execute_test_set. NEVER: use org-wide
+      list_tests when you already have the test set ID.
+    parameters:
+      test_set_identifier:
+        description: "REQUIRED. Test set UUID, nano_id, or slug."
 
   # ── Tests ─────────────────────────────────────────────────
   - name: list_tests
@@ -303,11 +366,26 @@ tools:
       $select: "id,name,description,score_type,threshold,metric_scope"
     page_size: 20
     description: >
-      List available metrics for evaluating test results. Metrics
-      define how endpoint responses are scored (e.g., accuracy,
-      safety compliance, response quality). By default only summary
-      fields are returned (excludes evaluation_prompt). Add fields
-      to $select if you need the full evaluation prompt.
+      List available metrics for evaluating test results. ENTITY: Metric.
+      PREREQUISITES: none. CHAIN: resolve by name here, then get_metric
+      for full evaluation_prompt before update_metric or improve_metric.
+      By default excludes evaluation_prompt — use get_metric for the
+      full prompt. Link to behaviors via add_behavior_to_metric.
+
+  - name: get_metric
+    label: Retrieving metric
+    method: GET
+    path: /metrics/{metric_id}
+    description: >
+      Get one metric with full fields including evaluation_prompt.
+      ENTITY: Metric. PREREQUISITES: metric_id from list_metrics.
+      CHAIN: read before update_metric (precise edits) or improve_metric
+      (natural-language refactors). Use get_metric_behaviors to see
+      linked behaviors. NEVER: add evaluation_prompt to list_metrics
+      $select on every call — use this tool instead.
+    parameters:
+      metric_id:
+        description: "REQUIRED. UUID of the metric."
 
   - name: create_metric
     label: Creating metric
@@ -403,22 +481,71 @@ tools:
           (e.g. "lower the threshold to 2", "switch to categorical with
           pass/fail categories").
 
+  - name: update_metric
+    label: Updating metric
+    method: PUT
+    path: /metrics/{metric_id}
+    requires_confirmation: true
+    description: >
+      Update metric fields directly. ENTITY: Metric. PREREQUISITES:
+      metric_id from list_metrics; call get_metric first to read current
+      values. CHAIN: for precise field edits (threshold, evaluation_prompt).
+      Use improve_metric for natural-language refactors. Does NOT change
+      behavior links — use add_behavior_to_metric or
+      remove_behavior_from_metric for those. Send ONLY fields to change.
+      Do NOT send server-managed fields (id, user_id, organization_id,
+      created_at, updated_at, owner_id, assignee_id, status_id, model_id,
+      backend_type_id, metric_type_id).
+    parameters:
+      metric_id:
+        description: "REQUIRED. UUID of the metric to update."
+      name:
+        description: "Metric name (string). Omit to keep unchanged."
+      description:
+        description: "What this metric evaluates (string). Omit to keep."
+      evaluation_prompt:
+        description: "Evaluation prompt template (string). Omit to keep."
+      score_type:
+        description: '"numeric" or "categorical". Omit to keep unchanged.'
+      threshold:
+        description: "Pass/fail threshold (number). Omit to keep unchanged."
+      threshold_operator:
+        description: 'Comparison operator: "=", "<", ">", "<=", ">=", "!=". Omit to keep.'
+
   - name: add_behavior_to_metric
     label: Linking behavior to metric
     method: POST
     path: /metrics/{metric_id}/behaviors/{behavior_id}
     requires_confirmation: true
     description: >
-      Link a behavior to a metric, so the metric is used to evaluate
-      that behavior during test runs. Both the metric and the behavior
-      must already exist. Call this after creating or generating a metric
-      to wire it to the relevant behaviors. Idempotent — calling it
-      again for the same pair is a no-op.
+      Link a behavior to a metric (Behavior ↔ Metric relation).
+      ENTITY: Behavior + Metric. PREREQUISITES: both must exist; all
+      planned mappings must complete before generate_test_set. CHAIN:
+      call after create_metric; verify with get_metric_behaviors; undo
+      with remove_behavior_from_metric. Idempotent — repeat calls are
+      no-ops.
     parameters:
       metric_id:
         description: "REQUIRED. UUID of the metric."
       behavior_id:
         description: "REQUIRED. UUID of the behavior to associate."
+
+  - name: remove_behavior_from_metric
+    label: Unlinking behavior from metric
+    method: DELETE
+    path: /metrics/{metric_id}/behaviors/{behavior_id}
+    requires_confirmation: true
+    description: >
+      Remove a behavior-to-metric link. ENTITY: Behavior ↔ Metric.
+      PREREQUISITES: metric_id and behavior_id; confirm link exists
+      via get_metric_behaviors. CHAIN: inverse of add_behavior_to_metric.
+      Removing links may block generate_test_set if behaviors in the
+      plan no longer have metrics.
+    parameters:
+      metric_id:
+        description: "REQUIRED. UUID of the metric."
+      behavior_id:
+        description: "REQUIRED. UUID of the behavior to unlink."
 
   - name: get_metric_behaviors
     label: Checking metric behaviors
@@ -440,9 +567,24 @@ tools:
     path: /endpoints/
     page_size: 50
     description: >
-      List configured endpoints. Endpoints are the AI systems being
-      tested (chat APIs, completion APIs, etc.). Use $select to request
-      only the fields you need (e.g. $select=name,id,url,description).
+      List configured endpoints. ENTITY: Endpoint. PREREQUISITES: none.
+      CHAIN: resolve by name here, then get_endpoint for full config
+      (mappings, auth) or pass id to check_endpoint, explore_endpoint,
+      execute_test_set. Use $select=name,id,url,description for browsing.
+
+  - name: get_endpoint
+    label: Retrieving endpoint
+    method: GET
+    path: /endpoints/{endpoint_id}
+    description: >
+      Get full endpoint configuration including request/response mappings
+      and auth settings. ENTITY: Endpoint. PREREQUISITES: endpoint_id
+      from list_endpoints. CHAIN: use before update_endpoint or when
+      debugging execute_test_set failures. NEVER: rely on list_endpoints
+      alone when you need mapping or auth details.
+    parameters:
+      endpoint_id:
+        description: "REQUIRED. UUID of the endpoint."
 
   - name: create_endpoint
     label: Creating endpoint
@@ -722,12 +864,47 @@ tools:
       "I have reference material". Search by name with
       $filter=contains(tolower(title), 'keyword'). The agent should
       NEVER fetch source content — pass IDs directly to generate_test_set
-      and the backend handles content injection.
+      and the backend handles content injection. CHAIN: if no match,
+      create_source then pass new id to generate_test_set (single-turn only).
     parameters:
       filter:
         description: >
           OData filter expression to search by title or description, e.g.
           $filter=contains(tolower(title), 'keyword').
+
+  - name: create_source
+    label: Creating knowledge source
+    method: POST
+    path: /sources/
+    requires_confirmation: true
+    description: >
+      Create a knowledge source for grounding test generation. ENTITY: Source.
+      PREREQUISITES: copy source_type_id from list_sources (same type) or
+      from an existing source of that type. CHAIN: after create, pass
+      [{"id": "<uuid>"}] to generate_test_set sources (single-turn only).
+      For pasted text: title + content (Manual type). For URLs: title + url
+      (Website type). NEVER fetch or pass raw content to generate_test_set —
+      only the ID. File uploads require the UI (POST /sources/upload not
+      available via MCP). Do NOT send server-managed fields (id, user_id,
+      organization_id, created_at, updated_at).
+    parameters:
+      title:
+        description: "REQUIRED. Source title (string)."
+      description:
+        description: "Optional description of the source (string)."
+      content:
+        description: >
+          Raw text content for Manual-type sources. Use when the user
+          pasted reference material in chat — create a source instead of
+          embedding text in generate_test_set.
+      url:
+        description: >
+          URL for Website-type sources (must start with http:// or https://).
+          Backend extracts content automatically.
+      source_type_id:
+        description: >
+          REQUIRED. UUID of the source type. Copy from list_sources on an
+          existing source of the same type (check source_type_id field).
 
   # ── Background Jobs ─────────────────────────────────────
   - name: get_job_status
@@ -742,7 +919,8 @@ tools:
       "result" field contains job-specific data:
       - explore_endpoint: full exploration findings including domain,
         capabilities, limits, conversation summary, and strategy_findings.
-      - generate_test_set: "test_set_id" (UUID of the created test set).
+      - generate_test_set: "test_set_id" — then call get_test_set and
+        list_test_set_tests to verify before offering execute_test_set.
       - execute_test_set: use the test_run_id from the original response.
       If FAILURE, the "error" field describes what went wrong.
     parameters:

--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -9,6 +9,20 @@ tools:
       List projects in the current organization. Use $select to request
       only the fields you need (e.g. $select=name,id).
 
+  - name: get_project
+    label: Retrieving project
+    method: GET
+    path: /projects/{project_id}
+    description: >
+      Get one project by ID. ENTITY: Project. PREREQUISITES: project_id
+      from list_projects. CHAIN: use before create_endpoint (project_id
+      is required) or when confirming project context for an endpoint.
+      NEVER: ask the user for a project ID when they gave a name — use
+      list_projects with $filter first.
+    parameters:
+      project_id:
+        description: "REQUIRED. UUID of the project."
+
   - name: create_project
     label: Creating project
     method: POST
@@ -211,6 +225,39 @@ tools:
       test_set_identifier:
         description: "REQUIRED. Test set UUID, nano_id, or slug."
 
+  - name: get_test_set_metrics
+    label: Checking test set metrics
+    method: GET
+    path: /test_sets/{test_set_identifier}/metrics
+    description: >
+      List metrics associated with a test set. ENTITY: TestSet → Metric.
+      PREREQUISITES: test_set_identifier from list_test_sets or
+      get_test_set. CHAIN: call before execute_test_set to see which
+      metrics will run (set-level overrides vs behavior defaults). Empty
+      list means behavior-linked metrics apply per test. Complement with
+      get_metric_behaviors on individual metrics.
+    parameters:
+      test_set_identifier:
+        description: "REQUIRED. Test set UUID, nano_id, or slug."
+
+  - name: get_test_set_last_run
+    label: Finding last test run
+    method: GET
+    path: /test_sets/{test_set_identifier}/last-run/{endpoint_id}
+    description: >
+      Get the most recent completed test run for a test set + endpoint
+      pair. ENTITY: TestSet + Endpoint → TestRun. PREREQUISITES:
+      test_set_identifier and endpoint_id from list_test_sets and
+      list_endpoints. CHAIN: use when offering run comparison ("compare
+      with last run") or before re-scoring. Returns 404 if no completed
+      run exists yet. Pass test_run_id to get_test_result_stats for
+      side-by-side analysis.
+    parameters:
+      test_set_identifier:
+        description: "REQUIRED. Test set UUID, nano_id, or slug."
+      endpoint_id:
+        description: "REQUIRED. UUID of the endpoint."
+
   # ── Tests ─────────────────────────────────────────────────
   - name: list_tests
     label: Listing tests
@@ -223,6 +270,50 @@ tools:
       List tests in the organization. Each test defines a prompt,
       expected response behavior, and optional metadata. By default
       only core fields are returned. Add fields to $select if needed.
+      Prefer list_test_set_tests when scoped to one test set.
+
+  - name: get_test
+    label: Retrieving test
+    method: GET
+    path: /tests/{test_id}
+    description: >
+      Get one test with full detail including prompt and configuration.
+      ENTITY: Test. PREREQUISITES: test_id from list_test_set_tests or
+      list_tests. CHAIN: after list_test_set_tests when fixing or
+      reviewing a specific prompt; before update_test. NEVER: re-list
+      the whole test set when you already have the test id.
+    parameters:
+      test_id:
+        description: "REQUIRED. UUID of the test."
+
+  - name: update_test
+    label: Updating test
+    method: PUT
+    path: /tests/{test_id}
+    requires_confirmation: true
+    description: >
+      Update an existing test's prompt or metadata. ENTITY: Test.
+      PREREQUISITES: test_id from list_test_set_tests; call get_test
+      first to see current values. CHAIN: use to fix individual bad
+      prompts after generate_test_set without regenerating the whole set.
+      Send ONLY fields to change. Does NOT replace generate_test_set for
+      bulk creation. Do NOT send server-managed fields (id, user_id,
+      organization_id, created_at, updated_at).
+    parameters:
+      test_id:
+        description: "REQUIRED. UUID of the test to update."
+      prompt:
+        description: >
+          Optional. Prompt object with content, language_code, and optional
+          expected_response. Omit unchanged fields at the test level.
+      behavior:
+        description: "Behavior name string. Omit to keep unchanged."
+      category:
+        description: "Category name string. Omit to keep unchanged."
+      topic:
+        description: "Topic name string. Omit to keep unchanged."
+      test_type:
+        description: '"Single-Turn" or "Multi-Turn". Omit to keep unchanged.'
 
   # ── Test Runs ─────────────────────────────────────────────
   - name: list_test_runs
@@ -299,7 +390,23 @@ tools:
     description: >
       List available behaviors. Behaviors define what an endpoint should
       do (e.g., "answer questions accurately", "refuse harmful requests").
-      Use $select to request only the fields you need.
+      Use $select to request only the fields you need. CHAIN: resolve
+      by name here, then get_behavior for full detail including linked
+      metrics.
+
+  - name: get_behavior
+    label: Retrieving behavior
+    method: GET
+    path: /behaviors/{behavior_id}
+    description: >
+      Get one behavior with linked metrics. ENTITY: Behavior ↔ Metric.
+      PREREQUISITES: behavior_id from list_behaviors. CHAIN: verify
+      behavior→metric links from the behavior side; complement
+      get_metric_behaviors (metric-centric view). Use during planning
+      to confirm reuse candidates include the right metrics.
+    parameters:
+      behavior_id:
+        description: "REQUIRED. UUID of the behavior."
 
   - name: create_behavior
     label: Creating behavior

--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -63,19 +63,19 @@ tools:
   - name: update_test_set
     label: Updating test set
     method: PUT
-    path: /test_sets/{test_set_id}
+    path: /test_sets/{test_set_identifier}
     requires_confirmation: true
     description: >
       Update test set metadata (name, description, etc.). ENTITY: TestSet.
-      PREREQUISITES: test_set_id from list_test_sets or get_test_set.
+      PREREQUISITES: test_set_identifier from list_test_sets or get_test_set.
       CHAIN: resolve with list_test_sets first; use get_test_set to
       confirm current values. Send ONLY fields to change. Does NOT
       regenerate or replace tests — use generate_test_set for new content.
       Do NOT send server-managed fields (id, user_id, organization_id,
       created_at, updated_at).
     parameters:
-      test_set_id:
-        description: "REQUIRED. UUID of the test set to update."
+      test_set_identifier:
+        description: "REQUIRED. Test set UUID, nano_id, or slug."
       name:
         description: "New test set name (string). Omit to keep unchanged."
       description:

--- a/apps/backend/src/rhesis/backend/app/mcp_server/server.py
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/server.py
@@ -77,9 +77,15 @@ def _create_mcp_server(fastapi_app: Any) -> MCPServer:
     server = MCPServer(
         name="Rhesis",
         instructions=(
-            "Rhesis platform API tools. Use these to create and manage "
-            "projects, test sets, tests, test configurations, test "
-            "runs, and view results."
+            "Rhesis platform API tools for AI test suite design and execution. "
+            "Entity model: Project owns Endpoints; Behaviors link to Metrics "
+            "(add_behavior_to_metric) before generate_test_set; Sources ground "
+            "single-turn generation; TestSet + Endpoint → execute_test_set → "
+            "TestRun → TestResults. "
+            "Creation order: behaviors → metrics → behavior-metric mappings → "
+            "generate_test_set → verify (get_test_set, list_test_set_tests) → "
+            "execute_test_set → analyze (get_test_run, get_test_result_stats). "
+            "Resolve entities by name via list_* + $filter; use get_* for full detail."
         ),
     )
 

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -440,19 +440,20 @@ async def delete_test_set(
     return db_test_set
 
 
-@router.put("/{test_set_id}", response_model=schemas.TestSet)
+@router.put("/{test_set_identifier}", response_model=schemas.TestSet)
 @handle_database_exceptions(
     entity_name="test set", custom_unique_message="Test set with this name already exists"
 )
 async def update_test_set(
-    test_set_id: uuid.UUID,
+    test_set_identifier: str,
     test_set: schemas.TestSetUpdate,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
 ):
-    """Update an existing test set."""
+    """Update an existing test set by UUID, nano_id, or slug."""
     organization_id, user_id = tenant_context
+    test_set_id = resolve_test_set_or_raise(test_set_identifier, db, organization_id).id
     db_test_set = crud.update_test_set(
         db,
         test_set_id=test_set_id,

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/system_prompt.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/system_prompt.j2
@@ -384,6 +384,8 @@ Not every request requires the full phased workflow. If the user asks you to per
 - "Unlink metric A from behavior B" → get_metric_behaviors, then remove_behavior_from_metric
 - "Ground tests in this doc" / pasted reference text → create_source with title + content, then pass source id to generate_test_set
 - "Show me what's in test set X" → list_test_sets to resolve X, then list_test_set_tests (not org-wide list_tests)
+- "Fix one bad test prompt" → list_test_set_tests → get_test → update_test
+- "Compare with last run" → get_test_set_last_run → get_test_result_stats(mode=test_runs)
 - "Register my chatbot at https://… as 'Support Bot'" → gather the required config (see "Registering a new endpoint"), confirm, then call create_endpoint
 - "Change endpoint Z's URL / auth token / response mapping" → list_endpoints to find Z, get_endpoint for current config, present the change, then update_endpoint with only changed fields
 

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/system_prompt.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/system_prompt.j2
@@ -2,6 +2,19 @@ You are the Rhesis Architect, an expert conversational agent that helps users de
 
 {% include "personality.j2" %}
 
+## Platform Data Model
+Understand how entities relate before chaining tools:
+- **Project** → **Endpoint** (endpoints belong to a project; resolve project_id via list_projects before create_endpoint)
+- **Behavior ↔ Metric** (many-to-many via add_behavior_to_metric; every behavior in test sets needs at least one linked metric **before** generate_test_set)
+- **Source → TestSet** (sources ground single-turn generate_test_set only; use list_sources or create_source, then pass [{"id": "…"}])
+- **TestSet → Test** (tests live inside a set; use list_test_set_tests, not org-wide list_tests, when you have the set ID)
+- **TestSet + Endpoint → TestRun** (execute_test_set; test configurations are created internally — never expose them)
+- **TestRun → TestResult** (always filter list_test_results by test_run_id; metrics score via the behavior link)
+
+**Resolution:** list_* + $filter by name → id → get_* (full detail) or mutate/execute.
+**After generate_test_set:** get_test_set + list_test_set_tests to verify before offering execute_test_set.
+**Metric edits:** get_metric (read prompt) → update_metric (precise fields) or improve_metric (natural language).
+
 ## Resolving Entities by Name
 When the user refers to any entity by name (endpoint, metric, behavior, test set, project, etc.), look it up yourself using the appropriate list_* tool — never ask the user for an ID. Always pass the search value lowercased and wrap the column with `tolower()` for case-insensitive matching. This applies to ALL entity types: endpoints, metrics, behaviors, categories, topics, test sets, projects, etc.
 
@@ -248,9 +261,10 @@ Metric and behavior names use **Title Case**, typically two to five words that d
 When the plan calls for a metric:
 1. list_metrics to see what already exists
 2. If a matching metric exists and is suitable — use it directly (note its ID)
-3. If a matching metric exists but needs changes — call improve_metric with edit instructions
+3. If a matching metric exists but needs changes — call get_metric first to read the current evaluation_prompt, then improve_metric (natural-language edits) or update_metric (precise field changes)
 4. If no match — call create_metric with the exact name from the plan
 5. After creating or selecting a metric, link it to relevant behaviors via add_behavior_to_metric
+6. Verify links with get_metric_behaviors; undo mistakes with remove_behavior_from_metric
 
 ## Entity Creation Order
 When creating entities on the platform, follow the saved plan (shown in "Current Plan") exactly. This sequence maps to the plan.
@@ -278,9 +292,10 @@ When creating entities on the platform, follow the saved plan (shown in "Current
    The response includes a `task_id` for monitoring.
    **Prefer generate_test_set over create_test_set_bulk.** Only use create_test_set_bulk when importing specific, user-provided test prompts that must be used verbatim.
 8. **Wait for generation** — after calling generate_test_set (one or more times), call **await_task** with the `task_id`(s) from the responses and a message telling the user what is being generated. Do NOT poll get_job_status manually — the system will automatically resume this conversation when all tasks finish and provide the results.
-9. **Stop and ask the user** — present a summary of what was created (by name, never IDs) and offer to run the tests: "Would you like me to run the tests against [endpoint name]?"
-10. **execute_test_set** — only when the user confirms. Pass the test set UUID as `test_set_identifier` and the endpoint UUID as `endpoint_id`. Do NOT create test configurations or test runs manually; the backend handles that automatically. The response includes a `test_run_id` and a `task_id`.
-11. **Wait for execution** — call **await_task** with the **`test_run_id`** (NOT the `task_id`) from the execute response and a message telling the user the tests are running. The system will resume automatically when the run completes. After resuming, fetch and present results in **three steps**:
+9. **Verify test sets** — after generation completes, call **get_test_set** for each new test set (metadata) and **list_test_set_tests** to spot-check generated prompts. Mention any surprises to the user before offering to run.
+10. **Stop and ask the user** — present a summary of what was created (by name, never IDs) and offer to run the tests: "Would you like me to run the tests against [endpoint name]?"
+11. **execute_test_set** — only when the user confirms. Pass the test set UUID as `test_set_identifier` and the endpoint UUID as `endpoint_id`. Do NOT create test configurations or test runs manually; the backend handles that automatically. The response includes a `test_run_id` and a `task_id`.
+12. **Wait for execution** — call **await_task** with the **`test_run_id`** (NOT the `task_id`) from the execute response and a message telling the user the tests are running. The system will resume automatically when the run completes. After resuming, fetch and present results in **three steps**:
     1. **Summary**: call `get_test_run` with the `test_run_id` to get accurate total counts (total tests, status, timing). Use these numbers in your summary — never count results manually from a list call.
     2. **Breakdown**: call `get_test_result_stats` with `mode=all` and `test_run_id` to get per-behavior and per-metric pass rates in one call. This tells you which behaviors are failing and which metrics are the problem areas.
     3. **Failures**: call `list_test_results` with `$filter=test_run_id eq '<id>' and status/name eq 'Failed'` and `$select=id,status,prompt,behavior,metric_scores` to get the failing tests. For the top 2-3 most informative failures, call `get_test_result` on the specific result ID to read the full metric reasoning (the `reason` field explains *why* the metric scored as it did).
@@ -363,11 +378,14 @@ If the user asks to analyze or dig into an existing test run (not one that just 
 
 ## Direct Requests
 Not every request requires the full phased workflow. If the user asks you to perform a specific action — such as updating a metric, listing entities, linking a behavior to a metric, or describing a behavior — execute it directly using the available tools. For example:
-- "Update metric X to include user management scenarios" → use list_metrics to find X by name, then call improve_metric with the user's instructions
+- "Update metric X to include user management scenarios" → list_metrics to find X, get_metric to read current fields, then improve_metric (NL) or update_metric (precise fields)
 - "Add a description to behavior Y" → use list_behaviors to find Y, then call update_behavior
-- "Link metric A to behavior B" → resolve both by name, then call add_behavior_to_metric
+- "Link metric A to behavior B" → resolve both by name, then call add_behavior_to_metric; verify with get_metric_behaviors
+- "Unlink metric A from behavior B" → get_metric_behaviors, then remove_behavior_from_metric
+- "Ground tests in this doc" / pasted reference text → create_source with title + content, then pass source id to generate_test_set
+- "Show me what's in test set X" → list_test_sets to resolve X, then list_test_set_tests (not org-wide list_tests)
 - "Register my chatbot at https://… as 'Support Bot'" → gather the required config (see "Registering a new endpoint"), confirm, then call create_endpoint
-- "Change endpoint Z's URL / auth token / response mapping" → use list_endpoints to find Z, present the change, then call update_endpoint with only the changed fields
+- "Change endpoint Z's URL / auth token / response mapping" → list_endpoints to find Z, get_endpoint for current config, present the change, then update_endpoint with only changed fields
 
 Only enter the phased workflow when the user asks you to design or create a test suite from scratch.
 
@@ -459,11 +477,12 @@ Knowledge sources are platform-managed documents and reference material (product
 - The user asks for multi-turn tests — multi-turn generation does not consume sources (see limitation below)
 
 ### Workflow
-1. If the user @mentioned a source, the ID is already in the "User Context" section — skip to step 4
+1. If the user @mentioned a source, the ID is already in the "User Context" section — skip to step 5
 2. Otherwise call `list_sources` with `$filter=contains(tolower(title), '<keyword>')` derived from the user's hint (e.g. "faq" → `contains(tolower(title), 'faq')`)
 3. Present matches by title and description; ask the user to confirm which to use
-4. When calling `generate_test_set`, include `sources: [{"id": "<uuid>"}]` for each confirmed source
-5. The backend loads the content and grounds the tests automatically — you do nothing else
+4. If no suitable source exists and the user provided reference text (chat paste or attachment), offer **create_source** with title + content (copy source_type_id from list_sources). For a URL, use title + url. File uploads still require the UI.
+5. When calling `generate_test_set`, include `sources: [{"id": "<uuid>"}]` for each confirmed source
+6. The backend loads the content and grounds the tests automatically — you do nothing else
 
 ### Hard rules
 - **Never attempt to fetch source content.** There is no content-fetching tool exposed to you and source text is large enough to overflow the context window. Pass the ID and let the backend handle the rest.

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/system_prompt.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/system_prompt.j2
@@ -328,7 +328,7 @@ When the user asks to compare test runs, analyze regressions, or understand how 
 - After presenting single-run results, if earlier runs exist for the same test set, offer: "Would you like me to compare this with a previous run?"
 
 ### Comparison workflow
-1. **Find runs to compare**: call `list_test_runs` filtered by endpoint or test set to find available runs. Use `$select=id,name,status,created_at` for a compact list. Present the options to the user if they haven't specified which runs to compare.
+1. **Find runs to compare**: call `get_test_set_last_run` when comparing the same test set against the same endpoint (fast path), or `list_test_runs` filtered by endpoint or test set when the user has not specified the pair. Use `$select=id,name,status,created_at` for a compact list. Present the options to the user if they haven't specified which runs to compare.
 2. **High-level comparison**: call `get_test_result_stats` with `mode=test_runs` and `test_run_ids` set to the two (or more) run IDs. This returns per-run pass/fail counts and pass rates — the most important overview.
 3. **Behavior drill-down**: to understand which behaviors improved or regressed, call `get_test_result_stats` with `mode=behavior` and `test_run_id` for each run separately. Compare the behavior-level pass rates to identify regressions and improvements.
 4. **Metric drill-down** (optional): call `get_test_result_stats` with `mode=metrics` to see per-metric pass rates when the user wants to understand which evaluation criteria changed.

--- a/skills/rhesis/SKILL.md
+++ b/skills/rhesis/SKILL.md
@@ -96,6 +96,8 @@ Only after the user confirms (yes / go ahead / looks good) should you call any c
 
 Execute the approved plan exactly — no additions, substitutions, or extra entities.
 
+**Why this order matters:** `generate_test_set` must run only after every behavior, metric, and behavior→metric link is in place. The backend rejects earlier calls with "Cannot generate test sets yet…", which wastes a retry. An older version of this skill listed generation before metrics — that was wrong and is corrected below. Full parameter detail lives in the Architect `system_prompt.j2` Entity Creation Order section.
+
 **Order of operations:**
 
 1. **Reuse lookup** — if you don't already have IDs for reused entities from planning, resolve them now via `list_behaviors` / `list_metrics` with `$filter`.
@@ -138,7 +140,7 @@ Never use snake_case, camelCase, or prefixes like "is_" or "check_".
 
 Only execute tests when the user explicitly asks.
 
-- Use **only `execute_test_set`** with `test_set_identifier` (the test set UUID) and `endpoint_id` (the endpoint UUID).
+- Use **only `execute_test_set`** with `test_set_identifier` (test set UUID, nano_id, or slug) and `endpoint_id` (the endpoint UUID).
 - Do NOT create test configurations or test runs manually — the backend handles that automatically.
 - If there are multiple test sets, call `execute_test_set` once per test set.
 - After calling `execute_test_set`, the response includes a `test_run_id` and a `task_id`. Poll `get_job_status` with `task_id` to wait for completion, then use `test_run_id` to fetch results.

--- a/skills/rhesis/SKILL.md
+++ b/skills/rhesis/SKILL.md
@@ -22,6 +22,8 @@ For self-hosted backends, set `RHESIS_MCP_URL=http://localhost:8080/mcp` instead
 5. **Execution** — run the test set against the endpoint when the user confirms
 6. **Analysis** — fetch results and present a structured summary
 
+See `references/entity-model.md` for the entity graph, relations, and tool chains.
+
 Not every request needs the full cycle. Direct requests ("update metric X", "list my test sets", "compare these two runs") skip straight to the relevant tools.
 
 ## Resolving entities by name
@@ -99,23 +101,13 @@ Execute the approved plan exactly — no additions, substitutions, or extra enti
 1. **Reuse lookup** — if you don't already have IDs for reused entities from planning, resolve them now via `list_behaviors` / `list_metrics` with `$filter`.
 2. **Create project** — only if the plan includes one. Use exact name and description from the plan.
 3. **Create new behaviors** — for each behavior marked **(new)**, call `create_behavior` with both `name` and `description`. Skip behaviors marked **(reuse)**.
-4. **Generate test sets** — for each test set, call `generate_test_set` with:
-   - `name` from the plan
-   - `config.generation_prompt` — specific and detailed (this drives the synthesizer)
-   - `config.behaviors` — required, non-empty list of behavior name strings
-   - `config.categories` and `config.topics` — optional
-   - `num_tests` — typically 5–15 per test set
-   - `test_type` — `"Single-Turn"` or `"Multi-Turn"`
-   - `sources` — optional, if the user mentioned reference material or documentation. Use `list_sources` to find available sources first, then pass `[{"id": "<uuid>"}]`. Only works with Single-Turn tests.
-   The response includes a `task_id`.
-5. **Wait for generation** — poll `get_job_status` with the `task_id` until `status` is `"SUCCESS"`. When done, extract `test_set_id` from `result`.
-6. **Resolve behavior IDs** — for reused behaviors, you have IDs from step 1. For newly created behaviors, call `list_behaviors` with batched OR filters: `$filter=name eq 'A' or name eq 'B'`. One call for all.
-7. **Create/improve metrics** — for each metric in the plan:
-   - **(reuse)**: use the existing ID — no call needed
-   - **(improve)**: call `improve_metric` with the existing metric's ID and edit instructions
-   - **(new)**: call `create_metric` with the **exact name from the plan**. Do NOT use `generate_metric` during plan execution — it produces its own name, which breaks plan tracking.
-8. **Link metrics to behaviors** — for each mapping in the plan, call `add_behavior_to_metric` with the metric ID and behavior ID.
-9. **Report and offer** — summarize what was created (by name, never IDs) and offer to run the tests.
+4. **Resolve behavior IDs** — batch OR filters on `list_behaviors` for any IDs you still need.
+5. **Create/improve metrics** — for each metric: **(reuse)** skip; **(improve)** call `improve_metric` (read with `get_metric` first); **(new)** call `create_metric` with the exact plan name. Do NOT use `generate_metric` during plan execution.
+6. **Link metrics to behaviors** — `add_behavior_to_metric` for every mapping. All mappings must complete before generating test sets.
+7. **Generate test sets** — for each test set, call `generate_test_set` with `name`, `config` (generation_prompt + behaviors), `num_tests`, `test_type`, and optional `sources` from `list_sources` or `create_source` (Single-Turn only). Response includes `task_id`.
+8. **Wait for generation** — poll `get_job_status` until `SUCCESS`; extract `test_set_id` from `result`.
+9. **Verify** — call `get_test_set` and `list_test_set_tests` to spot-check generated content.
+10. **Report and offer** — summarize what was created (by name, never IDs) and offer to run the tests.
 
 ### Naming conventions
 
@@ -227,6 +219,11 @@ Not every request needs the full workflow. If the user asks for a specific actio
 - "Link metric A to behavior B" → resolve both by name, call `add_behavior_to_metric`
 - "List my test sets" → call `list_test_sets` with `$select=name,id,description`
 - "What metrics exist?" → call `list_metrics`
+
+- "Ground tests in this doc" → `create_source` then `generate_test_set` with source id
+- "Show test set contents" → `list_test_sets` → `list_test_set_tests`
+- "Fix metric threshold" → `get_metric` → `update_metric`
+- "Unlink metric from behavior" → `get_metric_behaviors` → `remove_behavior_from_metric`
 
 Only enter the full phased workflow when the user asks to design or create a test suite from scratch.
 

--- a/skills/rhesis/references/entity-model.md
+++ b/skills/rhesis/references/entity-model.md
@@ -1,0 +1,112 @@
+# Rhesis Platform Entity Model
+
+How platform entities relate to each other and which MCP tools operate on them.
+
+> When `mcp_tools.yaml` changes, keep this file and `tool-catalog.md` in sync.
+
+---
+
+## Entity graph
+
+```mermaid
+flowchart TB
+  subgraph org [Organization]
+    Project
+    Behavior
+    Metric
+    Source
+    Category
+    Topic
+  end
+
+  Project --> Endpoint
+  Behavior -->|"add_behavior_to_metric"| Metric
+  Behavior --> Test
+  Category --> Test
+  Topic --> Test
+  Source -->|"sources param"| TestSet
+  Behavior --> TestSet
+  TestSet --> Test
+  TestSet -->|"execute_test_set"| TestRun
+  Endpoint --> TestRun
+  Metric -->|"evaluates via behavior link"| TestResult
+  Test --> TestResult
+  TestRun --> TestResult
+  TestConfiguration["TestConfiguration (internal)"] -.->|"auto-created"| TestRun
+```
+
+---
+
+## Key relations
+
+| Relation | Meaning | Tools |
+|----------|---------|-------|
+| Behavior ↔ Metric | Many-to-many; **required before test generation** | `add_behavior_to_metric`, `get_metric_behaviors`, `remove_behavior_from_metric` |
+| TestSet → Test | Tests belong to a set | `generate_test_set`, `list_test_set_tests`, `get_test_set` |
+| Source → TestSet | Sources ground **single-turn** generation only | `list_sources`, `create_source` → `generate_test_set` |
+| TestSet + Endpoint → TestRun | Execution is always a pair | `execute_test_set` |
+| TestRun → TestResult | Results scoped to a run | `list_test_results` with `$filter=test_run_id eq '…'` |
+| Metric → TestResult | Scores when metric is linked to the test's behavior | `get_test_result`, `get_test_result_stats` |
+
+**Resolution pattern:** `list_*` + `$filter` by name → use `id` in `get_*` / mutate / execute tools.
+
+---
+
+## Tool chains by intent
+
+### Register and explore an endpoint
+
+1. `list_projects` (if creating new endpoint)
+2. `create_endpoint` → `check_endpoint`
+3. `explore_endpoint` → `get_job_status` until SUCCESS
+
+### Ground tests in documentation
+
+1. `list_sources` with `$filter=contains(tolower(title), 'keyword')`
+2. If no match: `create_source` (Manual + `content`, or Website + `url`)
+3. `generate_test_set` with `sources: [{"id": "<uuid>"}]` (Single-Turn only)
+
+### Create a full test suite
+
+1. `list_behaviors`, `list_metrics` (reuse check)
+2. `create_behavior` (new behaviors only)
+3. `create_metric` or reuse existing
+4. `add_behavior_to_metric` for every mapping (**all must complete before step 5**)
+5. `generate_test_set` → `get_job_status` → `get_test_set` + `list_test_set_tests` (verify)
+6. Offer `execute_test_set`
+
+### Run and analyze
+
+1. `execute_test_set` (test_set_identifier + endpoint_id)
+2. `get_test_run` (accurate totals)
+3. `get_test_result_stats` with `mode=all` and `test_run_id`
+4. `list_test_results` filtered to failures
+5. `get_test_result` on top 2–3 failures (read `reason` field)
+
+### Fix a metric
+
+1. `list_metrics` → resolve by name
+2. `get_metric` (read `evaluation_prompt` and thresholds)
+3. `update_metric` for precise field edits, OR `improve_metric` for NL instructions
+4. `get_metric_behaviors` to confirm behavior links
+
+### Undo a behavior–metric link
+
+1. `get_metric_behaviors`
+2. `remove_behavior_from_metric`
+
+---
+
+## Entity → tools quick reference
+
+| Entity | List | Get | Create | Update | Other |
+|--------|------|-----|--------|--------|-------|
+| Project | `list_projects` | — | `create_project` | — | — |
+| Endpoint | `list_endpoints` | `get_endpoint` | `create_endpoint` | `update_endpoint` | `check_endpoint`, `explore_endpoint` |
+| Behavior | `list_behaviors` | — | `create_behavior` | `update_behavior` | — |
+| Metric | `list_metrics` | `get_metric` | `create_metric`, `generate_metric` | `update_metric`, `improve_metric` | `add_behavior_to_metric`, `remove_behavior_from_metric`, `get_metric_behaviors` |
+| TestSet | `list_test_sets` | `get_test_set` | `generate_test_set`, `create_test_set_bulk` | `update_test_set` | `list_test_set_tests`, `execute_test_set` |
+| Test | `list_tests`, `list_test_set_tests` | — | (via test set tools) | — | — |
+| Source | `list_sources` | — | `create_source` | — | — |
+| TestRun | `list_test_runs` | `get_test_run` | (via `execute_test_set`) | — | `get_test_run_stats` |
+| TestResult | `list_test_results` | `get_test_result` | — | — | `get_test_result_stats` |

--- a/skills/rhesis/references/entity-model.md
+++ b/skills/rhesis/references/entity-model.md
@@ -77,11 +77,22 @@ flowchart TB
 
 ### Run and analyze
 
-1. `execute_test_set` (test_set_identifier + endpoint_id)
-2. `get_test_run` (accurate totals)
-3. `get_test_result_stats` with `mode=all` and `test_run_id`
-4. `list_test_results` filtered to failures
-5. `get_test_result` on top 2–3 failures (read `reason` field)
+1. `get_test_set_metrics` (optional pre-flight)
+2. `execute_test_set` (test_set_identifier + endpoint_id)
+3. `get_test_run` (accurate totals)
+4. `get_test_result_stats` with `mode=all` and `test_run_id`
+5. `list_test_results` filtered to failures
+6. `get_test_result` on top 2–3 failures (read `reason` field)
+
+### Compare with previous run
+
+1. `get_test_set_last_run` with test set + endpoint IDs
+2. `get_test_result_stats` with `mode=test_runs` and both `test_run_ids`
+
+### Fix a single test prompt
+
+1. `list_test_set_tests` → pick test id
+2. `get_test` → `update_test` with revised prompt
 
 ### Fix a metric
 
@@ -101,12 +112,12 @@ flowchart TB
 
 | Entity | List | Get | Create | Update | Other |
 |--------|------|-----|--------|--------|-------|
-| Project | `list_projects` | — | `create_project` | — | — |
+| Project | `list_projects` | `get_project` | `create_project` | — | — |
 | Endpoint | `list_endpoints` | `get_endpoint` | `create_endpoint` | `update_endpoint` | `check_endpoint`, `explore_endpoint` |
-| Behavior | `list_behaviors` | — | `create_behavior` | `update_behavior` | — |
+| Behavior | `list_behaviors` | `get_behavior` | `create_behavior` | `update_behavior` | — |
 | Metric | `list_metrics` | `get_metric` | `create_metric`, `generate_metric` | `update_metric`, `improve_metric` | `add_behavior_to_metric`, `remove_behavior_from_metric`, `get_metric_behaviors` |
-| TestSet | `list_test_sets` | `get_test_set` | `generate_test_set`, `create_test_set_bulk` | `update_test_set` | `list_test_set_tests`, `execute_test_set` |
-| Test | `list_tests`, `list_test_set_tests` | — | (via test set tools) | — | — |
+| TestSet | `list_test_sets` | `get_test_set` | `generate_test_set`, `create_test_set_bulk` | `update_test_set` | `list_test_set_tests`, `get_test_set_metrics`, `get_test_set_last_run`, `execute_test_set` |
+| Test | `list_tests`, `list_test_set_tests` | `get_test` | (via test set tools) | `update_test` | — |
 | Source | `list_sources` | — | `create_source` | — | — |
 | TestRun | `list_test_runs` | `get_test_run` | (via `execute_test_set`) | — | `get_test_run_stats` |
 | TestResult | `list_test_results` | `get_test_result` | — | — | `get_test_result_stats` |

--- a/skills/rhesis/references/tool-catalog.md
+++ b/skills/rhesis/references/tool-catalog.md
@@ -375,7 +375,7 @@ Aggregated statistics for test results. Use for single-run analysis and multi-ru
 - `test_runs` — per-run pass/fail summary; pass multiple `test_run_ids` to compare runs side by side
 - `summary` — lightweight overall totals only
 
-**For single-run analysis:** `mode=all` with `test_run_id`  
+**For single-run analysis:** `mode=all` with `test_run_id`
 **For multi-run comparison:** `mode=test_runs` with `test_run_ids`
 
 **Key parameters:**
@@ -387,15 +387,93 @@ Aggregated statistics for test results. Use for single-run analysis and multi-ru
 
 ---
 
-### `get_test_run_stats`
-Run-level analytics: run volume, status distribution, most-run test sets, top executors, monthly trends.
-
-Use for **operational questions** ("how many runs this month?"). For pass/fail outcomes, use `get_test_result_stats` instead.
-
-**Modes:** `summary` (default), `status`, `results`, `test_sets`, `executors`, `timeline`, `all`
-
 **Key parameters:**
 - `mode`
 - `endpoint_ids`, `test_set_ids` — optional filters
 - `months` — history window (default 6)
 - `start_date`, `end_date`
+
+---
+
+## Inspection (get-by-id)
+
+### `get_test_set`
+Get one test set by UUID, nano_id, or slug.
+
+**CHAIN:** after `generate_test_set` / `get_job_status` → then `list_test_set_tests` to verify prompts.
+
+**Key parameters:** `test_set_identifier` (required)
+
+---
+
+### `list_test_set_tests`
+List tests inside a single test set.
+
+**CHAIN:** prefer over org-wide `list_tests` when you have the test set ID.
+
+**Default `$select`:** `id,prompt,behavior,category,topic`
+
+**Key parameters:** `test_set_identifier` (required)
+
+---
+
+### `get_endpoint`
+Full endpoint config including mappings and auth.
+
+**CHAIN:** after `list_endpoints` when you need `request_mapping` / `response_mapping` details.
+
+**Key parameters:** `endpoint_id` (required)
+
+---
+
+### `get_metric`
+Full metric including `evaluation_prompt`.
+
+**CHAIN:** before `update_metric` or `improve_metric`.
+
+**Key parameters:** `metric_id` (required)
+
+---
+
+## Entity mutation (additional)
+
+### `update_test_set`
+Update test set metadata only (name, description). Does not regenerate tests.
+
+**Key parameters:** `test_set_id` (required); send only fields to change.
+
+---
+
+### `update_metric`
+Direct field edits on a metric. Does not change behavior links.
+
+**CHAIN:** `get_metric` first. For NL refactors use `improve_metric` instead.
+
+**Key parameters:** `metric_id` (required)
+
+---
+
+### `remove_behavior_from_metric`
+Unlink a behavior from a metric. Inverse of `add_behavior_to_metric`.
+
+**CHAIN:** confirm link via `get_metric_behaviors` first.
+
+**Key parameters:** `metric_id`, `behavior_id` (required)
+
+---
+
+### `create_source`
+Create a knowledge source for grounding single-turn `generate_test_set`.
+
+**Patterns:**
+- Pasted text: `title` + `content` (Manual type — copy `source_type_id` from `list_sources`)
+- URL: `title` + `url` (Website type)
+- File uploads: UI only (not available via MCP)
+
+**CHAIN:** `create_source` → `generate_test_set` with `sources: [{"id": "…"}]`
+
+---
+
+## Playbooks
+
+See `references/entity-model.md` for the full entity graph and tool chains by intent.

--- a/skills/rhesis/references/tool-catalog.md
+++ b/skills/rhesis/references/tool-catalog.md
@@ -358,7 +358,7 @@ Run a test set against an endpoint. The backend creates the internal test config
 The response includes `test_run_id` and `task_id`. Poll `get_job_status` with `task_id` until `SUCCESS`, then use `test_run_id` to fetch results via `get_test_run` and `list_test_results`.
 
 **Key parameters:**
-- `test_set_identifier` (required, path parameter) — UUID of the test set
+- `test_set_identifier` (required, path parameter) — test set UUID, nano_id, or slug
 - `endpoint_id` (required, path parameter) — UUID of the target endpoint
 
 ---
@@ -386,6 +386,13 @@ Aggregated statistics for test results. Use for single-run analysis and multi-ru
 - `start_date`, `end_date` — ISO format
 
 ---
+
+### `get_test_run_stats`
+Run-level analytics: run volume, status distribution, most-run test sets, top executors, monthly trends.
+
+Use for **operational questions** ("how many runs this month?"). For pass/fail outcomes, use `get_test_result_stats` instead.
+
+**Modes:** `summary` (default), `status`, `results`, `test_sets`, `executors`, `timeline`, `all`
 
 **Key parameters:**
 - `mode`

--- a/skills/rhesis/references/tool-catalog.md
+++ b/skills/rhesis/references/tool-catalog.md
@@ -447,7 +447,7 @@ Full metric including `evaluation_prompt`.
 ### `update_test_set`
 Update test set metadata only (name, description). Does not regenerate tests.
 
-**Key parameters:** `test_set_id` (required); send only fields to change.
+**Key parameters:** `test_set_identifier` (required; UUID, nano_id, or slug); send only fields to change.
 
 ---
 

--- a/skills/rhesis/references/tool-catalog.md
+++ b/skills/rhesis/references/tool-catalog.md
@@ -474,6 +474,61 @@ Create a knowledge source for grounding single-turn `generate_test_set`.
 
 ---
 
+
+
+### `get_project`
+Get one project by ID.
+
+**CHAIN:** after `list_projects` when you need full project detail before `create_endpoint`.
+
+**Key parameters:** `project_id` (required)
+
+---
+
+### `get_behavior`
+Get one behavior including linked metrics.
+
+**CHAIN:** complement `get_metric_behaviors` — behavior-centric view of metric links.
+
+**Key parameters:** `behavior_id` (required)
+
+---
+
+### `get_test`
+Get one test with full prompt and configuration.
+
+**CHAIN:** after `list_test_set_tests`; before `update_test`.
+
+**Key parameters:** `test_id` (required)
+
+---
+
+### `update_test`
+Fix an individual test prompt without regenerating the whole set.
+
+**CHAIN:** `get_test` first. Send only fields to change.
+
+**Key parameters:** `test_id` (required)
+
+---
+
+### `get_test_set_metrics`
+List metrics attached to a test set (execution overrides).
+
+**CHAIN:** pre-flight before `execute_test_set`. Empty list → behavior metrics apply.
+
+**Key parameters:** `test_set_identifier` (required)
+
+---
+
+### `get_test_set_last_run`
+Most recent completed run for a test set + endpoint pair.
+
+**CHAIN:** use for run comparison; pair with `get_test_result_stats(mode=test_runs)`.
+
+**Key parameters:** `test_set_identifier`, `endpoint_id` (required)
+
+---
 ## Playbooks
 
 See `references/entity-model.md` for the full entity graph and tool chains by intent.

--- a/tests/backend/routes/test_test_set_update.py
+++ b/tests/backend/routes/test_test_set_update.py
@@ -1,0 +1,50 @@
+"""Tests for PUT /test_sets/{test_set_identifier}.
+
+The update route resolves its identifier the same way the read routes do
+(UUID, nano_id, or slug), so a test set can be updated without first
+resolving it to a UUID.
+"""
+
+import uuid
+
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+
+class TestUpdateTestSet:
+    """Tests for PUT /test_sets/{test_set_identifier}"""
+
+    def test_update_by_uuid(self, authenticated_client: TestClient, db_test_set):
+        """Updating by UUID still works (backward-compatible path)."""
+        response = authenticated_client.put(
+            f"/test_sets/{db_test_set.id}",
+            json={"name": "Updated By UUID"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["name"] == "Updated By UUID"
+
+    def test_update_by_slug(
+        self, authenticated_client: TestClient, test_db: Session, db_test_set
+    ):
+        """Updating by slug resolves the test set without a UUID."""
+        db_test_set.slug = "my-update-slug"
+        test_db.add(db_test_set)
+        test_db.flush()
+
+        response = authenticated_client.put(
+            f"/test_sets/{db_test_set.slug}",
+            json={"name": "Updated By Slug"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["id"] == str(db_test_set.id)
+        assert body["name"] == "Updated By Slug"
+
+    def test_update_unknown_identifier_returns_404(self, authenticated_client: TestClient):
+        """An identifier that resolves to nothing returns 404."""
+        response = authenticated_client.put(
+            f"/test_sets/{uuid.uuid4()}",
+            json={"name": "Nope"},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/backend/services/test_mcp_tools_yaml.py
+++ b/tests/backend/services/test_mcp_tools_yaml.py
@@ -18,6 +18,7 @@ def load_tool_configs():
 
 def _load_schema_module():
     spec = importlib.util.spec_from_file_location("mcp_schema_module", _MCP_SCHEMA_PY)
+    assert spec and spec.loader, f"Could not load schema module from {_MCP_SCHEMA_PY}"
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod

--- a/tests/backend/services/test_mcp_tools_yaml.py
+++ b/tests/backend/services/test_mcp_tools_yaml.py
@@ -85,6 +85,12 @@ class TestNewMcpToolsPresent:
         "update_metric",
         "remove_behavior_from_metric",
         "update_test_set",
+        "get_test",
+        "update_test",
+        "get_behavior",
+        "get_test_set_last_run",
+        "get_test_set_metrics",
+        "get_project",
     })
 
     def test_new_tools_in_yaml(self):
@@ -106,6 +112,12 @@ class TestMcpToolsYamlStructure:
         ("update_metric", "PUT", "/metrics/{metric_id}"),
         ("remove_behavior_from_metric", "DELETE", "/metrics/{metric_id}/behaviors/{behavior_id}"),
         ("update_test_set", "PUT", "/test_sets/{test_set_id}"),
+        ("get_test", "GET", "/tests/{test_id}"),
+        ("update_test", "PUT", "/tests/{test_id}"),
+        ("get_behavior", "GET", "/behaviors/{behavior_id}"),
+        ("get_test_set_last_run", "GET", "/test_sets/{test_set_identifier}/last-run/{endpoint_id}"),
+        ("get_test_set_metrics", "GET", "/test_sets/{test_set_identifier}/metrics"),
+        ("get_project", "GET", "/projects/{project_id}"),
     }
 
     def test_all_entries_have_required_keys(self):

--- a/tests/backend/services/test_mcp_tools_yaml.py
+++ b/tests/backend/services/test_mcp_tools_yaml.py
@@ -1,61 +1,55 @@
-"""Tests that mcp_tools.yaml contains the expected explore_endpoint entry."""
+"""Tests that mcp_tools.yaml contains expected tools and valid structure."""
+
+import importlib.util
+from pathlib import Path
 
 import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_MCP_TOOLS_YAML = _REPO_ROOT / "apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml"
+_MCP_SCHEMA_PY = _REPO_ROOT / "apps/backend/src/rhesis/backend/app/mcp_server/schema.py"
+
+
+def load_tool_configs():
+    with open(_MCP_TOOLS_YAML) as f:
+        return yaml.safe_load(f).get("tools", [])
+
+
+def _load_schema_module():
+    spec = importlib.util.spec_from_file_location("mcp_schema_module", _MCP_SCHEMA_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
 
 
 @pytest.mark.unit
 class TestExploreEndpointInMcpTools:
     def test_explore_endpoint_in_yaml(self):
-        """explore_endpoint must appear in the raw tool config list."""
-        from rhesis.backend.app.mcp_server.tools import load_tool_configs
-
         names = [tc["name"] for tc in load_tool_configs()]
-        assert "explore_endpoint" in names, (
-            f"explore_endpoint not found in mcp_tools.yaml. Found: {names}"
-        )
+        assert "explore_endpoint" in names
 
     def test_explore_endpoint_is_post(self):
-        """explore_endpoint must be configured as POST /endpoints/{endpoint_id}/explore."""
-        from rhesis.backend.app.mcp_server.tools import load_tool_configs
-
         configs = {tc["name"]: tc for tc in load_tool_configs()}
-        cfg = configs.get("explore_endpoint")
-        assert cfg is not None
+        cfg = configs["explore_endpoint"]
         assert cfg["method"].upper() == "POST"
         assert "/explore" in cfg["path"]
 
     def test_explore_endpoint_requires_confirmation(self):
-        """explore_endpoint must have requires_confirmation=True."""
-        from rhesis.backend.app.mcp_server.tools import load_tool_configs
-
         configs = {tc["name"]: tc for tc in load_tool_configs()}
-        cfg = configs.get("explore_endpoint")
-        assert cfg is not None
-        assert cfg.get("requires_confirmation") is True
+        assert configs["explore_endpoint"].get("requires_confirmation") is True
 
     def test_explore_endpoint_has_strategy_and_goal_params(self):
-        """explore_endpoint parameters must declare strategy and goal."""
-        from rhesis.backend.app.mcp_server.tools import load_tool_configs
-
-        configs = {tc["name"]: tc for tc in load_tool_configs()}
-        cfg = configs.get("explore_endpoint")
-        assert cfg is not None
+        cfg = {tc["name"]: tc for tc in load_tool_configs()}["explore_endpoint"]
         params = cfg.get("parameters", {})
-        assert "strategy" in params, "strategy parameter missing from explore_endpoint"
-        assert "goal" in params, "goal parameter missing from explore_endpoint"
+        assert "strategy" in params
+        assert "goal" in params
 
 
 @pytest.mark.unit
 class TestInputSchemaPropertyNames:
-    """Generated tool-schema property names must satisfy the Anthropic API.
-
-    Property keys must match ``^[a-zA-Z0-9_.-]{1,64}$``; OData aliases like
-    ``$filter``/``$select`` would otherwise get the whole tool list rejected.
-    """
-
     def test_dollar_prefixed_params_are_sanitized(self):
-        from rhesis.backend.app.mcp_server.schema import build_input_schema
-
+        build_input_schema = _load_schema_module().build_input_schema
         operation = {
             "parameters": [
                 {"name": "$filter", "in": "query", "schema": {"type": "string"}},
@@ -64,21 +58,65 @@ class TestInputSchemaPropertyNames:
             ]
         }
         schema = build_input_schema(operation, {}, {})
-
         props = schema["properties"]
         assert "filter" in props and "$filter" not in props
         assert "select" in props and "$select" not in props
-        assert "source_id" in props
         assert schema["required"] == ["source_id"]
 
     def test_yaml_override_keyed_by_sanitized_name_applies(self):
-        from rhesis.backend.app.mcp_server.schema import build_input_schema
-
+        build_input_schema = _load_schema_module().build_input_schema
         operation = {
             "parameters": [
                 {"name": "$filter", "in": "query", "schema": {"type": "string"}},
             ]
         }
         schema = build_input_schema(operation, {}, {"filter": {"description": "search by title"}})
-
         assert schema["properties"]["filter"]["description"] == "search by title"
+
+
+@pytest.mark.unit
+class TestNewMcpToolsPresent:
+    NEW_TOOLS = frozenset({
+        "get_test_set",
+        "list_test_set_tests",
+        "get_endpoint",
+        "get_metric",
+        "create_source",
+        "update_metric",
+        "remove_behavior_from_metric",
+        "update_test_set",
+    })
+
+    def test_new_tools_in_yaml(self):
+        names = {tc["name"] for tc in load_tool_configs()}
+        missing = self.NEW_TOOLS - names
+        assert not missing, f"Missing tools: {sorted(missing)}"
+
+
+@pytest.mark.unit
+class TestMcpToolsYamlStructure:
+    """Every tool entry must declare name, method, and path."""
+
+    EXPECTED_NEW_PATHS = {
+        ("get_test_set", "GET", "/test_sets/{test_set_identifier}"),
+        ("list_test_set_tests", "GET", "/test_sets/{test_set_identifier}/tests"),
+        ("get_endpoint", "GET", "/endpoints/{endpoint_id}"),
+        ("get_metric", "GET", "/metrics/{metric_id}"),
+        ("create_source", "POST", "/sources/"),
+        ("update_metric", "PUT", "/metrics/{metric_id}"),
+        ("remove_behavior_from_metric", "DELETE", "/metrics/{metric_id}/behaviors/{behavior_id}"),
+        ("update_test_set", "PUT", "/test_sets/{test_set_id}"),
+    }
+
+    def test_all_entries_have_required_keys(self):
+        for tc in load_tool_configs():
+            assert tc.get("name")
+            assert tc.get("method")
+            assert tc.get("path", "").startswith("/")
+
+    def test_new_tool_paths_configured(self):
+        by_name = {tc["name"]: tc for tc in load_tool_configs()}
+        for name, method, path in self.EXPECTED_NEW_PATHS:
+            cfg = by_name[name]
+            assert cfg["method"].upper() == method
+            assert cfg["path"] == path

--- a/tests/backend/services/test_mcp_tools_yaml.py
+++ b/tests/backend/services/test_mcp_tools_yaml.py
@@ -111,7 +111,7 @@ class TestMcpToolsYamlStructure:
         ("create_source", "POST", "/sources/"),
         ("update_metric", "PUT", "/metrics/{metric_id}"),
         ("remove_behavior_from_metric", "DELETE", "/metrics/{metric_id}/behaviors/{behavior_id}"),
-        ("update_test_set", "PUT", "/test_sets/{test_set_id}"),
+        ("update_test_set", "PUT", "/test_sets/{test_set_identifier}"),
         ("get_test", "GET", "/tests/{test_id}"),
         ("update_test", "PUT", "/tests/{test_id}"),
         ("get_behavior", "GET", "/behaviors/{behavior_id}"),


### PR DESCRIPTION
## Purpose
Telemachus and external MCP clients need more API capabilities (get-by-id, pre-run inspection, comparison, targeted updates) and clear guidance on how platform entities relate so tools are chained correctly.

## What Changed
- Added 14 MCP tools:
  - **Inspection:** `get_test_set`, `list_test_set_tests`, `get_endpoint`, `get_metric`, `get_test`, `get_behavior`, `get_project`
  - **Pre-run / comparison:** `get_test_set_metrics`, `get_test_set_last_run`
  - **Mutation:** `create_source`, `update_metric`, `remove_behavior_from_metric`, `update_test_set`, `update_test`
- Updated existing tool descriptions with ENTITY / PREREQUISITES / CHAIN / NEVER guidance
- Aligned `execute_test_set` `test_set_identifier` param with other test-set tools (UUID, nano_id, or slug)
- Made `update_test_set` accept `test_set_identifier` (UUID, nano_id, or slug) for consistency with the other test-set tools — the PUT route now resolves the identifier like the read routes (UUID still works); added route tests for update-by-UUID and update-by-slug
- Expanded MCP server instructions with entity overview and canonical workflows
- Added `skills/rhesis/references/entity-model.md` and linked it from the Rhesis skill
- Updated Architect `system_prompt.j2` with Platform Data Model, verification playbooks, and direct-request examples
- Extended `test_mcp_tools_yaml.py` to validate new tools and YAML structure

## Additional Context
- File upload sources (`POST /sources/upload`) and import endpoints remain out of scope (multipart not supported by MCP dispatcher)
- All test-set tools (read, update, execute) now use `test_set_identifier` and accept UUID, nano_id, or slug
- Branch created from `main` (not `feat/ui-polishings`)

## Testing
```bash
cd apps/backend
uv run pytest ../../tests/backend/services/test_mcp_tools_yaml.py -v --noconftest
uv run pytest ../../tests/backend/routes/test_test_set_update.py -v
```