### PR TITLE
Fix review icon not appearing in test run list after review

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -321,7 +321,9 @@ export default function TestRunMainView({
         return newMap;
       });
       void refetchTestResults();
-      queryClient.invalidateQueries({ queryKey: testRunKeys.all() });
+      void queryClient.invalidateQueries({
+        queryKey: [...testRunKeys.all(), 'list'],
+      });
     },
     [refetchTestResults, queryClient]
   );

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -9,6 +9,8 @@ import React, {
 } from 'react';
 import { Box, Typography, TextField } from '@mui/material';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
+import { testRunKeys } from '@/constants/query-keys';
 import DetailTabNav from '@/components/common/DetailTabNav';
 import TestRunDetailHeader from './TestRunDetailHeader';
 import TestRunConfigurationTab from './TestRunConfigurationTab';
@@ -108,6 +110,7 @@ export default function TestRunMainView({
   const notifications = useNotifications();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
 
   const preferLinkedEntities = Boolean(initialSelectedTestId);
   const activeTab = tabIndexFromKey(
@@ -318,8 +321,9 @@ export default function TestRunMainView({
         return newMap;
       });
       void refetchTestResults();
+      queryClient.invalidateQueries({ queryKey: testRunKeys.all() });
     },
-    [refetchTestResults]
+    [refetchTestResults, queryClient]
   );
 
   const previousTabRef = useRef(activeTab);


### PR DESCRIPTION
## Purpose
When a user sets a review on a test run and navigates back to the list, the review icon does not appear until the grid is manually reloaded.

## What Changed
- Invalidate the React Query test run list cache when a test result is updated in the detail view
- Covers all review flows (create, delete, confirm) via the shared `handleTestResultUpdate` handler

## Additional Context
- Fixes #2128

## Testing
1. Open a test run from the list that has no review icon
2. Set a review on any test case
3. Navigate back to the test run list
4. Confirm the review icon appears immediately without reloading the grid