### PR TITLE
docs: supersede PRs #1839, #1890, #2053 with verified documentation

### DIFF
--- a/docs/content/changelog.mdx
+++ b/docs/content/changelog.mdx
@@ -128,12 +128,12 @@ Adaptive testing surfaces were expanded and renamed:
 **File Storage Migration**
 
 All file content moved from Postgres `bytea` columns to object storage (GCS/S3/local-FS via `STORAGE_SERVICE_URI`). This eliminates Cloud Run memory crashes from multi-MB file buffers and brings consistent streaming upload/download semantics.
+**Test Explorer and Architect**
 
-**Breaking changes:**
-
-- `GET /files/{id}/content` now returns HTTP 302 to a presigned URL instead of streaming bytes directly. HTTP clients that follow redirects (including the SDK and all browsers) are unaffected.
-- `FileCreate` schema no longer accepts a `content` field. Upload bytes are streamed to object storage; only metadata is stored in Postgres.
-- `File.extracted_text` is now pre-computed at upload time rather than per-invocation. A brief soak window applies while the Celery extraction queue drains after deployment.
+- Test Explorer adds adaptive test-set creation, import, export, and evaluation workflows
+- Architect task progress events stream worker updates into the active chat bubble
+- Architect plan tracking includes per-category progress and ready/blocked gates
+- Adaptive testing surfaces are now named Explorer across backend, frontend, and SDK clients
 
 **New file features:**
 
@@ -142,10 +142,11 @@ All file content moved from Postgres `bytea` columns to object storage (GCS/S3/l
 - `FileReference` type in the SDK connector for passing file metadata through the execution pipeline without embedding bytes
 - `extraction_status` field on `FileResponse` (`pending | done | failed | not_applicable`)
 - ETag / If-None-Match support on `/content` and `/thumbnail` for browser-level caching
+### Deployment notes
 
-**Deployment:** Apply Alembic revision `9b25f353e9c8` (adds storage columns), deploy the new code, then apply revision `f1e2d3c4b5a6` to drop the legacy `content` column.
-
-**IAM prerequisite:** The backend Cloud Run service account needs `roles/storage.objectAdmin` on the storage bucket (previously `roles/storage.objectViewer` was sufficient).
+- Apply Alembic revision `9b25f353e9c8`, deploy the new code, then apply revision `f1e2d3c4b5a6` to drop the legacy file `content` column.
+- Backend and worker identities need object read/write permissions for the configured storage bucket or filesystem path.
+- `./rh start` now prompts interactively for `RHESIS_API_KEY` when the local environment file does not contain one.
 
 **Enterprise SSO**
 

--- a/docs/content/contribute/backend/architecture.mdx
+++ b/docs/content/contribute/backend/architecture.mdx
@@ -90,6 +90,21 @@ API endpoints are organized into routers by resource type, with each router hand
 
 Long-running operations are handled by Celery tasks defined in the `tasks/` directory, which are executed asynchronously.
 
+### Logging
+
+Backend startup calls `set_logger()` from `rhesis.backend.logging.logging_config`.
+The logger chooses handlers from runtime configuration:
+
+| Runtime condition | Output |
+| --- | --- |
+| Google Cloud runtime detected | JSON logs on stdout with `severity`, `module`, and `message` fields |
+| `BACKEND_ENV=local` or `BACKEND_ENV=development` | Colored console logs plus timestamped files under `LOG_DIR` |
+| Other environments | Root logger level and framework logger levels are controlled by `LOG_LEVEL` |
+
+All configured handlers wrap their formatter in `RedactingFormatter`, which
+scrubs bearer tokens, JWTs, API keys, database URLs, cookies, passwords, and
+private keys from final log output.
+
 ### Authentication
 
 Authentication is handled through a native provider-based system, with custom middleware to enforce different authentication requirements based on route configuration.

--- a/docs/content/contribute/backend/authentication.mdx
+++ b/docs/content/contribute/backend/authentication.mdx
@@ -91,6 +91,16 @@ GH_CLIENT_SECRET=your-github-client-secret`}
 
 If no OAuth credentials are provided, only email/password authentication is available.
 
+### Localhost redirects in development
+
+When `BACKEND_ENV` is not `production`, OAuth redirects may return to a loopback
+frontend origin stored in the login session. This supports workflows where a
+developer runs the Next.js frontend on `localhost`, `127.0.0.1`, or `::1` while
+pointing at a remote development backend.
+
+Production deployments never accept loopback redirect origins, and development
+matching uses exact hostnames so lookalike domains are rejected.
+
 ## Authentication Configuration
 
 <CodeBlock filename=".env" language="bash">

--- a/docs/content/contribute/backend/background-tasks.mdx
+++ b/docs/content/contribute/backend/background-tasks.mdx
@@ -56,7 +56,7 @@ All tasks inherit from a `BaseTask` class that provides retry logic, error handl
 {`from celery import Task
 from contextlib import contextmanager
 
-from rhesis.backend.app.database import SessionLocal, set_tenant
+from rhesis.backend.app.database import get_db_with_tenant_variables
 
 class BaseTask(Task):
     """Base task class with retry settings and tenant context management."""
@@ -71,23 +71,13 @@ class BaseTask(Task):
     @contextmanager
     def get_db_session(self):
         """Get a database session with the proper tenant context."""
-        db = SessionLocal()
-        try:
-            # Start with a clean session
-            db.expire_all()
+        request = getattr(self, 'request', None)
+        org_id = getattr(request, 'organization_id', None) or ''
+        user_id = getattr(request, 'user_id', None) or ''
+        project_id = getattr(request, 'project_id', None) or ''
 
-            # Get task context
-            request = getattr(self, 'request', None)
-            org_id = getattr(request, 'organization_id', None)
-            user_id = getattr(request, 'user_id', None)
-
-            # Set tenant context if available
-            if org_id or user_id:
-                set_tenant(db, org_id, user_id)
-
+        with get_db_with_tenant_variables(org_id, user_id, project_id) as db:
             yield db
-        finally:
-            db.close()
 
     def apply_async(self, args=None, kwargs=None, **options):
         """Store org_id and user_id in task context when task is queued."""
@@ -152,10 +142,6 @@ def with_tenant_context(func):
 
         # Get a database session
         with self.get_db_session() as db:
-            # Set tenant for this session
-            if organization_id or user_id:
-                set_tenant(db, organization_id, user_id)
-
             # Add db to kwargs and execute the task function
             kwargs['db'] = db
             return func(self, *args, **kwargs)
@@ -419,21 +405,15 @@ If tasks fail with errors related to the tenant context, such as:
 Ensure that:
 
 1. Your database has the proper configuration parameters set
-2. The `organization_id` and `user_id` are correctly passed to the task
-3. The tenant context is explicitly set at the beginning of database operations
+2. The `organization_id`, `user_id`, and `project_id` are correctly passed to the task
+3. Database work runs inside `self.get_db_session()` so tenant GUCs and ORM scope are bound
 
-The `execute_single_test` task in `tasks/execution/test.py` includes defensive coding to handle such issues:
+Tasks should open tenant-aware sessions through the task base class:
 
-<CodeBlock filename="test.py" language="python">
-{`# Explicitly set tenant context to ensure it's active for all queries
-if organization_id:
-    # Verify PostgreSQL has the parameter defined
-    try:
-        db.execute(text('SHOW "app.current_organization"'))
-    except Exception as e:
-        logger.warning(f"The database parameter 'app.current_organization' may not be defined: {e}")
-        # Continue without setting tenant context - will use normal filters instead
-
-    # Set the tenant context for this session
-    set_tenant(db, organization_id, user_id)`}
+<CodeBlock filename="tenant_aware_task.py" language="python">
+{`@app.task(base=BaseTask, bind=True)
+def execute_single_test(self, test_id: str):
+    with self.get_db_session() as db:
+        test = db.query(Test).filter(Test.id == test_id).first()
+        # The session has tenant GUCs and Session.info['_scope'] configured.`}
 </CodeBlock>

--- a/docs/content/contribute/backend/environment-config.mdx
+++ b/docs/content/contribute/backend/environment-config.mdx
@@ -30,33 +30,49 @@ load_dotenv()  # Loads variables from .env file`}
 
 ## Environment-Specific Configuration
 
-The application can load different configuration based on the environment:
+The backend uses `BACKEND_ENV` as the canonical runtime environment label in
+Python settings and logging. Valid values are `production`, `development`,
+`staging`, `local`, and `test`.
 
-<CodeBlock filename="python" language="python">
-{`import os
+<CodeBlock filename="settings.py" language="python">
+{`from rhesis.backend.app.config.settings import get_application_settings
 
-# Determine environment (ENVIRONMENT is preferred; ENV is supported for backward compatibility)
-ENVIRONMENT = os.getenv("ENVIRONMENT") or os.getenv("ENV", "development")
+settings = get_application_settings()
 
-# Load environment-specific settings
-if ENVIRONMENT == "production":
-    # Production settings
-    DEBUG = False
-    LOG_LEVEL = "INFO"
-elif ENVIRONMENT == "testing":
-    # Testing settings
-    DEBUG = True
-    LOG_LEVEL = "DEBUG"
-    # Use in-memory database (component env vars; settings.py builds the URL)
-    DB_HOST = "localhost"
-    DB_NAME = "test_db"
-    APP_DB_USER = "test_user"
-    APP_DB_PASS = "test_pass"
+if settings.backend_env == "production":
+    enable_local_debug = False
+elif settings.backend_env == "test":
+    enable_local_debug = True
 else:
-    # Development settings
-    DEBUG = True
-    LOG_LEVEL = "DEBUG"`}
+    enable_local_debug = settings.is_development`}
 </CodeBlock>
+
+Shell entrypoints may still read `ENVIRONMENT` for deployment-script behavior, but
+application code should use `BACKEND_ENV`.
+
+## Database credentials
+
+Database URLs are built from component environment variables. Runtime application
+sessions use `APP_DB_USER` / `APP_DB_PASS`; migrations and administrative jobs use
+`ADMIN_DB_USER` / `ADMIN_DB_PASS` when present and fall back to the app
+credentials for single-role local setups.
+
+| Variable | Required | Used for |
+| --- | --- | --- |
+| `DB_DRIVER` | No, defaults to `postgresql` | SQLAlchemy driver |
+| `DB_HOST` | Yes | Database host or Unix socket path |
+| `DB_PORT` | No, defaults to `5432` | TCP port when `DB_HOST` is not a socket |
+| `DB_NAME` | Yes | Database name |
+| `APP_DB_USER` | Yes for runtime backend and workers | Least-privilege application database role |
+| `APP_DB_PASS` | Yes when `APP_DB_USER` is set | Application role password |
+| `ADMIN_DB_USER` | Optional | Migration or admin database role |
+| `ADMIN_DB_PASS` | Required when `ADMIN_DB_USER` is set | Admin role password |
+
+<Callout type="info">
+  Managed Postgres deployments should use a separate migration role through
+  `ADMIN_DB_*` and a least-privilege runtime role through `APP_DB_*`. RLS-aware
+  migrations do not require a PostgreSQL superuser.
+</Callout>
 
 ## Configuration Validation
 

--- a/docs/content/contribute/backend/multi-tenancy.mdx
+++ b/docs/content/contribute/backend/multi-tenancy.mdx
@@ -2,191 +2,126 @@ import { CodeBlock } from '@/components/CodeBlock'
 
 # Multi-tenancy
 
-## Overview
+Rhesis isolates data by organization and active project. Backend code should rely
+on the request-scoped database session instead of threading tenant identifiers
+through every router, service, and CRUD helper.
 
-Organizations are isolated by design: models carry `organization_id`, CRUD and queries take tenant arguments or rely on session context, and list/search paths must never return another org’s rows.
+## Ambient request scope
 
-## Multi-tenant Database Design
+Every authenticated request receives an identity triple:
 
-### Organization Model
+| Field | Purpose |
+| --- | --- |
+| `organization_id` | Organization boundary for tenant data |
+| `user_id` | User responsible for created rows |
+| `project_id` | Active project boundary for project-scoped rows |
 
-The foundation of multi-tenancy is the `Organization` model:
+`get_db_with_tenant_variables()` stores that triple on `Session.info['_scope']`.
+SQLAlchemy listeners in `app/models/scope_events.py` read the session scope and
+apply it automatically.
 
-<CodeBlock filename="organization-model.py" language="python">
-{`class Organization(Base):
-    name = Column(String, nullable=False)
-    slug = Column(String, unique=True, nullable=False)
-    is_active = Column(Boolean, default=True)
-    # Additional fields...`}
+| Listener | SQLAlchemy hook | Behavior |
+| --- | --- | --- |
+| `auto_filter` | `Query.before_compile` | Adds organization and project predicates to ORM `db.query(...)` reads, updates, and deletes |
+| `auto_stamp` | `Session.before_flush` | Fills `organization_id`, `user_id`, and `project_id` on new ORM objects when those columns are present and unset |
+
+Normal FastAPI routers do not need to call scope helpers directly:
+
+<CodeBlock filename="router.py" language="python">
+{`from fastapi import Depends
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.database import get_db_with_tenant_variables
+from rhesis.backend.app.models.test import Test
+
+@router.get("/tests")
+def list_tests(db: Session = Depends(get_db_with_tenant_variables)):
+    # The query is automatically filtered by organization and active project.
+    return db.query(Test).all()`}
 </CodeBlock>
 
-### Organization References
+<Callout type="info">
+  `current_scope()` reads the ContextVar fallback used by scripts and tests. In
+  normal FastAPI and Celery database work, use `db.info.get('_scope')` if you need
+  to inspect the active scope.
+</Callout>
 
-Most models include a reference to the organization they belong to:
+## Project filtering behavior
 
-<CodeBlock filename="organization-reference.py" language="python">
-{`class SomeModel(Base):
-    # ...other fields
-    organization_id = Column(GUID(), ForeignKey("organization.id"))
-    organization = relationship("Organization")`}
+Project filtering is fail-closed once an organization scope is active:
+
+- If `project_id` is set, project-scoped tables return rows for that project plus
+  organization-level rows where `project_id` is `NULL`.
+- If `project_id` is missing, project-scoped tables return only
+  organization-level rows where `project_id` is `NULL`.
+- `project_membership` is exempt from the project predicate so project resolution
+  can list memberships across projects while still applying organization scope.
+
+The ORM listener skips identity tables such as `user`, `organization`, and
+`token` because those are queried before tenant context is known.
+
+## Choosing the right scope helper
+
+Use the narrowest helper for the runtime path you own.
+
+| Situation | Helper | Notes |
+| --- | --- | --- |
+| Standard FastAPI route | `Depends(get_db_with_tenant_variables)` | Sets tenant GUCs and stores scope on `Session.info` |
+| Celery task or long-lived owned session | `bind_scope_to_session(db, org, user, project)` | Activates ORM scope for that session lifetime |
+| Short project-scoped block inside a request | `temporary_project_scope(db, org, user, project)` | Restores the previous session scope and GUCs after the block |
+| Re-apply PostgreSQL GUCs after a mid-request commit | `set_session_variables(db, org, user, project)` | Does not change `Session.info['_scope']` |
+| Script or test without a DB dependency | `bind_scope(RequestScope(...))` / `reset_scope(token)` | ContextVar fallback for non-request code |
+
+Use `temporary_project_scope()` for short in-request project windows. Calling
+`bind_scope_to_session()` inside a request changes the session scope for the rest
+of that request and can silently filter later queries to the wrong project.
+
+<CodeBlock filename="temporary_project_scope.py" language="python">
+{`from rhesis.backend.app.database import temporary_project_scope
+
+with temporary_project_scope(db, organization_id, user_id, project_id):
+    project_rows = db.query(Test).all()
+
+# The previous request scope is restored here.`}
 </CodeBlock>
 
-## Direct Parameter Passing Architecture
+## Cross-tenant reads
 
-The application uses **direct parameter passing** for tenant context instead of session variables, providing better performance and security.
+Admin or maintenance paths can temporarily disable the ORM auto-filter:
 
-### Tenant Context Extraction
+<CodeBlock filename="cross_tenant_read.py" language="python">
+{`from rhesis.backend.app.scope import bypass_tenant_filter
 
-Tenant context is extracted from authenticated users and passed directly to CRUD operations:
-
-<CodeBlock filename="tenant-context.py" language="python">
-{`def get_tenant_context(current_user: User = Depends(require_current_user_or_token)):
-    """Extract tenant context from authenticated user."""
-    return current_user.organization_id, current_user.id`}
+with bypass_tenant_filter():
+    all_projects = db.query(Project).all()`}
 </CodeBlock>
 
-### CRUD Operations with Tenant Context
+Bypass only affects `auto_filter`. Inserts still receive the caller's
+organization, user, and project through `auto_stamp`.
 
-All CRUD operations accept `organization_id` and `user_id` parameters explicitly:
+For the legacy Query API, a single query can also set `_bypass_scope = True`.
 
-<CodeBlock filename="crud-with-tenant-context.py" language="python">
-{`def create_entity(
-    db: Session,
-    entity_data: EntityCreate,
-    organization_id: str,
-    user_id: str
-) -> Entity:
-    """Create entity with explicit tenant context."""
-    # Auto-populate tenant fields
-    populated_data = _auto_populate_tenant_fields(
-        Entity, entity_data.dict(), organization_id, user_id
-    )
+## Known limitations
 
-    db_entity = Entity(**populated_data)
-    db.add(db_entity)
-    db.commit()
-    db.refresh(db_entity)
-    return db_entity`}
-</CodeBlock>
+- `db.execute(select(...))` and `db.scalars(...)` are not filtered by the
+  `Query.before_compile` listener. Use `db.query(...)` or add explicit tenant
+  predicates for ORM 2.0 style queries.
+- `Session.bulk_insert_mappings()` and `bulk_save_objects()` bypass
+  `before_flush`; include `organization_id`, `user_id`, and `project_id` in bulk
+  payloads manually.
+- Raw SQL writes bypass both ORM listeners. Add explicit tenant predicates or
+  rely on PostgreSQL row-level security as the backstop.
+- Background scripts run outside `get_db_with_tenant_variables()`. Bind scope
+  explicitly before writing tenant-owned rows.
 
-### Query Filtering
+## Kill switch
 
-Database queries include organization filtering to prevent data leakage:
+Set `RHESIS_DISABLE_SCOPE_LISTENER=1` to disable the ORM auto-filter and
+auto-stamp listeners without redeploying. PostgreSQL row-level security remains
+active because the switch only affects the ORM listener layer.
 
-<CodeBlock filename="query-filtering.py" language="python">
-{`def get_entities(db: Session, organization_id: str) -> List[Entity]:
-    """Get entities filtered by organization."""
-    return db.query(Entity).filter(
-        Entity.organization_id == UUID(organization_id)
-    ).all()`}
-</CodeBlock>
+## Related pages
 
-## Database Session Management
-
-### Simple Session Management
-
-Database sessions are managed without tenant setup overhead:
-
-<CodeBlock filename="session-management.py" language="python">
-{`@contextmanager
-def get_db() -> Generator[Session, None, None]:
-    """Get a simple database session with transparent transaction management."""
-    db = SessionLocal()
-    try:
-        yield db
-        # Commit any pending transactions automatically
-        if db.in_transaction():
-            db.commit()
-    except Exception:
-        # Rollback on exception
-        if db.in_transaction():
-            db.rollback()
-        raise
-    finally:
-        # Close the session
-        db.close()`}
-</CodeBlock>
-
-### FastAPI Dependencies
-
-FastAPI dependencies provide both database sessions and tenant context:
-
-<CodeBlock filename="fastapi-dependencies.py" language="python">
-{`def get_db_with_tenant_context(tenant_context: tuple = Depends(get_tenant_context)):
-    """
-    FastAPI dependency that provides both a database session and tenant context.
-
-    This eliminates the need for SET LOCAL commands by providing the tenant
-    context directly to CRUD operations.
-
-    Returns:
-        tuple: (db_session, organization_id, user_id)
-    """
-    organization_id, user_id = tenant_context
-
-    with get_db() as db:
-        yield db, organization_id, user_id`}
-</CodeBlock>
-
-### Usage Patterns
-
-**For multi-entity operations (recommended):**
-
-<CodeBlock filename="multi-entity-operations.py" language="python">
-{`# Use get_db and pass tenant context directly to CRUD operations
-def load_initial_data(organization_id: str, user_id: str):
-    with get_db() as db:
-        # Pass tenant context directly to CRUD operations
-        create_statuses(db, initial_data["status"], organization_id=organization_id, user_id=user_id)
-        create_behaviors(db, initial_data["behavior"], organization_id=organization_id, user_id=user_id)
-        # Automatic commit on success, rollback on exception`}
-</CodeBlock>
-
-**For API request handling:**
-
-<CodeBlock filename="api-request-handling.py" language="python">
-{`# Standard dependency injection for regular API endpoints
-async def get_tests(
-    db: Session = Depends(get_db),
-    current_user: dict = Depends(require_current_user)
-):
-    # Tenant context is set by require_current_user dependency
-    return crud.get_tests(db)`}
-</CodeBlock>
-
-**When to use each approach:**
-
-- **`get_db` with direct parameters**: Multi-entity operations, background tasks, data migrations, initial data loading
-- **Standard dependencies**: Regular API endpoints where tenant context is set by authentication middleware
-
-## Authentication Integration
-
-The multi-tenancy system integrates with authentication to set tenant context based on the authenticated user:
-
-<CodeBlock filename="authentication-integration.py" language="python">
-{`async def require_current_user(request: Request, db: Session = Depends(get_db)):
-    user = request.session.get("user")
-    if not user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
-
-    # Set tenant context for database operations
-    set_tenant(db, user.get("organization_id"), user.get("sub"))
-
-    return user`}
-</CodeBlock>
-
-## API Request Flow
-
-Authenticated request → user/org from auth → tenant set on the session (where applicable) → queries respect RLS/org filters → context cleared after the request.
-
-## Superuser Access
-
-Superusers can access data across organizations by bypassing the row-level security policies:
-
-<CodeBlock filename="bypass-rls.py" language="python">
-{`def bypass_rls(db: Session):
-    """Temporarily bypass row-level security for superuser operations."""
-    db.execute(text("SET app.bypass_rls = true"))`}
-</CodeBlock>
-
-This feature is carefully controlled and only available to authenticated superusers.
+- [Backend security](/contribute/backend/security)
+- [Backend environment configuration](/contribute/backend/environment-config)
+- [Worker architecture](/contribute/worker/architecture)

--- a/docs/content/contribute/environment-variables.mdx
+++ b/docs/content/contribute/environment-variables.mdx
@@ -32,7 +32,8 @@ Note: These commands generate `apps/backend/.env` and `apps/frontend/.env.local`
     ['`DB_ENCRYPTION_KEY`', 'Fernet key for encrypted fields. **Keep secret.** Generate if not using init: `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`.'],
     ['`BROKER_URL`', 'Celery broker Redis URL (dev: port `11001`).'],
     ['`CELERY_RESULT_BACKEND`', 'Celery results store; use a different Redis DB index than `BROKER_URL` when both are Redis.'],
-    ['`BACKEND_ENV`', 'Deployment label for start/migrate scripts and logging. Accepted values: `production`, `development`, `staging`, `local`. Does not control auth cookies or OAuth callbacks.'],
+    ['`BACKEND_ENV`', 'Canonical backend runtime label: `production`, `development`, `staging`, `local`, or `test`.'],
+    ['`ENVIRONMENT`', 'Legacy shell-script label used by some entrypoints; application settings use `BACKEND_ENV`.'],
     ['`LOG_LEVEL`', 'Log level (e.g. `DEBUG`).'],
     ['`API_BASE_URL`', 'Public URL of this deployment\'s backend API (OAuth/SSO callbacks). A loopback hostname (`localhost`, `127.0.0.1`, `::1`) enables local session/cookie behavior.'],
     ['`FRONTEND_URL`', 'Public frontend URL (CORS and redirects), e.g. `http://localhost:3000`.'],
@@ -57,11 +58,13 @@ These are not added by `./rh dev init` but are commonly needed when you deploy, 
     ['`SESSION_SECRET_KEY`', 'Required in production', 'Session middleware signing key. Local dev may use a fallback when running locally; production must set this.'],
     ['`DEFAULT_GENERATION_MODEL`, `DEFAULT_EVALUATION_MODEL`, `DEFAULT_EXECUTION_MODEL`', 'Default: `rhesis/rhesis-default`', 'Model IDs in `provider/model` form for generation, evaluation, and endpoint execution. Rhesis defaults need `RHESIS_API_KEY`; switch to OpenAI, Gemini, Azure, or Vertex and set the matching provider env vars instead if you prefer not to use a platform key.'],
     ['`DEFAULT_EMBEDDING_MODEL`', 'Default: `rhesis/rhesis-embedding`', 'Embedding model ID in `provider/model` form. Explicit deployment secrets or `.env` values override this default; keep an older provider value only if you want to continue using that provider for embeddings.'],
+    ['`STORAGE_SERVICE_URI`', 'Required for durable file storage', 'Object storage URI for uploaded files, for example `file:///var/lib/rhesis/files`, `gs://bucket`, or `s3://bucket`. Backend and workers must share access.'],
     ['`OPENAI_API_KEY`, `GEMINI_API_KEY`, Azure / Vertex variables', 'Optional', 'Third-party LLM and embedding providers; set whichever providers you use.'],
     ['`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GH_CLIENT_ID`, `GH_CLIENT_SECRET`', 'Optional', 'OAuth sign-in providers.'],
     ['`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `FROM_EMAIL`, …', 'Optional', 'Outbound email.'],
     ['`OTEL_*` (e.g. `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_SERVICE_NAME`)', 'Optional', 'OpenTelemetry export and service metadata.'],
     ['`SERVICE_DELEGATION_EXPIRE_MINUTES`', 'Default: `15`', 'Lifetime, in minutes, for short-lived service delegation JWTs used by backend worker flows such as Architect local tool calls.'],
+    ['`RHESIS_DISABLE_SCOPE_LISTENER`', 'Default: unset', 'Emergency kill switch for the ORM auto-filter and auto-stamp listeners. PostgreSQL RLS remains active.'],
     ['`WS_MAX_MESSAGE_SIZE`, `WS_IDLE_TIMEOUT`, `WS_RATE_LIMIT`', 'Defaults documented in code', 'SDK connector WebSocket limits (`/connector/ws`).'],
     ['`CELERY_WORKER_*`', 'Defaults documented in code', 'Celery worker process tuning.'],
   ]}
