### PR TITLE
Mount MCP server in FastAPI lifespan

### DIFF
--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -432,6 +432,21 @@ async def lifespan(app: FastAPI):
 
     garak_cache_task.add_done_callback(_log_task_exception)
 
+    # Mount the MCP server (/mcp) only when the app is actually served over
+    # HTTP. This sets app.state.mcp_server, consumed by the session-manager
+    # block below. Doing it here (not at import time) keeps the /mcp endpoint
+    # and its OpenAPI/tool build out of processes that merely import the app
+    # object — e.g. the Celery architect worker, which dispatches tools
+    # in-process via LocalToolProvider and never serves /mcp.
+    #
+    # Guarded so it mounts once per app object: lifespan can run multiple
+    # times against the same app (test suites that restart it), and
+    # setup_mcp_server calls app.mount("/mcp", ...) which must not stack.
+    if getattr(app.state, "mcp_server", None) is None:
+        from rhesis.backend.app.mcp_server import setup_mcp_server
+
+        setup_mcp_server(app)
+
     # Start MCP session manager (Mount doesn't propagate lifespan).
     # StreamableHTTPSessionManager.run() can only be called once per
     # instance, so create a fresh one each time the lifespan starts
@@ -689,10 +704,9 @@ class LoggingMiddleware(BaseHTTPMiddleware):
 for router in routers:
     app.include_router(router)
 
-# Mount MCP server for agent tool access
-from rhesis.backend.app.mcp_server import setup_mcp_server
-
-setup_mcp_server(app)
+# MCP server (/mcp) is mounted inside the lifespan handler (see above), not at
+# import time, so processes that only import the app object (e.g. the Celery
+# architect worker) don't build/mount an endpoint they never serve.
 
 # Bootstrap Enterprise Edition features (no-op when ee extra is not installed).
 #

--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -432,16 +432,6 @@ async def lifespan(app: FastAPI):
 
     garak_cache_task.add_done_callback(_log_task_exception)
 
-    # Mount the MCP server (/mcp) only when the app is actually served over
-    # HTTP. This sets app.state.mcp_server, consumed by the session-manager
-    # block below. Doing it here (not at import time) keeps the /mcp endpoint
-    # and its OpenAPI/tool build out of processes that merely import the app
-    # object — e.g. the Celery architect worker, which dispatches tools
-    # in-process via LocalToolProvider and never serves /mcp.
-    #
-    # Guarded so it mounts once per app object: lifespan can run multiple
-    # times against the same app (test suites that restart it), and
-    # setup_mcp_server calls app.mount("/mcp", ...) which must not stack.
     if getattr(app.state, "mcp_server", None) is None:
         from rhesis.backend.app.mcp_server import setup_mcp_server
 


### PR DESCRIPTION
## Summary
- Move `setup_mcp_server(app)` from module import time into the FastAPI `lifespan` handler, so `/mcp` is only mounted when the backend is actually served over HTTP
- Add an idempotency guard (`app.state.mcp_server`) so test suites that restart lifespan on the same app object do not stack duplicate `/mcp` mounts
- Processes that only import `app` (e.g. the Celery architect worker using `LocalToolProvider`) no longer build/mount the MCP HTTP endpoint or emit misleading MCP init logs at import

## Context
The architect worker imports `rhesis.backend.app.main` for in-process ASGI tool dispatch but never serves `/mcp`. Mounting MCP at import time was unnecessary work and produced confusing logs (`MCP server initialized`, `MCP endpoint mounted at /mcp`) in worker output.

The architect worker warmup hook (already on `main`) handles first-message latency separately; this change is architectural cleanup and log clarity.

## Test plan
- [x] Bare `import app` does not mount `/mcp` or set `app.state.mcp_server`
- [x] `TestClient(app)` lifespan mounts `/mcp`, starts session manager, `GET /health` → 200
- [x] `POST /mcp` without auth → 401 (endpoint live)
- [x] Second lifespan cycle does not duplicate `/mcp` route (count stays 1)