### PR TITLE
Fix: restore DB_HOST in rh dev init env

### DIFF
--- a/rh
+++ b/rh
@@ -195,6 +195,8 @@ $DEV_ENV_MARKER on $timestamp
 QUICK_START=true
 
 # Database
+DB_HOST=localhost
+DB_NAME=rhesis-db
 DB_PORT=${DEV_POSTGRES_PORT}
 APP_DB_USER=rhesis-user
 APP_DB_PASS=rhesis-password


### PR DESCRIPTION
## Purpose
PR #2146 removed `DB_HOST` and `DB_NAME` from the backend `.env` generated by `./rh dev init`, relying on pydantic defaults. However, `apps/backend/start.sh` checks for `DB_HOST` in the shell environment to decide whether to run migrations — so fresh dev setups skip migrations entirely.

## What Changed
- Restore `DB_HOST=localhost` and `DB_NAME=rhesis-db` in the `rh dev init` backend env template

## Testing
- Run `./rh dev init` and confirm the generated `apps/backend/.env` includes `DB_HOST`
- Start the backend and verify migrations run