### PR TITLE
Normalize test type terminology to Single-Turn/Multi-Turn

### DIFF
--- a/apps/backend/src/rhesis/backend/app/constants.py
+++ b/apps/backend/src/rhesis/backend/app/constants.py
@@ -53,13 +53,20 @@ class TestType(str, Enum):
 
     @classmethod
     def from_string(cls, value: str):
-        """Get enum from string value (case-sensitive, accepts only allowed values)."""
+        """Get enum from string value, accepting canonical or snake_case forms."""
         if not value:
             return None
+        canonical = _TEST_TYPE_ALIASES.get(value, value)
         for test_type in cls:
-            if test_type.value == value:
+            if test_type.value == canonical:
                 return test_type
         return None
+
+
+_TEST_TYPE_ALIASES = {
+    "single_turn": "Single-Turn",
+    "multi_turn": "Multi-Turn",
+}
 
 
 # TestSetType Enum - DB-level test set classification aligned with initial_data.json type_lookup
@@ -76,11 +83,12 @@ class TestSetType(str, Enum):
 
     @classmethod
     def from_string(cls, value: str):
-        """Get enum from string value (case-sensitive, accepts only allowed values)."""
+        """Get enum from string value, accepting canonical or snake_case forms."""
         if not value:
             return None
+        canonical = _TEST_TYPE_ALIASES.get(value, value)
         for test_set_type in cls:
