### PR TITLE
fix(projects): close delete confirmation modal after successful deletion

### DIFF
--- a/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx
@@ -121,8 +121,8 @@ export default function ClientWrapper({
         error instanceof Error ? error.message : 'Failed to delete project',
         { severity: 'error' }
       );
-      setDeleteConfirmOpen(false);
     } finally {
+      setDeleteConfirmOpen(false);
       setIsDeleting(false);
     }
   };


### PR DESCRIPTION
## Summary
Moves `setDeleteConfirmOpen(false)` from the `catch` block to the `finally` block of `handleDeleteConfirm` so the delete confirmation modal closes on both success and error paths. Previously the modal only closed on error, leaving it stuck open over the `/projects` route after a successful delete.

## Linked issue
Fixes #1328

## Root cause
In `apps/frontend/src/app/(protected)/projects/[identifier]/client-wrapper.tsx`, `handleDeleteConfirm` called `router.push('/projects')` and showed the success notification on the success path, but only called `setDeleteConfirmOpen(false)` inside the `catch` block. As a result, after a successful deletion the modal remained open even though the user had been navigated away.

## Approach
Move `setDeleteConfirmOpen(false)` into the `finally` block so the modal closes regardless of whether the delete succeeded or failed. This:
- Fixes the success path (modal now closes)
- Preserves the error path behavior (modal still closes on error)
- Removes the duplicate call from `catch` (no longer needed)
- Follows the React convention of cleaning up state in `finally`

The `setIsDeleting(false)` call already in `finally` is preserved; `setDeleteConfirmOpen(false)` is placed before it so the modal unmounts first, avoiding any visual flicker from the loading state clearing while the modal is still visible.

## Testing
- Verified by code inspection that `setDeleteConfirmOpen(false)` now executes on both success and error paths via the `finally` block.
- No existing frontend test suite to extend — `apps/frontend` has jest + RTL + msw configured in `package.json` but contains 0 `*.test.tsx` files today. Happy to add the first test (with the required `jest.config.ts` / `jest.setup.ts` and mocks for `next/navigation`, `ApiClientFactory`, `useNotifications`) if the maintainers would prefer that; just let me know.

### Acceptance criteria from #1328
- [x] After confirming project delete, the delete confirmation dialog closes — via `finally`
- [x] After successful delete, the user is navigated to the projects list — `router.push('/projects')` (unchanged)
- [x] Success notification is shown — `notifications.show('Project deleted successfully', ...)` (unchanged)

## Notes
- DCO signed (`Signed-off-by: fei <3303354867@qq.com>`)
- Single-file change, 2 lines moved (no new logic added)
- Branch follows `feature/...` convention per CONTRIBUTING.md
