### PR TITLE
Remove unreliable schedule from create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -5,14 +5,6 @@ name: "[Release] 2. Create and deploy (stg)"
 
 on:
   workflow_dispatch:  # Allows manual triggering
-  schedule:
-    # The time is in UTC.
-    # 6:50 UTC = 08:50 CEST.
-    # 7:50 UTC = 08:50 CET.
-    # Need to be adjusted after the time change to CEST or CET.
-    # The workflow is scheduled not to be on the full hour, because full hours are busy
-    # for GitHub Actions and delays can be expected.
-    - cron: '50 6 * * 4'
 
 
 jobs:


### PR DESCRIPTION
## Purpose
The scheduled trigger on the create-release workflow became unreliable, with huge delays that made Thursday morning releases unpredictable. Releases should be triggered manually when ready.

## What Changed
- Removed the `schedule` cron trigger (`50 6 * * 4`) from `.github/workflows/create-release.yml`
- Kept `workflow_dispatch` as the sole trigger for creating and deploying releases to staging

## Additional Context
GitHub Actions scheduled runs are subject to queue delays, especially around full hours. The workflow was already offset to :50 past the hour to mitigate this, but delays remained unacceptable.

## Testing
- [x] Workflow YAML is valid
- [ ] Verify manual trigger via **Actions → [Release] 2. Create and deploy (stg) → Run workflow** still works as expected