### PR TITLE
Truncate test cleanup tables in a single statement

### DIFF
--- a/tests/backend/fixtures/cleanup.py
+++ b/tests/backend/fixtures/cleanup.py
@@ -132,16 +132,29 @@ def clean_test_database():
                 except Exception:
                     pass
 
+            # Resolve which managed tables actually exist up front (guards
+            # against schema drift, replacing the old per-table try/except).
+            existing_tables = {
+                row[0]
+                for row in connection.execute(
+                    text(
+                        "SELECT table_name FROM information_schema.tables "
+                        "WHERE table_schema = 'public'"
+                    )
+                )
+            }
+            managed_tables = [t for t in tables_to_truncate if t in existing_tables]
+
             # Disable FK-cascade triggers so TRUNCATE doesn't need to chase
             # every FK edge.  Restored in the finally block below.
             connection.execute(text("SET session_replication_role = 'replica'"))
             try:
-                for table_name in tables_to_truncate:
-                    try:
-                        connection.execute(text(f"TRUNCATE TABLE {table_name} CASCADE"))
-                    except Exception:
-                        # Table may not exist yet (schema drift) — keep going.
-                        pass
+                # Truncate every existing table in a single statement instead of
+                # looping one TRUNCATE per table — one round-trip and one set of
+                # locks rather than ~35.
+                if managed_tables:
+                    table_list = ", ".join(managed_tables)
+                    connection.execute(text(f"TRUNCATE TABLE {table_list} CASCADE"))
             finally:
                 # Always restore, even if a TRUNCATE raised; the SET is
                 # session-scoped so it survives a transaction rollback.


### PR DESCRIPTION
## Purpose
Speed up the backend test suite. The autouse `clean_test_database` fixture runs between every test and was the dominant per-test cost: it issued one `TRUNCATE ... CASCADE` per managed table (~35 statements), each taking its own `ACCESS EXCLUSIVE` lock and WAL sync.

## What Changed
- Replaced the per-table `TRUNCATE` loop in `clean_test_database` with a single `TRUNCATE TABLE <all tables> CASCADE` statement.
- Resolve which managed tables actually exist up front via `information_schema.tables`, so schema drift is handled without the old per-table `try/except`.
- Net effect: one round-trip and one set of locks per test instead of ~35.

## Additional Context
- No behavior change to what gets cleaned or to auth-row preservation (user/org/token DELETEs are untouched).
- Scope is limited to `tests/backend/fixtures/cleanup.py`.

## Testing
Run the backend test suite from `apps/backend`:
```bash
cd apps/backend
uv run pytest ../../tests/backend/ -v
```
Tests should pass with cleanup behaving identically between tests.