### PR TITLE
Improve consistency and DRY across targets and telemetry integrations

### DIFF
--- a/penelope/src/rhesis/penelope/targets/_content_blocks.py
+++ b/penelope/src/rhesis/penelope/targets/_content_blocks.py
@@ -27,25 +27,41 @@ def files_to_content_blocks(message: str, files: Optional[List[Any]]) -> Union[s
     return [create_text_block(message), *(_file_to_block(f) for f in files)]
 
 
-def _file_to_block(file: Any) -> Any:
+async def afiles_to_content_blocks(
+    message: str, files: Optional[List[Any]]
+) -> Union[str, List[Any]]:
+    """Async sibling of :func:`files_to_content_blocks`.
+
+    Uses ``FileReference.aread_bytes()`` to materialize object-storage
+    attachments so building the blocks doesn't block the event loop.
+    """
+    if not files:
+        return message
+
+    from langchain_core.messages.content import create_text_block
+
+    return [create_text_block(message), *[await _afile_to_block(f) for f in files]]
+
+
+def _extracted_text_block(file: Any, extracted_text: str) -> Any:
+    from langchain_core.messages.content import create_text_block
+
+    from rhesis.penelope._file_compat import file_attr
+
+    filename = file_attr(file, "filename", "attachment")
+    return create_text_block(f"[Attached file: {filename}]\n{extracted_text}")
+
+
+def _block_from_bytes(data: bytes, content_type: str) -> Any:
     import base64
 
     from langchain_core.messages.content import (
         create_audio_block,
         create_file_block,
         create_image_block,
-        create_text_block,
         create_video_block,
     )
 
-    from rhesis.penelope._file_compat import file_attr, file_bytes_and_type, file_extracted_text
-
-    extracted_text = file_extracted_text(file)
-    if extracted_text:
-        filename = file_attr(file, "filename", "attachment")
-        return create_text_block(f"[Attached file: {filename}]\n{extracted_text}")
-
-    data, content_type = file_bytes_and_type(file)
     kwargs = {"base64": base64.b64encode(data).decode(), "mime_type": content_type}
     if content_type.startswith("image/"):
         return create_image_block(**kwargs)
@@ -54,3 +70,26 @@ def _file_to_block(file: Any) -> Any:
     if content_type.startswith("video/"):
         return create_video_block(**kwargs)
     return create_file_block(**kwargs)
+
+
+def _file_to_block(file: Any) -> Any:
+    from rhesis.penelope._file_compat import file_bytes_and_type, file_extracted_text
+
+    extracted_text = file_extracted_text(file)
+    if extracted_text:
+        return _extracted_text_block(file, extracted_text)
+
+    data, content_type = file_bytes_and_type(file)
+    return _block_from_bytes(data, content_type)
+
+
+async def _afile_to_block(file: Any) -> Any:
+    """Async sibling of :func:`_file_to_block` - uses ``aread_bytes()``."""
+    from rhesis.penelope._file_compat import afile_bytes_and_type, file_extracted_text
+
+    extracted_text = file_extracted_text(file)
+    if extracted_text:
+        return _extracted_text_block(file, extracted_text)
+
+    data, content_type = await afile_bytes_and_type(file)
+    return _block_from_bytes(data, content_type)

--- a/penelope/src/rhesis/penelope/targets/_content_blocks.py
+++ b/penelope/src/rhesis/penelope/targets/_content_blocks.py
@@ -33,14 +33,18 @@ async def afiles_to_content_blocks(
     """Async sibling of :func:`files_to_content_blocks`.
 
     Uses ``FileReference.aread_bytes()`` to materialize object-storage
-    attachments so building the blocks doesn't block the event loop.
+    attachments so building the blocks doesn't block the event loop; the
+    attachments are fetched concurrently (order preserved).
     """
     if not files:
         return message
 
+    import asyncio
+
     from langchain_core.messages.content import create_text_block
 
-    return [create_text_block(message), *[await _afile_to_block(f) for f in files]]
+    blocks = await asyncio.gather(*(_afile_to_block(f) for f in files))
+    return [create_text_block(message), *blocks]
 
 
 def _extracted_text_block(file: Any, extracted_text: str) -> Any:

--- a/penelope/src/rhesis/penelope/targets/langchain.py
+++ b/penelope/src/rhesis/penelope/targets/langchain.py
@@ -7,7 +7,10 @@ testable with Penelope's autonomous testing agent.
 
 from typing import Any, List, Optional
 
-from rhesis.penelope.targets._content_blocks import files_to_content_blocks
+from rhesis.penelope.targets._content_blocks import (
+    afiles_to_content_blocks,
+    files_to_content_blocks,
+)
 from rhesis.sdk.targets import Target, TargetResponse
 
 
@@ -129,28 +132,7 @@ class LangChainTarget(Target):
             else:
                 response = self.runnable.invoke(input_data)
 
-            # Extract content from response
-            if hasattr(response, "content"):
-                # LangChain message object (AIMessage, etc.)
-                content = response.content
-                raw_response = {"content": content, "type": type(response).__name__}
-            elif isinstance(response, str):
-                content = response
-                raw_response = response
-            else:
-                content = str(response)
-                raw_response = str(response)
-
-            return TargetResponse(
-                success=True,
-                content=content,
-                conversation_id=conversation_id or "default",
-                metadata={
-                    "input_sent": message,
-                    "raw_response": raw_response,
-                    "runnable_type": type(self.runnable).__name__,
-                },
-            )
+            return self._success_response(response, message, conversation_id)
 
         except Exception as e:
             return TargetResponse(
@@ -158,6 +140,73 @@ class LangChainTarget(Target):
                 content="",
                 error=f"LangChain error: {str(e)}",
             )
+
+    async def a_send_message(
+        self,
+        message: str,
+        conversation_id: Optional[str] = None,
+        files: Optional[List] = None,
+        **kwargs: Any,
+    ) -> TargetResponse:
+        """Async version of send_message, using the runnable's native ainvoke().
+
+        Every LangChain Runnable exposes ``ainvoke()`` (the Runnable interface
+        provides it), so this avoids the base class thread-pool fallback. File
+        attachments are materialized with ``aread_bytes()`` so object-storage
+        fetches don't block the event loop. The files/kwargs semantics match
+        send_message (see its docstring).
+        """
+        if not message.strip():
+            return TargetResponse(success=False, content="", error="Empty message")
+
+        try:
+            if files:
+                from langchain_core.messages import HumanMessage
+
+                input_data = HumanMessage(content=await afiles_to_content_blocks(message, files))
+            else:
+                input_data = {self.input_key: message, **kwargs}
+
+            if hasattr(self.runnable, "get_session_history"):
+                config = {"configurable": {"session_id": conversation_id or "default"}}
+                response = await self.runnable.ainvoke(input_data, config=config)
+            else:
+                response = await self.runnable.ainvoke(input_data)
+
+            return self._success_response(response, message, conversation_id)
+
+        except Exception as e:
+            return TargetResponse(
+                success=False,
+                content="",
+                error=f"LangChain error: {str(e)}",
+            )
+
+    def _success_response(
+        self, response: Any, message: str, conversation_id: Optional[str]
+    ) -> TargetResponse:
+        """Build the TargetResponse for a successful invocation."""
+        if hasattr(response, "content"):
+            # LangChain message object (AIMessage, etc.)
+            content = response.content
+            raw_response = {"content": content, "type": type(response).__name__}
+        elif isinstance(response, str):
+            content = response
+            raw_response = response
+        else:
+            content = str(response)
+            raw_response = str(response)
+
+        return TargetResponse(
+            success=True,
+            content=content,
+            conversation_id=conversation_id or "default",
+            metadata={
+                "input_sent": message,
+                "raw_response": raw_response,
+                "runnable_type": type(self.runnable).__name__,
+            },
+        )
 
     def get_tool_documentation(self) -> str:
         """Get documentation for Penelope."""

--- a/penelope/src/rhesis/penelope/targets/langchain.py
+++ b/penelope/src/rhesis/penelope/targets/langchain.py
@@ -155,7 +155,14 @@ class LangChainTarget(Target):
         attachments are materialized with ``aread_bytes()`` so object-storage
         fetches don't block the event loop. The files/kwargs semantics match
         send_message (see its docstring).
+
+        Duck-typed runnables without ``ainvoke()`` (validate_configuration
+        only requires ``invoke()``) fall back to the base class thread-pool
+        path instead of raising.
         """
+        if not hasattr(self.runnable, "ainvoke"):
+            return await super().a_send_message(message, conversation_id, files, **kwargs)
+
         if not message.strip():
             return TargetResponse(success=False, content="", error="Empty message")
 

--- a/penelope/src/rhesis/penelope/targets/langgraph.py
+++ b/penelope/src/rhesis/penelope/targets/langgraph.py
@@ -151,7 +151,14 @@ class LangGraphTarget(Target):
         LangGraph CompiledGraphs expose ``ainvoke()``, so this avoids the base
         class thread-pool fallback. File attachments are materialized with
         ``aread_bytes()`` so object-storage fetches don't block the event loop.
+
+        Duck-typed graphs without ``ainvoke()`` (validate_configuration only
+        requires ``invoke()``) fall back to the base class thread-pool path
+        instead of raising.
         """
+        if not hasattr(self.graph, "ainvoke"):
+            return await super().a_send_message(message, conversation_id, files, **kwargs)
+
         if not message.strip():
             return TargetResponse(success=False, content="", error="Empty message")
 

--- a/penelope/src/rhesis/penelope/targets/langgraph.py
+++ b/penelope/src/rhesis/penelope/targets/langgraph.py
@@ -7,7 +7,10 @@ with Penelope's autonomous testing agent.
 
 from typing import Any, Dict, List, Optional
 
-from rhesis.penelope.targets._content_blocks import files_to_content_blocks
+from rhesis.penelope.targets._content_blocks import (
+    afiles_to_content_blocks,
+    files_to_content_blocks,
+)
 from rhesis.sdk.targets import Target, TargetResponse
 
 
@@ -127,39 +130,7 @@ class LangGraphTarget(Target):
             # Invoke the graph
             response = self.graph.invoke(state)
 
-            # Extract the latest message from response
-            if isinstance(response, dict) and self.state_key in response:
-                messages = response[self.state_key]
-                if messages:
-                    latest_message = messages[-1]
-                    # Update session state with all messages from response
-                    self._session_states[session_key] = messages
-
-                    # Extract content
-                    if hasattr(latest_message, "content"):
-                        content = latest_message.content
-                        raw_response = {"content": content, "type": type(latest_message).__name__}
-                    else:
-                        content = str(latest_message)
-                        raw_response = str(latest_message)
-                else:
-                    content = "No response generated"
-                    raw_response = response
-            else:
-                content = str(response)
-                raw_response = response
-
-            return TargetResponse(
-                success=True,
-                content=content,
-                conversation_id=session_key,
-                metadata={
-                    "input_sent": message,
-                    "raw_response": raw_response,
-                    "graph_type": type(self.graph).__name__,
-                    "session_messages_count": len(self._session_states[session_key]),
-                },
-            )
+            return self._success_response(response, message, session_key)
 
         except Exception as e:
             return TargetResponse(
@@ -167,6 +138,82 @@ class LangGraphTarget(Target):
                 content="",
                 error=f"LangGraph error: {str(e)}",
             )
+
+    async def a_send_message(
+        self,
+        message: str,
+        conversation_id: Optional[str] = None,
+        files: Optional[List] = None,
+        **kwargs: Any,
+    ) -> TargetResponse:
+        """Async version of send_message, using the graph's native ainvoke().
+
+        LangGraph CompiledGraphs expose ``ainvoke()``, so this avoids the base
+        class thread-pool fallback. File attachments are materialized with
+        ``aread_bytes()`` so object-storage fetches don't block the event loop.
+        """
+        if not message.strip():
+            return TargetResponse(success=False, content="", error="Empty message")
+
+        try:
+            session_key = conversation_id or "default"
+            if session_key not in self._session_states:
+                self._session_states[session_key] = []
+
+            from langchain_core.messages import HumanMessage
+
+            content = await afiles_to_content_blocks(message, files)
+            user_message = HumanMessage(content=content)
+            self._session_states[session_key].append(user_message)
+
+            state = {self.state_key: self._session_states[session_key], **kwargs}
+
+            response = await self.graph.ainvoke(state)
+
+            return self._success_response(response, message, session_key)
+
+        except Exception as e:
+            return TargetResponse(
+                success=False,
+                content="",
+                error=f"LangGraph error: {str(e)}",
+            )
+
+    def _success_response(self, response: Any, message: str, session_key: str) -> TargetResponse:
+        """Build the TargetResponse for a successful invocation, updating session state."""
+        # Extract the latest message from response
+        if isinstance(response, dict) and self.state_key in response:
+            messages = response[self.state_key]
+            if messages:
+                latest_message = messages[-1]
+                # Update session state with all messages from response
+                self._session_states[session_key] = messages
+
+                # Extract content
+                if hasattr(latest_message, "content"):
+                    content = latest_message.content
+                    raw_response = {"content": content, "type": type(latest_message).__name__}
+                else:
+                    content = str(latest_message)
+                    raw_response = str(latest_message)
+            else:
+                content = "No response generated"
+                raw_response = response
+        else:
+            content = str(response)
+            raw_response = response
+
+        return TargetResponse(
+            success=True,
+            content=content,
+            conversation_id=session_key,
+            metadata={
+                "input_sent": message,
+                "raw_response": raw_response,
+                "graph_type": type(self.graph).__name__,
+                "session_messages_count": len(self._session_states[session_key]),
+            },
+        )
 
     def get_tool_documentation(self) -> str:
         """Get documentation for Penelope."""

--- a/sdk/src/rhesis/sdk/targets/base.py
+++ b/sdk/src/rhesis/sdk/targets/base.py
@@ -6,6 +6,7 @@ or custom agents) can interact with.  This is the canonical location of
 the interface; Penelope re-exports it for backward compatibility.
 """
 
+import asyncio
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
@@ -93,6 +94,26 @@ class Target(ABC):
             Tuple of (is_valid, error_message)
         """
         pass
+
+    async def a_send_message(
+        self,
+        message: str,
+        conversation_id: Optional[str] = None,
+        files: Optional[List[Dict[str, str]]] = None,
+        **kwargs,
+    ) -> TargetResponse:
+        """
+        Async version of send_message with a default to_thread fallback.
+
+        Targets with native async implementations should override this method.
+        Others automatically get async support via the thread-pool fallback.
+
+        This default existed on the original Penelope base class (see the
+        ``rhesis.penelope.targets.base`` shim) but was not carried over when
+        ``Target`` moved here, leaving async callers of sync-only targets to
+        fail with ``AttributeError``.
+        """
+        return await asyncio.to_thread(self.send_message, message, conversation_id, files, **kwargs)
 
     def get_tool_documentation(self) -> str:
         """

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/integration.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/integration.py
@@ -145,14 +145,17 @@ class MAFIntegration(BaseIntegration):
         Steps:
 
         1. Verify MAF is installed.
-        2. Call ``enable_instrumentation(enable_sensitive_data=...)`` to flip
+        2. Wrap each existing OTLP exporter on the global ``TracerProvider``
+           with :class:`MAFTranslatingExporter` so MAF spans are rewritten to
+           the Rhesis ``ai.*`` schema before export. Done *before* turning on
+           MAF instrumentation: MAF exposes no off switch, so instrumentation
+           whose spans could never be translated (raw GenAI names fail
+           backend span-name validation) must not be enabled at all.
+        3. Call ``enable_instrumentation(enable_sensitive_data=...)`` to flip
            MAF's internal switch. Content capture (prompts, completions, tool
            I/O) defaults to on so the trace UI shows messages; set the
            ``RHESIS_DISABLE_CONTENT_CAPTURE`` env var to a truthy value to opt
            out for privacy-sensitive deployments.
-        3. Wrap each existing OTLP exporter on the global ``TracerProvider``
-           with :class:`MAFTranslatingExporter` so MAF spans are rewritten to
-           the Rhesis ``ai.*`` schema before export.
         4. Register :class:`MAFLLMDedupSpanProcessor` to toggle the LLM
            observation context flag during MAF ``chat`` spans so flag-checking
            auto-instrumentation (e.g. LangChain callbacks) skips duplicate
@@ -160,7 +163,8 @@ class MAFIntegration(BaseIntegration):
 
         Returns:
             ``True`` if successfully enabled, ``False`` if MAF is not
-            installed or instrumentation could not be turned on.
+            installed, no exporter could be wrapped for translation, or
+            instrumentation could not be turned on.
         """
         if self._enabled:
             logger.debug("agent_framework observation already enabled")
@@ -176,18 +180,6 @@ class MAFIntegration(BaseIntegration):
             logger.warning("agent_framework.observability is not importable: %s", exc)
             return False
 
-        capture_content = _content_capture_enabled()
-        try:
-            # ``enable_sensitive_data`` gates MAF's capture of prompts,
-            # completions, and tool arguments/results into spans (see
-            # ``agent_framework.observability.OBSERVABILITY_SETTINGS``). Without
-            # it the spans reach the backend empty and the trace UI shows no
-            # messages. Default to on; honor the opt-out env var.
-            enable_instrumentation(enable_sensitive_data=capture_content)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("Failed to enable MAF instrumentation: %s", exc)
-            return False
-
         provider = trace.get_tracer_provider()
         if not isinstance(provider, TracerProvider):
             logger.warning(
@@ -199,7 +191,35 @@ class MAFIntegration(BaseIntegration):
             )
             return False
 
-        self._wrap_existing_exporters(provider)
+        # Wrap the exporters *before* turning on instrumentation: MAF has no
+        # public off switch, so once enabled it keeps emitting spans, and raw
+        # GenAI span names like ``chat gpt-4`` would fail backend span-name
+        # validation and be silently dropped. Failing closed keeps
+        # auto_instrument() honest.
+        if not self._wrap_existing_exporters(provider):
+            return False
+
+        capture_content = _content_capture_enabled()
+        try:
+            # ``enable_sensitive_data`` gates MAF's capture of prompts,
+            # completions, and tool arguments/results into spans (see
+            # ``agent_framework.observability.OBSERVABILITY_SETTINGS``). Without
+            # it the spans reach the backend empty and the trace UI shows no
+            # messages. Default to on; honor the opt-out env var.
+            enable_instrumentation(enable_sensitive_data=capture_content)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to enable MAF instrumentation: %s", exc)
+            # Revert the exporter wrapping installed above so a failed enable
+            # leaves the provider exactly as it found it.
+            for processor, original_exporter in self._patched_processors:
+                try:
+                    _set_processor_exporter(processor, original_exporter)
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "Failed to revert exporter on processor %r", processor, exc_info=True
+                    )
+            self._patched_processors.clear()
+            return False
 
         self._dedup_processor = self._create_callback()
         if not self._dedup_registered:
