### PR TITLE
Fix EE boundary and authz coverage CI failures

### DIFF
--- a/apps/backend/src/rhesis/backend/app/auth/public_routes.py
+++ b/apps/backend/src/rhesis/backend/app/auth/public_routes.py
@@ -92,6 +92,13 @@ AUTHZ_EXEMPT_ROUTES: frozenset[tuple[str, str]] = frozenset(
         # they first complete their profile (name, picture, etc.) after OAuth sign-in.
         # Cross-user update authorization is enforced by the in-handler authorize() call.
         ("PUT", "/users/{user_id}"),
+        # Cross-project entity resolution: spans multiple resource types
+        # (test, endpoint, metric, ...) so no single resource+verb capability
+        # applies. Authorization is enforced in-handler: the lookup is always
+        # organization_id-scoped, and project-level access is resolved to
+        # "no_access" (details withheld) when the caller lacks a
+        # ProjectMembership row for the entity's project.
+        ("GET", "/resolve"),
     }
 )
 

--- a/apps/backend/src/rhesis/backend/local_init.py
+++ b/apps/backend/src/rhesis/backend/local_init.py
@@ -11,7 +11,6 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Mapping
 
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
@@ -188,7 +187,10 @@ def _ensure_local_admin_org_role(
     ``initialize_local_environment`` builds the org/user via direct ORM
     construction rather than ``crud.create_user``/the onboarding endpoint, so
     the hook that seeds the ``organization_member`` row never runs on its own.
-    No-op when RBAC is unavailable or a row already exists (idempotent).
+    No-op when RBAC is unavailable or a row already exists (idempotent). The
+    EE handler (``assign_default_org_role``) logs the outcome itself, so core
+    does not re-query the EE-owned ``organization_member`` table here — doing
+    so would violate the core/EE import boundary (``community-boundary`` CI job).
 
     Caller must set RLS session variables before invoking this function.
     """
@@ -196,37 +198,6 @@ def _ensure_local_admin_org_role(
 
     on_user_org_assigned(db, user_id, organization_id)
     db.flush()
-
-    try:
-        from rhesis.backend.ee.rbac.models import OrganizationMember
-
-        row = (
-            db.query(OrganizationMember)
-            .filter_by(organization_id=organization_id, user_id=user_id)
-            .first()
-        )
-        if row:
-            logger.info(
-                "Verified organization_member row for user %s (role_id=%s)",
-                user_id,
-                row.role_id,
-            )
-        else:
-            logger.warning(
-                "organization_member row NOT found for user %s in org %s "
-                "— RBAC may not be active or the insert was rejected by RLS",
-                user_id,
-                organization_id,
-            )
-    except ImportError:
-        pass
-    except SQLAlchemyError:
-        logger.warning(
-            "Could not verify organization_member row for user %s — "
-            "organization_member table may not exist yet (migrations pending)",
-            user_id,
-            exc_info=True,
-        )
 
 
 def _apply_default_model_ids_to_user(


### PR DESCRIPTION
## Purpose
Fixes two backend CI failures blocking the v0.10.0 release: a core/EE import-boundary violation and an unmapped route in the PEP authz coverage guard.

## What Changed
- `local_init.py`: removed the direct `rhesis.backend.ee.rbac.models` import used only to re-log whether the `organization_member` row was created. The EE handler (`assign_default_org_role`) already logs success/failure itself, so this redundant check violated the `community-boundary` CI job (core must never import EE outside `ee_bootstrap.py`/`alembic/env.py`).
- `public_routes.py`: added `("GET", "/resolve")` to `AUTHZ_EXEMPT_ROUTES`. The cross-project entity-resolution endpoint spans multiple resource types (test, endpoint, metric, ...), so no single resource+verb capability applies — it already enforces authorization inline (organization_id scoping plus a `ProjectMembership` check), the same pattern as the existing `PUT /users/{user_id}` exemption.

## Testing
- `tests/backend/test_ee_boundary.py` — both tests pass
- `tests/backend/security/test_authz_coverage.py` — all 5 tests pass