### PR TITLE
chore(charts): move vertex ai location to eu multi-region

### DIFF
--- a/charts/rhesis/values-dev.yaml
+++ b/charts/rhesis/values-dev.yaml
@@ -45,7 +45,7 @@ config:
   defaultEvaluationModel: "vertex_ai/gemini-3.1-flash-lite"
   defaultExecutionModel: "vertex_ai/gemini-3.1-flash-lite"
   defaultEmbeddingModel: "vertex_ai/text-embedding-005"
-  vertexAiLocation: "europe-west4"
+  vertexAiLocation: "eu"
   azureOpenAiApiVersion: "2024-02-01"
 
 # ---------------------------------------------------------------------------

--- a/charts/rhesis/values-prd.yaml
+++ b/charts/rhesis/values-prd.yaml
@@ -55,7 +55,7 @@ config:
   defaultEvaluationModel: "vertex_ai/gemini-3.1-flash-lite"
   defaultExecutionModel: "vertex_ai/gemini-3.1-flash-lite"
   defaultEmbeddingModel: "vertex_ai/text-embedding-005"
-  vertexAiLocation: "europe-west4"
+  vertexAiLocation: "eu"
   azureOpenAiApiVersion: "2024-02-01"
 
 # ---------------------------------------------------------------------------

--- a/charts/rhesis/values-stg.yaml
+++ b/charts/rhesis/values-stg.yaml
@@ -49,7 +49,7 @@ config:
   defaultEvaluationModel: "vertex_ai/gemini-3.1-flash-lite"
   defaultExecutionModel: "vertex_ai/gemini-3.1-flash-lite"
   defaultEmbeddingModel: "vertex_ai/text-embedding-005"
-  vertexAiLocation: "europe-west4"
+  vertexAiLocation: "eu"
   azureOpenAiApiVersion: "2024-02-01"
 
 # ---------------------------------------------------------------------------

--- a/charts/rhesis/values.yaml
+++ b/charts/rhesis/values.yaml
@@ -94,7 +94,7 @@ config:
   celeryWorkerLogLevel: "INFO"
 
   # GCP / Vertex AI
-  vertexAiLocation: "europe-west4"
+  vertexAiLocation: "eu"
   vertexAiProject: ""
 
   # Chatbot


### PR DESCRIPTION
## Purpose
Move Vertex AI to the `eu` multi-region setting, consistently across all deployment paths.

## What Changed
- `charts/rhesis/values.yaml`, `values-dev.yaml`, `values-stg.yaml`, `values-prd.yaml`: `vertexAiLocation` changed from `"europe-west4"` to `"eu"`.

## Additional Context
- The GitHub Actions deploy secrets (`VERTEX_AI_LOCATION` on the `dev`, `stg`, `prd` environments, consumed by `backend.yml`/`chatbot.yml`/`worker.yml` for Cloud Run/GKE-worker deploys) were already updated to `eu` directly via `gh secret set`.
- The GCP Secret Manager secrets `dev-rhesis-vertex-ai-location` and `stg-rhesis-vertex-ai-location` (which back the ExternalSecrets-synced `rhesis-app-secrets` K8s Secret and take precedence over this chart's ConfigMap value in the pod's `envFrom`) were already updated with new `eu` versions.
- `prd-rhesis-vertex-ai-location` in Secret Manager still needs to be updated by someone with access to the `rhesis-prd` GCP project — I don't have IAM access there. Command to run:
  ```bash
  printf 'eu' | gcloud secrets versions add prd-rhesis-vertex-ai-location --project=rhesis-prd --data-file=-
  ```
- No workflow or application code changes needed — `VERTEX_AI_LOCATION` is read from the environment at runtime with no hardcoded region logic.

## Testing
- Confirm `charts/rhesis/values*.yaml` render correctly: `helm template charts/rhesis -f charts/rhesis/values-dev.yaml`.
- After ArgoCD syncs and pods roll, verify the running backend/worker/chatbot pods have `VERTEX_AI_LOCATION=eu` (`kubectl exec ... -- env | grep VERTEX_AI_LOCATION`).
- Confirm Vertex AI calls (generation/evaluation/embedding) still succeed against the `eu` multi-region endpoint.