@@ -246,7 +266,7 @@ class MAFIntegration(BaseIntegration):
         self._enabled = False
         logger.info("✗ Stopped observing agent_framework")
 
-    def _wrap_existing_exporters(self, provider: TracerProvider) -> None:
+    def _wrap_existing_exporters(self, provider: TracerProvider) -> bool:
         """Find every wrappable span processor on the provider and wrap its exporter.
 
         Walks the provider's ``_active_span_processor`` (a multi-processor
@@ -260,13 +280,19 @@ class MAFIntegration(BaseIntegration):
         ``_batch_processor._exporter`` (newer Batch). :func:`_set_processor_exporter`
         handles both layouts. Other processor types (custom, multi-processor
         composites, etc.) are left untouched.
+
+        Returns:
+            ``True`` when at least one exporter is wrapped (or was already
+            wrapped), ``False`` when translation could not be installed —
+            in which case :meth:`enable` fails closed rather than turning on
+            instrumentation whose spans the backend would reject.
         """
         try:
             multi = getattr(provider, "_active_span_processor", None)
             children = getattr(multi, "_span_processors", ()) if multi is not None else ()
         except Exception:  # noqa: BLE001
-            logger.debug("Could not introspect provider span processors", exc_info=True)
-            return
+            logger.warning("Could not introspect provider span processors", exc_info=True)
+            return False
 
         verbose_workflow_spans = _verbose_workflow_spans_enabled()
 
