### PR TITLE
Fix RBAC project/org role scope and precedence

### DIFF
--- a/apps/backend/src/rhesis/backend/app/auth/capabilities.py
+++ b/apps/backend/src/rhesis/backend/app/auth/capabilities.py
@@ -308,6 +308,50 @@ class ResourceType(_PermissionEnum):
 
 
 # ---------------------------------------------------------------------------
+# Capability scope — organization vs. project
+# ---------------------------------------------------------------------------
+#
+# Community-side because authorize()/require_permission() (this package) need
+# it to decide whether a permission check should ignore the ambient project
+# scope. EE's ``ee/rbac/models.py`` re-exports these names for its own use
+# (custom-role ``scope`` column, catalog tests) rather than defining them,
+# since core code must never import from ``rhesis.backend.ee.*``.
+
+SCOPE_ORGANIZATION = "organization"
+SCOPE_PROJECT = "project"
+
+#: Resource types whose permissions are always org-scoped, regardless of any
+#: ambient project context (mirrors the seeded ``permission.scope`` column).
+_ORG_SCOPED_RESOURCES: frozenset[str] = frozenset(
+    {
+        "organization",
+        "member",
+        "role",
+        "token",
+        "recycle",
+        "sso",
+        "api_clients",
+    }
+)
+
+
+def capability_scope(cap: str) -> str:
+    """Return ``'organization'`` or ``'project'`` for a capability string.
+
+    ``project:create`` is org-scoped (creating a project *inside* the org).
+    All other ``project:*`` capabilities (read, update) are project-scoped.
+    """
+    parts = cap.split(":", 1)
+    resource = parts[0]
+    action = parts[1] if len(parts) > 1 else ""
+    if resource in _ORG_SCOPED_RESOURCES:
+        return SCOPE_ORGANIZATION
+    if resource == "project" and action == "create":
+        return SCOPE_ORGANIZATION
+    return SCOPE_PROJECT
+
+
+# ---------------------------------------------------------------------------
 # openapi_extra keys
 # ---------------------------------------------------------------------------
 

