### PR TITLE
Fix endpoint API token field behavior

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointConnectionTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointConnectionTab.tsx
@@ -184,8 +184,10 @@ export default function EndpointConnectionTab() {
               setDraft(prev => ({
                 ...prev,
                 auth_token: value,
-                // typing a replacement cancels a pending removal
-                clear_token: value !== '' ? false : prev.clear_token,
+                // typing a real replacement cancels a pending removal;
+                // whitespace-only input is treated as empty on save, so it
+                // must not silently cancel the removal
+                clear_token: value.trim() !== '' ? false : prev.clear_token,
               }))
             }
             onRequestHeadersChange={value =>

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointConnectionTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointConnectionTab.tsx
@@ -28,6 +28,8 @@ interface RestConnectionDraft {
 interface HeadersDraft {
   auth_token: string;
   request_headers: string;
+  // true when the user explicitly removed the saved token
+  clear_token: boolean;
 }
 
 function parseStringRecord(
@@ -73,6 +75,7 @@ export default function EndpointConnectionTab() {
     () => ({
       auth_token: '',
       request_headers: JSON.stringify(endpoint.request_headers || {}, null, 2),
+      clear_token: false,
     }),
     [endpoint.request_headers]
   );
@@ -152,7 +155,8 @@ export default function EndpointConnectionTab() {
         initialValue={headersInitial}
         isDirty={(draft, initial) =>
           draft.request_headers !== initial.request_headers ||
-          draft.auth_token.trim() !== ''
+          draft.auth_token.trim() !== '' ||
+          draft.clear_token
         }
         onSave={async draft => {
           const parsed = parseStringRecord(
@@ -162,9 +166,13 @@ export default function EndpointConnectionTab() {
           );
           const payload: {
             request_headers: Record<string, string>;
-            auth_token?: string;
+            auth_token?: string | null;
           } = { request_headers: parsed };
-          if (draft.auth_token.trim()) payload.auth_token = draft.auth_token;
+          if (draft.auth_token.trim()) {
+            payload.auth_token = draft.auth_token;
+          } else if (draft.clear_token) {
+            payload.auth_token = null;
+          }
           await saveFields(payload);
         }}
       >
@@ -173,7 +181,12 @@ export default function EndpointConnectionTab() {
             authToken={draft.auth_token}
             requestHeaders={draft.request_headers}
             onAuthTokenChange={value =>
-              setDraft(prev => ({ ...prev, auth_token: value }))
+              setDraft(prev => ({
+                ...prev,
+                auth_token: value,
+                // typing a replacement cancels a pending removal
+                clear_token: value !== '' ? false : prev.clear_token,
+              }))
             }
             onRequestHeadersChange={value =>
               setDraft(prev => ({ ...prev, request_headers: value }))
@@ -193,6 +206,14 @@ export default function EndpointConnectionTab() {
             onTokenBlur={() => {
               if (draft.auth_token === '') setTokenFieldFocused(false);
             }}
+            tokenCleared={draft.clear_token}
+            onToggleTokenCleared={() =>
+              setDraft(prev => ({
+                ...prev,
+                clear_token: !prev.clear_token,
+                auth_token: '',
+              }))
+            }
             editorWrapperStyle={editorWrapperStyle}
           />
         )}

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/endpointPatch.ts
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/endpointPatch.ts
@@ -11,6 +11,8 @@ export async function patchEndpointFields(
   payload: EndpointEditData
 ): Promise<Endpoint> {
   const cleaned = { ...payload };
+  // An empty string means "untouched / keep existing" and must not be sent.
+  // An explicit null means "remove the saved token" and must be sent through.
   if (cleaned.auth_token === '') {
     delete cleaned.auth_token;
   }

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/useEndpointDetail.ts
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/useEndpointDetail.ts
@@ -79,8 +79,18 @@ export function useEndpointDetail(initialEndpoint: Endpoint) {
     async (payload: EndpointEditData) => {
       try {
         await patchEndpointFields(endpoint.id, payload);
-        const { auth_token: _token, ...rest } = payload;
-        setEndpoint(prev => ({ ...prev, ...rest }));
+        const { auth_token, ...rest } = payload;
+        setEndpoint(prev => {
+          const next: Endpoint = { ...prev, ...rest };
+          // auth_token is write-only; keep the derived has_auth_token flag in
+          // sync so the UI reflects a newly set or removed token without a
+          // full reload. undefined means the token was left untouched.
+          if (auth_token !== undefined) {
+            next.has_auth_token =
+              typeof auth_token === 'string' && auth_token.trim() !== '';
+          }
+          return next;
+        });
         notifications.show('Endpoint updated successfully', {
           severity: 'success',
         });

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointHeadersFields.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointHeadersFields.tsx
@@ -11,7 +11,9 @@ import {
 import FormSectionDivider from '@/components/common/FormSectionDivider';
 import ViewField from '@/components/common/ViewField';
 import {
+  DeleteIcon,
   LockIcon,
+  RefreshIcon,
   VisibilityIcon,
   VisibilityOffIcon,
 } from '@/components/icons';
@@ -32,6 +34,8 @@ export interface EndpointHeadersFieldsProps {
   tokenFieldFocused?: boolean;
   onTokenFocus?: () => void;
   onTokenBlur?: () => void;
+  tokenCleared?: boolean;
+  onToggleTokenCleared?: () => void;
   editorWrapperStyle?: Record<string, unknown>;
 }
 
@@ -48,6 +52,8 @@ export default function EndpointHeadersFields({
   tokenFieldFocused = false,
   onTokenFocus,
   onTokenBlur,
+  tokenCleared = false,
+  onToggleTokenCleared,
   editorWrapperStyle,
 }: EndpointHeadersFieldsProps) {
   const tokenHelper = (
@@ -83,25 +89,32 @@ export default function EndpointHeadersFields({
           label="API Token (optional)"
           type={showAuthToken ? 'text' : 'password'}
           value={
-            tokenFieldFocused || authToken !== ''
-              ? authToken
-              : hasExistingToken
-                ? '••••••••••••••••••••••••'
-                : ''
+            tokenCleared
+              ? ''
+              : tokenFieldFocused || authToken !== ''
+                ? authToken
+                : hasExistingToken
+                  ? '••••••••••••••••••••••••'
+                  : ''
           }
           onChange={e => onAuthTokenChange(e.target.value)}
           onFocus={onTokenFocus}
           onBlur={onTokenBlur}
           placeholder={
-            hasExistingToken
-              ? 'Enter new token or leave empty to keep existing'
-              : 'sk-...'
+            tokenCleared
+              ? 'The saved token will be removed on save'
+              : hasExistingToken
+                ? 'Enter new token or leave empty to keep existing'
+                : 'sk-...'
           }
           sx={{ mb: 3 }}
+          error={tokenCleared}
           helperText={
-            hasExistingToken
-              ? 'Leave empty to keep the existing token.'
-              : tokenHelper
+            tokenCleared
+              ? 'The saved token will be removed when you save. Type a new token or restore to keep it.'
+              : hasExistingToken
+                ? 'Leave empty to keep the existing token, or enter a new one to replace it.'
+                : tokenHelper
           }
           InputProps={{
             startAdornment: (
@@ -111,6 +124,20 @@ export default function EndpointHeadersFields({
             ),
             endAdornment: (
               <InputAdornment position="end">
+                {hasExistingToken &&
+                  authToken === '' &&
+                  onToggleTokenCleared && (
+                    <IconButton
+                      aria-label={
+                        tokenCleared ? 'restore token' : 'remove token'
+                      }
+                      title={tokenCleared ? 'Restore token' : 'Remove token'}
+                      onClick={onToggleTokenCleared}
+                      edge="end"
+                    >
+                      {tokenCleared ? <RefreshIcon /> : <DeleteIcon />}
+                    </IconButton>
+                  )}
                 <IconButton
                   aria-label="toggle token visibility"
                   onClick={onToggleAuthToken}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
@@ -3,7 +3,7 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 import { auth } from '@/auth';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import type { UUID } from 'crypto';
 import ComparePageClient from './ComparePageClient';
@@ -38,7 +38,7 @@ export default async function TestRunComparePage({
     throw new Error('Authentication required');
   }
 
-  const apiFactory = new ApiClientFactory(session.session_token);
+  const apiFactory = await createServerApiFactory(session.session_token);
   const testRunsClient = apiFactory.getTestRunsClient();
   const testResultsClient = apiFactory.getTestResultsClient();
   const behaviorClient = apiFactory.getBehaviorClient();

--- a/apps/frontend/src/utils/api-client/interfaces/endpoint.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/endpoint.ts
@@ -84,7 +84,8 @@ export interface Endpoint {
 
 // Type for editing endpoints - includes write-only fields
 export interface EndpointEditData extends Partial<Endpoint> {
-  auth_token?: string;
+  // null clears the stored token; undefined leaves it untouched
+  auth_token?: string | null;
   client_secret?: string;
 }
 


### PR DESCRIPTION
## Purpose
The API token field in the endpoint "Authentication & headers" section behaved incorrectly:
- It showed masked dots (`••••`) for a saved token, but there was no way to delete the saved token.
- After adding a token and saving, the UI still claimed there was no token until a full page reload.

## What Changed
- `EndpointHeadersFields.tsx`: added a remove button (trash icon) for an existing token that toggles to a restore button, with an error-styled helper indicating the token will be removed on save.
- `EndpointConnectionTab.tsx`: added a `clear_token` draft flag; `onSave` now sends `auth_token: null` to remove the token, the typed value to replace it, or omits it when untouched. Typing a replacement cancels a pending removal.
- `endpointPatch.ts`: still strips an untouched empty string but lets an explicit `null` (clear) through to the backend.
- `useEndpointDetail.ts`: keeps the derived `has_auth_token` flag in sync after a save (true when set, false when cleared, unchanged when omitted) so the UI refreshes without a reload.
- `interfaces/endpoint.ts`: `EndpointEditData.auth_token` is now `string | null` (`null` clears, `undefined` keeps).

## Additional Context
- `auth_token` is a write-only field; the backend only returns `has_auth_token`. Sending `null` sets the column to `NULL` via the `EncryptedString` type, so `has_auth_token` becomes `false`.
- No backend changes were required; `EndpointUpdate` uses `exclude_unset=True`, so an explicit `null` is applied while an omitted field is preserved.

## Testing
- `npx tsc --noEmit`, `eslint`, and `prettier --check` pass on the changed files.
- Manual: edit an endpoint with a saved token → masked dots show; click trash → save → token removed and "No token configured" shown. Add a token → save → masked dots show immediately without reload. Leaving the field untouched preserves the existing token.