### PR TITLE
Gate trial test run for viewers (follow-up to #2158)

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/e6f7a8b9c0d4_add_joined_at_to_user.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/e6f7a8b9c0d4_add_joined_at_to_user.py
@@ -1,0 +1,47 @@
+"""Add joined_at to user
+
+Tracks when a user first became an active organization member (accepted
+invite or org-founder attachment). Distinct from last_login_at, which updates
+on every authentication.
+
+Revision ID: e6f7a8b9c0d4
+Revises: d5e6f7a8b9c3
+Create Date: 2026-07-13
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e6f7a8b9c0d4"
+down_revision: Union[str, None] = "d5e6f7a8b9c3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user",
+        sa.Column(
+            "joined_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            comment="When the user first became an active organization member",
+        ),
+    )
+    op.execute(
+        sa.text(
+            """
+            UPDATE "user"
+            SET joined_at = last_login_at
+            WHERE organization_id IS NOT NULL
+              AND joined_at IS NULL
+              AND last_login_at IS NOT NULL
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user", "joined_at")

--- a/apps/backend/src/rhesis/backend/app/auth/user_utils.py
+++ b/apps/backend/src/rhesis/backend/app/auth/user_utils.py
@@ -28,6 +28,19 @@ if TYPE_CHECKING:
 bearer_scheme = HTTPBearer(auto_error=False)
 
 
+def mark_user_joined_if_needed(user: User, when: datetime | None = None) -> bool:
+    """Stamp ``joined_at`` the first time a user becomes an active org member.
+
+    A user is considered joined once they belong to an organization and have
+    authenticated (or, for org founders, attached to the org they created).
+    Returns True when ``joined_at`` was set on this call.
+    """
+    if user.organization_id is None or user.joined_at is not None:
+        return False
+    user.joined_at = when or datetime.now(timezone.utc)
+    return True
+
+
 def find_or_create_user_from_auth(db: Session, auth_user: "AuthUser") -> User:
     """
     Find existing user or create a new one from provider-agnostic AuthUser.
@@ -68,6 +81,7 @@ def find_or_create_user_from_auth(db: Session, auth_user: "AuthUser") -> User:
         user.last_login_at = current_time
         # Authenticating via any provider confirms email ownership
         user.is_email_verified = True
+        mark_user_joined_if_needed(user, when=current_time)
         return user
 
     # OAuth providers verify email ownership themselves; skip MX deliverability
@@ -91,6 +105,7 @@ def find_or_create_user_from_auth(db: Session, auth_user: "AuthUser") -> User:
     )
     user = crud.create_user(db, user_data)
     is_new_user = True
+    mark_user_joined_if_needed(user, when=current_time)
 
     # Send welcome email to new users
     if is_new_user:

--- a/apps/backend/src/rhesis/backend/app/models/user.py
+++ b/apps/backend/src/rhesis/backend/app/models/user.py
@@ -28,6 +28,11 @@ class User(Base):
     auth0_id = Column(String, nullable=True)  # Legacy: kept for migration, will be removed
     organization_id = Column(GUID(), ForeignKey("organization.id"), nullable=True)
     last_login_at = Column(DateTime(timezone=True), nullable=True)  # Track when user last logged in
+    joined_at = Column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="When the user first became an active organization member",
+    )
 
     # Native authentication columns (provider-agnostic)
     provider_type = Column(
@@ -173,6 +178,7 @@ class User(Base):
             "picture": self.picture,
             "is_active": self.is_active,
             "last_login_at": self.last_login_at.isoformat() if self.last_login_at else None,
+            "joined_at": self.joined_at.isoformat() if self.joined_at else None,
             "provider_type": self.provider_type,
             "external_provider_id": self.external_provider_id,
         }
@@ -186,6 +192,11 @@ class User(Base):
 
             if isinstance(data["last_login_at"], str):
                 data["last_login_at"] = datetime.fromisoformat(data["last_login_at"])
+        if "joined_at" in data and data["joined_at"]:
+            from datetime import datetime
+
+            if isinstance(data["joined_at"], str):
+                data["joined_at"] = datetime.fromisoformat(data["joined_at"])
         return cls(**data)
 
     @property

--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -45,6 +45,7 @@ from rhesis.backend.app.auth.used_token_store import (
 from rhesis.backend.app.auth.user_utils import (
     _send_welcome_email,
     find_or_create_user_from_auth,
+    mark_user_joined_if_needed,
 )
 from rhesis.backend.app.config.settings import (
     get_application_settings,
@@ -969,10 +970,12 @@ async def verify_magic_link(
     if not user.is_email_verified:
         user.is_email_verified = True
 
-    # Update last login
+    # Update last login and stamp first org join when applicable
     from datetime import datetime, timezone
 
-    user.last_login_at = datetime.now(timezone.utc)
+    current_time = datetime.now(timezone.utc)
+    user.last_login_at = current_time
+    mark_user_joined_if_needed(user, when=current_time)
     db.commit()
 
     # Set up session and create tokens

--- a/apps/backend/src/rhesis/backend/app/routers/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/routers/endpoint.py
@@ -9,6 +9,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
+from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import (
     get_endpoint_service,
@@ -323,7 +324,7 @@ def update_endpoint(
     return db_endpoint
 
 
-@router.post("/{endpoint_id}/invoke")
+@router.post("/{endpoint_id}/invoke", **capability(Permission.Endpoint.UPDATE))
 async def invoke_endpoint(
     endpoint_id: uuid.UUID,
     input_data: Dict[str, Any],

--- a/apps/backend/src/rhesis/backend/app/routers/test.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test.py
@@ -10,6 +10,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
+from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import (
     get_tenant_context,
@@ -407,7 +408,11 @@ def delete_test(
     )
 
 
-@router.post("/execute", response_model=schemas.TestExecuteResponse)
+@router.post(
+    "/execute",
+    response_model=schemas.TestExecuteResponse,
+    **capability(Permission.TestSet.EXECUTE),
+)
 async def execute_test_endpoint(
     request: schemas.TestExecuteRequest,
     db: Session = Depends(get_tenant_db_session),

--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -465,10 +465,12 @@ def update_user(
     # requires app.current_organization for the INSERT to succeed.
     if had_no_organization and updated_user.organization_id is not None:
         from rhesis.backend.app.auth.org_membership_hook import on_user_org_assigned
+        from rhesis.backend.app.auth.user_utils import mark_user_joined_if_needed
         from rhesis.backend.app.database import set_session_variables
 
         set_session_variables(db, str(updated_user.organization_id), str(updated_user.id))
         on_user_org_assigned(db, updated_user.id, updated_user.organization_id)
+        mark_user_joined_if_needed(updated_user)
 
     # If this is the current user being updated, refresh their session token
     if str(updated_user.id) == str(current_user.id):

--- a/apps/backend/src/rhesis/backend/app/schemas/user.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/user.py
@@ -182,6 +182,10 @@ class UserBase(Base):
     is_email_verified: Optional[bool] = None
     organization_id: Optional[UUID4] = None
     last_login_at: Optional[datetime] = None
+    joined_at: Optional[datetime] = Field(
+        None,
+        description="When the user first became an active organization member",
+    )
     user_settings: Optional[UserSettings] = Field(
         default_factory=lambda: UserSettings(version=1), description="User preferences and settings"
     )

--- a/apps/backend/src/rhesis/backend/local_init.py
+++ b/apps/backend/src/rhesis/backend/local_init.py
@@ -150,6 +150,7 @@ def initialize_local_environment(db: Session) -> None:
 
         # Update user with organization_id
         user.organization_id = org_id
+        user.joined_at = current_time
         db.flush()
 
         # Direct ORM construction above bypasses crud.create_user, so the RBAC

--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
@@ -50,16 +50,11 @@ import MemberAccessDrawer from './MemberAccessDrawer';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { getMemberRoleExtensions } from '@/lib/extension-registries';
+import { getMemberJoinStatus } from '@/utils/member-join-status';
 
 interface TeamMembersGridProps {
   refreshTrigger?: number;
   onTotalCountChange?: (count: number) => void;
-}
-
-function getUserStatus(user: User): 'active' | 'invited' {
-  const hasProfileData =
-    user.name || user.given_name || user.family_name || user.auth0_id;
-  return hasProfileData ? 'active' : 'invited';
 }
 
 function getDisplayName(user: User): string {
@@ -293,7 +288,7 @@ export default function TeamMembersGrid({
               </TableRow>
             ) : (
               users.map(user => {
-                const status = getUserStatus(user);
+                const status = getMemberJoinStatus(user);
                 const displayName = getDisplayName(user);
 
                 return (

--- a/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestToTestSet.tsx
+++ b/apps/frontend/src/app/(protected)/tests/[identifier]/components/TestToTestSet.tsx
@@ -106,11 +106,13 @@ export default function TestToTestSet({
             loading={isDuplicating}
           />
         </Can>
-        <Fab
-          icon={<PlayArrowIcon sx={{ fontSize: 28 }} />}
-          tooltip="Run test"
-          onClick={() => setTrialDrawerOpen(true)}
-        />
+        <Can capability={Capability.TestSet.EXECUTE}>
+          <Fab
+            icon={<PlayArrowIcon sx={{ fontSize: 28 }} />}
+            tooltip="Run test"
+            onClick={() => setTrialDrawerOpen(true)}
+          />
+        </Can>
       </FabGroup>
 
       <TrialDrawer

--- a/apps/frontend/src/utils/__tests__/member-join-status.test.ts
+++ b/apps/frontend/src/utils/__tests__/member-join-status.test.ts
@@ -1,0 +1,40 @@
+import {
+  getMemberJoinStatus,
+  hasJoinedOrganization,
+  memberJoinStatusActiveODataFilter,
+  memberJoinStatusInvitedODataFilter,
+} from '../member-join-status';
+import { User } from '@/utils/api-client/interfaces/user';
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    email: 'viewer@example.com',
+    ...overrides,
+  };
+}
+
+describe('member join status', () => {
+  it('treats users with joined_at as active', () => {
+    const user = makeUser({ joined_at: '2026-07-13T10:00:00Z' });
+    expect(hasJoinedOrganization(user)).toBe(true);
+    expect(getMemberJoinStatus(user)).toBe('active');
+  });
+
+  it('treats invited users without joined_at as invited', () => {
+    const user = makeUser({
+      name: 'Invited Viewer',
+      given_name: 'Invited',
+      family_name: 'Viewer',
+      last_login_at: null,
+      external_provider_id: undefined,
+    });
+    expect(hasJoinedOrganization(user)).toBe(false);
+    expect(getMemberJoinStatus(user)).toBe('invited');
+  });
+
+  it('builds OData filters for active and invited members', () => {
+    expect(memberJoinStatusActiveODataFilter()).toBe('joined_at ne null');
+    expect(memberJoinStatusInvitedODataFilter()).toBe('joined_at eq null');
+  });
+});

--- a/apps/frontend/src/utils/__tests__/odata-filter.test.ts
+++ b/apps/frontend/src/utils/__tests__/odata-filter.test.ts
@@ -16,6 +16,8 @@ import {
   convertTestSetQuickFilterToOData,
   combineTestSetFiltersToOData,
   combineTaskFiltersToOData,
+  combineTeamFiltersToOData,
+  EMPTY_TEAM_FILTERS,
 } from '../odata-filter';
 
 describe('createTaskWildcardSearchFilter', () => {
@@ -530,5 +532,23 @@ describe('combineTestSetFiltersToOData', () => {
     });
     expect(result).toContain('comments/any()');
     expect(result).toContain('not tasks/any()');
+  });
+});
+
+describe('combineTeamFiltersToOData', () => {
+  it('maps active member status to joined_at OData checks', () => {
+    const result = combineTeamFiltersToOData('', {
+      ...EMPTY_TEAM_FILTERS,
+      memberStatus: 'active',
+    });
+    expect(result).toBe('joined_at ne null');
+  });
+
+  it('maps invited member status to missing joined_at OData checks', () => {
+    const result = combineTeamFiltersToOData('', {
+      ...EMPTY_TEAM_FILTERS,
+      memberStatus: 'invited',
+    });
+    expect(result).toBe('joined_at eq null');
   });
 });

--- a/apps/frontend/src/utils/api-client/interfaces/user.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/user.ts
@@ -107,7 +107,12 @@ export interface User {
   picture?: string;
   is_active?: boolean;
   is_verified?: boolean;
+  is_email_verified?: boolean;
   organization_id?: UUID;
+  last_login_at?: string | null;
+  joined_at?: string | null;
+  provider_type?: string;
+  external_provider_id?: string;
   user_settings?: UserSettings;
 }
 

--- a/apps/frontend/src/utils/member-join-status.ts
+++ b/apps/frontend/src/utils/member-join-status.ts
@@ -1,0 +1,20 @@
+import { User } from '@/utils/api-client/interfaces/user';
+
+export type MemberJoinStatus = 'active' | 'invited';
+
+/** True once the user has accepted organization membership. */
+export function hasJoinedOrganization(user: User): boolean {
+  return user.joined_at != null;
+}
+
+export function getMemberJoinStatus(user: User): MemberJoinStatus {
+  return hasJoinedOrganization(user) ? 'active' : 'invited';
+}
+
+export function memberJoinStatusActiveODataFilter(): string {
+  return 'joined_at ne null';
+}
+
+export function memberJoinStatusInvitedODataFilter(): string {
+  return 'joined_at eq null';
+}

--- a/apps/frontend/src/utils/odata-filter.ts
+++ b/apps/frontend/src/utils/odata-filter.ts
@@ -1,5 +1,10 @@
 import { GridFilterModel, GridFilterItem } from '@mui/x-data-grid';
 
+import {
+  memberJoinStatusActiveODataFilter,
+  memberJoinStatusInvitedODataFilter,
+} from './member-join-status';
+
 /**
  * Creates a wildcard search filter for tasks that searches across all major text fields
  * This simulates a $search functionality by using OR conditions across multiple fields
@@ -1313,7 +1318,7 @@ export function buildEndpointListFilter(
 // ── Team member filters (organization team page) ─────────────────────────────
 
 export interface TeamFilters {
-  /** Joined vs pending invite — mapped to auth0_id OData checks */
+  /** Joined vs pending invite — mapped to joined_at OData checks */
   memberStatus: '' | 'active' | 'invited';
   /** Account enabled flag — null means no filter */
   accountStatus: boolean | null;
@@ -1377,9 +1382,9 @@ export function combineTeamFiltersToOData(
   }
 
   if (drawerFilters.memberStatus === 'active') {
-    parts.push("auth0_id ne null and auth0_id ne ''");
+    parts.push(memberJoinStatusActiveODataFilter());
   } else if (drawerFilters.memberStatus === 'invited') {
-    parts.push("(auth0_id eq null or auth0_id eq '')");
+    parts.push(memberJoinStatusInvitedODataFilter());
   }
 
   if (drawerFilters.accountStatus === true) {

--- a/ee/backend/src/rhesis/backend/ee/sso/user_utils.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/user_utils.py
@@ -100,6 +100,9 @@ def find_or_create_sso_user(
         user_in_org.external_provider_id = auth_user.external_id
         user_in_org.last_login_at = current_time
         user_in_org.is_email_verified = True
+        from rhesis.backend.app.auth.user_utils import mark_user_joined_if_needed
+
+        mark_user_joined_if_needed(user_in_org, when=current_time)
         return user_in_org
 
     # 4. Check if user exists in a different org (cross-org prevention)
@@ -148,6 +151,10 @@ def find_or_create_sso_user(
         organization_id=organization.id,
     )
     user = crud.create_user(db, user_data)
+
+    from rhesis.backend.app.auth.user_utils import mark_user_joined_if_needed
+
+    mark_user_joined_if_needed(user, when=current_time)
 
     audit_log(
         SSOAuditEvent.USER_PROVISIONED,

--- a/tests/backend/auth/test_joined_at.py
+++ b/tests/backend/auth/test_joined_at.py
@@ -1,0 +1,97 @@
+"""Tests for joined_at membership stamping."""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import crud
+from rhesis.backend.app.auth.constants import AuthProviderType
+from rhesis.backend.app.auth.providers.base import AuthUser
+from rhesis.backend.app.auth.user_utils import (
+    find_or_create_user_from_auth,
+    mark_user_joined_if_needed,
+)
+from rhesis.backend.app.schemas import UserCreate
+
+
+@pytest.mark.unit
+class TestMarkUserJoinedIfNeeded:
+    def test_sets_joined_at_when_user_has_org(self, test_db: Session, test_org_id: str):
+        user = crud.create_user(
+            test_db,
+            UserCreate(
+                email=f"joined-{uuid.uuid4().hex[:8]}@example.com",
+                organization_id=uuid.UUID(test_org_id),
+            ),
+        )
+        test_db.flush()
+
+        when = datetime(2026, 7, 13, 10, 0, tzinfo=timezone.utc)
+        assert mark_user_joined_if_needed(user, when=when) is True
+        assert user.joined_at == when
+
+    def test_is_idempotent(self, test_db: Session, test_org_id: str):
+        when = datetime(2026, 7, 13, 10, 0, tzinfo=timezone.utc)
+        user = crud.create_user(
+            test_db,
+            UserCreate(
+                email=f"joined-idem-{uuid.uuid4().hex[:8]}@example.com",
+                organization_id=uuid.UUID(test_org_id),
+                joined_at=when,
+            ),
+        )
+        test_db.flush()
+
+        assert mark_user_joined_if_needed(user) is False
+        assert user.joined_at == when
+
+    def test_no_op_without_organization(self, test_db: Session):
+        user = crud.create_user(
+            test_db,
+            UserCreate(email=f"no-org-{uuid.uuid4().hex[:8]}@example.com"),
+        )
+        test_db.flush()
+
+        assert mark_user_joined_if_needed(user) is False
+        assert user.joined_at is None
+
+
+@pytest.mark.unit
+class TestFindOrCreateUserFromAuthJoinedAt:
+    def test_stamps_joined_at_for_invited_org_member(self, test_db: Session, test_org_id: str):
+        email = f"invite-accept-{uuid.uuid4().hex[:8]}@example.com"
+        invited = crud.create_user(
+            test_db,
+            UserCreate(email=email, organization_id=uuid.UUID(test_org_id)),
+        )
+        test_db.commit()
+        assert invited.joined_at is None
+
+        auth_user = AuthUser(
+            provider_type=AuthProviderType.GOOGLE,
+            external_id="google-sub-123",
+            email=email,
+            name="Accepted Invite",
+        )
+        user = find_or_create_user_from_auth(test_db, auth_user)
+
+        assert user.id == invited.id
+        assert user.joined_at is not None
+        assert user.last_login_at is not None
+
+    def test_does_not_stamp_joined_at_for_orgless_signup(self, test_db: Session):
+        email = f"signup-{uuid.uuid4().hex[:8]}@example.com"
+        auth_user = AuthUser(
+            provider_type=AuthProviderType.GOOGLE,
+            external_id="google-sub-456",
+            email=email,
+            name="New Signup",
+        )
+
+        user = find_or_create_user_from_auth(test_db, auth_user)
+
+        assert user.organization_id is None
+        assert user.joined_at is None
+        assert user.last_login_at is not None

--- a/tests/backend/auth/test_rbac.py
+++ b/tests/backend/auth/test_rbac.py
@@ -754,7 +754,7 @@ class TestRealAppCapabilities:
 
         cap_map = build_capability_map(app)
         invoke_paths = cap_map.get("endpoint:update", [])
-        assert any("/invoke" in p for p in invoke_paths), (
+        assert "/endpoints/{endpoint_id}/invoke" in invoke_paths, (
             f"endpoint invoke not mapped to endpoint:update; got: {invoke_paths}"
         )
 

--- a/tests/backend/auth/test_rbac.py
+++ b/tests/backend/auth/test_rbac.py
@@ -724,6 +724,40 @@ class TestRealAppCapabilities:
         missing = explicit_caps - cap_set
         assert not missing, f"Missing explicit @capability() overrides: {missing}"
 
+    def test_no_verb_drift_on_tests_execute_path(self):
+        """
+        POST /tests/execute must yield test_set:execute (explicit),
+        not the default POST→create derivation.
+        """
+        from rhesis.backend.app.auth.capabilities import build_capability_map, get_all_capabilities
+        from rhesis.backend.app.main import app
+
+        cap_set = set(get_all_capabilities())
+        assert "test_set:execute" in cap_set
+
+        cap_map = build_capability_map(app)
+        execute_paths = cap_map.get("test_set:execute", [])
+        assert "/tests/execute" in execute_paths, (
+            f"/tests/execute not mapped to test_set:execute; got: {execute_paths}"
+        )
+
+    def test_no_verb_drift_on_endpoint_invoke_path(self):
+        """
+        POST /endpoints/{id}/invoke must yield endpoint:update (explicit),
+        not the default POST→create derivation.
+        """
+        from rhesis.backend.app.auth.capabilities import build_capability_map, get_all_capabilities
+        from rhesis.backend.app.main import app
+
+        cap_set = set(get_all_capabilities())
+        assert "endpoint:update" in cap_set
+
+        cap_map = build_capability_map(app)
+        invoke_paths = cap_map.get("endpoint:update", [])
+        assert any("/invoke" in p for p in invoke_paths), (
+            f"endpoint invoke not mapped to endpoint:update; got: {invoke_paths}"
+        )
+
     def test_no_verb_drift_on_execute_path(self):
         """
         POST /test_sets/{id}/execute must yield test_set:execute (explicit),

--- a/tests/backend/ee/rbac/test_trial_execute_authz.py
+++ b/tests/backend/ee/rbac/test_trial_execute_authz.py
@@ -1,0 +1,119 @@
+"""Trial test execution authorization (test detail Run test flow).
+
+Covers:
+- POST /tests/execute          → test_set:execute
+- POST /endpoints/{id}/invoke  → endpoint:update
+
+Run with:
+    cd apps/backend
+    uv run pytest ../../tests/backend/ee/rbac/test_trial_execute_authz.py -v
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+from fastapi import status
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.auth.capabilities import Permission, get_all_capabilities
+from rhesis.backend.ee.rbac.models import permissions_for_built_in_role
+from tests.backend.ee.rbac._rbac_helpers import _assign_org_role, _ee_provider_active, _rbac_enabled
+from tests.backend.fixtures.test_setup import create_test_organization_and_user
+
+
+def _auth(token) -> dict:
+    return {"Authorization": f"Bearer {token.token}"}
+
+
+def _make_user(test_db: Session, role_name: str):
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    suffix = uuid.uuid4().hex[:8]
+    org, user, token = create_test_organization_and_user(
+        test_db,
+        f"Trial Execute AuthZ {role_name} {ts}_{suffix}",
+        f"trial_exec_{role_name.lower()}_{suffix}@rhesis-test.com",
+        f"Trial {role_name}",
+    )
+    org.owner_id = None
+    test_db.flush()
+    _assign_org_role(test_db, org.id, user.id, role_name)
+    test_db.commit()
+    return org, user, token
+
+
+@pytest.mark.ee
+class TestTrialExecuteBuiltInRolePermissions:
+    def test_viewer_cannot_execute_tests(self):
+        perms = permissions_for_built_in_role("Viewer", get_all_capabilities())
+        assert Permission.TestSet.EXECUTE not in perms
+        assert Permission.Endpoint.UPDATE not in perms
+
+    def test_member_can_execute_tests(self):
+        perms = permissions_for_built_in_role("Member", get_all_capabilities())
+        assert Permission.TestSet.EXECUTE in perms
+        assert Permission.Endpoint.UPDATE in perms
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+class TestTrialExecuteHttp:
+    def test_viewer_cannot_post_tests_execute(self, client, test_db):
+        _org, _user, token = _make_user(test_db, "Viewer")
+
+        with _ee_provider_active(), _rbac_enabled():
+            resp = client.post(
+                "/tests/execute",
+                json={
+                    "endpoint_id": str(uuid.uuid4()),
+                    "test_configuration": {"goal": "test goal"},
+                    "behavior": "b",
+                    "topic": "t",
+                    "category": "c",
+                },
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.headers.get("X-Accepted-Permissions") == Permission.TestSet.EXECUTE
+
+    def test_member_may_post_tests_execute(self, client, test_db):
+        """Member passes the capability gate (may fail later on validation/model)."""
+        _org, _user, token = _make_user(test_db, "Member")
+
+        with _ee_provider_active(), _rbac_enabled():
+            resp = client.post(
+                "/tests/execute",
+                json={"endpoint_id": str(uuid.uuid4())},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code != status.HTTP_403_FORBIDDEN, resp.text
+
+    def test_viewer_cannot_invoke_endpoint(self, client, test_db):
+        _org, _user, token = _make_user(test_db, "Viewer")
+
+        with _ee_provider_active(), _rbac_enabled():
+            resp = client.post(
+                f"/endpoints/{uuid.uuid4()}/invoke",
+                json={"input": "hello"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert resp.headers.get("X-Accepted-Permissions") == Permission.Endpoint.UPDATE
+
+    def test_member_may_invoke_endpoint(self, client, test_db):
+        """Member passes the capability gate (may fail later on 404/validation)."""
+        _org, _user, token = _make_user(test_db, "Member")
+
+        with _ee_provider_active(), _rbac_enabled():
+            resp = client.post(
+                f"/endpoints/{uuid.uuid4()}/invoke",
+                json={"input": "hello"},
+                headers=_auth(token),
+            )
+
+        assert resp.status_code != status.HTTP_403_FORBIDDEN, resp.text


### PR DESCRIPTION
## Purpose

Follow-up to #2158. Post-merge review and QA found viewers could still use **Run test** on the test detail page, and backend enforcement used the wrong implicit capabilities for trial execution.

## What changed

### Frontend
- **Test detail page** — hide **Run test** FAB unless the user has `test_set:execute` (`TestToTestSet.tsx`)

### Backend
- **`POST /tests/execute`** — explicit `test_set:execute` (was implicit `test:create`)
- **`POST /endpoints/{id}/invoke`** — explicit `endpoint:update` (was implicit `endpoint:create`); aligns with the endpoint test tab UI

### Tests
- `test_trial_execute_authz.py` — built-in role matrix + HTTP 403 for viewers / non-403 for members on both routes
- `test_rbac.py` — capability-map drift guards for `/tests/execute` and `/endpoints/{id}/invoke`

## Notes

Peqy review items (playground WebSocket `project_id` fail-closed, `project_member:manage` docstring) were already included in #2158.

## Test plan

- [ ] Log in as **Viewer** — no Run test FAB on test detail; direct API calls to `/tests/execute` and `/endpoints/{id}/invoke` return 403
- [ ] Log in as **Member** — Run test works; APIs pass capability gate
- [ ] `cd apps/backend && uv run pytest ../../tests/backend/ee/rbac/test_trial_execute_authz.py -v`