### PR TITLE
Improve playground endpoint selection UX

### DIFF
--- a/apps/frontend/src/app/(protected)/playground/components/MessageBubble.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/MessageBubble.tsx
@@ -14,12 +14,12 @@ import {
 } from '@mui/material';
 import PersonIcon from '@mui/icons-material/Person';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
-import TimelineIcon from '@mui/icons-material/Timeline';
 import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckIcon from '@mui/icons-material/Check';
 import DownloadIcon from '@mui/icons-material/Download';
 import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
+import { TracesIcon } from '@/components/icons';
 import { ChatMessage } from '@/hooks/usePlaygroundChat';
 import MarkdownContent from '@/components/common/MarkdownContent';
 import { BORDER_RADIUS } from '@/styles/theme-constants';
@@ -174,21 +174,114 @@ export default function MessageBubble({
               }),
             }}
           >
-            {/* Message text */}
-            {isUser ? (
-              <Typography
-                variant="body2"
+            {/* Message text + inline actions */}
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'flex-end',
+                justifyContent: 'space-between',
+                gap: 1,
+              }}
+            >
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                {isUser ? (
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      whiteSpace: 'pre-wrap',
+                      wordBreak: 'break-word',
+                      color: theme => theme.palette.greyscale.body,
+                    }}
+                  >
+                    {message.content}
+                  </Typography>
+                ) : (
+                  <MarkdownContent content={message.content} variant="body2" />
+                )}
+              </Box>
+
+              <Box
                 sx={{
-                  whiteSpace: 'pre-wrap',
-                  wordBreak: 'break-word',
-                  color: theme => theme.palette.greyscale.body,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 0.5,
+                  flexShrink: 0,
+                  alignSelf: 'flex-end',
                 }}
               >
-                {message.content}
-              </Typography>
-            ) : (
-              <MarkdownContent content={message.content} variant="body2" />
-            )}
+                {/* Create single-turn test (user messages) */}
+                {isUser && (
+                  <Tooltip title="Create single-turn test from this message">
+                    <IconButton
+                      size="small"
+                      onClick={e => {
+                        e.stopPropagation();
+                        onCreateSingleTurnTest?.(message.id);
+                      }}
+                      sx={{
+                        p: 0.5,
+                        color: theme => theme.palette.greyscale.label,
+                        '&:hover': {
+                          color: 'primary.main',
+                          bgcolor: theme => theme.palette.background.light1,
+                        },
+                      }}
+                    >
+                      <ScienceOutlinedIcon sx={{ fontSize: 16 }} />
+                    </IconButton>
+                  </Tooltip>
+                )}
+
+                {/* Copy (assistant messages) */}
+                {!isUser && !message.isError && (
+                  <Tooltip title={copied ? 'Copied!' : 'Copy message'}>
+                    <IconButton
+                      size="small"
+                      onClick={handleCopy}
+                      sx={{
+                        p: 0.5,
+                        color: theme => theme.palette.greyscale.label,
+                        '&:hover': {
+                          color: 'primary.main',
+                          bgcolor: theme => theme.palette.greyscale.surface2,
+                        },
+                      }}
+                    >
+                      {copied ? (
+                        <CheckIcon sx={{ fontSize: 16 }} />
+                      ) : (
+                        <ContentCopyIcon sx={{ fontSize: 16 }} />
+                      )}
+                    </IconButton>
+                  </Tooltip>
+                )}
+
+                {/* Trace link (assistant messages with trace) */}
+                {hasTrace && (
+                  <Tooltip title="View trace">
+                    <IconButton
+                      size="small"
+                      onClick={e => {
+                        e.stopPropagation();
+                        if (onViewTrace && message.traceId) {
+                          onViewTrace(message.traceId);
+                        }
+                      }}
+                      sx={{
+                        p: 0.5,
+                        color: theme => theme.palette.greyscale.label,
+                        '&:hover': {
+                          color: 'primary.main',
+                          bgcolor: theme => theme.palette.greyscale.surface2,
+                        },
+                      }}
+                    >
+                      <TracesIcon sx={{ fontSize: 16 }} />
+                    </IconButton>
+                  </Tooltip>
+                )}
+              </Box>
+            </Box>
 
             {/* User: attached file chips */}
             {isUser && message.files && message.files.length > 0 && (
@@ -289,76 +382,6 @@ export default function MessageBubble({
                   )}
                 </Box>
               )}
