### PR TITLE
Fix EE RBAC owner lockout when organization_member row is missing

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/f8e9a0b1c2d4_backfill_organization_member_catchup.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/f8e9a0b1c2d4_backfill_organization_member_catchup.py
@@ -1,0 +1,84 @@
+"""Catch-up backfill for organization_member rows missed by SP8 migration
+
+The original backfill (371c3c3cd787) ran once at deploy and only covered orgs
+that already existed with ``owner_id`` set at that moment.  Orgs created
+afterward depend on :func:`~rhesis.backend.ee.rbac.default_role.assign_default_org_role`
+during onboarding; when that handler no-oped (RBAC dark at signup), owners were
+left without an ``organization_member`` row and are denied every capability once
+RBAC activates.
+
+This migration re-runs the same idempotent owner and member inserts as
+371c3c3cd787 steps 2–3.  Safe to run on every environment; existing rows are
+skipped via ``ON CONFLICT DO NOTHING``.
+
+Revision ID: f8e9a0b1c2d4
+Revises: a7c3e9f10b24
+Create Date: 2026-07-09
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f8e9a0b1c2d4"
+down_revision: Union[str, None] = "a7c3e9f10b24"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            -- 1. Ensure Owner and Admin built-in roles exist.
+            INSERT INTO role (id, name, display_name, scope, level, is_built_in, organization_id)
+            VALUES
+                (gen_random_uuid(), 'Owner', 'Owner', 'organization', 100, true, NULL),
+                (gen_random_uuid(), 'Admin', 'Admin', 'organization', 80,  true, NULL)
+            ON CONFLICT DO NOTHING;
+
+            -- 2. Backfill org owner → Owner role.
+            INSERT INTO organization_member (id, organization_id, user_id, role_id)
+            SELECT
+                gen_random_uuid(),
+                o.id,
+                o.owner_id,
+                r.id
+            FROM organization o
+            JOIN role r
+              ON r.name = 'Owner'
+             AND r.is_built_in = true
+             AND r.organization_id IS NULL
+            WHERE o.owner_id IS NOT NULL
+            ON CONFLICT ON CONSTRAINT uq_organization_member_org_user DO NOTHING;
+
+            -- 3. Backfill all other org users → Admin role.
+            INSERT INTO organization_member (id, organization_id, user_id, role_id)
+            SELECT
+                gen_random_uuid(),
+                u.organization_id,
+                u.id,
+                r.id
+            FROM "user" u
+            JOIN organization o ON o.id = u.organization_id
+            JOIN role r
+              ON r.name = 'Admin'
+             AND r.is_built_in = true
+             AND r.organization_id IS NULL
+            WHERE u.organization_id IS NOT NULL
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM organization_member om2
+                    WHERE om2.organization_id = u.organization_id
+                      AND om2.user_id = u.id
+              )
+            ON CONFLICT ON CONSTRAINT uq_organization_member_org_user DO NOTHING;
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Data-only catch-up; rows are indistinguishable from API-created assignments.
+    pass

--- a/apps/backend/src/rhesis/backend/app/dependencies.py
+++ b/apps/backend/src/rhesis/backend/app/dependencies.py
@@ -2,6 +2,7 @@
 Dependency injection functions for FastAPI.
 """
 
+import logging
 import uuid
 from functools import lru_cache
 from typing import Optional
@@ -14,6 +15,8 @@ from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.database import get_db, get_db_with_tenant_variables
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.services.endpoint import EndpointService
+
+logger = logging.getLogger(__name__)
 
 
 @lru_cache()
