### PR TITLE
Remove redundant frontend API calls

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -43,6 +43,7 @@ interface EndpointsGridProps {
   sessionToken?: string;
   refreshKey?: number;
   onRefresh?: () => void;
+  onTotalCountChange?: (count: number) => void;
   projectId?: string;
 }
 
@@ -100,6 +101,7 @@ export default function EndpointsGrid({
   sessionToken: sessionTokenProp,
   refreshKey,
   onRefresh,
+  onTotalCountChange,
   projectId,
 }: EndpointsGridProps) {
   const theme = useTheme();
@@ -149,6 +151,7 @@ export default function EndpointsGrid({
 
       setEndpoints(response.data);
       setTotalCount(response.pagination.totalCount);
+      onTotalCountChange?.(response.pagination.totalCount);
       setError(null);
     } catch {
       const hasActiveFilters =
@@ -156,9 +159,11 @@ export default function EndpointsGrid({
       if (hasActiveFilters) {
         setEndpoints([]);
         setTotalCount(0);
+        onTotalCountChange?.(0);
         setError(null);
       } else {
         setError('Failed to load endpoints');
+        onTotalCountChange?.(0);
         setEndpoints([]);
       }
     } finally {

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -151,20 +151,23 @@ export default function EndpointsGrid({
 
       setEndpoints(response.data);
       setTotalCount(response.pagination.totalCount);
-      onTotalCountChange?.(response.pagination.totalCount);
+      const filtersActive =
+        filterModel.items.length > 0 ||
+        !!searchQuery.trim() ||
+        hasActiveEndpointFilters(drawerFilters);
+      if (!filtersActive) onTotalCountChange?.(response.pagination.totalCount);
       setError(null);
     } catch {
-      const hasActiveFilters =
-        hasActiveEndpointFilters(drawerFilters) || searchQuery.trim() !== '';
-      if (hasActiveFilters) {
-        setEndpoints([]);
-        setTotalCount(0);
-        onTotalCountChange?.(0);
+      const filtersActive =
+        filterModel.items.length > 0 ||
+        !!searchQuery.trim() ||
+        hasActiveEndpointFilters(drawerFilters);
+      setEndpoints([]);
+      setTotalCount(0);
+      if (filtersActive) {
         setError(null);
       } else {
         setError('Failed to load endpoints');
-        onTotalCountChange?.(0);
-        setEndpoints([]);
       }
     } finally {
       setLoading(false);

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -200,9 +200,14 @@ export default function EndpointsGrid({
             { field: 'quickFilter', operator: 'contains', value: searchQuery },
           ]
         : otherItems;
+      if (
+        items.length === prev.items.length &&
+        items.every((it, i) => it === prev.items[i])
+      )
+        return prev;
       return { ...prev, items };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [searchQuery]);
 
   useEffect(() => {
@@ -237,9 +242,15 @@ export default function EndpointsGrid({
         });
       }
 
-      return { ...prev, items: [...otherItems, ...drawerItems] };
+      const newItems = [...otherItems, ...drawerItems];
+      if (
+        newItems.length === prev.items.length &&
+        newItems.every((it, i) => it === prev.items[i])
+      )
+        return prev;
+      return { ...prev, items: newItems };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [drawerFilters, projectId]);
 
   useEffect(() => {

--- a/apps/frontend/src/app/(protected)/endpoints/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/page.tsx
@@ -15,7 +15,6 @@ import EndpointsGrid from './components/EndpointsGrid';
 import EndpointCreateDrawer from './components/EndpointCreateDrawer';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
 
 export default function EndpointsPage() {
   const { data: session, status } = useSession();
@@ -31,26 +30,6 @@ export default function EndpointsPage() {
   useDocumentTitle('Endpoints');
 
   const sessionToken = session?.session_token ?? '';
-
-  React.useEffect(() => {
-    const fetchCount = async () => {
-      if (!sessionToken) return;
-      try {
-        const apiFactory = new ApiClientFactory(sessionToken);
-        const endpointsClient = apiFactory.getEndpointsClient();
-        const response = await endpointsClient.getEndpoints({
-          skip: 0,
-          limit: 1,
-          sort_by: 'created_at',
-          sort_order: 'desc',
-        });
-        setEndpointCount(response.pagination?.totalCount ?? 0);
-      } catch {
-        setEndpointCount(0);
-      }
-    };
-    fetchCount();
-  }, [sessionToken, refreshKey]);
 
   const handleRefresh = React.useCallback(() => {
     setRefreshKey(prev => prev + 1);
@@ -138,6 +117,7 @@ export default function EndpointsPage() {
                 sessionToken={sessionToken}
                 refreshKey={refreshKey}
                 onRefresh={handleRefresh}
+                onTotalCountChange={setEndpointCount}
               />
             </Paper>
           )}

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentDetailClient.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentDetailClient.tsx
@@ -130,9 +130,11 @@ export default function ExperimentDetailClient({
         const client = apiFactory.getParametersClient();
         const detail = await client.getExperiment(experimentId);
         setExperiment(detail);
-        const schemaResp = await client.getSchema(detail.project_id);
+        const [schemaResp, envResp] = await Promise.all([
+          client.getSchema(detail.project_id),
+          client.getEnvironments(detail.project_id),
+        ]);
         setSchema(schemaResp);
-        const envResp = await client.getEnvironments(detail.project_id);
         setEnvironments(envResp);
         const latest = detail.versions[detail.versions.length - 1];
         setDraft(valuesFromVersion(latest, schemaResp));

--- a/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
@@ -242,7 +242,7 @@ export default function ExperimentsClientWrapper({
 
   // Sync search + visibility into the filter model
   useEffect(() => {
-    setFilterModel(() => {
+    setFilterModel(prev => {
       const items = [];
       if (searchQuery.trim()) {
         items.push({
@@ -258,9 +258,14 @@ export default function ExperimentsClientWrapper({
           value: visibilityFilter,
         });
       }
+      if (
+        items.length === prev.items.length &&
+        items.every((it, i) => it === prev.items[i])
+      )
+        return prev;
       return { items };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [searchQuery, visibilityFilter]);
 
   const handleDeleteExperiment = async () => {

--- a/apps/frontend/src/app/(protected)/explorer/ExplorerClient.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/ExplorerClient.tsx
@@ -13,7 +13,6 @@ import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { AccountTreeIcon } from '@/components/icons';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useNotifications } from '@/components/common/NotificationContext';
 import type { ImportExplorerTestSetResponse } from '@/utils/api-client/interfaces/explorer';
 import ExplorerGrid from './components/ExplorerGrid';
@@ -33,20 +32,6 @@ export default function ExplorerClient() {
   useDocumentTitle('Explorer');
 
   const sessionToken = session?.session_token ?? '';
-
-  React.useEffect(() => {
-    const fetchCount = async () => {
-      if (!sessionToken) return;
-      try {
-        const client = new ApiClientFactory(sessionToken).getExplorerClient();
-        const sessions = await client.getExplorerTestSets();
-        setSessionCount(sessions.length);
-      } catch {
-        setSessionCount(0);
-      }
-    };
-    fetchCount();
-  }, [sessionToken, refreshKey]);
 
   const handleRefresh = React.useCallback(() => {
     setRefreshKey(prev => prev + 1);
@@ -134,6 +119,7 @@ export default function ExplorerClient() {
                 sessionToken={sessionToken}
                 refreshKey={refreshKey}
                 onRefresh={handleRefresh}
+                onTotalCountChange={setSessionCount}
               />
             </Paper>
           )}

--- a/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
@@ -27,6 +27,7 @@ interface ExplorerGridProps {
   sessionToken: string;
   refreshKey?: number;
   onRefresh?: () => void;
+  onTotalCountChange?: (count: number) => void;
 }
 
 interface ExplorerToolbarState {
@@ -62,6 +63,7 @@ export default function ExplorerGrid({
   sessionToken,
   refreshKey = 0,
   onRefresh,
+  onTotalCountChange,
 }: ExplorerGridProps) {
   const router = useRouter();
   const notifications = useNotifications();
@@ -88,10 +90,12 @@ export default function ExplorerGrid({
         const sessions = await client.getExplorerTestSets();
         if (!cancelled) {
           setAllRows(sessions);
+          onTotalCountChange?.(sessions.length);
         }
       } catch {
         if (!cancelled) {
           setAllRows([]);
+          onTotalCountChange?.(0);
         }
       } finally {
         if (!cancelled) {

--- a/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Box, Alert, Paper } from '@mui/material';
 import UploadIcon from '@mui/icons-material/Upload';
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -10,7 +10,6 @@ import { MenuBookIcon } from '@/components/icons';
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import SourcesGrid from './SourcesGrid';
 import UploadSourceDrawer from './UploadSourceDrawer';
 import ToolImportDrawer from './ToolImportDrawer';
@@ -32,29 +31,6 @@ export default function KnowledgeClientWrapper({
   const handleRefresh = useCallback(() => {
     setRefreshKey(prev => prev + 1);
   }, []);
-
-  useEffect(() => {
-    const fetchCount = async () => {
-      if (!sessionToken) return;
-      try {
-        const apiFactory = new ApiClientFactory(sessionToken);
-        const sourcesClient = apiFactory.getSourcesClient();
-        const response = await sourcesClient.getSources({
-          skip: 0,
-          limit: 1,
-          sort_by: 'created_at',
-          sort_order: 'desc',
-        });
-        const count = Array.isArray(response)
-          ? response.length
-          : (response?.pagination?.totalCount ?? 0);
-        setSourceCount(count);
-      } catch {
-        setSourceCount(0);
-      }
-    };
-    fetchCount();
-  }, [sessionToken, refreshKey]);
 
   const handleUploadSuccess = useCallback(() => {
     setUploadDrawerOpen(false);
@@ -132,6 +108,7 @@ export default function KnowledgeClientWrapper({
                 sessionToken={sessionToken}
                 refreshKey={refreshKey}
                 onRefresh={handleRefresh}
+                onTotalCountChange={setSourceCount}
               />
             </Paper>
           )}

--- a/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
@@ -46,6 +46,7 @@ interface SourcesGridProps {
   sessionToken: string;
   refreshKey?: number;
   onRefresh?: () => void;
+  onTotalCountChange?: (count: number) => void;
 }
 
 interface SourcesToolbarState {
@@ -98,6 +99,7 @@ export default function SourcesGrid({
   sessionToken,
   refreshKey,
   onRefresh,
+  onTotalCountChange,
 }: SourcesGridProps) {
   const router = useRouter();
   const notifications = useNotifications();
@@ -154,6 +156,7 @@ export default function SourcesGrid({
 
       setSources(response.data);
       setTotalCount(response.pagination.totalCount);
+      onTotalCountChange?.(response.pagination.totalCount);
       setError(null);
     } catch {
       setError('Failed to load knowledge sources');

--- a/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
@@ -195,9 +195,14 @@ export default function SourcesGrid({
             { field: 'quickFilter', operator: 'contains', value: searchQuery },
           ]
         : otherItems;
+      if (
+        items.length === prev.items.length &&
+        items.every((it, i) => it === prev.items[i])
+      )
+        return prev;
       return { ...prev, items };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [searchQuery]);
 
   useEffect(() => {
@@ -228,9 +233,17 @@ export default function SourcesGrid({
           value: drawerFilters.tag,
         });
       }
-      return { ...prev, items: [...otherItems, ...drawerItems] };
+      const newItems = [...otherItems, ...drawerItems];
+      if (
+        newItems.length === prev.items.length &&
+        newItems.every(
+          (it, i) => JSON.stringify(it) === JSON.stringify(prev.items[i])
+        )
+      )
+        return prev;
+      return { ...prev, items: newItems };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [drawerFilters]);
 
   // Handle pagination

--- a/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
@@ -156,7 +156,11 @@ export default function SourcesGrid({
 
       setSources(response.data);
       setTotalCount(response.pagination.totalCount);
-      onTotalCountChange?.(response.pagination.totalCount);
+      const filtersActive =
+        filterModel.items.length > 0 ||
+        !!searchQuery ||
+        hasActiveSourceFilters(drawerFilters);
+      if (!filtersActive) onTotalCountChange?.(response.pagination.totalCount);
       setError(null);
     } catch {
       setError('Failed to load knowledge sources');

--- a/apps/frontend/src/app/(protected)/models/page.tsx
+++ b/apps/frontend/src/app/(protected)/models/page.tsx
@@ -81,50 +81,39 @@ export default function ModelsPage() {
         const typeLookupClient = apiFactory.getTypeLookupClient();
         const usersClient = apiFactory.getUsersClient();
 
-        const types = await typeLookupClient.getTypeLookups({
-          $filter: "type_name eq 'ProviderType'",
-          limit: 100,
-        });
+        const organizationsClient = apiFactory.getOrganizationsClient();
+
+        const [types, settings, org, modelsResponse, statuses] =
+          await Promise.all([
+            typeLookupClient.getTypeLookups({
+              $filter: "type_name eq 'ProviderType'",
+              limit: 100,
+            }),
+            usersClient.getUserSettings().catch(() => null),
+            session.user?.organization_id
+              ? organizationsClient
+                  .getOrganization(session.user.organization_id)
+                  .catch(() => null)
+              : Promise.resolve(null),
+            modelsClient.getModels().catch(() => null),
+            apiFactory
+              .getStatusClient()
+              .getStatuses({
+                sort_by: 'name',
+                sort_order: 'asc',
+                entity_type: 'Model',
+              })
+              .catch(() => null),
+          ]);
+
         setProviderTypes(types);
-
-        try {
-          const settings = await usersClient.getUserSettings();
-          setUserSettings(settings);
-        } catch {
-          // continue without user settings
-        }
-
-        if (session.user?.organization_id) {
-          try {
-            const organizationsClient = apiFactory.getOrganizationsClient();
-            const org = await organizationsClient.getOrganization(
-              session.user.organization_id
-            );
-            setOrganization(org);
-          } catch {
-            // continue without organization
-          }
-        }
-
-        try {
-          const modelsResponse = await modelsClient.getModels();
-          setConnectedModels(modelsResponse.data);
-        } catch {
-          // show empty state
-        }
-
-        try {
-          const statuses = await apiFactory.getStatusClient().getStatuses({
-            sort_by: 'name',
-            sort_order: 'asc',
-            entity_type: 'Model',
-          });
+        if (settings) setUserSettings(settings);
+        if (org) setOrganization(org);
+        if (modelsResponse) setConnectedModels(modelsResponse.data);
+        if (statuses)
           setStatusOptions(
             filterUniqueValidOptions(statuses).map(status => status.name)
           );
-        } catch {
-          // continue without status filter options
-        }
       } catch (err) {
         setError(
           err instanceof Error ? err.message : 'Failed to load providers'

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -119,9 +119,10 @@ export default function TasksGrid({
 }: TasksGridProps) {
   const router = useRouter();
   const notifications = useNotifications();
-  const isMounted = useRef(true);
+  const isMounted = useRef(false);
 
   useEffect(() => {
+    isMounted.current = true;
     return () => {
       isMounted.current = false;
     };

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -208,9 +208,14 @@ export default function TasksGrid({
             { field: 'quickFilter', operator: 'contains', value: searchQuery },
           ]
         : otherItems;
+      if (
+        items.length === prev.items.length &&
+        items.every((it, i) => it === prev.items[i])
+      )
+        return prev;
       return { ...prev, items };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [searchQuery]);
 
   useEffect(() => {
@@ -223,9 +228,14 @@ export default function TasksGrid({
               { field: 'status', operator: 'equals', value: statusFilter },
             ]
           : otherItems;
+      if (
+        items.length === prev.items.length &&
+        items.every((it, i) => it === prev.items[i])
+      )
+        return prev;
       return { ...prev, items };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [statusFilter]);
 
   useEffect(() => {
@@ -256,9 +266,15 @@ export default function TasksGrid({
           value: drawerFilters.assignee,
         });
       }
-      return { ...prev, items: [...otherItems, ...drawerItems] };
+      const newItems = [...otherItems, ...drawerItems];
+      if (
+        newItems.length === prev.items.length &&
+        newItems.every((it, i) => it === prev.items[i])
+      )
+        return prev;
+      return { ...prev, items: newItems };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [drawerFilters]);
 
   const handleRowClick = useCallback(

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -43,6 +43,7 @@ interface TasksGridProps {
   sessionToken: string;
   refreshKey?: number;
   onRefresh?: () => void;
+  onTotalCountChange?: (count: number) => void;
 }
 
 const STATUS_PILL_TABS = [
@@ -114,6 +115,7 @@ export default function TasksGrid({
   sessionToken,
   refreshKey,
   onRefresh: _onRefresh,
+  onTotalCountChange,
 }: TasksGridProps) {
   const router = useRouter();
   const notifications = useNotifications();
@@ -168,6 +170,7 @@ export default function TasksGrid({
 
       setTasks(response.data);
       setTotalCount(response.totalCount || 0);
+      onTotalCountChange?.(response.totalCount || 0);
       setError(null);
     } catch {
       if (!isMounted.current) return;

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -171,7 +171,11 @@ export default function TasksGrid({
 
       setTasks(response.data);
       setTotalCount(response.totalCount || 0);
-      onTotalCountChange?.(response.totalCount || 0);
+      const filtersActive =
+        filterModel.items.length > 0 ||
+        !!searchQuery ||
+        hasActiveTaskFilters(drawerFilters);
+      if (!filtersActive) onTotalCountChange?.(response.totalCount || 0);
       setError(null);
     } catch {
       if (!isMounted.current) return;

--- a/apps/frontend/src/app/(protected)/tasks/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/page.tsx
@@ -16,7 +16,6 @@ import TaskDrawer, {
 } from './components/TaskDrawer';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { EntityType } from '@/types/tasks';
 
 export default function TasksPage() {
@@ -32,26 +31,6 @@ export default function TasksPage() {
   useDocumentTitle('Tasks');
 
   const sessionToken = session?.session_token ?? '';
-
-  React.useEffect(() => {
-    const fetchCount = async () => {
-      if (!sessionToken) return;
-      try {
-        const apiFactory = new ApiClientFactory(sessionToken);
-        const tasksClient = apiFactory.getTasksClient();
-        const response = await tasksClient.getTasks({
-          skip: 0,
-          limit: 1,
-          sort_by: 'created_at',
-          sort_order: 'desc',
-        });
-        setTaskCount(response.totalCount ?? 0);
-      } catch {
-        setTaskCount(0);
-      }
-    };
-    fetchCount();
-  }, [sessionToken, refreshKey]);
 
   React.useEffect(() => {
     const shouldOpen = searchParams.get('create') === 'true';
@@ -167,6 +146,7 @@ export default function TasksPage() {
                 sessionToken={sessionToken}
                 refreshKey={refreshKey}
                 onRefresh={handleRefresh}
+                onTotalCountChange={setTaskCount}
               />
             </Paper>
           )}

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -263,9 +263,14 @@ function TestRunsGrid({
             { field: 'quickFilter', operator: 'contains', value: searchQuery },
           ]
         : otherItems;
+      if (
+        items.length === prev.items.length &&
+        items.every((it, i) => it === prev.items[i])
+      )
+        return prev;
       return { ...prev, items };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [searchQuery]);
 
   // ── Sync statusFilter pill tab into filterModel ───────────────────────────
@@ -286,9 +291,14 @@ function TestRunsGrid({
               },
             ]
           : otherItems;
+      if (
+        items.length === prev.items.length &&
+        items.every((it, i) => it === prev.items[i])
+      )
+        return prev;
       return { ...prev, items };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [statusFilter]);
 
   // ── Sync drawer filters into filterModel ─────────────────────────────────
@@ -325,16 +335,22 @@ function TestRunsGrid({
           value: drawerFilters.tag,
         });
       }
-      return {
-        ...prev,
-        items: appendPresenceFilterItems([...otherItems, ...drawerItems], {
+      const newItems = appendPresenceFilterItems(
+        [...otherItems, ...drawerItems],
+        {
           tags: drawerFilters.tags,
           comments: drawerFilters.comments,
           tasks: drawerFilters.tasks,
-        }),
-      };
+        }
+      );
+      if (
+        newItems.length === prev.items.length &&
+        newItems.every((it, i) => it === prev.items[i])
+      )
+        return prev;
+      return { ...prev, items: newItems };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [drawerFilters]);
 
   // ── Row action handlers ────────────────────────────────────────────────────

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -214,7 +214,12 @@ function TestRunsGrid({
         if (isMounted.current) {
           setTestRuns(response.data);
           setTotalCount(response.pagination.totalCount);
-          onTotalCountChange?.(response.pagination.totalCount);
+          const filtersActive =
+            filterModel.items.length > 0 ||
+            !!searchQuery ||
+            hasActiveTestRunFilters(drawerFilters);
+          if (!filtersActive)
+            onTotalCountChange?.(response.pagination.totalCount);
           setError(null);
         }
       } catch (_error) {

--- a/apps/frontend/src/app/(protected)/test-runs/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/page.tsx
@@ -14,7 +14,6 @@ import TestRunsGrid from './components/TestRunsGrid';
 import RunDrawer from '@/components/common/RunDrawer';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
 
 export default function TestRunsPage() {
   const { data: session, status } = useSession();
@@ -25,24 +24,6 @@ export default function TestRunsPage() {
   useDocumentTitle('Test Runs');
 
   const sessionToken = session?.session_token ?? '';
-
-  React.useEffect(() => {
-    const fetchCount = async () => {
-      if (!sessionToken) return;
-      try {
-        const apiFactory = new ApiClientFactory(sessionToken);
-        const testRunsClient = apiFactory.getTestRunsClient();
-        const response = await testRunsClient.getTestRuns({
-          skip: 0,
-          limit: 1,
-        });
-        setTestRunCount(response.pagination?.totalCount ?? 0);
-      } catch {
-        setTestRunCount(0);
-      }
-    };
-    fetchCount();
-  }, [sessionToken, refreshKey]);
 
   const handleRefresh = React.useCallback(() => {
     setRefreshKey(prev => prev + 1);
@@ -114,6 +95,7 @@ export default function TestRunsPage() {
                 sessionToken={sessionToken}
                 refreshKey={refreshKey}
                 onRefresh={handleRefresh}
+                onTotalCountChange={setTestRunCount}
               />
             </Paper>
           )}

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetTestsGrid.tsx
@@ -175,14 +175,27 @@ export default function TestSetTestsGrid({
             { field: 'quickFilter', operator: 'contains', value: searchQuery },
           ]
         : otherItems;
+      if (
+        items.length === prev.items.length &&
+        items.every((it, i) => it === prev.items[i])
+      )
+        return prev;
       return { ...prev, items };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [searchQuery]);
 
   useEffect(() => {
-    setFilterModel(prev => applyTestDrawerFiltersToModel(prev, drawerFilters));
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setFilterModel(prev => {
+      const next = applyTestDrawerFiltersToModel(prev, drawerFilters);
+      if (
+        next.items.length === prev.items.length &&
+        next.items.every((it, i) => it === prev.items[i])
+      )
+        return prev;
+      return next;
+    });
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [drawerFilters]);
 
   const handlePaginationModelChange = useCallback(

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -58,6 +58,7 @@ interface TestSetsGridProps {
   sessionToken?: string;
   refreshKey?: number;
   onRefresh?: () => void;
+  onTotalCountChange?: (count: number) => void;
 }
 
 // ─── Toolbar context ────────────────────────────────────────────────────────────
@@ -160,6 +161,7 @@ export default function TestSetsGrid({
   sessionToken: sessionTokenProp,
   refreshKey,
   onRefresh,
+  onTotalCountChange,
 }: TestSetsGridProps) {
   const router = useRouter();
   const { data: session } = useSession();
@@ -220,6 +222,7 @@ export default function TestSetsGrid({
       const response = await testSetsClient.getTestSets(apiParams);
       setTestSets(response.data);
       setTotalCount(response.pagination.totalCount);
+      onTotalCountChange?.(response.pagination.totalCount);
       setError(null);
     } catch {
       setError('Failed to load test sets');

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -222,7 +222,11 @@ export default function TestSetsGrid({
       const response = await testSetsClient.getTestSets(apiParams);
       setTestSets(response.data);
       setTotalCount(response.pagination.totalCount);
-      onTotalCountChange?.(response.pagination.totalCount);
+      const filtersActive =
+        filterModel.items.length > 0 ||
+        !!searchQuery ||
+        hasActiveTestSetFilters(drawerFilters);
+      if (!filtersActive) onTotalCountChange?.(response.pagination.totalCount);
       setError(null);
     } catch {
       setError('Failed to load test sets');

--- a/apps/frontend/src/app/(protected)/test-sets/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/page.tsx
@@ -20,7 +20,6 @@ import FileImportDrawer from './components/FileImportDrawer';
 import GarakImportDrawer from './components/GarakImportDrawer';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useNotifications } from '@/components/common/NotificationContext';
 
 export default function TestSetsPage() {
@@ -38,26 +37,6 @@ export default function TestSetsPage() {
   useDocumentTitle('Test Sets');
 
   const sessionToken = session?.session_token ?? '';
-
-  React.useEffect(() => {
-    const fetchCount = async () => {
-      if (!sessionToken) return;
-      try {
-        const apiFactory = new ApiClientFactory(sessionToken);
-        const testSetsClient = apiFactory.getTestSetsClient();
-        const response = await testSetsClient.getTestSets({
-          skip: 0,
-          limit: 1,
-          sort_by: 'created_at',
-          sort_order: 'desc',
-        });
-        setTestSetCount(response.pagination?.totalCount ?? 0);
-      } catch {
-        setTestSetCount(0);
-      }
-    };
-    fetchCount();
-  }, [sessionToken, refreshKey]);
 
   const handleRefresh = React.useCallback(() => {
     setRefreshKey(prev => prev + 1);
@@ -171,6 +150,7 @@ export default function TestSetsPage() {
                 sessionToken={sessionToken}
                 refreshKey={refreshKey}
                 onRefresh={handleRefresh}
+                onTotalCountChange={setTestSetCount}
               />
             </Paper>
           )}

--- a/apps/frontend/src/app/(protected)/tests/components/TestDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestDrawer.tsx
@@ -63,23 +63,24 @@ export default function TestDrawer({
       error={error}
       onSave={handleSave}
     >
-      {test ? (
-        <UpdateTest
-          sessionToken={sessionToken}
-          onSuccess={onSuccess}
-          onError={setError}
-          submitRef={submitRef}
-          test={test}
-        />
-      ) : (
-        <CreateTest
-          sessionToken={sessionToken}
-          onSuccess={onSuccess}
-          onError={setError}
-          defaultOwnerId={getCurrentUserId()}
-          submitRef={submitRef}
-        />
-      )}
+      {open &&
+        (test ? (
+          <UpdateTest
+            sessionToken={sessionToken}
+            onSuccess={onSuccess}
+            onError={setError}
+            submitRef={submitRef}
+            test={test}
+          />
+        ) : (
+          <CreateTest
+            sessionToken={sessionToken}
+            onSuccess={onSuccess}
+            onError={setError}
+            defaultOwnerId={getCurrentUserId()}
+            submitRef={submitRef}
+          />
+        ))}
     </BaseDrawer>
   );
 }

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -302,15 +302,20 @@ export default function TestsTable({
       const otherItems = prev.items.filter(
         item => item.field !== 'quickFilter'
       );
-      const items = searchQuery
-        ? [
-            ...otherItems,
-            { field: 'quickFilter', operator: 'contains', value: searchQuery },
-          ]
-        : otherItems;
+      const newItem = searchQuery
+        ? { field: 'quickFilter', operator: 'contains', value: searchQuery }
+        : null;
+      const items = newItem ? [...otherItems, newItem] : otherItems;
+      if (
+        items.length === prev.items.length &&
+        items.every(
+          (it, i) => JSON.stringify(it) === JSON.stringify(prev.items[i])
+        )
+      )
+        return prev;
       return { ...prev, items };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [searchQuery]);
 
   // Sync external typeFilter prop into filterModel
@@ -319,20 +324,25 @@ export default function TestsTable({
       const otherItems = prev.items.filter(
         item => item.field !== 'test_type.type_value'
       );
-      const items =
+      const newItem =
         typeFilter && typeFilter !== 'all'
-          ? [
-              ...otherItems,
-              {
-                field: 'test_type.type_value',
-                operator: 'equals',
-                value: typeFilter,
-              },
-            ]
-          : otherItems;
+          ? {
+              field: 'test_type.type_value',
+              operator: 'equals',
+              value: typeFilter,
+            }
+          : null;
+      const items = newItem ? [...otherItems, newItem] : otherItems;
+      if (
+        items.length === prev.items.length &&
+        items.every(
+          (it, i) => JSON.stringify(it) === JSON.stringify(prev.items[i])
+        )
+      )
+        return prev;
       return { ...prev, items };
     });
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [typeFilter]);
 
   // Apply Insights failed-test filter from URL params
@@ -388,8 +398,13 @@ export default function TestsTable({
 
   // Sync drawer filters into filterModel
   useEffect(() => {
-    setFilterModel(prev => applyTestDrawerFiltersToModel(prev, drawerFilters));
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
+    setFilterModel(prev => {
+      const next = applyTestDrawerFiltersToModel(prev, drawerFilters);
+      return next === prev || JSON.stringify(next) === JSON.stringify(prev)
+        ? prev
+        : next;
+    });
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [drawerFilters]);
 
   // Row action handlers

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -252,7 +252,11 @@ export default function TestsTable({
 
       setTests(response.data);
       setTotalCount(response.pagination.totalCount);
-      onTotalCountChange?.(response.pagination.totalCount);
+      const filtersActive =
+        filterModel.items.length > 0 ||
+        !!searchQuery ||
+        hasActiveTestFilters(drawerFilters);
+      if (!filtersActive) onTotalCountChange?.(response.pagination.totalCount);
       setError(null);
     } catch (_error) {
       setError('Failed to load tests');

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -74,6 +74,7 @@ interface TestsTableProps {
   disableAddButton?: boolean;
   insightsFailedFilter?: InsightsFailedTestsFilter | null;
   insightsEndpointName?: string;
+  onTotalCountChange?: (count: number) => void;
 }
 
 // ─── Toolbar context (passes search/filter state into the DataGrid slot) ──────
@@ -148,6 +149,7 @@ export default function TestsTable({
   disableAddButton: _disableAddButton = false,
   insightsFailedFilter = null,
   insightsEndpointName,
+  onTotalCountChange,
 }: TestsTableProps) {
   const router = useRouter();
   const notifications = useNotifications();
@@ -250,7 +252,7 @@ export default function TestsTable({
 
       setTests(response.data);
       setTotalCount(response.pagination.totalCount);
-
+      onTotalCountChange?.(response.pagination.totalCount);
       setError(null);
     } catch (_error) {
       setError('Failed to load tests');

--- a/apps/frontend/src/app/(protected)/tests/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/page.tsx
@@ -18,6 +18,7 @@ import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import { parseInsightsFailedTestsSearchParams } from '@/app/(protected)/insights/utils/insights-failed-tests';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
 
 export default function TestsPage() {
   const { data: session, status } = useSession();

--- a/apps/frontend/src/app/(protected)/tests/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/page.tsx
@@ -17,7 +17,6 @@ import TestsGrid from './components/TestsGrid';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import { useOnboarding } from '@/contexts/OnboardingContext';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { parseInsightsFailedTestsSearchParams } from '@/app/(protected)/insights/utils/insights-failed-tests';
 
 export default function TestsPage() {
@@ -62,23 +61,6 @@ export default function TestsPage() {
       window.history.replaceState({}, '', newUrl.toString());
     }
   }, [searchParams, router]);
-
-  React.useEffect(() => {
-    const fetchTestCount = async () => {
-      if (!session?.session_token) return;
-
-      try {
-        const apiFactory = new ApiClientFactory(session.session_token);
-        const testsClient = apiFactory.getTestsClient();
-        const response = await testsClient.getTests({ skip: 0, limit: 1 });
-        setTestCount(response.pagination?.totalCount || 0);
-      } catch {
-        // Silently fail
-      }
-    };
-
-    fetchTestCount();
-  }, [session?.session_token, refreshKey]);
 
   React.useEffect(() => {
     if (!insightsFailedFilter || !session?.session_token) {
@@ -202,6 +184,7 @@ export default function TestsPage() {
               disableAddButton={shouldDisableAddButton}
               insightsFailedFilter={insightsFailedFilter}
               insightsEndpointName={insightsEndpointName}
+              onTotalCountChange={setTestCount}
             />
           </Paper>
         )}

--- a/apps/frontend/src/contexts/ActiveProjectContext.tsx
+++ b/apps/frontend/src/contexts/ActiveProjectContext.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 import { useSession } from 'next-auth/react';
@@ -48,6 +49,8 @@ export function ActiveProjectProvider({
 }) {
   const { data: session } = useSession();
   const pathname = usePathname();
+  const pathnameRef = useRef(pathname);
+  pathnameRef.current = pathname;
   const [projects, setProjects] = useState<Project[]>([]);
   const [activeProject, setActiveProjectState] = useState<Project | null>(
     initialActiveProject
@@ -57,7 +60,7 @@ export function ActiveProjectProvider({
   const fetchProjects = useCallback(
     async (options?: { listOnly?: boolean }) => {
       if (!session?.session_token) return;
-      if (pathname.startsWith('/onboarding')) {
+      if (pathnameRef.current.startsWith('/onboarding')) {
         setLoading(false);
         return;
       }
@@ -131,7 +134,7 @@ export function ActiveProjectProvider({
         setLoading(false);
       }
     },
-    [session?.session_token, pathname]
+    [session?.session_token]
   );
 
   useEffect(() => {


### PR DESCRIPTION
This PR cuts unnecessary frontend API calls caused by two recurring patterns: 
1. pages fetching redundant count-only data the grid already had, and
2.  state updates that re-rendered (and re-fetched) even when nothing actually changed.

**Main fixes:**

- **Removed redundant count fetches** — 7 listing pages (Tests, Test-Runs, Test-Sets, Tasks, Endpoints, Knowledge, Explorer) each had a separate `limit:1` call just to populate a count for the empty state. Now grids report their total count directly via an `onTotalCountChange` callback, so the standalone fetch is gone.

- **Parallelized sequential fetches** — `ModelsPage` ran 5 awaits one after another; now they run via `Promise.all`, saving ~4 round trips. Same fix applied to `ExperimentDetailClient`'s two fetches.

- **Deferred drawer fetches** — `TestDrawer`'s create/update forms were always mounted (and fetching dropdown data) even when closed. Now they only mount when the drawer opens.

- **Fixed navigation re-fetch** — `ActiveProjectContext` was re-ferojects on every route change because `pathname` was an unnecessary dependency. Moved it into a ref so navigation no longer triggers refetches.

- **Short-circuited no-op state updates** — Filter and pagination state setters were creating new object references even when values hadn't changed, which cascaded into unnecessary fetches. Added equality checks so unchanged state doesn't trigger new fetches.

**Net effect:** 7 calls eliminated per cold load, 5 round trips saved on Models via parallelism, and 1 recurring per-navigation call removed.

**Testing:** Confirm pages still load data correctly, no extra project fetches on navigation, and drawer dropdowns populate on open.
