### PR TITLE
feat(sdk): stamp MAF workflow runs as conversation turn roots

### DIFF
--- a/agents/travel-agent/README.md
+++ b/agents/travel-agent/README.md
@@ -68,9 +68,16 @@ uv sync
 
 ### 3. Generate Traces (CLI)
 
-Run a batch of scenarios that exercise the full multi-agent workflow. Each
-scenario uses its own conversation id; multi-turn scenarios replay their
-history so the workflow remembers earlier turns:
+Run a minimal in-process `auto_instrument` smoke test: a batch of scenarios
+that exercise the full multi-agent workflow. There is no manual tracing here —
+the SDK produces and ships every span automatically. The only manual step is a
+single `shutdown_tracer_provider()` at the end to flush the final batch before
+this short-lived process exits. Each scenario is one-shot and single-turn: it
+sets no conversation/session id, so it produces a single ordinary trace rooted
+at MAF's `function.workflow.run` and shows up in the default Traces view (not as
+a multi-turn conversation). Multi-turn grouping is exercised separately by the
+chat session path (`travel_agent.session.run_chat_turn`) used by the app and
+playground:
 
 ```bash
 uv run python examples/run_traces.py
@@ -198,7 +205,11 @@ uvx ruff format src/ examples/
 
 ## How Travel Agent Exercises the SDK
 
-When the workflow runs with a Rhesis `TracerProvider` active, MAF emits spans that the SDK translator rewrites into the Rhesis schema:
+Travel Agent uses only `@endpoint` + `auto_instrument("agent_framework")`. It
+never creates a span, sets a span attribute, or flushes the tracer by hand —
+every span and attribute is produced by the SDK. When the workflow runs with a
+Rhesis `TracerProvider` active, MAF emits spans that the SDK translator rewrites
+into the Rhesis schema:
 
 - `ai.agent.invoke` for each agent activation (`trip_coordinator`, `destination_finder`, `sightseeing_scout`, `logistics_planner`)
 - `ai.llm.invoke` for Gemini chat completions

--- a/agents/travel-agent/docs/architecture.md
+++ b/agents/travel-agent/docs/architecture.md
@@ -108,20 +108,23 @@ This keeps the behavior simple and traceable. The specialist tools are mock tool
 
 ## Conversation Memory
 
-The FastAPI app stores per-conversation MAF `Message` history in memory:
+The FastAPI app stores per-conversation **user-visible** MAF ``Message`` history in
+memory (user turns plus the coordinator's final plan for each turn). Specialist
+outputs stay inside the workflow run and are not persisted:
 
 ```mermaid
 flowchart LR
     ConversationId[conversation_id]
