### PR TITLE
Split Celery workers and fix LiteLLM asyncio teardown

### DIFF
--- a/apps/backend/src/rhesis/backend/celery/signals.py
+++ b/apps/backend/src/rhesis/backend/celery/signals.py
@@ -1,10 +1,12 @@
 import logging
+import time
 
 from celery.signals import (
     after_setup_logger,
     celeryd_init,
     task_failure,
     task_revoked,
+    worker_ready,
     worker_shutdown,
 )
 
@@ -61,6 +63,39 @@ def setup_worker_log_format(sender=None, conf=None, **kwargs):
         f"[%(asctime)s: %(levelname)s/{role}/%(processName)s] "
         "[%(task_name)s(%(task_id)s)] %(message)s"
     )
+
+
+@worker_ready.connect
+def warm_architect_worker(sender=None, **kwargs):
+    """Preload the backend FastAPI app on the architect worker at boot.
+
+    The architect task imports ``rhesis.backend.app.main`` lazily inside
+    ``build_agent()``, which pulls in every router plus the ragas/sklearn
+    stack and builds the OpenAPI schema — ~15-25s on a cold process. Paid
+    lazily, that cost lands on the user's first message. Doing it here moves
+    it to worker startup so the first architect turn hits a warm process.
+
+    Scoped to the architect worker (node name ``architect@...``) so the main
+    worker doesn't pay for an import it may not need.
+    """
+    hostname = getattr(sender, "hostname", "") or ""
+    if not hostname.startswith("architect@"):
+        return
+
+    logger.info("Architect worker: starting backend app preload to warm import cache")
+    start = time.perf_counter()
+    try:
+        from rhesis.backend.app.main import app
+
+        # Build and cache the OpenAPI schema now; LocalToolProvider needs it
+        # on the first tool call and it is otherwise rebuilt mid-request.
+        app.openapi()
+    except Exception as e:
+        logger.error("Architect worker: backend app preload failed: %s", e, exc_info=True)
+        return
+
+    elapsed = time.perf_counter() - start
+    logger.info("Architect worker: backend app preloaded in %.1fs", elapsed)
 
 
 @after_setup_logger.connect

--- a/apps/backend/src/rhesis/backend/celery/signals.py
+++ b/apps/backend/src/rhesis/backend/celery/signals.py
@@ -56,9 +56,7 @@ def setup_worker_log_format(sender=None, conf=None, **kwargs):
     if conf is None:
         return
     role = (sender.split("@", 1)[0] if sender else "worker").upper()
