### PR TITLE
Fix architect stuck-thinking caused by project_isolation RLS on WS subscribe

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/file.py
+++ b/apps/backend/src/rhesis/backend/app/routers/file.py
@@ -251,6 +251,7 @@ async def upload_files(
                 content_type=content_type,
                 content_hash=content_hash,
                 organization_id=organization_id,
+                project_id=str(created.project_id) if created.project_id else "",
             )
         except Exception:
             # Surface broker / import / serialization failures so we don't

--- a/apps/backend/src/rhesis/backend/app/routers/file.py
+++ b/apps/backend/src/rhesis/backend/app/routers/file.py
@@ -23,8 +23,7 @@ import logging
 import uuid
 from typing import Any, Callable, List, Optional, TypeVar
 
-from fastapi import APIRouter, Depends, File, HTTPException, Query, Request, UploadFile
-from rhesis.backend.app.routers.base import RhesisRouter
+from fastapi import Depends, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import RedirectResponse, StreamingResponse
 from sqlalchemy.orm import Session
 
@@ -33,6 +32,7 @@ from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.database import get_db_with_tenant_variables
 from rhesis.backend.app.dependencies import get_tenant_context
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.file import FileEntityType
 from rhesis.backend.app.services.storage_service import NotSupportedError, StorageService
 

--- a/apps/backend/src/rhesis/backend/app/schemas/file.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/file.py
@@ -26,6 +26,7 @@ class FileResponse(Base):
     position: int = 0
     user_id: Optional[UUID4] = None
     organization_id: Optional[UUID4] = None
+    project_id: Optional[UUID4] = None
     created_at: Optional[Union[datetime, str]] = None
     updated_at: Optional[Union[datetime, str]] = None
     # New fields (nullable for backward compat with un-migrated rows)

--- a/apps/backend/src/rhesis/backend/app/schemas/websocket.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/websocket.py
@@ -36,6 +36,10 @@ class EventType(str, Enum):
     UNSUBSCRIBE = "unsubscribe"
     SUBSCRIBED = "subscribed"
     UNSUBSCRIBED = "unsubscribed"
+    # A SUBSCRIBE request was rejected (auth/not-found). Carries the offending
+    # ``channel`` so a subscriber can correlate the failure and stop waiting on
+    # events that will never arrive, instead of hanging silently.
+    SUBSCRIPTION_ERROR = "subscription_error"
 
     # Generic events (use-case specific events added as needed)
     NOTIFICATION = "notification"

--- a/apps/backend/src/rhesis/backend/app/services/websocket/manager.py
+++ b/apps/backend/src/rhesis/backend/app/services/websocket/manager.py
@@ -264,6 +264,17 @@ class WebSocketManager:
             await self._send_error(conn_id, "Missing channel in subscribe request")
             return
 
+        # The client sends the channel resource's own project_id so the
+        # authorization DB session can satisfy the fail-closed project_isolation
+        # RLS policy when looking the resource up. Without it the session opens
+        # with a blank app.current_project, and that policy (org set + project
+        # unset -> only project_id IS NULL rows) hides any project-scoped
+        # resource, making _resolve_channel_project_id return "not found" and
+        # silently denying an otherwise-authorized subscription.
+        subscribe_project_id = ""
+        if message.payload:
+            subscribe_project_id = message.payload.get("project_id") or ""
+
         # Security: Authorize channel subscription.
         # SP11: open a short-lived tenant session so the PDP can evaluate
         # the caller's read capability for resource-type channels.
@@ -272,7 +283,9 @@ class WebSocketManager:
 
         authorizer = get_channel_authorizer()
         stored_principal = self._principals.get(conn_id)
-        with get_db_with_tenant_variables(str(user.organization_id), str(user.id), "") as db:
+        with get_db_with_tenant_variables(
+            str(user.organization_id), str(user.id), subscribe_project_id
+        ) as db:
             authorized, error_message = await authorizer.authorize(
                 user, channel, db=db, principal=stored_principal
             )
@@ -280,7 +293,20 @@ class WebSocketManager:
             logger.warning(
                 f"Unauthorized subscription attempt by user {user.id} to {channel}: {error_message}"
             )
