### PR TITLE
Migrate grids and contexts to React Query

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -12,9 +12,8 @@ import { Box, Typography, useTheme, Alert } from '@mui/material';
 import GridBadge from '@/components/common/GridBadge';
 import GridToolbar from '@/components/common/GridToolbar';
 import {
-  GridColDef,
-  GridPaginationModel,
   GridFilterModel,
+  GridColDef,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
@@ -38,6 +37,10 @@ import {
   rowActionsHoverSx,
 } from '@/components/common/createRowActionsColumn';
 import { getProjectIcon } from './endpoint-icon-utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { endpointKeys } from '@/constants/query-keys';
+import { useGridState } from '@/hooks/useGridState';
+import { useGridQuery } from '@/hooks/useGridQuery';
 
 interface EndpointsGridProps {
   sessionToken?: string;
@@ -108,153 +111,126 @@ export default function EndpointsGrid({
   const router = useRouter();
   const { data: session } = useSession();
   const notifications = useNotifications();
+  const queryClient = useQueryClient();
 
   const sessionToken = sessionTokenProp || session?.session_token || '';
 
   const [searchQuery, setSearchQuery] = useState('');
-  const [endpoints, setEndpoints] = useState<Endpoint[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [totalCount, setTotalCount] = useState(0);
-  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
-    page: 0,
-    pageSize: 10,
-  });
-  const [filterModel, setFilterModel] = useState<GridFilterModel>({
-    items: [],
-  });
+  const [drawerFilters, setDrawerFilters] = useState<EndpointFilters>(
+    EMPTY_ENDPOINT_FILTERS
+  );
   const [projects, setProjects] = useState<Record<string, Project>>({});
   const [loadingProjects, setLoadingProjects] = useState(true);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [drawerFilters, setDrawerFilters] = useState<EndpointFilters>(
-    EMPTY_ENDPOINT_FILTERS
-  );
 
-  const fetchEndpoints = useCallback(async () => {
-    if (!sessionToken) return;
+  const {
+    filterModel,
+    paginationModel,
+    setPaginationModel,
+    handlePaginationModelChange,
+    handleFilterModelChange,
+  } = useGridState({
+    searchQuery,
+    applyDrawerFilters: useCallback(
+      (prev: GridFilterModel) => {
+        const otherItems = prev.items.filter(
+          item =>
+            !DRAWER_FILTER_FIELDS.includes(
+              item.field as (typeof DRAWER_FILTER_FIELDS)[number]
+            )
+        );
+        const drawerItems: typeof prev.items = [];
 
-    try {
-      setLoading(true);
-      const filterString = buildEndpointListFilter(filterModel, projectId);
-      const apiFactory = new ApiClientFactory(sessionToken);
-      const endpointsClient = apiFactory.getEndpointsClient();
-      const response = await endpointsClient.getEndpoints({
+        if (drawerFilters.connectionType) {
+          drawerItems.push({
+            field: 'connectionType',
+            operator: 'equals',
+            value: drawerFilters.connectionType,
+          });
+        }
+        if (drawerFilters.environment) {
+          drawerItems.push({
+            field: 'environment',
+            operator: 'equals',
+            value: drawerFilters.environment,
+          });
+        }
+        if (drawerFilters.status) {
+          drawerItems.push({
+            field: 'status',
+            operator: 'equals',
+            value: drawerFilters.status,
+          });
+        }
+
+        const newItems = [...otherItems, ...drawerItems];
+        if (
+          newItems.length === prev.items.length &&
+          newItems.every((it, i) => it === prev.items[i])
+        )
+          return prev;
+        return { ...prev, items: newItems };
+      },
+      [drawerFilters]
+    ),
+  });
+
+  const filterString = buildEndpointListFilter(filterModel, projectId);
+  const sort_by = 'created_at';
+  const sort_order = 'desc';
+
+  const {
+    data: endpointsData,
+    isLoading: loading,
+    error: fetchError,
+  } = useGridQuery({
+    queryKey: endpointKeys.list(
+      filterString,
+      paginationModel.page,
+      paginationModel.pageSize,
+      sort_by,
+      sort_order
+    ),
+    queryFn: () => {
+      const client = new ApiClientFactory(sessionToken).getEndpointsClient();
+      return client.getEndpoints({
         skip: paginationModel.page * paginationModel.pageSize,
         limit: paginationModel.pageSize,
-        sort_by: 'created_at',
-        sort_order: 'desc',
+        sort_by,
+        sort_order,
         ...(filterString && { $filter: filterString }),
       });
+    },
+    enabled: !!sessionToken,
+  });
 
-      setEndpoints(response.data);
-      setTotalCount(response.pagination.totalCount);
-      const filtersActive =
-        filterModel.items.length > 0 ||
-        !!searchQuery.trim() ||
-        hasActiveEndpointFilters(drawerFilters);
-      if (!filtersActive) onTotalCountChange?.(response.pagination.totalCount);
-      setError(null);
-    } catch {
-      const filtersActive =
-        filterModel.items.length > 0 ||
-        !!searchQuery.trim() ||
-        hasActiveEndpointFilters(drawerFilters);
-      setEndpoints([]);
-      setTotalCount(0);
-      if (filtersActive) {
-        setError(null);
-      } else {
-        setError('Failed to load endpoints');
-      }
-    } finally {
-      setLoading(false);
-    }
+  const endpoints = endpointsData?.data ?? [];
+  const totalCount = endpointsData?.pagination.totalCount ?? 0;
+  const error = fetchError ? 'Failed to load endpoints' : null;
+
+  useEffect(() => {
+    if (!endpointsData) return;
+    const filtersActive =
+      filterModel.items.length > 0 ||
+      !!searchQuery ||
+      hasActiveEndpointFilters(drawerFilters);
+    if (!filtersActive) onTotalCountChange?.(totalCount);
   }, [
-    sessionToken,
-    paginationModel,
-    filterModel,
-    projectId,
-    drawerFilters,
+    endpointsData,
+    filterModel.items.length,
     searchQuery,
+    drawerFilters,
+    onTotalCountChange,
+    totalCount,
   ]);
 
   useEffect(() => {
-    fetchEndpoints();
-  }, [fetchEndpoints]);
-
-  useEffect(() => {
-    if (refreshKey !== undefined && refreshKey > 0) {
-      fetchEndpoints();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshKey]);
-
-  useEffect(() => {
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => item.field !== 'quickFilter'
-      );
-      const items = searchQuery
-        ? [
-            ...otherItems,
-            { field: 'quickFilter', operator: 'contains', value: searchQuery },
-          ]
-        : otherItems;
-      if (
-        items.length === prev.items.length &&
-        items.every((it, i) => it === prev.items[i])
-      )
-        return prev;
-      return { ...prev, items };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [searchQuery]);
-
-  useEffect(() => {
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item =>
-          !DRAWER_FILTER_FIELDS.includes(
-            item.field as (typeof DRAWER_FILTER_FIELDS)[number]
-          )
-      );
-      const drawerItems: typeof prev.items = [];
-
-      if (drawerFilters.connectionType) {
-        drawerItems.push({
-          field: 'connectionType',
-          operator: 'equals',
-          value: drawerFilters.connectionType,
-        });
-      }
-      if (drawerFilters.environment) {
-        drawerItems.push({
-          field: 'environment',
-          operator: 'equals',
-          value: drawerFilters.environment,
-        });
-      }
-      if (drawerFilters.status) {
-        drawerItems.push({
-          field: 'status',
-          operator: 'equals',
-          value: drawerFilters.status,
-        });
-      }
-
-      const newItems = [...otherItems, ...drawerItems];
-      if (
-        newItems.length === prev.items.length &&
-        newItems.every((it, i) => it === prev.items[i])
-      )
-        return prev;
-      return { ...prev, items: newItems };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [drawerFilters, projectId]);
+    if (refreshKey !== undefined && refreshKey > 0)
+      queryClient.invalidateQueries({ queryKey: endpointKeys.all() });
+  }, [refreshKey, queryClient]);
 
   useEffect(() => {
     const fetchProjects = async () => {
@@ -289,22 +265,10 @@ export default function EndpointsGrid({
     }
   }, [sessionToken]);
 
-  const handleFilterModelChange = useCallback((model: GridFilterModel) => {
-    setFilterModel(model);
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
-  }, []);
-
-  const handlePaginationModelChange = useCallback(
-    (newModel: GridPaginationModel) => {
-      setPaginationModel(newModel);
-    },
-    []
-  );
-
   const handleRefresh = useCallback(() => {
-    fetchEndpoints();
+    queryClient.invalidateQueries({ queryKey: endpointKeys.all() });
     onRefresh?.();
-  }, [fetchEndpoints, onRefresh]);
+  }, [queryClient, onRefresh]);
 
   const handleDeleteEndpoints = async () => {
     if (!sessionToken || !pendingDeleteId) return;

--- a/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
@@ -9,10 +9,8 @@ import React, {
 } from 'react';
 import {
   GridColDef,
-  GridRowParams,
-  GridPaginationModel,
   GridFilterModel,
-  GridSortModel,
+  GridRowParams,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
@@ -41,6 +39,10 @@ import SourceFilterDrawer, {
   hasActiveSourceFilters,
   countActiveSourceFilters,
 } from './SourceFilterDrawer';
+import { useQueryClient } from '@tanstack/react-query';
+import { sourceKeys } from '@/constants/query-keys';
+import { useGridState } from '@/hooks/useGridState';
+import { useGridQuery } from '@/hooks/useGridQuery';
 
 interface SourcesGridProps {
   sessionToken: string;
@@ -103,23 +105,10 @@ export default function SourcesGrid({
 }: SourcesGridProps) {
   const router = useRouter();
   const notifications = useNotifications();
+  const queryClient = useQueryClient();
 
   // Component state
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
-  const [sources, setSources] = useState<Source[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [totalCount, setTotalCount] = useState<number>(0);
-  const [paginationModel, setPaginationModel] = useState({
-    page: 0,
-    pageSize: 25,
-  });
-  const [filterModel, setFilterModel] = useState<GridFilterModel>({
-    items: [],
-  });
-  const [sortModel, setSortModel] = useState<GridSortModel>([
-    { field: 'created_at', sort: 'desc' },
-  ]);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
@@ -127,150 +116,105 @@ export default function SourcesGrid({
     useState<SourceFilters>(EMPTY_SOURCE_FILTERS);
   const [searchQuery, setSearchQuery] = useState('');
 
-  // Data fetching function
-  const fetchSources = useCallback(async () => {
-    if (!sessionToken) return;
+  const {
+    filterModel,
+    paginationModel,
+    sortModel,
+    setPaginationModel,
+    handlePaginationModelChange,
+    handleFilterModelChange,
+    handleSortModelChange,
+  } = useGridState({
+    searchQuery,
+    applyDrawerFilters: useCallback(
+      (prev: GridFilterModel) => {
+        const DRAWER_FIELDS = ['source_type.type_value', 'user.name', 'tags'];
+        const otherItems = prev.items.filter(
+          item => !DRAWER_FIELDS.includes(item.field ?? '')
+        );
+        const drawerItems: typeof prev.items = [];
+        if (drawerFilters.sourceType) {
+          drawerItems.push({
+            field: 'source_type.type_value',
+            operator: 'equals',
+            value: drawerFilters.sourceType,
+          });
+        }
+        if (drawerFilters.creator) {
+          drawerItems.push({
+            field: 'user.name',
+            operator: 'contains',
+            value: drawerFilters.creator,
+          });
+        }
+        if (drawerFilters.tag) {
+          drawerItems.push({
+            field: 'tags',
+            operator: 'contains',
+            value: drawerFilters.tag,
+          });
+        }
+        const newItems = [...otherItems, ...drawerItems];
+        return { ...prev, items: newItems };
+      },
+      [drawerFilters]
+    ),
+  });
 
-    try {
-      setLoading(true);
+  const filterString = combineSourceFiltersToOData(filterModel);
+  const sortField = sortModel[0]?.field || 'created_at';
+  const sortOrder = (sortModel[0]?.sort || 'desc') as 'asc' | 'desc';
 
-      const clientFactory = new ApiClientFactory(sessionToken);
-      const sourcesClient = clientFactory.getSourcesClient();
-
-      // Convert filter model to OData filter string
-      const filterString = combineSourceFiltersToOData(filterModel);
-
-      // Get sort field and order from sortModel
-      const sortField = sortModel[0]?.field || 'created_at';
-      const sortOrder = sortModel[0]?.sort || 'desc';
-
-      const apiParams = {
+  const {
+    data: sourcesData,
+    isLoading: loading,
+    error: fetchError,
+  } = useGridQuery({
+    queryKey: sourceKeys.list(
+      filterString,
+      paginationModel.page,
+      paginationModel.pageSize,
+      sortField,
+      sortOrder
+    ),
+    queryFn: () => {
+      const client = new ApiClientFactory(sessionToken).getSourcesClient();
+      return client.getSources({
         skip: paginationModel.page * paginationModel.pageSize,
         limit: paginationModel.pageSize,
         sort_by: sortField,
-        sort_order: sortOrder as 'asc' | 'desc',
+        sort_order: sortOrder,
         ...(filterString && { $filter: filterString }),
-      };
+      });
+    },
+    enabled: !!sessionToken,
+  });
 
-      const response = await sourcesClient.getSources(apiParams);
+  const sources = sourcesData?.data ?? [];
+  const totalCount = sourcesData?.pagination.totalCount ?? 0;
+  const error = fetchError ? 'Failed to load knowledge sources' : null;
 
-      setSources(response.data);
-      setTotalCount(response.pagination.totalCount);
-      const filtersActive =
-        filterModel.items.length > 0 ||
-        !!searchQuery ||
-        hasActiveSourceFilters(drawerFilters);
-      if (!filtersActive) onTotalCountChange?.(response.pagination.totalCount);
-      setError(null);
-    } catch {
-      setError('Failed to load knowledge sources');
-      setSources([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [
-    sessionToken,
-    paginationModel.page,
-    paginationModel.pageSize,
-    filterModel,
-    sortModel,
-  ]);
-
-  // Initial data fetch
   useEffect(() => {
-    fetchSources();
-  }, [fetchSources]);
+    if (!sourcesData) return;
+    const filtersActive =
+      filterModel.items.length > 0 ||
+      !!searchQuery ||
+      hasActiveSourceFilters(drawerFilters);
+    if (!filtersActive) onTotalCountChange?.(totalCount);
+  }, [
+    sourcesData,
+    filterModel.items.length,
+    searchQuery,
+    drawerFilters,
+    onTotalCountChange,
+    totalCount,
+  ]);
 
   useEffect(() => {
     if (refreshKey !== undefined && refreshKey > 0) {
-      fetchSources();
+      queryClient.invalidateQueries({ queryKey: sourceKeys.all() });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshKey]);
-
-  useEffect(() => {
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => item.field !== 'quickFilter'
-      );
-      const items = searchQuery
-        ? [
-            ...otherItems,
-            { field: 'quickFilter', operator: 'contains', value: searchQuery },
-          ]
-        : otherItems;
-      if (
-        items.length === prev.items.length &&
-        items.every((it, i) => it === prev.items[i])
-      )
-        return prev;
-      return { ...prev, items };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [searchQuery]);
-
-  useEffect(() => {
-    const DRAWER_FIELDS = ['source_type.type_value', 'user.name', 'tags'];
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => !DRAWER_FIELDS.includes(item.field ?? '')
-      );
-      const drawerItems: typeof prev.items = [];
-      if (drawerFilters.sourceType) {
-        drawerItems.push({
-          field: 'source_type.type_value',
-          operator: 'equals',
-          value: drawerFilters.sourceType,
-        });
-      }
-      if (drawerFilters.creator) {
-        drawerItems.push({
-          field: 'user.name',
-          operator: 'contains',
-          value: drawerFilters.creator,
-        });
-      }
-      if (drawerFilters.tag) {
-        drawerItems.push({
-          field: 'tags',
-          operator: 'contains',
-          value: drawerFilters.tag,
-        });
-      }
-      const newItems = [...otherItems, ...drawerItems];
-      if (
-        newItems.length === prev.items.length &&
-        newItems.every(
-          (it, i) => JSON.stringify(it) === JSON.stringify(prev.items[i])
-        )
-      )
-        return prev;
-      return { ...prev, items: newItems };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [drawerFilters]);
-
-  // Handle pagination
-  const handlePaginationModelChange = useCallback(
-    (newModel: GridPaginationModel) => {
-      setPaginationModel(newModel);
-    },
-    []
-  );
-
-  // Handle filter change
-  const handleFilterModelChange = useCallback((newModel: GridFilterModel) => {
-    setFilterModel(newModel);
-    // Reset to first page when filters change
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
-  }, []);
-
-  // Handle sort change
-  const handleSortModelChange = useCallback((newModel: GridSortModel) => {
-    setSortModel(newModel);
-    // Reset to first page when sort changes
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
-  }, []);
+  }, [refreshKey, queryClient]);
 
   // Handle row click to navigate to preview
   const handleRowClick = useCallback(
@@ -304,7 +248,7 @@ export default function SourcesGrid({
       });
 
       setPendingDeleteId(null);
-      fetchSources();
+      queryClient.invalidateQueries({ queryKey: sourceKeys.all() });
       onRefresh?.();
     } catch {
       notifications.show('Failed to delete source', {

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -6,11 +6,9 @@ import React, {
   useCallback,
   useContext,
   useMemo,
-  useRef,
 } from 'react';
 import {
   GridColDef,
-  GridPaginationModel,
   GridFilterModel,
   GridRowParams,
   GridToolbarColumnsButton,
@@ -38,6 +36,10 @@ import {
 } from '@/components/common/createRowActionsColumn';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import { useNotifications } from '@/components/common/NotificationContext';
+import { useQueryClient } from '@tanstack/react-query';
+import { taskKeys } from '@/constants/query-keys';
+import { useGridState } from '@/hooks/useGridState';
+import { useGridQuery } from '@/hooks/useGridQuery';
 
 interface TasksGridProps {
   sessionToken: string;
@@ -119,28 +121,10 @@ export default function TasksGrid({
 }: TasksGridProps) {
   const router = useRouter();
   const notifications = useNotifications();
-  const isMounted = useRef(false);
-
-  useEffect(() => {
-    isMounted.current = true;
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
+  const queryClient = useQueryClient();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
-  const [tasks, setTasks] = useState<Task[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [totalCount, setTotalCount] = useState<number>(0);
-  const [paginationModel, setPaginationModel] = useState({
-    page: 0,
-    pageSize: 25,
-  });
-  const [filterModel, setFilterModel] = useState<GridFilterModel>({
-    items: [],
-  });
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
   const [drawerFilters, setDrawerFilters] =
     useState<TaskFilters>(EMPTY_TASK_FILTERS);
@@ -148,139 +132,107 @@ export default function TasksGrid({
   const [isDeleting, setIsDeleting] = useState(false);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
 
-  const fetchTasks = useCallback(async () => {
-    if (!sessionToken) return;
+  const {
+    filterModel,
+    paginationModel,
+    sortModel,
+    setPaginationModel,
+    handlePaginationModelChange,
+    handleFilterModelChange,
+    handleSortModelChange,
+  } = useGridState({
+    searchQuery,
+    typeFilter: statusFilter,
+    typeFilterField: 'status',
+    applyDrawerFilters: useCallback(
+      (prev: GridFilterModel) => {
+        const DRAWER_FIELDS = ['status', 'priority', 'assignee'];
+        const otherItems = prev.items.filter(
+          item => !DRAWER_FIELDS.includes(item.field ?? '')
+        );
+        const drawerItems: typeof prev.items = [];
+        if (drawerFilters.status) {
+          drawerItems.push({
+            field: 'status',
+            operator: 'equals',
+            value: drawerFilters.status,
+          });
+        }
+        if (drawerFilters.priority) {
+          drawerItems.push({
+            field: 'priority',
+            operator: 'equals',
+            value: drawerFilters.priority,
+          });
+        }
+        if (drawerFilters.assignee) {
+          drawerItems.push({
+            field: 'assignee',
+            operator: 'equals',
+            value: drawerFilters.assignee,
+          });
+        }
+        const newItems = [...otherItems, ...drawerItems];
+        if (
+          newItems.length === prev.items.length &&
+          newItems.every((it, i) => it === prev.items[i])
+        )
+          return prev;
+        return { ...prev, items: newItems };
+      },
+      [drawerFilters]
+    ),
+  });
 
-    try {
-      setLoading(true);
-
-      const clientFactory = new ApiClientFactory(sessionToken);
-      const tasksClient = clientFactory.getTasksClient();
-
-      const oDataFilter = combineTaskFiltersToOData(filterModel);
-
-      const response = await tasksClient.getTasks({
+  const filterString = combineTaskFiltersToOData(filterModel);
+  const {
+    data: tasksData,
+    isLoading: loading,
+    error: fetchError,
+  } = useGridQuery({
+    queryKey: taskKeys.list(
+      filterString,
+      paginationModel.page,
+      paginationModel.pageSize,
+      'created_at',
+      'desc'
+    ),
+    queryFn: () => {
+      const client = new ApiClientFactory(sessionToken).getTasksClient();
+      return client.getTasks({
         skip: paginationModel.page * paginationModel.pageSize,
         limit: paginationModel.pageSize,
         sort_by: 'created_at',
         sort_order: 'desc',
-        $filter: oDataFilter,
+        ...(filterString && { $filter: filterString }),
       });
+    },
+    enabled: !!sessionToken,
+  });
+  const tasks: Task[] = tasksData?.data ?? [];
+  const totalCount = tasksData?.totalCount ?? 0;
+  const error = fetchError ? 'Failed to load tasks' : null;
 
-      if (!isMounted.current) return;
-
-      setTasks(response.data);
-      setTotalCount(response.totalCount || 0);
-      const filtersActive =
-        filterModel.items.length > 0 ||
-        !!searchQuery ||
-        hasActiveTaskFilters(drawerFilters);
-      if (!filtersActive) onTotalCountChange?.(response.totalCount || 0);
-      setError(null);
-    } catch {
-      if (!isMounted.current) return;
-      setError('Failed to load tasks');
-      setTasks([]);
-    } finally {
-      if (isMounted.current) setLoading(false);
-    }
+  useEffect(() => {
+    if (!tasksData) return;
+    const filtersActive =
+      filterModel.items.length > 0 ||
+      !!searchQuery ||
+      hasActiveTaskFilters(drawerFilters);
+    if (!filtersActive) onTotalCountChange?.(totalCount);
   }, [
-    sessionToken,
-    paginationModel.page,
-    paginationModel.pageSize,
-    filterModel,
+    tasksData,
+    filterModel.items.length,
+    searchQuery,
+    drawerFilters,
+    onTotalCountChange,
+    totalCount,
   ]);
 
   useEffect(() => {
-    fetchTasks();
-  }, [fetchTasks]);
-
-  useEffect(() => {
-    if (refreshKey !== undefined && refreshKey > 0) {
-      fetchTasks();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshKey]);
-
-  useEffect(() => {
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => item.field !== 'quickFilter'
-      );
-      const items = searchQuery
-        ? [
-            ...otherItems,
-            { field: 'quickFilter', operator: 'contains', value: searchQuery },
-          ]
-        : otherItems;
-      if (
-        items.length === prev.items.length &&
-        items.every((it, i) => it === prev.items[i])
-      )
-        return prev;
-      return { ...prev, items };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [searchQuery]);
-
-  useEffect(() => {
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(item => item.field !== 'status');
-      const items =
-        statusFilter && statusFilter !== 'all'
-          ? [
-              ...otherItems,
-              { field: 'status', operator: 'equals', value: statusFilter },
-            ]
-          : otherItems;
-      if (
-        items.length === prev.items.length &&
-        items.every((it, i) => it === prev.items[i])
-      )
-        return prev;
-      return { ...prev, items };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [statusFilter]);
-
-  useEffect(() => {
-    const DRAWER_FIELDS = ['status', 'priority', 'assignee'];
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => !DRAWER_FIELDS.includes(item.field ?? '')
-      );
-      const drawerItems: typeof prev.items = [];
-      if (drawerFilters.status) {
-        drawerItems.push({
-          field: 'status',
-          operator: 'equals',
-          value: drawerFilters.status,
-        });
-      }
-      if (drawerFilters.priority) {
-        drawerItems.push({
-          field: 'priority',
-          operator: 'equals',
-          value: drawerFilters.priority,
-        });
-      }
-      if (drawerFilters.assignee) {
-        drawerItems.push({
-          field: 'assignee',
-          operator: 'equals',
-          value: drawerFilters.assignee,
-        });
-      }
-      const newItems = [...otherItems, ...drawerItems];
-      if (
-        newItems.length === prev.items.length &&
-        newItems.every((it, i) => it === prev.items[i])
-      )
-        return prev;
-      return { ...prev, items: newItems };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [drawerFilters]);
+    if (refreshKey !== undefined && refreshKey > 0)
+      queryClient.invalidateQueries({ queryKey: taskKeys.all() });
+  }, [refreshKey, queryClient]);
 
   const handleRowClick = useCallback(
     (params: GridRowParams) => {
@@ -288,18 +240,6 @@ export default function TasksGrid({
     },
     [router]
   );
-
-  const handlePaginationModelChange = useCallback(
-    (newModel: GridPaginationModel) => {
-      setPaginationModel(newModel);
-    },
-    []
-  );
-
-  const handleFilterModelChange = useCallback((newModel: GridFilterModel) => {
-    setFilterModel(newModel);
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
-  }, []);
 
   const handleRowDeleteAction = useCallback((id: string) => {
     setPendingDeleteId(id);
@@ -318,7 +258,7 @@ export default function TasksGrid({
         autoHideDuration: 4000,
       });
       setPendingDeleteId(null);
-      fetchTasks();
+      queryClient.invalidateQueries({ queryKey: taskKeys.all() });
     } catch {
       notifications.show('Failed to delete task', {
         severity: 'error',
@@ -328,7 +268,7 @@ export default function TasksGrid({
       setIsDeleting(false);
       setDeleteModalOpen(false);
     }
-  }, [pendingDeleteId, sessionToken, notifications, fetchTasks]);
+  }, [pendingDeleteId, sessionToken, notifications, queryClient]);
 
   const handleDeleteCancel = useCallback(() => {
     setDeleteModalOpen(false);

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -5,9 +5,12 @@ import React, {
   useState,
   useCallback,
   useContext,
-  useRef,
   useMemo,
 } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { testRunKeys } from '@/constants/query-keys';
+import { useGridState } from '@/hooks/useGridState';
+import { useGridQuery } from '@/hooks/useGridQuery';
 import ListIcon from '@mui/icons-material/List';
 import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
 import GridBadge from '@/components/common/GridBadge';
@@ -16,7 +19,6 @@ import {
   GridColDef,
   GridPaginationModel,
   GridFilterModel,
-  GridSortModel,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
@@ -49,7 +51,7 @@ import {
   appendPresenceFilterItems,
   stripPresenceFilterItems,
 } from '@/components/common/presence-filter';
-import { DEFAULT_GRID_SORT, gridSortToApiParams } from '@/utils/grid-sort';
+import { gridSortToApiParams } from '@/utils/grid-sort';
 import TestRunFilterDrawer, {
   type TestRunFilters,
   EMPTY_TEST_RUN_FILTERS,
@@ -147,7 +149,7 @@ function TestRunsGrid({
   onTotalCountChange,
   refreshKey,
 }: TestRunsGridProps) {
-  const isMounted = useRef(false);
+  const queryClient = useQueryClient();
   const router = useRouter();
   const notifications = useNotifications();
 
@@ -155,11 +157,13 @@ function TestRunsGrid({
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
 
-  // ── Core grid state ────────────────────────────────────────────────────────
-  const [testRuns, setTestRuns] = useState<TestRunDetail[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [totalCount, setTotalCount] = useState<number>(0);
+  // ── Filter drawer state ────────────────────────────────────────────────────
+  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
+  const [drawerFilters, setDrawerFilters] = useState<TestRunFilters>(
+    EMPTY_TEST_RUN_FILTERS
+  );
+
+  // ── Other UI state ─────────────────────────────────────────────────────────
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
@@ -167,154 +171,16 @@ function TestRunsGrid({
   const [isCancelling, setIsCancelling] = useState(false);
   const [pendingCancelId, setPendingCancelId] = useState<string | null>(null);
   const [runKindFilter, setRunKindFilter] = useState<RunKindFilter>('all');
-  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
-    page: 0,
-    pageSize: 50,
-  });
-  const [filterModel, setFilterModel] = useState<GridFilterModel>({
-    items: [],
-  });
-  const [sortModel, setSortModel] = useState<GridSortModel>(DEFAULT_GRID_SORT);
 
-  // ── Filter drawer state ────────────────────────────────────────────────────
-  const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [drawerFilters, setDrawerFilters] = useState<TestRunFilters>(
-    EMPTY_TEST_RUN_FILTERS
-  );
+  // ── Grid state (pagination, filter, sort) ─────────────────────────────────
 
-  // ── Data fetching ─────────────────────────────────────────────────────────
-
-  const fetchTestRuns = useCallback(
-    async (skip: number, limit: number) => {
-      if (!sessionToken) return;
-
-      try {
-        if (isMounted.current) {
-          setLoading(true);
-        }
-
-        const clientFactory = new ApiClientFactory(sessionToken);
-        const testRunsClient = clientFactory.getTestRunsClient();
-
-        const filterString = combineTestRunFiltersToOData(filterModel);
-        const { sort_by, sort_order } = gridSortToApiParams(sortModel);
-
-        const apiParams: Parameters<typeof testRunsClient.getTestRuns>[0] = {
-          skip,
-          limit,
-          sort_by,
-          sort_order,
-          ...(filterString && { filter: filterString }),
-          ...(runKindFilter === 'experiments' && { has_experiment: true }),
-          ...(runKindFilter === 'tests' && { has_experiment: false }),
-        };
-
-        const response = await testRunsClient.getTestRuns(apiParams);
-
-        if (isMounted.current) {
-          setTestRuns(response.data);
-          setTotalCount(response.pagination.totalCount);
-          const filtersActive =
-            filterModel.items.length > 0 ||
-            !!searchQuery ||
-            hasActiveTestRunFilters(drawerFilters);
-          if (!filtersActive)
-            onTotalCountChange?.(response.pagination.totalCount);
-          setError(null);
-        }
-      } catch (_error) {
-        if (isMounted.current) {
-          setError('Failed to load test runs');
-          setTestRuns([]);
-        }
-      } finally {
-        if (isMounted.current) {
-          setLoading(false);
-        }
-      }
-    },
-    [sessionToken, filterModel, sortModel, runKindFilter, onTotalCountChange]
-  );
-
-  useEffect(() => {
-    isMounted.current = true;
-    const skip = paginationModel.page * paginationModel.pageSize;
-    fetchTestRuns(skip, paginationModel.pageSize);
-    return () => {
-      isMounted.current = false;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionToken, paginationModel, filterModel, sortModel, runKindFilter]);
-
-  // Refetch when parent signals a refresh
-  useEffect(() => {
-    if (refreshKey !== undefined && refreshKey > 0) {
-      const skip = paginationModel.page * paginationModel.pageSize;
-      fetchTestRuns(skip, paginationModel.pageSize);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshKey]);
-
-  // ── Sync searchQuery into filterModel ────────────────────────────────────
-
-  useEffect(() => {
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => item.field !== 'quickFilter'
-      );
-      const items = searchQuery
-        ? [
-            ...otherItems,
-            { field: 'quickFilter', operator: 'contains', value: searchQuery },
-          ]
-        : otherItems;
-      if (
-        items.length === prev.items.length &&
-        items.every((it, i) => it === prev.items[i])
-      )
-        return prev;
-      return { ...prev, items };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [searchQuery]);
-
-  // ── Sync statusFilter pill tab into filterModel ───────────────────────────
-
-  useEffect(() => {
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => item.field !== 'status.name'
-      );
-      const items =
-        statusFilter && statusFilter !== 'all'
-          ? [
-              ...otherItems,
-              {
-                field: 'status.name',
-                operator: 'equals',
-                value: statusFilter,
-              },
-            ]
-          : otherItems;
-      if (
-        items.length === prev.items.length &&
-        items.every((it, i) => it === prev.items[i])
-      )
-        return prev;
-      return { ...prev, items };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [statusFilter]);
-
-  // ── Sync drawer filters into filterModel ─────────────────────────────────
-
-  useEffect(() => {
-    const DRAWER_FIELDS = [
-      'test_configuration.test_set.name',
-      'user.name',
-      'tags',
-    ];
-    setFilterModel(prev => {
+  const applyDrawerFilters = useCallback(
+    (prev: GridFilterModel): GridFilterModel => {
+      const DRAWER_FIELDS = [
+        'test_configuration.test_set.name',
+        'user.name',
+        'tags',
+      ];
       const otherItems = stripPresenceFilterItems(
         prev.items.filter(item => !DRAWER_FIELDS.includes(item.field ?? ''))
       );
@@ -348,15 +214,90 @@ function TestRunsGrid({
           tasks: drawerFilters.tasks,
         }
       );
-      if (
-        newItems.length === prev.items.length &&
-        newItems.every((it, i) => it === prev.items[i])
-      )
-        return prev;
       return { ...prev, items: newItems };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [drawerFilters]);
+    },
+    [drawerFilters]
+  );
+
+  const {
+    filterModel,
+    paginationModel,
+    sortModel,
+    setPaginationModel,
+    handlePaginationModelChange,
+    handleFilterModelChange,
+    handleSortModelChange,
+  } = useGridState({
+    searchQuery,
+    typeFilter: statusFilter,
+    typeFilterField: 'status.name',
+    applyDrawerFilters,
+  });
+
+  // ── Data fetching ─────────────────────────────────────────────────────────
+
+  const filterString = combineTestRunFiltersToOData(filterModel);
+  const { sort_by, sort_order } = gridSortToApiParams(sortModel);
+
+  const {
+    data: testRunsData,
+    isLoading: loading,
+    error: fetchError,
+  } = useGridQuery({
+    queryKey: [
+      ...testRunKeys.list(
+        filterString,
+        paginationModel.page,
+        paginationModel.pageSize,
+        sort_by,
+        sort_order
+      ),
+      runKindFilter,
+    ],
+    queryFn: () => {
+      const client = new ApiClientFactory(sessionToken).getTestRunsClient();
+      return client.getTestRuns({
+        skip: paginationModel.page * paginationModel.pageSize,
+        limit: paginationModel.pageSize,
+        sort_by,
+        sort_order,
+        ...(filterString && { filter: filterString }),
+        ...(runKindFilter === 'experiments' && { has_experiment: true }),
+        ...(runKindFilter === 'tests' && { has_experiment: false }),
+      });
+    },
+    enabled: !!sessionToken,
+  });
+
+  const testRuns = testRunsData?.data ?? [];
+  const totalCount = testRunsData?.pagination.totalCount ?? 0;
+  const error = fetchError ? 'Failed to load test runs' : null;
+
+  // ── Side effect: notify parent of total count ─────────────────────────────
+
+  useEffect(() => {
+    if (!testRunsData) return;
+    const filtersActive =
+      filterModel.items.length > 0 ||
+      !!searchQuery ||
+      hasActiveTestRunFilters(drawerFilters);
+    if (!filtersActive) onTotalCountChange?.(totalCount);
+  }, [
+    testRunsData,
+    filterModel.items.length,
+    searchQuery,
+    drawerFilters,
+    onTotalCountChange,
+    totalCount,
+  ]);
+
+  // ── Refresh via parent refreshKey ─────────────────────────────────────────
+
+  useEffect(() => {
+    if (refreshKey !== undefined && refreshKey > 0) {
+      queryClient.invalidateQueries({ queryKey: testRunKeys.all() });
+    }
+  }, [refreshKey, queryClient]);
 
   // ── Row action handlers ────────────────────────────────────────────────────
 
@@ -677,28 +618,6 @@ function TestRunsGrid({
     [router]
   );
 
-  const handlePaginationModelChange = useCallback(
-    (model: GridPaginationModel) => {
-      setPaginationModel(model);
-      const skip = model.page * model.pageSize;
-      fetchTestRuns(skip, model.pageSize);
-    },
-    [fetchTestRuns]
-  );
-
-  const handleFilterModelChange = useCallback(
-    (newFilterModel: GridFilterModel) => {
-      setFilterModel(newFilterModel);
-      setPaginationModel(prev => ({ ...prev, page: 0 }));
-    },
-    []
-  );
-
-  const handleSortModelChange = useCallback((newModel: GridSortModel) => {
-    setSortModel(newModel);
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
-  }, []);
-
   // ── Delete handlers ───────────────────────────────────────────────────────
 
   const handleDeleteConfirm = useCallback(async () => {
@@ -716,21 +635,14 @@ function TestRunsGrid({
       });
 
       setPendingDeleteId(null);
-      const skip = paginationModel.page * paginationModel.pageSize;
-      await fetchTestRuns(skip, paginationModel.pageSize);
+      queryClient.invalidateQueries({ queryKey: testRunKeys.all() });
     } catch (_error) {
       notifications.show('Failed to delete test run', { severity: 'error' });
     } finally {
       setIsDeleting(false);
       setDeleteModalOpen(false);
     }
-  }, [
-    pendingDeleteId,
-    sessionToken,
-    notifications,
-    paginationModel,
-    fetchTestRuns,
-  ]);
+  }, [pendingDeleteId, sessionToken, notifications, queryClient]);
 
   const handleDeleteCancel = useCallback(() => {
     setDeleteModalOpen(false);
@@ -754,8 +666,7 @@ function TestRunsGrid({
         severity: 'success',
       });
       setPendingCancelId(null);
-      const skip = paginationModel.page * paginationModel.pageSize;
-      await fetchTestRuns(skip, paginationModel.pageSize);
+      queryClient.invalidateQueries({ queryKey: testRunKeys.all() });
       onRefresh?.();
     } catch (_error) {
       notifications.show('Failed to cancel test run', { severity: 'error' });
@@ -763,24 +674,20 @@ function TestRunsGrid({
       setIsCancelling(false);
       setCancelModalOpen(false);
     }
-  }, [
-    pendingCancelId,
-    sessionToken,
-    notifications,
-    paginationModel,
-    fetchTestRuns,
-    onRefresh,
-  ]);
+  }, [pendingCancelId, sessionToken, notifications, queryClient, onRefresh]);
 
   const handleCancelClose = useCallback(() => {
     setCancelModalOpen(false);
     setPendingCancelId(null);
   }, []);
 
-  const handleRunKindFilterChange = useCallback((value: RunKindFilter) => {
-    setRunKindFilter(value);
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
-  }, []);
+  const handleRunKindFilterChange = useCallback(
+    (value: RunKindFilter) => {
+      setRunKindFilter(value);
+      setPaginationModel({ ...paginationModel, page: 0 });
+    },
+    [setPaginationModel]
+  );
 
   const runKindToolbar = useMemo(
     () => (

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -684,7 +684,7 @@ function TestRunsGrid({
   const handleRunKindFilterChange = useCallback(
     (value: RunKindFilter) => {
       setRunKindFilter(value);
-      setPaginationModel({ ...paginationModel, page: 0 });
+      setPaginationModel(prev => ({ ...prev, page: 0 }));
     },
     [setPaginationModel]
   );

--- a/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsGrid.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@/test-utils';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import TestRunsGrid from '../TestRunsGrid';

--- a/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsGrid.test.tsx
@@ -97,7 +97,14 @@ jest.mock('../TestRunFilterDrawer', () => ({
   __esModule: true,
   default: ({ open }: { open: boolean }) =>
     open ? <div data-testid="test-run-filter-drawer" /> : null,
-  EMPTY_TEST_RUN_FILTERS: { testSet: '', executor: '', tag: '' },
+  EMPTY_TEST_RUN_FILTERS: {
+    testSet: '',
+    executor: '',
+    tag: '',
+    tags: 'all',
+    comments: 'all',
+    tasks: 'all',
+  },
   hasActiveTestRunFilters: () => false,
   countActiveTestRunFilters: () => 0,
 }));

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -10,10 +10,8 @@ import React, {
 import {
   GridColDef,
   GridRowParams,
-  GridRowSelectionModel,
-  GridPaginationModel,
   GridFilterModel,
-  GridSortModel,
+  GridRowSelectionModel,
   GridToolbarColumnsButton,
   GridToolbarDensitySelector,
   GridToolbarExport,
@@ -25,7 +23,7 @@ import {
   appendPresenceFilterItems,
   stripPresenceFilterItems,
 } from '@/components/common/presence-filter';
-import { DEFAULT_GRID_SORT, gridSortToApiParams } from '@/utils/grid-sort';
+import { gridSortToApiParams } from '@/utils/grid-sort';
 import { TestSet } from '@/utils/api-client/interfaces/test-set';
 import { Tag } from '@/utils/api-client/interfaces/tag';
 import { Box, Tooltip, Typography, Avatar, Alert, Chip } from '@mui/material';
@@ -53,6 +51,10 @@ import {
 } from '@/components/common/createRowActionsColumn';
 import { TEST_TYPES } from '@/constants/test-types';
 import GridBadge from '@/components/common/GridBadge';
+import { useQueryClient } from '@tanstack/react-query';
+import { testSetKeys } from '@/constants/query-keys';
+import { useGridState } from '@/hooks/useGridState';
+import { useGridQuery } from '@/hooks/useGridQuery';
 
 interface TestSetsGridProps {
   sessionToken?: string;
@@ -166,6 +168,7 @@ export default function TestSetsGrid({
   const router = useRouter();
   const { data: session } = useSession();
   const notifications = useNotifications();
+  const queryClient = useQueryClient();
 
   const sessionToken = sessionTokenProp || session?.session_token || '';
 
@@ -173,186 +176,128 @@ export default function TestSetsGrid({
   const [searchQuery, setSearchQuery] = useState('');
   const [typeFilter, setTypeFilter] = useState('all');
 
-  // ── Core grid state ─────────────────────────────────────────────────────────
-  const [testSets, setTestSets] = useState<TestSet[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [totalCount, setTotalCount] = useState<number>(0);
-  const [paginationModel, setPaginationModel] = useState({
-    page: 0,
-    pageSize: 25,
-  });
-  const [filterModel, setFilterModel] = useState<GridFilterModel>({
-    items: [],
-  });
-  const [sortModel, setSortModel] = useState<GridSortModel>(DEFAULT_GRID_SORT);
+  // ── Drawer / dialog state ───────────────────────────────────────────────────
+  const [drawerFilters, setDrawerFilters] = useState<TestSetFilters>(
+    EMPTY_TEST_SET_FILTERS
+  );
   const [selectedRows, setSelectedRows] = useState<GridRowSelectionModel>([]);
-
-  // ── Drawer / dialog state (only what stays in the grid) ─────────────────────
   const [testRunDrawerOpen, setTestRunDrawerOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [drawerFilters, setDrawerFilters] = useState<TestSetFilters>(
-    EMPTY_TEST_SET_FILTERS
-  );
 
-  // ── Data fetching ────────────────────────────────────────────────────────────
+  // ── Grid state (pagination, filter, sort) via useGridState ──────────────────
+  const {
+    filterModel,
+    paginationModel,
+    sortModel,
+    setPaginationModel,
+    handlePaginationModelChange,
+    handleFilterModelChange,
+    handleSortModelChange,
+  } = useGridState({
+    searchQuery,
+    typeFilter,
+    typeFilterField: 'testSetType',
+    applyDrawerFilters: useCallback(
+      (prev: GridFilterModel) => {
+        const DRAWER_FIELDS = ['testSetType', 'status.name', 'creator', 'tags'];
+        const otherItems = stripPresenceFilterItems(
+          prev.items.filter(item => !DRAWER_FIELDS.includes(item.field ?? ''))
+        );
+        const drawerItems: typeof prev.items = [];
+        if (drawerFilters.testSetType) {
+          drawerItems.push({
+            field: 'testSetType',
+            operator: 'equals',
+            value: drawerFilters.testSetType,
+          });
+        }
+        if (drawerFilters.status) {
+          drawerItems.push({
+            field: 'status.name',
+            operator: 'contains',
+            value: drawerFilters.status,
+          });
+        }
+        if (drawerFilters.creator) {
+          drawerItems.push({
+            field: 'creator',
+            operator: 'contains',
+            value: drawerFilters.creator,
+          });
+        }
+        if (drawerFilters.tag) {
+          drawerItems.push({
+            field: 'tags',
+            operator: 'contains',
+            value: drawerFilters.tag,
+          });
+        }
+        const newItems = [...otherItems, ...drawerItems];
+        if (JSON.stringify(newItems) === JSON.stringify(prev.items))
+          return prev;
+        return { ...prev, items: newItems };
+      },
+      [drawerFilters]
+    ),
+  });
 
-  const fetchTestSets = useCallback(async () => {
-    if (!sessionToken) return;
-
-    try {
-      setLoading(true);
-      const clientFactory = new ApiClientFactory(sessionToken);
-      const testSetsClient = clientFactory.getTestSetsClient();
-
-      const filterString = combineTestSetFiltersToOData(filterModel);
-      const { sort_by, sort_order } = gridSortToApiParams(sortModel);
-
-      const apiParams = {
+  // ── Data fetching via React Query ────────────────────────────────────────────
+  const filterString = combineTestSetFiltersToOData(filterModel);
+  const { sort_by, sort_order } = gridSortToApiParams(sortModel);
+  const {
+    data: testSetsData,
+    isLoading: loading,
+    error: fetchError,
+  } = useGridQuery({
+    queryKey: testSetKeys.list(
+      filterString,
+      paginationModel.page,
+      paginationModel.pageSize,
+      sort_by,
+      sort_order
+    ),
+    queryFn: () => {
+      const client = new ApiClientFactory(sessionToken).getTestSetsClient();
+      return client.getTestSets({
         skip: paginationModel.page * paginationModel.pageSize,
         limit: paginationModel.pageSize,
         sort_by,
         sort_order,
         ...(filterString && { $filter: filterString }),
-      };
+      });
+    },
+    enabled: !!sessionToken,
+  });
+  const testSets = testSetsData?.data ?? [];
+  const totalCount = testSetsData?.pagination.totalCount ?? 0;
+  const error = fetchError ? 'Failed to load test sets' : null;
 
-      const response = await testSetsClient.getTestSets(apiParams);
-      setTestSets(response.data);
-      setTotalCount(response.pagination.totalCount);
-      const filtersActive =
-        filterModel.items.length > 0 ||
-        !!searchQuery ||
-        hasActiveTestSetFilters(drawerFilters);
-      if (!filtersActive) onTotalCountChange?.(response.pagination.totalCount);
-      setError(null);
-    } catch {
-      setError('Failed to load test sets');
-      setTestSets([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [sessionToken, paginationModel, filterModel, sortModel]);
-
+  // ── onTotalCountChange side effect ───────────────────────────────────────────
   useEffect(() => {
-    fetchTestSets();
-  }, [fetchTestSets]);
+    if (!testSetsData) return;
+    const filtersActive =
+      filterModel.items.length > 0 ||
+      !!searchQuery ||
+      hasActiveTestSetFilters(drawerFilters);
+    if (!filtersActive) onTotalCountChange?.(totalCount);
+  }, [
+    testSetsData,
+    filterModel.items.length,
+    searchQuery,
+    drawerFilters,
+    onTotalCountChange,
+    totalCount,
+  ]);
 
-  // Refetch when parent signals a refresh (after create/import)
+  // ── refreshKey effect ────────────────────────────────────────────────────────
   useEffect(() => {
     if (refreshKey !== undefined && refreshKey > 0) {
-      fetchTestSets();
+      queryClient.invalidateQueries({ queryKey: testSetKeys.all() });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refreshKey]);
-
-  // ── Sync searchQuery into filterModel ────────────────────────────────────────
-
-  useEffect(() => {
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => item.field !== 'quickFilter'
-      );
-      const items = searchQuery
-        ? [
-            ...otherItems,
-            { field: 'quickFilter', operator: 'contains', value: searchQuery },
-          ]
-        : otherItems;
-      if (JSON.stringify(items) === JSON.stringify(prev.items)) return prev;
-      return { ...prev, items };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [searchQuery]);
-
-  // ── Sync typeFilter pill tab into filterModel ────────────────────────────────
-
-  useEffect(() => {
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => item.field !== 'testSetType'
-      );
-      const items =
-        typeFilter && typeFilter !== 'all'
-          ? [
-              ...otherItems,
-              {
-                field: 'testSetType',
-                operator: 'equals',
-                value: typeFilter,
-              },
-            ]
-          : otherItems;
-      if (JSON.stringify(items) === JSON.stringify(prev.items)) return prev;
-      return { ...prev, items };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [typeFilter]);
-
-  // ── Sync drawer filters into filterModel ─────────────────────────────────────
-
-  useEffect(() => {
-    const DRAWER_FIELDS = ['testSetType', 'status.name', 'creator', 'tags'];
-    setFilterModel(prev => {
-      const otherItems = stripPresenceFilterItems(
-        prev.items.filter(item => !DRAWER_FIELDS.includes(item.field ?? ''))
-      );
-      const drawerItems: typeof prev.items = [];
-      if (drawerFilters.testSetType) {
-        drawerItems.push({
-          field: 'testSetType',
-          operator: 'equals',
-          value: drawerFilters.testSetType,
-        });
-      }
-      if (drawerFilters.status) {
-        drawerItems.push({
-          field: 'status.name',
-          operator: 'contains',
-          value: drawerFilters.status,
-        });
-      }
-      if (drawerFilters.creator) {
-        drawerItems.push({
-          field: 'creator',
-          operator: 'contains',
-          value: drawerFilters.creator,
-        });
-      }
-      if (drawerFilters.tag) {
-        drawerItems.push({
-          field: 'tags',
-          operator: 'contains',
-          value: drawerFilters.tag,
-        });
-      }
-      const newItems = [...otherItems, ...drawerItems];
-      if (JSON.stringify(newItems) === JSON.stringify(prev.items)) return prev;
-      return { ...prev, items: newItems };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [drawerFilters]);
-
-  // ── Pagination / filter handlers ─────────────────────────────────────────────
-
-  const handlePaginationModelChange = useCallback(
-    (newModel: GridPaginationModel) => {
-      setPaginationModel(newModel);
-    },
-    []
-  );
-
-  const handleFilterModelChange = useCallback((newModel: GridFilterModel) => {
-    setFilterModel(newModel);
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
-  }, []);
-
-  const handleSortModelChange = useCallback((newModel: GridSortModel) => {
-    setSortModel(newModel);
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
-  }, []);
+  }, [refreshKey, queryClient]);
 
   // ── Row + selection handlers ─────────────────────────────────────────────────
 
@@ -398,7 +343,7 @@ export default function TestSetsGrid({
 
       setPendingDeleteId(null);
       setSelectedRows([]);
-      fetchTestSets();
+      queryClient.invalidateQueries({ queryKey: testSetKeys.all() });
       onRefresh?.();
     } catch {
       notifications.show('Failed to delete test sets', {
@@ -414,7 +359,7 @@ export default function TestSetsGrid({
     selectedRows,
     sessionToken,
     notifications,
-    fetchTestSets,
+    queryClient,
     onRefresh,
   ]);
 

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -695,7 +695,7 @@ export default function TestsTable({
   const handleTestSaved = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: testKeys.all() });
     if (paginationModel.page > 0) {
-      setPaginationModel({ ...paginationModel, page: 0 });
+      setPaginationModel(prev => ({ ...prev, page: 0 }));
     }
     onRefresh?.();
   }, [queryClient, paginationModel.page, onRefresh]);

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -5,9 +5,12 @@ import React, {
   useState,
   useContext,
   useCallback,
-  useRef,
   useMemo,
 } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { testKeys } from '@/constants/query-keys';
+import { useGridState } from '@/hooks/useGridState';
+import { useGridQuery } from '@/hooks/useGridQuery';
 import ListIcon from '@mui/icons-material/ListOutlined';
 import DeleteIcon from '@mui/icons-material/DeleteOutlined';
 import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
@@ -60,7 +63,7 @@ import {
   buildTestIdsODataFilter,
   combineODataFilterExpressions,
 } from './test-filter-model';
-import { DEFAULT_GRID_SORT, gridSortToApiParams } from '@/utils/grid-sort';
+import { gridSortToApiParams } from '@/utils/grid-sort';
 import {
   fetchFailedTestIdsForInsights,
   formatInsightsFailedTestsBanner,
@@ -153,32 +156,39 @@ export default function TestsTable({
 }: TestsTableProps) {
   const router = useRouter();
   const notifications = useNotifications();
-  const isMounted = useRef(true);
+  const queryClient = useQueryClient();
 
   // Search + tab filter — managed here, shared to toolbar via context
   const [searchQuery, setSearchQuery] = useState('');
   const [typeFilter, setTypeFilter] = useState('all');
+  const [drawerFilters, setDrawerFilters] =
+    useState<TestFilters>(EMPTY_TEST_FILTERS);
+
+  const {
+    filterModel,
+    paginationModel,
+    sortModel,
+    setPaginationModel,
+    handlePaginationModelChange,
+    handleFilterModelChange,
+    handleSortModelChange,
+  } = useGridState({
+    searchQuery,
+    typeFilter,
+    typeFilterField: 'test_type.type_value',
+    applyDrawerFilters: useCallback(
+      (prev: GridFilterModel) =>
+        applyTestDrawerFiltersToModel(prev, drawerFilters),
+      [drawerFilters]
+    ),
+  });
 
   // Component state
   const [selectedRows, setSelectedRows] = useState<GridRowSelectionModel>([]);
-  const [tests, setTests] = useState<TestDetail[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [totalCount, setTotalCount] = useState<number>(0);
-  const [paginationModel, setPaginationModel] = useState({
-    page: 0,
-    pageSize: 25,
-  });
-  const [filterModel, setFilterModel] = useState<GridFilterModel>({
-    items: [],
-  });
-  const [sortModel, setSortModel] = useState<GridSortModel>(DEFAULT_GRID_SORT);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [selectedTest, setSelectedTest] = useState<TestDetail | undefined>();
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
-  const [drawerFilters, setDrawerFilters] =
-    useState<TestFilters>(EMPTY_TEST_FILTERS);
   const [testSetDialogOpen, setTestSetDialogOpen] = useState(false);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [insightsFailedTestIds, setInsightsFailedTestIds] = useState<
@@ -189,6 +199,49 @@ export default function TestsTable({
     null
   );
   const [isDeleting, setIsDeleting] = useState(false);
+
+  const insightsFilterReady =
+    !insightsFailedFilter || insightsFailedTestIds !== null;
+
+  const gridFilterString = combineTestFiltersToOData(filterModel);
+  const insightsIdFilter =
+    insightsFailedFilter && insightsFailedTestIds !== null
+      ? buildTestIdsODataFilter(insightsFailedTestIds)
+      : '';
+  const filterString = combineODataFilterExpressions(
+    gridFilterString,
+    insightsIdFilter
+  );
+  const { sort_by, sort_order } = gridSortToApiParams(sortModel);
+
+  const {
+    data: testsData,
+    isLoading: loading,
+    error: fetchError,
+  } = useGridQuery({
+    queryKey: testKeys.list(
+      filterString,
+      paginationModel.page,
+      paginationModel.pageSize,
+      sort_by,
+      sort_order
+    ),
+    queryFn: () => {
+      const testsClient = new ApiClientFactory(sessionToken).getTestsClient();
+      return testsClient.getTests({
+        skip: paginationModel.page * paginationModel.pageSize,
+        limit: paginationModel.pageSize,
+        sort_by,
+        sort_order,
+        ...(filterString && { filter: filterString }),
+      });
+    },
+    enabled: !!sessionToken && insightsFilterReady,
+  });
+
+  const tests = testsData?.data ?? [];
+  const totalCount = testsData?.pagination.totalCount ?? 0;
+  const error = fetchError ? 'Failed to load tests' : null;
 
   // Compute whether selected tests have mixed types
   const selectedTestTypes = useMemo(() => {
@@ -206,148 +259,19 @@ export default function TestsTable({
   }, [selectedRows, tests]);
 
   useEffect(() => {
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
-
-  const insightsFilterReady =
-    !insightsFailedFilter || insightsFailedTestIds !== null;
-
-  // Data fetching function
-  const fetchTests = useCallback(async () => {
-    if (!sessionToken || !insightsFilterReady) {
-      if (insightsFailedFilter) {
-        setLoading(true);
-      }
-      return;
-    }
-
-    try {
-      setLoading(true);
-
-      const clientFactory = new ApiClientFactory(sessionToken);
-      const testsClient = clientFactory.getTestsClient();
-
-      const gridFilterString = combineTestFiltersToOData(filterModel);
-      const insightsIdFilter =
-        insightsFailedFilter && insightsFailedTestIds !== null
-          ? buildTestIdsODataFilter(insightsFailedTestIds)
-          : '';
-      const filterString = combineODataFilterExpressions(
-        gridFilterString,
-        insightsIdFilter
-      );
-      const { sort_by, sort_order } = gridSortToApiParams(sortModel);
-
-      const apiParams: Parameters<typeof testsClient.getTests>[0] = {
-        skip: paginationModel.page * paginationModel.pageSize,
-        limit: paginationModel.pageSize,
-        sort_by,
-        sort_order,
-        ...(filterString && { filter: filterString }),
-      };
-
-      const response = await testsClient.getTests(apiParams);
-
-      setTests(response.data);
-      setTotalCount(response.pagination.totalCount);
-      const filtersActive =
-        filterModel.items.length > 0 ||
-        !!searchQuery ||
-        hasActiveTestFilters(drawerFilters);
-      if (!filtersActive) onTotalCountChange?.(response.pagination.totalCount);
-      setError(null);
-    } catch (_error) {
-      setError('Failed to load tests');
-      setTests([]);
-    } finally {
-      setLoading(false);
-    }
+    if (!testsData) return;
+    const filtersActive =
+      filterModel.items.length > 0 ||
+      !!searchQuery ||
+      hasActiveTestFilters(drawerFilters);
+    if (!filtersActive) onTotalCountChange?.(testsData.pagination.totalCount);
   }, [
-    sessionToken,
-    paginationModel.page,
-    paginationModel.pageSize,
-    filterModel,
-    sortModel,
-    insightsFilterReady,
-    insightsFailedFilter,
-    insightsFailedTestIds,
+    testsData,
+    filterModel.items.length,
+    searchQuery,
+    drawerFilters,
+    onTotalCountChange,
   ]);
-
-  // Initial data fetch
-  useEffect(() => {
-    fetchTests();
-  }, [fetchTests]);
-
-  // Handle pagination change
-  const handlePaginationModelChange = useCallback(
-    (newModel: GridPaginationModel) => {
-      setPaginationModel(newModel);
-    },
-    []
-  );
-
-  // Handle filter change
-  const handleFilterModelChange = useCallback((newModel: GridFilterModel) => {
-    setFilterModel(newModel);
-    // Reset to first page when filters change
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
-  }, []);
-
-  const handleSortModelChange = useCallback((newModel: GridSortModel) => {
-    setSortModel(newModel);
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
-  }, []);
-
-  // Sync external searchQuery prop into filterModel
-  useEffect(() => {
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => item.field !== 'quickFilter'
-      );
-      const newItem = searchQuery
-        ? { field: 'quickFilter', operator: 'contains', value: searchQuery }
-        : null;
-      const items = newItem ? [...otherItems, newItem] : otherItems;
-      if (
-        items.length === prev.items.length &&
-        items.every(
-          (it, i) => JSON.stringify(it) === JSON.stringify(prev.items[i])
-        )
-      )
-        return prev;
-      return { ...prev, items };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [searchQuery]);
-
-  // Sync external typeFilter prop into filterModel
-  useEffect(() => {
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => item.field !== 'test_type.type_value'
-      );
-      const newItem =
-        typeFilter && typeFilter !== 'all'
-          ? {
-              field: 'test_type.type_value',
-              operator: 'equals',
-              value: typeFilter,
-            }
-          : null;
-      const items = newItem ? [...otherItems, newItem] : otherItems;
-      if (
-        items.length === prev.items.length &&
-        items.every(
-          (it, i) => JSON.stringify(it) === JSON.stringify(prev.items[i])
-        )
-      )
-        return prev;
-      return { ...prev, items };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [typeFilter]);
 
   // Apply Insights failed-test filter from URL params
   useEffect(() => {
@@ -399,17 +323,6 @@ export default function TestsTable({
     sessionToken,
     insightsFailedFilter,
   ]);
-
-  // Sync drawer filters into filterModel
-  useEffect(() => {
-    setFilterModel(prev => {
-      const next = applyTestDrawerFiltersToModel(prev, drawerFilters);
-      return next === prev || JSON.stringify(next) === JSON.stringify(prev)
-        ? prev
-        : next;
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [drawerFilters]);
 
   // Row action handlers
   const handleRowDeleteAction = useCallback((id: string) => {
@@ -700,17 +613,14 @@ export default function TestsTable({
           selectedRows as string[]
         );
 
-        if (isMounted.current) {
-          notifications.show(
-            `Successfully associated ${selectedRows.length} ${selectedRows.length === 1 ? 'test' : 'tests'} with test set "${testSet.name}"`,
-            {
-              severity: 'success',
-              autoHideDuration: 6000,
-            }
-          );
-
-          setTestSetDialogOpen(false);
-        }
+        notifications.show(
+          `Successfully associated ${selectedRows.length} ${selectedRows.length === 1 ? 'test' : 'tests'} with test set "${testSet.name}"`,
+          {
+            severity: 'success',
+            autoHideDuration: 6000,
+          }
+        );
+        setTestSetDialogOpen(false);
       } catch (_error) {
         notifications.show('Failed to associate tests with test set', {
           severity: 'error',
@@ -747,7 +657,7 @@ export default function TestsTable({
 
       setPendingDeleteId(null);
       setSelectedRows([]);
-      fetchTests();
+      queryClient.invalidateQueries({ queryKey: testKeys.all() });
       onRefresh?.();
     } catch (_error) {
       notifications.show('Failed to delete tests', {
@@ -763,7 +673,7 @@ export default function TestsTable({
     selectedRows,
     sessionToken,
     notifications,
-    fetchTests,
+    queryClient,
     onRefresh,
   ]);
 
@@ -782,57 +692,13 @@ export default function TestsTable({
     setSelectedTest(undefined);
   }, []);
 
-  const handleTestSaved = useCallback(async () => {
-    if (sessionToken) {
-      try {
-        // Fetch the most recent test (the one just created)
-        const clientFactory = new ApiClientFactory(sessionToken);
-        const testsClient = clientFactory.getTestsClient();
-
-        const response = await testsClient.getTests({
-          skip: 0,
-          limit: 1,
-          sort_by: 'created_at',
-          sort_order: 'desc',
-        });
-
-        if (response.data.length > 0) {
-          const newTest = response.data[0];
-
-          // Add the new test to the top of the current list
-          setTests(prevTests => {
-            // Check if the test already exists to avoid duplicates
-            const existingIndex = prevTests.findIndex(
-              test => test.id === newTest.id
-            );
-            if (existingIndex >= 0) {
-              // Update existing test
-              const updatedTests = [...prevTests];
-              updatedTests[existingIndex] = newTest;
-              return updatedTests;
-            } else {
-              // Add new test to the top
-              return [newTest, ...prevTests];
-            }
-          });
-
-          // Update total count
-          setTotalCount(prev => prev + 1);
-
-          // If we're not on the first page, go to first page to show the new test
-          if (paginationModel.page > 0) {
-            setPaginationModel(prev => ({ ...prev, page: 0 }));
-          }
-        }
-
-        onRefresh?.();
-      } catch (_error) {
-        // Fallback to full refresh
-        fetchTests();
-        onRefresh?.();
-      }
+  const handleTestSaved = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: testKeys.all() });
+    if (paginationModel.page > 0) {
+      setPaginationModel({ ...paginationModel, page: 0 });
     }
-  }, [sessionToken, onRefresh, fetchTests, paginationModel.page]);
+    onRefresh?.();
+  }, [queryClient, paginationModel.page, onRefresh]);
 
   // Get action buttons based on selection (Add Tests removed — FAB in page header handles it)
   const getActionButtons = useCallback(() => {

--- a/apps/frontend/src/app/(protected)/tests/components/__tests__/TestsGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/__tests__/TestsGrid.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@/test-utils';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import TestsTable from '../TestsGrid';

--- a/apps/frontend/src/constants/query-keys.ts
+++ b/apps/frontend/src/constants/query-keys.ts
@@ -1,0 +1,25 @@
+function createEntityKeys<T extends string>(root: T) {
+  return {
+    all: () => [root] as const,
+    list: (filter = '', page = 0, pageSize = 25, sortBy = '', sortOrder = '') =>
+      [root, 'list', filter, page, pageSize, sortBy, sortOrder] as const,
+    detail: (id: string) => [root, 'detail', id] as const,
+  };
+}
+
+export const testKeys = createEntityKeys('tests');
+export const testSetKeys = createEntityKeys('test-sets');
+export const testRunKeys = createEntityKeys('test-runs');
+export const endpointKeys = createEntityKeys('endpoints');
+export const sourceKeys = createEntityKeys('sources');
+export const taskKeys = createEntityKeys('tasks');
+
+// Other keys that do not fit the pattern above: they are single fetches for a single value
+
+export const featureKeys = {
+  all: () => ['features'] as const,
+};
+
+export const permissionKeys = {
+  all: (projectId: string) => ['permissions', projectId] as const,
+};

--- a/apps/frontend/src/constants/query-keys.ts
+++ b/apps/frontend/src/constants/query-keys.ts
@@ -14,6 +14,14 @@ export const endpointKeys = createEntityKeys('endpoints');
 export const sourceKeys = createEntityKeys('sources');
 export const taskKeys = createEntityKeys('tasks');
 
+export const fileKeys = {
+  all: ['files'] as const,
+  metadata: (fileId: string) => ['files', 'metadata', fileId] as const,
+  thumbnail: (fileId: string, size: number) =>
+    ['files', 'thumbnail', fileId, size] as const,
+  contentUrl: (fileId: string) => ['files', 'contentUrl', fileId] as const,
+};
+
 // Other keys that do not fit the pattern above: they are single fetches for a single value
 
 export const featureKeys = {

--- a/apps/frontend/src/contexts/FeaturesContext.tsx
+++ b/apps/frontend/src/contexts/FeaturesContext.tsx
@@ -18,17 +18,12 @@
  */
 
 import { FeatureName } from '@/constants/features';
+import { featureKeys } from '@/constants/query-keys';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import type { LicenseInfo } from '@/utils/api-client/features-client';
+import { useQuery } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from 'react';
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
 
 interface FeaturesState {
   license: LicenseInfo | null;
@@ -48,56 +43,33 @@ const FeaturesContext = createContext<FeaturesState>(DEFAULT_STATE);
 
 export function FeaturesProvider({ children }: { children: ReactNode }) {
   const { data: session, status } = useSession();
-  const [state, setState] = useState<FeaturesState>(DEFAULT_STATE);
+  const sessionToken =
+    status === 'authenticated' ? session?.session_token : undefined;
 
-  useEffect(() => {
-    // Wait for the session to resolve before attempting the fetch.
-    // Unauthenticated users never reach protected layouts, but if the
-    // session is still loading we stay in the fail-closed default state.
-    if (status !== 'authenticated' || !session?.session_token) {
-      return;
-    }
+  const { data, isLoading, error } = useQuery({
+    queryKey: featureKeys.all(),
+    queryFn: () =>
+      new ApiClientFactory(sessionToken!).getFeaturesClient().getFeatures(),
+    enabled: !!sessionToken,
+    staleTime: 5 * 60_000,
+  });
 
-    // Reset to loading each time the token changes (e.g. after re-login).
-    // Without this the component stays in the previous error/stale state
-    // while the new fetch is in flight, keeping gated UI hidden.
-    setState(DEFAULT_STATE);
-
-    let cancelled = false;
-    const client = new ApiClientFactory(
-      session.session_token
-    ).getFeaturesClient();
-
-    client
-      .getFeatures()
-      .then(response => {
-        if (cancelled) return;
-        setState({
-          license: response.license,
-          enabled: new Set<string>(response.enabled),
-          loading: false,
-          error: null,
-        });
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const error = err instanceof Error ? err : new Error(String(err));
-        setState({
-          license: null,
-          enabled: new Set<string>(),
-          loading: false,
-          error,
-        });
-      });
-
-    return () => {
-      cancelled = true;
+  const value = useMemo<FeaturesState>(() => {
+    if (isLoading || !data) return DEFAULT_STATE;
+    if (error)
+      return {
+        license: null,
+        enabled: new Set<string>(),
+        loading: false,
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+    return {
+      license: data.license,
+      enabled: new Set<string>(data.enabled),
+      loading: false,
+      error: null,
     };
-  }, [status, session?.session_token]);
-
-  // Stable reference avoids re-rendering every consumer on unrelated
-  // parent re-renders.
-  const value = useMemo(() => state, [state]);
+  }, [data, isLoading, error]);
 
   return (
     <FeaturesContext.Provider value={value}>

--- a/apps/frontend/src/contexts/FeaturesContext.tsx
+++ b/apps/frontend/src/contexts/FeaturesContext.tsx
@@ -56,12 +56,16 @@ export function FeaturesProvider({ children }: { children: ReactNode }) {
 
   const value = useMemo<FeaturesState>(() => {
     if (isLoading) return DEFAULT_STATE;
-    if (error)
+    if (error || !data)
       return {
         license: null,
         enabled: new Set<string>(),
         loading: false,
-        error: error instanceof Error ? error : new Error(String(error)),
+        error: error
+          ? error instanceof Error
+            ? error
+            : new Error(String(error))
+          : null,
       };
     return {
       license: data.license,

--- a/apps/frontend/src/contexts/FeaturesContext.tsx
+++ b/apps/frontend/src/contexts/FeaturesContext.tsx
@@ -55,7 +55,7 @@ export function FeaturesProvider({ children }: { children: ReactNode }) {
   });
 
   const value = useMemo<FeaturesState>(() => {
-    if (isLoading || !data) return DEFAULT_STATE;
+    if (isLoading) return DEFAULT_STATE;
     if (error)
       return {
         license: null,

--- a/apps/frontend/src/contexts/PermissionsContext.tsx
+++ b/apps/frontend/src/contexts/PermissionsContext.tsx
@@ -27,15 +27,10 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { useFeature, useFeaturesState } from '@/contexts/FeaturesContext';
 import { FeatureName } from '@/constants/features';
+import { permissionKeys } from '@/constants/query-keys';
+import { useQuery } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
-import {
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-  type ReactNode,
-} from 'react';
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
 import type { WithPermittedActions } from '@/types/affordances';
 
 export interface AmbientPermissions extends WithPermittedActions {
@@ -73,73 +68,40 @@ export function PermissionsProvider({ children }: { children: ReactNode }) {
   const { activeProject } = useActiveProject();
   const { loading: featuresLoading } = useFeaturesState();
   const rbacEnabled = useFeature(FeatureName.RBAC);
-  const [state, setState] = useState<AmbientPermissions>(DEFAULT_STATE);
+  const sessionToken =
+    status === 'authenticated' ? session?.session_token : undefined;
 
-  useEffect(() => {
-    // Feature flags still loading ⇒ RBAC status unknown. Stay loading (so useCan
-    // is fail-closed) rather than dropping to permissive, which would briefly
-    // fail-open and flash EE nav unlocked→locked.
-    if (featuresLoading) {
-      setState(DEFAULT_STATE);
-      return;
-    }
+  const { data, isLoading, error, isSuccess } = useQuery({
+    queryKey: permissionKeys.all(activeProject?.id ?? ''),
+    queryFn: () =>
+      new ApiClientFactory(sessionToken!)
+        .getPermissionsClient()
+        .getMyPermissions(activeProject?.id ?? undefined),
+    enabled: !featuresLoading && rbacEnabled && !!sessionToken,
+    staleTime: 5 * 60_000,
+  });
 
-    // RBAC off ⇒ role-level gating is inert. No request; useCan stays permissive.
-    if (!rbacEnabled) {
-      setState(DISABLED_STATE);
-      return;
-    }
-
-    if (status !== 'authenticated' || !session?.session_token) {
-      // Logout / session expiry: clear any prior permissions so they cannot
-      // leak across an auth transition (fail-closed).
-      setState(DEFAULT_STATE);
-      return;
-    }
-
-    // Reset to loading whenever the token or scope changes so gated UI stays
-    // hidden while the new set is in flight.
-    setState({ ...DEFAULT_STATE, enabled: true });
-
-    let cancelled = false;
-    const client = new ApiClientFactory(
-      session.session_token
-    ).getPermissionsClient();
-
-    client
-      .getMyPermissions(activeProject?.id ?? undefined)
-      .then(caps => {
-        if (cancelled) return;
-        setState({
-          permitted_actions: caps,
-          loading: false,
-          error: null,
-          enabled: true,
-        });
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const error = err instanceof Error ? err : new Error(String(err));
-        setState({
-          permitted_actions: [],
-          loading: false,
-          error,
-          enabled: true,
-        });
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    featuresLoading,
-    rbacEnabled,
-    status,
-    session?.session_token,
-    activeProject?.id,
-  ]);
-
-  const value = useMemo(() => state, [state]);
+  const value = useMemo<AmbientPermissions>(() => {
+    if (featuresLoading) return DEFAULT_STATE;
+    if (!rbacEnabled && !featuresLoading) return DISABLED_STATE;
+    if (isLoading || (!isSuccess && !error))
+      return { ...DEFAULT_STATE, enabled: true };
+    if (error)
+      return {
+        permitted_actions: [],
+        loading: false,
+        error: error instanceof Error ? error : new Error(String(error)),
+        enabled: true,
+      };
+    if (data)
+      return {
+        permitted_actions: data,
+        loading: false,
+        error: null,
+        enabled: true,
+      };
+    return DEFAULT_STATE;
+  }, [featuresLoading, rbacEnabled, isLoading, isSuccess, error, data]);
 
   return (
     <PermissionsContext.Provider value={value}>

--- a/apps/frontend/src/contexts/__tests__/FeaturesContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/FeaturesContext.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@/test-utils';
 import '@testing-library/jest-dom';
 
 import { FeatureName } from '@/constants/features';

--- a/apps/frontend/src/hooks/useFileQueries.ts
+++ b/apps/frontend/src/hooks/useFileQueries.ts
@@ -10,22 +10,7 @@ import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { FileResponse } from '@/utils/api-client/interfaces/file';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-
-// ApiClientFactory is an instance-based factory (no static helpers). We
-// instantiate it per-token so the cached, lazy ``getFilesClient()`` accessor
-// is the one issuing requests.
-
-// ---------------------------------------------------------------------------
-// Query key factory
-// ---------------------------------------------------------------------------
-export const fileKeys = {
-  all: ['files'] as const,
-  metadata: (fileId: string) => [...fileKeys.all, 'metadata', fileId] as const,
-  thumbnail: (fileId: string, size: number) =>
-    [...fileKeys.all, 'thumbnail', fileId, size] as const,
-  contentUrl: (fileId: string) =>
-    [...fileKeys.all, 'contentUrl', fileId] as const,
-};
+import { fileKeys } from '@/constants/query-keys';
 
 // ---------------------------------------------------------------------------
 // useFileMetadata — cached file metadata from GET /files/{id}

--- a/apps/frontend/src/hooks/useGridQuery.ts
+++ b/apps/frontend/src/hooks/useGridQuery.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
+
+export interface UseGridQueryOptions<T> {
+  queryKey: readonly unknown[];
+  queryFn: () => Promise<T>;
+  enabled?: boolean;
+}
+
+export function useGridQuery<T>({
+  queryKey,
+  queryFn,
+  enabled = true,
+}: UseGridQueryOptions<T>) {
+  return useQuery<T>({
+    queryKey,
+    queryFn,
+    enabled,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/apps/frontend/src/hooks/useGridState.ts
+++ b/apps/frontend/src/hooks/useGridState.ts
@@ -1,0 +1,132 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type {
+  GridFilterModel,
+  GridPaginationModel,
+  GridSortModel,
+} from '@mui/x-data-grid';
+import { DEFAULT_GRID_SORT } from '@/utils/grid-sort';
+
+export interface UseGridStateOptions {
+  searchQuery?: string;
+  typeFilter?: string;
+  typeFilterField?: string;
+  applyDrawerFilters?: (prev: GridFilterModel) => GridFilterModel;
+}
+
+export interface UseGridStateResult {
+  filterModel: GridFilterModel;
+  paginationModel: GridPaginationModel;
+  sortModel: GridSortModel;
+  setFilterModel: (model: GridFilterModel) => void;
+  setPaginationModel: (model: GridPaginationModel) => void;
+  handlePaginationModelChange: (model: GridPaginationModel) => void;
+  handleFilterModelChange: (model: GridFilterModel) => void;
+  handleSortModelChange: (model: GridSortModel) => void;
+}
+
+export function useGridState({
+  searchQuery = '',
+  typeFilter,
+  typeFilterField,
+  applyDrawerFilters,
+}: UseGridStateOptions = {}): UseGridStateResult {
+  const [filterModel, setFilterModel] = useState<GridFilterModel>({
+    items: [],
+  });
+  const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
+    page: 0,
+    pageSize: 25,
+  });
+  const [sortModel, setSortModel] = useState<GridSortModel>(DEFAULT_GRID_SORT);
+
+  // Sync searchQuery into filterModel
+  useEffect(() => {
+    setFilterModel(prev => {
+      const otherItems = prev.items.filter(
+        item => item.field !== 'quickFilter'
+      );
+      const newItem = searchQuery
+        ? { field: 'quickFilter', operator: 'contains', value: searchQuery }
+        : null;
+      const items = newItem ? [...otherItems, newItem] : otherItems;
+      if (
+        items.length === prev.items.length &&
+        items.every(
+          (it, i) => JSON.stringify(it) === JSON.stringify(prev.items[i])
+        )
+      )
+        return prev;
+      return { ...prev, items };
+    });
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
+  }, [searchQuery]);
+
+  // Sync typeFilter pill tab into filterModel
+  useEffect(() => {
+    if (!typeFilterField) return;
+    setFilterModel(prev => {
+      const otherItems = prev.items.filter(
+        item => item.field !== typeFilterField
+      );
+      const newItem =
+        typeFilter && typeFilter !== 'all'
+          ? { field: typeFilterField, operator: 'equals', value: typeFilter }
+          : null;
+      const items = newItem ? [...otherItems, newItem] : otherItems;
+      if (
+        items.length === prev.items.length &&
+        items.every(
+          (it, i) => JSON.stringify(it) === JSON.stringify(prev.items[i])
+        )
+      )
+        return prev;
+      return { ...prev, items };
+    });
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
+  }, [typeFilter, typeFilterField]);
+
+  // Sync drawer filters into filterModel
+  useEffect(() => {
+    if (!applyDrawerFilters) return;
+    setFilterModel(prev => {
+      const next = applyDrawerFilters(prev);
+      return next === prev || JSON.stringify(next) === JSON.stringify(prev)
+        ? prev
+        : next;
+    });
+    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
+    // applyDrawerFilters is a new function reference each render when drawerFilters changes,
+    // so depending on it here is the correct way to react to drawer filter changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [applyDrawerFilters]);
+
+  const handlePaginationModelChange = useCallback(
+    (model: GridPaginationModel) => {
+      setPaginationModel(model);
+    },
+    []
+  );
+
+  const handleFilterModelChange = useCallback((model: GridFilterModel) => {
+    setFilterModel(model);
+    setPaginationModel(prev => ({ ...prev, page: 0 }));
+  }, []);
+
+  const handleSortModelChange = useCallback((model: GridSortModel) => {
+    setSortModel(model);
+    setPaginationModel(prev => ({ ...prev, page: 0 }));
+  }, []);
+
+  return {
+    filterModel,
+    paginationModel,
+    sortModel,
+    setFilterModel,
+    setPaginationModel,
+    handlePaginationModelChange,
+    handleFilterModelChange,
+    handleSortModelChange,
+  };
+}

--- a/apps/frontend/src/hooks/useGridState.ts
+++ b/apps/frontend/src/hooks/useGridState.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import type {
   GridFilterModel,
   GridPaginationModel,
@@ -20,7 +20,7 @@ export interface UseGridStateResult {
   paginationModel: GridPaginationModel;
   sortModel: GridSortModel;
   setFilterModel: (model: GridFilterModel) => void;
-  setPaginationModel: (model: GridPaginationModel) => void;
+  setPaginationModel: React.Dispatch<React.SetStateAction<GridPaginationModel>>;
   handlePaginationModelChange: (model: GridPaginationModel) => void;
   handleFilterModelChange: (model: GridFilterModel) => void;
   handleSortModelChange: (model: GridSortModel) => void;

--- a/apps/frontend/src/test-utils.tsx
+++ b/apps/frontend/src/test-utils.tsx
@@ -16,10 +16,18 @@ if (typeof afterEach === 'function') {
   });
 }
 import { ThemeProvider } from '@mui/material/styles';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import lightTheme from '@/styles/theme';
 
 function AllProviders({ children }: { children: React.ReactNode }) {
-  return <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>;
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
+    </QueryClientProvider>
+  );
 }
 
 function render(

--- a/apps/frontend/src/test-utils.tsx
+++ b/apps/frontend/src/test-utils.tsx
@@ -19,12 +19,17 @@ import { ThemeProvider } from '@mui/material/styles';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import lightTheme from '@/styles/theme';
 
-function AllProviders({ children }: { children: React.ReactNode }) {
-  const queryClient = new QueryClient({
+let testQueryClient: QueryClient;
+
+beforeEach(() => {
+  testQueryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+});
+
+function AllProviders({ children }: { children: React.ReactNode }) {
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={testQueryClient}>
       <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
     </QueryClientProvider>
   );


### PR DESCRIPTION
## Purpose

Every data grid managed its own fetch lifecycle — manual useState for data/loading/error, a useCallback wrapping the API call, a useEffect to trigger it, and three more useEffects to sync search, type filter, and drawer filters into the MUI filter model. The same ~80 lines of boilerplate were copy-pasted across 6 grids. FeaturesContext and PermissionsContext had the same manual useEffect + cancelled flag pattern. This PR replaces all of it with TanStack Query, which was already installed but only used for file queries.

## What Changed

- `constants/query-keys.ts` — centralised key factories for all entities so cache invalidation always matches the query key
- `hooks/useGridState.ts` — shared hook owning filterModel/paginationModel/sortModel and the three sync effects that every grid duplicated
- `hooks/useGridQuery.ts` — thin wrapper around useQuery with keepPreviousData baked in
- `FeaturesContext` / `PermissionsContext` — manual effect loops replaced with useQuery, cancelled flags and intermediate state removed, public APIs unchanged
- All 6 grids — fetch boilerplate replaced with useGridState + useGridQuery, post-mutation fetchX() calls replaced with queryClient.invalidateQueries

## Performance Improvements

Navigating away from a grid and back no longer triggers a loading spinner — results stay cached for 5 minutes and render instantly, with a silent background refetch if stale. Changing page or applying a filter no longer flashes empty rows — keepPreviousData keeps the current rows visible while the next fetch completes. Features and permissions are now cached too, so re-renders that previously triggered duplicate fetches now hit the cache instead.

## Additional Context

- Net ~600 lines deleted across 12 files
- refreshKey props are kept on grids that have them — the effect now calls invalidateQueries instead of the old fetch callback, so callers don't need to change
- fileKeys moved from useFileQueries.ts into constants/query-keys.ts so all cache keys live in one place

## Testing

- TypeScript compiles clean
- Run each grid page and verify data loads, search/filter/sort/pagination all work, and creating/deleting records refreshes the grid