### PR TITLE
Fix project-switch 404 UX, Architect errors, and minor frontend polish

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/architect/event_handler.py
+++ b/apps/backend/src/rhesis/backend/app/services/architect/event_handler.py
@@ -9,6 +9,7 @@ from rhesis.backend.app.schemas.websocket import (
     WebSocketMessage,
 )
 from rhesis.backend.app.services.websocket.publisher import publish_event
+from rhesis.sdk.agents.errors import format_user_facing_error
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +135,11 @@ class WebSocketEventHandler:
         error: Optional[str] = None,
         **kw: Any,
     ) -> None:
-        self.publish(EventType.ARCHITECT_STREAM_END, {"content": content, "error": error})
+        friendly_error = format_user_facing_error(error) if error else None
+        self.publish(
+            EventType.ARCHITECT_STREAM_END,
+            {"content": content, "error": friendly_error},
+        )
 
     async def on_agent_end(self, *, result: Any, **kw: Any) -> None:
         pass  # handled after chat_async returns
@@ -142,5 +147,8 @@ class WebSocketEventHandler:
     async def on_error(self, *, error: Exception, **kw: Any) -> None:
         self.publish(
             EventType.ARCHITECT_ERROR,
-            {"error": str(error), "error_type": type(error).__name__},
+            {
+                "error": format_user_facing_error(error),
+                "error_type": type(error).__name__,
+            },
         )

--- a/apps/backend/src/rhesis/backend/app/services/architect/runner.py
+++ b/apps/backend/src/rhesis/backend/app/services/architect/runner.py
@@ -7,7 +7,6 @@ constructing an :class:`~rhesis.sdk.context.EndpointContext` to carry
 tenant identity.
 """
 
-import asyncio
 import logging
 from typing import Any, Dict, List, Optional
 from uuid import UUID
@@ -299,12 +298,13 @@ def _make_target_factory(org_id: str, user_id: str, project_id: Optional[str] = 
     """Build a target factory that invokes endpoints via EndpointService."""
     from rhesis.backend.app.services.endpoint.service import EndpointService
     from rhesis.sdk.agents.targets import LocalEndpointTarget
+    from rhesis.sdk.async_utils import run_sync
 
     svc = EndpointService()
 
     def _invoke(endpoint_id: str, input_data: dict) -> dict:
         with get_db_with_tenant_variables(org_id or "", user_id or "", project_id or "") as db:
-            return asyncio.run(
+            return run_sync(
                 svc.invoke_endpoint(
                     db,
                     endpoint_id,

--- a/apps/backend/src/rhesis/backend/app/services/websocket/handlers/architect.py
+++ b/apps/backend/src/rhesis/backend/app/services/websocket/handlers/architect.py
@@ -19,6 +19,8 @@ from rhesis.backend.app.schemas.websocket import (
 if TYPE_CHECKING:
     from rhesis.backend.app.services.websocket.manager import WebSocketManager
 
+from rhesis.sdk.agents.errors import format_user_facing_error
+
 logger = logging.getLogger(__name__)
 
 
@@ -176,7 +178,7 @@ async def handle_architect_message(
             manager,
             conn_id,
             correlation_id,
-            str(e),
+            format_user_facing_error(e),
             error_type=type(e).__name__,
         )
 

--- a/apps/backend/src/rhesis/backend/tasks/architect/chat.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/chat.py
@@ -19,6 +19,7 @@ from rhesis.backend.tasks.architect.telemetry import (
 )
 from rhesis.backend.tasks.base import SilentTask
 from rhesis.backend.worker import app
+from rhesis.sdk.agents.errors import format_user_facing_error
 
 logger = logging.getLogger(__name__)
 
@@ -61,13 +62,12 @@ def architect_chat_task(
     )
 
     try:
-        import asyncio
-
         from rhesis.backend.app.database import get_db_with_tenant_variables
         from rhesis.backend.app.services.architect.runner import (
             ArchitectChatResult,
             run_architect_turn,
         )
+        from rhesis.sdk.async_utils import run_sync
         from rhesis.sdk.context import EndpointContext
 
         prior_trace_id = _load_session_trace_id(session_id, org_id, user_id, project_id)
@@ -94,7 +94,7 @@ def architect_chat_task(
                     project_id=project_id,
                 )
 
-        result: ArchitectChatResult = asyncio.run(_run())
+        result: ArchitectChatResult = run_sync(_run())
 
         if result.content:
             try:
@@ -166,7 +166,7 @@ def architect_chat_task(
                 type=EventType.ARCHITECT_ERROR,
                 payload={
                     "session_id": session_id,
-                    "error": str(e),
+                    "error": format_user_facing_error(e),
                     "error_type": type(e).__name__,
                 },
             ),

--- a/apps/backend/src/rhesis/backend/tasks/endpoint/explore.py
+++ b/apps/backend/src/rhesis/backend/tasks/endpoint/explore.py
@@ -8,7 +8,6 @@ Follows the same async/polling pattern as ``generate_and_save_test_set``
 and ``execute_test_configuration``.
 """
 
-import asyncio
 import json
 import logging
 import time
