### PR TITLE
Fix module-level app imports in alembic migration

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/6a7b8c9d0e1f_fix_garak_metric_missing_fields.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/6a7b8c9d0e1f_fix_garak_metric_missing_fields.py
@@ -26,8 +26,6 @@ from alembic import op
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app import crud, models, schemas
-
 # revision identifiers, used by Alembic.
 revision: str = "6a7b8c9d0e1f"
 down_revision: Union[str, None] = "5d7e4f2a3b1c"
@@ -43,6 +41,8 @@ def upgrade() -> None:
     metric_scope, backend_type_id, metric_type_id, status_id, or incorrect
     score_type and updates them using the existing CRUD infrastructure.
     """
+    from rhesis.backend.app import crud, models, schemas
+
     bind = op.get_bind()
 
     # Use raw SQL for the initial check so this migration does not SELECT columns


### PR DESCRIPTION
## Purpose
One migration file imports app code at the module level, causing \`alembic heads\` to crash without a DB connection. This is a prerequisite for adding a CI check that uses \`alembic heads\`.

## What Changed
- Moved \`from rhesis.backend.app import crud, models, schemas\` inside \`upgrade()\` in \`6a7b8c9d0e1f_fix_garak_metric_missing_fields.py\`

## Additional Context
Migration files should never import app code at the module level — Alembic executes the entire file just to read the revision metadata, which triggers the full app import chain and requires a DB connection even for read-only commands like \`alembic heads\`.