### PR TITLE
Fix missing project member roles after org RBAC backfill

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/f9e8d7c6b5a4_backfill_project_membership_role_catchup.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/f9e8d7c6b5a4_backfill_project_membership_role_catchup.py
@@ -1,0 +1,54 @@
+"""Catch-up backfill for project_membership.role_id missed by e3f4a5b6c7d8
+
+Migration ``e3f4a5b6c7d8`` copied ``organization_member.role_id`` into
+``project_membership.role_id`` where the project role was still NULL.  That
+one-shot ran before some orgs had ``organization_member`` rows (RBAC-dark
+onboarding), so their project memberships stayed NULL even after the org
+catch-up (``f8e9a0b1c2d4``) repaired ``organization_member``.
+
+Members with NULL project roles still inherit their org role for authorization
+(see ``PermissionAuthorizationProvider._resolve_role``), but
+``GET /rbac/projects/{id}/members`` reads the stored column and the Members tab
+shows "—".
+
+This migration re-runs the same idempotent UPDATE as e3f4a5b6c7d8.  Rows that
+already have an explicit project role are untouched.
+
+Revision ID: f9e8d7c6b5a4
+Revises: f8e9a0b1c2d4
+Create Date: 2026-07-10
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f9e8d7c6b5a4"
+down_revision: Union[str, None] = "f8e9a0b1c2d4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    result = conn.execute(
+        sa.text(
+            """
+            UPDATE project_membership pm
+            SET    role_id = om.role_id
+            FROM   organization_member om
+            WHERE  pm.user_id         = om.user_id
+              AND  pm.organization_id = om.organization_id
+              AND  pm.role_id         IS NULL
+              AND  om.role_id         IS NOT NULL
+            """
+        )
+    )
+    updated = result.rowcount if result.rowcount is not None else 0
+    print(f"[f9e8d7c6b5a4] Backfilled role_id for {updated} project_membership row(s).")
+
+
+def downgrade() -> None:
+    # Data-only catch-up; cannot distinguish backfilled rows from explicit assignments.
+    pass

--- a/apps/backend/src/rhesis/backend/local_init.py
+++ b/apps/backend/src/rhesis/backend/local_init.py
@@ -93,6 +93,9 @@ def initialize_local_environment(db: Session) -> None:
                     default_model_ids = load_initial_data(db, str(org.id), str(user.id))
                     _apply_default_model_ids_to_user(user, default_model_ids)
                     db.flush()
+                    # Seed data enrolls the admin in projects after the org-role
+                    # hook may have already run — re-fire so project roles sync.
+                    _ensure_local_admin_org_role(db, user.id, org.id)
                     db.commit()
                     logger.info("✅ Initial seed data loaded successfully!")
                 else:
@@ -166,6 +169,10 @@ def initialize_local_environment(db: Session) -> None:
         default_model_ids = load_initial_data(db, str(org_id), str(user_id))
         _apply_default_model_ids_to_user(user, default_model_ids)
         db.flush()
+
+        # enroll_user_in_project runs inside load_initial_data after the org-role
+        # hook above — re-fire so project_membership.role_id is backfilled.
+        _ensure_local_admin_org_role(db, user_id, org_id)
 
         db.commit()
 

--- a/ee/backend/src/rhesis/backend/ee/rbac/default_role.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/default_role.py
@@ -30,6 +30,28 @@ from sqlalchemy.orm import Session
 logger = logging.getLogger(__name__)
 
 
+def _sync_project_roles_from_org_role(
+    db: Session,
+    user_id: UUID,
+    organization_id: UUID,
+    role_id: UUID,
+) -> None:
+    """Copy *role_id* into project memberships that have no explicit project role.
+
+    Idempotent — never overwrites an existing ``project_membership.role_id``.
+    """
+    from rhesis.backend.app.models.project_membership import ProjectMembership
+
+    db.query(ProjectMembership).filter_by(
+        organization_id=organization_id,
+        user_id=user_id,
+    ).filter(ProjectMembership.role_id.is_(None)).update(
+        {ProjectMembership.role_id: role_id},
+        synchronize_session=False,
+    )
+    db.flush()
+
+
 def assign_default_org_role(db: Session, user_id: UUID, organization_id: UUID) -> None:
     """Insert the default ``organization_member`` row for *user_id* in *organization_id*.
 
