### PR TITLE
fix(backend): self-heal empty capability catalog in matrix test

### DIFF
--- a/tests/backend/security/test_role_capability_matrix.py
+++ b/tests/backend/security/test_role_capability_matrix.py
@@ -47,10 +47,27 @@ from tests.backend.ee.rbac._rbac_helpers import (
 
 
 def _all_capabilities() -> list[str]:
+    """Return the live capability catalog, self-registering if empty.
+
+    Under the normal ``tests/backend`` suite, ``tests/backend/conftest.py``
+    imports ``tests/backend/fixtures/client.py`` at module load, which
+    imports ``rhesis.backend.app.main`` — whose own module-level code calls
+    ``register_capabilities(app)`` — well before this file's
+    ``pytest_generate_tests`` hook runs. A fully standalone invocation of
+    just this file could theoretically reach collection without that chain
+    having fired, so fall back to calling it directly: it is documented as
+    idempotent, so doing this redundantly (the common case) is harmless.
+    """
     capabilities = sorted(get_all_capabilities())
+    if not capabilities:
+        from rhesis.backend.app.auth.capabilities import register_capabilities
+        from rhesis.backend.app.main import app
+
+        register_capabilities(app)
+        capabilities = sorted(get_all_capabilities())
     assert capabilities, (
-        "Capability catalog is empty — register_capabilities() must run before "
-        "collection (see tests/backend/conftest.py::_ensure_ee_features_registered)."
+        "Capability catalog is still empty after calling register_capabilities(app) "
+        "— capability derivation itself must be broken, not just its ordering."
     )
     return capabilities
 


### PR DESCRIPTION
## Purpose
Follow-up from peqy's review on #2101. `test_role_capability_matrix.py`'s
`pytest_generate_tests()` hook depends on `register_capabilities(app)` having
already run — true for every normal invocation (`tests/backend/conftest.py`
imports `tests/backend/fixtures/client.py`, which imports
`rhesis.backend.app.main` at module load), but a fully standalone
`pytest tests/backend/security/test_role_capability_matrix.py` could
theoretically reach collection before that import chain fires.

## What Changed
- `_all_capabilities()` now calls `register_capabilities(app)` directly when
  the catalog comes back empty, instead of just asserting. `register_capabilities`
  is documented idempotent, so this is a no-op in the common (already-warm) case.

## Testing
- Verified the self-heal path actually works: reset the capability cache via
  `reset_capabilities()` and confirmed `_all_capabilities()` repopulates it.
- Full matrix: `pytest tests/backend/security/test_role_capability_matrix.py` —
  915 passed.
- `uvx ruff check` / `format --check` clean.