### PR TITLE
Fix review indicators and conflicting-review detection

### DIFF
--- a/apps/backend/src/rhesis/backend/app/models/mixins.py
+++ b/apps/backend/src/rhesis/backend/app/models/mixins.py
@@ -321,7 +321,11 @@ class ReviewsMixin:
             review_status = last_review.get("status")
             if review_status and isinstance(review_status, dict):
                 review_status_id = review_status.get("status_id")
-                status_id = self._get_status_id_for_match()
+                # Prefer the pre-review snapshot: applying a review overwrites
+                # the live status to match the verdict, so comparing against
+                # it would always match and hide genuine disagreements.
+                metadata = self._get_reviews_data().get("metadata") or {}
+                status_id = metadata.get("original_status_id") or self._get_status_id_for_match()
                 if review_status_id and status_id:
                     matches = str(status_id) == str(review_status_id)
 

--- a/apps/backend/src/rhesis/backend/app/routers/test_result.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_result.py
@@ -712,9 +712,7 @@ def update_review(
     latest_status = review_to_update["status"]
     update_review_metadata(db_test_result.test_reviews, current_user, latest_status)
     if preserved_original_status_id is not None:
-        db_test_result.test_reviews["metadata"]["original_status_id"] = (
-            preserved_original_status_id
-        )
+        db_test_result.test_reviews["metadata"]["original_status_id"] = preserved_original_status_id
 
     # Mark as modified for SQLAlchemy
     flag_modified(db_test_result, "test_reviews")

--- a/apps/backend/src/rhesis/backend/app/routers/test_result.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_result.py
@@ -581,8 +581,23 @@ def add_review(
     # Add the review
     db_test_result.test_reviews["reviews"].append(new_review)
 
+    # Preserve any already-snapshotted original status before metadata gets
+    # rebuilt below (update_review_metadata overwrites the whole dict).
+    preserved_original_status_id = (db_test_result.test_reviews.get("metadata") or {}).get(
+        "original_status_id"
+    )
+
     # Update metadata
     update_review_metadata(db_test_result.test_reviews, current_user, status_details)
+
+    # Snapshot the automated status once, before apply_review_override() below
+    # overwrites status_id to match the reviewer's verdict. Without this,
+    # matches_review/classify_test_result_review_counts would compare the
+    # verdict against itself post-override and never detect a disagreement.
+    db_test_result.test_reviews["metadata"]["original_status_id"] = (
+        preserved_original_status_id
+        or (str(db_test_result.status_id) if db_test_result.status_id else None)
+    )
 
     # Mark as modified for SQLAlchemy
     flag_modified(db_test_result, "test_reviews")
@@ -687,9 +702,19 @@ def update_review(
     # Update timestamp
     review_to_update["updated_at"] = datetime.now(timezone.utc).isoformat()
 
+    # Preserve the snapshotted original status before metadata gets rebuilt
+    # below (update_review_metadata overwrites the whole dict).
+    preserved_original_status_id = (db_test_result.test_reviews.get("metadata") or {}).get(
+        "original_status_id"
+    )
+
     # Update metadata
     latest_status = review_to_update["status"]
     update_review_metadata(db_test_result.test_reviews, current_user, latest_status)
+    if preserved_original_status_id is not None:
+        db_test_result.test_reviews["metadata"]["original_status_id"] = (
+            preserved_original_status_id
+        )
 
     # Mark as modified for SQLAlchemy
     flag_modified(db_test_result, "test_reviews")
@@ -781,6 +806,9 @@ def delete_review(
 
     # Update metadata if there are remaining reviews
     if reviews:
+        preserved_original_status_id = (db_test_result.test_reviews.get("metadata") or {}).get(
+            "original_status_id"
+        )
         latest_review = max(
             reviews,
             key=lambda r: r.get("updated_at", r.get("created_at", "")),
@@ -791,6 +819,10 @@ def delete_review(
             current_user,
             latest_status,
         )
+        if preserved_original_status_id is not None:
+            db_test_result.test_reviews["metadata"]["original_status_id"] = (
+                preserved_original_status_id
+            )
     else:
         db_test_result.test_reviews["metadata"] = {
             "last_updated_at": datetime.now(timezone.utc).isoformat(),

--- a/apps/backend/src/rhesis/backend/app/services/review.py
+++ b/apps/backend/src/rhesis/backend/app/services/review.py
@@ -111,10 +111,15 @@ def classify_test_result_review_counts(
     )
     review_status = last_review.get("status") or {}
     review_status_id = review_status.get("status_id")
-    if not review_status_id or not status_id:
+    # Prefer the pre-review snapshot over the live status_id: applying a
+    # review overwrites the live status to match the verdict, so comparing
+    # against it would always match and hide genuine disagreements.
+    metadata = test_reviews.get("metadata") or {}
+    original_status_id = metadata.get("original_status_id") or status_id
+    if not review_status_id or not original_status_id:
         return is_reviewed, False
 
-    is_corrected = str(review_status_id) != str(status_id)
+    is_corrected = str(review_status_id) != str(original_status_id)
     return is_reviewed, is_corrected
 
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ReviewJudgementDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/ReviewJudgementDrawer.tsx
@@ -246,7 +246,11 @@ export default function ReviewJudgementDrawer({
         mentionableMetrics={mentionableMetrics}
         mentionableTurns={mentionableTurns}
         error={!!error && !selectedStatusId}
-        helperText="Add a comment to support your review decision"
+        helperText={
+          reason.trim().length < 10
+            ? `Minimum 10 characters required (${reason.trim().length}/10)`
+            : 'Add a comment to support your review decision'
+        }
         minRows={4}
       />
     </BaseDrawer>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsList.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsList.tsx
@@ -18,6 +18,7 @@ import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 import ChatIcon from '@mui/icons-material/Chat';
 import TaskIcon from '@mui/icons-material/Task';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import RateReviewOutlinedIcon from '@mui/icons-material/RateReviewOutlined';
 import {
   TestResultDetail,
   ConversationTurn,
@@ -27,6 +28,7 @@ import {
   hasConflictingReview,
   type TestResultStatus,
 } from '@/utils/test-result-status';
+import { resultHasAnyHumanReview } from './test-run-summary-utils';
 
 interface TestsListProps {
   tests: TestResultDetail[];
@@ -100,7 +102,7 @@ function TestListItem({
 
   // Check if there's a conflicting review
   const conflictingReview = hasConflictingReview(test);
-  const _hasHumanReview = !!test.last_review;
+  const reviewed = resultHasAnyHumanReview(test);
 
   // Truncate prompt content for display
   const truncatedPrompt =
@@ -243,7 +245,7 @@ function TestListItem({
               )}
 
               {/* Human Review Indicator */}
-              {conflictingReview && (
+              {conflictingReview ? (
                 <Tooltip
                   title={`Human review overrides automated result (${test.last_review?.user.name})`}
                   arrow
@@ -255,6 +257,17 @@ function TestListItem({
                     }}
                   />
                 </Tooltip>
+              ) : (
+                reviewed && (
+                  <Tooltip title="This test has been reviewed" arrow>
+                    <RateReviewOutlinedIcon
+                      sx={{
+                        fontSize: 14,
+                        color: 'text.secondary',
+                      }}
+                    />
+                  </Tooltip>
+                )
               )}
             </Box>
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsTableView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsTableView.tsx
@@ -46,6 +46,7 @@ import {
   getTestResultDisplayStatus,
   truncateText,
 } from './test-run-results-grid-utils';
+import { resultHasAnyHumanReview } from './test-run-summary-utils';
 import { EntityType } from '@/types/entity-type';
 
 interface TestsTableViewProps {
@@ -609,7 +610,7 @@ export default function TestsTableView({
                 width: '100%',
               }}
             >
-              {!test.last_review && (
+              {!resultHasAnyHumanReview(test) && (
                 <Tooltip title="Confirm Review">
                   <span>
                     <IconButton

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/test-run-results-grid-utils.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/test-run-results-grid-utils.ts
@@ -6,6 +6,7 @@ import {
   getTestEvaluationSummary,
   isPassedStatusName,
 } from '@/utils/test-result-status';
+import { getLatestMetricReviewForResult } from './test-run-summary-utils';
 
 export type TestResultDisplayStatus = {
   passed: boolean;
@@ -124,6 +125,28 @@ export function getTestResultDisplayStatus(
       };
     }
 
+    // No entity-level review, but a metric-targeted review may still exist.
+    const latestMetricReview = getLatestMetricReviewForResult(test);
+    if (latestMetricReview?.status?.name) {
+      const reviewPassed = isPassedStatusName(latestMetricReview.status.name);
+
+      return {
+        passed: originalPassed,
+        label: originalPassed ? 'Passed' : 'Failed',
+        count: `${metCriteria}/${totalCriteria}`,
+        isOverruled: true,
+        hasConflict: false,
+        automatedPassed: originalPassed,
+        hasExecutionError: false,
+        reviewData: {
+          reviewer: latestMetricReview.user?.name || 'Unknown',
+          comments: latestMetricReview.comments ?? '',
+          updated_at: latestMetricReview.updated_at,
+          newStatus: reviewPassed ? 'passed' : 'failed',
+        },
+      };
+    }
+
     return {
       passed: originalPassed,
       label: originalPassed ? 'Passed' : 'Failed',
@@ -171,6 +194,31 @@ export function getTestResultDisplayStatus(
         reviewer: lastReview.user?.name || 'Unknown',
         comments: lastReview.comments,
         updated_at: lastReview.updated_at,
+        newStatus: reviewPassed ? 'passed' : 'failed',
+      },
+    };
+  }
+
+  // No entity-level review, but a metric-targeted review may still exist
+  // (e.g. an @mention review left on a specific metric). last_review only
+  // tracks entity-level reviews, so without this the "Review" column would
+  // show "No manual review yet" even though the test has been reviewed.
+  const latestMetricReview = getLatestMetricReviewForResult(test);
+  if (latestMetricReview?.status?.name) {
+    const reviewPassed = isPassedStatusName(latestMetricReview.status.name);
+
+    return {
+      passed: originalPassed,
+      label: originalPassed ? 'Passed' : 'Failed',
+      count: `${passedMetrics}/${totalMetrics}`,
+      isOverruled: true,
+      hasConflict: false,
+      automatedPassed: originalPassed,
+      hasExecutionError: false,
+      reviewData: {
+        reviewer: latestMetricReview.user?.name || 'Unknown',
+        comments: latestMetricReview.comments ?? '',
+        updated_at: latestMetricReview.updated_at,
         newStatus: reviewPassed ? 'passed' : 'failed',
       },
     };

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/test-run-summary-utils.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/test-run-summary-utils.ts
@@ -111,10 +111,12 @@ export function findMetricKey(
   return Object.keys(metrics).find(key => metricNameMatches(key, metricName));
 }
 
-interface ResultReview {
+export interface ResultReview {
   status?: { name?: string };
   target?: { type?: string; reference?: string | null };
   comments?: string;
+  user?: { name?: string };
+  updated_at?: string;
 }
 
 function isTestResultReviewTarget(review: ResultReview): boolean {


### PR DESCRIPTION
## Purpose
Four test-run review bugs reported by QA: no min-character hint on review comments, metric-targeted reviews invisible in the grid, the "conflicting reviews" filter never matching anything, and stale review counts.

## What Changed
- Show a live "Minimum 10 characters required (X/10)" helper text on the review comment field instead of only surfacing it as a post-submit error.
- Fix the Review column/action in the Test Cases table and the split-view test list: they only checked entity-level `last_review`, so a review targeted at a specific metric (via `@mention`) never showed any indicator. Now falls back to the latest metric-targeted review.
- Fix `matches_review` (and the run-level "corrected" counts) always evaluating to `true` after any review: applying a review overwrites the test result's live `status_id` to match the verdict, and the comparison was reading that same overwritten value. Now snapshots the pre-review `status_id` once per test result and compares against that instead.

## Additional Context
Backend fix affects `test_reviews.metadata.original_status_id`, a new key in the existing JSONB blob — no migration needed, backward compatible with existing review data (falls back to live `status_id` when the snapshot is absent).

## Testing
- `tsc --noEmit` and `ruff check` pass on all changed files.
- Manual verification pending — recommend exercising: creating a metric-targeted review (`@mention` a metric) and confirming it shows in both the Test Cases table and split-view list; creating a review that disagrees with the automated result and confirming the "Conflicting" filter now surfaces it.