### PR TITLE
Fix: disable telemetry by default in local dev and tests

### DIFF
--- a/rh
+++ b/rh
@@ -190,6 +190,7 @@ CELERY_RESULT_BACKEND=redis://:rhesis-redis-pass@localhost:${DEV_REDIS_PORT}/1
 BACKEND_ENV=local
 DEV_MODE=true
 LOG_LEVEL=DEBUG
+OTEL_RHESIS_TELEMETRY_ENABLED=false
 
 # URLs
 API_BASE_URL=http://localhost:8080

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -40,6 +40,7 @@ _TEST_ENV_VARS = {
     "JWT_ACCESS_TOKEN_EXPIRE_MINUTES": "10080",
     "DB_ENCRYPTION_KEY": "Zb21wZbPsUpb-c2JKj8uMugk767pWXHFTsjocd0Orac=",
     "SSO_ENCRYPTION_KEY": "9KgQ8O8Dx3xfUejfiAwkDgYMqD_2vekaNYw2WvqvJdw=",
+    "OTEL_RHESIS_TELEMETRY_ENABLED": "false",
     "AUTH0_DOMAIN": "test.auth0.com",
 }
 

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -29,6 +29,7 @@ x-sdk-backend-config: &sdk-backend-config
   LOG_LEVEL: DEBUG
   RHESIS_CONNECTOR_DISABLED: true
   API_BASE_URL: "http://localhost:10003"
+  OTEL_RHESIS_TELEMETRY_ENABLED: "false"
 
 services:
   # ==========================================================================


### PR DESCRIPTION
## Purpose
Tests and local dev were silently exporting spans to the production OTLP endpoint (`https://telemetry.rhesis.ai`). `OTEL_RHESIS_TELEMETRY_ENABLED` was not set in any of these environments, so it defaulted to `true` under the `self-hosted` deployment type.

## What Changed
- **`tests/backend/conftest.py`**: added `OTEL_RHESIS_TELEMETRY_ENABLED=false` to `_TEST_ENV_VARS` — prevents the OTLP exporter from initializing at all during backend unit tests (previously the exporter was initialized; only the per-request ContextVar being reset to `False` by the autouse fixture was blocking export)
- **`tests/docker-compose.test.yml`**: added `OTEL_RHESIS_TELEMETRY_ENABLED=false` to `x-sdk-backend-config` — the SDK integration test backend was fully live: `TelemetryMiddleware` was setting `_telemetry_enabled=True` on every authenticated request and exporting spans to production
- **`rh`**: added `OTEL_RHESIS_TELEMETRY_ENABLED=false` to the `./rh dev init` `.env` template so future local dev setups have telemetry off by default

## Additional Context
- `apps/backend/.env` (gitignored) was also updated locally with the same flag
- The `OTEL_RHESIS_TELEMETRY_ENABLED` flag remains the single opt-out mechanism for self-hosted and local deployments; no logic changes to `instrumentation.py`

## Testing
Run backend tests and confirm no outbound connections to `telemetry.rhesis.ai`. Run SDK integration tests and verify the same.