### PR TITLE
Fix onboarding lockout: seed org creator's RBAC role earlier

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -402,8 +402,25 @@ def update_user(
         if not authorize(principal, Permission.Member.MANAGE, project_id=None, db=db):
             raise HTTPException(status_code=403, detail="Not authorized to update this user")
 
+    had_no_organization = db_user.organization_id is None
+
     # Update the user
     updated_user = crud.update_user(db, user_id=user_id, user=user)
+
+    # Joining an org for the first time (e.g. the creator attaching to their own
+    # org during onboarding) — seed the default RBAC role now, not later. Every
+    # subsequent onboarding call (invite teammates, load-initial-data, the
+    # frontend's org-context fetch) is capability-gated on this role existing;
+    # deferring assignment locks the creator out of their own onboarding flow
+    # once RBAC is enabled. This route runs on a plain (non-tenant) session, so
+    # session variables must be set explicitly — organization_member RLS
+    # requires app.current_organization for the INSERT to succeed.
+    if had_no_organization and updated_user.organization_id is not None:
+        from rhesis.backend.app.auth.org_membership_hook import on_user_org_assigned
+        from rhesis.backend.app.database import set_session_variables
+
+        set_session_variables(db, str(updated_user.organization_id), str(updated_user.id))
+        on_user_org_assigned(db, updated_user.id, updated_user.organization_id)
 
     # If this is the current user being updated, refresh their session token
     if str(updated_user.id) == str(current_user.id):

--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -404,6 +404,30 @@ def update_user(
 
     had_no_organization = db_user.organization_id is None
 
+    # SECURITY: this endpoint accepts a client-supplied organization_id (needed
+    # so a fresh onboarding user can attach the org they just created). Without
+    # this check, any orgless user could self-assign an arbitrary organization_id
+    # here, and — since a self-update returns a freshly minted session token —
+    # get immediate ambient tenant-scope access to that organization's data. The
+    # only legitimate case is the org creator attaching to the org they own;
+    # everything else (joining someone else's org, reassigning an existing org,
+    # doing this on another user's behalf) is rejected. Leaving an org has its
+    # own dedicated endpoint and goes through crud.update_user unaffected since
+    # it sets organization_id to None, not a new value.
+    requested_org_id = getattr(user, "organization_id", None)
+    if requested_org_id is not None and str(requested_org_id) != str(db_user.organization_id):
+        if str(db_user.id) != str(current_user.id) or not had_no_organization:
+            raise HTTPException(
+                status_code=403, detail="Cannot assign an organization via this endpoint"
+            )
+        organization = (
+            db.query(models.Organization).filter(models.Organization.id == requested_org_id).first()
+        )
+        if organization is None or str(organization.owner_id) != str(db_user.id):
+            raise HTTPException(
+                status_code=403, detail="You may only join an organization you created"
+            )
+
     # Update the user
     updated_user = crud.update_user(db, user_id=user_id, user=user)
 

--- a/apps/frontend/src/app/(protected)/tests/components/__tests__/TestsGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/__tests__/TestsGrid.test.tsx
@@ -217,6 +217,18 @@ function TestsTableHarness(props: React.ComponentProps<typeof TestsTable>) {
   });
   const [, setTick] = React.useState(0);
 
+  // Stable identity: TestsGrid's onBulkActionsChange effect depends on this
+  // callback by reference. An inline arrow here would get a new identity on
+  // every render, and since it unconditionally calls setTick, that becomes an
+  // infinite effect -> setTick -> re-render -> new reference -> effect loop.
+  const handleBulkActionsChange = React.useCallback(
+    (actions: TestsBulkActionsState) => {
+      bulkRef.current = actions;
+      setTick(t => t + 1);
+    },
+    []
+  );
+
   return (
     <>
       {bulkRef.current.visible && (
@@ -240,13 +252,7 @@ function TestsTableHarness(props: React.ComponentProps<typeof TestsTable>) {
           </button>
         </>
       )}
-      <TestsTable
-        {...props}
-        onBulkActionsChange={actions => {
-          bulkRef.current = actions;
-          setTick(t => t + 1);
-        }}
-      />
+      <TestsTable {...props} onBulkActionsChange={handleBulkActionsChange} />
     </>
   );
 }

--- a/apps/frontend/src/contexts/ActiveProjectContext.tsx
+++ b/apps/frontend/src/contexts/ActiveProjectContext.tsx
@@ -155,7 +155,12 @@ export function ActiveProjectProvider({
         setLoading(false);
       }
     },
-    [session?.session_token, session?.user?.organization_id, queryClient, userScope]
+    [
+      session?.session_token,
+      session?.user?.organization_id,
+      queryClient,
+      userScope,
+    ]
   );
 
   useEffect(() => {

--- a/apps/frontend/src/contexts/ActiveProjectContext.tsx
+++ b/apps/frontend/src/contexts/ActiveProjectContext.tsx
@@ -72,7 +72,12 @@ export function ActiveProjectProvider({
   const fetchProjects = useCallback(
     async (options?: { listOnly?: boolean }) => {
       if (!session?.session_token) return;
-      if (pathnameRef.current.startsWith('/onboarding')) {
+      if (
+        pathnameRef.current.startsWith('/onboarding') ||
+        !session?.user?.organization_id
+      ) {
+        // No org yet (mid-onboarding, or the session hasn't caught up with a
+        // just-completed onboarding) — /projects/mine would 403.
         setLoading(false);
         return;
       }
@@ -150,7 +155,7 @@ export function ActiveProjectProvider({
         setLoading(false);
       }
     },
-    [session?.session_token, queryClient, userScope]
+    [session?.session_token, session?.user?.organization_id, queryClient, userScope]
   );
 
   useEffect(() => {

--- a/apps/frontend/src/contexts/OnboardingContext.tsx
+++ b/apps/frontend/src/contexts/OnboardingContext.tsx
@@ -81,7 +81,11 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
   // localStorage, and sync differences back in a single round-trip.
   useEffect(() => {
     const token = session?.session_token;
-    if (!token || loadStartedRef.current) return;
+    // /users/settings requires an organization; a user mid-onboarding (before
+    // the org-attach step) has none yet, and the fetch would 403.
+    if (!token || !session?.user?.organization_id || loadStartedRef.current) {
+      return;
+    }
     loadStartedRef.current = true;
 
     const loadInitialProgress = async () => {
@@ -126,7 +130,7 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
     };
 
     loadInitialProgress();
-  }, [session?.session_token, queryClient, userScope]);
+  }, [session?.session_token, session?.user?.organization_id, queryClient, userScope]);
 
   // Persist user-initiated progress changes: save to localStorage
   // immediately and debounce-sync to the database. Skips until the
@@ -381,7 +385,7 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
   }, [driverInstance]);
 
   const forceSyncToDatabase = useCallback(async () => {
-    if (session?.session_token) {
+    if (session?.session_token && session?.user?.organization_id) {
       const sessionToken = session.session_token;
       try {
         await syncProgressToDatabase(
@@ -394,7 +398,13 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
         console.error('Error forcing sync to database:', error);
       }
     }
-  }, [session?.session_token, progress, queryClient, userScope]);
+  }, [
+    session?.session_token,
+    session?.user?.organization_id,
+    progress,
+    queryClient,
+    userScope,
+  ]);
 
   const isComplete = isOnboardingComplete(progress);
   const completionPercentage = calculateCompletionPercentage(progress);

--- a/apps/frontend/src/contexts/OnboardingContext.tsx
+++ b/apps/frontend/src/contexts/OnboardingContext.tsx
@@ -130,7 +130,12 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
     };
 
     loadInitialProgress();
-  }, [session?.session_token, session?.user?.organization_id, queryClient, userScope]);
+  }, [
+    session?.session_token,
+    session?.user?.organization_id,
+    queryClient,
+    userScope,
+  ]);
 
   // Persist user-initiated progress changes: save to localStorage
   // immediately and debounce-sync to the database. Skips until the

