### PR TITLE
fix(logging): replace GCP-inferred gating with explicit JSON logging flag

### DIFF
--- a/apps/backend/src/rhesis/backend/app/config/settings.py
+++ b/apps/backend/src/rhesis/backend/app/config/settings.py
@@ -94,6 +94,7 @@ class ApplicationSettings(BaseSettings):
     google_cloud_project: str | None = Field(default=None, alias="GOOGLE_CLOUD_PROJECT")
     cloud_run_service: str | None = Field(default=None, alias="K_SERVICE")
     cloud_run_revision: str | None = Field(default=None, alias="K_REVISION")
+    json_logger_enabled: bool = Field(default=False, alias="JSON_LOGGER_ENABLED")
     api_base_url: str = Field(default="http://localhost:8080", alias="API_BASE_URL")
 
     @field_validator("api_base_url")

--- a/apps/backend/src/rhesis/backend/celery/config.py
+++ b/apps/backend/src/rhesis/backend/celery/config.py
@@ -68,9 +68,6 @@ CELERY_CONFIG = {
     # Reduce verbose task result logging
     "task_always_eager": False,
     "task_eager_propagates": False,
-    # Suppress verbose task result logging
-    "worker_log_format": "[%(asctime)s: %(levelname)s/%(processName)s] %(message)s",
-    "worker_task_log_format": "[%(asctime)s: %(levelname)s/%(processName)s] %(message)s",
     # Task annotations
     "task_annotations": {
         "rhesis.backend.tasks.execute_test_configuration": {

--- a/apps/backend/src/rhesis/backend/celery/signals.py
+++ b/apps/backend/src/rhesis/backend/celery/signals.py
@@ -102,7 +102,7 @@ def warm_architect_worker(sender=None, **kwargs):
 @after_setup_logger.connect
 def configure_worker_logging(logger=None, **kw):
     """Replace Celery's default root logger setup with our shared pipeline
-    (RedactingFormatter + JSON/plain-text stdout, per JSON_LOGGER_ENABLED).
+    (RedactingFormatter + JSON/color/plain stdout; file logs when BACKEND_ENV=local).
 
     Runs after Celery hijacks the root logger at worker boot (the default
     `worker_hijack_root_logger` behavior), so calling this at import time

--- a/apps/backend/src/rhesis/backend/celery/signals.py
+++ b/apps/backend/src/rhesis/backend/celery/signals.py
@@ -17,6 +17,8 @@ from rhesis.backend.tasks.enums import RunStatus
 logger = logging.getLogger("celery.signals")
 
 _EXECUTE_TEST_CONFIGURATION_TASK = "rhesis.backend.tasks.execute_test_configuration"
+# Set in celeryd_init from the worker node name (e.g. main@host → MAIN).
+_worker_role: str | None = None
 
 
 def _update_test_run_status(task_id: str, new_status: RunStatus, error_message: str = None):
@@ -54,16 +56,14 @@ def _update_test_run_status(task_id: str, new_status: RunStatus, error_message: 
 
 
 @celeryd_init.connect
-def setup_worker_log_format(sender=None, conf=None, **kwargs):
-    """Prefix Celery log lines with MAIN/ARCHITECT so both workers are distinguishable."""
-    if conf is None:
-        return
-    role = (sender.split("@", 1)[0] if sender else "worker").upper()
-    conf.worker_log_format = f"[%(asctime)s: %(levelname)s/{role}/%(processName)s] %(message)s"
-    conf.worker_task_log_format = (
-        f"[%(asctime)s: %(levelname)s/{role}/%(processName)s] "
-        "[%(task_name)s(%(task_id)s)] %(message)s"
-    )
+def capture_worker_role(sender=None, conf=None, **kwargs):
+    """Derive MAIN/ARCHITECT from the Celery node name (``-n main@host``).
+
+    Runs before ``after_setup_logger`` in Celery's worker boot sequence, so the
+    role is available when we install our shared logging pipeline.
+    """
+    global _worker_role
+    _worker_role = (sender.split("@", 1)[0] if sender else "worker").upper()
 
 
 @worker_ready.connect
@@ -101,14 +101,15 @@ def warm_architect_worker(sender=None, **kwargs):
 
 @after_setup_logger.connect
 def configure_worker_logging(logger=None, **kw):
-    """Replace Celery's default root logger setup with our shared pipeline
-    (RedactingFormatter + JSON/color/plain stdout; file logs when BACKEND_ENV=local).
+    """Replace Celery's default root logger setup with our shared pipeline.
 
     Runs after Celery hijacks the root logger at worker boot (the default
     `worker_hijack_root_logger` behavior), so calling this at import time
     would just get overwritten by Celery's own setup.
+
+    Uses the role captured from the Celery hostname in ``celeryd_init``.
     """
-    set_logger()
+    set_logger(worker_role=_worker_role)
 
 
 @after_setup_logger.connect

--- a/apps/backend/src/rhesis/backend/celery/signals.py
+++ b/apps/backend/src/rhesis/backend/celery/signals.py
@@ -11,6 +11,7 @@ from celery.signals import (
 )
 
 import rhesis.backend.tasks.architect.monitor  # noqa: F401
+from rhesis.backend.logging import set_logger
 from rhesis.backend.tasks.enums import RunStatus
 
 logger = logging.getLogger("celery.signals")
@@ -96,6 +97,18 @@ def warm_architect_worker(sender=None, **kwargs):
 
     elapsed = time.perf_counter() - start
     logger.info("Architect worker: backend app preloaded in %.1fs", elapsed)
+
+
+@after_setup_logger.connect
+def configure_worker_logging(logger=None, **kw):
+    """Replace Celery's default root logger setup with our shared pipeline
+    (RedactingFormatter + JSON/plain-text stdout, per JSON_LOGGER_ENABLED).
+
+    Runs after Celery hijacks the root logger at worker boot (the default
+    `worker_hijack_root_logger` behavior), so calling this at import time
+    would just get overwritten by Celery's own setup.
+    """
+    set_logger()
 
 
 @after_setup_logger.connect

--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -14,6 +14,7 @@ logging_settings = get_logging_settings()
 LOG_LEVEL = logging_settings.log_level
 LOG_DIR = logging_settings.log_dir
 ENVIRONMENT = application_settings.backend_env
+JSON_LOGGER_ENABLED = application_settings.json_logger_enabled
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 LOG_DATE_FORMAT = "%m/%d/%Y %I:%M:%S%p"
 
@@ -249,14 +250,20 @@ def set_logger():
         file_handler.setLevel(LOG_LEVEL)
         file_handler.setFormatter(RedactingFormatter(_create_formatter()))
         root_logger.addHandler(file_handler)
-    else:
-        # Any non-local environment (GKE dev/staging/production, Cloud Run, etc.)
-        # gets structured JSON on stdout so container log collection always
-        # captures request/error output, regardless of which cloud runs it.
+    elif JSON_LOGGER_ENABLED:
+        # Explicit opt-in (e.g. Rhesis-managed deployments) for structured
+        # JSON on stdout, consumed by a container log collector.
         json_console_handler = logging.StreamHandler(stream=sys.stdout)
         json_console_handler.setLevel(LOG_LEVEL)
         json_console_handler.setFormatter(RedactingFormatter(JsonLogFormatter()))
         root_logger.addHandler(json_console_handler)
+    else:
+        # Default for non-local environments (e.g. self-hosted deployments):
+        # plain-text stdout, readable without a structured log collector.
+        plain_console_handler = logging.StreamHandler(stream=sys.stdout)
+        plain_console_handler.setLevel(LOG_LEVEL)
+        plain_console_handler.setFormatter(RedactingFormatter(_create_formatter()))
+        root_logger.addHandler(plain_console_handler)
 
     for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "websockets", "fastapi"):
         logger = logging.getLogger(name)

--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -215,14 +215,11 @@ _configured = False
 
 
 def set_logger():
-    """Configure the root logger for the application.
+    """Configure the root logger once at startup.
 
-    Sets up JSON console output with extra local-development output.
-    All handlers use RedactingFormatter to ensure sensitive data is scrubbed
-    from the final output without mutating shared LogRecord objects.
-
-    Must be called once during application startup (e.g. in main.py).
-    Subsequent calls are no-ops to prevent duplicate handlers.
+    Console: JSON if ``JSON_LOGGER_ENABLED``, else color on a TTY, else plain text.
+    When ``BACKEND_ENV=local``, also write a timestamped plain-text file under
+    ``LOG_DIR``. All handlers redact sensitive data via ``RedactingFormatter``.
     """
     global _configured
     if _configured:
@@ -236,12 +233,20 @@ def set_logger():
     # default lastResort handler) so we control all output.
     root_logger.handlers.clear()
 
-    if ENVIRONMENT == "local":
-        color_console_handler = logging.StreamHandler(stream=sys.stdout)
-        color_console_handler.setLevel(LOG_LEVEL)
-        color_console_handler.setFormatter(RedactingFormatter(_create_color_formatter()))
-        root_logger.addHandler(color_console_handler)
+    console_handler = logging.StreamHandler(stream=sys.stdout)
+    console_handler.setLevel(LOG_LEVEL)
+    if JSON_LOGGER_ENABLED:
+        # Explicit opt-in (e.g. Rhesis-managed deployments) for structured
+        # JSON on stdout, consumed by a container log collector.
+        console_handler.setFormatter(RedactingFormatter(JsonLogFormatter()))
+    elif sys.stdout.isatty():
+        console_handler.setFormatter(RedactingFormatter(_create_color_formatter()))
+    else:
+        # Non-interactive stdout (pipes, containers without a TTY): plain text.
+        console_handler.setFormatter(RedactingFormatter(_create_formatter()))
+    root_logger.addHandler(console_handler)
 
+    if ENVIRONMENT == "local":
         timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         Path(LOG_DIR).mkdir(parents=True, exist_ok=True)
 
@@ -250,20 +255,6 @@ def set_logger():
         file_handler.setLevel(LOG_LEVEL)
         file_handler.setFormatter(RedactingFormatter(_create_formatter()))
         root_logger.addHandler(file_handler)
-    elif JSON_LOGGER_ENABLED:
-        # Explicit opt-in (e.g. Rhesis-managed deployments) for structured
-        # JSON on stdout, consumed by a container log collector.
-        json_console_handler = logging.StreamHandler(stream=sys.stdout)
-        json_console_handler.setLevel(LOG_LEVEL)
-        json_console_handler.setFormatter(RedactingFormatter(JsonLogFormatter()))
-        root_logger.addHandler(json_console_handler)
-    else:
-        # Default for non-local environments (e.g. self-hosted deployments):
-        # plain-text stdout, readable without a structured log collector.
-        plain_console_handler = logging.StreamHandler(stream=sys.stdout)
-        plain_console_handler.setLevel(LOG_LEVEL)
-        plain_console_handler.setFormatter(RedactingFormatter(_create_formatter()))
-        root_logger.addHandler(plain_console_handler)
 
     for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "websockets", "fastapi"):
         logger = logging.getLogger(name)

--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -15,7 +15,8 @@ LOG_LEVEL = logging_settings.log_level
 LOG_DIR = logging_settings.log_dir
 ENVIRONMENT = application_settings.backend_env
 JSON_LOGGER_ENABLED = application_settings.json_logger_enabled
-LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+# role_prefix is "" for API; Celery workers get "[MAIN] - " via the filter.
+LOG_FORMAT = "%(asctime)s - %(role_prefix)s%(name)s - %(levelname)s - %(message)s"
 LOG_DATE_FORMAT = "%m/%d/%Y %I:%M:%S%p"
 
 
@@ -173,13 +174,27 @@ class JsonLogFormatter(logging.Formatter):
     """Format log records as Google Cloud-compatible structured JSON."""
 
     def format(self, record: logging.LogRecord) -> str:
-        return json.dumps(
-            {
-                "severity": record.levelname,
-                "module": record.name,
-                "message": f"{record.name}: {record.getMessage()}",
-            }
-        )
+        payload = {
+            "severity": record.levelname,
+            "module": record.name,
+            "message": f"{record.name}: {record.getMessage()}",
+        }
+        if role := getattr(record, "worker_role", None):
+            payload["worker_role"] = role
+        return json.dumps(payload)
+
+
+class _WorkerContextFilter(logging.Filter):
+    """Stamp ``worker_role`` / ``role_prefix`` on every record (empty for API)."""
+
+    def __init__(self, worker_role: str | None = None):
+        super().__init__()
+        self.worker_role = worker_role
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.worker_role = self.worker_role
+        record.role_prefix = f"[{self.worker_role}] - " if self.worker_role else ""
+        return True
 
 
 class ColorFormatter(logging.Formatter):
@@ -203,23 +218,16 @@ class ColorFormatter(logging.Formatter):
         return result
 
 
-def _create_formatter():
-    return logging.Formatter(LOG_FORMAT, datefmt=LOG_DATE_FORMAT)
-
-
-def _create_color_formatter():
-    return ColorFormatter(LOG_FORMAT, datefmt=LOG_DATE_FORMAT)
-
-
 _configured = False
 
 
-def set_logger():
+def set_logger(worker_role: str | None = None):
     """Configure the root logger once at startup.
 
     Console: JSON if ``JSON_LOGGER_ENABLED``, else color on a TTY, else plain text.
     When ``BACKEND_ENV=local``, also write a timestamped plain-text file under
-    ``LOG_DIR``. All handlers redact sensitive data via ``RedactingFormatter``.
+    ``LOG_DIR``. Optional ``worker_role`` (e.g. MAIN/ARCHITECT from Celery's
+    node name) is included in JSON and as a plain-text prefix.
     """
     global _configured
     if _configured:
@@ -233,30 +241,42 @@ def set_logger():
     # default lastResort handler) so we control all output.
     root_logger.handlers.clear()
 
+    if JSON_LOGGER_ENABLED:
+        formatter: logging.Formatter = RedactingFormatter(JsonLogFormatter())
+    elif sys.stdout.isatty():
+        formatter = RedactingFormatter(ColorFormatter(LOG_FORMAT, datefmt=LOG_DATE_FORMAT))
+    else:
+        formatter = RedactingFormatter(logging.Formatter(LOG_FORMAT, datefmt=LOG_DATE_FORMAT))
+
     console_handler = logging.StreamHandler(stream=sys.stdout)
     console_handler.setLevel(LOG_LEVEL)
-    if JSON_LOGGER_ENABLED:
-        # Explicit opt-in (e.g. Rhesis-managed deployments) for structured
-        # JSON on stdout, consumed by a container log collector.
-        console_handler.setFormatter(RedactingFormatter(JsonLogFormatter()))
-    elif sys.stdout.isatty():
-        console_handler.setFormatter(RedactingFormatter(_create_color_formatter()))
-    else:
-        # Non-interactive stdout (pipes, containers without a TTY): plain text.
-        console_handler.setFormatter(RedactingFormatter(_create_formatter()))
+    console_handler.setFormatter(formatter)
     root_logger.addHandler(console_handler)
 
     if ENVIRONMENT == "local":
         timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
         Path(LOG_DIR).mkdir(parents=True, exist_ok=True)
 
-        log_file_path = os.path.join(LOG_DIR, f"rhesis_{timestamp}.log")
-        file_handler = logging.FileHandler(log_file_path)
+        file_handler = logging.FileHandler(os.path.join(LOG_DIR, f"rhesis_{timestamp}.log"))
         file_handler.setLevel(LOG_LEVEL)
-        file_handler.setFormatter(RedactingFormatter(_create_formatter()))
+        file_handler.setFormatter(
+            RedactingFormatter(logging.Formatter(LOG_FORMAT, datefmt=LOG_DATE_FORMAT))
+        )
         root_logger.addHandler(file_handler)
 
-    for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "websockets", "fastapi"):
+    context_filter = _WorkerContextFilter(worker_role)
+    for handler in root_logger.handlers:
+        handler.addFilter(context_filter)
+
+    for name in (
+        "uvicorn",
+        "uvicorn.access",
+        "uvicorn.error",
+        "websockets",
+        "fastapi",
+        "celery",
+        "celery.worker",
+    ):
         logger = logging.getLogger(name)
         logger.handlers.clear()
         logger.propagate = True

--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -14,7 +14,6 @@ logging_settings = get_logging_settings()
 LOG_LEVEL = logging_settings.log_level
 LOG_DIR = logging_settings.log_dir
 ENVIRONMENT = application_settings.backend_env
-IS_GOOGLE_CLOUD = application_settings.is_google_cloud
 LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 LOG_DATE_FORMAT = "%m/%d/%Y %I:%M:%S%p"
 
@@ -236,12 +235,6 @@ def set_logger():
     # default lastResort handler) so we control all output.
     root_logger.handlers.clear()
 
-    if IS_GOOGLE_CLOUD:
-        json_console_handler = logging.StreamHandler(stream=sys.stdout)
-        json_console_handler.setLevel(LOG_LEVEL)
-        json_console_handler.setFormatter(RedactingFormatter(JsonLogFormatter()))
-        root_logger.addHandler(json_console_handler)
-
     if ENVIRONMENT == "local":
         color_console_handler = logging.StreamHandler(stream=sys.stdout)
         color_console_handler.setLevel(LOG_LEVEL)
@@ -256,6 +249,14 @@ def set_logger():
         file_handler.setLevel(LOG_LEVEL)
         file_handler.setFormatter(RedactingFormatter(_create_formatter()))
         root_logger.addHandler(file_handler)
+    else:
+        # Any non-local environment (GKE dev/staging/production, Cloud Run, etc.)
+        # gets structured JSON on stdout so container log collection always
+        # captures request/error output, regardless of which cloud runs it.
+        json_console_handler = logging.StreamHandler(stream=sys.stdout)
+        json_console_handler.setLevel(LOG_LEVEL)
+        json_console_handler.setFormatter(RedactingFormatter(JsonLogFormatter()))
+        root_logger.addHandler(json_console_handler)
 
     for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "websockets", "fastapi"):
         logger = logging.getLogger(name)

--- a/charts/rhesis/templates/configmap.yaml
+++ b/charts/rhesis/templates/configmap.yaml
@@ -28,6 +28,7 @@ data:
   BACKEND_ENV: {{ .Values.config.environment | quote }}
   WORKER_ENV: {{ .Values.config.environment | quote }}
   LOG_LEVEL: {{ .Values.config.logLevel | quote }}
+  JSON_LOGGER_ENABLED: {{ .Values.config.jsonLoggerEnabled | quote }}
 
   # -------------------------------------------------------------------------
   # Frontend

--- a/charts/rhesis/values-dev.yaml
+++ b/charts/rhesis/values-dev.yaml
@@ -19,6 +19,7 @@ config:
   environment: "development"
   # INFO reduces API log I/O under load; use DEBUG only when actively tracing.
   logLevel: "INFO"
+  jsonLoggerEnabled: true
 
   # App DB name (ConfigMap DB_NAME) and Bitnami PostgreSQL bootstrap database.
   dbName: &rhesis_db_name "rhesis-dev-db"

--- a/charts/rhesis/values-prd.yaml
+++ b/charts/rhesis/values-prd.yaml
@@ -29,6 +29,7 @@ database:
 config:
   environment: "production"
   logLevel: "INFO"
+  jsonLoggerEnabled: true
 
   # Must match kubernetes/clusters/prd/cnpg-cluster/cnpg-cluster.yaml bootstrap.initdb.database
   dbName: "rhesis-prd-db"

--- a/charts/rhesis/values-stg.yaml
+++ b/charts/rhesis/values-stg.yaml
@@ -25,6 +25,7 @@ database:
 config:
   environment: "staging"
   logLevel: "INFO"
+  jsonLoggerEnabled: true
 
   # Must match kubernetes/clusters/stg/cnpg-cluster/cnpg-cluster.yaml bootstrap.initdb.database
   dbName: "rhesis-stg-db"

--- a/charts/rhesis/values.yaml
+++ b/charts/rhesis/values.yaml
@@ -48,6 +48,10 @@ database:
 config:
   environment: "production"
   logLevel: "INFO"
+  # Structured JSON logs on stdout, for a container log collector. Defaults
+  # to false so self-hosted deployments get human-readable text logs;
+  # Rhesis-managed environments override this to true.
+  jsonLoggerEnabled: false
 
   # Database (host/port/name/user are computed from subchart or externalDatabase)
   dbPort: "5432"

--- a/docs/content/contribute/backend/architecture.mdx
+++ b/docs/content/contribute/backend/architecture.mdx
@@ -97,9 +97,10 @@ The logger chooses handlers from runtime configuration:
 
 | Runtime condition | Output |
 | --- | --- |
-| Google Cloud runtime detected | JSON logs on stdout with `severity`, `module`, and `message` fields |
-| `BACKEND_ENV=local` | Colored console logs plus timestamped files under `LOG_DIR` |
-| Other environments | Root logger level and framework logger levels are controlled by `LOG_LEVEL` |
+| `JSON_LOGGER_ENABLED=true` | JSON logs on stdout (`severity`, `module`, `message`) — never colored |
+| Interactive TTY (and JSON off) | Colored plain-text logs on stdout |
+| Non-TTY stdout (and JSON off) | Plain-text logs on stdout |
+| `BACKEND_ENV=local` (any of the above) | Additionally writes a timestamped plain-text file under `LOG_DIR` |
 
 `DEV_MODE=true` enables Uvicorn hot reload and `--log-level debug` in `start.sh`, and forces `CELERY_WORKER_LOGLEVEL=DEBUG` in the worker. Set `DEV_MODE=true` in `apps/backend/.env` when running via `./rh dev`; leave it unset or `false` everywhere else (Docker Compose local, cloud deployments).
 

--- a/docs/content/contribute/backend/architecture.mdx
+++ b/docs/content/contribute/backend/architecture.mdx
@@ -101,6 +101,7 @@ The logger chooses handlers from runtime configuration:
 | Interactive TTY (and JSON off) | Colored plain-text logs on stdout |
 | Non-TTY stdout (and JSON off) | Plain-text logs on stdout |
 | `BACKEND_ENV=local` (any of the above) | Additionally writes a timestamped plain-text file under `LOG_DIR` |
+| Celery worker (node name ``-n main@…`` / ``architect@…``) | Adds `worker_role` to JSON; `[ROLE] -` prefix in plain/color |
 
 `DEV_MODE=true` enables Uvicorn hot reload and `--log-level debug` in `start.sh`, and forces `CELERY_WORKER_LOGLEVEL=DEBUG` in the worker. Set `DEV_MODE=true` in `apps/backend/.env` when running via `./rh dev`; leave it unset or `false` everywhere else (Docker Compose local, cloud deployments).
 


### PR DESCRIPTION
## Purpose
Backend logging was silently disabled on GKE — logging was gated on `IS_GOOGLE_CLOUD` (only true on Cloud Run, via `K_SERVICE`/`K_REVISION`), which GKE never sets, and `ENVIRONMENT == "local"`. Neither branch fired on GKE, so `kubectl logs` showed nothing. Separately, adopting the shared `set_logger()` pipeline on Celery workers dropped the MAIN/ARCHITECT labels that previously came from Celery's own format strings.

## What Changed
- Replaced environment/platform inference with an explicit `JSON_LOGGER_ENABLED` setting. Defaults to `false` (plain-text stdout) so self-hosted deployments get readable logs with zero config; Rhesis-managed envs set it to `true` via Helm for structured JSON.
- Console format selection: `JSON_LOGGER_ENABLED` → JSON; else color on a TTY; else plain text. File logging remains gated on `BACKEND_ENV=local`.
- Wired the Celery worker into the same logging pipeline (`set_logger()` via `after_setup_logger`), including clearing `celery` / `celery.worker` handlers so they propagate into the redacting/JSON path.
- Preserve MAIN/ARCHITECT on worker logs via a shared filter (`worker_role` in JSON; `[ROLE] -` prefix in plain/color). Remove unused Celery `worker_log_format` / `worker_task_log_format` config.

## Additional Context
- `is_google_cloud` / `K_SERVICE` / `K_REVISION` in `settings.py` are untouched — still used by the Quick Start gate.
- API processes pass no `worker_role`; `role_prefix` is empty so their log lines are unchanged.

## Testing
- [ ] Redeploy staging; confirm JSON logs for backend and worker pods
- [ ] Local TTY: colored stdout; `BACKEND_ENV=local` also writes under `LOG_DIR`
- [ ] Dual workers: MAIN vs ARCHITECT distinguishable in shared log stream
- [ ] `JSON_LOGGER_ENABLED=true`: JSON lines include `worker_role` on workers only