@@ -53,6 +75,10 @@ def assign_default_org_role(db: Session, user_id: UUID, organization_id: UUID) -
         .first()
     )
     if existing is not None:
+        if existing.role_id is not None:
+            _sync_project_roles_from_org_role(
+                db, user_id, organization_id, existing.role_id
+            )
         return
 
     role_name = "Owner" if str(org.owner_id) == str(user_id) else "Member"
@@ -80,6 +106,7 @@ def assign_default_org_role(db: Session, user_id: UUID, organization_id: UUID) -
         )
     )
     db.flush()
+    _sync_project_roles_from_org_role(db, user_id, organization_id, role.id)
 
     # Revocation/grant must take effect immediately for this user.
     try:

--- a/ee/backend/src/rhesis/backend/ee/rbac/router.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/router.py
@@ -135,6 +135,40 @@ def _get_actor_permissions(principal, project_id, db: Session) -> set[str]:
     )
 
 
+def _resolve_member_project_role_read(
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    project_id: uuid.UUID,
+    stored_role_id: Optional[uuid.UUID],
+    db: Session,
+) -> Optional[RoleRead]:
+    """Return the role a member effectively holds in *project_id* for display.
+
+    When ``stored_role_id`` is set, returns that role.  Otherwise resolves via
+    the auth provider so inherited org roles (and the owner floor) surface in the
+    Members grid even before ``project_membership.role_id`` is backfilled.
+    """
+    from rhesis.backend.app.auth.principal import AuthKind, Principal
+    from rhesis.backend.ee.rbac.provider import PermissionAuthorizationProvider
+
+    if stored_role_id is not None:
+        stored = _load_role(stored_role_id, db)
+        if stored is not None:
+            return _role_to_read(stored, db)
+
+    member_principal = Principal(
+        user_id=user_id,
+        organization_id=organization_id,
+        kind=AuthKind.SESSION,
+    )
+    effective = PermissionAuthorizationProvider().resolve_effective_role(
+        member_principal, project_id, db
+    )
+    if effective is not None:
+        return _role_to_read(effective, db)
+    return None
+
+
 def _resolve_permission_ids(permission_names: list[str], db: Session) -> list[uuid.UUID]:
     """Map capability strings to Permission PKs. Raises 422 on unknown names."""
     from rhesis.backend.ee.rbac.models import Permission
@@ -799,19 +833,18 @@ def list_user_project_memberships(
         .all()
     )
 
