### PR TITLE
Fix Insights empty states to match Figma card layout

### DIFF
--- a/apps/frontend/src/app/(protected)/insights/components/BehaviorInsightsView.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/BehaviorInsightsView.tsx
@@ -8,7 +8,6 @@ import { BehaviorInsightColumn } from '../utils/behavior-insights-utils';
 import InsightsSummaryBar from './InsightsSummaryBar';
 import BehaviorColumn from './BehaviorColumn';
 import BehaviorInsightsRow from './BehaviorInsightsRow';
-import InsightsEmptyState from './InsightsEmptyState';
 
 interface BehaviorInsightsViewProps {
   sessionToken: string;
@@ -20,7 +19,6 @@ interface BehaviorInsightsViewProps {
   searchQuery?: string;
   endpointName?: string;
   endpointsLoading?: boolean;
-  noEndpoints?: boolean;
   columnRows: BehaviorInsightColumn[][];
   expandedRows: Set<number>;
   onRowToggle: (rowIndex: number) => void;
@@ -38,19 +36,14 @@ export default function BehaviorInsightsView({
   searchQuery = '',
   endpointName,
   endpointsLoading = false,
-  noEndpoints = false,
   columnRows,
   expandedRows,
   onRowToggle,
 }: BehaviorInsightsViewProps) {
-  const { summary, loading, error, noRuns } = insights;
+  const { summary, loading, error } = insights;
 
   const isLoading = endpointsLoading || loading;
   const hasVisibleColumns = columnRows.some(row => row.length > 0);
-
-  if (noEndpoints) {
-    return <InsightsEmptyState variant="no-endpoints" />;
-  }
 
   if (!filters.endpointId) {
     if (endpointsLoading) {
@@ -68,10 +61,6 @@ export default function BehaviorInsightsView({
         </Typography>
       </Box>
     );
-  }
-
-  if (noRuns && !isLoading && !error) {
-    return <InsightsEmptyState variant="no-test-results" />;
   }
 
   return (

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsEmptyState.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsEmptyState.tsx
@@ -39,17 +39,9 @@ export default function InsightsEmptyState({
   const config = VARIANT_CONFIG[variant];
 
   return (
-    <Box
-      sx={{
-        flex: 1,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        minHeight: 320,
-        width: '100%',
-      }}
-    >
+    <Box sx={{ mt: 2, mb: 2, width: '100%' }}>
       <EntityEmptyState
+        card
         icon={config.icon}
         title={config.title}
         description={config.description}

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsPage.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useMemo, useEffect } from 'react';
-import { Box } from '@mui/material';
+import { Box, CircularProgress } from '@mui/material';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -24,6 +24,8 @@ import {
   InsightsBehaviorOption,
 } from '../utils/insights-filter-utils';
 import { useBehaviorInsightsData } from '../hooks/useBehaviorInsightsData';
+import InsightsEmptyState from './InsightsEmptyState';
+import { resolveInsightsPageView } from '../utils/insights-page-view';
 
 interface InsightsPageProps {
   sessionToken: string;
@@ -191,6 +193,15 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
   const failedCount = summary?.failed ?? 0;
   const fabLoading = endpointsLoading || insightsLoading;
 
+  const pageView = resolveInsightsPageView({
+    endpointsLoading,
+    projectEndpointCount: projectEndpoints.length,
+    endpointId: filters.endpointId,
+    insightsLoading,
+    error,
+    noRuns,
+  });
+
   return (
     <PageLayout
       title="Insights"
@@ -212,41 +223,52 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
           gap: 0,
         }}
       >
-        <TestResultsFilters
-          filters={filters}
-          onFiltersChange={handleFiltersChange}
-          projectEndpoints={projectEndpoints}
-          endpointsLoading={endpointsLoading}
-          behaviorOptions={behaviorOptions}
-          searchQuery={searchQuery}
-          onSearchChange={setSearchQuery}
-          showExpandToggle={
-            !fabLoading &&
-            expandableRowIndices.length > 0 &&
-            projectEndpoints.length > 0
-          }
-          allExpanded={allExpanded}
-          onToggleAll={handleToggleAll}
-        />
+        {pageView === 'loading-endpoints' ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 10 }}>
+            <CircularProgress />
+          </Box>
+        ) : pageView === 'empty-no-endpoints' ? (
+          <InsightsEmptyState variant="no-endpoints" />
+        ) : pageView === 'empty-no-test-results' ? (
+          <InsightsEmptyState variant="no-test-results" />
+        ) : (
+          <>
+            <TestResultsFilters
+              filters={filters}
+              onFiltersChange={handleFiltersChange}
+              projectEndpoints={projectEndpoints}
+              endpointsLoading={endpointsLoading}
+              behaviorOptions={behaviorOptions}
+              searchQuery={searchQuery}
+              onSearchChange={setSearchQuery}
+              showExpandToggle={
+                !fabLoading &&
+                expandableRowIndices.length > 0 &&
+                projectEndpoints.length > 0
+              }
+              allExpanded={allExpanded}
+              onToggleAll={handleToggleAll}
+            />
 
-        <BehaviorInsightsView
-          sessionToken={sessionToken}
-          filters={filters}
-          insights={{
-            summary,
-            columns: filteredColumns,
-            loading: insightsLoading,
-            error,
-            noRuns,
-          }}
-          searchQuery={searchQuery}
-          endpointName={selectedEndpointName}
-          endpointsLoading={endpointsLoading}
-          noEndpoints={!endpointsLoading && projectEndpoints.length === 0}
-          columnRows={columnRows}
-          expandedRows={expandedRows}
-          onRowToggle={handleRowToggle}
-        />
+            <BehaviorInsightsView
+              sessionToken={sessionToken}
+              filters={filters}
+              insights={{
+                summary,
+                columns: filteredColumns,
+                loading: insightsLoading,
+                error,
+                noRuns,
+              }}
+              searchQuery={searchQuery}
+              endpointName={selectedEndpointName}
+              endpointsLoading={endpointsLoading}
+              columnRows={columnRows}
+              expandedRows={expandedRows}
+              onRowToggle={handleRowToggle}
+            />
+          </>
+        )}
       </Box>
     </PageLayout>
   );

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsPage.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useCallback, useMemo, useEffect } from 'react';
-import { Box, CircularProgress } from '@mui/material';
+import { Alert, Box, Button, CircularProgress } from '@mui/material';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -40,6 +40,7 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
   const [endpoints, setEndpoints] = useState<Endpoint[]>([]);
   const [endpointsLoading, setEndpointsLoading] = useState(true);
+  const [endpointsError, setEndpointsError] = useState<string | null>(null);
 
   const projectEndpoints = useMemo(
     () =>
@@ -121,33 +122,31 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
     });
   }, []);
 
