### PR TITLE
fix(telemetry): validate project access on span-body project_id

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -63,10 +63,12 @@ logger = logging.getLogger(__name__)
 
 @router.post("/traces", response_model=TraceResponse)
 def ingest_trace(
+    request: Request,
     trace_batch: OTELTraceBatch,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
     scope_project_id: str | None = Depends(get_project_context),
+    current_user: User = Depends(require_current_user_or_token),
 ) -> TraceResponse:
     """
     Ingest OpenTelemetry traces from SDK.
@@ -97,7 +99,7 @@ def ingest_trace(
     # Resolve project_id: prefer span value, fall back to token/header scope
     span_project_id = trace_batch.spans[0].project_id if trace_batch.spans else None
     if span_project_id and span_project_id != "unknown":
-        project_id = span_project_id
+        project_id = assert_project_access(request, current_user, span_project_id, db=db)
     elif scope_project_id:
         project_id = scope_project_id
         for span in trace_batch.spans:

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -100,6 +100,8 @@ def ingest_trace(
     span_project_id = trace_batch.spans[0].project_id if trace_batch.spans else None
     if span_project_id and span_project_id != "unknown":
         project_id = assert_project_access(request, current_user, span_project_id, db=db)
+        for span in trace_batch.spans:
+            span.project_id = project_id
     elif scope_project_id:
         project_id = scope_project_id
         for span in trace_batch.spans:


### PR DESCRIPTION
## Purpose

Security follow-up to #2083. The ingest endpoint was accepting any `project_id` from the span body without verifying the caller is a member of that project, allowing cross-project writes within the same org.



## What Changed

- Added `request` and `current_user` dependencies to `ingest_trace`

- Call `assert_project_access` on the span-body `project_id` before binding `temporary_project_scope`



## Testing

Same reproduction as #2083 — span with a `project_id` the caller is not a member of should now return 403 instead of 200.
