### PR TITLE
Fix search on filtered Tests list

### DIFF
--- a/apps/frontend/src/hooks/__tests__/useGridState.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useGridState.test.ts
@@ -127,4 +127,59 @@ describe('useGridState', () => {
       ])
     );
   });
+
+  it('drops stale column filters when the same field becomes toolbar-managed', () => {
+    const drawerFilters = { ...EMPTY_TEST_FILTERS, status: 'Active' };
+
+    const { result, rerender } = renderHook(
+      ({
+        searchQuery,
+        drawerFilters: filters,
+      }: {
+        searchQuery: string;
+        drawerFilters: typeof EMPTY_TEST_FILTERS;
+      }) =>
+        useGridState({
+          searchQuery,
+          applyDrawerFilters: (prev: GridFilterModel) =>
+            applyTestDrawerFiltersToModel(prev, filters),
+        }),
+      {
+        initialProps: {
+          searchQuery: '',
+          drawerFilters: EMPTY_TEST_FILTERS,
+        },
+      }
+    );
+
+    act(() => {
+      result.current.handleFilterModelChange({
+        items: [
+          {
+            field: 'status.name',
+            operator: 'contains',
+            value: 'Draft',
+          },
+        ],
+      });
+    });
+
+    expect(result.current.filterModel.items).toEqual([
+      {
+        field: 'status.name',
+        operator: 'contains',
+        value: 'Draft',
+      },
+    ]);
+
+    rerender({ searchQuery: '', drawerFilters });
+
+    expect(result.current.filterModel.items).toEqual([
+      {
+        field: 'status.name',
+        operator: 'contains',
+        value: 'Active',
+      },
+    ]);
+  });
 });

--- a/apps/frontend/src/hooks/__tests__/useGridState.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useGridState.test.ts
@@ -1,0 +1,130 @@
+import { act, renderHook } from '@testing-library/react';
+import type { GridFilterModel } from '@mui/x-data-grid';
+import { useGridState } from '../useGridState';
+import { applyTestDrawerFiltersToModel } from '@/app/(protected)/tests/components/test-filter-model';
+import { EMPTY_TEST_FILTERS } from '@/app/(protected)/tests/components/TestFilterDrawer';
+
+describe('useGridState', () => {
+  it('keeps search when drawer filters are applied first', () => {
+    const drawerFilters = { ...EMPTY_TEST_FILTERS, status: 'Active' };
+
+    const { result, rerender } = renderHook(
+      ({
+        searchQuery,
+        drawerFilters: filters,
+      }: {
+        searchQuery: string;
+        drawerFilters: typeof EMPTY_TEST_FILTERS;
+      }) =>
+        useGridState({
+          searchQuery,
+          applyDrawerFilters: (prev: GridFilterModel) =>
+            applyTestDrawerFiltersToModel(prev, filters),
+        }),
+      {
+        initialProps: {
+          searchQuery: '',
+          drawerFilters,
+        },
+      }
+    );
+
+    expect(result.current.filterModel.items).toEqual([
+      {
+        field: 'status.name',
+        operator: 'contains',
+        value: 'Active',
+      },
+    ]);
+
+    rerender({ searchQuery: 'refund', drawerFilters });
+
+    expect(result.current.filterModel.items).toEqual(
+      expect.arrayContaining([
+        {
+          field: 'quickFilter',
+          operator: 'contains',
+          value: 'refund',
+        },
+        {
+          field: 'status.name',
+          operator: 'contains',
+          value: 'Active',
+        },
+      ])
+    );
+  });
+
+  it('preserves toolbar search when DataGrid echoes a stripped filter model', () => {
+    const drawerFilters = { ...EMPTY_TEST_FILTERS, behavior: 'Safety' };
+
+    const { result } = renderHook(() =>
+      useGridState({
+        searchQuery: 'prompt text',
+        applyDrawerFilters: (prev: GridFilterModel) =>
+          applyTestDrawerFiltersToModel(prev, drawerFilters),
+      })
+    );
+
+    act(() => {
+      result.current.handleFilterModelChange({
+        items: [
+          {
+            field: 'behavior.name',
+            operator: 'contains',
+            value: 'Safety',
+          },
+        ],
+      });
+    });
+
+    expect(result.current.filterModel.items).toEqual(
+      expect.arrayContaining([
+        {
+          field: 'quickFilter',
+          operator: 'contains',
+          value: 'prompt text',
+        },
+        {
+          field: 'behavior.name',
+          operator: 'contains',
+          value: 'Safety',
+        },
+      ])
+    );
+  });
+
+  it('combines type pill, drawer, and search filters atomically', () => {
+    const drawerFilters = { ...EMPTY_TEST_FILTERS, topic: 'Billing' };
+
+    const { result } = renderHook(() =>
+      useGridState({
+        searchQuery: 'invoice',
+        typeFilter: 'Single-Turn',
+        typeFilterField: 'test_type.type_value',
+        applyDrawerFilters: (prev: GridFilterModel) =>
+          applyTestDrawerFiltersToModel(prev, drawerFilters),
+      })
+    );
+
+    expect(result.current.filterModel.items).toEqual(
+      expect.arrayContaining([
+        {
+          field: 'quickFilter',
+          operator: 'contains',
+          value: 'invoice',
+        },
+        {
+          field: 'test_type.type_value',
+          operator: 'equals',
+          value: 'Single-Turn',
+        },
+        {
+          field: 'topic.name',
+          operator: 'contains',
+          value: 'Billing',
+        },
+      ])
+    );
+  });
+});