-
-            {/* Action icons — bottom-right of card */}
-            <Box
-              sx={{
-                display: 'flex',
-                justifyContent: 'flex-end',
-                alignItems: 'center',
-                gap: 0.5,
-                mt: 1,
-              }}
-            >
-              {/* Create single-turn test (user messages) */}
-              {isUser && (
-                <Tooltip title="Create single-turn test from this message">
-                  <IconButton
-                    size="small"
-                    onClick={e => {
-                      e.stopPropagation();
-                      onCreateSingleTurnTest?.(message.id);
-                    }}
-                    sx={{
-                      p: 0.5,
-                      color: theme => theme.palette.greyscale.label,
-                      '&:hover': {
-                        color: 'primary.main',
-                        bgcolor: theme => theme.palette.background.light1,
-                      },
-                    }}
-                  >
-                    <ScienceOutlinedIcon sx={{ fontSize: 16 }} />
-                  </IconButton>
-                </Tooltip>
-              )}
-
-              {/* Copy (assistant messages) */}
-              {!isUser && !message.isError && (
-                <Tooltip title={copied ? 'Copied!' : 'Copy message'}>
-                  <IconButton
-                    size="small"
-                    onClick={handleCopy}
-                    sx={{
-                      p: 0.5,
-                      color: theme => theme.palette.greyscale.label,
-                      '&:hover': {
-                        color: 'primary.main',
-                        bgcolor: theme => theme.palette.greyscale.surface2,
-                      },
-                    }}
-                  >
-                    {copied ? (
-                      <CheckIcon sx={{ fontSize: 16 }} />
-                    ) : (
-                      <ContentCopyIcon sx={{ fontSize: 16 }} />
-                    )}
-                  </IconButton>
-                </Tooltip>
-              )}
-
-              {/* Trace link (assistant messages with trace) */}
-              {hasTrace && (
-                <Tooltip title="View trace">
-                  <TimelineIcon
-                    sx={{
-                      fontSize: 18,
-                      color: theme => theme.palette.greyscale.label,
-                    }}
-                  />
-                </Tooltip>
-              )}
-            </Box>
           </Paper>
         </Tooltip>
       </Box>

--- a/apps/frontend/src/app/(protected)/playground/components/PlaygroundChat.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/PlaygroundChat.tsx
@@ -23,6 +23,11 @@ import Tooltip from '@mui/material/Tooltip';
 import { useSession } from 'next-auth/react';
 import { usePlaygroundChat } from '@/hooks/usePlaygroundChat';
 import { playgroundPanelSx } from './playgroundPanelSx';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
+import {
+  formatEnvironment,
+  getEnvironmentColor,
+} from './playgroundEndpointUtils';
 import { FileAttachment } from '@/utils/websocket';
 import MessageBubble, { MessageBubbleSkeleton } from './MessageBubble';
 import TraceDrawer from '@/app/(protected)/traces/components/TraceDrawer';
