### PR TITLE
Enable gzip/brotli for JSON on ingress-nginx

### DIFF
--- a/kubernetes/base/ingress-nginx-external/ingress-external-application.yaml
+++ b/kubernetes/base/ingress-nginx-external/ingress-external-application.yaml
@@ -14,6 +14,11 @@ spec:
     helm:
       valuesObject:
         controller:
+          config:
+            use-gzip: "true"
+            gzip-types: "application/json application/javascript text/css text/plain application/xml"
+            enable-brotli: "true"
+            brotli-types: "application/json application/javascript text/css text/plain application/xml"
           ingressClassResource:
             name: external
             enabled: true

--- a/kubernetes/base/ingress-nginx-internal/ingress-internal-application.yaml
+++ b/kubernetes/base/ingress-nginx-internal/ingress-internal-application.yaml
@@ -14,6 +14,11 @@ spec:
     helm:
       valuesObject:
         controller:
+          config:
+            use-gzip: "true"
+            gzip-types: "application/json application/javascript text/css text/plain application/xml"
+            enable-brotli: "true"
+            brotli-types: "application/json application/javascript text/css text/plain application/xml"
           ingressClassResource:
             name: internal
             enabled: true


### PR DESCRIPTION
## Summary
- Enable gzip and brotli compression for `application/json` (and a few other text types) on both ingress-nginx controllers (internal + external).
- Re-targets #2125, which was merged into main by mistake; that change is reverted in #2126.