### PR TITLE
fix(backend): add name to UserReference schema

### DIFF
--- a/apps/backend/src/rhesis/backend/app/schemas/user.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/user.py
@@ -219,6 +219,7 @@ class User(UserBase):
 # For use in responses where we need minimal user info
 class UserReference(Base):
     id: UUID4
+    name: Optional[str] = ""  # Default to empty string to avoid validation errors
     given_name: Optional[str] = ""  # Default to empty string to avoid validation errors
     family_name: Optional[str] = ""  # Default to empty string to avoid validation errors
     email: Optional[str] = ""  # Default to empty string to avoid validation errors


### PR DESCRIPTION
## Bug
Behavior detail pages showed "Created by: —" because the API embeds the creator using `UserReference`, which lacks a `name` field (unlike Test/Metric, which use detailed schemas).

## Fix
Add `name` to `UserReference` in `schemas/user.py`.