@@ -144,6 +143,7 @@ def run_exploration_task(
     _step("Connecting to endpoint")
 
     from rhesis.sdk.agents.tools import ExploreEndpointTool
+    from rhesis.sdk.async_utils import run_sync
 
     start = time.monotonic()
 
@@ -174,7 +174,7 @@ def run_exploration_task(
         # silently drop the entire progress trail.
         event_handlers: List[Any] = [_PenelopeProgressHandler(_emit)]
 
-        result = asyncio.run(
+        result = run_sync(
             tool.execute(
                 endpoint_id=endpoint_id,
                 strategy=strategy,

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/page.tsx
@@ -5,6 +5,7 @@ import { Box, Typography, CircularProgress } from '@mui/material';
 import { PageLayout } from '@/components/layout/PageLayout';
 import DetailMetadataStrip from '@/components/common/DetailMetadataStrip';
 import { use } from 'react';
+import { notFound } from 'next/navigation';
 import { format } from 'date-fns';
 import { useSession } from 'next-auth/react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
@@ -13,6 +14,7 @@ import EndpointDetailView from './components/EndpointDetailView';
 import EndpointHeaderActions from './components/EndpointHeaderActions';
 import { useQuery } from '@tanstack/react-query';
 import { endpointKeys } from '@/constants/query-keys';
+import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 
 interface PageProps {
   params: Promise<{ identifier: string }>;
@@ -91,6 +93,10 @@ export default function EndpointPage({ params }: PageProps) {
         <Typography>Loading endpoint...</Typography>
       </Box>
     );
+  }
+
+  if (fetchError && isNotFoundApiError(fetchError)) {
+    notFound();
   }
 
   if (error) {

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/page.tsx
@@ -4,8 +4,9 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { Box, Typography, CircularProgress } from '@mui/material';
 import { PageLayout } from '@/components/layout/PageLayout';
 import DetailMetadataStrip from '@/components/common/DetailMetadataStrip';
+import DetailNotFoundState from '@/components/common/DetailNotFoundState';
 import { use } from 'react';
-import { notFound } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { format } from 'date-fns';
 import { useSession } from 'next-auth/react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
@@ -26,6 +27,7 @@ const UUID_REGEX =
 
 export default function EndpointPage({ params }: PageProps) {
   const { identifier } = use(params);
+  const router = useRouter();
 
   const { data: session, status } = useSession();
   const sessionToken = session?.session_token ?? '';
@@ -35,7 +37,9 @@ export default function EndpointPage({ params }: PageProps) {
   const {
     data: endpoint,
     isLoading,
+    isFetching,
     error: fetchError,
+    refetch,
   } = useQuery({
     queryKey: endpointKeys.detail(identifier),
     queryFn: async () => {
@@ -96,7 +100,19 @@ export default function EndpointPage({ params }: PageProps) {
   }
 
   if (fetchError && isNotFoundApiError(fetchError)) {
-    notFound();
+    return (
+      <DetailNotFoundState
+        entityLabel="Endpoint"
+        entityId={identifier}
+        breadcrumbs={[
+          { label: 'Endpoints', href: '/endpoints' },
+          { label: 'Not Found', href: `/endpoints/${identifier}` },
+        ]}
+        onBack={() => router.push('/endpoints')}
+        onRetry={() => refetch()}
+        isRetrying={isFetching}
+      />
+    );
   }
 
   if (error) {

--- a/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
@@ -100,6 +100,7 @@ export default function KnowledgeClientWrapper({
         <Box sx={{ mt: 2, mb: 2 }}>
           {sourceCount === 0 ? (
             <EntityEmptyState
+              card
               icon={MenuBookIcon}
               title="No knowledge sources yet"
               description="Upload files or import from tool connections to use as context for test generation and evaluation."

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
@@ -4,8 +4,9 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { Box, Typography, CircularProgress } from '@mui/material';
 import { PageLayout } from '@/components/layout/PageLayout';
 import DetailMetadataStrip from '@/components/common/DetailMetadataStrip';
-import { useEffect, useState } from 'react';
-import { notFound, useParams } from 'next/navigation';
+import DetailNotFoundState from '@/components/common/DetailNotFoundState';
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
 import { format } from 'date-fns';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
@@ -17,59 +18,68 @@ import EndpointHeaderActions from '@/app/(protected)/endpoints/[identifier]/comp
 
 export default function ProjectEndpointPage() {
   const params = useParams<{ identifier: string; endpointId: string }>();
+  const router = useRouter();
   const { data: session, status } = useSession();
   const [endpoint, setEndpoint] = useState<Endpoint | null>(null);
   const [projectName, setProjectName] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [isEntityNotFound, setIsEntityNotFound] = useState(false);
+  const [retryCount, setRetryCount] = useState(0);
 
   useDocumentTitle(endpoint?.name || null);
 
-  useEffect(() => {
-    const fetchEndpoint = async () => {
-      try {
-        if (status === 'loading') return;
-        if (!params?.endpointId) return;
+  const fetchEndpoint = useCallback(async () => {
+    if (status === 'loading') return;
+    if (!params?.endpointId) return;
 
-        if (!session) {
-          throw new Error('No session available');
-        }
+    setLoading(true);
+    setError(null);
+    setIsEntityNotFound(false);
+    setEndpoint(null);
 
-        const uuidRegex =
-          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-        if (!uuidRegex.test(params.endpointId)) {
-          throw new Error('Invalid endpoint identifier format');
-        }
-
-        const sessionToken = session.session_token || '';
-        const apiFactory = new ApiClientFactory(sessionToken);
-        const endpointsClient = apiFactory.getEndpointsClient();
-        const data = await endpointsClient.getEndpoint(params.endpointId);
-        setEndpoint(data);
-
-        if (params.identifier) {
-          try {
-            const projectsClient = apiFactory.getProjectsClient();
-            const project = await projectsClient.getProject(params.identifier);
-            setProjectName(project.name);
-          } catch {
-            // ignore
-          }
-        }
-      } catch (err) {
-        if (isNotFoundApiError(err)) {
-          setIsEntityNotFound(true);
-        } else {
-          setError((err as Error).message);
-        }
-      } finally {
-        setLoading(false);
+    try {
+      if (!session) {
+        throw new Error('No session available');
       }
-    };
 
-    fetchEndpoint();
+      const uuidRegex =
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      if (!uuidRegex.test(params.endpointId)) {
+        throw new Error('Invalid endpoint identifier format');
+      }
+
+      const sessionToken = session.session_token || '';
+      const apiFactory = new ApiClientFactory(sessionToken);
+      const endpointsClient = apiFactory.getEndpointsClient();
+      const data = await endpointsClient.getEndpoint(params.endpointId);
+      setEndpoint(data);
+
+      if (params.identifier) {
+        try {
+          const projectsClient = apiFactory.getProjectsClient();
+          const project = await projectsClient.getProject(params.identifier);
+          setProjectName(project.name);
+        } catch {
+          // ignore
+        }
+      }
+    } catch (err) {
+      if (isNotFoundApiError(err)) {
+        setIsEntityNotFound(true);
+      } else {
+        setError(
+          err instanceof Error ? err.message : 'Failed to load endpoint'
+        );
+      }
+    } finally {
+      setLoading(false);
+    }
   }, [params?.endpointId, params?.identifier, session, status]);
+
+  useEffect(() => {
+    fetchEndpoint();
+  }, [fetchEndpoint, retryCount]);
 
   if (status === 'loading' || loading || !params?.endpointId) {
     return (
@@ -97,8 +107,27 @@ export default function ProjectEndpointPage() {
     );
   }
 
-  if (isEntityNotFound) {
-    notFound();
+  if (isEntityNotFound && params?.endpointId) {
+    return (
+      <DetailNotFoundState
+        entityLabel="Endpoint"
+        entityId={params.endpointId}
+        breadcrumbs={[
+          { label: 'Projects', href: '/projects' },
+          {
+            label: projectName || 'Project',
+            href: `/projects/${params.identifier}`,
+          },
+          {
+            label: 'Not Found',
+            href: `/projects/${params.identifier}/endpoints/${params.endpointId}`,
+          },
+        ]}
+        onBack={() => router.push(`/projects/${params.identifier}`)}
+        onRetry={() => setRetryCount(count => count + 1)}
+        isRetrying={loading}
+      />
+    );
   }
 
   if (error) {

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
@@ -5,11 +5,12 @@ import { Box, Typography, CircularProgress } from '@mui/material';
 import { PageLayout } from '@/components/layout/PageLayout';
 import DetailMetadataStrip from '@/components/common/DetailMetadataStrip';
 import { useEffect, useState } from 'react';
+import { notFound, useParams } from 'next/navigation';
 import { format } from 'date-fns';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
+import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 import { useSession } from 'next-auth/react';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { useParams } from 'next/navigation';
 import { EndpointDetailProvider } from '@/app/(protected)/endpoints/[identifier]/components/EndpointDetailContext';
 import EndpointDetailView from '@/app/(protected)/endpoints/[identifier]/components/EndpointDetailView';
 import EndpointHeaderActions from '@/app/(protected)/endpoints/[identifier]/components/EndpointHeaderActions';
@@ -21,6 +22,7 @@ export default function ProjectEndpointPage() {
   const [projectName, setProjectName] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [isEntityNotFound, setIsEntityNotFound] = useState(false);
 
   useDocumentTitle(endpoint?.name || null);
 
@@ -56,7 +58,11 @@ export default function ProjectEndpointPage() {
           }
         }
       } catch (err) {
-        setError((err as Error).message);
+        if (isNotFoundApiError(err)) {
+          setIsEntityNotFound(true);
+        } else {
+          setError((err as Error).message);
+        }
       } finally {
         setLoading(false);
       }
@@ -89,6 +95,10 @@ export default function ProjectEndpointPage() {
         </Typography>
       </Box>
     );
+  }
+
+  if (isEntityNotFound) {
+    notFound();
   }
 
   if (error) {

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
@@ -18,6 +18,7 @@ import { Task, TaskUpdate } from '@/types/tasks';
 import { getStatusesForTask, getPrioritiesForTask } from '@/utils/task-lookup';
 import type { Status, Priority } from '@/utils/api-client/interfaces/task';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 import { User } from '@/utils/api-client/interfaces/user';
 import { useNotifications } from '@/components/common/NotificationContext';
 import CreateJiraIssueButton from '../components/CreateJiraIssueButton';
@@ -201,8 +202,9 @@ function TaskDetailNotFoundState({
             Sorry, we couldn&apos;t load this task
           </Typography>
           <Typography variant="body2" sx={{ mb: 2 }}>
-            The task you&apos;re looking for might have been deleted, moved, or
-            you may not have permission to view it.
+            The task you&apos;re looking for might have been deleted, moved,
+            belongs to a different project, or you may not have permission to
+            view it.
           </Typography>
           <Typography variant="body2" color="text.secondary">
             Task ID: {taskId}
@@ -234,11 +236,12 @@ export default function TaskDetailPage({ params }: PageProps) {
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
     Capability.Task.READ
   );
-  const { getTask, updateTask } = useTasks({ autoFetch: false });
+  const { updateTask } = useTasks({ autoFetch: false });
   const { show } = useNotifications();
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isTaskNotFound, setIsTaskNotFound] = useState(false);
   const [hasInitialLoad, setHasInitialLoad] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
   const [loadingTimeout, setLoadingTimeout] = useState(false);
@@ -275,6 +278,7 @@ export default function TaskDetailPage({ params }: PageProps) {
           setIsLoading(true);
         }
         setError(null);
+        setIsTaskNotFound(false);
 
         if (!taskId) {
           throw new Error('No task ID provided');
@@ -285,10 +289,9 @@ export default function TaskDetailPage({ params }: PageProps) {
         }
 
         const sessionToken = session.session_token;
-        const taskData = await getTask(taskId);
-        if (!taskData) {
-          throw new Error('Task not found');
-        }
+        const clientFactory = new ApiClientFactory(sessionToken);
+        const tasksClient = clientFactory.getTasksClient();
+        const taskData = await tasksClient.getTask(taskId);
 
         const [fetchedStatuses, fetchedPriorities, fetchedUsers] =
           await Promise.all([
@@ -308,6 +311,12 @@ export default function TaskDetailPage({ params }: PageProps) {
         setTask(taskData);
         setHasInitialLoad(true);
       } catch (err) {
+        if (isNotFoundApiError(err)) {
+          setIsTaskNotFound(true);
+          setHasInitialLoad(true);
+          return;
+        }
+
         const errorMessage =
           err instanceof Error ? err.message : 'Failed to load task data';
         setError(errorMessage);
@@ -322,7 +331,7 @@ export default function TaskDetailPage({ params }: PageProps) {
         setIsRetrying(false);
       }
     },
-    [taskId, getTask, session?.session_token, show, hasInitialLoad]
+    [taskId, session?.session_token, show, hasInitialLoad]
   );
 
   useEffect(() => {
@@ -354,6 +363,7 @@ export default function TaskDetailPage({ params }: PageProps) {
   const handleRetry = () => {
     setLoadingTimeout(false);
     setHasInitialLoad(false);
+    setIsTaskNotFound(false);
     loadInitialData(true);
   };
 
@@ -365,6 +375,17 @@ export default function TaskDetailPage({ params }: PageProps) {
       <TaskDetailLoadingState
         taskId={taskId}
         loadingTimeout={loadingTimeout}
+        onBack={() => router.push('/tasks')}
+        onRetry={handleRetry}
+      />
+    );
+  }
+
+  if (isTaskNotFound) {
+    return (
+      <TaskDetailNotFoundState
+        taskId={taskId}
+        isRetrying={isRetrying}
         onBack={() => router.push('/tasks')}
         onRetry={handleRetry}
       />

--- a/apps/frontend/src/app/(protected)/traces/components/SpanDetailsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/SpanDetailsPanel.tsx
@@ -34,6 +34,7 @@ import TestResultTab from './TestResultTab';
 import TraceMetricsTab from './TraceMetricsTab';
 import TraceReviewsTab from './TraceReviewsTab';
 import { TasksAndCommentsWrapper } from '@/components/tasks/TasksAndCommentsWrapper';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
 
 interface SpanDetailsPanelProps {
   span: SpanNode | null;
@@ -505,7 +506,7 @@ export default function SpanDetailsPanel({
                                 theme.palette.mode === 'dark'
                                   ? theme.palette.grey[800]
                                   : theme.palette.grey[100],
-                              borderRadius: theme => theme.shape.borderRadius,
+                              borderRadius: BORDER_RADIUS.xs,
                               overflow: 'auto',
                               fontSize: theme =>
                                 theme.typography.body2.fontSize,
@@ -537,7 +538,7 @@ export default function SpanDetailsPanel({
                                 theme.palette.mode === 'dark'
                                   ? theme.palette.grey[800]
                                   : theme.palette.grey[100],
-                              borderRadius: theme => theme.shape.borderRadius,
+                              borderRadius: BORDER_RADIUS.xs,
                               overflow: 'auto',
                               fontSize: theme =>
                                 theme.typography.body2.fontSize,
@@ -577,7 +578,7 @@ export default function SpanDetailsPanel({
                             theme.palette.mode === 'dark'
                               ? theme.palette.grey[800]
                               : theme.palette.grey[100],
-                          borderRadius: theme => theme.shape.borderRadius,
+                          borderRadius: BORDER_RADIUS.xs,
                           overflow: 'auto',
                           fontSize: theme => theme.typography.body2.fontSize,
                           fontFamily: 'monospace',
@@ -644,8 +645,7 @@ export default function SpanDetailsPanel({
                                     theme.palette.mode === 'dark'
                                       ? theme.palette.grey[800]
                                       : theme.palette.grey[100],
-                                  borderRadius: theme =>
-                                    `${theme.shape.borderRadius}px`,
+                                  borderRadius: BORDER_RADIUS.xs,
                                   borderLeft: theme =>
                                     `3px solid ${
                                       msg.role === 'system'
@@ -717,7 +717,7 @@ export default function SpanDetailsPanel({
                             theme.palette.mode === 'dark'
                               ? theme.palette.grey[800]
                               : theme.palette.grey[100],
-                          borderRadius: theme => theme.shape.borderRadius,
+                          borderRadius: BORDER_RADIUS.xs,
                           overflow: 'auto',
                           fontSize: theme => theme.typography.body2.fontSize,
                           fontFamily: 'monospace',
@@ -774,7 +774,7 @@ export default function SpanDetailsPanel({
                             theme.palette.mode === 'dark'
                               ? theme.palette.grey[800]
                               : theme.palette.grey[100],
-                          borderRadius: theme => theme.shape.borderRadius,
+                          borderRadius: BORDER_RADIUS.xs,
                           overflow: 'auto',
                           fontSize: theme => theme.typography.body2.fontSize,
                           fontFamily: 'monospace',
@@ -813,7 +813,7 @@ export default function SpanDetailsPanel({
                             theme.palette.mode === 'dark'
                               ? theme.palette.grey[800]
                               : theme.palette.grey[100],
-                          borderRadius: theme => theme.shape.borderRadius,
+                          borderRadius: BORDER_RADIUS.xs,
                           overflow: 'auto',
                           fontSize: theme => theme.typography.body2.fontSize,
                           fontFamily: 'monospace',
@@ -870,7 +870,7 @@ export default function SpanDetailsPanel({
                             theme.palette.mode === 'dark'
                               ? theme.palette.grey[800]
                               : theme.palette.grey[100],
-                          borderRadius: theme => theme.shape.borderRadius,
+                          borderRadius: BORDER_RADIUS.xs,
                           overflow: 'auto',
                           fontSize: theme => theme.typography.body2.fontSize,
                           fontFamily: 'monospace',
@@ -909,7 +909,7 @@ export default function SpanDetailsPanel({
                             theme.palette.mode === 'dark'
                               ? theme.palette.grey[800]
                               : theme.palette.grey[100],
-                          borderRadius: theme => theme.shape.borderRadius,
+                          borderRadius: BORDER_RADIUS.xs,
                           overflow: 'auto',
                           fontSize: theme => theme.typography.body2.fontSize,
                           fontFamily: 'monospace',

--- a/apps/frontend/src/components/common/DetailNotFoundState.tsx
+++ b/apps/frontend/src/components/common/DetailNotFoundState.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Typography,
+} from '@mui/material';
+import { PageLayout } from '@/components/layout/PageLayout';
+
+interface Breadcrumb {
+  label: string;
+  href?: string;
+}
+
+interface DetailNotFoundStateProps {
+  entityLabel: string;
+  entityId: string;
+  breadcrumbs: Breadcrumb[];
+  onBack: () => void;
+  onRetry?: () => void;
+  isRetrying?: boolean;
+}
+
+export default function DetailNotFoundState({
+  entityLabel,
+  entityId,
+  breadcrumbs,
+  onBack,
+  onRetry,
+  isRetrying = false,
+}: DetailNotFoundStateProps) {
+  const listLabel = entityLabel.endsWith('s') ? entityLabel : `${entityLabel}s`;
+
+  return (
+    <PageLayout title={`${entityLabel} Not Found`} breadcrumbs={breadcrumbs}>
+      <Box sx={{ flexGrow: 1, pt: 3 }}>
+        <Alert severity="warning" sx={{ mb: 3 }}>
+          <Typography variant="h6" sx={{ mb: 1 }}>
+            Sorry, we couldn&apos;t load this {entityLabel.toLowerCase()}
+          </Typography>
+          <Typography variant="body2" sx={{ mb: 2 }}>
+            The {entityLabel.toLowerCase()} you&apos;re looking for might have
+            been deleted, moved, belongs to a different project, or you may not
+            have permission to view it.
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {entityLabel} ID: {entityId}
+          </Typography>
+        </Alert>
+        <Box sx={{ display: 'flex', gap: 2 }}>
+          <Button variant="contained" onClick={onBack}>
+            Back to {listLabel}
+          </Button>
+          {onRetry && (
+            <Button variant="outlined" onClick={onRetry} disabled={isRetrying}>
+              {isRetrying ? (
+                <>
+                  <CircularProgress color="inherit" size={16} sx={{ mr: 1 }} />
+                  Retrying...
+                </>
+              ) : (
+                'Try Again'
+              )}
+            </Button>
+          )}
+        </Box>
+      </Box>
+    </PageLayout>
+  );
+}

--- a/apps/frontend/src/hooks/__tests__/useArchitectChat.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useArchitectChat.test.ts
@@ -606,9 +606,7 @@ describe('useArchitectChat', () => {
       expect(result.current.error).toBe('Something went wrong');
       expect(result.current.messages).toHaveLength(2);
       expect(result.current.messages[1].role).toBe('assistant');
-      expect(result.current.messages[1].content).toBe(
-        'Error: Something went wrong'
-      );
+      expect(result.current.messages[1].content).toBe('Something went wrong');
       expect(result.current.messages[1].isError).toBe(true);
     });
 

--- a/apps/frontend/src/hooks/useArchitectChat.ts
+++ b/apps/frontend/src/hooks/useArchitectChat.ts
@@ -642,7 +642,7 @@ export function useArchitectChat(
           {
             id: generateId(),
             role: 'assistant',
-            content: `Error: ${errorMsg}`,
+            content: errorMsg,
             timestamp: new Date(),
             isError: true,
           },

--- a/sdk/src/rhesis/sdk/agents/base.py
+++ b/sdk/src/rhesis/sdk/agents/base.py
@@ -17,6 +17,7 @@ from opentelemetry import trace
 from pydantic import ValidationError
 
 from rhesis.sdk.agents.constants import Action, InternalTool
+from rhesis.sdk.agents.errors import format_user_facing_error
 from rhesis.sdk.agents.events import AgentEventHandler, _emit
 from rhesis.sdk.agents.schemas import (
     AgentAction,
@@ -778,7 +779,8 @@ class BaseAgent:
                 span.set_attribute(AIAttributes.ERROR_TYPE, "transport_error")
                 span.set_status(trace.Status(trace.StatusCode.ERROR, str(e)))
                 span.record_exception(e)
-                await _emit(self._event_handlers, "on_error", error=e)
+                friendly = RuntimeError(format_user_facing_error(e))
+                await _emit(self._event_handlers, "on_error", error=friendly)
                 return None
 
     async def _handle_finish_action(
@@ -850,7 +852,7 @@ class BaseAgent:
                 self._event_handlers,
                 "on_stream_end",
                 content=fallback_content,
-                error=str(e),
+                error=format_user_facing_error(e),
             )
             return fallback_content
 

--- a/sdk/src/rhesis/sdk/agents/errors.py
+++ b/sdk/src/rhesis/sdk/agents/errors.py
@@ -1,0 +1,102 @@
+"""User-facing error messages for agent failures."""
+
+from __future__ import annotations
+
+import re
+from typing import Union
+
+_DEFAULT_MESSAGE = (
+    "Something went wrong while processing your message. "
+    "Please try again. If the problem persists, check your generation "
+    "model settings in workspace settings."
+)
+
+_MODEL_SETTINGS_HINT = "Check your generation model settings in workspace settings and try again."
+
+# litellm and provider exceptions often stringify with a full traceback.
+_TRACEBACK_SPLIT = re.compile(r"\n\s*Traceback \(most recent call last\):", re.IGNORECASE)
+
+
+def _strip_traceback(text: str) -> str:
+    """Return only the message portion before any embedded traceback."""
+    parts = _TRACEBACK_SPLIT.split(text, maxsplit=1)
+    return parts[0].strip()
+
+
+def _normalize(text: str) -> str:
+    """Collapse noisy provider prefixes like ``litellm.APIConnectionError:``."""
+    cleaned = _strip_traceback(text)
+    if not cleaned:
+        return ""
+
+    # Drop ``module.ExceptionName:`` prefix when present.
+    if ":" in cleaned:
+        head, _, tail = cleaned.partition(":")
+        if "." in head and tail.strip():
+            return tail.strip()
+    return cleaned
+
+
+def format_user_facing_error(error: Union[BaseException, str, None]) -> str:
+    """Convert an internal agent/LLM failure into a safe user message.
+
+    Strips tracebacks and maps common provider/transport failures to
+    actionable guidance. Full details should be logged server-side.
+    """
+    if error is None:
+        return _DEFAULT_MESSAGE
+
+    raw = str(error).strip()
+    if not raw:
+        return _DEFAULT_MESSAGE
+
+    text = _normalize(raw).lower()
+
+    if "event loop" in text or "different event loop" in text:
+        return "The Architect hit a temporary processing issue. Please send your message again."
+
+    if "rate limit" in text or "ratelimit" in text or "429" in text:
+        return "The AI provider rate limit was reached. Please wait a moment and try again."
+
+    if "timeout" in text or "timed out" in text:
+        return "The request timed out. Please try again."
+
+    if any(
+        token in text
+        for token in (
+            "authentication",
+            "unauthorized",
+            "invalid api key",
+            "api key",
+            "permission denied",
+            "401",
+            "403",
+        )
+    ):
+        return f"Could not connect to the configured AI provider. {_MODEL_SETTINGS_HINT}"
+
+    if any(
+        token in text
+        for token in (
+            "apiconnectionerror",
+            "connection error",
+            "connection refused",
+            "failed to connect",
+            "service unavailable",
+            "503",
+            "502",
+            "bad gateway",
+        )
+    ):
+        return "The AI service is temporarily unavailable. Please try again in a moment."
+
+    if "not capable" in text or "structured-output" in text:
+        return raw if "generation model" in raw.lower() else _normalize(raw)
+
+    # Already user-facing (e.g. validation messages from the WS handler).
+    if "traceback" not in raw.lower() and len(_normalize(raw)) <= 300:
+        normalized = _normalize(raw)
+        if normalized and not normalized.startswith("/"):
+            return normalized
+
+    return _DEFAULT_MESSAGE

--- a/sdk/src/rhesis/sdk/async_utils.py
+++ b/sdk/src/rhesis/sdk/async_utils.py
@@ -6,16 +6,45 @@ using a persistent background thread/loop to avoid event loop lifecycle issues.
 
 import asyncio
 import atexit
+import logging
 from threading import Thread
+
+logger = logging.getLogger(__name__)
 
 _background_loop = None
 _background_thread = None
+
+
+def reset_litellm_vertex_async_locks() -> None:
+    """Clear litellm Vertex AI asyncio locks tied to a dead event loop.
+
+    litellm.main keeps a module-level ``vertex_chat_completion`` singleton
+    whose ``_async_refresh_locks`` are bound to whichever event loop first
+    touched them.  After ``asyncio.run()`` closes its loop, the next call
+    on a fresh loop raises "Lock ... is bound to a different event loop".
+    """
+    try:
+        import litellm.main as litellm_main
+
+        vertex = getattr(litellm_main, "vertex_chat_completion", None)
+        if vertex is None:
+            return
+        vertex._async_refresh_locks.clear()
+        vertex._async_refresh_lock_refcounts.clear()
+        for task in vertex._background_refresh_tasks.values():
+            if not task.done():
+                task.cancel()
+        vertex._background_refresh_tasks.clear()
+    except Exception:
+        logger.debug("Could not reset litellm Vertex async locks", exc_info=True)
 
 
 def _get_background_loop():
     """Lazily create a single background thread with its own event loop."""
     global _background_loop, _background_thread
     if _background_loop is None or _background_loop.is_closed():
+        if _background_loop is not None and _background_loop.is_closed():
+            reset_litellm_vertex_async_locks()
         _background_loop = asyncio.new_event_loop()
         _background_thread = Thread(
             target=_background_loop.run_forever,

--- a/tests/backend/tasks/architect/test_event_handler.py
+++ b/tests/backend/tasks/architect/test_event_handler.py
@@ -174,6 +174,21 @@ class TestWebSocketEventHandlerEvents:
         assert payload["error_type"] == "ValueError"
 
     @pytest.mark.asyncio
+    async def test_on_error_sanitizes_provider_traceback(self, handler):
+        err = RuntimeError(
+            "litellm.APIConnectionError: connection failed\n"
+            "Traceback (most recent call last):\n"
+            '  File "/app/litellm/main.py", line 639, in acompletion\n'
+            "    response = await init_response\n"
+        )
+        with patch.object(handler, "publish") as mock_pub:
+            await handler.on_error(error=err)
+
+        payload = mock_pub.call_args[0][1]
+        assert "Traceback" not in payload["error"]
+        assert "litellm" not in payload["error"]
+
+    @pytest.mark.asyncio
     async def test_on_agent_end_is_noop(self, handler):
         with patch.object(handler, "publish") as mock_pub:
             await handler.on_agent_end(result="done")

--- a/tests/backend/tasks/architect/test_event_handler.py
+++ b/tests/backend/tasks/architect/test_event_handler.py
@@ -15,6 +15,7 @@ from rhesis.backend.app.services.architect.event_handler import (
     _safe_preview,
     _tool_description,
 )
+from rhesis.sdk.agents.errors import format_user_facing_error
 
 _HANDLER_MODULE = "rhesis.backend.app.services.architect.event_handler"
 
@@ -245,7 +246,7 @@ class TestWebSocketEventHandlerStreaming:
 
         payload = mock_pub.call_args[0][1]
         assert payload["content"] == "partial"
-        assert payload["error"] == "LLM timeout"
+        assert payload["error"] == format_user_facing_error("LLM timeout")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/tasks/architect/test_progress.py
+++ b/tests/backend/tasks/architect/test_progress.py
@@ -191,7 +191,7 @@ class TestExplorationEmitsProgress:
     """
 
     @patch("rhesis.backend.tasks.endpoint.explore.publish_task_progress")
-    @patch("rhesis.backend.tasks.endpoint.explore.asyncio.run")
+    @patch("rhesis.sdk.async_utils.run_sync")
     @patch("rhesis.sdk.agents.tools.ExploreEndpointTool")
     @patch("rhesis.backend.tasks.endpoint.explore.make_target_factory")
     @patch("rhesis.backend.tasks.endpoint.explore.get_db_with_tenant_variables")
@@ -243,7 +243,7 @@ class TestExplorationEmitsProgress:
         assert all(call.kwargs.get("task_id") == "task-abc" for call in mock_publish.call_args_list)
 
     @patch("rhesis.backend.tasks.endpoint.explore.publish_task_progress")
-    @patch("rhesis.backend.tasks.endpoint.explore.asyncio.run")
+    @patch("rhesis.sdk.async_utils.run_sync")
     @patch("rhesis.sdk.agents.tools.ExploreEndpointTool")
     @patch("rhesis.backend.tasks.endpoint.explore.make_target_factory")
     @patch("rhesis.backend.tasks.endpoint.explore.get_db_with_tenant_variables")
@@ -284,7 +284,7 @@ class TestExplorationEmitsProgress:
         mock_publish.assert_not_called()
 
     @patch("rhesis.backend.tasks.endpoint.explore.publish_task_progress")
-    @patch("rhesis.backend.tasks.endpoint.explore.asyncio.run")
+    @patch("rhesis.sdk.async_utils.run_sync")
     @patch("rhesis.sdk.agents.tools.ExploreEndpointTool")
     @patch("rhesis.backend.tasks.endpoint.explore.make_target_factory")
     @patch("rhesis.backend.tasks.endpoint.explore.get_db_with_tenant_variables")
@@ -418,7 +418,7 @@ class TestExplorationProjectIdFlow:
     """Verify that project_id from tenant context flows to make_target_factory."""
 
     @patch("rhesis.backend.tasks.endpoint.explore.publish_task_progress")
-    @patch("rhesis.backend.tasks.endpoint.explore.asyncio.run")
+    @patch("rhesis.sdk.async_utils.run_sync")
     @patch("rhesis.sdk.agents.tools.ExploreEndpointTool")
     @patch("rhesis.backend.tasks.endpoint.explore.make_target_factory")
     @patch("rhesis.backend.tasks.endpoint.explore.get_db_with_tenant_variables")

--- a/tests/backend/tasks/test_explore.py
+++ b/tests/backend/tasks/test_explore.py
@@ -25,7 +25,7 @@ def _make_tool_result(success: bool = True, content: dict | None = None, error: 
 
 
 class TestRunExplorationTaskSuccess:
-    @patch("rhesis.backend.tasks.endpoint.explore.asyncio.run")
+    @patch("rhesis.sdk.async_utils.run_sync")
     @patch("rhesis.sdk.agents.tools.ExploreEndpointTool")
     @patch("rhesis.backend.tasks.endpoint.explore.make_target_factory")
     @patch("rhesis.backend.tasks.endpoint.explore.get_db_with_tenant_variables")
@@ -62,7 +62,7 @@ class TestRunExplorationTaskSuccess:
         assert result["strategy"] == "domain_probing"
         assert "duration_ms" in result
 
-    @patch("rhesis.backend.tasks.endpoint.explore.asyncio.run")
+    @patch("rhesis.sdk.async_utils.run_sync")
     @patch("rhesis.sdk.agents.tools.ExploreEndpointTool")
     @patch("rhesis.backend.tasks.endpoint.explore.make_target_factory")
     @patch("rhesis.backend.tasks.endpoint.explore.get_db_with_tenant_variables")
@@ -102,7 +102,7 @@ class TestRunExplorationTaskSuccess:
 
 
 class TestRunExplorationTaskFailure:
-    @patch("rhesis.backend.tasks.endpoint.explore.asyncio.run")
+    @patch("rhesis.sdk.async_utils.run_sync")
     @patch("rhesis.sdk.agents.tools.ExploreEndpointTool")
     @patch("rhesis.backend.tasks.endpoint.explore.make_target_factory")
     @patch("rhesis.backend.tasks.endpoint.explore.get_db_with_tenant_variables")

--- a/tests/sdk/agents/test_errors.py
+++ b/tests/sdk/agents/test_errors.py
@@ -1,0 +1,49 @@
+"""Tests for user-facing agent error formatting."""
+
+from rhesis.sdk.agents.errors import format_user_facing_error
+
+
+class TestFormatUserFacingError:
+    def test_strips_embedded_traceback(self):
+        raw = (
+            "litellm.APIConnectionError: connection failed\n"
+            "Traceback (most recent call last):\n"
+            '  File "/app/litellm/main.py", line 639, in acompletion\n'
+            "    response = await init_response\n"
+            "RuntimeError: boom"
+        )
+        message = format_user_facing_error(raw)
+        assert "Traceback" not in message
+        assert "litellm" not in message
+        assert "main.py" not in message
+
+    def test_event_loop_error_is_friendly(self):
+        raw = (
+            "litellm.APIConnectionError: <asyncio.locks.Lock object "
+            "at 0x7c1450015150 [unlocked, waiters:2]> is bound to a "
+            "different event loop"
+        )
+        message = format_user_facing_error(raw)
+        assert "asyncio" not in message
+        assert "event loop" not in message.lower()
+        assert "try again" in message.lower() or "again" in message.lower()
+
+    def test_rate_limit_message(self):
+        message = format_user_facing_error("RateLimitError: 429 Too Many Requests")
+        assert "rate limit" in message.lower()
+
+    def test_timeout_message(self):
+        message = format_user_facing_error("Request timed out after 60s")
+        assert "timed out" in message.lower()
+
+    def test_auth_message(self):
+        message = format_user_facing_error("AuthenticationError: invalid api key")
+        assert "generation model settings" in message.lower()
+
+    def test_preserves_short_user_messages(self):
+        message = format_user_facing_error("Session not found or access denied")
+        assert message == "Session not found or access denied"
+
+    def test_none_returns_default(self):
+        message = format_user_facing_error(None)
+        assert "something went wrong" in message.lower()

--- a/tests/sdk/test_async_utils.py
+++ b/tests/sdk/test_async_utils.py
@@ -45,6 +45,7 @@ def test_reset_litellm_vertex_async_locks_clears_stale_locks():
     """Locks created on a closed loop must be cleared before the next use."""
     loop_a = asyncio.new_event_loop()
     try:
+        asyncio.set_event_loop(loop_a)
         lock = asyncio.Lock()
         import litellm.main as litellm_main
 
@@ -54,6 +55,7 @@ def test_reset_litellm_vertex_async_locks_clears_stale_locks():
         vertex._async_refresh_lock_refcounts[key] = 1
     finally:
         loop_a.close()
+        asyncio.set_event_loop(None)
 
     reset_litellm_vertex_async_locks()
 

--- a/tests/sdk/test_async_utils.py
+++ b/tests/sdk/test_async_utils.py
@@ -1,8 +1,14 @@
 """Tests for rhesis.sdk.async_utils."""
 
+import asyncio
+
 import pytest
 
-from rhesis.sdk.async_utils import close_background_loop, run_sync
+from rhesis.sdk.async_utils import (
+    close_background_loop,
+    reset_litellm_vertex_async_locks,
+    run_sync,
+)
 
 
 def test_close_background_loop_idempotent():
@@ -32,4 +38,43 @@ async def test_close_background_loop_after_run_sync():
     result2 = run_sync(dummy())
     assert result2 == "ok"
 
+    close_background_loop()
+
+
+def test_reset_litellm_vertex_async_locks_clears_stale_locks():
+    """Locks created on a closed loop must be cleared before the next use."""
+    loop_a = asyncio.new_event_loop()
+    try:
+        lock = asyncio.Lock()
+        import litellm.main as litellm_main
+
+        vertex = litellm_main.vertex_chat_completion
+        key = ("creds", "project")
+        vertex._async_refresh_locks[key] = lock
+        vertex._async_refresh_lock_refcounts[key] = 1
+    finally:
+        loop_a.close()
+
+    reset_litellm_vertex_async_locks()
+
+    import litellm.main as litellm_main
+
+    vertex = litellm_main.vertex_chat_completion
+    assert vertex._async_refresh_locks == {}
+    assert vertex._async_refresh_lock_refcounts == {}
+
+
+def test_run_sync_reuses_background_loop_across_calls():
+    """Celery-style repeated sync entry points must share one loop."""
+    loop_ids: list[int] = []
+
+    async def record_loop():
+        loop_ids.append(id(asyncio.get_running_loop()))
+        return "ok"
+
+    close_background_loop()
+    run_sync(record_loop())
+    run_sync(record_loop())
+    assert len(loop_ids) == 2
+    assert loop_ids[0] == loop_ids[1]
     close_background_loop()


### PR DESCRIPTION
## Purpose
This PR bundles several frontend and backend fixes discovered while investigating project-scoped detail pages and Architect chat reliability.

1. **Project switch on detail pages** — Switching the active project while viewing an endpoint or task from another project correctly returns 404 from the backend (project scoping via `X-Project-Id`). The frontend was showing a raw API error string instead of the friendly not-found UI.
2. **Architect chat reliability** — Raw Python tracebacks (e.g. `litellm.APIConnectionError` with asyncio lock errors) could appear in the chat UI. Repeat turns in the same Celery worker could fail because `asyncio.run()` closed the event loop while litellm's Vertex AI singleton reused locks from the dead loop.
3. **Minor UI polish** — Knowledge empty state and trace span detail styling.

## What Changed

### Project switch not-found UX
- **Endpoint detail** (`/endpoints/[id]`): call `notFound()` on 404/410 API errors (React Query fetch)
- **Project-nested endpoint detail** (`/projects/[id]/endpoints/[endpointId]`): same `notFound()` handling
- **Task detail** (`/tasks/[id]`): fetch task directly so 404 propagates with `.status`, then render `TaskDetailNotFoundState` with copy mentioning project switching

### Architect error handling and event loop
- Add `format_user_facing_error()` in the SDK to strip tracebacks and map provider failures to actionable messages
- Route Architect and explore Celery tasks through `run_sync()` (persistent background event loop) instead of `asyncio.run()`
- Use `run_sync()` for in-process endpoint invocations from the Architect runner
- Add `reset_litellm_vertex_async_locks()` when the background loop is recreated
- Sanitize stream-end and error events in `WebSocketEventHandler`
- Frontend: show sanitized error text in the chat bubble without a redundant `Error:` prefix

### Other frontend fixes
- **Knowledge page**: use card empty state for consistency
- **Trace span detail**: fix code block corner radius (use `BORDER_RADIUS.xs` tokens instead of numeric `theme.shape.borderRadius` values that MUI sx multiplies)

### Tests
- Add SDK tests for `format_user_facing_error` and `run_sync`
- Update Architect/explore task tests for the new async path
- Fix `test_on_stream_end_with_error` to expect sanitized timeout message

## Additional Context
- Backend project isolation via ORM auto-filter is working as designed; the detail-page bug was frontend-only
- litellm keeps a module-level `vertex_chat_completion` singleton whose `asyncio.Lock` objects bind to the first event loop — `asyncio.run()` per Celery task was the root cause of Architect failures on subsequent messages
- Test runs already used the `notFound()` pattern; endpoints and tasks are now aligned

## Testing
### Project switch
- [ ] Open an endpoint in Project A, switch to Project B → shared protected 404 page with "belongs to a different project" messaging
- [ ] Same flow for `/projects/{id}/endpoints/{endpointId}`
- [ ] Open a task in Project A, switch to Project B → `TaskDetailNotFoundState` with "Back to Tasks"
- [ ] Confirm genuine network/5xx errors still show the generic error UI

### Architect
- [ ] Restart Celery worker, send two Architect messages in the same session — second turn should not show event-loop errors
- [ ] On provider failure, chat shows a friendly retry message instead of a Python traceback

### Automated
- [x] Backend tests, frontend unit, SDK tests, and E2E all pass on CI