### PR TITLE
Fix Insights failed test count clarity

### DIFF
--- a/apps/frontend/src/app/(protected)/insights/components/BehaviorInsightsView.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/BehaviorInsightsView.tsx
@@ -14,7 +14,12 @@ interface BehaviorInsightsViewProps {
   filters: InsightsFilters;
   insights: Pick<
     BehaviorInsightsData,
-    'summary' | 'columns' | 'loading' | 'error' | 'noRuns'
+    | 'summary'
+    | 'columns'
+    | 'loading'
+    | 'error'
+    | 'noRuns'
+    | 'failedTestCaseCount'
   >;
   searchQuery?: string;
   endpointName?: string;
@@ -69,6 +74,7 @@ export default function BehaviorInsightsView({
         summary={summary}
         endpointName={endpointName}
         loading={isLoading}
+        failedTestCaseCount={insights.failedTestCaseCount}
       />
 
       {error && <Alert severity="error">{error}</Alert>}

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsPage.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsPage.tsx
@@ -190,7 +190,10 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
     [projectEndpoints, filters.endpointId]
   );
 
-  const fabLoading = endpointsLoading || insightsLoading;
+  const fabLoading =
+    endpointsLoading ||
+    insightsLoading ||
+    (failedTestCaseCount === null && (summary?.failed ?? 0) > 0);
 
   const pageView = resolveInsightsPageView({
     endpointsLoading,
@@ -220,7 +223,7 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
       actions={
         <InsightsFailedTestsFab
           filters={filters}
-          failedCount={failedTestCaseCount}
+          failedCount={failedTestCaseCount ?? 0}
           loading={fabLoading}
           disabled={projectEndpoints.length === 0}
         />

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsPage.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsPage.tsx
@@ -55,6 +55,7 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
   const {
     summary,
     columns,
+    failedTestCaseCount,
     loading: insightsLoading,
     error,
     noRuns,
@@ -189,7 +190,6 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
     [projectEndpoints, filters.endpointId]
   );
 
-  const failedCount = summary?.failed ?? 0;
   const fabLoading = endpointsLoading || insightsLoading;
 
   const pageView = resolveInsightsPageView({
@@ -220,7 +220,7 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
       actions={
         <InsightsFailedTestsFab
           filters={filters}
-          failedCount={failedCount}
+          failedCount={failedTestCaseCount}
           loading={fabLoading}
           disabled={projectEndpoints.length === 0}
         />
@@ -276,6 +276,7 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
               insights={{
                 summary,
                 columns: filteredColumns,
+                failedTestCaseCount,
                 loading: insightsLoading,
                 error,
                 noRuns,

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsSummaryBar.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsSummaryBar.tsx
@@ -3,11 +3,13 @@
 import React from 'react';
 import { Box, LinearProgress, Typography } from '@mui/material';
 import { PassFailStats } from '@/utils/api-client/interfaces/test-results';
+import { formatInsightsSummaryDetail } from '../utils/insights-failed-tests';
 
 interface InsightsSummaryBarProps {
   summary: PassFailStats | null;
   endpointName?: string;
   loading?: boolean;
+  failedTestCaseCount?: number;
 }
 
 function progressColor(passRate: number): 'success' | 'warning' | 'error' {
@@ -20,6 +22,7 @@ export default function InsightsSummaryBar({
   summary,
   endpointName,
   loading = false,
+  failedTestCaseCount,
 }: InsightsSummaryBarProps) {
   const passRate = summary?.pass_rate ?? 0;
   const passed = summary?.passed ?? 0;
@@ -57,8 +60,12 @@ export default function InsightsSummaryBar({
               variant="caption"
               sx={{ color: 'text.disabled', fontWeight: 400 }}
             >
-              ({passed}/{total} tests passed
-              {failed > 0 ? `, ${failed} failed` : ''})
+              {formatInsightsSummaryDetail(
+                passed,
+                total,
+                failed,
+                failedTestCaseCount
+              )}
               {endpointName ? ` · ${endpointName}` : ''}
             </Typography>
           </>

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsSummaryBar.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsSummaryBar.tsx
@@ -9,7 +9,7 @@ interface InsightsSummaryBarProps {
   summary: PassFailStats | null;
   endpointName?: string;
   loading?: boolean;
-  failedTestCaseCount?: number;
+  failedTestCaseCount?: number | null;
 }
 
 function progressColor(passRate: number): 'success' | 'warning' | 'error' {
@@ -64,7 +64,7 @@ export default function InsightsSummaryBar({
                 passed,
                 total,
                 failed,
-                failedTestCaseCount
+                failedTestCaseCount ?? undefined
               )}
               {endpointName ? ` · ${endpointName}` : ''}
             </Typography>

--- a/apps/frontend/src/app/(protected)/insights/components/__tests__/BehaviorInsightsView.test.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/__tests__/BehaviorInsightsView.test.tsx
@@ -41,6 +41,7 @@ function renderView(
     insights: {
       summary: { total: 10, passed: 8, failed: 2, pass_rate: 80 },
       columns: [defaultColumn],
+      failedTestCaseCount: 2,
       loading: false,
       error: null,
       noRuns: false,
@@ -68,6 +69,7 @@ describe('BehaviorInsightsView', () => {
       insights: {
         summary: null,
         columns: [],
+        failedTestCaseCount: 0,
         loading: true,
         error: null,
         noRuns: false,

--- a/apps/frontend/src/app/(protected)/insights/components/__tests__/InsightsSummaryBar.test.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/__tests__/InsightsSummaryBar.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InsightsSummaryBar from '../InsightsSummaryBar';
+
+describe('InsightsSummaryBar', () => {
+  it('shows test results wording and unique failed count when they differ', () => {
+    render(
+      <InsightsSummaryBar
+        summary={{ total: 20, passed: 10, failed: 10, pass_rate: 50 }}
+        endpointName="Insurance Chatbot"
+        failedTestCaseCount={5}
+      />
+    );
+
+    expect(screen.getByText(/50\.0%/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /\(10\/20 test results passed, 10 failed · 5 unique test cases failed\) · Insurance Chatbot/
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('omits unique failed count when it matches execution failures', () => {
+    render(
+      <InsightsSummaryBar
+        summary={{ total: 10, passed: 7, failed: 3, pass_rate: 70 }}
+        failedTestCaseCount={3}
+      />
+    );
+
+    expect(
+      screen.getByText(/\(7\/10 test results passed, 3 failed\)/)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/unique test cases failed/)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/insights/hooks/__tests__/useBehaviorInsightsData.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/hooks/__tests__/useBehaviorInsightsData.test.ts
@@ -71,12 +71,71 @@ describe('useBehaviorInsightsData', () => {
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
+    await waitFor(() => {
+      expect(result.current.failedTestCaseCount).toBe(5);
+    });
 
     expect(result.current.summary?.failed).toBe(10);
-    expect(result.current.failedTestCaseCount).toBe(5);
     expect(mockFetchFailedIds).toHaveBeenCalledWith('token', {
       endpointId: 'ep-1',
       timeRange: '1m',
+      testRunIds: ['run-1', 'run-2'],
+    });
+  });
+
+  it('finishes main loading before unique failed count resolves', async () => {
+    mockFetchTestRunIds.mockResolvedValue(['run-1']);
+    let resolveFailed!: (ids: string[]) => void;
+    mockFetchFailedIds.mockImplementation(
+      () =>
+        new Promise<string[]>(resolve => {
+          resolveFailed = resolve;
+        })
+    );
+
+    const { result } = renderHook(() =>
+      useBehaviorInsightsData('token', {
+        ...DEFAULT_INSIGHTS_FILTERS,
+        endpointId: 'ep-1',
+        timeRange: '1m',
+      })
+    );
+
+    jest.advanceTimersByTime(300);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.failedTestCaseCount).toBeNull();
+
+    resolveFailed(['test-1']);
+    await waitFor(() => {
+      expect(result.current.failedTestCaseCount).toBe(1);
+    });
+  });
+
+  it('still renders insights when unique failed count fetch fails', async () => {
+    mockFetchTestRunIds.mockResolvedValue(['run-1']);
+    mockFetchFailedIds.mockRejectedValue(new Error('network'));
+
+    const { result } = renderHook(() =>
+      useBehaviorInsightsData('token', {
+        ...DEFAULT_INSIGHTS_FILTERS,
+        endpointId: 'ep-1',
+        timeRange: '1m',
+      })
+    );
+
+    jest.advanceTimersByTime(300);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.summary?.failed).toBe(10);
+    await waitFor(() => {
+      expect(result.current.failedTestCaseCount).toBe(0);
     });
   });
 

--- a/apps/frontend/src/app/(protected)/insights/hooks/__tests__/useBehaviorInsightsData.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/hooks/__tests__/useBehaviorInsightsData.test.ts
@@ -1,0 +1,123 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { DEFAULT_INSIGHTS_FILTERS } from '../../types';
+import { useBehaviorInsightsData } from '../useBehaviorInsightsData';
+
+jest.mock('../../utils/behavior-insights-utils', () => ({
+  fetchTestRunIdsForEndpoint: jest.fn(),
+  buildBehaviorColumns: jest.fn(() => []),
+}));
+
+jest.mock('../../utils/insights-failed-tests', () => ({
+  fetchFailedTestIdsForInsights: jest.fn(),
+}));
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getTestResultsClient: () => ({
+      getComprehensiveTestResultsStats: jest.fn().mockResolvedValue({
+        overall_pass_rates: {
+          total: 20,
+          passed: 10,
+          failed: 10,
+          pass_rate: 50,
+        },
+        behavior_pass_rates: {},
+        metadata: null,
+      }),
+    }),
+    getBehaviorClient: () => ({
+      getBehaviors: jest.fn().mockResolvedValue([]),
+    }),
+  })),
+}));
+
+import { fetchTestRunIdsForEndpoint } from '../../utils/behavior-insights-utils';
+import { fetchFailedTestIdsForInsights } from '../../utils/insights-failed-tests';
+
+const mockFetchTestRunIds = fetchTestRunIdsForEndpoint as jest.Mock;
+const mockFetchFailedIds = fetchFailedTestIdsForInsights as jest.Mock;
+
+describe('useBehaviorInsightsData', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockFetchTestRunIds.mockReset();
+    mockFetchFailedIds.mockReset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('resolves deduped failedTestCaseCount when summary has failures', async () => {
+    mockFetchTestRunIds.mockResolvedValue(['run-1', 'run-2']);
+    mockFetchFailedIds.mockResolvedValue([
+      'test-1',
+      'test-2',
+      'test-3',
+      'test-4',
+      'test-5',
+    ]);
+
+    const { result } = renderHook(() =>
+      useBehaviorInsightsData('token', {
+        ...DEFAULT_INSIGHTS_FILTERS,
+        endpointId: 'ep-1',
+        timeRange: '1m',
+      })
+    );
+
+    jest.advanceTimersByTime(300);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.summary?.failed).toBe(10);
+    expect(result.current.failedTestCaseCount).toBe(5);
+    expect(mockFetchFailedIds).toHaveBeenCalledWith('token', {
+      endpointId: 'ep-1',
+      timeRange: '1m',
+    });
+  });
+
+  it('skips failed ID fetch when summary has zero failures', async () => {
+    const { ApiClientFactory } = jest.requireMock(
+      '@/utils/api-client/client-factory'
+    );
+    ApiClientFactory.mockImplementation(() => ({
+      getTestResultsClient: () => ({
+        getComprehensiveTestResultsStats: jest.fn().mockResolvedValue({
+          overall_pass_rates: {
+            total: 10,
+            passed: 10,
+            failed: 0,
+            pass_rate: 100,
+          },
+          behavior_pass_rates: {},
+          metadata: null,
+        }),
+      }),
+      getBehaviorClient: () => ({
+        getBehaviors: jest.fn().mockResolvedValue([]),
+      }),
+    }));
+
+    mockFetchTestRunIds.mockResolvedValue(['run-1']);
+
+    const { result } = renderHook(() =>
+      useBehaviorInsightsData('token', {
+        ...DEFAULT_INSIGHTS_FILTERS,
+        endpointId: 'ep-1',
+      })
+    );
+
+    jest.advanceTimersByTime(300);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.failedTestCaseCount).toBe(0);
+    expect(mockFetchFailedIds).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/(protected)/insights/hooks/useBehaviorInsightsData.ts
+++ b/apps/frontend/src/app/(protected)/insights/hooks/useBehaviorInsightsData.ts
@@ -16,6 +16,7 @@ import {
   buildBehaviorColumns,
   fetchTestRunIdsForEndpoint,
 } from '../utils/behavior-insights-utils';
+import { fetchFailedTestIdsForInsights } from '../utils/insights-failed-tests';
 
 const EMPTY_SUMMARY: PassFailStats = {
   total: 0,
@@ -28,6 +29,7 @@ export interface BehaviorInsightsData {
   summary: PassFailStats | null;
   metadata: TestResultsStatsMetadata | null;
   columns: BehaviorInsightColumn[];
+  failedTestCaseCount: number;
   loading: boolean;
   error: string | null;
   noRuns: boolean;
@@ -42,6 +44,7 @@ export function useBehaviorInsightsData(
     null
   );
   const [columns, setColumns] = useState<BehaviorInsightColumn[]>([]);
+  const [failedTestCaseCount, setFailedTestCaseCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [noRuns, setNoRuns] = useState(false);
@@ -57,6 +60,7 @@ export function useBehaviorInsightsData(
       setSummary(null);
       setMetadata(null);
       setColumns([]);
+      setFailedTestCaseCount(0);
       setNoRuns(false);
       setError(null);
       return;
@@ -85,6 +89,7 @@ export function useBehaviorInsightsData(
             setSummary(EMPTY_SUMMARY);
             setMetadata(null);
             setColumns([]);
+            setFailedTestCaseCount(0);
             setNoRuns(true);
             setLoading(false);
             return;
@@ -146,7 +151,9 @@ export function useBehaviorInsightsData(
 
           if (!isCurrentRequest(requestId)) return;
 
-          setSummary(summaryResult.overall_pass_rates ?? EMPTY_SUMMARY);
+          const overallSummary =
+            summaryResult.overall_pass_rates ?? EMPTY_SUMMARY;
+          setSummary(overallSummary);
           setMetadata(
             summaryResult.metadata ?? behaviorResult.metadata ?? null
           );
@@ -157,6 +164,21 @@ export function useBehaviorInsightsData(
               perBehaviorResults
             )
           );
+
+          if ((overallSummary.failed ?? 0) > 0) {
+            const failedIds = await fetchFailedTestIdsForInsights(
+              sessionToken,
+              {
+                endpointId: filters.endpointId,
+                timeRange: resolveInsightsTimeRange(filters.timeRange),
+              }
+            );
+            if (!isCurrentRequest(requestId)) return;
+            setFailedTestCaseCount(failedIds.length);
+          } else {
+            setFailedTestCaseCount(0);
+          }
+
           setLoading(false);
         } catch (err) {
           if (!isCurrentRequest(requestId)) return;
@@ -175,5 +197,13 @@ export function useBehaviorInsightsData(
     };
   }, [sessionToken, filters.endpointId, filters.timeRange]);
 
-  return { summary, metadata, columns, loading, error, noRuns };
+  return {
+    summary,
+    metadata,
+    columns,
+    failedTestCaseCount,
+    loading,
+    error,
+    noRuns,
+  };
 }

--- a/apps/frontend/src/app/(protected)/insights/hooks/useBehaviorInsightsData.ts
+++ b/apps/frontend/src/app/(protected)/insights/hooks/useBehaviorInsightsData.ts
@@ -29,7 +29,8 @@ export interface BehaviorInsightsData {
   summary: PassFailStats | null;
   metadata: TestResultsStatsMetadata | null;
   columns: BehaviorInsightColumn[];
-  failedTestCaseCount: number;
+  /** Unique failed test case count; null while resolving or after filter change. */
+  failedTestCaseCount: number | null;
   loading: boolean;
   error: string | null;
   noRuns: boolean;
@@ -44,7 +45,9 @@ export function useBehaviorInsightsData(
     null
   );
   const [columns, setColumns] = useState<BehaviorInsightColumn[]>([]);
-  const [failedTestCaseCount, setFailedTestCaseCount] = useState(0);
+  const [failedTestCaseCount, setFailedTestCaseCount] = useState<number | null>(
+    null
+  );
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [noRuns, setNoRuns] = useState(false);
@@ -68,6 +71,7 @@ export function useBehaviorInsightsData(
 
     const requestId = ++requestIdRef.current;
     setLoading(true);
+    setFailedTestCaseCount(null);
     setError(null);
 
     if (debounceRef.current) {
@@ -165,21 +169,29 @@ export function useBehaviorInsightsData(
             )
           );
 
+          setLoading(false);
+
           if ((overallSummary.failed ?? 0) > 0) {
-            const failedIds = await fetchFailedTestIdsForInsights(
-              sessionToken,
-              {
-                endpointId: filters.endpointId,
-                timeRange: resolveInsightsTimeRange(filters.timeRange),
+            void (async () => {
+              try {
+                const failedIds = await fetchFailedTestIdsForInsights(
+                  sessionToken,
+                  {
+                    endpointId: filters.endpointId,
+                    timeRange: resolveInsightsTimeRange(filters.timeRange),
+                    testRunIds,
+                  }
+                );
+                if (!isCurrentRequest(requestId)) return;
+                setFailedTestCaseCount(failedIds.length);
+              } catch {
+                if (!isCurrentRequest(requestId)) return;
+                setFailedTestCaseCount(0);
               }
-            );
-            if (!isCurrentRequest(requestId)) return;
-            setFailedTestCaseCount(failedIds.length);
+            })();
           } else {
             setFailedTestCaseCount(0);
           }
-
-          setLoading(false);
         } catch (err) {
           if (!isCurrentRequest(requestId)) return;
           setError(

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-failed-tests.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-failed-tests.test.ts
@@ -1,6 +1,7 @@
 import {
   buildInsightsFailedTestsUrl,
   formatInsightsFailedTestsBanner,
+  formatInsightsSummaryDetail,
   formatInsightsTimeRangeLabel,
   parseInsightsFailedTestsSearchParams,
 } from '../insights-failed-tests';
@@ -69,6 +70,24 @@ describe('insights-failed-tests', () => {
   it('formats time range labels', () => {
     expect(formatInsightsTimeRangeLabel('1d')).toBe('1 day');
     expect(formatInsightsTimeRangeLabel('3m')).toBe('3 months');
+  });
+
+  it('formats summary detail with test results wording', () => {
+    expect(formatInsightsSummaryDetail(10, 20, 10)).toBe(
+      '(10/20 test results passed, 10 failed)'
+    );
+  });
+
+  it('appends unique failed test case count when it differs from failures', () => {
+    expect(formatInsightsSummaryDetail(10, 20, 10, 5)).toBe(
+      '(10/20 test results passed, 10 failed · 5 unique test cases failed)'
+    );
+  });
+
+  it('omits unique failed test case count when it matches failures', () => {
+    expect(formatInsightsSummaryDetail(7, 10, 3, 3)).toBe(
+      '(7/10 test results passed, 3 failed)'
+    );
   });
 
   it('formats banner for metric drill-down', () => {

--- a/apps/frontend/src/app/(protected)/insights/utils/insights-failed-tests.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/insights-failed-tests.ts
@@ -178,17 +178,20 @@ const TEST_RUN_ID_CHUNK = 15;
  */
 export async function fetchFailedTestIdsForInsights(
   sessionToken: string,
-  filters: InsightsRunContextFilters & InsightsFailedTestsScope
+  filters: InsightsRunContextFilters &
+    InsightsFailedTestsScope & { testRunIds?: string[] }
 ): Promise<string[]> {
   if (!filters.endpointId) {
     return [];
   }
 
-  const testRunIds = await fetchTestRunIdsForEndpoint(
-    sessionToken,
-    filters.endpointId,
-    filters.timeRange
-  );
+  const testRunIds =
+    filters.testRunIds ??
+    (await fetchTestRunIdsForEndpoint(
+      sessionToken,
+      filters.endpointId,
+      filters.timeRange
+    ));
   if (testRunIds.length === 0) {
     return [];
   }

--- a/apps/frontend/src/app/(protected)/insights/utils/insights-failed-tests.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/insights-failed-tests.ts
@@ -267,6 +267,28 @@ export async function fetchFailedTestIdsForInsights(
   return testIds;
 }
 
+export function formatInsightsSummaryDetail(
+  passed: number,
+  total: number,
+  failed: number,
+  failedTestCaseCount?: number
+): string {
+  let detail = `(${passed}/${total} test results passed`;
+  if (failed > 0) {
+    detail += `, ${failed} failed`;
+    if (
+      failedTestCaseCount !== undefined &&
+      failedTestCaseCount > 0 &&
+      failedTestCaseCount !== failed
+    ) {
+      const noun = failedTestCaseCount === 1 ? 'test case' : 'test cases';
+      detail += ` · ${failedTestCaseCount} unique ${noun} failed`;
+    }
+  }
+  detail += ')';
+  return detail;
+}
+
 export function formatInsightsTimeRangeLabel(
   timeRange: InsightsTimeRange
 ): string {


### PR DESCRIPTION
## Purpose
Insights showed mismatched failed counts: the summary/FAB reported failed test result executions (e.g. 10), while the Tests page listed unique failed test cases (e.g. 5).

## What Changed
- Align Insights FAB with unique failed test case count (same resolver as Tests page)
- Clarify summary bar copy: use "test results" for executions and show unique failed test case count when it differs
- Fetch `failedTestCaseCount` in `useBehaviorInsightsData` via `fetchFailedTestIdsForInsights`
- Add unit tests for summary copy, hook behavior, and summary bar rendering

## Additional Context
- Empty-state work was already merged in #2046; this PR only adds the failed-count clarity fix
- Example: 5 test cases failing in 2 runs → 10 failed results, 5 unique test cases
- Pass rate remains execution-based (unchanged)

## Testing
- [x] `npm test -- --testPathPatterns="useBehaviorInsightsData|insights-failed-tests|InsightsSummaryBar|BehaviorInsightsView"`
- [x] `npm run type-check`
- [ ] Manual: Insurance Chatbot / 1M shows `(10/20 test results passed, 10 failed · 5 unique test cases failed)` and FAB `View 5 failed test cases`