-            await self._send_error(conn_id, error_message or "Subscription denied")
+            # Channel-scoped error so the subscriber can correlate the denial and
+            # stop waiting (e.g. clear a "Thinking…" spinner) instead of hanging.
+            await self.broadcast(
+                WebSocketMessage(
+                    type=EventType.SUBSCRIPTION_ERROR,
+                    channel=channel,
+                    correlation_id=message.correlation_id,
+                    payload={
+                        "channel": channel,
+                        "error": error_message or "Subscription denied",
+                    },
+                ),
+                ConnectionTarget(connection_id=conn_id),
+            )
             return
 
         success = self.subscribe(conn_id, channel)

--- a/apps/backend/src/rhesis/backend/app/services/websocket/manager.py
+++ b/apps/backend/src/rhesis/backend/app/services/websocket/manager.py
@@ -271,9 +271,29 @@ class WebSocketManager:
         # unset -> only project_id IS NULL rows) hides any project-scoped
         # resource, making _resolve_channel_project_id return "not found" and
         # silently denying an otherwise-authorized subscription.
+        #
+        # The value is validated as a UUID before being used: project_isolation
+        # policies cast app.current_project to ::uuid, so a malformed string
+        # would cause a Postgres cast error on every query during the auth
+        # lookup and turn the subscribe into a server error/disconnect. An
+        # invalid value is treated as blank (fail-closed: the resource will not
+        # be found, subscription is denied with SUBSCRIPTION_ERROR).
         subscribe_project_id = ""
         if message.payload:
-            subscribe_project_id = message.payload.get("project_id") or ""
+            raw_project_id = message.payload.get("project_id") or ""
+            if raw_project_id:
+                try:
+                    import uuid as _uuid
+
+                    _uuid.UUID(str(raw_project_id))
+                    subscribe_project_id = str(raw_project_id)
+                except (ValueError, AttributeError):
+                    logger.warning(
+                        "SUBSCRIBE from conn %s carries malformed project_id %r"
+                        " — treating as blank",
+                        conn_id,
+                        raw_project_id,
+                    )
 
         # Security: Authorize channel subscription.
         # SP11: open a short-lived tenant session so the PDP can evaluate

--- a/apps/backend/src/rhesis/backend/tasks/file/extract_text.py
+++ b/apps/backend/src/rhesis/backend/tasks/file/extract_text.py
@@ -27,11 +27,18 @@ def extract_file_text(
     content_type: str,
     content_hash: str,
     organization_id: str,
+    project_id: str = "",
 ) -> None:
     """Fetch file bytes from storage and persist extracted text on the File row.
 
     Idempotent: if a File row with the same content_hash already has
     ``extraction_status='done'``, the task exits early without re-running.
+
+    ``project_id`` is the file's own project (empty for org-level files). It must
+    be passed so the session's ``app.current_project`` GUC matches the row: under
+    the fail-closed project_isolation RLS policy, a session with the org set but
+    no project can only see ``project_id IS NULL`` rows, so a project-scoped file
+    would otherwise be invisible here and extraction would silently no-op.
     """
     import uuid
 