@@ -298,17 +324,18 @@ class MAFIntegration(BaseIntegration):
 
         if wrapped_count == 0 and already_wrapped_count == 0:
             # No batch / simple span processor with a wrappable exporter
-            # (e.g. only a custom processor, or no processors at all). MAF
-            # spans will pass through untranslated and raw GenAI span names
-            # like ``chat gpt-4`` will fail backend span-name validation.
-            # Log loudly so the surprise is debuggable.
+            # (e.g. only a custom processor, or no processors at all). Raw
+            # GenAI span names like ``chat gpt-4`` would fail backend
+            # span-name validation, so enable() fails closed on this result.
             logger.warning(
                 "agent_framework: no batch/simple span processor with a "
                 "wrappable exporter found on the active TracerProvider; "
-                "MAF spans will be emitted but not translated into the "
-                "Rhesis ai.* schema. Ensure RhesisClient is created before "
-                "auto_instrument()."
+                "refusing to enable instrumentation whose spans could not "
+                "be translated into the Rhesis ai.* schema. Ensure "
+                "RhesisClient is created before auto_instrument()."
             )
+            return False
+        return True
 
 
 _maf_integration = MAFIntegration()

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/integration.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/integration.py
@@ -291,7 +291,12 @@ class MAFIntegration(BaseIntegration):
             multi = getattr(provider, "_active_span_processor", None)
             children = getattr(multi, "_span_processors", ()) if multi is not None else ()
         except Exception:  # noqa: BLE001