@@ -35,12 +40,20 @@ interface PlaygroundChatProps {
   endpointId: string;
   /** The project ID for trace viewing */
   projectId: string;
+  /** Display name of the endpoint */
+  endpointName: string;
+  /** Display name of the project */
+  projectName: string;
+  /** Endpoint environment label */
+  environment: string;
   /** Optional label shown in the header bar (e.g. "Chat 1") */
   label?: string;
   /** Callback when the close button in the header is clicked */
   onClose?: () => void;
   /** Callback to add a split pane (renders a "+" button in the top-right) */
   onSplit?: () => void;
+  /** Opens the endpoint selection drawer */
+  onChangeEndpoint?: () => void;
 }
 
 /**
@@ -52,9 +65,13 @@ interface PlaygroundChatProps {
 export default function PlaygroundChat({
   endpointId,
   projectId,
+  endpointName,
+  projectName,
+  environment,
   label,
   onClose,
   onSplit,
+  onChangeEndpoint,
 }: PlaygroundChatProps) {
   const { data: session } = useSession();
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -239,7 +256,7 @@ export default function PlaygroundChat({
           sx={{
             display: 'flex',
             alignItems: 'center',
-            justifyContent: label ? 'space-between' : 'flex-end',
+            justifyContent: 'space-between',
             px: 1.5,
             minHeight: theme => theme.spacing(4),
             bgcolor: theme => theme.palette.greyscale.surface1,
@@ -247,14 +264,92 @@ export default function PlaygroundChat({
             borderColor: theme => theme.palette.greyscale.border,
           }}
         >
-          {label && (
-            <Typography
-              variant="captionBold"
-              sx={{ color: theme => theme.palette.greyscale.label }}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 1,
+              minWidth: 0,
+              flex: 1,
+            }}
+          >
+            {label && (
+              <Typography
+                variant="captionBold"
+                sx={{
+                  color: theme => theme.palette.greyscale.label,
+                  flexShrink: 0,
+                }}
+              >
+                {label}
+              </Typography>
+            )}
+            {label && (
+              <Typography
+                variant="captionBold"
+                sx={{ color: theme => theme.palette.greyscale.border }}
+              >
+                ·
+              </Typography>
+            )}
+            <Tooltip
+              title="Change endpoint"
+              disableHoverListener={!onChangeEndpoint}
             >
-              {label}
-            </Typography>
-          )}
+              <Box
+                component={onChangeEndpoint ? 'button' : 'div'}
+                type={onChangeEndpoint ? 'button' : undefined}
+                onClick={onChangeEndpoint}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 1,
+                  minWidth: 0,
+                  border: 'none',
+                  background: 'none',
+                  p: 0,
+                  m: 0,
+                  textAlign: 'left',
+                  cursor: onChangeEndpoint ? 'pointer' : 'default',
+                  ...(onChangeEndpoint && {
+                    '&:hover .endpoint-label': {
+                      color: 'primary.main',
+                    },
+                  }),
+                }}
+              >
+                <Typography
+                  className="endpoint-label"
+                  variant="captionBold"
+                  noWrap
+                  sx={{
+                    color: theme => theme.palette.greyscale.body,
+                    transition: theme =>
+                      theme.transitions.create('color', {
+                        duration: theme.transitions.duration.short,
+                      }),
+                  }}
+                >
+                  {`${projectName} › ${endpointName}`}
+                </Typography>
+                <Typography
+                  component="span"
+                  variant="caption"
+                  sx={{
+                    flexShrink: 0,
+                    px: 1,
+                    py: 0.25,
+                    borderRadius: BORDER_RADIUS.pill,
+                    bgcolor: theme => theme.palette.greyscale.surface2,
+                    color: getEnvironmentColor(environment),
+                    fontWeight: 600,
+                  }}
+                >
+                  {formatEnvironment(environment)}
+                </Typography>
+              </Box>
+            </Tooltip>
+          </Box>
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             {/* Create Multi-Turn Test Button */}
             <Tooltip