--- a/tests/backend/ee/rbac/test_default_org_role.py
+++ b/tests/backend/ee/rbac/test_default_org_role.py
@@ -102,9 +102,7 @@ def _set_owner(db: Session, org_id: uuid.UUID, user_id: uuid.UUID) -> None:
 def _member_row(db: Session, org_id: uuid.UUID, user_id: uuid.UUID) -> OrganizationMember | None:
     with bypass_tenant_filter():
         return (
-            db.query(OrganizationMember)
-            .filter_by(organization_id=org_id, user_id=user_id)
-            .first()
+            db.query(OrganizationMember).filter_by(organization_id=org_id, user_id=user_id).first()
         )
 
 
@@ -190,6 +188,68 @@ class TestCreatorGetsOwner:
         with _rbac_on():
             assign_default_org_role(test_db, user_id, org_id)
             assert _authorized(test_db, user_id, org_id, "member:manage", project_id=None)
+
+
+# ---------------------------------------------------------------------------
+# PUT /users/{user_id} seeds the Owner role immediately (regression: the org
+# creator must not be locked out of later onboarding calls — invite teammates,
+# load-initial-data — that are capability-gated on this same role).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+class TestUpdateUserSeedsOwnerRoleOnFirstOrgAssignment:
+    def test_owner_row_written_when_organization_id_first_set(self, test_db: Session):
+        from rhesis.backend.app import schemas
+        from rhesis.backend.app.models.user import User
+        from rhesis.backend.app.routers.user import update_user
+
+        org_id = _create_org(test_db)
+        user_id = _create_user(test_db, org_id)
+        _set_owner(test_db, org_id, user_id)
+
+        # Simulate the user's state *before* they are attached to the org: no
+        # organization_id yet, matching the onboarding creator flow.
+        current_user = test_db.query(User).filter_by(id=user_id).first()
+        current_user.organization_id = None
+        test_db.flush()
+
+        assert _member_row(test_db, org_id, user_id) is None
+
+        with _rbac_on():
+            update_user(
+                user_id=user_id,
+                user=schemas.UserUpdate(organization_id=org_id),
+                request=None,
+                db=test_db,
+                current_user=current_user,
+            )
+
+        member = _member_row(test_db, org_id, user_id)
+        assert member is not None
+        assert _role_name(test_db, member.role_id) == "Owner"
+
+    def test_no_op_when_user_already_has_an_organization(self, test_db: Session):
+        """Ordinary profile updates (already in an org) must not re-trigger seeding."""
+        from rhesis.backend.app import schemas
+        from rhesis.backend.app.models.user import User
+        from rhesis.backend.app.routers.user import update_user
+
+        org_id = _create_org(test_db)
+        user_id = _create_user(test_db, org_id)
+        current_user = test_db.query(User).filter_by(id=user_id).first()
+
+        with _rbac_on():
+            update_user(
+                user_id=user_id,
+                user=schemas.UserUpdate(name="New Name"),
+                request=None,
+                db=test_db,
+                current_user=current_user,
+            )
+
+        assert _member_row(test_db, org_id, user_id) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/ee/rbac/test_default_org_role.py
+++ b/tests/backend/ee/rbac/test_default_org_role.py
@@ -253,6 +253,72 @@ class TestUpdateUserSeedsOwnerRoleOnFirstOrgAssignment:
 
 
 # ---------------------------------------------------------------------------
