### PR TITLE
Fix knowledge tool import UX

### DIFF
--- a/apps/frontend/src/app/(protected)/knowledge/components/ToolImportDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/ToolImportDrawer.tsx
@@ -10,6 +10,7 @@ import {
   Select,
   MenuItem,
   Link,
+  Chip,
 } from '@mui/material';
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
@@ -19,6 +20,7 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import {
   TOOL_PROVIDER_ICONS,
   EXTRACT_PROVIDERS,
+  formatToolProviderDisplayName,
 } from '@/config/tool-providers';
 import { drawerOutlinedFieldSx } from '@/components/common/drawerFormFieldSx';
 import ToolImportPanel, {
@@ -93,10 +95,10 @@ export default function ToolImportDrawer({
     return TOOL_PROVIDER_ICONS[key] ?? <SmartToyIcon />;
   };
 
-  const providerLabel = (tool: Tool) => {
-    const v = tool.tool_provider_type?.type_value ?? '';
-    return v.charAt(0).toUpperCase() + v.slice(1);
-  };
+  const toolLabel = (tool: Tool) => tool.name;
+
+  const toolSecondaryLabel = (tool: Tool) =>
+    formatToolProviderDisplayName(tool.tool_provider_type?.type_value ?? '');
 
   const hasTools = !loadingTools && tools.length > 0;
 
@@ -127,7 +129,37 @@ export default function ToolImportDrawer({
         </Alert>
       ) : (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
-          {tools.length > 1 && (
+          {tools.length === 1 ? (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Chip
+                icon={
+                  <Box
+                    sx={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      '& svg': { width: 16, height: 16 },
+                      pl: 0.5,
+                    }}
+                  >
+                    {getProviderIcon(tools[0])}
+                  </Box>
+                }
+                label={
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+                    <span>{toolLabel(tools[0])}</span>
+                    <Box
+                      component="span"
+                      sx={{ opacity: 0.6, fontSize: '0.75rem' }}
+                    >
+                      · {toolSecondaryLabel(tools[0])}
+                    </Box>
+                  </Box>
+                }
+                variant="outlined"
+                size="medium"
+              />
+            </Box>
+          ) : (
             <FormControl fullWidth sx={drawerOutlinedFieldSx}>
               <InputLabel id="tool-select-label">Source</InputLabel>
               <Select
@@ -152,7 +184,18 @@ export default function ToolImportDrawer({
                     >
                       {getProviderIcon(tool)}
                     </Box>
-                    {providerLabel(tool)}
+                    <Box>
+                      <Box>{toolLabel(tool)}</Box>
+                      <Box
+                        component="span"
+                        sx={{
+                          fontSize: '0.75rem',
+                          color: 'text.secondary',
+                        }}
+                      >
+                        {toolSecondaryLabel(tool)}
+                      </Box>
+                    </Box>
                   </MenuItem>
                 ))}
               </Select>

--- a/apps/frontend/src/app/(protected)/knowledge/components/ToolImportPanel.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/ToolImportPanel.tsx
@@ -186,7 +186,17 @@ const ToolImportPanel = forwardRef<ToolImportPanelHandle, ToolImportPanelProps>(
 
     const handleUrlChange = (id: string, url: string) => {
       setUrlItems(prev =>
-        prev.map(item => (item.id === id ? { ...item, url } : item))
+        prev.map(item =>
+          item.id === id
+            ? {
+                ...item,
+                url,
+                status: 'pending',
+                error: undefined,
+                title: undefined,
+              }
+            : item
+        )
       );
     };
 
@@ -477,14 +487,38 @@ const ToolImportPanel = forwardRef<ToolImportPanelHandle, ToolImportPanelProps>(
               placeholder={providerLabels.placeholder}
               value={item.url}
               onChange={e => handleUrlChange(item.id, e.target.value)}
-              disabled={item.status !== 'pending'}
+              disabled={
+                item.status === 'importing' || item.status === 'success'
+              }
               error={item.status === 'error'}
               helperText={
-                item.status === 'error'
-                  ? item.error
-                  : item.status === 'success'
-                    ? `Imported: ${item.title}`
-                    : ''
+                item.status === 'error' ? (
+                  <Box
+                    component="span"
+                    sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}
+                  >
+                    <ErrorIcon fontSize="inherit" color="error" />
+                    {item.error ||
+                      'Import failed. Check the URL and try again.'}
+                  </Box>
+                ) : item.status === 'success' ? (
+                  <Box
+                    component="span"
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      color: 'success.main',
+                    }}
+                  >
+                    <CheckCircleIcon fontSize="inherit" />
+                    {item.title && item.title !== item.url
+                      ? `Imported: ${item.title}`
+                      : 'Imported successfully'}
+                  </Box>
+                ) : (
+                  ''
+                )
               }
               sx={drawerOutlinedFieldSx}
               InputProps={{

--- a/apps/frontend/src/app/(protected)/knowledge/components/ToolImportPanel.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/ToolImportPanel.tsx
@@ -487,9 +487,7 @@ const ToolImportPanel = forwardRef<ToolImportPanelHandle, ToolImportPanelProps>(
               placeholder={providerLabels.placeholder}
               value={item.url}
               onChange={e => handleUrlChange(item.id, e.target.value)}
-              disabled={
-                item.status === 'importing' || item.status === 'success'
-              }
+              disabled={previewing || importing || item.status === 'success'}
               error={item.status === 'error'}
               helperText={
                 item.status === 'error' ? (

--- a/apps/frontend/src/config/tool-providers.tsx
+++ b/apps/frontend/src/config/tool-providers.tsx
@@ -6,6 +6,7 @@ import {
   SiGitlab,
   SiShortcut,
   SiLinear,
+  SiAsana,
 } from '@icons-pack/react-simple-icons';
 
 /**
@@ -56,22 +57,6 @@ export const TOOL_PROVIDER_DESCRIPTIONS: Record<string, string> = {
     'Import work items, epics, and user stories from Azure DevOps boards',
 };
 
-function AsanaIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      className={className}
-      role="img"
-      aria-label="Asana"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <circle cx="12" cy="6" r="3.5" fill="#F06A6A" />
-      <circle cx="5.5" cy="16" r="3.5" fill="#F06A6A" />
-      <circle cx="18.5" cy="16" r="3.5" fill="#F06A6A" />
-    </svg>
-  );
-}
-
 function AzureDevOpsIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -96,7 +81,7 @@ export const TOOL_PROVIDER_ICONS: Record<string, React.ReactNode> = {
   jira: <SiJira className="h-8 w-8" />,
   gitlab: <SiGitlab className="h-8 w-8" />,
   shortcut: <SiShortcut className="h-8 w-8" />,
-  asana: <AsanaIcon className="h-8 w-8" />,
+  asana: <SiAsana className="h-8 w-8" />,
   linear: <SiLinear className="h-8 w-8" />,
   azure_devops: <AzureDevOpsIcon className="h-8 w-8" />,
 };


### PR DESCRIPTION
## Purpose
Several small UX issues in the Knowledge page tool import drawer.

## What Changed
- Always show which tool is selected: chip with icon + name when one tool, dropdown when multiple
- Dropdown now shows the tool actual name instead of just provider type, with provider as secondary label
- Replace custom Asana SVG with SiAsana from react-simple-icons for consistency
- URL fields are now editable after a fetch error (were incorrectly disabled)
- Editing an errored field resets it to pending, clearing the error state
- Success helper text falls back to "Imported successfully" when title is a raw URL
- Error helper text always shows a fallback message when no error detail is available

## Testing
1. Go to Knowledge > Import from Tool
2. With one tool: confirm chip shows tool name and provider type
3. With multiple tools of same type: confirm each is distinguishable in dropdown
4. Paste an invalid URL, confirm error shows and field stays editable
5. Fix the URL and re-import, confirm it works