### PR TITLE
Fix telemetry trace ingest failing with RLS project_isolation violation

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -142,7 +142,8 @@ def ingest_trace(
     # Store spans, then enqueue linking + enrichment as a background task.
     _stage = "span_storage"
     try:
-        stored_spans = crud.create_trace_spans(db, trace_batch.spans, organization_id)
+        with temporary_project_scope(db, organization_id, user_id or "", project_id):
+            stored_spans = crud.create_trace_spans(db, trace_batch.spans, organization_id)
 
         if not stored_spans:
             logger.warning(f"No spans were stored for trace_id={trace_id}")


### PR DESCRIPTION
## Purpose

`POST /telemetry/traces` was returning 500 for any SDK user whose API token was not project-scoped (i.e. `RHESIS_PROJECT_ID` set in the SDK but token not bound to a project). This made tracing completely unusable for those users.



## What Changed

- Wrapped `create_trace_spans` in `temporary_project_scope` using the project_id resolved from the span payload, so the PostgreSQL RLS `project_isolation` policy is satisfied during the INSERT.



## Additional Context

- Root cause: `get_tenant_db_session` sets `app.current_project = ""` from the token/header scope. When the endpoint resolves `project_id` from the span body instead, the GUC was never updated to match, causing the fail-closed `project_isolation` RLS policy (introduced in migration `b8c9d0e1f2a3`) to block the INSERT.

- Same class of bug as [#2047](https://github.com/rhesis-ai/rhesis/pull/2047) (WebSocket subscribe) and [#2055](https://github.com/rhesis-ai/rhesis/pull/2055) (trace listing). The fix for the read path (`GET /telemetry/traces`) used `temporary_project_scope` — this applies the same pattern to the write path.

- Introduced in `d90de0ab9` (between 0.9.0 and 0.9.1), which added span-body project_id resolution without syncing the RLS session variable.

- Fixes [#2081](https://github.com/rhesis-ai/rhesis/issues/2081).



## Testing

1. Create a non-project-scoped token (`project_id = NULL` in the `token` table).

2. `POST /telemetry/traces` with `project_id` in the span body and that token → before fix: `500`, after fix: `{"status": "received", ...}`.
