### PR TITLE
Fix onboarding welcome video via server-side env

### DIFF
--- a/.github/workflows/frontend-k8s.yml
+++ b/.github/workflows/frontend-k8s.yml
@@ -78,8 +78,6 @@ jobs:
       context: .
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ inputs.tag || github.event.inputs.tag }}
-      build_args: |
-        NEXT_PUBLIC_ONBOARDING_VIDEO_URL=https://youtu.be/fNtxqGtBu2Y
     secrets: inherit
 
   deploy:

--- a/.github/workflows/frontend-k8s.yml
+++ b/.github/workflows/frontend-k8s.yml
@@ -78,6 +78,8 @@ jobs:
       context: .
       environment: ${{ inputs.environment || github.event.inputs.environment || 'dev' }}
       tag: ${{ inputs.tag || github.event.inputs.tag }}
+      build_args: |
+        NEXT_PUBLIC_ONBOARDING_VIDEO_URL=https://youtu.be/fNtxqGtBu2Y
     secrets: inherit
 
   deploy:

--- a/apps/frontend/src/app/(protected)/onboarding/components/OnboardingPageClient.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/OnboardingPageClient.tsx
@@ -36,11 +36,13 @@ interface FormData {
 interface OnboardingPageClientProps {
   sessionToken: string;
   userId: UUID;
+  onboardingVideoUrl?: string;
 }
 
 export default function OnboardingPageClient({
   sessionToken,
   userId,
+  onboardingVideoUrl,
 }: OnboardingPageClientProps) {
   const notifications = useNotifications();
   const [activeStep, setActiveStep] = React.useState(0);
@@ -354,6 +356,7 @@ export default function OnboardingPageClient({
             onBack={handleBack}
             isSubmitting={isSubmitting}
             onboardingStatus={onboardingStatus}
+            videoUrl={onboardingVideoUrl}
           />
         );
       default:

--- a/apps/frontend/src/app/(protected)/onboarding/components/WelcomeVideoStep.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/WelcomeVideoStep.tsx
@@ -6,7 +6,6 @@ import OnboardingStepHeader from './OnboardingStepHeader';
 import OnboardingNavButtons from './OnboardingNavButtons';
 import OnboardingVideoPlayer from './OnboardingVideoPlayer';
 import { ONBOARDING_STEPS } from './onboarding-steps';
-import { getOnboardingVideoUrl } from '@/utils/onboarding-video';
 import { onboardingVideoShellSx } from './onboarding-styles';
 
 type OnboardingStatus =
@@ -22,6 +21,7 @@ interface WelcomeVideoStepProps {
   onBack: () => void;
   isSubmitting?: boolean;
   onboardingStatus: OnboardingStatus;
+  videoUrl?: string;
 }
 
 export default function WelcomeVideoStep({
@@ -29,9 +29,9 @@ export default function WelcomeVideoStep({
   onBack,
   isSubmitting = false,
   onboardingStatus,
+  videoUrl,
 }: WelcomeVideoStepProps) {
   const step = ONBOARDING_STEPS[3];
-  const videoUrl = getOnboardingVideoUrl();
 
   const getButtonText = () => {
     switch (onboardingStatus) {

--- a/apps/frontend/src/app/(protected)/onboarding/page.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from '@/auth';
 import OnboardingPageClient from './components/OnboardingPageClient';
+import { getOnboardingVideoUrl } from '@/utils/onboarding-video';
 import { UUID } from 'crypto';
 
 export default async function OnboardingPage() {
@@ -12,10 +13,14 @@ export default async function OnboardingPage() {
     throw new Error('No user ID available in session');
   }
 
+  // Resolved at request time from pod env (Helm ConfigMap), not client bundle.
+  const onboardingVideoUrl = getOnboardingVideoUrl();
+
   return (
     <OnboardingPageClient
       sessionToken={session.session_token}
       userId={session.user.id as UUID}
+      onboardingVideoUrl={onboardingVideoUrl}
     />
   );
 }


### PR DESCRIPTION
## Summary
- Read `NEXT_PUBLIC_ONBOARDING_VIDEO_URL` in the server `onboarding/page.tsx` and pass it as a prop to `WelcomeVideoStep`
- No workflow/YAML changes — uses the existing pod env from Helm ConfigMap (`values-*.yaml` → ConfigMap)

## Why this works
`WelcomeVideoStep` is a client component; `process.env.NEXT_PUBLIC_*` there is only populated at Next.js **build time**. On K8s, the value is already provided at **runtime** via ConfigMap. Server components read pod env on each request.

The GitHub **environment** secret `NEXT_PUBLIC_ONBOARDING_VIDEO_URL` (stg/dev) is used by Cloud Run deploys (`frontend.yml`). K8s runtime uses Helm values — no hardcoding in workflows.

## Test plan
- [ ] Deploy frontend to staging
- [ ] Onboarding welcome step shows video thumbnail (not "coming soon")