@@ -161,17 +164,28 @@ def get_project_context(
     values must match — a project-scoped token cannot be used to access a
     different project (403).
 
-    When a project_id is resolved the dependency validates that the authenticated
-    user is a member of that project.  Non-members receive **403**.
+    Scope source determines strictness:
+
+    * **Project-scoped API token** — the token *asserts* a project (it is a
+      credential, not a UI hint). A stale/mismatched/non-member project is a hard
+      **403**.
+    * **Ambient header only** (the browser's ``rh_active_project_id`` cookie
+      forwarded as ``X-Project-Id``) — the header is only a hint. A stale or
+      unauthorized value must not lock the user out of every endpoint, so it
+      **degrades to no project scope** (returns ``None``) instead of raising. The
+      request then runs org-level scoped; RLS stays fail-closed to org-level rows
+      (``project_id = NULL``), so nothing leaks — the frontend simply drops the
+      stale cookie on its next fetch.
 
     Returns:
-        The project UUID as a string, or None if no project scope was requested.
-        When None, the request is fail-closed to org-level rows (project_id = NULL)
-        only -- project-scoped rows are not visible.
+        The project UUID as a string, or None if no project scope was requested
+        (or an ambient scope was stale and degraded). When None, the request is
+        fail-closed to org-level rows (project_id = NULL) only -- project-scoped
+        rows are not visible.
     """
     # 1. Prefer explicit header (FastAPI already parsed it via the Header() annotation)
     explicit_project_id = x_project_id or request.headers.get("X-Project-Id")
-    token_project_id = getattr(request.state, "api_token_project_id", None)
+    token_project_id = getattr(request.state, REQUEST_STATE_API_TOKEN_PROJECT_ID, None)
 
     # 2. Fall back to the project bound to the API token
     project_id_str = explicit_project_id or token_project_id
@@ -179,9 +193,37 @@ def get_project_context(
     if not project_id_str:
         return None
 
-    return assert_project_access(
-        request, current_user, project_id_str, invalid_uuid_detail="Invalid X-Project-Id format"
-    )
+    # A project-scoped API token asserts a project — keep it strict (may raise 400/403,
+    # including the token/header mismatch check inside assert_project_access).
+    if token_project_id:
+        return assert_project_access(
+            request,
+            current_user,
+            project_id_str,
+            invalid_uuid_detail="Invalid X-Project-Id format",
+        )
+
+    # Ambient header only (cookie-derived hint). A stale/invalid value degrades to
+    # org-level scope instead of hard-locking the user out of unrelated endpoints.
+    try:
+        return assert_project_access(
+            request,
+            current_user,
+            project_id_str,
+            invalid_uuid_detail="Invalid X-Project-Id format",
+        )
+    except HTTPException as exc:
+        if exc.status_code in (400, 403):
+            logger.info(
+                "Ignoring stale/unauthorized ambient X-Project-Id %r for user %s "
+                "(status %s: %s); falling back to org-level scope.",
+                project_id_str,
+                getattr(current_user, "id", None),
+                exc.status_code,
+                exc.detail,
+            )
+            return None
+        raise
 
 
 def get_db_session():

--- a/ee/backend/src/rhesis/backend/ee/rbac/default_role.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/default_role.py
@@ -12,10 +12,12 @@ Role choice (matches the SP8 backfill mapping):
 - everyone else → **Member** (deliberately *not* Admin — Admin would grant new
   invitees write access to org settings).
 
-The handler **no-ops when RBAC is not available for the org** (the default, since
-RBAC ships dark): rows are written at activation time by the backfill migration
-and from then on by this handler, keeping the cut-over seamless without writing
-inert rows while RBAC is off.  Idempotent — re-invites and double-fires are safe.
+Rows are written on every user↔org association regardless of whether RBAC is
+currently licensed for the org.  While RBAC is off the EE provider is inactive
+and the row is dormant; once RBAC activates the user is not locked out.  The
+SP8 backfill migration (371c3c3cd787) and its catch-up (f8e9a0b1c2d4) cover
+orgs that existed before this handler could run.  Idempotent — re-invites and
+double-fires are safe.
 """
 
 from __future__ import annotations
@@ -31,10 +33,9 @@ logger = logging.getLogger(__name__)
 def assign_default_org_role(db: Session, user_id: UUID, organization_id: UUID) -> None:
     """Insert the default ``organization_member`` row for *user_id* in *organization_id*.
 
-    No-op when RBAC is unavailable for the org, when a row already exists, or
-    when the relevant built-in role is missing.  Never commits/rolls back.
+    No-op when a row already exists or when the relevant built-in role is missing.
+    Never commits/rolls back.
     """
-    from rhesis.backend.app.features import FeatureName, FeatureRegistry
     from rhesis.backend.app.models.organization import Organization
     from rhesis.backend.app.scope import bypass_tenant_filter
     from rhesis.backend.ee.rbac.models import OrganizationMember, Role
@@ -42,9 +43,6 @@ def assign_default_org_role(db: Session, user_id: UUID, organization_id: UUID) -
     with bypass_tenant_filter():
         org = db.query(Organization).filter_by(id=organization_id).first()
     if org is None:
-        return
-    # RBAC ships dark; only seed rows once the org is actually licensed for it.
-    if not FeatureRegistry.is_available(FeatureName.RBAC, org):
         return
 
     # Idempotent: never overwrite an existing assignment (e.g. an Owner who is

--- a/ee/backend/src/rhesis/backend/ee/rbac/provider.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/provider.py
@@ -7,18 +7,21 @@ for orgs with the RBAC feature enabled.  Installed via
 
 Resolution order:
 1. If RBAC is not available for the org → delegate to the community provider.
-2. No org role at all (org-scoped checks) → deny; org-scoped permissions
-   require an org role. (For project-scoped checks, see step 5 — a pure
+2. No ``organization_member`` row (or ``role_id`` is NULL) but
+   ``organization.owner_id == principal.user_id`` → built-in **Owner** role
+   (owner floor — mirrors the community bypass; SP9 token scopes still apply).
+3. No org role at all (org-scoped checks) → deny; org-scoped permissions
+   require an org role. (For project-scoped checks, see step 6 — a pure
    project member with no org role is still governed by their explicit
    project role.)
-3. Org Admin or Owner (level >= 80): implicit access to all projects. Their
+4. Org Admin or Owner (level >= 80): implicit access to all projects. Their
    org role applies as the effective project role. They do not need to be
    individually enrolled in every project.
-4. Org Member or Viewer (level < 80): explicit project enrollment is
+5. Org Member or Viewer (level < 80): explicit project enrollment is
    required. If a ``project_membership`` row exists (even with
    ``role_id = NULL``), their org role applies to that project. If no
    membership row exists, access is denied for that project.
-5. If the user also has an explicit ``project_membership.role_id`` for this
+6. If the user also has an explicit ``project_membership.role_id`` for this
    project, it is compared against the org role (when one exists) and the
    **higher-level** role wins — an explicit project role can elevate access
    above the org role, but can never restrict it below what the org role
@@ -30,7 +33,7 @@ GitHub, Linear, and Notion: org-level administrators see and can manage all
 workspaces/projects without being individually added to each one.  Contributors
 (Member/Viewer) are scoped to projects they have been explicitly invited to.
 
-"Higher role wins, never restricts" (step 5) mirrors GitLab's inherited-membership
+"Higher role wins, never restricts" (step 6) mirrors GitLab's inherited-membership
 rule and GCP IAM's resource-hierarchy inheritance: a narrower scope (project) can
 only add to what a broader scope (organization) already grants. An org Owner
 assigned a lower explicit role on one project still keeps Owner-level access to
@@ -225,7 +228,9 @@ class PermissionAuthorizationProvider:
 
     def _get_org_role(self, principal: "Principal", db: "Session"):
         """Return the org-level role for the principal, or None."""
-        from rhesis.backend.ee.rbac.models import OrganizationMember
+        from rhesis.backend.app.models.organization import Organization
+        from rhesis.backend.app.scope import bypass_tenant_filter
+        from rhesis.backend.ee.rbac.models import OrganizationMember, Role
 
         member = (
             db.query(OrganizationMember)
@@ -235,10 +240,27 @@ class PermissionAuthorizationProvider:
             )
             .first()
         )
-        if member is None or member.role_id is None:
-            return None
+        if member is not None and member.role_id is not None:
+            return self._load_role(member.role_id, db)
 
-        return self._load_role(member.role_id, db)
+        # Owner floor: missing organization_member rows must not lock out the
+        # org creator (post-backfill orgs, RBAC-dark onboarding).  Flows
+        # through the built-in Owner role so SP9 token-scope intersection
+        # still applies — unlike the community provider's raw allow bypass.
+        with bypass_tenant_filter():
+            org = (
+                db.query(Organization)
+                .filter_by(id=principal.organization_id, owner_id=principal.user_id)
+                .first()
+            )
+            if org is not None:
+                return (
+                    db.query(Role)
+                    .filter_by(name="Owner", is_built_in=True, organization_id=None)
+                    .first()
+                )
+
+        return None
 
     def _role_has_permission(self, role, perm_str: str, db: "Session") -> bool:
         """Return True when *role* carries *perm_str*.

--- a/tests/backend/auth/test_project_context_owner_exception.py
+++ b/tests/backend/auth/test_project_context_owner_exception.py
@@ -156,7 +156,7 @@ class TestOwnerException:
         # Owner is NOT enrolled in the project, yet may enter its context.
         assert _call(owner_id, org_id, project_id) == str(project_id)
 
-    def test_plain_member_still_denied(self, patch_ctx_session):
+    def test_plain_member_ambient_header_degrades_to_org_scope(self, patch_ctx_session):
         db = patch_ctx_session
         org_id = _create_org(db)
         owner_id = _create_user(db, org_id)
@@ -165,19 +165,38 @@ class TestOwnerException:
         project_id = _create_project(db, org_id)
         _point_session_at_org(db, org_id)
 
-        with pytest.raises(HTTPException) as exc:
-            _call(other_id, org_id, project_id)
-        assert exc.value.status_code == 403
+        # Ambient X-Project-Id is a hint — stale/unauthorized values degrade to None.
+        assert _call(other_id, org_id, project_id) is None
 
-    def test_nonexistent_project_denied_even_for_owner(self, patch_ctx_session):
+    def test_nonexistent_project_ambient_header_degrades_to_org_scope(self, patch_ctx_session):
         db = patch_ctx_session
         org_id = _create_org(db)
         owner_id = _create_user(db, org_id)
         _set_owner(db, org_id, owner_id)
         _point_session_at_org(db, org_id)
 
+        assert _call(owner_id, org_id, uuid.uuid4()) is None
+
+    def test_token_scoped_project_stays_strict(self, patch_ctx_session):
+        db = patch_ctx_session
+        org_id = _create_org(db)
+        owner_id = _create_user(db, org_id)
+        _set_owner(db, org_id, owner_id)
+        project_id = _create_project(db, org_id)
+        _point_session_at_org(db, org_id)
+
+        request = SimpleNamespace(
+            headers={},
+            state=SimpleNamespace(api_token_project_id=str(project_id)),
+        )
+        current_user = SimpleNamespace(id=owner_id, organization_id=org_id)
+        # Mismatched ambient header vs token — credential wins, hard 403.
         with pytest.raises(HTTPException) as exc:
-            _call(owner_id, org_id, uuid.uuid4())  # no such project
+            get_project_context(
+                request,
+                current_user,
+                x_project_id=str(uuid.uuid4()),
+            )
         assert exc.value.status_code == 403
 
 
@@ -202,7 +221,7 @@ class TestEeAdminException:
         with _ee_provider_active():
             assert _call(admin_id, org_id, project_id) == str(project_id)
 
-    def test_ee_viewer_denied(self, patch_ctx_session):
+    def test_ee_viewer_ambient_header_degrades_to_org_scope(self, patch_ctx_session):
         from rhesis.backend.ee.rbac.models import OrganizationMember, Role
 
         db = patch_ctx_session
@@ -220,6 +239,4 @@ class TestEeAdminException:
         _point_session_at_org(db, org_id)
 
         with _ee_provider_active():
-            with pytest.raises(HTTPException) as exc:
-                _call(viewer_id, org_id, project_id)
-            assert exc.value.status_code == 403
+            assert _call(viewer_id, org_id, project_id) is None

--- a/tests/backend/ee/rbac/test_default_org_role.py
+++ b/tests/backend/ee/rbac/test_default_org_role.py
@@ -9,7 +9,7 @@ Deny-first matrix:
 - new invitee (user != owner) → **Member**: allowed on Member endpoints,
   denied on Admin-only ones;
 - org creator (user == owner) → **Owner**: allowed everywhere;
-- RBAC off / community build → handler no-ops (no row written);
+- RBAC off / community build → handler still writes the row (dormant until RBAC on);
 - idempotent: an existing Owner is never downgraded on re-invite.
 
 Run with:
@@ -412,16 +412,28 @@ class TestOnboardingHttpSequenceUnderRbac:
 @pytest.mark.ee
 @pytest.mark.integration
 class TestNoOpAndIdempotency:
-    def test_rbac_off_writes_no_row(self, test_db: Session):
+    def test_writes_row_even_when_rbac_off(self, test_db: Session):
         org_id = _create_org(test_db)
         user_id = _create_user(test_db, org_id)
 
-        # DefaultLicenseProvider allows RBAC by default (dev/unlicensed EE);
-        # force it off here to cover the licensed-off / community-build case.
         with _rbac_off():
             assign_default_org_role(test_db, user_id, org_id)
 
-        assert _member_row(test_db, org_id, user_id) is None
+        member = _member_row(test_db, org_id, user_id)
+        assert member is not None
+        assert _role_name(test_db, member.role_id) == "Member"
+
+    def test_creator_gets_owner_even_when_rbac_off(self, test_db: Session):
+        org_id = _create_org(test_db)
+        user_id = _create_user(test_db, org_id)
+        _set_owner(test_db, org_id, user_id)
+
+        with _rbac_off():
+            assign_default_org_role(test_db, user_id, org_id)
+
+        member = _member_row(test_db, org_id, user_id)
+        assert member is not None
+        assert _role_name(test_db, member.role_id) == "Owner"
 
     def test_existing_owner_not_downgraded(self, test_db: Session):
         """Re-invite of an existing Owner must keep Owner, not reset to Member."""

--- a/tests/backend/ee/rbac/test_sp8_provider.py
+++ b/tests/backend/ee/rbac/test_sp8_provider.py
@@ -543,3 +543,69 @@ class TestBuiltInRoleBranch:
 
         assert perms == set()
         db.query.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Owner floor — org owner without organization_member row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+class TestOwnerFloor:
+    def test_owner_without_member_row_gets_owner_permissions(self, test_db):
+        from sqlalchemy import text
+
+        from tests.backend.ee.rbac._rbac_helpers import _authorized, _create_org, _create_user
+
+        org_id = _create_org(test_db)
+        user_id = _create_user(test_db, org_id)
+        test_db.execute(
+            text("UPDATE organization SET owner_id = :owner WHERE id = :id"),
+            {"owner": str(user_id), "id": str(org_id)},
+        )
+        test_db.flush()
+
+        assert _authorized(test_db, user_id, org_id, "member:manage", project_id=None)
+
+    def test_non_owner_without_member_row_still_denied(self, test_db):
+        from tests.backend.ee.rbac._rbac_helpers import _authorized, _create_org, _create_user
+
+        org_id = _create_org(test_db)
+        _create_user(test_db, org_id)  # owner not set — plain member
+        other_id = _create_user(test_db, org_id)
+
+        assert not _authorized(test_db, other_id, org_id, "test_set:read", project_id=None)
+
+    def test_owner_floor_respects_token_scope_intersection(self, test_db):
+        from sqlalchemy import text
+
+        from rhesis.backend.app.auth.rbac import authorize
+
+        from tests.backend.ee.rbac._rbac_helpers import (
+            _create_org,
+            _create_user,
+            _ee_provider_active,
+            _principal,
+        )
+
+        org_id = _create_org(test_db)
+        user_id = _create_user(test_db, org_id)
+        test_db.execute(
+            text("UPDATE organization SET owner_id = :owner WHERE id = :id"),
+            {"owner": str(user_id), "id": str(org_id)},
+        )
+        test_db.flush()
+
+        principal = _principal(user_id, org_id)
+        principal = Principal(
+            user_id=principal.user_id,
+            organization_id=principal.organization_id,
+            kind="token",
+            scopes=frozenset(["test_set:read"]),
+        )
+
+        with _ee_provider_active():
+            assert authorize(principal, "test_set:read", project_id=None, db=test_db)
+            assert not authorize(principal, "test_set:delete", project_id=None, db=test_db)
+


### PR DESCRIPTION
## Purpose
Org owners created after the SP8 `organization_member` backfill (2026-06-18) were locked out once RBAC activated on staging. Onboarding completed while RBAC was dark, so `assign_default_org_role` no-oped and no row was written. This is a v0.10.0 release blocker.

Also hardens project scope: a stale `rh_active_project_id` cookie (sent as `X-Project-Id`) must not 403 unrelated endpoints when the user no longer has access to that project.

## What Changed
- Add catch-up migration `f8e9a0b1c2d4` to backfill missing `organization_member` rows (owners → Owner, other members → Admin; idempotent)
- Remove RBAC availability gate from `assign_default_org_role` so onboarding always seeds the row
- Add owner floor in `PermissionAuthorizationProvider._get_org_role()` when `organization.owner_id` matches but no row exists (SP9 token scoping still applies)
- Degrade stale ambient `X-Project-Id` to org-level scope (`None`); project-scoped API tokens remain strict
- Add/update tests for owner floor, RBAC-off row seeding, and ambient project degrade

## Additional Context
- Staging forensics: Harry/Emanuele orgs predated backfill and got rows; Arkadiusz/Nicolai orgs created 2026-06-25 missed it
- Ambient header degrade lets `/projects/mine` and other org-level routes succeed so the frontend can clear a stale cookie

## Testing
- [x] `uv run pytest ../../tests/backend/ee/rbac/test_default_org_role.py -v`
- [x] `uv run pytest ../../tests/backend/ee/rbac/test_sp8_provider.py::TestOwnerFloor -v`
- [x] `uv run pytest ../../tests/backend/auth/test_project_context_owner_exception.py -v`
- [x] `uv run alembic upgrade head` (locally applies `f8e9a0b1c2d4`)