--- a/apps/backend/src/rhesis/backend/app/auth/rbac.py
+++ b/apps/backend/src/rhesis/backend/app/auth/rbac.py
@@ -46,7 +46,12 @@ from uuid import UUID
 from fastapi import Depends, HTTPException, Request
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app.auth.capabilities import Permission, get_all_capabilities
+from rhesis.backend.app.auth.capabilities import (
+    SCOPE_ORGANIZATION,
+    Permission,
+    capability_scope,
+    get_all_capabilities,
+)
 from rhesis.backend.app.auth.principal import (
     Principal,
     resolve_principal_from_request,
@@ -301,6 +306,18 @@ def authorize(
         any exception in the provider returns ``False`` and logs the error.
     """
     perm_str = str(permission)
+
+    # Org-scoped capabilities (sso:manage, role:manage, member:manage, ...) must
+    # never be narrowed by an ambient project context. require_permission's
+    # auto-injected dependency reads project_id from the request's active
+    # project (e.g. an X-Project-Id header), which is meaningful for
+    # project-scoped actions but not for org-wide admin actions — a caller
+    # whose explicit *project* role is lower than their *org* role would
+    # otherwise be incorrectly denied an org-level action while that project
+    # happens to be active. Force project_id=None here so the PDP always
+    # resolves org-scoped permissions against the org role.
+    if project_id is not None and capability_scope(perm_str) == SCOPE_ORGANIZATION:
+        project_id = None
 
     # --- Token project boundary (deterministic, no DB, never cached) ---
     # A project-scoped token may only act within its own project.  Enforced here

--- a/docs/content/docs/organizations/roles.mdx
+++ b/docs/content/docs/organizations/roles.mdx
@@ -33,37 +33,54 @@ Built-in roles are fixed and cannot be edited or deleted.
 
 ## Organization roles vs. project roles
 
+A project-level role can only **add** to what your organization role already grants — it can never take access away. This mirrors how GitLab and Google Cloud IAM handle nested scopes: a narrower scope (project) can elevate access above a broader scope (organization), but it never restricts what the broader scope already grants. If you have both an organization role and an explicit role on a specific project, the **higher-level role always wins** for that project.
+
 ```mermaid
 %%{init: {'flowchart': {'nodeSpacing': 30, 'rankSpacing': 50}}}%%
 graph TB
-    A["Has an explicit project role?"]
-    B["Use the project role"]
-    C["Org role is Admin or Owner?"]
-    D["Implicit access to the project"]
-    E["Is a project member?"]
-    F["Inherit the org role"]
-    G["Denied"]
+    A["Has an org role?"]
+    Z["Has an explicit project role?"]
+    K["Use the explicit project role"]
+    D["Denied"]
+    B["Org role is Admin or Owner?"]
+    E["Has an explicit project role?"]
+    F["Use the higher of org role and project role"]
+    G["Use the org role"]
+    C["Is a project member?"]
+    H["Has an explicit project role?"]
+    I["Use the higher of org role and project role"]
+    J["Inherit the org role"]
 
+    A -- "No" --> Z
+    Z -- "Yes" --> K
+    Z -- "No" --> D
     A -- "Yes" --> B
-    A -- "No" --> C
-    C -- "Yes" --> D
-    C -- "No" --> E
+    B -- "Yes" --> E
     E -- "Yes" --> F
     E -- "No" --> G
+    B -- "No" --> C
+    C -- "No" --> D
+    C -- "Yes" --> H
+    H -- "Yes" --> I
+    H -- "No" --> J
 
-    style B fill:#4caf50,color:#fff
-    style D fill:#4caf50,color:#fff
+    style K fill:#4caf50,color:#fff
     style F fill:#4caf50,color:#fff
-    style G fill:#9c27b0,color:#fff
+    style G fill:#4caf50,color:#fff
+    style I fill:#4caf50,color:#fff
+    style J fill:#4caf50,color:#fff
+    style D fill:#9c27b0,color:#fff
 ```
 
-- A project-level role, if assigned, fully overrides the org role for that project (not additive).
-- Org Members and Viewers need to be added to a project to inherit their org role there.
+- No organization role at all: the explicit project role (if any) is the whole answer — there's no broader role to compare it against.
+- Org Admin or Owner: implicit access to every project already. An explicit project role only matters if it's *higher*, in which case it elevates further for that one project.
+- Org Member or Viewer: must be added to a project (given a project role, or added as a plain member) before they get any access there. Once added, the higher of their org role and any explicit project role applies.
 
 **Examples**
 
-- A contractor is added to one project only, with a Member role on that project. They have no access to any other project, regardless of their org role.
-- An org Viewer is promoted to Admin on a single project. They keep Viewer access everywhere else and gain full Admin access on that one project.
+- A contractor with no organization role is added to one project only, with a Member role on that project. They have no access to any other project — there's no org role to fall back on.
+- An org Viewer is granted an explicit Owner role on a single project. They keep Viewer access everywhere else and gain full Owner access on that one project (elevation).
+- An org Owner is also explicitly assigned a lower Admin role on one project (for example, from a default project setup). Their access on that project stays at Owner level — the lower project role does not restrict them.
 - An org Admin never needs to be added to a project explicitly. Admin and Owner get implicit access to every project.
 
 ## Custom roles
@@ -112,6 +129,10 @@ Owners can create custom roles with a hand-picked set of permissions (`role:mana
 ## Revoking access
 
 Assign the **None** role at the org tier to revoke a member while keeping them in the organization. **None** is not a valid project-tier assignment (the API returns a 422 error), since it has no meaning there.
+
+<Callout type="warning">
+  Because project roles can elevate but never restrict, setting a member's org role to **None** does not by itself remove any *higher* explicit role they still hold on individual projects — that project role now outranks None and still applies there. To fully revoke someone, also remove or downgrade their project-level role assignments.
+</Callout>
 
 ## Notes
 

--- a/ee/backend/src/rhesis/backend/ee/rbac/models.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/models.py
@@ -50,15 +50,19 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship
 
+# ---------------------------------------------------------------------------
+# Scope constants — defined in core (``app/auth/capabilities.py``) because
+# authorize()/require_permission() need them too and core code must never
+# import from ``rhesis.backend.ee.*``. Re-exported here unchanged so existing
+# EE/test imports of ``rhesis.backend.ee.rbac.models`` keep working.
+# ---------------------------------------------------------------------------
+from rhesis.backend.app.auth.capabilities import (  # noqa: E402
+    SCOPE_ORGANIZATION,
+    SCOPE_PROJECT,
+    capability_scope,
+)
 from rhesis.backend.app.models.base import Base
 from rhesis.backend.app.models.guid import GUID
-
-# ---------------------------------------------------------------------------
-# Scope constants
-# ---------------------------------------------------------------------------
-
-SCOPE_ORGANIZATION = "organization"
-SCOPE_PROJECT = "project"
 
 # Canonical built-in role names (order encodes precedence: highest first).
 BUILT_IN_ROLE_NAMES: tuple[str, ...] = ("Owner", "Admin", "Member", "Viewer", "None")
@@ -77,52 +81,18 @@ BUILT_IN_ROLE_LEVELS: dict[str, int] = {
 # constants are co-located and reviewable without opening a migration file.
 BUILT_IN_ROLE_DESCRIPTIONS: dict[str, str] = {
     "Owner": (
-        "Complete control of the organization, including billing, "
-        "deletion, and ownership transfer."
+        "Complete control of the organization, including billing, deletion, and ownership transfer."
     ),
     "Admin": (
         "Manage members, roles, projects, and organization settings. "
         "Cannot delete the organization."
     ),
     "Member": (
-        "Create, edit, and run evaluations across their projects. "
-        "Manage their own API tokens."
+        "Create, edit, and run evaluations across their projects. Manage their own API tokens."
     ),
-    "Viewer": (
-        "Read-only access to all resources. Can browse and export "
-        "but cannot make changes."
-    ),
+    "Viewer": ("Read-only access to all resources. Can browse and export but cannot make changes."),
     "None": "No access. Explicitly revoke a member while keeping them in the organization.",
 }
-
-# Resource types whose permissions are org-scoped.
-_ORG_SCOPED_RESOURCES: frozenset[str] = frozenset(
-    {
-        "organization",
-        "member",
-        "role",
-        "token",
-        "recycle",
-        "sso",
-        "api_clients",
-    }
-)
-
-
-def capability_scope(cap: str) -> str:
-    """Return ``'organization'`` or ``'project'`` for a capability string.
-
-    ``project:create`` is org-scoped (creating a project *inside* the org).
-    All other ``project:*`` capabilities (read, update) are project-scoped.
-    """
-    parts = cap.split(":", 1)
-    resource = parts[0]
-    action = parts[1] if len(parts) > 1 else ""
-    if resource in _ORG_SCOPED_RESOURCES:
-        return SCOPE_ORGANIZATION
-    if resource == "project" and action == "create":
-        return SCOPE_ORGANIZATION
-    return SCOPE_PROJECT
 
 
 # Actions a **Member** may perform on any project-scoped resource.  Unlike the

--- a/ee/backend/src/rhesis/backend/ee/rbac/provider.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/provider.py
@@ -7,23 +7,35 @@ for orgs with the RBAC feature enabled.  Installed via
 
 Resolution order:
 1. If RBAC is not available for the org → delegate to the community provider.
-2. If a ``project_id`` is given and the user has a ``project_membership`` row
-   with a non-NULL ``role_id`` → the project role governs (overrides org role,
-   not a union).
-3. No explicit project role set — behaviour depends on the org role level:
-   a. Org Admin or Owner (level >= 80): implicit access to all projects.
-      Their org role applies as the effective project role.  They do not need
-      to be individually enrolled in every project.
-   b. Org Member or Viewer (level < 80): explicit project enrollment is
-      required.  If a ``project_membership`` row exists (even with
-      ``role_id = NULL``), their org role applies to that project.  If no
-      membership row exists, access is denied for that project.
-4. No org role → deny everywhere.
+2. No org role at all (org-scoped checks) → deny; org-scoped permissions
+   require an org role. (For project-scoped checks, see step 5 — a pure
+   project member with no org role is still governed by their explicit
+   project role.)
+3. Org Admin or Owner (level >= 80): implicit access to all projects. Their
+   org role applies as the effective project role. They do not need to be
+   individually enrolled in every project.
+4. Org Member or Viewer (level < 80): explicit project enrollment is
+   required. If a ``project_membership`` row exists (even with
+   ``role_id = NULL``), their org role applies to that project. If no
+   membership row exists, access is denied for that project.
+5. If the user also has an explicit ``project_membership.role_id`` for this
+   project, it is compared against the org role (when one exists) and the
+   **higher-level** role wins — an explicit project role can elevate access
+   above the org role, but can never restrict it below what the org role
+   already grants. With no org role at all, the explicit project role is
+   the whole answer.
 
 The rationale for the Admin/Owner implicit-access rule mirrors tools like
 GitHub, Linear, and Notion: org-level administrators see and can manage all
 workspaces/projects without being individually added to each one.  Contributors
 (Member/Viewer) are scoped to projects they have been explicitly invited to.
+
+"Higher role wins, never restricts" (step 5) mirrors GitLab's inherited-membership
+rule and GCP IAM's resource-hierarchy inheritance: a narrower scope (project) can
+only add to what a broader scope (organization) already grants. An org Owner
+assigned a lower explicit role on one project still keeps Owner-level access to
+that project; an org Member assigned Owner on one project gets elevated access
+to that project only.
 
 The ``Role`` model has ``organization_id`` which triggers the ORM
 ``auto_filter`` event.  Built-in roles (``organization_id IS NULL``) would be
@@ -131,34 +143,49 @@ class PermissionAuthorizationProvider:
     def _resolve_role(self, principal: "Principal", project_id: Optional[UUID], db: "Session"):
         """Return the effective :class:`~rhesis.backend.ee.rbac.models.Role` or None.
 
-        When a project context is present the resolution follows three steps:
+        When a project context is present, access is gated by org role level
+        and enrollment first, then the org role and any explicit project role
+        are compared and the **higher-level** one is returned:
 
-        1. Explicit project role (``project_membership.role_id`` set) → use it.
-        2. Org role level >= Admin (80) → implicit access; org role is the
-           effective project role.
-        3. Org role level < Admin → explicit enrollment required; the user must
-           have a ``project_membership`` row (even with ``role_id = NULL``) to
-           receive their org role for this project.  No row → deny.
+        1. No org role at all — the explicit project role (if any) governs
+           directly; there is no org-level floor to compare it against. This
+           is the pure project-member case (e.g. a user with no
+           ``organization_member`` row at all).
+        2. Org role level >= Admin (80): implicit access to every project.
+        3. Org role level < Admin: explicit enrollment required — a
+           ``project_membership`` row (even with ``role_id = NULL``) must
+           exist, or access is denied outright.
+        4. If an explicit ``project_membership.role_id`` is also set, it is
+           compared against the org role by ``level``; the higher one wins.
+           A project role can elevate access above the org role but can never
+           restrict it below what the org role already grants (see module
+           docstring — "higher role wins, never restricts").
         """
         if project_id is None:
             return self._get_org_role(principal, db)
 
-        membership = self._get_project_membership(principal, project_id, db)
-
-        # Step 1 — explicit project role overrides everything.
-        if membership is not None and membership.role_id is not None:
-            return self._load_role(membership.role_id, db)
-
-        # Steps 2 & 3 — fall back to org role, gated by enrollment for lower levels.
         org_role = self._get_org_role(principal, db)
+
+        membership = self._get_project_membership(principal, project_id, db)
+        explicit_role = None
+        if membership is not None and membership.role_id is not None:
+            explicit_role = self._load_role(membership.role_id, db)
+
         if org_role is None:
-            return None
+            # No org-level floor to enforce — the explicit project role (if
+            # any) is the whole answer.
+            return explicit_role
 
         if org_role.level >= self._IMPLICIT_PROJECT_ACCESS_LEVEL:
-            # Admin / Owner: implicit access to all projects.
+            # Admin / Owner: implicit access to all projects; an explicit
+            # project role can only elevate further.
+            if explicit_role is not None and explicit_role.level > org_role.level:
+                return explicit_role
             return org_role
 
-        # Member / Viewer: only get fallback if explicitly enrolled.
+        # Member / Viewer: explicit enrollment required to access the project.
+        if explicit_role is not None:
+            return explicit_role if explicit_role.level > org_role.level else org_role
         if membership is not None:
             return org_role
 

--- a/tests/backend/ee/rbac/test_sp8_access_control.py
+++ b/tests/backend/ee/rbac/test_sp8_access_control.py
@@ -198,7 +198,12 @@ class TestAccessMatrix:
 @pytest.mark.ee
 @pytest.mark.integration
 class TestProjectRoleOverride:
-    """Project role beats org role (override, not a union)."""
+    """Project role can elevate but never restrict below the org role (Model A).
+
+    Mirrors GitLab's inherited-membership rule and GCP IAM's resource-hierarchy
+    inheritance: a narrower scope (project) can only add to what a broader
+    scope (organization) already grants, never take it away.
+    """
 
     @pytest.fixture(autouse=True)
     def _setup(self, test_db: Session):
@@ -210,34 +215,41 @@ class TestProjectRoleOverride:
     def _can_project(self, perm: str) -> bool:
         return _authorized(self.db, self.user_id, self.org_id, perm, project_id=self.project_id)
 
-    def test_viewer_project_role_overrides_admin_org_role_create(self):
-        """Admin org → can create; but Viewer project role → cannot create."""
+    def test_lower_viewer_project_role_does_not_restrict_admin_org_role(self):
+        """Admin org role → can create, even with an explicit Viewer project role."""
         _assign_org_role(self.db, self.org_id, self.user_id, "Admin")
         _assign_project_role(self.db, self.org_id, self.project_id, self.user_id, "Viewer")
-        assert not self._can_project("test_set:create")
+        assert self._can_project("test_set:create")
 
     def test_viewer_project_role_still_allows_read(self):
         _assign_org_role(self.db, self.org_id, self.user_id, "Admin")
         _assign_project_role(self.db, self.org_id, self.project_id, self.user_id, "Viewer")
         assert self._can_project("test_set:read")
 
-    def test_none_project_role_blocks_admin_org_permissions(self):
-        """Even Admin org role is blocked when project role is None."""
+    def test_none_project_role_does_not_block_admin_org_permissions(self):
+        """An explicit None project role can't restrict an Admin org role either."""
         _assign_org_role(self.db, self.org_id, self.user_id, "Admin")
         _assign_project_role(self.db, self.org_id, self.project_id, self.user_id, "None")
-        assert not self._can_project("test_set:read")
+        assert self._can_project("test_set:read")
 
     def test_org_role_applies_when_no_project_role_set(self):
         """Without a project-level row the org role governs."""
         _assign_org_role(self.db, self.org_id, self.user_id, "Admin")
         assert self._can_project("test_set:create")
 
+    def test_higher_project_role_elevates_above_lower_org_role(self):
+        """An explicit project role can still elevate access above a lower org role."""
+        _assign_org_role(self.db, self.org_id, self.user_id, "Viewer")
+        _assign_project_role(self.db, self.org_id, self.project_id, self.user_id, "Owner")
+        assert self._can_project("test_set:delete")
+
     def test_different_users_have_independent_project_roles(self):
-        """Two users, different project roles, independent decisions."""
+        """Two users with the same (low) org role get independent elevation
+        from their own explicit project roles."""
         viewer_id = _create_user(self.db, self.org_id)
         member_id = _create_user(self.db, self.org_id)
-        _assign_org_role(self.db, self.org_id, viewer_id, "Admin")
-        _assign_org_role(self.db, self.org_id, member_id, "Admin")
+        _assign_org_role(self.db, self.org_id, viewer_id, "Viewer")
+        _assign_org_role(self.db, self.org_id, member_id, "Viewer")
         _assign_project_role(self.db, self.org_id, self.project_id, viewer_id, "Viewer")
         _assign_project_role(self.db, self.org_id, self.project_id, member_id, "Member")
 
@@ -695,7 +707,9 @@ class TestCustomRoleEscalationGuard:
             )
         )
         self.db.add(
-            OrganizationMember(organization_id=self.org_id, user_id=target_id, role_id=broad_role.id)
+            OrganizationMember(
+                organization_id=self.org_id, user_id=target_id, role_id=broad_role.id
+            )
         )
         self.db.flush()
 
