### PR TITLE
Fix RBAC member performance and server-driven affordances

### DIFF
--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -39,7 +39,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-06-18T18:21:04.545382Z"
+exclude-newer = "2026-07-01T07:58:38.904485Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -6773,19 +6773,22 @@ requires-dist = [
     { name = "langgraph", marker = "extra == 'langgraph'", specifier = ">=0.2.0" },
     { name = "notebook", specifier = ">=7.5.6" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydantic-ai", marker = "extra == 'all'", specifier = ">=0.0.49" },
+    { name = "pydantic-ai", marker = "extra == 'pydantic-ai'", specifier = ">=0.0.49" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "rhesis-sdk", editable = "../../sdk" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "tenacity", specifier = ">=8.2.3" },
     { name = "tiktoken", specifier = ">=0.9.0" },
 ]
-provides-extras = ["langchain", "langgraph", "microsoft-agent-framework", "all"]
+provides-extras = ["langchain", "langgraph", "pydantic-ai", "microsoft-agent-framework", "all"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "hatch", specifier = ">=1.14.1" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "pydantic-ai", specifier = ">=0.0.49" },
     { name = "pyright", specifier = ">=1.1.406" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
@@ -6822,6 +6825,7 @@ dependencies = [
     { name = "nest-asyncio" },
     { name = "numpy" },
     { name = "pandas" },
+    { name = "pdfminer-six" },
     { name = "pillow" },
     { name = "pydantic" },
     { name = "python-dotenv" },
@@ -6892,11 +6896,15 @@ requires-dist = [
     { name = "nest-asyncio" },
     { name = "numpy" },
     { name = "pandas", specifier = ">=2.2.2" },
+    { name = "pdfminer-six", specifier = ">=20231228" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pyautogen", marker = "extra == 'all'", specifier = ">=0.2.0" },
     { name = "pyautogen", marker = "extra == 'all-integrations'", specifier = ">=0.2.0" },
     { name = "pyautogen", marker = "extra == 'autogen'", specifier = ">=0.2.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "pydantic-ai", marker = "extra == 'all'", specifier = ">=0.0.49" },
+    { name = "pydantic-ai", marker = "extra == 'all-integrations'", specifier = ">=0.0.49" },
+    { name = "pydantic-ai", marker = "extra == 'pydantic-ai'", specifier = ">=0.0.49" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ragas", specifier = ">=0.3.7,<0.4" },
@@ -6913,7 +6921,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'huggingface'", specifier = ">=5.0.0" },
     { name = "websockets", specifier = ">=12.0" },
 ]
-provides-extras = ["huggingface", "garak", "langchain", "langgraph", "autogen", "agent-framework", "all-integrations", "all"]
+provides-extras = ["huggingface", "garak", "langchain", "langgraph", "autogen", "pydantic-ai", "agent-framework", "all-integrations", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -6927,6 +6935,7 @@ dev = [
     { name = "pandas-stubs", specifier = ">=2.2.3.250308" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "psycopg2-binary", specifier = "==2.9.9" },
+    { name = "pydantic-ai", specifier = ">=0.0.49" },
     { name = "pyright", specifier = ">=1.1.407" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=7.0.0" },

--- a/apps/frontend/src/app/(protected)/organizations/team/components/MemberAccessDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/MemberAccessDrawer.tsx
@@ -76,11 +76,8 @@ export default function MemberAccessDrawer({
   const { data: session } = useSession();
   const [projectAccess, setProjectAccess] = useState<ProjectAccess[]>([]);
   const [loading, setLoading] = useState(false);
-  const {
-    OrgRoleCell,
-    ProjectRoleCell,
-    fetchUserProjectMemberships,
-  } = getMemberRoleExtensions();
+  const { OrgRoleCell, ProjectRoleCell, fetchUserProjectMemberships } =
+    getMemberRoleExtensions();
 
   useEffect(() => {
     if (!open || !user || !session?.session_token) return;
@@ -115,9 +112,7 @@ export default function MemberAccessDrawer({
                 project.id as string
               );
               const row = members.find(m => m.user_id === user.id);
-              return row
-                ? ({ project, member: row } as ProjectAccess)
-                : null;
+              return row ? ({ project, member: row } as ProjectAccess) : null;
             } catch {
               return null;
             }

--- a/apps/frontend/src/app/(protected)/organizations/team/components/MemberAccessDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/MemberAccessDrawer.tsx
@@ -259,6 +259,7 @@ export default function MemberAccessDrawer({
                             userId={user.id}
                             projectId={projectId}
                             sessionToken={sessionToken}
+                            currentUserId={session?.user?.id}
                           />
                         </Box>
                       ) : (

--- a/apps/frontend/src/app/(protected)/organizations/team/components/MemberAccessDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/MemberAccessDrawer.tsx
@@ -188,11 +188,7 @@ export default function MemberAccessDrawer({
                 <Typography variant="overline" color="text.secondary">
                   Org Role
                 </Typography>
-                <OrgRoleCell
-                  userId={user.id}
-                  sessionToken={sessionToken}
-                  currentUserId={session?.user?.id}
-                />
+                <OrgRoleCell userId={user.id} sessionToken={sessionToken} />
               </Box>
             )}
           </Box>
@@ -259,7 +255,6 @@ export default function MemberAccessDrawer({
                             userId={user.id}
                             projectId={projectId}
                             sessionToken={sessionToken}
-                            currentUserId={session?.user?.id}
                           />
                         </Box>
                       ) : (

--- a/apps/frontend/src/app/(protected)/organizations/team/components/MemberAccessDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/MemberAccessDrawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Avatar,
   Box,
@@ -18,7 +18,10 @@ import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { User } from '@/utils/api-client/interfaces/user';
 import { Project, ProjectMember } from '@/utils/api-client/interfaces/project';
-import { getMemberRoleExtensions } from '@/lib/extension-registries';
+import {
+  getMemberRoleExtensions,
+  type UserProjectMembership,
+} from '@/lib/extension-registries';
 import {
   memberAvatarSx,
   orgRoleContainerSx,
@@ -30,8 +33,8 @@ import {
 } from './memberCardSx';
 
 interface ProjectAccess {
-  project: Project;
-  member: ProjectMember;
+  project: Pick<Project, 'id' | 'name' | 'description' | 'icon'>;
+  member: Pick<ProjectMember, 'role'>;
 }
 
 function getDisplayName(user: User): string {
@@ -45,6 +48,18 @@ function getDisplayName(user: User): string {
 function formatRole(role: string | null | undefined): string {
   if (!role) return 'Member';
   return role.charAt(0).toUpperCase() + role.slice(1);
+}
+
+function toBulkProjectAccess(m: UserProjectMembership): ProjectAccess {
+  return {
+    project: {
+      id: m.project.id,
+      name: m.project.name,
+      description: m.project.description ?? undefined,
+      icon: m.project.icon ?? undefined,
+    },
+    member: { role: m.role?.display_name ?? null },
+  };
 }
 
 export interface MemberAccessDrawerProps {
@@ -61,13 +76,31 @@ export default function MemberAccessDrawer({
   const { data: session } = useSession();
   const [projectAccess, setProjectAccess] = useState<ProjectAccess[]>([]);
   const [loading, setLoading] = useState(false);
-  const { OrgRoleCell, ProjectRoleCell } = getMemberRoleExtensions();
+  const {
+    OrgRoleCell,
+    ProjectRoleCell,
+    fetchUserProjectMemberships,
+  } = getMemberRoleExtensions();
 
   useEffect(() => {
     if (!open || !user || !session?.session_token) return;
 
     setLoading(true);
     setProjectAccess([]);
+
+    if (fetchUserProjectMemberships) {
+      fetchUserProjectMemberships(session.session_token, user.id)
+        .then(memberships => {
+          setProjectAccess(
+            memberships
+              .map(toBulkProjectAccess)
+              .sort((a, b) => a.project.name.localeCompare(b.project.name))
+          );
+        })
+        .catch(() => setProjectAccess([]))
+        .finally(() => setLoading(false));
+      return;
+    }
 
     const factory = new ApiClientFactory(session.session_token);
     const projectsClient = factory.getProjectsClient();
@@ -82,7 +115,9 @@ export default function MemberAccessDrawer({
                 project.id as string
               );
               const row = members.find(m => m.user_id === user.id);
-              return row ? { project, member: row } : null;
+              return row
+                ? ({ project, member: row } as ProjectAccess)
+                : null;
             } catch {
               return null;
             }
@@ -95,7 +130,7 @@ export default function MemberAccessDrawer({
         );
       })
       .finally(() => setLoading(false));
-  }, [open, user?.id, session?.session_token]);
+  }, [open, user?.id, session?.session_token, fetchUserProjectMemberships]);
 
   const displayName = user ? getDisplayName(user) : '';
   const sessionToken = session?.session_token ?? '';
@@ -153,7 +188,11 @@ export default function MemberAccessDrawer({
                 <Typography variant="overline" color="text.secondary">
                   Org Role
                 </Typography>
-                <OrgRoleCell userId={user.id} sessionToken={sessionToken} />
+                <OrgRoleCell
+                  userId={user.id}
+                  sessionToken={sessionToken}
+                  currentUserId={session?.user?.id}
+                />
               </Box>
             )}
           </Box>

--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
@@ -322,7 +322,6 @@ export default function TeamMembersGrid({
             <CellComponent
               userId={(params.row as User).id}
               sessionToken={sessionToken}
-              currentUserId={session?.user?.id}
             />
           </Box>
         ),

--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
@@ -102,6 +102,7 @@ export default function TeamMembersGrid({
 }: TeamMembersGridProps) {
   const { data: session } = useSession();
   const canDeleteMember = useCan(Capability.Member.DELETE);
+  const canManageMembers = useCan(Capability.Member.MANAGE);
   const notifications = useNotifications();
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
@@ -226,8 +227,14 @@ export default function TeamMembersGrid({
     setAccessDrawerOpen(true);
   }, []);
 
-  const { OrgRoleCell } = getMemberRoleExtensions();
+  const { OrgRoleCell, prewarmCaches } = getMemberRoleExtensions();
   const sessionToken = session?.session_token ?? '';
+
+  useEffect(() => {
+    if (sessionToken) {
+      prewarmCaches?.(sessionToken, { canManageRoles: canManageMembers });
+    }
+  }, [sessionToken, prewarmCaches, canManageMembers]);
 
   const columns: GridColDef[] = useMemo(() => {
     const cols: GridColDef[] = [

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMembers.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMembers.tsx
@@ -5,7 +5,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { Alert, Avatar, Box, IconButton, Typography } from '@mui/material';
 import { GridColDef, GridPaginationModel } from '@mui/x-data-grid';
 import PersonIcon from '@mui/icons-material/Person';
-import { useSession } from 'next-auth/react';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
 import SectionEmptyState from '@/components/common/SectionEmptyState';
 import { DeleteModal } from '@/components/common/DeleteModal';
@@ -45,7 +44,6 @@ export default function ProjectMembers({
   ownerId,
   onMembersLoaded,
 }: ProjectMembersProps) {
-  const { data: session } = useSession();
   const notifications = useNotifications();
   const canManageMembers = useCan(Capability.ProjectMember.MANAGE);
   const queryClient = useQueryClient();
@@ -139,7 +137,6 @@ export default function ProjectMembers({
               userId={(params.row as ProjectMember).user_id}
               projectId={projectId}
               sessionToken={sessionToken}
-              currentUserId={session?.user?.id}
             />
           ),
         }
@@ -237,7 +234,6 @@ export default function ProjectMembers({
     ownerId,
     canManageMembers,
     handleRemoveClick,
-    session?.user?.id,
   ]);
 
   return (

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMembers.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMembers.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Alert, Avatar, Box, IconButton, Typography } from '@mui/material';
 import { GridColDef, GridPaginationModel } from '@mui/x-data-grid';
 import PersonIcon from '@mui/icons-material/Person';
@@ -112,7 +112,15 @@ export default function ProjectMembers({
     }
   };
 
-  const { ProjectRoleCell } = getMemberRoleExtensions();
+  const { ProjectRoleCell, prewarmProjectCaches } = getMemberRoleExtensions();
+
+  useEffect(() => {
+    if (sessionToken && projectId) {
+      prewarmProjectCaches?.(sessionToken, projectId, {
+        canManageRoles: canManageMembers,
+      });
+    }
+  }, [sessionToken, projectId, prewarmProjectCaches, canManageMembers]);
 
   const columns: GridColDef[] = React.useMemo(() => {
     const RoleCell = ProjectRoleCell;

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMembers.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMembers.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Alert, Avatar, Box, IconButton, Typography } from '@mui/material';
 import { GridColDef, GridPaginationModel } from '@mui/x-data-grid';
 import PersonIcon from '@mui/icons-material/Person';
+import { useSession } from 'next-auth/react';
 import BaseDataGrid from '@/components/common/BaseDataGrid';
 import SectionEmptyState from '@/components/common/SectionEmptyState';
 import { DeleteModal } from '@/components/common/DeleteModal';
@@ -44,6 +45,7 @@ export default function ProjectMembers({
   ownerId,
   onMembersLoaded,
 }: ProjectMembersProps) {
+  const { data: session } = useSession();
   const notifications = useNotifications();
   const canManageMembers = useCan(Capability.ProjectMember.MANAGE);
   const queryClient = useQueryClient();
@@ -137,6 +139,7 @@ export default function ProjectMembers({
               userId={(params.row as ProjectMember).user_id}
               projectId={projectId}
               sessionToken={sessionToken}
+              currentUserId={session?.user?.id}
             />
           ),
         }
@@ -234,6 +237,7 @@ export default function ProjectMembers({
     ownerId,
     canManageMembers,
     handleRemoveClick,
+    session?.user?.id,
   ]);
 
   return (

--- a/apps/frontend/src/lib/extension-registries/index.ts
+++ b/apps/frontend/src/lib/extension-registries/index.ts
@@ -50,6 +50,7 @@ export type {
   OrgRoleCellProps,
   ProjectRoleCellProps,
   AddMemberRoleFieldProps,
+  UserProjectMembership,
 } from './member-role-extensions';
 
 export {

--- a/apps/frontend/src/lib/extension-registries/member-role-extensions.ts
+++ b/apps/frontend/src/lib/extension-registries/member-role-extensions.ts
@@ -32,6 +32,11 @@ export interface ProjectRoleCellProps {
   projectId: string;
   sessionToken: string;
   onRoleChanged?: () => void;
+  /** The signed-in viewer's user id. When it matches `userId`, the cell
+   *  should render read-only — changing your own project role is high-risk
+   *  (self-demotion) and gets no confirmation loop, so it is disabled
+   *  rather than merely discouraged. */
+  currentUserId?: string;
 }
 
 export interface AddMemberRoleFieldProps {

--- a/apps/frontend/src/lib/extension-registries/member-role-extensions.ts
+++ b/apps/frontend/src/lib/extension-registries/member-role-extensions.ts
@@ -43,6 +43,23 @@ export interface AddMemberRoleFieldProps {
   size?: 'small' | 'medium';
 }
 
+/** Minimal project fields returned by the bulk project-memberships endpoint. */
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  description?: string | null;
+  icon?: string | null;
+}
+
+/** A user's membership in a single project, returned by the bulk endpoint. */
+export interface UserProjectMembership {
+  project_id: string;
+  user_id: string;
+  role_id: string | null;
+  role?: { display_name: string } | null;
+  project: ProjectSummary;
+}
+
 // ---------------------------------------------------------------------------
 // Extension bundle
 // ---------------------------------------------------------------------------
@@ -61,6 +78,35 @@ export interface MemberRoleExtensions {
     userId: string,
     roleId: string
   ) => Promise<void>;
+  /** Fetches all project memberships for a user in a single call (EE bulk endpoint). */
+  fetchUserProjectMemberships?: (
+    sessionToken: string,
+    userId: string
+  ) => Promise<UserProjectMembership[]>;
+  /**
+   * Pre-warm RBAC caches so chips render immediately instead of each row
+   * triggering its own fetch. Org members are always fetched (every role
+   * chip needs them). Roles are gated on `canManageRoles` — `GET /rbac/roles`
+   * requires `Permission.Role.READ`, which viewers without member-management
+   * rights don't hold, so fetching it unconditionally would fire a doomed
+   * 403 for every non-admin page load.
+   */
+  prewarmCaches?: (
+    sessionToken: string,
+    opts?: { canManageRoles?: boolean }
+  ) => void;
+  /**
+   * Pre-warm RBAC caches for a single project's members grid, so
+   * `ProjectRoleCell` renders immediately instead of each row triggering its
+   * own fetch after the community members query resolves. Same
+   * `canManageRoles` gate as `prewarmCaches` — `GET /rbac/roles` requires
+   * `Permission.Role.READ`.
+   */
+  prewarmProjectCaches?: (
+    sessionToken: string,
+    projectId: string,
+    opts?: { canManageRoles?: boolean }
+  ) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/frontend/src/lib/extension-registries/member-role-extensions.ts
+++ b/apps/frontend/src/lib/extension-registries/member-role-extensions.ts
@@ -20,11 +20,6 @@ export interface OrgRoleCellProps {
   userId: string;
   sessionToken: string;
   onRoleChanged?: () => void;
-  /** The signed-in viewer's user id. When it matches `userId`, the cell
-   *  should render read-only — changing your own org role is high-risk
-   *  (self-demotion) and gets no confirmation loop, so it is disabled
-   *  rather than merely discouraged. */
-  currentUserId?: string;
 }
 
 export interface ProjectRoleCellProps {
@@ -32,11 +27,6 @@ export interface ProjectRoleCellProps {
   projectId: string;
   sessionToken: string;
   onRoleChanged?: () => void;
-  /** The signed-in viewer's user id. When it matches `userId`, the cell
-   *  should render read-only — changing your own project role is high-risk
-   *  (self-demotion) and gets no confirmation loop, so it is disabled
-   *  rather than merely discouraged. */
-  currentUserId?: string;
 }
 
 export interface AddMemberRoleFieldProps {

--- a/ee/backend/src/rhesis/backend/ee/rbac/router.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/router.py
@@ -919,6 +919,12 @@ def assign_project_role(
     from rhesis.backend.app.models.project_membership import ProjectMembership
     from rhesis.backend.ee.rbac.schemas import ProjectMemberRoleRead
 
+    if str(user_id) == str(current_user.id):
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot change your own project role",
+        )
+
     target_role = check_project_role_assignment(db, current_user, body.role_id, project_id)
 
     membership = (

--- a/ee/backend/src/rhesis/backend/ee/rbac/router.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/router.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.orm import Session
@@ -285,6 +286,74 @@ def _is_last_owner(member, org_id: uuid.UUID, db: Session) -> bool:
         .count()
     )
     return owner_count <= 1
+
+
+def _member_permitted_actions(
+    *,
+    is_self: bool,
+    current_role_level: Optional[int],
+    actor_level: int,
+    actor_permissions: set[str],
+    current_role_is_built_in: bool = True,
+    current_role_permission_names: Optional[set[str]] = None,
+    is_last_owner: bool = False,
+    include_delete: bool = True,
+) -> list[str]:
+    """Capability strings the actor may exercise on a member currently
+    holding a role at *current_role_level* (``None`` when unassigned).
+
+    Populates the object-level ``permitted_actions`` on ``OrgMemberRead`` /
+    ``ProjectMemberRoleRead`` so the frontend never re-derives escalation
+    logic itself. Gates apply, mirroring the write-path guards enforced by
+    ``assign_org_role``, ``assign_project_role``, and ``remove_org_member``:
+
+    1. The actor holds the action in their own effective permission set —
+       the same vocabulary as the route-level capability gate, so a Viewer
+       (``member:read`` only) never gets ``member:manage`` here just
+       because the escalation math happens to pass.
+    2. The member being acted on is not the actor themselves.
+    3. The member's current role does not outrank the actor's.
+    4. For a **custom** current role only: its permission set must be a
+       subset of the actor's. Every custom role is created at a hardcoded
+       level (50, see ``create_role``) with no correlation to its
+       permissions, so two custom roles routinely share a level while
+       holding very different — and differently dangerous — permission
+       sets. The level check alone would let an actor holding a narrow
+       custom role modify or remove someone holding an unrelated custom
+       role that happens to sit at the same level but grants far more.
+       Built-in roles skip this: their permission sets form a fixed,
+       strictly-ordered chain keyed by level (``BUILT_IN_ROLE_LEVELS``), so
+       the level check alone is sufficient there. Mirrors
+       ``_check_escalation`` and the frontend's ``isWithinActorAuthority``,
+       which apply the same extra check on the create/grant paths.
+
+    ``member:delete`` is additionally withheld when *is_last_owner* is True
+    (removing the sole Owner is never allowed, regardless of authority).
+    Pass ``include_delete=False`` for project members: unlike org members,
+    project membership removal goes through the community
+    ``remove_project_member`` endpoint, which this escalation guard does not
+    reach, so asserting the affordance here would be misleading.
+    """
+    if is_self:
+        return []
+    if current_role_level is not None and current_role_level > actor_level:
+        return []
+    if (
+        not current_role_is_built_in
+        and current_role_permission_names is not None
+        and not current_role_permission_names.issubset(actor_permissions)
+    ):
+        return []
+    actions = []
+    if Permission.Member.MANAGE.value in actor_permissions:
+        actions.append(Permission.Member.MANAGE.value)
+    if (
+        include_delete
+        and not is_last_owner
+        and Permission.Member.DELETE.value in actor_permissions
+    ):
+        actions.append(Permission.Member.DELETE.value)
+    return actions
 
 
 def _member_counts_for_roles(
@@ -627,8 +696,7 @@ def list_org_members(
     listener, so the ORM relationship always returns None).
     """
     from rhesis.backend.app.models.user import User as UserModel
-    from rhesis.backend.ee.rbac.models import OrganizationMember
-    from rhesis.backend.ee.rbac.schemas import UserSummary
+    from rhesis.backend.ee.rbac.models import OrganizationMember, Role
 
     members = (
         db.query(OrganizationMember).filter_by(organization_id=current_user.organization_id).all()
@@ -645,19 +713,52 @@ def list_org_members(
     users = db.query(UserModel).filter(UserModel.id.in_(user_ids)).all() if user_ids else []
     users_by_id = {u.id: u for u in users}
 
-    return [
-        OrgMemberRead(
-            id=m.id,
-            organization_id=m.organization_id,
-            user_id=m.user_id,
-            role_id=m.role_id,
-            role=roles_by_id.get(m.role_id),
-            user=UserSummary.model_validate(users_by_id[m.user_id])
-            if m.user_id in users_by_id
+    # Resolve the actor's authority and the org's current Owner count once
+    # (not per row) so `permitted_actions` can be computed without an N+1.
+    # This is the server-side source of truth for "can I modify this member
+    # at all" — the frontend must not re-derive escalation logic itself.
+    from rhesis.backend.app.scope import bypass_tenant_filter
+    from rhesis.backend.ee.rbac.schemas import UserSummary
+
+    principal = resolve_principal(current_user)
+    actor_level = _get_actor_level(principal, project_id=None, db=db)
+    actor_permissions = _get_actor_permissions(principal, project_id=None, db=db)
+    with bypass_tenant_filter():
+        owner_role = db.query(Role).filter_by(name="Owner", is_built_in=True).first()
+    owner_role_id = owner_role.id if owner_role is not None else None
+    owner_count = sum(1 for m in members if m.role_id == owner_role_id)
+
+    result = []
+    for m in members:
+        current_role = roles_by_id.get(m.role_id)
+        is_self = str(m.user_id) == str(current_user.id)
+        is_last_owner = m.role_id == owner_role_id and owner_count <= 1
+        actions = _member_permitted_actions(
+            is_self=is_self,
+            current_role_level=current_role.level if current_role else None,
+            current_role_is_built_in=current_role.is_built_in if current_role else True,
+            current_role_permission_names={p.name for p in current_role.permissions}
+            if current_role
             else None,
+            actor_level=actor_level,
+            actor_permissions=actor_permissions,
+            is_last_owner=is_last_owner,
         )
-        for m in members
-    ]
+
+        result.append(
+            OrgMemberRead(
+                id=m.id,
+                organization_id=m.organization_id,
+                user_id=m.user_id,
+                role_id=m.role_id,
+                role=roles_by_id.get(m.role_id),
+                user=UserSummary.model_validate(users_by_id[m.user_id])
+                if m.user_id in users_by_id
+                else None,
+                permitted_actions=actions,
+            )
+        )
+    return result
 
 
 @router.get(
@@ -773,6 +874,33 @@ def assign_org_role(
         .first()
     )
     if member is not None and member.role_id != body.role_id:
+        # Symmetric escalation guard: _check_escalation above only validates
+        # the *new* role's level against the actor. Without this, an Admin
+        # could freely downgrade a member who currently outranks them (e.g.
+        # a second Owner) since the requested role (e.g. Viewer) is always
+        # ≤ the actor's level. Reuse the same helper that computes
+        # `permitted_actions` on list_org_members so the write guard and the
+        # affordance the frontend reads from can never drift apart.
+        current_role = _load_role(member.role_id, db)
+        current_role_level = current_role.level if current_role is not None else None
+        if not _member_permitted_actions(
+            is_self=False,
+            current_role_level=current_role_level,
+            current_role_is_built_in=current_role.is_built_in if current_role else True,
+            current_role_permission_names=set(_role_permission_names_resolved(current_role, db))
+            if current_role
+            else None,
+            actor_level=actor_level,
+            actor_permissions=actor_permissions,
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "Privilege escalation denied: cannot modify a member "
+                    f"whose current role level ({current_role_level}) exceeds "
+                    f"your own ({actor_level})"
+                ),
+            )
         # Last-owner protection: refuse to demote the sole Owner.
         if _is_last_owner(member, current_user.organization_id, db):
             raise HTTPException(
@@ -823,6 +951,35 @@ def remove_org_member(
     if member is None:
         raise HTTPException(status_code=404, detail="Org membership not found")
 
+    # Symmetric escalation guard, mirroring assign_org_role: removal isn't
+    # gated on a *new* role's level the way assignment is, so without this
+    # an Admin could remove a member who currently outranks them (e.g. a
+    # second Owner) outright. Self-removal ("leave organization") is
+    # deliberately not blocked here, unlike role changes.
+    principal = resolve_principal(current_user)
+    actor_level = _get_actor_level(principal, project_id=None, db=db)
+    actor_permissions = _get_actor_permissions(principal, project_id=None, db=db)
+    current_role = _load_role(member.role_id, db)
+    current_role_level = current_role.level if current_role is not None else None
+    if Permission.Member.DELETE.value not in _member_permitted_actions(
+        is_self=False,
+        current_role_level=current_role_level,
+        current_role_is_built_in=current_role.is_built_in if current_role else True,
+        current_role_permission_names=set(_role_permission_names_resolved(current_role, db))
+        if current_role
+        else None,
+        actor_level=actor_level,
+        actor_permissions=actor_permissions,
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Privilege escalation denied: cannot remove a member whose "
+                f"current role level ({current_role_level}) exceeds your own "
+                f"({actor_level})"
+            ),
+        )
+
     if _is_last_owner(member, current_user.organization_id, db):
         raise HTTPException(
             status_code=400,
@@ -864,7 +1021,10 @@ def list_project_members(
     enumerate any project's members.
 
     Batch-loads unique roles to avoid N+1 lazy-load queries, mirroring
-    ``list_org_members``.
+    ``list_org_members``. Also resolves the actor's authority once so
+    `permitted_actions` (whether the caller may change *this* member's role)
+    can be computed server-side — the frontend must not re-derive escalation
+    logic itself.
     """
     from rhesis.backend.app.models.project_membership import ProjectMembership
 
@@ -886,15 +1046,35 @@ def list_project_members(
         if role is not None:
             roles_by_id[role_id] = _role_to_read(role, db)
 
-    return [
-        ProjectMemberRoleRead(
-            project_id=project_id,
-            user_id=m.user_id,
-            role_id=m.role_id,
-            role=roles_by_id.get(m.role_id),
+    principal = resolve_principal(current_user)
+    actor_level = _get_actor_level(principal, project_id=project_id, db=db)
+    actor_permissions = _get_actor_permissions(principal, project_id=project_id, db=db)
+
+    result = []
+    for m in memberships:
+        current_role = roles_by_id.get(m.role_id)
+        is_self = str(m.user_id) == str(current_user.id)
+        actions = _member_permitted_actions(
+            is_self=is_self,
+            current_role_level=current_role.level if current_role else None,
+            current_role_is_built_in=current_role.is_built_in if current_role else True,
+            current_role_permission_names={p.name for p in current_role.permissions}
+            if current_role
+            else None,
+            actor_level=actor_level,
+            actor_permissions=actor_permissions,
+            include_delete=False,
         )
-        for m in memberships
-    ]
+        result.append(
+            ProjectMemberRoleRead(
+                project_id=project_id,
+                user_id=m.user_id,
+                role_id=m.role_id,
+                role=roles_by_id.get(m.role_id),
+                permitted_actions=actions,
+            )
+        )
+    return result
 
 
 @router.put(
@@ -939,6 +1119,41 @@ def assign_project_role(
     if membership is None:
         raise HTTPException(status_code=404, detail="Project membership not found")
 
+    principal = resolve_principal(current_user)
+    actor_level = _get_actor_level(principal, project_id=project_id, db=db)
+    actor_permissions = _get_actor_permissions(principal, project_id=project_id, db=db)
+
+    if membership.role_id is not None and membership.role_id != body.role_id:
+        # Symmetric escalation guard, mirroring assign_org_role: without this,
+        # an actor could downgrade a member who currently outranks them (e.g.
+        # a project Admin demoting an org Owner's project role) since
+        # check_project_role_assignment above only validates the *new*
+        # role's level, which is always ≤ the actor's own level. Reuse the
+        # same helper that computes `permitted_actions` on
+        # list_project_members so the write guard and the affordance the
+        # frontend reads from can never drift apart.
+        current_role = _load_role(membership.role_id, db)
+        current_role_level = current_role.level if current_role is not None else None
+        if not _member_permitted_actions(
+            is_self=False,
+            current_role_level=current_role_level,
+            current_role_is_built_in=current_role.is_built_in if current_role else True,
+            current_role_permission_names=set(_role_permission_names_resolved(current_role, db))
+            if current_role
+            else None,
+            actor_level=actor_level,
+            actor_permissions=actor_permissions,
+            include_delete=False,
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "Privilege escalation denied: cannot modify a member "
+                    f"whose current role level ({current_role_level}) exceeds "
+                    f"your own ({actor_level})"
+                ),
+            )
+
     membership.role_id = body.role_id
     db.flush()
     _bust(user_id, current_user.organization_id)
@@ -947,6 +1162,17 @@ def assign_project_role(
         user_id=user_id,
         role_id=body.role_id,
         role=_role_to_read(target_role, db),
+        permitted_actions=_member_permitted_actions(
+            is_self=False,
+            current_role_level=target_role.level,
+            current_role_is_built_in=target_role.is_built_in,
+            current_role_permission_names=set(
+                _role_permission_names_resolved(target_role, db)
+            ),
+            actor_level=actor_level,
+            actor_permissions=actor_permissions,
+            include_delete=False,
+        ),
     )
 
 

--- a/ee/backend/src/rhesis/backend/ee/rbac/router.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/router.py
@@ -14,6 +14,7 @@ Role catalog:
 
 Org-level role assignment:
   GET    /organization-members         — list org-level role assignments
+  GET    /organization-members/{user_id}/project-memberships — user's projects + roles
   PUT    /organization-members/{user_id}/role   — assign org role
   DELETE /organization-members/{user_id}        — remove org membership row
 
@@ -47,9 +48,11 @@ from rhesis.backend.ee.rbac.schemas import (
     OrgRoleAssign,
     ProjectMemberRoleAssign,
     ProjectMemberRoleRead,
+    ProjectSummary,
     RoleCreate,
     RoleRead,
     RoleUpdate,
+    UserProjectMembershipRead,
 )
 
 logger = logging.getLogger(__name__)
@@ -613,13 +616,100 @@ def list_org_members(
     current_user: User = Depends(require_current_user_or_token),
     _org=_RBAC_DEP,
 ):
-    """List all org-level role assignments for the current organization."""
+    """List all org-level role assignments with user details for the current org.
+
+    Returns user summary alongside each membership so the team grid can be
+    built from this single call instead of ``GET /users`` + ``GET /rbac/
+    organization-members``.
+
+    Batch-loads unique roles to avoid N+1 lazy-load queries (built-in roles
+    have ``organization_id IS NULL`` and are filtered out by the tenant
+    listener, so the ORM relationship always returns None).
+    """
+    from rhesis.backend.app.models.user import User as UserModel
     from rhesis.backend.ee.rbac.models import OrganizationMember
+    from rhesis.backend.ee.rbac.schemas import UserSummary
 
     members = (
         db.query(OrganizationMember).filter_by(organization_id=current_user.organization_id).all()
     )
-    return [OrgMemberRead.model_validate(m) for m in members]
+
+    unique_role_ids = {m.role_id for m in members}
+    roles_by_id = {}
+    for role_id in unique_role_ids:
+        role = _load_role(role_id, db)
+        if role is not None:
+            roles_by_id[role_id] = _role_to_read(role, db)
+
+    user_ids = [m.user_id for m in members]
+    users = db.query(UserModel).filter(UserModel.id.in_(user_ids)).all() if user_ids else []
+    users_by_id = {u.id: u for u in users}
+
+    return [
+        OrgMemberRead(
+            id=m.id,
+            organization_id=m.organization_id,
+            user_id=m.user_id,
+            role_id=m.role_id,
+            role=roles_by_id.get(m.role_id),
+            user=UserSummary.model_validate(users_by_id[m.user_id])
+            if m.user_id in users_by_id
+            else None,
+        )
+        for m in members
+    ]
+
+
+@router.get(
+    "/organization-members/{user_id}/project-memberships",
+    response_model=list[UserProjectMembershipRead],
+    **capability(Permission.Member.READ),
+)
+def list_user_project_memberships(
+    user_id: uuid.UUID,
+    db: Session = Depends(get_tenant_db_session),
+    current_user: User = Depends(require_current_user_or_token),
+    _org=_RBAC_DEP,
+):
+    """Return every project membership for *user_id* in a single call.
+
+    Replaces the N per-project ``GET /projects/{id}/members`` waterfall
+    that the Member Access drawer previously required.
+
+    Batch-loads unique roles and eager-loads ``project`` to avoid N+1
+    lazy-load queries, mirroring ``list_org_members``.
+    """
+    from sqlalchemy.orm import joinedload
+
+    from rhesis.backend.app.models.project_membership import ProjectMembership
+
+    memberships = (
+        db.query(ProjectMembership)
+        .filter_by(
+            user_id=user_id,
+            organization_id=current_user.organization_id,
+        )
+        .options(joinedload(ProjectMembership.project))
+        .all()
+    )
+
+    unique_role_ids = {m.role_id for m in memberships if m.role_id is not None}
+    roles_by_id = {}
+    for role_id in unique_role_ids:
+        role = _load_role(role_id, db)
+        if role is not None:
+            roles_by_id[role_id] = _role_to_read(role, db)
+
+    return [
+        UserProjectMembershipRead(
+            project_id=m.project_id,
+            user_id=m.user_id,
+            role_id=m.role_id,
+            role=roles_by_id.get(m.role_id),
+            project=ProjectSummary.model_validate(m.project),
+        )
+        for m in memberships
+    ]
 
 
 @router.put(
@@ -645,6 +735,12 @@ def assign_org_role(
     principal = resolve_principal(current_user)
     actor_permissions = _get_actor_permissions(principal, project_id=None, db=db)
     actor_level = _get_actor_level(principal, project_id=None, db=db)
+
+    if str(user_id) == str(current_user.id):
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot change your own organization role",
+        )
 
     target_role = _get_role_or_404(body.role_id, db)
 
@@ -766,6 +862,9 @@ def list_project_members(
     explicitly: the caller must be enrolled in the project or hold an org-level
     ``member:manage`` role (Admin/Owner). Otherwise a plain org Viewer could
     enumerate any project's members.
+
+    Batch-loads unique roles to avoid N+1 lazy-load queries, mirroring
+    ``list_org_members``.
     """
     from rhesis.backend.app.models.project_membership import ProjectMembership
 
@@ -780,18 +879,22 @@ def list_project_members(
         .all()
     )
 
-    result = []
-    for m in memberships:
-        role = _load_role(m.role_id, db) if m.role_id is not None else None
-        result.append(
-            ProjectMemberRoleRead(
-                project_id=project_id,
-                user_id=m.user_id,
-                role_id=m.role_id,
-                role=_role_to_read(role, db) if role is not None else None,
-            )
+    unique_role_ids = {m.role_id for m in memberships if m.role_id is not None}
+    roles_by_id = {}
+    for role_id in unique_role_ids:
+        role = _load_role(role_id, db)
+        if role is not None:
+            roles_by_id[role_id] = _role_to_read(role, db)
+
+    return [
+        ProjectMemberRoleRead(
+            project_id=project_id,
+            user_id=m.user_id,
+            role_id=m.role_id,
+            role=roles_by_id.get(m.role_id),
         )
-    return result
+        for m in memberships
+    ]
 
 
 @router.put(

--- a/ee/backend/src/rhesis/backend/ee/rbac/schemas.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/schemas.py
@@ -99,6 +99,12 @@ class OrgMemberRead(BaseModel):
     role_id: UUID
     role: Optional[RoleRead] = None
     user: Optional[UserSummary] = None
+    #: Capability strings the caller may exercise on THIS member (e.g.
+    #: "member:manage", "member:delete"), server-resolved by the router.
+    #: Encodes the privilege-escalation guard (self-change and outranking
+    #: are both denied) so the frontend never re-derives it. See
+    #: `_member_permitted_actions` in router.py.
+    permitted_actions: list[str] = Field(default_factory=list)
 
     model_config = {"from_attributes": True}
 
@@ -127,6 +133,12 @@ class ProjectMemberRoleRead(BaseModel):
     user_id: UUID
     role_id: Optional[UUID] = None
     role: Optional[RoleRead] = None
+    #: Capability strings the caller may exercise on THIS member (e.g.
+    #: "member:manage"), server-resolved by the router. Encodes the
+    #: privilege-escalation guard (self-change and outranking are both
+    #: denied) so the frontend never re-derives it. See
+    #: `_member_permitted_actions` in router.py.
+    permitted_actions: list[str] = Field(default_factory=list)
 
     model_config = {"from_attributes": True}
 

--- a/ee/backend/src/rhesis/backend/ee/rbac/schemas.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/schemas.py
@@ -69,6 +69,25 @@ class RoleUpdate(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# User summary (for enriched org-member responses)
+# ---------------------------------------------------------------------------
+
+
+class UserSummary(BaseModel):
+    """Minimal user fields for the team members grid."""
+
+    id: UUID
+    name: Optional[str] = None
+    given_name: Optional[str] = None
+    family_name: Optional[str] = None
+    email: str
+    picture: Optional[str] = None
+    auth0_id: Optional[str] = None
+
+    model_config = {"from_attributes": True}
+
+
+# ---------------------------------------------------------------------------
 # Organization member role assignment
 # ---------------------------------------------------------------------------
 
@@ -79,6 +98,7 @@ class OrgMemberRead(BaseModel):
     user_id: UUID
     role_id: UUID
     role: Optional[RoleRead] = None
+    user: Optional[UserSummary] = None
 
     model_config = {"from_attributes": True}
 
@@ -111,13 +131,44 @@ class ProjectMemberRoleRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+# ---------------------------------------------------------------------------
+# Bulk user-project membership (single-call alternative to N per-project fetches)
+# ---------------------------------------------------------------------------
+
+
+class ProjectSummary(BaseModel):
+    """Minimal project fields needed by the Member Access drawer."""
+
+    id: UUID
+    name: str
+    description: Optional[str] = None
+    icon: Optional[str] = None
+
+    model_config = {"from_attributes": True}
+
+
+class UserProjectMembershipRead(BaseModel):
+    """A user's membership in a single project, including project summary and role."""
+
+    project_id: UUID
+    user_id: UUID
+    role_id: Optional[UUID] = None
+    role: Optional[RoleRead] = None
+    project: ProjectSummary
+
+    model_config = {"from_attributes": True}
+
+
 __all__ = [
     "OrgMemberRead",
     "OrgRoleAssign",
     "PermissionRead",
+    "UserSummary",
     "ProjectMemberRoleAssign",
     "ProjectMemberRoleRead",
+    "ProjectSummary",
     "RoleCreate",
     "RoleRead",
     "RoleUpdate",
+    "UserProjectMembershipRead",
 ]

--- a/ee/frontend/src/rbac/__mocks__/_mocks.tsx
+++ b/ee/frontend/src/rbac/__mocks__/_mocks.tsx
@@ -19,7 +19,12 @@ import type { RoleRead } from '../types';
 // ---------------------------------------------------------------------------
 
 export const canMock = {
-  can: jest.fn(() => true),
+  can: jest.fn(
+    (
+      _subject: { permitted_actions?: string[] } | null | undefined,
+      _capability: string
+    ) => true
+  ),
   useCan: jest.fn((_capability?: string) => true),
   useCanWithStatus: jest.fn(() => ({ allowed: true, loading: false })),
   // Ambient-only stub (no `subject` support): mirrors useCan so a single

--- a/ee/frontend/src/rbac/__tests__/register.test.ts
+++ b/ee/frontend/src/rbac/__tests__/register.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Focused tests for register.tsx's `prewarmCaches` / `prewarmProjectCaches`.
+ *
+ * These gate `GET /rbac/roles` behind `canManageRoles`, since that endpoint
+ * requires `Permission.Role.READ`, which viewers without member-management
+ * rights don't hold — fetching it unconditionally would fire a doomed 403 on
+ * every non-admin page load (see TeamMembersGrid.tsx / ProjectMembers.tsx).
+ * Org/project members are always fetched: every role chip needs them
+ * regardless of the viewer's own permissions.
+ */
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+jest.mock('../api/org-members-cache', () => ({
+  fetchOrgMembers: jest.fn(),
+}));
+jest.mock('../api/project-members-cache', () => ({
+  fetchProjectMembers: jest.fn(),
+}));
+jest.mock('../api/role-cache', () => ({
+  fetchRoles: jest.fn(),
+}));
+
+import {
+  getMemberRoleExtensions,
+  resetMemberRoleExtensions,
+} from '@/lib/extension-registries';
+import { registerRBAC } from '../register';
+import { fetchOrgMembers } from '../api/org-members-cache';
+import { fetchProjectMembers } from '../api/project-members-cache';
+import { fetchRoles } from '../api/role-cache';
+
+const SESSION_TOKEN = 'session-token';
+const PROJECT_ID = 'project-1';
+
+describe('register.tsx — prewarm caches', () => {
+  beforeEach(() => {
+    resetMemberRoleExtensions();
+    jest.clearAllMocks();
+    registerRBAC();
+  });
+
+  describe('prewarmCaches', () => {
+    it('always fetches org members', () => {
+      getMemberRoleExtensions().prewarmCaches?.(SESSION_TOKEN);
+      expect(fetchOrgMembers).toHaveBeenCalledWith(SESSION_TOKEN);
+    });
+
+    it('fetches roles when canManageRoles is true', () => {
+      getMemberRoleExtensions().prewarmCaches?.(SESSION_TOKEN, {
+        canManageRoles: true,
+      });
+      expect(fetchRoles).toHaveBeenCalledWith(SESSION_TOKEN);
+    });
+
+    it('does not fetch roles when canManageRoles is false or omitted', () => {
+      getMemberRoleExtensions().prewarmCaches?.(SESSION_TOKEN, {
+        canManageRoles: false,
+      });
+      getMemberRoleExtensions().prewarmCaches?.(SESSION_TOKEN);
+      expect(fetchRoles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('prewarmProjectCaches', () => {
+    it('always fetches project members', () => {
+      getMemberRoleExtensions().prewarmProjectCaches?.(
+        SESSION_TOKEN,
+        PROJECT_ID
+      );
+      expect(fetchProjectMembers).toHaveBeenCalledWith(
+        SESSION_TOKEN,
+        PROJECT_ID
+      );
+    });
+
+    it('fetches roles when canManageRoles is true', () => {
+      getMemberRoleExtensions().prewarmProjectCaches?.(
+        SESSION_TOKEN,
+        PROJECT_ID,
+        { canManageRoles: true }
+      );
+      expect(fetchRoles).toHaveBeenCalledWith(SESSION_TOKEN);
+    });
+
+    it('does not fetch roles when canManageRoles is false or omitted', () => {
+      getMemberRoleExtensions().prewarmProjectCaches?.(
+        SESSION_TOKEN,
+        PROJECT_ID,
+        { canManageRoles: false }
+      );
+      getMemberRoleExtensions().prewarmProjectCaches?.(
+        SESSION_TOKEN,
+        PROJECT_ID
+      );
+      expect(fetchRoles).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ee/frontend/src/rbac/api/__tests__/rbac-client.test.ts
+++ b/ee/frontend/src/rbac/api/__tests__/rbac-client.test.ts
@@ -109,6 +109,13 @@ describe('RbacClient', () => {
     );
   });
 
+  it('getUserProjectMemberships hits GET /rbac/organization-members/<userId>/project-memberships', async () => {
+    await client.getUserProjectMemberships(USER_ID);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `/rbac/organization-members/${USER_ID}/project-memberships`
+    );
+  });
+
   it('getProjectMembers hits GET /rbac/projects/<projectId>/members', async () => {
     await client.getProjectMembers(PROJECT_ID);
     expect(fetchSpy).toHaveBeenCalledWith(

--- a/ee/frontend/src/rbac/api/rbac-client.ts
+++ b/ee/frontend/src/rbac/api/rbac-client.ts
@@ -18,6 +18,7 @@ import type {
   OrgRoleAssign,
   ProjectMemberRoleRead,
   ProjectMemberRoleAssign,
+  UserProjectMembershipRead,
 } from '../types';
 
 const BASE = '/rbac';
@@ -84,6 +85,14 @@ export class RbacClient extends BaseApiClient {
   async getProjectMembers(projectId: string): Promise<ProjectMemberRoleRead[]> {
     return this.fetch<ProjectMemberRoleRead[]>(
       `${BASE}/projects/${projectId}/members`
+    );
+  }
+
+  async getUserProjectMemberships(
+    userId: string
+  ): Promise<UserProjectMembershipRead[]> {
+    return this.fetch<UserProjectMembershipRead[]>(
+      `${BASE}/organization-members/${userId}/project-memberships`
     );
   }
 

--- a/ee/frontend/src/rbac/components/OrgRoleChip.tsx
+++ b/ee/frontend/src/rbac/components/OrgRoleChip.tsx
@@ -192,7 +192,11 @@ export default function OrgRoleChip({
       sx={{ minWidth: 120, fontSize: 13 }}
     >
       {extraCurrentRole && (
-        <MenuItem key={extraCurrentRole.id} value={extraCurrentRole.id} disabled>
+        <MenuItem
+          key={extraCurrentRole.id}
+          value={extraCurrentRole.id}
+          disabled
+        >
           {extraCurrentRole.display_name}
         </MenuItem>
       )}

--- a/ee/frontend/src/rbac/components/OrgRoleChip.tsx
+++ b/ee/frontend/src/rbac/components/OrgRoleChip.tsx
@@ -9,7 +9,7 @@ import {
   Skeleton,
   Typography,
 } from '@mui/material';
-import { useCan } from '@/components/common/Can';
+import { can, useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { useFeature } from '@/contexts/FeaturesContext';
 import { FeatureName } from '@/constants/features';
@@ -37,7 +37,6 @@ interface OrgRoleChipProps {
   userId: string;
   sessionToken: string;
   onRoleChanged?: () => void;
-  currentUserId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -48,7 +47,6 @@ export default function OrgRoleChip({
   userId,
   sessionToken,
   onRoleChanged,
-  currentUserId,
 }: OrgRoleChipProps) {
   const rbacEnabled = useFeature(FeatureName.RBAC);
   const canManage = useCan(Capability.Member.MANAGE);
@@ -145,10 +143,11 @@ export default function OrgRoleChip({
     return <Skeleton variant="rounded" width={110} height={32} />;
   }
 
-  // Changing your own org role is high-risk (self-demotion, including the
-  // last-Owner case) and gets no confirmation step, so it is read-only here
-  // rather than merely discouraged.
-  if (currentUserId && userId === currentUserId) {
+  // `member.permitted_actions` is server-resolved and already encodes every
+  // reason this member can't be modified — self-change, last-Owner, or
+  // outranking the actor (e.g. a project Admin viewing an org Owner). The
+  // frontend must not re-derive any of that; it only checks membership.
+  if (!can(member, Capability.Member.MANAGE)) {
     if (!member?.role) {
       return (
         <Typography variant="body2" color="text.disabled">
@@ -169,7 +168,7 @@ export default function OrgRoleChip({
     <Select
       value={member?.role_id ?? ''}
       onChange={handleChange}
-      disabled={!canManage || assigning}
+      disabled={assigning}
       size="small"
       displayEmpty
       renderValue={selected => {

--- a/ee/frontend/src/rbac/components/OrgRoleChip.tsx
+++ b/ee/frontend/src/rbac/components/OrgRoleChip.tsx
@@ -105,6 +105,13 @@ export default function OrgRoleChip({
       isAssignableOrgRole(r) &&
       isWithinActorAuthority(r, myLevel, myPermissions)
   );
+  // The member's current role (e.g. Owner, or a role above the viewer's
+  // authority) may not be in `assignableRoles`. MUI's Select warns
+  // ("out-of-range value") when the controlled value has no matching
+  // MenuItem, so always render it — disabled — if it's missing.
+  const currentRoleInList = assignableRoles.some(r => r.id === member?.role_id);
+  const extraCurrentRole =
+    !currentRoleInList && member?.role ? member.role : null;
 
   const handleChange = useCallback(
     async (e: SelectChangeEvent<string>) => {
@@ -173,13 +180,23 @@ export default function OrgRoleChip({
             </Typography>
           );
         }
-        // Use the full roles list so non-assignable roles (e.g. Owner) still
-        // display their name rather than falling back to the raw UUID.
-        const role = roles.find(r => r.id === selected);
-        return role?.display_name ?? selected;
+        // `member.role` is already resolved by the backend and arrives with
+        // the members fetch that gates the loading skeleton, so prefer it
+        // over the separate (slower, permission-gated) roles catalog fetch —
+        // otherwise the raw UUID flashes until that catalog resolves. Fall
+        // back to the catalog only for the unexpected case where it's stale.
+        const label =
+          member?.role?.display_name ??
+          roles.find(r => r.id === selected)?.display_name;
+        return label ?? selected;
       }}
       sx={{ minWidth: 120, fontSize: 13 }}
     >
+      {extraCurrentRole && (
+        <MenuItem key={extraCurrentRole.id} value={extraCurrentRole.id} disabled>
+          {extraCurrentRole.display_name}
+        </MenuItem>
+      )}
       {assignableRoles.map(role => (
         <MenuItem key={role.id} value={role.id}>
           {role.display_name}

--- a/ee/frontend/src/rbac/components/ProjectRoleChip.tsx
+++ b/ee/frontend/src/rbac/components/ProjectRoleChip.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import {
+  Chip,
   MenuItem,
   Select,
   SelectChangeEvent,
@@ -22,6 +23,7 @@ import {
   getCachedProjectMembers,
 } from '../api/project-members-cache';
 import {
+  getRoleChipSx,
   isAssignableProjectRole,
   isWithinActorAuthority,
 } from '../role-display';
@@ -37,6 +39,11 @@ interface ProjectRoleChipProps {
   projectId: string;
   sessionToken: string;
   onRoleChanged?: () => void;
+  /** The signed-in viewer's user id. When it matches `userId`, the cell
+   *  should render read-only — changing your own project role is high-risk
+   *  and gets no confirmation loop, so it is disabled rather than merely
+   *  discouraged. */
+  currentUserId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -48,6 +55,7 @@ export default function ProjectRoleChip({
   projectId,
   sessionToken,
   onRoleChanged,
+  currentUserId,
 }: ProjectRoleChipProps) {
   const rbacEnabled = useFeature(FeatureName.RBAC);
   const canManage = useCan(Capability.ProjectMember.MANAGE);
@@ -103,6 +111,15 @@ export default function ProjectRoleChip({
       isAssignableProjectRole(r) &&
       isWithinActorAuthority(r, myLevel, myPermissions)
   );
+  // The member's current role (e.g. Owner, or a role above the viewer's
+  // authority) may not be in `assignableRoles`. MUI's Select warns
+  // ("out-of-range value") when the controlled value has no matching
+  // MenuItem, so always render it — disabled — if it's missing.
+  const currentRoleInList = assignableRoles.some(
+    r => r.id === memberEntry?.role_id
+  );
+  const extraCurrentRole =
+    !currentRoleInList && memberEntry?.role ? memberEntry.role : null;
 
   const handleChange = useCallback(
     async (e: SelectChangeEvent<string>) => {
@@ -140,6 +157,25 @@ export default function ProjectRoleChip({
     return <Skeleton variant="rounded" width={110} height={32} />;
   }
 
+  // Changing your own project role is high-risk and gets no confirmation
+  // step, so it is read-only here rather than merely discouraged.
+  if (currentUserId && userId === currentUserId) {
+    if (!memberEntry?.role) {
+      return (
+        <Typography variant="body2" color="text.disabled">
+          —
+        </Typography>
+      );
+    }
+    return (
+      <Chip
+        label={memberEntry.role.display_name}
+        size="small"
+        sx={getRoleChipSx(memberEntry.role)}
+      />
+    );
+  }
+
   return (
     <Select
       value={memberEntry?.role_id ?? ''}
@@ -155,13 +191,24 @@ export default function ProjectRoleChip({
             </Typography>
           );
         }
-        // Use the full roles list so non-assignable roles (e.g. Owner) still
-        // display their name rather than falling back to the raw UUID.
-        const role = roles.find(r => r.id === selected);
-        return role?.display_name ?? selected;
+        // `memberEntry.role` is already resolved by the backend and arrives
+        // with the members fetch that gates the loading skeleton, so prefer
+        // it over the separate (slower, permission-gated) roles catalog
+        // fetch — otherwise the raw UUID flashes until that catalog
+        // resolves. Fall back to the catalog only for the unexpected case
+        // where it's stale.
+        const label =
+          memberEntry?.role?.display_name ??
+          roles.find(r => r.id === selected)?.display_name;
+        return label ?? selected;
       }}
       sx={{ minWidth: 120, fontSize: 13 }}
     >
+      {extraCurrentRole && (
+        <MenuItem key={extraCurrentRole.id} value={extraCurrentRole.id} disabled>
+          {extraCurrentRole.display_name}
+        </MenuItem>
+      )}
       {assignableRoles.map(role => (
         <MenuItem key={role.id} value={role.id}>
           {role.display_name}

--- a/ee/frontend/src/rbac/components/ProjectRoleChip.tsx
+++ b/ee/frontend/src/rbac/components/ProjectRoleChip.tsx
@@ -9,7 +9,7 @@ import {
   Skeleton,
   Typography,
 } from '@mui/material';
-import { useCan } from '@/components/common/Can';
+import { can, useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { useFeature } from '@/contexts/FeaturesContext';
 import { FeatureName } from '@/constants/features';
@@ -39,11 +39,6 @@ interface ProjectRoleChipProps {
   projectId: string;
   sessionToken: string;
   onRoleChanged?: () => void;
-  /** The signed-in viewer's user id. When it matches `userId`, the cell
-   *  should render read-only — changing your own project role is high-risk
-   *  and gets no confirmation loop, so it is disabled rather than merely
-   *  discouraged. */
-  currentUserId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -55,7 +50,6 @@ export default function ProjectRoleChip({
   projectId,
   sessionToken,
   onRoleChanged,
-  currentUserId,
 }: ProjectRoleChipProps) {
   const rbacEnabled = useFeature(FeatureName.RBAC);
   const canManage = useCan(Capability.ProjectMember.MANAGE);
@@ -157,9 +151,14 @@ export default function ProjectRoleChip({
     return <Skeleton variant="rounded" width={110} height={32} />;
   }
 
-  // Changing your own project role is high-risk and gets no confirmation
-  // step, so it is read-only here rather than merely discouraged.
-  if (currentUserId && userId === currentUserId) {
+  // `memberEntry.permitted_actions` is server-resolved and already encodes
+  // every reason this member can't be modified — self-change or outranking
+  // the actor. The frontend must not re-derive any of that; it only checks
+  // membership. Uses `Capability.Member.MANAGE` (not `ProjectMember.MANAGE`)
+  // because `assign_project_role`/`list_project_members` are gated by the
+  // same `member:manage` capability as the org-level endpoints, evaluated
+  // at project scope.
+  if (!can(memberEntry, Capability.Member.MANAGE)) {
     if (!memberEntry?.role) {
       return (
         <Typography variant="body2" color="text.disabled">
@@ -180,7 +179,7 @@ export default function ProjectRoleChip({
     <Select
       value={memberEntry?.role_id ?? ''}
       onChange={handleChange}
-      disabled={!canManage || assigning}
+      disabled={assigning}
       size="small"
       displayEmpty
       renderValue={selected => {

--- a/ee/frontend/src/rbac/components/ProjectRoleChip.tsx
+++ b/ee/frontend/src/rbac/components/ProjectRoleChip.tsx
@@ -204,7 +204,11 @@ export default function ProjectRoleChip({
       sx={{ minWidth: 120, fontSize: 13 }}
     >
       {extraCurrentRole && (
-        <MenuItem key={extraCurrentRole.id} value={extraCurrentRole.id} disabled>
+        <MenuItem
+          key={extraCurrentRole.id}
+          value={extraCurrentRole.id}
+          disabled
+        >
           {extraCurrentRole.display_name}
         </MenuItem>
       )}

--- a/ee/frontend/src/rbac/components/__tests__/OrgRoleChip.test.tsx
+++ b/ee/frontend/src/rbac/components/__tests__/OrgRoleChip.test.tsx
@@ -2,8 +2,16 @@
  * OrgRoleChip — org-level role chip/selector in the team members grid.
  *
  * Covers the reviewer-flagged regression (unlicensed fetch no longer hangs in
- * the loading skeleton — OrgRoleChip.tsx:73-79), the read-only own-row branch
- * (144-159), and the error toast on a failed role change (122-129).
+ * the loading skeleton — OrgRoleChip.tsx:73-79), the read-only branch driven
+ * by the server-resolved `permitted_actions` (144-159), and the error toast
+ * on a failed role change (122-129).
+ *
+ * The read-only branch is gated by `can(member, Capability.Member.MANAGE)`,
+ * which is a pure membership check against `member.permitted_actions` — the
+ * backend (`_member_permitted_actions` in router.py) is the single source of
+ * truth for self-change/outranking/ambient-permission logic, not this
+ * component. Tests that exercise that branch override `canMock.can` with a
+ * real membership check so the mock doesn't mask a component regression.
  */
 
 import React from 'react';
@@ -59,8 +67,22 @@ function member(overrides: Partial<OrgMemberRead> = {}): OrgMemberRead {
     user_id: USER_ID,
     role_id: VIEWER_ROLE.id,
     role: VIEWER_ROLE,
+    permitted_actions: ['member:manage', 'member:delete'],
     ...overrides,
   };
+}
+
+/** Mirrors the real `can()` in `@/utils/affordances`: pure membership check
+ *  against `subject.permitted_actions`. Tests that care about the
+ *  read-only/editable branch install this so the mock doesn't just return
+ *  `true` unconditionally and mask a regression in that branch. */
+function useRealCanImplementation() {
+  canMock.can.mockImplementation(
+    (
+      subject: { permitted_actions?: string[] } | null | undefined,
+      capability: string
+    ) => subject?.permitted_actions?.includes(capability) ?? false
+  );
 }
 
 beforeEach(() => {
@@ -82,19 +104,30 @@ describe('OrgRoleChip', () => {
     expect(await screen.findByText('Assign role')).toBeInTheDocument();
   });
 
-  it('renders a read-only chip for the caller’s own row', async () => {
-    rbacClientInstanceMock.getOrganizationMembers.mockResolvedValue([member()]);
+  it('renders a read-only chip when permitted_actions excludes member:manage', async () => {
+    // The backend returns an empty permitted_actions for the caller's own
+    // row, an outranked member, or an ambient-permission miss — the
+    // component treats all of these identically via `can()`.
+    useRealCanImplementation();
+    rbacClientInstanceMock.getOrganizationMembers.mockResolvedValue([
+      member({ permitted_actions: [] }),
+    ]);
 
-    render(
-      <OrgRoleChip
-        userId={USER_ID}
-        sessionToken={SESSION_TOKEN}
-        currentUserId={USER_ID}
-      />
-    );
+    render(<OrgRoleChip userId={USER_ID} sessionToken={SESSION_TOKEN} />);
 
     expect(await screen.findByText('Viewer')).toBeInTheDocument();
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('renders an editable select when permitted_actions includes member:manage', async () => {
+    useRealCanImplementation();
+    rbacClientInstanceMock.getOrganizationMembers.mockResolvedValue([
+      member({ permitted_actions: ['member:manage'] }),
+    ]);
+
+    render(<OrgRoleChip userId={USER_ID} sessionToken={SESSION_TOKEN} />);
+
+    expect(await screen.findByRole('combobox')).toBeInTheDocument();
   });
 
   it('shows an error toast when a role change is rejected', async () => {

--- a/ee/frontend/src/rbac/components/__tests__/ProjectRoleChip.test.tsx
+++ b/ee/frontend/src/rbac/components/__tests__/ProjectRoleChip.test.tsx
@@ -2,9 +2,13 @@
  * ProjectRoleChip — project-level role selector in the project members grid.
  *
  * Mirrors OrgRoleChip.test.tsx's shape (loading/404-exits-skeleton/assign
- * flow), minus the own-row read-only branch: ProjectRoleChip has no self-row
- * exclusion, so every row (including the caller's own) is an assignable
- * Select.
+ * flow), including the read-only branch: it's gated by
+ * `can(memberEntry, Capability.Member.MANAGE)`, a pure membership check
+ * against `memberEntry.permitted_actions` — the backend
+ * (`_member_permitted_actions` in router.py) is the single source of truth
+ * for self-change/outranking/ambient-permission logic, not this component.
+ * Tests that exercise that branch override `canMock.can` with a real
+ * membership check so the mock doesn't mask a component regression.
  */
 
 import React from 'react';
@@ -62,8 +66,22 @@ function member(
     user_id: USER_ID,
     role_id: null,
     role: null,
+    permitted_actions: ['member:manage'],
     ...overrides,
   };
+}
+
+/** Mirrors the real `can()` in `@/utils/affordances`: pure membership check
+ *  against `subject.permitted_actions`. Tests that care about the
+ *  read-only/editable branch install this so the mock doesn't just return
+ *  `true` unconditionally and mask a regression in that branch. */
+function useRealCanImplementation() {
+  canMock.can.mockImplementation(
+    (
+      subject: { permitted_actions?: string[] } | null | undefined,
+      capability: string
+    ) => subject?.permitted_actions?.includes(capability) ?? false
+  );
 }
 
 beforeEach(() => {
@@ -91,6 +109,44 @@ describe('ProjectRoleChip', () => {
 
     // Falls through to the assignable Select instead of hanging forever.
     expect(await screen.findByText('Assign role')).toBeInTheDocument();
+  });
+
+  it('renders a read-only chip when permitted_actions excludes member:manage', async () => {
+    // The backend returns an empty permitted_actions for the caller's own
+    // row or an outranked member (e.g. a project Admin viewing a project
+    // Owner) — the component treats both identically via `can()`.
+    useRealCanImplementation();
+    rbacClientInstanceMock.getProjectMembers.mockResolvedValue([
+      member({ role_id: ADMIN_ROLE.id, role: ADMIN_ROLE, permitted_actions: [] }),
+    ]);
+
+    render(
+      <ProjectRoleChip
+        userId={USER_ID}
+        projectId={PROJECT_ID}
+        sessionToken={SESSION_TOKEN}
+      />
+    );
+
+    expect(await screen.findByText('Admin')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('renders an editable select when permitted_actions includes member:manage', async () => {
+    useRealCanImplementation();
+    rbacClientInstanceMock.getProjectMembers.mockResolvedValue([
+      member({ permitted_actions: ['member:manage'] }),
+    ]);
+
+    render(
+      <ProjectRoleChip
+        userId={USER_ID}
+        projectId={PROJECT_ID}
+        sessionToken={SESSION_TOKEN}
+      />
+    );
+
+    expect(await screen.findByRole('combobox')).toBeInTheDocument();
   });
 
   it('assigns a role and shows the updated value', async () => {

--- a/ee/frontend/src/rbac/components/__tests__/ProjectRoleChip.test.tsx
+++ b/ee/frontend/src/rbac/components/__tests__/ProjectRoleChip.test.tsx
@@ -117,7 +117,11 @@ describe('ProjectRoleChip', () => {
     // Owner) — the component treats both identically via `can()`.
     useRealCanImplementation();
     rbacClientInstanceMock.getProjectMembers.mockResolvedValue([
-      member({ role_id: ADMIN_ROLE.id, role: ADMIN_ROLE, permitted_actions: [] }),
+      member({
+        role_id: ADMIN_ROLE.id,
+        role: ADMIN_ROLE,
+        permitted_actions: [],
+      }),
     ]);
 
     render(

--- a/ee/frontend/src/rbac/register.tsx
+++ b/ee/frontend/src/rbac/register.tsx
@@ -26,6 +26,9 @@ import ProjectRoleChip from './components/ProjectRoleChip';
 import RoleSelectField from './components/RoleSelectField';
 import TokenScopeField from './components/TokenScopeField';
 import { RbacClient } from './api/rbac-client';
+import { fetchOrgMembers } from './api/org-members-cache';
+import { fetchProjectMembers } from './api/project-members-cache';
+import { fetchRoles } from './api/role-cache';
 
 const RolesTab = React.lazy(() => import('./components/RolesTab'));
 
@@ -67,6 +70,25 @@ export function registerRBAC(): void {
       await client.assignProjectRole(projectId, userId, {
         role_id: roleId,
       });
+    },
+    fetchUserProjectMemberships: async (
+      sessionToken: string,
+      userId: string
+    ) => {
+      const client = new RbacClient(sessionToken);
+      return client.getUserProjectMemberships(userId);
+    },
+    prewarmCaches: (sessionToken, opts) => {
+      fetchOrgMembers(sessionToken);
+      if (opts?.canManageRoles) {
+        fetchRoles(sessionToken);
+      }
+    },
+    prewarmProjectCaches: (sessionToken, projectId, opts) => {
+      fetchProjectMembers(sessionToken, projectId);
+      if (opts?.canManageRoles) {
+        fetchRoles(sessionToken);
+      }
     },
   });
 

--- a/ee/frontend/src/rbac/types.ts
+++ b/ee/frontend/src/rbac/types.ts
@@ -47,12 +47,23 @@ export interface RoleUpdate {
   permission_names?: string[];
 }
 
+export interface UserSummary {
+  id: string;
+  name?: string | null;
+  given_name?: string | null;
+  family_name?: string | null;
+  email: string;
+  picture?: string | null;
+  auth0_id?: string | null;
+}
+
 export interface OrgMemberRead {
   id: string;
   organization_id: string;
   user_id: string;
   role_id: string;
   role?: RoleRead;
+  user?: UserSummary | null;
 }
 
 export interface OrgRoleAssign {
@@ -68,4 +79,19 @@ export interface ProjectMemberRoleRead {
 
 export interface ProjectMemberRoleAssign {
   role_id: string;
+}
+
+export interface ProjectSummary {
+  id: string;
+  name: string;
+  description?: string | null;
+  icon?: string | null;
+}
+
+export interface UserProjectMembershipRead {
+  project_id: string;
+  user_id: string;
+  role_id: string | null;
+  role?: RoleRead | null;
+  project: ProjectSummary;
 }

--- a/ee/frontend/src/rbac/types.ts
+++ b/ee/frontend/src/rbac/types.ts
@@ -64,6 +64,11 @@ export interface OrgMemberRead {
   role_id: string;
   role?: RoleRead;
   user?: UserSummary | null;
+  /** Capability strings the caller may exercise on THIS member (e.g.
+   *  "member:manage", "member:delete"), server-resolved. Encodes the
+   *  privilege-escalation guard (self-change and outranking are both
+   *  denied) — check with `can()`, never re-derive it client-side. */
+  permitted_actions?: string[];
 }
 
 export interface OrgRoleAssign {
@@ -75,6 +80,11 @@ export interface ProjectMemberRoleRead {
   user_id: string;
   role_id: string | null;
   role?: RoleRead | null;
+  /** Capability strings the caller may exercise on THIS member (e.g.
+   *  "member:manage"), server-resolved. Encodes the privilege-escalation
+   *  guard (self-change and outranking are both denied) — check with
+   *  `can()`, never re-derive it client-side. */
+  permitted_actions?: string[];
 }
 
 export interface ProjectMemberRoleAssign {

--- a/tests/backend/ee/rbac/test_project_members_authz.py
+++ b/tests/backend/ee/rbac/test_project_members_authz.py
@@ -28,6 +28,7 @@ from rhesis.backend.ee.rbac.router import list_project_members
 from tests.backend.ee.rbac._rbac_helpers import (
     _add_project_member,
     _assign_org_role,
+    _builtin_role,
     _create_org,
     _create_project,
     _create_user,
@@ -88,3 +89,70 @@ class TestProjectMembersListingAuthz:
         with _rbac_enabled():
             result = self._list(owner)
         assert self.enrolled_id in {m.user_id for m in result}
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+class TestProjectMemberPermittedActions:
+    """`permitted_actions` on ProjectMemberRoleRead must reflect the same
+    escalation gates as list_org_members (see `_member_permitted_actions`),
+    minus `member:delete` — project membership removal goes through the
+    community `remove_project_member` endpoint, which this guard does not
+    reach, so the affordance is never asserted for project rows.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db: Session):
+        self.db = test_db
+        self.org_id = _create_org(test_db)
+        self.project_id = _create_project(test_db, self.org_id)
+
+    def _list(self, actor_id):
+        with _rbac_enabled():
+            return list_project_members(
+                project_id=self.project_id,
+                request=_request(),
+                db=self.db,
+                current_user=_user(actor_id, self.org_id),
+                _org=None,
+            )
+
+    def _row(self, results, user_id):
+        return next(r for r in results if r.user_id == user_id)
+
+    def test_own_row_has_no_permitted_actions(self):
+        admin_id = _create_user(self.db, self.org_id)
+        _add_project_member(
+            self.db, self.org_id, self.project_id, admin_id, _builtin_role(self.db, "Admin").id
+        )
+
+        results = self._list(admin_id)
+        assert self._row(results, admin_id).permitted_actions == []
+
+    def test_admin_sees_manage_but_not_delete_on_ordinary_member(self):
+        admin_id = _create_user(self.db, self.org_id)
+        member_id = _create_user(self.db, self.org_id)
+        _add_project_member(
+            self.db, self.org_id, self.project_id, admin_id, _builtin_role(self.db, "Admin").id
+        )
+        _add_project_member(
+            self.db, self.org_id, self.project_id, member_id, _builtin_role(self.db, "Member").id
+        )
+
+        results = self._list(admin_id)
+        assert self._row(results, member_id).permitted_actions == ["member:manage"]
+
+    def test_admin_sees_no_permitted_actions_on_project_owner_row(self):
+        """Regression test surfaced on the read side: a project Admin
+        viewing a project Owner's row must not see member:manage."""
+        admin_id = _create_user(self.db, self.org_id)
+        owner_id = _create_user(self.db, self.org_id)
+        _add_project_member(
+            self.db, self.org_id, self.project_id, admin_id, _builtin_role(self.db, "Admin").id
+        )
+        _add_project_member(
+            self.db, self.org_id, self.project_id, owner_id, _builtin_role(self.db, "Owner").id
+        )
+
+        results = self._list(admin_id)
+        assert self._row(results, owner_id).permitted_actions == []

--- a/tests/backend/ee/rbac/test_sp8_access_control.py
+++ b/tests/backend/ee/rbac/test_sp8_access_control.py
@@ -50,6 +50,7 @@ from rhesis.backend.ee.rbac.router import (
     delete_role,
     list_org_members,
     list_roles,
+    list_user_project_memberships,
     remove_org_member,
     update_role,
 )
@@ -425,13 +426,20 @@ class TestMultiUserScenarios:
         assert result.role_id == _builtin_role(self.db, "Admin").id
 
     def test_sole_owner_cannot_be_demoted(self):
+        """A self-assign is blocked by the (more general) self-change guard
+        before the last-owner check is ever reached — same outcome (denied),
+        different reason than the historical "last Owner" message. See
+        ``test_self_role_change_denied`` for that guard in isolation and
+        ``test_sole_owner_cannot_be_removed`` for the last-owner check, which
+        stays reachable via self-*removal* (``remove_org_member`` allows it).
+        """
         owner_id = _create_user(self.db, self.org_id)
         _assign_org_role(self.db, self.org_id, owner_id, "Owner")
 
         with pytest.raises(HTTPException) as exc:
             self._assign(owner_id, owner_id, _builtin_role(self.db, "Admin"))
         assert exc.value.status_code == 400
-        assert "last Owner" in exc.value.detail
+        assert "own organization role" in exc.value.detail
 
     def test_sole_owner_cannot_be_removed(self):
         owner_id = _create_user(self.db, self.org_id)
@@ -445,6 +453,50 @@ class TestMultiUserScenarios:
                 _org=None,
             )
         assert exc.value.status_code == 400
+
+    def test_self_role_change_denied(self):
+        """Self-role-change guard applies to any actor, not just Owners."""
+        admin_id = _create_user(self.db, self.org_id)
+        _assign_org_role(self.db, self.org_id, admin_id, "Admin")
+
+        with pytest.raises(HTTPException) as exc:
+            self._assign(admin_id, admin_id, _builtin_role(self.db, "Viewer"))
+        assert exc.value.status_code == 400
+        assert "own organization role" in exc.value.detail
+
+    def test_admin_cannot_demote_second_owner(self):
+        """Regression test for the reported bug: an Admin could freely
+        downgrade an Owner's role because the escalation guard only checked
+        the *requested* role's level (e.g. Viewer, well within an Admin's
+        authority) and never the target's *current* level. An Admin must not
+        be able to modify a member who currently outranks them at all,
+        regardless of what role is being requested."""
+        admin_id = _create_user(self.db, self.org_id)
+        owner_id = _create_user(self.db, self.org_id)
+        _assign_org_role(self.db, self.org_id, admin_id, "Admin")
+        _assign_org_role(self.db, self.org_id, owner_id, "Owner")
+
+        with pytest.raises(HTTPException) as exc:
+            self._assign(admin_id, owner_id, _builtin_role(self.db, "Viewer"))
+        assert exc.value.status_code == 403
+        assert "exceeds your own" in exc.value.detail
+
+    def test_admin_cannot_remove_second_owner(self):
+        """Same outranking guard applies to removal, not just role changes."""
+        admin_id = _create_user(self.db, self.org_id)
+        owner_id = _create_user(self.db, self.org_id)
+        _assign_org_role(self.db, self.org_id, admin_id, "Admin")
+        _assign_org_role(self.db, self.org_id, owner_id, "Owner")
+
+        with pytest.raises(HTTPException) as exc, _rbac_enabled():
+            remove_org_member(
+                user_id=owner_id,
+                db=self.db,
+                current_user=_user(admin_id, self.org_id),
+                _org=None,
+            )
+        assert exc.value.status_code == 403
+        assert "exceeds your own" in exc.value.detail
 
     def test_assign_rejects_foreign_user(self):
         """User from a different org → 404."""
@@ -591,6 +643,94 @@ class TestEscalationGuards:
 
 
 # ---------------------------------------------------------------------------
+# 4c. Custom-role equal-level escalation guard — _member_permitted_actions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+class TestCustomRoleEscalationGuard:
+    """Every custom role is created at a hardcoded level (50, see
+    ``create_role``), decoupled from its permission content — two custom
+    roles routinely share a level while holding very different permission
+    sets. The level check alone (``current_role_level > actor_level``) is
+    not sufficient to authorize modifying/removing such a member:
+    ``_member_permitted_actions`` also requires the target's *current*
+    custom role's permission set to be a subset of the actor's.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db: Session):
+        self.db = test_db
+        self.org_id = _create_org(test_db)
+
+    def _assign(self, actor_id: uuid.UUID, target_id: uuid.UUID, role: Role):
+        with _rbac_enabled():
+            return assign_org_role(
+                user_id=target_id,
+                body=OrgRoleAssign(role_id=role.id),
+                db=self.db,
+                current_user=_user(actor_id, self.org_id),
+                _org=None,
+            )
+
+    def test_narrow_custom_role_cannot_modify_broader_equal_level_role(self):
+        """Actor holds a narrow custom role; target holds an unrelated
+        custom role at the *same* level with strictly more permissions.
+        The requested new role (None) is well within the actor's authority,
+        so only the custom-role subset check can be denying this."""
+        narrow_role = _custom_role(self.db, self.org_id, name="Narrow", scope=SCOPE_ORGANIZATION)
+        broad_role = _custom_role(self.db, self.org_id, name="Broad", scope=SCOPE_ORGANIZATION)
+        _grant_permission(self.db, narrow_role.id, "member:manage")
+        _grant_permission(self.db, broad_role.id, "member:manage")
+        _grant_permission(self.db, broad_role.id, "role:manage")
+        _grant_permission(self.db, broad_role.id, "token:manage")
+        assert narrow_role.level == broad_role.level, "both custom roles default to level 50"
+
+        actor_id = _create_user(self.db, self.org_id)
+        target_id = _create_user(self.db, self.org_id)
+        self.db.add(
+            OrganizationMember(
+                organization_id=self.org_id, user_id=actor_id, role_id=narrow_role.id
+            )
+        )
+        self.db.add(
+            OrganizationMember(organization_id=self.org_id, user_id=target_id, role_id=broad_role.id)
+        )
+        self.db.flush()
+
+        with pytest.raises(HTTPException) as exc:
+            self._assign(actor_id, target_id, _builtin_role(self.db, "None"))
+        assert exc.value.status_code == 403
+        assert "exceeds your own" in exc.value.detail
+
+    def test_broad_custom_role_can_modify_narrower_equal_level_role(self):
+        """Mirror case: the actor's custom role permissions are a superset
+        of the target's — same level, but the modification is allowed."""
+        narrow_role = _custom_role(self.db, self.org_id, name="Narrow2", scope=SCOPE_ORGANIZATION)
+        broad_role = _custom_role(self.db, self.org_id, name="Broad2", scope=SCOPE_ORGANIZATION)
+        _grant_permission(self.db, narrow_role.id, "member:manage")
+        _grant_permission(self.db, broad_role.id, "member:manage")
+        _grant_permission(self.db, broad_role.id, "role:manage")
+
+        actor_id = _create_user(self.db, self.org_id)
+        target_id = _create_user(self.db, self.org_id)
+        self.db.add(
+            OrganizationMember(organization_id=self.org_id, user_id=actor_id, role_id=broad_role.id)
+        )
+        self.db.add(
+            OrganizationMember(
+                organization_id=self.org_id, user_id=target_id, role_id=narrow_role.id
+            )
+        )
+        self.db.flush()
+
+        none_role = _builtin_role(self.db, "None")
+        result = self._assign(actor_id, target_id, none_role)
+        assert result.role_id == none_role.id
+
+
+# ---------------------------------------------------------------------------
 # 5. Project-level assignment API
 # ---------------------------------------------------------------------------
 
@@ -679,6 +819,51 @@ class TestProjectMemberAPI:
             self._assign(self.project_id, non_member_id, role)
         assert exc.value.status_code == 404
 
+    def test_self_project_role_change_denied(self):
+        """Self-role-change guard applies at the project tier too."""
+        user_id = _create_user(self.db, self.org_id)
+
+        with pytest.raises(HTTPException) as exc, _rbac_enabled():
+            assign_project_role(
+                project_id=self.project_id,
+                user_id=user_id,
+                body=ProjectMemberRoleAssign(role_id=_builtin_role(self.db, "Viewer").id),
+                db=self.db,
+                current_user=_user(user_id, self.org_id),
+                _org=None,
+            )
+        assert exc.value.status_code == 400
+        assert "own project role" in exc.value.detail
+
+    def test_project_admin_cannot_change_role_of_project_owner(self):
+        """Regression test for the reported bug (screenshot scenario): a
+        project Admin could downgrade a project Owner's role, since the
+        escalation guard only validated the *requested* role's level (e.g.
+        Admin, well within the actor's own authority) and never the
+        target's *current* level. A project Admin must not be able to
+        modify a member who currently outranks them at the project tier,
+        regardless of what role is being requested."""
+        admin_id = _create_user(self.db, self.org_id)
+        owner_member_id = _create_user(self.db, self.org_id)
+        admin_role = _builtin_role(self.db, "Admin")
+        owner_role = _builtin_role(self.db, "Owner")
+        _add_project_member(self.db, self.org_id, self.project_id, admin_id, admin_role.id)
+        _add_project_member(
+            self.db, self.org_id, self.project_id, owner_member_id, owner_role.id
+        )
+
+        with pytest.raises(HTTPException) as exc, _rbac_enabled():
+            assign_project_role(
+                project_id=self.project_id,
+                user_id=owner_member_id,
+                body=ProjectMemberRoleAssign(role_id=admin_role.id),
+                db=self.db,
+                current_user=_user(admin_id, self.org_id),
+                _org=None,
+            )
+        assert exc.value.status_code == 403
+        assert "exceeds your own" in exc.value.detail
+
 
 # ---------------------------------------------------------------------------
 # 6. Org-member listing
@@ -714,6 +899,153 @@ class TestOrgMemberListing:
 
         results = list_org_members(db=self.db, current_user=_user(u_mine, self.org_id), _org=None)
         assert u_other not in {r.user_id for r in results}
+
+
+# ---------------------------------------------------------------------------
+# 6b. permitted_actions field — list_org_members
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+class TestOrgMemberPermittedActions:
+    """`permitted_actions` on OrgMemberRead must reflect every escalation
+    gate server-side (see `_member_permitted_actions`), so the frontend
+    never re-derives self-change / outranking / ambient-permission logic.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db: Session):
+        self.db = test_db
+        self.org_id = _create_org(test_db)
+
+    def _list(self, actor_id: uuid.UUID):
+        with _rbac_enabled():
+            return list_org_members(
+                db=self.db, current_user=_user(actor_id, self.org_id), _org=None
+            )
+
+    def _row(self, results, user_id: uuid.UUID):
+        return next(r for r in results if r.user_id == user_id)
+
+    def test_own_row_has_no_permitted_actions(self):
+        owner_id = _create_user(self.db, self.org_id)
+        _assign_org_role(self.db, self.org_id, owner_id, "Owner")
+
+        results = self._list(owner_id)
+        assert self._row(results, owner_id).permitted_actions == []
+
+    def test_admin_sees_manage_and_delete_on_ordinary_member(self):
+        admin_id = _create_user(self.db, self.org_id)
+        member_id = _create_user(self.db, self.org_id)
+        _assign_org_role(self.db, self.org_id, admin_id, "Admin")
+        _assign_org_role(self.db, self.org_id, member_id, "Member")
+
+        results = self._list(admin_id)
+        actions = self._row(results, member_id).permitted_actions
+        assert "member:manage" in actions
+        assert "member:delete" in actions
+
+    def test_admin_sees_no_permitted_actions_on_owner_row(self):
+        """The core regression, surfaced on the read side too: an Admin
+        viewing an Owner's row must not see member:manage, even though
+        _check_escalation on the write path would happily let them grant a
+        low role — the fix is symmetric across list and write paths."""
+        admin_id = _create_user(self.db, self.org_id)
+        owner_id = _create_user(self.db, self.org_id)
+        _assign_org_role(self.db, self.org_id, admin_id, "Admin")
+        _assign_org_role(self.db, self.org_id, owner_id, "Owner")
+
+        results = self._list(admin_id)
+        assert self._row(results, owner_id).permitted_actions == []
+
+    def test_actor_without_manage_permission_sees_no_actions(self):
+        """Ambient-permission gate: even when level and permission-subset
+        checks would pass, an actor who doesn't hold member:manage at all
+        must not see it in permitted_actions on any row."""
+        readonly_role = _custom_role(self.db, self.org_id, name="ReadOnlyA", scope=SCOPE_ORGANIZATION)
+        target_role = _custom_role(self.db, self.org_id, name="ReadOnlyB", scope=SCOPE_ORGANIZATION)
+        _grant_permission(self.db, readonly_role.id, "member:read")
+        _grant_permission(self.db, target_role.id, "member:read")
+
+        actor_id = _create_user(self.db, self.org_id)
+        target_id = _create_user(self.db, self.org_id)
+        self.db.add(
+            OrganizationMember(
+                organization_id=self.org_id, user_id=actor_id, role_id=readonly_role.id
+            )
+        )
+        self.db.add(
+            OrganizationMember(
+                organization_id=self.org_id, user_id=target_id, role_id=target_role.id
+            )
+        )
+        self.db.flush()
+
+        results = self._list(actor_id)
+        assert self._row(results, target_id).permitted_actions == []
+
+
+# ---------------------------------------------------------------------------
+# 6c. Bulk user-project-memberships endpoint (Member Access drawer)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+class TestListUserProjectMemberships:
+    """list_user_project_memberships — single-call replacement for the N
+    per-project ``GET /projects/{id}/members`` waterfall the Member Access
+    drawer previously required."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db: Session):
+        self.db = test_db
+        self.org_id = _create_org(test_db)
+
+    def _list(self, target_user_id: uuid.UUID):
+        with _rbac_enabled():
+            return list_user_project_memberships(
+                user_id=target_user_id,
+                db=self.db,
+                current_user=_user(target_user_id, self.org_id),
+                _org=None,
+            )
+
+    def test_returns_project_and_role_for_each_membership(self):
+        user_id = _create_user(self.db, self.org_id)
+        _assign_org_role(self.db, self.org_id, user_id, "Owner")
+        project1 = _create_project(self.db, self.org_id)
+        project2 = _create_project(self.db, self.org_id)
+        _assign_project_role(self.db, self.org_id, project1, user_id, "Admin")
+        _assign_project_role(self.db, self.org_id, project2, user_id, "Viewer")
+
+        results = self._list(user_id)
+        by_project = {r.project_id: r for r in results}
+        assert by_project[project1].role.name == "Admin"
+        assert by_project[project2].role.name == "Viewer"
+        assert by_project[project1].project.id == project1
+
+    def test_excludes_other_users_memberships(self):
+        user_id = _create_user(self.db, self.org_id)
+        other_id = _create_user(self.db, self.org_id)
+        _assign_org_role(self.db, self.org_id, user_id, "Owner")
+        project = _create_project(self.db, self.org_id)
+        _assign_project_role(self.db, self.org_id, project, user_id, "Admin")
+        _assign_project_role(self.db, self.org_id, project, other_id, "Viewer")
+
+        results = self._list(user_id)
+        assert {r.user_id for r in results} == {user_id}
+
+    def test_membership_without_role_returns_none_role(self):
+        user_id = _create_user(self.db, self.org_id)
+        _assign_org_role(self.db, self.org_id, user_id, "Owner")
+        project = _create_project(self.db, self.org_id)
+        _add_project_member(self.db, self.org_id, project, user_id)
+
+        results = self._list(user_id)
+        assert results[0].role_id is None
+        assert results[0].role is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Eliminate N+1 queries when loading org/project members by batching role and user lookups, and add a bulk project-memberships endpoint for the Member Access drawer
- Block self-demotion on both org and project role assignment (backend guard + read-only UI for the signed-in user's row)
- Fix role-select flicker and MUI out-of-range warnings by resolving labels from member data and always rendering the current role as a menu item
- Expose server-resolved `permitted_actions` on member list responses so role chips gate edits via `can(member, …)` instead of re-deriving escalation logic on the client

## Test plan
- [ ] Open Organization → Team as an Admin; confirm the grid loads without per-member request storms in the network tab
- [ ] Verify your own org/project role cell is read-only; attempting self-demotion via API returns an error
- [ ] Confirm Owner role displays correctly with no MUI Select warnings in the console
- [ ] As a project Admin viewing an org Owner, confirm the Owner's role chip is read-only (server `permitted_actions` respected)
- [ ] Run backend RBAC tests: `cd apps/backend && uv run pytest ../../tests/backend/ee/rbac/ -v`
- [ ] Run frontend RBAC tests: `cd ee/frontend && npm test -- --testPathPattern=rbac`