@@ -83,6 +86,10 @@ For a full production file (many more keys), teams often load secrets from Googl
     ['`NEXT_TELEMETRY_DISABLED`', 'Disables Next.js telemetry in local dev when set (e.g. `1`).'],
   ]}
 />
+
+The production frontend image is built once and configured at container start. `apps/frontend/scripts/replace-runtime-env.sh` replaces `__NEXT_PUBLIC_API_BASE_URL__` and `__NEXT_PUBLIC_QUICK_START__` placeholders in the built bundle, then exports the resolved values. Prefer setting `NEXT_PUBLIC_API_BASE_URL` explicitly; if it is absent, startup falls back to `API_BASE_URL`, then `BACKEND_URL`, then `http://localhost:8080`.
+
+`BACKEND_URL` is also read by the server-side `/api/*` Route Handler proxy on each request, so internal service routing can change without rebuilding the frontend image.
 
 ### Optional frontend variables
 

--- a/docs/content/contribute/frontend/api-integration.mdx
+++ b/docs/content/contribute/frontend/api-integration.mdx
@@ -42,7 +42,7 @@ The API client is implemented in `src/utils/api-client/`:
           description: "Main export file",
         },
         {
-          name: "client.ts",
+          name: "base-client.ts",
           type: "file",
           description: "Base API client implementation",
         },
@@ -107,113 +107,100 @@ The API client is implemented in `src/utils/api-client/`:
 
 ### Base Client
 
-The base client is implemented in `src/utils/api-client/client.ts` and handles communication with the Rhesis backend API:
+The base client is implemented in `src/utils/api-client/base-client.ts` and resolves the backend URL when each client instance is constructed. This avoids holding a server-only URL in a browser bundle.
 
