### PR TITLE
Fix quick start EE feature gating and local admin role

### DIFF
--- a/apps/backend/src/rhesis/backend/app/features/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/features/__init__.py
@@ -6,15 +6,18 @@ point where license validation plugs in (by swapping
 :class:`DefaultLicenseProvider` for :class:`JwtLicenseProvider` via
 :meth:`FeatureRegistry.set_license_provider`).
 
-Two query methods, both fail-closed:
+Three query tiers, all fail-closed:
 
-- :meth:`is_registered` — registered + runtime check passes. Does NOT consult
-  the license provider. Use this for early-bailout checks before an
-  organization has been resolved (e.g. inside an OIDC callback before
-  validating the signed state).
-- :meth:`is_available` — registered + license provider allows it for the
-  given organization + runtime check passes. The organization argument is
-  required; this is the call you want for any per-tenant gating.
+- :meth:`is_registered` — in the registry. Does NOT consult the license
+  provider or runtime checks. Use as an early bailout when an organization
+  has not yet been resolved (e.g. inside an OIDC callback).
+- :meth:`is_licensed` — registered + license provider allows it for the
+  given organization. Does NOT run the runtime check. Use for UI visibility
+  (the ``GET /features`` endpoint) so licensed features always appear even
+  when their backing infrastructure is not yet configured.
+- :meth:`is_available` — registered + licensed + runtime check passes.
+  The strictest gate; use for route-level enforcement via
+  ``require_feature`` / ``has_feature``.
 
 :class:`FeatureName` is the canonical source of truth for EE feature
 identifiers. Add new members here when adding a new EE feature, then register
@@ -122,8 +125,9 @@ class FeatureRegistry:
     """Singleton registry of EE features.
 
     Holds the installed :class:`LicenseProvider` and the map of registered
-    :class:`Feature` instances. Two queries: :meth:`is_registered` (no
-    license check) and :meth:`is_available` (full check, requires org).
+    :class:`Feature` instances. Three query tiers: :meth:`is_registered`
+    (cheapest), :meth:`is_licensed` (license only, no runtime check), and
+    :meth:`is_available` (strictest, includes runtime check).
     """
 
     _features: dict[FeatureName, Feature] = {}
@@ -151,33 +155,26 @@ class FeatureRegistry:
 
     @classmethod
     def is_registered(cls, name: FeatureNameLike) -> bool:
-        """Return ``True`` iff the feature is registered and its runtime check passes.
+        """Return ``True`` iff the feature is in the registry.
 
-        Does NOT consult the license provider. Use as an early bailout when
-        an organization has not yet been resolved — for example inside an
-        OIDC callback before the signed state has been validated. License
-        enforcement happens via :meth:`is_available` (or the
-        ``require_feature`` route dependency) once the org is in hand.
+        Does NOT consult the license provider or run the runtime check.
+        Use as an early bailout when an organization has not yet been
+        resolved — for example inside an OIDC callback before the signed
+        state has been validated.
         """
         key = cls._coerce(name)
         if key is None:
             return False
-        feature = cls._features.get(key)
-        if feature is None:
-            return False
-        if feature.runtime_check is not None and not feature.runtime_check():
-            return False
-        return True
+        return key in cls._features
 
     @classmethod
-    def is_available(cls, name: FeatureNameLike, org: Optional[Organization]) -> bool:
-        """Return ``True`` iff *name* is registered, licensed for *org*, and
-        passes its runtime check.
+    def is_licensed(cls, name: FeatureNameLike, org: Optional[Organization]) -> bool:
+        """Return ``True`` iff *name* is registered and licensed for *org*.
 
-        Organization is required: feature gating without org context cannot
-        consult the license provider, which is precisely what
-        :meth:`is_registered` exists for. Passing ``None`` fails closed —
-        a user with no associated organization is never granted EE features.
+        Does NOT run the feature's runtime check. Use this for UI
+        visibility decisions (e.g. the ``GET /features`` endpoint) so
+        that licensed features always appear even when their backing
+        infrastructure is not yet configured.
         """
         if org is None:
             return False
