### PR TITLE
fix(helm): increase nginx ingress body-size limit for backend

### DIFF
--- a/charts/rhesis/values-dev.yaml
+++ b/charts/rhesis/values-dev.yaml
@@ -76,6 +76,7 @@ backend:
     annotations:
       cert-manager.io/cluster-issuer: "letsencrypt-prod-dns01"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/proxy-body-size: "25m"
   # Observed startup time: ~93s after container start (StatReload + Garak/LiteLLM imports).
   # Image pull adds ~90s before container start but doesn't count toward probe delay.
   # Helm replaces nested maps — keep full blocks.

--- a/charts/rhesis/values-prd.yaml
+++ b/charts/rhesis/values-prd.yaml
@@ -83,6 +83,7 @@ backend:
     annotations:
       cert-manager.io/cluster-issuer: "letsencrypt-prod-dns01"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/proxy-body-size: "25m"
   livenessProbe:
     httpGet:
       path: /health

--- a/charts/rhesis/values-stg.yaml
+++ b/charts/rhesis/values-stg.yaml
@@ -70,6 +70,7 @@ backend:
     annotations:
       cert-manager.io/cluster-issuer: "letsencrypt-prod-dns01"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/proxy-body-size: "25m"
   livenessProbe:
     httpGet:
       path: /health

--- a/charts/rhesis/values.yaml
+++ b/charts/rhesis/values.yaml
@@ -156,6 +156,7 @@ backend:
     annotations:
       cert-manager.io/cluster-issuer: "letsencrypt-prod"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
+      nginx.ingress.kubernetes.io/proxy-body-size: "25m"
     host: ""
     tlsSecretName: "rhesis-backend-tls"
   env: []


### PR DESCRIPTION
## Purpose

Fixes #2135 — source file uploads under the documented 5MB product limit are rejected with a 413 on staging.

## What Changed

Add `nginx.ingress.kubernetes.io/proxy-body-size: "25m"` to the backend ingress annotations in `charts/rhesis/values.yaml` (chart default) and `values-stg.yaml` / `values-prd.yaml` / `values-dev.yaml`.

## Root Cause

As [Arkadiusz noted on the issue](https://github.com/rhesis-ai/rhesis/issues/2135#issuecomment-4933711511), this is very likely caused by nginx's default `client_max_body_size` (1MB) being lower than the application's 5MB upload cap. The backend ingress only set `cert-manager.io/cluster-issuer` and `ssl-redirect` — no per-ingress body-size override existed anywhere in the chart, and the ingress-nginx controller config has no global override either. So nginx was rejecting anything over 1MB before it ever reached the app.

25m gives headroom above the largest current app-level cap (20MB total per entity on the attachments endpoint) without hard-coding to the exact limit.

## Testing

Not yet verifiable end-to-end on staging: ArgoCD's `stg` Application tracks `main` (`targetRevision: main`), and this fix isn't on `main` yet, so it can't be deployed and confirmed against `stg-api.rhesis.ai` until this branch reaches `main`.

What we used to confirm the diagnosis instead: 
1. A direct curl repro against staging (`curl -F "file=@3MB-file" stg-api.rhesis.ai/sources/upload`) reproduced the exact failure from the issue — nginx aborted the upload with `413 Request Entity Too Large` and an nginx-branded HTML error page (not a JSON response from the app), confirming the request never reaches the backend. 
2. We also ran the app locally, bypassing the ingress entirely, and confirmed uploads succeed for any file size above 1MB (nginx's default limit) and below 5MB (the app's own limit), and are only rejected once they exceed the app's 5MB cap, confirming the application logic is correct. (Note: if running the backend natively (not via `docker compose`), `STORAGE_SERVICE_URI` must be set to `file:///tmp/rhesis-files` in `apps/backend/.env`.)

## Follow-up

Once merged and deployed, re-run the curl repro against `stg-api.rhesis.ai` with a 3.16MB file to confirm the 413 is gone.