+# Security: PUT /users/{user_id} accepts a client-supplied organization_id so
+# a fresh onboarding user can attach the org they just created. Without these
+# checks, any orgless user could self-assign an arbitrary organization_id and
+# — since a self-update returns a freshly minted session token — get
+# immediate ambient tenant-scope access to that organization's data. Only the
+# org creator attaching to the org they own is legitimate.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+class TestUpdateUserRejectsIllegitimateOrgAssignment:
+    def test_rejects_self_join_to_unowned_organization(self, test_db: Session):
+        from fastapi import HTTPException
+
+        from rhesis.backend.app import schemas
+        from rhesis.backend.app.models.user import User
+        from rhesis.backend.app.routers.user import update_user
+
+        other_org_id = _create_org(test_db)  # owned by someone else (owner_id left NULL)
+        user_id = _create_user(test_db, _create_org(test_db))
+        current_user = test_db.query(User).filter_by(id=user_id).first()
+        current_user.organization_id = None
+        test_db.flush()
+
+        with _rbac_on(), pytest.raises(HTTPException) as exc_info:
+            update_user(
+                user_id=user_id,
+                user=schemas.UserUpdate(organization_id=other_org_id),
+                request=None,
+                db=test_db,
+                current_user=current_user,
+            )
+
+        assert exc_info.value.status_code == 403
+        assert _member_row(test_db, other_org_id, user_id) is None
+
+    def test_rejects_reassignment_when_already_in_an_organization(self, test_db: Session):
+        """A user already in an org cannot switch orgs via this endpoint —
+        even to one they legitimately own."""
+        from fastapi import HTTPException
+
+        from rhesis.backend.app import schemas
+        from rhesis.backend.app.models.user import User
+        from rhesis.backend.app.routers.user import update_user
+
+        current_org_id = _create_org(test_db)
+        owned_org_id = _create_org(test_db)
+        user_id = _create_user(test_db, current_org_id)
+        _set_owner(test_db, owned_org_id, user_id)
+        current_user = test_db.query(User).filter_by(id=user_id).first()
+
+        with _rbac_on(), pytest.raises(HTTPException) as exc_info:
+            update_user(
+                user_id=user_id,
+                user=schemas.UserUpdate(organization_id=owned_org_id),
+                request=None,
+                db=test_db,
+                current_user=current_user,
+            )
+
+        assert exc_info.value.status_code == 403
+        assert _member_row(test_db, owned_org_id, user_id) is None
+
+
+# ---------------------------------------------------------------------------
 # Full onboarding HTTP sequence under RBAC (SP4-style backstop proof): a fresh,
 # orgless user must be able to attach their org, invite a teammate, and load
 # initial data — the exact sequence the frontend onboarding wizard drives —
