### PR TITLE
Harden Penelope Microsoft Agent Framework target

### DIFF
--- a/docs/content/changelog.mdx
+++ b/docs/content/changelog.mdx
@@ -17,7 +17,7 @@ This is the aggregated changelog for the entire Rhesis repository. For detailed 
 - **One-line auto-instrumentation**: `auto_instrument("agent_framework")` (alias `"maf"`) translates MAF GenAI spans into the Rhesis schema - agents, model calls, tools, embeddings, and workflows - with no agent code changes.
 - **Native handoff tracing**: handoffs in `HandoffBuilder` workflows are synthesized into `ai.agent.handoff` spans for the Graph View.
 - **Privacy controls**: `RHESIS_DISABLE_CONTENT_CAPTURE` omits prompt/completion/tool payloads; `RHESIS_MAF_VERBOSE_WORKFLOW_SPANS` keeps full workflow infrastructure spans.
-- **Penelope MAF target**: `MicrosoftAgentFrameworkTarget` drives any MAF agent through multi-turn conversation simulation.
+- **Penelope MAF target**: `MAFTarget` drives any MAF agent through multi-turn conversation simulation.
 
 The legacy `autogen` integration is now a deprecated no-op; use `agent_framework` instead.
 

--- a/docs/content/docs/tests/conversation-simulation/extending.mdx
+++ b/docs/content/docs/tests/conversation-simulation/extending.mdx
@@ -88,16 +88,16 @@ target = LangGraphTarget(graph=my_graph)`}
 <CodeBlock filename="maf_target.py" language="python">
 {`from agent_framework import ChatAgent
 from agent_framework.openai import OpenAIChatClient
-from rhesis.penelope import MicrosoftAgentFrameworkTarget
+from rhesis.penelope import MAFTarget
 
 maf_agent = ChatAgent(
     chat_client=OpenAIChatClient(),
     instructions="You are helpful.",
 )
-target = MicrosoftAgentFrameworkTarget(maf_agent, target_id="maf-bot")`}
+target = MAFTarget(maf_agent, target_id="maf-bot")`}
 </CodeBlock>
 
-The Microsoft Agent Framework target preserves multi-turn context by keeping a MAF thread/session object per `conversation_id`, and bridges MAF's async `run()` to Penelope's synchronous target contract - so you can drive any MAF agent through Penelope's multi-turn testing without changing the agent.
+The MAF target preserves multi-turn context by keeping a MAF thread/session object per `conversation_id`, and bridges MAF's async `run()` to Penelope's synchronous target contract - so you can drive any MAF agent through Penelope's multi-turn testing without changing the agent.
 
 ### Built-in Tools
 

--- a/penelope/README.md
+++ b/penelope/README.md
@@ -47,13 +47,13 @@ from rhesis.penelope import (
     EndpointTarget,
     LangChainTarget,
     LangGraphTarget,
-    MicrosoftAgentFrameworkTarget,
+    MAFTarget,
 )
 
 penelope = PenelopeAgent()
 