-            logger.warning("Could not introspect provider span processors", exc_info=True)
+            logger.warning(
+                "Could not introspect provider span processors; refusing to "
+                "enable MAF instrumentation since translation of its spans "
+                "cannot be guaranteed",
+                exc_info=True,
+            )
             return False
 
         verbose_workflow_spans = _verbose_workflow_spans_enabled()

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
@@ -38,6 +38,7 @@ from rhesis.sdk.telemetry.integrations.agent_framework import mapping
 
 # Shared with other native-GenAI integrations (see genai.py); imported under
 # the historical private names so existing references keep working.
+from rhesis.sdk.telemetry.integrations.genai import AncestryRegistry
 from rhesis.sdk.telemetry.integrations.genai import (
     TranslatedSpan as _TranslatedSpan,
 )
@@ -307,111 +308,22 @@ def _find_ancestor_agent_in_batch(
 _INVOKE_AGENT_NAME_PREFIX = "invoke_agent "
 
 
-class _HandoffAncestryRegistry:
-    """Persistent (process-lifetime) span ancestry index for handoff edges.
+class _HandoffAncestryRegistry(AncestryRegistry):
+    """MAF ancestry registry (see :class:`~...integrations.genai.AncestryRegistry`).
 
-    The batch-local lookup in :func:`_find_ancestor_agent_in_batch` fails when
-    a handoff tool span and its enclosing ``invoke_agent`` span are exported in
-    different batches. That is the common case under ``BatchSpanProcessor``:
-    a child span ends (and is enqueued) *before* its parent, so on long runs
-    the agent ancestor lands in a later batch than the tool span that needs it.
-
-    This registry sidesteps batching entirely by recording ancestry at span
-    *start* time (a parent always starts before its children, and MAF embeds
-    the agent name in the ``invoke_agent <name>`` span name from the start).
-    The exporter then resolves ``from_agent`` against this index regardless of
-    which batch each span exports in.
-
-    Both dicts are bounded; the oldest entries are evicted once the cap is hit.
+    Sibling tracking is on because MAF's ``HandoffBuilder`` workflow path does
+    not always nest the chat span under the ``invoke_agent`` span: in those
+    runs the ``invoke_agent`` span and the ``chat`` span are SIBLINGS sharing
+    the same ``executor.process`` parent, so the plain parent-chain walk alone
+    can't see the agent.
     """
 
     def __init__(self, max_entries: int = 8192) -> None:
-        self._parent_by_span_id: dict[int, int] = {}
-        self._agent_by_span_id: dict[int, str] = {}
-        # Agent name indexed by its *parent* span id. MAF's workflow path does
-        # not always nest the chat span under the ``invoke_agent`` span: in
-        # ``HandoffBuilder`` runs the ``invoke_agent`` span and the ``chat``
-        # span are SIBLINGS sharing the same ``executor.process`` parent. The
-        # parent-chain walk alone can't see the agent in that layout, so we also
-        # remember "this parent owns agent X" to resolve handoffs from sibling
-        # chat spans.
-        self._agent_by_parent_span_id: dict[int, str] = {}
-        self._max_entries = max_entries
-
-    @staticmethod
-    def _span_id(span: Any) -> int | None:
-        ctx = getattr(span, "context", None)
-        if ctx is None:
-            try:
-                ctx = span.get_span_context()
-            except Exception:  # noqa: BLE001
-                return None
-        return getattr(ctx, "span_id", None)
-
-    def _evict_if_needed(self, store: dict[int, Any]) -> None:
-        if len(store) < self._max_entries:
-            return
-        try:
-            first = next(iter(store))
-            store.pop(first, None)
-        except StopIteration:  # pragma: no cover - racy but harmless
-            pass
-
-    def record(self, span: Any) -> None:
-        """Index a MAF span's parent link and (if an agent span) its name.
-
-        Safe to call from a span processor's ``on_start``; never raises.
-        """
-        try:
-            span_id = self._span_id(span)
-            if span_id is None:
-                return
-            parent_ctx = getattr(span, "parent", None)
-            parent_sid = getattr(parent_ctx, "span_id", None)
-            if parent_sid is not None:
-                self._evict_if_needed(self._parent_by_span_id)
-                self._parent_by_span_id[span_id] = parent_sid
-            name = getattr(span, "name", "") or ""
-            if name.startswith(_INVOKE_AGENT_NAME_PREFIX):
-                agent_name = name[len(_INVOKE_AGENT_NAME_PREFIX) :].strip()
-                if agent_name:
-                    self._evict_if_needed(self._agent_by_span_id)
-                    self._agent_by_span_id[span_id] = agent_name
-                    if parent_sid is not None:
-                        self._evict_if_needed(self._agent_by_parent_span_id)
-                        self._agent_by_parent_span_id[parent_sid] = agent_name
-        except Exception:  # noqa: BLE001 - recording must never break tracing
-            logger.debug("Failed to record span ancestry", exc_info=True)
-
-    def find_ancestor_agent(self, span: ReadableSpan) -> str | None:
-        """Resolve the calling agent for a handoff/chat span.
-
-        Walks the persistent parent chain and, at each hop, checks two ways the
-        agent name may be reachable:
-
-        1. an ancestor ``invoke_agent`` span (the classic nested layout, e.g.
-           tool -> chat -> invoke_agent), and
-        2. a *sibling* ``invoke_agent`` span sharing the current parent (MAF's
-           ``HandoffBuilder`` layout, where chat and invoke_agent are both
-           children of the same ``executor.process`` span).
-        """
-        cur_sid = self._span_id(span)
-        # Bound the walk defensively against malformed parent cycles.
-        for _ in range(64):
-            if cur_sid is None:
-                return None
-            parent_sid = self._parent_by_span_id.get(cur_sid)
-            if parent_sid is None:
-                return None
-            agent = self._agent_by_span_id.get(parent_sid)
-            if agent is not None:
-                return agent
-            # Sibling layout: an invoke_agent span shares this parent.
-            sibling_agent = self._agent_by_parent_span_id.get(parent_sid)
-            if sibling_agent is not None:
-                return sibling_agent
-            cur_sid = parent_sid
-        return None
+        super().__init__(
+            agent_name_prefix=_INVOKE_AGENT_NAME_PREFIX,
+            track_siblings=True,
+            max_entries=max_entries,
+        )
 
 
 # Shared singleton: the dedup processor populates it at span start, the
@@ -827,19 +739,6 @@ class MAFLLMDedupSpanProcessor(SpanProcessor):
                 pass
         self._prev_flags[span_id] = prev
 
-    def _retrieve_prev_flag(self, span) -> bool:
-        """Read back the flag value stashed by :meth:`_store_prev_flag`.
-
-        Pops the entry to keep the dict bounded across long-running runs.
-        ``False`` is returned when the span_id was never stashed (e.g.
-        because the on_start hook saw the span before our chat-name check
-        recognized it).
-        """
-        span_id = self._span_id(span)
-        if span_id is None:
-            return False
-        return bool(self._prev_flags.pop(span_id, False))
-
     def on_start(self, span, parent_context=None) -> None:  # noqa: D401
         if not self._active:
             return
@@ -888,20 +787,29 @@ class MAFLLMDedupSpanProcessor(SpanProcessor):
             if not _is_maf_span(span):
                 return
             attrs = span.attributes or {}
-            if attrs.get(mapping.GEN_AI_OPERATION_NAME) != mapping.OP_CHAT:
+            if attrs.get(mapping.GEN_AI_OPERATION_NAME) == mapping.OP_CHAT:
+                # Record this chat span's user input / assistant output so the
+                # exporter can stamp conversation turn-root attributes on the
+                # enclosing root ``workflow.run`` span (which itself carries no
+                # input/output). Keyed by trace id; safe and bounded.
+                ctx = getattr(span, "context", None)
+                trace_id = getattr(ctx, "trace_id", None)
+                _conversation_content.record_chat(
+                    trace_id,
+                    input_text=mapping.extract_conversation_input(attrs),
+                    output_text=mapping.extract_conversation_output(attrs),
+                )
+            # Restore the flag based on what on_start actually recorded rather
+            # than re-deriving chat-ness from attributes: if the
+            # gen_ai.operation.name attribute were ever missing or renamed, an
+            # attribute-gated restore would return early and leave the flag
+            # stuck True for the rest of the context. _prev_flags only contains
+            # entries for spans whose start hook toggled the flag, so
+            # membership is the exact restore condition.
+            span_id = self._span_id(span)
+            if span_id is None or span_id not in self._prev_flags:
                 return
-            # Record this chat span's user input / assistant output so the
-            # exporter can stamp conversation turn-root attributes on the
-            # enclosing root ``workflow.run`` span (which itself carries no
-            # input/output). Keyed by trace id; safe and bounded.
-            ctx = getattr(span, "context", None)
-            trace_id = getattr(ctx, "trace_id", None)
-            _conversation_content.record_chat(
-                trace_id,
-                input_text=mapping.extract_conversation_input(attrs),
-                output_text=mapping.extract_conversation_output(attrs),
-            )
-            prev = self._retrieve_prev_flag(span)
+            prev = bool(self._prev_flags.pop(span_id, False))
             if not prev:
                 set_llm_observation_active(False)
         except Exception:  # noqa: BLE001 - on_end must never raise

--- a/sdk/src/rhesis/sdk/telemetry/integrations/genai.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/genai.py
@@ -523,6 +523,125 @@ def translate_events(
 
 
 # ---------------------------------------------------------------------------
+# Span ancestry registry for handoff from-agent resolution
+# ---------------------------------------------------------------------------
+
+
+class AncestryRegistry:
+    """Persistent (process-lifetime) span ancestry index for handoff edges.
+
+    A batch-local parent walk fails when a delegated/handed-off span and its
+    enclosing agent spans are exported in different batches. That is the
+    common case under ``BatchSpanProcessor``: a child span ends (and is
+    enqueued) *before* its parent, so on long runs the agent ancestor lands in
+    a later batch than the span that needs it.
+
+    This registry sidesteps batching entirely by recording ancestry at span
+    *start* time (a parent always starts before its children, and both MAF and
+    Pydantic AI embed the agent name in the ``invoke_agent <name>`` span name
+    from the start). The exporter then resolves the calling agent against this
+    index regardless of which batch each span exports in.
+
+    ``track_siblings`` covers MAF's ``HandoffBuilder`` layout, where the
+    ``invoke_agent`` span and the ``chat`` span are SIBLINGS sharing the same
+    ``executor.process`` parent, so the plain parent-chain walk can't see the
+    agent. It must stay **off** for frameworks with properly nested delegation
+    (like Pydantic AI, where the chain is ``invoke_agent (child) ->
+    execute_tool -> invoke_agent (parent)``): with siblings on, a delegated
+    agent span would resolve *itself* through its own parent entry and report
+    its own name as the calling agent.
+
+    All stores are bounded; the oldest entries are evicted once the cap is hit.
+    """
+
+    def __init__(
+        self,
+        *,
+        agent_name_prefix: str = "invoke_agent ",
+        track_siblings: bool = False,
+        max_entries: int = 8192,
+    ) -> None:
+        self._agent_name_prefix = agent_name_prefix
+        self._track_siblings = track_siblings
+        self._parent_by_span_id: dict[int, int] = {}
+        self._agent_by_span_id: dict[int, str] = {}
+        # Agent name indexed by its *parent* span id (sibling layout, see
+        # class docstring). Only populated when ``track_siblings`` is on.
+        self._agent_by_parent_span_id: dict[int, str] = {}
+        self._max_entries = max_entries
+
+    @staticmethod
+    def _span_id(span: Any) -> int | None:
+        ctx = getattr(span, "context", None)
+        if ctx is None:
+            try:
+                ctx = span.get_span_context()
+            except Exception:  # noqa: BLE001
+                return None
+        return getattr(ctx, "span_id", None)
+
+    def _evict_if_needed(self, store: dict[int, Any]) -> None:
+        if len(store) < self._max_entries:
+            return
+        try:
+            first = next(iter(store))
+            store.pop(first, None)
+        except StopIteration:  # pragma: no cover - racy but harmless
+            pass
+
+    def record(self, span: Any) -> None:
+        """Index a span's parent link and (if an agent span) its name.
+
+        Safe to call from a span processor's ``on_start``; never raises.
+        """
+        try:
+            span_id = self._span_id(span)
+            if span_id is None:
+                return
+            parent_ctx = getattr(span, "parent", None)
+            parent_sid = getattr(parent_ctx, "span_id", None)
+            if parent_sid is not None:
+                self._evict_if_needed(self._parent_by_span_id)
+                self._parent_by_span_id[span_id] = parent_sid
+            name = getattr(span, "name", "") or ""
+            if name.startswith(self._agent_name_prefix):
+                agent_name = name[len(self._agent_name_prefix) :].strip()
+                if agent_name:
+                    self._evict_if_needed(self._agent_by_span_id)
+                    self._agent_by_span_id[span_id] = agent_name
+                    if self._track_siblings and parent_sid is not None:
+                        self._evict_if_needed(self._agent_by_parent_span_id)
+                        self._agent_by_parent_span_id[parent_sid] = agent_name
+        except Exception:  # noqa: BLE001 - recording must never break tracing
+            logger.debug("Failed to record span ancestry", exc_info=True)
+
+    def find_ancestor_agent(self, span: Any) -> str | None:
+        """Resolve the calling agent for a delegated/handoff span.
+
+        Walks the persistent parent chain and, at each hop, checks an ancestor
+        agent span; when ``track_siblings`` is on it also checks a *sibling*
+        agent span sharing the current parent. The bounded loop guard
+        guarantees termination even in the face of a malformed parent cycle.
+        """
+        cur_sid = self._span_id(span)
+        for _ in range(64):
+            if cur_sid is None:
+                return None
+            parent_sid = self._parent_by_span_id.get(cur_sid)
+            if parent_sid is None:
+                return None
+            agent = self._agent_by_span_id.get(parent_sid)
+            if agent is not None:
+                return agent
+            if self._track_siblings:
+                sibling_agent = self._agent_by_parent_span_id.get(parent_sid)
+                if sibling_agent is not None:
+                    return sibling_agent
+            cur_sid = parent_sid
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Exporter swapping on existing span processors
 # ---------------------------------------------------------------------------
 

--- a/sdk/src/rhesis/sdk/telemetry/integrations/pydantic_ai/integration.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/pydantic_ai/integration.py
@@ -283,7 +283,12 @@ class PydanticAIIntegration(BaseIntegration):
             multi = getattr(provider, "_active_span_processor", None)
             children = getattr(multi, "_span_processors", ()) if multi is not None else ()
         except Exception:  # noqa: BLE001
-            logger.warning("Could not introspect provider span processors", exc_info=True)
+            logger.warning(
+                "Could not introspect provider span processors; refusing to "
+                "enable Pydantic AI instrumentation since translation of its "
+                "spans cannot be guaranteed",
+                exc_info=True,
+            )
             return False
 
         wrapped_count = 0

--- a/sdk/src/rhesis/sdk/telemetry/integrations/pydantic_ai/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/pydantic_ai/translator.py
@@ -41,7 +41,11 @@ from rhesis.sdk.telemetry.context import (
     is_llm_observation_active,
     set_llm_observation_active,
 )
-from rhesis.sdk.telemetry.integrations.genai import TranslatedSpan, translate_events
+from rhesis.sdk.telemetry.integrations.genai import (
+    AncestryRegistry,
+    TranslatedSpan,
+    translate_events,
+)
 from rhesis.sdk.telemetry.integrations.pydantic_ai import mapping
 
 logger = logging.getLogger(__name__)
@@ -175,98 +179,15 @@ def _safe_fallback_span(span: ReadableSpan) -> ReadableSpan:
         return span
 
 
-class _AncestryRegistry:
-    """Persistent (process-lifetime) span ancestry index for handoff edges.
-
-    A batch-local parent walk fails when a delegated ``invoke_agent`` span and
-    its enclosing spans are exported in different batches. That is the common
-    case under ``BatchSpanProcessor``: a child span ends (and is enqueued)
-    *before* its parent, so on long runs the delegating agent's spans land in
-    a later batch than the child run that needs them.
-
-    This registry sidesteps batching entirely by recording ancestry at span
-    *start* time (a parent always starts before its children, and Pydantic AI
-    embeds the agent name in the ``invoke_agent <name>`` span name from the
-    start). The exporter then resolves the delegating agent against this index
-    regardless of which batch each span exports in.
-
-    Both dicts are bounded; the oldest entries are evicted once the cap is hit.
-    """
-
-    def __init__(self, max_entries: int = 8192) -> None:
-        self._parent_by_span_id: dict[int, int] = {}
-        self._agent_by_span_id: dict[int, str] = {}
-        self._max_entries = max_entries
-
-    @staticmethod
-    def _span_id(span: Any) -> int | None:
-        ctx = getattr(span, "context", None)
-        if ctx is None:
-            try:
-                ctx = span.get_span_context()
-            except Exception:  # noqa: BLE001
-                return None
-        return getattr(ctx, "span_id", None)
-
-    def _evict_if_needed(self, store: dict[int, Any]) -> None:
-        if len(store) < self._max_entries:
-            return
-        try:
-            first = next(iter(store))
-            store.pop(first, None)
-        except StopIteration:  # pragma: no cover - racy but harmless
-            pass
-
-    def record(self, span: Any) -> None:
-        """Index a Pydantic AI span's parent link and (if an agent span) its name.
-
-        Safe to call from a span processor's ``on_start``; never raises.
-        """
-        try:
-            span_id = self._span_id(span)
-            if span_id is None:
-                return
-            parent_ctx = getattr(span, "parent", None)
-            parent_sid = getattr(parent_ctx, "span_id", None)
-            if parent_sid is not None:
-                self._evict_if_needed(self._parent_by_span_id)
-                self._parent_by_span_id[span_id] = parent_sid
-            name = getattr(span, "name", "") or ""
-            if name.startswith(_INVOKE_AGENT_NAME_PREFIX):
-                agent_name = name[len(_INVOKE_AGENT_NAME_PREFIX) :].strip()
-                if agent_name:
-                    self._evict_if_needed(self._agent_by_span_id)
-                    self._agent_by_span_id[span_id] = agent_name
-        except Exception:  # noqa: BLE001 - recording must never break tracing
-            logger.debug("Failed to record span ancestry", exc_info=True)
-
-    def find_ancestor_agent(self, span: ReadableSpan) -> str | None:
-        """Resolve the nearest enclosing agent for a delegated span.
-
-        Walks the persistent parent chain looking for an ``invoke_agent``
-        ancestor. In Pydantic AI's delegation layout the chain is
-        ``invoke_agent (child) -> execute_tool -> invoke_agent (parent)``, so
-        the walk typically terminates in two hops.
-        """
-        cur_sid = self._span_id(span)
-        # Bound the walk defensively against malformed parent cycles.
-        for _ in range(64):
-            if cur_sid is None:
-                return None
-            parent_sid = self._parent_by_span_id.get(cur_sid)
-            if parent_sid is None:
-                return None
-            agent = self._agent_by_span_id.get(parent_sid)
-            if agent is not None:
-                return agent
-            cur_sid = parent_sid
-        return None
-
-
 # Shared singleton: the dedup processor populates it at span start, the
 # translating exporter reads it at export time. Both live in this module so a
 # module-level instance is the simplest correct wiring.
-_ancestry = _AncestryRegistry()
+#
+# Sibling tracking stays OFF: Pydantic AI's delegation nests properly
+# (``invoke_agent (child) -> execute_tool -> invoke_agent (parent)``), and
+# with siblings on a delegated agent span would resolve *itself* through its
+# own parent entry and report its own name as the calling agent.
+_ancestry = AncestryRegistry(agent_name_prefix=_INVOKE_AGENT_NAME_PREFIX)
 
 
 def _build_batch_lookups(
@@ -397,7 +318,8 @@ class PydanticAILLMDedupSpanProcessor(SpanProcessor):
 
     1. Records every Pydantic AI span's parent link (and agent names from
        ``invoke_agent <name>`` span names) into the module-level
-       :class:`_AncestryRegistry`, so the exporter can resolve handoff
+       shared :class:`~rhesis.sdk.telemetry.integrations.genai.AncestryRegistry`,
+       so the exporter can resolve handoff
        ``from`` agents across export batches.
     2. Toggles :func:`~rhesis.sdk.telemetry.context.is_llm_observation_active`
        for the duration of Pydantic AI ``chat`` spans so that any flag-checking

--- a/tests/penelope/targets/test_langchain.py
+++ b/tests/penelope/targets/test_langchain.py
@@ -48,3 +48,96 @@ def test_send_message_with_files_builds_content_blocks():
     assert content[0]["text"] == "What is this?"
     assert content[1]["type"] == "image"
     assert content[1]["mime_type"] == "image/png"
+
+
+# --- Native async path (a_send_message via ainvoke) ---
+
+
+class _AsyncOnlyRunnable:
+    """Runnable whose async path is observable: ainvoke records, invoke fails.
+
+    Ensures a_send_message really goes through ainvoke() rather than the
+    base-class thread-pool fallback (which would call invoke()).
+    """
+
+    def __init__(self):
+        self.received = {}
+
+    def invoke(self, x, config=None):
+        raise AssertionError("sync invoke() must not be called by a_send_message")
+
+    async def ainvoke(self, x, config=None):
+        self.received["input"] = x
+        return "async ok"
+
+
+def test_a_send_message_uses_native_ainvoke():
+    import asyncio
+
+    runnable = _AsyncOnlyRunnable()
+    target = LangChainTarget(runnable, "test-target")
+
+    response = asyncio.run(target.a_send_message("hello"))
+
+    assert response.success is True
+    assert response.content == "async ok"
+    assert runnable.received["input"] == {"input": "hello"}
+
+
+def test_a_send_message_with_files_builds_content_blocks():
+    import asyncio
+
+    runnable = _AsyncOnlyRunnable()
+    target = LangChainTarget(runnable, "test-target")
+
+    response = asyncio.run(target.a_send_message("What is this?", files=SAMPLE_FILES))
+
+    assert response.success is True
+    received = runnable.received["input"]
+    assert isinstance(received, HumanMessage)
+    assert received.content[0]["type"] == "text"
+    assert received.content[1]["type"] == "image"
+
+
+def test_a_send_message_with_file_reference_uses_aread_bytes():
+    import asyncio
+
+    class _FakeFileReference:
+        def __init__(self):
+            self.filename = "photo.png"
+            self.content_type = "image/png"
+            self.extracted_text = None
+            self.aread_called = False
+
+        def read_bytes(self):
+            raise AssertionError("blocking read_bytes() must not be used on the async path")
+
+        async def aread_bytes(self):
+            self.aread_called = True
+            return b"rawbytes"
+
+    runnable = _AsyncOnlyRunnable()
+    target = LangChainTarget(runnable, "test-target")
+    file_ref = _FakeFileReference()
+
+    response = asyncio.run(target.a_send_message("What is this?", files=[file_ref]))
+
+    assert response.success is True
+    assert file_ref.aread_called is True
+
+
+def test_a_send_message_error_is_captured():
+    import asyncio
+
+    class _Boom:
+        def invoke(self, x, config=None):
+            raise AssertionError("must use ainvoke")
+
+        async def ainvoke(self, x, config=None):
+            raise RuntimeError("async boom")
+
+    target = LangChainTarget(_Boom(), "test-target")
+    response = asyncio.run(target.a_send_message("hello"))
+
+    assert response.success is False
+    assert "async boom" in response.error

--- a/tests/penelope/targets/test_langchain.py
+++ b/tests/penelope/targets/test_langchain.py
@@ -126,6 +126,30 @@ def test_a_send_message_with_file_reference_uses_aread_bytes():
     assert file_ref.aread_called is True
 
 
+def test_a_send_message_falls_back_without_ainvoke():
+    """Regression: validate_configuration only requires invoke(), so a
+    duck-typed runnable without ainvoke() must fall back to the thread-pool
+    path instead of raising AttributeError."""
+    import asyncio
+
+    class _SyncOnlyRunnable:
+        def __init__(self):
+            self.received = {}
+
+        def invoke(self, x, config=None):
+            self.received["input"] = x
+            return "sync ok"
+
+    runnable = _SyncOnlyRunnable()
+    target = LangChainTarget(runnable, "test-target")
+
+    response = asyncio.run(target.a_send_message("hello"))
+
+    assert response.success is True
+    assert response.content == "sync ok"
+    assert runnable.received["input"] == {"input": "hello"}
+
+
 def test_a_send_message_error_is_captured():
     import asyncio
 

--- a/tests/penelope/targets/test_langgraph.py
+++ b/tests/penelope/targets/test_langgraph.py
@@ -98,3 +98,21 @@ def test_a_send_message_with_files_builds_content_blocks(echo_graph):
     assert isinstance(stored.content, list)
     assert stored.content[0]["type"] == "text"
     assert stored.content[1]["type"] == "image"
+
+
+def test_a_send_message_falls_back_without_ainvoke():
+    """Regression: validate_configuration only requires invoke(), so a
+    duck-typed graph without ainvoke() must fall back to the thread-pool
+    path instead of raising AttributeError."""
+    import asyncio
+
+    class _SyncOnlyGraph:
+        def invoke(self, state):
+            return {"messages": [*state["messages"], AIMessage(content="sync ok")]}
+
+    target = LangGraphTarget(_SyncOnlyGraph(), "test-target")
+
+    response = asyncio.run(target.a_send_message("hello"))
+
+    assert response.success is True
+    assert response.content == "sync ok"

--- a/tests/penelope/targets/test_langgraph.py
+++ b/tests/penelope/targets/test_langgraph.py
@@ -51,3 +51,50 @@ def test_send_message_with_files_builds_content_blocks(echo_graph):
     assert stored.content[0]["type"] == "text"
     assert stored.content[1]["type"] == "image"
     assert stored.content[1]["mime_type"] == "image/png"
+
+
+# --- Native async path (a_send_message via ainvoke) ---
+
+
+def test_a_send_message_uses_native_ainvoke(echo_graph):
+    import asyncio
+    from unittest.mock import patch
+
+    target = LangGraphTarget(echo_graph, "test-target")
+
+    # a_send_message must go through the graph's native ainvoke, never the
+    # sync invoke (which the base-class thread-pool fallback would call).
+    with patch.object(
+        type(echo_graph), "invoke", side_effect=AssertionError("sync invoke must not be called")
+    ):
+        response = asyncio.run(target.a_send_message("hello"))
+
+    assert response.success is True
+    assert "echo:" in response.content
+
+
+def test_a_send_message_maintains_session_state(echo_graph):
+    import asyncio
+
+    target = LangGraphTarget(echo_graph, "test-target")
+
+    asyncio.run(target.a_send_message("first", conversation_id="s1"))
+    response = asyncio.run(target.a_send_message("second", conversation_id="s1"))
+
+    assert response.success is True
+    # user+ai per turn, accumulated across both turns
+    assert response.metadata["session_messages_count"] == 4
+
+
+def test_a_send_message_with_files_builds_content_blocks(echo_graph):
+    import asyncio
+
+    target = LangGraphTarget(echo_graph, "test-target")
+
+    response = asyncio.run(target.a_send_message("What is this?", files=SAMPLE_FILES))
+
+    assert response.success is True
+    stored: HumanMessage = target._session_states["default"][0]
+    assert isinstance(stored.content, list)
+    assert stored.content[0]["type"] == "text"
+    assert stored.content[1]["type"] == "image"

--- a/tests/penelope/targets/test_optional_imports.py
+++ b/tests/penelope/targets/test_optional_imports.py
@@ -1,10 +1,11 @@
 """Regression test: rhesis.penelope.targets must import without optional deps.
 
-langchain, langgraph, and pydantic-ai are all optional dependencies of
-rhesis-penelope (see penelope/pyproject.toml). LangChainTarget, LangGraphTarget,
-and PydanticAITarget are imported unconditionally from targets/__init__.py, so
-none of their modules may import those optional packages at module level - only
-inside the functions that actually need them.
+langchain, langgraph, pydantic-ai, and the agent-framework packages are all
+optional dependencies of rhesis-penelope (see penelope/pyproject.toml).
+LangChainTarget, LangGraphTarget, PydanticAITarget, and MAFTarget are imported
+unconditionally from targets/__init__.py, so none of their modules may import
+those optional packages at module level - only inside the functions that
+actually need them.
 """
 
 import builtins
@@ -12,7 +13,7 @@ import sys
 
 import pytest
 
-_BLOCKED = {"langchain_core", "langgraph", "pydantic_ai"}
+_BLOCKED = {"langchain_core", "langgraph", "pydantic_ai", "agent_framework"}
 
 
 @pytest.fixture
@@ -47,6 +48,7 @@ def test_targets_package_imports_without_optional_deps(block_optional_deps):
     assert targets.LangChainTarget is not None
     assert targets.LangGraphTarget is not None
     assert targets.PydanticAITarget is not None
+    assert targets.MAFTarget is not None
 
 
 def test_endpoint_target_usable_without_optional_deps(block_optional_deps):

--- a/tests/sdk/telemetry/integrations/test_agent_framework.py
+++ b/tests/sdk/telemetry/integrations/test_agent_framework.py
@@ -1690,6 +1690,38 @@ def test_integration_disable_neutralizes_dedup_at_runtime(
     assert is_llm_observation_active() is False
 
 
+def test_dedup_flag_restored_even_without_operation_attribute(
+    session_provider, reset_llm_observation_flag, reset_observability_settings
+):
+    """Regression: on_end restores based on what on_start recorded, so a
+    chat-named span missing gen_ai.operation.name cannot leave the flag
+    stuck True."""
+    provider, _captured, _bsp = session_provider
+    proc = MAFLLMDedupSpanProcessor()
+    proc.activate()
+
+    tracer = provider.get_tracer("agent_framework.test")
+    span = tracer.start_span("chat gpt-4")  # no operation attribute set
+    proc.on_start(span)
+    assert is_llm_observation_active() is True
+    span.end()
+    proc.on_end(span)
+    assert is_llm_observation_active() is False
+
+
+def test_enable_fails_without_wrappable_exporter(monkeypatch, reset_observability_settings):
+    """Regression: enable() fails closed when translation cannot be installed,
+    instead of turning on instrumentation whose spans the backend would
+    reject. MAF has no off switch, so wrapping is checked before enabling."""
+    bare_provider = TracerProvider()  # no span processors attached
+    monkeypatch.setattr(otel_trace, "get_tracer_provider", lambda: bare_provider)
+
+    integ = MAFIntegration()
+    assert integ.enable() is False
+    assert integ.enabled is False
+    assert integ._patched_processors == []
+
+
 def test_integration_returns_false_when_provider_is_not_rhesis(
     monkeypatch, reset_observability_settings
 ):


### PR DESCRIPTION
## Purpose

Closes #2070. The cross-cutting consistency and DRY pass across Penelope targets and SDK telemetry integrations, sequenced after the translator migration (#2104) as agreed on #2057 — two of the original deliverables were reshaped by that work (details below).

## What Changed

- **Native async paths for `LangChainTarget` and `LangGraphTarget`**: `a_send_message()` built on the runnable/graph's native `ainvoke()` instead of the base-class `asyncio.to_thread` fallback, matching `PydanticAITarget` and `MAFTarget`. `files_to_content_blocks()` gains an async sibling that materializes `FileReference` attachments via `aread_bytes()` so object-storage fetches don't block the event loop; sync and async share the block-building logic.
- **Shared `AncestryRegistry` in `genai.py`** (requested by @harry-rhesis in the #2104 review): the handoff from-agent resolution registry moves out of both translators. MAF's sibling-layout case (`HandoffBuilder` puts `invoke_agent` and `chat` as siblings under `executor.process`) is behind an opt-in `track_siblings` flag — it must stay off for properly nested delegation like Pydantic AI's, where a delegated agent span would otherwise resolve *itself* through its own parent entry and report its own name as the calling agent. `_HandoffAncestryRegistry` becomes a thin subclass with unchanged behavior.
- **MAF hardening parity** (ports of the #2104 fixes): `MAFLLMDedupSpanProcessor.on_end` now restores the LLM-observation flag from what `on_start` recorded rather than re-deriving chat-ness from attributes (no more stuck-True leak), and `enable()` wraps exporters *before* turning on instrumentation, failing closed when none can be wrapped. The ordering fix matters more for MAF than it did for pydantic_ai: MAF has no off switch, so previously a failed provider check still left instrumentation permanently on.

## Original #2070 deliverables accounting

- **Import guards**: already satisfied by the deferred-import pattern from #2057 (0517dc3) — `import rhesis.penelope.targets` succeeds without any optional dep. This PR extends the regression test to also block `agent_framework` and assert `MAFTarget` imports cleanly.
- **Native async for LangChain/LangGraph**: delivered here.
- **`PatchState` base extraction**: moot — `AgentPatchState` was deleted by the #2104 migration, leaving `GraphPatchState` (langgraph) as the only patch-state class, so there is no duplication left to extract. If langgraph later migrates to a translator too, it goes away entirely.
- **`ai.llm.invoke` child spans for Pydantic AI**: delivered by #2104's native chat spans.

## Testing

- `uv run pytest tests/sdk/telemetry/integrations/` — 161 passed (2 new MAF regressions)
- `uv run pytest tests/penelope` — 594 passed (7 new: async paths for both targets, aread_bytes usage, error capture, session state, MAF import guard)
- Full SDK regression: 2308 passed; the 3 failures are the known timing-flaky `connector/test_executor*` and `test_exporter` deadline tests, unrelated to this change
- `ruff check` / `ruff format` clean on all new/modified files
