### PR TITLE
Fix: scope token listing to active project

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -1810,6 +1810,7 @@ def get_user_tokens(
     filter: str | None = None,
     valid_only: bool = False,
     organization_id: str = None,
+    project_id: str = None,
 ) -> List[models.Token]:
     """Get all active bearer tokens for a user with pagination and sorting
 
@@ -1822,6 +1823,8 @@ def get_user_tokens(
         sort_order: Sort order (asc/desc)
         filter: OData filter string
         valid_only: If True, only returns valid (non-expired) tokens
+        organization_id: Organization ID for filtering
+        project_id: Project ID for filtering (Token is exempt from auto-filter)
 
     Returns:
         List of token objects
@@ -1833,6 +1836,11 @@ def get_user_tokens(
             lambda q: q.filter(models.Token.user_id == user_id, models.Token.token_type == "bearer")
         )
     )
+
+    if project_id is not None:
+        query_builder = query_builder.with_custom_filter(
+            lambda q: q.filter(models.Token.project_id == project_id)
+        )
 
     # Add validity check if requested
     if valid_only:
@@ -1857,6 +1865,7 @@ def count_user_tokens(
     user_id: uuid.UUID,
     filter: str | None = None,
     organization_id: str = None,
+    project_id: str = None,
 ) -> int:
     """Count all active bearer tokens for a user
 
@@ -1868,6 +1877,7 @@ def count_user_tokens(
         user_id: User ID to count tokens for
         filter: OData filter string
         organization_id: Organization ID for filtering
+        project_id: Project ID for filtering (Token is exempt from auto-filter)
 
     Returns:
         Count of token objects
@@ -1879,6 +1889,11 @@ def count_user_tokens(
             lambda q: q.filter(models.Token.user_id == user_id, models.Token.token_type == "bearer")
         )
     )
+
+    if project_id is not None:
+        query_builder = query_builder.with_custom_filter(
+            lambda q: q.filter(models.Token.project_id == project_id)
+        )
 
     return query_builder.with_odata_filter(filter).count()
 

--- a/apps/backend/src/rhesis/backend/app/routers/token.py
+++ b/apps/backend/src/rhesis/backend/app/routers/token.py
@@ -205,14 +205,18 @@ async def read_tokens(
     filter: str | None = Query(None, alias="$filter", description="OData filter expression"),
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
+    project_id: str | None = Depends(get_project_context),
     current_user: User = Depends(require_current_user_or_token),
 ):
-    """List all active API tokens for the current user"""
+    """List active API tokens for the current user, scoped to the active project."""
     organization_id, user_id = tenant_context
 
-    # Set the count header with user-specific token count
     count = crud.count_user_tokens(
-        db=db, user_id=current_user.id, filter=filter, organization_id=organization_id
+        db=db,
+        user_id=current_user.id,
+        filter=filter,
+        organization_id=organization_id,
+        project_id=project_id,
     )
     response.headers["X-Total-Count"] = str(count)
 
@@ -225,6 +229,7 @@ async def read_tokens(
         sort_order=sort_order,
         filter=filter,
         organization_id=organization_id,
+        project_id=project_id,
     )
 
 

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -116,12 +116,12 @@ def get_explorer_test_sets(
         .filter(models.TestSet.attributes["metadata"]["behaviors"].contains(target))
     )
 
-    # Apply sorting
+    # Apply sorting with id tiebreaker for stable pagination
     sort_column = getattr(models.TestSet, sort_by, models.TestSet.created_at)
     if sort_order == "asc":
-        query = query.order_by(sort_column.asc())
+        query = query.order_by(sort_column.asc(), models.TestSet.id.asc())
     else:
-        query = query.order_by(sort_column.desc())
+        query = query.order_by(sort_column.desc(), models.TestSet.id.asc())
 
     test_sets = query.offset(skip).limit(limit).all()
 

--- a/apps/frontend/src/app/(protected)/tokens/components/CreateTokenDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/CreateTokenDrawer.tsx
@@ -15,6 +15,7 @@ import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { TokenResponse } from '@/utils/api-client/interfaces/token';
 import dayjs from 'dayjs';
 import BaseDrawer from '@/components/common/BaseDrawer';
+import { useActiveProject } from '@/contexts/ActiveProjectContext';
 
 interface CreateTokenDrawerProps {
   open: boolean;
@@ -30,6 +31,7 @@ export default function CreateTokenDrawer({
   onClose,
   onCreateToken,
 }: CreateTokenDrawerProps) {
+  const { activeProject } = useActiveProject();
   const [name, setName] = useState('');
   const [expiryOption, setExpiryOption] = useState<
     '30' | '60' | '90' | 'custom' | 'never'
@@ -90,6 +92,13 @@ export default function CreateTokenDrawer({
       loading={loading}
     >
       <Stack spacing={3}>
+        <TextField
+          label="Project"
+          fullWidth
+          value={activeProject?.name ?? 'Organization-level'}
+          disabled
+          InputProps={{ readOnly: true }}
+        />
         <TextField
           autoFocus
           label="Token Name"

--- a/apps/frontend/src/app/(protected)/tokens/components/__tests__/CreateTokenDrawer.test.tsx
+++ b/apps/frontend/src/app/(protected)/tokens/components/__tests__/CreateTokenDrawer.test.tsx
@@ -6,6 +6,16 @@ import { ThemeProvider } from '@mui/material/styles';
 import lightTheme from '@/styles/theme';
 import CreateTokenDrawer from '../CreateTokenDrawer';
 
+jest.mock('@/contexts/ActiveProjectContext', () => ({
+  useActiveProject: () => ({
+    activeProject: { id: 'proj-1', name: 'My Project' },
+    projects: [],
+    loading: false,
+    setActiveProject: jest.fn(),
+    refresh: jest.fn(),
+  }),
+}));
+
 const onClose = jest.fn();
 const onCreateToken = jest.fn();
 


### PR DESCRIPTION
## Summary
- **Backend**: Add explicit `project_id` filtering to `GET /tokens`. Token is exempt from the auto-filter listener (needed for auth lookups before tenant context is known), so the endpoint was returning all tokens across projects. Now passes the active project context through to the CRUD layer.
- **Frontend**: Show the active project name in the create-token drawer so users are aware the token is project-scoped.

Closes #2087

## Test plan
- [ ] Switch between projects and verify `GET /tokens` only returns tokens for the active project
- [ ] Create a token and confirm the drawer shows the correct project name
- [ ] Verify old org-level tokens (null `project_id`) are not returned when a project is active