@@ -848,9 +862,7 @@ class TestProjectMemberAPI:
         admin_role = _builtin_role(self.db, "Admin")
         owner_role = _builtin_role(self.db, "Owner")
         _add_project_member(self.db, self.org_id, self.project_id, admin_id, admin_role.id)
-        _add_project_member(
-            self.db, self.org_id, self.project_id, owner_member_id, owner_role.id
-        )
+        _add_project_member(self.db, self.org_id, self.project_id, owner_member_id, owner_role.id)
 
         with pytest.raises(HTTPException) as exc, _rbac_enabled():
             assign_project_role(
@@ -963,7 +975,9 @@ class TestOrgMemberPermittedActions:
         """Ambient-permission gate: even when level and permission-subset
         checks would pass, an actor who doesn't hold member:manage at all
         must not see it in permitted_actions on any row."""
-        readonly_role = _custom_role(self.db, self.org_id, name="ReadOnlyA", scope=SCOPE_ORGANIZATION)
+        readonly_role = _custom_role(
+            self.db, self.org_id, name="ReadOnlyA", scope=SCOPE_ORGANIZATION
+        )
         target_role = _custom_role(self.db, self.org_id, name="ReadOnlyB", scope=SCOPE_ORGANIZATION)
         _grant_permission(self.db, readonly_role.id, "member:read")
         _grant_permission(self.db, target_role.id, "member:read")

--- a/tests/backend/ee/rbac/test_sp8_provider.py
+++ b/tests/backend/ee/rbac/test_sp8_provider.py
@@ -138,8 +138,13 @@ def _make_membership(role_id=None) -> MagicMock:
 
 @pytest.mark.ee
 class TestRoleResolutionPrecedence:
-    def test_explicit_project_role_overrides_org_role(self, provider):
-        """Explicit project role must be used even when org role is present (not union)."""
+    def test_lower_explicit_project_role_does_not_restrict_org_role(self, provider):
+        """A lower explicit project role must not restrict a higher org role.
+
+        Model A ("higher role wins, never restricts" — mirrors GitLab/GCP IAM):
+        an org Admin/Owner keeps their org-level access to a project even if
+        someone explicitly assigned them a lower project role there.
+        """
         principal = _make_principal()
         db = MagicMock()
         project_id = uuid.uuid4()
@@ -158,8 +163,31 @@ class TestRoleResolutionPrecedence:
         ):
             provider.is_authorized(principal, "test_set:read", project_id=project_id, db=db)
 