--- a/apps/frontend/src/app/(protected)/playground/components/PlaygroundChat.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/PlaygroundChat.tsx
@@ -299,6 +299,7 @@ export default function PlaygroundChat({
               <Box
                 component={onChangeEndpoint ? 'button' : 'div'}
                 type={onChangeEndpoint ? 'button' : undefined}
+                aria-label={onChangeEndpoint ? 'Change endpoint' : undefined}
                 onClick={onChangeEndpoint}
                 sx={{
                   display: 'flex',

--- a/apps/frontend/src/app/(protected)/playground/components/PlaygroundClient.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/PlaygroundClient.tsx
@@ -272,12 +272,14 @@ export default function PlaygroundClient() {
           <Fab
             icon={<EndpointsIcon />}
             tooltip={endpointFabTooltip}
+            aria-label="Select endpoint"
             onClick={openEndpointDrawer}
             loading={isLoading && endpointDrawerOpen}
           />
           <Fab
             icon={<RestartAltIcon />}
             tooltip="Reset playground"
+            aria-label="Reset playground"
             onClick={handleReset}
             disabled={!hasActiveSession}
           />

--- a/apps/frontend/src/app/(protected)/playground/components/PlaygroundClient.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/PlaygroundClient.tsx
@@ -1,42 +1,30 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Box,
   Typography,
   Paper,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  CircularProgress,
-  Alert,
   Stack,
   IconButton,
   Tooltip,
 } from '@mui/material';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { Fab } from '@/components/common/Fab';
+import { Fab, FabGroup } from '@/components/common/Fab';
 import AddIcon from '@mui/icons-material/Add';
 import CloseIcon from '@mui/icons-material/Close';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
 import PlaygroundIcon from '@/components/PlaygroundIcon';
+import EndpointsIcon from '@/components/EndpointsIcon';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import { Project } from '@/utils/api-client/interfaces/project';
-import { BORDER_RADIUS } from '@/styles/theme-constants';
 import { playgroundPanelSx } from './playgroundPanelSx';
 import PlaygroundChat from './PlaygroundChat';
-
-interface EndpointOption {
-  endpointId: string;
-  endpointName: string;
-  projectId: string;
-  projectName: string;
-  environment: string;
-}
+import PlaygroundEndpointDrawer from './PlaygroundEndpointDrawer';
+import { EndpointOption, formatEndpointLabel } from './playgroundEndpointUtils';
 
 /**
  * Placeholder shown when no endpoint is selected.
@@ -151,6 +139,14 @@ export default function PlaygroundClient() {
   const [error, setError] = useState<string | null>(null);
   const [initialEndpointApplied, setInitialEndpointApplied] = useState(false);
   const [isSplit, setIsSplit] = useState(false);
+  const [endpointDrawerOpen, setEndpointDrawerOpen] = useState(false);
+
+  const selectedOption = useMemo(
+    () =>
+      endpointOptions.find(opt => opt.endpointId === selectedEndpointId) ??
+      null,
+    [endpointOptions, selectedEndpointId]
+  );
 
   // Apply initial endpoint from URL params after endpoints are loaded
   useEffect(() => {
@@ -245,41 +241,26 @@ export default function PlaygroundClient() {
     setIsSplit(false);
   }, []);
 
-  const handleEndpointChange = (
-    event: React.ChangeEvent<HTMLInputElement> | { target: { value: string } }
-  ) => {
-    const value = event.target.value;
-    setSelectedEndpointId(value === '' ? null : value);
-
-    // Find the project ID for the selected endpoint
-    if (value) {
-      const selectedOption = endpointOptions.find(
-        opt => opt.endpointId === value
+  const handleEndpointSelect = useCallback(
+    (endpointId: string) => {
+      setSelectedEndpointId(endpointId);
+      const selected = endpointOptions.find(
+        opt => opt.endpointId === endpointId
       );
-      setSelectedProjectId(selectedOption?.projectId || null);
-    } else {
-      setSelectedProjectId(null);
-    }
-  };
+      setSelectedProjectId(selected?.projectId ?? null);
+    },
+    [endpointOptions]
+  );
 
-  const formatEnvironment = (env: string) => {
-    return env.charAt(0).toUpperCase() + env.slice(1);
-  };
-
-  const getEnvironmentColor = (env: string) => {
-    switch (env.toLowerCase()) {
-      case 'production':
-        return 'error.main';
-      case 'staging':
-        return 'warning.main';
-      case 'development':
-        return 'info.main';
-      default:
-        return 'text.secondary';
-    }
-  };
+  const openEndpointDrawer = useCallback(() => {
+    setEndpointDrawerOpen(true);
+  }, []);
 
   const hasActiveSession = !!(selectedEndpointId || isSplit);
+
+  const endpointFabTooltip = selectedOption
+    ? formatEndpointLabel(selectedOption)
+    : 'Select endpoint';
 
   return (
     <PageLayout
@@ -287,91 +268,26 @@ export default function PlaygroundClient() {
       description="Chat with your endpoints interactively to test their responses and generate test cases from your conversations."
       breadcrumbs={[]}
       actions={
-        <Fab
-          icon={<RestartAltIcon />}
-          tooltip="Reset playground"
-          onClick={handleReset}
-          disabled={!hasActiveSession}
-        />
+        <FabGroup>
+          <Fab
+            icon={<EndpointsIcon />}
+            tooltip={endpointFabTooltip}
+            onClick={openEndpointDrawer}
+            loading={isLoading && endpointDrawerOpen}
+          />
+          <Fab
+            icon={<RestartAltIcon />}
+            tooltip="Reset playground"
+            onClick={handleReset}
+            disabled={!hasActiveSession}
+          />
+        </FabGroup>
       }
     >
-      {/* Endpoint Selector */}
-      <Paper elevation={0} sx={{ ...playgroundPanelSx, p: 2, mb: 2 }}>
-        {isLoading ? (
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
-            <CircularProgress size={20} />
-            <Typography variant="body2" color="text.secondary">
-              Loading endpoints...
-            </Typography>
-          </Box>
-        ) : error ? (
-          <Alert severity="error">{error}</Alert>
-        ) : endpointOptions.length === 0 ? (
-          <Alert severity="info">
-            No endpoints available. Please create an endpoint in a project
-            first.
-          </Alert>
-        ) : (
-          <FormControl fullWidth size="small">
-            <InputLabel id="endpoint-selector-label">
-              Select an Endpoint
-            </InputLabel>
-            <Select
-              labelId="endpoint-selector-label"
-              id="endpoint-selector"
-              value={selectedEndpointId || ''}
-              label="Select an Endpoint"
-              onChange={handleEndpointChange}
-            >
-              <MenuItem value="">
-                <Typography variant="body2" color="text.secondary">
-                  Choose an endpoint to chat with...
-                </Typography>
-              </MenuItem>
-              {endpointOptions.map(option => (
-                <MenuItem key={option.endpointId} value={option.endpointId}>
-                  <Box
-                    sx={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      width: '100%',
-                    }}
-                  >
-                    <Typography
-                      variant="body2"
-                      sx={{
-                        flexGrow: 1,
-                        color: theme => theme.palette.greyscale.body,
-                      }}
-                    >
-                      {option.projectName} › {option.endpointName}
-                    </Typography>
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        ml: 2,
-                        px: 1,
-                        py: 0.25,
-                        borderRadius: BORDER_RADIUS.pill,
-                        bgcolor: theme => theme.palette.greyscale.surface2,
-                        color: getEnvironmentColor(option.environment),
-                        fontWeight: 600,
-                      }}
-                    >
-                      {formatEnvironment(option.environment)}
-                    </Typography>
-                  </Box>
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        )}
-      </Paper>
-
       {/* Chat Area */}
       <Box
         sx={{
-          height: 'calc(100vh - 340px)',
+          height: 'calc(100vh - 260px)',
           minHeight: 400,
           display: 'flex',
           flexDirection: 'row',
@@ -379,14 +295,18 @@ export default function PlaygroundClient() {
         }}
       >
         {/* Pane 1 */}
-        {selectedEndpointId && selectedProjectId ? (
+        {selectedEndpointId && selectedProjectId && selectedOption ? (
           <PlaygroundChat
             key="pane-left"
             endpointId={selectedEndpointId}
             projectId={selectedProjectId}
+            endpointName={selectedOption.endpointName}
+            projectName={selectedOption.projectName}
+            environment={selectedOption.environment}
             label={isSplit ? 'Chat 1' : undefined}
             onClose={isSplit ? () => setIsSplit(false) : undefined}
             onSplit={!isSplit ? () => setIsSplit(true) : undefined}
+            onChangeEndpoint={openEndpointDrawer}
           />
         ) : (
           <ChatPlaceholder
@@ -398,18 +318,32 @@ export default function PlaygroundClient() {
 
         {/* Pane 2 (split mode only) */}
         {isSplit &&
-          (selectedEndpointId && selectedProjectId ? (
+          (selectedEndpointId && selectedProjectId && selectedOption ? (
             <PlaygroundChat
               key="pane-right"
               endpointId={selectedEndpointId}
               projectId={selectedProjectId}
+              endpointName={selectedOption.endpointName}
+              projectName={selectedOption.projectName}
+              environment={selectedOption.environment}
               label="Chat 2"
               onClose={() => setIsSplit(false)}
+              onChangeEndpoint={openEndpointDrawer}
             />
           ) : (
             <ChatPlaceholder label="Chat 2" onClose={() => setIsSplit(false)} />
           ))}
       </Box>
+
+      <PlaygroundEndpointDrawer
+        open={endpointDrawerOpen}
+        onClose={() => setEndpointDrawerOpen(false)}
+        endpointOptions={endpointOptions}
+        selectedEndpointId={selectedEndpointId}
+        isLoading={isLoading}
+        error={error}
+        onSelect={handleEndpointSelect}
+      />
     </PageLayout>
   );
 }

--- a/apps/frontend/src/app/(protected)/playground/components/PlaygroundEndpointDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/PlaygroundEndpointDrawer.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import React from 'react';
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  List,
+  ListItemButton,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import CheckIcon from '@mui/icons-material/Check';
+import BaseDrawer from '@/components/common/BaseDrawer';
+import EndpointsIcon from '@/components/EndpointsIcon';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
+import {
+  EndpointOption,
+  formatEnvironment,
+  formatEndpointLabel,
+  getEnvironmentColor,
+} from './playgroundEndpointUtils';
+
+interface PlaygroundEndpointDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  endpointOptions: EndpointOption[];
+  selectedEndpointId: string | null;
+  isLoading: boolean;
+  error: string | null;
+  onSelect: (endpointId: string) => void;
+}
+
+export default function PlaygroundEndpointDrawer({
+  open,
+  onClose,
+  endpointOptions,
+  selectedEndpointId,
+  isLoading,
+  error,
+  onSelect,
+}: PlaygroundEndpointDrawerProps) {
+  const handleSelect = (endpointId: string) => {
+    onSelect(endpointId);
+    onClose();
+  };
+
+  return (
+    <BaseDrawer
+      open={open}
+      onClose={onClose}
+      title="Select Endpoint"
+      titleIcon={<EndpointsIcon />}
+      closeButtonText="Close"
+    >
+      {isLoading ? (
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, py: 2 }}>
+          <CircularProgress size={20} />
+          <Typography variant="body2" color="text.secondary">
+            Loading endpoints...
+          </Typography>
+        </Box>
+      ) : error ? (
+        <Alert severity="error">{error}</Alert>
+      ) : endpointOptions.length === 0 ? (
+        <Alert severity="info">
+          No endpoints available. Please create an endpoint in a project first.
+        </Alert>
+      ) : (
+        <List disablePadding sx={{ mx: -1 }}>
+          {endpointOptions.map(option => {
+            const isSelected = option.endpointId === selectedEndpointId;
+            return (
+              <ListItemButton
+                key={option.endpointId}
+                selected={isSelected}
+                onClick={() => handleSelect(option.endpointId)}
+                sx={{
+                  borderRadius: BORDER_RADIUS.sm,
+                  mb: 0.5,
+                  alignItems: 'flex-start',
+                }}
+              >
+                <ListItemText
+                  primary={formatEndpointLabel(option)}
+                  primaryTypographyProps={{
+                    variant: 'body2',
+                    sx: { color: theme => theme.palette.greyscale.body },
+                  }}
+                  secondary={
+                    <Typography
+                      component="span"
+                      variant="caption"
+                      sx={{
+                        display: 'inline-block',
+                        mt: 0.5,
+                        px: 1,
+                        py: 0.25,
+                        borderRadius: BORDER_RADIUS.pill,
+                        bgcolor: theme => theme.palette.greyscale.surface2,
+                        color: getEnvironmentColor(option.environment),
+                        fontWeight: 600,
+                      }}
+                    >
+                      {formatEnvironment(option.environment)}
+                    </Typography>
+                  }
+                />
+                {isSelected && (
+                  <CheckIcon
+                    fontSize="small"
+                    sx={{ color: 'primary.main', mt: 0.5 }}
+                  />
+                )}
+              </ListItemButton>
+            );
+          })}
+        </List>
+      )}
+    </BaseDrawer>
+  );
+}

--- a/apps/frontend/src/app/(protected)/playground/components/__tests__/PlaygroundChat.test.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/__tests__/PlaygroundChat.test.tsx
@@ -91,7 +91,13 @@ function mockPlaygroundChat(
 function renderChat(
   props: Partial<React.ComponentProps<typeof PlaygroundChat>> = {}
 ) {
-  const defaults = { endpointId: 'endpoint-1', projectId: 'project-1' };
+  const defaults = {
+    endpointId: 'endpoint-1',
+    projectId: 'project-1',
+    endpointName: 'Test Endpoint',
+    projectName: 'Test Project',
+    environment: 'development',
+  };
   return render(
     <ThemeProvider theme={lightTheme}>
       <PlaygroundChat {...defaults} {...props} />
@@ -397,6 +403,16 @@ describe('PlaygroundChat — header buttons', () => {
     mockPlaygroundChat();
     renderChat({ label: 'Chat 1' });
     expect(screen.getByText('Chat 1')).toBeInTheDocument();
+  });
+
+  it('shows the endpoint name in the pane header', () => {
+    mockSession();
+    mockPlaygroundChat();
+    renderChat();
+    expect(
+      screen.getByText('Test Project › Test Endpoint')
+    ).toBeInTheDocument();
+    expect(screen.getByText('Development')).toBeInTheDocument();
   });
 });
 

--- a/apps/frontend/src/app/(protected)/playground/components/playgroundEndpointUtils.ts
+++ b/apps/frontend/src/app/(protected)/playground/components/playgroundEndpointUtils.ts
@@ -1,0 +1,28 @@
+export interface EndpointOption {
+  endpointId: string;
+  endpointName: string;
+  projectId: string;
+  projectName: string;
+  environment: string;
+}
+
+export function formatEnvironment(env: string): string {
+  return env.charAt(0).toUpperCase() + env.slice(1);
+}
+
+export function getEnvironmentColor(env: string): string {
+  switch (env.toLowerCase()) {
+    case 'production':
+      return 'error.main';
+    case 'staging':
+      return 'warning.main';
+    case 'development':
+      return 'info.main';
+    default:
+      return 'text.secondary';
+  }
+}
+
+export function formatEndpointLabel(option: EndpointOption): string {
+  return `${option.projectName} › ${option.endpointName}`;
+}

--- a/apps/frontend/tests/e2e/pages/PlaygroundPage.ts
+++ b/apps/frontend/tests/e2e/pages/PlaygroundPage.ts
@@ -28,7 +28,9 @@ export class PlaygroundPage extends BasePage {
   async expectContentVisible() {
     await this.page.waitForLoadState('networkidle');
 
-    const endpointFab = this.page.locator('main button').first();
+    const endpointFab = this.page.getByRole('button', {
+      name: /select endpoint/i,
+    });
     const noEndpointsMsg = this.page.getByText(/no endpoints available/i);
     const emptyState = this.page.getByText(
       /select an endpoint to start chatting/i

--- a/apps/frontend/tests/e2e/pages/PlaygroundPage.ts
+++ b/apps/frontend/tests/e2e/pages/PlaygroundPage.ts
@@ -23,28 +23,25 @@ export class PlaygroundPage extends BasePage {
   }
 
   /**
-   * Assert that either the endpoint selector or a "no endpoints" message
-   * is visible — both indicate the page rendered correctly.
+   * Assert that the playground page rendered — endpoint FAB, empty state, or chat area.
    */
   async expectContentVisible() {
     await this.page.waitForLoadState('networkidle');
 
-    // The endpoint dropdown combobox or select element
-    const endpointSelect = this.page
-      .locator('[role="combobox"]')
-      .or(this.page.locator('select'));
-    // Shown when the user has no endpoints configured
+    const endpointFab = this.page.locator('main button').first();
     const noEndpointsMsg = this.page.getByText(/no endpoints available/i);
-    // The prompt/chat input area
+    const emptyState = this.page.getByText(
+      /select an endpoint to start chatting/i
+    );
     const chatArea = this.page.locator('main, [role="main"]').first();
 
-    const hasSelect = await endpointSelect
-      .first()
-      .isVisible()
-      .catch(() => false);
+    const hasEndpointFab = await endpointFab.isVisible().catch(() => false);
     const hasNoEndpoints = await noEndpointsMsg.isVisible().catch(() => false);
+    const hasEmptyState = await emptyState.isVisible().catch(() => false);
     const hasMain = await chatArea.isVisible().catch(() => false);
 
-    expect(hasSelect || hasNoEndpoints || hasMain).toBeTruthy();
+    expect(
+      hasEndpointFab || hasNoEndpoints || hasEmptyState || hasMain
+    ).toBeTruthy();
   }
 }


### PR DESCRIPTION
## Purpose
Clean up the Playground layout by moving endpoint selection out of the main toolbar and surfacing the active endpoint in the chat pane.

## What Changed
- Move endpoint picker into a drawer opened via an Endpoints FAB
- Show selected project and endpoint name in the chat pane header (clickable to reopen drawer)
- Keep experiment/trace actions inline with short message text
- Use `TracesIcon` for trace actions instead of MUI Timeline icon
- Update Playground unit tests and e2e page object for the new UI

## Additional Context
- UI-only change; no auth, env, or backend changes included

## Testing
- [x] `npx jest PlaygroundChat.test --no-coverage` (43 tests passed)
- [ ] Manual: open `/playground`, use FAB to pick an endpoint, verify header + drawer + inline message actions