### PR TITLE
Fix Linear import option in Knowledge

### DIFF
--- a/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Box, Alert, Paper } from '@mui/material';
+import { Box, Alert, Paper, Button } from '@mui/material';
 import UploadIcon from '@mui/icons-material/Upload';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabGroup } from '@/components/common/Fab';
@@ -11,6 +11,7 @@ import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { isExtractProvider } from '@/config/tool-providers';
 import SourcesGrid from './SourcesGrid';
 import UploadSourceDrawer from './UploadSourceDrawer';
 import ToolImportDrawer from './ToolImportDrawer';
@@ -24,6 +25,7 @@ export default function KnowledgeClientWrapper({
 }: KnowledgeClientWrapperProps) {
   const [refreshKey, setRefreshKey] = useState(0);
   const [sourceCount, setSourceCount] = useState<number | null>(null);
+  const [hasImportTools, setHasImportTools] = useState(false);
   const [uploadDrawerOpen, setUploadDrawerOpen] = useState(false);
   const [toolImportDrawerOpen, setToolImportDrawerOpen] = useState(false);
 
@@ -39,18 +41,28 @@ export default function KnowledgeClientWrapper({
       try {
         const apiFactory = new ApiClientFactory(sessionToken);
         const sourcesClient = apiFactory.getSourcesClient();
-        const response = await sourcesClient.getSources({
-          skip: 0,
-          limit: 1,
-          sort_by: 'created_at',
-          sort_order: 'desc',
-        });
+        const toolsClient = apiFactory.getToolsClient();
+        const [response, toolsResponse] = await Promise.all([
+          sourcesClient.getSources({
+            skip: 0,
+            limit: 1,
+            sort_by: 'created_at',
+            sort_order: 'desc',
+          }),
+          toolsClient.getTools({ limit: 100 }).catch(() => ({ data: [] })),
+        ]);
         const count = Array.isArray(response)
           ? response.length
           : (response?.pagination?.totalCount ?? 0);
         setSourceCount(count);
+        setHasImportTools(
+          (toolsResponse.data || []).some(t =>
+            isExtractProvider(t.tool_provider_type?.type_value ?? '')
+          )
+        );
       } catch {
         setSourceCount(0);
+        setHasImportTools(false);
       }
     };
     fetchCount();
@@ -110,13 +122,32 @@ export default function KnowledgeClientWrapper({
       >
         <Box sx={{ mt: 2, mb: 2 }}>
           {sourceCount === 0 ? (
-            <EntityEmptyState
-              icon={MenuBookIcon}
-              title="No knowledge sources yet"
-              description="Upload files or import from tool connections to use as context for test generation and evaluation."
-              actionLabel="Upload source"
-              onAction={() => setUploadDrawerOpen(true)}
-            />
+            <Box
+              sx={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 2,
+              }}
+            >
+              <EntityEmptyState
+                icon={MenuBookIcon}
+                title="No knowledge sources yet"
+                description="Upload files or import from tool connections to use as context for test generation and evaluation."
+                actionLabel="Upload source"
+                onAction={() => setUploadDrawerOpen(true)}
+              />
+              {hasImportTools && (
+                <Button
+                  variant="outlined"
+                  startIcon={<CloudDownloadIcon />}
+                  onClick={() => setToolImportDrawerOpen(true)}
+                  sx={{ textTransform: 'none', fontWeight: 700 }}
+                >
+                  Import from tool
+                </Button>
+              )}
+            </Box>
           ) : (
             <Paper
               sx={{

--- a/apps/frontend/src/app/(protected)/knowledge/components/ToolImportDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/ToolImportDrawer.tsx
@@ -18,7 +18,7 @@ import { Tool } from '@/utils/api-client/interfaces/tool';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import {
   TOOL_PROVIDER_ICONS,
-  EXTRACT_PROVIDERS,
+  isExtractProvider,
 } from '@/config/tool-providers';
 import { drawerOutlinedFieldSx } from '@/components/common/drawerFormFieldSx';
 import ToolImportPanel, {
@@ -60,7 +60,7 @@ export default function ToolImportDrawer({
         .getToolsClient()
         .getTools({ limit: 100 });
       const supported = (response.data || []).filter(t =>
-        EXTRACT_PROVIDERS.includes(t.tool_provider_type?.type_value ?? '')
+        isExtractProvider(t.tool_provider_type?.type_value ?? '')
       );
       setTools(supported);
       if (supported.length === 1) {

--- a/apps/frontend/src/app/(protected)/knowledge/components/ToolImportPanel.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/ToolImportPanel.tsx
@@ -109,6 +109,18 @@ function getProviderLabel(provider: string): {
       placeholder: 'Paste Asana task or project URL...',
     };
   }
+  if (provider === 'linear') {
+    return {
+      checkbox: '',
+      placeholder: 'Paste Linear issue or project URL...',
+    };
+  }
+  if (provider === 'azure_devops') {
+    return {
+      checkbox: '',
+      placeholder: 'Paste Azure DevOps work item or wiki URL...',
+    };
+  }
   return {
     checkbox: 'Include linked items',
     placeholder: 'Paste URL...',

--- a/apps/frontend/src/config/tool-providers.tsx
+++ b/apps/frontend/src/config/tool-providers.tsx
@@ -26,7 +26,13 @@ export const EXTRACT_PROVIDERS = [
   'asana',
   'azure_devops',
   'linear',
-];
+] as const;
+
+export type ExtractProvider = (typeof EXTRACT_PROVIDERS)[number];
+
+export function isExtractProvider(typeValue: string): typeValue is ExtractProvider {
+  return (EXTRACT_PROVIDERS as readonly string[]).includes(typeValue);
+}
 
 const TOOL_PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   azure_devops: 'Azure DevOps',


### PR DESCRIPTION
## Purpose
After connecting a Linear (or other MCP extract) tool, users had no obvious way to import content into Knowledge — the empty state only offered upload, and Linear/Azure DevOps lacked provider-specific labels in the import drawer.

## What Changed
- Show an **Import from tool** button on the Knowledge empty state when extract-capable tool connections exist
- Add Linear and Azure DevOps URL placeholders in `ToolImportPanel` (matching GitLab, Shortcut, Asana)
- Add `isExtractProvider` helper in `tool-providers.tsx` and use it in the import drawer filter

## Additional Context
- Closes gap from #2005 (Linear MCP integration) acceptance criteria for Knowledge import
- `linear` was already in `EXTRACT_PROVIDERS`; this PR improves discoverability and UX

## Testing
- Connect a Linear tool in Settings → Tools
- Open Knowledge with no sources — confirm **Import from tool** appears
- Click it and confirm Linear is available with the Linear URL placeholder
- Paste a Linear issue URL and verify preview/import flow