### PR TITLE
Fix test-run compare page 404 for project-scoped runs

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 import { auth } from '@/auth';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import type { UUID } from 'crypto';
 import ComparePageClient from './ComparePageClient';
@@ -38,7 +38,7 @@ export default async function TestRunComparePage({
     throw new Error('Authentication required');
   }
 
-  const apiFactory = new ApiClientFactory(session.session_token);
+  const apiFactory = await createServerApiFactory(session.session_token);
   const testRunsClient = apiFactory.getTestRunsClient();
   const testResultsClient = apiFactory.getTestResultsClient();
   const behaviorClient = apiFactory.getBehaviorClient();


### PR DESCRIPTION
## Purpose
Opening `/test-runs/{id}/compare` for a test run created under a project scope returns a 404 ("Resource not found"), while the same page works for older org-scoped runs. This makes comparison unusable for any run created in a project.

## What Changed
- `apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx` now builds its API client with `createServerApiFactory(...)` instead of `new ApiClientFactory(...)`.

## Root Cause
The compare page is a Server Component. It constructed the API factory directly, so during SSR there was no way to read the active project (`document.cookie` is unavailable on the server and no `projectId` was passed). Requests to the backend therefore went out **without the `X-Project-Id` header**.

The backend's `get_project_context` is fail-closed: with no project scope it returns only org-level rows (`project_id = NULL`). So:
- project-scoped runs (`project_id != NULL`) -> filtered out -> backend 404 -> `notFound()`
- legacy org-scoped runs (`project_id = NULL`) -> returned -> works

`createServerApiFactory` reads the `rh_active_project_id` cookie via `next/headers` and threads it into every client, so the `X-Project-Id` header is sent. This matches what the working test-run detail page (`page.tsx`) already does.

## Testing
- With an active project selected, open a project-scoped test run and navigate to its `/compare` page -> loads instead of 404.
- Repeat for a legacy org-scoped run -> still works (no regression).

## Additional Context
- The client-side baseline loader in `ComparePageClient.tsx` is unaffected: it runs in the browser where the cookie is readable.
- Follow-up worth considering: a lint guard to prevent direct `new ApiClientFactory(...)` in Server Components, since that is exactly how this regression slipped in.