### PR TITLE
Remove GCR auto-deploy triggers and limit deploy workflows to production

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,23 +1,14 @@
 name: "[Deploy] Backend"
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'apps/backend/**'
-      - 'ee/backend/**'
-      - '.github/workflows/backend.yml'
-      - 'sdk/**'
   workflow_dispatch:
     inputs:
       environment:
         description: 'Environment to deploy to'
         required: true
-        default: 'dev'
+        default: 'prd'
         type: choice
         options:
-          - dev
-          - stg
           - prd
       deploy_only:
         description: 'Skip build and only deploy latest image'
@@ -87,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      ENVIRONMENT: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+      ENVIRONMENT: ${{ inputs.environment || github.event.inputs.environment || 'prd' }}
 
     outputs:
       environment: ${{ steps.set_build_metadata.outputs.environment }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -3,22 +3,14 @@ name: "[Deploy] Frontend"
 # Workflow file for building and deploying the frontend application
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'apps/frontend/**'
-      - 'ee/frontend/**'
-      - '.github/workflows/frontend.yml'
   workflow_dispatch:
     inputs:
       environment:
         description: 'Environment to deploy to'
         required: true
-        default: 'dev'
+        default: 'prd'
         type: choice
         options:
-          - dev
-          - stg
           - prd
       deploy_only:
         description: 'Skip build and only deploy latest image'
@@ -90,10 +82,10 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+    environment: ${{ inputs.environment || github.event.inputs.environment || 'prd' }}
 
     env:
-      ENVIRONMENT: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+      ENVIRONMENT: ${{ inputs.environment || github.event.inputs.environment || 'prd' }}
       SERVICE: frontend
 
     outputs:

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -1,24 +1,14 @@
 name: "[Deploy] Worker"
 
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'apps/worker/**'
-      - 'apps/backend/**'
-      - 'sdk/**'
-      - 'penelope/**'
-      - '.github/workflows/worker.yml'
   workflow_dispatch:
     inputs:
       environment:
         description: 'Environment to deploy to'
         required: true
-        default: 'dev'
+        default: 'prd'
         type: choice
         options:
-          - dev
-          - stg
           - prd
       deploy_only:
         description: 'Skip build and only deploy latest image'
@@ -58,10 +48,10 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+    environment: ${{ inputs.environment || github.event.inputs.environment || 'prd' }}
 
     env:
-      ENVIRONMENT: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
+      ENVIRONMENT: ${{ inputs.environment || github.event.inputs.environment || 'prd' }}
       SERVICE: worker
 
     outputs:
@@ -157,7 +147,7 @@ jobs:
     environment: ${{ needs.build.outputs.environment || inputs.environment || github.event.inputs.environment }}
 
     env:
-      ENVIRONMENT: ${{ needs.build.outputs.environment || inputs.environment || github.event.inputs.environment || 'dev' }}
+      ENVIRONMENT: ${{ needs.build.outputs.environment || inputs.environment || github.event.inputs.environment || 'prd' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -201,7 +191,7 @@ jobs:
           # Ensure ENVIRONMENT is set with fallback
           ENV_VALUE="${{ env.ENVIRONMENT }}"
           if [ -z "$ENV_VALUE" ]; then
-            ENV_VALUE="dev"
+            ENV_VALUE="prd"
             echo "⚠️ ENVIRONMENT not set, defaulting to: $ENV_VALUE"
           fi
           echo "ENVIRONMENT=$ENV_VALUE" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Purpose
Stop automatic deploys to GCR on pushes to `main` and simplify the backend, frontend, and worker deploy workflows to production-only manual dispatch.

## What Changed
- Removed `push` triggers from `backend.yml`, `frontend.yml`, and `worker.yml` deploy workflows
- Restricted `workflow_dispatch` environment choices to `prd` only (removed `dev` and `stg`)
- Updated default and fallback environment values from `dev` to `prd`

## Additional Context
- Deploy workflows are now manual-only via `workflow_dispatch`
- Aligns with moving away from GCR-based automatic deployments on merge to `main`

## Testing
- [ ] Verify backend, frontend, and worker deploy workflows can be triggered manually with `prd` selected
- [ ] Confirm workflows no longer run automatically on pushes to `main`