### PR TITLE
Temporarily disable Cluster View tab on test sets

### DIFF
--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
@@ -86,7 +86,7 @@ export default function EmbeddingTestsPanel({
   const theme = useTheme();
   const router = useRouter();
   const [activeTab, setActiveTab] = useState(LIST_VIEW_TAB);
-  const clustersActive = activeTab === CLUSTER_VIEW_TAB;
+  const clustersActive = CLUSTER_VIEW_ENABLED && activeTab === CLUSTER_VIEW_TAB;
 
   const { graph, isLoading, isComputing, error, computeGraph } =
     useEmbeddingGraph(testSetId, sessionToken, { enabled: clustersActive });

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/EmbeddingTestsPanel.tsx
@@ -67,6 +67,9 @@ const HOVER_LIST_WIDTH = '38%';
 const LIST_VIEW_TAB = 0;
 const CLUSTER_VIEW_TAB = 1;
 
+// TODO: re-enable once embedding cluster view issues are resolved
+const CLUSTER_VIEW_ENABLED = false;
+
 interface EmbeddingTestsPanelProps {
   testSetId: string;
   sessionToken: string;
@@ -279,26 +282,28 @@ export default function EmbeddingTestsPanel({
             : undefined,
       }}
     >
-      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs
-          value={activeTab}
-          onChange={(_, tabIndex: number) => setActiveTab(tabIndex)}
-          aria-label="Tests view"
-        >
-          <Tab
-            label="List View"
-            icon={<ViewListIcon fontSize="small" />}
-            iconPosition="start"
-          />
-          <Tab
-            label="Cluster View"
-            icon={<BubbleChartOutlinedIcon fontSize="small" />}
-            iconPosition="start"
-          />
-        </Tabs>
-      </Box>
+      {CLUSTER_VIEW_ENABLED && (
+        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+          <Tabs
+            value={activeTab}
+            onChange={(_, tabIndex: number) => setActiveTab(tabIndex)}
+            aria-label="Tests view"
+          >
+            <Tab
+              label="List View"
+              icon={<ViewListIcon fontSize="small" />}
+              iconPosition="start"
+            />
+            <Tab
+              label="Cluster View"
+              icon={<BubbleChartOutlinedIcon fontSize="small" />}
+              iconPosition="start"
+            />
+          </Tabs>
+        </Box>
+      )}
 
-      {activeTab === LIST_VIEW_TAB && (
+      {(!CLUSTER_VIEW_ENABLED || activeTab === LIST_VIEW_TAB) && (
         <Box sx={{ p: 2.5, width: '100%', minHeight: 400 }}>
           <TestSetTestsGrid
             testSetId={testSetId}
@@ -310,7 +315,7 @@ export default function EmbeddingTestsPanel({
         </Box>
       )}
 
-      {activeTab === CLUSTER_VIEW_TAB && (
+      {CLUSTER_VIEW_ENABLED && activeTab === CLUSTER_VIEW_TAB && (
         <Box
           sx={{
             p: 2.5,


### PR DESCRIPTION
## Purpose
Hide the Cluster View tab on the test set detail page. The embedding graph that powers it is currently unstable and can fail to generate.

## What Changed
- Added a `CLUSTER_VIEW_ENABLED` flag (currently `false`) to `EmbeddingTestsPanel.tsx`, hiding the tab and always showing List View.
- No backend changes — this only affects what's shown in the UI.

## Why it's unstable
Two separate issues currently affect embedding generation, either of which can leave the cluster graph empty or broken:

1. **Missing tenant context.** The background task that computes the graph is missing required context (organization) when queued from a couple of places (test sets and sources). When that happens, the task fails outright instead of producing a graph.

2. **Wrong Vertex AI region.** Embeddings are generated via Google Vertex AI, currently configured to use the `eu` multi-region alias. That alias works for some Vertex AI resources (e.g. Feature Store, newer unified Gemini endpoints), but not for Publisher/Model-Garden model calls (`publishers/google/models/*`) — which is exactly the API embeddings use. So embedding requests fail with a 404 regardless of which embedding model is configured. This needs to be reverted to a concrete region (previously `europe-west4`, which is confirmed working).

## Additional Context
This is a stopgap, not a fix. Both underlying issues need a proper follow-up before Cluster View is re-enabled.

## Testing
- Verified the test set detail page shows only List View with no Cluster View tab.