### PR TITLE
Fix AND logic for multiple Tests drawer filters

### DIFF
--- a/apps/frontend/src/app/(protected)/tests/components/TestFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestFilterDrawer.tsx
@@ -29,13 +29,13 @@ import {
 export interface TestFilters {
   /** test_type/type_value equals: Single-Turn | Multi-Turn | '' */
   testType: string;
-  /** status/name contains */
+  /** status/name equals */
   status: string;
-  /** behavior/name contains */
+  /** behavior/name equals */
   behavior: string;
-  /** category/name contains */
+  /** category/name equals */
   category: string;
-  /** topic/name contains */
+  /** topic/name equals */
   topic: string;
   tags: ActivityPresenceFilters['tags'];
   comments: ActivityPresenceFilters['comments'];

--- a/apps/frontend/src/app/(protected)/tests/components/test-filter-model.ts
+++ b/apps/frontend/src/app/(protected)/tests/components/test-filter-model.ts
@@ -72,28 +72,28 @@ export function applyTestDrawerFiltersToModel(
   if (drawerFilters.status) {
     drawerItems.push({
       field: 'status.name',
-      operator: 'contains',
+      operator: 'equals',
       value: drawerFilters.status,
     });
   }
   if (drawerFilters.behavior) {
     drawerItems.push({
       field: 'behavior.name',
-      operator: 'contains',
+      operator: 'equals',
       value: drawerFilters.behavior,
     });
   }
   if (drawerFilters.category) {
     drawerItems.push({
       field: 'category.name',
-      operator: 'contains',
+      operator: 'equals',
       value: drawerFilters.category,
     });
   }
   if (drawerFilters.topic) {
     drawerItems.push({
       field: 'topic.name',
-      operator: 'contains',
+      operator: 'equals',
       value: drawerFilters.topic,
     });
   }

--- a/apps/frontend/src/hooks/__tests__/useGridState.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useGridState.test.ts
@@ -1,6 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
-import type { GridFilterModel } from '@mui/x-data-grid';
-import { GridLogicOperator } from '@mui/x-data-grid';
+import { GridLogicOperator, type GridFilterModel } from '@mui/x-data-grid';
 import { useGridState } from '../useGridState';
 import { applyTestDrawerFiltersToModel } from '@/app/(protected)/tests/components/test-filter-model';
 import { EMPTY_TEST_FILTERS } from '@/app/(protected)/tests/components/TestFilterDrawer';

--- a/apps/frontend/src/hooks/__tests__/useGridState.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useGridState.test.ts
@@ -1,8 +1,10 @@
 import { act, renderHook } from '@testing-library/react';
 import type { GridFilterModel } from '@mui/x-data-grid';
+import { GridLogicOperator } from '@mui/x-data-grid';
 import { useGridState } from '../useGridState';
 import { applyTestDrawerFiltersToModel } from '@/app/(protected)/tests/components/test-filter-model';
 import { EMPTY_TEST_FILTERS } from '@/app/(protected)/tests/components/TestFilterDrawer';
+import { combineTestFiltersToOData } from '@/utils/odata-filter';
 
 describe('useGridState', () => {
   it('keeps search when drawer filters are applied first', () => {
@@ -32,7 +34,7 @@ describe('useGridState', () => {
     expect(result.current.filterModel.items).toEqual([
       {
         field: 'status.name',
-        operator: 'contains',
+        operator: 'equals',
         value: 'Active',
       },
     ]);
@@ -48,7 +50,7 @@ describe('useGridState', () => {
         },
         {
           field: 'status.name',
-          operator: 'contains',
+          operator: 'equals',
           value: 'Active',
         },
       ])
@@ -71,7 +73,7 @@ describe('useGridState', () => {
         items: [
           {
             field: 'behavior.name',
-            operator: 'contains',
+            operator: 'equals',
             value: 'Safety',
           },
         ],
@@ -87,7 +89,7 @@ describe('useGridState', () => {
         },
         {
           field: 'behavior.name',
-          operator: 'contains',
+          operator: 'equals',
           value: 'Safety',
         },
       ])
@@ -121,7 +123,7 @@ describe('useGridState', () => {
         },
         {
           field: 'topic.name',
-          operator: 'contains',
+          operator: 'equals',
           value: 'Billing',
         },
       ])
@@ -157,7 +159,7 @@ describe('useGridState', () => {
         items: [
           {
             field: 'status.name',
-            operator: 'contains',
+            operator: 'equals',
             value: 'Draft',
           },
         ],
@@ -167,7 +169,7 @@ describe('useGridState', () => {
     expect(result.current.filterModel.items).toEqual([
       {
         field: 'status.name',
-        operator: 'contains',
+        operator: 'equals',
         value: 'Draft',
       },
     ]);
@@ -177,9 +179,45 @@ describe('useGridState', () => {
     expect(result.current.filterModel.items).toEqual([
       {
         field: 'status.name',
-        operator: 'contains',
+        operator: 'equals',
         value: 'Active',
       },
     ]);
+  });
+
+  it('forces AND logic when DataGrid echoes logicOperator or', () => {
+    const drawerFilters = {
+      ...EMPTY_TEST_FILTERS,
+      behavior: 'Accuracy Testing',
+      status: 'New',
+    };
+
+    const { result } = renderHook(() =>
+      useGridState({
+        applyDrawerFilters: (prev: GridFilterModel) =>
+          applyTestDrawerFiltersToModel(prev, drawerFilters),
+      })
+    );
+
+    act(() => {
+      result.current.handleFilterModelChange({
+        logicOperator: GridLogicOperator.Or,
+        items: [
+          {
+            field: 'behavior.name',
+            operator: 'equals',
+            value: 'Accuracy Testing',
+          },
+        ],
+      });
+    });
+
+    expect(result.current.filterModel.logicOperator).toBe(
+      GridLogicOperator.And
+    );
+
+    const odata = combineTestFiltersToOData(result.current.filterModel);
+    expect(odata).toContain(' and ');
+    expect(odata).not.toMatch(/\bor\b/);
   });
 });

--- a/apps/frontend/src/hooks/useGridState.ts
+++ b/apps/frontend/src/hooks/useGridState.ts
@@ -1,13 +1,13 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import type {
-  GridFilterModel,
-  GridFilterItem,
-  GridPaginationModel,
-  GridSortModel,
+import {
+  GridLogicOperator,
+  type GridFilterModel,
+  type GridFilterItem,
+  type GridPaginationModel,
+  type GridSortModel,
 } from '@mui/x-data-grid';
-import { GridLogicOperator } from '@mui/x-data-grid';
 import { DEFAULT_GRID_SORT } from '@/utils/grid-sort';
 
 export interface UseGridStateOptions {

--- a/apps/frontend/src/hooks/useGridState.ts
+++ b/apps/frontend/src/hooks/useGridState.ts
@@ -7,6 +7,7 @@ import type {
   GridPaginationModel,
   GridSortModel,
 } from '@mui/x-data-grid';
+import { GridLogicOperator } from '@mui/x-data-grid';
 import { DEFAULT_GRID_SORT } from '@/utils/grid-sort';
 
 export interface UseGridStateOptions {
@@ -136,6 +137,9 @@ export function useGridState({
   const filterModel = useMemo(
     () => ({
       ...gridFilterMeta,
+      // Drawer/toolbar filters must always combine with AND. DataGrid can echo
+      // logicOperator: 'or', which would incorrectly broaden multi-filter results.
+      logicOperator: GridLogicOperator.And,
       items: [...managedFilterModel.items, ...reconciledColumnFilterItems],
     }),
     [gridFilterMeta, managedFilterModel, reconciledColumnFilterItems]


### PR DESCRIPTION
## Purpose
Follow-up to #2163 / #1221. @asadaaron reported that combining drawer filters (e.g. Behavior = Accuracy Testing + Status = New) still returned rows outside the filter (e.g. Robustness).

## Root Cause
DataGrid was echoing `logicOperator: or` into the filter model, so multiple drawer filters were combined with OR instead of AND. Any test matching *either* filter appeared — e.g. all New-status tests, including Robustness.

## What Changed
- Force `logicOperator: And` in `useGridState` for toolbar/drawer-managed filters
- Switch drawer behavior/status/category/topic filters from `contains` to `equals` (exact autocomplete values)
- Add regression test for behavior + status AND combination

Fixes #1221

## Testing
- [x] `npm test -- --testPathPatterns=useGridState.test.ts`
- [ ] Manual: Tests → filter Behavior = Accuracy Testing + Status = New → only matching rows shown