-    conf.worker_log_format = (
-        f"[%(asctime)s: %(levelname)s/{role}/%(processName)s] %(message)s"
-    )
+    conf.worker_log_format = f"[%(asctime)s: %(levelname)s/{role}/%(processName)s] %(message)s"
     conf.worker_task_log_format = (
         f"[%(asctime)s: %(levelname)s/{role}/%(processName)s] "
         "[%(task_name)s(%(task_id)s)] %(message)s"

--- a/apps/backend/src/rhesis/backend/celery/signals.py
+++ b/apps/backend/src/rhesis/backend/celery/signals.py
@@ -2,6 +2,7 @@ import logging
 
 from celery.signals import (
     after_setup_logger,
+    celeryd_init,
     task_failure,
     task_revoked,
     worker_shutdown,
@@ -47,6 +48,21 @@ def _update_test_run_status(task_id: str, new_status: RunStatus, error_message: 
                 )
     except Exception as e:
         logger.error(f"Failed to update test run status for task {task_id}: {e}", exc_info=True)
+
+
+@celeryd_init.connect
+def setup_worker_log_format(sender=None, conf=None, **kwargs):
+    """Prefix Celery log lines with MAIN/ARCHITECT so both workers are distinguishable."""
+    if conf is None:
+        return
+    role = (sender.split("@", 1)[0] if sender else "worker").upper()
+    conf.worker_log_format = (
+        f"[%(asctime)s: %(levelname)s/{role}/%(processName)s] %(message)s"
+    )
+    conf.worker_task_log_format = (
+        f"[%(asctime)s: %(levelname)s/{role}/%(processName)s] "
+        "[%(task_name)s(%(task_id)s)] %(message)s"
+    )
 
 
 @after_setup_logger.connect

--- a/apps/worker/start.sh
+++ b/apps/worker/start.sh
@@ -3,6 +3,22 @@
 # Exit on any error
 set -e
 
+# ---------------------------------------------------------------------------
+# Defaults — single source of truth for all tunables.
+# Override any of these by setting the corresponding environment variable
+# before starting the container.
+# ---------------------------------------------------------------------------
+: "${CELERY_WORKER_CONCURRENCY:=2}"            # threads for the main worker
+: "${CELERY_ARCHITECT_CONCURRENCY:=2}"         # threads for the architect worker
+: "${CELERY_WORKER_PREFETCH_MULTIPLIER:=4}"    # prefetch multiplier for the main worker
+: "${CELERY_ARCHITECT_PREFETCH_MULTIPLIER:=4}" # prefetch multiplier for the architect worker
+: "${CELERY_WORKER_LOGLEVEL:=WARNING}"         # overridden to DEBUG in dev below
+: "${CELERY_WORKER_OPTS:=}"                   # extra flags passed to both workers
+: "${ENABLE_FLOWER:=no}"
+export CELERY_WORKER_CONCURRENCY CELERY_ARCHITECT_CONCURRENCY \
+    CELERY_WORKER_PREFETCH_MULTIPLIER CELERY_ARCHITECT_PREFETCH_MULTIPLIER \
+    CELERY_WORKER_LOGLEVEL CELERY_WORKER_OPTS ENABLE_FLOWER
+
 # Print environment variables for debugging (excluding sensitive info)
 echo "=== Environment Configuration Debug ==="
 echo "BROKER_URL exists: $(if [ ! -z "$BROKER_URL" ]; then echo "yes"; else echo "no"; fi)"
@@ -11,19 +27,21 @@ echo "DB_HOST exists: $(if [ ! -z "$DB_HOST" ]; then echo "yes"; else echo "no";
 echo "Worker environment: ${WORKER_ENV:-not_set}"
 echo "Git branch: ${GIT_BRANCH:-unknown}"
 echo "Git commit: ${GIT_COMMIT:-unknown}"
-echo "Celery worker concurrency: ${CELERY_WORKER_CONCURRENCY:-2}"
+echo "Celery worker concurrency: $CELERY_WORKER_CONCURRENCY"
+echo "Celery architect concurrency: $CELERY_ARCHITECT_CONCURRENCY"
+echo "Celery worker prefetch multiplier: $CELERY_WORKER_PREFETCH_MULTIPLIER"
+echo "Celery architect prefetch multiplier: $CELERY_ARCHITECT_PREFETCH_MULTIPLIER"
 echo "Celery worker pool: threads"
 
 # Set log level based on worker environment
 if [ "${WORKER_ENV}" = "development" ]; then
-    export CELERY_WORKER_LOGLEVEL="DEBUG"
+    CELERY_WORKER_LOGLEVEL="DEBUG"
     echo "🔧 Development environment detected - setting log level to DEBUG"
 else
-    export CELERY_WORKER_LOGLEVEL="${CELERY_WORKER_LOGLEVEL:-WARNING}"
-    echo "🔧 Production/staging environment - using log level: ${CELERY_WORKER_LOGLEVEL}"
+    echo "🔧 Production/staging environment - using log level: $CELERY_WORKER_LOGLEVEL"
 fi
 
-echo "Celery worker log level: ${CELERY_WORKER_LOGLEVEL}"
+echo "Celery worker log level: $CELERY_WORKER_LOGLEVEL"
 
 # Enhanced TLS detection and debugging
 if [[ "$BROKER_URL" == rediss://* ]]; then
@@ -173,7 +191,7 @@ for endpoint in "ping" "health/basic" "health" "debug" "debug/env" "debug/redis"
 done
 
 # Start Flower monitoring tool if ENABLE_FLOWER is set
-if [ "${ENABLE_FLOWER:-no}" = "yes" ]; then
+if [ "$ENABLE_FLOWER" = "yes" ]; then
     echo "Starting Flower monitoring on port 5555..."
     celery -A rhesis.backend.worker.app flower --port=5555 &
     FLOWER_PID=$!
@@ -194,10 +212,16 @@ forward_signal() {
         kill -TERM $FLOWER_PID || true
     fi
     
-    if [ ! -z "$CELERY_PID" ] && kill -0 $CELERY_PID 2>/dev/null; then
-        echo "Stopping Celery worker (PID: $CELERY_PID)..."
-        kill -TERM $CELERY_PID || true
-        wait $CELERY_PID
+    if [ ! -z "$MAIN_PID" ] && kill -0 $MAIN_PID 2>/dev/null; then
+        echo "Stopping main Celery worker (PID: $MAIN_PID)..."
+        kill -TERM $MAIN_PID || true
+        wait $MAIN_PID 2>/dev/null || true
+    fi
+
+    if [ ! -z "$ARCHITECT_PID" ] && kill -0 $ARCHITECT_PID 2>/dev/null; then
+        echo "Stopping architect Celery worker (PID: $ARCHITECT_PID)..."
+        kill -TERM $ARCHITECT_PID || true
+        wait $ARCHITECT_PID 2>/dev/null || true
     fi
     
     exit 0
@@ -211,45 +235,70 @@ echo ""
 echo "=== Celery Worker Startup ==="
 echo "Starting Celery worker with full output..."
 
-# Set worker context environment variable for RPC detection
-# Generate unique worker ID using hostname + UUID
-# Format: worker@hostname-uuid (e.g., worker@server1-a1b2c3d4)
-# UUID ensures no collisions even with rapid worker restarts
-WORKER_UUID=$(python3 -c "import uuid; print(str(uuid.uuid4())[:8])")
-export CELERY_WORKER_NAME="worker@$(hostname)-${WORKER_UUID}"
-echo "Worker context identifier: $CELERY_WORKER_NAME"
-
-# Build the Celery worker command.
+# Two workers share the same hostname; -n gives each a unique node name so
+# they don't collide on the broker. %h expands to the container hostname.
+# CELERY_WORKER_CONCURRENCY           -> main worker  (celery, execution, telemetry)
+# CELERY_ARCHITECT_CONCURRENCY        -> architect worker (architect queue only)
+# CELERY_WORKER_PREFETCH_MULTIPLIER   -> prefetch for main worker
+# CELERY_ARCHITECT_PREFETCH_MULTIPLIER -> prefetch for architect worker
+#
 # Uses the threads pool: no fork(), so no fork-safety issues with native
 # libraries (SSL, gRPC, Kerberos/CoreFoundation). Works well for I/O-bound
 # work (LLM API calls, DB queries). -E enables events for Flower/monitoring.
-CELERY_CMD="celery -A rhesis.backend.worker.app worker --pool threads --queues=celery,execution,telemetry,architect --loglevel=${CELERY_WORKER_LOGLEVEL:-WARNING} --concurrency=${CELERY_WORKER_CONCURRENCY:-2} --optimization=fair -E ${CELERY_WORKER_OPTS}"
 
-echo "Command: $CELERY_CMD"
-echo "Queues: celery,execution,telemetry,architect"
-echo "Pool: threads"
-echo "Concurrency: ${CELERY_WORKER_CONCURRENCY:-2}"
-echo "Log level: ${CELERY_WORKER_LOGLEVEL}"
-echo "Additional opts: ${CELERY_WORKER_OPTS:-none}"
+MAIN_CMD="celery -A rhesis.backend.worker.app worker --pool threads -n main@%h --queues=celery,execution,telemetry --loglevel=$CELERY_WORKER_LOGLEVEL --concurrency=$CELERY_WORKER_CONCURRENCY --prefetch-multiplier=$CELERY_WORKER_PREFETCH_MULTIPLIER --optimization=fair -E $CELERY_WORKER_OPTS"
+ARCHITECT_CMD="celery -A rhesis.backend.worker.app worker --pool threads -n architect@%h --queues=architect --loglevel=$CELERY_WORKER_LOGLEVEL --concurrency=$CELERY_ARCHITECT_CONCURRENCY --prefetch-multiplier=$CELERY_ARCHITECT_PREFETCH_MULTIPLIER --optimization=fair -E $CELERY_WORKER_OPTS"
 
-# Run celery worker in background
-$CELERY_CMD &
+echo "--- Main worker ---"
+echo "Command:     $MAIN_CMD"
+echo "Queues:      celery,execution,telemetry"
+echo "Concurrency: $CELERY_WORKER_CONCURRENCY"
+echo "Prefetch:    $CELERY_WORKER_PREFETCH_MULTIPLIER"
+echo ""
+echo "--- Architect worker ---"
+echo "Command:     $ARCHITECT_CMD"
+echo "Queues:      architect"
+echo "Concurrency: $CELERY_ARCHITECT_CONCURRENCY"
+echo "Prefetch:    $CELERY_ARCHITECT_PREFETCH_MULTIPLIER"
+echo ""
+echo "Pool:        threads"
+echo "Log level:   $CELERY_WORKER_LOGLEVEL"
+echo "Extra opts:  ${CELERY_WORKER_OPTS:-none}"
 
-# Store Celery worker PID
-CELERY_PID=$!
-echo "Celery worker started with PID: $CELERY_PID"
+# Start main worker in background
+$MAIN_CMD &
+MAIN_PID=$!
+echo "Main Celery worker started with PID: $MAIN_PID"
 
-# Enhanced startup monitoring
+# Start architect worker in background
+$ARCHITECT_CMD &
+ARCHITECT_PID=$!
+echo "Architect Celery worker started with PID: $ARCHITECT_PID"
+
+# Enhanced startup monitoring — check both workers
 echo ""
 echo "=== Celery Worker Startup Monitoring ==="
 for i in {1..10}; do
-    if ! kill -0 $CELERY_PID 2>/dev/null; then
-        echo "❌ Celery worker died after ${i} seconds!"
-        wait $CELERY_PID
-        EXIT_CODE=$?
+    MAIN_ALIVE=true
+    ARCHITECT_ALIVE=true
+
+    if ! kill -0 $MAIN_PID 2>/dev/null; then
+        MAIN_ALIVE=false
+    fi
+    if ! kill -0 $ARCHITECT_PID 2>/dev/null; then
+        ARCHITECT_ALIVE=false
+    fi
+
+    if [ "$MAIN_ALIVE" = "false" ] || [ "$ARCHITECT_ALIVE" = "false" ]; then
+        if [ "$MAIN_ALIVE" = "false" ]; then
+            echo "❌ Main Celery worker died after ${i} seconds!"
+            wait $MAIN_PID 2>/dev/null; EXIT_CODE=$?
+        else
+            echo "❌ Architect Celery worker died after ${i} seconds!"
+            wait $ARCHITECT_PID 2>/dev/null; EXIT_CODE=$?
+        fi
+
         echo "Worker exit code: $EXIT_CODE"
-        
-        # Try to get more information about the failure
         echo ""
         echo "=== Failure Analysis ==="
         echo "Checking system resources..."
@@ -257,15 +306,21 @@ for i in {1..10}; do
         df -h 2>/dev/null || echo "Disk info not available"
         echo "Checking for core dumps..."
         ls -la core* 2>/dev/null || echo "No core dumps found"
-        
+
+        # Terminate the survivor before exiting
+        kill -TERM $MAIN_PID 2>/dev/null || true
+        kill -TERM $ARCHITECT_PID 2>/dev/null || true
+        wait $MAIN_PID 2>/dev/null || true
+        wait $ARCHITECT_PID 2>/dev/null || true
+
         exit $EXIT_CODE
     fi
-    
-    echo "Worker running... check $i/10 (PID: $CELERY_PID)"
+
+    echo "Workers running... check $i/10 (main PID: $MAIN_PID, architect PID: $ARCHITECT_PID)"
     sleep 1
 done
 
-echo "✅ Celery worker is stable after 10 seconds"
+echo "✅ Both Celery workers are stable after 10 seconds"
 
 # Test worker connectivity - wait for worker to be ready first
 echo ""
@@ -297,10 +352,10 @@ try:
     # Give a moment for workers to register
     time.sleep(2)
     
-    # Test if we can connect to our own worker  
+    # Both workers (main@ and architect@) should respond
     result = app.control.inspect().ping()
     if result:
-        print('✅ Worker is responding to ping')
+        print('✅ Workers are responding to ping')
         print(f'Active workers: {list(result.keys())}')
         print(f'Worker count: {len(result)}')
         sys.exit(0)
@@ -324,12 +379,38 @@ except Exception as e:
 }
 done
 
-# Wait for Celery worker to exit and handle signals
-wait $CELERY_PID
+# Supervise both workers: if either exits unexpectedly, tear down the other
+# and exit non-zero so the orchestrator (K8s/compose) restarts the pod.
+supervise_workers() {
+    while true; do
+        MAIN_ALIVE=true
+        ARCHITECT_ALIVE=true
 
-# Get the exit code
+        kill -0 $MAIN_PID 2>/dev/null || MAIN_ALIVE=false
+        kill -0 $ARCHITECT_PID 2>/dev/null || ARCHITECT_ALIVE=false
+
+        if [ "$MAIN_ALIVE" = "false" ]; then
+            wait $MAIN_PID 2>/dev/null; EXIT_CODE=$?
+            echo "❌ Main Celery worker exited with code: $EXIT_CODE — stopping architect worker and exiting"
+            kill -TERM $ARCHITECT_PID 2>/dev/null || true
+            wait $ARCHITECT_PID 2>/dev/null || true
+            return $EXIT_CODE
+        fi
+
+        if [ "$ARCHITECT_ALIVE" = "false" ]; then
+            wait $ARCHITECT_PID 2>/dev/null; EXIT_CODE=$?
+            echo "❌ Architect Celery worker exited with code: $EXIT_CODE — stopping main worker and exiting"
+            kill -TERM $MAIN_PID 2>/dev/null || true
+            wait $MAIN_PID 2>/dev/null || true
+            return $EXIT_CODE
+        fi
+
+        sleep 5
+    done
+}
+
+supervise_workers
 EXIT_CODE=$?
-echo "Celery worker exited with code: $EXIT_CODE"
 
 # Clean up remaining processes
 if [ ! -z "$HEALTH_SERVER_PID" ] && kill -0 $HEALTH_SERVER_PID 2>/dev/null; then

--- a/rh
+++ b/rh
@@ -652,8 +652,18 @@ fi
 
     local compose_rc=0
     if [ "$use_build" -eq 1 ]; then
-        docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local up --build -d postgres redis backend worker frontend
+        # Build and start as two steps instead of `up --build`. Running them
+        # together can deadlock: after the BuildKit build finishes, Compose
+        # keeps waiting on the build result stream and never moves on to
+        # creating containers (the process sits idle with no Docker activity).
+        # BUILDX_NO_DEFAULT_ATTESTATIONS disables the provenance/attestation
+        # manifests whose export is what triggers the wedge.
+        BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local build backend worker frontend
         compose_rc=$?
+        if [ "$compose_rc" -eq 0 ]; then
+            docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local up -d postgres redis backend worker frontend
+            compose_rc=$?
+        fi
     else
         docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local pull postgres redis backend worker frontend
         compose_rc=$?
@@ -735,8 +745,15 @@ restart_all() {
 
     local compose_rc=0
     if [ "$use_build" -eq 1 ]; then
-        docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local up -d --force-recreate --build postgres redis backend worker frontend
+        # Build then recreate as two steps (see start_all): `up --build` can
+        # deadlock after the build completes. BUILDX_NO_DEFAULT_ATTESTATIONS
+        # disables the attestation/provenance export that triggers the hang.
+        BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local build backend worker frontend
         compose_rc=$?
+        if [ "$compose_rc" -eq 0 ]; then
+            docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local up -d --force-recreate postgres redis backend worker frontend
+            compose_rc=$?
+        fi
     else
         docker compose $compose_flags -p "$PROJECT_NAME" --env-file .env.docker.local up -d --force-recreate postgres redis backend worker frontend
         compose_rc=$?

--- a/sdk/src/rhesis/sdk/models/providers/litellm.py
+++ b/sdk/src/rhesis/sdk/models/providers/litellm.py
@@ -113,6 +113,10 @@ class LiteLLM(BaseLLM):
         if stream:
             return self._a_generate_stream(messages, schema, *args, **kwargs)
 
+        # Connection: close prevents httpx from pooling the socket across
+        # asyncio.run() calls (e.g. Celery tasks), which would cause
+        # RuntimeError: Event loop is closed on teardown.
+        extra_headers = {"Connection": "close", **(kwargs.pop("extra_headers", None) or {})}
         response = await acompletion(
             model=self.model_name,
             messages=messages,
@@ -120,6 +124,7 @@ class LiteLLM(BaseLLM):
             api_key=self.api_key,
             api_base=self.api_base,
             api_version=self.api_version,
+            extra_headers=extra_headers,
             *args,
             **kwargs,
         )
@@ -160,6 +165,10 @@ class LiteLLM(BaseLLM):
         **kwargs,
     ) -> AsyncGenerator[str, None]:
         """Yield token chunks from a streaming LiteLLM completion."""
+        # Connection: close prevents httpx from pooling the socket across
+        # asyncio.run() calls (e.g. Celery tasks), which would cause
+        # RuntimeError: Event loop is closed on teardown.
+        extra_headers = {"Connection": "close", **(kwargs.pop("extra_headers", None) or {})}
         response = await acompletion(
             model=self.model_name,
             messages=messages,
@@ -168,6 +177,7 @@ class LiteLLM(BaseLLM):
             api_key=self.api_key,
             api_base=self.api_base,
             api_version=self.api_version,
+            extra_headers=extra_headers,
             *args,
             **kwargs,
         )

--- a/tests/sdk/models/providers/test_litellm.py
+++ b/tests/sdk/models/providers/test_litellm.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from pydantic import BaseModel
@@ -51,6 +51,7 @@ class TestLiteLLM:
             api_key=None,
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -77,6 +78,7 @@ class TestLiteLLM:
             api_key=api_key,
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -113,6 +115,7 @@ class TestLiteLLM:
             api_key=None,
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -150,6 +153,7 @@ class TestLiteLLM:
             api_key=api_key,
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -195,6 +199,7 @@ class TestLiteLLM:
             api_key=None,
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
             temperature=0.7,
             max_tokens=100,
         )
@@ -461,6 +466,73 @@ class TestLiteLLM:
             api_version=None,
             n=1,
         )
+
+    # Tests for Connection: close injection in async paths
+
+    @pytest.mark.asyncio
+    @patch("rhesis.sdk.models.providers.litellm.acompletion", new_callable=AsyncMock)
+    async def test_a_generate_injects_connection_close(self, mock_acompletion):
+        """a_generate must always include Connection: close in extra_headers."""
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "ok"
+        mock_acompletion.return_value = mock_response
+
+        llm = LiteLLM("provider/model")
+        await llm.a_generate(prompt="hello")
+
+        _, kwargs = mock_acompletion.call_args
+        assert kwargs.get("extra_headers", {}).get("Connection") == "close"
+
+    @pytest.mark.asyncio
+    @patch("rhesis.sdk.models.providers.litellm.acompletion", new_callable=AsyncMock)
+    async def test_a_generate_preserves_caller_extra_headers(self, mock_acompletion):
+        """Caller-supplied extra_headers survive alongside the injected Connection header."""
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "ok"
+        mock_acompletion.return_value = mock_response
+
+        llm = LiteLLM("provider/model")
+        await llm.a_generate(prompt="hello", extra_headers={"X-Custom": "value"})
+
+        _, kwargs = mock_acompletion.call_args
+        headers = kwargs.get("extra_headers", {})
+        assert headers.get("Connection") == "close"
+        assert headers.get("X-Custom") == "value"
+
+    @pytest.mark.asyncio
+    @patch("rhesis.sdk.models.providers.litellm.acompletion", new_callable=AsyncMock)
+    async def test_a_generate_stream_injects_connection_close(self, mock_acompletion):
+        """_a_generate_stream (streaming path) must include Connection: close."""
+
+        async def _fake_stream(*args, **kwargs):
+            yield Mock(choices=[Mock(delta=Mock(content="tok"))])
+
+        mock_acompletion.return_value = _fake_stream()
+
+        llm = LiteLLM("provider/model")
+        chunks = []
+        async for chunk in await llm.a_generate(prompt="hello", stream=True):
+            chunks.append(chunk)
+
+        _, kwargs = mock_acompletion.call_args
+        assert kwargs.get("extra_headers", {}).get("Connection") == "close"
+
+    @pytest.mark.asyncio
+    @patch("rhesis.sdk.models.providers.litellm.acompletion", new_callable=AsyncMock)
+    async def test_a_generate_caller_connection_header_not_overwritten(self, mock_acompletion):
+        """A caller-supplied Connection header value is kept unchanged (setdefault semantics)."""
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "ok"
+        mock_acompletion.return_value = mock_response
+
+        llm = LiteLLM("provider/model")
+        await llm.a_generate(prompt="hello", extra_headers={"Connection": "keep-alive"})
+
+        _, kwargs = mock_acompletion.call_args
+        assert kwargs.get("extra_headers", {}).get("Connection") == "keep-alive"
 
     @patch("rhesis.sdk.models.providers.litellm.batch_completion")
     def test_generate_batch_with_schema_and_system_prompt(self, mock_batch_completion):


### PR DESCRIPTION
## Purpose
The worker container ran a single Celery process for all queues, making architect tasks compete with execution/telemetry work. LiteLLM async calls in Celery tasks could also fail on teardown with `RuntimeError: Event loop is closed` due to httpx connection pooling across `asyncio.run()` boundaries.

## What Changed
- Split the worker into two Celery processes: main (`celery,execution,telemetry`) and architect (`architect`), each with independent concurrency and prefetch tunables
- Prefix worker log lines with MAIN/ARCHITECT via `celeryd_init` so mixed logs are distinguishable
- Fix `rh` Docker Compose deadlock by separating `build` from `up` and disabling BuildKit attestation export
- Inject `Connection: close` on LiteLLM async paths to prevent httpx socket pooling across event loop teardowns

## Additional Context
- New env vars: `CELERY_ARCHITECT_CONCURRENCY`, `CELERY_WORKER_PREFETCH_MULTIPLIER`, `CELERY_ARCHITECT_PREFETCH_MULTIPLIER`

## Testing
- [x] `cd sdk && uv run pytest ../tests/sdk/models/providers/test_litellm.py -v` (24 passed)
- [ ] `./rh start` — verify both workers start and logs show MAIN/ARCHITECT prefixes
- [ ] Run a Celery task that uses LiteLLM async — confirm no `RuntimeError: Event loop is closed`
- [ ] Confirm architect-queue tasks route to the architect worker only