### PR TITLE
Fix fail-closed feature gating and grid defaults after React Query migration

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -176,6 +176,7 @@ export default function EndpointsGrid({
       },
       [drawerFilters]
     ),
+    initialPageSize: 10,
   });
 
   const filterString = buildEndpointListFilter(filterModel, projectId);

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -232,6 +232,7 @@ function TestRunsGrid({
     typeFilter: statusFilter,
     typeFilterField: 'status.name',
     applyDrawerFilters,
+    initialPageSize: 50,
   });
 
   // ── Data fetching ─────────────────────────────────────────────────────────

--- a/apps/frontend/src/constants/query-keys.ts
+++ b/apps/frontend/src/constants/query-keys.ts
@@ -22,12 +22,15 @@ export const fileKeys = {
   contentUrl: (fileId: string) => ['files', 'contentUrl', fileId] as const,
 };
 
-// Other keys that do not fit the pattern above: they are single fetches for a single value
+// Other keys that do not fit the pattern above: they are single fetches for a single value.
+// These are scoped by a stable per-user identifier so cached auth data never bleeds
+// across login/logout or user switches while the QueryClient is alive.
 
 export const featureKeys = {
-  all: () => ['features'] as const,
+  all: (userScope: string) => ['features', userScope] as const,
 };
 
 export const permissionKeys = {
-  all: (projectId: string) => ['permissions', projectId] as const,
+  all: (userScope: string, projectId: string) =>
+    ['permissions', userScope, projectId] as const,
 };

