### PR TITLE
Fix v0.10.0 UI polish and onboarding video build

### DIFF
--- a/.github/workflows/frontend-k8s.yml
+++ b/.github/workflows/frontend-k8s.yml
@@ -78,6 +78,8 @@ jobs:
       context: .
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ inputs.tag || github.event.inputs.tag }}
+      build_args: |
+        NEXT_PUBLIC_ONBOARDING_VIDEO_URL=${{ secrets.NEXT_PUBLIC_ONBOARDING_VIDEO_URL }}
     secrets: inherit
 
   deploy:

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -51,17 +51,20 @@ ARG FRONTEND_ENV=production
 # Git metadata injected by CI pipeline (NEXT_PUBLIC_ prefix for client-side access)
 ARG GIT_BRANCH
 ARG GIT_COMMIT
+ARG NEXT_PUBLIC_ONBOARDING_VIDEO_URL
 ENV GIT_BRANCH=${GIT_BRANCH}
 ENV GIT_COMMIT=${GIT_COMMIT}
 ENV NEXT_PUBLIC_GIT_BRANCH=${GIT_BRANCH}
 ENV NEXT_PUBLIC_GIT_COMMIT=${GIT_COMMIT}
+ENV NEXT_PUBLIC_ONBOARDING_VIDEO_URL=${NEXT_PUBLIC_ONBOARDING_VIDEO_URL}
 
 # Create a temporary .env file for build-time server configuration.
 RUN echo "NEXTAUTH_SECRET=temporary-build-secret-not-for-production" > apps/frontend/.env && \
     echo "BACKEND_URL=${BACKEND_URL}" >> apps/frontend/.env && \
     echo "GOOGLE_CLIENT_ID=placeholder-client-id" >> apps/frontend/.env && \
     echo "GOOGLE_CLIENT_SECRET=placeholder-client-secret" >> apps/frontend/.env && \
-    echo "AUTH_SECRET=placeholder-auth-secret" >> apps/frontend/.env
+    echo "AUTH_SECRET=placeholder-auth-secret" >> apps/frontend/.env && \
+    echo "NEXT_PUBLIC_ONBOARDING_VIDEO_URL=${NEXT_PUBLIC_ONBOARDING_VIDEO_URL}" >> apps/frontend/.env
 
 # Set environment variables for better Next.js performance
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectChat.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectChat.tsx
@@ -30,6 +30,7 @@ interface ArchitectChatProps {
   onSessionTitleUpdate?: (sessionId: string, title: string) => void;
   initialMessage?: string | null;
   onInitialMessageSent?: () => void;
+  onUserActivity?: () => void;
   /** The project_id the session was created under (from the session object). */
   sessionProjectId?: string | null;
 }
