### PR TITLE
Refactor travel-agent: move parse helpers to utils

### DIFF
--- a/agents/travel-agent/docs/architecture.md
+++ b/agents/travel-agent/docs/architecture.md
@@ -51,11 +51,11 @@ flowchart TB
 | File | Responsibility |
 |---|---|
 | `app.py` | FastAPI API surface, Rhesis `@endpoint` tracing, conversation history. |
-| `workflow.py` | Builds the `HandoffBuilder` workflow, streams events, extracts handoffs and tool calls. |
+| `workflow.py` | Builds the `HandoffBuilder` workflow and runs it, streaming events into a structured result. |
 | `agents/` | Defines the coordinator and three specialist agent factories. |
 | `client.py` | Builds the Gemini-backed OpenAI-compatible MAF chat client. |
 | `tools.py` | Defines `get_random_destination`, `find_sightseeing`, and `estimate_travel`. |
-| `utils.py` | Formats `agent_workflow` and `tool_chain` response fields. |
+| `utils.py` | Parses streamed events (tool calls, text segments, final answer) and formats the `agent_workflow` and `tool_chain` response fields. |
 
 ## Request Flow
 

--- a/agents/travel-agent/src/travel_agent/utils.py
+++ b/agents/travel-agent/src/travel_agent/utils.py
@@ -1,6 +1,13 @@
-"""Formatting helpers for the Travel Agent multi-agent system."""
+"""Formatting and stream-parsing helpers for the Travel Agent multi-agent system."""
 
 from __future__ import annotations
