### PR TITLE
Fix RBAC token project boundary bypass for org-scoped caps

### DIFF
--- a/apps/backend/src/rhesis/backend/app/auth/rbac.py
+++ b/apps/backend/src/rhesis/backend/app/auth/rbac.py
@@ -307,23 +307,16 @@ def authorize(
     """
     perm_str = str(permission)
 
-    # Org-scoped capabilities (sso:manage, role:manage, member:manage, ...) must
-    # never be narrowed by an ambient project context. require_permission's
-    # auto-injected dependency reads project_id from the request's active
-    # project (e.g. an X-Project-Id header), which is meaningful for
-    # project-scoped actions but not for org-wide admin actions — a caller
-    # whose explicit *project* role is lower than their *org* role would
-    # otherwise be incorrectly denied an org-level action while that project
-    # happens to be active. Force project_id=None here so the PDP always
-    # resolves org-scoped permissions against the org role.
-    if project_id is not None and capability_scope(perm_str) == SCOPE_ORGANIZATION:
-        project_id = None
-
     # --- Token project boundary (deterministic, no DB, never cached) ---
-    # A project-scoped token may only act within its own project.  Enforced here
-    # in the PDP so the rule holds for every transport (HTTP, WebSocket, future
-    # callers), not just the HTTP get_project_context dependency.  Org-scoped
-    # checks (project_id is None) are intentionally not blocked.
+    # A project-scoped token may only act within its own project. Checked here,
+    # against the *unnormalized* project_id, before the org-scope normalization
+    # below can null it out — otherwise a token minted for project A could reach
+    # org-scoped capabilities while the ambient request context is project B
+    # (a mismatch this check exists to catch) simply because org-scoped caps get
+    # their project_id cleared first. Enforced here in the PDP so the rule holds
+    # for every transport (HTTP, WebSocket, future callers), not just the HTTP
+    # get_project_context dependency. Org-scoped checks (project_id is None from
+    # the start) are intentionally not blocked.
     if (
         principal.token_project_id is not None
         and project_id is not None
@@ -335,6 +328,18 @@ def authorize(
             project_id,
         )
         return False
+
+    # Org-scoped capabilities (sso:manage, role:manage, member:manage, ...) must
+    # never be narrowed by an ambient project context. require_permission's
+    # auto-injected dependency reads project_id from the request's active
+    # project (e.g. an X-Project-Id header), which is meaningful for
+    # project-scoped actions but not for org-wide admin actions — a caller
+    # whose explicit *project* role is lower than their *org* role would
+    # otherwise be incorrectly denied an org-level action while that project
+    # happens to be active. Force project_id=None here so the PDP always
+    # resolves org-scoped permissions against the org role.
+    if project_id is not None and capability_scope(perm_str) == SCOPE_ORGANIZATION:
+        project_id = None
 
     # Cache is keyed on org context; skip entirely when the org is absent
     # (those are always denies — no value in caching them).

--- a/ee/backend/src/rhesis/backend/ee/rbac/provider.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/provider.py
@@ -173,7 +173,17 @@ class PermissionAuthorizationProvider:
 
         if org_role is None:
             # No org-level floor to enforce — the explicit project role (if
-            # any) is the whole answer.
+            # any) is the whole answer. If the membership row exists but
+            # role_id is NULL (e.g. its custom role was deleted — see
+            # delete_role's docstring in router.py), this deliberately
+            # resolves to None (deny) rather than falling back to some
+            # default project role: with no org role to compare against,
+            # there is no floor to fall back to, and granting access here
+            # would let a role deletion silently re-grant standard access to
+            # holders an admin may be deliberately locking out. Community
+            # mode's DefaultAuthorizationProvider treats a bare membership
+            # row as implicit standard access with no equivalent "delete the
+            # role" trigger, so the two tiers are not directly comparable.
             return explicit_role
 
         if org_role.level >= self._IMPLICIT_PROJECT_ACCESS_LEVEL:

--- a/ee/backend/src/rhesis/backend/ee/rbac/router.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/router.py
@@ -626,6 +626,11 @@ def delete_role(
       explicitly revoked and must be deliberately re-granted.
     - Project-tier members (``project_membership.role_id`` is nullable) have
       their ``role_id`` cleared, so they fall back to their inherited org role.
+      A holder with **no** org role at all (a pure project member — see
+      ``_resolve_role`` in ``ee/rbac/provider.py``) has no floor to fall back
+      to and loses project access entirely until a role is explicitly
+      reassigned; this is intentional (deleting a role is meant to revoke,
+      not silently downgrade to a default), not an oversight.
     """
     from rhesis.backend.app.models.project_membership import ProjectMembership
     from rhesis.backend.app.scope import bypass_tenant_filter

--- a/tests/backend/ee/rbac/test_sp9_token_scoping.py
+++ b/tests/backend/ee/rbac/test_sp9_token_scoping.py
@@ -222,6 +222,32 @@ class TestTokenProjectBoundary:
             # Org-scoped permission with project_id=None — boundary does not apply.
             assert authorize(principal, "organization:update", project_id=None, db=db) is True
 
+    def test_org_scoped_request_still_denied_on_project_mismatch(self, test_db):
+        """A token scoped to project A must not reach org-scoped caps while the
+        ambient request context is a *different* project B — the org-scope
+        normalization in authorize() must not bypass the token boundary check."""
+        db = test_db
+        org_id = _create_org(db)
+        user_id = _create_user(db, org_id)
+        _set_owner(db, org_id, user_id)
+        _point_session_at_org(db, org_id)
+        token_project = uuid.uuid4()
+        other_project = uuid.uuid4()
+        principal = Principal(
+            user_id=user_id,
+            organization_id=org_id,
+            kind="token",
+            token_project_id=token_project,
+        )
+        with _rbac_on(db, org_id, user_id, "Owner"):
+            # Ambient project (other_project) mismatches the token's own project
+            # boundary (token_project) — must deny even though the permission
+            # is org-scoped and the owner's role would otherwise allow it.
+            assert (
+                authorize(principal, "organization:update", project_id=other_project, db=db)
+                is False
+            )
+
 
 # ---------------------------------------------------------------------------
 # Unit-level: token scopes are immutable on update


### PR DESCRIPTION
## Purpose
Follow-up to #2130 addressing two peqy review comments left after that PR merged.

## What Changed
- `authorize()` now checks the token project-boundary (`token_project_id`) against the *unnormalized* `project_id`, before the org-scope normalization nulls it out. Previously, a project-scoped API token could reach org-scoped capabilities (`sso:manage`, `role:manage`, `member:manage`, ...) whenever the ambient project context didn't match the token's own project boundary, because the boundary check only fires when `project_id is not None` and normalization ran first.
- Added a regression test (`test_org_scoped_request_still_denied_on_project_mismatch`) covering the mismatch case.
- Documented (no behavior change) why `_resolve_role` intentionally denies a project member with no org role and a NULL project `role_id` (e.g. after their custom role is deleted) rather than falling back to a default role — this was flagged as a question by peqy but is existing intended behavior; deleting a role is meant to revoke access, not silently downgrade it.

## Additional Context
peqy left two comments on #2130 (already merged to `release/v0.10.0`) which couldn't be addressed in that PR:
1. Token project-scope vs org-scoped capabilities — confirmed to be a real bypass, fixed here.
2. `org_role=None` + `project_membership.role_id=NULL` edge case — confirmed reachable via role deletion, kept as intentional deny with clarifying docs.

## Testing
- `tests/backend/ee/rbac/test_sp9_token_scoping.py` (16 tests, including the new regression test) — all pass
- `tests/backend/auth/test_rbac.py`, `tests/backend/routes/test_capabilities.py`, `tests/backend/ee/rbac/` (270 tests total) — all pass