### PR TITLE
Revert "enable gzip/brotli for JSON on ingress-nginx"

### DIFF
--- a/kubernetes/base/ingress-nginx-external/ingress-external-application.yaml
+++ b/kubernetes/base/ingress-nginx-external/ingress-external-application.yaml
@@ -14,11 +14,6 @@ spec:
     helm:
       valuesObject:
         controller:
-          config:
-            use-gzip: "true"
-            gzip-types: "application/json application/javascript text/css text/plain application/xml"
-            enable-brotli: "true"
-            brotli-types: "application/json application/javascript text/css text/plain application/xml"
           ingressClassResource:
             name: external
             enabled: true

--- a/kubernetes/base/ingress-nginx-internal/ingress-internal-application.yaml
+++ b/kubernetes/base/ingress-nginx-internal/ingress-internal-application.yaml
@@ -14,11 +14,6 @@ spec:
     helm:
       valuesObject:
         controller:
-          config:
-            use-gzip: "true"
-            gzip-types: "application/json application/javascript text/css text/plain application/xml"
-            enable-brotli: "true"
-            brotli-types: "application/json application/javascript text/css text/plain application/xml"
           ingressClassResource:
             name: internal
             enabled: true


### PR DESCRIPTION
## Summary
- Reverts #2125 — it was merged into main by mistake; the intended target was release/v0.10.0.