### PR TITLE
Add DEV_MODE toggle for hot reload and debug logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -159,6 +159,9 @@ FRONTEND_PORT=3000
 FRONTEND_ENV=local
 BACKEND_ENV=local
 WORKER_ENV=local
+# Enable hot reload + DEBUG logging in start.sh. Set to true when running via ./rh dev.
+# Docker Compose local leaves this false (no reload in containers).
+DEV_MODE=false
 
 # Skip migrations in start.sh when a deployment pipeline already ran migrate.sh
 # (Cloud Run backend sets this to true; local dev leaves it unset/false)

--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -242,7 +242,7 @@ def set_logger():
         json_console_handler.setFormatter(RedactingFormatter(JsonLogFormatter()))
         root_logger.addHandler(json_console_handler)
 
-    if ENVIRONMENT in ("local", "development"):
+    if ENVIRONMENT == "local":
         color_console_handler = logging.StreamHandler(stream=sys.stdout)
         color_console_handler.setLevel(LOG_LEVEL)
         color_console_handler.setFormatter(RedactingFormatter(_create_color_formatter()))

--- a/apps/backend/start.sh
+++ b/apps/backend/start.sh
@@ -26,12 +26,8 @@ is_production() {
     [ "${BACKEND_ENV}" = "production" ]
 }
 