-# Microsoft Agent Framework agent (async run() is bridged automatically)
-target = MicrosoftAgentFrameworkTarget(maf_agent, target_id="maf-bot")
+# MAF (Microsoft Agent Framework) agent (async run() is bridged automatically)
+target = MAFTarget(maf_agent, target_id="maf-bot")
 
 result = penelope.execute_test(
     target=target,
@@ -131,7 +131,7 @@ uv sync
 
 - **True Multi-Turn Understanding**: Native support for stateful conversations
 - **Provider Agnostic**: Works with OpenAI, Anthropic, Vertex AI, and more
-- **Target Flexible**: Test any conversational system (Rhesis endpoints, LangChain, LangGraph, Microsoft Agent Framework, custom targets)
+- **Target Flexible**: Test any conversational system (Rhesis endpoints, LangChain, LangGraph, MAF, custom targets)
 - **Smart Defaults**: Just specify a goal, Penelope plans the rest
 - **LLM-Driven Evaluation**: Intelligent goal achievement detection
 - **Transparent Reasoning**: See Penelope's thought process

--- a/penelope/examples/maf_minimal.py
+++ b/penelope/examples/maf_minimal.py
@@ -10,7 +10,7 @@ Requirements:
 
 Usage:
     export GEMINI_API_KEY=...   # or GOOGLE_API_KEY
-    uv run python microsoft_agent_framework_minimal.py
+    uv run python maf_minimal.py
 """
 
 import os
@@ -22,7 +22,7 @@ load_dotenv()
 
 google_api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
 
-# 1. Create a simple Microsoft Agent Framework agent using Gemini.
+# 1. Create a simple MAF agent using Gemini.
 #    Gemini exposes an OpenAI-compatible endpoint, so MAF's OpenAI chat-completion
 #    client can talk to it by pointing base_url at Google.
 from agent_framework import Agent
@@ -39,9 +39,9 @@ agent = Agent(
 )
 
 # 2. Wrap it in a Penelope target
-from rhesis.penelope import MicrosoftAgentFrameworkTarget
+from rhesis.penelope import MAFTarget
 
-target = MicrosoftAgentFrameworkTarget(agent, "customer-service-agent", "Customer service agent")
+target = MAFTarget(agent, "customer-service-agent", "Customer service agent")
 
 # 3. Test with Penelope (also driven by Gemini, so only a Google key is needed)
 from rhesis.penelope import PenelopeAgent

--- a/penelope/examples/microsoft_agent_framework_minimal.py
+++ b/penelope/examples/microsoft_agent_framework_minimal.py
@@ -2,46 +2,56 @@
 """
 Minimal example of using Penelope with the Microsoft Agent Framework (MAF).
 
-This is the simplest possible example showing MAF integration using OpenAI.
+This is the simplest possible example showing MAF integration using Gemini
+(via Google's OpenAI-compatible endpoint), so it only needs a Google API key.
 
 Requirements:
     uv sync --extra microsoft-agent-framework
-    export OPENAI_API_KEY=...
 
 Usage:
+    export GEMINI_API_KEY=...   # or GOOGLE_API_KEY
     uv run python microsoft_agent_framework_minimal.py
 """
 
+import os
+
 from dotenv import load_dotenv
 
-# Load environment variables from .env file (expects OPENAI_API_KEY)
+# Load environment variables from .env file (expects GEMINI_API_KEY or GOOGLE_API_KEY)
 load_dotenv()
 
-# 1. Create a Microsoft Agent Framework agent backed by OpenAI.
-#    Older MAF releases call this class ``ChatAgent``; current releases call it
-#    ``Agent``. Both expose the same async ``run`` contract the target relies on.
+google_api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+
+# 1. Create a simple Microsoft Agent Framework agent using Gemini.
+#    Gemini exposes an OpenAI-compatible endpoint, so MAF's OpenAI chat-completion
+#    client can talk to it by pointing base_url at Google.
 from agent_framework import Agent
-from agent_framework.openai import OpenAIChatClient
+from agent_framework.openai import OpenAIChatCompletionClient
 
 agent = Agent(
-    client=OpenAIChatClient(),
+    client=OpenAIChatCompletionClient(
+        model="gemini-2.5-flash",
+        api_key=google_api_key,
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+    ),
     instructions="You are a helpful customer service assistant.",
-    name="customer-service-bot",
+    name="customer-service-agent",
 )
 
 # 2. Wrap it in a Penelope target
 from rhesis.penelope import MicrosoftAgentFrameworkTarget
 
-target = MicrosoftAgentFrameworkTarget(
-    agent=agent,
-    target_id="customer-service-bot",
-    description="Customer service chatbot (Microsoft Agent Framework)",
-)
+target = MicrosoftAgentFrameworkTarget(agent, "customer-service-agent", "Customer service agent")
 
-# 3. Test with Penelope
+# 3. Test with Penelope (also driven by Gemini, so only a Google key is needed)
 from rhesis.penelope import PenelopeAgent
 
-penelope = PenelopeAgent(enable_transparency=True, verbose=True, max_turns=5)
+penelope = PenelopeAgent(
+    model="gemini/gemini-2.5-flash",
+    enable_transparency=True,
+    verbose=True,
+    max_turns=5,
+)
 
 result = penelope.execute_test(
     target=target, goal="Ask 2 questions about shipping and get helpful answers"

--- a/penelope/src/rhesis/penelope/__init__.py
+++ b/penelope/src/rhesis/penelope/__init__.py
@@ -24,7 +24,7 @@ from rhesis.penelope.targets import (
     EndpointTarget,
     LangChainTarget,
     LangGraphTarget,
-    MicrosoftAgentFrameworkTarget,
+    MAFTarget,
     Target,
 )
 from rhesis.penelope.tools.base import Tool
@@ -50,5 +50,5 @@ __all__ = [
     "EndpointTarget",
     "LangChainTarget",
     "LangGraphTarget",
-    "MicrosoftAgentFrameworkTarget",
+    "MAFTarget",
 ]

--- a/penelope/src/rhesis/penelope/__init__.py
+++ b/penelope/src/rhesis/penelope/__init__.py
@@ -52,3 +52,19 @@ __all__ = [
     "LangGraphTarget",
     "MAFTarget",
 ]
+
+# Deprecated alias: MicrosoftAgentFrameworkTarget was renamed to MAFTarget.
+_DEPRECATED_ALIASES = {"MicrosoftAgentFrameworkTarget": MAFTarget}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED_ALIASES:
+        import warnings
+
+        warnings.warn(
+            f"{name} is deprecated; use MAFTarget instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _DEPRECATED_ALIASES[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/penelope/src/rhesis/penelope/targets/__init__.py
+++ b/penelope/src/rhesis/penelope/targets/__init__.py
@@ -27,3 +27,19 @@ __all__ = [
     "LangGraphTarget",
     "MAFTarget",
 ]
+
+# Deprecated alias: MicrosoftAgentFrameworkTarget was renamed to MAFTarget.
+_DEPRECATED_ALIASES = {"MicrosoftAgentFrameworkTarget": MAFTarget}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED_ALIASES:
+        import warnings
+
+        warnings.warn(
+            f"{name} is deprecated; use MAFTarget instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _DEPRECATED_ALIASES[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/penelope/src/rhesis/penelope/targets/__init__.py
+++ b/penelope/src/rhesis/penelope/targets/__init__.py
@@ -5,7 +5,7 @@ Targets represent what Penelope tests. Currently supports:
 - EndpointTarget: Rhesis endpoints (via SDK)
 - LangChainTarget: LangChain chains, agents, and runnables
 - LangGraphTarget: LangGraph compiled graphs and agents
-- MicrosoftAgentFrameworkTarget: Microsoft Agent Framework (MAF) agents
+- MAFTarget: MAF (Microsoft Agent Framework) agents
 
 Future targets may include:
 - AgentTarget: Other AI agents
@@ -16,7 +16,7 @@ Future targets may include:
 from rhesis.penelope.targets.endpoint import EndpointTarget
 from rhesis.penelope.targets.langchain import LangChainTarget
 from rhesis.penelope.targets.langgraph import LangGraphTarget
-from rhesis.penelope.targets.microsoft_agent_framework import MicrosoftAgentFrameworkTarget
+from rhesis.penelope.targets.maf import MAFTarget
 from rhesis.sdk.targets import Target, TargetResponse
 
 __all__ = [
@@ -25,5 +25,5 @@ __all__ = [
     "EndpointTarget",
     "LangChainTarget",
     "LangGraphTarget",
-    "MicrosoftAgentFrameworkTarget",
+    "MAFTarget",
 ]

--- a/penelope/src/rhesis/penelope/targets/maf.py
+++ b/penelope/src/rhesis/penelope/targets/maf.py
@@ -1,7 +1,7 @@
 """
 Microsoft Agent Framework (MAF) target implementation for Penelope.
 
-Wraps any Microsoft Agent Framework agent (``agent-framework`` Python package)
+Wraps any MAF agent (``agent-framework`` Python package)
 so it can be driven by Penelope's autonomous, multi-turn testing agent.
 
 MAF agents expose an *async* ``run`` method while Penelope's :class:`Target`
@@ -31,7 +31,7 @@ Usage::
     >>> from agent_framework.openai import OpenAIChatClient
     >>>
     >>> agent = Agent(client=OpenAIChatClient(), instructions="You are helpful.")
-    >>> target = MicrosoftAgentFrameworkTarget(agent, "maf-bot", "My MAF agent")
+    >>> target = MAFTarget(agent, "maf-bot", "My MAF agent")
     >>> response = target.send_message("Hello!")
     >>> follow_up = target.send_message("And again?", response.conversation_id)
 """
@@ -96,9 +96,9 @@ def _json_safe(value: Any) -> Any:
     return str(value)
 
 
-class MicrosoftAgentFrameworkTarget(Target):
+class MAFTarget(Target):
     """
-    Target for Microsoft Agent Framework agents.
+    Target for MAF (Microsoft Agent Framework) agents.
 
     Works with any MAF agent (``ChatAgent``, ``Agent``, ``AIAgent`` or anything
     implementing the framework's async ``run`` method).  Multi-turn context is
@@ -113,7 +113,7 @@ class MicrosoftAgentFrameworkTarget(Target):
         description: Optional[str] = None,
     ):
         """
-        Initialize the Microsoft Agent Framework target.
+        Initialize the MAF target.
 
         Args:
             agent: Any MAF agent exposing an async ``run`` method.
@@ -123,7 +123,7 @@ class MicrosoftAgentFrameworkTarget(Target):
         self.agent = agent
         self._target_id = target_id
         self._description = description or (
-            f"Microsoft Agent Framework {type(agent).__name__}: {target_id}"
+            f"MAF {type(agent).__name__}: {target_id}"
         )
 
         # Registry mapping the string conversation_id Penelope uses to the MAF
@@ -132,11 +132,11 @@ class MicrosoftAgentFrameworkTarget(Target):
 
         is_valid, error = self.validate_configuration()
         if not is_valid:
-            raise ValueError(f"Invalid Microsoft Agent Framework target: {error}")
+            raise ValueError(f"Invalid MAF target: {error}")
 
     @property
     def target_type(self) -> str:
-        return "microsoft_agent_framework"
+        return "maf"
 
     @property
     def target_id(self) -> str:
@@ -147,7 +147,7 @@ class MicrosoftAgentFrameworkTarget(Target):
         return self._description
 
     def validate_configuration(self) -> tuple[bool, Optional[str]]:
-        """Validate the Microsoft Agent Framework target configuration."""
+        """Validate the MAF target configuration."""
         if self.agent is None:
             return False, "Agent cannot be None"
         if not self._target_id:
@@ -213,7 +213,7 @@ class MicrosoftAgentFrameworkTarget(Target):
             return TargetResponse(
                 success=False,
                 content="",
-                error=f"Microsoft Agent Framework error: {e}",
+                error=f"MAF error: {e}",
             )
 
     async def _resolve_thread(self, conversation_id: Optional[str]) -> Tuple[Any, str]:
@@ -376,7 +376,7 @@ class MicrosoftAgentFrameworkTarget(Target):
             )
         return f"""
 Target: {self._description}
-Type: Microsoft Agent Framework {type(self.agent).__name__}
+Type: MAF {type(self.agent).__name__}
 Memory: {memory}
 
 Send messages using send_message_to_target(message, conversation_id).

--- a/penelope/src/rhesis/penelope/targets/maf.py
+++ b/penelope/src/rhesis/penelope/targets/maf.py
@@ -293,17 +293,20 @@ class MAFTarget(Target):
 
         accepts_var_keyword = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
 
-        # Prefer the factory-matched kwarg whenever ``run`` can receive it, either
-        # as an explicit parameter or via ``**kwargs``.
-        if preferred and (preferred in params or accepts_var_keyword):
+        # 1. Best case: the factory-matched kwarg is an explicit ``run`` parameter.
+        if preferred and preferred in params:
             return preferred
 
-        # Otherwise fall back to whatever named state kwarg ``run`` actually exposes.
+        # 2. An explicitly declared state kwarg is honored reliably, whereas
+        #    ``**kwargs`` may silently drop an unknown name.  So for a mixed-shape
+        #    agent (e.g. ``create_session`` but ``run(..., thread=..., **kwargs)``)
+        #    prefer the explicit ``thread`` over routing ``session`` into the void.
         for name in _THREAD_RUN_KWARGS:
             if name in params:
                 return name
 
-        # No named state kwarg; only pass one if ``run`` accepts ``**kwargs``.
+        # 3. No explicit state parameter; route the factory-matched kwarg through
+        #    ``**kwargs`` (the only remaining channel).
         if accepts_var_keyword:
             return preferred or _THREAD_RUN_KWARGS[0]
         return None

--- a/penelope/src/rhesis/penelope/targets/maf.py
+++ b/penelope/src/rhesis/penelope/targets/maf.py
@@ -122,9 +122,7 @@ class MAFTarget(Target):
         """
         self.agent = agent
         self._target_id = target_id
-        self._description = description or (
-            f"MAF {type(agent).__name__}: {target_id}"
-        )
+        self._description = description or (f"MAF {type(agent).__name__}: {target_id}")
 
         # Registry mapping the string conversation_id Penelope uses to the MAF
         # thread/session object that holds that conversation's context.
@@ -293,9 +291,7 @@ class MAFTarget(Target):
             # Signature unavailable (e.g. C-implemented); trust the factory kwarg.
             return preferred or _THREAD_RUN_KWARGS[0]
 
-        accepts_var_keyword = any(
-            p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
-        )
+        accepts_var_keyword = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
 
         # Prefer the factory-matched kwarg whenever ``run`` can receive it, either
         # as an explicit parameter or via ``**kwargs``.

--- a/penelope/src/rhesis/penelope/targets/microsoft_agent_framework.py
+++ b/penelope/src/rhesis/penelope/targets/microsoft_agent_framework.py
@@ -18,10 +18,12 @@ adapter bridges both gaps:
 
 The ``agent-framework`` package is intentionally **not** imported at module load
 time; the adapter only duck-types the agent object, so importing this module never
-hard-requires the dependency.  MAF API names differ between versions (older builds
-expose ``ChatAgent`` / ``get_new_thread()`` / ``run(thread=...)`` while newer ones
-expose ``Agent`` / ``create_session()`` / ``run(session=...)``); the helpers below
-adapt to whatever the installed agent provides.
+hard-requires the dependency.  MAF API names differ between versions: current builds
+expose ``Agent`` / ``create_session()`` / ``run(session=...)`` while older builds
+expose ``ChatAgent`` / ``get_new_thread()`` / ``run(thread=...)``.  The helpers below
+try the current names first and fall back to the legacy ones, always passing the
+conversation-state object under the keyword that matches the factory that produced
+it.
 
 Usage::
 
@@ -43,25 +45,55 @@ from uuid import uuid4
 from rhesis.sdk.targets import Target, TargetResponse
 
 # Candidate factory methods used to mint a fresh conversation thread/session,
-# in priority order.  Different MAF versions name this differently.
+# in priority order.  Different MAF versions name this differently; the current
+# ``create_session`` API is tried before the legacy ``get_new_thread`` one.
 _THREAD_FACTORY_METHODS: Tuple[str, ...] = (
-    "get_new_thread",
     "create_session",
     "get_new_session",
+    "get_new_thread",
     "new_thread",
 )
 
 # Candidate keyword names under which the thread/session object is passed to
-# ``agent.run(...)``, in priority order.
-_THREAD_RUN_KWARGS: Tuple[str, ...] = ("thread", "session")
+# ``agent.run(...)``, in priority order (current ``session`` before legacy
+# ``thread``).
+_THREAD_RUN_KWARGS: Tuple[str, ...] = ("session", "thread")
 
 # Maps each thread/session factory method to the ``run`` kwarg it expects.
 _FACTORY_TO_RUN_KWARG: Dict[str, str] = {
-    "get_new_thread": "thread",
     "create_session": "session",
     "get_new_session": "session",
+    "get_new_thread": "thread",
     "new_thread": "thread",
 }
+
+
+def _json_safe(value: Any) -> Any:
+    """
+    Coerce a MAF framework object into something ``json.dumps`` can serialize.
+
+    Response metadata (e.g. ``usage`` / ``usage_details``) is placed into the
+    :class:`TargetResponse` metadata dict, which Penelope's executor serializes
+    with ``json.dumps`` *without* a fallback encoder.  Real MAF responses expose
+    these as framework objects (not plain dicts), so they must be reduced to JSON
+    primitives here to avoid a ``TypeError`` that the target cannot catch.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return _json_safe(model_dump(mode="json"))
+        except Exception:
+            try:
+                return _json_safe(model_dump())
+            except Exception:
+                pass
+    return str(value)
 
 
 class MicrosoftAgentFrameworkTarget(Target):
@@ -210,14 +242,25 @@ class MicrosoftAgentFrameworkTarget(Target):
         agent); the conversation_id remains stable regardless, but per-turn
         context will only persist if the agent itself supports threads/sessions.
         """
+        method_name = self._state_factory_method()
+        if method_name is None:
+            return None
+        factory = getattr(self.agent, method_name)
+        result = factory()
+        if inspect.isawaitable(result):
+            result = await result
+        return result
+
+    def _state_factory_method(self) -> Optional[str]:
+        """Return the name of the first thread/session factory the agent exposes."""
         for method_name in _THREAD_FACTORY_METHODS:
-            factory = getattr(self.agent, method_name, None)
-            if callable(factory):
-                result = factory()
-                if inspect.isawaitable(result):
-                    result = await result
-                return result
+            if callable(getattr(self.agent, method_name, None)):
+                return method_name
         return None
+
+    def is_stateful(self) -> bool:
+        """Whether the agent exposes a thread/session factory for multi-turn memory."""
+        return self._state_factory_method() is not None
 
     async def _run_agent(self, message: str, thread: Any) -> Any:
         """Invoke the agent's async ``run`` with the right thread/session kwarg."""
@@ -233,28 +276,48 @@ class MicrosoftAgentFrameworkTarget(Target):
         return result
 
     def _thread_run_kwarg(self) -> Optional[str]:
-        """Pick the keyword (``thread`` vs ``session``) ``run`` accepts for state."""
+        """
+        Pick the keyword (``session`` vs ``thread``) under which to pass state to ``run``.
+
+        The kwarg is derived from the factory that produced the state object so it
+        always matches what :meth:`_create_thread` built, then validated against
+        ``run``'s real signature.  This keeps object creation and invocation in
+        lock-step: an agent whose ``create_session`` minted a *session* never has
+        that object passed under ``thread=`` (which ``run`` would drop into
+        ``**kwargs`` and silently ignore, losing conversation memory).
+        """
+        preferred = self._state_kwarg_from_factory()
         try:
             params = inspect.signature(self.agent.run).parameters
         except (TypeError, ValueError):
-            # Signature unavailable (e.g. C-implemented); infer from factory API.
-            return self._state_kwarg_from_factory() or _THREAD_RUN_KWARGS[0]
+            # Signature unavailable (e.g. C-implemented); trust the factory kwarg.
+            return preferred or _THREAD_RUN_KWARGS[0]
 
-        if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
-            # ``**kwargs`` accepts both names; pick the one matching the factory
-            # API so modern ``create_session`` agents still get ``session=``.
-            return self._state_kwarg_from_factory() or _THREAD_RUN_KWARGS[0]
+        accepts_var_keyword = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()
+        )
+
+        # Prefer the factory-matched kwarg whenever ``run`` can receive it, either
+        # as an explicit parameter or via ``**kwargs``.
+        if preferred and (preferred in params or accepts_var_keyword):
+            return preferred
+
+        # Otherwise fall back to whatever named state kwarg ``run`` actually exposes.
         for name in _THREAD_RUN_KWARGS:
             if name in params:
                 return name