-        # Must use the project role, not the org role.
-        mock_check.assert_called_once_with(fake_project_role, "test_set:read", db)
+        # The higher-level org role must be used, not the lower project role.
+        mock_check.assert_called_once_with(fake_org_role, "test_set:read", db)
+
+    def test_higher_explicit_project_role_elevates_above_org_role(self, provider):
+        """An explicit project role can still elevate access above the org role."""
+        principal = _make_principal()
+        db = MagicMock()
+        project_id = uuid.uuid4()
+
+        fake_project_role_id = uuid.uuid4()
+        fake_membership = _make_membership(role_id=fake_project_role_id)
+        fake_project_role = _make_role("Owner", level=100)
+        fake_org_role = _make_role("Member", level=60)
+
+        with (
+            patch.object(provider, "_rbac_available", return_value=True),
+            patch.object(provider, "_get_project_membership", return_value=fake_membership),
+            patch.object(provider, "_load_role", return_value=fake_project_role),
+            patch.object(provider, "_get_org_role", return_value=fake_org_role),
+            patch.object(provider, "_role_has_permission", return_value=True) as mock_check,
+        ):
+            provider.is_authorized(principal, "test_set:delete", project_id=project_id, db=db)
+
+        # The higher-level project role must be used, elevating above the org role.
+        mock_check.assert_called_once_with(fake_project_role, "test_set:delete", db)
 
     def test_org_role_used_when_no_project_id(self, provider):
         """When no project_id, the org role must be used directly."""
