### PR TITLE
Fix K8s frontend build secret for onboarding video URL

### DIFF
--- a/.github/workflows/frontend-k8s.yml
+++ b/.github/workflows/frontend-k8s.yml
@@ -78,8 +78,6 @@ jobs:
       context: .
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ inputs.tag || github.event.inputs.tag }}
-      build_args: |
-        NEXT_PUBLIC_ONBOARDING_VIDEO_URL=${{ secrets.NEXT_PUBLIC_ONBOARDING_VIDEO_URL }}
     secrets: inherit
 
   deploy:

--- a/.github/workflows/k8s-build-push.yml
+++ b/.github/workflows/k8s-build-push.yml
@@ -35,6 +35,9 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
+      NEXT_PUBLIC_ONBOARDING_VIDEO_URL:
+        required: false
     outputs:
       tag:
         description: 'Resolved image tag (override or short git SHA)'
@@ -122,6 +125,8 @@ jobs:
         run: gcloud auth configure-docker "${{ env.REGISTRY_HOST }}" --quiet
 
       - name: Build Container
+        env:
+          NEXT_PUBLIC_ONBOARDING_VIDEO_URL: ${{ secrets.NEXT_PUBLIC_ONBOARDING_VIDEO_URL }}
         run: |
           TARGET_ARGS=()
           if [ -n "${{ inputs.target }}" ]; then
@@ -135,6 +140,10 @@ jobs:
               [ -z "$line" ] && continue
               BUILD_ARG_FLAGS+=(--build-arg "$line")
             done <<< "$BUILD_ARG_LINES"
+          fi
+
+          if [ -n "$NEXT_PUBLIC_ONBOARDING_VIDEO_URL" ]; then
+            BUILD_ARG_FLAGS+=(--build-arg "NEXT_PUBLIC_ONBOARDING_VIDEO_URL=$NEXT_PUBLIC_ONBOARDING_VIDEO_URL")
           fi
 
           docker build --platform linux/amd64 \

--- a/.github/workflows/k8s-build-push.yml
+++ b/.github/workflows/k8s-build-push.yml
@@ -35,9 +35,6 @@ on:
         required: false
         type: string
         default: ''
-    secrets:
-      NEXT_PUBLIC_ONBOARDING_VIDEO_URL:
-        required: false
     outputs:
       tag:
         description: 'Resolved image tag (override or short git SHA)'


### PR DESCRIPTION
## Summary
- Fix invalid `release.yml` workflow parse error caused by referencing `secrets` inside a reusable workflow `with:` input
- Declare `NEXT_PUBLIC_ONBOARDING_VIDEO_URL` on `k8s-build-push` and inject it during the Docker build step instead

## Test plan
- [ ] `release.yml` workflow file validates on GitHub
- [ ] `deploy-all-k8s` → `frontend-k8s` → `k8s-build-push` chain runs successfully
- [ ] Frontend image build receives `NEXT_PUBLIC_ONBOARDING_VIDEO_URL` build arg when secret is set