@@ -189,14 +186,45 @@ class FeatureRegistry:
             return False
         if not cls._license.allows_feature(feature, org):
             return False
+        return True
+
+    @classmethod
+    def is_available(cls, name: FeatureNameLike, org: Optional[Organization]) -> bool:
+        """Return ``True`` iff *name* is registered, licensed for *org*, and
+        passes its runtime check.
+
+        This is the strictest gate. Use for route-level enforcement via
+        ``require_feature`` / ``has_feature``. For UI visibility, use
+        :meth:`is_licensed` instead.
+        """
+        if not cls.is_licensed(name, org):
+            return False
+        feature = cls._features[cls._coerce(name)]  # type: ignore[index]
         if feature.runtime_check is not None and not feature.runtime_check():
             return False
         return True
 
     @classmethod
+    def licensed_features(cls, org: Optional[Organization]) -> list[Feature]:
+        """Return all EE features licensed for *org* (ignoring runtime checks)."""
+        return [f for f in cls._features.values() if cls.is_licensed(f.name, org)]
+
+    @classmethod
     def enabled_features(cls, org: Optional[Organization]) -> list[Feature]:
-        """Return all EE features currently available for *org*."""
+        """Return all EE features fully available for *org* (including runtime checks)."""
         return [f for f in cls._features.values() if cls.is_available(f.name, org)]
+
+    @classmethod
+    def feature_warnings(cls, org: Optional[Organization]) -> dict[str, str]:
+        """Return warnings for features licensed but not operationally ready."""
+        warnings: dict[str, str] = {}
+        for f in cls.licensed_features(org):
+            if f.runtime_check is not None and not f.runtime_check():
+                warnings[f.name.value] = (
+                    f"{f.display_name} is licensed but not yet configured. "
+                    f"Contact your administrator to complete the setup."
+                )
+        return warnings
 
     @classmethod
     def license_info(cls) -> dict:

--- a/apps/backend/src/rhesis/backend/app/routers/features.py
+++ b/apps/backend/src/rhesis/backend/app/routers/features.py
@@ -16,7 +16,7 @@ from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi import status as http_status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.dependencies import get_tenant_context, get_tenant_db_session
@@ -34,7 +34,7 @@ class LicenseInfo(BaseModel):
 class FeaturesResponse(BaseModel):
     license: LicenseInfo
     enabled: List[str]
-    warnings: Dict[str, str] = {}
+    warnings: Dict[str, str] = Field(default_factory=dict)
 
 
 @router.get("", response_model=FeaturesResponse)

--- a/apps/backend/src/rhesis/backend/app/routers/features.py
+++ b/apps/backend/src/rhesis/backend/app/routers/features.py
@@ -12,7 +12,7 @@ the wire format stable independent of Python enum evolution.
 
 from __future__ import annotations
 
-from typing import List
+from typing import Dict, List
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi import status as http_status
@@ -34,6 +34,7 @@ class LicenseInfo(BaseModel):
 class FeaturesResponse(BaseModel):
     license: LicenseInfo
     enabled: List[str]
+    warnings: Dict[str, str] = {}
 
 
 @router.get("", response_model=FeaturesResponse)
@@ -59,7 +60,8 @@ def list_features(
             status_code=http_status.HTTP_403_FORBIDDEN,
             detail="Organization not found",
         )