+
+        # No named state kwarg; only pass one if ``run`` accepts ``**kwargs``.
+        if accepts_var_keyword:
+            return preferred or _THREAD_RUN_KWARGS[0]
         return None
 
     def _state_kwarg_from_factory(self) -> Optional[str]:
         """Return the ``run`` kwarg that matches the agent's thread/session factory."""
-        for method_name in _THREAD_FACTORY_METHODS:
-            if callable(getattr(self.agent, method_name, None)):
-                return _FACTORY_TO_RUN_KWARG[method_name]
-        return None
+        method_name = self._state_factory_method()
+        if method_name is None:
+            return None
+        return _FACTORY_TO_RUN_KWARG[method_name]
 
     @staticmethod
     def _extract_text(response: Any) -> str:
@@ -274,7 +337,7 @@ class MicrosoftAgentFrameworkTarget(Target):
         for field in ("response_id", "usage", "usage_details"):
             value = getattr(response, field, None)
             if value is not None:
-                metadata[field] = value
+                metadata[field] = _json_safe(value)
         return metadata
 
     @staticmethod
@@ -297,15 +360,27 @@ class MicrosoftAgentFrameworkTarget(Target):
 
     def get_tool_documentation(self) -> str:
         """Get documentation for Penelope."""
+        if self.is_stateful():
+            memory = "Yes (stateful agent with conversation history via thread/session)"
+            continuity = (
+                "Maintain conversation_id for conversation continuity across multiple turns.\n"
+                "The agent maintains full conversation context automatically for a given\n"
+                "conversation_id; the first turn returns a new conversation_id to reuse."
+            )
+        else:
+            memory = "No (stateless agent; each turn is independent)"
+            continuity = (
+                "This agent exposes no thread/session factory, so each message is\n"
+                "independent. A conversation_id is still returned for tracking, but it\n"
+                "does not restore prior context."
+            )
         return f"""
 Target: {self._description}
 Type: Microsoft Agent Framework {type(self.agent).__name__}
-Memory: Yes (stateful agent with conversation history via thread/session)
+Memory: {memory}
 
 Send messages using send_message_to_target(message, conversation_id).
-Maintain conversation_id for conversation continuity across multiple turns.
-The agent maintains full conversation context automatically for a given
-conversation_id; the first turn returns a new conversation_id to reuse.
+{continuity}
 """
 
     def clear_session(self, conversation_id: str) -> None:

