### PR TITLE
Fix backend and E2E test failures on v0.10.0

### DIFF
--- a/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
@@ -40,6 +40,10 @@ export default function KnowledgeClientWrapper({
 
   const handleUploadSuccess = useCallback(() => {
     setUploadDrawerOpen(false);
+    // When the empty state is showing (sourceCount === 0) SourcesGrid is
+    // unmounted, so bump the count so the grid remounts and can list the
+    // newly uploaded source.
+    setSourceCount(prev => (prev === 0 ? 1 : prev));
     queryClient.invalidateQueries({ queryKey: sourceKeys.all() });
   }, [queryClient]);
 

--- a/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
@@ -38,19 +38,24 @@ export default function KnowledgeClientWrapper({
 
   useDocumentTitle('Knowledge');
 
+  const remountSourcesGridAfterCreate = useCallback(() => {
+    // Empty state uses `sourceCount === 0`, which unmounts SourcesGrid. Reset to
+    // `null` (initial load state) so the grid remounts and `onTotalCountChange`
+    // can set the real count once the refetch succeeds.
+    setSourceCount(prev => (prev === 0 ? null : prev));
+  }, []);
+
   const handleUploadSuccess = useCallback(() => {
     setUploadDrawerOpen(false);
-    // When the empty state is showing (sourceCount === 0) SourcesGrid is
-    // unmounted, so bump the count so the grid remounts and can list the
-    // newly uploaded source.
-    setSourceCount(prev => (prev === 0 ? 1 : prev));
+    remountSourcesGridAfterCreate();
     queryClient.invalidateQueries({ queryKey: sourceKeys.all() });
-  }, [queryClient]);
+  }, [queryClient, remountSourcesGridAfterCreate]);
 
   const handleMcpImportSuccess = useCallback(() => {
     setToolImportDrawerOpen(false);
+    remountSourcesGridAfterCreate();
     queryClient.invalidateQueries({ queryKey: sourceKeys.all() });
-  }, [queryClient]);
+  }, [queryClient, remountSourcesGridAfterCreate]);
 
   if (!sessionToken) {
     return (

--- a/apps/frontend/tests/e2e/pages/InsightsPage.ts
+++ b/apps/frontend/tests/e2e/pages/InsightsPage.ts
@@ -33,14 +33,19 @@ export class InsightsPage extends BasePage {
       timeout: 10_000,
     });
 
-    const noEndpoints = this.page.getByText(/no endpoints in this project/i);
-    const noTestResults = this.page.getByText(/no test results yet/i);
-    const searchBehaviors = this.page.getByPlaceholder(/search behaviors/i);
+    const noEndpoints = this.page.getByRole('heading', {
+      name: /no endpoints in this project/i,
+    });
+    const noTestResults = this.page.getByRole('heading', {
+      name: /no test results yet/i,
+    });
+    const passRate = this.page.getByText(/pass rate/i);
     const timeRange1M = this.page.getByRole('button', { name: '1M' });
 
-    await expect(noEndpoints.or(noTestResults).or(searchBehaviors)).toBeVisible(
-      { timeout: 15_000 }
-    );
+    // Wait for endpoint auto-selection and insights fetch to settle.
+    await expect(noEndpoints.or(noTestResults).or(passRate)).toBeVisible({
+      timeout: 30_000,
+    });
 
     if (await noEndpoints.isVisible()) {
       await expect(
@@ -54,13 +59,11 @@ export class InsightsPage extends BasePage {
       return;
     }
 
-    await expect(searchBehaviors).toBeVisible();
-    await expect(timeRange1M).toBeVisible();
     await expect(
-      this.page.getByText(/\d+\.\d+%\s*pass rate/i).first()
-    ).toBeVisible({
-      timeout: 10_000,
-    });
+      this.page.getByPlaceholder(/search behaviors/i)
+    ).toBeVisible();
+    await expect(timeRange1M).toBeVisible();
+    await expect(passRate.first()).toBeVisible({ timeout: 15_000 });
   }
 
   /** Expand a collapsible sidebar section (e.g. CONNECT for Endpoints). */

--- a/apps/frontend/tests/e2e/pages/InsightsPage.ts
+++ b/apps/frontend/tests/e2e/pages/InsightsPage.ts
@@ -59,9 +59,7 @@ export class InsightsPage extends BasePage {
       return;
     }
 
-    await expect(
-      this.page.getByPlaceholder(/search behaviors/i)
-    ).toBeVisible();
+    await expect(this.page.getByPlaceholder(/search behaviors/i)).toBeVisible();
     await expect(timeRange1M).toBeVisible();
     await expect(passRate.first()).toBeVisible({ timeout: 15_000 });
   }

