### PR TITLE
Normalize test_type at pipeline entry

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud
 from rhesis.backend.app.config.settings import get_model_settings
+from rhesis.backend.app.constants import TestSetType
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.schemas.services import (
     SourceData,
@@ -212,6 +213,10 @@ async def test_generation_pipeline_stream(
       - ``{"type": "error", "phase": str, "message": str}``
       - ``{"type": "done"}``
     """
+    resolved_type = TestSetType.from_string(test_type)
+    if resolved_type is None:
+        resolved_type = TestSetType.SINGLE_TURN
+    test_type = resolved_type.value
 
     config_response: Optional[TestConfigResponse] = config
 

--- a/tests/backend/services/test_test_generation_pipeline.py
+++ b/tests/backend/services/test_test_generation_pipeline.py
@@ -562,6 +562,54 @@ class TestPipelineStream:
         assert test_events[0]["test_type"] == "Multi-Turn"
         mock_gen.assert_called_once()
 
+    async def test_multi_turn_pipeline_accepts_legacy_snake_case_alias(self):
+        """Direct pipeline calls normalize legacy multi_turn to Multi-Turn."""
+        user = _make_user()
+        mock_db = MagicMock()
+        org_id = str(uuid.uuid4())
+
+        llm = _streaming_llm(
+            behaviors=[{"name": "B", "description": "d", "active": True}],
+            topics=[{"name": "T", "description": "d", "active": True}],
+            categories=[{"name": "C", "description": "d", "active": True}],
+        )
+
+        fake_tests = [{"test_configuration": {"goal": "test goal"}, "behavior": "B"}]
+
+        async def _fake_stream(**kwargs):
+            for t in fake_tests:
+                yield t
+
+        with (
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._resolve_config_llm",
+                return_value=llm,
+            ),
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline._fetch_db_context",
+                return_value=_db_context(),
+            ),
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline.generate_multiturn_tests_stream",
+                side_effect=_fake_stream,
+            ) as mock_gen,
+        ):
+            events = await _collect_ndjson(
+                test_generation_pipeline_stream(
+                    db=mock_db,
+                    user=user,
+                    prompt="test chatbot",
+                    organization_id=org_id,
+                    test_type="multi_turn",
+                    num_tests=1,
+                )
+            )
+
+        test_events = [e for e in events if e["type"] == "test"]
+        assert len(test_events) == 1
+        assert test_events[0]["test_type"] == "Multi-Turn"
+        mock_gen.assert_called_once()
+
     async def test_config_failure_aborts_pipeline(self):
         """If config generation fails, pipeline skips Phase 2 entirely."""
         user = _make_user()


### PR DESCRIPTION
## Purpose
Follow-up to #2149 (peqy review). The HTTP route normalizes `test_type` via `TestPipelineRequest`, but `test_generation_pipeline_stream()` still branched on the raw string `== 'Multi-Turn'`, so direct callers with legacy `multi_turn` silently took the single-turn path.

## What Changed
- Normalize `test_type` via `TestSetType.from_string()` at the start of `test_generation_pipeline_stream()`
- Add `test_multi_turn_pipeline_accepts_legacy_snake_case_alias` test

## Additional Context
- Cherry-pick of `6a19535f5` from `feat/normalize-test-types`, which landed after #2149 was merged

## Testing
- [x] `RHESIS_SKIP_MIGRATIONS=1 uv run pytest ../../tests/backend/services/test_test_generation_pipeline.py::TestPipelineStream::test_multi_turn_pipeline_accepts_legacy_snake_case_alias`
- [x] `uvx ruff check` on changed files