@@ -42,7 +49,7 @@ def extract_file_text(
     try:
         storage = StorageService()
 
-        with get_db_with_tenant_variables(organization_id, "") as db:
+        with get_db_with_tenant_variables(organization_id, "", project_id) as db:
             file_row = db.query(File).filter(File.id == uuid.UUID(file_id)).first()
             if not file_row:
                 logger.warning(f"[EXTRACT] File row not found: file_id={file_id}")
@@ -85,7 +92,7 @@ def extract_file_text(
     except Exception as exc:
         logger.error(f"[EXTRACT] Extraction failed for file_id={file_id}: {exc}", exc_info=True)
         try:
-            with get_db_with_tenant_variables(organization_id, "") as db:
+            with get_db_with_tenant_variables(organization_id, "", project_id) as db:
                 file_row = db.query(File).filter(File.id == uuid.UUID(file_id)).first()
                 if file_row:
                     file_row.extraction_status = "failed"

--- a/apps/frontend/src/contexts/WebSocketContext.tsx
+++ b/apps/frontend/src/contexts/WebSocketContext.tsx
@@ -33,7 +33,7 @@ interface WebSocketContextValue {
     handler: EventHandler
   ) => () => void;
   /** Subscribe to a backend channel */
-  subscribeToChannel: (channel: string) => void;
+  subscribeToChannel: (channel: string, projectId?: string | null) => void;
   /** Unsubscribe from a backend channel */
   unsubscribeFromChannel: (channel: string) => void;
   /** Manually trigger a reconnection attempt */
@@ -152,13 +152,16 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   /**
    * Subscribe to a backend channel.
    */
-  const subscribeToChannel = useCallback((channel: string): void => {
-    if (!clientRef.current) {
-      console.warn('WebSocket client not initialized');
-      return;
-    }
-    clientRef.current.subscribeToChannel(channel);
-  }, []);
+  const subscribeToChannel = useCallback(
+    (channel: string, projectId?: string | null): void => {
+      if (!clientRef.current) {
+        console.warn('WebSocket client not initialized');
+        return;
+      }
+      clientRef.current.subscribeToChannel(channel, projectId);
+    },
+    []
+  );
 
   /**
    * Unsubscribe from a backend channel.

--- a/apps/frontend/src/hooks/__tests__/useArchitectChat.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useArchitectChat.test.ts
@@ -68,7 +68,10 @@ describe('useArchitectChat', () => {
   it('subscribes to architect channel when session and connection are ready', () => {
     renderHook(() => useArchitectChat({ sessionId: 'sess-1' }));
 
-    expect(mockSubscribeToChannel).toHaveBeenCalledWith('architect:sess-1', undefined);
+    expect(mockSubscribeToChannel).toHaveBeenCalledWith(
+      'architect:sess-1',
+      undefined
+    );
   });
 
   it('passes sessionProjectId when subscribing to architect channel', () => {

--- a/apps/frontend/src/hooks/__tests__/useArchitectChat.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useArchitectChat.test.ts
@@ -68,7 +68,18 @@ describe('useArchitectChat', () => {
   it('subscribes to architect channel when session and connection are ready', () => {
     renderHook(() => useArchitectChat({ sessionId: 'sess-1' }));
 
-    expect(mockSubscribeToChannel).toHaveBeenCalledWith('architect:sess-1');
+    expect(mockSubscribeToChannel).toHaveBeenCalledWith('architect:sess-1', undefined);
+  });
+
+  it('passes sessionProjectId when subscribing to architect channel', () => {
+    renderHook(() =>
+      useArchitectChat({ sessionId: 'sess-1', sessionProjectId: 'proj-42' })
+    );
+
+    expect(mockSubscribeToChannel).toHaveBeenCalledWith(
+      'architect:sess-1',
+      'proj-42'
+    );
   });
 
   it('unsubscribes from architect channel on unmount', () => {

--- a/apps/frontend/src/hooks/__tests__/useWebSocket.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useWebSocket.test.ts
@@ -92,8 +92,14 @@ describe('useWebSocket', () => {
         useWebSocket({ channels: ['test_run:123', 'test_run:456'] })
       );
 
-      expect(mockSubscribeToChannel).toHaveBeenCalledWith('test_run:123', undefined);
-      expect(mockSubscribeToChannel).toHaveBeenCalledWith('test_run:456', undefined);
+      expect(mockSubscribeToChannel).toHaveBeenCalledWith(
+        'test_run:123',
+        undefined
+      );
+      expect(mockSubscribeToChannel).toHaveBeenCalledWith(
+        'test_run:456',
+        undefined
+      );
     });
 
     it('subscribes with projectId when using object form', () => {
@@ -103,7 +109,10 @@ describe('useWebSocket', () => {
         })
       );
 
-      expect(mockSubscribeToChannel).toHaveBeenCalledWith('test_run:123', 'proj-42');
+      expect(mockSubscribeToChannel).toHaveBeenCalledWith(
+        'test_run:123',
+        'proj-42'
+      );
     });
 
     it('does not subscribe to channels when not connected', () => {

--- a/apps/frontend/src/hooks/__tests__/useWebSocket.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useWebSocket.test.ts
@@ -87,13 +87,23 @@ describe('useWebSocket', () => {
   });
 
   describe('channel subscriptions', () => {
-    it('subscribes to specified channels when connected', () => {
+    it('subscribes to specified channels when connected (string form)', () => {
       renderHook(() =>
         useWebSocket({ channels: ['test_run:123', 'test_run:456'] })
       );
 
-      expect(mockSubscribeToChannel).toHaveBeenCalledWith('test_run:123');
-      expect(mockSubscribeToChannel).toHaveBeenCalledWith('test_run:456');
+      expect(mockSubscribeToChannel).toHaveBeenCalledWith('test_run:123', undefined);
+      expect(mockSubscribeToChannel).toHaveBeenCalledWith('test_run:456', undefined);
+    });
+
+    it('subscribes with projectId when using object form', () => {
+      renderHook(() =>
+        useWebSocket({
+          channels: [{ channel: 'test_run:123', projectId: 'proj-42' }],
+        })
+      );
+
+      expect(mockSubscribeToChannel).toHaveBeenCalledWith('test_run:123', 'proj-42');
     });
 
     it('does not subscribe to channels when not connected', () => {

--- a/apps/frontend/src/hooks/useArchitectChat.ts
+++ b/apps/frontend/src/hooks/useArchitectChat.ts
@@ -667,8 +667,7 @@ export function useArchitectChat(
         pendingCorrelationRef.current = null;
 
         subscriptionDeniedRef.current = true;
-        const errorMsg =
-          payload?.error || 'Could not connect to this session';
+        const errorMsg = payload?.error || 'Could not connect to this session';
         setError(errorMsg);
       })
     );
@@ -764,7 +763,7 @@ export function useArchitectChat(
         pendingCorrelationRef.current = null;
       }
     },
-    [sessionId, isConnected, isLoading, send]
+    [sessionId, sessionProjectId, isConnected, isLoading, send]
   );
 
   const visiblePlan = useMemo(

--- a/apps/frontend/src/hooks/useArchitectChat.ts
+++ b/apps/frontend/src/hooks/useArchitectChat.ts
@@ -199,6 +199,12 @@ export function useArchitectChat(
   const prevAwaitingRef = useRef(false);
   const autoApproveRef = useRef(autoApproveAll);
   autoApproveRef.current = autoApproveAll;
+  // Tracks whether the current `error` originated from a denied channel
+  // subscription, so a later successful (re)subscribe can clear it without
+  // clobbering a genuine ARCHITECT_ERROR. The subscribe effect re-subscribes
+  // when sessionProjectId resolves, so a transient empty-project denial may be
+  // followed by a successful subscribe.
+  const subscriptionDeniedRef = useRef(false);
 
   // Reset state when switching sessions. Seed the initial user message
   // immediately so it is visible before the WebSocket connection is ready.
@@ -225,6 +231,7 @@ export function useArchitectChat(
     pendingCorrelationRef.current = null;
     waitingMessageIdRef.current = null;
     prevAwaitingRef.current = false;
+    subscriptionDeniedRef.current = false;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId]);
 
@@ -271,11 +278,23 @@ export function useArchitectChat(
     if (!sessionId || !isConnected) return;
 
     const channel = `architect:${sessionId}`;
-    subscribeToChannel(channel);
+    // Pass the session's project_id so the backend's subscribe-time
+    // authorization lookup can satisfy the fail-closed project_isolation RLS
+    // policy. Without it the lookup runs with a blank project and cannot see
+    // the project-scoped session, denying the subscription and leaving the
+    // chat stuck on "Thinking…". sessionProjectId is included in the deps so
+    // we re-subscribe once it resolves from the async-loaded session list.
+    subscribeToChannel(channel, sessionProjectId);
     return () => {
       unsubscribeFromChannel(channel);
     };
-  }, [sessionId, isConnected, subscribeToChannel, unsubscribeFromChannel]);
+  }, [
+    sessionId,
+    isConnected,
+    sessionProjectId,
+    subscribeToChannel,
+    unsubscribeFromChannel,
+  ]);
 
   // Subscribe to all architect event types
   useEffect(() => {
@@ -628,6 +647,42 @@ export function useArchitectChat(
             isError: true,
           },
         ]);
+      })
+    );
+
+    // A denied channel subscription means no architect events will ever arrive
+    // for this session. Surface it and stop waiting instead of hanging on the
+    // "Thinking…" spinner forever. Scoped to this session's channel so denials
+    // for other channels are ignored.
+    unsubs.push(
+      subscribe(EventType.SUBSCRIPTION_ERROR, (msg: WebSocketMessage) => {
+        const payload = msg.payload as
+          | { channel?: string; error?: string }
+          | undefined;
+        const deniedChannel = payload?.channel ?? msg.channel;
+        if (deniedChannel !== `architect:${sessionId}`) return;
+
+        setIsLoading(false);
+        setStreamingState(initialStreamingState);
+        pendingCorrelationRef.current = null;
+
+        subscriptionDeniedRef.current = true;
+        const errorMsg =
+          payload?.error || 'Could not connect to this session';
+        setError(errorMsg);
+      })
+    );
+
+    // A successful (re)subscribe clears a prior subscription-denial error —
+    // the subscribe effect retries once sessionProjectId resolves, so an early
+    // empty-project denial shouldn't leave a stale alert on screen.
+    unsubs.push(
+      subscribe(EventType.SUBSCRIBED, (msg: WebSocketMessage) => {
+        if (msg.channel !== `architect:${sessionId}`) return;
+        if (subscriptionDeniedRef.current) {
+          subscriptionDeniedRef.current = false;
+          setError(null);
+        }
       })
     );
 

--- a/apps/frontend/src/hooks/useWebSocket.ts
+++ b/apps/frontend/src/hooks/useWebSocket.ts
@@ -110,7 +110,9 @@ export function useWebSocket(
     // Subscribe to all specified channels
     options.channels.forEach(entry => {
       const { channel, projectId } =
-        typeof entry === 'string' ? { channel: entry, projectId: undefined } : entry;
+        typeof entry === 'string'
+          ? { channel: entry, projectId: undefined }
+          : entry;
       subscribeToChannel(channel, projectId);
     });
 

--- a/apps/frontend/src/hooks/useWebSocket.ts
+++ b/apps/frontend/src/hooks/useWebSocket.ts
@@ -3,11 +3,27 @@ import { useWebSocketContext } from '@/contexts/WebSocketContext';
 import { EventType, WebSocketMessage, EventHandler } from '@/utils/websocket';
 
 /**
+ * A channel to subscribe to on mount.
+ *
+ * Use the object form for project-scoped resource channels (e.g.
+ * `test_run:{id}`, `test_set:{id}`, `architect:{id}`) so the backend can
+ * satisfy the project_isolation RLS policy when it resolves the resource for
+ * authorization. Omitting `projectId` for a project-scoped resource makes the
+ * backend open the auth lookup with a blank project, which the fail-closed RLS
+ * policy hides — the subscription is then denied and the channel silently
+ * receives no events. Org-/user-scoped and ephemeral channels (e.g.
+ * `preflight:{id}`) can use the plain string form.
+ */
+export type ChannelSubscription =
+  | string
+  | { channel: string; projectId?: string | null };
+
+/**
  * Options for the useWebSocket hook.
  */
 interface UseWebSocketOptions {
   /** Channels to subscribe to on mount */
-  channels?: string[];
+  channels?: ChannelSubscription[];
   /** Handler for all messages (regardless of type) */
   onMessage?: EventHandler;
   /** Specific event type handlers */
@@ -34,7 +50,7 @@ interface UseWebSocketResult {
     handler: EventHandler
   ) => () => void;
   /** Subscribe to a backend channel */
-  subscribeToChannel: (channel: string) => void;
+  subscribeToChannel: (channel: string, projectId?: string | null) => void;
   /** Unsubscribe from a backend channel */
   unsubscribeFromChannel: (channel: string) => void;
   /** Manually trigger a reconnection attempt */
@@ -92,13 +108,16 @@ export function useWebSocket(
     }
 
     // Subscribe to all specified channels
-    options.channels.forEach(channel => {
-      subscribeToChannel(channel);
+    options.channels.forEach(entry => {
+      const { channel, projectId } =
+        typeof entry === 'string' ? { channel: entry, projectId: undefined } : entry;
+      subscribeToChannel(channel, projectId);
     });
 
     // Unsubscribe on unmount
     return () => {
-      options.channels?.forEach(channel => {
+      options.channels?.forEach(entry => {
+        const channel = typeof entry === 'string' ? entry : entry.channel;
         unsubscribeFromChannel(channel);
       });
     };

--- a/apps/frontend/src/utils/websocket/client.ts
+++ b/apps/frontend/src/utils/websocket/client.ts
@@ -186,11 +186,19 @@ export class WebSocketClient {
    * start forwarding messages on that channel to this client.
    *
    * @param channel - The channel name to subscribe to
+   * @param projectId - The channel resource's project_id. Required for
+   *   project-scoped resource channels (e.g. `architect:{id}`) so the backend
+   *   can satisfy the project_isolation RLS policy when resolving the resource
+   *   for authorization; omitted/blank for org- or user-scoped channels.
    */
-  subscribeToChannel(channel: string): void {
+  subscribeToChannel(channel: string, projectId?: string | null): void {
+    const payload: Record<string, unknown> = { channel };
+    if (projectId) {
+      payload.project_id = projectId;
+    }
     this.send({
       type: EventType.SUBSCRIBE,
-      payload: { channel },
+      payload,
     });
   }
 

--- a/apps/frontend/src/utils/websocket/types.ts
+++ b/apps/frontend/src/utils/websocket/types.ts
@@ -25,6 +25,9 @@ export enum EventType {
   UNSUBSCRIBE = 'unsubscribe',
   SUBSCRIBED = 'subscribed',
   UNSUBSCRIBED = 'unsubscribed',
+  // A SUBSCRIBE was rejected; payload carries the offending `channel` so a
+  // subscriber can correlate the failure and stop waiting for events.
+  SUBSCRIPTION_ERROR = 'subscription_error',
 
   // Generic events (use-case specific events added as needed)
   NOTIFICATION = 'notification',


### PR DESCRIPTION
## Purpose

The architect chat frontend was stuck on "Thinking…" indefinitely after every message, even though the worker completed the task and persisted the reply correctly (the response appeared on page reload). Root cause: the fail-closed project_isolation RLS migration (`b8c9d0e1f2a3`) broke WebSocket channel subscription auth for all project-scoped resources.

## Root Cause

The subscribe handler opened its authorization DB session with a blank `app.current_project` GUC. The RLS policy semantics are:

- org set + project set → that project's rows + org-level (NULL) rows
- **org set + project unset → org-level (NULL) rows only** (fail-closed)

So `_resolve_channel_project_id` queried `ArchitectSession` in a session with a blank project, the policy hid the row (it has a non-NULL `project_id` from the project-stamping work), the lookup returned `None`, and the subscription was denied. No channel events (streaming or terminal `ARCHITECT_RESPONSE`) ever reached the frontend. The backend logged a clear `WARNING: not found in org` but the UI just hung.

## What Changed

**Backend**
- `services/websocket/manager.py`: `_handle_subscribe` reads optional `payload.project_id` and passes it to `get_db_with_tenant_variables` so the auth session satisfies the RLS policy. A wrong/forged value just yields the same "not found" denial — no escalation.
- `schemas/websocket.py`: new `SUBSCRIPTION_ERROR` event type that carries the denied channel name.
- `services/websocket/manager.py`: denial path now broadcasts `SUBSCRIPTION_ERROR` (channel-scoped) instead of the anonymous generic `ERROR`, so subscribers can correlate the failure.
- `tasks/file/extract_text.py`: accept `project_id` and scope both DB sessions to it — defensive fix for the same RLS pattern if files become project-scoped.
- `schemas/file.py`: `FileResponse` now exposes `project_id`.
- `routers/file.py`: `extract_file_text.delay(...)` passes `project_id` from the created file.

**Frontend**
- `utils/websocket/client.ts`: `subscribeToChannel(channel, projectId?)` includes `project_id` in the SUBSCRIBE payload when provided.
- `contexts/WebSocketContext.tsx` + `hooks/useWebSocket.ts`: `projectId` threaded through. `ChannelSubscription` type exported — either a plain string (org/user/ephemeral channels) or `{ channel, projectId }` (project-scoped resource channels).
- `hooks/useArchitectChat.ts`:
  - Subscribes with `sessionProjectId` and adds it to effect deps (re-subscribes once it resolves from the async session list).
  - Handles `SUBSCRIPTION_ERROR` matching the session's channel: clears spinner, shows error alert.
  - Handles `SUBSCRIBED` for the same channel: clears a prior subscription-denial error so a successful re-subscribe doesn't leave a stale alert.

## Additional Context

- `test_run:` and `test_set:` channel types are declared in the authorizer but not yet used by any live publisher or frontend subscriber. The backend `_handle_subscribe` change is generic so they work correctly the moment a consumer is wired up (just pass `projectId` in the `ChannelSubscription`).
- `preflight:` channels are ephemeral (no model lookup), unaffected.
- `project:` channels resolve against `Project` which has no `project_isolation` policy, unaffected.

## Testing

1. Deploy to staging with `project_id`-stamped sessions.
2. Open architect chat → send a message → confirm "Thinking…" clears and the response streams in.
3. Confirm no `WebSocket subscription denied` warnings in backend logs for the session channel.
4. To verify the fail-loud path: temporarily remove `sessionProjectId` from the `subscribeToChannel` call in `useArchitectChat` — the UI should now show an error alert ("Resource not found or access denied") immediately instead of hanging.