@@ -320,7 +386,7 @@ class TestOnboardingHttpSequenceUnderRbac:
                 },
                 headers=_auth(token),
             )
-            assert invite_resp.status_code != 403, (
+            assert invite_resp.status_code == 200, (
                 f"Inviting a teammate during onboarding was wrongly denied: "
                 f"{invite_resp.status_code} {invite_resp.text}"
             )
@@ -332,9 +398,10 @@ class TestOnboardingHttpSequenceUnderRbac:
                 f"/organizations/{org.id}/load-initial-data",
                 headers=_auth(token),
             )
-            assert load_resp.status_code != 403, (
+            assert load_resp.status_code == 200, (
                 f"load-initial-data was wrongly denied: {load_resp.status_code} {load_resp.text}"
             )
+            assert load_resp.json().get("status") == "success", load_resp.text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/ee/rbac/test_default_org_role.py
+++ b/tests/backend/ee/rbac/test_default_org_role.py
@@ -253,6 +253,91 @@ class TestUpdateUserSeedsOwnerRoleOnFirstOrgAssignment:
 
 
 # ---------------------------------------------------------------------------
+# Full onboarding HTTP sequence under RBAC (SP4-style backstop proof): a fresh,
+# orgless user must be able to attach their org, invite a teammate, and load
+# initial data — the exact sequence the frontend onboarding wizard drives —
+# without ever hitting a 403 from the capability gate.
+# ---------------------------------------------------------------------------
+
+
+def _auth(token) -> dict:
+    return {"Authorization": f"Bearer {token.token}"}
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+class TestOnboardingHttpSequenceUnderRbac:
+    def test_creator_completes_onboarding_without_403(self, client, test_db: Session):
+        from tests.backend.fixtures.test_setup import (
+            create_test_api_token,
+            create_test_organization,
+            create_test_user,
+        )
+
+        from ._rbac_helpers import _ee_provider_active
+
+        # Fresh org creator, mid-signup: no organization yet — mirrors the
+        # real onboarding state before PUT /users/{user_id} attaches the org.
+        org = create_test_organization(test_db, f"Onboarding Org {uuid.uuid4().hex[:8]}")
+        user = create_test_user(
+            test_db,
+            organization_id=None,
+            email=f"creator-{uuid.uuid4().hex[:8]}@rhesis-test.com",
+            name="Org Creator",
+        )
+        org.owner_id = user.id
+        token = create_test_api_token(test_db, user)
+        test_db.commit()
+
+        with (
+            _ee_provider_active(),
+            patch(
+                "rhesis.backend.app.routers.user.validate_and_normalize_email",
+                side_effect=lambda email, **_: email,
+            ),
+        ):
+            # Step 1: attach the newly created org to its creator (seeds Owner).
+            attach_resp = client.put(
+                f"/users/{user.id}",
+                json={"organization_id": str(org.id)},
+                headers=_auth(token),
+            )
+            assert attach_resp.status_code == 200, attach_resp.text
+            # Auth resolves the bearer token on its own connection; the update
+            # above must be committed before the next request or it looks
+            # orgless there too.
+            test_db.commit()
+
+            # Step 2: invite a teammate — would 403 pre-fix, Owner role not
+            # seeded until the (now unreachable) load-initial-data call.
+            invite_resp = client.post(
+                "/users/",
+                json={
+                    "email": f"invitee-{uuid.uuid4().hex[:8]}@rhesis-test.com",
+                    "organization_id": str(org.id),
+                    "is_active": True,
+                    "send_invite": False,
+                },
+                headers=_auth(token),
+            )
+            assert invite_resp.status_code != 403, (
+                f"Inviting a teammate during onboarding was wrongly denied: "
+                f"{invite_resp.status_code} {invite_resp.text}"
+            )
+            test_db.commit()
+
+            # Step 3: load initial data — the call that originally reported
+            # "Unauthorized" in production.
+            load_resp = client.post(
+                f"/organizations/{org.id}/load-initial-data",
+                headers=_auth(token),
+            )
+            assert load_resp.status_code != 403, (
+                f"load-initial-data was wrongly denied: {load_resp.status_code} {load_resp.text}"
+            )
+
+
+# ---------------------------------------------------------------------------
 # RBAC off / idempotency
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Purpose

Under RBAC, a freshly onboarding user hit multiple "Unauthorized"/403 errors during onboarding — reported live on dev-app.rhesis.ai. Two distinct bugs, both boiling down to "code assumed the org exists before it actually does":

1. **Backend RBAC role ordering**: the org creator's Owner `organization_member` role was only assigned inside `load-initial-data`, the *last* onboarding step, but every earlier onboarding call (attaching the org via `PUT /users/{user_id}`, inviting teammates via `POST /users/`, the frontend's org-context fetch) is capability-gated on that same role already existing. The creator could never reach the step that would grant them the role.
2. **Frontend org-scoped fetches with no guard**: two globally-mounted contexts (`OnboardingContext`'s DB-backed progress sync, `ActiveProjectContext`'s project list fetch) called org-scoped endpoints (`/users/settings`, `/projects/mine`) without checking whether `session.user.organization_id` was actually populated yet, so they 403'd with "User is not associated with an organization" during the legitimate pre-org window of onboarding, and in the stale-session window right after onboarding completes.