+
+import json
+from typing import Any
+
+from agent_framework import Content, Message
+
+COORDINATOR_NAME = "trip_coordinator"
 
 AGENT_LABELS: dict[str, str] = {
     "trip_coordinator": "Coordinator",
@@ -35,3 +42,130 @@ def format_tool_chain(tools_called: list[dict]) -> str:
 
     parts = [f"[{agent_name}] {', '.join(by_agent[agent_name])}" for agent_name in order]
     return " -> ".join(parts)
+
+
+def coerce_args(arguments: Any) -> dict[str, Any]:
+    """Coerce a MAF ``function_call`` ``arguments`` payload into a plain dict.
+
+    MAF carries tool arguments either as a JSON string (the OpenAI-compat
+    path streams it that way) or as an already-decoded ``dict``. Anything
+    else is wrapped so the FastAPI response stays JSON-serialisable.
+    """
+    if arguments is None:
+        return {}
+    if isinstance(arguments, dict):
+        return arguments
+    if isinstance(arguments, str):
+        try:
+            parsed = json.loads(arguments)
+            return parsed if isinstance(parsed, dict) else {"value": parsed}
+        except (ValueError, TypeError):
+            return {"raw": arguments}
+    return {"value": arguments}
+
+
+def record_function_calls(
+    update: Any,
+    *,
+    tools_called: list[dict[str, Any]],
+    agents_seen: list[str],
+) -> None:
+    """Pull domain tool invocations out of one streamed agent update."""
+    role = getattr(update, "role", None)
+    author = getattr(update, "author_name", None) or "unknown"
+    if author not in agents_seen:
+        agents_seen.append(author)
+
+    if role != "assistant":
+        return
+
+    for content in getattr(update, "contents", None) or ():
+        if getattr(content, "type", None) != "function_call":
+            continue
+        tool_name = getattr(content, "name", None) or "unknown"
+        if tool_name.startswith("handoff_to_"):
+            continue
+        tools_called.append(
+            {
+                "tool_name": tool_name,
+                "tool_args": coerce_args(getattr(content, "arguments", None)),
+                "agent": author,
+            }
+        )
+
+
+def segment_texts(segments: list[dict[str, Any]]) -> list[str]:
+    """Concatenate each segment's streamed chunks into one non-empty string each."""
+    texts: list[str] = []
+    for segment in segments:
+        joined = "".join(segment["parts"]).strip()
+        if joined:
+            texts.append(joined)
+    return texts
+
+
+def last_segment_text(segments: list[dict[str, Any]], *, author: str) -> str | None:
+    """Return the concatenated text of the last contiguous segment by ``author``."""
+    for segment in reversed(segments):
+        if segment["author"] == author:
+            joined = "".join(segment["parts"]).strip()
+            if joined:
+                return joined
+    return None
+
+
+def user_visible_assistant_message(text: str) -> Message:
+    """Build the single assistant message persisted for a completed turn."""
+    return Message(
+        role="assistant",
+        contents=[Content.from_text(text=text)],
+        author_name=COORDINATOR_NAME,
+    )
+
+
+def capture_final_text(request_info_data: Any, *, fallback: list[str]) -> str | None:
+    """Pull the synthesised final answer out of a handoff request-info event."""
+    agent_response = getattr(request_info_data, "agent_response", None)
+    text = getattr(agent_response, "text", None)
+    if isinstance(text, str) and text.strip():
+        return text
+    if fallback:
+        joined = "\n".join(text for text in fallback if text).strip()
+        return joined or None
+    return None
+
+
+def normalize_agent_order(agents_seen: list[str], handoff_targets: list[str]) -> list[str]:
+    """Build the ordered, deduped list of agents that participated."""
+    ordered: list[str] = []
+    if "trip_coordinator" in agents_seen or "trip_coordinator" in handoff_targets:
+        ordered.append("trip_coordinator")
+    for agent_name in agents_seen:
+        if agent_name and agent_name not in ordered:
+            ordered.append(agent_name)
+    for target in handoff_targets:
+        if target and target not in ordered:
+            ordered.append(target)
+    return ordered
+
+
+def resolve_response(
+    assistant_segments: list[dict[str, Any]],
+    *,
+    final_text: str | None,
+) -> tuple[str, str]:
+    """Pick the user-facing response text and the agent that authored it."""
+    coordinator_text = last_segment_text(assistant_segments, author=COORDINATOR_NAME)
+    if coordinator_text:
+        return coordinator_text, COORDINATOR_NAME
+
+    if final_text:
+        return final_text, COORDINATOR_NAME
+
+    for segment in reversed(assistant_segments):
+        joined = "".join(segment["parts"]).strip()
+        if joined:
+            author = segment.get("author") or "unknown"
+            return joined, author
+
+    return "", "unknown"

--- a/agents/travel-agent/src/travel_agent/workflow.py
+++ b/agents/travel-agent/src/travel_agent/workflow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from typing import Any
 
 from agent_framework import Agent, Content, Message, Workflow
@@ -16,10 +15,19 @@ from travel_agent.agents import (
     create_sightseeing_scout,
 )
 from travel_agent.client import build_chat_client
-from travel_agent.utils import format_agent_workflow, format_tool_chain
+from travel_agent.utils import (
+    COORDINATOR_NAME,
+    capture_final_text,
+    format_agent_workflow,
+    format_tool_chain,
+    normalize_agent_order,
+    record_function_calls,
+    resolve_response,
+    segment_texts,
+    user_visible_assistant_message,
+)
 
 WORKFLOW_TIMEOUT_SECONDS = 120
-COORDINATOR_NAME = "trip_coordinator"
 
 # Autonomous-mode retry prompt for specialists that reply without handing back.
 # Replaces MAF's generic "Continue assisting autonomously" default with a
@@ -87,133 +95,6 @@ def build_travel_workflow() -> Workflow:
     )
 
 