--- a/apps/frontend/src/hooks/useGridState.ts
+++ b/apps/frontend/src/hooks/useGridState.ts
@@ -49,9 +49,7 @@ function stripManagedColumnItems(
 ): GridFilterItem[] {
   return columnItems.filter(
     item =>
-      item.field &&
-      !managedFields.has(item.field) &&
-      !isQuickFilterItem(item)
+      item.field && !managedFields.has(item.field) && !isQuickFilterItem(item)
   );
 }
 

--- a/apps/frontend/src/hooks/useGridState.ts
+++ b/apps/frontend/src/hooks/useGridState.ts
@@ -35,6 +35,26 @@ function isQuickFilterItem(item: GridFilterItem): boolean {
   return QUICK_FILTER_FIELDS.has(item.field ?? '');
 }
 
+function getManagedFilterFields(model: GridFilterModel): Set<string> {
+  return new Set(
+    model.items
+      .map(item => item.field)
+      .filter((field): field is string => !!field)
+  );
+}
+
+function stripManagedColumnItems(
+  columnItems: GridFilterItem[],
+  managedFields: Set<string>
+): GridFilterItem[] {
+  return columnItems.filter(
+    item =>
+      item.field &&
+      !managedFields.has(item.field) &&
+      !isQuickFilterItem(item)
+  );
+}
+
 function buildManagedFilterModel(
   searchQuery: string,
   typeFilter: string | undefined,
@@ -82,6 +102,12 @@ export function useGridState({
   const [columnFilterItems, setColumnFilterItems] = useState<GridFilterItem[]>(
     []
   );
+  const [gridFilterMeta, setGridFilterMeta] = useState<
+    Pick<
+      GridFilterModel,
+      'logicOperator' | 'quickFilterValues' | 'quickFilterLogicOperator'
+    >
+  >({});
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
     page: 0,
     pageSize: initialPageSize,
@@ -99,11 +125,22 @@ export function useGridState({
     [searchQuery, typeFilter, typeFilterField, applyDrawerFilters]
   );
 
+  const managedFields = useMemo(
+    () => getManagedFilterFields(managedFilterModel),
+    [managedFilterModel]
+  );
+
+  const reconciledColumnFilterItems = useMemo(
+    () => stripManagedColumnItems(columnFilterItems, managedFields),
+    [columnFilterItems, managedFields]
+  );
+
   const filterModel = useMemo(
     () => ({
-      items: [...managedFilterModel.items, ...columnFilterItems],
+      ...gridFilterMeta,
+      items: [...managedFilterModel.items, ...reconciledColumnFilterItems],
     }),
-    [managedFilterModel, columnFilterItems]
+    [gridFilterMeta, managedFilterModel, reconciledColumnFilterItems]
   );
 
   useEffect(() => {
@@ -119,23 +156,17 @@ export function useGridState({
 
   const handleFilterModelChange = useCallback(
     (model: GridFilterModel) => {
-      const managedFields = new Set(
-        managedFilterModel.items
-          .map(item => item.field)
-          .filter((field): field is string => !!field)
-      );
-
-      const columnItems = model.items.filter(
-        item =>
-          item.field &&
-          !managedFields.has(item.field) &&
-          !isQuickFilterItem(item)
-      );
+      const columnItems = stripManagedColumnItems(model.items, managedFields);
 
       setColumnFilterItems(columnItems);
+      setGridFilterMeta({
+        logicOperator: model.logicOperator,
+        quickFilterValues: model.quickFilterValues,
+        quickFilterLogicOperator: model.quickFilterLogicOperator,
+      });
       setPaginationModel(prev => ({ ...prev, page: 0 }));
     },
-    [managedFilterModel]
+    [managedFields]
   );
 
   const setFilterModel = useCallback(

--- a/apps/frontend/src/hooks/useGridState.ts
+++ b/apps/frontend/src/hooks/useGridState.ts
@@ -1,8 +1,9 @@
 'use client';
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import type {
   GridFilterModel,
+  GridFilterItem,
   GridPaginationModel,
   GridSortModel,
 } from '@mui/x-data-grid';
@@ -28,6 +29,49 @@ export interface UseGridStateResult {
   handleSortModelChange: (model: GridSortModel) => void;
 }
 
+const QUICK_FILTER_FIELDS = new Set(['quickFilter', '__quickFilter__']);
+
+function isQuickFilterItem(item: GridFilterItem): boolean {
+  return QUICK_FILTER_FIELDS.has(item.field ?? '');
+}
+
+function buildManagedFilterModel(
+  searchQuery: string,
+  typeFilter: string | undefined,
+  typeFilterField: string | undefined,
+  applyDrawerFilters: ((prev: GridFilterModel) => GridFilterModel) | undefined
+): GridFilterModel {
+  let model: GridFilterModel = { items: [] };
+
+  if (searchQuery) {
+    model = {
+      ...model,
+      items: [
+        ...model.items,
+        { field: 'quickFilter', operator: 'contains', value: searchQuery },
+      ],
+    };
+  }
+
+  if (applyDrawerFilters) {
+    model = applyDrawerFilters(model);
+  }
+
+  // Apply pill-tab type filter after drawer filters so drawer helpers that
+  // strip test_type.type_value do not remove an active toolbar tab selection.
+  if (typeFilterField && typeFilter && typeFilter !== 'all') {
+    model = {
+      ...model,
+      items: [
+        ...model.items.filter(item => item.field !== typeFilterField),
+        { field: typeFilterField, operator: 'equals', value: typeFilter },
+      ],
+    };
+  }
+
+  return model;
+}
+
 export function useGridState({
   searchQuery = '',
   typeFilter,
@@ -35,75 +79,36 @@ export function useGridState({
   applyDrawerFilters,
   initialPageSize = 25,
 }: UseGridStateOptions = {}): UseGridStateResult {
-  const [filterModel, setFilterModel] = useState<GridFilterModel>({
-    items: [],
-  });
+  const [columnFilterItems, setColumnFilterItems] = useState<GridFilterItem[]>(
+    []
+  );
   const [paginationModel, setPaginationModel] = useState<GridPaginationModel>({
     page: 0,
     pageSize: initialPageSize,
   });
   const [sortModel, setSortModel] = useState<GridSortModel>(DEFAULT_GRID_SORT);
 
-  // Sync searchQuery into filterModel
-  useEffect(() => {
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => item.field !== 'quickFilter'
-      );
-      const newItem = searchQuery
-        ? { field: 'quickFilter', operator: 'contains', value: searchQuery }
-        : null;
-      const items = newItem ? [...otherItems, newItem] : otherItems;
-      if (
-        items.length === prev.items.length &&
-        items.every(
-          (it, i) => JSON.stringify(it) === JSON.stringify(prev.items[i])
-        )
-      )
-        return prev;
-      return { ...prev, items };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [searchQuery]);
+  const managedFilterModel = useMemo(
+    () =>
+      buildManagedFilterModel(
+        searchQuery,
+        typeFilter,
+        typeFilterField,
+        applyDrawerFilters
+      ),
+    [searchQuery, typeFilter, typeFilterField, applyDrawerFilters]
+  );
 
-  // Sync typeFilter pill tab into filterModel
-  useEffect(() => {
-    if (!typeFilterField) return;
-    setFilterModel(prev => {
-      const otherItems = prev.items.filter(
-        item => item.field !== typeFilterField
-      );
-      const newItem =
-        typeFilter && typeFilter !== 'all'
-          ? { field: typeFilterField, operator: 'equals', value: typeFilter }
-          : null;
-      const items = newItem ? [...otherItems, newItem] : otherItems;
-      if (
-        items.length === prev.items.length &&
-        items.every(
-          (it, i) => JSON.stringify(it) === JSON.stringify(prev.items[i])
-        )
-      )
-        return prev;
-      return { ...prev, items };
-    });
-    setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-  }, [typeFilter, typeFilterField]);
+  const filterModel = useMemo(
+    () => ({
+      items: [...managedFilterModel.items, ...columnFilterItems],
+    }),
+    [managedFilterModel, columnFilterItems]
+  );
 
-  // Sync drawer filters into filterModel
   useEffect(() => {
-    if (!applyDrawerFilters) return;
-    setFilterModel(prev => {
-      const next = applyDrawerFilters(prev);
-      return next === prev || JSON.stringify(next) === JSON.stringify(prev)
-        ? prev
-        : next;
-    });
     setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
-    // applyDrawerFilters is a new function reference each render when drawerFilters changes,
-    // so depending on it here is the correct way to react to drawer filter changes.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [applyDrawerFilters]);
+  }, [managedFilterModel]);
 
   const handlePaginationModelChange = useCallback(
     (model: GridPaginationModel) => {
@@ -112,10 +117,33 @@ export function useGridState({
     []
   );
 
-  const handleFilterModelChange = useCallback((model: GridFilterModel) => {
-    setFilterModel(model);
-    setPaginationModel(prev => ({ ...prev, page: 0 }));
-  }, []);
+  const handleFilterModelChange = useCallback(
+    (model: GridFilterModel) => {
+      const managedFields = new Set(
+        managedFilterModel.items
+          .map(item => item.field)
+          .filter((field): field is string => !!field)
+      );
+
+      const columnItems = model.items.filter(
+        item =>
+          item.field &&
+          !managedFields.has(item.field) &&
+          !isQuickFilterItem(item)
+      );
+
+      setColumnFilterItems(columnItems);
+      setPaginationModel(prev => ({ ...prev, page: 0 }));
+    },
+    [managedFilterModel]
+  );
+
+  const setFilterModel = useCallback(
+    (model: GridFilterModel) => {
+      handleFilterModelChange(model);
+    },
+    [handleFilterModelChange]
+  );
 
   const handleSortModelChange = useCallback((model: GridSortModel) => {
     setSortModel(model);


### PR DESCRIPTION
## Purpose
Search on the Tests page stopped working after applying drawer filters because the DataGrid echoed back a stripped `filterModel` that overwrote toolbar-managed quick search.

Fixes #1221

## Root Cause
Root cause was in `useGridState`, shared by Tests, Test Sets, Test Runs, Tasks, and other grids:

- Search, type pill, and drawer filters were synced through three separate `useEffect`s, which could race.
- `handleFilterModelChange` blindly replaced the full `filterModel` when MUI DataGrid echoed back changes.
- DataGrid does not know about the custom `quickFilter` item from the toolbar, so after filters were applied it often echoed a model without search, wiping the query while the search box still showed text.

## Scope
The fix is in the shared `useGridState` hook, so every grid that uses it is covered automatically — no per-page changes needed.

**Fixed by this PR:**
- Tests (`TestsGrid.tsx`)
- Test Sets (`TestSetsGrid.tsx`)
- Test Set detail — tests in a set (`TestSetTestsGrid.tsx`)
- Test Runs (`TestRunsGrid.tsx`)
- Tasks (`TasksGrid.tsx`)
- Sources (`SourcesGrid.tsx`)
- Endpoints (`EndpointsGrid.tsx`)

**Not covered** — grids that manage search/filters independently (e.g. Team Members, Experiments, Traces, Behaviors, Insights).

Issue #1221 was reported on Tests, but the same race could affect any of the grids above.

## What Changed
- Refactored `useGridState` to derive search, type pill, and drawer filters atomically via `useMemo`
- Updated `handleFilterModelChange` to treat DataGrid updates as column-only filters instead of replacing toolbar-managed filters
- Applied type pill filters after drawer filters so active tab selections are not stripped
- Added unit tests covering filter-then-search and DataGrid echo scenarios

## Testing
- [x] `npm test -- --testPathPatterns=useGridState.test.ts`
- [ ] Manual: open Tests, apply a drawer filter, search within the filtered list, confirm results narrow correctly