### PR TITLE
Add execution history tab on test detail page

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailHistoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailHistoryTab.tsx
@@ -1,26 +1,10 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import {
-  Box,
-  Typography,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Chip,
-  CircularProgress,
-  Alert,
-  useTheme,
-} from '@mui/material';
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
-import Link from 'next/link';
+import React from 'react';
+import { Box, Typography, CircularProgress, Alert } from '@mui/material';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
-import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import { formatDate } from '@/utils/date';
-import StatusChip from '@/components/common/StatusChip';
+import TestExecutionHistoryTable from '@/components/tests/TestExecutionHistoryTable';
+import { useTestExecutionHistory } from '@/components/tests/useTestExecutionHistory';
 
 interface TestDetailHistoryTabProps {
   test: TestResultDetail;
@@ -28,134 +12,15 @@ interface TestDetailHistoryTabProps {
   sessionToken: string;
 }
 
-interface HistoricalResult {
-  id: string;
-  testRunId: string;
-  testRunName: string;
-  passed: boolean;
-  passedMetrics: number;
-  totalMetrics: number;
-  executedAt: string;
-}
-
 export default function TestDetailHistoryTab({
   test,
   testRunId,
   sessionToken,
 }: TestDetailHistoryTabProps) {
-  const theme = useTheme();
-  const [history, setHistory] = useState<HistoricalResult[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    async function fetchHistory() {
-      if (!test.test_id) {
-        setError('No test ID available');
-        setLoading(false);
-        return;
-      }
-
-      try {
-        setLoading(true);
-        const clientFactory = new ApiClientFactory(sessionToken);
-        const testResultsClient = clientFactory.getTestResultsClient();
-
-        // Fetch historical test results for this test
-        const results = await testResultsClient.getTestResults({
-          filter: `test_id eq '${test.test_id}'`,
-          limit: 10,
-          skip: 0,
-        });
-
-        // Get unique test run IDs to fetch their names
-        const testRunIds = [
-          ...new Set(
-            results.data
-              .filter(
-                (r): r is typeof r & { test_run_id: string } => !!r.test_run_id
-              )
-              .map(r => r.test_run_id)
-          ),
-        ];
-
-        // Fetch test run details to get actual names
-        const testRunsClient = clientFactory.getTestRunsClient();
-        const testRunsData = await Promise.allSettled(
-          testRunIds.map(id => testRunsClient.getTestRun(id))
-        );
-
-        // Create a map of test run IDs to names
-        const testRunNamesMap = new Map<string, string>();
-        testRunsData.forEach((result, index) => {
-          if (result.status === 'fulfilled') {
-            const testRun = result.value;
-            // Use name if available, otherwise use the test run ID
-            const displayName = testRun.name || testRunIds[index];
-            testRunNamesMap.set(testRun.id, displayName);
-          } else {
-            // If fetch failed, use the ID as fallback
-            testRunNamesMap.set(testRunIds[index], testRunIds[index]);
-          }
-        });
-
-        // Process results into historical format
-        const historicalData: HistoricalResult[] = results.data.map(result => {
-          const metrics = result.test_metrics?.metrics || {};
-          const metricValues = Object.values(metrics);
-          const passedMetrics = metricValues.filter(
-            m => m.is_successful
-          ).length;
-          const totalMetrics = metricValues.length;
-          const passed = totalMetrics > 0 && passedMetrics === totalMetrics;
-
-          return {
-            id: result.id,
-            testRunId: result.test_run_id || 'unknown',
-            testRunName: result.test_run_id
-              ? testRunNamesMap.get(result.test_run_id) || result.test_run_id
-              : 'unknown',
-            passed,
-            passedMetrics,
-            totalMetrics,
-            executedAt: result.created_at || new Date().toISOString(),
-          };
-        });
-
-        // Sort by execution date (most recent first)
-        historicalData.sort(
-          (a, b) =>
-            new Date(b.executedAt).getTime() - new Date(a.executedAt).getTime()
-        );
-
-        // Group by test run - only show one result per test run (the most recent one)
-        const uniqueByTestRun = new Map<string, HistoricalResult>();
-        historicalData.forEach(item => {
-          if (!uniqueByTestRun.has(item.testRunId)) {
-            uniqueByTestRun.set(item.testRunId, item);
-          }
-        });
-
-        // Convert back to array and limit to 10
-        const dedupedHistory = Array.from(uniqueByTestRun.values())
-          .sort(
-            (a, b) =>
-              new Date(b.executedAt).getTime() -
-              new Date(a.executedAt).getTime()
-          )
-          .slice(0, 10);
-
-        setHistory(dedupedHistory);
-        setError(null);
-      } catch (_err) {
-        setError('Failed to load test history');
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchHistory();
-  }, [test.test_id, sessionToken]);
+  const { rows, loading, error } = useTestExecutionHistory({
+    testId: test.test_id,
+    sessionToken,
+  });
 
   if (loading) {
     return (
@@ -182,31 +47,30 @@ export default function TestDetailHistoryTab({
 
   return (
     <Box sx={{ p: 3 }}>
-      {/* Summary Statistics */}
-      {history.length > 0 && (
+      {rows.length > 0 && (
         <Box sx={{ display: 'flex', gap: '26px', mb: 3 }}>
           {[
             {
               label: 'Total Executions',
-              value: history.length,
+              value: rows.length,
               color: '#1a1c20',
             },
             {
               label: 'Pass Rate',
-              value: `${((history.filter(h => h.passed).length / history.length) * 100).toFixed(1)}%`,
+              value: `${((rows.filter(h => h.passed).length / rows.length) * 100).toFixed(1)}%`,
               color:
-                history.filter(h => h.passed).length / history.length >= 0.8
+                rows.filter(h => h.passed).length / rows.length >= 0.8
                   ? '#38ad87'
                   : '#de3355',
             },
             {
               label: 'Passed',
-              value: history.filter(h => h.passed).length,
+              value: rows.filter(h => h.passed).length,
               color: '#38ad87',
             },
             {
               label: 'Failed',
-              value: history.filter(h => !h.passed).length,
+              value: rows.filter(h => !h.passed).length,
               color: '#de3355',
             },
           ].map(stat => (
@@ -248,7 +112,7 @@ export default function TestDetailHistoryTab({
         </Box>
       )}
 
-      {history.length === 0 ? (
+      {rows.length === 0 ? (
         <Box
           sx={{
             bgcolor: 'background.paper',
@@ -264,154 +128,11 @@ export default function TestDetailHistoryTab({
           </Typography>
         </Box>
       ) : (
-        <Box
-          sx={{
-            bgcolor: 'background.paper',
-            borderRadius: '12px',
-            border: '1px solid #cdd2da',
-            boxShadow: '0px 2px 4px rgba(84,90,101,0.25)',
-            overflow: 'hidden',
-          }}
-        >
-          <TableContainer>
-            <Table
-              sx={{
-                '& .MuiTableCell-root': {
-                  borderBottom: '1px solid #cdd2da',
-                  fontSize: 14,
-                  lineHeight: '22px',
-                  py: '13px',
-                  px: '12px',
-                  backgroundColor: '#ffffff',
-                },
-                '& .MuiTableBody-root .MuiTableRow-root:last-child .MuiTableCell-root':
-                  {
-                    borderBottom: 'none',
-                  },
-                '& .MuiTableRow-root:hover .MuiTableCell-root': {
-                  backgroundColor: '#f9fafb',
-                },
-              }}
-            >
-              <TableHead>
-                <TableRow>
-                  <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
-                    Status
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
-                    Test Run
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
-                    Metrics
-                  </TableCell>
-                  <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
-                    Executed At
-                  </TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {history.map(item => (
-                  <TableRow
-                    key={item.id}
-                    sx={{
-                      '&:hover .MuiTableCell-root': {
-                        bgcolor: '#f9fafb',
-                      },
-                    }}
-                  >
-                    <TableCell>
-                      <StatusChip
-                        passed={item.passed}
-                        label={item.passed ? 'Pass' : 'Fail'}
-                        size="small"
-                        variant="outlined"
-                        sx={{
-                          borderColor: item.passed ? '#38ad87' : '#de3355',
-                          color: item.passed ? '#38ad87' : '#de3355',
-                          '& .MuiChip-icon': { color: 'inherit' },
-                        }}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      <Box
-                        sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                      >
-                        {item.testRunId !== 'unknown' ? (
-                          <Link
-                            href={`/test-runs/${item.testRunId}${test.test_id ? `?selectedresult=${test.test_id}` : ''}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            style={{ textDecoration: 'none' }}
-                            onClick={() => {}}
-                          >
-                            <Box
-                              sx={{
-                                display: 'flex',
-                                alignItems: 'center',
-                                gap: 0.5,
-                                '&:hover': {
-                                  '& .test-run-name': {
-                                    color: theme.palette.primary.main,
-                                    textDecoration: 'underline',
-                                  },
-                                },
-                              }}
-                            >
-                              <Typography
-                                className="test-run-name"
-                                sx={{
-                                  fontSize: 14,
-                                  lineHeight: '22px',
-                                  transition: 'color 0.2s',
-                                  color: '#2a2e36',
-                                  fontWeight:
-                                    item.testRunId === testRunId ? 600 : 400,
-                                }}
-                              >
-                                {item.testRunName}
-                              </Typography>
-                              <OpenInNewIcon
-                                sx={{ fontSize: 14, color: 'text.disabled' }}
-                              />
-                            </Box>
-                          </Link>
-                        ) : (
-                          <Typography
-                            sx={{
-                              fontSize: 14,
-                              lineHeight: '22px',
-                              color: '#2a2e36',
-                            }}
-                          >
-                            {item.testRunName}
-                          </Typography>
-                        )}
-                        {item.testRunId === testRunId && (
-                          <Chip
-                            label="Current"
-                            size="small"
-                            variant="outlined"
-                            sx={{
-                              borderColor: '#cdd2da',
-                              color: '#2a2e36',
-                              fontSize: 12,
-                            }}
-                          />
-                        )}
-                      </Box>
-                    </TableCell>
-                    <TableCell sx={{ color: '#2a2e36' }}>
-                      {item.passedMetrics}/{item.totalMetrics} passed
-                    </TableCell>
-                    <TableCell sx={{ color: 'text.secondary' }}>
-                      {formatDate(item.executedAt)}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        </Box>
+        <TestExecutionHistoryTable
+          rows={rows}
+          testId={test.test_id}
+          highlightTestRunId={testRunId}
+        />
       )}
     </Box>
   );

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailHistoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailHistoryTab.tsx
@@ -1,16 +1,26 @@
 'use client';
 
-import React from 'react';
-import { Box, Typography, CircularProgress, Alert } from '@mui/material';
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  CircularProgress,
+  Alert,
+} from '@mui/material';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import TestExecutionHistoryTable from '@/components/tests/TestExecutionHistoryTable';
 import { useTestExecutionHistory } from '@/components/tests/useTestExecutionHistory';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
 
 interface TestDetailHistoryTabProps {
   test: TestResultDetail;
   testRunId: string;
   sessionToken: string;
 }
+
+type StatColor = 'primary' | 'success' | 'error';
 
 export default function TestDetailHistoryTab({
   test,
@@ -21,6 +31,35 @@ export default function TestDetailHistoryTab({
     testId: test.test_id,
     sessionToken,
   });
+
+  const stats = useMemo(() => {
+    const passedCount = rows.filter(h => h.passed).length;
+    const passRate =
+      rows.length > 0 ? (passedCount / rows.length) * 100 : 0;
+
+    return [
+      {
+        label: 'Total Executions',
+        value: rows.length,
+        color: 'primary' as StatColor,
+      },
+      {
+        label: 'Pass Rate',
+        value: `${passRate.toFixed(1)}%`,
+        color: (passRate >= 80 ? 'success' : 'error') as StatColor,
+      },
+      {
+        label: 'Passed',
+        value: passedCount,
+        color: 'success' as StatColor,
+      },
+      {
+        label: 'Failed',
+        value: rows.filter(h => !h.passed).length,
+        color: 'error' as StatColor,
+      },
+    ];
+  }, [rows]);
 
   if (loading) {
     return (
@@ -48,66 +87,46 @@ export default function TestDetailHistoryTab({
   return (
     <Box sx={{ p: 3 }}>
       {rows.length > 0 && (
-        <Box sx={{ display: 'flex', gap: '26px', mb: 3 }}>
-          {[
-            {
-              label: 'Total Executions',
-              value: rows.length,
-              color: '#1a1c20',
-            },
-            {
-              label: 'Pass Rate',
-              value: `${((rows.filter(h => h.passed).length / rows.length) * 100).toFixed(1)}%`,
-              color:
-                rows.filter(h => h.passed).length / rows.length >= 0.8
-                  ? '#38ad87'
-                  : '#de3355',
-            },
-            {
-              label: 'Passed',
-              value: rows.filter(h => h.passed).length,
-              color: '#38ad87',
-            },
-            {
-              label: 'Failed',
-              value: rows.filter(h => !h.passed).length,
-              color: '#de3355',
-            },
-          ].map(stat => (
-            <Box
+        <Box sx={{ display: 'flex', gap: 3, mb: 3 }}>
+          {stats.map(stat => (
+            <Card
               key={stat.label}
               sx={{
                 flex: 1,
-                bgcolor: '#f3f4f6',
-                borderRadius: '10px',
-                boxShadow: '0px 3px 5px rgba(0,0,0,0.09)',
-                p: '30px',
-                height: '140px',
-                display: 'flex',
-                flexDirection: 'column',
-                justifyContent: 'space-between',
+                bgcolor: 'grey.100',
+                borderRadius: BORDER_RADIUS.sm,
+                boxShadow: ELEVATION.xs,
               }}
             >
-              <Typography
+              <CardContent
                 sx={{
-                  fontSize: 12,
-                  lineHeight: '18px',
-                  color: '#1a1c20',
+                  p: 3,
+                  height: 140,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'space-between',
+                  '&:last-child': { pb: 3 },
                 }}
               >
-                {stat.label}
-              </Typography>
-              <Typography
-                sx={{
-                  fontSize: 36,
-                  fontWeight: 700,
-                  lineHeight: 1,
-                  color: stat.color,
-                }}
-              >
-                {stat.value}
-              </Typography>
-            </Box>
+                <Typography variant="caption" color="text.primary">
+                  {stat.label}
+                </Typography>
+                <Typography
+                  variant="h3"
+                  sx={{
+                    fontWeight: 700,
+                    color:
+                      stat.color === 'success'
+                        ? 'success.main'
+                        : stat.color === 'error'
+                          ? 'error.main'
+                          : 'text.primary',
+                  }}
+                >
+                  {stat.value}
+                </Typography>
+              </CardContent>
+            </Card>
           ))}
         </Box>
       )}
@@ -116,9 +135,10 @@ export default function TestDetailHistoryTab({
         <Box
           sx={{
             bgcolor: 'background.paper',
-            borderRadius: '12px',
-            border: '1px solid #cdd2da',
-            boxShadow: '0px 2px 4px rgba(84,90,101,0.25)',
+            borderRadius: BORDER_RADIUS.md,
+            border: 1,
+            borderColor: 'divider',
+            boxShadow: ELEVATION.xs,
             p: 3,
             textAlign: 'center',
           }}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailHistoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailHistoryTab.tsx
@@ -12,7 +12,7 @@ import {
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import TestExecutionHistoryTable from '@/components/tests/TestExecutionHistoryTable';
 import { useTestExecutionHistory } from '@/components/tests/useTestExecutionHistory';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
 
 interface TestDetailHistoryTabProps {
   test: TestResultDetail;
@@ -34,8 +34,7 @@ export default function TestDetailHistoryTab({
 
   const stats = useMemo(() => {
     const passedCount = rows.filter(h => h.passed).length;
-    const passRate =
-      rows.length > 0 ? (passedCount / rows.length) * 100 : 0;
+    const passRate = rows.length > 0 ? (passedCount / rows.length) * 100 : 0;
 
     return [
       {
@@ -91,11 +90,12 @@ export default function TestDetailHistoryTab({
           {stats.map(stat => (
             <Card
               key={stat.label}
+              elevation={0}
               sx={{
                 flex: 1,
                 bgcolor: 'grey.100',
                 borderRadius: BORDER_RADIUS.sm,
-                boxShadow: ELEVATION.xs,
+                boxShadow: 'none',
               }}
             >
               <CardContent
@@ -132,26 +132,13 @@ export default function TestDetailHistoryTab({
       )}
 
       {rows.length === 0 ? (
-        <Box
-          sx={{
-            bgcolor: 'background.paper',
-            borderRadius: BORDER_RADIUS.md,
-            border: 1,
-            borderColor: 'divider',
-            boxShadow: ELEVATION.xs,
-            p: 3,
-            textAlign: 'center',
-          }}
-        >
+        <Box sx={{ py: 3, textAlign: 'center' }}>
           <Typography variant="body2" color="text.secondary">
             No historical data available for this test
           </Typography>
         </Box>
       ) : (
-        <TestExecutionHistoryTable
-          rows={rows}
-          highlightTestRunId={testRunId}
-        />
+        <TestExecutionHistoryTable rows={rows} highlightTestRunId={testRunId} />
       )}
     </Box>
   );

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailHistoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailHistoryTab.tsx
@@ -150,7 +150,6 @@ export default function TestDetailHistoryTab({
       ) : (
         <TestExecutionHistoryTable
           rows={rows}
-          testId={test.test_id}
           highlightTestRunId={testRunId}
         />
       )}

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestDetailTabs.tsx
@@ -9,11 +9,12 @@ import { useRouter } from 'next/navigation';
 import { TestDetail } from '@/utils/api-client/interfaces/tests';
 import { TasksAndCommentsWrapper } from '@/components/tasks/TasksAndCommentsWrapper';
 import LinkedTestSetsSection from '@/components/tests/LinkedTestSetsSection';
+import TestExecutionHistorySection from '@/components/tests/TestExecutionHistorySection';
 import TestMetadataCard from './TestMetadataCard';
 import TestTechnicalCard from './TestTechnicalCard';
 import TestFormElementsCard from './TestFormElementsCard';
 
-const TAB_KEYS = ['basic', 'linked', 'tasks'] as const;
+const TAB_KEYS = ['basic', 'linked', 'history', 'tasks'] as const;
 
 interface TestDetailTabsProps {
   test: TestDetail;
@@ -40,7 +41,9 @@ export default function TestDetailTabs({
         ? 'Overview'
         : key === 'linked'
           ? 'Linked Test Sets'
-          : 'Tasks',
+          : key === 'history'
+            ? 'Execution History'
+            : 'Tasks',
     id: `test-detail-tab-${index}`,
     'aria-controls': `test-detail-tabpanel-${index}`,
   }));
@@ -81,6 +84,13 @@ export default function TestDetailTabs({
       </DetailTabPanel>
 
       <DetailTabPanel value={activeTab} index={2} prefix="test-detail">
+        <TestExecutionHistorySection
+          testId={test.id}
+          sessionToken={sessionToken}
+        />
+      </DetailTabPanel>
+
+      <DetailTabPanel value={activeTab} index={3} prefix="test-detail">
         <TasksAndCommentsWrapper
           entityType="Test"
           entityId={test.id}

--- a/apps/frontend/src/components/tests/TestExecutionHistorySection.tsx
+++ b/apps/frontend/src/components/tests/TestExecutionHistorySection.tsx
@@ -1,14 +1,7 @@
 'use client';
 
-import React, { useMemo, useState } from 'react';
-import {
-  Alert,
-  Box,
-  CircularProgress,
-  Paper,
-  TablePagination,
-  Typography,
-} from '@mui/material';
+import React from 'react';
+import { Alert, Box, CircularProgress, Paper, Typography } from '@mui/material';
 import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
 import EntityEmptyState from '@/components/common/EntityEmptyState';
 import TestExecutionHistoryTable from './TestExecutionHistoryTable';
@@ -19,8 +12,6 @@ interface TestExecutionHistorySectionProps {
   sessionToken: string;
 }
 
-const PAGE_SIZE_OPTIONS = [10, 25, 50];
-
 export default function TestExecutionHistorySection({
   testId,
   sessionToken,
@@ -29,13 +20,6 @@ export default function TestExecutionHistorySection({
     testId,
     sessionToken,
   });
-  const [page, setPage] = useState(0);
-  const [rowsPerPage, setRowsPerPage] = useState(10);
-
-  const paginatedRows = useMemo(() => {
-    const start = page * rowsPerPage;
-    return rows.slice(start, start + rowsPerPage);
-  }, [rows, page, rowsPerPage]);
 
   if (loading) {
     return (
@@ -90,24 +74,7 @@ export default function TestExecutionHistorySection({
         Execution History ({rows.length})
       </Typography>
 
-      <TestExecutionHistoryTable rows={paginatedRows} />
-
-      {rows.length > PAGE_SIZE_OPTIONS[0] && (
-        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-          <TablePagination
-            component="div"
-            count={rows.length}
-            page={page}
-            onPageChange={(_, newPage) => setPage(newPage)}
-            rowsPerPage={rowsPerPage}
-            onRowsPerPageChange={event => {
-              setRowsPerPage(parseInt(event.target.value, 10));
-              setPage(0);
-            }}
-            rowsPerPageOptions={PAGE_SIZE_OPTIONS}
-          />
-        </Box>
-      )}
+      <TestExecutionHistoryTable rows={rows} />
     </Paper>
   );
 }

--- a/apps/frontend/src/components/tests/TestExecutionHistorySection.tsx
+++ b/apps/frontend/src/components/tests/TestExecutionHistorySection.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  CircularProgress,
+  Paper,
+  TablePagination,
+  Typography,
+} from '@mui/material';
+import HistoryOutlinedIcon from '@mui/icons-material/HistoryOutlined';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import TestExecutionHistoryTable from './TestExecutionHistoryTable';
+import { useTestExecutionHistory } from './useTestExecutionHistory';
+
+interface TestExecutionHistorySectionProps {
+  testId: string;
+  sessionToken: string;
+}
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50];
+
+export default function TestExecutionHistorySection({
+  testId,
+  sessionToken,
+}: TestExecutionHistorySectionProps) {
+  const { rows, loading, error } = useTestExecutionHistory({
+    testId,
+    sessionToken,
+  });
+  const [page, setPage] = useState(0);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
+
+  const paginatedRows = useMemo(() => {
+    const start = page * rowsPerPage;
+    return rows.slice(start, start + rowsPerPage);
+  }, [rows, page, rowsPerPage]);
+
+  if (loading) {
+    return (
+      <Paper
+        elevation={0}
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          py: 8,
+          border: 1,
+          borderColor: 'divider',
+          borderRadius: 2,
+        }}
+      >
+        <CircularProgress />
+      </Paper>
+    );
+  }
+
+  if (error) {
+    return (
+      <Paper
+        elevation={0}
+        sx={{ p: 3, border: 1, borderColor: 'divider', borderRadius: 2 }}
+      >
+        <Alert severity="error">{error}</Alert>
+      </Paper>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <EntityEmptyState
+        card
+        icon={HistoryOutlinedIcon}
+        title="No executions yet"
+        description="This test hasn't been run yet. Run it as part of a test set to see execution history here."
+      />
+    );
+  }
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{ p: 3, border: 1, borderColor: 'divider', borderRadius: 2 }}
+    >
+      <Typography
+        variant="h6"
+        sx={{ fontWeight: 600, color: 'primary.main', mb: 2 }}
+      >
+        Execution History ({rows.length})
+      </Typography>
+
+      <TestExecutionHistoryTable rows={paginatedRows} testId={testId} />
+
+      {rows.length > PAGE_SIZE_OPTIONS[0] && (
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <TablePagination
+            component="div"
+            count={rows.length}
+            page={page}
+            onPageChange={(_, newPage) => setPage(newPage)}
+            rowsPerPage={rowsPerPage}
+            onRowsPerPageChange={event => {
+              setRowsPerPage(parseInt(event.target.value, 10));
+              setPage(0);
+            }}
+            rowsPerPageOptions={PAGE_SIZE_OPTIONS}
+          />
+        </Box>
+      )}
+    </Paper>
+  );
+}

--- a/apps/frontend/src/components/tests/TestExecutionHistorySection.tsx
+++ b/apps/frontend/src/components/tests/TestExecutionHistorySection.tsx
@@ -90,7 +90,7 @@ export default function TestExecutionHistorySection({
         Execution History ({rows.length})
       </Typography>
 
-      <TestExecutionHistoryTable rows={paginatedRows} testId={testId} />
+      <TestExecutionHistoryTable rows={paginatedRows} />
 
       {rows.length > PAGE_SIZE_OPTIONS[0] && (
         <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>

--- a/apps/frontend/src/components/tests/TestExecutionHistoryTable.tsx
+++ b/apps/frontend/src/components/tests/TestExecutionHistoryTable.tsx
@@ -17,6 +17,7 @@ import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import Link from 'next/link';
 import { formatDate } from '@/utils/date';
 import StatusChip from '@/components/common/StatusChip';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
 import { TestExecutionHistoryRow } from './test-execution-history';
 
 interface TestExecutionHistoryTableProps {
@@ -36,9 +37,10 @@ export default function TestExecutionHistoryTable({
     <Box
       sx={{
         bgcolor: 'background.paper',
-        borderRadius: '12px',
-        border: '1px solid #cdd2da',
-        boxShadow: '0px 2px 4px rgba(84,90,101,0.25)',
+        borderRadius: BORDER_RADIUS.md,
+        border: 1,
+        borderColor: 'divider',
+        boxShadow: ELEVATION.xs,
         overflow: 'hidden',
       }}
     >
@@ -46,34 +48,35 @@ export default function TestExecutionHistoryTable({
         <Table
           sx={{
             '& .MuiTableCell-root': {
-              borderBottom: '1px solid #cdd2da',
+              borderBottom: 1,
+              borderColor: 'divider',
               fontSize: 14,
               lineHeight: '22px',
               py: '13px',
               px: '12px',
-              backgroundColor: '#ffffff',
+              bgcolor: 'background.paper',
             },
             '& .MuiTableBody-root .MuiTableRow-root:last-child .MuiTableCell-root':
               {
                 borderBottom: 'none',
               },
             '& .MuiTableRow-root:hover .MuiTableCell-root': {
-              backgroundColor: '#f9fafb',
+              bgcolor: 'action.hover',
             },
           }}
         >
           <TableHead>
             <TableRow>
-              <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
+              <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>
                 Status
               </TableCell>
-              <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
+              <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>
                 Test Run
               </TableCell>
-              <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
+              <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>
                 Metrics
               </TableCell>
-              <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
+              <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>
                 Executed At
               </TableCell>
             </TableRow>
@@ -87,11 +90,6 @@ export default function TestExecutionHistoryTable({
                     label={item.passed ? 'Pass' : 'Fail'}
                     size="small"
                     variant="outlined"
-                    sx={{
-                      borderColor: item.passed ? '#38ad87' : '#de3355',
-                      color: item.passed ? '#38ad87' : '#de3355',
-                      '& .MuiChip-icon': { color: 'inherit' },
-                    }}
                   />
                 </TableCell>
                 <TableCell>
@@ -120,7 +118,7 @@ export default function TestExecutionHistoryTable({
                               fontSize: 14,
                               lineHeight: '22px',
                               transition: 'color 0.2s',
-                              color: '#2a2e36',
+                              color: 'text.primary',
                               fontWeight:
                                 item.testRunId === highlightTestRunId
                                   ? 600
@@ -139,7 +137,7 @@ export default function TestExecutionHistoryTable({
                         sx={{
                           fontSize: 14,
                           lineHeight: '22px',
-                          color: '#2a2e36',
+                          color: 'text.primary',
                         }}
                       >
                         {item.testRunName}
@@ -152,15 +150,15 @@ export default function TestExecutionHistoryTable({
                           size="small"
                           variant="outlined"
                           sx={{
-                            borderColor: '#cdd2da',
-                            color: '#2a2e36',
+                            borderColor: 'divider',
+                            color: 'text.primary',
                             fontSize: 12,
                           }}
                         />
                       )}
                   </Box>
                 </TableCell>
-                <TableCell sx={{ color: '#2a2e36' }}>
+                <TableCell sx={{ color: 'text.primary' }}>
                   {item.passedMetrics}/{item.totalMetrics} passed
                 </TableCell>
                 <TableCell sx={{ color: 'text.secondary' }}>

--- a/apps/frontend/src/components/tests/TestExecutionHistoryTable.tsx
+++ b/apps/frontend/src/components/tests/TestExecutionHistoryTable.tsx
@@ -22,13 +22,11 @@ import { TestExecutionHistoryRow } from './test-execution-history';
 
 interface TestExecutionHistoryTableProps {
   rows: TestExecutionHistoryRow[];
-  testId?: string;
   highlightTestRunId?: string;
 }
 
 export default function TestExecutionHistoryTable({
   rows,
-  testId,
   highlightTestRunId,
 }: TestExecutionHistoryTableProps) {
   const theme = useTheme();
@@ -96,7 +94,7 @@ export default function TestExecutionHistoryTable({
                   <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
                     {item.testRunId !== 'unknown' ? (
                       <Link
-                        href={`/test-runs/${item.testRunId}${testId ? `?selectedresult=${testId}` : ''}`}
+                        href={`/test-runs/${item.testRunId}?selectedresult=${item.id}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         style={{ textDecoration: 'none' }}

--- a/apps/frontend/src/components/tests/TestExecutionHistoryTable.tsx
+++ b/apps/frontend/src/components/tests/TestExecutionHistoryTable.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import React from 'react';
+import {
+  Box,
+  Chip,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import Link from 'next/link';
+import { formatDate } from '@/utils/date';
+import StatusChip from '@/components/common/StatusChip';
+import { TestExecutionHistoryRow } from './test-execution-history';
+
+interface TestExecutionHistoryTableProps {
+  rows: TestExecutionHistoryRow[];
+  testId?: string;
+  highlightTestRunId?: string;
+}
+
+export default function TestExecutionHistoryTable({
+  rows,
+  testId,
+  highlightTestRunId,
+}: TestExecutionHistoryTableProps) {
+  const theme = useTheme();
+
+  return (
+    <Box
+      sx={{
+        bgcolor: 'background.paper',
+        borderRadius: '12px',
+        border: '1px solid #cdd2da',
+        boxShadow: '0px 2px 4px rgba(84,90,101,0.25)',
+        overflow: 'hidden',
+      }}
+    >
+      <TableContainer>
+        <Table
+          sx={{
+            '& .MuiTableCell-root': {
+              borderBottom: '1px solid #cdd2da',
+              fontSize: 14,
+              lineHeight: '22px',
+              py: '13px',
+              px: '12px',
+              backgroundColor: '#ffffff',
+            },
+            '& .MuiTableBody-root .MuiTableRow-root:last-child .MuiTableCell-root':
+              {
+                borderBottom: 'none',
+              },
+            '& .MuiTableRow-root:hover .MuiTableCell-root': {
+              backgroundColor: '#f9fafb',
+            },
+          }}
+        >
+          <TableHead>
+            <TableRow>
+              <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
+                Status
+              </TableCell>
+              <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
+                Test Run
+              </TableCell>
+              <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
+                Metrics
+              </TableCell>
+              <TableCell sx={{ fontWeight: 700, color: '#2a2e36' }}>
+                Executed At
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {rows.map(item => (
+              <TableRow key={item.id}>
+                <TableCell>
+                  <StatusChip
+                    passed={item.passed}
+                    label={item.passed ? 'Pass' : 'Fail'}
+                    size="small"
+                    variant="outlined"
+                    sx={{
+                      borderColor: item.passed ? '#38ad87' : '#de3355',
+                      color: item.passed ? '#38ad87' : '#de3355',
+                      '& .MuiChip-icon': { color: 'inherit' },
+                    }}
+                  />
+                </TableCell>
+                <TableCell>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    {item.testRunId !== 'unknown' ? (
+                      <Link
+                        href={`/test-runs/${item.testRunId}${testId ? `?selectedresult=${testId}` : ''}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{ textDecoration: 'none' }}
+                      >
+                        <Box
+                          sx={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 0.5,
+                            '&:hover .test-run-name': {
+                              color: theme.palette.primary.main,
+                              textDecoration: 'underline',
+                            },
+                          }}
+                        >
+                          <Typography
+                            className="test-run-name"
+                            sx={{
+                              fontSize: 14,
+                              lineHeight: '22px',
+                              transition: 'color 0.2s',
+                              color: '#2a2e36',
+                              fontWeight:
+                                item.testRunId === highlightTestRunId
+                                  ? 600
+                                  : 400,
+                            }}
+                          >
+                            {item.testRunName}
+                          </Typography>
+                          <OpenInNewIcon
+                            sx={{ fontSize: 14, color: 'text.disabled' }}
+                          />
+                        </Box>
+                      </Link>
+                    ) : (
+                      <Typography
+                        sx={{
+                          fontSize: 14,
+                          lineHeight: '22px',
+                          color: '#2a2e36',
+                        }}
+                      >
+                        {item.testRunName}
+                      </Typography>
+                    )}
+                    {highlightTestRunId &&
+                      item.testRunId === highlightTestRunId && (
+                        <Chip
+                          label="Current"
+                          size="small"
+                          variant="outlined"
+                          sx={{
+                            borderColor: '#cdd2da',
+                            color: '#2a2e36',
+                            fontSize: 12,
+                          }}
+                        />
+                      )}
+                  </Box>
+                </TableCell>
+                <TableCell sx={{ color: '#2a2e36' }}>
+                  {item.passedMetrics}/{item.totalMetrics} passed
+                </TableCell>
+                <TableCell sx={{ color: 'text.secondary' }}>
+                  {formatDate(item.executedAt)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/tests/TestExecutionHistoryTable.tsx
+++ b/apps/frontend/src/components/tests/TestExecutionHistoryTable.tsx
@@ -1,23 +1,13 @@
 'use client';
 
-import React from 'react';
-import {
-  Box,
-  Chip,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TableRow,
-  Typography,
-  useTheme,
-} from '@mui/material';
+import React, { useMemo } from 'react';
+import { Box, Chip, Typography, useTheme } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import Link from 'next/link';
+import { GridColDef } from '@mui/x-data-grid';
+import BaseDataGrid from '@/components/common/BaseDataGrid';
 import { formatDate } from '@/utils/date';
 import StatusChip from '@/components/common/StatusChip';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
 import { TestExecutionHistoryRow } from './test-execution-history';
 
 interface TestExecutionHistoryTableProps {
@@ -31,142 +21,130 @@ export default function TestExecutionHistoryTable({
 }: TestExecutionHistoryTableProps) {
   const theme = useTheme();
 
-  return (
-    <Box
-      sx={{
-        bgcolor: 'background.paper',
-        borderRadius: BORDER_RADIUS.md,
-        border: 1,
-        borderColor: 'divider',
-        boxShadow: ELEVATION.xs,
-        overflow: 'hidden',
-      }}
-    >
-      <TableContainer>
-        <Table
-          sx={{
-            '& .MuiTableCell-root': {
-              borderBottom: 1,
-              borderColor: 'divider',
-              fontSize: 14,
-              lineHeight: '22px',
-              py: '13px',
-              px: '12px',
-              bgcolor: 'background.paper',
-            },
-            '& .MuiTableBody-root .MuiTableRow-root:last-child .MuiTableCell-root':
-              {
-                borderBottom: 'none',
-              },
-            '& .MuiTableRow-root:hover .MuiTableCell-root': {
-              bgcolor: 'action.hover',
-            },
-          }}
-        >
-          <TableHead>
-            <TableRow>
-              <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>
-                Status
-              </TableCell>
-              <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>
-                Test Run
-              </TableCell>
-              <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>
-                Metrics
-              </TableCell>
-              <TableCell sx={{ fontWeight: 700, color: 'text.primary' }}>
-                Executed At
-              </TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            {rows.map(item => (
-              <TableRow key={item.id}>
-                <TableCell>
-                  <StatusChip
-                    passed={item.passed}
-                    label={item.passed ? 'Pass' : 'Fail'}
-                    size="small"
-                    variant="outlined"
-                  />
-                </TableCell>
-                <TableCell>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    {item.testRunId !== 'unknown' ? (
-                      <Link
-                        href={`/test-runs/${item.testRunId}?selectedresult=${item.id}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={{ textDecoration: 'none' }}
-                      >
-                        <Box
-                          sx={{
-                            display: 'flex',
-                            alignItems: 'center',
-                            gap: 0.5,
-                            '&:hover .test-run-name': {
-                              color: theme.palette.primary.main,
-                              textDecoration: 'underline',
-                            },
-                          }}
-                        >
-                          <Typography
-                            className="test-run-name"
-                            sx={{
-                              fontSize: 14,
-                              lineHeight: '22px',
-                              transition: 'color 0.2s',
-                              color: 'text.primary',
-                              fontWeight:
-                                item.testRunId === highlightTestRunId
-                                  ? 600
-                                  : 400,
-                            }}
-                          >
-                            {item.testRunName}
-                          </Typography>
-                          <OpenInNewIcon
-                            sx={{ fontSize: 14, color: 'text.disabled' }}
-                          />
-                        </Box>
-                      </Link>
-                    ) : (
-                      <Typography
-                        sx={{
-                          fontSize: 14,
-                          lineHeight: '22px',
-                          color: 'text.primary',
-                        }}
-                      >
-                        {item.testRunName}
-                      </Typography>
-                    )}
-                    {highlightTestRunId &&
-                      item.testRunId === highlightTestRunId && (
-                        <Chip
-                          label="Current"
-                          size="small"
-                          variant="outlined"
-                          sx={{
-                            borderColor: 'divider',
-                            color: 'text.primary',
-                            fontSize: 12,
-                          }}
-                        />
-                      )}
+  const columns = useMemo<GridColDef[]>(
+    () => [
+      {
+        field: 'passed',
+        headerName: 'Status',
+        width: 120,
+        sortable: false,
+        renderCell: params => (
+          <StatusChip
+            passed={params.row.passed}
+            label={params.row.passed ? 'Pass' : 'Fail'}
+            size="small"
+            variant="outlined"
+          />
+        ),
+      },
+      {
+        field: 'testRunName',
+        headerName: 'Test Run',
+        flex: 1,
+        minWidth: 220,
+        sortable: false,
+        renderCell: params => {
+          const item = params.row as TestExecutionHistoryRow;
+
+          return (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              {item.testRunId !== 'unknown' ? (
+                <Link
+                  href={`/test-runs/${item.testRunId}?selectedresult=${item.id}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ textDecoration: 'none' }}
+                >
+                  <Box
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 0.5,
+                      '&:hover .test-run-name': {
+                        color: theme.palette.primary.main,
+                        textDecoration: 'underline',
+                      },
+                    }}
+                  >
+                    <Typography
+                      className="test-run-name"
+                      variant="body2"
+                      sx={{
+                        transition: 'color 0.2s',
+                        color: 'text.primary',
+                        fontWeight:
+                          item.testRunId === highlightTestRunId ? 600 : 400,
+                      }}
+                    >
+                      {item.testRunName}
+                    </Typography>
+                    <OpenInNewIcon
+                      sx={{ fontSize: 14, color: 'text.disabled' }}
+                    />
                   </Box>
-                </TableCell>
-                <TableCell sx={{ color: 'text.primary' }}>
-                  {item.passedMetrics}/{item.totalMetrics} passed
-                </TableCell>
-                <TableCell sx={{ color: 'text.secondary' }}>
-                  {formatDate(item.executedAt)}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </Box>
+                </Link>
+              ) : (
+                <Typography variant="body2" color="text.primary">
+                  {item.testRunName}
+                </Typography>
+              )}
+              {highlightTestRunId && item.testRunId === highlightTestRunId && (
+                <Chip
+                  label="Current"
+                  size="small"
+                  variant="outlined"
+                  sx={{
+                    borderColor: 'divider',
+                    color: 'text.primary',
+                    fontSize: 12,
+                  }}
+                />
+              )}
+            </Box>
+          );
+        },
+      },
+      {
+        field: 'metrics',
+        headerName: 'Metrics',
+        width: 140,
+        sortable: false,
+        renderCell: params => {
+          const item = params.row as TestExecutionHistoryRow;
+          return (
+            <Typography variant="body2" color="text.primary">
+              {item.passedMetrics}/{item.totalMetrics} passed
+            </Typography>
+          );
+        },
+      },
+      {
+        field: 'executedAt',
+        headerName: 'Executed At',
+        width: 200,
+        sortable: false,
+        renderCell: params => (
+          <Typography variant="body2" color="text.secondary">
+            {formatDate(params.row.executedAt)}
+          </Typography>
+        ),
+      },
+    ],
+    [highlightTestRunId, theme.palette.primary.main]
+  );
+
+  return (
+    <BaseDataGrid
+      rows={rows}
+      columns={columns}
+      getRowId={row => row.id}
+      disableRowSelectionOnClick
+      showToolbar={false}
+      disablePaperWrapper
+      pageSizeOptions={[10, 25, 50]}
+      initialState={{
+        pagination: { paginationModel: { pageSize: 10, page: 0 } },
+      }}
+    />
   );
 }

--- a/apps/frontend/src/components/tests/__tests__/test-execution-history.test.ts
+++ b/apps/frontend/src/components/tests/__tests__/test-execution-history.test.ts
@@ -45,6 +45,23 @@ describe('mapTestResultToHistoryRow', () => {
     expect(row.testRunName).toBe('spinning-caracal');
   });
 
+  it('prefers expanded test_run name over lookup map', () => {
+    const result = {
+      id: 'result-1',
+      test_run_id: 'run-1',
+      test_run: { id: 'run-1', name: 'embedded-run-name' },
+      created_at: '2026-07-01T10:00:00Z',
+      test_metrics: { metrics: {} },
+    } as TestResultDetail;
+
+    const row = mapTestResultToHistoryRow(
+      result,
+      new Map([['run-1', 'map-name']])
+    );
+
+    expect(row.testRunName).toBe('embedded-run-name');
+  });
+
   it('computes fail when any metric fails', () => {
     const result = {
       id: 'result-2',

--- a/apps/frontend/src/components/tests/__tests__/test-execution-history.test.ts
+++ b/apps/frontend/src/components/tests/__tests__/test-execution-history.test.ts
@@ -23,20 +23,23 @@ function makeRow(
 describe('mapTestResultToHistoryRow', () => {
   it('computes pass when all metrics succeed', () => {
     const result = {
-      id: 'result-1',
-      test_run_id: 'run-1',
+      id: 'a1111111-1111-4111-8111-111111111111',
+      test_run_id: 'b1111111-1111-4111-8111-111111111111',
+      updated_at: '2026-07-01T10:00:00Z',
+      test_configuration_id: 'c1111111-1111-4111-8111-111111111111',
       created_at: '2026-07-01T10:00:00Z',
       test_metrics: {
         metrics: {
           a: { is_successful: true },
           b: { is_successful: true },
         },
+        execution_time: 1,
       },
-    } as TestResultDetail;
+    } as unknown as TestResultDetail;
 
     const row = mapTestResultToHistoryRow(
       result,
-      new Map([['run-1', 'spinning-caracal']])
+      new Map([['b1111111-1111-4111-8111-111111111111', 'spinning-caracal']])
     );
 
     expect(row.passed).toBe(true);
@@ -47,16 +50,21 @@ describe('mapTestResultToHistoryRow', () => {
 
   it('prefers expanded test_run name over lookup map', () => {
     const result = {
-      id: 'result-1',
-      test_run_id: 'run-1',
-      test_run: { id: 'run-1', name: 'embedded-run-name' },
+      id: 'a1111111-1111-4111-8111-111111111111',
+      test_run_id: 'b1111111-1111-4111-8111-111111111111',
+      test_run: {
+        id: 'b1111111-1111-4111-8111-111111111111',
+        name: 'embedded-run-name',
+      },
+      updated_at: '2026-07-01T10:00:00Z',
+      test_configuration_id: 'c1111111-1111-4111-8111-111111111111',
       created_at: '2026-07-01T10:00:00Z',
-      test_metrics: { metrics: {} },
-    } as TestResultDetail;
+      test_metrics: { metrics: {}, execution_time: 0 },
+    } as unknown as TestResultDetail;
 
     const row = mapTestResultToHistoryRow(
       result,
-      new Map([['run-1', 'map-name']])
+      new Map([['b1111111-1111-4111-8111-111111111111', 'map-name']])
     );
 
     expect(row.testRunName).toBe('embedded-run-name');
@@ -64,16 +72,19 @@ describe('mapTestResultToHistoryRow', () => {
 
   it('computes fail when any metric fails', () => {
     const result = {
-      id: 'result-2',
-      test_run_id: 'run-2',
+      id: 'd2222222-2222-4222-8222-222222222222',
+      test_run_id: 'e2222222-2222-4222-8222-222222222222',
+      updated_at: '2026-07-02T10:00:00Z',
+      test_configuration_id: 'c1111111-1111-4111-8111-111111111111',
       created_at: '2026-07-02T10:00:00Z',
       test_metrics: {
         metrics: {
           a: { is_successful: true },
           b: { is_successful: false },
         },
+        execution_time: 1,
       },
-    } as TestResultDetail;
+    } as unknown as TestResultDetail;
 
     const row = mapTestResultToHistoryRow(result, new Map());
 

--- a/apps/frontend/src/components/tests/__tests__/test-execution-history.test.ts
+++ b/apps/frontend/src/components/tests/__tests__/test-execution-history.test.ts
@@ -1,0 +1,94 @@
+import {
+  dedupeHistoryByTestRun,
+  mapTestResultToHistoryRow,
+  TestExecutionHistoryRow,
+} from '../test-execution-history';
+import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+
+function makeRow(
+  overrides: Partial<TestExecutionHistoryRow>
+): TestExecutionHistoryRow {
+  return {
+    id: 'result-1',
+    testRunId: 'run-1',
+    testRunName: 'run-one',
+    passed: true,
+    passedMetrics: 2,
+    totalMetrics: 2,
+    executedAt: '2026-07-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('mapTestResultToHistoryRow', () => {
+  it('computes pass when all metrics succeed', () => {
+    const result = {
+      id: 'result-1',
+      test_run_id: 'run-1',
+      created_at: '2026-07-01T10:00:00Z',
+      test_metrics: {
+        metrics: {
+          a: { is_successful: true },
+          b: { is_successful: true },
+        },
+      },
+    } as TestResultDetail;
+
+    const row = mapTestResultToHistoryRow(
+      result,
+      new Map([['run-1', 'spinning-caracal']])
+    );
+
+    expect(row.passed).toBe(true);
+    expect(row.passedMetrics).toBe(2);
+    expect(row.totalMetrics).toBe(2);
+    expect(row.testRunName).toBe('spinning-caracal');
+  });
+
+  it('computes fail when any metric fails', () => {
+    const result = {
+      id: 'result-2',
+      test_run_id: 'run-2',
+      created_at: '2026-07-02T10:00:00Z',
+      test_metrics: {
+        metrics: {
+          a: { is_successful: true },
+          b: { is_successful: false },
+        },
+      },
+    } as TestResultDetail;
+
+    const row = mapTestResultToHistoryRow(result, new Map());
+
+    expect(row.passed).toBe(false);
+    expect(row.passedMetrics).toBe(1);
+    expect(row.totalMetrics).toBe(2);
+  });
+});
+
+describe('dedupeHistoryByTestRun', () => {
+  it('keeps the most recent result per test run', () => {
+    const rows = [
+      makeRow({
+        id: 'older',
+        testRunId: 'run-1',
+        executedAt: '2026-07-01T10:00:00Z',
+      }),
+      makeRow({
+        id: 'newer',
+        testRunId: 'run-1',
+        executedAt: '2026-07-06T10:00:00Z',
+      }),
+      makeRow({
+        id: 'other-run',
+        testRunId: 'run-2',
+        executedAt: '2026-07-05T10:00:00Z',
+      }),
+    ];
+
+    const deduped = dedupeHistoryByTestRun(rows);
+
+    expect(deduped).toHaveLength(2);
+    expect(deduped.map(row => row.id)).toEqual(['newer', 'other-run']);
+  });
+});

--- a/apps/frontend/src/components/tests/test-execution-history.ts
+++ b/apps/frontend/src/components/tests/test-execution-history.ts
@@ -24,7 +24,9 @@ export function mapTestResultToHistoryRow(
     id: result.id,
     testRunId: result.test_run_id || 'unknown',
     testRunName: result.test_run_id
-      ? testRunNamesMap.get(result.test_run_id) || result.test_run_id
+      ? result.test_run?.name ||
+        testRunNamesMap.get(result.test_run_id) ||
+        result.test_run_id
       : 'unknown',
     passed,
     passedMetrics,

--- a/apps/frontend/src/components/tests/test-execution-history.ts
+++ b/apps/frontend/src/components/tests/test-execution-history.ts
@@ -1,0 +1,55 @@
+import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
+
+export interface TestExecutionHistoryRow {
+  id: string;
+  testRunId: string;
+  testRunName: string;
+  passed: boolean;
+  passedMetrics: number;
+  totalMetrics: number;
+  executedAt: string;
+}
+
+export function mapTestResultToHistoryRow(
+  result: TestResultDetail,
+  testRunNamesMap: Map<string, string>
+): TestExecutionHistoryRow {
+  const metrics = result.test_metrics?.metrics || {};
+  const metricValues = Object.values(metrics);
+  const passedMetrics = metricValues.filter(m => m.is_successful).length;
+  const totalMetrics = metricValues.length;
+  const passed = totalMetrics > 0 && passedMetrics === totalMetrics;
+
+  return {
+    id: result.id,
+    testRunId: result.test_run_id || 'unknown',
+    testRunName: result.test_run_id
+      ? testRunNamesMap.get(result.test_run_id) || result.test_run_id
+      : 'unknown',
+    passed,
+    passedMetrics,
+    totalMetrics,
+    executedAt: result.created_at || new Date().toISOString(),
+  };
+}
+
+export function dedupeHistoryByTestRun(
+  rows: TestExecutionHistoryRow[]
+): TestExecutionHistoryRow[] {
+  const sorted = [...rows].sort(
+    (a, b) =>
+      new Date(b.executedAt).getTime() - new Date(a.executedAt).getTime()
+  );
+
+  const uniqueByTestRun = new Map<string, TestExecutionHistoryRow>();
+  sorted.forEach(item => {
+    if (!uniqueByTestRun.has(item.testRunId)) {
+      uniqueByTestRun.set(item.testRunId, item);
+    }
+  });
+
+  return Array.from(uniqueByTestRun.values()).sort(
+    (a, b) =>
+      new Date(b.executedAt).getTime() - new Date(a.executedAt).getTime()
+  );
+}

--- a/apps/frontend/src/components/tests/useTestExecutionHistory.ts
+++ b/apps/frontend/src/components/tests/useTestExecutionHistory.ts
@@ -8,7 +8,7 @@ import {
   TestExecutionHistoryRow,
 } from './test-execution-history';
 
-const MAX_RESULTS = 500;
+const MAX_RESULTS = 100;
 
 interface UseTestExecutionHistoryOptions {
   testId: string | undefined;

--- a/apps/frontend/src/components/tests/useTestExecutionHistory.ts
+++ b/apps/frontend/src/components/tests/useTestExecutionHistory.ts
@@ -1,0 +1,124 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import {
+  dedupeHistoryByTestRun,
+  mapTestResultToHistoryRow,
+  TestExecutionHistoryRow,
+} from './test-execution-history';
+
+const MAX_RESULTS = 500;
+
+interface UseTestExecutionHistoryOptions {
+  testId: string | undefined;
+  sessionToken: string;
+  enabled?: boolean;
+}
+
+interface UseTestExecutionHistoryResult {
+  rows: TestExecutionHistoryRow[];
+  loading: boolean;
+  error: string | null;
+  refetch: () => void;
+}
+
+export function useTestExecutionHistory({
+  testId,
+  sessionToken,
+  enabled = true,
+}: UseTestExecutionHistoryOptions): UseTestExecutionHistoryResult {
+  const [rows, setRows] = useState<TestExecutionHistoryRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [fetchKey, setFetchKey] = useState(0);
+
+  const refetch = useCallback(() => {
+    setFetchKey(key => key + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
+
+    if (!testId) {
+      setError('No test ID available');
+      setRows([]);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchHistory() {
+      try {
+        setLoading(true);
+        const clientFactory = new ApiClientFactory(sessionToken);
+        const testResultsClient = clientFactory.getTestResultsClient();
+
+        const results = await testResultsClient.getTestResults({
+          filter: `test_id eq '${testId}'`,
+          limit: MAX_RESULTS,
+          skip: 0,
+          sort_by: 'created_at',
+          sort_order: 'desc',
+        });
+
+        if (cancelled) return;
+
+        const testRunIds = [
+          ...new Set(
+            results.data
+              .filter(
+                (r): r is typeof r & { test_run_id: string } => !!r.test_run_id
+              )
+              .map(r => r.test_run_id)
+          ),
+        ];
+
+        const testRunsClient = clientFactory.getTestRunsClient();
+        const testRunsData = await Promise.allSettled(
+          testRunIds.map(id => testRunsClient.getTestRun(id))
+        );
+
+        if (cancelled) return;
+
+        const testRunNamesMap = new Map<string, string>();
+        testRunsData.forEach((result, index) => {
+          if (result.status === 'fulfilled') {
+            const testRun = result.value;
+            testRunNamesMap.set(testRun.id, testRun.name || testRunIds[index]);
+          } else {
+            testRunNamesMap.set(testRunIds[index], testRunIds[index]);
+          }
+        });
+
+        const historicalData = results.data.map(result =>
+          mapTestResultToHistoryRow(result, testRunNamesMap)
+        );
+
+        setRows(dedupeHistoryByTestRun(historicalData));
+        setError(null);
+      } catch {
+        if (!cancelled) {
+          setError('Failed to load execution history');
+          setRows([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchHistory();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [testId, sessionToken, enabled, fetchKey]);
+
+  return { rows, loading, error, refetch };
+}

--- a/apps/frontend/src/components/tests/useTestExecutionHistory.ts
+++ b/apps/frontend/src/components/tests/useTestExecutionHistory.ts
@@ -68,32 +68,47 @@ export function useTestExecutionHistory({
 
         if (cancelled) return;
 
-        const testRunIds = [
+        const testRunNamesMap = new Map<string, string>();
+        for (const result of results.data) {
+          if (result.test_run_id && result.test_run?.name) {
+            testRunNamesMap.set(result.test_run_id, result.test_run.name);
+          }
+        }
+
+        const missingTestRunIds = [
           ...new Set(
             results.data
               .filter(
-                (r): r is typeof r & { test_run_id: string } => !!r.test_run_id
+                (r): r is typeof r & { test_run_id: string } =>
+                  !!r.test_run_id && !testRunNamesMap.has(r.test_run_id)
               )
               .map(r => r.test_run_id)
           ),
         ];
 
-        const testRunsClient = clientFactory.getTestRunsClient();
-        const testRunsData = await Promise.allSettled(
-          testRunIds.map(id => testRunsClient.getTestRun(id))
-        );
+        if (missingTestRunIds.length > 0) {
+          const testRunsClient = clientFactory.getTestRunsClient();
+          const testRunsData = await Promise.allSettled(
+            missingTestRunIds.map(id => testRunsClient.getTestRun(id))
+          );
 
-        if (cancelled) return;
+          if (cancelled) return;
 
-        const testRunNamesMap = new Map<string, string>();
-        testRunsData.forEach((result, index) => {
-          if (result.status === 'fulfilled') {
-            const testRun = result.value;
-            testRunNamesMap.set(testRun.id, testRun.name || testRunIds[index]);
-          } else {
-            testRunNamesMap.set(testRunIds[index], testRunIds[index]);
-          }
-        });
+          testRunsData.forEach((result, index) => {
+            if (result.status === 'fulfilled') {
+              const testRun = result.value;
+              testRunNamesMap.set(
+                testRun.id,
+                testRun.name || missingTestRunIds[index]
+              );
+            } else {
+              testRunNamesMap.set(
+                missingTestRunIds[index],
+                missingTestRunIds[index]
+              );
+            }
+          });
+        }
 
         const historicalData = results.data.map(result =>
           mapTestResultToHistoryRow(result, testRunNamesMap)

--- a/apps/frontend/tests/e2e/tests/tokens.spec.ts
+++ b/apps/frontend/tests/e2e/tests/tokens.spec.ts
@@ -14,23 +14,14 @@ test.describe('API Tokens @sanity', () => {
   test('tokens page shows empty state or token list', async ({ page }) => {
     await page.goto('/tokens');
 
-    // Either the empty state or a data grid should be present
     const emptyState = page.getByText(/no api tokens yet/i);
     const createButton = page.getByRole('button', {
       name: /create api token/i,
     });
     const dataGrid = page.locator('[role="grid"]');
 
-    // Wait for the page to settle (loading completes)
-    await page.waitForLoadState('networkidle');
+    await expect(emptyState.or(dataGrid)).toBeVisible({ timeout: 15_000 });
 
-    const hasEmptyState = await emptyState.isVisible().catch(() => false);
-    const hasGrid = await dataGrid.isVisible().catch(() => false);
-
-    // One of these should be true
-    expect(hasEmptyState || hasGrid).toBeTruthy();
-
-    // The create button should always be available
     await expect(createButton).toBeVisible();
   });
 });


### PR DESCRIPTION
## Purpose
Users need to see when and how a test was executed without opening a test run drawer. This adds an Execution History tab on the test detail page.

## What Changed
- Added an **Execution History** tab between Linked Test Sets and Tasks on `/tests/[identifier]` (`?tab=history`)
- New shared components for fetching, deduplicating, and rendering execution history rows
- Empty state uses the Figma-aligned `EntityEmptyState` card (no CTA)
- Populated state shows Status, Test Run, Metrics, and Executed At with links to the test run
- Refactored the test run drawer History tab to reuse the shared hook and table

## Additional Context
- Reuses existing `GET /test_results?$filter=test_id eq '…'` API — no backend changes
- Drawer History tab keeps summary stat cards and the "Current" test run badge

## Testing
- [x] `npm test -- --testPathPatterns=test-execution-history`
- [x] `npx tsc --noEmit -p tsconfig.json`
- [ ] Manual: open a test with no runs → empty state on Execution History tab
- [ ] Manual: open a test with runs → table rows link to test runs with `?selectedresult=`
- [ ] Manual: verify drawer History tab still works