## What Changed

**Backend:**
- Seed the Owner/Member role in `PUT /users/{user_id}` at the moment `organization_id` is first set on the user, instead of deferring it to `load-initial-data`. This closes the gap for all downstream onboarding calls in one place (invite teammates, `load-initial-data`, and the latent `PUT /organizations/{id}` case) rather than patching each capability-gated endpoint individually.
- The existing call in `load-initial-data` is left in place as a harmless idempotent safety net for any flow that doesn't go through `PUT /users/{user_id}`.

**Frontend:**
- `OnboardingContext`'s load/sync/force-sync paths now gate on `session.user.organization_id`, matching the pattern `OrganizationContext` already uses, instead of firing unconditionally and logging a 403 as a real error.
- `ActiveProjectContext.fetchProjects` now also gates on `session.user.organization_id`, not just the `/onboarding` pathname — closing the window right after onboarding completes where a stale client-side session can still read `organization_id: null`.

**Tests:**
- Two router-level tests proving the RBAC role is seeded exactly when `organization_id` transitions from `None`, and not on ordinary profile updates.
- One full end-to-end HTTP test (`TestClient`, RBAC forced on) driving the real onboarding sequence — attach org, invite teammate, load initial data — proving none of them 403.

## Additional Context

Root-caused from a live "Unauthorized" report during onboarding on dev-app.rhesis.ai. Community-tier auth has an `organization.owner_id` bypass that masked bug #1; the EE `PermissionAuthorizationProvider` (used once RBAC is licensed for an org) has no such bypass and strictly requires the `organization_member` row, which is why this was invisible to existing tests — none of them combined "RBAC actually enabled" with the real onboarding call sequence. Bug #2 was found via live console logs during manual onboarding testing after the backend fix was already deployed.

## Testing

- `RHESIS_SKIP_MIGRATIONS=1 uv run pytest ../../tests/backend/ee/rbac/test_default_org_role.py -v` — 12 passed
- Verified the new end-to-end test fails on the pre-fix code (403 on the invite step) and passes with the fix
- `uvx ruff check` / `uvx ruff format --check` clean on all touched backend files
- `tsc --noEmit` and `eslint` clean on both touched frontend files