### PR TITLE
Add cross-project entity resolution for detail pages

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/routers/__init__.py
@@ -35,6 +35,7 @@ from .project import router as project_router
 from .prompt import router as prompt_router
 from .prompt_template import router as prompt_template_router
 from .recycle import router as recycle_router
+from .resolve import router as resolve_router
 from .response_pattern import router as response_pattern_router
 from .risk import router as risk_router
 from .services import router as services_router
@@ -152,6 +153,7 @@ routers = sorted(
         task_management_router,
         tools_router,
         recycle_router,
+        resolve_router,
         garak_router,
         features_router,
         feedback_router,

--- a/apps/backend/src/rhesis/backend/app/routers/resolve.py
+++ b/apps/backend/src/rhesis/backend/app/routers/resolve.py
@@ -7,6 +7,7 @@ offer a "switch project" prompt instead of a confusing "Not Found" page.
 """
 
 import uuid
+from functools import lru_cache
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
@@ -22,14 +23,30 @@ from rhesis.backend.app.scope import bypass_tenant_filter
 
 router = APIRouter(prefix="/resolve", tags=["resolve"])
 
+# Entity tables with a protected detail page and cross-project link UX.
+# Keep in sync with frontend ``parseEntityFromPathname`` / detail routes.
+RESOLVABLE_ENTITY_TABLES = frozenset(
+    {
+        "behavior",
+        "endpoint",
+        "experiment",
+        "metric",
+        "source",
+        "task",
+        "test",
+        "test_run",
+        "test_set",
+    }
+)
 
+
+@lru_cache(maxsize=1)
 def get_resolvable_entities() -> dict[str, type]:
-    """Discover project-scoped models eligible for cross-project resolution.
+    """Return project-scoped models eligible for cross-project resolution.
 
-    Mirrors the ``get_all_models()`` pattern in ``routers/recycle.py``: every
-    model is found via SQLAlchemy's own class registry instead of a hand-kept
-    list, so newly added project-scoped models are picked up automatically.
-    Only models carrying both ``project_id`` and ``organization_id`` qualify.
+    Restricted to ``RESOLVABLE_ENTITY_TABLES`` so internal tables are not
+    exposed via guessed ``entity_type`` values. Model classes are resolved from
+    SQLAlchemy's registry (same pattern as ``routers/recycle.py``).
     """
     entities: dict[str, type] = {}
     for mapper in Base.registry.mappers:
@@ -37,8 +54,11 @@ def get_resolvable_entities() -> dict[str, type]:
             model_class = mapper.class_
         except UnmappedClassError:
             continue
+        table_name = model_class.__tablename__
+        if table_name not in RESOLVABLE_ENTITY_TABLES:
+            continue
         if hasattr(model_class, "project_id") and hasattr(model_class, "organization_id"):
-            entities[model_class.__tablename__] = model_class
+            entities[table_name] = model_class
     return entities
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/resolve.py
+++ b/apps/backend/src/rhesis/backend/app/routers/resolve.py
@@ -1,0 +1,137 @@
+"""Cross-project entity resolution endpoint.
+
+When a user follows a shared link to an entity that belongs to a different
+project than their currently active one, the auto-filter returns 404. This
+endpoint lets the frontend discover the entity's actual project so it can
+offer a "switch project" prompt instead of a confusing "Not Found" page.
+"""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from sqlalchemy.orm.exc import UnmappedClassError
+
+from rhesis.backend.app import models
+from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+from rhesis.backend.app.dependencies import get_project_context, get_tenant_db_session
+from rhesis.backend.app.models.base import Base
+from rhesis.backend.app.models.user import User
+from rhesis.backend.app.scope import bypass_tenant_filter
+
+router = APIRouter(prefix="/resolve", tags=["resolve"])
+
+
+def get_resolvable_entities() -> dict[str, type]:
+    """Discover project-scoped models eligible for cross-project resolution.
+
+    Mirrors the ``get_all_models()`` pattern in ``routers/recycle.py``: every
+    model is found via SQLAlchemy's own class registry instead of a hand-kept
+    list, so newly added project-scoped models are picked up automatically.
+    Only models carrying both ``project_id`` and ``organization_id`` qualify.
+    """
+    entities: dict[str, type] = {}
+    for mapper in Base.registry.mappers:
+        try:
+            model_class = mapper.class_
+        except UnmappedClassError:
+            continue
+        if hasattr(model_class, "project_id") and hasattr(model_class, "organization_id"):
+            entities[model_class.__tablename__] = model_class
+    return entities
+
+
+class ResolvedEntity(BaseModel):
+    resolution: str
+    entity_type: str
+    entity_id: str
+    project_id: str | None = None
+    project_name: str | None = None
+
+
+@router.get("", response_model=ResolvedEntity)
+def resolve_entity(
+    entity_type: str,
+    entity_id: uuid.UUID,
+    db: Session = Depends(get_tenant_db_session),
+    project_id: str | None = Depends(get_project_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Resolve an entity across projects within the caller's organization.
+
+    Returns one of three resolutions:
+    - ``switchable``: entity is in a different project the caller can access
+    - ``no_access``: entity exists but the caller lacks project membership
+      (project details are withheld)
+    - 404: entity does not exist, is deleted, or belongs to another org
+    """
+    model_cls = get_resolvable_entities().get(entity_type)
+    if model_cls is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unknown entity type: {entity_type}",
+        )
+
+    organization_id = str(current_user.organization_id)
+    user_id = str(current_user.id)
+
+    with bypass_tenant_filter():
+        entity = (
+            db.query(model_cls)
+            .filter(
+                model_cls.id == entity_id,
+                model_cls.organization_id == organization_id,
+            )
+            .first()
+        )
+
+    if entity is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    if hasattr(entity, "deleted_at") and entity.deleted_at is not None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    entity_project_id = str(entity.project_id) if entity.project_id else None
+
+    if entity_project_id is None or entity_project_id == (project_id or ""):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    with bypass_tenant_filter():
+        membership = (
+            db.query(models.ProjectMembership)
+            .filter(
+                models.ProjectMembership.user_id == user_id,
+                models.ProjectMembership.project_id == entity_project_id,
+                models.ProjectMembership.organization_id == organization_id,
+            )
+            .first()
+        )
+
+    if membership is None:
+        return ResolvedEntity(
+            resolution="no_access",
+            entity_type=entity_type,
+            entity_id=str(entity_id),
+        )
+
+    with bypass_tenant_filter():
+        project = (
+            db.query(models.Project)
+            .filter(
+                models.Project.id == entity_project_id,
+                models.Project.organization_id == organization_id,
+            )
+            .first()
+        )
+
+    if project is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    return ResolvedEntity(
+        resolution="switchable",
+        entity_type=entity_type,
+        entity_id=str(entity_id),
+        project_id=str(project.id),
+        project_name=project.name,
+    )

--- a/apps/frontend/src/app/(protected)/behaviors/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/[identifier]/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next';
 import { auth } from '@/auth';
 import { BehaviorClient } from '@/utils/api-client/behavior-client';
 import { getServerActiveProjectId } from '@/utils/server-active-project';
+import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import BehaviorDetailClient from './components/BehaviorDetailClient';
 import type { UUID } from 'crypto';
 
@@ -37,10 +38,12 @@ export default async function BehaviorDetailPage({ params }: PageProps) {
     projectId
   );
 
-  const behavior = await client.getBehaviorWithMetrics(identifier as UUID);
-
-  if (!behavior) {
-    throw new Error('Behavior not found');
+  let behavior;
+  try {
+    behavior = await client.getBehaviorWithMetrics(identifier as UUID);
+  } catch (error) {
+    notFoundIfEntityMissing(error);
+    throw error;
   }
 
   const serializedBehavior = JSON.parse(JSON.stringify(behavior));

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/page.tsx
@@ -91,6 +91,8 @@ export default function EndpointPage({ params }: PageProps) {
       <DetailNotFoundState
         entityLabel="Endpoint"
         entityId={identifier}
+        entityTableName="endpoint"
+        listUrl="/endpoints"
         breadcrumbs={[
           { label: 'Endpoints', href: '/endpoints' },
           { label: 'Not Found', href: `/endpoints/${identifier}` },

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/page.tsx
@@ -3,7 +3,7 @@
 import { Box, Typography, CircularProgress } from '@mui/material';
 import { PageLayout } from '@/components/layout/PageLayout';
 import DetailMetadataStrip from '@/components/common/DetailMetadataStrip';
-import DetailNotFoundState from '@/components/common/DetailNotFoundState';
+import DetailEntityMissingState from '@/components/common/DetailEntityMissingState';
 import { use } from 'react';
 import { useRouter } from 'next/navigation';
 import { format } from 'date-fns';
@@ -88,7 +88,8 @@ export default function EndpointPage({ params }: PageProps) {
 
   if (fetchError && isNotFoundApiError(fetchError)) {
     return (
-      <DetailNotFoundState
+      <DetailEntityMissingState
+        error={fetchError}
         entityLabel="Endpoint"
         entityId={identifier}
         entityTableName="endpoint"

--- a/apps/frontend/src/app/(protected)/error.tsx
+++ b/apps/frontend/src/app/(protected)/error.tsx
@@ -5,16 +5,20 @@ import { Paper, Typography, Button, Box, Alert } from '@mui/material';
 import { PageLayout } from '@/components/layout/PageLayout';
 import Link from 'next/link';
 import ArrowBackIcon from '@mui/icons-material/ArrowBackOutlined';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { usePathname } from 'next/navigation';
+import { useSession } from 'next-auth/react';
 import { DeletedEntityAlert } from '@/components/common/DeletedEntityAlert';
-import { NotFoundAlert } from '@/components/common/NotFoundAlert';
+import DetailNotFoundState from '@/components/common/DetailNotFoundState';
 import {
   getDeletedEntityData,
   getNotFoundEntityData,
   getErrorMessage,
+  isForbiddenError,
+  parseEntityFromPathname,
+  urlSegmentToResolveEntityType,
 } from '@/utils/entity-error-handler';
-import { useSession } from 'next-auth/react';
 
 interface ErrorProps {
   error: Error & {
@@ -28,30 +32,75 @@ interface ErrorProps {
 /**
  * Global error handler for all protected routes.
  *
- * Features:
- * - Automatically handles 404 (not found) errors with navigation UI
- * - Automatically handles 410 (deleted entity) errors with restore UI
- * - Gracefully handles all other errors with retry functionality
- * - Performance optimized with memoization
- * - Type-safe and accessible
- *
- * Works for ALL entities without manual error handling!
+ * Entity 404s render DetailNotFoundState (with cross-project resolution).
+ * Deleted entities, forbidden access, and other errors have dedicated UI.
  */
 export default function ProtectedError({ error, reset }: ErrorProps) {
   const { data: session } = useSession();
   const [isResetting, setIsResetting] = useState(false);
 
-  // Check if this is a not found error (404)
   const notFoundEntityData = useMemo(
     () => getNotFoundEntityData(error),
     [error]
   );
-
-  // Check if this is a deleted entity error (410)
+  const isForbidden = useMemo(() => isForbiddenError(error), [error]);
   const deletedEntityData = useMemo(() => getDeletedEntityData(error), [error]);
 
+  const pathname = usePathname();
+  const pathSegments = useMemo(
+    () => pathname.split('/').filter(Boolean),
+    [pathname]
+  );
+  const parsedPathEntity = useMemo(
+    () => parseEntityFromPathname(pathname),
+    [pathname]
+  );
+
+  const backUrl = useMemo(() => {
+    if (parsedPathEntity?.listUrl) {
+      return parsedPathEntity.listUrl;
+    }
+    if (pathSegments.length > 1) {
+      return `/${pathSegments[0]}`;
+    }
+    return '/';
+  }, [parsedPathEntity, pathSegments]);
+
+  const formatEntityName = (segment: string): string => {
+    return segment
+      .split('-')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+  };
+
+  const breadcrumbs = useMemo(() => {
+    if (pathSegments.length === 0) return [];
+
+    const entityName = formatEntityName(pathSegments[0]);
+    const crumbs = [{ label: entityName, href: `/${pathSegments[0]}` }];
+
+    if (pathSegments.length > 1) {
+      const itemId = pathSegments[1];
+      let itemTitle = itemId;
+
+      if (deletedEntityData?.item_name) {
+        itemTitle = deletedEntityData.item_name;
+      } else if (deletedEntityData) {
+        const displayName =
+          deletedEntityData.model_name_display || deletedEntityData.model_name;
+        itemTitle = `${displayName} (${itemId.substring(0, 8)}...)`;
+      }
+
+      crumbs.push({
+        label: itemTitle,
+        href: pathname,
+      });
+    }
+
+    return crumbs;
+  }, [pathSegments, deletedEntityData, pathname]);
+
   useEffect(() => {
-    // Use different log levels for expected vs unexpected states
     if (notFoundEntityData) {
       console.warn('Entity not found:', {
         entity: notFoundEntityData.model_name,
@@ -71,37 +120,17 @@ export default function ProtectedError({ error, reset }: ErrorProps) {
         digest: error.digest,
         stack: error.stack,
       });
-
-      // TODO: Send to error tracking service in production
-      // if (process.env.FRONTEND_ENV === 'production') {
-      //   reportErrorToService(error);
-      // }
     }
   }, [error, notFoundEntityData, deletedEntityData]);
 
-  // Get current pathname and parse segments (reactive to navigation changes)
-  const pathname = usePathname();
-  const pathSegments = useMemo(() => {
-    return pathname.split('/').filter(Boolean);
-  }, [pathname]);
-
-  // Format entity name from URL segment (e.g., "test-runs" -> "Test Runs")
-  const formatEntityName = (segment: string): string => {
-    return segment
-      .split('-')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
-  };
-
-  // Get page title based on error type (memoized)
   const pageTitle = useMemo(() => {
-    if (notFoundEntityData) {
-      const displayName =
-        notFoundEntityData.model_name_display || notFoundEntityData.model_name;
-      return `${displayName} not found`;
+    if (isForbidden) {
+      if (pathSegments.length > 0) {
+        return `${formatEntityName(pathSegments[0])} — Access denied`;
+      }
+      return 'Access denied';
     }
     if (deletedEntityData) {
-      // Use actual item name if available, otherwise use model type
       if (deletedEntityData.item_name) {
         return `${deletedEntityData.item_name} (Deleted)`;
       }
@@ -110,95 +139,82 @@ export default function ProtectedError({ error, reset }: ErrorProps) {
       return `${displayName} Deleted`;
     }
     return 'Error';
-  }, [notFoundEntityData, deletedEntityData]);
+  }, [deletedEntityData, isForbidden, pathSegments]);
 
-  // Determine back URL based on current path (memoized)
-  const backUrl = useMemo(() => {
-    if (pathSegments.length > 1) {
-      return `/${pathSegments[0]}`;
-    }
-    return '/';
-  }, [pathSegments]);
-
-  // Get back button label (memoized)
   const backLabel = useMemo(() => {
     if (pathSegments.length > 0) {
-      const entityName = formatEntityName(pathSegments[0]);
-      return `Back to ${entityName}`;
+      return `Back to ${formatEntityName(pathSegments[0])}`;
     }
     return 'Back';
   }, [pathSegments]);
 
-  // Generate breadcrumbs based on current path (memoized)
-  const breadcrumbs = useMemo(() => {
-    if (pathSegments.length === 0) return [];
-
-    // Get entity name for the list page
-    const entityName = formatEntityName(pathSegments[0]);
-
-    const crumbs = [{ label: entityName, href: `/${pathSegments[0]}` }];
-
-    // If we're on a detail page, add the current item
-    if (pathSegments.length > 1) {
-      const itemId = pathSegments[1];
-      let itemTitle = itemId;
-
-      if (deletedEntityData) {
-        // Use actual item name if available
-        if (deletedEntityData.item_name) {
-          itemTitle = deletedEntityData.item_name;
-        } else {
-          // Fallback: show type with short ID
-          const displayName =
-            deletedEntityData.model_name_display ||
-            deletedEntityData.model_name;
-          const shortId = itemId.substring(0, 8);
-          itemTitle = `${displayName} (${shortId}...)`;
-        }
-      }
-
-      crumbs.push({
-        label: itemTitle,
-        href: typeof window !== 'undefined' ? window.location.pathname : '',
-      });
-    }
-
-    return crumbs;
-  }, [pathSegments, deletedEntityData]);
-
-  // Handle reset with loading state
   const handleReset = () => {
     setIsResetting(true);
     reset();
-    // Note: reset() will reload the component, so setIsResetting(false) won't be needed
   };
+
+  if (notFoundEntityData) {
+    const displayName =
+      notFoundEntityData.model_name_display || notFoundEntityData.model_name;
+
+    return (
+      <DetailNotFoundState
+        entityLabel={displayName}
+        entityId={notFoundEntityData.item_id}
+        entityTableName={
+          notFoundEntityData.table_name ||
+          parsedPathEntity?.entityType ||
+          (pathSegments[0]
+            ? urlSegmentToResolveEntityType(pathSegments[0])
+            : 'item')
+        }
+        entityData={notFoundEntityData}
+        listUrl={backUrl}
+        breadcrumbs={breadcrumbs}
+        onBack={() => window.history.back()}
+      />
+    );
+  }
 
   return (
     <PageLayout title={pageTitle} breadcrumbs={breadcrumbs}>
-      {notFoundEntityData ? (
-        // Not found entity UI (404)
-        <NotFoundAlert
-          entityData={notFoundEntityData}
-          backUrl={backUrl}
-          backLabel={backLabel}
-        />
-      ) : deletedEntityData ? (
-        // Deleted entity UI with restore functionality (410)
+      {deletedEntityData ? (
         <DeletedEntityAlert
           entityData={deletedEntityData}
           sessionToken={session?.session_token}
           backUrl={backUrl}
           backLabel={backLabel}
           onRestoreSuccess={() => {
-            // After restore, reload the page to fetch fresh server-side data
-            // Use a brief delay to let the success message show
             setTimeout(() => {
               window.location.reload();
             }, 1000);
           }}
         />
+      ) : isForbidden ? (
+        <Alert severity="warning" icon={<LockOutlinedIcon />}>
+          <Box mb={2}>
+            <Typography>
+              You don't have permission to view this{' '}
+              {pathSegments.length > 0
+                ? formatEntityName(pathSegments[0])
+                    .toLowerCase()
+                    .replace(/s$/, '')
+                : 'resource'}
+              . Contact your project administrator if you need access.
+            </Typography>
+          </Box>
+          <Box display="flex" gap={2} flexWrap="wrap">
+            <Button
+              variant="outlined"
+              size="medium"
+              startIcon={<ArrowBackIcon />}
+              onClick={() => window.history.back()}
+            >
+              Back
+            </Button>
+          </Box>
+        </Alert>
       ) : (
-        // Generic error UI with retry
         <Paper role="alert" aria-live="assertive" aria-atomic="true">
           <Box p={3}>
             <Typography variant="h6" color="error" gutterBottom>
@@ -209,7 +225,6 @@ export default function ProtectedError({ error, reset }: ErrorProps) {
               {getErrorMessage(error)}
             </Typography>
 
-            {/* Show error digest in development for debugging */}
             {process.env.FRONTEND_ENV === 'development' && error.digest && (
               <Alert severity="info">
                 <Typography variant="caption" component="div">

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentDetailClient.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentDetailClient.tsx
@@ -45,7 +45,7 @@ import ExperimentVersionsGrid from './ExperimentVersionsGrid';
 import ExperimentRunsTab from './ExperimentRunsTab';
 import ExperimentParametersTab from './ExperimentParametersTab';
 import { formatDate } from '@/utils/date';
-import DetailNotFoundState from '@/components/common/DetailNotFoundState';
+import DetailEntityMissingState from '@/components/common/DetailEntityMissingState';
 import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 
 const TAB_KEYS = ['overview', 'parameters', 'versions', 'runs'] as const;
@@ -282,7 +282,8 @@ export default function ExperimentDetailClient({
 
   if (fetchError && isNotFoundApiError(fetchError)) {
     return (
-      <DetailNotFoundState
+      <DetailEntityMissingState
+        error={fetchError}
         entityLabel="Experiment"
         entityId={experimentId}
         entityTableName="experiment"

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentDetailClient.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentDetailClient.tsx
@@ -45,6 +45,8 @@ import ExperimentVersionsGrid from './ExperimentVersionsGrid';
 import ExperimentRunsTab from './ExperimentRunsTab';
 import ExperimentParametersTab from './ExperimentParametersTab';
 import { formatDate } from '@/utils/date';
+import DetailNotFoundState from '@/components/common/DetailNotFoundState';
+import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 
 const TAB_KEYS = ['overview', 'parameters', 'versions', 'runs'] as const;
 
@@ -275,6 +277,22 @@ export default function ExperimentDetailClient({
           <Typography color="text.secondary">Loading experiment...</Typography>
         </Box>
       </PageLayout>
+    );
+  }
+
+  if (fetchError && isNotFoundApiError(fetchError)) {
+    return (
+      <DetailNotFoundState
+        entityLabel="Experiment"
+        entityId={experimentId}
+        entityTableName="experiment"
+        listUrl="/experiments"
+        breadcrumbs={[
+          { label: 'Experiments', href: '/experiments' },
+          { label: 'Not Found', href: `/experiments/${experimentId}` },
+        ]}
+        onBack={() => window.history.back()}
+      />
     );
   }
 

--- a/apps/frontend/src/app/(protected)/explorer/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/[identifier]/page.tsx
@@ -1,7 +1,6 @@
-import Typography from '@mui/material/Typography';
-import Box from '@mui/material/Box';
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import ExplorerDetail from './components/ExplorerDetail';
 
 interface ExplorerDetailPageProps {
@@ -13,34 +12,31 @@ interface ExplorerDetailPageProps {
 export default async function ExplorerDetailPage({
   params,
 }: ExplorerDetailPageProps) {
+  const { identifier } = await params;
+  const session = await auth();
+
+  if (!session?.session_token) {
+    throw new Error('No session token available');
+  }
+
+  const clientFactory = await createServerApiFactory(session.session_token);
+  const explorerClient = clientFactory.getExplorerClient();
+
   try {
-    const { identifier } = await params;
-    const session = await auth();
-
-    if (!session?.session_token) {
-      throw new Error('No session token available');
-    }
-
-    const clientFactory = await createServerApiFactory(session.session_token);
-    const explorerClient = clientFactory.getExplorerClient();
-
-    // Fetch tree data (all nodes) and topics in parallel
     const [treeNodes, topics] = await Promise.all([
       explorerClient.getTree(identifier),
       explorerClient.getTopics(identifier),
     ]);
 
-    // Separate tests from topic markers
     const tests = treeNodes.filter(node => node.label !== 'topic_marker');
 
-    // Try to get the test set name for the breadcrumb
     let testSetName = identifier;
     try {
       const testSetsClient = clientFactory.getTestSetsClient();
       const testSet = await testSetsClient.getTestSet(identifier);
       testSetName = testSet.name || identifier;
-    } catch {
-      // Fall back to identifier if test set fetch fails
+    } catch (error) {
+      notFoundIfEntityMissing(error);
     }
 
     return (
@@ -53,13 +49,7 @@ export default async function ExplorerDetailPage({
       />
     );
   } catch (error) {
-    const errorMessage = (error as Error).message;
-    return (
-      <Box sx={{ p: 3 }}>
-        <Typography color="error">
-          Error loading test explorer: {errorMessage}
-        </Typography>
-      </Box>
-    );
+    notFoundIfEntityMissing(error);
+    throw error;
   }
 }

--- a/apps/frontend/src/app/(protected)/knowledge/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/[identifier]/page.tsx
@@ -2,10 +2,10 @@ export const dynamic = 'force-dynamic';
 
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import SourcePreviewClientWrapper from './components/SourcePreviewClientWrapper';
 import { Alert, Paper } from '@mui/material';
 import styles from '@/styles/Knowledge.module.css';
-import { notFound } from 'next/navigation';
 
 interface SourcePreviewPageProps {
   params: Promise<{
@@ -54,12 +54,8 @@ export default async function SourcePreviewPage({
       />
     );
   } catch (error) {
-    // If source not found, return 404
-    if (error instanceof Error && error.message.includes('404')) {
-      notFound();
-    }
+    notFoundIfEntityMissing(error);
 
-    // Show error state for other errors
     return (
       <Paper className={styles.errorContainer}>
         <Alert severity="error">

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailView.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailView.tsx
@@ -31,7 +31,9 @@ import {
 import EditableSectionCard from '@/components/common/EditableSection';
 import TagsField from '@/components/common/TagsField';
 import { PageLayout } from '@/components/layout/PageLayout';
+import DetailNotFoundState from '@/components/common/DetailNotFoundState';
 import { useRouter } from 'next/navigation';
+import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import {
@@ -193,6 +195,7 @@ export function MetricDetailView({
   const canEditMetric = useCan(Capability.Metric.UPDATE);
   const [metric, setMetric] = useState<MetricDetail | null>(null);
   const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
   const notifications = useNotifications();
   const [isEditing, setIsEditing] = useState<EditableSectionType | null>(null);
   const [editData, setEditData] = useState<Partial<EditData>>({});
@@ -223,6 +226,7 @@ export function MetricDetailView({
     dataFetchedRef.current = false;
     setLoading(true);
     setMetric(null);
+    setNotFound(false);
   }, [metricId]);
 
   useEffect(() => {
@@ -261,12 +265,14 @@ export function MetricDetailView({
           }
           return;
         }
-      } catch (_error) {
-        // Use notifications without depending on it
-        const notificationsContext = notifications;
-        notificationsContext.show('Failed to load metric details', {
-          severity: 'error',
-        });
+      } catch (error: unknown) {
+        if (isNotFoundApiError(error)) {
+          setNotFound(true);
+        } else {
+          notifications.show('Failed to load metric details', {
+            severity: 'error',
+          });
+        }
       } finally {
         setLoading(false);
       }
@@ -821,6 +827,22 @@ export function MetricDetailView({
   }
 
   if (!metric) {
+    if (notFound && mode === 'page') {
+      return (
+        <DetailNotFoundState
+          entityLabel="Metric"
+          entityId={metricId}
+          entityTableName="metric"
+          listUrl="/metrics"
+          breadcrumbs={[
+            { label: 'Metrics', href: '/metrics' },
+            { label: 'Not Found', href: `/metrics/${metricId}` },
+          ]}
+          onBack={() => router.push('/metrics')}
+        />
+      );
+    }
+
     if (mode === 'embedded') {
       return (
         <Box

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailView.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/MetricDetailView.tsx
@@ -31,7 +31,7 @@ import {
 import EditableSectionCard from '@/components/common/EditableSection';
 import TagsField from '@/components/common/TagsField';
 import { PageLayout } from '@/components/layout/PageLayout';
-import DetailNotFoundState from '@/components/common/DetailNotFoundState';
+import DetailEntityMissingState from '@/components/common/DetailEntityMissingState';
 import { useRouter } from 'next/navigation';
 import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
 import { useSession } from 'next-auth/react';
@@ -195,7 +195,7 @@ export function MetricDetailView({
   const canEditMetric = useCan(Capability.Metric.UPDATE);
   const [metric, setMetric] = useState<MetricDetail | null>(null);
   const [loading, setLoading] = useState(true);
-  const [notFound, setNotFound] = useState(false);
+  const [missingError, setMissingError] = useState<unknown>(null);
   const notifications = useNotifications();
   const [isEditing, setIsEditing] = useState<EditableSectionType | null>(null);
   const [editData, setEditData] = useState<Partial<EditData>>({});
@@ -226,7 +226,7 @@ export function MetricDetailView({
     dataFetchedRef.current = false;
     setLoading(true);
     setMetric(null);
-    setNotFound(false);
+    setMissingError(null);
   }, [metricId]);
 
   useEffect(() => {
@@ -267,7 +267,7 @@ export function MetricDetailView({
         }
       } catch (error: unknown) {
         if (isNotFoundApiError(error)) {
-          setNotFound(true);
+          setMissingError(error);
         } else {
           notifications.show('Failed to load metric details', {
             severity: 'error',
@@ -827,9 +827,10 @@ export function MetricDetailView({
   }
 
   if (!metric) {
-    if (notFound && mode === 'page') {
+    if (missingError && mode === 'page') {
       return (
-        <DetailNotFoundState
+        <DetailEntityMissingState
+          error={missingError}
           entityLabel="Metric"
           entityId={metricId}
           entityTableName="metric"

--- a/apps/frontend/src/app/(protected)/not-found.tsx
+++ b/apps/frontend/src/app/(protected)/not-found.tsx
@@ -8,6 +8,8 @@ import FolderOffOutlinedIcon from '@mui/icons-material/FolderOffOutlined';
 import { PageLayout } from '@/components/layout/PageLayout';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import DetailNotFoundState from '@/components/common/DetailNotFoundState';
+import { parseEntityFromPathname } from '@/utils/entity-error-handler';
 
 function formatEntityName(segment: string): string {
   return segment
@@ -25,10 +27,15 @@ function pluralize(name: string): string {
  *
  * Shown when a server component calls notFound() — e.g. when the backend
  * returns 404 because the resource doesn't exist or belongs to a different
- * project.
+ * project. Detail pages with a UUID attempt cross-project resolution.
  */
 export default function ProtectedNotFound() {
   const pathname = usePathname();
+
+  const parsedEntity = useMemo(
+    () => parseEntityFromPathname(pathname),
+    [pathname]
+  );
 
   const { entityName, listHref, breadcrumbs } = useMemo(() => {
     const segments = pathname.split('/').filter(Boolean);
@@ -36,12 +43,37 @@ export default function ProtectedNotFound() {
     const name = rawEntity ? formatEntityName(rawEntity) : 'Page';
     const href = rawEntity ? `/${rawEntity}` : '/';
 
+    const crumbs: { label: string; href?: string }[] = [
+      { label: name, href },
+      { label: 'Not Found' },
+    ];
+
+    if (parsedEntity && segments.length >= 2) {
+      crumbs.splice(1, 0, {
+        label: parsedEntity.entityId,
+        href: pathname,
+      });
+    }
+
     return {
       entityName: name,
-      listHref: href,
-      breadcrumbs: [{ label: name, href }, { label: 'Not Found' }],
+      listHref: parsedEntity?.listUrl ?? href,
+      breadcrumbs: crumbs,
     };
-  }, [pathname]);
+  }, [pathname, parsedEntity]);
+
+  if (parsedEntity) {
+    return (
+      <DetailNotFoundState
+        entityLabel={parsedEntity.entityLabel}
+        entityId={parsedEntity.entityId}
+        entityTableName={parsedEntity.entityType}
+        listUrl={parsedEntity.listUrl}
+        breadcrumbs={breadcrumbs}
+        onBack={() => window.history.back()}
+      />
+    );
+  }
 
   return (
     <PageLayout title="" breadcrumbs={breadcrumbs}>
@@ -54,7 +86,6 @@ export default function ProtectedNotFound() {
         textAlign="center"
         px={3}
       >
-        {/* Large backdrop number */}
         <Box position="relative" mb={2}>
           <Typography
             component="span"
@@ -71,7 +102,6 @@ export default function ProtectedNotFound() {
             404
           </Typography>
 
-          {/* Overlay icon */}
           <Box
             sx={{ position: 'absolute', inset: 0 }}
             display="flex"

--- a/apps/frontend/src/app/(protected)/not-found.tsx
+++ b/apps/frontend/src/app/(protected)/not-found.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { useMemo } from 'react';
-import { alpha, Box, Button, Typography } from '@mui/material';
+import { Box } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBackOutlined';
 import SearchIcon from '@mui/icons-material/SearchOutlined';
 import FolderOffOutlinedIcon from '@mui/icons-material/FolderOffOutlined';
 import { PageLayout } from '@/components/layout/PageLayout';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import DetailNotFoundState from '@/components/common/DetailNotFoundState';
+import EntityMessageState from '@/components/common/EntityMessageState';
 import { parseEntityFromPathname } from '@/utils/entity-error-handler';
 
 function formatEntityName(segment: string): string {
@@ -31,6 +31,7 @@ function pluralize(name: string): string {
  */
 export default function ProtectedNotFound() {
   const pathname = usePathname();
+  const router = useRouter();
 
   const parsedEntity = useMemo(
     () => parseEntityFromPathname(pathname),
@@ -77,77 +78,23 @@ export default function ProtectedNotFound() {
 
   return (
     <PageLayout title="" breadcrumbs={breadcrumbs}>
-      <Box
-        display="flex"
-        flexDirection="column"
-        alignItems="center"
-        justifyContent="center"
-        minHeight="60vh"
-        textAlign="center"
-        px={3}
-      >
-        <Box position="relative" mb={2}>
-          <Typography
-            component="span"
-            sx={{
-              fontSize: { xs: '6rem', sm: '9rem' },
-              fontWeight: 800,
-              lineHeight: 1,
-              color: theme => alpha(theme.palette.text.primary, 0.07),
-              userSelect: 'none',
-              letterSpacing: '-0.04em',
-            }}
-            aria-hidden
-          >
-            404
-          </Typography>
-
-          <Box
-            sx={{ position: 'absolute', inset: 0 }}
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-          >
-            <FolderOffOutlinedIcon
-              sx={{
-                fontSize: { xs: '2.5rem', sm: '3.5rem' },
-                color: 'text.secondary',
-              }}
-            />
-          </Box>
-        </Box>
-
-        <Typography variant="h5" fontWeight={600} gutterBottom>
-          Resource not found
-        </Typography>
-
-        <Typography
-          variant="body1"
-          color="text.secondary"
-          sx={{ maxWidth: 440, mb: 4 }}
-        >
-          The resource you&apos;re looking for doesn&apos;t exist, was deleted,
-          or belongs to a different project. Switch to the correct project and
-          try again.
-        </Typography>
-
-        <Box display="flex" gap={1.5} flexWrap="wrap" justifyContent="center">
-          <Button
-            variant="outlined"
-            startIcon={<ArrowBackIcon />}
-            onClick={() => window.history.back()}
-          >
-            Go Back
-          </Button>
-          <Button
-            component={Link}
-            href={listHref}
-            variant="outlined"
-            startIcon={<SearchIcon />}
-          >
-            Browse {pluralize(entityName)}
-          </Button>
-        </Box>
+      <Box sx={{ mt: 2, mb: 2 }}>
+        <EntityMessageState
+          icon={FolderOffOutlinedIcon}
+          title="Resource not found"
+          description="The resource you're looking for doesn't exist, was deleted, or belongs to a different project. Switch to the correct project and try again."
+          primaryAction={{
+            label: `Browse ${pluralize(entityName)}`,
+            onClick: () => router.push(listHref),
+            startIcon: <SearchIcon />,
+            variant: 'contained',
+          }}
+          secondaryAction={{
+            label: 'Go Back',
+            onClick: () => window.history.back(),
+            startIcon: <ArrowBackIcon />,
+          }}
+        />
       </Box>
     </PageLayout>
   );

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
@@ -83,6 +83,8 @@ export default function ProjectEndpointPage() {
       <DetailNotFoundState
         entityLabel="Endpoint"
         entityId={params.endpointId}
+        entityTableName="endpoint"
+        listUrl={`/projects/${params.identifier}`}
         breadcrumbs={[
           { label: 'Projects', href: '/projects' },
           {

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/endpoints/[endpointId]/page.tsx
@@ -3,7 +3,7 @@
 import { Box, Typography, CircularProgress } from '@mui/material';
 import { PageLayout } from '@/components/layout/PageLayout';
 import DetailMetadataStrip from '@/components/common/DetailMetadataStrip';
-import DetailNotFoundState from '@/components/common/DetailNotFoundState';
+import DetailEntityMissingState from '@/components/common/DetailEntityMissingState';
 import { useParams, useRouter } from 'next/navigation';
 import { format } from 'date-fns';
 import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
@@ -80,7 +80,8 @@ export default function ProjectEndpointPage() {
 
   if (fetchError && isNotFoundApiError(fetchError) && params?.endpointId) {
     return (
-      <DetailNotFoundState
+      <DetailEntityMissingState
+        error={fetchError}
         entityLabel="Endpoint"
         entityId={params.endpointId}
         entityTableName="endpoint"

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
@@ -25,6 +25,7 @@ import CreateJiraIssueButton from '../components/CreateJiraIssueButton';
 import TaskDetailTabs from './components/TaskDetailTabs';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
+import DetailNotFoundState from '@/components/common/DetailNotFoundState';
 import { useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 
@@ -156,59 +157,6 @@ function TaskDetailErrorState({
           >
             Error: {error}
           </Box>
-        </Alert>
-        <Box sx={{ display: 'flex', gap: 2 }}>
-          <Button variant="contained" onClick={onBack}>
-            Back to Tasks
-          </Button>
-          <Button variant="outlined" onClick={onRetry} disabled={isRetrying}>
-            {isRetrying ? (
-              <>
-                <CircularProgress color="inherit" size={16} sx={{ mr: 1 }} />
-                Retrying...
-              </>
-            ) : (
-              'Try Again'
-            )}
-          </Button>
-        </Box>
-      </Box>
-    </PageLayout>
-  );
-}
-
-function TaskDetailNotFoundState({
-  taskId,
-  isRetrying,
-  onBack,
-  onRetry,
-}: {
-  taskId: string;
-  isRetrying: boolean;
-  onBack: () => void;
-  onRetry: () => void;
-}) {
-  return (
-    <PageLayout
-      title="Task Not Found"
-      breadcrumbs={[
-        { label: 'Tasks', href: '/tasks' },
-        { label: 'Not Found', href: `/tasks/${taskId}` },
-      ]}
-    >
-      <Box sx={{ flexGrow: 1, pt: 3 }}>
-        <Alert severity="warning" sx={{ mb: 3 }}>
-          <Typography variant="h6" sx={{ mb: 1 }}>
-            Sorry, we couldn&apos;t load this task
-          </Typography>
-          <Typography variant="body2" sx={{ mb: 2 }}>
-            The task you&apos;re looking for might have been deleted, moved,
-            belongs to a different project, or you may not have permission to
-            view it.
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Task ID: {taskId}
-          </Typography>
         </Alert>
         <Box sx={{ display: 'flex', gap: 2 }}>
           <Button variant="contained" onClick={onBack}>
@@ -381,13 +329,20 @@ export default function TaskDetailPage({ params }: PageProps) {
     );
   }
 
-  if (isTaskNotFound) {
+  if (isTaskNotFound || (!task && hasInitialLoad && !error)) {
     return (
-      <TaskDetailNotFoundState
-        taskId={taskId}
-        isRetrying={isRetrying}
+      <DetailNotFoundState
+        entityLabel="Task"
+        entityId={taskId}
+        entityTableName="task"
+        listUrl="/tasks"
+        breadcrumbs={[
+          { label: 'Tasks', href: '/tasks' },
+          { label: 'Not Found', href: `/tasks/${taskId}` },
+        ]}
         onBack={() => router.push('/tasks')}
         onRetry={handleRetry}
+        isRetrying={isRetrying}
       />
     );
   }
@@ -405,14 +360,7 @@ export default function TaskDetailPage({ params }: PageProps) {
   }
 
   if (!task) {
-    return (
-      <TaskDetailNotFoundState
-        taskId={taskId}
-        isRetrying={isRetrying}
-        onBack={() => router.push('/tasks')}
-        onRetry={handleRetry}
-      />
-    );
+    return null;
   }
 
   const metadataStrip = (

--- a/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/[identifier]/page.tsx
@@ -25,6 +25,7 @@ import CreateJiraIssueButton from '../components/CreateJiraIssueButton';
 import TaskDetailTabs from './components/TaskDetailTabs';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
+import DetailEntityMissingState from '@/components/common/DetailEntityMissingState';
 import DetailNotFoundState from '@/components/common/DetailNotFoundState';
 import { useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
@@ -189,7 +190,7 @@ export default function TaskDetailPage({ params }: PageProps) {
 
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isTaskNotFound, setIsTaskNotFound] = useState(false);
+  const [missingError, setMissingError] = useState<unknown>(null);
   const [hasInitialLoad, setHasInitialLoad] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
   const [loadingTimeout, setLoadingTimeout] = useState(false);
@@ -226,7 +227,7 @@ export default function TaskDetailPage({ params }: PageProps) {
           setIsLoading(true);
         }
         setError(null);
-        setIsTaskNotFound(false);
+        setMissingError(null);
 
         if (!taskId) {
           throw new Error('No task ID provided');
@@ -260,7 +261,7 @@ export default function TaskDetailPage({ params }: PageProps) {
         setHasInitialLoad(true);
       } catch (err) {
         if (isNotFoundApiError(err)) {
-          setIsTaskNotFound(true);
+          setMissingError(err);
           setHasInitialLoad(true);
           return;
         }
@@ -311,7 +312,7 @@ export default function TaskDetailPage({ params }: PageProps) {
   const handleRetry = () => {
     setLoadingTimeout(false);
     setHasInitialLoad(false);
-    setIsTaskNotFound(false);
+    setMissingError(null);
     loadInitialData(true);
   };
 
@@ -329,7 +330,26 @@ export default function TaskDetailPage({ params }: PageProps) {
     );
   }
 
-  if (isTaskNotFound || (!task && hasInitialLoad && !error)) {
+  if (missingError) {
+    return (
+      <DetailEntityMissingState
+        error={missingError}
+        entityLabel="Task"
+        entityId={taskId}
+        entityTableName="task"
+        listUrl="/tasks"
+        breadcrumbs={[
+          { label: 'Tasks', href: '/tasks' },
+          { label: 'Not Found', href: `/tasks/${taskId}` },
+        ]}
+        onBack={() => router.push('/tasks')}
+        onRetry={handleRetry}
+        isRetrying={isRetrying}
+      />
+    );
+  }
+
+  if (!task && hasInitialLoad && !error) {
     return (
       <DetailNotFoundState
         entityLabel="Task"

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/compare/page.tsx
@@ -1,7 +1,6 @@
 import { Box } from '@mui/material';
 import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
-import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
+import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
@@ -47,9 +46,7 @@ export default async function TestRunComparePage({
   try {
     testRun = await testRunsClient.getTestRun(identifier);
   } catch (error) {
-    if (isNotFoundApiError(error)) {
-      notFound();
-    }
+    notFoundIfEntityMissing(error);
     throw error;
   }
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/page.tsx
@@ -1,9 +1,8 @@
 import { Metadata } from 'next';
 import { PageLayout } from '@/components/layout/PageLayout';
-import { notFound } from 'next/navigation';
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
-import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
+import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import TestRunMainView from './components/TestRunMainViewClient';
 
 interface _PageProps {
@@ -54,9 +53,7 @@ export default async function TestRunPage({
   try {
     testRun = await testRunsClient.getTestRun(identifier);
   } catch (error) {
-    if (isNotFoundApiError(error)) {
-      notFound();
-    }
+    notFoundIfEntityMissing(error);
     throw error;
   }
 

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/page.tsx
@@ -3,6 +3,7 @@ import { Box, CircularProgress } from '@mui/material';
 import { Metadata } from 'next';
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import { format } from 'date-fns';
 
 import { PageLayout } from '@/components/layout/PageLayout';
@@ -40,17 +41,12 @@ export default async function TestSetPage({ params }: PageProps) {
   const apiFactory = await createServerApiFactory(session.session_token);
   const testSetsClient = apiFactory.getTestSetsClient();
 
-  const response = await testSetsClient.getTestSets({
-    limit: 1,
-    $filter: `id eq ${identifier}`,
-  } as {
-    limit: number;
-    $filter: string;
-  });
-
-  let testSet = response.data[0];
-  if (!testSet) {
-    throw new Error('Test set not found');
+  let testSet;
+  try {
+    testSet = await testSetsClient.getTestSet(identifier);
+  } catch (error) {
+    notFoundIfEntityMissing(error);
+    throw error;
   }
 
   if (testSet.test_set_type_id) {

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/page.tsx
@@ -3,6 +3,7 @@ import { Box, Button, CircularProgress } from '@mui/material';
 import { Metadata } from 'next';
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { notFoundIfEntityMissing } from '@/utils/entity-not-found-server';
 import Link from 'next/link';
 import { format } from 'date-fns';
 
@@ -45,7 +46,13 @@ export default async function TestDetailPage({ params }: PageProps) {
   const promptsClient = apiFactory.getPromptsClient();
   const { identifier } = await params;
 
-  const test = await testsClient.getTest(identifier);
+  let test;
+  try {
+    test = await testsClient.getTest(identifier);
+  } catch (error) {
+    notFoundIfEntityMissing(error);
+    throw error;
+  }
 
   if (test.prompt_id) {
     const promptData = await promptsClient.getPrompt(test.prompt_id);

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Metadata } from 'next';
+import Script from 'next/script';
 import { cookies } from 'next/headers';
 import ThemeAwareLogo from '../components/common/ThemeAwareLogo';
 import '../styles/fonts.css';
@@ -300,14 +301,10 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
 
   return (
     <html lang="en" suppressHydrationWarning data-theme-mode={initialThemeMode}>
-      <head>
-        <script
-          dangerouslySetInnerHTML={{
-            __html: runtimeEnvScript,
-          }}
-        />
-      </head>
       <body suppressHydrationWarning>
+        <Script id="rhesis-runtime-env" strategy="beforeInteractive">
+          {runtimeEnvScript}
+        </Script>
         <ThemeContextProvider
           disableTransitionOnChange
           initialMode={initialThemeMode}

--- a/apps/frontend/src/components/common/CrossProjectAlert.tsx
+++ b/apps/frontend/src/components/common/CrossProjectAlert.tsx
@@ -1,13 +1,16 @@
 'use client';
 
 import { useState } from 'react';
-import { Alert, Button, Box, Typography } from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBackOutlined';
-import SwapHorizIcon from '@mui/icons-material/SwapHorizOutlined';
-import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import EntityMessageState from '@/components/common/EntityMessageState';
 import { ResolvedEntity } from '@/utils/api-client/resolve-client';
 import { NotFoundEntityData } from '@/utils/entity-error-handler';
+import {
+  getResolveEntityIcon,
+  LockOutlinedIcon,
+  SwapHorizOutlinedIcon,
+} from '@/utils/entity-detail-icons';
 import { writeActiveProjectId } from '@/utils/active-project';
 
 interface CrossProjectAlertProps {
@@ -26,28 +29,20 @@ export function CrossProjectAlert({
 
   const displayName =
     entityData.model_name_display || entityData.model_name || 'item';
+  const EntityIcon = getResolveEntityIcon(entityData.table_name);
 
   if (resolvedEntity.resolution === 'no_access') {
     return (
-      <Alert severity="warning" icon={<LockOutlinedIcon />}>
-        <Box mb={2}>
-          <Typography>
-            This {displayName.toLowerCase()} belongs to a project you don't have
-            access to. Contact your administrator to request access.
-          </Typography>
-        </Box>
-
-        <Box display="flex" gap={2} flexWrap="wrap">
-          <Button
-            variant="outlined"
-            size="medium"
-            startIcon={<ArrowBackIcon />}
-            onClick={() => window.history.back()}
-          >
-            Back
-          </Button>
-        </Box>
-      </Alert>
+      <EntityMessageState
+        icon={LockOutlinedIcon}
+        title={`${displayName} is in another project`}
+        description={`This ${displayName.toLowerCase()} belongs to a project you don't have access to. Contact your administrator to request access.`}
+        secondaryAction={{
+          label: 'Back',
+          onClick: () => window.history.back(),
+          startIcon: <ArrowBackIcon />,
+        }}
+      />
     );
   }
 
@@ -69,42 +64,31 @@ export function CrossProjectAlert({
 
   if (switching) {
     return (
-      <Alert severity="info">
-        <Typography>
-          Switching to <strong>{resolvedEntity.project_name}</strong>...
-        </Typography>
-      </Alert>
+      <EntityMessageState
+        icon={SwapHorizOutlinedIcon}
+        title={`Switching to ${resolvedEntity.project_name}...`}
+        description="Updating your active project."
+        loading
+      />
     );
   }
 
   return (
-    <Alert severity="info">
-      <Box mb={2}>
-        <Typography>
-          This {displayName.toLowerCase()} belongs to project{' '}
-          <strong>{resolvedEntity.project_name}</strong>. Switch to that project
-          to view it.
-        </Typography>
-      </Box>
-
-      <Box display="flex" gap={2} flexWrap="wrap">
-        <Button
-          variant="contained"
-          size="medium"
-          startIcon={<SwapHorizIcon />}
-          onClick={handleSwitch}
-        >
-          Switch to {resolvedEntity.project_name}
-        </Button>
-        <Button
-          variant="outlined"
-          size="medium"
-          startIcon={<ArrowBackIcon />}
-          onClick={() => window.history.back()}
-        >
-          Back
-        </Button>
-      </Box>
-    </Alert>
+    <EntityMessageState
+      icon={EntityIcon}
+      title={`${displayName} is in another project`}
+      description={`This ${displayName.toLowerCase()} belongs to project ${resolvedEntity.project_name}. Switch to that project to view it.`}
+      primaryAction={{
+        label: `Switch to ${resolvedEntity.project_name}`,
+        onClick: handleSwitch,
+        startIcon: <SwapHorizOutlinedIcon />,
+        variant: 'contained',
+      }}
+      secondaryAction={{
+        label: 'Back',
+        onClick: () => window.history.back(),
+        startIcon: <ArrowBackIcon />,
+      }}
+    />
   );
 }

--- a/apps/frontend/src/components/common/CrossProjectAlert.tsx
+++ b/apps/frontend/src/components/common/CrossProjectAlert.tsx
@@ -58,7 +58,12 @@ export function CrossProjectAlert({
       return;
     }
 
-    writeActiveProjectId(resolvedEntity.project_id!);
+    const projectId = resolvedEntity.project_id;
+    if (!projectId) {
+      return;
+    }
+
+    writeActiveProjectId(projectId);
     window.location.reload();
   };
 

--- a/apps/frontend/src/components/common/CrossProjectAlert.tsx
+++ b/apps/frontend/src/components/common/CrossProjectAlert.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState } from 'react';
+import { Alert, Button, Box, Typography } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBackOutlined';
+import SwapHorizIcon from '@mui/icons-material/SwapHorizOutlined';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { ResolvedEntity } from '@/utils/api-client/resolve-client';
+import { NotFoundEntityData } from '@/utils/entity-error-handler';
+import { writeActiveProjectId } from '@/utils/active-project';
+
+interface CrossProjectAlertProps {
+  resolvedEntity: ResolvedEntity;
+  entityData: NotFoundEntityData;
+  backUrl?: string;
+  backLabel?: string;
+}
+
+export function CrossProjectAlert({
+  resolvedEntity,
+  entityData,
+}: CrossProjectAlertProps) {
+  const { projects, setActiveProject } = useActiveProject();
+  const [switching, setSwitching] = useState(false);
+
+  const displayName =
+    entityData.model_name_display || entityData.model_name || 'item';
+
+  if (resolvedEntity.resolution === 'no_access') {
+    return (
+      <Alert severity="warning" icon={<LockOutlinedIcon />}>
+        <Box mb={2}>
+          <Typography>
+            This {displayName.toLowerCase()} belongs to a project you don't have
+            access to. Contact your administrator to request access.
+          </Typography>
+        </Box>
+
+        <Box display="flex" gap={2} flexWrap="wrap">
+          <Button
+            variant="outlined"
+            size="medium"
+            startIcon={<ArrowBackIcon />}
+            onClick={() => window.history.back()}
+          >
+            Back
+          </Button>
+        </Box>
+      </Alert>
+    );
+  }
+
+  const handleSwitch = () => {
+    setSwitching(true);
+
+    const targetProject = projects.find(
+      p => String(p.id) === resolvedEntity.project_id
+    );
+
+    if (targetProject) {
+      setActiveProject(targetProject);
+      return;
+    }
+
+    writeActiveProjectId(resolvedEntity.project_id!);
+    window.location.reload();
+  };
+
+  if (switching) {
+    return (
+      <Alert severity="info">
+        <Typography>
+          Switching to <strong>{resolvedEntity.project_name}</strong>...
+        </Typography>
+      </Alert>
+    );
+  }
+
+  return (
+    <Alert severity="info">
+      <Box mb={2}>
+        <Typography>
+          This {displayName.toLowerCase()} belongs to project{' '}
+          <strong>{resolvedEntity.project_name}</strong>. Switch to that project
+          to view it.
+        </Typography>
+      </Box>
+
+      <Box display="flex" gap={2} flexWrap="wrap">
+        <Button
+          variant="contained"
+          size="medium"
+          startIcon={<SwapHorizIcon />}
+          onClick={handleSwitch}
+        >
+          Switch to {resolvedEntity.project_name}
+        </Button>
+        <Button
+          variant="outlined"
+          size="medium"
+          startIcon={<ArrowBackIcon />}
+          onClick={() => window.history.back()}
+        >
+          Back
+        </Button>
+      </Box>
+    </Alert>
+  );
+}

--- a/apps/frontend/src/components/common/DetailEntityMissingState.tsx
+++ b/apps/frontend/src/components/common/DetailEntityMissingState.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { DeletedEntityAlert } from '@/components/common/DeletedEntityAlert';
+import DetailNotFoundState from '@/components/common/DetailNotFoundState';
+import {
+  getDeletedEntityData,
+  isDeletedEntityError,
+} from '@/utils/entity-error-handler';
+import { is404ApiError } from '@/utils/api-client/is-not-found-error';
+
+interface Breadcrumb {
+  label: string;
+  href?: string;
+}
+
+interface DetailEntityMissingStateProps {
+  error: unknown;
+  entityLabel: string;
+  entityId: string;
+  entityTableName: string;
+  breadcrumbs: Breadcrumb[];
+  listUrl?: string;
+  onBack: () => void;
+  onRetry?: () => void;
+  isRetrying?: boolean;
+}
+
+/**
+ * Routes client-side entity fetch failures to restore UI (410) or cross-project
+ * not-found handling (404).
+ */
+export default function DetailEntityMissingState({
+  error,
+  entityLabel,
+  entityId,
+  entityTableName,
+  breadcrumbs,
+  listUrl,
+  onBack,
+  onRetry,
+  isRetrying,
+}: DetailEntityMissingStateProps) {
+  const { data: session } = useSession();
+
+  if (isDeletedEntityError(error)) {
+    const deletedData = getDeletedEntityData(error);
+    if (deletedData) {
+      const displayName =
+        deletedData.model_name_display || deletedData.model_name || entityLabel;
+      const pageTitle = deletedData.item_name
+        ? `${deletedData.item_name} (Deleted)`
+        : `${displayName} Deleted`;
+
+      return (
+        <PageLayout title={pageTitle} breadcrumbs={breadcrumbs}>
+          <DeletedEntityAlert
+            entityData={deletedData}
+            sessionToken={session?.session_token}
+            backUrl={listUrl}
+            backLabel={
+              listUrl ? `Back to ${entityLabel}s` : `Back to ${entityLabel}`
+            }
+            onRestoreSuccess={() => window.location.reload()}
+          />
+        </PageLayout>
+      );
+    }
+  }
+
+  if (is404ApiError(error)) {
+    return (
+      <DetailNotFoundState
+        entityLabel={entityLabel}
+        entityId={entityId}
+        entityTableName={entityTableName}
+        breadcrumbs={breadcrumbs}
+        listUrl={listUrl}
+        onBack={onBack}
+        onRetry={onRetry}
+        isRetrying={isRetrying}
+      />
+    );
+  }
+
+  return null;
+}

--- a/apps/frontend/src/components/common/DetailNotFoundState.tsx
+++ b/apps/frontend/src/components/common/DetailNotFoundState.tsx
@@ -52,10 +52,8 @@ export default function DetailNotFoundState({
   onRetry,
   isRetrying = false,
 }: DetailNotFoundStateProps) {
-  const { crossProjectData, isResolving } = useCrossProjectResolve(
-    entityTableName,
-    entityId
-  );
+  const { crossProjectData, isResolving, resolveError, retryResolve } =
+    useCrossProjectResolve(entityTableName, entityId);
 
   const entityData = useMemo(
     () =>
@@ -113,11 +111,19 @@ export default function DetailNotFoundState({
     ? displayLabel
     : `${displayLabel}s`;
 
+  const showResolveRetry = Boolean(resolveError);
+  const handleRetry = showResolveRetry ? retryResolve : onRetry;
+  const retrying = showResolveRetry ? isResolving : isRetrying;
+
   return contentWrapper(
     <EntityMessageState
       icon={FolderOffOutlinedIcon}
       title={`Couldn't load this ${displayLabel.toLowerCase()}`}
-      description={entityData.message}
+      description={
+        showResolveRetry
+          ? 'We could not check other projects right now. Try again in a moment.'
+          : entityData.message
+      }
       meta={`${displayLabel} ID: ${entityId}`}
       primaryAction={{
         label: `Back to ${listLabel}`,
@@ -126,13 +132,13 @@ export default function DetailNotFoundState({
         variant: 'contained',
       }}
       secondaryAction={
-        onRetry
+        handleRetry
           ? {
-              label: isRetrying ? 'Retrying...' : 'Try Again',
-              onClick: onRetry,
+              label: retrying ? 'Retrying...' : 'Try Again',
+              onClick: handleRetry,
               startIcon: <RefreshIcon />,
-              disabled: isRetrying,
-              loading: isRetrying,
+              disabled: retrying,
+              loading: retrying,
             }
           : undefined
       }

--- a/apps/frontend/src/components/common/DetailNotFoundState.tsx
+++ b/apps/frontend/src/components/common/DetailNotFoundState.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo } from 'react';
 import {
   Alert,
   Box,
@@ -8,6 +9,12 @@ import {
   Typography,
 } from '@mui/material';
 import { PageLayout } from '@/components/layout/PageLayout';
+import { CrossProjectAlert } from '@/components/common/CrossProjectAlert';
+import { useCrossProjectResolve } from '@/hooks/useCrossProjectResolve';
+import {
+  buildNotFoundEntityData,
+  NotFoundEntityData,
+} from '@/utils/entity-error-handler';
 
 interface Breadcrumb {
   label: string;
@@ -17,36 +24,95 @@ interface Breadcrumb {
 interface DetailNotFoundStateProps {
   entityLabel: string;
   entityId: string;
+  /** Database table name for the /resolve endpoint (e.g. "endpoint", "task"). */
+  entityTableName: string;
+  /** Structured data from a 404 API response, when available. */
+  entityData?: NotFoundEntityData;
   breadcrumbs: Breadcrumb[];
+  listUrl?: string;
   onBack: () => void;
   onRetry?: () => void;
   isRetrying?: boolean;
 }
 
+/**
+ * Shared not-found UI for entity detail pages.
+ * Attempts cross-project resolution, then falls back to a standard warning.
+ */
 export default function DetailNotFoundState({
   entityLabel,
   entityId,
+  entityTableName,
+  entityData: entityDataProp,
   breadcrumbs,
+  listUrl,
   onBack,
   onRetry,
   isRetrying = false,
 }: DetailNotFoundStateProps) {
-  const listLabel = entityLabel.endsWith('s') ? entityLabel : `${entityLabel}s`;
+  const { crossProjectData, isResolving } = useCrossProjectResolve(
+    entityTableName,
+    entityId
+  );
+
+  const entityData = useMemo(
+    () =>
+      entityDataProp ??
+      buildNotFoundEntityData({
+        entityLabel,
+        entityId,
+        tableName: entityTableName,
+        listUrl,
+      }),
+    [entityDataProp, entityLabel, entityId, entityTableName, listUrl]
+  );
+
+  const displayLabel =
+    entityData.model_name_display || entityData.model_name || entityLabel;
+
+  const pageTitle = crossProjectData
+    ? crossProjectData.resolution === 'no_access'
+      ? `${displayLabel} — No access`
+      : `${displayLabel} in another project`
+    : `${displayLabel} not found`;
+
+  if (isResolving) {
+    return (
+      <PageLayout title={pageTitle} breadcrumbs={breadcrumbs}>
+        <Box sx={{ flexGrow: 1, pt: 3 }}>
+          <Alert severity="info">Checking other projects...</Alert>
+        </Box>
+      </PageLayout>
+    );
+  }
+
+  if (crossProjectData) {
+    return (
+      <PageLayout title={pageTitle} breadcrumbs={breadcrumbs}>
+        <Box sx={{ flexGrow: 1, pt: 3 }}>
+          <CrossProjectAlert
+            resolvedEntity={crossProjectData}
+            entityData={entityData}
+          />
+        </Box>
+      </PageLayout>
+    );
+  }
+
+  const listLabel = displayLabel.endsWith('s') ? displayLabel : `${displayLabel}s`;
 
   return (
-    <PageLayout title={`${entityLabel} Not Found`} breadcrumbs={breadcrumbs}>
+    <PageLayout title={pageTitle} breadcrumbs={breadcrumbs}>
       <Box sx={{ flexGrow: 1, pt: 3 }}>
         <Alert severity="warning" sx={{ mb: 3 }}>
           <Typography variant="h6" sx={{ mb: 1 }}>
-            Sorry, we couldn&apos;t load this {entityLabel.toLowerCase()}
+            Sorry, we couldn&apos;t load this {displayLabel.toLowerCase()}
           </Typography>
           <Typography variant="body2" sx={{ mb: 2 }}>
-            The {entityLabel.toLowerCase()} you&apos;re looking for might have
-            been deleted, moved, belongs to a different project, or you may not
-            have permission to view it.
+            {entityData.message}
           </Typography>
           <Typography variant="body2" color="text.secondary">
-            {entityLabel} ID: {entityId}
+            {displayLabel} ID: {entityId}
           </Typography>
         </Alert>
         <Box sx={{ display: 'flex', gap: 2 }}>

--- a/apps/frontend/src/components/common/DetailNotFoundState.tsx
+++ b/apps/frontend/src/components/common/DetailNotFoundState.tsx
@@ -1,20 +1,22 @@
 'use client';
 
-import { useMemo } from 'react';
-import {
-  Alert,
-  Box,
-  Button,
-  CircularProgress,
-  Typography,
-} from '@mui/material';
+import { useMemo, type ReactNode } from 'react';
+import { Box } from '@mui/material';
+import ArrowBackIcon from '@mui/icons-material/ArrowBackOutlined';
+import RefreshIcon from '@mui/icons-material/RefreshOutlined';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { CrossProjectAlert } from '@/components/common/CrossProjectAlert';
+import EntityMessageState from '@/components/common/EntityMessageState';
 import { useCrossProjectResolve } from '@/hooks/useCrossProjectResolve';
 import {
   buildNotFoundEntityData,
   NotFoundEntityData,
 } from '@/utils/entity-error-handler';
+import {
+  FolderOffOutlinedIcon,
+  getResolveEntityIcon,
+} from '@/utils/entity-detail-icons';
+import { AccountTreeIcon } from '@/components/icons';
 
 interface Breadcrumb {
   label: string;
@@ -70,69 +72,68 @@ export default function DetailNotFoundState({
   const displayLabel =
     entityData.model_name_display || entityData.model_name || entityLabel;
 
+  const EntityIcon =
+    entityLabel === 'Session'
+      ? AccountTreeIcon
+      : getResolveEntityIcon(entityTableName);
+
   const pageTitle = crossProjectData
     ? crossProjectData.resolution === 'no_access'
       ? `${displayLabel} — No access`
       : `${displayLabel} in another project`
     : `${displayLabel} not found`;
 
+  const contentWrapper = (children: ReactNode) => (
+    <PageLayout title={pageTitle} breadcrumbs={breadcrumbs}>
+      <Box sx={{ mt: 2, mb: 2 }}>{children}</Box>
+    </PageLayout>
+  );
+
   if (isResolving) {
-    return (
-      <PageLayout title={pageTitle} breadcrumbs={breadcrumbs}>
-        <Box sx={{ flexGrow: 1, pt: 3 }}>
-          <Alert severity="info">Checking other projects...</Alert>
-        </Box>
-      </PageLayout>
+    return contentWrapper(
+      <EntityMessageState
+        icon={EntityIcon}
+        title="Checking other projects..."
+        description="Looking for this item in projects you have access to."
+        loading
+      />
     );
   }
 
   if (crossProjectData) {
-    return (
-      <PageLayout title={pageTitle} breadcrumbs={breadcrumbs}>
-        <Box sx={{ flexGrow: 1, pt: 3 }}>
-          <CrossProjectAlert
-            resolvedEntity={crossProjectData}
-            entityData={entityData}
-          />
-        </Box>
-      </PageLayout>
+    return contentWrapper(
+      <CrossProjectAlert
+        resolvedEntity={crossProjectData}
+        entityData={entityData}
+      />
     );
   }
 
   const listLabel = displayLabel.endsWith('s') ? displayLabel : `${displayLabel}s`;
 
-  return (
-    <PageLayout title={pageTitle} breadcrumbs={breadcrumbs}>
-      <Box sx={{ flexGrow: 1, pt: 3 }}>
-        <Alert severity="warning" sx={{ mb: 3 }}>
-          <Typography variant="h6" sx={{ mb: 1 }}>
-            Sorry, we couldn&apos;t load this {displayLabel.toLowerCase()}
-          </Typography>
-          <Typography variant="body2" sx={{ mb: 2 }}>
-            {entityData.message}
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            {displayLabel} ID: {entityId}
-          </Typography>
-        </Alert>
-        <Box sx={{ display: 'flex', gap: 2 }}>
-          <Button variant="contained" onClick={onBack}>
-            Back to {listLabel}
-          </Button>
-          {onRetry && (
-            <Button variant="outlined" onClick={onRetry} disabled={isRetrying}>
-              {isRetrying ? (
-                <>
-                  <CircularProgress color="inherit" size={16} sx={{ mr: 1 }} />
-                  Retrying...
-                </>
-              ) : (
-                'Try Again'
-              )}
-            </Button>
-          )}
-        </Box>
-      </Box>
-    </PageLayout>
+  return contentWrapper(
+    <EntityMessageState
+      icon={FolderOffOutlinedIcon}
+      title={`Couldn't load this ${displayLabel.toLowerCase()}`}
+      description={entityData.message}
+      meta={`${displayLabel} ID: ${entityId}`}
+      primaryAction={{
+        label: `Back to ${listLabel}`,
+        onClick: onBack,
+        startIcon: <ArrowBackIcon />,
+        variant: 'contained',
+      }}
+      secondaryAction={
+        onRetry
+          ? {
+              label: isRetrying ? 'Retrying...' : 'Try Again',
+              onClick: onRetry,
+              startIcon: <RefreshIcon />,
+              disabled: isRetrying,
+              loading: isRetrying,
+            }
+          : undefined
+      }
+    />
   );
 }

--- a/apps/frontend/src/components/common/DetailNotFoundState.tsx
+++ b/apps/frontend/src/components/common/DetailNotFoundState.tsx
@@ -109,7 +109,9 @@ export default function DetailNotFoundState({
     );
   }
 
-  const listLabel = displayLabel.endsWith('s') ? displayLabel : `${displayLabel}s`;
+  const listLabel = displayLabel.endsWith('s')
+    ? displayLabel
+    : `${displayLabel}s`;
 
   return contentWrapper(
     <EntityMessageState

--- a/apps/frontend/src/components/common/EntityEmptyState.tsx
+++ b/apps/frontend/src/components/common/EntityEmptyState.tsx
@@ -4,9 +4,24 @@ import React from 'react';
 import { Box, Button, Typography } from '@mui/material';
 import type { SvgIconProps } from '@mui/material/SvgIcon';
 import AddIcon from '@mui/icons-material/Add';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
 import type { EntityEmptyStateEnrichment } from '@/constants/entity-empty-state-types';
 import { hasEnrichmentContent } from '@/constants/entity-empty-state-env';
+import {
+  EMPTY_STATE,
+  emptyStateActionsRowSx,
+  emptyStateCompactContentSx,
+  emptyStateCompactTitleSx,
+  emptyStateContainedActionSx,
+  emptyStateDescriptionSx,
+  emptyStateEnrichedActionSx,
+  emptyStateHeaderStackSx,
+  emptyStateIconSx,
+  emptyStateInnerStackSx,
+  emptyStateOutlinedActionSx,
+  emptyStateStandaloneContainedActionSx,
+  emptyStateStandaloneContentSx,
+  emptyStateStandaloneTitleSx,
+} from '@/components/common/entityEmptyStateSx';
 import {
   EnrichmentCardExtras,
   EnrichmentPrimaryAction,
@@ -80,34 +95,24 @@ export default function EntityEmptyState({
   const isEnriched = hasEnrichmentContent(enrichment);
   const useCompactLayout = card || isEnriched || embedded;
   const wrapInCardShell = (card || isEnriched) && !embedded;
-  const resolvedIconSize = iconSize ?? (useCompactLayout ? 32 : 64);
+  const resolvedIconSize =
+    iconSize ??
+    (useCompactLayout
+      ? EMPTY_STATE.iconSize.compact
+      : EMPTY_STATE.iconSize.standalone);
   const resolvedShowAddIcon = showAddIcon ?? useCompactLayout;
 
   const headerBlock = (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        gap: useCompactLayout ? '10px' : 0,
-      }}
-    >
+    <Box sx={emptyStateHeaderStackSx(useCompactLayout)}>
       <Icon
-        sx={{
-          fontSize: resolvedIconSize,
-          color: 'primary.main',
-          opacity: useCompactLayout ? 1 : 0.6,
-        }}
+        sx={emptyStateIconSx(resolvedIconSize, {
+          standalone: !useCompactLayout,
+        })}
       />
 
       <Typography
         variant="h6"
-        sx={{
-          fontWeight: useCompactLayout ? 600 : 700,
-          fontSize: useCompactLayout ? 20 : undefined,
-          lineHeight: useCompactLayout ? '24px' : undefined,
-          color: useCompactLayout ? 'primary.main' : 'text.primary',
-        }}
+        sx={useCompactLayout ? emptyStateCompactTitleSx : emptyStateStandaloneTitleSx}
       >
         {title}
       </Typography>
@@ -117,11 +122,10 @@ export default function EntityEmptyState({
   const descriptionBlock = description && (
     <Typography
       variant="body2"
-      sx={{
-        color: 'text.secondary',
-        maxWidth: isEnriched ? 734 : 480,
-        lineHeight: useCompactLayout ? '22px' : undefined,
-      }}
+      sx={emptyStateDescriptionSx({
+        compact: useCompactLayout,
+        enriched: isEnriched,
+      })}
     >
       {description}
     </Typography>
@@ -136,30 +140,8 @@ export default function EntityEmptyState({
         disabled={actionDisabled}
         sx={
           useCompactLayout
-            ? {
-                fontWeight: 700,
-                fontSize: 18,
-                lineHeight: '25px',
-                borderRadius: BORDER_RADIUS.md,
-                textTransform: 'none',
-                px: '20px',
-                py: '12px',
-                borderWidth: 2,
-                '&:hover': {
-                  borderWidth: 2,
-                },
-              }
-            : {
-                mt: 1,
-                fontWeight: 700,
-                fontSize: 18,
-                lineHeight: '25px',
-                borderRadius: BORDER_RADIUS.pill,
-                textTransform: 'none',
-                px: '20px',
-                py: '12px',
-                boxShadow: ELEVATION.xs,
-              }
+            ? emptyStateOutlinedActionSx
+            : emptyStateStandaloneContainedActionSx
         }
       >
         {actionLabel}
@@ -168,15 +150,7 @@ export default function EntityEmptyState({
 
   const enrichedActions =
     isEnriched && enrichment ? (
-      <Box
-        sx={{
-          display: 'flex',
-          gap: '10px',
-          alignItems: 'center',
-          justifyContent: 'center',
-          flexWrap: 'wrap',
-        }}
-      >
+      <Box sx={emptyStateActionsRowSx}>
         {enrichment.secondaryAction && (
           <Button
             component={enrichment.secondaryAction.href ? 'a' : 'button'}
@@ -190,17 +164,7 @@ export default function EntityEmptyState({
             variant="outlined"
             disabled={enrichment.secondaryAction.disabled}
             onClick={enrichment.secondaryAction.onAction}
-            sx={{
-              fontWeight: 700,
-              fontSize: 14,
-              lineHeight: '22px',
-              borderRadius: BORDER_RADIUS.sm,
-              textTransform: 'none',
-              px: '16px',
-              py: '8px',
-              borderWidth: 2,
-              '&:hover': { borderWidth: 2 },
-            }}
+            sx={emptyStateEnrichedActionSx('outlined')}
           >
             {enrichment.secondaryAction.label}
           </Button>
@@ -217,26 +181,12 @@ export default function EntityEmptyState({
     ) : null;
 
   const cardContent = (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        textAlign: 'center',
-        py: useCompactLayout ? 0 : 10,
-        px: useCompactLayout ? { xs: 2, md: '200px' } : 4,
-        gap: isEnriched ? '50px' : useCompactLayout ? '20px' : 2,
-      }}
-    >
+    <Box sx={emptyStateCompactContentSx({ enriched: isEnriched })}>
       <Box
         sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: isEnriched ? '30px' : useCompactLayout ? '20px' : 0,
+          ...emptyStateInnerStackSx(isEnriched ? 'lg' : 'md'),
           width: isEnriched ? '100%' : undefined,
-          maxWidth: isEnriched ? 734 : undefined,
+          maxWidth: isEnriched ? EMPTY_STATE.enrichedMaxWidth : undefined,
         }}
       >
         {headerBlock}
@@ -251,18 +201,7 @@ export default function EntityEmptyState({
   );
 
   const standaloneContent = (
-    <Box
-      sx={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        textAlign: 'center',
-        py: 10,
-        px: 4,
-        gap: 2,
-      }}
-    >
+    <Box sx={emptyStateStandaloneContentSx}>
       {headerBlock}
       {descriptionBlock}
       {basicAction}

--- a/apps/frontend/src/components/common/EntityEmptyState.tsx
+++ b/apps/frontend/src/components/common/EntityEmptyState.tsx
@@ -11,7 +11,6 @@ import {
   emptyStateActionsRowSx,
   emptyStateCompactContentSx,
   emptyStateCompactTitleSx,
-  emptyStateContainedActionSx,
   emptyStateDescriptionSx,
   emptyStateEnrichedActionSx,
   emptyStateHeaderStackSx,

--- a/apps/frontend/src/components/common/EntityEmptyState.tsx
+++ b/apps/frontend/src/components/common/EntityEmptyState.tsx
@@ -112,7 +112,11 @@ export default function EntityEmptyState({
 
       <Typography
         variant="h6"
-        sx={useCompactLayout ? emptyStateCompactTitleSx : emptyStateStandaloneTitleSx}
+        sx={
+          useCompactLayout
+            ? emptyStateCompactTitleSx
+            : emptyStateStandaloneTitleSx
+        }
       >
         {title}
       </Typography>

--- a/apps/frontend/src/components/common/EntityEmptyStateEnrichmentParts.tsx
+++ b/apps/frontend/src/components/common/EntityEmptyStateEnrichmentParts.tsx
@@ -4,7 +4,11 @@ import React from 'react';
 import { Box, Button, Paper, Skeleton, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import { ArrowOutwardIcon } from '@/components/icons';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
+import { BORDER_RADIUS } from '@/styles/theme-constants';
+import {
+  emptyStateCardShellSx,
+  emptyStateEnrichedActionSx,
+} from '@/components/common/entityEmptyStateSx';
 import type {
   EmptyStateAction,
   EmptyStateArticle,
@@ -75,20 +79,7 @@ function EnrichmentActionButton({
   showAddIcon?: boolean;
   enriched?: boolean;
 }) {
-  const commonSx = enriched
-    ? {
-        fontWeight: 700,
-        fontSize: 14,
-        lineHeight: '22px',
-        borderRadius: BORDER_RADIUS.sm,
-        textTransform: 'none' as const,
-        px: '16px',
-        py: '8px',
-        ...(variant === 'outlined'
-          ? { borderWidth: 2, '&:hover': { borderWidth: 2 } }
-          : {}),
-      }
-    : undefined;
+  const commonSx = enriched ? emptyStateEnrichedActionSx(variant) : undefined;
 
   if (action.href) {
     return (
@@ -467,16 +458,7 @@ export function EntityEmptyStateCardShell({
   children: React.ReactNode;
 }) {
   return (
-    <Paper
-      elevation={0}
-      sx={{
-        border: theme => `1px solid ${theme.palette.greyscale.border}`,
-        borderRadius: BORDER_RADIUS.md,
-        boxShadow: ELEVATION.xs,
-        px: '30px',
-        py: '40px',
-      }}
-    >
+    <Paper elevation={0} sx={emptyStateCardShellSx}>
       {children}
     </Paper>
   );

--- a/apps/frontend/src/components/common/EntityMessageState.tsx
+++ b/apps/frontend/src/components/common/EntityMessageState.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import React from 'react';
+import {
+  Box,
+  Button,
+  CircularProgress,
+  Typography,
+} from '@mui/material';
+import type { SvgIconProps } from '@mui/material/SvgIcon';
+import {
+  EMPTY_STATE,
+  emptyStateActionsRowSx,
+  emptyStateCompactContentSx,
+  emptyStateCompactTitleSx,
+  emptyStateContainedActionSx,
+  emptyStateDescriptionSx,
+  emptyStateHeaderStackSx,
+  emptyStateIconSx,
+  emptyStateInnerStackSx,
+  emptyStateOutlinedActionSx,
+} from '@/components/common/entityEmptyStateSx';
+import { EntityEmptyStateCardShell } from '@/components/common/EntityEmptyStateEnrichmentParts';
+
+export interface EntityMessageAction {
+  label: string;
+  onClick: () => void;
+  startIcon?: React.ReactNode;
+  variant?: 'contained' | 'outlined';
+  disabled?: boolean;
+  loading?: boolean;
+}
+
+export interface EntityMessageStateProps {
+  icon: React.ComponentType<SvgIconProps>;
+  title: string;
+  description?: string;
+  meta?: string;
+  primaryAction?: EntityMessageAction;
+  secondaryAction?: EntityMessageAction;
+  /** When true, shows a spinner instead of the icon. */
+  loading?: boolean;
+  card?: boolean;
+}
+
+function MessageActionButton({ action }: { action: EntityMessageAction }) {
+  const variant = action.variant ?? 'outlined';
+
+  return (
+    <Button
+      variant={variant}
+      startIcon={
+        action.loading ? (
+          <CircularProgress
+            color="inherit"
+            size={EMPTY_STATE.spinnerSize.button}
+          />
+        ) : (
+          action.startIcon
+        )
+      }
+      onClick={action.onClick}
+      disabled={action.disabled || action.loading}
+      sx={
+        variant === 'contained'
+          ? emptyStateContainedActionSx
+          : emptyStateOutlinedActionSx
+      }
+    >
+      {action.label}
+    </Button>
+  );
+}
+
+/**
+ * Figma-aligned status message used for entity detail not-found and
+ * cross-project states. Matches EntityEmptyState card styling.
+ */
+export default function EntityMessageState({
+  icon: Icon,
+  title,
+  description,
+  meta,
+  primaryAction,
+  secondaryAction,
+  loading = false,
+  card = true,
+}: EntityMessageStateProps) {
+  const content = (
+    <Box sx={emptyStateCompactContentSx()}>
+      <Box sx={emptyStateInnerStackSx('md')}>
+        <Box sx={emptyStateHeaderStackSx(true)}>
+          {loading ? (
+            <CircularProgress
+              size={EMPTY_STATE.spinnerSize.icon}
+              sx={{ color: 'primary.main' }}
+            />
+          ) : (
+            <Icon sx={emptyStateIconSx(EMPTY_STATE.iconSize.compact)} />
+          )}
+
+          <Typography variant="h6" sx={emptyStateCompactTitleSx}>
+            {title}
+          </Typography>
+        </Box>
+
+        {description && (
+          <Typography
+            variant="body2"
+            sx={emptyStateDescriptionSx({ compact: true })}
+          >
+            {description}
+          </Typography>
+        )}
+
+        {meta && (
+          <Typography variant="body2" color="text.secondary">
+            {meta}
+          </Typography>
+        )}
+
+        {(primaryAction || secondaryAction) && (
+          <Box sx={emptyStateActionsRowSx}>
+            {secondaryAction && <MessageActionButton action={secondaryAction} />}
+            {primaryAction && <MessageActionButton action={primaryAction} />}
+          </Box>
+        )}
+      </Box>
+    </Box>
+  );
+
+  if (!card) {
+    return <Box sx={{ width: '100%' }}>{content}</Box>;
+  }
+
+  return (
+    <Box sx={{ width: '100%' }}>
+      <EntityEmptyStateCardShell>{content}</EntityEmptyStateCardShell>
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/common/EntityMessageState.tsx
+++ b/apps/frontend/src/components/common/EntityMessageState.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import React from 'react';
-import {
-  Box,
-  Button,
-  CircularProgress,
-  Typography,
-} from '@mui/material';
+import { Box, Button, CircularProgress, Typography } from '@mui/material';
 import type { SvgIconProps } from '@mui/material/SvgIcon';
 import {
   EMPTY_STATE,
@@ -121,7 +116,9 @@ export default function EntityMessageState({
 
         {(primaryAction || secondaryAction) && (
           <Box sx={emptyStateActionsRowSx}>
-            {secondaryAction && <MessageActionButton action={secondaryAction} />}
+            {secondaryAction && (
+              <MessageActionButton action={secondaryAction} />
+            )}
             {primaryAction && <MessageActionButton action={primaryAction} />}
           </Box>
         )}

--- a/apps/frontend/src/components/common/SectionEmptyState.tsx
+++ b/apps/frontend/src/components/common/SectionEmptyState.tsx
@@ -4,7 +4,15 @@ import React from 'react';
 import { Box, Button, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import type { SvgIconComponent } from '@mui/icons-material';
-import { BORDER_RADIUS } from '@/styles/theme-constants';
+import {
+  EMPTY_STATE,
+  emptyStateCompactTitleSx,
+  emptyStateContainedActionSx,
+  emptyStateDescriptionSx,
+  emptyStateHeaderStackSx,
+  emptyStateIconSx,
+  emptyStateSectionInsetSx,
+} from '@/components/common/entityEmptyStateSx';
 
 export interface SectionEmptyStateProps {
   /** MUI SvgIcon component class (not an element). */
@@ -42,39 +50,10 @@ export default function SectionEmptyState({
   inset = true,
 }: SectionEmptyStateProps) {
   return (
-    <Box
-      sx={{
-        ...(inset && {
-          border: theme => `1px solid ${theme.palette.greyscale.border}`,
-          borderRadius: BORDER_RADIUS.md,
-        }),
-        px: { xs: 2, sm: 4, md: '200px' },
-        py: inset ? '40px' : 0,
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        textAlign: 'center',
-        gap: '20px',
-      }}
-    >
-      <Box
-        sx={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '10px',
-        }}
-      >
-        <Icon sx={{ fontSize: 32, color: 'primary.main' }} />
-        <Typography
-          variant="h6"
-          sx={{
-            fontWeight: 600,
-            fontSize: 20,
-            lineHeight: '24px',
-            color: 'primary.main',
-          }}
-        >
+    <Box sx={emptyStateSectionInsetSx(inset)}>
+      <Box sx={emptyStateHeaderStackSx(true)}>
+        <Icon sx={emptyStateIconSx(EMPTY_STATE.iconSize.compact)} />
+        <Typography variant="h6" sx={emptyStateCompactTitleSx}>
           {title}
         </Typography>
       </Box>
@@ -82,11 +61,7 @@ export default function SectionEmptyState({
       {description && (
         <Typography
           variant="body2"
-          sx={{
-            color: 'text.secondary',
-            maxWidth: 480,
-            lineHeight: '22px',
-          }}
+          sx={emptyStateDescriptionSx({ compact: true })}
         >
           {description}
         </Typography>
@@ -98,15 +73,7 @@ export default function SectionEmptyState({
           startIcon={showAddIcon ? <AddIcon /> : undefined}
           onClick={onAction}
           disabled={actionDisabled}
-          sx={{
-            fontWeight: 700,
-            fontSize: 18,
-            lineHeight: '25px',
-            borderRadius: BORDER_RADIUS.md,
-            textTransform: 'none',
-            px: '20px',
-            py: '12px',
-          }}
+          sx={emptyStateContainedActionSx}
         >
           {actionLabel}
         </Button>

--- a/apps/frontend/src/components/common/entityEmptyStateSx.ts
+++ b/apps/frontend/src/components/common/entityEmptyStateSx.ts
@@ -118,12 +118,25 @@ export const emptyStateEnrichedOutlinedBorderSx: SxProps<Theme> = {
 export function emptyStateEnrichedActionSx(
   variant: 'outlined' | 'contained'
 ): SxProps<Theme> {
-  return variant === 'outlined'
-    ? {
-        ...emptyStateEnrichedActionBaseSx,
-        ...emptyStateEnrichedOutlinedBorderSx,
-      }
-    : emptyStateEnrichedActionBaseSx;
+  const base = {
+    fontWeight: 700,
+    fontSize: 14,
+    lineHeight: '22px',
+    borderRadius: BORDER_RADIUS.sm,
+    textTransform: 'none' as const,
+    px: '16px',
+    py: '8px',
+  };
+
+  if (variant === 'outlined') {
+    return {
+      ...base,
+      borderWidth: 2,
+      '&:hover': { borderWidth: 2 },
+    };
+  }
+
+  return base;
 }
 
 export const emptyStateActionsRowSx: SxProps<Theme> = {

--- a/apps/frontend/src/components/common/entityEmptyStateSx.ts
+++ b/apps/frontend/src/components/common/entityEmptyStateSx.ts
@@ -119,7 +119,10 @@ export function emptyStateEnrichedActionSx(
   variant: 'outlined' | 'contained'
 ): SxProps<Theme> {
   return variant === 'outlined'
-    ? { ...emptyStateEnrichedActionBaseSx, ...emptyStateEnrichedOutlinedBorderSx }
+    ? {
+        ...emptyStateEnrichedActionBaseSx,
+        ...emptyStateEnrichedOutlinedBorderSx,
+      }
     : emptyStateEnrichedActionBaseSx;
 }
 

--- a/apps/frontend/src/components/common/entityEmptyStateSx.ts
+++ b/apps/frontend/src/components/common/entityEmptyStateSx.ts
@@ -1,0 +1,201 @@
+import type { SxProps, Theme } from '@mui/material/styles';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
+
+/**
+ * Figma-aligned tokens for compact card empty states (node 1435:49277) and
+ * related status/message variants. Shared by EntityEmptyState, SectionEmptyState,
+ * and EntityMessageState.
+ */
+export const EMPTY_STATE = {
+  iconSize: {
+    compact: 32,
+    standalone: 64,
+  },
+  gap: {
+    sm: '10px',
+    md: '20px',
+    lg: '30px',
+    xl: '50px',
+  },
+  descriptionMaxWidth: 480,
+  enrichedMaxWidth: 734,
+  horizontalPadding: { xs: 2, md: '200px' },
+  cardShell: {
+    px: '30px',
+    py: '40px',
+  },
+  spinnerSize: {
+    icon: 32,
+    button: 16,
+  },
+} as const;
+
+export const emptyStateCompactTitleSx: SxProps<Theme> = {
+  fontWeight: 600,
+  fontSize: 20,
+  lineHeight: '24px',
+  color: 'primary.main',
+};
+
+export const emptyStateStandaloneTitleSx: SxProps<Theme> = {
+  fontWeight: 700,
+  color: 'text.primary',
+};
+
+export function emptyStateIconSx(
+  size: number,
+  options?: { standalone?: boolean }
+): SxProps<Theme> {
+  return {
+    fontSize: size,
+    color: 'primary.main',
+    opacity: options?.standalone ? 0.6 : 1,
+  };
+}
+
+export function emptyStateDescriptionSx(options?: {
+  compact?: boolean;
+  enriched?: boolean;
+}): SxProps<Theme> {
+  return {
+    color: 'text.secondary',
+    maxWidth: options?.enriched
+      ? EMPTY_STATE.enrichedMaxWidth
+      : EMPTY_STATE.descriptionMaxWidth,
+    ...(options?.compact ? { lineHeight: '22px' } : {}),
+  };
+}
+
+export const emptyStateOutlinedActionSx: SxProps<Theme> = {
+  fontWeight: 700,
+  fontSize: 18,
+  lineHeight: '25px',
+  borderRadius: BORDER_RADIUS.md,
+  textTransform: 'none',
+  px: '20px',
+  py: '12px',
+  borderWidth: 2,
+  '&:hover': { borderWidth: 2 },
+};
+
+export const emptyStateContainedActionSx: SxProps<Theme> = {
+  fontWeight: 700,
+  fontSize: 18,
+  lineHeight: '25px',
+  borderRadius: BORDER_RADIUS.md,
+  textTransform: 'none',
+  px: '20px',
+  py: '12px',
+};
+
+export const emptyStateStandaloneContainedActionSx: SxProps<Theme> = {
+  mt: 1,
+  fontWeight: 700,
+  fontSize: 18,
+  lineHeight: '25px',
+  borderRadius: BORDER_RADIUS.pill,
+  textTransform: 'none',
+  px: '20px',
+  py: '12px',
+  boxShadow: ELEVATION.xs,
+};
+
+export const emptyStateEnrichedActionBaseSx: SxProps<Theme> = {
+  fontWeight: 700,
+  fontSize: 14,
+  lineHeight: '22px',
+  borderRadius: BORDER_RADIUS.sm,
+  textTransform: 'none',
+  px: '16px',
+  py: '8px',
+};
+
+export const emptyStateEnrichedOutlinedBorderSx: SxProps<Theme> = {
+  borderWidth: 2,
+  '&:hover': { borderWidth: 2 },
+};
+
+export function emptyStateEnrichedActionSx(
+  variant: 'outlined' | 'contained'
+): SxProps<Theme> {
+  return variant === 'outlined'
+    ? { ...emptyStateEnrichedActionBaseSx, ...emptyStateEnrichedOutlinedBorderSx }
+    : emptyStateEnrichedActionBaseSx;
+}
+
+export const emptyStateActionsRowSx: SxProps<Theme> = {
+  display: 'flex',
+  gap: EMPTY_STATE.gap.sm,
+  alignItems: 'center',
+  justifyContent: 'center',
+  flexWrap: 'wrap',
+};
+
+export function emptyStateHeaderStackSx(compact: boolean): SxProps<Theme> {
+  return {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: compact ? EMPTY_STATE.gap.sm : 0,
+  };
+}
+
+export function emptyStateInnerStackSx(
+  gap: keyof typeof EMPTY_STATE.gap = 'md'
+): SxProps<Theme> {
+  return {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: EMPTY_STATE.gap[gap],
+  };
+}
+
+export const emptyStateCenteredColumnSx: SxProps<Theme> = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  textAlign: 'center',
+};
+
+export function emptyStateCompactContentSx(options?: {
+  enriched?: boolean;
+}): SxProps<Theme> {
+  return {
+    ...emptyStateCenteredColumnSx,
+    py: 0,
+    px: EMPTY_STATE.horizontalPadding,
+    gap: options?.enriched ? EMPTY_STATE.gap.xl : EMPTY_STATE.gap.md,
+  };
+}
+
+export const emptyStateStandaloneContentSx: SxProps<Theme> = {
+  ...emptyStateCenteredColumnSx,
+  py: 10,
+  px: 4,
+  gap: 2,
+};
+
+export const emptyStateCardShellSx: SxProps<Theme> = {
+  border: theme => `1px solid ${theme.palette.greyscale.border}`,
+  borderRadius: BORDER_RADIUS.md,
+  boxShadow: ELEVATION.xs,
+  px: EMPTY_STATE.cardShell.px,
+  py: EMPTY_STATE.cardShell.py,
+};
+
+export function emptyStateSectionInsetSx(inset: boolean): SxProps<Theme> {
+  return {
+    ...(inset
+      ? {
+          border: theme => `1px solid ${theme.palette.greyscale.border}`,
+          borderRadius: BORDER_RADIUS.md,
+        }
+      : {}),
+    px: { xs: 2, sm: 4, md: EMPTY_STATE.horizontalPadding.md },
+    py: inset ? EMPTY_STATE.cardShell.py : 0,
+    ...emptyStateCenteredColumnSx,
+    gap: EMPTY_STATE.gap.md,
+  };
+}

--- a/apps/frontend/src/hooks/useCrossProjectResolve.ts
+++ b/apps/frontend/src/hooks/useCrossProjectResolve.ts
@@ -18,9 +18,8 @@ export function useCrossProjectResolve(
   enabled = true
 ): UseCrossProjectResolveResult {
   const { data: session } = useSession();
-  const [crossProjectData, setCrossProjectData] = useState<ResolvedEntity | null>(
-    null
-  );
+  const [crossProjectData, setCrossProjectData] =
+    useState<ResolvedEntity | null>(null);
   const [resolveAttempted, setResolveAttempted] = useState(false);
 
   useEffect(() => {

--- a/apps/frontend/src/hooks/useCrossProjectResolve.ts
+++ b/apps/frontend/src/hooks/useCrossProjectResolve.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { ResolvedEntity } from '@/utils/api-client/resolve-client';
+import { UUID_PATTERN } from '@/utils/entity-error-handler';
+
+interface UseCrossProjectResolveResult {
+  crossProjectData: ResolvedEntity | null;
+  isResolving: boolean;
+  resolveAttempted: boolean;
+}
+
+export function useCrossProjectResolve(
+  entityType: string | undefined,
+  entityId: string | undefined,
+  enabled = true
+): UseCrossProjectResolveResult {
+  const { data: session } = useSession();
+  const [crossProjectData, setCrossProjectData] = useState<ResolvedEntity | null>(
+    null
+  );
+  const [resolveAttempted, setResolveAttempted] = useState(false);
+
+  useEffect(() => {
+    setCrossProjectData(null);
+    setResolveAttempted(false);
+  }, [entityType, entityId, enabled]);
+
+  useEffect(() => {
+    if (!enabled || !entityType || !entityId) {
+      return;
+    }
+
+    if (!session?.session_token) {
+      setResolveAttempted(true);
+      return;
+    }
+
+    if (!UUID_PATTERN.test(entityId)) {
+      setResolveAttempted(true);
+      return;
+    }
+
+    let cancelled = false;
+    const factory = new ApiClientFactory(session.session_token);
+    const resolveClient = factory.getResolveClient();
+
+    resolveClient
+      .resolveEntity(entityType, entityId)
+      .then(result => {
+        if (!cancelled) {
+          setCrossProjectData(result);
+          setResolveAttempted(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setResolveAttempted(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, entityType, entityId, session?.session_token]);
+
+  const isResolving =
+    enabled &&
+    !!entityType &&
+    !!entityId &&
+    UUID_PATTERN.test(entityId) &&
+    !resolveAttempted &&
+    !!session?.session_token;
+
+  return {
+    crossProjectData,
+    isResolving,
+    resolveAttempted: resolveAttempted || !session?.session_token,
+  };
+}

--- a/apps/frontend/src/hooks/useCrossProjectResolve.ts
+++ b/apps/frontend/src/hooks/useCrossProjectResolve.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { ResolvedEntity } from '@/utils/api-client/resolve-client';
@@ -10,6 +10,8 @@ interface UseCrossProjectResolveResult {
   crossProjectData: ResolvedEntity | null;
   isResolving: boolean;
   resolveAttempted: boolean;
+  resolveError: unknown;
+  retryResolve: () => void;
 }
 
 export function useCrossProjectResolve(
@@ -21,10 +23,20 @@ export function useCrossProjectResolve(
   const [crossProjectData, setCrossProjectData] =
     useState<ResolvedEntity | null>(null);
   const [resolveAttempted, setResolveAttempted] = useState(false);
+  const [resolveError, setResolveError] = useState<unknown>(null);
+  const [retryCount, setRetryCount] = useState(0);
+  const requestIdRef = useRef(0);
+
+  const retryResolve = useCallback(() => {
+    setResolveAttempted(false);
+    setResolveError(null);
+    setRetryCount(count => count + 1);
+  }, []);
 
   useEffect(() => {
     setCrossProjectData(null);
     setResolveAttempted(false);
+    setResolveError(null);
   }, [entityType, entityId, enabled]);
 
   useEffect(() => {
@@ -42,28 +54,32 @@ export function useCrossProjectResolve(
       return;
     }
 
-    let cancelled = false;
+    const requestId = ++requestIdRef.current;
     const factory = new ApiClientFactory(session.session_token);
     const resolveClient = factory.getResolveClient();
 
     resolveClient
       .resolveEntity(entityType, entityId)
       .then(result => {
-        if (!cancelled) {
-          setCrossProjectData(result);
-          setResolveAttempted(true);
+        if (requestIdRef.current !== requestId) {
+          return;
         }
+        setCrossProjectData(result);
+        setResolveError(null);
+        setResolveAttempted(true);
       })
-      .catch(() => {
-        if (!cancelled) {
-          setResolveAttempted(true);
+      .catch(error => {
+        if (requestIdRef.current !== requestId) {
+          return;
         }
+        setResolveError(error);
+        setResolveAttempted(true);
       });
 
     return () => {
-      cancelled = true;
+      requestIdRef.current += 1;
     };
-  }, [enabled, entityType, entityId, session?.session_token]);
+  }, [enabled, entityType, entityId, session?.session_token, retryCount]);
 
   const isResolving =
     enabled &&
@@ -77,5 +93,7 @@ export function useCrossProjectResolve(
     crossProjectData,
     isResolving,
     resolveAttempted: resolveAttempted || !session?.session_token,
+    resolveError,
+    retryResolve,
   };
 }

--- a/apps/frontend/src/utils/__tests__/entity-error-handler.test.ts
+++ b/apps/frontend/src/utils/__tests__/entity-error-handler.test.ts
@@ -5,6 +5,9 @@ import {
   getNotFoundEntityData,
   getDeletedEntityData,
   getErrorMessage,
+  parseEntityFromPathname,
+  urlSegmentToResolveEntityType,
+  buildNotFoundEntityData,
 } from '../entity-error-handler';
 
 // ============================================================================
@@ -232,5 +235,81 @@ describe('getErrorMessage', () => {
     expect(getErrorMessage(42)).toBe('An unexpected error occurred');
     expect(getErrorMessage(null)).toBe('An unexpected error occurred');
     expect(getErrorMessage({})).toBe('An unexpected error occurred');
+  });
+});
+
+describe('parseEntityFromPathname', () => {
+  it('parses standard detail routes', () => {
+    const result = parseEntityFromPathname(
+      '/test-sets/694490e0-55a7-40ff-9785-527c15d6a602'
+    );
+
+    expect(result).toEqual({
+      entityType: 'test_set',
+      entityId: '694490e0-55a7-40ff-9785-527c15d6a602',
+      listUrl: '/test-sets',
+      entityLabel: 'Test Set',
+    });
+  });
+
+  it('maps knowledge routes to source entities', () => {
+    const result = parseEntityFromPathname(
+      '/knowledge/694490e0-55a7-40ff-9785-527c15d6a602'
+    );
+
+    expect(result?.entityType).toBe('source');
+    expect(result?.listUrl).toBe('/knowledge');
+  });
+
+  it('parses nested project endpoint routes', () => {
+    const result = parseEntityFromPathname(
+      '/projects/11111111-1111-1111-1111-111111111111/endpoints/22222222-2222-2222-2222-222222222222'
+    );
+
+    expect(result).toEqual({
+      entityType: 'endpoint',
+      entityId: '22222222-2222-2222-2222-222222222222',
+      listUrl: '/projects/11111111-1111-1111-1111-111111111111',
+      entityLabel: 'Endpoint',
+    });
+  });
+
+  it('maps explorer routes to test_set entities', () => {
+    const result = parseEntityFromPathname(
+      '/explorer/694490e0-55a7-40ff-9785-527c15d6a602'
+    );
+
+    expect(result?.entityType).toBe('test_set');
+    expect(result?.entityLabel).toBe('Session');
+    expect(result?.listUrl).toBe('/explorer');
+  });
+
+  it('returns null for list pages', () => {
+    expect(parseEntityFromPathname('/test-sets')).toBeNull();
+  });
+});
+
+describe('urlSegmentToResolveEntityType', () => {
+  it('applies knowledge override', () => {
+    expect(urlSegmentToResolveEntityType('knowledge')).toBe('source');
+  });
+
+  it('applies explorer override', () => {
+    expect(urlSegmentToResolveEntityType('explorer')).toBe('test_set');
+  });
+});
+
+describe('buildNotFoundEntityData', () => {
+  it('builds structured not-found data', () => {
+    const result = buildNotFoundEntityData({
+      entityLabel: 'Test Set',
+      entityId: 'abc-123',
+      tableName: 'test_set',
+      listUrl: '/test-sets',
+    });
+
+    expect(result.model_name).toBe('TestSet');
+    expect(result.table_name).toBe('test_set');
+    expect(result.list_url).toBe('/test-sets');
   });
 });

--- a/apps/frontend/src/utils/api-client/client-factory.ts
+++ b/apps/frontend/src/utils/api-client/client-factory.ts
@@ -33,6 +33,7 @@ import { FeaturesClient } from './features-client';
 import { PermissionsClient } from './permissions-client';
 import { ParametersClient } from './parameters-client';
 import { PreflightClient } from './preflight-client';
+import { ResolveClient } from './resolve-client';
 
 export class ApiClientFactory {
   private sessionToken: string;
@@ -55,6 +56,7 @@ export class ApiClientFactory {
   private architectClient: ArchitectClient | null = null;
   private parametersClient: ParametersClient | null = null;
   private preflightClient: PreflightClient | null = null;
+  private resolveClient: ResolveClient | null = null;
 
   /**
    * @param sessionToken The user's session token.
@@ -336,5 +338,16 @@ export class ApiClientFactory {
       );
     }
     return this.preflightClient;
+  }
+
+  getResolveClient(): ResolveClient {
+    if (!this.resolveClient) {
+      this.resolveClient = new ResolveClient(
+        this.sessionToken,
+        undefined,
+        this.projectId
+      );
+    }
+    return this.resolveClient;
   }
 }

--- a/apps/frontend/src/utils/api-client/is-not-found-error.ts
+++ b/apps/frontend/src/utils/api-client/is-not-found-error.ts
@@ -1,8 +1,16 @@
-export function isNotFoundApiError(error: unknown): boolean {
+export function getApiErrorStatus(error: unknown): number | undefined {
   if (!(error instanceof Error) || !('status' in error)) {
-    return false;
+    return undefined;
   }
 
-  const status = (error as Error & { status?: number }).status;
+  return (error as Error & { status?: number }).status;
+}
+
+export function is404ApiError(error: unknown): boolean {
+  return getApiErrorStatus(error) === 404;
+}
+
+export function isNotFoundApiError(error: unknown): boolean {
+  const status = getApiErrorStatus(error);
   return status === 404 || status === 410;
 }

--- a/apps/frontend/src/utils/api-client/resolve-client.ts
+++ b/apps/frontend/src/utils/api-client/resolve-client.ts
@@ -1,0 +1,26 @@
+import { BaseApiClient } from './base-client';
+
+export type EntityResolution = 'switchable' | 'no_access';
+
+export interface ResolvedEntity {
+  resolution: EntityResolution;
+  entity_type: string;
+  entity_id: string;
+  project_id: string | null;
+  project_name: string | null;
+}
+
+export class ResolveClient extends BaseApiClient {
+  async resolveEntity(
+    entityType: string,
+    entityId: string
+  ): Promise<ResolvedEntity | null> {
+    try {
+      return await this.fetch<ResolvedEntity>(
+        `/resolve?entity_type=${encodeURIComponent(entityType)}&entity_id=${encodeURIComponent(entityId)}`
+      );
+    } catch {
+      return null;
+    }
+  }
+}

--- a/apps/frontend/src/utils/api-client/resolve-client.ts
+++ b/apps/frontend/src/utils/api-client/resolve-client.ts
@@ -1,4 +1,5 @@
 import { BaseApiClient } from './base-client';
+import { getApiErrorStatus } from './is-not-found-error';
 
 export type EntityResolution = 'switchable' | 'no_access';
 
@@ -19,8 +20,11 @@ export class ResolveClient extends BaseApiClient {
       return await this.fetch<ResolvedEntity>(
         `/resolve?entity_type=${encodeURIComponent(entityType)}&entity_id=${encodeURIComponent(entityId)}`
       );
-    } catch {
-      return null;
+    } catch (error: unknown) {
+      if (getApiErrorStatus(error) === 404) {
+        return null;
+      }
+      throw error;
     }
   }
 }

--- a/apps/frontend/src/utils/entity-detail-icons.ts
+++ b/apps/frontend/src/utils/entity-detail-icons.ts
@@ -16,7 +16,10 @@ import {
   TracesIcon,
 } from '@/components/icons';
 
-const RESOLVE_ENTITY_ICONS: Record<string, React.ComponentType<SvgIconProps>> = {
+const RESOLVE_ENTITY_ICONS: Record<
+  string,
+  React.ComponentType<SvgIconProps>
+> = {
   test_set: CategoryIcon,
   test: ScienceIcon,
   test_run: PlayArrowIcon,

--- a/apps/frontend/src/utils/entity-detail-icons.ts
+++ b/apps/frontend/src/utils/entity-detail-icons.ts
@@ -3,7 +3,6 @@ import FolderOffOutlinedIcon from '@mui/icons-material/FolderOffOutlined';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import SwapHorizOutlinedIcon from '@mui/icons-material/SwapHorizOutlined';
 import {
-  AccountTreeIcon,
   BehaviorsIcon,
   BiotechIcon,
   CategoryIcon,

--- a/apps/frontend/src/utils/entity-detail-icons.ts
+++ b/apps/frontend/src/utils/entity-detail-icons.ts
@@ -1,0 +1,38 @@
+import type { SvgIconProps } from '@mui/material/SvgIcon';
+import FolderOffOutlinedIcon from '@mui/icons-material/FolderOffOutlined';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import SwapHorizOutlinedIcon from '@mui/icons-material/SwapHorizOutlined';
+import {
+  AccountTreeIcon,
+  BehaviorsIcon,
+  BiotechIcon,
+  CategoryIcon,
+  EndpointsIcon,
+  InsertChartIcon,
+  KnowledgeIcon,
+  PlayArrowIcon,
+  ScienceIcon,
+  TasksIcon,
+  TracesIcon,
+} from '@/components/icons';
+
+const RESOLVE_ENTITY_ICONS: Record<string, React.ComponentType<SvgIconProps>> = {
+  test_set: CategoryIcon,
+  test: ScienceIcon,
+  test_run: PlayArrowIcon,
+  endpoint: EndpointsIcon,
+  behavior: BehaviorsIcon,
+  metric: InsertChartIcon,
+  experiment: BiotechIcon,
+  task: TasksIcon,
+  source: KnowledgeIcon,
+  trace: TracesIcon,
+};
+
+export function getResolveEntityIcon(
+  tableName: string
+): React.ComponentType<SvgIconProps> {
+  return RESOLVE_ENTITY_ICONS[tableName] ?? FolderOffOutlinedIcon;
+}
+
+export { FolderOffOutlinedIcon, LockOutlinedIcon, SwapHorizOutlinedIcon };

--- a/apps/frontend/src/utils/entity-error-handler.ts
+++ b/apps/frontend/src/utils/entity-error-handler.ts
@@ -33,7 +33,107 @@ export interface NotFoundEntityData {
  * @param urlSegment - The URL segment (e.g., 'test-runs')
  * @returns The database table name (e.g., 'test_run')
  */
-function urlSegmentToTableName(urlSegment: string): string {
+export const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** URL segments whose resolve entity type differs from urlSegmentToTableName. */
+const URL_SEGMENT_TABLE_OVERRIDES: Record<string, string> = {
+  knowledge: 'source',
+  explorer: 'test_set',
+};
+
+/** URL segments whose display label differs from the path segment name. */
+const URL_SEGMENT_LABEL_OVERRIDES: Record<string, string> = {
+  knowledge: 'Source',
+  explorer: 'Session',
+};
+
+export function urlSegmentToResolveEntityType(urlSegment: string): string {
+  return URL_SEGMENT_TABLE_OVERRIDES[urlSegment] ?? urlSegmentToTableName(urlSegment);
+}
+
+export interface ParsedPathEntity {
+  entityType: string;
+  entityId: string;
+  listUrl: string;
+  entityLabel: string;
+}
+
+function formatEntityLabelFromSegment(urlSegment: string): string {
+  if (URL_SEGMENT_LABEL_OVERRIDES[urlSegment]) {
+    return URL_SEGMENT_LABEL_OVERRIDES[urlSegment];
+  }
+
+  const formatted = urlSegment
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+
+  if (formatted.endsWith('s') && !formatted.endsWith('ss')) {
+    return formatted.slice(0, -1);
+  }
+
+  return formatted;
+}
+
+/**
+ * Extract entity type and id from a protected detail-page pathname.
+ * Returns null for list pages or non-UUID detail routes.
+ */
+export function parseEntityFromPathname(pathname: string): ParsedPathEntity | null {
+  const segments = pathname.split('/').filter(Boolean);
+
+  if (
+    segments.length >= 4 &&
+    segments[0] === 'projects' &&
+    segments[2] === 'endpoints' &&
+    UUID_PATTERN.test(segments[3])
+  ) {
+    return {
+      entityType: 'endpoint',
+      entityId: segments[3],
+      listUrl: `/projects/${segments[1]}`,
+      entityLabel: 'Endpoint',
+    };
+  }
+
+  if (segments.length >= 2 && UUID_PATTERN.test(segments[1])) {
+    const urlSegment = segments[0];
+    return {
+      entityType: urlSegmentToResolveEntityType(urlSegment),
+      entityId: segments[1],
+      listUrl: `/${urlSegment}`,
+      entityLabel: formatEntityLabelFromSegment(urlSegment),
+    };
+  }
+
+  return null;
+}
+
+export function buildNotFoundEntityData({
+  entityLabel,
+  entityId,
+  tableName,
+  listUrl,
+}: {
+  entityLabel: string;
+  entityId: string;
+  tableName: string;
+  listUrl?: string;
+}): NotFoundEntityData {
+  const modelName = entityLabel.replace(/\s+/g, '');
+
+  return {
+    model_name: modelName,
+    model_name_display: entityLabel,
+    item_id: entityId,
+    table_name: tableName,
+    list_url: listUrl ?? `/${tableName.replace(/_/g, '-')}s`,
+    message: `The ${entityLabel.toLowerCase()} you're looking for doesn't exist or you don't have permission to access it.`,
+  };
+}
+
+export function urlSegmentToTableName(urlSegment: string): string {
   // First convert hyphens to underscores
   let tableName = urlSegment.replace(/-/g, '_');
 
@@ -309,6 +409,24 @@ export function getDeletedEntityData(error: unknown): DeletedEntityData | null {
   }
 
   return null;
+}
+
+// ============================================================================
+// 403 Forbidden Error Handling
+// ============================================================================
+
+export function isForbiddenError(error: unknown): boolean {
+  const e = error as ErrorLike | null | undefined;
+  if (e?.status === 403) {
+    return true;
+  }
+  if (e?.message?.includes('API error: 403')) {
+    return true;
+  }
+  if (e?.digest && e?.message?.includes('403')) {
+    return true;
+  }
+  return false;
 }
 
 // ============================================================================

--- a/apps/frontend/src/utils/entity-error-handler.ts
+++ b/apps/frontend/src/utils/entity-error-handler.ts
@@ -49,7 +49,9 @@ const URL_SEGMENT_LABEL_OVERRIDES: Record<string, string> = {
 };
 
 export function urlSegmentToResolveEntityType(urlSegment: string): string {
-  return URL_SEGMENT_TABLE_OVERRIDES[urlSegment] ?? urlSegmentToTableName(urlSegment);
+  return (
+    URL_SEGMENT_TABLE_OVERRIDES[urlSegment] ?? urlSegmentToTableName(urlSegment)
+  );
 }
 
 export interface ParsedPathEntity {
@@ -80,7 +82,9 @@ function formatEntityLabelFromSegment(urlSegment: string): string {
  * Extract entity type and id from a protected detail-page pathname.
  * Returns null for list pages or non-UUID detail routes.
  */
-export function parseEntityFromPathname(pathname: string): ParsedPathEntity | null {
+export function parseEntityFromPathname(
+  pathname: string
+): ParsedPathEntity | null {
   const segments = pathname.split('/').filter(Boolean);
 
   if (

--- a/apps/frontend/src/utils/entity-not-found-server.ts
+++ b/apps/frontend/src/utils/entity-not-found-server.ts
@@ -1,12 +1,13 @@
 import { notFound } from 'next/navigation';
-import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
+import { is404ApiError } from '@/utils/api-client/is-not-found-error';
 
 /**
- * Server-component helper: route entity 404/410 responses to the shared
- * not-found page instead of the error boundary.
+ * Server-component helper: route entity 404 responses to the shared not-found
+ * page instead of the error boundary. Soft-deleted entities (410) are left to
+ * propagate so ``error.tsx`` can render restore UI.
  */
 export function notFoundIfEntityMissing(error: unknown): void {
-  if (isNotFoundApiError(error)) {
+  if (is404ApiError(error)) {
     notFound();
   }
 }

--- a/apps/frontend/src/utils/entity-not-found-server.ts
+++ b/apps/frontend/src/utils/entity-not-found-server.ts
@@ -1,0 +1,12 @@
+import { notFound } from 'next/navigation';
+import { isNotFoundApiError } from '@/utils/api-client/is-not-found-error';
+
+/**
+ * Server-component helper: route entity 404/410 responses to the shared
+ * not-found page instead of the error boundary.
+ */
+export function notFoundIfEntityMissing(error: unknown): void {
+  if (isNotFoundApiError(error)) {
+    notFound();
+  }
+}

--- a/tests/backend/routes/test_resolve.py
+++ b/tests/backend/routes/test_resolve.py
@@ -168,6 +168,21 @@ class TestResolveEntityEndpoint:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_non_detail_entity_type_returns_400(self, authenticated_client: TestClient):
+        """Internal project-scoped tables without detail pages are not resolvable."""
+        entities = get_resolvable_entities()
+        assert "comment" not in entities
+
+        response = authenticated_client.get(
+            "/resolve",
+            params={
+                "entity_type": "comment",
+                "entity_id": "123e4567-e89b-12d3-a456-426614174000",
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
     def test_missing_entity_returns_404(self, authenticated_client: TestClient):
         response = authenticated_client.get(
             "/resolve",

--- a/tests/backend/routes/test_resolve.py
+++ b/tests/backend/routes/test_resolve.py
@@ -1,0 +1,180 @@
+"""Tests for cross-project entity resolution."""
+
+import pytest
+from faker import Faker
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from rhesis.backend.app.dependencies import get_project_context
+from rhesis.backend.app.main import app
+from rhesis.backend.app.models.project import Project
+from rhesis.backend.app.models.project_membership import ProjectMembership
+from rhesis.backend.app.models.test_set import TestSet
+from rhesis.backend.app.routers.resolve import get_resolvable_entities
+
+fake = Faker()
+
+
+def _override_active_project(project_id: str):
+    def _dependency():
+        return project_id
+
+    return _dependency
+
+
+@pytest.fixture
+def active_project_context(db_project):
+    """Pin the active project for resolve endpoint tests."""
+    app.dependency_overrides[get_project_context] = _override_active_project(
+        str(db_project.id)
+    )
+    yield db_project
+    app.dependency_overrides.pop(get_project_context, None)
+
+
+class TestResolvableEntities:
+    def test_includes_project_scoped_models(self):
+        entities = get_resolvable_entities()
+        assert "test_set" in entities
+        assert "endpoint" in entities
+        assert entities["test_set"].__tablename__ == "test_set"
+
+
+@pytest.mark.integration
+class TestResolveEntityEndpoint:
+    def _create_project_with_membership(
+        self,
+        test_db,
+        test_organization,
+        db_user,
+        db_owner_user,
+        db_status,
+        user_id,
+        name_suffix: str,
+    ) -> Project:
+        project = Project(
+            name=f"Resolve Project {name_suffix}",
+            description=fake.text(max_nb_chars=100),
+            icon="🧪",
+            is_active=True,
+            user_id=db_user.id,
+            owner_id=db_owner_user.id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+        )
+        test_db.add(project)
+        test_db.flush()
+
+        test_db.add(
+            ProjectMembership(
+                project_id=project.id,
+                user_id=user_id,
+                organization_id=test_organization.id,
+            )
+        )
+        test_db.flush()
+        test_db.refresh(project)
+        return project
+
+    def test_switchable_when_entity_in_other_project(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_organization,
+        db_user,
+        db_owner_user,
+        db_status,
+        active_project_context,
+        authenticated_user_id,
+    ):
+        other_project = self._create_project_with_membership(
+            test_db,
+            test_organization,
+            db_user,
+            db_owner_user,
+            db_status,
+            authenticated_user_id,
+            "other",
+        )
+
+        test_set = TestSet(
+            name="Cross-project test set",
+            description="Belongs to another project",
+            user_id=db_user.id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+            project_id=other_project.id,
+            is_published=False,
+            visibility="organization",
+        )
+        test_db.add(test_set)
+        test_db.flush()
+
+        response = authenticated_client.get(
+            "/resolve",
+            params={
+                "entity_type": "test_set",
+                "entity_id": str(test_set.id),
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["resolution"] == "switchable"
+        assert data["project_id"] == str(other_project.id)
+        assert data["project_name"] == other_project.name
+
+    def test_same_project_returns_404(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_organization,
+        db_user,
+        db_status,
+        active_project_context,
+    ):
+        db_project = active_project_context
+        test_set = TestSet(
+            name="Same-project test set",
+            description="Visible in active project",
+            user_id=db_user.id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+            project_id=db_project.id,
+            is_published=False,
+            visibility="organization",
+        )
+        test_db.add(test_set)
+        test_db.flush()
+
+        response = authenticated_client.get(
+            "/resolve",
+            params={
+                "entity_type": "test_set",
+                "entity_id": str(test_set.id),
+            },
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_unknown_entity_type_returns_400(self, authenticated_client: TestClient):
+        response = authenticated_client.get(
+            "/resolve",
+            params={
+                "entity_type": "not_a_real_table",
+                "entity_id": "123e4567-e89b-12d3-a456-426614174000",
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_missing_entity_returns_404(self, authenticated_client: TestClient):
+        response = authenticated_client.get(
+            "/resolve",
+            params={
+                "entity_type": "test_set",
+                "entity_id": "123e4567-e89b-12d3-a456-426614174000",
+            },
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Purpose
When a user opens an entity link while the wrong project is active, the API returns 404 and the UI previously showed a generic "not found" or "something went wrong" error. This change detects when the entity exists in another accessible project and offers a switch-project action instead.

## What Changed
- **Backend**: add `GET /resolve?entity_type=&entity_id=` to distinguish switchable, no-access, and true-not-found cases
- **Frontend**: unify entity detail not-found handling via `DetailNotFoundState`, `CrossProjectAlert`, and `not-found.tsx` / `error.tsx`
- **Frontend**: standardize server detail pages with `notFoundIfEntityMissing()` and client pages on direct `get*` fetches
- **Frontend**: add `EntityMessageState` and shared `entityEmptyStateSx` so cross-project / not-found UI matches empty-state card styling
- **Tests**: backend resolve route tests and frontend entity path parsing tests

## Additional Context
- Explorer routes resolve as `test_set` but display as **Session**
- Knowledge routes resolve as `source`
- Unrelated local RBAC work was left unstaged and is not part of this PR

## Test plan
- [ ] Open a test set (or other entity) URL from project A while project B is active — expect "in another project" card with switch action
- [ ] Switch project via the button and confirm the entity loads
- [ ] Open an entity ID you have no access to — expect no-access message
- [ ] Open a non-existent UUID — expect generic not-found card with back action
- [ ] Verify explorer (`/explorer/{id}`) shows Session label and resolves correctly
- [ ] `cd apps/backend && uv run pytest ../../tests/backend/routes/test_resolve.py -v`
- [ ] `cd apps/frontend && npm test -- --testPathPatterns=entity-error-handler`


<img width="965" height="491" alt="image" src="https://github.com/user-attachments/assets/1e69c18d-8fec-4cb1-add5-638aff8db83c" />