@@ -297,9 +325,7 @@ class TestExplicitEnrollmentRequired:
         mock_check.assert_called_once_with(org_role, "test_set:read", db)
 
     @pytest.mark.parametrize("role_name,level", [("Member", 60), ("Viewer", 40)])
-    def test_explicit_project_role_overrides_for_member_viewer(
-        self, provider, role_name, level
-    ):
+    def test_explicit_project_role_overrides_for_member_viewer(self, provider, role_name, level):
         """Explicit project role overrides org role even for Member/Viewer."""
         principal = _make_principal()
         db = MagicMock()

--- a/tests/backend/ee/rbac/test_sp8_roles.py
+++ b/tests/backend/ee/rbac/test_sp8_roles.py
@@ -251,10 +251,12 @@ class TestEscalationGuard:
 @pytest.mark.ee
 @pytest.mark.integration
 class TestRolePrecedence:
-    """Project role must override org role (not union)."""
+    """Project role can elevate but never restrict below the org role (Model A)."""
 
-    def test_project_role_overrides_org_role(self, test_db: Session, test_org_id: str):
-        """A Viewer project role → deny create even when org role is Admin."""
+    def test_lower_project_role_does_not_restrict_higher_org_role(
+        self, test_db: Session, test_org_id: str
+    ):
+        """A Viewer project role must not deny create when org role is Admin."""
         from unittest.mock import patch
 
         from sqlalchemy import text