-    unique_role_ids = {m.role_id for m in memberships if m.role_id is not None}
-    roles_by_id = {}
-    for role_id in unique_role_ids:
-        role = _load_role(role_id, db)
-        if role is not None:
-            roles_by_id[role_id] = _role_to_read(role, db)
-
     return [
         UserProjectMembershipRead(
             project_id=m.project_id,
             user_id=m.user_id,
             role_id=m.role_id,
-            role=roles_by_id.get(m.role_id),
+            role=_resolve_member_project_role_read(
+                m.user_id,
+                current_user.organization_id,
+                m.project_id,
+                m.role_id,
+                db,
+            ),
             project=ProjectSummary.model_validate(m.project),
         )
         for m in memberships
@@ -1015,9 +1048,10 @@ def list_project_members(
 ):
     """List all project members with their RBAC role assignments.
 
-    Returns every ``project_membership`` row for *project_id*, including the
-    resolved role when ``role_id`` is set.  Members without an explicit
-    project-level role have ``role_id`` and ``role`` as ``None``.
+    Returns every ``project_membership`` row for *project_id*.  ``role_id`` is
+    the stored explicit assignment (nullable).  ``role`` is the *effective*
+    project role — when ``role_id`` is NULL the member's inherited org role
+    (or owner floor) is resolved for display and ``permitted_actions``.
 
     ``member:read`` is org-scoped, so the capability gate alone does not confirm
     the caller may see *this* project's roster. Enforce project access
@@ -1044,20 +1078,19 @@ def list_project_members(
         .all()
     )
 
-    unique_role_ids = {m.role_id for m in memberships if m.role_id is not None}
-    roles_by_id = {}
-    for role_id in unique_role_ids:
-        role = _load_role(role_id, db)
-        if role is not None:
-            roles_by_id[role_id] = _role_to_read(role, db)
-
     principal = resolve_principal(current_user)
     actor_level = _get_actor_level(principal, project_id=project_id, db=db)
     actor_permissions = _get_actor_permissions(principal, project_id=project_id, db=db)
 
     result = []
     for m in memberships:
-        current_role = roles_by_id.get(m.role_id)
+        current_role = _resolve_member_project_role_read(
+            m.user_id,
+            current_user.organization_id,
+            project_id,
+            m.role_id,
+            db,
+        )
         is_self = str(m.user_id) == str(current_user.id)
         actions = _member_permitted_actions(
             is_self=is_self,
@@ -1075,7 +1108,7 @@ def list_project_members(
                 project_id=project_id,
                 user_id=m.user_id,
                 role_id=m.role_id,
-                role=roles_by_id.get(m.role_id),
+                role=current_role,
                 permitted_actions=actions,
             )
         )

--- a/tests/backend/ee/rbac/test_default_org_role.py
+++ b/tests/backend/ee/rbac/test_default_org_role.py
@@ -453,6 +453,75 @@ class TestNoOpAndIdempotency:
         member = _member_row(test_db, org_id, user_id)
         assert _role_name(test_db, member.role_id) == "Owner"
 
+    def test_seeds_null_project_membership_roles_from_org_role(self, test_db: Session):
+        from sqlalchemy import text
+
+        from rhesis.backend.app.models.project_membership import ProjectMembership
+        from tests.backend.ee.rbac._rbac_helpers import _create_project
+
+        org_id = _create_org(test_db)
+        user_id = _create_user(test_db, org_id)
+        project_id = _create_project(test_db, org_id)
+        test_db.execute(
+            text(
+                "INSERT INTO project_membership "
+                "(id, project_id, user_id, organization_id, role_id) "
+                "VALUES (gen_random_uuid(), :pid, :uid, :oid, NULL)"
+            ),
+            {"pid": str(project_id), "uid": str(user_id), "oid": str(org_id)},
+        )
+        test_db.flush()
+
+        with _rbac_on():
+            assign_default_org_role(test_db, user_id, org_id)
+
+        with bypass_tenant_filter():
+            pm = (
+                test_db.query(ProjectMembership)
+                .filter_by(project_id=project_id, user_id=user_id)
+                .first()
+            )
+        member = _member_row(test_db, org_id, user_id)
+        assert pm is not None
+        assert pm.role_id == member.role_id
+        assert _role_name(test_db, pm.role_id) == "Member"
+
+    def test_existing_org_member_syncs_null_project_roles(self, test_db: Session):
+        from sqlalchemy import text
+
+        from rhesis.backend.app.models.project_membership import ProjectMembership
+        from tests.backend.ee.rbac._rbac_helpers import _create_project
+
+        org_id = _create_org(test_db)
+        user_id = _create_user(test_db, org_id)
+        project_id = _create_project(test_db, org_id)
+        with bypass_tenant_filter():
+            owner_role = test_db.query(Role).filter_by(name="Owner", is_built_in=True).first()
+        test_db.add(
+            OrganizationMember(organization_id=org_id, user_id=user_id, role_id=owner_role.id)
+        )
+        test_db.execute(
+            text(
+                "INSERT INTO project_membership "
+                "(id, project_id, user_id, organization_id, role_id) "
+                "VALUES (gen_random_uuid(), :pid, :uid, :oid, NULL)"
+            ),
+            {"pid": str(project_id), "uid": str(user_id), "oid": str(org_id)},
+        )
+        test_db.flush()
+
+        with _rbac_on():
+            assign_default_org_role(test_db, user_id, org_id)
+
+        with bypass_tenant_filter():
+            pm = (
+                test_db.query(ProjectMembership)
+                .filter_by(project_id=project_id, user_id=user_id)
+                .first()
+            )
+        assert pm is not None
+        assert pm.role_id == owner_role.id
+
 
 # ---------------------------------------------------------------------------
 # Core hook dispatch — community build (no handler) no-ops

--- a/tests/backend/ee/rbac/test_project_members_authz.py
+++ b/tests/backend/ee/rbac/test_project_members_authz.py
@@ -156,3 +156,51 @@ class TestProjectMemberPermittedActions:
 
         results = self._list(admin_id)
         assert self._row(results, owner_id).permitted_actions == []
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+class TestProjectMemberInheritedRoleDisplay:
+    """Members with NULL project_membership.role_id inherit their org role for
+    authorization; list_project_members must surface that effective role in the
+  ``role`` field so the Members grid does not show "—"."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db: Session):
+        self.db = test_db
+        self.org_id = _create_org(test_db)
+        self.project_id = _create_project(test_db, self.org_id)
+
+    def _list(self, actor_id):
+        with _rbac_enabled():
+            return list_project_members(
+                project_id=self.project_id,
+                request=_request(),
+                db=self.db,
+                current_user=_user(actor_id, self.org_id),
+                _org=None,
+            )
+
+    def test_owner_without_project_role_shows_inherited_owner(self):
+        owner_id = _create_user(self.db, self.org_id)
+        _assign_org_role(self.db, self.org_id, owner_id, "Owner")
+        _add_project_member(self.db, self.org_id, self.project_id, owner_id)
+
+        row = next(r for r in self._list(owner_id) if r.user_id == owner_id)
+        assert row.role_id is None
+        assert row.role is not None
+        assert row.role.name == "Owner"
+
+    def test_admin_sees_no_manage_on_inherited_owner_row(self):
+        admin_id = _create_user(self.db, self.org_id)
+        owner_id = _create_user(self.db, self.org_id)
+        _assign_org_role(self.db, self.org_id, admin_id, "Admin")
+        _assign_org_role(self.db, self.org_id, owner_id, "Owner")
+        _add_project_member(self.db, self.org_id, self.project_id, admin_id)
+        _add_project_member(self.db, self.org_id, self.project_id, owner_id)
+
+        results = self._list(admin_id)
+        owner_row = next(r for r in results if r.user_id == owner_id)
+        assert owner_row.role is not None
+        assert owner_row.role.name == "Owner"
+        assert owner_row.permitted_actions == []


### PR DESCRIPTION
## Summary
- Adds catch-up migration `f9e8d7c6b5a4` to copy `organization_member.role_id` into `project_membership.role_id` where still NULL (same gap that left Nicolai's Members tab showing "—" after the org-member fix).
- Syncs project roles when org roles are assigned (`assign_default_org_role`), including re-sync on existing org-member rows and after Quick Start seed data for `admin@local.dev`.
- Resolves effective inherited roles in `GET /rbac/projects/{id}/members` so the UI shows Owner/Member even before the DB column is backfilled.

## Context
The org-member catch-up (`f8e9a0b1c2d4`, #2139) restored access for owners missing `organization_member` rows, but `project_membership.role_id` stayed NULL when migration `e3f4a5b6c7d8` had already run without a matching org row. Authorization worked via org-role inheritance; the Members grid did not.

## Test plan
- [x] `uv run pytest ../../tests/backend/ee/rbac/test_default_org_role.py -v`
- [x] `uv run pytest ../../tests/backend/ee/rbac/test_project_members_authz.py -v`
- [ ] Run `alembic upgrade head` on staging and verify affected users show project roles in Members tab
- [ ] Confirm `admin@local.dev` shows Owner on Example Project after backend restart