### PR TITLE
Centralize Celery worker env defaults in rh

### DIFF
--- a/rh
+++ b/rh
@@ -13,6 +13,10 @@ NC='\033[0m' # No Color
 # Get the directory where this script is located
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+CELERY_WORKER_CONCURRENCY="${CELERY_WORKER_CONCURRENCY:-4}"
+CELERY_WORKER_PREFETCH_MULTIPLIER="${CELERY_WORKER_PREFETCH_MULTIPLIER:-4}"
+FLOWER_PORT="${FLOWER_PORT:-5555}"
+
 # Function to display help
 show_help() {
     echo -e "${CYAN}"
@@ -1142,7 +1146,6 @@ start_worker() {
     }
 
     LOG_FILE="$SCRIPT_DIR/celery.log"
-    FLOWER_PORT="${FLOWER_PORT:-5555}"
 
     echo -e "${GREEN}Starting new Celery worker...${NC}"
     echo -e "${BLUE}Logs will be written to: ${LOG_FILE}${NC}"
@@ -1189,8 +1192,8 @@ start_worker() {
         --pool threads \
         --loglevel=DEBUG \
         --queues=celery,execution,telemetry,architect \
-        --concurrency=${CELERY_WORKER_CONCURRENCY:-4} \
-        --prefetch-multiplier=4 \
+        --concurrency=${CELERY_WORKER_CONCURRENCY} \
+        --prefetch-multiplier=${CELERY_WORKER_PREFETCH_MULTIPLIER} \
         --optimization=fair \
         -E &
     WORKER_PID=$!


### PR DESCRIPTION
## Purpose
Worker env var defaults were scattered inline across the `rh` worker command. This consolidates them in one place.

## What Changed
- Define `CELERY_WORKER_CONCURRENCY`, `CELERY_WORKER_PREFETCH_MULTIPLIER`, and `FLOWER_PORT` defaults once at the top of `rh`
- Introduce `CELERY_WORKER_PREFETCH_MULTIPLIER` (matching the name already used in docker-compose, Helm, and `apps/worker/start.sh`) instead of the hardcoded `--prefetch-multiplier=4`
- Worker command now references the vars without repeating defaults

## Testing
All three vars remain overridable via environment; defaults unchanged (4 / 4 / 5555).