### PR TITLE
Add resource flags to regular Cloud Run deploy

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -619,6 +619,12 @@ jobs:
               --platform=managed \
               --allow-unauthenticated \
               --port=8080 \
+              --memory=2Gi \
+              --cpu=2 \
+              --concurrency=80 \
+              --timeout=3600 \
+              --max-instances=10 \
+              --min-instances=1 \
               --add-cloudsql-instances=${{ env.PROJECT_ID }}:${{ env.REGION }}:${{ env.CLOUDSQL_INSTANCE }} \
               --set-env-vars="$(cat <<EOF
           DB_DRIVER=${{ secrets.DB_DRIVER }},


### PR DESCRIPTION
Purpose The regular (non-preview) gcloud run deploy was missing resource configuration flags. For an existing service this doesn't matter since settings persist, but deploying to a new service falls back to Cloud Run defaults (256MB RAM, 1 vCPU), causing an OOM crash on startup.

What Changed

Added `--memory=2Gi, --cpu=2, --concurrency=80, --timeout=3600, --max-instances=10, --min-instances=1` to the regular deploy path, matching the existing preview deploy configuration

Additional Context

Root cause of the failing dev deployment (revision 00001 on a new service)


Values copied from the preview deploy path — worth aligning with the team on whether these are the right numbers for the regular environment

Testing Re-run the backend deploy workflow against the dev environment.