-def _coerce_args(arguments: Any) -> dict[str, Any]:
-    """Coerce a MAF ``function_call`` ``arguments`` payload into a plain dict.
-
-    MAF carries tool arguments either as a JSON string (the OpenAI-compat
-    path streams it that way) or as an already-decoded ``dict``. Anything
-    else is wrapped so the FastAPI response stays JSON-serialisable.
-    """
-    if arguments is None:
-        return {}
-    if isinstance(arguments, dict):
-        return arguments
-    if isinstance(arguments, str):
-        try:
-            parsed = json.loads(arguments)
-            return parsed if isinstance(parsed, dict) else {"value": parsed}
-        except (ValueError, TypeError):
-            return {"raw": arguments}
-    return {"value": arguments}
-
-
-def _record_function_calls(
-    update: Any,
-    *,
-    tools_called: list[dict[str, Any]],
-    agents_seen: list[str],
-) -> None:
-    """Pull domain tool invocations out of one streamed agent update."""
-    role = getattr(update, "role", None)
-    author = getattr(update, "author_name", None) or "unknown"
-    if author not in agents_seen:
-        agents_seen.append(author)
-
-    if role != "assistant":
-        return
-
-    for content in getattr(update, "contents", None) or ():
-        if getattr(content, "type", None) != "function_call":
-            continue
-        tool_name = getattr(content, "name", None) or "unknown"
-        if tool_name.startswith("handoff_to_"):
-            continue
-        tools_called.append(
-            {
-                "tool_name": tool_name,
-                "tool_args": _coerce_args(getattr(content, "arguments", None)),
-                "agent": author,
-            }
-        )
-
-
-def _segment_texts(segments: list[dict[str, Any]]) -> list[str]:
-    """Concatenate each segment's streamed chunks into one non-empty string each."""
-    texts: list[str] = []
-    for segment in segments:
-        joined = "".join(segment["parts"]).strip()
-        if joined:
-            texts.append(joined)
-    return texts
-
-
-def _last_segment_text(segments: list[dict[str, Any]], *, author: str) -> str | None:
-    """Return the concatenated text of the last contiguous segment by ``author``."""
-    for segment in reversed(segments):
-        if segment["author"] == author:
-            joined = "".join(segment["parts"]).strip()
-            if joined:
-                return joined
-    return None
-
-
-def _user_visible_assistant_message(text: str) -> Message:
-    """Build the single assistant message persisted for a completed turn."""
-    return Message(
-        role="assistant",
-        contents=[Content.from_text(text=text)],
-        author_name=COORDINATOR_NAME,
-    )
-
-
-def _capture_final_text(request_info_data: Any, *, fallback: list[str]) -> str | None:
-    """Pull the synthesised final answer out of a handoff request-info event."""
-    agent_response = getattr(request_info_data, "agent_response", None)
-    text = getattr(agent_response, "text", None)
-    if isinstance(text, str) and text.strip():
-        return text
-    if fallback:
-        joined = "\n".join(text for text in fallback if text).strip()
-        return joined or None
-    return None
-
-
-def _normalize_agent_order(agents_seen: list[str], handoff_targets: list[str]) -> list[str]:
-    """Build the ordered, deduped list of agents that participated."""
-    ordered: list[str] = []
-    if "trip_coordinator" in agents_seen or "trip_coordinator" in handoff_targets:
-        ordered.append("trip_coordinator")
-    for agent_name in agents_seen:
-        if agent_name and agent_name not in ordered:
-            ordered.append(agent_name)
-    for target in handoff_targets:
-        if target and target not in ordered:
-            ordered.append(target)
-    return ordered
-
-
-def _resolve_response(
-    assistant_segments: list[dict[str, Any]],
-    *,
-    final_text: str | None,
-) -> tuple[str, str]:
-    """Pick the user-facing response text and the agent that authored it."""
-    coordinator_text = _last_segment_text(assistant_segments, author=COORDINATOR_NAME)
-    if coordinator_text:
-        return coordinator_text, COORDINATOR_NAME
-
-    if final_text:
-        return final_text, COORDINATOR_NAME
-
-    for segment in reversed(assistant_segments):
-        joined = "".join(segment["parts"]).strip()
-        if joined:
-            author = segment.get("author") or "unknown"
-            return joined, author
-
-    return "", "unknown"
-
-
 async def invoke_travel_workflow_async(
     workflow: Workflow,
     user_message: str,
@@ -251,7 +132,7 @@ async def invoke_travel_workflow_async(
                 continue
 
             if event_type == "output" and data is not None:
-                _record_function_calls(data, tools_called=tools_called, agents_seen=agents_seen)
+                record_function_calls(data, tools_called=tools_called, agents_seen=agents_seen)
                 if getattr(data, "role", None) == "assistant":
                     text = getattr(data, "text", "") or ""
                     if text:
@@ -262,7 +143,7 @@ async def invoke_travel_workflow_async(
                 continue
 
             if event_type == "request_info":
-                captured = _capture_final_text(data, fallback=_segment_texts(assistant_segments))
+                captured = capture_final_text(data, fallback=segment_texts(assistant_segments))
                 if captured:
                     final_text = captured
                 continue
@@ -276,16 +157,16 @@ async def invoke_travel_workflow_async(
     except asyncio.TimeoutError as exc:
         raise TimeoutError(f"Travel workflow timed out after {WORKFLOW_TIMEOUT_SECONDS}s") from exc
 
-    response_text, final_agent = _resolve_response(
+    response_text, final_agent = resolve_response(
         assistant_segments,
         final_text=final_text,
     )
     if not response_text:
         raise RuntimeError("Travel workflow completed without producing a user-facing response.")
 
-    agents_involved = _normalize_agent_order(agents_seen, handoff_targets)
+    agents_involved = normalize_agent_order(agents_seen, handoff_targets)
     updated_history = [*(conversation_history or []), user_msg]
-    updated_history.append(_user_visible_assistant_message(response_text))
+    updated_history.append(user_visible_assistant_message(response_text))
 
     return {
         "response": response_text,


### PR DESCRIPTION
## Purpose

Behavior-preserving refactor of the Microsoft Agent Framework (MAF) travel-agent example so its module boundaries match the `research-assistant/` gold standard. Most of the agent was already modular (serving glue in `examples/`, tools/config/prompts/session already extracted); the one module still mixing "core" with "peripheral" was `workflow.py`, which held workflow construction + the streaming-invocation loop + a pile of private parsing helpers.

## What Changed

- Moved the stream/segment parsing helpers out of `workflow.py` into `utils.py`, mirroring `research-assistant`'s convention of keeping helpers in `utils.py` while the workflow module stays focused on build + invoke:
  `coerce_args`, `record_function_calls`, `segment_texts`, `last_segment_text`, `user_visible_assistant_message`, `capture_final_text`, `normalize_agent_order`, `resolve_response` (leading underscore dropped to match the gold standard's public-helper naming).
- Moved `COORDINATOR_NAME` alongside the helpers that use it (its natural home next to `AGENT_LABELS`); it is re-imported and re-exported from `workflow` so `travel_agent.workflow.COORDINATOR_NAME` and `workflow.__all__` are unchanged.
- `workflow.py` now imports these from `travel_agent.utils` and keeps only construction (`build_travel_workflow`), invocation (`invoke_travel_workflow_async` / `invoke_travel_workflow` / `run_query`), and `get_participants`.
- Updated the Package Layout table in `docs/architecture.md` to reflect the new responsibilities.

### Before / After

Before: `workflow.py` ~354 lines (build + invoke + 8 private helpers + `COORDINATOR_NAME`); `utils.py` = formatting only.

After: `workflow.py` = build + invoke; `utils.py` = constants + formatting + stream-parsing helpers. No other files moved.

## Behavior unchanged

This is a pure relocation + rename (private -> public) with import rewiring. No logic edits, no new features, no changes to inputs/outputs or runtime behavior. Tracing remains the SDK's responsibility via `auto_instrument("agent_framework")` — no manual OpenTelemetry spans were added. The `app.py` vs `examples/serve_playground.py` boundary is untouched. The moved helpers were all private (`_`-prefixed) and grep-confirmed to be used only inside `workflow.py`.

## Testing

- `uv run python -c "import travel_agent; import travel_agent.workflow; import travel_agent.utils"` imports cleanly; `travel_agent.app`, `travel_agent.session`, and both `examples/*.py` import/compile.
- Exercised the moved pure helpers directly (`segment_texts`, `last_segment_text`, `resolve_response`, `coerce_args`, `normalize_agent_order`, `format_tool_chain`, `format_agent_workflow`, `user_visible_assistant_message`) — all pass; `workflow.COORDINATOR_NAME` and `utils.COORDINATOR_NAME` both resolve.
- `uvx ruff format --check src/ examples/` and `uvx ruff check src/ examples/` both clean (line-length 100, `I,E,F`).
- Pre-commit hooks passed on both commits. No travel-agent tests exist to break.

Made with [Cursor](https://cursor.com)