-  useEffect(() => {
+  const loadEndpoints = useCallback(async () => {
     if (!sessionToken) return;
 
-    let mounted = true;
+    setEndpointsLoading(true);
+    setEndpointsError(null);
 
-    const loadEndpoints = async () => {
-      setEndpointsLoading(true);
-      try {
-        const client = new ApiClientFactory(sessionToken).getEndpointsClient();
-        const response = await client.getEndpoints({
-          limit: 100,
-          sort_by: 'name',
-          sort_order: 'asc',
-        });
-        if (mounted) setEndpoints(response.data);
-      } catch {
-        if (mounted) setEndpoints([]);
-      } finally {
-        if (mounted) setEndpointsLoading(false);
-      }
-    };
-
-    void loadEndpoints();
-    return () => {
-      mounted = false;
-    };
+    try {
+      const client = new ApiClientFactory(sessionToken).getEndpointsClient();
+      const response = await client.getEndpoints({
+        limit: 100,
+        sort_by: 'name',
+        sort_order: 'asc',
+      });
+      setEndpoints(response.data);
+    } catch {
+      setEndpoints([]);
+      setEndpointsError('Failed to load endpoints. Please try again.');
+    } finally {
+      setEndpointsLoading(false);
+    }
   }, [sessionToken]);
+
+  useEffect(() => {
+    void loadEndpoints();
+  }, [loadEndpoints]);
 
   useEffect(() => {
     if (endpointsLoading) return;
@@ -195,12 +194,23 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
 
   const pageView = resolveInsightsPageView({
     endpointsLoading,
+    endpointsError,
     projectEndpointCount: projectEndpoints.length,
     endpointId: filters.endpointId,
     insightsLoading,
     error,
     noRuns,
   });
+
+  const filterBarProps = {
+    filters,
+    onFiltersChange: handleFiltersChange,
+    projectEndpoints,
+    endpointsLoading,
+    behaviorOptions,
+    searchQuery,
+    onSearchChange: setSearchQuery,
+  } as const;
 
   return (
     <PageLayout
@@ -227,20 +237,30 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
           <Box sx={{ display: 'flex', justifyContent: 'center', py: 10 }}>
             <CircularProgress />
           </Box>
+        ) : pageView === 'endpoints-error' ? (
+          <Box sx={{ mt: 2 }}>
+            <Alert
+              severity="error"
+              action={
+                <Button color="inherit" size="small" onClick={loadEndpoints}>
+                  Retry
+                </Button>
+              }
+            >
+              {endpointsError}
+            </Alert>
+          </Box>
         ) : pageView === 'empty-no-endpoints' ? (
           <InsightsEmptyState variant="no-endpoints" />
         ) : pageView === 'empty-no-test-results' ? (
-          <InsightsEmptyState variant="no-test-results" />
+          <>
+            <TestResultsFilters {...filterBarProps} variant="compact" />
+            <InsightsEmptyState variant="no-test-results" />
+          </>
         ) : (
           <>
             <TestResultsFilters
-              filters={filters}
-              onFiltersChange={handleFiltersChange}
-              projectEndpoints={projectEndpoints}
-              endpointsLoading={endpointsLoading}
-              behaviorOptions={behaviorOptions}
-              searchQuery={searchQuery}
-              onSearchChange={setSearchQuery}
+              {...filterBarProps}
               showExpandToggle={
                 !fabLoading &&
                 expandableRowIndices.length > 0 &&

--- a/apps/frontend/src/app/(protected)/insights/components/TestResultsFilters.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/TestResultsFilters.tsx
@@ -32,6 +32,11 @@ interface TestResultsFiltersProps {
   showExpandToggle?: boolean;
   allExpanded?: boolean;
   onToggleAll?: () => void;
+  /**
+   * `compact` keeps endpoint/time controls (filter drawer + time range) but
+   * hides behavior search — used on the no-test-results empty state.
+   */
+  variant?: 'full' | 'compact';
 }
 
 export default function TestResultsFilters({
@@ -45,7 +50,9 @@ export default function TestResultsFilters({
   showExpandToggle = false,
   allExpanded = false,
   onToggleAll,
+  variant = 'full',
 }: TestResultsFiltersProps) {
+  const isCompact = variant === 'compact';
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
 
   const drawerFilters = useMemo<InsightsDrawerFilters>(
@@ -80,6 +87,7 @@ export default function TestResultsFilters({
         searchQuery={searchQuery}
         onSearchChange={onSearchChange}
         searchPlaceholder="Search behaviors…"
+        showSearch={!isCompact}
         onFilterClick={() => setFilterDrawerOpen(true)}
         hasActiveFilters={hasActiveInsightsDrawerFilters(drawerFilters)}
         activeFilterCount={countActiveInsightsDrawerFilters(drawerFilters)}

--- a/apps/frontend/src/app/(protected)/insights/components/__tests__/BehaviorInsightsView.test.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/__tests__/BehaviorInsightsView.test.tsx
@@ -1,15 +1,8 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import BehaviorInsightsView from '../BehaviorInsightsView';
 import { DEFAULT_INSIGHTS_FILTERS } from '../../types';
-
-const mockPush = jest.fn();
-
-jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush, refresh: jest.fn() }),
-}));
 
 jest.mock('../BehaviorInsightsRow', () => {
   return function MockBehaviorInsightsRow({
@@ -60,59 +53,17 @@ function renderView(
   return render(<BehaviorInsightsView {...defaults} {...props} />);
 }
 
-afterEach(() => {
-  jest.clearAllMocks();
-});
-
 describe('BehaviorInsightsView', () => {
-  it('renders no-endpoints empty state with navigation CTA', async () => {
-    const user = userEvent.setup();
-    renderView({ noEndpoints: true });
+  it('renders summary bar and behavior rows when runs exist', () => {
+    renderView();
 
-    expect(
-      screen.getByRole('heading', { name: 'No endpoints in this project' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Create an endpoint to view behavior insights for your AI application.'
-      )
-    ).toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: 'Go to Endpoints' }));
-    expect(mockPush).toHaveBeenCalledWith('/endpoints');
+    expect(screen.getByText(/80\.0%/)).toBeInTheDocument();
+    expect(screen.getByTestId('behavior-insights-row')).toHaveTextContent(
+      'Safety'
+    );
   });
 
-  it('renders no-test-results empty state without summary bar or info alert', async () => {
-    const user = userEvent.setup();
-    renderView({
-      insights: {
-        summary: { total: 0, passed: 0, failed: 0, pass_rate: 0 },
-        columns: [],
-        loading: false,
-        error: null,
-        noRuns: true,
-      },
-      columnRows: [],
-    });
-
-    expect(
-      screen.getByRole('heading', { name: 'No test results yet' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Run a test set against your endpoint to generate your first test run and view behavior insights.'
-      )
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/pass rate/i)).not.toBeInTheDocument();
-    expect(
-      screen.queryByText(/no test runs found for this endpoint/i)
-    ).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole('button', { name: 'Go to Test Sets' }));
-    expect(mockPush).toHaveBeenCalledWith('/test-sets');
-  });
-
-  it('does not show empty state while loading test results', () => {
+  it('shows loading skeleton while insights are loading', () => {
     renderView({
       insights: {
         summary: null,
@@ -124,19 +75,7 @@ describe('BehaviorInsightsView', () => {
       columnRows: [],
     });
 
-    expect(
-      screen.queryByRole('heading', { name: 'No test results yet' })
-    ).not.toBeInTheDocument();
     expect(screen.getByText('Loading results…')).toBeInTheDocument();
     expect(screen.getAllByTestId('behavior-column-skeleton')).toHaveLength(6);
-  });
-
-  it('renders summary bar and behavior rows when runs exist', () => {
-    renderView();
-
-    expect(screen.getByText(/80\.0%/)).toBeInTheDocument();
-    expect(screen.getByTestId('behavior-insights-row')).toHaveTextContent(
-      'Safety'
-    );
   });
 });

--- a/apps/frontend/src/app/(protected)/insights/components/__tests__/InsightsEmptyState.test.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/__tests__/InsightsEmptyState.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import InsightsEmptyState from '../InsightsEmptyState';
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, refresh: jest.fn() }),
+}));
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('InsightsEmptyState', () => {
+  it('renders card empty state for no endpoints', async () => {
+    const user = userEvent.setup();
+    render(<InsightsEmptyState variant="no-endpoints" />);
+
+    expect(
+      screen.getByRole('heading', { name: 'No endpoints in this project' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to Endpoints' })).toHaveClass(
+      'MuiButton-outlined'
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Go to Endpoints' }));
+    expect(mockPush).toHaveBeenCalledWith('/endpoints');
+  });
+
+  it('renders card empty state for no test results', async () => {
+    const user = userEvent.setup();
+    render(<InsightsEmptyState variant="no-test-results" />);
+
+    expect(
+      screen.getByRole('heading', { name: 'No test results yet' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Go to Test Sets' })).toHaveClass(
+      'MuiButton-outlined'
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Go to Test Sets' }));
+    expect(mockPush).toHaveBeenCalledWith('/test-sets');
+  });
+});

--- a/apps/frontend/src/app/(protected)/insights/components/__tests__/TestResultsFilters.test.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/__tests__/TestResultsFilters.test.tsx
@@ -160,4 +160,16 @@ describe('TestResultsFilters', () => {
       'true'
     );
   });
+
+  it('hides behavior search in compact variant but keeps filters and time range', () => {
+    renderFilters({ variant: 'compact' });
+
+    expect(
+      screen.queryByPlaceholderText(/search behaviors/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /filters/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '1M' })).toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-page-view.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-page-view.test.ts
@@ -1,0 +1,68 @@
+import { resolveInsightsPageView } from '../insights-page-view';
+
+describe('resolveInsightsPageView', () => {
+  it('returns loading-endpoints while endpoints are loading', () => {
+    expect(
+      resolveInsightsPageView({
+        endpointsLoading: true,
+        projectEndpointCount: 0,
+        endpointId: '',
+        insightsLoading: false,
+        error: null,
+        noRuns: false,
+      })
+    ).toBe('loading-endpoints');
+  });
+
+  it('returns empty-no-endpoints when project has no endpoints', () => {
+    expect(
+      resolveInsightsPageView({
+        endpointsLoading: false,
+        projectEndpointCount: 0,
+        endpointId: '',
+        insightsLoading: false,
+        error: null,
+        noRuns: false,
+      })
+    ).toBe('empty-no-endpoints');
+  });
+
+  it('returns empty-no-test-results when endpoint has no runs', () => {
+    expect(
+      resolveInsightsPageView({
+        endpointsLoading: false,
+        projectEndpointCount: 2,
+        endpointId: 'ep-1',
+        insightsLoading: false,
+        error: null,
+        noRuns: true,
+      })
+    ).toBe('empty-no-test-results');
+  });
+
+  it('returns content while insights are loading', () => {
+    expect(
+      resolveInsightsPageView({
+        endpointsLoading: false,
+        projectEndpointCount: 2,
+        endpointId: 'ep-1',
+        insightsLoading: true,
+        error: null,
+        noRuns: true,
+      })
+    ).toBe('content');
+  });
+
+  it('returns content when runs exist', () => {
+    expect(
+      resolveInsightsPageView({
+        endpointsLoading: false,
+        projectEndpointCount: 2,
+        endpointId: 'ep-1',
+        insightsLoading: false,
+        error: null,
+        noRuns: false,
+      })
+    ).toBe('content');
+  });
+});

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-page-view.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-page-view.test.ts
@@ -1,28 +1,41 @@
 import { resolveInsightsPageView } from '../insights-page-view';
 
+const baseInput = {
+  endpointsLoading: false,
+  endpointsError: null,
+  projectEndpointCount: 2,
+  endpointId: 'ep-1',
+  insightsLoading: false,
+  error: null,
+  noRuns: false,
+};
+
 describe('resolveInsightsPageView', () => {
   it('returns loading-endpoints while endpoints are loading', () => {
     expect(
       resolveInsightsPageView({
+        ...baseInput,
         endpointsLoading: true,
-        projectEndpointCount: 0,
-        endpointId: '',
-        insightsLoading: false,
-        error: null,
-        noRuns: false,
       })
     ).toBe('loading-endpoints');
+  });
+
+  it('returns endpoints-error when endpoints fetch failed', () => {
+    expect(
+      resolveInsightsPageView({
+        ...baseInput,
+        endpointsError: 'Failed to load endpoints. Please try again.',
+        projectEndpointCount: 0,
+      })
+    ).toBe('endpoints-error');
   });
 
   it('returns empty-no-endpoints when project has no endpoints', () => {
     expect(
       resolveInsightsPageView({
-        endpointsLoading: false,
+        ...baseInput,
         projectEndpointCount: 0,
         endpointId: '',
-        insightsLoading: false,
-        error: null,
-        noRuns: false,
       })
     ).toBe('empty-no-endpoints');
   });
@@ -30,11 +43,7 @@ describe('resolveInsightsPageView', () => {
   it('returns empty-no-test-results when endpoint has no runs', () => {
     expect(
       resolveInsightsPageView({
-        endpointsLoading: false,
-        projectEndpointCount: 2,
-        endpointId: 'ep-1',
-        insightsLoading: false,
-        error: null,
+        ...baseInput,
         noRuns: true,
       })
     ).toBe('empty-no-test-results');
@@ -43,26 +52,14 @@ describe('resolveInsightsPageView', () => {
   it('returns content while insights are loading', () => {
     expect(
       resolveInsightsPageView({
-        endpointsLoading: false,
-        projectEndpointCount: 2,
-        endpointId: 'ep-1',
+        ...baseInput,
         insightsLoading: true,
-        error: null,
         noRuns: true,
       })
     ).toBe('content');
   });
 
   it('returns content when runs exist', () => {
-    expect(
-      resolveInsightsPageView({
-        endpointsLoading: false,
-        projectEndpointCount: 2,
-        endpointId: 'ep-1',
-        insightsLoading: false,
-        error: null,
-        noRuns: false,
-      })
-    ).toBe('content');
+    expect(resolveInsightsPageView(baseInput)).toBe('content');
   });
 });

--- a/apps/frontend/src/app/(protected)/insights/utils/insights-page-view.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/insights-page-view.ts
@@ -1,0 +1,37 @@
+export type InsightsPageView =
+  | 'loading-endpoints'
+  | 'empty-no-endpoints'
+  | 'empty-no-test-results'
+  | 'content';
+
+interface ResolveInsightsPageViewInput {
+  endpointsLoading: boolean;
+  projectEndpointCount: number;
+  endpointId: string;
+  insightsLoading: boolean;
+  error: string | null;
+  noRuns: boolean;
+}
+
+export function resolveInsightsPageView({
+  endpointsLoading,
+  projectEndpointCount,
+  endpointId,
+  insightsLoading,
+  error,
+  noRuns,
+}: ResolveInsightsPageViewInput): InsightsPageView {
+  if (endpointsLoading) {
+    return 'loading-endpoints';
+  }
+
+  if (projectEndpointCount === 0) {
+    return 'empty-no-endpoints';
+  }
+
+  if (endpointId && !insightsLoading && !error && noRuns) {
+    return 'empty-no-test-results';
+  }
+
+  return 'content';
+}

--- a/apps/frontend/src/app/(protected)/insights/utils/insights-page-view.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/insights-page-view.ts
@@ -1,11 +1,13 @@
 export type InsightsPageView =
   | 'loading-endpoints'
+  | 'endpoints-error'
   | 'empty-no-endpoints'
   | 'empty-no-test-results'
   | 'content';
 
 interface ResolveInsightsPageViewInput {
   endpointsLoading: boolean;
+  endpointsError: string | null;
   projectEndpointCount: number;
   endpointId: string;
   insightsLoading: boolean;
@@ -15,6 +17,7 @@ interface ResolveInsightsPageViewInput {
 
 export function resolveInsightsPageView({
   endpointsLoading,
+  endpointsError,
   projectEndpointCount,
   endpointId,
   insightsLoading,
@@ -23,6 +26,10 @@ export function resolveInsightsPageView({
 }: ResolveInsightsPageViewInput): InsightsPageView {
   if (endpointsLoading) {
     return 'loading-endpoints';
+  }
+
+  if (endpointsError) {
+    return 'endpoints-error';
   }
 
   if (projectEndpointCount === 0) {

--- a/apps/frontend/src/components/common/GridToolbar.tsx
+++ b/apps/frontend/src/components/common/GridToolbar.tsx
@@ -28,6 +28,8 @@ export interface GridToolbarProps {
   activeFilterCount?: number;
   middleContent?: React.ReactNode;
   rightContent?: React.ReactNode;
+  /** When false, hides the search pill (e.g. insights empty state toolbar). */
+  showSearch?: boolean;
   sx?: SxProps<Theme>;
 }
 
@@ -225,6 +227,7 @@ export function GridToolbar({
   activeFilterCount,
   middleContent,
   rightContent,
+  showSearch = true,
   sx,
 }: GridToolbarProps) {
   // Figma grid-card default: 30px all around. Directory pages and drawers
@@ -248,27 +251,34 @@ export function GridToolbar({
           activeFilterCount={activeFilterCount}
         />
       ) : null}
-      {searchFullWidth ? (
-        <Box sx={{ flex: 1, minWidth: 0 }}>
+      {showSearch ? (
+        searchFullWidth ? (
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            <SearchPill
+              value={searchQuery}
+              onChange={onSearchChange}
+              placeholder={searchPlaceholder}
+              width="100%"
+              variant={searchVariant}
+            />
+          </Box>
+        ) : (
           <SearchPill
             value={searchQuery}
             onChange={onSearchChange}
             placeholder={searchPlaceholder}
-            width="100%"
+            width={searchWidth}
             variant={searchVariant}
           />
-        </Box>
-      ) : (
-        <SearchPill
-          value={searchQuery}
-          onChange={onSearchChange}
-          placeholder={searchPlaceholder}
-          width={searchWidth}
-          variant={searchVariant}
-        />
-      )}
+        )
+      ) : null}
       {middleContent}
-      {!middleContent && !searchFullWidth && <Box sx={{ flex: 1 }} />}
+      {!middleContent && !searchFullWidth && showSearch && (
+        <Box sx={{ flex: 1 }} />
+      )}
+      {!middleContent && !searchFullWidth && !showSearch && (
+        <Box sx={{ flex: 1 }} />
+      )}
       {rightContent ? (
         <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
           {rightContent}


### PR DESCRIPTION
## Purpose
The previous Insights empty state implementation did not match the Figma design: it lacked the bordered Paper card and incorrectly kept the filter/search toolbar visible during empty states.

## What Changed
- Added `InsightsEmptyState` using `EntityEmptyState` with `card` (Paper shell, border, shadow)
- Added `resolveInsightsPageView` to centralize when the page shows empty vs content states
- Updated `InsightsPage` to hide `TestResultsFilters` for both no-endpoints and no-test-results empty states
- Removed duplicate empty-state handling from `BehaviorInsightsView`
- Added unit tests for view resolution and card empty states

## Additional Context
- Targets `release/v0.9.1`
- Supersedes the layout issues in #2039
- No-endpoints CTA: `/endpoints`
- No-test-results CTA: `/test-sets`

## Testing
- [x] `cd apps/frontend && npm test -- --testPathPatterns="insights-page-view|InsightsEmptyState|BehaviorInsightsView"`
- [ ] Manual: `/insights` with no endpoints — only header + Paper empty state (no filter/search/time range)
- [ ] Manual: `/insights` with endpoint but no runs — same Paper empty state, no toolbar
- [ ] Manual: endpoint with runs — toolbar + summary bar + behavior grid unchanged