@@ -127,6 +128,7 @@ export default function ArchitectChat({
   onSessionTitleUpdate: _onSessionTitleUpdate,
   initialMessage,
   onInitialMessageSent,
+  onUserActivity,
   sessionProjectId,
 }: ArchitectChatProps) {
   const { data: authSession } = useSession();
@@ -264,13 +266,15 @@ export default function ArchitectChat({
   const handleSend = useCallback(
     (message: string, attachments?: ChatAttachments) => {
       sendMessage(message, attachments);
+      onUserActivity?.();
     },
-    [sendMessage]
+    [sendMessage, onUserActivity]
   );
 
   const handleSuggestedPrompt = (prompt: string) => {
     if (!isLoading) {
       sendMessage(prompt);
+      onUserActivity?.();
     }
   };
 
@@ -446,7 +450,10 @@ export default function ArchitectChat({
                   streamingState={
                     message.isStreaming ? streamingState : undefined
                   }
-                  onAccept={() => sendMessage('Yes, go ahead.')}
+                  onAccept={() => {
+                    sendMessage('Yes, go ahead.');
+                    onUserActivity?.();
+                  }}
                   onReject={() => chatInputRef.current?.focus()}
                 />
               );

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
@@ -6,6 +6,11 @@ import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { ArchitectSession } from '@/utils/api-client/architect-client';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import {
+  clearResumeHint,
+  pickResumableSessionId,
+  writeResumeHint,
+} from '@/utils/architect-resume';
 import ArchitectSidebar from './ArchitectSidebar';
 import ArchitectChat from './ArchitectChat';
 import ArchitectWelcome from './ArchitectWelcome';
@@ -25,6 +30,15 @@ export default function ArchitectClient() {
     return new ApiClientFactory(session.session_token).getArchitectClient();
   }, [session?.session_token]);
 
+  const touchResumeHint = useCallback(
+    (sessionId: string) => {
+      if (activeProject?.id) {
+        writeResumeHint(activeProject.id, sessionId);
+      }
+    },
+    [activeProject?.id]
+  );
+
   // Reload sessions whenever the active project changes so the sidebar always
   // shows only sessions belonging to the current project. The backend already
   // filters by project via RLS (X-Project-Id header); we just need to re-fetch
@@ -34,18 +48,37 @@ export default function ArchitectClient() {
       const client = getClient();
       if (!client) return;
       setIsLoadingSessions(true);
-      setActiveSessionId(null);
       try {
         const data = await client.getSessions();
         setSessions(data);
+
+        const projectId = activeProject?.id;
+        if (projectId) {
+          const resumeSessionId = pickResumableSessionId(projectId, data);
+          setActiveSessionId(resumeSessionId);
+        } else {
+          setActiveSessionId(null);
+        }
       } catch (err) {
         console.error('Failed to load architect sessions:', err);
+        setActiveSessionId(null);
       } finally {
         setIsLoadingSessions(false);
       }
     };
     loadSessions();
   }, [getClient, activeProject?.id]);
+
+  // Bump last-activity when navigating away mid-conversation.
+  useEffect(() => {
+    const projectId = activeProject?.id;
+    const sessionId = activeSessionId;
+    return () => {
+      if (projectId && sessionId) {
+        writeResumeHint(projectId, sessionId);
+      }
+    };
+  }, [activeProject?.id, activeSessionId]);
 
   const handleNewSession = useCallback(async () => {
     const client = getClient();
@@ -54,10 +87,11 @@ export default function ArchitectClient() {
       const newSession = await client.createSession();
       setSessions(prev => [newSession, ...prev]);
       setActiveSessionId(newSession.id);
+      touchResumeHint(newSession.id);
     } catch (err) {
       console.error('Failed to create session:', err);
     }
-  }, [getClient]);
+  }, [getClient, touchResumeHint]);
 
   const handleNewSessionWithMessage = useCallback(
     async (message: string) => {
@@ -70,17 +104,22 @@ export default function ArchitectClient() {
         setSessions(prev => [newSession, ...prev]);
         setPendingMessage(message);
         setActiveSessionId(newSession.id);
+        touchResumeHint(newSession.id);
       } catch (err) {
         console.error('Failed to create session:', err);
         setIsCreatingSession(false);
       }
     },
-    [getClient]
+    [getClient, touchResumeHint]
   );
 