--- a/penelope/src/rhesis/penelope/targets/microsoft_agent_framework.py
+++ b/penelope/src/rhesis/penelope/targets/microsoft_agent_framework.py
@@ -1,0 +1,25 @@
+"""
+Deprecated import path for the MAF (Microsoft Agent Framework) target.
+
+``MicrosoftAgentFrameworkTarget`` was renamed to :class:`MAFTarget` and now
+lives in :mod:`rhesis.penelope.targets.maf`.  This shim re-exports the old name
+for backwards compatibility and will be removed in a future release; import
+``MAFTarget`` from ``rhesis.penelope`` instead.
+"""
+
+import warnings
+
+from rhesis.penelope.targets.maf import MAFTarget
+
+warnings.warn(
+    "MicrosoftAgentFrameworkTarget and the "
+    "rhesis.penelope.targets.microsoft_agent_framework module are deprecated; "
+    "use MAFTarget from rhesis.penelope instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+# Backwards-compatible alias for the renamed class.
+MicrosoftAgentFrameworkTarget = MAFTarget
+
+__all__ = ["MicrosoftAgentFrameworkTarget", "MAFTarget"]

--- a/tests/penelope/targets/test_maf.py
+++ b/tests/penelope/targets/test_maf.py
@@ -75,6 +75,32 @@ class ModernFakeAgentWithKwargs:
         return FakeResponse(f"kwargs reply to '{messages}' (turn {turn})")
 
 
+class MixedShapeFakeAgent:
+    """Mixed-shape agent: ``create_session`` but ``run(..., thread=..., **kwargs)``.
+
+    ``run`` honors the explicit ``thread`` parameter and would silently drop a
+    ``session`` passed via ``**kwargs``.  The target must therefore prefer the
+    explicitly declared ``thread`` over routing ``session`` through ``**kwargs``.
+    """
+
+    def __init__(self):
+        self._counter = 0
+        self.calls: list[tuple[str, FakeSession | None, dict[str, Any]]] = []
+
+    def create_session(self, *, session_id: str | None = None) -> FakeSession:
+        self._counter += 1
+        return FakeSession(session_id or f"session-{self._counter}")
+
+    async def run(
+        self, messages: str | None = None, *, thread: FakeSession | None = None, **kwargs
+    ):
+        self.calls.append((messages, thread, kwargs))
+        if thread is not None:
+            thread.history.append(messages or "")
+        turn = len(thread.history) if thread is not None else 1
+        return FakeResponse(f"mixed reply to '{messages}' (turn {turn})")
+
+
 class LegacyFakeAgent:
     """MAF agent exposing the legacy ``get_new_thread`` + ``run(thread=...)`` API."""
 
@@ -229,6 +255,24 @@ def test_kwargs_run_uses_session_for_modern_agent():
     assert agent.calls[0][1] is agent.calls[1][1]
     assert "session" in agent.calls[0][2]
     assert "thread" not in agent.calls[0][2]
+    assert agent.calls[0][1].history == ["turn one", "turn two"]
+
+
+def test_mixed_shape_prefers_explicit_thread_over_kwargs():
+    # create_session() suggests session=, but run() explicitly declares thread=
+    # and only honors that; an explicit param must win over the **kwargs channel
+    # so conversation memory is not silently dropped.
+    agent = MixedShapeFakeAgent()
+    target = MAFTarget(agent, "mixed-bot")
+
+    first = target.send_message("turn one")
+    second = target.send_message("turn two", conversation_id=first.conversation_id)
+
+    assert second.conversation_id == first.conversation_id
+    # State was passed under the explicit ``thread`` param, not through **kwargs.
+    assert agent.calls[0][1] is not None
+    assert "session" not in agent.calls[0][2]
+    assert agent.calls[0][1] is agent.calls[1][1]
     assert agent.calls[0][1].history == ["turn one", "turn two"]
 
 

--- a/tests/penelope/targets/test_maf.py
+++ b/tests/penelope/targets/test_maf.py
@@ -1,7 +1,7 @@
-"""Tests for MicrosoftAgentFrameworkTarget.
+"""Tests for MAFTarget.
 
-These tests use lightweight fakes that mimic the Microsoft Agent Framework
-(MAF) agent contract, so no LLM or network access is required.  Two fakes are
+These tests use lightweight fakes that mimic the MAF (Microsoft Agent Framework)
+agent contract, so no LLM or network access is required.  Two fakes are
 provided to cover both the modern (``create_session`` / ``run(session=...)``)
 and legacy (``get_new_thread`` / ``run(thread=...)``) MAF API shapes.
 """
@@ -12,7 +12,7 @@ from typing import Any
 
 import pytest
 
-from rhesis.penelope.targets.microsoft_agent_framework import MicrosoftAgentFrameworkTarget
+from rhesis.penelope.targets.maf import MAFTarget
 from rhesis.sdk.targets import Target, TargetResponse
 
 
@@ -99,25 +99,25 @@ def modern_agent() -> ModernFakeAgent:
 
 
 @pytest.fixture
-def target(modern_agent: ModernFakeAgent) -> MicrosoftAgentFrameworkTarget:
-    return MicrosoftAgentFrameworkTarget(modern_agent, "maf-bot", "A MAF test agent")
+def target(modern_agent: ModernFakeAgent) -> MAFTarget:
+    return MAFTarget(modern_agent, "maf-bot", "A MAF test agent")
 
 
-def test_is_a_target(target: MicrosoftAgentFrameworkTarget):
+def test_is_a_target(target: MAFTarget):
     assert isinstance(target, Target)
 
 
-def test_identity_properties(target: MicrosoftAgentFrameworkTarget):
-    assert target.target_type == "microsoft_agent_framework"
+def test_identity_properties(target: MAFTarget):
+    assert target.target_type == "maf"
     assert isinstance(target.target_id, str) and target.target_id
     assert isinstance(target.description, str) and target.description
 
 
-def test_validate_configuration_good(target: MicrosoftAgentFrameworkTarget):
+def test_validate_configuration_good(target: MAFTarget):
     assert target.validate_configuration() == (True, None)
 
 
-def test_validate_configuration_none_agent(target: MicrosoftAgentFrameworkTarget):
+def test_validate_configuration_none_agent(target: MAFTarget):
     target.agent = None
     is_valid, error = target.validate_configuration()
     assert is_valid is False
@@ -125,8 +125,8 @@ def test_validate_configuration_none_agent(target: MicrosoftAgentFrameworkTarget
 
 
 def test_init_rejects_none_agent():
-    with pytest.raises(ValueError, match="Invalid Microsoft Agent Framework target"):
-        MicrosoftAgentFrameworkTarget(None, "maf-bot")
+    with pytest.raises(ValueError, match="Invalid MAF target"):
+        MAFTarget(None, "maf-bot")
 
 
 def test_init_rejects_agent_without_run():
@@ -134,10 +134,10 @@ def test_init_rejects_agent_without_run():
         pass
 
     with pytest.raises(ValueError, match="callable async run"):
-        MicrosoftAgentFrameworkTarget(NoRun(), "maf-bot")
+        MAFTarget(NoRun(), "maf-bot")
 
 
-def test_send_message_success(target: MicrosoftAgentFrameworkTarget):
+def test_send_message_success(target: MAFTarget):
     response = target.send_message("hello")
     assert isinstance(response, TargetResponse)
     assert response.success is True
@@ -150,7 +150,7 @@ def test_send_message_success(target: MicrosoftAgentFrameworkTarget):
 
 
 @pytest.mark.parametrize("message", ["", "   ", "\n\t"])
-def test_send_message_empty_does_not_raise(target: MicrosoftAgentFrameworkTarget, message: str):
+def test_send_message_empty_does_not_raise(target: MAFTarget, message: str):
     response = target.send_message(message)
     assert response.success is False
     assert response.error == "Empty message"
@@ -158,14 +158,14 @@ def test_send_message_empty_does_not_raise(target: MicrosoftAgentFrameworkTarget
 
 def test_agent_exception_surfaces_as_failure():
     agent = ModernFakeAgent(raises=True)
-    target = MicrosoftAgentFrameworkTarget(agent, "maf-bot")
+    target = MAFTarget(agent, "maf-bot")
     response = target.send_message("hello")
     assert response.success is False
     assert response.content == ""
-    assert response.error and "Microsoft Agent Framework error" in response.error
+    assert response.error and "MAF error" in response.error
 
 
-def test_multi_turn_preserves_thread(target: MicrosoftAgentFrameworkTarget, modern_agent):
+def test_multi_turn_preserves_thread(target: MAFTarget, modern_agent):
     first = target.send_message("turn one")
     conv_id = first.conversation_id
     assert conv_id
@@ -181,17 +181,17 @@ def test_multi_turn_preserves_thread(target: MicrosoftAgentFrameworkTarget, mode
     assert session_turn1.history == ["turn one", "turn two"]
 
 
-def test_unknown_conversation_id_gets_fresh_thread(target: MicrosoftAgentFrameworkTarget):
+def test_unknown_conversation_id_gets_fresh_thread(target: MAFTarget):
     response = target.send_message("hi", conversation_id="caller-supplied-id")
     assert response.success is True
     assert response.conversation_id == "caller-supplied-id"
 
 
-def test_a_send_message_is_coroutine_function(target: MicrosoftAgentFrameworkTarget):
+def test_a_send_message_is_coroutine_function(target: MAFTarget):
     assert inspect.iscoroutinefunction(target.a_send_message)
 
 
-async def test_a_send_message_returns_valid_response(target: MicrosoftAgentFrameworkTarget):
+async def test_a_send_message_returns_valid_response(target: MAFTarget):
     response = await target.a_send_message("hello async")
     assert isinstance(response, TargetResponse)
     assert response.success is True
@@ -199,7 +199,7 @@ async def test_a_send_message_returns_valid_response(target: MicrosoftAgentFrame
     assert response.conversation_id
 
 
-async def test_send_message_works_inside_running_loop(target: MicrosoftAgentFrameworkTarget):
+async def test_send_message_works_inside_running_loop(target: MAFTarget):
     # Called from within an active event loop -> exercises the worker-thread bridge.
     response = target.send_message("from inside loop")
     assert response.success is True
@@ -208,7 +208,7 @@ async def test_send_message_works_inside_running_loop(target: MicrosoftAgentFram
 
 def test_legacy_thread_api_multi_turn():
     agent = LegacyFakeAgent()
-    target = MicrosoftAgentFrameworkTarget(agent, "legacy-bot")
+    target = MAFTarget(agent, "legacy-bot")
 
     first = target.send_message("turn one")
     second = target.send_message("turn two", conversation_id=first.conversation_id)
@@ -220,7 +220,7 @@ def test_legacy_thread_api_multi_turn():
 
 def test_kwargs_run_uses_session_for_modern_agent():
     agent = ModernFakeAgentWithKwargs()
-    target = MicrosoftAgentFrameworkTarget(agent, "kwargs-bot")
+    target = MAFTarget(agent, "kwargs-bot")
 
     first = target.send_message("turn one")
     second = target.send_message("turn two", conversation_id=first.conversation_id)
@@ -269,7 +269,7 @@ def test_metadata_is_json_serializable_with_object_usage():
         async def run(self, messages: str | None = None, *, session=None):
             return ResponseWithObjectUsage(NonSerializableUsage())
 
-    target = MicrosoftAgentFrameworkTarget(AgentWithObjectUsage(), "usage-bot")
+    target = MAFTarget(AgentWithObjectUsage(), "usage-bot")
     response = target.send_message("hi")
 
     assert response.success is True
@@ -283,7 +283,7 @@ def test_metadata_coerces_opaque_usage_to_string():
         async def run(self, messages: str | None = None, *, session=None):
             return ResponseWithObjectUsage(OpaqueUsage())
 
-    target = MicrosoftAgentFrameworkTarget(AgentWithOpaqueUsage(), "usage-bot")
+    target = MAFTarget(AgentWithOpaqueUsage(), "usage-bot")
     response = target.send_message("hi")
 
     assert response.success is True
@@ -292,7 +292,7 @@ def test_metadata_coerces_opaque_usage_to_string():
 
 
 def test_stateless_agent_reports_no_memory():
-    target = MicrosoftAgentFrameworkTarget(StatelessAgent(), "stateless-bot")
+    target = MAFTarget(StatelessAgent(), "stateless-bot")
     assert target.is_stateful() is False
     doc = target.get_tool_documentation()
     assert "Memory: No" in doc
@@ -302,14 +302,14 @@ def test_stateless_agent_reports_no_memory():
     assert response.conversation_id
 
 
-def test_get_tool_documentation(target: MicrosoftAgentFrameworkTarget):
+def test_get_tool_documentation(target: MAFTarget):
     doc = target.get_tool_documentation()
-    assert "Microsoft Agent Framework" in doc
+    assert "MAF" in doc
     assert "conversation_id" in doc
     assert "send_message_to_target" in doc
 
 
-def test_clear_session(target: MicrosoftAgentFrameworkTarget):
+def test_clear_session(target: MAFTarget):
     first = target.send_message("hello")
     conv_id = first.conversation_id
     assert conv_id in target._threads

--- a/tests/penelope/targets/test_maf.py
+++ b/tests/penelope/targets/test_maf.py
@@ -346,6 +346,35 @@ def test_stateless_agent_reports_no_memory():
     assert response.conversation_id
 
 
+def test_deprecated_module_alias_still_works():
+    import sys
+    import warnings
+
+    sys.modules.pop("rhesis.penelope.targets.microsoft_agent_framework", None)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        from rhesis.penelope.targets.microsoft_agent_framework import (
+            MicrosoftAgentFrameworkTarget,
+        )
+
+    assert MicrosoftAgentFrameworkTarget is MAFTarget
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_deprecated_package_aliases_warn():
+    import warnings
+
+    import rhesis.penelope as pen
+    import rhesis.penelope.targets as targets_pkg
+
+    for module in (pen, targets_pkg):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            alias = module.MicrosoftAgentFrameworkTarget
+        assert alias is MAFTarget
+        assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
 def test_get_tool_documentation(target: MAFTarget):
     doc = target.get_tool_documentation()
     assert "MAF" in doc

--- a/tests/penelope/targets/test_microsoft_agent_framework.py
+++ b/tests/penelope/targets/test_microsoft_agent_framework.py
@@ -6,9 +6,9 @@ provided to cover both the modern (``create_session`` / ``run(session=...)``)
 and legacy (``get_new_thread`` / ``run(thread=...)``) MAF API shapes.
 """
 
-from typing import Any
-
 import inspect
+import json
+from typing import Any
 
 import pytest
 
@@ -230,6 +230,76 @@ def test_kwargs_run_uses_session_for_modern_agent():
     assert "session" in agent.calls[0][2]
     assert "thread" not in agent.calls[0][2]
     assert agent.calls[0][1].history == ["turn one", "turn two"]
+
+
+class NonSerializableUsage:
+    """Object-style ``usage`` like real MAF returns (not a plain dict)."""
+
+    def __init__(self):
+        self.total_tokens = 42
+
+    def model_dump(self, *args: Any, **kwargs: Any) -> dict:
+        return {"total_tokens": self.total_tokens}
+
+
+class OpaqueUsage:
+    """Framework object with no ``model_dump`` (must fall back to ``str``)."""
+
+    def __repr__(self) -> str:
+        return "OpaqueUsage(total_tokens=99)"
+
+
+class ResponseWithObjectUsage:
+    def __init__(self, usage: Any):
+        self.text = "hello"
+        self.usage = usage
+
+
+class StatelessAgent:
+    """MAF agent with no thread/session factory (each turn is independent)."""
+
+    async def run(self, messages: str | None = None):
+        return FakeResponse(f"stateless reply to '{messages}'")
+
+
+def test_metadata_is_json_serializable_with_object_usage():
+    # Real MAF returns framework objects for ``usage``; metadata must stay
+    # JSON-serializable because the executor json.dumps() it without a fallback.
+    class AgentWithObjectUsage(ModernFakeAgent):
+        async def run(self, messages: str | None = None, *, session=None):
+            return ResponseWithObjectUsage(NonSerializableUsage())
+
+    target = MicrosoftAgentFrameworkTarget(AgentWithObjectUsage(), "usage-bot")
+    response = target.send_message("hi")
+
+    assert response.success is True
+    # Must not raise -> this is the crash the fix prevents.
+    json.dumps(response.metadata)
+    assert response.metadata["usage"] == {"total_tokens": 42}
+
+
+def test_metadata_coerces_opaque_usage_to_string():
+    class AgentWithOpaqueUsage(ModernFakeAgent):
+        async def run(self, messages: str | None = None, *, session=None):
+            return ResponseWithObjectUsage(OpaqueUsage())
+
+    target = MicrosoftAgentFrameworkTarget(AgentWithOpaqueUsage(), "usage-bot")
+    response = target.send_message("hi")
+
+    assert response.success is True
+    json.dumps(response.metadata)
+    assert response.metadata["usage"] == "OpaqueUsage(total_tokens=99)"
+
+
+def test_stateless_agent_reports_no_memory():
+    target = MicrosoftAgentFrameworkTarget(StatelessAgent(), "stateless-bot")
+    assert target.is_stateful() is False
+    doc = target.get_tool_documentation()
+    assert "Memory: No" in doc
+    # Still returns a conversation_id for tracking, just without restored context.
+    response = target.send_message("hi")
+    assert response.success is True
+    assert response.conversation_id
 
 
 def test_get_tool_documentation(target: MicrosoftAgentFrameworkTarget):


### PR DESCRIPTION
## Purpose
The Penelope Microsoft Agent Framework (MAF) target had a few latent issues that could surface only against a real MAF agent (the tests used fakes that didn't exercise them). This PR hardens the target, adds regression coverage, shortens the verbose naming to `MAF`, and makes the minimal example runnable with just a Google/Gemini key.

## What Changed
- **fix (target):**
  - Coerce run-response `usage`/`usage_details` into JSON-safe values in metadata. Real MAF responses expose these as framework objects, and the executor serializes tool results with `json.dumps()` *without* a fallback encoder, so raw objects could raise an uncatchable `TypeError`.
  - `get_tool_documentation()` now reports `Memory: No` when the agent exposes no thread/session factory, instead of unconditionally claiming statefulness.
  - The `run()` state kwarg is derived from the factory that created the session/thread object; an explicitly declared `run` parameter is now preferred over the `**kwargs` passthrough so mixed-shape agents don't silently lose memory.
- **refactor (rename):** `MicrosoftAgentFrameworkTarget` -> `MAFTarget`; modules renamed to `targets/maf.py`, `examples/maf_minimal.py`, `tests/penelope/targets/test_maf.py`; `target_type` -> `"maf"`; repeated prose collapsed to `MAF`.
- **feat (backwards-compat):** the old `MicrosoftAgentFrameworkTarget` name and `targets/microsoft_agent_framework` module path still work as deprecated aliases (emit `DeprecationWarning`). `target_type` is not shimmed.
- **test:** regression tests for JSON-safe metadata (object/opaque `usage`), stateless-agent memory reporting, the mixed-shape `**kwargs` kwarg selection, and the deprecated aliases.
- **docs (example):** `examples/maf_minimal.py` drives both the MAF target and Penelope's tester through Gemini via Google's OpenAI-compatible endpoint, so it runs with only `GEMINI_API_KEY`/`GOOGLE_API_KEY`; trimmed to mirror the langgraph minimal example.

## Additional Context
- Verified against the real `agent-framework-core==1.8.1`: `Agent.create_session` exists (sync) and `Agent.run(..., session=...)` has no `thread`/`**kwargs`, so the adapter resolves to `run(message, session=session)` correctly.
- Only tracked files are included; the untracked `agents/chat-completion/` scaffold is intentionally left out.

## Testing
```bash
cd penelope
uv run --group dev pytest ../tests/penelope/targets/test_maf.py -v
```
All tests pass. To run the example end-to-end:
```bash
cd penelope
uv sync --extra microsoft-agent-framework
export GEMINI_API_KEY=...   # or GOOGLE_API_KEY
uv run python examples/maf_minimal.py
```