### PR TITLE
Fix navbar project name sync and verify-email CTA

### DIFF
--- a/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
@@ -17,6 +17,7 @@ import { useNotifications } from '@/components/common/NotificationContext';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import { Can } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
+import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import ProjectEditDrawer from './edit-drawer';
 import ProjectDetailTabs from './components/ProjectDetailTabs';
 import { format } from 'date-fns';
@@ -44,6 +45,7 @@ export default function ClientWrapper({
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
   const notifications = useNotifications();
+  const { syncProject } = useActiveProject();
 
   const title = currentProject.name || `Project ${params.identifier}`;
   const breadcrumbs: BreadcrumbItem[] = [
@@ -86,6 +88,7 @@ export default function ClientWrapper({
         };
 
         setCurrentProject(updatedProjectWithOwner);
+        syncProject(updatedProjectWithOwner);
         notifications.show('Project updated successfully', {
           severity: 'success',
         });
@@ -100,7 +103,7 @@ export default function ClientWrapper({
         setIsUpdating(false);
       }
     },
-    [projectId, sessionToken, notifications, currentProject]
+    [projectId, sessionToken, notifications, currentProject, syncProject]
   );
 
   const handleDeleteConfirm = async () => {

--- a/apps/frontend/src/app/auth/verify-email/page.tsx
+++ b/apps/frontend/src/app/auth/verify-email/page.tsx
@@ -97,11 +97,11 @@ export default function VerifyEmailPage() {
             sx={{
               mt: 1,
               height: 46,
-              borderRadius: '10px',
+              borderRadius: '10px', // Intentional: button border radius
               bgcolor: 'primary.main',
               '&:hover': {
                 bgcolor: BUTTON_HOVER,
-                boxShadow: '0 4px 12px rgba(80,185,224,0.3)',
+                boxShadow: '0 4px 12px rgba(80,185,224,0.3)', // Intentional: button hover glow
               },
             }}
           >

--- a/apps/frontend/src/app/auth/verify-email/page.tsx
+++ b/apps/frontend/src/app/auth/verify-email/page.tsx
@@ -7,6 +7,7 @@ import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import { useSearchParams } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import { getClientApiBaseUrl } from '@/utils/url-resolver';
+import { DEFAULT_AUTHENTICATED_PATH } from '@/constants/paths';
 import AuthPageShell from '@/components/auth/AuthPageShell';
 
 const BUTTON_HOVER = '#3aabcf'; // Intentional: auth form button hover
@@ -91,7 +92,7 @@ export default function VerifyEmailPage() {
           </Typography>
           <Button
             variant="contained"
-            href="/architect"
+            href={DEFAULT_AUTHENTICATED_PATH}
             fullWidth
             sx={{
               mt: 1,
@@ -104,7 +105,7 @@ export default function VerifyEmailPage() {
               },
             }}
           >
-            Go to dashboard
+            Go back to app
           </Button>
         </>
       )}

--- a/apps/frontend/src/contexts/ActiveProjectContext.tsx
+++ b/apps/frontend/src/contexts/ActiveProjectContext.tsx
@@ -30,6 +30,8 @@ interface ActiveProjectContextValue {
   setActiveProject: (project: Project | null) => void;
   /** Reload the member-project list from the API. */
   refresh: (options?: { listOnly?: boolean }) => Promise<void>;
+  /** Update cached project data after an in-place edit (no reload). */
+  syncProject: (project: Project) => void;
 }
 
 const ActiveProjectContext = createContext<ActiveProjectContextValue>({
@@ -38,6 +40,7 @@ const ActiveProjectContext = createContext<ActiveProjectContextValue>({
   loading: false,
   setActiveProject: () => {},
   refresh: async () => {},
+  syncProject: () => {},
 });
 
 export function ActiveProjectProvider({
@@ -186,6 +189,16 @@ export function ActiveProjectProvider({
     [fetchProjects]
   );
 
+  const syncProject = useCallback((project: Project) => {
+    const id = String(project.id);
+    setProjects(prev =>
+      prev.map(p => (String(p.id) === id ? { ...p, ...project } : p))
+    );
+    setActiveProjectState(prev =>
+      prev && String(prev.id) === id ? { ...prev, ...project } : prev
+    );
+  }, []);
+
   return (
     <ActiveProjectContext.Provider
       value={{
@@ -194,6 +207,7 @@ export function ActiveProjectProvider({
         loading,
         setActiveProject,
         refresh,
+        syncProject,
       }}
     >
       {children}

--- a/apps/frontend/src/contexts/ActiveProjectContext.tsx
+++ b/apps/frontend/src/contexts/ActiveProjectContext.tsx
@@ -54,7 +54,9 @@ export function ActiveProjectProvider({
   const pathname = usePathname();
   const pathnameRef = useRef(pathname);
   pathnameRef.current = pathname;
-  const [projects, setProjects] = useState<Project[]>([]);
+  const [projects, setProjects] = useState<Project[]>(
+    initialActiveProject ? [initialActiveProject] : []
+  );
   const [activeProject, setActiveProjectState] = useState<Project | null>(
     initialActiveProject
   );
@@ -191,9 +193,11 @@ export function ActiveProjectProvider({
 
   const syncProject = useCallback((project: Project) => {
     const id = String(project.id);
-    setProjects(prev =>
-      prev.map(p => (String(p.id) === id ? { ...p, ...project } : p))
-    );
+    setProjects(prev => {
+      const exists = prev.some(p => String(p.id) === id);
+      if (!exists) return [...prev, project];
+      return prev.map(p => (String(p.id) === id ? { ...p, ...project } : p));
+    });
     setActiveProjectState(prev =>
       prev && String(prev.id) === id ? { ...prev, ...project } : prev
     );

--- a/apps/frontend/src/contexts/__tests__/ActiveProjectContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/ActiveProjectContext.test.tsx
@@ -59,6 +59,9 @@ describe('ActiveProjectProvider.syncProject', () => {
     expect(screen.getByTestId('active-name')).toHaveTextContent(
       'Original Name'
     );
+    expect(screen.getByTestId('project-list')).toHaveTextContent(
+      'Original Name'
+    );
 
     act(() => {
       screen.getByRole('button', { name: 'sync' }).click();
@@ -67,5 +70,47 @@ describe('ActiveProjectProvider.syncProject', () => {
     expect(screen.getByTestId('active-name')).toHaveTextContent(
       'Renamed Project'
     );
+    expect(screen.getByTestId('project-list')).toHaveTextContent(
+      'Renamed Project'
+    );
+  });
+
+  it('upserts into the project list when the project was not cached', () => {
+    function UpsertProbe() {
+      const { projects, syncProject } = useActiveProject();
+
+      return (
+        <div>
+          <span data-testid="project-list">
+            {projects.map(p => p.name).join(',')}
+          </span>
+          <button
+            type="button"
+            onClick={() =>
+              syncProject({
+                id: 'proj-2',
+                name: 'New Name',
+              } as Project)
+            }
+          >
+            sync
+          </button>
+        </div>
+      );
+    }
+
+    render(
+      <ActiveProjectProvider>
+        <UpsertProbe />
+      </ActiveProjectProvider>
+    );
+
+    expect(screen.getByTestId('project-list')).toHaveTextContent('');
+
+    act(() => {
+      screen.getByRole('button', { name: 'sync' }).click();
+    });
+
+    expect(screen.getByTestId('project-list')).toHaveTextContent('New Name');
   });
 });

--- a/apps/frontend/src/contexts/__tests__/ActiveProjectContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/ActiveProjectContext.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  ActiveProjectProvider,
+  useActiveProject,
+} from '@/contexts/ActiveProjectContext';
+import type { Project } from '@/utils/api-client/interfaces/project';
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null }),
+}));
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/projects/proj-1',
+}));
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn(),
+}));
+
+function Probe() {
+  const { activeProject, projects, syncProject } = useActiveProject();
+
+  return (
+    <div>
+      <span data-testid="active-name">{activeProject?.name ?? 'none'}</span>
+      <span data-testid="project-list">
+        {projects.map(p => p.name).join(',')}
+      </span>
+      <button
+        type="button"
+        onClick={() =>
+          syncProject({
+            id: 'proj-1',
+            name: 'Renamed Project',
+          } as Project)
+        }
+      >
+        sync
+      </button>
+    </div>
+  );
+}
+
+describe('ActiveProjectProvider.syncProject', () => {
+  it('updates active project and project list without refetch', () => {
+    const initialProject = {
+      id: 'proj-1',
+      name: 'Original Name',
+    } as Project;
+
+    render(
+      <ActiveProjectProvider initialActiveProject={initialProject}>
+        <Probe />
+      </ActiveProjectProvider>
+    );
+
+    expect(screen.getByTestId('active-name')).toHaveTextContent(
+      'Original Name'
+    );
+
+    act(() => {
+      screen.getByRole('button', { name: 'sync' }).click();
+    });
+
+    expect(screen.getByTestId('active-name')).toHaveTextContent(
+      'Renamed Project'
+    );
+  });
+});


### PR DESCRIPTION
## Purpose
The sidebar project name did not update after renaming a project on the detail page until a full page reload. The email verification success screen also still referenced a removed "dashboard" concept.

## What Changed
- Add `syncProject()` to `ActiveProjectContext` and call it after successful project updates on the detail page
- Update the verify-email success button label from "Go to dashboard" to "Go back to app"
- Use `DEFAULT_AUTHENTICATED_PATH` for the verify-email redirect target

## Testing
- [x] `npm test -- --testPathPatterns=ActiveProjectContext.test`
- [ ] Rename a project on `/projects/[id]` and confirm the sidebar updates immediately
- [ ] Complete email verification and confirm the success button reads "Go back to app"