-    History[Message History]
-    NextTurn[Next Chat Turn]
+    History[User-visible history]
+    NextTurn[Next chat turn]
 
     ConversationId --> History
     History --> NextTurn
     NextTurn --> History
 ```
 
-This is enough for a local trace-generation demo. A production deployment would persist this state in a database.
+This is enough for a local trace-generation demo. A production deployment would
+persist this state in a database.
 
 ## Trace Surface Generated
 
@@ -134,4 +137,4 @@ A single user query can produce the following Rhesis span shapes:
 | `ai.llm.invoke` | Gemini chat completions through MAF. |
 | `ai.tool.invoke` | Domain tool execution: `get_random_destination`, `find_sightseeing`, `estimate_travel`. |
 
-The example scripts also create a manual turn-root span with `rhesis.conversation.*` attributes so trace details can be grouped by conversation outside the FastAPI endpoint path.
+The example scripts contain no manual tracing: every span and attribute is produced by the SDK via `auto_instrument`. The in-process `examples/run_traces.py` smoke test runs with no `@endpoint` and sets no conversation/session id, so each scenario is a one-shot single-turn run that produces a single ordinary trace rooted at MAF's `function.workflow.run` and appears in the default Traces view (not as a multi-turn conversation). Multi-turn conversation grouping is exercised separately by the chat session path (`travel_agent.session.run_chat_turn`): the FastAPI `/chat` route and the playground connector go through the `@endpoint` decorator, where that decorator's span is the turn root and conversation grouping is handled by the SDK request/response mapping plus backend backfill.

--- a/agents/travel-agent/examples/run_traces.py
+++ b/agents/travel-agent/examples/run_traces.py
@@ -2,11 +2,12 @@
 
 This script's only job is to fire a handful of representative queries through
 the Travel Agent multi-agent handoff workflow so the Rhesis SDK's MAF
-integration has something real to translate and ship to the backend.
-
-Each scenario is a single user turn. The script creates one Rhesis-visible
-turn-root span per scenario so the frontend can render the Conversation tab
-from ``rhesis.conversation.input`` / ``rhesis.conversation.output``.
+integration has something real to translate and ship to the backend. It is a
+minimal in-process ``auto_instrument`` smoke test: turn Rhesis on, run the
+workflow, and let the SDK produce and ship every span automatically. There is
+no manual span creation and no manual attribute stamping; the only manual step
+is a single ``shutdown_tracer_provider()`` at the end to flush the last batch
+before this short-lived process exits.
 
 Run from ``agents/travel-agent/``:
 
@@ -22,15 +23,18 @@ Optional env vars:
     RHESIS_API_KEY      - Set both to ship spans to the Rhesis backend
     RHESIS_PROJECT_ID
 
-Each query produces a small but rich trace tree:
+Each scenario is one workflow run and produces a single plain trace rooted at
+MAF's ``function.workflow.run``. These are one-shot single-turn runs: they do
+not set a conversation/session id, so the MAF integration leaves them as
+ordinary traces (they appear in the default Traces view, not as multi-turn
+conversations). Multi-turn grouping is exercised separately by the chat session
+path (``travel_agent.session.run_chat_turn``), used by the playground/app:
 
-    function.travel_agent.run
-    +-- function.workflow.build
-    +-- function.workflow.run
-        +-- function.workflow.executor.process (per executor activation)
-            +-- ai.agent.invoke (per agent activation)
-                +-- ai.llm.invoke (per chat completion)
-                +-- ai.tool.invoke (per tool call, with input/output events)
+    function.workflow.run                     (trace root)
+    +-- function.workflow.executor.process    (per executor activation)
+        +-- ai.agent.invoke                   (per agent activation)
+            +-- ai.llm.invoke                 (per chat completion)
+            +-- ai.tool.invoke                (per tool call, with input/output events)
 """
 
 from __future__ import annotations
@@ -42,12 +46,10 @@ import sys
 import uuid
 
 from dotenv import load_dotenv
-from opentelemetry import trace
 
 from rhesis.sdk import RhesisClient
 from rhesis.sdk.clients import DisabledClient
 from rhesis.sdk.telemetry import auto_instrument, shutdown_tracer_provider
-from rhesis.telemetry.constants import ConversationContext
 from travel_agent.workflow import build_travel_workflow, invoke_travel_workflow_async
 
 logging.basicConfig(
@@ -92,40 +94,19 @@ def _section(title: str) -> None:
 
 
 async def _run_scenario(label: str, query: str) -> None:
-    """Run one single-turn scenario under a frontend-readable root span."""
+    """Run one single-turn scenario; auto_instrument captures the full trace tree."""
     conversation_id = str(uuid.uuid4())
-    attrs = ConversationContext.SpanAttributes
-
     _section(f"[{label}] {query}")
 
-    # MAF's workflow/agent spans do not carry Rhesis conversation attributes.
-    # This explicit turn-root span makes the frontend Conversation tab work and
-    # keeps workflow.build/workflow.run under one trace tree for the scenario.
-    tracer = trace.get_tracer("travel_agent.examples.run_traces")
-    with tracer.start_as_current_span("function.travel_agent.run") as span:
-        span.set_attribute(attrs.IS_TURN_ROOT, True)
-        span.set_attribute(attrs.CONVERSATION_ID, conversation_id)
-        span.set_attribute(
-            attrs.CONVERSATION_INPUT,
-            query[: ConversationContext.MAX_IO_LENGTH],
-        )
-
-        span.set_attribute("travel_agent.scenario", label)
-
-        workflow = build_travel_workflow()
-        result = await invoke_travel_workflow_async(
-            workflow,
-            query,
-            conversation_id=conversation_id,
-        )
-
-        response = str(result["response"])
-        span.set_attribute(
-            attrs.CONVERSATION_OUTPUT,
-            response[: ConversationContext.MAX_IO_LENGTH],
-        )
-        span.set_attribute("travel_agent.agent_workflow", result["agent_workflow"])
-        span.set_attribute("travel_agent.tool_chain", result["tool_chain"])
+    # Build a fresh workflow per scenario. MAF agents use
+    # ``require_per_service_call_history_persistence=True``, so reusing a cached
+    # workflow leaks prior scenarios' internal history into later runs.
+    workflow = build_travel_workflow()
+    result = await invoke_travel_workflow_async(
+        workflow,
+        query,
+        conversation_id=conversation_id,
+    )
 
     logger.info("Agents: %s", result["agent_workflow"])
     logger.info("Tools : %s", result["tool_chain"])
@@ -146,23 +127,35 @@ async def main() -> None:
     # returned instance.
     if os.getenv("RHESIS_API_KEY") and os.getenv("RHESIS_PROJECT_ID"):
         RhesisClient.from_environment()
-    else:
         logger.info(
-            "RHESIS_API_KEY/RHESIS_PROJECT_ID not set; using DisabledClient (no remote traces)."
+            "Remote traces enabled for project %s (%s). "
+            "Select this project in the frontend Traces page to view them.",
+            os.getenv("RHESIS_PROJECT_ID"),
+            os.getenv("RHESIS_BASE_URL", "http://localhost:8080"),
+        )
+    else:
+        logger.warning(
+            "RHESIS_API_KEY/RHESIS_PROJECT_ID not set; using DisabledClient. "
+            "Traces will NOT be shipped to the backend."
         )
         DisabledClient()
 
     instrumented = auto_instrument("agent_framework")
     logger.info("auto_instrument: %s", instrumented)
 
-    for label, query in SCENARIOS:
-        try:
-            await _run_scenario(label, query)
-        except Exception:  # noqa: BLE001
-            logger.exception("Scenario failed (this still produces an error span):")
+    try:
+        for label, query in SCENARIOS:
+            try:
+                await _run_scenario(label, query)
+            except Exception:  # noqa: BLE001
+                logger.exception("Scenario failed (this still produces an error span):")
+    finally:
+        # This is a short-lived script: flush and shut the tracer provider down
+        # explicitly so the final batch of spans is exported before the process
+        # exits (the BatchSpanProcessor only flushes every few seconds otherwise).
+        shutdown_tracer_provider()
 
     _section("Done")
-    shutdown_tracer_provider()
 
 
 if __name__ == "__main__":

--- a/agents/travel-agent/examples/serve_playground.py
+++ b/agents/travel-agent/examples/serve_playground.py
@@ -24,26 +24,19 @@ from __future__ import annotations
 import logging
 import os
 import sys
-import uuid
 
-from agent_framework import Message
 from dotenv import load_dotenv
-from opentelemetry import trace as otel_trace
-from rhesis.telemetry.constants import ConversationContext
 
 from rhesis.sdk import RhesisClient, endpoint
 from rhesis.sdk.telemetry import auto_instrument
-from travel_agent import build_travel_workflow, invoke_travel_workflow
+from travel_agent.session import run_chat_turn_sync
+from travel_agent.workflow import build_travel_workflow
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger("travel_agent.examples.serve_playground")
-
-# Per-conversation message history so the playground gets real multi-turn
-# memory. In-memory is fine for a demo; production would persist this.
-conversations: dict[str, list[Message]] = {}
 
 
 def _build_chat_endpoint():
@@ -70,35 +63,20 @@ def _build_chat_endpoint():
         },
     )
     def travel_agent_chat(message: str, conversation_id: str | None = None) -> dict:
-        conv_id = conversation_id or str(uuid.uuid4())
-
         logger.info("=" * 80)
-        logger.info("PLAYGROUND TURN | conversation_id=%s", conv_id)
+        logger.info("PLAYGROUND TURN | conversation_id=%s", conversation_id)
         logger.info("Q: %s", message[:100])
         logger.info("=" * 80)
 
-        # Stamp conversation attributes on the active @endpoint span (the turn
-        # root). On the first turn the playground sends no conversation_id, so
-        # the SDK cannot inject one before the span is created.
-        conv_attr = ConversationContext.SpanAttributes
-        max_io = ConversationContext.MAX_IO_LENGTH
-        span = otel_trace.get_current_span()
-        span.set_attribute(conv_attr.IS_TURN_ROOT, True)
-        span.set_attribute(conv_attr.CONVERSATION_ID, conv_id)
-        span.set_attribute(conv_attr.CONVERSATION_INPUT, message[:max_io])
-
-        # Replay prior turns so the workflow actually remembers the conversation.
-        history = conversations.get(conv_id, [])
-        workflow = build_travel_workflow()
-        result = invoke_travel_workflow(
-            workflow,
+        # Build a fresh workflow per turn. The connector runs this sync handler
+        # in a thread pool and ``run_chat_turn_sync`` opens a new event loop via
+        # ``asyncio.run`` each turn; reusing a cached MAF workflow across those
+        # loops fails with "Queue is bound to a different event loop".
+        result = run_chat_turn_sync(
+            build_travel_workflow(),
             message,
-            conversation_history=history,
-            conversation_id=conv_id,
+            conversation_id=conversation_id,
         )
-        conversations[conv_id] = result["messages"]
-
-        span.set_attribute(conv_attr.CONVERSATION_OUTPUT, (result["response"] or "")[:max_io])
 
         logger.info("--- Travel plan ---")
         logger.info(result["response"])
@@ -107,11 +85,12 @@ def _build_chat_endpoint():
 
         return {
             "response": result["response"],
-            "conversation_id": conv_id,
+            "conversation_id": result["conversation_id"],
             "tools_called": result["tools_called"],
             "agents_involved": result["agents_involved"],
             "agent_workflow": result["agent_workflow"],
             "tool_chain": result["tool_chain"],
+            "agent": result.get("agent", "trip_coordinator"),
         }
 
     return travel_agent_chat

--- a/agents/travel-agent/src/travel_agent/__init__.py
+++ b/agents/travel-agent/src/travel_agent/__init__.py
@@ -7,6 +7,12 @@ from travel_agent.agents import (
     create_logistics_planner,
     create_sightseeing_scout,
 )
+from travel_agent.session import (
+    ConversationStore,
+    default_store,
+    run_chat_turn,
+    run_chat_turn_sync,
+)
 from travel_agent.tools import (
     DESTINATION_TOOLS,
     DESTINATIONS,
@@ -40,17 +46,21 @@ __all__ = [
     "DESTINATION_TOOLS",
     "LOGISTICS_TOOLS",
     "SIGHTSEEING_TOOLS",
+    "ConversationStore",
     "app",
     "build_travel_workflow",
     "create_coordinator",
     "create_destination_finder",
     "create_logistics_planner",
     "create_sightseeing_scout",
+    "default_store",
     "estimate_travel",
     "find_sightseeing",
     "get_participants",
     "get_random_destination",
     "invoke_travel_workflow",
     "invoke_travel_workflow_async",
+    "run_chat_turn",
+    "run_chat_turn_sync",
     "run_query",
 ]

--- a/agents/travel-agent/src/travel_agent/agents/coordinator.py
+++ b/agents/travel-agent/src/travel_agent/agents/coordinator.py
@@ -57,6 +57,19 @@ Critical routing rule: on every turn you must do exactly one of two things.
   the whole plan fresh, as if the user has seen nothing so far - never a one-line
   continuation of the last specialist's message.
 
+Follow-up turns (when prior user messages and your earlier travel plans appear in the
+conversation history):
+
+7. When the user asks to refine or adjust an existing plan (for example "make it more
+   family friendly" or "slow the pace down") without naming a new city or replacing the
+   whole itinerary:
+   - Do NOT hand off to destination_finder unless the user explicitly asks for a new or
+     random destination or names a different city.
+   - Do NOT re-invoke sightseeing_scout or logistics_planner unless the user adds new
+     sights, changes the destination, or explicitly asks for new logistics estimates.
+   - Reply directly with a complete updated travel plan that preserves the existing
+     destination and sightseeing stops unless the user changed them.
+
 Never end a turn with plain text while a required specialist still needs to run, and never
 just describe which specialist you would call. Use the handoff tools to act."""
 

--- a/agents/travel-agent/src/travel_agent/agents/destination_finder.py
+++ b/agents/travel-agent/src/travel_agent/agents/destination_finder.py
@@ -14,9 +14,8 @@ You choose a city for trips when the coordinator needs a destination.
 How to behave:
 
 1. Call get_random_destination. Do not choose a city without using the tool.
-2. Reply with the selected destination in one short sentence.
-3. You must end every turn by calling the handoff_to_trip_coordinator tool. Do not reply
-   with plain text only and do not keep talking after handing off."""
+2. Immediately call handoff_to_trip_coordinator to return the selected destination.
+   Do not send user-facing prose; the coordinator presents the destination to the user."""
 
 DESCRIPTION = "Selects a random travel destination with get_random_destination."
 

--- a/agents/travel-agent/src/travel_agent/agents/logistics_planner.py
+++ b/agents/travel-agent/src/travel_agent/agents/logistics_planner.py
@@ -15,10 +15,8 @@ and the sightseeing stops in the plan.
 How to behave:
 
 1. Call estimate_travel with the destination and sightseeing stops you received.
-2. Summarize practical travel-time guidance from the city center, central station,
-   and airport.
-3. You must end every turn by calling the handoff_to_trip_coordinator tool. Do not reply
-   with plain text only and do not keep talking after handing off."""
+2. Immediately call handoff_to_trip_coordinator to return the travel-time guidance.
+   Do not send user-facing prose; the coordinator presents logistics to the user."""
 
 DESCRIPTION = "Estimates mock sightseeing distances and travel times."
 

--- a/agents/travel-agent/src/travel_agent/agents/sightseeing_scout.py
+++ b/agents/travel-agent/src/travel_agent/agents/sightseeing_scout.py
@@ -14,9 +14,8 @@ You suggest sightseeing stops when the user did not already name specific sights
 How to behave:
 
 1. Call find_sightseeing with the destination and the user's stated interests or trip style.
-2. Distill the tool output into a short list of useful sightseeing stops.
-3. You must end every turn by calling the handoff_to_trip_coordinator tool. Do not reply
-   with plain text only and do not keep talking after handing off."""
+2. Immediately call handoff_to_trip_coordinator to return the sightseeing list.
+   Do not send user-facing prose; the coordinator presents the stops to the user."""
 
 DESCRIPTION = "Finds mock sightseeing stops for a destination using an LLM-style tool."
 

--- a/agents/travel-agent/src/travel_agent/app.py
+++ b/agents/travel-agent/src/travel_agent/app.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field
 from rhesis.sdk import RhesisClient, endpoint
 from rhesis.sdk.clients import DisabledClient
 from rhesis.sdk.telemetry import auto_instrument
-from travel_agent.session import default_store, run_chat_turn, run_chat_turn_sync
+from travel_agent.session import default_store, run_chat_turn
 from travel_agent.workflow import build_travel_workflow
 
 logging.basicConfig(
@@ -213,18 +213,25 @@ async def health():
         ),
     },
 )
-def chat_endpoint_traced(
+async def chat_endpoint_traced(
     message: str,
     conversation_id: str | None = None,
 ) -> ChatResponse:
-    """Traced entry point for the MAF travel multi-agent workflow."""
+    """Traced entry point for the MAF travel multi-agent workflow.
+
+    Async so the FastAPI ``/chat`` route can ``await`` it directly from the
+    running event loop while still going through the ``@endpoint`` decorator
+    (which creates the Rhesis endpoint span and applies the request/response
+    mappings used for conversation grouping). A sync helper would have to use
+    ``run_chat_turn_sync``, which cannot run inside an active event loop.
+    """
     logger.info("=" * 80)
     logger.info("TRAVEL AGENT MULTI-AGENT CHAT")
     logger.info("Message: %s...", message[:100])
     logger.info("Conversation ID: %s", conversation_id)
     logger.info("=" * 80)
 
-    result = run_chat_turn_sync(
+    result = await run_chat_turn(
         build_travel_workflow(),
         message,
         conversation_id=conversation_id,
@@ -248,12 +255,10 @@ async def chat(request: ChatRequest):
         raise HTTPException(status_code=503, detail="Travel Agent not initialised")
 
     try:
-        result = await run_chat_turn(
-            build_travel_workflow(),
-            request.message,
+        return await chat_endpoint_traced(
+            message=request.message,
             conversation_id=request.conversation_id,
         )
-        return _chat_response_from_result(result)
     except TimeoutError as exc:
         logger.error("Travel workflow timed out: %s", exc, exc_info=True)
         raise HTTPException(status_code=504, detail="Travel Agent request timed out")

--- a/agents/travel-agent/src/travel_agent/app.py
+++ b/agents/travel-agent/src/travel_agent/app.py
@@ -53,7 +53,7 @@ _startup_validated: bool = False
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Validate and cache the travel workflow once at startup."""
+    """Validate the travel workflow once at startup."""
     global _startup_validated
 
     logger.info("Initialising Travel Agent multi-agent workflow (MAF)...")

--- a/agents/travel-agent/src/travel_agent/app.py
+++ b/agents/travel-agent/src/travel_agent/app.py
@@ -8,20 +8,18 @@ from __future__ import annotations
 
 import logging
 import os
-import uuid
 from contextlib import asynccontextmanager
+from typing import Any
 
-from agent_framework import Message
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
-from opentelemetry import trace as otel_trace
 from pydantic import BaseModel, Field
-from rhesis.telemetry.constants import ConversationContext
 
 from rhesis.sdk import RhesisClient, endpoint
 from rhesis.sdk.clients import DisabledClient
 from rhesis.sdk.telemetry import auto_instrument
-from travel_agent.workflow import build_travel_workflow, invoke_travel_workflow
+from travel_agent.session import default_store, run_chat_turn, run_chat_turn_sync
+from travel_agent.workflow import build_travel_workflow
 
 logging.basicConfig(
     level=logging.INFO,
@@ -50,24 +48,26 @@ else:
 # THE line under test: turn on the SDK's MAF integration.
 auto_instrument("agent_framework")
 
-# Per-conversation message history. Production deployments would persist this
-# in a database; in-memory is fine for a trace-generation demo.
-conversations: dict[str, list[Message]] = {}
-
 _startup_validated: bool = False
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Validate travel workflow construction once at startup."""
+    """Validate and cache the travel workflow once at startup."""
     global _startup_validated
 
-    logger.info("Validating Travel Agent multi-agent workflow construction (MAF)...")
+    logger.info("Initialising Travel Agent multi-agent workflow (MAF)...")
+    # Build once at startup purely to validate construction. Each chat turn
+    # builds its own fresh workflow instead of reusing a cached instance: MAF
+    # agents keep per-call history, and the connector runs sync handlers in a
+    # thread pool with a new event loop per turn, so a shared workflow both
+    # leaks state across conversations and breaks with "Queue is bound to a
+    # different event loop".
     build_travel_workflow()
     _startup_validated = True
     logger.info(
-        "Travel Agent workflow construction validated: trip_coordinator + "
-        "destination_finder + sightseeing_scout + logistics_planner"
+        "Travel Agent workflow ready: trip_coordinator + destination_finder + "
+        "sightseeing_scout + logistics_planner"
     )
 
     yield
@@ -139,6 +139,26 @@ class ConversationInfo(BaseModel):
     message_count: int
 
 
+def _chat_response_from_result(result: dict[str, Any]) -> ChatResponse:
+    tools_called = [
+        ToolCall(
+            tool_name=tc["tool_name"],
+            agent=tc.get("agent", "travel_agent"),
+            tool_args=tc.get("tool_args", {}),
+        )
+        for tc in result.get("tools_called", [])
+    ]
+    return ChatResponse(
+        response=result["response"],
+        conversation_id=result["conversation_id"],
+        tools_called=tools_called,
+        tool_chain=result.get("tool_chain", ""),
+        agents_involved=result.get("agents_involved", []),
+        agent_workflow=result.get("agent_workflow", ""),
+        agent=result.get("agent", "trip_coordinator"),
+    )
+
+
 @app.get("/")
 async def root():
     """Root endpoint with a quick orientation."""
@@ -204,66 +224,39 @@ def chat_endpoint_traced(
     logger.info("Conversation ID: %s", conversation_id)
     logger.info("=" * 80)
 
-    conv_id = conversation_id or str(uuid.uuid4())
-
-    # Stamp the conversation attributes on the active @endpoint span (the
-    # turn root). On the first turn the playground sends no conversation_id,
-    # so the SDK/backend cannot inject one before the span is created.
-    conv_attr = ConversationContext.SpanAttributes
-    max_io = ConversationContext.MAX_IO_LENGTH
-    span = otel_trace.get_current_span()
-    span.set_attribute(conv_attr.IS_TURN_ROOT, True)
-    span.set_attribute(conv_attr.CONVERSATION_ID, conv_id)
-    span.set_attribute(conv_attr.CONVERSATION_INPUT, message[:max_io])
-
-    # Replay prior turns so the workflow actually remembers the conversation.
-    history = conversations.get(conv_id, [])
-    workflow = build_travel_workflow()
-    result = invoke_travel_workflow(
-        workflow,
+    result = run_chat_turn_sync(
+        build_travel_workflow(),
         message,
-        conversation_history=history,
-        conversation_id=conv_id,
+        conversation_id=conversation_id,
     )
-    conversations[conv_id] = result["messages"]
-
-    span.set_attribute(conv_attr.CONVERSATION_OUTPUT, (result["response"] or "")[:max_io])
-
-    tools_called = [
-        ToolCall(
-            tool_name=tc["tool_name"],
-            agent=tc.get("agent", "travel_agent"),
-            tool_args=tc.get("tool_args", {}),
-        )
-        for tc in result.get("tools_called", [])
-    ]
 
     logger.info("Travel response generated")
     logger.info("Agents involved: %s", result.get("agents_involved", []))
-    logger.info("Tools called: %s", [tc.tool_name for tc in tools_called])
+    logger.info(
+        "Tools called: %s",
+        [tc["tool_name"] for tc in result.get("tools_called", [])],
+    )
     logger.info("=" * 80)
 
-    return ChatResponse(
-        response=result["response"],
-        conversation_id=conv_id,
-        tools_called=tools_called,
-        tool_chain=result.get("tool_chain", ""),
-        agents_involved=result.get("agents_involved", []),
-        agent_workflow=result.get("agent_workflow", ""),
-    )
+    return _chat_response_from_result(result)
 
 
 @app.post("/chat", response_model=ChatResponse)
-def chat(request: ChatRequest):
+async def chat(request: ChatRequest):
     """Chat with the Microsoft Agent Framework travel multi-agent system."""
     if not _startup_validated:
         raise HTTPException(status_code=503, detail="Travel Agent not initialised")
 
     try:
-        return chat_endpoint_traced(
-            message=request.message,
+        result = await run_chat_turn(
+            build_travel_workflow(),
+            request.message,
             conversation_id=request.conversation_id,
         )
+        return _chat_response_from_result(result)
+    except TimeoutError as exc:
+        logger.error("Travel workflow timed out: %s", exc, exc_info=True)
+        raise HTTPException(status_code=504, detail="Travel Agent request timed out")
     except Exception as exc:
         logger.error("Error in /chat: %s", exc, exc_info=True)
         raise HTTPException(status_code=500, detail="Error processing request")
@@ -273,18 +266,18 @@ def chat(request: ChatRequest):
 async def list_conversations():
     """List every active conversation."""
     return [
-        ConversationInfo(conversation_id=cid, message_count=len(messages))
-        for cid, messages in conversations.items()
+        ConversationInfo(conversation_id=conversation_id, message_count=message_count)
+        for conversation_id, message_count in default_store.list_conversations().items()
     ]
 
 
 @app.get("/conversations/{conversation_id}")
 async def get_conversation(conversation_id: str):
-    """Return a conversation's flat message history."""
-    if conversation_id not in conversations:
+    """Return a conversation's user-visible message history."""
+    messages = default_store.get_messages(conversation_id)
+    if messages is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    messages = conversations[conversation_id]
     history = [
         {
             "role": message.role,
@@ -303,9 +296,8 @@ async def get_conversation(conversation_id: str):
 @app.delete("/conversations/{conversation_id}")
 async def delete_conversation(conversation_id: str):
     """Delete a stored conversation."""
-    if conversation_id not in conversations:
+    if not default_store.delete(conversation_id):
         raise HTTPException(status_code=404, detail="Conversation not found")
-    del conversations[conversation_id]
     return {"message": f"Conversation {conversation_id} deleted"}
 
 

--- a/agents/travel-agent/src/travel_agent/session.py
+++ b/agents/travel-agent/src/travel_agent/session.py
@@ -14,19 +14,44 @@ from travel_agent.workflow import invoke_travel_workflow_async
 
 
 class ConversationStore:
-    """Thread-safe in-memory store of user-visible MAF message history."""
+    """Thread-safe in-memory store of user-visible MAF message history.
 
-    def __init__(self) -> None:
+    Bounded so a long-running demo server does not grow memory without limit.
+    Defaults are generous for local development; tighten via constructor args
+    when running unattended.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_conversations: int = 256,
+        max_messages_per_conversation: int = 200,
+    ) -> None:
         self._conversations: dict[str, list[Message]] = {}
         self._lock = Lock()
+        self._max_conversations = max_conversations
+        self._max_messages_per_conversation = max_messages_per_conversation
+
+    def _trim_messages(self, messages: list[Message]) -> list[Message]:
+        if len(messages) <= self._max_messages_per_conversation:
+            return messages
+        return messages[-self._max_messages_per_conversation :]
+
+    def _evict_oldest_conversation_if_needed(self) -> None:
+        while len(self._conversations) >= self._max_conversations:
+            oldest_id = next(iter(self._conversations))
+            del self._conversations[oldest_id]
 
     def get_history(self, conversation_id: str) -> list[Message]:
         with self._lock:
             return list(self._conversations.get(conversation_id, []))
 
     def set_history(self, conversation_id: str, messages: list[Message]) -> None:
+        trimmed = self._trim_messages(messages)
         with self._lock:
-            self._conversations[conversation_id] = messages
+            if conversation_id not in self._conversations:
+                self._evict_oldest_conversation_if_needed()
+            self._conversations[conversation_id] = trimmed
 
     def list_conversations(self) -> dict[str, int]:
         with self._lock:

--- a/agents/travel-agent/src/travel_agent/session.py
+++ b/agents/travel-agent/src/travel_agent/session.py
@@ -1,0 +1,115 @@
+"""In-memory conversation sessions for multi-turn Travel Agent chat."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from threading import Lock
+from typing import Any
+
+from agent_framework import Message, Workflow
+
+from rhesis.sdk.telemetry.context import get_conversation_id, set_conversation_id
+from travel_agent.workflow import invoke_travel_workflow_async
+
+
+class ConversationStore:
+    """Thread-safe in-memory store of user-visible MAF message history."""
+
+    def __init__(self) -> None:
+        self._conversations: dict[str, list[Message]] = {}
+        self._lock = Lock()
+
+    def get_history(self, conversation_id: str) -> list[Message]:
+        with self._lock:
+            return list(self._conversations.get(conversation_id, []))
+
+    def set_history(self, conversation_id: str, messages: list[Message]) -> None:
+        with self._lock:
+            self._conversations[conversation_id] = messages
+
+    def list_conversations(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                conversation_id: len(messages)
+                for conversation_id, messages in self._conversations.items()
+            }
+
+    def get_messages(self, conversation_id: str) -> list[Message] | None:
+        with self._lock:
+            stored = self._conversations.get(conversation_id)
+            return list(stored) if stored is not None else None
+
+    def delete(self, conversation_id: str) -> bool:
+        with self._lock:
+            if conversation_id not in self._conversations:
+                return False
+            del self._conversations[conversation_id]
+            return True
+
+
+default_store = ConversationStore()
+
+
+async def run_chat_turn(
+    workflow: Workflow,
+    message: str,
+    *,
+    conversation_id: str | None = None,
+    store: ConversationStore | None = None,
+) -> dict[str, Any]:
+    """Run one chat turn: load history, invoke the workflow, persist user-visible turns."""
+    active_store = store or default_store
+    conv_id = conversation_id or str(uuid.uuid4())
+    history = active_store.get_history(conv_id)
+
+    # Mark this as a real conversation turn so the MAF integration stamps the
+    # workflow's root span as a Rhesis conversation turn root (keyed by this id,
+    # so turns sharing the session group together). One-shot callers that invoke
+    # the workflow directly (e.g. run_traces) skip this and stay single-turn.
+    previous_conversation_id = get_conversation_id()
+    set_conversation_id(conv_id)
+    try:
+        result = await invoke_travel_workflow_async(
+            workflow,
+            message,
+            conversation_history=history or None,
+            conversation_id=conv_id,
+        )
+    finally:
+        set_conversation_id(previous_conversation_id)
+    active_store.set_history(conv_id, result["messages"])
+    result["conversation_id"] = conv_id
+    return result
+
+
+def run_chat_turn_sync(
+    workflow: Workflow,
+    message: str,
+    *,
+    conversation_id: str | None = None,
+    store: ConversationStore | None = None,
+) -> dict[str, Any]:
+    """Sync wrapper for callers without a running event loop (e.g. connector handlers)."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(
+            run_chat_turn(
+                workflow,
+                message,
+                conversation_id=conversation_id,
+                store=store,
+            )
+        )
+    raise RuntimeError(
+        "run_chat_turn_sync cannot be called from an active event loop; use run_chat_turn instead."
+    )
+
+
+__all__ = [
+    "ConversationStore",
+    "default_store",
+    "run_chat_turn",
+    "run_chat_turn_sync",
+]

--- a/agents/travel-agent/src/travel_agent/workflow.py
+++ b/agents/travel-agent/src/travel_agent/workflow.py
@@ -18,6 +18,9 @@ from travel_agent.agents import (
 from travel_agent.client import build_chat_client
 from travel_agent.utils import format_agent_workflow, format_tool_chain
 
+WORKFLOW_TIMEOUT_SECONDS = 120
+COORDINATOR_NAME = "trip_coordinator"
+
 # Autonomous-mode retry prompt for specialists that reply without handing back.
 # Replaces MAF's generic "Continue assisting autonomously" default with a
 # targeted nudge so the next turn returns control to the coordinator.
@@ -154,6 +157,15 @@ def _last_segment_text(segments: list[dict[str, Any]], *, author: str) -> str | 
     return None
 
 
+def _user_visible_assistant_message(text: str) -> Message:
+    """Build the single assistant message persisted for a completed turn."""
+    return Message(
+        role="assistant",
+        contents=[Content.from_text(text=text)],
+        author_name=COORDINATOR_NAME,
+    )
+
+
 def _capture_final_text(request_info_data: Any, *, fallback: list[str]) -> str | None:
     """Pull the synthesised final answer out of a handoff request-info event."""
     agent_response = getattr(request_info_data, "agent_response", None)
@@ -180,6 +192,28 @@ def _normalize_agent_order(agents_seen: list[str], handoff_targets: list[str]) -
     return ordered
 
 
+def _resolve_response(
+    assistant_segments: list[dict[str, Any]],
+    *,
+    final_text: str | None,
+) -> tuple[str, str]:
+    """Pick the user-facing response text and the agent that authored it."""
+    coordinator_text = _last_segment_text(assistant_segments, author=COORDINATOR_NAME)
+    if coordinator_text:
+        return coordinator_text, COORDINATOR_NAME
+
+    if final_text:
+        return final_text, COORDINATOR_NAME
+
+    for segment in reversed(assistant_segments):
+        joined = "".join(segment["parts"]).strip()
+        if joined:
+            author = segment.get("author") or "unknown"
+            return joined, author
+
+    return "", "unknown"
+
+
 async def invoke_travel_workflow_async(
     workflow: Workflow,
     user_message: str,
@@ -197,65 +231,54 @@ async def invoke_travel_workflow_async(
     # text per segment, so word boundaries between chunks are preserved.
     assistant_segments: list[dict[str, Any]] = []
     final_text: str | None = None
-    final_messages: list[Message] = []
 
     user_msg = Message(role="user", contents=[Content.from_text(text=user_message)])
-    workflow_input: Any = (
-        [*conversation_history, user_msg] if conversation_history else user_message
+    # Always pass a ``list[Message]`` to ``Workflow.run``. Its ``message`` param
+    # is typed ``Any`` and is forwarded to the start executor, which accepts a
+    # message list (the multi-turn path already relied on this by passing
+    # ``[*conversation_history, user_msg]``). Using the list form uniformly keeps
+    # single-turn and multi-turn runs on the same, verified input shape.
+    workflow_input = [*(conversation_history or []), user_msg]
+
+    async def _consume_events() -> None:
+        nonlocal final_text
+        async for event in workflow.run(workflow_input, stream=True):
+            event_type = getattr(event, "type", None)
+            data = getattr(event, "data", None)
+
+            if event_type == "handoff_sent" and isinstance(data, HandoffSentEvent):
+                handoff_targets.append(data.target)
+                continue
+
+            if event_type == "output" and data is not None:
+                _record_function_calls(data, tools_called=tools_called, agents_seen=agents_seen)
+                if getattr(data, "role", None) == "assistant":
+                    text = getattr(data, "text", "") or ""
+                    if text:
+                        author = getattr(data, "author_name", None)
+                        if not assistant_segments or assistant_segments[-1]["author"] != author:
+                            assistant_segments.append({"author": author, "parts": []})
+                        assistant_segments[-1]["parts"].append(text)
+                continue
+
+            if event_type == "request_info":
+                captured = _capture_final_text(data, fallback=_segment_texts(assistant_segments))
+                if captured:
+                    final_text = captured
+                continue
+
+    await asyncio.wait_for(_consume_events(), timeout=WORKFLOW_TIMEOUT_SECONDS)
+
+    response_text, final_agent = _resolve_response(
+        assistant_segments,
+        final_text=final_text,
     )
+    if not response_text:
+        raise RuntimeError("Travel workflow completed without producing a user-facing response.")
 
-    async for event in workflow.run(workflow_input, stream=True):
-        event_type = getattr(event, "type", None)
-        data = getattr(event, "data", None)
-
-        if event_type == "handoff_sent" and isinstance(data, HandoffSentEvent):
-            handoff_targets.append(data.target)
-            continue
-
-        if event_type == "output" and data is not None:
-            _record_function_calls(data, tools_called=tools_called, agents_seen=agents_seen)
-            if getattr(data, "role", None) == "assistant":
-                text = getattr(data, "text", "") or ""
-                if text:
-                    author = getattr(data, "author_name", None)
-                    if not assistant_segments or assistant_segments[-1]["author"] != author:
-                        assistant_segments.append({"author": author, "parts": []})
-                    assistant_segments[-1]["parts"].append(text)
-                    msg = Message(
-                        role="assistant",
-                        contents=[
-                            content
-                            for content in (getattr(data, "contents", None) or [])
-                            if getattr(content, "type", None) == "text"
-                        ],
-                        author_name=author,
-                    )
-                    final_messages.append(msg)
-            continue
-
-        if event_type == "request_info":
-            captured = _capture_final_text(data, fallback=_segment_texts(assistant_segments))
-            if captured:
-                final_text = captured
-                agent_response_messages = (
-                    getattr(getattr(data, "agent_response", None), "messages", None) or []
-                )
-                if agent_response_messages:
-                    final_messages = list(agent_response_messages)
-            continue
-
-    # Prefer the coordinator's own synthesis (the last contiguous segment it
-    # authored). Fall back to the request_info agent_response (which, with the
-    # coordinator non-autonomous, is normally that same synthesis), then to the
-    # concatenated streamed text from every agent.
-    coordinator_text = _last_segment_text(assistant_segments, author="trip_coordinator")
-    response_text = (
-        coordinator_text
-        or final_text
-        or "\n".join(_segment_texts(assistant_segments)).strip()
-    )
     agents_involved = _normalize_agent_order(agents_seen, handoff_targets)
-    updated_history = [*(conversation_history or []), user_msg, *final_messages]
+    updated_history = [*(conversation_history or []), user_msg]
+    updated_history.append(_user_visible_assistant_message(response_text))
 
     return {
         "response": response_text,
@@ -265,6 +288,7 @@ async def invoke_travel_workflow_async(
         "agent_workflow": format_agent_workflow(agents_involved),
         "tool_chain": format_tool_chain(tools_called),
         "conversation_id": conversation_id,
+        "agent": final_agent,
     }
 
 
@@ -287,9 +311,14 @@ def invoke_travel_workflow(
 
 
 async def run_query(query: str) -> dict[str, Any]:
-    """Build a fresh workflow and run a single query."""
-    workflow = build_travel_workflow()
-    return await invoke_travel_workflow_async(workflow, query)
+    """Build a fresh workflow and run a single query.
+
+    A new workflow is built per call on purpose: the participating agents use
+    ``require_per_service_call_history_persistence=True``, so a shared instance
+    would carry one caller's conversation context into later calls (cross-session
+    leakage in a multi-user or long-lived service).
+    """
+    return await invoke_travel_workflow_async(build_travel_workflow(), query)
 
 
 def get_participants(workflow: Workflow) -> list[Agent]:
@@ -307,6 +336,8 @@ def get_participants(workflow: Workflow) -> list[Agent]:
 
 
 __all__ = [
+    "COORDINATOR_NAME",
+    "WORKFLOW_TIMEOUT_SECONDS",
     "build_travel_workflow",
     "get_participants",
     "invoke_travel_workflow",

--- a/agents/travel-agent/src/travel_agent/workflow.py
+++ b/agents/travel-agent/src/travel_agent/workflow.py
@@ -267,7 +267,14 @@ async def invoke_travel_workflow_async(
                     final_text = captured
                 continue
 
-    await asyncio.wait_for(_consume_events(), timeout=WORKFLOW_TIMEOUT_SECONDS)
+    # ``asyncio.wait_for`` raises ``asyncio.TimeoutError`` which is only an alias
+    # of the builtin ``TimeoutError`` on Python 3.11+. Normalize to the builtin so
+    # callers (e.g. the FastAPI ``/chat`` route) can catch ``TimeoutError`` on
+    # every supported Python version.
+    try:
+        await asyncio.wait_for(_consume_events(), timeout=WORKFLOW_TIMEOUT_SECONDS)
+    except asyncio.TimeoutError as exc:
+        raise TimeoutError(f"Travel workflow timed out after {WORKFLOW_TIMEOUT_SECONDS}s") from exc
 
     response_text, final_agent = _resolve_response(
         assistant_segments,

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/mapping.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/mapping.py
@@ -23,6 +23,13 @@ from rhesis.telemetry.schemas import AIOperationType
 
 INSTRUMENTATION_SCOPE_PREFIX = "agent_framework"
 
+# MAF's top-level workflow execution span name. It is the structural root of a
+# workflow run (every executor/agent/chat/tool span nests under it). The
+# translator treats it as the Rhesis conversation turn root when it is also the
+# trace root (i.e. the workflow was run directly, not inside an enclosing
+# Rhesis @endpoint/@observe span).
+WORKFLOW_RUN_SPAN_NAME = "workflow.run"
+
 # MAF's HandoffBuilder workflow implements agent-to-agent handoffs as
 # auto-generated tool calls named ``handoff_to_<target_agent>``. These are
 # scheduling primitives, not real domain tools — we recognise them so the
@@ -412,17 +419,29 @@ def extract_handoff_targets_from_messages(attributes: Mapping[str, Any]) -> list
 
 
 # Original MAF span-name prefixes for low-value workflow infrastructure spans.
-# These are routing/transport primitives that carry no agent/chat/tool payload
-# and never *parent* a meaningful span (edge-group and message-send spans use
-# OTel links rather than nesting for causality — see
-# ``agent_framework.observability.create_edge_group_processing_span``). Dropping
-# them sharply reduces span volume for fan-out topologies (e.g. MAF's
+# These are routing/transport/construction primitives that carry no
+# agent/chat/tool payload and never *parent* a meaningful span:
+#
+# - ``edge_group.`` / ``message.send`` are routing primitives that use OTel
+#   links rather than nesting for causality (see
+#   ``agent_framework.observability.create_edge_group_processing_span``).
+# - ``workflow.build`` wraps graph validation/compilation at
+#   ``WorkflowBuilder.build()`` time. It is emitted *outside* any
+#   ``workflow.run`` span, so it surfaces as its own standalone (and otherwise
+#   empty) trace — one extra root per build. Its only children would be the
+#   ``build.*`` events it records itself; agents are constructed before
+#   ``.build()`` and are not nested under it. Dropping it keeps each workflow
+#   run a single trace instead of a build-trace plus a run-trace.
+#
+# Dropping these sharply reduces span volume for fan-out topologies (e.g. MAF's
 # ``HandoffBuilder`` broadcasts to every participant each superstep) without
 # orphaning children. Note: ``executor.process`` is deliberately NOT here — it
-# is the structural parent of ``invoke_agent`` spans.
+# is the structural parent of ``invoke_agent`` spans, and ``workflow.run`` is
+# kept because it is the run's trace root.
 _LOW_VALUE_WORKFLOW_PREFIXES: tuple[str, ...] = (
     "edge_group.",
     "message.send",
+    "workflow.build",
 )
 
 
@@ -517,6 +536,84 @@ def _join_message_parts(parts: Any) -> str:
         elif part is not None:
             chunks.append(_to_json_text(part))
     return "".join(chunks)
+
+
+def _join_text_parts(parts: Any) -> str:
+    """Concatenate only the human-readable ``text``/``reasoning`` parts.
+
+    Unlike :func:`_join_message_parts`, non-text parts (tool calls, blobs, ...)
+    are skipped rather than JSON-encoded. Used for conversation input/output
+    capture, where we want the user's query and the assistant's prose answer,
+    not the JSON of a ``handoff_to_*`` tool call.
+    """
+    if isinstance(parts, str):
+        return parts
+    if not isinstance(parts, list):
+        return ""
+    chunks: list[str] = []
+    for part in parts:
+        if isinstance(part, Mapping):
+            if part.get("type") in ("text", "reasoning"):
+                content = part.get("content")
+                if isinstance(content, str):
+                    chunks.append(content)
+        elif isinstance(part, str):
+            chunks.append(part)
+    return "".join(chunks)
+
+
+def is_workflow_run_span(original_name: str | None) -> bool:
+    """Return True for MAF's top-level ``workflow.run`` span (the run root)."""
+    return original_name == WORKFLOW_RUN_SPAN_NAME
+
+
+def extract_conversation_input(attributes: Mapping[str, Any]) -> str | None:
+    """Return the original user query text from a chat span's input messages.
+
+    Reads ``gen_ai.input.messages`` and returns the text of the first
+    ``role == "user"`` message. Within a single workflow run every agent's chat
+    span carries the same original user message as the first user entry, so the
+    caller can record the first non-empty result and treat it as the turn input.
+    Returns ``None`` for non-chat spans, missing/empty content, or when capture
+    is disabled.
+    """
+    if attributes.get(GEN_AI_OPERATION_NAME) != OP_CHAT:
+        return None
+    messages = _coerce_message_list(attributes.get(GEN_AI_INPUT_MESSAGES))
+    if not messages:
+        return None
+    for message in messages:
+        if not isinstance(message, Mapping) or message.get("role") != "user":
+            continue
+        content = _join_text_parts(message.get("parts")).strip()
+        if content:
+            return content
+    return None
+
+
+def extract_conversation_output(attributes: Mapping[str, Any]) -> str | None:
+    """Return the assistant response text from a chat span's output messages.
+
+    Reads ``gen_ai.output.messages`` and joins the text parts of every output
+    message. Tool-call-only turns (e.g. a ``handoff_to_*`` decision) yield an
+    empty string and are skipped. The caller records the latest non-empty
+    result per run, so the final synthesizing agent's answer is what remains.
+    Returns ``None`` for non-chat spans or when there is no text output.
+    """
+    if attributes.get(GEN_AI_OPERATION_NAME) != OP_CHAT:
+        return None
+    messages = _coerce_message_list(attributes.get(GEN_AI_OUTPUT_MESSAGES))
+    if not messages:
+        return None
+    chunks: list[str] = []
+    for message in messages:
+        if not isinstance(message, Mapping):
+            continue
+        content = _join_text_parts(message.get("parts")).strip()
+        if content:
+            chunks.append(content)
+    joined = "\n".join(chunks).strip()
+    return joined or None
 
 
 def synthesize_message_events(

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/mapping.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/mapping.py
@@ -594,11 +594,15 @@ def extract_conversation_input(attributes: Mapping[str, Any]) -> str | None:
 def extract_conversation_output(attributes: Mapping[str, Any]) -> str | None:
     """Return the assistant response text from a chat span's output messages.
 
-    Reads ``gen_ai.output.messages`` and joins the text parts of every output
-    message. Tool-call-only turns (e.g. a ``handoff_to_*`` decision) yield an
-    empty string and are skipped. The caller records the latest non-empty
-    result per run, so the final synthesizing agent's answer is what remains.
-    Returns ``None`` for non-chat spans or when there is no text output.
+    Reads ``gen_ai.output.messages`` and joins the text parts of every
+    ``role == "assistant"`` message. Restricting to assistant messages mirrors
+    :func:`extract_conversation_input` (which restricts to ``role == "user"``)
+    and guards against stamping non-assistant text (e.g. a tool/user entry MAF
+    may include in the output array) into ``conversation.output``. Tool-call-only
+    turns (e.g. a ``handoff_to_*`` decision) yield an empty string and are
+    skipped. The caller records the latest non-empty result per run, so the final
+    synthesizing agent's answer is what remains. Returns ``None`` for non-chat
+    spans or when there is no assistant text output.
     """
     if attributes.get(GEN_AI_OPERATION_NAME) != OP_CHAT:
         return None
@@ -607,7 +611,7 @@ def extract_conversation_output(attributes: Mapping[str, Any]) -> str | None:
         return None
     chunks: list[str] = []
     for message in messages:
-        if not isinstance(message, Mapping):
+        if not isinstance(message, Mapping) or message.get("role") != "assistant":
             continue
         content = _join_text_parts(message.get("parts")).strip()
         if content:

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 from typing import Any, Iterable, Mapping, Sequence
 
 from opentelemetry.sdk.trace import Event, ReadableSpan, SpanProcessor
@@ -514,6 +515,7 @@ class _ConversationContentRegistry:
         self._output_by_trace: dict[int, str] = {}
         self._session_by_trace: dict[int, str] = {}
         self._max_entries = max_entries
+        self._lock = threading.Lock()
 
     def _evict_if_needed(self, store: dict[int, str]) -> None:
         if len(store) < self._max_entries:
@@ -534,12 +536,13 @@ class _ConversationContentRegistry:
         if trace_id is None:
             return
         try:
-            if input_text and trace_id not in self._input_by_trace:
-                self._evict_if_needed(self._input_by_trace)
-                self._input_by_trace[trace_id] = input_text
-            if output_text:
-                self._evict_if_needed(self._output_by_trace)
-                self._output_by_trace[trace_id] = output_text
+            with self._lock:
+                if input_text and trace_id not in self._input_by_trace:
+                    self._evict_if_needed(self._input_by_trace)
+                    self._input_by_trace[trace_id] = input_text
+                if output_text:
+                    self._evict_if_needed(self._output_by_trace)
+                    self._output_by_trace[trace_id] = output_text
         except Exception:  # noqa: BLE001 - recording must never break tracing
             logger.debug("Failed to record conversation content", exc_info=True)
 
@@ -548,9 +551,10 @@ class _ConversationContentRegistry:
         if trace_id is None or not session_id:
             return
         try:
-            if trace_id not in self._session_by_trace:
-                self._evict_if_needed(self._session_by_trace)
-                self._session_by_trace[trace_id] = session_id
+            with self._lock:
+                if trace_id not in self._session_by_trace:
+                    self._evict_if_needed(self._session_by_trace)
+                    self._session_by_trace[trace_id] = session_id
         except Exception:  # noqa: BLE001 - recording must never break tracing
             logger.debug("Failed to record conversation session id", exc_info=True)
 
@@ -558,13 +562,32 @@ class _ConversationContentRegistry:
         """Return ``(input, output)`` recorded for ``trace_id`` (None if absent)."""
         if trace_id is None:
             return None, None
-        return self._input_by_trace.get(trace_id), self._output_by_trace.get(trace_id)
+        with self._lock:
+            return self._input_by_trace.get(trace_id), self._output_by_trace.get(trace_id)
 
     def get_session(self, trace_id: int | None) -> str | None:
         """Return the conversation/session id recorded for ``trace_id`` (None if absent)."""
         if trace_id is None:
             return None
-        return self._session_by_trace.get(trace_id)
+        with self._lock:
+            return self._session_by_trace.get(trace_id)
+
+    def consume(self, trace_id: int | None) -> tuple[str | None, str | None, str | None]:
+        """Pop and return ``(session_id, input, output)`` for ``trace_id``.
+
+        Called exactly once per trace when its root ``workflow.run`` span is
+        exported, so per-trace entries do not linger for the process lifetime
+        (bounding memory beyond the eviction cap and removing any risk of stale
+        content resurfacing if a trace id were ever reused). Returns all-``None``
+        when nothing was recorded for the trace.
+        """
+        if trace_id is None:
+            return None, None, None
+        with self._lock:
+            session = self._session_by_trace.pop(trace_id, None)
+            conv_input = self._input_by_trace.pop(trace_id, None)
+            conv_output = self._output_by_trace.pop(trace_id, None)
+        return session, conv_input, conv_output
 
 
 # Shared singleton: the dedup processor records chat I/O at span end, the
@@ -611,8 +634,10 @@ def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
     if trace_id is None:
         return None
 
-    session_id = _conversation_content.get_session(trace_id)
-    conv_input, conv_output = _conversation_content.get(trace_id)
+    # Pop the recorded content: the root span is exported once, so consuming
+    # here also frees the per-trace entries instead of retaining them for the
+    # process lifetime.
+    session_id, conv_input, conv_output = _conversation_content.consume(trace_id)
 
     attrs: dict[str, Any] = {}
     if session_id:

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
@@ -29,10 +29,12 @@ from opentelemetry.trace.status import Status, StatusCode
 
 from rhesis.sdk.telemetry.attributes import AIAttributes
 from rhesis.sdk.telemetry.context import (
+    get_conversation_id,
     is_llm_observation_active,
     set_llm_observation_active,
 )
 from rhesis.sdk.telemetry.integrations.agent_framework import mapping
+from rhesis.telemetry.constants import ConversationContext
 
 logger = logging.getLogger(__name__)
 
@@ -134,10 +136,17 @@ def _translate_events(
     return new_events
 
 
-def translate_span(span: ReadableSpan) -> _TranslatedSpan:
+def translate_span(
+    span: ReadableSpan,
+    extra_attributes: Mapping[str, Any] | None = None,
+) -> _TranslatedSpan:
     """Build the translated wrapper for a single MAF span.
 
     Pure function so it's trivially testable without an exporter.
+
+    ``extra_attributes`` are merged on top of the translated attributes (they
+    win on conflict). The exporter uses this to stamp Rhesis conversation
+    turn-root attributes on a root ``workflow.run`` span.
     """
     raw_attrs = span.attributes or {}
     new_name = mapping.translate_span_name(span.name, raw_attrs)
@@ -147,6 +156,8 @@ def translate_span(span: ReadableSpan) -> _TranslatedSpan:
     # the trace remains debuggable downstream.
     if new_name.startswith("function.maf.") and span.name and span.name != new_name:
         new_attrs.setdefault("gen_ai.original_span_name", span.name)
+    if extra_attributes:
+        new_attrs.update(extra_attributes)
     new_events = _translate_events(span.events or (), raw_attrs)
     return _TranslatedSpan(span, new_name, new_attrs, new_events)
 
@@ -468,6 +479,158 @@ class _HandoffAncestryRegistry:
 _handoff_ancestry = _HandoffAncestryRegistry()
 
 
+class _ConversationContentRegistry:
+    """Process-lifetime store of per-trace conversation input/output text.
+
+    MAF's ``workflow.run`` span (the structural trace root of an in-process
+    workflow run) carries only ``workflow.id``/``workflow.name``/
+    ``workflow.description`` — it has no record of the user's query or the final
+    response. Those live on the nested ``chat`` spans
+    (``gen_ai.input.messages`` / ``gen_ai.output.messages``).
+
+    To let the translator stamp Rhesis conversation turn-root attributes on the
+    root ``workflow.run`` span — so a pure ``auto_instrument`` workflow run
+    shows up in the Conversation tab without any manual span code — we record
+    each chat span's input/output here at span *end*, keyed by trace id. Under
+    ``BatchSpanProcessor`` every chat span ends (and is recorded here) before
+    the enclosing ``workflow.run`` span ends, so the registry is fully populated
+    by the time the root span is exported, even across export batches.
+
+    The first non-empty user input wins (the original query, which every agent's
+    chat span echoes as its first user message); the output is overwritten so
+    the last assistant turn (the synthesizing agent's answer) is what remains.
+
+    A per-trace conversation/session id is also recorded here. It is the gate
+    for turn-root stamping: only when the agent has set a real conversation id
+    (via ``rhesis.sdk.telemetry.context.set_conversation_id``) for the run does
+    the root ``workflow.run`` span become a Rhesis conversation turn root. Pure
+    single-turn runs (e.g. the ``run_traces`` smoke test) set no id and stay
+    plain traces. All stores are bounded; the oldest entries are evicted once
+    the cap is hit.
+    """
+
+    def __init__(self, max_entries: int = 4096) -> None:
+        self._input_by_trace: dict[int, str] = {}
+        self._output_by_trace: dict[int, str] = {}
+        self._session_by_trace: dict[int, str] = {}
+        self._max_entries = max_entries
+
+    def _evict_if_needed(self, store: dict[int, str]) -> None:
+        if len(store) < self._max_entries:
+            return
+        try:
+            store.pop(next(iter(store)), None)
+        except StopIteration:  # pragma: no cover - racy but harmless
+            pass
+
+    def record_chat(
+        self,
+        trace_id: int | None,
+        *,
+        input_text: str | None = None,
+        output_text: str | None = None,
+    ) -> None:
+        """Record a chat span's input/output for its trace. Never raises."""
+        if trace_id is None:
+            return
+        try:
+            if input_text and trace_id not in self._input_by_trace:
+                self._evict_if_needed(self._input_by_trace)
+                self._input_by_trace[trace_id] = input_text
+            if output_text:
+                self._evict_if_needed(self._output_by_trace)
+                self._output_by_trace[trace_id] = output_text
+        except Exception:  # noqa: BLE001 - recording must never break tracing
+            logger.debug("Failed to record conversation content", exc_info=True)
+
+    def record_session(self, trace_id: int | None, session_id: str | None) -> None:
+        """Record the agent-supplied conversation/session id for a trace. Never raises."""
+        if trace_id is None or not session_id:
+            return
+        try:
+            if trace_id not in self._session_by_trace:
+                self._evict_if_needed(self._session_by_trace)
+                self._session_by_trace[trace_id] = session_id
+        except Exception:  # noqa: BLE001 - recording must never break tracing
+            logger.debug("Failed to record conversation session id", exc_info=True)
+
+    def get(self, trace_id: int | None) -> tuple[str | None, str | None]:
+        """Return ``(input, output)`` recorded for ``trace_id`` (None if absent)."""
+        if trace_id is None:
+            return None, None
+        return self._input_by_trace.get(trace_id), self._output_by_trace.get(trace_id)
+
+    def get_session(self, trace_id: int | None) -> str | None:
+        """Return the conversation/session id recorded for ``trace_id`` (None if absent)."""
+        if trace_id is None:
+            return None
+        return self._session_by_trace.get(trace_id)
+
+
+# Shared singleton: the dedup processor records chat I/O at span end, the
+# translating exporter reads it when stamping a root ``workflow.run`` span.
+_conversation_content = _ConversationContentRegistry()
+
+
+def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
+    """Build conversation attributes for a root ``workflow.run`` span.
+
+    Returns ``None`` (no stamping) unless both of the following hold:
+
+    1. The span is MAF's ``workflow.run`` span.
+    2. It is the trace root (``parent is None``). This scopes stamping to the
+       in-process / pure-``auto_instrument`` path: when the workflow runs inside
+       a Rhesis ``@endpoint``/``@observe`` span (FastAPI route or playground
+       connector), that enclosing span is the turn root and already carries
+       conversation attributes, so ``workflow.run`` has a parent and is left
+       untouched (no double turn root).
+
+    When stamped, the span always gets the conversation ``input``/``output``
+    (from the nested chat spans via :data:`_conversation_content`) so the
+    recorded run shows its conversation content in the UI. Whether it is *also*
+    a multi-turn turn root depends on the agent having set a real
+    conversation/session id (via ``rhesis.sdk.telemetry.context``,
+    ``set_conversation_id``), recorded per trace at span end:
+
+    - **Session id present** (multi-turn chat session, e.g. the playground):
+      additionally stamp ``is_turn_root=True`` and ``conversation.id=<session_id>``
+      so turns sharing the session group together as a conversation.
+    - **No session id** (one-shot single-turn run, e.g. the ``run_traces`` smoke
+      test): stamp only input/output. The run stays a plain single-turn trace
+      (``conversation.id`` remains null) but its conversation is still visible.
+
+    Returns ``None`` when there is neither a session id nor any captured
+    input/output (e.g. content capture disabled), leaving the span untouched.
+    """
+    if not mapping.is_workflow_run_span(getattr(span, "name", None)):
+        return None
+    if getattr(span, "parent", None) is not None:
+        return None
+    ctx = getattr(span, "context", None)
+    trace_id = getattr(ctx, "trace_id", None)
+    if trace_id is None:
+        return None
+
+    session_id = _conversation_content.get_session(trace_id)
+    conv_input, conv_output = _conversation_content.get(trace_id)
+
+    attrs: dict[str, Any] = {}
+    if session_id:
+        # Real conversation/session: mark as a multi-turn turn root keyed by the
+        # session id so turns sharing it group together.
+        attrs[ConversationContext.SpanAttributes.IS_TURN_ROOT] = True
+        attrs[ConversationContext.SpanAttributes.CONVERSATION_ID] = session_id
+    if conv_input:
+        attrs[ConversationContext.SpanAttributes.CONVERSATION_INPUT] = conv_input[
+            : ConversationContext.MAX_IO_LENGTH
+        ]
+    if conv_output:
+        attrs[ConversationContext.SpanAttributes.CONVERSATION_OUTPUT] = conv_output[
+            : ConversationContext.MAX_IO_LENGTH
+        ]
+    return attrs or None
+
+
 class MAFTranslatingExporter(SpanExporter):
     """Wrap any ``SpanExporter`` and rewrite MAF spans on their way out.
 
@@ -549,7 +712,13 @@ class MAFTranslatingExporter(SpanExporter):
                             )
                         translated.append(translate_handoff_span(span, from_agent))
                     else:
-                        translated.append(translate_span(span))
+                        # Stamp Rhesis conversation turn-root attributes when
+                        # this is a root ``workflow.run`` span (the in-process /
+                        # pure-auto_instrument path). Returns None otherwise, so
+                        # workflow runs nested under a Rhesis @endpoint/@observe
+                        # span are left to that span's own turn-root handling.
+                        conv_attrs = conversation_root_attributes(span)
+                        translated.append(translate_span(span, extra_attributes=conv_attrs))
                         # Synthesize ai.agent.handoff spans from handoff tool
                         # calls recorded in this chat span's output messages.
                         # This is the primary handoff path for current MAF,
@@ -744,6 +913,22 @@ class MAFLLMDedupSpanProcessor(SpanProcessor):
             attrs = span.attributes or {}
             if attrs.get(mapping.GEN_AI_OPERATION_NAME) != mapping.OP_CHAT:
                 return
+            # Record this chat span's user input / assistant output so the
+            # exporter can stamp conversation turn-root attributes on the
+            # enclosing root ``workflow.run`` span (which itself carries no
+            # input/output). Keyed by trace id; safe and bounded.
+            ctx = getattr(span, "context", None)
+            trace_id = getattr(ctx, "trace_id", None)
+            _conversation_content.record_chat(
+                trace_id,
+                input_text=mapping.extract_conversation_input(attrs),
+                output_text=mapping.extract_conversation_output(attrs),
+            )
+            # Capture the agent-supplied conversation/session id (if any) while
+            # we are still on the thread that ran the workflow, so the exporter
+            # can decide whether this run is a conversation turn root. Runs that
+            # set no id stay plain single-turn traces.
+            _conversation_content.record_session(trace_id, get_conversation_id())
             prev = self._retrieve_prev_flag(span)
             if not prev:
                 set_llm_observation_active(False)

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
@@ -501,13 +501,15 @@ class _ConversationContentRegistry:
     chat span echoes as its first user message); the output is overwritten so
     the last assistant turn (the synthesizing agent's answer) is what remains.
 
-    A per-trace conversation/session id is also recorded here. It is the gate
-    for turn-root stamping: only when the agent has set a real conversation id
-    (via ``rhesis.sdk.telemetry.context.set_conversation_id``) for the run does
-    the root ``workflow.run`` span become a Rhesis conversation turn root. Pure
-    single-turn runs (e.g. the ``run_traces`` smoke test) set no id and stay
-    plain traces. All stores are bounded; the oldest entries are evicted once
-    the cap is hit.
+    A per-trace conversation/session id is also recorded here at chat-span
+    *start* (while the caller's ``set_conversation_id`` contextvar is active).
+    It is the gate for turn-root stamping: only when the agent has set a real
+    conversation id for the run does the root ``workflow.run`` span become a
+    Rhesis conversation turn root. Pure single-turn runs (e.g. the ``run_traces``
+    smoke test) set no id and stay plain traces. All stores are bounded; the
+    oldest entries are evicted once the cap is hit. Input/output strings are
+    truncated to :data:`~rhesis.telemetry.constants.ConversationContext.MAX_IO_LENGTH`
+    at record time.
     """
 
     def __init__(self, max_entries: int = 4096) -> None:
@@ -535,6 +537,11 @@ class _ConversationContentRegistry:
         """Record a chat span's input/output for its trace. Never raises."""
         if trace_id is None:
             return
+        max_len = ConversationContext.MAX_IO_LENGTH
+        if input_text:
+            input_text = input_text[:max_len]
+        if output_text:
+            output_text = output_text[:max_len]
         try:
             with self._lock:
                 if input_text and trace_id not in self._input_by_trace:
@@ -596,24 +603,23 @@ _conversation_content = _ConversationContentRegistry()
 
 
 def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
-    """Build conversation attributes for a root ``workflow.run`` span.
+    """Build conversation attributes for a ``workflow.run`` span.
 
-    Returns ``None`` (no stamping) unless both of the following hold:
-
-    1. The span is MAF's ``workflow.run`` span.
-    2. It is the trace root (``parent is None``). This scopes stamping to the
-       in-process / pure-``auto_instrument`` path: when the workflow runs inside
-       a Rhesis ``@endpoint``/``@observe`` span (FastAPI route or playground
-       connector), that enclosing span is the turn root and already carries
-       conversation attributes, so ``workflow.run`` has a parent and is left
-       untouched (no double turn root).
+    Always :meth:`consumes <_ConversationContentRegistry.consume>` the per-trace
+    chat I/O recorded for this span's trace id so entries do not linger when the
+    ``workflow.run`` span is nested under a Rhesis ``@endpoint``/``@observe``
+    parent (the common long-running-service path). Stamping is limited to trace
+    roots only (``parent is None``): when the workflow runs inside an enclosing
+    Rhesis span, that span owns turn-root semantics and ``workflow.run`` must
+    not be stamped again.
 
     When stamped, the span always gets the conversation ``input``/``output``
     (from the nested chat spans via :data:`_conversation_content`) so the
     recorded run shows its conversation content in the UI. Whether it is *also*
     a multi-turn turn root depends on the agent having set a real
     conversation/session id (via ``rhesis.sdk.telemetry.context``,
-    ``set_conversation_id``), recorded per trace at span end:
+    ``set_conversation_id``), captured at chat-span *start* while the
+    contextvar is still active:
 
     - **Session id present** (multi-turn chat session, e.g. the playground):
       additionally stamp ``is_turn_root=True`` and ``conversation.id=<session_id>``
@@ -622,22 +628,23 @@ def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
       test): stamp only input/output. The run stays a plain single-turn trace
       (``conversation.id`` remains null) but its conversation is still visible.
 
-    Returns ``None`` when there is neither a session id nor any captured
-    input/output (e.g. content capture disabled), leaving the span untouched.
+    Returns ``None`` when this is not a ``workflow.run`` span, or when it is a
+    trace root with neither a session id nor any captured input/output (e.g.
+    content capture disabled), leaving the span untouched.
     """
     if not mapping.is_workflow_run_span(getattr(span, "name", None)):
-        return None
-    if getattr(span, "parent", None) is not None:
         return None
     ctx = getattr(span, "context", None)
     trace_id = getattr(ctx, "trace_id", None)
     if trace_id is None:
         return None
 
-    # Pop the recorded content: the root span is exported once, so consuming
-    # here also frees the per-trace entries instead of retaining them for the
-    # process lifetime.
+    # Release per-trace entries on every workflow.run export, even when nested
+    # under @endpoint/@observe (no stamping in that case).
     session_id, conv_input, conv_output = _conversation_content.consume(trace_id)
+
+    if getattr(span, "parent", None) is not None:
+        return None
 
     attrs: dict[str, Any] = {}
     if session_id:
@@ -646,13 +653,9 @@ def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
         attrs[ConversationContext.SpanAttributes.IS_TURN_ROOT] = True
         attrs[ConversationContext.SpanAttributes.CONVERSATION_ID] = session_id
     if conv_input:
-        attrs[ConversationContext.SpanAttributes.CONVERSATION_INPUT] = conv_input[
-            : ConversationContext.MAX_IO_LENGTH
-        ]
+        attrs[ConversationContext.SpanAttributes.CONVERSATION_INPUT] = conv_input
     if conv_output:
-        attrs[ConversationContext.SpanAttributes.CONVERSATION_OUTPUT] = conv_output[
-            : ConversationContext.MAX_IO_LENGTH
-        ]
+        attrs[ConversationContext.SpanAttributes.CONVERSATION_OUTPUT] = conv_output
     return attrs or None
 
 
@@ -922,6 +925,15 @@ class MAFLLMDedupSpanProcessor(SpanProcessor):
             span_name = getattr(span, "name", "") or ""
             if not span_name.startswith("chat "):
                 return
+            # Capture the conversation/session id while this chat span starts on
+            # the workflow thread. OTel invokes ``on_start`` synchronously on
+            # the thread that created the span, so the ``set_conversation_id``
+            # contextvar set by the caller (e.g. ``run_chat_turn``) is still
+            # active. Recording here avoids relying on ``on_end`` context, which
+            # could differ if a future processor ever deferred span completion.
+            ctx = getattr(span, "context", None)
+            trace_id = getattr(ctx, "trace_id", None)
+            _conversation_content.record_session(trace_id, get_conversation_id())
             prev = is_llm_observation_active()
             self._store_prev_flag(span, prev)
             if not prev:
@@ -949,11 +961,6 @@ class MAFLLMDedupSpanProcessor(SpanProcessor):
                 input_text=mapping.extract_conversation_input(attrs),
                 output_text=mapping.extract_conversation_output(attrs),
             )
-            # Capture the agent-supplied conversation/session id (if any) while
-            # we are still on the thread that ran the workflow, so the exporter
-            # can decide whether this run is a conversation turn root. Runs that
-            # set no id stay plain single-turn traces.
-            _conversation_content.record_session(trace_id, get_conversation_id())
             prev = self._retrieve_prev_flag(span)
             if not prev:
                 set_llm_observation_active(False)

--- a/tests/sdk/models/providers/test_azure_ai.py
+++ b/tests/sdk/models/providers/test_azure_ai.py
@@ -93,6 +93,7 @@ class TestAzureAILLMGenerate:
             api_key="test_key",
             api_base="https://endpoint.inference.ai.azure.com/",
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -118,6 +119,7 @@ class TestAzureAILLMGenerate:
             api_key="test_key",
             api_base="https://endpoint.inference.ai.azure.com/",
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -179,6 +181,7 @@ class TestAzureAILLMGenerate:
             api_key="test_key",
             api_base="https://endpoint.inference.ai.azure.com/",
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -201,6 +204,7 @@ class TestAzureAILLMGenerate:
             api_key="test_key",
             api_base="https://endpoint.inference.ai.azure.com/",
             api_version=None,
+            extra_headers={"Connection": "close"},
             temperature=0.7,
             max_tokens=100,
         )

--- a/tests/sdk/models/providers/test_azure_openai.py
+++ b/tests/sdk/models/providers/test_azure_openai.py
@@ -115,6 +115,7 @@ class TestAzureOpenAILLMGenerate:
             api_key="test_key",
             api_base="https://resource.openai.azure.com/",
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -140,6 +141,7 @@ class TestAzureOpenAILLMGenerate:
             api_key="test_key",
             api_base="https://resource.openai.azure.com/",
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -201,6 +203,7 @@ class TestAzureOpenAILLMGenerate:
             api_key="test_key",
             api_base="https://resource.openai.azure.com/",
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -223,6 +226,7 @@ class TestAzureOpenAILLMGenerate:
             api_key="test_key",
             api_base="https://resource.openai.azure.com/",
             api_version=None,
+            extra_headers={"Connection": "close"},
             temperature=0.7,
             max_tokens=100,
         )

--- a/tests/sdk/models/providers/test_gemini.py
+++ b/tests/sdk/models/providers/test_gemini.py
@@ -70,6 +70,7 @@ class TestGeminiLLM:
             api_key="test_key",
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -105,6 +106,7 @@ class TestGeminiLLM:
             api_key="test_key",
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -148,6 +150,7 @@ class TestGeminiLLM:
             api_key="test_key",
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
             temperature=0.7,
             max_tokens=100,
         )
@@ -173,4 +176,5 @@ class TestGeminiLLM:
             api_key="test_key",
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
         )

--- a/tests/sdk/models/providers/test_openrouter.py
+++ b/tests/sdk/models/providers/test_openrouter.py
@@ -64,6 +64,7 @@ class TestOpenRouterLLM:
             api_key="test_key",
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -99,6 +100,7 @@ class TestOpenRouterLLM:
             api_key="test_key",
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -142,6 +144,7 @@ class TestOpenRouterLLM:
             api_key="test_key",
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
             temperature=0.7,
             max_tokens=100,
         )
@@ -167,6 +170,7 @@ class TestOpenRouterLLM:
             api_key="test_key",
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -193,4 +197,5 @@ class TestOpenRouterLLM:
             api_key="test_key",
             api_base=None,
             api_version=None,
+            extra_headers={"Connection": "close"},
         )

--- a/tests/sdk/models/providers/test_vllm.py
+++ b/tests/sdk/models/providers/test_vllm.py
@@ -60,6 +60,7 @@ class TestVllmLLM:
             api_key=None,
             api_base="http://localhost:8000",
             api_version=None,
+            extra_headers={"Connection": "close"},
         )
 
     @patch("rhesis.sdk.models.factory._create_from_spec")

--- a/tests/sdk/telemetry/integrations/test_agent_framework.py
+++ b/tests/sdk/telemetry/integrations/test_agent_framework.py
@@ -47,6 +47,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcess
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (  # noqa: E402
     InMemorySpanExporter,
 )
+from rhesis.telemetry.constants import ConversationContext  # noqa: E402
 
 from rhesis.sdk.telemetry.attributes import AIAttributes, validate_span_name  # noqa: E402
 from rhesis.sdk.telemetry.context import (  # noqa: E402
@@ -537,10 +538,11 @@ def test_extract_handoff_targets_empty_without_output_messages():
         ("edge_group.process", True),
         ("message.send", True),
         ("message.send Foo", True),
+        # workflow.build is a standalone build-time trace with no run payload.
+        ("workflow.build", True),
         # Structural spans must be kept.
         ("executor.process coordinator", False),
         ("workflow.run", False),
-        ("workflow.build", False),
         ("invoke_agent coordinator", False),
         ("chat gpt-4", False),
         ("execute_tool calc", False),
@@ -1289,6 +1291,213 @@ def test_verbose_workflow_spans_env_default(monkeypatch):
 
     monkeypatch.setenv("RHESIS_MAF_VERBOSE_WORKFLOW_SPANS", "1")
     assert tr_mod.MAFTranslatingExporter(InMemorySpanExporter())._verbose_workflow_spans is True
+
+
+def test_exporter_drops_workflow_build_keeps_workflow_run():
+    """The build-time ``workflow.build`` span is dropped; ``workflow.run`` stays.
+
+    ``workflow.build`` is emitted outside any run and would otherwise surface as
+    its own standalone trace (one extra root per build). Dropping it keeps each
+    workflow run a single trace.
+    """
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    build = _FakeSpan(span_id=730, name="workflow.build")
+    run = _FakeSpan(span_id=731, name="workflow.run")
+
+    captured_inner = InMemorySpanExporter()
+    exporter = tr_mod.MAFTranslatingExporter(captured_inner, verbose_workflow_spans=False)
+    exporter.export([build, run])
+
+    names = [s.name for s in captured_inner.get_finished_spans()]
+    assert "function.workflow.run" in names
+    assert all("build" not in n for n in names)
+
+
+# ---------------------------------------------------------------------------
+# Conversation turn-root stamping on the root workflow.run span
+# ---------------------------------------------------------------------------
+
+
+def test_extract_conversation_input_returns_first_user_text():
+    import json as _json
+
+    attrs = {
+        mapping.GEN_AI_OPERATION_NAME: "chat",
+        mapping.GEN_AI_INPUT_MESSAGES: _json.dumps(
+            [
+                {"role": "system", "parts": [{"type": "text", "content": "be helpful"}]},
+                {"role": "user", "parts": [{"type": "text", "content": "Plan a day trip"}]},
+            ]
+        ),
+    }
+    assert mapping.extract_conversation_input(attrs) == "Plan a day trip"
+
+
+def test_extract_conversation_output_joins_text_and_skips_tool_calls():
+    import json as _json
+
+    text_attrs = {
+        mapping.GEN_AI_OPERATION_NAME: "chat",
+        mapping.GEN_AI_OUTPUT_MESSAGES: _json.dumps(
+            [{"role": "assistant", "parts": [{"type": "text", "content": "Here is your plan"}]}]
+        ),
+    }
+    assert mapping.extract_conversation_output(text_attrs) == "Here is your plan"
+
+    # A handoff (tool-call-only) turn carries no prose -> None.
+    handoff_attrs = {
+        mapping.GEN_AI_OPERATION_NAME: "chat",
+        mapping.GEN_AI_OUTPUT_MESSAGES: _json.dumps(
+            [
+                {
+                    "role": "assistant",
+                    "parts": [{"type": "tool_call", "name": "handoff_to_x", "arguments": "{}"}],
+                }
+            ]
+        ),
+    }
+    assert mapping.extract_conversation_output(handoff_attrs) is None
+
+
+def test_extract_conversation_input_output_ignore_non_chat_spans():
+    attrs = {mapping.GEN_AI_OPERATION_NAME: "invoke_agent"}
+    assert mapping.extract_conversation_input(attrs) is None
+    assert mapping.extract_conversation_output(attrs) is None
+
+
+def test_conversation_content_registry_first_input_wins_last_output_wins():
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    reg = tr_mod._ConversationContentRegistry()
+    reg.record_chat(7, input_text="first query", output_text="routing...")
+    # Later turns echo the same query and produce newer output.
+    reg.record_chat(7, input_text="first query", output_text="final plan")
+    reg.record_chat(7, input_text="ignored second input", output_text=None)
+
+    assert reg.get(7) == ("first query", "final plan")
+    assert reg.get(999) == (None, None)
+
+
+def test_conversation_content_registry_records_session_first_wins():
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    reg = tr_mod._ConversationContentRegistry()
+    reg.record_session(7, "session-a")
+    # First session id wins; later turns / empty values do not overwrite it.
+    reg.record_session(7, "session-b")
+    reg.record_session(7, None)
+
+    assert reg.get_session(7) == "session-a"
+    assert reg.get_session(999) is None
+
+
+def test_exporter_stamps_turn_root_on_root_workflow_run():
+    """A root ``workflow.run`` span with a recorded session id becomes a turn root.
+
+    The conversation id is the agent-supplied session id (not the trace id), so
+    multiple turns sharing a session group together.
+    """
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    trace_id = 0xABCDEF
+    tr_mod._conversation_content.record_chat(
+        trace_id, input_text="Plan a day trip", output_text="Here is your plan"
+    )
+    tr_mod._conversation_content.record_session(trace_id, "sess-1")
+    run = _FakeChatSpan(span_id=740, trace_id=trace_id, parent_id=None, name="workflow.run")
+
+    captured_inner = InMemorySpanExporter()
+    exporter = tr_mod.MAFTranslatingExporter(captured_inner)
+    exporter.export([run])
+
+    out = captured_inner.get_finished_spans()
+    assert len(out) == 1
+    attrs = dict(out[0].attributes or {})
+    sa = ConversationContext.SpanAttributes
+    assert out[0].name == "function.workflow.run"
+    assert attrs.get(sa.IS_TURN_ROOT) is True
+    assert attrs.get(sa.CONVERSATION_ID) == "sess-1"
+    assert attrs.get(sa.CONVERSATION_INPUT) == "Plan a day trip"
+    assert attrs.get(sa.CONVERSATION_OUTPUT) == "Here is your plan"
+
+
+def test_exporter_stamps_io_but_not_turn_root_without_session_id():
+    """A root ``workflow.run`` with no session id shows its conversation but stays single-turn.
+
+    This is the single-turn ``run_traces`` path: spans are recorded but no
+    conversation id was set, so input/output are stamped (the conversation is
+    visible) while ``is_turn_root`` / ``conversation.id`` are NOT stamped (the
+    run remains a plain single-turn trace, not grouped as a conversation).
+    """
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    trace_id = 0xFACADE
+    tr_mod._conversation_content.record_chat(
+        trace_id, input_text="Plan a day trip", output_text="Here is your plan"
+    )
+    # No record_session(...) call: this is a one-shot single-turn run.
+    run = _FakeChatSpan(span_id=742, trace_id=trace_id, parent_id=None, name="workflow.run")
+
+    captured_inner = InMemorySpanExporter()
+    exporter = tr_mod.MAFTranslatingExporter(captured_inner)
+    exporter.export([run])
+
+    out = captured_inner.get_finished_spans()
+    assert len(out) == 1
+    attrs = dict(out[0].attributes or {})
+    sa = ConversationContext.SpanAttributes
+    assert out[0].name == "function.workflow.run"
+    assert sa.IS_TURN_ROOT not in attrs
+    assert sa.CONVERSATION_ID not in attrs
+    assert attrs.get(sa.CONVERSATION_INPUT) == "Plan a day trip"
+    assert attrs.get(sa.CONVERSATION_OUTPUT) == "Here is your plan"
+
+
+def test_exporter_skips_root_without_session_or_content():
+    """A root ``workflow.run`` with neither session id nor captured I/O is untouched."""
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    trace_id = 0xC0FFEE
+    # No record_chat and no record_session for this trace.
+    run = _FakeChatSpan(span_id=743, trace_id=trace_id, parent_id=None, name="workflow.run")
+
+    captured_inner = InMemorySpanExporter()
+    exporter = tr_mod.MAFTranslatingExporter(captured_inner)
+    exporter.export([run])
+
+    out = captured_inner.get_finished_spans()
+    assert len(out) == 1
+    attrs = dict(out[0].attributes or {})
+    sa = ConversationContext.SpanAttributes
+    assert out[0].name == "function.workflow.run"
+    assert sa.IS_TURN_ROOT not in attrs
+    assert sa.CONVERSATION_ID not in attrs
+    assert sa.CONVERSATION_INPUT not in attrs
+    assert sa.CONVERSATION_OUTPUT not in attrs
+
+
+def test_exporter_skips_turn_root_on_nested_workflow_run():
+    """A ``workflow.run`` nested under a parent (e.g. a Rhesis @endpoint span)
+    must NOT be stamped as a turn root -- the enclosing span owns that role.
+    """
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    trace_id = 0x123456
+    tr_mod._conversation_content.record_chat(trace_id, input_text="hi", output_text="hello")
+    run = _FakeChatSpan(span_id=741, trace_id=trace_id, parent_id=510, name="workflow.run")
+
+    captured_inner = InMemorySpanExporter()
+    exporter = tr_mod.MAFTranslatingExporter(captured_inner)
+    exporter.export([run])
+
+    out = captured_inner.get_finished_spans()
+    assert len(out) == 1
+    attrs = dict(out[0].attributes or {})
+    sa = ConversationContext.SpanAttributes
+    assert out[0].name == "function.workflow.run"
+    assert sa.IS_TURN_ROOT not in attrs
+    assert sa.CONVERSATION_ID not in attrs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sdk/telemetry/integrations/test_agent_framework.py
+++ b/tests/sdk/telemetry/integrations/test_agent_framework.py
@@ -521,9 +521,9 @@ def test_extract_handoff_targets_skips_non_chat_spans():
 
 def test_extract_handoff_targets_empty_without_output_messages():
     """No output messages (e.g. content capture disabled) -> no targets."""
-    assert mapping.extract_handoff_targets_from_messages(
-        {mapping.GEN_AI_OPERATION_NAME: "chat"}
-    ) == []
+    assert (
+        mapping.extract_handoff_targets_from_messages({mapping.GEN_AI_OPERATION_NAME: "chat"}) == []
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -921,8 +921,7 @@ async def test_handoff_workflow_emits_synthesized_agent_handoff_spans(
     spans = _drain_spans(provider, captured_spans)
     handoffs = [s for s in spans if s.name == "ai.agent.handoff"]
     assert handoffs, (
-        "no ai.agent.handoff span synthesized from chat output; "
-        f"got {[s.name for s in spans]!r}"
+        f"no ai.agent.handoff span synthesized from chat output; got {[s.name for s in spans]!r}"
     )
     targets = {s.attributes.get(AIAttributes.AGENT_HANDOFF_TO) for s in handoffs}
     assert "specialist" in targets
@@ -1360,6 +1359,32 @@ def test_extract_conversation_output_joins_text_and_skips_tool_calls():
     assert mapping.extract_conversation_output(handoff_attrs) is None
 
 
+def test_extract_conversation_output_filters_non_assistant_roles():
+    """Only ``role == "assistant"`` output text is stamped into conversation.output."""
+    import json as _json
+
+    attrs = {
+        mapping.GEN_AI_OPERATION_NAME: "chat",
+        mapping.GEN_AI_OUTPUT_MESSAGES: _json.dumps(
+            [
+                {"role": "tool", "parts": [{"type": "text", "content": "tool noise"}]},
+                {"role": "user", "parts": [{"type": "text", "content": "echoed user text"}]},
+                {"role": "assistant", "parts": [{"type": "text", "content": "Here is your plan"}]},
+            ]
+        ),
+    }
+    assert mapping.extract_conversation_output(attrs) == "Here is your plan"
+
+    # Output array with no assistant message -> nothing to stamp.
+    no_assistant = {
+        mapping.GEN_AI_OPERATION_NAME: "chat",
+        mapping.GEN_AI_OUTPUT_MESSAGES: _json.dumps(
+            [{"role": "tool", "parts": [{"type": "text", "content": "tool noise"}]}]
+        ),
+    }
+    assert mapping.extract_conversation_output(no_assistant) is None
+
+
 def test_extract_conversation_input_output_ignore_non_chat_spans():
     attrs = {mapping.GEN_AI_OPERATION_NAME: "invoke_agent"}
     assert mapping.extract_conversation_input(attrs) is None
@@ -1390,6 +1415,41 @@ def test_conversation_content_registry_records_session_first_wins():
 
     assert reg.get_session(7) == "session-a"
     assert reg.get_session(999) is None
+
+
+def test_conversation_content_registry_consume_pops_entries():
+    """``consume`` returns the recorded triple once and clears it afterwards."""
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    reg = tr_mod._ConversationContentRegistry()
+    reg.record_chat(7, input_text="first query", output_text="final plan")
+    reg.record_session(7, "session-a")
+
+    assert reg.consume(7) == ("session-a", "first query", "final plan")
+    # Entries are gone after the first consume: the root span is exported once.
+    assert reg.consume(7) == (None, None, None)
+    assert reg.get(7) == (None, None)
+    assert reg.get_session(7) is None
+    # Unknown trace ids yield an all-None triple.
+    assert reg.consume(999) == (None, None, None)
+
+
+def test_exporter_consumes_conversation_content_after_stamping():
+    """After the root span is exported, its per-trace content is released."""
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    trace_id = 0xBEEF01
+    tr_mod._conversation_content.record_chat(
+        trace_id, input_text="Plan a day trip", output_text="Here is your plan"
+    )
+    tr_mod._conversation_content.record_session(trace_id, "sess-consume")
+    run = _FakeChatSpan(span_id=760, trace_id=trace_id, parent_id=None, name="workflow.run")
+
+    exporter = tr_mod.MAFTranslatingExporter(InMemorySpanExporter())
+    exporter.export([run])
+
+    # The registry no longer retains anything for this trace.
+    assert tr_mod._conversation_content.consume(trace_id) == (None, None, None)
 
 
 def test_exporter_stamps_turn_root_on_root_workflow_run():

--- a/tests/sdk/telemetry/integrations/test_agent_framework.py
+++ b/tests/sdk/telemetry/integrations/test_agent_framework.py
@@ -1540,11 +1540,13 @@ def test_exporter_skips_root_without_session_or_content():
 def test_exporter_skips_turn_root_on_nested_workflow_run():
     """A ``workflow.run`` nested under a parent (e.g. a Rhesis @endpoint span)
     must NOT be stamped as a turn root -- the enclosing span owns that role.
+    Per-trace registry entries must still be released on export.
     """
     from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
 
     trace_id = 0x123456
     tr_mod._conversation_content.record_chat(trace_id, input_text="hi", output_text="hello")
+    tr_mod._conversation_content.record_session(trace_id, "sess-nested")
     run = _FakeChatSpan(span_id=741, trace_id=trace_id, parent_id=510, name="workflow.run")
 
     captured_inner = InMemorySpanExporter()
@@ -1558,6 +1560,20 @@ def test_exporter_skips_turn_root_on_nested_workflow_run():
     assert out[0].name == "function.workflow.run"
     assert sa.IS_TURN_ROOT not in attrs
     assert sa.CONVERSATION_ID not in attrs
+    assert sa.CONVERSATION_INPUT not in attrs
+    assert sa.CONVERSATION_OUTPUT not in attrs
+    assert tr_mod._conversation_content.consume(trace_id) == (None, None, None)
+
+
+def test_conversation_content_registry_truncates_io_at_record_time():
+    from rhesis.sdk.telemetry.integrations.agent_framework import translator as tr_mod
+
+    reg = tr_mod._ConversationContentRegistry()
+    long_text = "x" * (ConversationContext.MAX_IO_LENGTH + 500)
+    reg.record_chat(42, input_text=long_text, output_text=long_text)
+    conv_input, conv_output = reg.get(42)
+    assert conv_input is not None and len(conv_input) == ConversationContext.MAX_IO_LENGTH
+    assert conv_output is not None and len(conv_output) == ConversationContext.MAX_IO_LENGTH
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

Auto-instrumented Microsoft Agent Framework (MAF) workflow runs did not surface in the Rhesis Conversation tab, because the structural trace root (`workflow.run`) carries only workflow metadata - the user query and final response live on nested `chat` spans.

## What Changed

- `mapping.py`: add `WORKFLOW_RUN_SPAN_NAME`, `is_workflow_run_span`, and `extract_conversation_input` / `extract_conversation_output` helpers that pull the user query and assistant answer from a chat span's `gen_ai.input.messages` / `gen_ai.output.messages` (text/reasoning parts only). Also drop low-value `workflow.build` spans so each run stays a single trace.
- `translator.py`: add a process-lifetime `_ConversationContentRegistry` (populated by the dedup processor at chat-span end) and `conversation_root_attributes`, which stamps `conversation.input` / `conversation.output` on the root `workflow.run` span and, when the agent set a real conversation id via `set_conversation_id`, also `is_turn_root` + `conversation.id` so multi-turn runs group together. Nested-under-`@endpoint`/`@observe` runs are left untouched (no double turn root).
- Tests: extend `test_agent_framework.py` covering the registry, input/output extraction, and turn-root stamping (single-turn vs session).

## Testing

- `uvx ruff check` on the changed files - clean
- `uv run pytest ../tests/sdk/telemetry/integrations/test_agent_framework.py` - 86 passed

Made with [Cursor](https://cursor.com)