-<CodeBlock filename="client.ts" language="typescript">
-{`import { getTokens } from '@/auth';
-import { getClientApiBaseUrl } from '@/utils/url-resolver';
+<CodeBlock filename="src/utils/api-client/base-client.ts" language="typescript">
+{`import { API_CONFIG, API_ENDPOINTS } from './config';
+import { getBaseUrl } from '../url-resolver';
+import { readActiveProjectId } from '../active-project';
+import { joinUrl } from '@/utils/url';
 
-const API_BASE_URL = getClientApiBaseUrl();
+export class BaseApiClient {
+  protected baseUrl: string;
+  protected sessionToken?: string;
+  protected projectId?: string;
 
-export class ApiError extends Error {
-  constructor(public status: number, message: string) {
-    super(message);
-    this.name = 'ApiError';
+  constructor(sessionToken?: string, projectId?: string) {
+    this.baseUrl = getBaseUrl();
+    this.sessionToken = sessionToken;
+    this.projectId = projectId;
   }
-}
 
-export async function apiClient<T>(
-  endpoint: string,
-  options: RequestInit = {}
-): Promise<T> {
-  const tokens = getTokens();
-  const headers = new Headers(options.headers);
+  protected getHeaders(): HeadersInit {
+    const headers: Record<string, string> = { ...API_CONFIG.defaultHeaders };
+    if (this.sessionToken) {
+      headers.Authorization = \`Bearer \${this.sessionToken}\`;
+    }
 
-// Add authentication header if tokens exist
-if (tokens?.accessToken) {
-headers.append('Authorization', \`Bearer \${tokens.accessToken}\`);
-}
+    const activeProject = this.projectId ?? readActiveProjectId();
+    if (activeProject) {
+      headers['X-Project-Id'] = activeProject;
+    }
+    return headers;
+  }
 
-// Add content type if not present
-if (!headers.has('Content-Type') && options.method !== 'GET') {
-headers.append('Content-Type', 'application/json');
-}
-
-const response = await fetch(\`\${API_BASE_URL}\${endpoint}\`, {
-...options,
-headers,
-});
-
-// Handle non-JSON responses
-const contentType = response.headers.get('Content-Type');
-if (contentType && !contentType.includes('application/json')) {
-if (!response.ok) {
-throw new ApiError(response.status, response.statusText);
-}
-return response as unknown as T;
-}
-
-// Parse JSON response
-const data = await response.json();
-
-// Handle error responses
-if (!response.ok) {
-throw new ApiError(
-response.status,
-data.message || response.statusText
-);
-}
-
-return data;
+  protected async fetch<T>(
+    endpoint: keyof typeof API_ENDPOINTS | string,
+    options: RequestInit = {}
+  ): Promise<T> {
+    const path = API_ENDPOINTS[endpoint as keyof typeof API_ENDPOINTS] || endpoint;
+    const url = joinUrl(this.baseUrl, path);
+    const response = await fetch(url, { ...options, headers: this.getHeaders() });
+    return response.json() as Promise<T>;
+  }
 }`}
-
 </CodeBlock>
+
+`getBaseUrl()` chooses `BACKEND_URL` for server-side code and `NEXT_PUBLIC_API_BASE_URL` for browser-side code, with localhost normalized to `127.0.0.1` to avoid IPv6 localhost issues.
+
+### Runtime backend proxy
+
+Route handlers under `src/app/api/` proxy frontend `/api/*` requests to the backend at runtime:
+
+<CodeBlock filename="src/app/api/[...path]/route.ts" language="typescript">
+{`import { NextRequest } from 'next/server';
+import { proxyToBackend } from '@/utils/backend-proxy';
+
+export const dynamic = 'force-dynamic';
+
+export function GET(req: NextRequest) {
+  return proxyToBackend(req);
+}
+export function POST(req: NextRequest) {
+  return proxyToBackend(req);
+}`}
+</CodeBlock>
+
+`proxyToBackend()` reads `BACKEND_URL` on every request, forwards authorization, content, and active-project headers, and preserves redirect responses. Do not add `next.config.mjs` rewrites for `/api/*`; rewrite destinations are baked into `.next/routes-manifest.json` at build time.
 
 ### Endpoint Definitions
 
 API endpoints are defined in separate files for each resource, all targeting the Rhesis backend API:
 
-<CodeBlock language="tsx" filename="src/utils/api-client/endpoints/projects.ts">
-{`// src/utils/api-client/endpoints/projects.ts
-import { apiClient } from "../client";
-import type { Project, ProjectCreate, ProjectUpdate } from "../types/projects";
+<CodeBlock language="tsx" filename="src/utils/api-client/projects-client.ts">
+{`import { BaseApiClient } from './base-client';
+import { API_ENDPOINTS } from './config';
+import { Project, ProjectCreate, ProjectUpdate } from './interfaces/project';
 
-export const projectsApi = {
-  getAll: async (params?: { skip?: number; limit?: number }) => {
-    return apiClient<{ data: Project[]; total: number }>("/projects", {
-      method: "GET",
-      ...(params && {
-        query: new URLSearchParams(params as Record<string, string>).toString(),
-      }),
-    });
-  },
+export class ProjectsClient extends BaseApiClient {
+  async getProject(id: string): Promise<Project> {
+    return this.fetch<Project>(\`\${API_ENDPOINTS.projects}/\${id}\`);
+  }
 
-  getById: async (id: string) => {
-    return apiClient<Project>(\`/projects/\${id}\`, {
-      method: "GET",
+  async createProject(project: ProjectCreate): Promise<Project> {
+    return this.fetch<Project>(API_ENDPOINTS.projects, {
+      method: 'POST',
+      body: JSON.stringify(project),
     });
-  },
+  }
 
-  create: async (data: ProjectCreate) => {
-    return apiClient<Project>("/projects", {
-      method: "POST",
-      body: JSON.stringify(data),
+  async updateProject(id: string, project: ProjectUpdate): Promise<Project> {
+    return this.fetch<Project>(\`\${API_ENDPOINTS.projects}/\${id}\`, {
+      method: 'PUT',
+      body: JSON.stringify(project),
     });
-  },
-
-  update: async (id: string, data: ProjectUpdate) => {
-    return apiClient<Project>(\`/projects/\${id}\`, {
-      method: "PUT",
-      body: JSON.stringify(data),
-    });
-  },
-
-  delete: async (id: string) => {
-    return apiClient<void>(\`/projects/\${id}\`, {
-      method: "DELETE",
-    });
-  },
-};`}
+  }
+}`}
 </CodeBlock>
 
 ### WebSocket API for Playground chat
@@ -446,16 +433,22 @@ export async function deleteProject(id: string) {
 The Rhesis backend API URL is configured in environment variables:
 
 <CodeBlock filename=".env.local" language="bash">
-  {`# .env.local
-API_BASE_URL=https://api.rhesis.ai`}
+{`# Browser-visible API URL
+NEXT_PUBLIC_API_BASE_URL=https://api.rhesis.ai
+
+# Server-side Route Handler proxy target
+BACKEND_URL=http://backend:8080`}
 </CodeBlock>
 
-For local development, you might point to a local instance of the Rhesis backend:
+For local development, both can point to your local backend:
 
 <CodeBlock language="bash" filename=".env.local">
 {`# .env.local
-API_BASE_URL=http://localhost:3001`}
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
+BACKEND_URL=http://localhost:8080`}
 </CodeBlock>
+
+Container startup runs `scripts/replace-runtime-env.sh`, which replaces the `__NEXT_PUBLIC_API_BASE_URL__` and `__NEXT_PUBLIC_QUICK_START__` placeholders in the built bundle. This lets one frontend image move between local, preview, staging, and production deployments without rebuilding.
 
 ## Error Handling
 
@@ -466,7 +459,6 @@ The API client includes centralized error handling for Rhesis backend API errors
 "use client";
 
 import { useEffect } from "react";
-import { ApiError } from "@/utils/api-client/client";
 
 export default function ErrorBoundary({
   error,
@@ -476,13 +468,14 @@ export default function ErrorBoundary({
   reset: () => void;
 }) {
   useEffect(() => {
-    // Log error to monitoring service
     console.error(error);
   }, [error]);
 
-  if (error instanceof ApiError) {
+  const apiStatus = "status" in error ? (error as Error & { status?: number }).status : undefined;
+
+  if (apiStatus) {
     // Handle API-specific errors from the Rhesis backend
-    if (error.status === 401) {
+    if (apiStatus === 401) {
       return (
         <div>
           <h2>Session expired</h2>
@@ -494,7 +487,7 @@ export default function ErrorBoundary({
       );
     }
 
-    if (error.status === 403) {
+    if (apiStatus === 403) {
       return (
         <div>
           <h2>Access denied</h2>

--- a/docs/content/contribute/frontend/index.mdx
+++ b/docs/content/contribute/frontend/index.mdx
@@ -352,24 +352,22 @@ export function middleware(request: NextRequest) {
 
 ### API Client
 
-Centralized API client with automatic error handling:
+Centralized API clients resolve the backend URL at runtime through `getBaseUrl()`:
 
 <CodeBlock language="typescript" filename="API Client Configuration">
-{`// API client configuration
-const apiClient = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
-  timeout: 10000,
-});
+{`import { getBaseUrl } from "@/utils/url-resolver";
 
-// Request interceptor for authentication
-apiClient.interceptors.request.use((config) => {
-  const token = getAuthToken();
-  if (token) {
-    config.headers.Authorization = \`Bearer \${token}\`;
+export class BaseApiClient {
+  protected baseUrl = getBaseUrl();
+
+  protected async fetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+    const response = await fetch(new URL(path, this.baseUrl), options);
+    return response.json() as Promise<T>;
   }
-  return config;
-});`}
+}`}
 </CodeBlock>
+
+Server-side `/api/*` requests are handled by Next.js Route Handlers and proxied to `BACKEND_URL` at request time. Avoid `next.config.mjs` rewrites for backend proxying because rewrite destinations are build-time artifacts.
 
 ### API Hooks
 
@@ -510,16 +508,19 @@ npm run build`}
 Key environment variables:
 
 <CodeBlock language="bash" filename=".env.local">
-{`# API Configuration
-NEXT_PUBLIC_API_URL=http://localhost:8080
+{`# Browser-visible API URL
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8080
+
+# Server-side proxy target
+BACKEND_URL=http://localhost:8080
+
+# Quick Start is replaced at container start from QUICK_START
+NEXT_PUBLIC_QUICK_START=false
 
 # Authentication
-NEXT_PUBLIC_AUTH_DOMAIN=your-auth-domain
-NEXT_PUBLIC_AUTH_CLIENT_ID=your-client-id
-
-# Feature Flags
-NEXT_PUBLIC_ENABLE_ANALYTICS=true
-NEXT_PUBLIC_ENABLE_BETA_FEATURES=false`}
+NEXTAUTH_URL=http://localhost:3000
+NEXTAUTH_SECRET=your-nextauth-secret
+AUTH_SECRET=your-nextauth-secret`}
 </CodeBlock>
 
 ## Testing

--- a/docs/content/contribute/polyphemus/index.mdx
+++ b/docs/content/contribute/polyphemus/index.mdx
@@ -12,6 +12,29 @@ It proxies generation requests to Vertex AI and exposes authenticated REST endpo
 - Request schemas: `apps/polyphemus/src/rhesis/polyphemus/schemas/schemas.py`
 - Docker image: API-only service image. PyTorch is not bundled in the Polyphemus
   container; model weights and serving runtime live behind Vertex AI.
+- Dependency shape: Polyphemus depends on backend core only. The SDK, Penelope,
+  Garak, and model-serving stacks live outside the runtime image.
+
+## Building the Docker image
+
+Build the Polyphemus image from the repository root. The Dockerfile depends on
+monorepo paths outside `apps/polyphemus`, so using `apps/polyphemus` as the build
+context will fail.
+
+<CodeBlock filename="terminal" language="bash">
+{`# From repository root
+docker build -t polyphemus:latest -f apps/polyphemus/Dockerfile .`}
+</CodeBlock>
+
+The image uses a two-stage build: the builder installs dependencies with
+`uv sync --no-dev`, and the runtime stage copies only the API service and
+required backend package files. The builder copies `uv` and `uvx` from
+`mirror.gcr.io/astral/uv:0.11.19` for reproducible and reliable Docker builds.
+
+<Callout type="info">
+  Keep the `uv` tag and registry mirror aligned with the Dockerfile when
+  upgrading service image builds.
+</Callout>
 
 ## API endpoints
 
@@ -24,6 +47,22 @@ Polyphemus exposes two primary generation endpoints:
 
 `/generate_batch` accepts up to `50` items per call (`MAX_BATCH_SIZE`).
 
+### Request fields
+
+Both endpoints use the same `GenerateRequest` shape. Batch requests wrap multiple `GenerateRequest` objects under `requests`.
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `messages` | `Message[]` | Required | Chat messages with `role` and `content` |
+| `model` | `string \| null` | `polyphemus-default` | Public alias resolved by the service |
+| `temperature` | `float \| null` | `0.7` | Values less than or equal to `0` are reset to `0.7` |
+| `max_tokens` | `int \| null` | Not sent | Passed to vLLM only when provided |
+| `top_p` | `float \| null` | `1.0` | Must be greater than `0` and less than or equal to `1` |
+| `top_k` | `int \| null` | Not sent | Negative values are ignored |
+| `json_schema` | `object \| null` | Not sent | Enables structured output and test-generation hardening |
+
+The service retries transient Vertex AI failures (`429`, `500`, `502`, `503`, `504`) up to three attempts with exponential backoff.
+
 ## Environment configuration
 
 Polyphemus reads Vertex AI target configuration from environment variables:
@@ -33,9 +72,27 @@ Polyphemus reads Vertex AI target configuration from environment variables:
 | `POLYPHEMUS_ENDPOINT_ID` | Yes | Vertex AI endpoint identifier |
 | `POLYPHEMUS_PROJECT_ID` | Yes | GCP project ID for endpoint invocation |
 | `POLYPHEMUS_LOCATION` | No | Vertex AI region (defaults to `us-central1`) |
+| `POLYPHEMUS_DEFAULT_MODEL` | For default alias | Internal Vertex/vLLM model backing the `polyphemus-default` alias |
+| `POLYPHEMUS_OPUS_MODEL` | For opus alias | Internal Vertex/vLLM model backing the `polyphemus-opus` alias |
+| `POLYPHEMUS_BATCH_CONCURRENCY` | No | Maximum concurrent Vertex calls per batch request (defaults to `10`) |
 | `VLLM_LOGGING_LEVEL` | No | vLLM container log verbosity for Vertex serving (for example, `DEBUG`, `INFO`) |
 
 If required variables are missing, the service returns HTTP `400` with configuration error details.
+
+### Authentication and rate limits
+
+Polyphemus accepts two Bearer-token formats:
+
+| Token type | Format | Typical caller |
+|---|---|---|
+| Rhesis API token | `rh-*` | SDK users, scripts, and notebooks |
+| Delegation JWT | JWT | Backend service-to-service calls |
+
+API tokens are validated through the backend token store and require an active, verified user. Delegation JWTs are validated by the Polyphemus delegation-token validator. Rate limiting uses the authenticated user identity when available.
+
+<Callout type="info">
+  Batch rate limiting counts the HTTP request, not every item inside `requests`.
+</Callout>
 
 ### Deployment region variable mapping (v0.2.8+)
 
@@ -67,6 +124,31 @@ If set, deployment injects `VLLM_LOGGING_LEVEL` into the serving container envir
   Polyphemus deployment separates the lightweight API container from the Vertex AI serving
   container. Configure vLLM logging on the Vertex deployment, not by installing PyTorch or model
   runtime dependencies into the Polyphemus API image.
+</Callout>
+
+## Request hardening and adversarial primer
+
+Polyphemus enforces adversarial behavior on the server side before forwarding a request to Vertex AI. This keeps SDK, platform, and direct API callers aligned even if they assemble messages differently.
+
+The hardening path is:
+
+1. The service validates that at least one non-system message has content.
+2. It resolves the public model alias (`polyphemus-default` or `polyphemus-opus`).
+3. It injects an adversarial primer into the system message if that primer is not already present.
+4. It builds the Vertex AI `rawPredict` request body.
+
+Structured-output requests and direct conversation requests are handled slightly differently:
+
+| Request shape | System-message handling | User-message handling |
+|---|---|---|
+| `json_schema` present | Primer is inserted after `/no_think` and before schema instructions | User content receives the adversarial attack prefix |
+| No `json_schema` | Conversational primer is prepended to the system message | User content is unchanged |
+| No system message | A new system message is inserted | Same behavior as above for the request shape |
+
+The injection is idempotent: if the primer text is already present, Polyphemus does not add it again.
+
+<Callout type="info">
+  Product callers do not need to add their own adversarial primer. Add domain-specific instructions in the normal system prompt and let the service enforce the shared hardening layer.
 </Callout>
 
 ## Batch request and response format
@@ -107,9 +189,12 @@ If set, deployment injects `VLLM_LOGGING_LEVEL` into the serving container envir
 </CodeBlock>
 
 <Callout type="info">
-  Rate limiting is applied through `check_rate_limit`. For batch calls, one HTTP request counts as one
-  rate-limit unit regardless of item count.
+  Batch execution is partially tolerant: one failed item does not fail the whole
+  HTTP request. The failed item returns an `error` field, and the service logs
+  the exception at error level with stack trace details for operators.
 </Callout>
+
+Batch concurrency is capped by `POLYPHEMUS_BATCH_CONCURRENCY` to avoid overwhelming the shared HTTP pool or Vertex quota. The default is `10`.
 
 ## Related pages
 

--- a/docs/content/contribute/worker/architecture.mdx
+++ b/docs/content/contribute/worker/architecture.mdx
@@ -50,7 +50,7 @@ Example import hierarchy:
 <CodeBlock language="python" filename="worker_task_example.py" isTerminal={false}>
 {`# In a worker task
 from rhesis.backend.app import models, crud    # Backend models and database operations
-from rhesis.backend.app.database import SessionLocal, set_tenant  # Backend database utilities
+from rhesis.backend.app.database import get_db_with_tenant_variables
 from rhesis.backend.tasks.base import BaseTask # Worker-specific task base class
 from rhesis.sdk import client                  # Shared SDK components`}
 </CodeBlock>
@@ -80,8 +80,11 @@ The worker requires the same environment variables as the backend, plus addition
 
 <CodeBlock language="bash" filename=".env" isTerminal={false}>
 {`# Backend variables also needed by worker
-DATABASE_URL=postgresql://user:password@host/dbname
-TENANT_ENABLED=true
+BACKEND_ENV=production
+DB_HOST=postgres.example.com
+DB_NAME=rhesis
+APP_DB_USER=rhesis_app
+APP_DB_PASS=...
 LOG_LEVEL=INFO
 
 # Worker-specific variables

--- a/docs/content/contribute/worker/background-tasks.mdx
+++ b/docs/content/contribute/worker/background-tasks.mdx
@@ -66,7 +66,7 @@ All tasks inherit from a `BaseTask` class that provides retry logic, error handl
 {`from celery import Task
 from contextlib import contextmanager
 
-from rhesis.backend.app.database import SessionLocal, set_tenant
+from rhesis.backend.app.database import get_db_with_tenant_variables
 
 class BaseTask(Task):
     """Base task class with retry settings and tenant context management."""
@@ -81,23 +81,13 @@ class BaseTask(Task):
     @contextmanager
     def get_db_session(self):
         """Get a database session with the proper tenant context."""
-        db = SessionLocal()
-        try:
-            # Start with a clean session
-            db.expire_all()
+        request = getattr(self, 'request', None)
+        org_id = getattr(request, 'organization_id', None) or ''
+        user_id = getattr(request, 'user_id', None) or ''
+        project_id = getattr(request, 'project_id', None) or ''
 
-            # Get task context
-            request = getattr(self, 'request', None)
-            org_id = getattr(request, 'organization_id', None)
-            user_id = getattr(request, 'user_id', None)
-
-            # Set tenant context if available
-            if org_id or user_id:
-                set_tenant(db, org_id, user_id)
-
+        with get_db_with_tenant_variables(org_id, user_id, project_id) as db:
             yield db
-        finally:
-            db.close()
 
     def apply_async(self, args=None, kwargs=None, **options):
         """Store org_id and user_id in task context when task is queued."""
@@ -161,10 +151,6 @@ def with_tenant_context(func):
 
         # Get a database session
         with self.get_db_session() as db:
-            # Set tenant for this session
-            if organization_id or user_id:
-                set_tenant(db, organization_id, user_id)
-
             # Add db to kwargs and execute the task function
             kwargs['db'] = db
             return func(self, *args, **kwargs)

--- a/docs/content/contribute/worker/trace-ingestion-pipeline.mdx
+++ b/docs/content/contribute/worker/trace-ingestion-pipeline.mdx
@@ -91,6 +91,7 @@ After linking, the pipeline dispatches an enrichment chain per unique trace ID. 
 def enrich_trace_async(self, trace_id, project_id, organization_id):
     db = SessionLocal()
     try:
+        bind_scope_to_session(db, organization_id, "", project_id)
         enricher = TraceEnricher(db)
         enriched_data = enricher.enrich_trace(trace_id, project_id, organization_id)
         # ...

--- a/docs/content/docs/behaviors/index.mdx
+++ b/docs/content/docs/behaviors/index.mdx
@@ -13,6 +13,27 @@ Rhesis uses a two-layer model: **behaviors** state what you expect; **metrics** 
 
 Tests are tagged with a behavior so results roll up by expectation. See [Tests](/docs/tests) and [Test Results](/docs/test-results).
 
+## Behavior tags
+
+Behavior tags are optional labels for organizing and filtering behavior records.
+Use them when multiple behaviors belong to the same feature area, risk theme, or
+team workflow.
+
+You can add tags while creating or editing a behavior. Start typing in the tags
+field, select an existing tag from suggestions, or press Enter to create a new
+tag value. Tags are organization-scoped and can be reused across behaviors.
+
+| Where | What tags do |
+| --- | --- |
+| Behavior grid | Filter behaviors by one or more tag chips |
+| Behavior cards | Show the tags attached to each behavior |
+| Behavior detail | Review and update tags alongside the behavior's metrics |
+
+<Callout type="info">
+  Behavior tags are different from test category and topic fields. Tags organize
+  behavior definitions; category and topic classify individual tests.
+</Callout>
+
 
 <div style={{ position: "relative", paddingBottom: "56.25%", height: 0, overflow: "hidden", marginBottom: "2rem" }}>
   <iframe

--- a/docs/content/docs/deployment/running-locally.mdx
+++ b/docs/content/docs/deployment/running-locally.mdx
@@ -57,7 +57,8 @@ cd rhesis
 
 # 4. (Optional) Enable test generation
 # Get your API key from https://app.rhesis.ai/
-# Edit .env.docker.local and update RHESIS_API_KEY=your-actual-key`}
+# ./rh start prompts for RHESIS_API_KEY when it is missing.
+# You can press Enter to skip and add it later.`}
 </CodeBlock>
 
 By default, `./rh start` uses **prebuilt container images** from GitHub Container Registry (GHCR), then starts the stack. Use `./rh start --build` when you need images built from the local Dockerfiles (for example, testing unreleased changes). `./rh restart --build` applies the same idea on restart.
@@ -67,6 +68,7 @@ The `./rh start` command automatically:
 - Generates a secure database encryption key
 - Creates `.env.docker.local` with all required configuration
 - Enables local authentication bypass (auto-login)
+- Prompts for `RHESIS_API_KEY` when it is missing or unset
 - Pulls (default) or builds (`--build`) images, then starts all services
 - Creates the database and runs migrations
 - Creates the default admin user (`Local Admin`)
@@ -152,8 +154,9 @@ By default, the system uses `rhesis/rhesis-default` as the AI model, which requi
 
 **Option 1: Use Rhesis API (Recommended)**
 
-1. Get your API key from https://app.rhesis.ai/
-2. Edit `.env.docker.local` and add:
+1. Get your API key from https://app.rhesis.ai/tokens
+2. Run `./rh start` in an interactive terminal and paste the key when prompted.
+3. If you skipped the prompt, edit `.env.docker.local` and add:
 
 <CodeBlock filename=".env.docker.local" language="bash">
 {`RHESIS_API_KEY=your-actual-rhesis-api-key-here`}

--- a/docs/content/docs/deployment/self-hosting.mdx
+++ b/docs/content/docs/deployment/self-hosting.mdx
@@ -187,6 +187,22 @@ The backend container startup process:
 3. Runs all pending migrations
 4. Starts the FastAPI application
 
+### Database roles for production
+
+Use separate database credentials for runtime traffic and migrations when your
+Postgres provider supports it:
+
+| Variable | Purpose |
+| --- | --- |
+| `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_DRIVER` | Shared database connection components |
+| `APP_DB_USER`, `APP_DB_PASS` | Runtime backend and worker database role |
+| `ADMIN_DB_USER`, `ADMIN_DB_PASS` | Migration or administrative database role |
+
+If `ADMIN_DB_*` is not set, migrations fall back to the app credentials for
+single-role setups. On managed Postgres, the admin role does not need to be a
+PostgreSQL superuser; RLS-aware migrations set the required tenant session
+variables during backfills.
+
 ## Environment Configuration
 
 ### Required Environment Variables
@@ -299,6 +315,48 @@ DEFAULT_EMBEDDING_MODEL=openai/text-embedding-3-small`}
 For embeddings, supported default provider prefixes are `rhesis`, `openai`, `gemini`, and `vertex_ai`. If you previously relied on an explicit deployment secret such as `DEFAULT_EMBEDDING_MODEL=vertex_ai/text-embedding-005`, that explicit value continues to override the new `rhesis/rhesis-embedding` code default.
 
 Supported language-model provider prefixes: `openai`, `gemini`, `azure`, `anthropic`, `groq`, `mistral`, `together_ai`, `perplexity`, `replicate`, `openrouter`, `cohere`, `ollama`.
+
+#### Object Storage for Files
+
+Rhesis stores uploaded file bytes in object storage. Metadata remains in Postgres, but file content, thumbnails, and execution attachments are read from the configured storage backend.
+
+Set `STORAGE_SERVICE_URI` in `.env.docker`:
+
+<CodeBlock filename=".env.docker" language="bash">
+{`# Local filesystem for single-host deployments or CI
+STORAGE_SERVICE_URI=file:///var/lib/rhesis/files
+
+# Google Cloud Storage
+# STORAGE_SERVICE_URI=gs://your-rhesis-files-bucket
+
+# S3-compatible object storage
+# STORAGE_SERVICE_URI=s3://your-rhesis-files-bucket`}
+</CodeBlock>
+
+| Backend | Example | Operational notes |
+|---|---|---|
+| Local filesystem | `file:///var/lib/rhesis/files` | Mount the same persistent volume into backend and worker containers |
+| Google Cloud Storage | `gs://bucket-name` | Grant the backend and worker identity object read/write permissions |
+| S3-compatible storage | `s3://bucket-name` | Provide credentials through the standard AWS environment variables |
+
+Downloads from `GET /files/{id}/content` and thumbnails from `GET /files/{id}/thumbnail` redirect to presigned URLs. Browsers and the SDK follow these redirects automatically; custom clients should allow redirects.
+
+<Callout type="info">
+  If you are upgrading from a pre-0.8.0 deployment, apply the storage-column
+  migration, deploy code that streams file bytes to object storage, and only
+  then apply the migration that drops the legacy database `content` column.
+</Callout>
+
+#### Enterprise Features
+
+Enterprise Edition features are discovered at runtime through `GET /features`. The endpoint returns license metadata and enabled feature names for the current organization. Frontend pages hide gated UI until the feature appears in that response.
+
+| Feature | Feature name | Related docs |
+|---|---|---|
+| Single Sign-On | `sso` | [Single Sign-On](/docs/organizations/sso) |
+| API Clients | `api_clients` | [API Clients](/docs/organizations/api-clients) |
+
+When the Enterprise package is not installed, Rhesis runs in Community mode and these features are unavailable.
 
 ## Telemetry & Privacy
 

--- a/docs/content/docs/endpoints/creating-endpoints.mdx
+++ b/docs/content/docs/endpoints/creating-endpoints.mdx
@@ -9,12 +9,12 @@ There are two ways to set up an endpoint:
 
 ## Manual Configuration
 
-The creation wizard has four tabs: **Overview**, **Headers**, **Mapping**, and **Connection Test**.
+The creation wizard has four tabs: **Overview**, **Connection**, **Mapping**, and **Test**.
 
 <Steps>
 ### Fill in the Overview
 
-Enter the endpoint **Name**, **URL**, **HTTP method**, **protocol** (REST or WebSocket), **project**, and **environment**.
+Enter the endpoint **Name**, **URL**, **HTTP method**, **protocol** (REST or WebSocket), and **environment**. When you create an endpoint from a project-scoped view, the active project is applied automatically.
 
 **Environment** tags the endpoint as Development, Staging, or Production — useful for keeping configurations separate and quickly identifying production-critical endpoints on the grid.
 
@@ -22,7 +22,7 @@ Enter the endpoint **Name**, **URL**, **HTTP method**, **protocol** (REST or Web
 
 ### Set up authentication
 
-In the **Headers** tab, set your API token and any custom request headers.
+In the **Connection** tab, set your API token, OAuth client credentials, and any custom request headers.
 
 The token is stored securely and available as `{{ auth_token }}` in your request template. If you set a token without an explicit `Authorization` header, Rhesis adds `Authorization: Bearer <token>` automatically.
 
@@ -57,11 +57,11 @@ For response variable details and extraction syntax, see [Response Mapping](/doc
 
 ### Verify with a connection test
 
-In the **Connection Test** tab, fire a live request to confirm everything works end-to-end before saving.
+In the **Test** tab, fire a live request to confirm everything works end-to-end before saving.
 
 Fill in the input variable rows on the left, then click **Run test**. You'll see the rendered request preview alongside the raw API response and the extracted mapped output.
 
-<img src="/screenshots/rhesis-ai-endpoint-create-connection-test.png" alt="Connection Test tab — request preview, input variables, and mapped output" className="screenshot" />
+<img src="/screenshots/rhesis-ai-endpoint-create-connection-test.png" alt="Test tab — request preview, input variables, and mapped output" className="screenshot" />
 
 ### Save
 
@@ -79,7 +79,7 @@ Auto-Configure generates your request and response mappings automatically. Use i
 <img src="/screenshots/rhesis-ai-endpoints-auto-configure.png" alt="Auto-configure Endpoint" className="screenshot" />
 
 <Steps>
-### Fill in the Overview and Headers tabs
+### Fill in the Overview and Connection tabs
 
 Provide the endpoint **Name**, **URL**, and **API Token** before running Auto-Configure.
 
@@ -148,7 +148,7 @@ Click **Show probe response** to see the raw JSON your endpoint returned — use
 
 ### Apply and verify
 
-Click **Apply to Endpoint** to populate the Mapping tab, then switch to **Connection Test** to verify end-to-end.
+Click **Apply to Endpoint** to populate the Mapping tab, then switch to **Test** to verify end-to-end.
 
 If only some fields were mapped, apply the partial result as a starting point and fill in the missing fields manually. Even partial results save significant time compared to configuring from scratch.
 </Steps>
@@ -159,7 +159,7 @@ If only some fields were mapped, apply the partial result as a starting point an
 
 **"Could not parse input"** — paste a working curl command with a real request body, or include both a request and response example.
 
-**"Mapping generated but unverified"** — the probe failed; use the **Connection Test** tab to debug manually. Common causes: API requires specific field values, rate limits block the probe, or the endpoint expects pre-existing state (e.g., a valid session).
+**"Mapping generated but unverified"** — the probe failed; use the **Test** tab to debug manually. Common causes: API requires specific field values, rate limits block the probe, or the endpoint expects pre-existing state (e.g., a valid session).
 
 **Partial results** — when only some fields were mapped, apply as a starting point and fill in the rest manually.
 
@@ -169,7 +169,7 @@ If only some fields were mapped, apply the partial result as a starting point an
 - Include **both request and response examples** when possible
 - Mention the **response structure** if your API returns nested JSON
 - Specify the **conversation pattern** for multi-turn endpoints (messages array or conversation IDs)
-- Always **verify in Connection Test** after applying, especially for low-confidence results
+- Always **verify in Test** after applying, especially for low-confidence results
 
 ### From the SDK
 

--- a/docs/content/docs/endpoints/index.mdx
+++ b/docs/content/docs/endpoints/index.mdx
@@ -103,7 +103,23 @@ When no experiment is associated with a test run, `params` is an empty object an
 }`}
 </CodeBlock>
 
-SDK connector endpoints can also receive parameters as keyword arguments or via `Parameters.get()` — see [Connector Injection](/docs/experiments/connector-injection).
+### How it works
+
+Parameter injection follows the same flow for both REST and SDK connector endpoints:
+
+1. When a test run is created, the experiment's parameter values are **resolved once** and stored as an immutable snapshot on the test run.
+2. During execution, the snapshot is injected into the Jinja2 template context as `params`.
+3. The template renderer evaluates `\{\{ params.model \}\}` (or any other parameter name) against the snapshot.
+
+This means every test in a run uses the exact same parameter values, and those values are recorded alongside the test results for full reproducibility.
+
+### REST vs. SDK connector
+
+Both endpoint types receive the same resolved parameters:
+
+- **REST endpoints** access parameters through `\{\{ params.* \}\}` in request mappings, as shown above. Your external API receives the rendered values in the HTTP request body.
+- **SDK connector endpoints** should access parameters through `\{\{ params.* \}\}` in `request_mapping`, or read the test-run snapshot through `Parameters.get()` from inside the function. The legacy `@endpoint(parameters=...)` kwarg-merging path is deprecated. See [Connector Injection](/docs/experiments/connector-injection) for details.
+
 
 ## Managing Endpoints
 
@@ -111,7 +127,12 @@ SDK connector endpoints can also receive parameters as keyword arguments or via 
 - **Duplicate** — Click **Duplicate** on the detail page to copy the full configuration. "(Copy)" is appended to the name. You can also bulk-duplicate from the grid.
 - **Delete** — Select one or more endpoints from the grid and click **Delete**. Historical test results are preserved.
 
-The detail page has four tabs: **Overview** (template + response mapping), **Headers** (auth token + custom headers), **Test** (interactive test-and-map workbench), and **Test Runs** (execution history).
+The detail page uses the same configuration structure as the creation wizard:
+**Overview** (name, URL, protocol, method, environment, and tracing toggle),
+**Connection** (auth token, OAuth client credentials, and custom headers),
+**Mapping** (request template and response mapping), and **Test**
+(interactive test-and-map workbench). Test execution history is available from
+the Test Runs pages and grids rather than an endpoint detail tab.
 
 <Callout type="default">
   **Next Steps**

--- a/docs/content/docs/endpoints/management.mdx
+++ b/docs/content/docs/endpoints/management.mdx
@@ -13,17 +13,20 @@ Click **Test** to send the request. A collapsible request preview shows the full
 After a successful response, the JSON tree is clickable. Click any key to map it to an output variable (`output`, `context`, `metadata`, etc.). The mapping is saved to the endpoint's response mapping automatically.
 
 <Callout type="info">
-  The response mapping you build here is the same one used during test runs. You can also edit it directly in the **Overview** tab.
+  The response mapping you build here is the same one used during test runs. You can also edit it directly in the **Mapping** tab.
 </Callout>
 
 ## Endpoint Detail Tabs
 
 | Tab | Description |
 |---|---|
-| **Overview** | Name, URL, protocol, method, request body template, and response mapping |
-| **Headers** | Authentication token and custom request headers |
+| **Overview** | Name, URL, protocol, method, environment, and tracing toggle |
+| **Connection** | Authentication token, OAuth client credentials, and custom request headers |
+| **Mapping** | Request body template and response mapping |
 | **Test** | Interactive test-and-map workbench |
-| **Test Runs** | History of test runs executed against this endpoint |
+
+Execution history is available from the [Test Runs](/docs/test-runs) pages and
+grids rather than an endpoint detail tab.
 
 ## Exploring an Endpoint Programmatically
 

--- a/docs/content/docs/endpoints/response-mapping.mdx
+++ b/docs/content/docs/endpoints/response-mapping.mdx
@@ -67,6 +67,37 @@ Each field is evaluated independently — you can mix JSONPath and Jinja2 in the
 
 Custom fields beyond these are passed through and stored but not actively used by the platform.
 
+## SDK endpoint return values
+
+For SDK connection-type endpoints, response mapping is applied only when the
+decorated function returns a dictionary. If the function returns a string, list,
+or another non-dictionary value, Rhesis skips the configured response mapping and
+wraps the value as `output`.
+
+<CodeBlock filename="sdk_endpoint_return.py" language="python">
+{`from rhesis.sdk import endpoint
+
+@endpoint()
+def search(input: str) -> list[str]:
+    return ["first match", "second match"]
+
+# Rhesis receives:
+# {"output": ["first match", "second match"]}`}
+</CodeBlock>
+
+Return a dictionary when you need response mapping to extract multiple fields:
+
+<CodeBlock filename="sdk_endpoint_mapped_return.py" language="python">
+{`from rhesis.sdk import endpoint
+
+@endpoint()
+def chat(input: str) -> dict:
+    return {
+        "message": "Hello",
+        "metadata": {"model": "demo"},
+    }`}
+</CodeBlock>
+
 ## Complete Example
 
 **Request headers:**

--- a/docs/content/docs/endpoints/sdk-endpoints.mdx
+++ b/docs/content/docs/endpoints/sdk-endpoints.mdx
@@ -52,12 +52,12 @@ client = RhesisClient(
 {`from rhesis.sdk import endpoint
 
 @endpoint()
-def chat(input: str, session_id: str = None) -> dict:
+def chat(input: str, conversation_id: str = None) -> dict:
     """Handle chat messages."""
     response = generate_response(input)
     return {
         "output": response,
-        "session_id": session_id or generate_session_id(),
+        "conversation_id": conversation_id or generate_conversation_id(),
     }`}
 </CodeBlock>
 
@@ -73,19 +73,19 @@ with connection type `SDK` and status `Active`.
 When your function uses standard field names, the SDK automatically maps them
 to platform variables. No manual mapping configuration is needed.
 
-**Standard request fields**: `input`, `session_id` (or `conversation_id`),
+**Standard request fields**: `input`, `conversation_id` (or legacy `session_id`),
 `context`, `metadata`, `tool_calls`
 
 **Standard response fields**: `output`, `context`, `metadata`, `tool_calls`,
-`session_id` (or `conversation_id`)
+`conversation_id` (or legacy `session_id`)
 
 <CodeBlock filename="auto_mapped.py" language="python">
 {`@endpoint()
-def chat(input: str, session_id: str = None) -> dict:
+def chat(input: str, conversation_id: str = None) -> dict:
     """Standard names are auto-detected."""
     return {
         "output": process_message(input),
-        "session_id": session_id,
+        "conversation_id": conversation_id,
     }`}
 </CodeBlock>
 
@@ -121,9 +121,9 @@ becomes its own endpoint:
 
 <CodeBlock filename="multi_function.py" language="python">
 {`@endpoint()
-def handle_chat(input: str, session_id: str = None) -> dict:
+def handle_chat(input: str, conversation_id: str = None) -> dict:
     """Process chat messages."""
-    return {"output": generate_response(input), "session_id": session_id}
+    return {"output": generate_response(input), "conversation_id": conversation_id}
 
 @endpoint()
 def search_documents(input: str) -> dict:
@@ -163,19 +163,33 @@ For full details on binding patterns, see
 
 ## Parameter-aware Endpoints
 
-When your project uses **[Parameters & Experiments](/docs/experiments/parameter-schema)**, the SDK connector automatically merges the resolved parameter snapshot into your function's keyword arguments if you specify the `parameters` list in the decorator:
+When your project uses **[Parameters & Experiments](/docs/experiments/parameter-schema)**, map resolved parameter values from `params` into your function arguments with `request_mapping`. This is the same `{{ params.* }}` path used by REST endpoints, so SDK and REST endpoints behave consistently during test runs.
 
-```python
+<CodeBlock filename="parameter_aware_endpoint.py" language="python">
+{`from rhesis.sdk import endpoint
+
 @endpoint(
     name="chat",
-    parameters=["model", "temperature", "system_prompt"]
+    request_mapping={
+        "input": "{{ input }}",
+        "model": "{{ params.model | default('gpt-4o') }}",
+        "temperature": "{{ params.temperature | default(0.7) }}",
+        "system_prompt": "{{ params.system_prompt | default('You are helpful.') }}",
+    },
+    response_mapping={"output": "$.answer"},
 )
 def chat(input: str, *, model: str, temperature: float, system_prompt: str) -> dict:
-    """The platform injects model, temperature, and system_prompt directly."""
-    return {"output": "..."}
-```
+    answer = run_chat(input, model=model, temperature=temperature, system_prompt=system_prompt)
+    return {"answer": answer}`}
+</CodeBlock>
 
-For more details on both kwarg-injection and context-resolved injection, see [Connector Injection](/docs/experiments/connector-injection).
+<Callout type="info">
+  The older `@endpoint(parameters=["model", "temperature"])` kwarg-merging
+  path is deprecated. It still works for existing applications, but new
+  endpoints should use `{{ params.* }}` in `request_mapping`.
+</Callout>
+
+For more details on request-mapping and context-resolved injection, see [Connector Injection](/docs/experiments/connector-injection).
 
 ## SDK vs. REST Endpoints
 

--- a/docs/content/docs/experiments/sdk-usage.mdx
+++ b/docs/content/docs/experiments/sdk-usage.mdx
@@ -98,9 +98,10 @@ You can provide a default value as the second argument: `params.get_number("temp
 The `Parameters.get()` method resolves values using a strict precedence order (first match wins):
 
 1. **Connector Contextvar:** Injected by the platform during a test run. This wins unconditionally so tests cannot accidentally hit the network for live configuration.
-2. **Environment Variables:** `RHESIS_PARAMETERS_PIN` or `RHESIS_PARAMETERS_ENVIRONMENT` (legacy: `RHESIS_PARAMETERS_LABEL`). Lets ops pin a deploy without code changes.
-3. **Explicit Kwargs:** `version` > `experiment_id` > `environment` > implicit `environment='default'`. Lets application code be explicit.
-4. **HTTP API Fetch:** If none of the above short-circuit the resolution, it fetches from the Rhesis API.
+2. **Explicit Kwargs:** `version` > `experiment_id` > `environment`. Lets application code be explicit.
+3. **Environment Variables:** `RHESIS_PARAMETERS_ENVIRONMENT` (legacy: `RHESIS_PARAMETERS_LABEL`). Lets ops choose an environment without code changes when no explicit kwargs are passed.
+4. **Implicit default:** If nothing else is provided, the SDK resolves the `default` environment.
+5. **HTTP API Fetch:** If none of the above short-circuit the resolution, it fetches from the Rhesis API.
 
 The order is "innermost wins" — overrides closer to the running call beat global settings.
 
@@ -117,10 +118,10 @@ You can manually invalidate the cache during testing using `Parameters.invalidat
 
 The SDK respects environment variables as a deployment primitive. 
 
-- `RHESIS_PARAMETERS_PIN=v3` pins the application to an immutable version regardless of environment movement. This acts as a production safety net or staged rollout mechanism.
 - `RHESIS_PARAMETERS_ENVIRONMENT=production` switches the application to a non-default environment without requiring code changes.
+- `RHESIS_PARAMETERS_LABEL=production` is accepted as a legacy alias for the same behavior.
 
-This gives operators a code-free escape hatch to manage configuration rollouts.
+For immutable pins, pass `version="v3"` explicitly in code or deployment configuration that calls `Parameters.get()`.
 
 ## Error handling & graceful degradation
 

--- a/docs/content/docs/getting-started/default-chatbot.mdx
+++ b/docs/content/docs/getting-started/default-chatbot.mdx
@@ -185,11 +185,35 @@ Retrieve conversation history for a specific session.
 
 Delete a conversation session and its history.
 
+### Session storage
+
+When `BROKER_URL` is configured, chatbot session history is stored in Redis DB
+`4` using keys prefixed with `chatbot:session:`. Each session is stored as a
+Redis list, and reads or writes refresh the session TTL.
+
+If `BROKER_URL` is not set, the chatbot uses an in-memory session store. That is
+useful for local development, but it is single-process only and does not survive
+process restarts.
+
+| Redis DB | Purpose |
+| --- | --- |
+| `0` | Celery broker |
+| `1` | Celery result backend |
+| `2` | Garak probe cache |
+| `3` | Conversation linking and trace metric debounce |
+| `4` | Chatbot sessions |
+| `5` | Permission cache |
+
+<Callout type="info">
+  Use Redis-backed sessions for multi-replica chatbot deployments so conversation
+  history is shared across workers.
+</Callout>
+
 ## Parameter Awareness
 
 The default chatbot is a parameter-aware endpoint. It uses **[Parameters & Experiments](/docs/experiments/parameter-schema)** to manage its system prompt, use case, model, temperature, and output mode.
 
-In the Streamlit UI, you will see an **Experiment Pill** indicating which experiment and version is currently live (and which label was used to fetch it). This allows you to explore the parameter management workflow immediately: simply create a new experiment in the project, promote it to the `default` label, and watch the chatbot pick up the new behavior after the next TTL cache refresh.
+In the Streamlit UI, you will see an **Experiment Pill** indicating which experiment and version is currently live (and which environment was used to fetch it). This allows you to explore the parameter management workflow immediately: simply create a new experiment in the project, promote it to the `default` environment, and watch the chatbot pick up the new behavior after the next TTL cache refresh.
 
 During test execution, Rhesis resolves the selected experiment once and exposes
 its values to the endpoint request mapping as `params`. The chatbot endpoint
@@ -201,7 +225,7 @@ receive a nested `parameters` object.
   "message": "{{ input }}",
   "session_id": "{{ session_id }}",
   "system_prompt": "{{ params.system_prompt | default(none) }}",
-  "use_case": "{{ params.use_case | default('insurance') }}",
+  "use_case": "{{ params.use_case | default('travel') }}",
   "model": "{{ params.model | default(none) }}",
   "temperature": "{{ params.temperature | default(0.7) }}",
   "max_tokens": "{{ params.max_tokens | default(1024) }}",

--- a/docs/content/docs/getting-started/index.mdx
+++ b/docs/content/docs/getting-started/index.mdx
@@ -135,6 +135,8 @@ Generate test sets interactively and run automated evaluations against your appl
 
 ## Need Help?
 
+- **In-app support drawer**: Click **Support** in the sidebar footer to open
+  links to the documentation site, support email, GitHub, and Discord.
 - **Documentation**: Browse the docs using the navigation menu
 - **GitHub Issues**: [Report bugs or request features](https://github.com/rhesis-ai/rhesis/issues)
 - **Community**: Join discussions and get support

--- a/docs/content/docs/getting-started/projects.mdx
+++ b/docs/content/docs/getting-started/projects.mdx
@@ -22,6 +22,29 @@ Organize and manage your testing projects with comprehensive project management 
 
 A project also owns a **[Parameter Schema](/docs/experiments/parameter-schema)**, which defines the typed configuration slots your application supports (like model selection, temperature, and system prompts). Within the project, users create and manage **[Experiments](/docs/experiments)** that bundle values for these slots.
 
+## Working in a Project
+
+Most Rhesis views are scoped to the active project. The frontend sends the active
+project as `X-Project-Id`, and backend queries use that project scope for
+endpoints, tests, test sets, test runs, traces, and related records.
+
+The sidebar shows the active project name with the organization name underneath.
+Open the organization menu and choose **Switch project** to select a different
+project from a searchable drawer.
+
+| Project switcher behavior | Details |
+| --- | --- |
+| Single project | Automatically selected |
+| Multiple projects | Choose from project memberships in the switcher drawer |
+| Persistence | Stored in a browser cookie and saved as your `default_project` setting |
+| Switching | Reloads the page so every view refetches with the new project scope |
+| No memberships | Shows **No project access** with create-project and refresh actions |
+
+<Callout type="info">
+  If a grid appears empty after switching workstreams, confirm the active project
+  in the sidebar before changing filters.
+</Callout>
+
 ## Creating a Project
 
 Create a project by clicking on **Project** in the Requirement section, then **Create Project**.

--- a/docs/content/docs/models/index.mdx
+++ b/docs/content/docs/models/index.mdx
@@ -51,19 +51,33 @@ Rhesis supports connections to major AI providers including:
 
 ## Connecting a Model Provider
 
-1. Click **"Add Model"** on the Models page
-2. Select a provider (e.g., Google Gemini, OpenAI, Anthropic)
-3. Fill in the required fields:
-   - **Connection Name**: Unique identifier for this connection
-   - **Model Name**: Specific model to use (e.g., "gemini-1.5-pro", "gpt-4-turbo")
-   - **API Key**: Your API key from the provider's dashboard
-4. (Optional) Configure additional settings:
-   - **Custom Headers**: Add HTTP headers required for your API calls
-   - **Default for Test Generation**: Use this model when generating test cases
-   - **Default for Evaluation**: Use this model for metrics evaluation
-   - **Default for Execution (Multi-Turn)**: Use this model for multi-turn test execution with Penelope
-5. Click **"Test Connection"** to verify your configuration
-6. Click **"Save"** to add the model
+Click **Add Model** to open the model connection drawer. The drawer has two
+steps:
+
+<Steps>
+### Select a provider
+
+Choose whether you are adding a language model or an embedder, then select the
+provider from the provider list. Providers display icons and badges so you can
+quickly distinguish hosted, cloud, and restricted-access options.
+
+### Connect to the provider
+
+Fill in the connection details and defaults:
+
+| Field | Purpose |
+| --- | --- |
+| **Connection Name** | Unique display name for this connection |
+| **Model Name** | Provider-specific model or deployment name, such as `gemini-1.5-pro` or `gpt-4-turbo` |
+| **API Key** | Provider API key, when required |
+| **Custom Headers** | Optional HTTP headers for gateways or proxies |
+| **Default for Test Generation** | Use this model when generating tests |
+| **Default for Evaluation** | Use this model for LLM-as-judge metrics |
+| **Default for Execution (Multi-Turn)** | Use this model for conversation simulation with Penelope |
+
+Click **Test Connection** before saving. Click **Connect** for a new provider
+connection or **Update** when editing an existing connection.
+</Steps>
 
 ## Provider-Specific Connection Fields
 

--- a/docs/content/docs/organizations/_meta.tsx
+++ b/docs/content/docs/organizations/_meta.tsx
@@ -1,7 +1,9 @@
 import type { MetaRecord } from 'nextra'
 
 const meta: MetaRecord = {
-  index: 'Organizations & Team',
+  index: 'Overview',
+  sso: 'Single Sign-On',
+  'api-clients': 'API Clients',
 }
 
 export default meta

--- a/docs/content/docs/organizations/api-clients.mdx
+++ b/docs/content/docs/organizations/api-clients.mdx
@@ -1,0 +1,118 @@
+import { CodeBlock } from '@/components/CodeBlock'
+
+# API Clients
+
+API Clients let external services exchange an organization-scoped OIDC access token for a Rhesis JWT using RFC 8693 token exchange. Use them for machine-to-machine integrations that should authenticate through your identity provider instead of a human API token.
+
+<Callout type="info">
+  API Clients are an Enterprise Edition feature and require SSO to be configured for the organization.
+</Callout>
+
+## How token exchange works
+
+1. An organization admin creates an API Client in Rhesis.
+2. Rhesis returns a plaintext `client_secret` exactly once.
+3. The external service obtains an OIDC access token from the organization's IdP.
+4. The service calls `POST /auth/token-exchange` with RFC 8693 form fields.
+5. Rhesis validates the subject token against the organization's SSO issuer and returns a Rhesis access token.
+
+The exchange audience binds the request to one organization:
+
+<CodeBlock filename="audience.txt" language="text">
+{`rhesis:org:acme`}
+</CodeBlock>
+
+The slug after `rhesis:org:` must match the organization's slug.
+
+## Create an API Client
+
+Create clients from the organization settings UI or with the API:
+
+<CodeBlock filename="create_api_client.sh" language="bash">
+{`curl -X POST "https://api.example.com/organizations/<org-id>/auth-clients" \
+  -H "Authorization: Bearer $RHESIS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "client_id": "warehouse-sync",
+    "name": "Warehouse Sync",
+    "expected_subject_azp": "warehouse-sync",
+    "expected_subject_audience": "account",
+    "allowed_scopes": ["read", "offline_access"],
+    "default_scope": "read"
+  }'`}
+</CodeBlock>
+
+Request fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `client_id` | Yes | Public identifier matching `^[a-z0-9][a-z0-9_-]{2,63}$` |
+| `name` | No | Human-readable label for the admin UI |
+| `expected_subject_azp` | Yes | Required `azp` claim on the subject token |
+| `expected_subject_audience` | Yes | Required `aud` claim on the subject token |
+| `allowed_scopes` | Yes | Supported values: `read`, `full`, `offline_access` |
+| `default_scope` | Yes | Single scope applied when token exchange omits `scope` |
+
+<Callout type="info">
+  The plaintext `client_secret` is returned only on create and rotate. Copy it immediately and store it in your secret manager.
+</Callout>
+
+## Exchange a token
+
+Call `POST /auth/token-exchange` with `application/x-www-form-urlencoded`. Client credentials can be sent with HTTP Basic authentication or in the form body, but not both.
+
+<CodeBlock filename="token_exchange.sh" language="bash">
+{`SUBJECT_TOKEN="<oidc-access-token-from-your-idp>"
+
+curl -X POST "https://api.example.com/auth/token-exchange" \
+  -u "warehouse-sync:$CLIENT_SECRET" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+  --data-urlencode "subject_token=$SUBJECT_TOKEN" \
+  --data-urlencode "subject_token_type=urn:ietf:params:oauth:token-type:access_token" \
+  --data-urlencode "audience=rhesis:org:acme" \
+  --data-urlencode "scope=read offline_access"`}
+</CodeBlock>
+
+Successful responses follow the OAuth token response shape:
+
+<CodeBlock filename="token_exchange_response.json" language="json">
+{`{
+  "access_token": "<rhesis-jwt>",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+  "token_type": "Bearer",
+  "expires_in": 900,
+  "scope": "read offline_access",
+  "refresh_token": "<refresh-token>",
+  "refresh_expires_in": 2592000
+}`}
+</CodeBlock>
+
+`refresh_token` is present only when the resolved scope includes `offline_access`.
+
+## Manage clients
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /organizations/{org_id}/auth-clients` | Create a client and return one-shot secret |
+| `GET /organizations/{org_id}/auth-clients` | List clients without secrets |
+| `GET /organizations/{org_id}/auth-clients/{id}` | Read one client without secret |
+| `POST /organizations/{org_id}/auth-clients/{id}/rotate` | Rotate secret and token epoch |
+| `POST /organizations/{org_id}/auth-clients/{id}/disable` | Disable a client |
+| `POST /organizations/{org_id}/auth-clients/{id}/enable` | Re-enable a client |
+| `DELETE /organizations/{org_id}/auth-clients/{id}` | Delete a disabled client |
+
+Rotating a client secret also advances the client's token epoch. Existing client-bound refresh chains stop working after rotation.
+
+## Common errors
+
+- `invalid_target`: audience is malformed, the organization slug does not exist, SSO is unavailable, or API Clients are not enabled.
+- `invalid_client`: client credentials are missing or invalid.
+- `invalid_grant`: the subject token is invalid, expired, replayed, or does not match the configured `azp` and audience.
+- `invalid_scope`: requested scopes are not allowed for the client.
+
+## Related pages
+
+- [Single Sign-On](/docs/organizations/sso)
+- [Integrations](/docs/integrations)
+- [Self-Hosting](/docs/deployment/self-hosting)

--- a/docs/content/docs/organizations/index.mdx
+++ b/docs/content/docs/organizations/index.mdx
@@ -8,9 +8,27 @@ Manage your organization's profile, settings, and team members.
 
 You can configure your organization's information and contact details in [Organization Settings](https://app.rhesis.ai/organizations/settings).
 
+## Organization menu and sidebar
 
+The sidebar brand block shows the active project and organization. Open it to
+access organization settings, team management, projects, and **Switch project**.
 
+The main sidebar is organized into product areas:
 
+| Section | Pages |
+| --- | --- |
+| Define | Knowledge, Behaviors, Metrics |
+| Generate | Playground, Explorer, Tests, Test Sets |
+| Improve | Insights, Test Runs, Experiments, Traces, Tasks |
+| CONNECT | Endpoints, Models, Tools, API |
+
+Metrics and Models are visible to all users. If your role does not include the
+required permission, the item appears locked instead of hidden.
+
+Enterprise installations can also enable:
+
+- [Single Sign-On](/docs/organizations/sso) for per-organization OIDC login
+- [API Clients](/docs/organizations/api-clients) for machine-to-machine token exchange
 
 ## Team Management
 
@@ -38,5 +56,6 @@ You'll immediately lose access and be signed out. A new invitation is required t
 
 <Callout type="default">
   **Next Steps** - Create [Projects](/docs/projects) to organize your
-  work - Configure [Integrations](/docs/integrations) for your workflow
+  work - Configure [Integrations](/docs/integrations) for your workflow -
+  Enable [Single Sign-On](/docs/organizations/sso) for enterprise identity
 </Callout>

--- a/docs/content/docs/organizations/sso.mdx
+++ b/docs/content/docs/organizations/sso.mdx
@@ -1,0 +1,94 @@
+import { CodeBlock } from '@/components/CodeBlock'
+
+# Single Sign-On
+
+Single Sign-On lets an Enterprise Edition organization authenticate users through its own OIDC provider. Use it when your organization needs centralized identity, domain-based access rules, and IdP-managed login policy.
+
+<Callout type="info">
+  SSO is an Enterprise Edition feature. Community installations return a feature-unavailable response and hide the SSO settings UI.
+</Callout>
+
+## How it works
+
+Rhesis stores SSO configuration per organization. When a user starts SSO login, Rhesis builds an OIDC authorization request with PKCE, validates the callback state, exchanges the code with your provider, and signs the user into the matching organization.
+
+The login URL uses the organization slug when one is configured:
+
+<CodeBlock filename="sso-login-url.txt" language="text">
+{`https://api.example.com/auth/sso/acme`}
+</CodeBlock>
+
+If the organization has no slug, the API can fall back to the organization ID, but API Clients require a slug for token-exchange audiences.
+
+## Configure an OIDC provider
+
+In your identity provider, create an OIDC client for Rhesis:
+
+| Setting | Value |
+|---|---|
+| Application type | Confidential OIDC client |
+| Redirect URI | `https://<your-rhesis-api>/auth/sso/callback` |
+| Grant type | Authorization Code with PKCE |
+| Scopes | `openid email profile` unless your deployment requires more |
+
+Then configure the organization in Rhesis with these values:
+
+| Field | Required | Description |
+|---|---|---|
+| `enabled` | Yes | Turns SSO login on or off |
+| `provider_type` | Yes | Currently `oidc` |
+| `issuer_url` | Yes | HTTPS issuer URL for OIDC discovery |
+| `client_id` | Yes | OIDC client ID |
+| `client_secret` | Yes on first setup | OIDC client secret, encrypted at rest |
+| `scopes` | No | Defaults to `openid email profile` |
+| `auto_provision_users` | No | Creates users on first valid SSO login |
+| `allowed_domains` | No | Restricts login to normalized email domains |
+| `allowed_auth_methods` | No | Optional list from `sso`, `email`, `google`, `github` |
+| `slug` | Recommended | Stable login slug used in SSO URLs and API Client audiences |
+
+## Admin API
+
+Organization admins can manage SSO through the organization settings UI or the API:
+
+<CodeBlock filename="configure_sso.sh" language="bash">
+{`curl -X PUT "https://api.example.com/organizations/<org-id>/sso" \
+  -H "Authorization: Bearer $RHESIS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": true,
+    "provider_type": "oidc",
+    "issuer_url": "https://idp.example.com/realms/acme",
+    "client_id": "rhesis",
+    "client_secret": "client-secret",
+    "scopes": "openid email profile",
+    "auto_provision_users": true,
+    "allowed_domains": ["acme.example"],
+    "allowed_auth_methods": ["sso", "email"],
+    "slug": "acme"
+  }'`}
+</CodeBlock>
+
+Useful endpoints:
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /organizations/{org_id}/sso` | Read masked configuration and login URL |
+| `PUT /organizations/{org_id}/sso` | Create or update configuration |
+| `DELETE /organizations/{org_id}/sso` | Remove configuration |
+| `POST /organizations/{org_id}/sso/test` | Test OIDC discovery |
+| `GET /auth/sso/{org_id_or_slug}` | Start SSO login |
+| `GET /auth/sso/callback` | OIDC callback |
+
+## Troubleshooting
+
+- `issuer_url` must use HTTPS in production and cannot point to private or cloud metadata addresses.
+- If you omit `client_secret` on an update, Rhesis preserves the existing encrypted secret.
+- `allowed_domains` values are lowercased and normalized without leading dots.
+- Slugs must be lowercase, 3-50 characters, alphanumeric or hyphenated, and cannot contain consecutive hyphens.
+- Failed login attempts redirect to the SSO error page without exposing provider details.
+
+## Related pages
+
+- [API Clients](/docs/organizations/api-clients)
+- [Organizations & Team](/docs/organizations)
+- [Self-Hosting](/docs/deployment/self-hosting)

--- a/docs/content/docs/test-runs/execution.mdx
+++ b/docs/content/docs/test-runs/execution.mdx
@@ -92,6 +92,27 @@ This is particularly useful when you want to:
 - **Compare evaluation criteria** by re-scoring the same outputs with different metric configurations
 - **Validate metric changes** by checking how updated metrics affect existing results
 
+## Preflight Checks
+
+Before execution, the run drawer can validate the selected endpoint, models, test
+sets, and metrics through `POST /preflight-checks`. Results stream back to the
+drawer while checks run, so you can retry, continue, or adjust configuration
+before starting the test run.
+
+| Check | When it runs | What it validates |
+| --- | --- | --- |
+| Endpoint Connectivity | Fresh-output runs | The selected endpoint can be reached before live execution |
+| Evaluation Model | All runs | An evaluation model is configured and usable |
+| Execution Model | Multi-turn runs | A Penelope execution model is configured and usable |
+| Test Set Has Tests | All runs | Each selected test set contains tests |
+| Behavior-Metric Coverage | All runs | Tests have behavior and metric coverage for scoring |
+| Metric Functionality | All runs | Selected metrics can run before the full execution starts |
+
+<Callout type="info">
+  Endpoint connectivity is skipped for **Reuse Outputs** runs because the endpoint
+  is not called in that mode.
+</Callout>
+
 ## Model Settings
 
 Override the default models used for evaluation and execution on a per-run basis.

--- a/docs/content/docs/test-runs/index.mdx
+++ b/docs/content/docs/test-runs/index.mdx
@@ -33,7 +33,7 @@ For multi-turn tests, the **Conversation** tab supports trace-driven debugging:
 
 ## Parameters Used
 
-When a test run targets a parameter experiment, it snapshots the experiment's resolved values at queue time. This guarantees that test runs remain reproducible even if the experiment or label changes later.
+When a test run targets a parameter experiment, it snapshots the experiment's resolved values at queue time. This guarantees that test runs remain reproducible even if the experiment or environment changes later.
 
 The Test Run detail page displays an **Experiment** card showing the experiment name, version (e.g., `v3`), the source environment (if any), and an expandable **Resolved Values** panel. (Values for `secret_ref` slots are masked so credentials never leak into the test run record.)
 

--- a/docs/content/docs/tests/adversarial-testing/polyphemus.mdx
+++ b/docs/content/docs/tests/adversarial-testing/polyphemus.mdx
@@ -18,6 +18,7 @@ Key properties:
 - Handles sensitive and policy-adjacent content for evaluation purposes
 - Maintains strong reasoning and language quality
 - Supports multi-turn conversations and structured output
+- Applies server-side adversarial request hardening so SDK, platform, and direct API calls follow the same generation policy
 
 ## Access
 
@@ -36,6 +37,12 @@ model = get_model("polyphemus")`}
 </CodeBlock>
 
 See [Using Polyphemus with the SDK](/adversarial-testing/sdk-usage) for full integration examples.
+
+<Callout type="info">
+  Polyphemus is not a drop-in raw model endpoint. The service adds an
+  adversarial primer before forwarding requests to the serving backend, and
+  structured-output generation receives additional adversarial instructions.
+</Callout>
 
 ## Environment Variables
 

--- a/docs/content/docs/tests/adversarial-testing/sdk-usage.mdx
+++ b/docs/content/docs/tests/adversarial-testing/sdk-usage.mdx
@@ -42,6 +42,7 @@ model = get_model("polyphemus")
 synthesizer = PromptSynthesizer(
     prompt="Generate adversarial tests for a medical advice chatbot",
     model=model,
+    harmful=True,
 )
 test_set = synthesizer.generate(num_tests=20)
 
@@ -63,6 +64,7 @@ synthesizer = Synthesizer(
     categories=["fraudulent claims", "policy disputes", "escalation attempts"],
     topics=["coverage denial", "claim manipulation", "social engineering"],
     model=model,
+    harmful=True,
 )
 test_set = synthesizer.generate(num_tests=30)`}
 </CodeBlock>
@@ -88,8 +90,23 @@ adversarial_model = get_model("polyphemus")
 adversarial_synthesizer = PromptSynthesizer(
     prompt="Generate adversarial tests targeting policy violations and edge cases",
     model=adversarial_model,
+    harmful=True,
 )
 adversarial_tests = adversarial_synthesizer.generate(num_tests=20)`}
+</CodeBlock>
+
+<Callout type="info">
+  `harmful=True` switches SDK synthesizer prompts to adversarial-only generation.
+  Polyphemus also injects a server-side adversarial primer, so direct
+  `model.generate()` calls can differ from raw model-serving responses.
+</Callout>
+
+## Notebook example
+
+The repository includes a runnable notebook for adversarial test generation:
+
+<CodeBlock filename="terminal" language="bash">
+{`jupyter notebook examples/polyphemus.ipynb`}
 </CodeBlock>
 
 ## Generating Text Directly

--- a/docs/content/docs/tests/index.mdx
+++ b/docs/content/docs/tests/index.mdx
@@ -56,6 +56,22 @@ Goal-based conversations that test your AI system across multiple turns. Powered
 
 Create tests manually or generate them automatically from behaviors and requirements. See [Generation](/docs/tests-generation) for automated test generation.
 
+### Manual Test Writer
+
+Use **Manual Test Writer** when you want to enter or paste multiple tests without
+running AI generation. It provides a spreadsheet-style workflow for single-turn
+and multi-turn test rows.
+
+| Test type | Fields |
+| --- | --- |
+| Single-turn | Prompt, category, topic, behavior, expected output, and optional file attachments |
+| Multi-turn | Goal, instructions, restrictions, scenario, min turns, max turns, category, topic, behavior, and optional file attachments |
+
+From the Tests page, choose manual creation, select the test type, add or remove
+rows, attach files when needed, then save the rows as tests or as a test set.
+Use the single-test drawer from the Tests page when you only need to create or
+edit one test.
+
 ## Running Tests
 
 Run individual tests from the [Tests page](https://app.rhesis.ai/tests) or execute multiple tests together using [Test Sets](/docs/test-sets).

--- a/docs/content/docs/tracing/index.mdx
+++ b/docs/content/docs/tracing/index.mdx
@@ -99,6 +99,10 @@ In this example:
 
 View all traces from your application in the Rhesis dashboard. Each row shows the operation name, linked endpoint, duration, span count, status, and environment.
 
+The dashboard shows traces for the active project. If the list looks empty or
+stale, use the organization menu to switch projects and reload the trace list
+under the correct project scope.
+
 ![Traces Dashboard](/screenshots/rhesis-ai-tracing-overview.png)
 
 ## Conversation Traces (v0.6.6+)

--- a/docs/content/sdk/agents.mdx
+++ b/docs/content/sdk/agents.mdx
@@ -47,6 +47,73 @@ print(result.final_answer)`}
 
 `MCPTool` reconnects on the next call when the underlying transport or session is lost. This makes it safe to reuse across repeated script or notebook calls that create new event loops. If the transport drops *during* a tool call, that call fails and the caller is responsible for retrying.
 
+## Connect to external MCP servers
+
+Use `MCPAgent` when your workflow needs tools from an external MCP server such
+as GitHub, Jira, Linear, Notion, or a custom stdio, HTTP, or SSE server. The
+public import path is `rhesis.sdk.agents.mcp`.
+
+<CodeBlock filename="external_mcp_agent.py" language="python">
+{`from rhesis.sdk.agents.mcp import MCPAgent, MCPClientFactory
+
+factory = MCPClientFactory.from_provider(
+    "github",
+    credentials={
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "ghp_...",
+    },
+)
+client = factory.create_client("github")
+
+agent = MCPAgent(
+    model="openai/gpt-4o-mini",
+    mcp_client=client,
+    max_iterations=8,
+)
+
+result = agent.run("List the open issues assigned to me and summarize the blockers.")
+print(result.final_answer)`}
+</CodeBlock>
+
+`MCPAgent` connects before each run and disconnects afterward. It raises
+MCP-specific exceptions for configuration, validation, application, and
+connection failures.
+
+| Class | Purpose |
+| --- | --- |
+| `MCPClient` | Low-level client for one MCP server using `stdio`, `http`, or `sse` transport |
+| `MCPClientFactory` | Builds clients from an `mcpServers` configuration or built-in provider template |
+| `MCPAgent` | ReAct agent that discovers and calls tools exposed by the MCP client |
+| `ToolExecutor` | Executes tool calls against the connected MCP server |
+
+For custom servers, pass a config dictionary with an `mcpServers` key:
+
+<CodeBlock filename="custom_mcp_server.py" language="python">
+{`from rhesis.sdk.agents.mcp import MCPAgent, MCPClientFactory
+
+factory = MCPClientFactory(
+    config_dict={
+        "mcpServers": {
+            "local-tools": {
+                "transport": "stdio",
+                "command": "python",
+                "args": ["./server.py"],
+                "env": {"LOG_LEVEL": "INFO"},
+            }
+        }
+    }
+)
+
+client = factory.create_client("local-tools")
+agent = MCPAgent(mcp_client=client)
+result = agent.run("Use the local tools to inspect today's queue.")
+print(result.final_answer)`}
+</CodeBlock>
+
+<Callout type="info">
+  If you imported MCP helpers from the old `rhesis.sdk.services.mcp` path, move
+  those imports to `rhesis.sdk.agents.mcp`.
+</Callout>
+
 ## Create a custom tool
 
 Subclass `BaseTool` when your agent needs SDK-side behavior that is not exposed by MCP.

--- a/docs/content/sdk/client.mdx
+++ b/docs/content/sdk/client.mdx
@@ -138,9 +138,9 @@ client = RhesisClient(
 )
 
 @endpoint()
-def chat(input: str, session_id: str = None) -> dict:
+def chat(input: str, conversation_id: str = None) -> dict:
     # Automatically traced and registered as endpoint
-    return {"output": process(input), "session_id": session_id}`}
+    return {"output": process(input), "conversation_id": conversation_id}`}
 </CodeBlock>
 
 ---

--- a/docs/content/sdk/connector/_meta.tsx
+++ b/docs/content/sdk/connector/_meta.tsx
@@ -3,6 +3,7 @@ import type { MetaRecord } from "nextra";
 const meta: MetaRecord = {
   index: "Overview",
   mapping: "Input/Output Mapping",
+  files: "File Attachments",
   serializers: "Advanced Mapping",
   binding: "Parameter Binding",
   examples: "Examples",

--- a/docs/content/sdk/connector/files.mdx
+++ b/docs/content/sdk/connector/files.mdx
@@ -1,0 +1,75 @@
+import { CodeBlock } from '@/components/CodeBlock'
+
+# File Attachments in SDK Connector Endpoints
+
+Rhesis passes file attachments through SDK connector executions as metadata-rich references instead of embedding raw bytes in the WebSocket payload. Use `FileReference` when your endpoint needs uploaded images, PDFs, audio, or other supported files during test execution.
+
+<Callout type="info">
+  Prefer `extracted_text` when it is enough for your use case. Fetch raw bytes only when your endpoint must inspect the original file.
+</Callout>
+
+## How files reach your function
+
+Add `files` to your endpoint's request mapping and type the function argument as a list of `FileReference` objects:
+
+<CodeBlock filename="endpoint_with_files.py" language="python">
+{`from rhesis.sdk import endpoint
+from rhesis.sdk.connector.types import FileReference
+
+@endpoint(
+    name="document-review",
+    request_mapping={
+        "question": "{{ input }}",
+        "files": "{{ files }}",
+    },
+    response_mapping={"output": "$.answer"},
+)
+def document_review(question: str, files: list[FileReference]) -> dict:
+    snippets = [f.extracted_text or f.filename for f in files]
+    answer = answer_question(question, snippets)
+    return {"answer": answer}`}
+</CodeBlock>
+
+## `FileReference` fields
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `str` | File identifier in Rhesis |
+| `filename` | `str` | Original filename |
+| `content_type` | `str` | MIME type such as `image/png` or `application/pdf` |
+| `size_bytes` | `int` | File size in bytes |
+| `content_hash` | `str` | SHA-256 digest of the file bytes |
+| `storage_path` | `str \| None` | Internal object-storage path when available |
+| `signed_url` | `str \| None` | Temporary URL for raw byte reads |
+| `extracted_text` | `str \| None` | Text or image description extracted at upload time |
+
+## Reading bytes on demand
+
+Most endpoints should use `extracted_text`. If you need the original bytes, call `read_bytes()` from synchronous code or `aread_bytes()` from async code.
+
+<CodeBlock filename="read_file_bytes.py" language="python">
+{`from rhesis.sdk.connector.types import FileReference
+
+def first_file_size(files: list[FileReference]) -> int:
+    if not files:
+        return 0
+    return len(files[0].read_bytes())`}
+</CodeBlock>
+
+<CodeBlock filename="read_file_bytes_async.py" language="python">
+{`import aiohttp
+
+from rhesis.sdk.connector.types import FileReference
+
+async def read_all(files: list[FileReference]) -> list[bytes]:
+    async with aiohttp.ClientSession() as session:
+        return [await file.aread_bytes(session=session) for file in files]`}
+</CodeBlock>
+
+`read_bytes()` and `aread_bytes()` require a populated `signed_url`. During platform-initiated test execution, the backend signs URLs before passing `FileReference` objects to SDK code that needs raw bytes.
+
+## Related pages
+
+- [Input/Output Mapping](/sdk/connector/mapping)
+- [Files entity reference](/sdk/entities/files)
+- [Multi-modal Testing](/docs/multimodal-testing)

--- a/docs/content/sdk/connector/index.mdx
+++ b/docs/content/sdk/connector/index.mdx
@@ -34,11 +34,11 @@ client = RhesisClient(
 {`from rhesis.sdk import endpoint
 
 @endpoint()
-def chat(input: str, session_id: str = None) -> dict:
+def chat(input: str, conversation_id: str = None) -> dict:
     """Handle chat messages."""
     return {
         "output": process_message(input),
-        "session_id": session_id or generate_session_id(),
+        "conversation_id": conversation_id or generate_conversation_id(),
     }`}
 
 </CodeBlock>
@@ -59,11 +59,11 @@ For a script that only defines endpoints and does not run a web server, call `cl
 client = RhesisClient.from_environment()
 
 @endpoint()
-def chat(input: str, session_id: str = None) -> dict:
+def chat(input: str, conversation_id: str = None) -> dict:
     """Handle chat messages."""
     return {
         "output": "Echo: " + input,
-        "session_id": session_id or "default-session",
+        "conversation_id": conversation_id or "default-conversation",
     }
 
 if __name__ == "__main__":
@@ -71,6 +71,51 @@ if __name__ == "__main__":
 </CodeBlock>
 
 If you already have a running event loop (e.g. in an async REPL or Jupyter), do not call `connect()`. Run the connector as a task in that loop instead.
+
+## Platform context with `EndpointContext`
+
+Most SDK endpoint functions only need business inputs such as `input`, `files`, or
+`conversation_id`. Backend-integrated endpoint functions can also declare an
+`EndpointContext` parameter when they need tenant-scoped platform access during
+execution.
+
+<CodeBlock filename="endpoint_context.py" language="python">
+{`from sqlalchemy import text
+
+from rhesis.sdk import EndpointContext, endpoint
+
+@endpoint()
+def enrich_with_project_data(input: str, ctx: EndpointContext) -> dict:
+    with ctx.get_db() as db:
+        # The session carries the organization, user, and project scope
+        # injected by the platform connector execution context.
+        scoped_count = db.execute(text("select 1")).scalar_one()
+
+    return {
+        "output": f"Scoped DB check {scoped_count}: {input}",
+    }`}
+</CodeBlock>
+
+`EndpointContext` is injected by type annotation. It is never accepted from
+remote inputs, so callers cannot forge `organization_id`, `user_id`, or
+`project_id` through the request payload. The context exposes:
+
+| Attribute or method | Description |
+| --- | --- |
+| `organization_id` | Organization associated with the connector execution |
+| `user_id` | User associated with the connector execution |
+| `project_id` | Active project for this execution, if available |
+| `get_db()` | Returns a context-managed database session scoped to the tenant |
+
+When the endpoint runs inside the Rhesis backend, `get_db()` uses the backend
+tenant-aware session factory. If you construct `EndpointContext` outside the
+backend process, pass `_db_factory` so `get_db()` can create a scoped session.
+
+<Callout type="info">
+  External SDK users are unaffected by this refactor unless they declare an
+  `EndpointContext` parameter. The connector WebSocket execution path is the
+  supported way to run SDK endpoints from the platform.
+</Callout>
 
 ## SDK-side metrics with `@metric` (v0.6.9+)
 
@@ -83,10 +128,10 @@ These metric functions are executed from the backend during evaluation.
 client = RhesisClient.from_environment()
 
 @endpoint()
-def chat(input: str, session_id: str | None = None) -> dict:
+def chat(input: str, conversation_id: str | None = None) -> dict:
     return {
         "output": f"Echo: {input}",
-        "session_id": session_id or "default-session",
+        "conversation_id": conversation_id or "default-conversation",
     }
 
 @metric(name="groundedness_check", score_type="binary")
@@ -246,7 +291,7 @@ Registered endpoints appear in the Rhesis dashboard:
 
 **Mapping problems**:
 
-- **Auto-mapping**: Use standard field names (`input`, `session_id`, `output`)
+- **Auto-mapping**: Use standard field names (`input`, `conversation_id`, `output`)
 - **Manual mapping**: Verify Jinja2/JSONPath syntax
 - **Custom fields**: Ensure custom request fields are included in API requests
 

--- a/docs/content/sdk/connector/mapping.mdx
+++ b/docs/content/sdk/connector/mapping.mdx
@@ -10,11 +10,11 @@ Use standard field names for automatic detection:
 
 <CodeBlock filename="auto_mapping.py" language="python">
 {`@endpoint()
-def chat(input: str, session_id: str = None) -> dict:
+def chat(input: str, conversation_id: str = None) -> dict:
     """Standard names auto-detect."""
     return {
         "output": process_message(input),
-        "session_id": session_id,
+        "conversation_id": conversation_id,
     }`}
 </CodeBlock>
 
@@ -23,15 +23,20 @@ def chat(input: str, session_id: str = None) -> dict:
 | Direction | Field | Description |
 |-----------|-------|-------------|
 | Request | `input` | The user query or test prompt |
-| Request | `session_id` | Conversation tracking identifier |
+| Request | `conversation_id` | Conversation tracking identifier |
 | Request | `context` | Additional context provided with the request |
 | Request | `metadata` | Structured metadata passed to the endpoint |
 | Request | `tool_calls` | Tool call data passed to the endpoint |
+| Request | `files` | File attachments passed as `FileReference` objects |
+| Request | `params` | Resolved experiment parameters available in request mappings |
 | Response | `output` | The main response text |
 | Response | `context` | Retrieval context (e.g., RAG sources) |
 | Response | `metadata` | Structured response metadata (e.g., confidence scores) |
 | Response | `tool_calls` | Tool/function calls made during response generation |
-| Response | `session_id` | Session identifier for conversation tracking |
+| Response | `conversation_id` | Conversation identifier for multi-turn tracking |
+
+`session_id` remains supported as a legacy alias for existing endpoints and
+mappings.
 
 ## Manual Mapping
 
@@ -41,11 +46,11 @@ For custom parameter names or complex structures, provide explicit mappings:
 {`@endpoint(
     request_mapping={
         "user_query": "{{ input }}",
-        "conv_id": "{{ session_id }}",
+        "conv_id": "{{ conversation_id }}",
     },
     response_mapping={
         "output": "$.result.text",
-        "session_id": "$.conv_id",
+        "conversation_id": "$.conv_id",
     },
 )
 def chat(user_query: str, conv_id: str = None) -> dict:
@@ -58,7 +63,7 @@ def chat(user_query: str, conv_id: str = None) -> dict:
 Request mapping transforms incoming Rhesis request fields to your function parameters.
 
 - Use Jinja2 template syntax: `{{ variable_name }}`
-- Maps standard Rhesis request fields (`input`, `session_id`, `context`, `metadata`, `tool_calls`) to your function parameters
+- Maps standard Rhesis request fields (`input`, `conversation_id`, `context`, `metadata`, `tool_calls`, `files`, `params`) to your function parameters
 - Custom fields from the request are passed through automatically
 - Example: `"user_message": "{{ input }}"` maps the Rhesis `input` field to your function's `user_message` parameter
 
@@ -68,7 +73,7 @@ Request mapping transforms incoming Rhesis request fields to your function param
 {`@endpoint(
     request_mapping={
         "user_message": "{{ input }}",
-        "conv_id": "{{ session_id }}",
+        "conv_id": "{{ conversation_id }}",
     }
 )
 def chat(user_message: str, conv_id: str = None) -> dict:
@@ -84,7 +89,7 @@ For functions that accept complex types (like Pydantic models), mapping keys sho
     request_mapping={
         "request": {
             "messages": [{"role": "user", "content": "{{ input }}"}],
-            "context": {"conversation_id": "{{ session_id }}"},
+            "context": {"conversation_id": "{{ conversation_id }}"},
         },
     }
 )
@@ -96,6 +101,53 @@ def agent(request: ChatAgentRequest) -> ChatAgentResponse:
 <Callout type="info">
   See [Advanced Mapping](./serializers) for how complex types like Pydantic models are automatically constructed from mapped dictionaries.
 </Callout>
+
+### Experiment parameters
+
+When a test run is associated with an experiment, resolved values are available under `params`. Prefer mapping those values into your function arguments instead of using the deprecated `parameters=` decorator option.
+
+<CodeBlock filename="params_mapping.py" language="python">
+{`@endpoint(
+    name="chat",
+    request_mapping={
+        "user_message": "{{ input }}",
+        "model": "{{ params.model | default('gpt-4o') }}",
+        "temperature": "{{ params.temperature | default(0.7) }}",
+    },
+    response_mapping={"output": "$.answer"},
+)
+def chat(user_message: str, *, model: str, temperature: float) -> dict:
+    answer = llm.invoke(user_message, model=model, temperature=temperature)
+    return {"answer": answer}`}
+</CodeBlock>
+
+<Callout type="info">
+  The legacy `@endpoint(parameters=["model", "temperature"])` path still works
+  for older applications, but it emits a deprecation warning. Use
+  `{{ params.* }}` in `request_mapping` for new endpoints.
+</Callout>
+
+### File attachments
+
+Use the `files` variable when your endpoint needs test attachments. Map it directly into a function argument and handle the items as `FileReference` objects.
+
+<CodeBlock filename="files_mapping.py" language="python">
+{`from rhesis.sdk.connector.types import FileReference
+
+@endpoint(
+    name="vision-check",
+    request_mapping={
+        "question": "{{ input }}",
+        "files": "{{ files }}",
+    },
+    response_mapping={"output": "$.answer"},
+)
+def vision_check(question: str, files: list[FileReference]) -> dict:
+    descriptions = [f.extracted_text or f.filename for f in files]
+    return {"answer": answer_with_context(question, descriptions)}`}
+</CodeBlock>
+
+See [Connector Files](/sdk/connector/files) for raw byte access and extraction details.
 
 ## Response Mapping (JSONPath or Jinja2)
 
@@ -109,7 +161,7 @@ Use JSONPath expressions (starting with `$`) for direct field extraction:
 {`@endpoint(
     response_mapping={
         "output": "$.choices[0].message.content",       # Nested extraction
-        "session_id": "$.conv_id",                      # Top-level field
+        "conversation_id": "$.conv_id",                 # Top-level field
         "context": "$.sources",                         # Array field
         "metadata": "$.usage",                          # Structured metadata
         "tool_calls": "$.choices[0].message.tool_calls",# Tool call data

--- a/docs/content/sdk/entities/endpoints.mdx
+++ b/docs/content/sdk/entities/endpoints.mdx
@@ -57,16 +57,19 @@ endpoint = Endpoints.pull(name="Customer Support Bot")
 response = endpoint.invoke(input="What are your business hours?")
 print(f"Response: {response['output']}")
 
-# Multi-turn with session
+# Multi-turn with a conversation ID
 response1 = endpoint.invoke(
     input="I need help with my order",
-    session_id="session-abc"
+    conversation_id="conversation-abc"
 )
 response2 = endpoint.invoke(
     input="It was order #12345",
-    session_id="session-abc"  # Same session for context
+    conversation_id=response1.get("conversation_id", "conversation-abc")
 )`}
 </CodeBlock>
+
+`conversation_id` is the preferred parameter for multi-turn invocations.
+`session_id` remains available as a deprecated alias for older scripts.
 
 ### Response Structure
 
@@ -75,7 +78,7 @@ The `invoke()` method returns a standardized response:
 <CodeBlock filename="response_structure.py" language="python">
 {`{
     "output": "Response text from the endpoint",
-    "session_id": "session-abc",
+    "conversation_id": "conversation-abc",
     "context": [...],       # Optional retrieval context (e.g. RAG sources)
     "metadata": {...},      # Optional structured metadata (e.g. confidence scores)
     "tool_calls": [...]     # Optional tool/function calls made by the endpoint
@@ -151,8 +154,8 @@ client = RhesisClient(
 )
 
 @endpoint()
-def my_chatbot(input: str, session_id: str = None) -> dict:
-    return {"output": process(input), "session_id": session_id}`}
+def my_chatbot(input: str, conversation_id: str = None) -> dict:
+    return {"output": process(input), "conversation_id": conversation_id}`}
 </CodeBlock>
 
 These endpoints can be fetched and used like any other:

--- a/docs/content/sdk/entities/experiments.mdx
+++ b/docs/content/sdk/entities/experiments.mdx
@@ -2,7 +2,7 @@ import { CodeBlock } from "@/components/CodeBlock";
 
 # Experiments
 
-An experiment is a named bundle of parameter values for a project. Each save creates an immutable version identified by a content hash.
+An experiment is a named bundle of parameter values for a project. Each save creates an immutable sequential version such as `v1`, `v2`, or `v3`.
 
 ## Properties
 
@@ -14,7 +14,7 @@ An experiment is a named bundle of parameter values for a project. Each save cre
 | `project_id` | `str` | Parent project ID |
 | `visibility` | `str` | `"private"` (default) or `"shared"` |
 | `versions_count` | `int` | Number of committed versions |
-| `latest_version` | `str` | Content hash of the most recent version |
+| `latest_version` | `str` | Sequential identifier of the most recent version |
 
 ## Creating experiments
 
@@ -39,7 +39,7 @@ Each commit creates an immutable version. Pass bare Python values -- the SDK wra
     {"model": "gpt-4o", "temperature": 0.9},
     message="bump temp",
 )
-print(f"Version: {version['version']}")  # v_a3f9b8...`}
+print(f"Version: {version['version']}")  # v3`}
 </CodeBlock>
 
 Chain versions using `parent_version`:
@@ -94,8 +94,8 @@ for v in exp.list_versions():
 latest = exp.latest_version_data()
 print(f"{latest['version']}: {latest['message']}")
 
-# Specific version by content hash
-v = exp.get_version("v_abc123")
+# Specific version by sequential identifier
+v = exp.get_version("v3")
 print(v["values"])`}
 </CodeBlock>
 
@@ -175,7 +175,7 @@ Deleting an experiment automatically unbinds any environments that point to it:
 | `commit(values, *, message, parent_version)` | `dict` | Append an immutable version |
 | `list_versions()` | `list[dict]` | All versions, oldest to newest |
 | `latest_version_data()` | `dict \| None` | Most recent version entry |
-| `get_version(version)` | `dict` | Single version by content hash |
+| `get_version(version)` | `dict` | Single version by sequential identifier |
 | `share()` | `None` | Set visibility to shared |
 | `unshare()` | `None` | Set visibility to private |
 | `promote(environment)` | `None` | Bind latest version to environment |

--- a/docs/content/sdk/entities/files.mdx
+++ b/docs/content/sdk/entities/files.mdx
@@ -4,7 +4,7 @@ import { CodeBlock } from '@/components/CodeBlock'
 
 Files are binary attachments (images, PDFs, audio) that can be associated with Tests and TestResults. They are managed through a dedicated upload API rather than the standard `push()` method.
 
-Note: As of version 0.8.0, file bytes are stored in object storage (GCS/S3) rather than Postgres. Downloads return a 302 redirect to a presigned URL; the SDK `File.download()` method follows the redirect transparently.
+Note: As of version 0.8.0, file bytes are stored in object storage (GCS/S3/local filesystem) rather than Postgres. Downloads return a 302 redirect to a presigned URL; the SDK `File.download()` method follows the redirect transparently.
 
 ## File
 
@@ -111,6 +111,44 @@ for f in files:
     path = f.download(directory="./downloads")
     print(f"Saved: {path}")`}
 </CodeBlock>
+
+For custom HTTP clients, follow redirects when calling `GET /files/{id}/content`. The API returns `ETag` headers, so clients can send `If-None-Match` on later reads to reuse cached content when the file has not changed.
+
+### Thumbnails
+
+Image-capable clients can request server-generated WebP thumbnails through the REST API:
+
+<CodeBlock filename="thumbnail.sh" language="bash">
+{`curl -L \
+  -H "Authorization: Bearer $RHESIS_API_KEY" \
+  "https://api.rhesis.ai/files/<file-id>/thumbnail?size=144" \
+  --output thumbnail.webp`}
+</CodeBlock>
+
+Supported thumbnail sizes are `72`, `144`, and `288` pixels. The endpoint also uses redirects and `ETag` caching.
+
+## File references during execution
+
+When a test with files runs against an SDK connector endpoint, the execution pipeline passes `FileReference` objects instead of raw bytes. Each reference includes metadata, pre-extracted text, and a signed URL for on-demand byte reads.
+
+<CodeBlock filename="connector_files.py" language="python">
+{`from rhesis.sdk import endpoint
+from rhesis.sdk.connector.types import FileReference
+
+@endpoint(
+    name="review-upload",
+    request_mapping={
+        "prompt": "{{ input }}",
+        "files": "{{ files }}",
+    },
+    response_mapping={"output": "$.answer"},
+)
+def review_upload(prompt: str, files: list[FileReference]) -> dict:
+    extracted = [file.extracted_text or "" for file in files]
+    return {"answer": answer_with_files(prompt, extracted)}`}
+</CodeBlock>
+
+See [Connector File Attachments](/sdk/connector/files) for raw byte reads with `read_bytes()` and `aread_bytes()`.
 
 ## Managing Files
 

--- a/docs/content/sdk/models.mdx
+++ b/docs/content/sdk/models.mdx
@@ -152,6 +152,37 @@ You can pass provider-specific keyword arguments through `generate(...)` or `a_g
 For example, streaming is exposed through `stream=True` on providers that support token streaming,
 and structured output is requested with the `schema` argument.
 
+### Multi-turn messages
+
+Pass a pre-built `messages` list to `a_generate(...)` when you already have
+conversation history. When `messages` is provided, `prompt` and `system_prompt`
+are ignored because the full chat payload is supplied by the caller.
+
+<CodeBlock filename="multi_turn_messages.py" language="python">
+{`import asyncio
+
+from rhesis.sdk.models import get_model
+
+model = get_model("openai/gpt-4o-mini")
+
+messages = [
+    {"role": "system", "content": "You are a concise support assistant."},
+    {"role": "user", "content": "Can I change my delivery address?"},
+    {"role": "assistant", "content": "Yes, before the package ships."},
+    {"role": "user", "content": "Where do I do that?"},
+]
+
+async def main():
+    response = await model.a_generate(messages=messages)
+    print(response)
+
+asyncio.run(main())`}
+</CodeBlock>
+
+Use either `messages` or `prompt` plus `system_prompt` for a single call. Keeping
+the two modes separate avoids accidentally dropping system instructions when a
+multi-turn history is already assembled.
+
 **Generate text using prompt only:**
 
 <CodeBlock filename="generate_text.py" language="python">

--- a/docs/content/sdk/parameters.mdx
+++ b/docs/content/sdk/parameters.mdx
@@ -96,13 +96,27 @@ for field in schema.fields:
 params = Parameters.get("My Project", environment="production")
 
 # By project UUID (no lookup needed)
-params = Parameters.get(project_id="550e8400-...", version="v_abc123")
+params = Parameters.get(project_id="550e8400-...", version="v3")
 
 # From a Project entity
 from rhesis.sdk.entities import Projects
 project = Projects.pull(name="My Project")
 params = project.parameters(experiment_id="exp-uuid")`}
 </CodeBlock>
+
+### Resolution order
+
+`Parameters.get()` resolves from the most specific pin to the broadest environment pointer. Use this order when you need predictable deployment behavior:
+
+| Source | How to request it | When to use it |
+|---|---|---|
+| Explicit version | `Parameters.get("My Project", version="v3")` | Immutable deploy pins and reproducing a past run |
+| Explicit experiment | `Parameters.get("My Project", experiment_id="exp-uuid")` | Latest version of one experiment |
+| Explicit environment | `Parameters.get("My Project", environment="production")` | Runtime routing through an environment pointer |
+| Environment variable | `RHESIS_PARAMETERS_ENVIRONMENT=production` | Code-free deployment routing when no explicit argument is passed |
+| Default environment | No `version`, `experiment_id`, or `environment` | The implicit `default` environment |
+
+The SDK also accepts the legacy `RHESIS_PARAMETERS_LABEL` environment variable as an alias for `RHESIS_PARAMETERS_ENVIRONMENT`.
 
 ### Accessing values
 
@@ -144,7 +158,7 @@ Every `ResolvedParameters` carries metadata about where the values came from:
 
 <CodeBlock filename="provenance.py" language="python">
 {`params.experiment_id   # UUID of the source experiment
-params.version         # content hash, e.g. "v_a3f9b8..."
+params.version         # sequential version, e.g. "v3"
 params.source          # "environment", "experiment_id", or "version"
 params.source_environment    # "default", "production", etc. (if resolved via environment)`}
 </CodeBlock>
@@ -163,6 +177,25 @@ Parameters.invalidate()                # all projects`}
 
 ## Managing environments
 
+Rhesis always recognizes the built-in environments exported by `BuiltInEnvironment`. Environment names are still free-form strings, but using the constants avoids typos in application code.
+
+| Constant | Value | Typical use |
+|---|---|---|
+| `BuiltInEnvironment.DEFAULT` | `default` | The implicit fallback used by `Parameters.get()` |
+| `BuiltInEnvironment.DEVELOPMENT` | `development` | Local or development deployments |
+| `BuiltInEnvironment.STAGING` | `staging` | Pre-production validation |
+| `BuiltInEnvironment.PRODUCTION` | `production` | Production traffic |
+
+<CodeBlock filename="builtin_environments.py" language="python">
+{`from rhesis.sdk import Parameters
+from rhesis.sdk.models.parameters import BuiltInEnvironment
+
+params = Parameters.get(
+    "My Project",
+    environment=BuiltInEnvironment.PRODUCTION,
+)`}
+</CodeBlock>
+
 <CodeBlock filename="environments.py" language="python">
 {`# Read current environment bindings
 envs = Parameters.environments("My Project")
@@ -173,9 +206,16 @@ for name, pointer in envs.environments.items():
 Parameters.put_environment(
     "My Project", "staging",
     experiment_id="exp-uuid",
-    version="v_abc123",
+    version="v3",
 )`}
 </CodeBlock>
+
+<Callout type="info">
+  Older SDK and API payloads may still contain `labels`, `source_label`, or
+  `parameter_source_label`. The v0.8.0 SDK normalizes those names to
+  environments on read. Use `environment` and `RHESIS_PARAMETERS_ENVIRONMENT` in
+  new code.
+</Callout>
 
 ## Experiments
 
@@ -258,7 +298,7 @@ result = test_set.execute(endpoint, experiment_id="exp-uuid")`}
 </CodeBlock>
 
 <Callout type="default">
-  When you pass only `experiment_id` without a `version`, the backend automatically resolves to the experiment's latest version. You don't need to look up the version hash yourself.
+  When you pass only `experiment_id` without a `version`, the backend automatically resolves to the experiment's latest version. You don't need to look up the version identifier yourself.
 </Callout>
 
 The resolved values are snapshotted at queue time. Moving an environment after the run is queued does not affect it.
@@ -316,6 +356,16 @@ def chat(query: str):
         temperature=params.temperature,
         prompt=query,
     )`}
+</CodeBlock>
+
+If you only need the current test-run snapshot and do not want fallback API resolution, use `get_parameters()`:
+
+<CodeBlock filename="current_snapshot.py" language="python">
+{`from rhesis.sdk import get_parameters
+
+params = get_parameters()
+if params is not None:
+    print(params.source, params.version)`}
 </CodeBlock>
 
 ---

--- a/docs/content/sdk/synthesizers.mdx
+++ b/docs/content/sdk/synthesizers.mdx
@@ -34,6 +34,26 @@ synthesizer = PromptSynthesizer(
 test_set = synthesizer.generate(num_tests=10)`}
 </CodeBlock>
 
+## Adversarial-only generation
+
+Set `harmful=True` when you want the synthesizer prompt to generate adversarial attack tests only. This removes the default harmless category mix and asks the model to focus on harmful, manipulative, or policy-violating inputs.
+
+<CodeBlock filename="harmful_generation.py" language="python">
+{`from rhesis.sdk.synthesizers import PromptSynthesizer
+
+synthesizer = PromptSynthesizer(
+    prompt="Generate attacks against a travel booking chatbot",
+    model="rhesis/polyphemus-default",
+    harmful=True,
+)
+
+test_set = synthesizer.generate(num_tests=20)`}
+</CodeBlock>
+
+<Callout type="info">
+  `OwaspSynthesizer` enables adversarial-only generation by default. For general-purpose synthesizers, pass `harmful=True` explicitly.
+</Callout>
+
 ## Available Synthesizers
 
 ### PromptSynthesizer
@@ -103,10 +123,65 @@ Bluetooth 5.2, and active noise cancellation with transparency mode.
 test_set = synthesizer.generate(num_tests=10, context=product_description)`}
 </CodeBlock>
 
+### OWASPSynthesizer
+
+Generate red-team tests aligned with the OWASP LLM Top 10. Use this when you want
+security-focused prompts tailored to the purpose of your application instead of a
+generic adversarial prompt list.
+
+<CodeBlock filename="owasp_synthesizer.py" language="python">
+{`from rhesis.sdk.synthesizers import OWASPSynthesizer
+
+synthesizer = OWASPSynthesizer(
+    purpose="Customer support chatbot for a bank with access to account data",
+    categories=["llm01", "llm02", "llm07"],  # Omit to cover all 10 categories
+    batch_size=10,
+    model="gemini/gemini-2.0-flash",
+)
+
+test_set = synthesizer.generate(num_tests=30)
+
+for test in test_set.tests:
+    print(test.prompt.content)
+    print(test.metadata["owasp_category"], test.metadata["owasp_name"])`}
+</CodeBlock>
+
+`OWASPSynthesizer` always creates harmful single-turn tests. The generator spreads
+`num_tests` as evenly as possible across the selected OWASP categories and tags
+each generated test with `metadata["owasp_category"]` and `metadata["owasp_name"]`.
+
+| Category ID | OWASP category | Rhesis behavior |
+| --- | --- | --- |
+| `llm01` | Prompt Injection | Robustness |
+| `llm02` | Sensitive Information Disclosure | Compliance |
+| `llm03` | Supply Chain Vulnerabilities | Reliability |
+| `llm04` | Data and Model Poisoning | Reliability |
+| `llm05` | Improper Output Handling | Compliance |
+| `llm06` | Excessive Agency | Robustness |
+| `llm07` | System Prompt Leakage | Compliance |
+| `llm08` | Vector and Embedding Weaknesses | Reliability |
+| `llm09` | Misinformation | Reliability |
+| `llm10` | Unbounded Consumption | Robustness |
+
+You can inspect the registry programmatically with `OWASP_LLM_TOP_10`:
+
+<CodeBlock filename="owasp_categories.py" language="python">
+{`from rhesis.sdk.synthesizers import OWASP_LLM_TOP_10
+
+for category_id, category in OWASP_LLM_TOP_10.items():
+    print(category_id, category.name, category.topic)`}
+</CodeBlock>
+
+<Callout type="info">
+  OWASP generation uses an LLM to create fresh attacks for each run. For high-risk
+  adversarial testing, pair these tests with a suitable generation model and review
+  outputs before running them against production systems.
+</Callout>
+
 
 ## Using Source Documents
 
-Synthesizers can extract content from documents to generate contextually relevant tests.
+Synthesizers can extract content from documents, websites, text snippets, and images to generate contextually relevant tests.
 
 <CodeBlock filename="with_sources.py" language="python">
 {`from rhesis.sdk.services.extractor import SourceSpecification, SourceType
@@ -123,6 +198,11 @@ sources = [
         name="Knowledge Base",
         metadata={"path": "./knowledge_base.pdf"},
     ),
+    SourceSpecification(
+        type=SourceType.IMAGE,
+        name="Product Screenshot",
+        metadata={"path": "./screenshot.png"},
+    ),
 ]
 
 synthesizer = PromptSynthesizer(
@@ -131,6 +211,40 @@ synthesizer = PromptSynthesizer(
 )
 test_set = synthesizer.generate(num_tests=50)`}
 </CodeBlock>
+
+### Image sources
+
+`SourceType.IMAGE` supports local image paths and image URLs. Without a vision-capable model, extraction falls back to metadata available through MarkItDown. Pass a model to enable vision-based image descriptions.
+
+<CodeBlock filename="image_sources.py" language="python">
+{`from rhesis.sdk.models.factory import get_language_model
+from rhesis.sdk.services.extractor import SourceSpecification, SourceType
+from rhesis.sdk.synthesizers import PromptSynthesizer
+
+vision_model = get_language_model("openai/gpt-4o")
+
+sources = [
+    SourceSpecification(
+        type=SourceType.IMAGE,
+        name="Checkout Screenshot",
+        metadata={"path": "./checkout.png"},
+    ),
+    SourceSpecification(
+        type=SourceType.IMAGE,
+        name="Remote Diagram",
+        metadata={"url": "https://example.com/flow.png"},
+    ),
+]
+
+synthesizer = PromptSynthesizer(
+    prompt="Generate UI validation tests from these images",
+    sources=sources,
+    model=vision_model,
+)
+test_set = synthesizer.generate(num_tests=12)`}
+</CodeBlock>
+
+For uploaded test attachments, the execution pipeline uses the shared `extract_with_vision_fallback` path: images go through image extraction first, documents use their text layer first, and image-heavy documents can fall back to a vision model when one is configured.
 
 ## Chunking strategies for source-based generation (v0.6.11)
 


### PR DESCRIPTION
## Purpose

Supersede three stale open documentation PRs (#1839, #1890, #2053) with a single, codebase-verified update. Each PR was generated against main but never merged; several had conflicts with each other and a handful of inaccuracies relative to the actual implementation.

## What Changed

**New files (3):**
- `docs/content/docs/organizations/api-clients.mdx` — RFC 8693 token exchange / API Clients (EE)
- `docs/content/docs/organizations/sso.mdx` — per-organization OIDC SSO setup and troubleshooting (EE)
- `docs/content/sdk/connector/files.mdx` — `FileReference` usage, byte-fetching, extracted-text guidance

**Updated (45 files) covering:**
- Changelog: v0.8.0 and v0.9.0 release blocks
- SDK: parameters precedence order, experiments (sequential version labels), files (`FileReference`), synthesizers (`OWASPSynthesizer`), connector (mapping, `conversation_id`, `files`/`params` variables), agents (MCP), models
- Backend contributor docs: ambient scope / multi-tenancy rewrite, authentication, background tasks, environment config, architecture
- Worker contributor docs: architecture, background tasks, trace ingestion
- Frontend contributor docs: `BaseApiClient`, runtime URL resolution, `/api/*` proxy
- Polyphemus contributor docs: adversarial primer injection, model aliases, batch semantics, Docker build
- Platform docs: behaviors (tags), getting started (projects, default chatbot), models drawer, endpoints (wizard tabs, response mapping, REST vs SDK), test runs (execution), tests, tracing, organizations, deployment (self-hosting)

## Accuracy corrections

| PR had | Actual codebase |
|---|---|
| `RHESIS_PARAMETERS_PIN` env var documented | Not in codebase — removed; only `RHESIS_PARAMETERS_ENVIRONMENT` / legacy `RHESIS_PARAMETERS_LABEL` exist |
| Experiment version IDs described as content hashes | SDK uses sequential labels `v1`, `v2`, `v3` |
| `client.ts` / `ApiClient` class | File is `base-client.ts` with `BaseApiClient` |
| `session_id` as primary connector field | `conversation_id` is primary; `session_id` is the deprecated alias |
| `docs/adversarial-testing/` path | Actual path is `docs/tests/adversarial-testing/` |
| `docs/endpoints/default-chatbot.mdx` path | Actual path is `docs/getting-started/default-chatbot.mdx` |

## Additional Context

- Supersedes #1839, #1890, #2053 (all three can be closed after this merges)
- Conflict resolutions: changelog kept most complete version; overlapping files (endpoints/index, organizations, connector/mapping, environment-variables) were merged to include all correct additions from each PR
- No source code changes — documentation only

## Testing

- All code examples verified against source
- No unescaped curly braces in MDX prose
- New directories already have `_meta.tsx` entries
- Internal links verified against existing pages