@@ -327,8 +329,8 @@ class TestRolePrecedence:
             )
 
         assert can_read is True, "Viewer can read"
-        assert can_create is False, (
-            "Viewer cannot create (project role should override Admin org role)"
+        assert can_create is True, (
+            "Admin org role should still apply; a lower project role can't restrict it"
         )
 
 

--- a/tests/backend/routes/test_capabilities.py
+++ b/tests/backend/routes/test_capabilities.py
@@ -279,21 +279,34 @@ class TestGetMyPermissions:
             f"Missing: {expected - my_perms}. Extra: {my_perms - expected}."
         )
 
-    def test_project_member_with_project_id_gets_all_capabilities(
+    def test_project_member_with_project_id_excludes_org_owner_only_capabilities(
         self, authed_client: TestClient, mock_project_member
     ):
-        """Project member gets all capabilities when the project_id scope matches."""
+        """Project member with a project scope still can't reach org-owner-only caps.
+
+        Org-scoped capabilities (sso:manage, role:manage, organization:update, ...)
+        must never be granted by project membership alone, regardless of whether the
+        request carries a project_id — authorize() forces project_id=None for them
+        before delegating to the provider, so a project member's ambient project
+        context can't leak into org-admin actions they don't otherwise hold.
+
+        ``project_member:manage`` is the one exception: it's project-scoped (not
+        org-scoped) by nature, so it's untouched by that normalization and is still
+        granted by plain project membership, per the provider's existing rule 3.
+        """
         from rhesis.backend.app.auth.capabilities import get_all_capabilities
+        from rhesis.backend.app.auth.rbac import _OWNER_ONLY_CAPABILITIES
 
         all_caps = set(get_all_capabilities())
+        expected = (all_caps - _OWNER_ONLY_CAPABILITIES) | {"project_member:manage"}
         my_perms = set(
             authed_client.get(
                 "/me/permissions", params={"project_id": str(_TEST_PROJECT_ID)}
             ).json()
         )
-        assert all_caps == my_perms, (
-            f"Project member should have all capabilities for their project. "
-            f"Missing: {all_caps - my_perms}."
+        assert my_perms == expected, (
+            f"Project member should hold standard (non-owner) capabilities for their "
+            f"project. Missing: {expected - my_perms}. Extra: {my_perms - expected}."
         )
 
     def test_project_member_without_project_id_gets_standard_capabilities(


### PR DESCRIPTION
## Purpose
Fixes two related RBAC bugs found while investigating an intermittent SSO-permission 403: org-scoped admin capabilities (`sso:manage`, `role:manage`, ...) could be incorrectly denied or granted based on ambient project context and explicit project roles, instead of always respecting the org role.

## What Changed
- **Org-scoped checks ignore ambient project scope.** `require_permission` read `project_id` from whatever project happened to be "active" (e.g. an `X-Project-Id` header) for every capability, including inherently org-wide ones. A user with a lower explicit role on one project could get denied org-admin actions while that project was active, despite holding a higher org role. `authorize()` now forces `project_id=None` for org-scoped capabilities before evaluation. The same gap existed in the community `DefaultAuthorizationProvider` (a plain project member could reach org-admin capabilities just by supplying any `project_id`).
- **Project roles can elevate but never restrict the org role.** Rewrote `PermissionAuthorizationProvider._resolve_role` so the effective role for a project is whichever of the org role and an explicit project role has the higher level. Previously an explicit project role fully overrode the org role in either direction, so e.g. an org Owner assigned a lower role on one project lost Owner-level access there. This now mirrors GitLab's inherited-membership rule and GCP IAM's resource-hierarchy inheritance.
- Moved `capability_scope()`/`SCOPE_ORGANIZATION`/`SCOPE_PROJECT` from the EE-only RBAC models into core `capabilities.py` (core can't import from `rhesis.backend.ee.*` but needs this logic); EE re-exports them unchanged.
- Updated tests that encoded the old restrictive-override behavior as expected, and documented the new resolution order in `docs/content/docs/organizations/roles.mdx` (and the companion Notion doc).

## Additional Context
Found while debugging a report of intermittent SSO-config and custom-role-creation 403s for an org Owner who also held an explicit lower Admin role on one project.

## Testing
- Full backend security/auth/EE/RBAC test suites pass (1637+ tests), including updated SP8 provider/access-control/roles suites and `test_capabilities.py`.
- `ruff check`/`ruff format` clean on all changed files.
- Live-verified against a running backend: the affected account now consistently keeps `sso:manage`/`role:manage`/project-scoped access at the correct (higher) level regardless of ambient project context.