### PR TITLE
Add entity index for comment, task, and tagged_item

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/a49cd5bee3d0_index_polymorphic_entity_lookups.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/a49cd5bee3d0_index_polymorphic_entity_lookups.py
@@ -1,0 +1,43 @@
+"""index polymorphic entity lookups
+
+Adds a composite index on (entity_id, entity_type) for comment, task, and
+tagged_item -- the columns filtered by CommentsMixin/TasksMixin/TagsMixin's
+polymorphic relationships (see app/models/mixins.py). These relationships
+are lazy-loaded once per object during list-endpoint serialization
+(counts/tags on Test, TestSet, Prompt, Behavior, etc.), and without an
+index each lookup was a full sequential scan. Confirmed via EXPLAIN
+ANALYZE: a single lookup against a 50k-row comment table took ~27ms doing
+`Seq Scan ... Rows Removed by Filter: 50000`.
+
+`file` already has single-column indexes on both columns and is
+intentionally left alone here.
+
+Revision ID: a49cd5bee3d0
+Revises: b3c4d5e6f7a8
+Create Date: 2026-07-06
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "a49cd5bee3d0"
+down_revision: Union[str, None] = "b3c4d5e6f7a8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+INDEXES = [
+    ("ix_comment_entity_id_entity_type", "comment", ["entity_id", "entity_type"]),
+    ("ix_task_entity_id_entity_type", "task", ["entity_id", "entity_type"]),
+    ("ix_tagged_item_entity_id_entity_type", "tagged_item", ["entity_id", "entity_type"]),
+]
+
+
+def upgrade() -> None:
+    for name, table, columns in INDEXES:
+        op.create_index(name, table, columns)
+
+
+def downgrade() -> None:
+    for name, table, _columns in reversed(INDEXES):
+        op.drop_index(name, table_name=table)


### PR DESCRIPTION
## Purpose

List endpoints like `GET /tests/` and `GET /test_sets/` serialize `comments_count`, `tasks_count`, and `tags` for every object they return, including nested relations like `prompt` and `behavior`. Those fields come from polymorphic relationships (`CommentsMixin`/`TasksMixin`/`TagsMixin`) that filter on `entity_id`/`entity_type`, and those columns had no index. Each lookup was a full sequential scan — confirmed with `EXPLAIN ANALYZE`, where a single `comment` lookup against a 50k-row table took ~27ms and scanned every row to come up empty.

## What changed

This adds a composite index on `(entity_id, entity_type)` for `comment`, `task`, and `tagged_item`, the three tables these mixins query against. `file` already had indexes on both columns, so it's untouched. It's a plain additive migration — no application code changes.

Worth noting this doesn't reduce how many times these tables get queried per request (that's a separate N+1 pattern, one lookup per object plus its nested relations, tracks follow-up work if it turns out to still matter after this ships). It just makes each of those lookups cheap instead of a full table scan, which is the highest-leverage, lowest-risk piece of this to land first.

## Testing

Applied locally via `alembic upgrade head` and verified directly with `EXPLAIN (ANALYZE, BUFFERS)`: the same query plan went from `Seq Scan` (~27ms, `Rows Removed by Filter: 50000`) to `Index Scan` (~0.2ms). `downgrade()` drops all three indexes cleanly.