--- a/apps/frontend/tests/e2e/tests/knowledge-crud.spec.ts
+++ b/apps/frontend/tests/e2e/tests/knowledge-crud.spec.ts
@@ -65,10 +65,17 @@ test.describe('Knowledge — CRUD @crud', () => {
     await knowledgePage.setSourceTitle(UNIQUE_TITLE);
     await knowledgePage.setSourceDescription('Uploaded by Playwright E2E test');
 
-    // Submit the upload
+    // Submit the upload and wait for the grid to refetch
+    const listRefresh = page.waitForResponse(
+      resp =>
+        resp.url().includes('/sources') &&
+        resp.request().method() === 'GET' &&
+        resp.ok(),
+      { timeout: 30_000 }
+    );
     await knowledgePage.submitUpload();
     await knowledgePage.waitForUploadDrawerClosed();
-    await page.waitForLoadState('networkidle');
+    await listRefresh;
     await expectGridRowVisible(page, UNIQUE_TITLE);
   });
 

--- a/apps/frontend/tests/e2e/tests/knowledge-crud.spec.ts
+++ b/apps/frontend/tests/e2e/tests/knowledge-crud.spec.ts
@@ -65,15 +65,19 @@ test.describe('Knowledge — CRUD @crud', () => {
     await knowledgePage.setSourceTitle(UNIQUE_TITLE);
     await knowledgePage.setSourceDescription('Uploaded by Playwright E2E test');
 
-    // Submit the upload and wait for the grid to refetch
+    // Register the list waiter before upload, but only accept GETs that land
+    // after the POST completes so we don't match a stale in-flight request.
+    let postCompleted = false;
     const listRefresh = page.waitForResponse(
       resp =>
+        postCompleted &&
         resp.url().includes('/sources') &&
         resp.request().method() === 'GET' &&
         resp.ok(),
       { timeout: 30_000 }
     );
     await knowledgePage.submitUpload();
+    postCompleted = true;
     await knowledgePage.waitForUploadDrawerClosed();
     await listRefresh;
     await expectGridRowVisible(page, UNIQUE_TITLE);

--- a/tests/backend/ee/rbac/test_sp8_access_control.py
+++ b/tests/backend/ee/rbac/test_sp8_access_control.py
@@ -1063,7 +1063,9 @@ class TestListUserProjectMemberships:
         results = self._list(user_id)
         assert {r.user_id for r in results} == {user_id}
 
-    def test_membership_without_role_returns_none_role(self):
+    def test_membership_without_explicit_role_inherits_org_role_for_display(self):
+        """``role_id`` stays NULL when no project role was assigned, but the
+        API resolves the member's effective inherited org role for display."""
         user_id = _create_user(self.db, self.org_id)
         _assign_org_role(self.db, self.org_id, user_id, "Owner")
         project = _create_project(self.db, self.org_id)
@@ -1071,7 +1073,8 @@ class TestListUserProjectMemberships:
 
         results = self._list(user_id)
         assert results[0].role_id is None
-        assert results[0].role is None
+        assert results[0].role is not None
+        assert results[0].role.name == "Owner"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/ee/sso/test_sso_user_utils.py
+++ b/tests/backend/ee/sso/test_sso_user_utils.py
@@ -62,6 +62,7 @@ def _user_row(email, org_id, **extra):
         external_provider_id=None,
         last_login_at=None,
         is_email_verified=False,
+        joined_at=None,
     )
     for k, v in extra.items():
         setattr(row, k, v)
@@ -185,7 +186,12 @@ class TestFindOrCreateSSOUser:
         config = _sso_config(auto_provision_users=True)
         auth_user = _auth_user(email="newuser@example.com", name="New User")
 
-        fake_created = SimpleNamespace(id=uuid4(), email="newuser@example.com")
+        fake_created = SimpleNamespace(
+            id=uuid4(),
+            email="newuser@example.com",
+            organization_id=org.id,
+            joined_at=None,
+        )
         mock_create_user.return_value = fake_created
 
         user = find_or_create_sso_user(db, auth_user, org, config)


### PR DESCRIPTION
## Purpose
The v0.10.0 release CI run left backend unit tests and frontend E2E shard 1 failing due to new `joined_at`, inherited project-role display, and insights/knowledge UI behavior that the tests had not caught up with.

## What Changed
- Update SSO user-utils mocks with `joined_at` and `organization_id` for `mark_user_joined_if_needed`
- Update RBAC membership listing test to expect inherited org role in `role` when `role_id` is null
- Harden insights E2E page object to wait for settled content instead of filter chrome alone
- Remount knowledge grid after first upload from empty state and wait for sources refetch in E2E

## Additional Context
- Backend failures: https://github.com/rhesis-ai/rhesis/actions/runs/29273219518/job/86895790606
- E2E failures: https://github.com/rhesis-ai/rhesis/actions/runs/29273219232/job/86896972358

## Test plan
- [ ] Backend: `cd apps/backend && uv run pytest ../../tests/backend/ee/sso/test_sso_user_utils.py ../../tests/backend/ee/rbac/test_sp8_access_control.py::TestListUserProjectMemberships::test_membership_without_explicit_role_inherits_org_role_for_display -v`
- [ ] Frontend E2E: `cd apps/frontend && make test-e2e-ci` (or targeted insights/knowledge specs)