-  const handleSelectSession = useCallback(async (id: string) => {
-    setActiveSessionId(id);
-  }, []);
+  const handleSelectSession = useCallback(
+    (id: string) => {
+      setActiveSessionId(id);
+      touchResumeHint(id);
+    },
+    [touchResumeHint]
+  );
 
   const handleDeleteSession = useCallback(
     async (id: string) => {
@@ -91,12 +130,15 @@ export default function ArchitectClient() {
         setSessions(prev => prev.filter(s => s.id !== id));
         if (activeSessionId === id) {
           setActiveSessionId(null);
+          if (activeProject?.id) {
+            clearResumeHint(activeProject.id);
+          }
         }
       } catch (err) {
         console.error('Failed to delete session:', err);
       }
     },
-    [getClient, activeSessionId]
+    [getClient, activeSessionId, activeProject?.id]
   );
 
   const handleSessionTitleUpdate = useCallback(
@@ -110,7 +152,16 @@ export default function ArchitectClient() {
 
   const handleInitialMessageSent = useCallback(() => {
     setPendingMessage(null);
-  }, []);
+    if (activeSessionId) {
+      touchResumeHint(activeSessionId);
+    }
+  }, [activeSessionId, touchResumeHint]);
+
+  const handleUserActivity = useCallback(() => {
+    if (activeSessionId) {
+      touchResumeHint(activeSessionId);
+    }
+  }, [activeSessionId, touchResumeHint]);
 
   return (
     <Box
@@ -139,6 +190,7 @@ export default function ArchitectClient() {
             onSessionTitleUpdate={handleSessionTitleUpdate}
             initialMessage={pendingMessage}
             onInitialMessageSent={handleInitialMessageSent}
+            onUserActivity={handleUserActivity}
             sessionProjectId={
               sessions.find(s => s.id === activeSessionId)?.project_id
             }

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
@@ -48,6 +48,8 @@ export default function ArchitectClient() {
       const client = getClient();
       if (!client) return;
       setIsLoadingSessions(true);
+      setActiveSessionId(null);
+      setSessions([]);
       try {
         const data = await client.getSessions();
         setSessions(data);

--- a/apps/frontend/src/app/(protected)/knowledge/[identifier]/components/SourcePreviewClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/[identifier]/components/SourcePreviewClientWrapper.tsx
@@ -688,13 +688,6 @@ export default function SourcePreviewClientWrapper({
           )}
         </Paper>
 
-        <SourceTagsCard
-          sessionToken={sessionToken}
-          source={localSource}
-          userId={currentUserId ? (currentUserId as UUID) : undefined}
-          onUpdate={handleTagsUpdate}
-        />
-
         {/* Extracted Content Section */}
         {content && (
           <Paper
@@ -784,24 +777,22 @@ export default function SourcePreviewClientWrapper({
           </Paper>
         )}
 
+        <SourceTagsCard
+          sessionToken={sessionToken}
+          source={localSource}
+          userId={currentUserId ? (currentUserId as UUID) : undefined}
+          onUpdate={handleTagsUpdate}
+        />
+
         {/* Comments Section */}
-        <Paper
-          sx={{
-            p: theme.spacing(3),
-            borderRadius: theme.spacing(1),
-            bgcolor: theme.palette.background.paper,
-            boxShadow: theme.shadows[1],
-          }}
-        >
-          <CommentsWrapper
-            entityType="Source"
-            entityId={localSource.id}
-            sessionToken={sessionToken}
-            currentUserId={currentUserId}
-            currentUserName={currentUserName}
-            currentUserPicture={currentUserPicture}
-          />
-        </Paper>
+        <CommentsWrapper
+          entityType="Source"
+          entityId={localSource.id}
+          sessionToken={sessionToken}
+          currentUserId={currentUserId}
+          currentUserName={currentUserName}
+          currentUserPicture={currentUserPicture}
+        />
       </Stack>
     </PageLayout>
   );

--- a/apps/frontend/src/app/(protected)/onboarding/components/OnboardingSidebar.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/OnboardingSidebar.tsx
@@ -3,6 +3,7 @@
 import Image from 'next/image';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { Box, Typography } from '@mui/material';
+import { DEFAULT_AUTHENTICATED_PATH } from '@/constants/paths';
 import { ONBOARDING_STEPS } from './onboarding-steps';
 import { onboardingSidebarSx } from './onboarding-styles';
 
@@ -141,9 +142,7 @@ export default function OnboardingSidebar({
 
       <Box
         component="a"
-        href="https://www.rhesis.ai"
-        target="_blank"
-        rel="noopener noreferrer"
+        href={DEFAULT_AUTHENTICATED_PATH}
         sx={{
           display: 'inline-flex',
           alignItems: 'center',

--- a/apps/frontend/src/components/common/EndpointSelectField.tsx
+++ b/apps/frontend/src/components/common/EndpointSelectField.tsx
@@ -47,13 +47,16 @@ export default function EndpointSelectField({
 
   return (
     <FormControl fullWidth>
-      <InputLabel id={labelId}>{label}</InputLabel>
+      <InputLabel id={labelId} shrink>
+        {label}
+      </InputLabel>
       <Select
         labelId={labelId}
         id={selectId}
         value={value ?? ''}
         label={label}
         displayEmpty
+        notched
         onChange={handleChange}
         renderValue={selected => {
           if (!selected) {

--- a/apps/frontend/src/utils/__tests__/architect-resume.test.ts
+++ b/apps/frontend/src/utils/__tests__/architect-resume.test.ts
@@ -38,10 +38,7 @@ describe('architect-resume', () => {
   });
 
   it('clears invalid stored JSON', () => {
-    sessionStorage.setItem(
-      `architect:resume:${PROJECT_ID}`,
-      '{not valid json'
-    );
+    sessionStorage.setItem(`architect:resume:${PROJECT_ID}`, '{not valid json');
 
     expect(readResumeHint(PROJECT_ID)).toBeNull();
     expect(sessionStorage.getItem(`architect:resume:${PROJECT_ID}`)).toBeNull();

--- a/apps/frontend/src/utils/__tests__/architect-resume.test.ts
+++ b/apps/frontend/src/utils/__tests__/architect-resume.test.ts
@@ -1,0 +1,79 @@
+import {
+  ARCHITECT_RESUME_TTL_MS,
+  clearResumeHint,
+  pickResumableSessionId,
+  readResumeHint,
+  writeResumeHint,
+} from '../architect-resume';
+
+const PROJECT_ID = 'project-1';
+const SESSION_ID = 'session-abc';
+
+beforeEach(() => {
+  sessionStorage.clear();
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2026-07-09T12:00:00.000Z'));
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('architect-resume', () => {
+  it('writes and reads a resume hint', () => {
+    writeResumeHint(PROJECT_ID, SESSION_ID);
+
+    expect(readResumeHint(PROJECT_ID)).toEqual({
+      sessionId: SESSION_ID,
+      lastActiveAt: Date.now(),
+    });
+  });
+
+  it('returns null when hint is expired', () => {
+    writeResumeHint(PROJECT_ID, SESSION_ID);
+    jest.advanceTimersByTime(ARCHITECT_RESUME_TTL_MS + 1);
+
+    expect(readResumeHint(PROJECT_ID)).toBeNull();
+    expect(sessionStorage.getItem(`architect:resume:${PROJECT_ID}`)).toBeNull();
+  });
+
+  it('clears invalid stored JSON', () => {
+    sessionStorage.setItem(
+      `architect:resume:${PROJECT_ID}`,
+      '{not valid json'
+    );
+
+    expect(readResumeHint(PROJECT_ID)).toBeNull();
+    expect(sessionStorage.getItem(`architect:resume:${PROJECT_ID}`)).toBeNull();
+  });
+
+  it('pickResumableSessionId returns hint when session exists', () => {
+    writeResumeHint(PROJECT_ID, SESSION_ID);
+
+    expect(
+      pickResumableSessionId(PROJECT_ID, [{ id: SESSION_ID }, { id: 'other' }])
+    ).toBe(SESSION_ID);
+  });
+
+  it('pickResumableSessionId clears hint when session is missing', () => {
+    writeResumeHint(PROJECT_ID, SESSION_ID);
+
+    expect(pickResumableSessionId(PROJECT_ID, [{ id: 'other' }])).toBeNull();
+    expect(readResumeHint(PROJECT_ID)).toBeNull();
+  });
+
+  it('clearResumeHint removes stored hint', () => {
+    writeResumeHint(PROJECT_ID, SESSION_ID);
+    clearResumeHint(PROJECT_ID);
+
+    expect(readResumeHint(PROJECT_ID)).toBeNull();
+  });
+
+  it('scopes hints per project', () => {
+    writeResumeHint('project-a', 'session-a');
+    writeResumeHint('project-b', 'session-b');
+
+    expect(readResumeHint('project-a')?.sessionId).toBe('session-a');
+    expect(readResumeHint('project-b')?.sessionId).toBe('session-b');
+  });
+});

--- a/apps/frontend/src/utils/architect-resume.ts
+++ b/apps/frontend/src/utils/architect-resume.ts
@@ -10,9 +10,7 @@ function storageKey(projectId: string): string {
   return `architect:resume:${projectId}`;
 }
 
-export function readResumeHint(
-  projectId: string
-): ArchitectResumeHint | null {
+export function readResumeHint(projectId: string): ArchitectResumeHint | null {
   if (typeof window === 'undefined') return null;
 
   try {

--- a/apps/frontend/src/utils/architect-resume.ts
+++ b/apps/frontend/src/utils/architect-resume.ts
@@ -1,0 +1,79 @@
+/** Resume a recent Architect session when returning within this window. */
+export const ARCHITECT_RESUME_TTL_MS = 15 * 60 * 1000;
+
+export interface ArchitectResumeHint {
+  sessionId: string;
+  lastActiveAt: number;
+}
+
+function storageKey(projectId: string): string {
+  return `architect:resume:${projectId}`;
+}
+
+export function readResumeHint(
+  projectId: string
+): ArchitectResumeHint | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    const raw = sessionStorage.getItem(storageKey(projectId));
+    if (!raw) return null;
+
+    const hint = JSON.parse(raw) as ArchitectResumeHint;
+    if (!hint.sessionId || typeof hint.lastActiveAt !== 'number') {
+      clearResumeHint(projectId);
+      return null;
+    }
+
+    if (Date.now() - hint.lastActiveAt > ARCHITECT_RESUME_TTL_MS) {
+      clearResumeHint(projectId);
+      return null;
+    }
+
+    return hint;
+  } catch {
+    clearResumeHint(projectId);
+    return null;
+  }
+}
+
+export function writeResumeHint(projectId: string, sessionId: string): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const hint: ArchitectResumeHint = {
+      sessionId,
+      lastActiveAt: Date.now(),
+    };
+    sessionStorage.setItem(storageKey(projectId), JSON.stringify(hint));
+  } catch {
+    // sessionStorage may be unavailable in private browsing / SSR
+  }
+}
+
+export function clearResumeHint(projectId: string): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    sessionStorage.removeItem(storageKey(projectId));
+  } catch {
+    // ignore
+  }
+}
+
+/** Returns a session id to auto-open, or null when no valid resume hint exists. */
+export function pickResumableSessionId(
+  projectId: string,
+  sessions: Array<{ id: string }>
+): string | null {
+  const hint = readResumeHint(projectId);
+  if (!hint) return null;
+
+  const exists = sessions.some(session => session.id === hint.sessionId);
+  if (!exists) {
+    clearResumeHint(projectId);
+    return null;
+  }
+
+  return hint.sessionId;
+}

--- a/ee/frontend/src/rbac/components/TokenScopeField.tsx
+++ b/ee/frontend/src/rbac/components/TokenScopeField.tsx
@@ -105,6 +105,10 @@ export default function TokenScopeField({
 
   const handleRoleChange = (roleId: string) => {
     setSelectedRoleId(roleId);
+    if (!roleId) {
+      onChange([]);
+      return;
+    }
     const role = roles.find(r => r.id === roleId);
     if (role?.permissions) {
       onChange(role.permissions.map(p => p.name));
@@ -155,14 +159,34 @@ export default function TokenScopeField({
 
       {mode === 'restricted' && (
         <>
-          <FormControl fullWidth size="small" sx={drawerOutlinedFieldSx}>
-            <InputLabel id="token-role-label">Role template</InputLabel>
+          <FormControl fullWidth sx={drawerOutlinedFieldSx}>
+            <InputLabel id="token-role-label" shrink>
+              Role template
+            </InputLabel>
             <Select
               labelId="token-role-label"
               label="Role template"
               value={selectedRoleId}
+              displayEmpty
+              notched
               onChange={e => handleRoleChange(e.target.value)}
+              renderValue={value => {
+                if (!value) {
+                  return (
+                    <Typography variant="body1" color="text.secondary">
+                      Select a role
+                    </Typography>
+                  );
+                }
+                const role = assignableRoles.find(r => r.id === value);
+                return role?.display_name ?? value;
+              }}
             >
+              <MenuItem value="">
+                <Typography variant="body1" color="text.secondary">
+                  Select a role
+                </Typography>
+              </MenuItem>
               {assignableRoles.map(role => (
                 <MenuItem key={role.id} value={role.id}>
                   {role.display_name}

--- a/ee/frontend/src/rbac/components/TokenScopeField.tsx
+++ b/ee/frontend/src/rbac/components/TokenScopeField.tsx
@@ -159,7 +159,7 @@ export default function TokenScopeField({
 
       {mode === 'restricted' && (
         <>
-          <FormControl fullWidth sx={drawerOutlinedFieldSx}>
+          <FormControl fullWidth size="small" sx={drawerOutlinedFieldSx}>
             <InputLabel id="token-role-label" shrink>
               Role template
             </InputLabel>


### PR DESCRIPTION
## Summary
- Fix Playground endpoint select label overlay (`InputLabel shrink` + `notched`)
- Resume recent Architect conversations within 15 minutes via `sessionStorage`
- Reorder knowledge source detail sections (tags below extracted content) and remove double-elevated comments card
- Fix token creation role template select label/placeholder styling
- Point onboarding "Back home" to `/architect` instead of marketing site
- Bake `NEXT_PUBLIC_ONBOARDING_VIDEO_URL` into K8s frontend Docker builds so the welcome video works on staging

## Test plan
- [ ] Playground: endpoint select shows floated label without overlap
- [ ] Architect: start chat, navigate away, return within 15 min — conversation restores
- [ ] Knowledge source detail: tags below extracted content; comments single card elevation
- [ ] Create token drawer: role template shows "Select a role" placeholder correctly
- [ ] Onboarding: "Back home" navigates to app home (`/architect`)
- [ ] Rebuild/deploy frontend on K8s and verify onboarding welcome video plays