### PR TITLE
Fix Insights empty states for no endpoints and no test results

### DIFF
--- a/apps/frontend/src/app/(protected)/insights/components/BehaviorInsightsView.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/BehaviorInsightsView.tsx
@@ -1,20 +1,14 @@
 'use client';
 
 import React from 'react';
-import Link from 'next/link';
-import {
-  Alert,
-  Box,
-  Button,
-  CircularProgress,
-  Typography,
-} from '@mui/material';
+import { Alert, Box, CircularProgress, Typography } from '@mui/material';
 import { InsightsFilters } from '../types';
 import { BehaviorInsightsData } from '../hooks/useBehaviorInsightsData';
 import { BehaviorInsightColumn } from '../utils/behavior-insights-utils';
 import InsightsSummaryBar from './InsightsSummaryBar';
 import BehaviorColumn from './BehaviorColumn';
 import BehaviorInsightsRow from './BehaviorInsightsRow';
+import InsightsEmptyState from './InsightsEmptyState';
 
 interface BehaviorInsightsViewProps {
   sessionToken: string;
@@ -55,19 +49,7 @@ export default function BehaviorInsightsView({
   const hasVisibleColumns = columnRows.some(row => row.length > 0);
 
   if (noEndpoints) {
-    return (
-      <Box sx={{ py: 6, textAlign: 'center' }}>
-        <Typography variant="h6" gutterBottom>
-          No endpoints in this project
-        </Typography>
-        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-          Create an endpoint to view behavior insights for your AI application.
-        </Typography>
-        <Button component={Link} href="/endpoints" variant="contained">
-          Go to Endpoints
-        </Button>
-      </Box>
-    );
+    return <InsightsEmptyState variant="no-endpoints" />;
   }
 
   if (!filters.endpointId) {
@@ -88,6 +70,10 @@ export default function BehaviorInsightsView({
     );
   }
 
+  if (noRuns && !isLoading && !error) {
+    return <InsightsEmptyState variant="no-test-results" />;
+  }
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
       <InsightsSummaryBar
@@ -97,12 +83,6 @@ export default function BehaviorInsightsView({
       />
 
       {error && <Alert severity="error">{error}</Alert>}
-
-      {noRuns && !isLoading && !error && (
-        <Alert severity="info">
-          No test runs found for this endpoint in the selected time range.
-        </Alert>
-      )}
 
       {isLoading ? (
         <Box
@@ -143,7 +123,6 @@ export default function BehaviorInsightsView({
         </Box>
       ) : (
         !isLoading &&
-        !noRuns &&
         !error && (
           <Typography variant="body2" color="text.secondary" sx={{ py: 4 }}>
             {searchQuery.trim()

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsEmptyState.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsEmptyState.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import React from 'react';
+import { Box } from '@mui/material';
+import { useRouter } from 'next/navigation';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import EndpointsIcon from '@/components/EndpointsIcon';
+import { PlayArrowIcon } from '@/components/icons';
+
+export type InsightsEmptyStateVariant = 'no-endpoints' | 'no-test-results';
+
+interface InsightsEmptyStateProps {
+  variant: InsightsEmptyStateVariant;
+}
+
+const VARIANT_CONFIG = {
+  'no-endpoints': {
+    icon: EndpointsIcon,
+    title: 'No endpoints in this project',
+    description:
+      'Create an endpoint to view behavior insights for your AI application.',
+    actionLabel: 'Go to Endpoints',
+    href: '/endpoints',
+  },
+  'no-test-results': {
+    icon: PlayArrowIcon,
+    title: 'No test results yet',
+    description:
+      'Run a test set against your endpoint to generate your first test run and view behavior insights.',
+    actionLabel: 'Go to Test Sets',
+    href: '/test-sets',
+  },
+} as const;
+
+export default function InsightsEmptyState({
+  variant,
+}: InsightsEmptyStateProps) {
+  const router = useRouter();
+  const config = VARIANT_CONFIG[variant];
+
+  return (
+    <Box
+      sx={{
+        flex: 1,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: 320,
+        width: '100%',
+      }}
+    >
+      <EntityEmptyState
+        icon={config.icon}
+        title={config.title}
+        description={config.description}
+        actionLabel={config.actionLabel}
+        onAction={() => router.push(config.href)}
+        showAddIcon={false}
+      />
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/insights/components/__tests__/BehaviorInsightsView.test.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/__tests__/BehaviorInsightsView.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import BehaviorInsightsView from '../BehaviorInsightsView';
+import { DEFAULT_INSIGHTS_FILTERS } from '../../types';
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, refresh: jest.fn() }),
+}));
+
+jest.mock('../BehaviorInsightsRow', () => {
+  return function MockBehaviorInsightsRow({
+    row,
+  }: {
+    row: Array<{ name: string }>;
+  }) {
+    return (
+      <div data-testid="behavior-insights-row">
+        {row.map(column => column.name).join(',')}
+      </div>
+    );
+  };
+});
+
+jest.mock('../BehaviorColumn', () => {
+  return function MockBehaviorColumn() {
+    return <div data-testid="behavior-column-skeleton" />;
+  };
+});
+
+const defaultColumn = {
+  id: 'beh-1',
+  name: 'Safety',
+  overall: { total: 10, passed: 8, failed: 2, pass_rate: 80 },
+  metrics: [],
+  topics: [],
+};
+
+function renderView(
+  props: Partial<React.ComponentProps<typeof BehaviorInsightsView>> = {}
+) {
+  const defaults: React.ComponentProps<typeof BehaviorInsightsView> = {
+    sessionToken: 'token',
+    filters: { ...DEFAULT_INSIGHTS_FILTERS, endpointId: 'ep-1' },
+    insights: {
+      summary: { total: 10, passed: 8, failed: 2, pass_rate: 80 },
+      columns: [defaultColumn],
+      loading: false,
+      error: null,
+      noRuns: false,
+    },
+    columnRows: [[defaultColumn]],
+    expandedRows: new Set([0]),
+    onRowToggle: jest.fn(),
+  };
+
+  return render(<BehaviorInsightsView {...defaults} {...props} />);
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('BehaviorInsightsView', () => {
+  it('renders no-endpoints empty state with navigation CTA', async () => {
+    const user = userEvent.setup();
+    renderView({ noEndpoints: true });
+
+    expect(
+      screen.getByRole('heading', { name: 'No endpoints in this project' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Create an endpoint to view behavior insights for your AI application.'
+      )
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Go to Endpoints' }));
+    expect(mockPush).toHaveBeenCalledWith('/endpoints');
+  });
+
+  it('renders no-test-results empty state without summary bar or info alert', async () => {
+    const user = userEvent.setup();
+    renderView({
+      insights: {
+        summary: { total: 0, passed: 0, failed: 0, pass_rate: 0 },
+        columns: [],
+        loading: false,
+        error: null,
+        noRuns: true,
+      },
+      columnRows: [],
+    });
+
+    expect(
+      screen.getByRole('heading', { name: 'No test results yet' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Run a test set against your endpoint to generate your first test run and view behavior insights.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/pass rate/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/no test runs found for this endpoint/i)
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Go to Test Sets' }));
+    expect(mockPush).toHaveBeenCalledWith('/test-sets');
+  });
+
+  it('does not show empty state while loading test results', () => {
+    renderView({
+      insights: {
+        summary: null,
+        columns: [],
+        loading: true,
+        error: null,
+        noRuns: false,
+      },
+      columnRows: [],
+    });
+
+    expect(
+      screen.queryByRole('heading', { name: 'No test results yet' })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Loading results…')).toBeInTheDocument();
+    expect(screen.getAllByTestId('behavior-column-skeleton')).toHaveLength(6);
+  });
+
+  it('renders summary bar and behavior rows when runs exist', () => {
+    renderView();
+
+    expect(screen.getByText(/80\.0%/)).toBeInTheDocument();
+    expect(screen.getByTestId('behavior-insights-row')).toHaveTextContent(
+      'Safety'
+    );
+  });
+});


### PR DESCRIPTION
## Purpose
The Insights page showed weak empty states: a plain text block when no endpoints exist, and a misleading 0% pass-rate summary plus info alert when an endpoint had no test runs. This fix aligns both cases with the intended UX and guides users to the right next step.

## What Changed
- Added `InsightsEmptyState` component wrapping shared `EntityEmptyState` with `no-endpoints` and `no-test-results` variants
- Refactored `BehaviorInsightsView` to use the new empty states and hide the summary bar when no runs exist
- Added unit tests covering both empty states, loading state, and the happy path

## Additional Context
- Targets `release/v0.9.1`
- No-endpoints CTA navigates to `/endpoints`
- No-test-results CTA navigates to `/test-sets`

## Testing
- [x] `cd apps/frontend && npm test -- --testPathPatterns=BehaviorInsightsView`
- [ ] Manual: open `/insights` in a project with no endpoints — toolbar visible, centered empty state with "Go to Endpoints"
- [ ] Manual: open `/insights` with an endpoint but no test runs — "No test results yet" with "Go to Test Sets" (no 0% summary bar)
- [ ] Manual: endpoint with test runs — summary bar and behavior columns unchanged