--- a/apps/frontend/src/contexts/FeaturesContext.tsx
+++ b/apps/frontend/src/contexts/FeaturesContext.tsx
@@ -45,7 +45,9 @@ export function FeaturesProvider({ children }: { children: ReactNode }) {
   const { data: session, status } = useSession();
   const sessionToken =
     status === 'authenticated' ? session?.session_token : undefined;
-  const userScope = session?.user?.id ?? '';
+  // Prefer the stable user id, but fall back to the per-user session token so
+  // the cache key is never shared across users even if `user.id` is missing.
+  const userScope = session?.user?.id ?? sessionToken ?? '';
 
   const { data, isLoading, error } = useQuery({
     queryKey: featureKeys.all(userScope),

--- a/apps/frontend/src/contexts/FeaturesContext.tsx
+++ b/apps/frontend/src/contexts/FeaturesContext.tsx
@@ -45,9 +45,10 @@ export function FeaturesProvider({ children }: { children: ReactNode }) {
   const { data: session, status } = useSession();
   const sessionToken =
     status === 'authenticated' ? session?.session_token : undefined;
+  const userScope = session?.user?.id ?? '';
 
   const { data, isLoading, error } = useQuery({
-    queryKey: featureKeys.all(),
+    queryKey: featureKeys.all(userScope),
     queryFn: () =>
       new ApiClientFactory(sessionToken!).getFeaturesClient().getFeatures(),
     enabled: !!sessionToken,
@@ -55,25 +56,27 @@ export function FeaturesProvider({ children }: { children: ReactNode }) {
   });
 
   const value = useMemo<FeaturesState>(() => {
-    if (isLoading) return DEFAULT_STATE;
-    if (error || !data)
+    // Fail-closed while the session is still resolving or the query is idle/
+    // in-flight. A disabled react-query (enabled: false) reports isLoading=false
+    // with data=undefined, so we must gate on sessionToken explicitly --
+    // otherwise the idle state would be mistaken for "loaded, no features" and
+    // gated UI (and downstream RBAC permissions) would flash permissive.
+    if (!sessionToken || isLoading) return DEFAULT_STATE;
+    if (error)
       return {
         license: null,
         enabled: new Set<string>(),
         loading: false,
-        error: error
-          ? error instanceof Error
-            ? error
-            : new Error(String(error))
-          : null,
+        error: error instanceof Error ? error : new Error(String(error)),
       };
+    if (!data) return DEFAULT_STATE;
     return {
       license: data.license,
       enabled: new Set<string>(data.enabled),
       loading: false,
       error: null,
     };
-  }, [data, isLoading, error]);
+  }, [sessionToken, data, isLoading, error]);
 
   return (
     <FeaturesContext.Provider value={value}>

--- a/apps/frontend/src/contexts/PermissionsContext.tsx
+++ b/apps/frontend/src/contexts/PermissionsContext.tsx
@@ -70,9 +70,10 @@ export function PermissionsProvider({ children }: { children: ReactNode }) {
   const rbacEnabled = useFeature(FeatureName.RBAC);
   const sessionToken =
     status === 'authenticated' ? session?.session_token : undefined;
+  const userScope = session?.user?.id ?? '';
 
   const { data, isLoading, error, isSuccess } = useQuery({
-    queryKey: permissionKeys.all(activeProject?.id ?? ''),
+    queryKey: permissionKeys.all(userScope, activeProject?.id ?? ''),
     queryFn: () =>
       new ApiClientFactory(sessionToken!)
         .getPermissionsClient()

--- a/apps/frontend/src/contexts/PermissionsContext.tsx
+++ b/apps/frontend/src/contexts/PermissionsContext.tsx
@@ -70,7 +70,9 @@ export function PermissionsProvider({ children }: { children: ReactNode }) {
   const rbacEnabled = useFeature(FeatureName.RBAC);
   const sessionToken =
     status === 'authenticated' ? session?.session_token : undefined;
-  const userScope = session?.user?.id ?? '';
+  // Prefer the stable user id, but fall back to the per-user session token so
+  // the cache key is never shared across users even if `user.id` is missing.
+  const userScope = session?.user?.id ?? sessionToken ?? '';
 
   const { data, isLoading, error, isSuccess } = useQuery({
     queryKey: permissionKeys.all(userScope, activeProject?.id ?? ''),

--- a/apps/frontend/src/contexts/__tests__/FeaturesContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/FeaturesContext.test.tsx
@@ -12,11 +12,17 @@ import {
 
 const mockGetFeatures = jest.fn();
 
+const AUTHENTICATED_SESSION = {
+  data: { session_token: 'test-token', user: { id: 'user-1' } },
+  status: 'authenticated',
+};
+
+// Mutable so individual tests can simulate an unauthenticated/loading session.
+// Named with the `mock` prefix so jest.mock's factory may reference it.
+let mockSession: { data: unknown; status: string } = AUTHENTICATED_SESSION;
+
 jest.mock('next-auth/react', () => ({
-  useSession: () => ({
-    data: { session_token: 'test-token' },
-    status: 'authenticated',
-  }),
+  useSession: () => mockSession,
 }));
 
 jest.mock('@/utils/api-client/client-factory', () => ({
@@ -31,6 +37,7 @@ const LICENSE = { edition: 'community', licensed: false };
 
 beforeEach(() => {
   mockGetFeatures.mockReset();
+  mockSession = AUTHENTICATED_SESSION;
 });
 
 function Probe({ feature }: { feature: FeatureName }) {
@@ -111,6 +118,27 @@ describe('FeaturesProvider', () => {
     await waitFor(() =>
       expect(screen.getByTestId('edition')).toHaveTextContent('enterprise')
     );
+  });
+});
+
+describe('FeaturesProvider session gating', () => {
+  it('stays fail-closed (loading) while the session is still resolving', () => {
+    // While next-auth resolves the session there is no token, so the query is
+    // disabled/idle (isLoading=false, data=undefined). The provider must report
+    // loading=true rather than treating idle as "loaded, no features".
+    mockSession = { data: null, status: 'loading' };
+    mockGetFeatures.mockResolvedValue({ license: LICENSE, enabled: ['sso'] });
+
+    render(
+      <FeaturesProvider>
+        <Probe feature={FeatureName.SSO} />
+        <StateProbe />
+      </FeaturesProvider>
+    );
+
+    expect(screen.getByTestId('probe')).toHaveTextContent('off');
+    expect(screen.getByTestId('loading')).toHaveTextContent('true');
+    expect(mockGetFeatures).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/frontend/src/hooks/useGridState.ts
+++ b/apps/frontend/src/hooks/useGridState.ts
@@ -13,6 +13,8 @@ export interface UseGridStateOptions {
   typeFilter?: string;
   typeFilterField?: string;
   applyDrawerFilters?: (prev: GridFilterModel) => GridFilterModel;
+  /** Initial rows-per-page. Defaults to 25; pass each grid's prior default. */
+  initialPageSize?: number;
 }
 
 export interface UseGridStateResult {
@@ -31,13 +33,14 @@ export function useGridState({
   typeFilter,
   typeFilterField,
   applyDrawerFilters,
+  initialPageSize = 25,
 }: UseGridStateOptions = {}): UseGridStateResult {
   const [filterModel, setFilterModel] = useState<GridFilterModel>({
     items: [],
   });
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
     page: 0,
-    pageSize: 25,
+    pageSize: initialPageSize,
   });
   const [sortModel, setSortModel] = useState<GridSortModel>(DEFAULT_GRID_SORT);
 


### PR DESCRIPTION
## Purpose

Follow-up to #2072 (React Query migration), addressing the critical issue and two improvements flagged in review that were merged unresolved.

The migration changed `FeaturesContext` so that a **disabled/idle** React Query (`enabled: false` while the next-auth session is still resolving) is mistaken for "loaded with no features". A disabled query reports `isLoading === false` with `data === undefined`, so the old `if (error || !data) … loading: false` branch reported `loading: false` before features were actually known.

Because `PermissionsContext` reads `featuresLoading`, this briefly flipped RBAC to **permissive** on every fresh page load (`useCan` returns true), contradicting the documented fail-closed contract. The backend still enforces, so this is a UI flash of gated controls rather than an exploit — but it's the regression `peqy[bot]` flagged across five review rounds.

## What Changed

- **`FeaturesContext`** — gate the resolved state on `sessionToken`, so the idle/in-flight state stays `loading: true` (fail-closed) until features are actually known. Error is checked before `data`.
- **`constants/query-keys.ts`** — `featureKeys` / `permissionKeys` now take a stable per-user scope (`session.user.id`) so cached features/permissions can't bleed across login/logout or user switches while the long-lived `QueryClient` is alive.
- **`PermissionsContext`** — pass the user scope into `permissionKeys.all(...)`.
- **`useGridState`** — add an `initialPageSize` option (default 25). Restore the pre-migration defaults that silently regressed to 25: **Test Runs to 50**, **Endpoints to 10**.
- **Tests** — added a regression test asserting the provider stays `loading: true` (and never fires the request) while the session is unauthenticated/resolving.

## Testing

- `tsc --noEmit` clean
- `jest` green (29/29 in the affected suites, including the new regression test)
- `eslint` clean (no new errors/warnings)