-is_local() {
-    [ "${BACKEND_ENV}" = "local" ]
-}
-
-is_development() {
-    [ "${BACKEND_ENV}" = "development" ]
+dev_mode_enabled() {
+    [ "${DEV_MODE:-false}" = "true" ]
 }
 
 # Function to display banner
@@ -121,7 +117,8 @@ start_server() {
     log "  Port: $port"
     log "  Workers: $workers"
     log "  Timeout: ${timeout}s"
-    log "  Environment: $(is_production && echo "production" || echo "development")"
+    log "  Environment: ${BACKEND_ENV:-unset}"
+    log "  DEV_MODE (reload): $(dev_mode_enabled && echo "true" || echo "false")"
     echo ""
 
     # Determine command prefix
@@ -145,14 +142,8 @@ start_server() {
             --error-logfile - \
             --log-level info \
             rhesis.backend.app.main:app
-    elif is_local; then
-        log "${BLUE}🛠️  Starting local production server with Uvicorn...${NC}"
-        exec ${CMD_PREFIX}uvicorn \
-            rhesis.backend.app.main:app \
-            --host "$host" \
-            --port "$port"
-    elif is_development; then
-        log "${BLUE}🛠️  Starting development server with Uvicorn (hot reload)...${NC}"
+    elif dev_mode_enabled; then
+        log "${BLUE}🛠️  Starting server with Uvicorn (hot reload)...${NC}"
         exec ${CMD_PREFIX}uvicorn \
             rhesis.backend.app.main:app \
             --host "$host" \
@@ -160,13 +151,12 @@ start_server() {
             --log-level debug \
             --reload
     else
-        # Default: no BACKEND_ENV (e.g. docker-compose for integration tests)
-        log "${BLUE}🛠️  Starting server with Uvicorn (default)...${NC}"
+        # Default: local, development, staging, integration tests — no reload
+        log "${BLUE}🛠️  Starting server with Uvicorn...${NC}"
         exec ${CMD_PREFIX}uvicorn \
             rhesis.backend.app.main:app \
             --host "$host" \
-            --port "$port" \
-            --log-level debug
+            --port "$port"
     fi
 }
 

--- a/apps/worker/start.sh
+++ b/apps/worker/start.sh
@@ -33,12 +33,13 @@ echo "Celery worker prefetch multiplier: $CELERY_WORKER_PREFETCH_MULTIPLIER"
 echo "Celery architect prefetch multiplier: $CELERY_ARCHITECT_PREFETCH_MULTIPLIER"
 echo "Celery worker pool: threads"
 
-# Set log level based on worker environment
-if [ "${WORKER_ENV}" = "development" ]; then
-    CELERY_WORKER_LOGLEVEL="DEBUG"
-    echo "🔧 Development environment detected - setting log level to DEBUG"
+# Set log level: DEBUG when DEV_MODE=true (local dev) or WORKER_ENV=development (cloud dev tier)
+if [ "${DEV_MODE:-false}" = "true" ] || [ "${WORKER_ENV}" = "development" ]; then
+    export CELERY_WORKER_LOGLEVEL="DEBUG"
+    echo "🔧 Debug logging enabled (DEV_MODE=${DEV_MODE:-false}, WORKER_ENV=${WORKER_ENV:-not_set}) - setting log level to DEBUG"
 else
-    echo "🔧 Production/staging environment - using log level: $CELERY_WORKER_LOGLEVEL"
+    export CELERY_WORKER_LOGLEVEL="${CELERY_WORKER_LOGLEVEL:-WARNING}"
+    echo "🔧 Using log level: ${CELERY_WORKER_LOGLEVEL}"
 fi
 
 echo "Celery worker log level: $CELERY_WORKER_LOGLEVEL"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ x-common-environment: &common-environment
   BACKEND_ENV: ${BACKEND_ENV:-local}
   FRONTEND_ENV: ${FRONTEND_ENV:-local}
   WORKER_ENV: ${WORKER_ENV:-local}
+  DEV_MODE: ${DEV_MODE:-false}
   LOG_LEVEL: ${LOG_LEVEL:-DEBUG}
   QUICK_START: ${QUICK_START:-false}
 

--- a/docs/content/contribute/backend/architecture.mdx
+++ b/docs/content/contribute/backend/architecture.mdx
@@ -98,8 +98,10 @@ The logger chooses handlers from runtime configuration:
 | Runtime condition | Output |
 | --- | --- |
 | Google Cloud runtime detected | JSON logs on stdout with `severity`, `module`, and `message` fields |
-| `BACKEND_ENV=local` or `BACKEND_ENV=development` | Colored console logs plus timestamped files under `LOG_DIR` |
+| `BACKEND_ENV=local` | Colored console logs plus timestamped files under `LOG_DIR` |
 | Other environments | Root logger level and framework logger levels are controlled by `LOG_LEVEL` |
+
+`DEV_MODE=true` enables Uvicorn hot reload and `--log-level debug` in `start.sh`, and forces `CELERY_WORKER_LOGLEVEL=DEBUG` in the worker. Set `DEV_MODE=true` in `apps/backend/.env` when running via `./rh dev`; leave it unset or `false` everywhere else (Docker Compose local, cloud deployments).
 
 All configured handlers wrap their formatter in `RedactingFormatter`, which
 scrubs bearer tokens, JWTs, API keys, database URLs, cookies, passwords, and

--- a/rh
+++ b/rh
@@ -187,7 +187,8 @@ BROKER_URL=redis://:rhesis-redis-pass@localhost:${DEV_REDIS_PORT}/0
 CELERY_RESULT_BACKEND=redis://:rhesis-redis-pass@localhost:${DEV_REDIS_PORT}/1
 
 # Environment
-BACKEND_ENV=development
+BACKEND_ENV=local
+DEV_MODE=true
 LOG_LEVEL=DEBUG
 
 # URLs


### PR DESCRIPTION
## Purpose
`BACKEND_ENV=development` was overloaded to mean both "cloud dev tier" and "enable Uvicorn hot reload + DEBUG logging." That caused Docker Compose local stacks to run with reload/debug when they should behave like production containers.

This PR introduces an explicit `DEV_MODE` flag so reload and verbose logging are opt-in for `./rh dev` only.

## What Changed
- Add `DEV_MODE` to `.env.example`, `docker-compose.yml`, and the `./rh dev` generated env (`DEV_MODE=true`, `BACKEND_ENV=local`)
- Update `apps/backend/start.sh` to enable Uvicorn `--reload` and `--log-level debug` only when `DEV_MODE=true`
- Update `apps/worker/start.sh` to set `CELERY_WORKER_LOGLEVEL=DEBUG` when `DEV_MODE=true` or `WORKER_ENV=development`
- Restrict colored console logging in `logging_config.py` to `BACKEND_ENV=local` only (not `development`)
- Document the new flag in `docs/content/contribute/backend/architecture.mdx`

## Additional Context
- `DEV_MODE` defaults to `false` everywhere except `./rh dev`
- Cloud dev tiers can keep `WORKER_ENV=development` for Celery DEBUG without enabling backend hot reload

## Testing
- [ ] Run `./rh dev` and confirm backend starts with Uvicorn reload and DEBUG logs
- [ ] Run `docker compose up` with default env and confirm no reload and WARNING-level worker logs
- [ ] Set `DEV_MODE=true` in compose and confirm worker logs at DEBUG