-    enabled = [f.name.value for f in FeatureRegistry.enabled_features(org)]
+    enabled = [f.name.value for f in FeatureRegistry.licensed_features(org)]
+    warnings = FeatureRegistry.feature_warnings(org)
     info = FeatureRegistry.license_info()
     return FeaturesResponse(
         license=LicenseInfo(
@@ -67,4 +69,5 @@ def list_features(
             licensed=bool(info.get("licensed", False)),
         ),
         enabled=enabled,
+        warnings=warnings,
     )

--- a/apps/backend/src/rhesis/backend/local_init.py
+++ b/apps/backend/src/rhesis/backend/local_init.py
@@ -11,6 +11,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Mapping
 
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
@@ -219,6 +220,13 @@ def _ensure_local_admin_org_role(
             )
     except ImportError:
         pass
+    except SQLAlchemyError:
+        logger.warning(
+            "Could not verify organization_member row for user %s — "
+            "organization_member table may not exist yet (migrations pending)",
+            user_id,
+            exc_info=True,
+        )
 
 
 def _apply_default_model_ids_to_user(

--- a/apps/backend/src/rhesis/backend/local_init.py
+++ b/apps/backend/src/rhesis/backend/local_init.py
@@ -14,6 +14,7 @@ from typing import Any, Mapping
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
+from rhesis.backend.app.database import set_session_variables
 from rhesis.backend.app.services.organization import load_initial_data
 from rhesis.backend.app.utils.encryption import hash_token
 from rhesis.backend.app.utils.quick_start import is_quick_start_enabled
@@ -58,6 +59,7 @@ def initialize_local_environment(db: Session) -> None:
                 # so the RBAC default-org-role hook never fired for pre-existing
                 # local envs. Seed it now — no-op if RBAC is unavailable or the
                 # row already exists.
+                set_session_variables(db, str(org.id), str(user.id))
                 _ensure_local_admin_org_role(db, user.id, org.id)
                 db.commit()
 
@@ -151,6 +153,7 @@ def initialize_local_environment(db: Session) -> None:
         # default-org-role hook never fires on its own. owner_id is already set
         # on the org, so this resolves the admin to Owner (mirrors
         # routers/organization.py's post-onboarding hook invocation).
+        set_session_variables(db, str(org_id), str(user_id))
         _ensure_local_admin_org_role(db, user_id, org_id)
 
         # Create API token
@@ -185,11 +188,37 @@ def _ensure_local_admin_org_role(
     construction rather than ``crud.create_user``/the onboarding endpoint, so
     the hook that seeds the ``organization_member`` row never runs on its own.
     No-op when RBAC is unavailable or a row already exists (idempotent).
+
+    Caller must set RLS session variables before invoking this function.
     """
     from rhesis.backend.app.auth.org_membership_hook import on_user_org_assigned
 
     on_user_org_assigned(db, user_id, organization_id)
     db.flush()
+
+    try:
+        from rhesis.backend.ee.rbac.models import OrganizationMember
+
+        row = (
+            db.query(OrganizationMember)
+            .filter_by(organization_id=organization_id, user_id=user_id)
+            .first()
+        )
+        if row:
+            logger.info(
+                "Verified organization_member row for user %s (role_id=%s)",
+                user_id,
+                row.role_id,
+            )
+        else:
+            logger.warning(
+                "organization_member row NOT found for user %s in org %s "
+                "— RBAC may not be active or the insert was rejected by RLS",
+                user_id,
+                organization_id,
+            )
+    except ImportError:
+        pass
 
 
 def _apply_default_model_ids_to_user(

--- a/apps/frontend/src/contexts/FeaturesContext.tsx
+++ b/apps/frontend/src/contexts/FeaturesContext.tsx
@@ -28,6 +28,7 @@ import { createContext, useContext, useMemo, type ReactNode } from 'react';
 interface FeaturesState {
   license: LicenseInfo | null;
   enabled: ReadonlySet<string>;
+  warnings: Readonly<Record<string, string>>;
   loading: boolean;
   error: Error | null;
 }
@@ -35,6 +36,7 @@ interface FeaturesState {
 const DEFAULT_STATE: FeaturesState = {
   license: null,
   enabled: new Set<string>(),
+  warnings: {},
   loading: true,
   error: null,
 };
@@ -68,6 +70,7 @@ export function FeaturesProvider({ children }: { children: ReactNode }) {
       return {
         license: null,
         enabled: new Set<string>(),
+        warnings: {},
         loading: false,
         error: error instanceof Error ? error : new Error(String(error)),
       };
@@ -75,6 +78,7 @@ export function FeaturesProvider({ children }: { children: ReactNode }) {
     return {
       license: data.license,
       enabled: new Set<string>(data.enabled),
+      warnings: data.warnings ?? {},
       loading: false,
       error: null,
     };
@@ -95,6 +99,17 @@ export function useFeature(name: FeatureName): boolean {
   const { enabled, loading } = useContext(FeaturesContext);
   if (loading) return false;
   return enabled.has(name);
+}
+
+/**
+ * Returns the warning message for a feature, or null if the feature
+ * is fully operational. Use this to show a banner when a feature is
+ * licensed but its backing infrastructure is not yet configured.
+ */
+export function useFeatureWarning(name: FeatureName): string | null {
+  const { warnings, loading } = useContext(FeaturesContext);
+  if (loading) return null;
+  return warnings[name] ?? null;
 }
 
 /**

--- a/apps/frontend/src/utils/api-client/features-client.ts
+++ b/apps/frontend/src/utils/api-client/features-client.ts
@@ -9,6 +9,8 @@ export interface FeaturesResponse {
   license: LicenseInfo;
   /** Wire type is string[] to tolerate unknown feature names from newer backends. */
   enabled: string[];
+  /** Per-feature warnings for features that are licensed but not operationally ready. */
+  warnings?: Record<string, string>;
 }
 
 /**

--- a/ee/backend/src/rhesis/backend/ee/__init__.py
+++ b/ee/backend/src/rhesis/backend/ee/__init__.py
@@ -219,4 +219,12 @@ def bootstrap(app: "FastAPI") -> None:
         r.route_class = app.router.route_class
         app.include_router(r)
 
+    # ---- Startup diagnostics -----------------------------------------------
+    if not sso_runtime_check():
+        logger.warning(
+            "SSO_ENCRYPTION_KEY not detected — SSO and API Clients features "
+            "are licensed but not operationally ready. Set the key to enable "
+            "SSO configuration and token exchange."
+        )
+
     logger.info("EE bootstrap complete - registered features: [sso, api_clients, rbac]")

--- a/ee/backend/src/rhesis/backend/ee/sso/router.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/router.py
@@ -48,6 +48,7 @@ from rhesis.backend.ee.sso.rate_limits import (
     SSO_LOGIN_RATE_LIMIT,
     SSO_TEST_CONNECTION_RATE_LIMIT,
 )
+from rhesis.backend.ee.sso.runtime_check import sso_runtime_check
 from rhesis.backend.ee.sso.schemas import SSOConfig
 from rhesis.backend.ee.sso.user_utils import SSOLoginError, find_or_create_sso_user
 
@@ -65,16 +66,20 @@ def check_sso_available(organization: Optional[Organization] = None) -> bool:
     """Return ``True`` iff SSO can be served at all.
 
     With ``organization`` set, this is the full per-tenant check
-    (registered + licensed + runtime ready). Without it, only the
-    runtime/registration half is checked — which is what the OIDC
-    callback needs as an early bailout *before* the signed state has
-    been validated and the org resolved. The license decision is then
-    made downstream once the org is in hand (typically by reading the
-    SSO config from the DB; full per-tenant gating arrives with the
-    JWT license provider).
+    (registered + licensed + runtime ready). Without it, this checks
+    registration plus the runtime precondition directly — which is what
+    the OIDC callback needs as an early bailout *before* the signed state
+    has been validated and the org resolved. ``is_registered`` alone does
+    not run the runtime check (it is the cheapest, license/runtime-agnostic
+    tier), so it is paired with an explicit ``sso_runtime_check()`` call
+    here. The license decision is made downstream once the org is in hand
+    (typically by reading the SSO config from the DB; full per-tenant
+    gating arrives with the JWT license provider).
     """
     if organization is None:
-        return FeatureRegistry.is_registered(FeatureName.SSO)
+        if not FeatureRegistry.is_registered(FeatureName.SSO):
+            return False
+        return sso_runtime_check()
     return FeatureRegistry.is_available(FeatureName.SSO, organization)
 
 

--- a/ee/frontend/src/api-clients/register.tsx
+++ b/ee/frontend/src/api-clients/register.tsx
@@ -18,9 +18,9 @@
  */
 
 import * as React from 'react';
-import { Box, CircularProgress } from '@mui/material';
+import { Alert, Box, CircularProgress } from '@mui/material';
 import { FeatureName } from '@/constants/features';
-import { FeatureGate } from '@/contexts/FeaturesContext';
+import { FeatureGate, useFeatureWarning } from '@/contexts/FeaturesContext';
 import { registerOrgSettingsTab } from '@/lib/extension-registries';
 import ApiClientsEmptyState from './components/ApiClientsEmptyState';
 
@@ -29,11 +29,18 @@ const ApiClientsSection = React.lazy(
 );
 
 function ApiClientsSectionGate() {
+  const warning = useFeatureWarning(FeatureName.API_CLIENTS);
+
   return (
     <FeatureGate
       feature={FeatureName.API_CLIENTS}
       fallback={<ApiClientsEmptyState />}
     >
+      {warning && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          {warning}
+        </Alert>
+      )}
       <React.Suspense
         fallback={
           <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>

--- a/ee/frontend/src/sso/register.tsx
+++ b/ee/frontend/src/sso/register.tsx
@@ -21,9 +21,9 @@
  */
 
 import * as React from 'react';
-import { Box, CircularProgress } from '@mui/material';
+import { Alert, Box, CircularProgress } from '@mui/material';
 import { FeatureName } from '@/constants/features';
-import { FeatureGate } from '@/contexts/FeaturesContext';
+import { FeatureGate, useFeatureWarning } from '@/contexts/FeaturesContext';
 import { registerOrgSettingsTab } from '@/lib/extension-registries';
 import { SectionCard } from '@/components/common/SectionCard';
 import SSOEmptyState from './components/SSOEmptyState';
@@ -31,8 +31,15 @@ import SSOEmptyState from './components/SSOEmptyState';
 const SSOConfigForm = React.lazy(() => import('./components/SSOConfigForm'));
 
 function SSOSection() {
+  const warning = useFeatureWarning(FeatureName.SSO);
+
   return (
     <FeatureGate feature={FeatureName.SSO} fallback={<SSOEmptyState />}>
+      {warning && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          {warning}
+        </Alert>
+      )}
       <React.Suspense
         fallback={
           <Box sx={{ display: 'flex', justifyContent: 'center', p: 3 }}>

--- a/tests/backend/app/test_feature_registry.py
+++ b/tests/backend/app/test_feature_registry.py
@@ -49,7 +49,7 @@ class _AllowingProvider:
 
 
 class TestIsRegistered:
-    """The cheap check: in the registry + runtime check passes. No license."""
+    """Cheapest check: is the feature in the registry? No license, no runtime."""
 
     def test_unknown_feature_is_not_registered(self, clean_registry):
         assert FeatureRegistry.is_registered("nonsense") is False
@@ -65,7 +65,7 @@ class TestIsRegistered:
         FeatureRegistry.register(Feature(name=FeatureName.SSO, display_name="SSO"))
         assert FeatureRegistry.is_registered("sso") is True
 
-    def test_runtime_check_failure_makes_unavailable(self, clean_registry):
+    def test_ignores_runtime_check(self, clean_registry):
         FeatureRegistry.register(
             Feature(
                 name=FeatureName.SSO,
@@ -73,7 +73,7 @@ class TestIsRegistered:
                 runtime_check=lambda: False,
             )
         )
-        assert FeatureRegistry.is_registered(FeatureName.SSO) is False
+        assert FeatureRegistry.is_registered(FeatureName.SSO) is True
 
     def test_does_not_consult_license_provider(self, clean_registry):
         """is_registered ignores the license provider entirely.
@@ -86,8 +86,52 @@ class TestIsRegistered:
         assert FeatureRegistry.is_registered(FeatureName.SSO) is True
 
 
+class TestIsLicensed:
+    """Middle tier: registered + license allows. No runtime check."""
+
+    def test_unknown_feature_returns_false(self, clean_registry):
+        assert FeatureRegistry.is_licensed("nonsense", org=object()) is False
+
+    def test_unregistered_known_enum_returns_false(self, clean_registry):
+        assert FeatureRegistry.is_licensed(FeatureName.SSO, org=object()) is False
+
+    def test_none_org_fails_closed(self, clean_registry):
+        FeatureRegistry.register(Feature(name=FeatureName.SSO, display_name="SSO"))
+        assert FeatureRegistry.is_licensed(FeatureName.SSO, org=None) is False
+
+    def test_default_provider_allows(self, clean_registry):
+        FeatureRegistry.register(Feature(name=FeatureName.SSO, display_name="SSO"))
+        assert FeatureRegistry.is_licensed(FeatureName.SSO, org=object()) is True
+
+    def test_denying_provider_blocks(self, clean_registry):
+        FeatureRegistry.register(Feature(name=FeatureName.SSO, display_name="SSO"))
+        FeatureRegistry.set_license_provider(_DenyingProvider())
+        assert FeatureRegistry.is_licensed(FeatureName.SSO, org=object()) is False
+
+    def test_ignores_runtime_check(self, clean_registry):
+        FeatureRegistry.register(
+            Feature(
+                name=FeatureName.SSO,
+                display_name="SSO",
+                runtime_check=lambda: False,
+            )
+        )
+        assert FeatureRegistry.is_licensed(FeatureName.SSO, org=object()) is True
+
+    def test_ignores_runtime_check_with_real_license(self, clean_registry):
+        FeatureRegistry.set_license_provider(_AllowingProvider())
+        FeatureRegistry.register(
+            Feature(
+                name=FeatureName.SSO,
+                display_name="SSO",
+                runtime_check=lambda: False,
+            )
+        )
+        assert FeatureRegistry.is_licensed(FeatureName.SSO, org=object()) is True
+
+
 class TestIsAvailable:
-    """The full check: registered + licensed for org + runtime check."""
+    """Strictest check: registered + licensed + runtime check passes."""
 
     def test_unknown_feature_returns_false(self, clean_registry):
         assert FeatureRegistry.is_available("nonsense", org=object()) is False
@@ -97,7 +141,6 @@ class TestIsAvailable:
 
     def test_registered_and_default_provider_returns_true(self, clean_registry):
         FeatureRegistry.register(Feature(name=FeatureName.SSO, display_name="SSO"))
-        # DefaultLicenseProvider allows everything; org is just a sentinel here.
         assert FeatureRegistry.is_available(FeatureName.SSO, org=object()) is True
 
     def test_accepts_raw_string_equivalent(self, clean_registry):
@@ -119,6 +162,17 @@ class TestIsAvailable:
         )
         assert FeatureRegistry.is_available(FeatureName.SSO, org=object()) is False
 
+    def test_runtime_check_failure_blocks_with_real_license(self, clean_registry):
+        FeatureRegistry.set_license_provider(_AllowingProvider())
+        FeatureRegistry.register(
+            Feature(
+                name=FeatureName.SSO,
+                display_name="SSO",
+                runtime_check=lambda: False,
+            )
+        )
+        assert FeatureRegistry.is_available(FeatureName.SSO, org=object()) is False
+
     def test_provider_swap_changes_behaviour(self, clean_registry):
         FeatureRegistry.register(Feature(name=FeatureName.SSO, display_name="SSO"))
         org = object()
@@ -130,7 +184,34 @@ class TestIsAvailable:
         assert FeatureRegistry.is_available(FeatureName.SSO, org=org) is True
 
 
+class TestLicensedFeatures:
+    """licensed_features ignores runtime checks — drives GET /features."""
+
+    def test_lists_licensed_features(self, clean_registry):
+        FeatureRegistry.register(Feature(name=FeatureName.SSO, display_name="SSO"))
+        licensed = FeatureRegistry.licensed_features(org=object())
+        assert [f.name for f in licensed] == [FeatureName.SSO]
+
+    def test_includes_features_with_failing_runtime_check(self, clean_registry):
+        FeatureRegistry.register(
+            Feature(
+                name=FeatureName.SSO,
+                display_name="SSO",
+                runtime_check=lambda: False,
+            )
+        )
+        licensed = FeatureRegistry.licensed_features(org=object())
+        assert [f.name for f in licensed] == [FeatureName.SSO]
+
+    def test_excludes_unlicensed_features(self, clean_registry):
+        FeatureRegistry.set_license_provider(_DenyingProvider())
+        FeatureRegistry.register(Feature(name=FeatureName.SSO, display_name="SSO"))
+        assert FeatureRegistry.licensed_features(org=object()) == []
+
+
 class TestEnabledFeatures:
+    """enabled_features checks runtime — the strict operational set."""
+
     def test_lists_only_available_features(self, clean_registry):
         FeatureRegistry.register(Feature(name=FeatureName.SSO, display_name="SSO"))
         enabled = FeatureRegistry.enabled_features(org=object())

--- a/tests/backend/routes/test_features.py
+++ b/tests/backend/routes/test_features.py
@@ -93,7 +93,11 @@ class TestFeaturesEndpoint:
         body = response.json()
         assert body["enabled"] == ["sso"]
 
-    def test_omits_feature_when_runtime_check_fails(self, client: TestClient, mock_current_user):
+    def test_includes_feature_with_failing_runtime_check(
+        self, client: TestClient, mock_current_user
+    ):
+        """GET /features uses licensed_features, so a failing runtime check
+        does not hide the feature from the UI but produces a warning."""
         FeatureRegistry.reset()
         FeatureRegistry.register(
             Feature(
@@ -105,9 +109,18 @@ class TestFeaturesEndpoint:
         try:
             response = client.get("/features")
             assert response.status_code == status.HTTP_200_OK
-            assert response.json()["enabled"] == []
+            body = response.json()
+            assert body["enabled"] == ["sso"]
+            assert "sso" in body["warnings"]
         finally:
             FeatureRegistry.reset()
+
+    def test_no_warnings_when_runtime_check_passes(
+        self, client: TestClient, registered_sso, mock_current_user
+    ):
+        response = client.get("/features")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["warnings"] == {}
 
     def test_omits_feature_when_license_denies(self, client: TestClient, mock_current_user):
         class _Deny:
@@ -130,7 +143,8 @@ class TestFeaturesEndpoint:
     def test_response_shape_is_stable(self, client: TestClient, registered_sso, mock_current_user):
         response = client.get("/features")
         body = response.json()
-        assert set(body.keys()) == {"license", "enabled"}
+        assert set(body.keys()) == {"license", "enabled", "warnings"}
         assert set(body["license"].keys()) == {"edition", "licensed"}
         assert isinstance(body["enabled"], list)
         assert all(isinstance(name, str) for name in body["enabled"])
+        assert isinstance(body["warnings"], dict)


### PR DESCRIPTION
## Purpose

In quick start / local dev mode, SSO and API Clients tabs on Organization Settings incorrectly show "Enterprise feature" upsell screens instead of their actual UI. The root cause is that `FeatureRegistry.is_available()` conflated license entitlement with operational readiness — `sso_runtime_check()` returns `False` when `SSO_ENCRYPTION_KEY` is absent, hiding licensed features from the UI.

A secondary issue: `local_init.py` never sets RLS session variables before inserting `organization_member` rows, so the INSERT is silently rejected by `FORCE ROW LEVEL SECURITY`, leaving the local admin with no role.

## What Changed

- **Three-tier FeatureRegistry query model**: `is_registered` (registry only) → `is_licensed` (+ license, no runtime check) → `is_available` (+ runtime check, strictest)
- **`GET /features` uses `licensed_features()`** so gated UI always appears when the feature is licensed, plus a `warnings` dict for features not operationally ready
- **Frontend `useFeatureWarning` hook** and warning Alert banners on SSO and API Clients tabs when infrastructure is missing
- **`local_init.py` sets RLS GUCs** before `organization_member` INSERT so the local admin gets the Owner role
- **Backend startup warning** when `SSO_ENCRYPTION_KEY` is not detected
- **Comprehensive test updates** for the three-tier model (44 tests passing)

## Testing

- All 44 backend tests pass (`test_feature_registry.py` + `test_features.py`)
- Verify in quick start mode: SSO, API, and Roles tabs show actual content
- Verify `GET /features` returns `enabled: ["sso", "api_clients", "rbac"]` with appropriate warnings
- Verify backend logs show `Verified organization_member row for user ... (role_id=...)` on startup