### PR TITLE
Fix test set linked attributes stale after update_test

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -2238,8 +2238,44 @@ def update_test(
     organization_id: str = None,
     user_id: str = None,
 ) -> Optional[models.Test]:
-    """Update test."""
-    return update_item(db, models.Test, test_id, test, organization_id, user_id)
+    """Update test and refresh parent test set attributes when metadata changes."""
+    from rhesis.backend.app.services.test_set import update_test_set_attributes
+
+    if isinstance(test, dict):
+        update_fields = set(test.keys())
+    else:
+        update_fields = set(test.model_dump(exclude_unset=True).keys())
+
+    metadata_fields = {
+        "behavior",
+        "behavior_id",
+        "topic",
+        "topic_id",
+        "category",
+        "category_id",
+        "test_type",
+        "test_type_id",
+    }
+    should_refresh_attributes = bool(metadata_fields & update_fields)
+
+    db_test = update_item(db, models.Test, test_id, test, organization_id, user_id)
+    if db_test is None:
+        return None
+
+    if should_refresh_attributes:
+        test_set_ids = db.execute(
+            test_test_set_association.select().where(test_test_set_association.c.test_id == test_id)
+        ).fetchall()
+
+        for row in test_set_ids:
+            update_test_set_attributes(
+                db=db,
+                test_set_id=str(row.test_set_id),
+                organization_id=organization_id,
+                user_id=user_id,
+            )
+
+    return db_test
 
 
 def delete_test(

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -2234,17 +2234,16 @@ def create_test(
 def update_test(
     db: Session,
     test_id: uuid.UUID,
-    test: schemas.TestUpdate,
+    test: Dict[str, Any],
     organization_id: str = None,
     user_id: str = None,
 ) -> Optional[models.Test]:
-    """Update test and refresh parent test set attributes when metadata changes."""
-    from rhesis.backend.app.services.test_set import update_test_set_attributes
+    """Update test and refresh parent test set attributes when metadata changes.
 
-    if isinstance(test, dict):
-        update_fields = set(test.keys())
-    else:
-        update_fields = set(test.model_dump(exclude_unset=True).keys())
+    ``test`` must be the resolved update payload (e.g. from
+    ``resolve_test_entity_names``), not the raw API schema.
+    """
+    from rhesis.backend.app.services.test_set import update_test_set_attributes
 
     metadata_fields = {
         "behavior",
@@ -2256,21 +2255,28 @@ def update_test(
         "test_type",
         "test_type_id",
     }
-    should_refresh_attributes = bool(metadata_fields & update_fields)
+    should_refresh_attributes = bool(metadata_fields & set(test.keys()))
 
     db_test = update_item(db, models.Test, test_id, test, organization_id, user_id)
     if db_test is None:
         return None
 
     if should_refresh_attributes:
-        test_set_ids = db.execute(
-            test_test_set_association.select().where(test_test_set_association.c.test_id == test_id)
-        ).fetchall()
+        affected_test_set_ids = (
+            db.execute(
+                select(test_test_set_association.c.test_set_id).where(
+                    test_test_set_association.c.test_id == test_id,
+                    test_test_set_association.c.organization_id == organization_id,
+                )
+            )
+            .scalars()
+            .all()
+        )
 
-        for row in test_set_ids:
+        for test_set_id in affected_test_set_ids:
             update_test_set_attributes(
                 db=db,
-                test_set_id=str(row.test_set_id),
+                test_set_id=str(test_set_id),
                 organization_id=organization_id,
                 user_id=user_id,
             )

--- a/apps/backend/src/rhesis/backend/app/services/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_set.py
@@ -613,6 +613,7 @@ def update_test_set_attributes(
     test_set.attributes = generate_test_set_attributes(
         db=db, test_set=test_set, defaults=defaults, license_type=license_type
     )
+    db.flush()
 
     # Transaction commit is handled by the session context manager
 

--- a/tests/backend/crud/test_test_crud.py
+++ b/tests/backend/crud/test_test_crud.py
@@ -112,8 +112,14 @@ class TestTestOperations:
             organization_id=test_org_id,
             user_id=authenticated_user_id,
         )
-        test_db.refresh(test_set)
-        assert test_set.attributes["metadata"]["behaviors"] == ["Compliance"]
+        seeded_test_set = crud.get_test_set(
+            test_db,
+            test_set.id,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        assert seeded_test_set is not None
+        assert seeded_test_set.attributes["metadata"]["behaviors"] == ["Compliance"]
 
         result = crud.update_test(
             db=test_db,

--- a/tests/backend/crud/test_test_crud.py
+++ b/tests/backend/crud/test_test_crud.py
@@ -126,8 +126,14 @@ class TestTestOperations:
         assert result is not None
         assert result.behavior_id == robustness.id
 
-        test_db.refresh(test_set)
-        assert test_set.attributes["metadata"]["behaviors"] == ["Robustness"]
+        reloaded_test_set = crud.get_test_set(
+            test_db,
+            test_set.id,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        assert reloaded_test_set is not None
+        assert reloaded_test_set.attributes["metadata"]["behaviors"] == ["Robustness"]
 
     def test_update_test_skips_attribute_refresh_for_non_metadata_fields(
         self, test_db: Session, db_test_minimal, test_org_id: str, authenticated_user_id: str
@@ -196,5 +202,13 @@ class TestTestOperations:
             user_id=authenticated_user_id,
         )
 
-        test_db.refresh(explorer_test_set)
-        assert explorer_test_set.attributes["metadata"]["behaviors"] == [ADAPTIVE_TESTING_BEHAVIOR]
+        reloaded_explorer_test_set = crud.get_test_set(
+            test_db,
+            explorer_test_set.id,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        assert reloaded_explorer_test_set is not None
+        assert reloaded_explorer_test_set.attributes["metadata"]["behaviors"] == [
+            ADAPTIVE_TESTING_BEHAVIOR
+        ]

--- a/tests/backend/crud/test_test_crud.py
+++ b/tests/backend/crud/test_test_crud.py
@@ -7,16 +7,21 @@ isolation and data integrity.
 
 Functions tested:
 - delete_test: Delete test entities
+- update_test: Update test entities and refresh test set attributes
 
 Run with: python -m pytest tests/backend/crud/test_test_crud.py -v
 """
 
 import uuid
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
+from rhesis.backend.app.constants import ADAPTIVE_TESTING_BEHAVIOR
+from rhesis.backend.app.models.test import test_test_set_association
+from rhesis.backend.app.services import test_set as test_set_service
 
 
 @pytest.mark.unit
@@ -60,3 +65,136 @@ class TestTestOperations:
 
         # Should return None for non-existent test
         assert result is None
+
+    def test_update_test_refreshes_test_set_attributes_on_behavior_change(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        """Updating test behavior refreshes linked test set denormalized attributes."""
+        compliance = models.Behavior(
+            name="Compliance",
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        robustness = models.Behavior(
+            name="Robustness",
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.add_all([compliance, robustness])
+        test_db.flush()
+
+        db_test = models.Test(
+            behavior_id=compliance.id,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_set = models.TestSet(
+            name="Linked Attributes Test Set",
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.add_all([db_test, test_set])
+        test_db.flush()
+
+        test_db.execute(
+            test_test_set_association.insert().values(
+                test_id=db_test.id,
+                test_set_id=test_set.id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+        )
+        test_db.flush()
+
+        test_set_service.update_test_set_attributes(
+            db=test_db,
+            test_set_id=str(test_set.id),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.refresh(test_set)
+        assert test_set.attributes["metadata"]["behaviors"] == ["Compliance"]
+
+        result = crud.update_test(
+            db=test_db,
+            test_id=db_test.id,
+            test={"behavior_id": robustness.id},
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        assert result is not None
+        assert result.behavior_id == robustness.id
+
+        test_db.refresh(test_set)
+        assert test_set.attributes["metadata"]["behaviors"] == ["Robustness"]
+
+    def test_update_test_skips_attribute_refresh_for_non_metadata_fields(
+        self, test_db: Session, db_test_minimal, test_org_id: str, authenticated_user_id: str
+    ):
+        """Non-metadata updates should not trigger test set attribute regeneration."""
+        with patch(
+            "rhesis.backend.app.services.test_set.update_test_set_attributes"
+        ) as mock_refresh:
+            result = crud.update_test(
+                db=test_db,
+                test_id=db_test_minimal.id,
+                test={"priority": 3},
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+
+        assert result is not None
+        mock_refresh.assert_not_called()
+
+    def test_update_test_skips_explorer_test_set_attribute_refresh(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        """Explorer test sets keep their own attributes when a linked test changes."""
+        compliance = models.Behavior(
+            name="Compliance",
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        robustness = models.Behavior(
+            name="Robustness",
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.add_all([compliance, robustness])
+        test_db.flush()
+
+        db_test = models.Test(
+            behavior_id=compliance.id,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        explorer_test_set = models.TestSet(
+            name="Explorer Test Set",
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": [ADAPTIVE_TESTING_BEHAVIOR]}},
+        )
+        test_db.add_all([db_test, explorer_test_set])
+        test_db.flush()
+
+        test_db.execute(
+            test_test_set_association.insert().values(
+                test_id=db_test.id,
+                test_set_id=explorer_test_set.id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+        )
+        test_db.flush()
+
+        crud.update_test(
+            db=test_db,
+            test_id=db_test.id,
+            test={"behavior_id": robustness.id},
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        test_db.refresh(explorer_test_set)
+        assert explorer_test_set.attributes["metadata"]["behaviors"] == [ADAPTIVE_TESTING_BEHAVIOR]


### PR DESCRIPTION
## Purpose
When a test's behavior, topic, category, or test type is updated via `PUT /tests/{id}`, the parent test set's denormalized `attributes` (used by the Linked tab) were not refreshed. The UI showed stale metadata until the test set was saved again.

Closes #2096

## What Changed
- After `update_test` changes metadata fields, look up linked test sets via `test_test_set_association` and call `update_test_set_attributes()` for each (mirrors `delete_test`)
- Only refresh when behavior/topic/category/test_type fields are in the update payload
- Explorer test sets still opt out via the existing `Adaptive Testing` check in `update_test_set_attributes`
- Added unit tests covering behavior refresh, non-metadata skip, and explorer opt-out

## Additional Context
- Existing refresh paths (bulk create, delete, test set PUT) are unchanged
- Workaround before this fix: re-save the test set via `PUT /test_sets/{id}`

## Testing
- [x] `uv run --extra cpu pytest ../../tests/backend/crud/test_test_crud.py -v`