-            if test_set_type.value == value:
+            if test_set_type.value == canonical:
                 return test_set_type
         return None
 

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -275,8 +275,8 @@ def list_traces(
     trace_type: TraceType = Query(
         TraceType.ALL,
         description=(
-            "Filter: 'all' (default), 'single_turn' (no conversation_id), "
-            "'multi_turn' (has conversation_id)"
+            "Filter: 'all' (default), 'Single-Turn' (no conversation_id), "
+            "'Multi-Turn' (has conversation_id)"
         ),
     ),
     trace_metrics_status: Optional[TestResultStatus] = Query(

--- a/apps/backend/src/rhesis/backend/app/schemas/services.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/services.py
@@ -176,11 +176,24 @@ class TestPipelineRequest(BaseModel):
     prompt: str
     project_id: Optional[UUID4] = None
     previous_messages: Optional[List[IterationMessage]] = None
-    test_type: str = "single_turn"
+    test_type: str = TestSetType.SINGLE_TURN.value
     num_tests: int = Field(default=5, ge=1, le=20)
     sources: Optional[List[SourceData]] = None
     model_id: Optional[UUID4] = None
     config: Optional[TestConfigResponse] = None
+
+    @field_validator("test_type", mode="before")
+    @classmethod
+    def normalize_test_type(cls, v: Optional[str]) -> Optional[str]:
+        """Normalize test_type to canonical form, accepting snake_case (single_turn) or
+        hyphenated (Single-Turn) from any client."""
+        if v is None:
+            return TestSetType.SINGLE_TURN.value
+        resolved = TestSetType.from_string(v)
+        if resolved is None:
+            valid = [t.value for t in TestSetType]
+            raise ValueError(f"Unsupported test_type {v!r}. Valid values: {valid}")
+        return resolved.value
 
 
 class TestConfigRequest(BaseModel):

--- a/apps/backend/src/rhesis/backend/app/schemas/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/telemetry.py
@@ -41,8 +41,18 @@ class TraceType(str, Enum):
     """Filter traces by single-turn vs multi-turn (conversation)."""
 
     ALL = "all"
-    SINGLE_TURN = "single_turn"  # Traces without conversation_id
-    MULTI_TURN = "multi_turn"  # Traces with conversation_id
+    SINGLE_TURN = "Single-Turn"  # Traces without conversation_id
+    MULTI_TURN = "Multi-Turn"  # Traces with conversation_id
+
+    @classmethod
+    def _missing_(cls, value: object):
+        """Accept legacy snake_case query values during the canonical migration."""
+        if not isinstance(value, str):
+            return None
+        return {
+            "single_turn": cls.SINGLE_TURN,
+            "multi_turn": cls.MULTI_TURN,
+        }.get(value)
 
 
 # Re-export SDK schemas for backward compatibility

--- a/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
@@ -192,7 +192,7 @@ async def test_generation_pipeline_stream(
     organization_id: str,
     project_id: Optional[str] = None,
     previous_messages: Optional[list] = None,
-    test_type: str = "single_turn",
+    test_type: str = "Single-Turn",
     num_tests: int = 5,
     sources: Optional[List[SourceData]] = None,
     model_id: Optional[str] = None,
@@ -252,7 +252,7 @@ async def test_generation_pipeline_stream(
     tests_generated = 0
 
     try:
-        if test_type == "multi_turn":
+        if test_type == "Multi-Turn":
             config_dict = {
                 "generation_prompt": prompt,
                 "behaviors": active_behaviors,
@@ -271,7 +271,7 @@ async def test_generation_pipeline_stream(
                         "type": "test",
                         "index": test_index,
                         "test": test,
-                        "test_type": "multi_turn",
+                        "test_type": "Multi-Turn",
                     }
                 )
                 test_index += 1
@@ -302,7 +302,7 @@ async def test_generation_pipeline_stream(
                         "type": "test",
                         "index": test_index,
                         "test": test,
-                        "test_type": "single_turn",
+                        "test_type": "Single-Turn",
                     }
                 )
                 test_index += 1
@@ -331,7 +331,7 @@ async def test_generation_pipeline_stream(
                         "type": "test",
                         "index": test_index,
                         "test": test,
-                        "test_type": "single_turn",
+                        "test_type": "Single-Turn",
                     }
                 )
                 test_index += 1

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetFilterDrawer.tsx
@@ -9,7 +9,7 @@ import {
   filterDrawerTextFieldSx,
 } from '@/components/common/FilterDrawer';
 import { filterUniqueValidOptions } from '@/components/common/BaseDrawer';
-import { TEST_TYPES } from '@/constants/test-types';
+import { TEST_TYPE_FILTER_OPTIONS } from '@/constants/test-types';
 import { ENTITY_TYPES } from '@/utils/api-client/config';
 import { useStatuses, useUsers, useTags } from '@/hooks/useLookups';
 import ActivityPresenceFiltersSection from '@/components/common/ActivityPresenceFilters';
@@ -61,11 +61,6 @@ export function countActiveTestSetFilters(f: TestSetFilters): number {
     countActivePresenceFilters(f)
   );
 }
-
-const TEST_SET_TYPE_OPTIONS = [
-  { label: 'Single Turn', value: TEST_TYPES.SINGLE_TURN },
-  { label: 'Multi Turn', value: TEST_TYPES.MULTI_TURN },
-] as const;
 
 const textFieldSx = filterDrawerTextFieldSx;
 
@@ -163,7 +158,7 @@ export default function TestSetFilterDrawer({
     >
       <FilterSection title="Test Set Type">
         <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-          {TEST_SET_TYPE_OPTIONS.map(opt => (
+          {TEST_TYPE_FILTER_OPTIONS.map(opt => (
             <Box
               key={opt.value}
               component="button"

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -51,7 +51,7 @@ import {
 } from '@/components/common/createRowActionsColumn';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
-import { TEST_TYPES } from '@/constants/test-types';
+import { TEST_TYPE_PILL_TABS } from '@/constants/test-types';
 import GridBadge from '@/components/common/GridBadge';
 import { useQueryClient } from '@tanstack/react-query';
 import { testSetKeys } from '@/constants/query-keys';
@@ -85,11 +85,7 @@ const TestSetsToolbarContext = React.createContext<TestSetsToolbarState>({
   activeFilterCount: 0,
 });
 
-const PILL_TABS = [
-  { label: 'All', value: 'all' },
-  { label: 'Single Turn', value: TEST_TYPES.SINGLE_TURN },
-  { label: 'Multi Turn', value: TEST_TYPES.MULTI_TURN },
-];
+const PILL_TABS = TEST_TYPE_PILL_TABS;
 
 function TestSetsUnifiedToolbar() {
   const {

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/SelectTestCreationMethod.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/SelectTestCreationMethod.tsx
@@ -39,7 +39,7 @@ export default function SelectTestCreationMethod({
   onSelectAI,
   onSelectManual,
   onSelectTemplate,
-  testType = 'single_turn',
+  testType = 'Single-Turn',
 }: SelectTestCreationMethodProps) {
   const [showAllTemplates, setShowAllTemplates] = useState(false);
   const visibleTemplates = showAllTemplates ? TEMPLATES : TEMPLATES.slice(0, 4);
@@ -53,7 +53,7 @@ export default function SelectTestCreationMethod({
   }, [open, markStepComplete]);
 
   const testTypeLabel =
-    testType === 'single_turn' ? TEST_TYPES.SINGLE_TURN : TEST_TYPES.MULTI_TURN;
+    testType === 'Single-Turn' ? TEST_TYPES.SINGLE_TURN : TEST_TYPES.MULTI_TURN;
 
   const cards: SelectionCardConfig[] = [
     {

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestConfigurationConfirmation.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestConfigurationConfirmation.tsx
@@ -173,11 +173,11 @@ export default function TestConfigurationConfirmation({
                 </Typography>
                 <Chip
                   label={
-                    testType === 'single_turn'
+                    testType === 'Single-Turn'
                       ? 'Single-Turn Tests'
                       : 'Multi-Turn Tests'
                   }
-                  color={testType === 'single_turn' ? 'primary' : 'secondary'}
+                  color={testType === 'Single-Turn' ? 'primary' : 'secondary'}
                 />
               </Box>
 

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestGenerationFlow.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestGenerationFlow.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/utils/api-client/interfaces/test-set';
 import { Model } from '@/utils/api-client/interfaces/model';
 import { Source } from '@/utils/api-client/interfaces/source';
+import { normalizeTestType } from '@/constants/test-types';
 import TestInputScreen from './TestInputScreen';
 import TestGenerationInterface from './TestGenerationInterface';
 import TestConfigurationConfirmation from './TestConfigurationConfirmation';
@@ -100,7 +101,7 @@ const generateSamplesForTestType = async (
   numTests: number = 5,
   modelId?: string | null
 ): Promise<AnyTestSample[]> => {
-  if (testType === 'multi_turn') {
+  if (testType === 'Multi-Turn') {
     // Generate multi-turn tests
     const response = await servicesClient.generateMultiTurnTests({
       generation_prompt: description,
@@ -117,7 +118,7 @@ const generateSamplesForTestType = async (
           const t = test as GeneratedMultiTurnTest;
           return {
             id: `sample-${Date.now()}-${index}`,
-            testType: 'multi_turn',
+            testType: 'Multi-Turn',
             prompt: {
               goal: t.test_configuration.goal,
               instructions: t.test_configuration.instructions,
@@ -162,7 +163,7 @@ const generateSamplesForTestType = async (
         const t = test as GeneratedSingleTurnTest;
         return {
           id: `sample-${Date.now()}-${index}`,
-          testType: 'single_turn',
+          testType: 'Single-Turn',
           prompt: t.prompt.content,
           behavior: t.behavior,
           topic: t.topic,
@@ -208,11 +209,11 @@ const categoryColorVariant: Record<
 const convertTestEventToSample = (
   event: Extract<TestPipelineEvent, { type: 'test' }>
 ): AnyTestSample => {
-  if (event.test_type === 'multi_turn') {
+  if (event.test_type === 'Multi-Turn') {
     const t = event.test as unknown as GeneratedMultiTurnTest;
     return {
       id: `sample-${Date.now()}-${event.index}`,
-      testType: 'multi_turn',
+      testType: 'Multi-Turn',
       prompt: {
         goal: t.test_configuration.goal,
         instructions: t.test_configuration.instructions,
@@ -230,7 +231,7 @@ const convertTestEventToSample = (
   const t = event.test as unknown as GeneratedSingleTurnTest;
   return {
     id: `sample-${Date.now()}-${event.index}`,
-    testType: 'single_turn',
+    testType: 'Single-Turn',
     prompt: t.prompt.content,
     behavior: t.behavior,
     topic: t.topic,
@@ -261,10 +262,9 @@ export default function TestGenerationFlow({
     typeof window !== 'undefined' &&
     sessionStorage.getItem('selectedTemplateId') !== null;
 
-  // Get test type from sessionStorage
   const storedTestType =
     typeof window !== 'undefined'
-      ? (sessionStorage.getItem('testType') as TestType | null)
+      ? sessionStorage.getItem('testType')
       : null;
 
   // Navigation State - start with null to prevent premature rendering
@@ -275,7 +275,7 @@ export default function TestGenerationFlow({
     hasTemplate ? 'template' : 'ai'
   );
   const [testType, setTestType] = useState<TestType>(
-    storedTestType || 'single_turn'
+    normalizeTestType(storedTestType) as TestType
   );
 
   // Data State
@@ -587,7 +587,7 @@ export default function TestGenerationFlow({
           .map(c => c.label);
 
         // For single-turn tests, use rated samples
-        if (testType === 'single_turn' && sample.testType === 'single_turn') {
+        if (testType === 'Single-Turn' && sample.testType === 'Single-Turn') {
           const generationPrompt = `Generate an improved test case based on feedback: ${feedback}`;
 
           const ratedSample = {
@@ -621,7 +621,7 @@ export default function TestGenerationFlow({
             const t = response.tests[0] as GeneratedSingleTurnTest;
             const newSample: TestSample = {
               id: `sample-${Date.now()}-regenerated`,
-              testType: 'single_turn',
+              testType: 'Single-Turn',
               prompt: t?.prompt?.content || '',
               behavior: t?.behavior || '',
               topic: t?.topic || '',

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestGenerationFlow.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestGenerationFlow.tsx
@@ -263,9 +263,7 @@ export default function TestGenerationFlow({
     sessionStorage.getItem('selectedTemplateId') !== null;
 
   const storedTestType =
-    typeof window !== 'undefined'
-      ? sessionStorage.getItem('testType')
-      : null;
+    typeof window !== 'undefined' ? sessionStorage.getItem('testType') : null;
 
   // Navigation State - start with null to prevent premature rendering
   const [currentScreen, setCurrentScreen] = useState<FlowStep | null>(

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestGenerationInterface.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestGenerationInterface.tsx
@@ -193,8 +193,8 @@ export default function TestGenerationInterface({
 
         // Preserve conversation data for multi-turn
         if (
-          existingSample.testType === 'multi_turn' &&
-          newSample.testType === 'multi_turn'
+          existingSample.testType === 'Multi-Turn' &&
+          newSample.testType === 'Multi-Turn'
         ) {
           const mergedMultiTurn = merged as MultiTurnTestSample;
           if (existingSample.conversation) {
@@ -288,7 +288,7 @@ export default function TestGenerationInterface({
       setLocalTestSamples(prev =>
         prev.map(sample => {
           if (!samplesToFetch.some(s => s.id === sample.id)) return sample;
-          if (sample.testType === 'single_turn') {
+          if (sample.testType === 'Single-Turn') {
             const s = { ...sample, isLoadingResponse: true };
             delete s.response;
             delete s.responseError;
@@ -306,7 +306,7 @@ export default function TestGenerationInterface({
       // Fire all requests in parallel, updating each card as it resolves
       const promises = samplesToFetch.map(async sample => {
         try {
-          if (sample.testType === 'single_turn') {
+          if (sample.testType === 'Single-Turn') {
             const response = await invokeEndpointMutation.mutateAsync({
               id: selectedEndpointId,
               inputData: { input: sample.prompt },
@@ -377,7 +377,7 @@ export default function TestGenerationInterface({
           setLocalTestSamples(prev =>
             prev.map(s => {
               if (s.id !== sample.id) return s;
-              if (s.testType === 'single_turn') {
+              if (s.testType === 'Single-Turn') {
                 return {
                   ...s,
                   isLoadingResponse: false,
@@ -470,7 +470,7 @@ export default function TestGenerationInterface({
       const sample = localTestSamples.find(s => s.id === sampleId);
       if (!sample) return;
       if (processedSampleIds.has(sampleId) || sample.isLoadingResponse) return;
-      if (sample.testType === 'multi_turn' && sample.isLoadingConversation)
+      if (sample.testType === 'Multi-Turn' && sample.isLoadingConversation)
         return;
 
       const apiFactory = new ApiClientFactory(session.session_token);
@@ -480,7 +480,7 @@ export default function TestGenerationInterface({
       setLocalTestSamples(prev =>
         prev.map(s => {
           if (s.id !== sampleId) return s;
-          return s.testType === 'single_turn'
+          return s.testType === 'Single-Turn'
             ? {
                 ...s,
                 isLoadingResponse: true,
@@ -499,7 +499,7 @@ export default function TestGenerationInterface({
       );
 
       try {
-        if (sample.testType === 'single_turn') {
+        if (sample.testType === 'Single-Turn') {
           const response = await invokeEndpointMutation.mutateAsync({
             id: selectedEndpointId,
             inputData: { input: sample.prompt },
@@ -569,7 +569,7 @@ export default function TestGenerationInterface({
         setLocalTestSamples(prev =>
           prev.map(s => {
             if (s.id !== sampleId) return s;
-            return s.testType === 'single_turn'
+            return s.testType === 'Single-Turn'
               ? {
                   ...s,
                   isLoadingResponse: false,
@@ -953,13 +953,13 @@ export default function TestGenerationInterface({
                     </Typography>
                     <Chip
                       label={
-                        testType === 'single_turn'
+                        testType === 'Single-Turn'
                           ? TEST_TYPES.SINGLE_TURN
                           : TEST_TYPES.MULTI_TURN
                       }
                       size="small"
                       color={
-                        testType === 'single_turn' ? 'primary' : 'secondary'
+                        testType === 'Single-Turn' ? 'primary' : 'secondary'
                       }
                       sx={{ ml: 1 }}
                     />
@@ -1018,7 +1018,7 @@ export default function TestGenerationInterface({
                     >
                       {endpointInfo
                         ? endpointInfo.name
-                        : testType === 'multi_turn'
+                        : testType === 'Multi-Turn'
                           ? 'Show Live Responses'
                           : 'Show Live Responses'}
                     </Button>
@@ -1081,8 +1081,8 @@ export default function TestGenerationInterface({
                         projectName={endpointInfo?.projectName}
                         projectIcon={endpointInfo?.projectIcon}
                         actionButton={
-                          testType === 'multi_turn' &&
-                          sample.testType === 'multi_turn' &&
+                          testType === 'Multi-Turn' &&
+                          sample.testType === 'Multi-Turn' &&
                           selectedEndpointId ? (
                             <Button
                               variant="contained"

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestInputScreen.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestInputScreen.tsx
@@ -128,7 +128,7 @@ const SCAFFOLD_CATEGORIES = [
  */
 export default function TestInputScreen({
   sessionToken,
-  testType = 'single_turn',
+  testType = 'Single-Turn',
   onTestTypeChange,
   onContinue,
   initialDescription = '',
@@ -216,8 +216,8 @@ export default function TestInputScreen({
                 }}
                 size="small"
               >
-                <ToggleButton value="single_turn">Single-Turn</ToggleButton>
-                <ToggleButton value="multi_turn">Multi-Turn</ToggleButton>
+                <ToggleButton value="Single-Turn">Single-Turn</ToggleButton>
+                <ToggleButton value="Multi-Turn">Multi-Turn</ToggleButton>
               </ToggleButtonGroup>
             </Box>
           )}

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestTypeSelectionScreen.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/TestTypeSelectionScreen.tsx
@@ -33,7 +33,7 @@ export default function TestTypeSelectionScreen({
       iconColor: 'warning.main',
       buttonLabel: 'Select Single-Turn',
       buttonVariant: 'outlined',
-      onClick: () => onSelectTestType('single_turn'),
+      onClick: () => onSelectTestType('Single-Turn'),
       preview: (
         <ChatPreview
           messages={[
@@ -59,7 +59,7 @@ export default function TestTypeSelectionScreen({
       iconColor: 'secondary.main',
       buttonLabel: 'Select Multi-Turn',
       buttonVariant: 'contained',
-      onClick: () => onSelectTestType('multi_turn'),
+      onClick: () => onSelectTestType('Multi-Turn'),
       preview: (
         <ChatPreview
           messages={[

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/TestSampleCard.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/TestSampleCard.tsx
@@ -93,7 +93,7 @@ export default function TestSampleCard({
 
   // Determine what to display based on test type
   const displayText =
-    sample.testType === 'multi_turn' ? sample.prompt.goal : sample.prompt;
+    sample.testType === 'Multi-Turn' ? sample.prompt.goal : sample.prompt;
 
   return (
     <Card
@@ -152,7 +152,7 @@ export default function TestSampleCard({
                 color="success"
                 variant="outlined"
               />
-              {sample.testType === 'multi_turn' && (
+              {sample.testType === 'Multi-Turn' && (
                 <Chip
                   label={sample.category}
                   size="small"
@@ -186,7 +186,7 @@ export default function TestSampleCard({
                   py: 1,
                 }}
               >
-                {sample.testType === 'multi_turn' ? (
+                {sample.testType === 'Multi-Turn' ? (
                   <Box>
                     {/* Goal - Always Visible */}
                     <Typography
@@ -331,7 +331,7 @@ export default function TestSampleCard({
             </Box>
 
             {/* Single-turn response preview */}
-            {sample.testType === 'single_turn' &&
+            {sample.testType === 'Single-Turn' &&
               /* Single-turn response (Right-aligned) - if present or loading */
               (sample.response ||
                 sample.isLoadingResponse ||
@@ -446,7 +446,7 @@ export default function TestSampleCard({
         )}
 
         {/* Action Button - for multi-turn, show either simulate or view response button */}
-        {sample.testType === 'multi_turn' &&
+        {sample.testType === 'Multi-Turn' &&
           (actionButton ||
             sample.conversation ||
             sample.isLoadingConversation ||
@@ -488,7 +488,7 @@ export default function TestSampleCard({
           )}
 
         {/* Action Button - for single-turn, just show the action button if provided */}
-        {sample.testType === 'single_turn' && actionButton && (
+        {sample.testType === 'Single-Turn' && actionButton && (
           <Box
             sx={{
               mt: 2,
@@ -505,7 +505,7 @@ export default function TestSampleCard({
       </CardContent>
 
       {/* Conversation History Modal for Multi-Turn Tests */}
-      {sample.testType === 'multi_turn' && sample.conversation && (
+      {sample.testType === 'Multi-Turn' && sample.conversation && (
         <ConversationHistoryModal
           open={showConversationModal}
           onClose={() => setShowConversationModal(false)}

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/types.ts
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/types.ts
@@ -8,7 +8,7 @@ import { ConversationTurn } from '@/utils/api-client/interfaces/test-results';
 /**
  * Test type selection
  */
-export type TestType = 'single_turn' | 'multi_turn';
+export type TestType = 'Single-Turn' | 'Multi-Turn';
 
 /**
  * Multi-turn prompt structure
@@ -55,7 +55,7 @@ export interface ChipState {
  */
 export interface TestSample {
   id: string;
-  testType: 'single_turn';
+  testType: 'Single-Turn';
   prompt: string;
   response?: string;
   behavior: string;
@@ -72,7 +72,7 @@ export interface TestSample {
  */
 export interface MultiTurnTestSample {
   id: string;
-  testType: 'multi_turn';
+  testType: 'Multi-Turn';
   prompt: MultiTurnPrompt;
   response?: string;
   behavior: string;
@@ -112,7 +112,7 @@ export interface GenerationConfig {
   project: Project | null;
   behaviors: string[];
   purposes: string[];
-  testType: 'single_turn' | 'multi_turn';
+  testType: 'Single-Turn' | 'Multi-Turn';
   responseGeneration: 'prompt_only' | 'prompt_and_response';
   testCoverage: 'focused' | 'standard' | 'comprehensive';
   tags: string[];

--- a/apps/frontend/src/app/(protected)/tests/components/TestFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestFilterDrawer.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/common/FilterDrawer';
 import { filterUniqueValidOptions } from '@/components/common/BaseDrawer';
 import { ENTITY_TYPES } from '@/utils/api-client/config';
-import { TEST_TYPES } from '@/constants/test-types';
+import { TEST_TYPE_FILTER_OPTIONS } from '@/constants/test-types';
 import {
   useStatuses,
   useBehaviors,
@@ -72,11 +72,6 @@ export function countActiveTestFilters(f: TestFilters): number {
     countActivePresenceFilters(f)
   );
 }
-
-const TEST_TYPE_OPTIONS = [
-  { label: 'Single Turn', value: TEST_TYPES.SINGLE_TURN },
-  { label: 'Multi Turn', value: TEST_TYPES.MULTI_TURN },
-] as const;
 
 const textFieldSx = filterDrawerTextFieldSx;
 
@@ -185,7 +180,7 @@ export default function TestFilterDrawer({
     >
       <FilterSection title="Test Type">
         <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-          {TEST_TYPE_OPTIONS.map(opt => (
+          {TEST_TYPE_FILTER_OPTIONS.map(opt => (
             <Box
               key={opt.value}
               component="button"

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -65,7 +65,7 @@ import {
   renderTestContentCell,
 } from './test-grid-helpers';
 import { formatDate } from '@/utils/date';
-import { TEST_TYPES } from '@/constants/test-types';
+import { TEST_TYPE_PILL_TABS } from '@/constants/test-types';
 import {
   applyTestDrawerFiltersToModel,
   buildTestIdsODataFilter,
@@ -121,11 +121,7 @@ const TestsToolbarContext = React.createContext<TestsToolbarState>({
   setCheckboxSelectionMode: () => {},
 });
 
-const PILL_TABS = [
-  { label: 'All', value: 'all' },
-  { label: 'Single Turn', value: TEST_TYPES.SINGLE_TURN },
-  { label: 'Multi Turn', value: TEST_TYPES.MULTI_TURN },
-];
+const PILL_TABS = TEST_TYPE_PILL_TABS;
 
 function TestsUnifiedToolbar() {
   const {

--- a/apps/frontend/src/app/(protected)/tests/components/TrialDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TrialDrawer.tsx
@@ -98,7 +98,7 @@ export default function TrialDrawer({
     []
   );
   const [trialResponse, setTrialResponse] = useState<{
-    type: 'single_turn' | 'multi_turn';
+    type: 'Single-Turn' | 'Multi-Turn';
     output?: unknown;
     conversation?: ConversationTurn[];
     execution_time?: number;
@@ -348,7 +348,7 @@ export default function TrialDrawer({
         }
 
         setTrialResponse({
-          type: 'multi_turn',
+          type: 'Multi-Turn',
           conversation,
           execution_time: executeResponse.execution_time,
           status: executeResponse.status,
@@ -363,7 +363,7 @@ export default function TrialDrawer({
         });
 
         setTrialResponse({
-          type: 'single_turn',
+          type: 'Single-Turn',
           output: data?.output || data,
         });
       }
@@ -725,7 +725,7 @@ export default function TrialDrawer({
               >
                 Run the test to see the response
               </Typography>
-            ) : trialResponse.type === 'multi_turn' ? (
+            ) : trialResponse.type === 'Multi-Turn' ? (
               // Multi-turn response
               <Box>
                 {trialResponse.conversation &&

--- a/apps/frontend/src/app/(protected)/tests/new-manual/components/ManualTestWriter.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-manual/components/ManualTestWriter.tsx
@@ -51,16 +51,16 @@ import {
 } from '@/utils/api-client/interfaces/tests';
 import { UUID } from 'crypto';
 import { MultiTurnTestConfig } from '@/utils/api-client/interfaces/multi-turn-test-config';
-import { TEST_TYPES, TYPE_NAMES } from '@/constants/test-types';
+import { TEST_TYPES, TYPE_NAMES, normalizeTestType } from '@/constants/test-types';
 import MultiFileUpload from '@/components/common/MultiFileUpload';
 import { EntityType } from '@/types/entity-type';
 import { useTypeLookups } from '@/hooks/useLookups';
 
-type TestType = 'single_turn' | 'multi_turn';
+type TestType = 'Single-Turn' | 'Multi-Turn';
 
 interface SingleTurnTestCase {
   id: string;
-  testType: 'single_turn';
+  testType: 'Single-Turn';
   prompt: string;
   category: string;
   topic: string;
@@ -70,7 +70,7 @@ interface SingleTurnTestCase {
 
 interface MultiTurnTestCase {
   id: string;
-  testType: 'multi_turn';
+  testType: 'Multi-Turn';
   goal: string;
   instructions: string;
   restrictions: string;
@@ -93,10 +93,10 @@ export default function ManualTestWriter() {
 
   const [testType, setTestType] = useState<TestType>(() => {
     if (typeof window !== 'undefined') {
-      const storedType = sessionStorage.getItem('testType') as TestType | null;
-      return storedType || 'single_turn';
+      const storedType = sessionStorage.getItem('testType');
+      return normalizeTestType(storedType) as TestType;
     }
-    return 'single_turn';
+    return 'Single-Turn';
   });
 
   const handleTestTypeChange = (newType: TestType) => {
@@ -106,10 +106,10 @@ export default function ManualTestWriter() {
       sessionStorage.setItem('testType', newType);
     }
     const initialCase: TestCase =
-      newType === 'single_turn'
+      newType === 'Single-Turn'
         ? {
             id: '1',
-            testType: 'single_turn',
+            testType: 'Single-Turn',
             prompt: '',
             category: '',
             topic: '',
@@ -118,7 +118,7 @@ export default function ManualTestWriter() {
           }
         : {
             id: '1',
-            testType: 'multi_turn',
+            testType: 'Multi-Turn',
             goal: '',
             instructions: '',
             restrictions: '',
@@ -135,10 +135,10 @@ export default function ManualTestWriter() {
 
   const [testCases, setTestCases] = useState<TestCase[]>(() => {
     const initialTestCase: TestCase =
-      testType === 'single_turn'
+      testType === 'Single-Turn'
         ? {
             id: '1',
-            testType: 'single_turn',
+            testType: 'Single-Turn',
             prompt: '',
             category: '',
             topic: '',
@@ -147,7 +147,7 @@ export default function ManualTestWriter() {
           }
         : {
             id: '1',
-            testType: 'multi_turn',
+            testType: 'Multi-Turn',
             goal: '',
             instructions: '',
             restrictions: '',
@@ -178,7 +178,7 @@ export default function ManualTestWriter() {
   // Test set type ID resolved from testType
   const [testSetTypeId, setTestSetTypeId] = useState<UUID | undefined>();
   const testTypeValue =
-    testType === 'single_turn' ? TEST_TYPES.SINGLE_TURN : TEST_TYPES.MULTI_TURN;
+    testType === 'Single-Turn' ? TEST_TYPES.SINGLE_TURN : TEST_TYPES.MULTI_TURN;
   const { data: resolvedTestSetTypes } = useTypeLookups(
     session?.session_token ?? '',
     `type_name eq '${TYPE_NAMES.TEST_SET_TYPE}' and type_value eq '${testTypeValue}'`,
@@ -248,10 +248,10 @@ export default function ManualTestWriter() {
 
   const addNewRow = () => {
     const newTestCase: TestCase =
-      testType === 'single_turn'
+      testType === 'Single-Turn'
         ? {
             id: Date.now().toString(),
-            testType: 'single_turn',
+            testType: 'Single-Turn',
             prompt: '',
             category: '',
             topic: '',
@@ -260,7 +260,7 @@ export default function ManualTestWriter() {
           }
         : {
             id: Date.now().toString(),
-            testType: 'multi_turn',
+            testType: 'Multi-Turn',
             goal: '',
             instructions: '',
             restrictions: '',
@@ -298,7 +298,7 @@ export default function ManualTestWriter() {
   const handleSave = () => {
     // Filter out completely empty rows
     const nonEmptyTestCases = testCases.filter(tc => {
-      if (tc.testType === 'single_turn') {
+      if (tc.testType === 'Single-Turn') {
         return (
           tc.prompt.trim() ||
           tc.category.trim() ||
@@ -329,7 +329,7 @@ export default function ManualTestWriter() {
 
     // Validate that all non-empty rows have required fields filled
     const hasIncompleteRows = nonEmptyTestCases.some(tc => {
-      if (tc.testType === 'single_turn') {
+      if (tc.testType === 'Single-Turn') {
         return (
           !tc.prompt.trim() ||
           !tc.category.trim() ||
@@ -348,7 +348,7 @@ export default function ManualTestWriter() {
 
     if (hasIncompleteRows) {
       const requiredFields =
-        testType === 'single_turn'
+        testType === 'Single-Turn'
           ? 'Prompt, Category, Topic, Behavior'
           : 'Goal, Category, Topic, Behavior';
       notifications.show(
@@ -373,7 +373,7 @@ export default function ManualTestWriter() {
 
       // Filter out completely empty rows
       const nonEmptyTestCases = testCases.filter(tc => {
-        if (tc.testType === 'single_turn') {
+        if (tc.testType === 'Single-Turn') {
           return (
             tc.prompt.trim() ||
             tc.category.trim() ||
@@ -500,7 +500,7 @@ export default function ManualTestWriter() {
 
   /** Build payload for single createTest (returns ID for file upload). */
   const buildTestPayload = (tc: TestCase): TestCreate => {
-    if (tc.testType === 'single_turn') {
+    if (tc.testType === 'Single-Turn') {
       const prompt: TestPromptCreate = {
         content: tc.prompt,
         expected_response: tc.expectedOutput || undefined,
@@ -530,7 +530,7 @@ export default function ManualTestWriter() {
 
   /** Build payload for bulk createTestsBulk (no file support). */
   const buildBulkPayload = (tc: TestCase): TestBulkCreate => {
-    if (tc.testType === 'single_turn') {
+    if (tc.testType === 'Single-Turn') {
       return {
         prompt: {
           content: tc.prompt,
@@ -673,8 +673,8 @@ export default function ManualTestWriter() {
                 }}
                 size="small"
               >
-                <ToggleButton value="single_turn">Single-Turn</ToggleButton>
-                <ToggleButton value="multi_turn">Multi-Turn</ToggleButton>
+                <ToggleButton value="Single-Turn">Single-Turn</ToggleButton>
+                <ToggleButton value="Multi-Turn">Multi-Turn</ToggleButton>
               </ToggleButtonGroup>
             </Box>
             <TableContainer
@@ -753,7 +753,7 @@ export default function ManualTestWriter() {
               <Table>
                 <TableHead>
                   <TableRow>
-                    {testType === 'single_turn' ? (
+                    {testType === 'Single-Turn' ? (
                       <>
                         <TableCell sx={{ minWidth: 300 }}>
                           Test Prompt *
@@ -792,7 +792,7 @@ export default function ManualTestWriter() {
                 <TableBody>
                   {testCases.map(testCase => (
                     <TableRow key={testCase.id}>
-                      {testCase.testType === 'single_turn' ? (
+                      {testCase.testType === 'Single-Turn' ? (
                         <>
                           <TableCell sx={{ p: 1 }}>
                             <TextField

--- a/apps/frontend/src/app/(protected)/tests/new-manual/components/ManualTestWriter.tsx
+++ b/apps/frontend/src/app/(protected)/tests/new-manual/components/ManualTestWriter.tsx
@@ -51,7 +51,11 @@ import {
 } from '@/utils/api-client/interfaces/tests';
 import { UUID } from 'crypto';
 import { MultiTurnTestConfig } from '@/utils/api-client/interfaces/multi-turn-test-config';
-import { TEST_TYPES, TYPE_NAMES, normalizeTestType } from '@/constants/test-types';
+import {
+  TEST_TYPES,
+  TYPE_NAMES,
+  normalizeTestType,
+} from '@/constants/test-types';
 import MultiFileUpload from '@/components/common/MultiFileUpload';
 import { EntityType } from '@/types/entity-type';
 import { useTypeLookups } from '@/hooks/useLookups';

--- a/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
@@ -22,6 +22,7 @@ import { isPassedStatusName } from '@/utils/test-result-status';
 import { formatDistanceToNowStrict } from 'date-fns';
 import { formatDuration } from '@/utils/format-duration';
 import { formatDate } from '@/utils/date';
+import { TEST_TYPE_PILL_TABS } from '@/constants/test-types';
 import TraceFilterDrawer, {
   type TraceDrawerFilters,
 } from './TraceFilterDrawer';
@@ -30,11 +31,7 @@ import {
   countActiveTraceDrawerFilters,
 } from './trace-filter-params';
 
-const PILL_TABS = [
-  { label: 'All', value: 'all' },
-  { label: 'Single Turn', value: 'Single-Turn' },
-  { label: 'Multi Turn', value: 'Multi-Turn' },
-];
+const PILL_TABS = TEST_TYPE_PILL_TABS;
 
 interface TracesToolbarState {
   searchQuery: string;

--- a/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TracesTable.tsx
@@ -32,8 +32,8 @@ import {
 
 const PILL_TABS = [
   { label: 'All', value: 'all' },
-  { label: 'Single Turn', value: 'single_turn' },
-  { label: 'Multi Turn', value: 'multi_turn' },
+  { label: 'Single Turn', value: 'Single-Turn' },
+  { label: 'Multi Turn', value: 'Multi-Turn' },
 ];
 
 interface TracesToolbarState {

--- a/apps/frontend/src/app/(protected)/traces/components/__tests__/trace-filter-params.test.ts
+++ b/apps/frontend/src/app/(protected)/traces/components/__tests__/trace-filter-params.test.ts
@@ -15,7 +15,7 @@ describe('trace-filter-params', () => {
         timeRange: '24h',
       },
       'llm.invoke',
-      'single_turn',
+      'Single-Turn',
       50,
       0
     );
@@ -23,7 +23,7 @@ describe('trace-filter-params', () => {
     expect(params.project_id).toBe('proj-1');
     expect(params.trace_source).toBe('test');
     expect(params.search).toBe('llm.invoke');
-    expect(params.trace_type).toBe('single_turn');
+    expect(params.trace_type).toBe('Single-Turn');
     expect(params.start_time_after).toBeDefined();
     expect(params.limit).toBe(50);
     expect(params.offset).toBe(0);

--- a/apps/frontend/src/constants/__tests__/test-types.test.ts
+++ b/apps/frontend/src/constants/__tests__/test-types.test.ts
@@ -1,5 +1,7 @@
 import {
   TEST_TYPES,
+  TEST_TYPE_FILTER_OPTIONS,
+  TEST_TYPE_PILL_TABS,
   getTestType,
   isMultiTurnTest,
   isSingleTurnTest,
@@ -87,5 +89,21 @@ describe('TEST_TYPES constants', () => {
   it('has expected values', () => {
     expect(TEST_TYPES.SINGLE_TURN).toBe('Single-Turn');
     expect(TEST_TYPES.MULTI_TURN).toBe('Multi-Turn');
+  });
+});
+
+describe('TEST_TYPE_FILTER_OPTIONS', () => {
+  it('uses hyphenated labels matching canonical values', () => {
+    expect(TEST_TYPE_FILTER_OPTIONS).toEqual([
+      { label: 'Single-Turn', value: 'Single-Turn' },
+      { label: 'Multi-Turn', value: 'Multi-Turn' },
+    ]);
+  });
+});
+
+describe('TEST_TYPE_PILL_TABS', () => {
+  it('includes All plus filter options', () => {
+    expect(TEST_TYPE_PILL_TABS[0]).toEqual({ label: 'All', value: 'all' });
+    expect(TEST_TYPE_PILL_TABS.slice(1)).toEqual([...TEST_TYPE_FILTER_OPTIONS]);
   });
 });

--- a/apps/frontend/src/constants/__tests__/test-types.test.ts
+++ b/apps/frontend/src/constants/__tests__/test-types.test.ts
@@ -3,6 +3,7 @@ import {
   getTestType,
   isMultiTurnTest,
   isSingleTurnTest,
+  normalizeTestType,
 } from '../test-types';
 
 describe('getTestType', () => {
@@ -15,6 +16,11 @@ describe('getTestType', () => {
     expect(getTestType('single-turn')).toBe(TEST_TYPES.SINGLE_TURN);
     expect(getTestType('MULTI-TURN')).toBe(TEST_TYPES.MULTI_TURN);
     expect(getTestType('Single-turn')).toBe(TEST_TYPES.SINGLE_TURN);
+  });
+
+  it('accepts legacy snake_case aliases', () => {
+    expect(getTestType('single_turn')).toBe(TEST_TYPES.SINGLE_TURN);
+    expect(getTestType('multi_turn')).toBe(TEST_TYPES.MULTI_TURN);
   });
 
   it('returns null for unknown types', () => {
@@ -60,6 +66,20 @@ describe('isSingleTurnTest', () => {
   it('returns false for null/undefined', () => {
     expect(isSingleTurnTest(null)).toBe(false);
     expect(isSingleTurnTest(undefined)).toBe(false);
+  });
+});
+
+describe('normalizeTestType', () => {
+  it('returns canonical values for known inputs', () => {
+    expect(normalizeTestType('Single-Turn')).toBe(TEST_TYPES.SINGLE_TURN);
+    expect(normalizeTestType('multi_turn')).toBe(TEST_TYPES.MULTI_TURN);
+  });
+
+  it('falls back for unknown values', () => {
+    expect(normalizeTestType('unknown')).toBe(TEST_TYPES.SINGLE_TURN);
+    expect(normalizeTestType(null, TEST_TYPES.MULTI_TURN)).toBe(
+      TEST_TYPES.MULTI_TURN
+    );
   });
 });
 

--- a/apps/frontend/src/constants/test-types.ts
+++ b/apps/frontend/src/constants/test-types.ts
@@ -20,6 +20,18 @@ export const TEST_TYPES = {
  */
 export type TestTypeValue = (typeof TEST_TYPES)[keyof typeof TEST_TYPES];
 
+/** Filter/dropdown options — label matches the canonical value. */
+export const TEST_TYPE_FILTER_OPTIONS = [
+  { label: TEST_TYPES.SINGLE_TURN, value: TEST_TYPES.SINGLE_TURN },
+  { label: TEST_TYPES.MULTI_TURN, value: TEST_TYPES.MULTI_TURN },
+] as const;
+
+/** Grid toolbar pill tabs including "All". */
+export const TEST_TYPE_PILL_TABS = [
+  { label: 'All', value: 'all' },
+  ...TEST_TYPE_FILTER_OPTIONS,
+] as const;
+
 const TEST_TYPE_ALIASES: Record<string, TestTypeValue> = {
   single_turn: TEST_TYPES.SINGLE_TURN,
   multi_turn: TEST_TYPES.MULTI_TURN,

--- a/apps/frontend/src/constants/test-types.ts
+++ b/apps/frontend/src/constants/test-types.ts
@@ -21,16 +21,19 @@ export const TEST_TYPES = {
 export type TestTypeValue = (typeof TEST_TYPES)[keyof typeof TEST_TYPES];
 
 /** Filter/dropdown options — label matches the canonical value. */
-export const TEST_TYPE_FILTER_OPTIONS = [
+export const TEST_TYPE_FILTER_OPTIONS: {
+  label: TestTypeValue;
+  value: TestTypeValue;
+}[] = [
   { label: TEST_TYPES.SINGLE_TURN, value: TEST_TYPES.SINGLE_TURN },
   { label: TEST_TYPES.MULTI_TURN, value: TEST_TYPES.MULTI_TURN },
-] as const;
+];
 
 /** Grid toolbar pill tabs including "All". */
-export const TEST_TYPE_PILL_TABS = [
+export const TEST_TYPE_PILL_TABS: { label: string; value: string }[] = [
   { label: 'All', value: 'all' },
   ...TEST_TYPE_FILTER_OPTIONS,
-] as const;
+];
 
 const TEST_TYPE_ALIASES: Record<string, TestTypeValue> = {
   single_turn: TEST_TYPES.SINGLE_TURN,

--- a/apps/frontend/src/constants/test-types.ts
+++ b/apps/frontend/src/constants/test-types.ts
@@ -20,6 +20,11 @@ export const TEST_TYPES = {
  */
 export type TestTypeValue = (typeof TEST_TYPES)[keyof typeof TEST_TYPES];
 
+const TEST_TYPE_ALIASES: Record<string, TestTypeValue> = {
+  single_turn: TEST_TYPES.SINGLE_TURN,
+  multi_turn: TEST_TYPES.MULTI_TURN,
+};
+
 /**
  * Check if a string value matches a known test type (case-insensitive)
  * @param value The value to check
@@ -30,12 +35,25 @@ export function getTestType(
 ): TestTypeValue | null {
   if (!value) return null;
 
+  const alias = TEST_TYPE_ALIASES[value.toLowerCase()];
+  if (alias) return alias;
+
   const valueLower = value.toLowerCase();
   const entries = Object.values(TEST_TYPES);
 
   return (
     entries.find(testType => testType.toLowerCase() === valueLower) || null
   );
+}
+
+/**
+ * Normalize legacy or variant test type strings to canonical values.
+ */
+export function normalizeTestType(
+  value: string | undefined | null,
+  fallback: TestTypeValue = TEST_TYPES.SINGLE_TURN
+): TestTypeValue {
+  return getTestType(value) ?? fallback;
 }
 
 /**

--- a/apps/frontend/src/utils/api-client/interfaces/multi-turn-test-config.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/multi-turn-test-config.ts
@@ -2,7 +2,7 @@
  * Multi-turn test configuration interfaces.
  *
  * These define the structure stored in test.test_configuration JSON
- * for multi-turn tests (when test_type is multi-turn).
+ * for multi-turn tests (when test_type is Multi-Turn).
  */
 
 export interface MultiTurnTestConfig {

--- a/apps/frontend/src/utils/api-client/interfaces/telemetry.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/telemetry.ts
@@ -224,7 +224,7 @@ export type TraceSource = 'all' | 'test' | 'operation';
 /**
  * Trace type filter enum (single-turn vs multi-turn)
  */
-export type TraceType = 'all' | 'single_turn' | 'multi_turn';
+export type TraceType = 'all' | 'Single-Turn' | 'Multi-Turn';
 
 /**
  * Evaluation status for trace metrics (Pass/Fail/Error)
@@ -258,7 +258,7 @@ export interface TraceQueryParams {
   test_id?: string;
   endpoint_id?: string; // Filter by endpoint ID
   trace_source?: TraceSource; // Filter by trace source (all/test/operation)
-  trace_type?: TraceType; // Filter by trace type (all/single_turn/multi_turn)
+  trace_type?: TraceType; // Filter by trace type (all/Single-Turn/Multi-Turn)
   trace_metrics_status?: TraceMetricsStatus;
   root_spans_only?: boolean; // Return only root spans (defaults to true in backend)
   limit?: number;

--- a/apps/frontend/src/utils/api-client/interfaces/test-set.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/test-set.ts
@@ -319,7 +319,7 @@ export interface GenerateTestsRequest {
   batch_size?: number;
   sources?: SourceData[];
   name?: string; // Only used for bulk generation
-  test_type?: 'single_turn' | 'multi_turn'; // Type of tests to generate
+  test_type?: 'Single-Turn' | 'Multi-Turn'; // Type of tests to generate
   model_id?: string; // Override user's default generation model for this request
   project_id?: string; // Required for bulk generation via POST /test_sets/generate
 }

--- a/tests/backend/services/test_test_generation_pipeline.py
+++ b/tests/backend/services/test_test_generation_pipeline.py
@@ -499,7 +499,7 @@ class TestPipelineStream:
 
         test_events = [e for e in events if e["type"] == "test"]
         assert len(test_events) == 2
-        assert all(e["test_type"] == "single_turn" for e in test_events)
+        assert all(e["test_type"] == "Single-Turn" for e in test_events)
 
         done_event = next(e for e in events if e["type"] == "tests_done")
         assert done_event["total"] == 2
@@ -552,14 +552,14 @@ class TestPipelineStream:
                     user=user,
                     prompt="test chatbot",
                     organization_id=org_id,
-                    test_type="multi_turn",
+                    test_type="Multi-Turn",
                     num_tests=1,
                 )
             )
 
         test_events = [e for e in events if e["type"] == "test"]
         assert len(test_events) == 1
-        assert test_events[0]["test_type"] == "multi_turn"
+        assert test_events[0]["test_type"] == "Multi-Turn"
         mock_gen.assert_called_once()
 
     async def test_config_failure_aborts_pipeline(self):

--- a/tests/backend/test_constants.py
+++ b/tests/backend/test_constants.py
@@ -1,6 +1,8 @@
 """Tests for backend constants."""
 
-from rhesis.backend.app.constants import TestExecutionContext
+import pytest
+
+from rhesis.backend.app.constants import TestExecutionContext, TestSetType, TestType
 
 
 def test_test_execution_context_has_context_key():
@@ -85,3 +87,17 @@ def test_backend_and_sdk_constants_match():
         TestExecutionContext.SpanAttributes.TEST_CONFIGURATION_ID
         == SDKTestContext.SpanAttributes.TEST_CONFIGURATION_ID
     )
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Single-Turn", TestType.SINGLE_TURN),
+        ("Multi-Turn", TestType.MULTI_TURN),
+        ("single_turn", TestType.SINGLE_TURN),
+        ("multi_turn", TestType.MULTI_TURN),
+    ],
+)
+def test_test_type_from_string_accepts_canonical_and_legacy_aliases(raw, expected):
+    assert TestType.from_string(raw) == expected
+    assert TestSetType.from_string(raw) == TestSetType(expected.value)

--- a/tests/backend/test_constants.py
+++ b/tests/backend/test_constants.py
@@ -75,8 +75,7 @@ def test_backend_and_sdk_constants_match():
 
     # Span attributes should match
     assert (
-        TestExecutionContext.SpanAttributes.TEST_RUN_ID
-        == SDKTestContext.SpanAttributes.TEST_RUN_ID
+        TestExecutionContext.SpanAttributes.TEST_RUN_ID == SDKTestContext.SpanAttributes.TEST_RUN_ID
     )
     assert TestExecutionContext.SpanAttributes.TEST_ID == SDKTestContext.SpanAttributes.TEST_ID
     assert (


### PR DESCRIPTION
## Purpose
Unify test type terminology across the application. Release still mixed snake_case (`single_turn`/`multi_turn`) with canonical `Single-Turn`/`Multi-Turn` values in enums, pipelines, and parts of the UI.

## What Changed
- Backend: accept legacy snake_case aliases in `TestType`/`TestSetType.from_string`, normalize `TestPipelineRequest.test_type`, and use canonical values in the generation pipeline
- Backend: align `TraceType` filter values to `Single-Turn`/`Multi-Turn` while still accepting legacy query params
- Frontend: add `normalizeTestType()` and switch test generation, manual writer, and traces to canonical literals
- Frontend: add shared `TEST_TYPE_FILTER_OPTIONS` / `TEST_TYPE_PILL_TABS` so filter labels match canonical values everywhere
- Tests updated for alias acceptance and canonical pipeline output

## Additional Context
- Follow-up to #1535 (centralized test type validation) — completes the normalization that was only partially landed on release
- Endpoint `conversation_mode` (`single_turn`/`stateless`/`stateful`) is intentionally unchanged; it is a separate concept from test classification

## Testing
- [x] `npm test -- --testPathPatterns="test-types|trace-filter-params"` (21 passed)
- [x] `RHESIS_SKIP_MIGRATIONS=1 uv run pytest ../../tests/backend/test_constants.py::test_test_type_from_string_accepts_canonical_and_legacy_aliases` (4 passed)