### PR TITLE
Remove environment-name-based gating in backend

### DIFF
--- a/apps/backend/src/rhesis/backend/app/auth/url_utils.py
+++ b/apps/backend/src/rhesis/backend/app/auth/url_utils.py
@@ -1,15 +1,7 @@
 from urllib.parse import parse_qs, urlparse
 
 from rhesis.backend.app.auth.token_utils import create_auth_code
-from rhesis.backend.app.config.settings import (
-    get_application_settings,
-    get_frontend_settings,
-)
-
-# Loopback hostnames accepted as redirect targets in development. Matched
-# exactly against ``urlparse(...).hostname`` so that lookalikes such as
-# ``evil-localhost.com`` or ``localhost.attacker.com`` cannot slip through.
-_LOOPBACK_HOSTNAMES = frozenset(("localhost", "127.0.0.1", "::1"))
+from rhesis.backend.app.config.settings import get_frontend_settings
 
 
 def build_redirect_url(request, session_token, refresh_token=None):
@@ -28,14 +20,6 @@ def build_redirect_url(request, session_token, refresh_token=None):
         parsed_origin = urlparse(original_frontend)
         # Exact netloc match to prevent open redirects.
         if parsed_origin.netloc == frontend_settings.allowed_domain:
-            frontend_url = f"{parsed_origin.scheme}://{parsed_origin.netloc}"
-        elif _is_loopback_dev_origin(parsed_origin):
-            # Dev-only escape hatch: a frontend running on the developer's
-            # loopback (e.g. ``http://localhost:3000``) is allowed to point
-            # at a remote dev backend and still receive the redirect back.
-            # Dev-only: gated on BACKEND_ENV so production never honours
-            # loopback origins regardless of the Origin/Referer the browser
-            # sent on /auth/login/{provider}.
             frontend_url = f"{parsed_origin.scheme}://{parsed_origin.netloc}"
 
         # Clean up session
@@ -66,26 +50,3 @@ def build_redirect_url(request, session_token, refresh_token=None):
     final_url = f"{final_url}?code={code}&return_to={return_to}"
 
     return final_url
-
-
-def _is_loopback_dev_origin(parsed_origin) -> bool:
-    """Return True only for safe loopback origins on dev backends.
-
-    Three independent conditions must all hold:
-
-    * The deployment is **not** production (``BACKEND_ENV`` is not
-      ``production``). Production deployments never accept loopback origins,
-      regardless of what the browser sent.
-    * The hostname is an exact match against the loopback whitelist.
-      ``urlparse`` lowercases the hostname and strips the port, so
-      ``LocalHost:3000`` and ``localhost:9999`` both reduce to
-      ``localhost``; lookalikes such as ``evil-localhost.com`` or
-      ``localhost.attacker.com`` do not.
-    * The scheme is ``http`` or ``https``. This rejects pathological
-      values such as ``javascript:`` if they ever appear in a Referer.
-    """
-    if not get_application_settings().is_development:
-        return False
-    if parsed_origin.scheme not in ("http", "https"):
-        return False
-    return (parsed_origin.hostname or "").lower() in _LOOPBACK_HOSTNAMES

--- a/apps/backend/src/rhesis/backend/app/config/settings.py
+++ b/apps/backend/src/rhesis/backend/app/config/settings.py
@@ -79,12 +79,6 @@ class FrontendSettings(BaseSettings):
     def allowed_domain(self) -> str:
         return urlparse(self.url).netloc
 
-    @property
-    def loopback_cors_regex(self) -> str | None:
-        if get_application_settings().is_development:
-            return r"^http://(localhost|127\.0\.0\.1|\[::1\])(:\d{1,5})?$"
-        return None
-
 
 class ApplicationSettings(BaseSettings):
     """General application runtime configuration."""

--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -595,7 +595,6 @@ _frontend_settings = get_frontend_settings()
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_frontend_settings.cors_origins,
-    allow_origin_regex=_frontend_settings.loopback_cors_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/apps/backend/src/rhesis/backend/app/utils/git_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/git_utils.py
@@ -6,8 +6,6 @@ import os
 import subprocess
 from typing import Optional, Tuple
 
-from rhesis.backend.app.config.settings import get_application_settings
-
 
 def get_git_info() -> Tuple[Optional[str], Optional[str]]:
     """
@@ -40,20 +38,9 @@ def get_git_info() -> Tuple[Optional[str], Optional[str]]:
         return None, None
 
 
-def should_show_git_info() -> bool:
-    """
-    Determine if git information should be shown based on environment.
-    Returns True for non-production environments.
-    """
-    settings = get_application_settings()
-
-    # Don't show git info in production
-    return settings.is_development
-
-
 def get_version_info() -> dict:
     """
-    Get version information including git details when appropriate.
+    Get version information including git details when available.
 
     Returns:
         Dictionary with version information
@@ -62,11 +49,10 @@ def get_version_info() -> dict:
 
     version_info = {"version": __version__}
 
-    if should_show_git_info():
-        branch, commit = get_git_info()
-        if branch:
-            version_info["branch"] = branch
-        if commit:
-            version_info["commit"] = commit
+    branch, commit = get_git_info()
+    if branch:
+        version_info["branch"] = branch
+    if commit:
+        version_info["commit"] = commit
 
     return version_info

--- a/tests/backend/app/test_settings.py
+++ b/tests/backend/app/test_settings.py
@@ -1,5 +1,3 @@
-import re
-
 import pytest
 from pydantic import ValidationError
 
@@ -662,8 +660,7 @@ def test_application_settings_defaults(minimal_application_env):
     assert settings.cloud_run_service is None
     assert settings.cloud_run_revision is None
     assert settings.api_base_url == "https://api.example.com"
-    # Default posture is non-production (dev-only affordances are on by
-    # default, matching utils/git_utils.should_show_git_info).
+    # Default posture is non-production.
     assert settings.is_production is False
     assert settings.is_development is True
 
@@ -747,68 +744,6 @@ def test_get_application_settings_api_base_url_cache_clear(
     get_application_settings.cache_clear()
 
     assert get_application_settings().api_base_url == "https://cached-api.example.com"
-
-
-@pytest.mark.unit
-class TestLoopbackCorsRegex:
-    """``FrontendSettings.loopback_cors_regex`` returns a regex only on dev backends.
-
-    Mirrors the loopback redirect gate in ``auth/url_utils.py`` so that
-    a frontend dev server on the developer's loopback can call a remote
-    dev backend (FRONTEND_URL on a different host) without CORS blocking
-    XHR/fetch requests.
-    """
-
-    @pytest.fixture(autouse=True)
-    def _frontend_url(self, clean_frontend_env, minimal_application_env, monkeypatch):
-        monkeypatch.setenv("FRONTEND_URL", "https://dev-app.rhesis.ai")
-
-    def test_returns_none_in_production(self, monkeypatch):
-        monkeypatch.setenv("BACKEND_ENV", "production")
-        get_application_settings.cache_clear()
-
-        assert get_frontend_settings().loopback_cors_regex is None
-
-    def test_returns_regex_when_only_environment_is_production(self, monkeypatch):
-        """ENVIRONMENT=production alone no longer gates; only BACKEND_ENV drives is_production."""
-        monkeypatch.setenv("BACKEND_ENV", "development")
-        get_application_settings.cache_clear()
-
-        assert get_frontend_settings().loopback_cors_regex is not None
-
-    def test_returns_regex_in_development(self, monkeypatch):
-        monkeypatch.setenv("BACKEND_ENV", "development")
-        get_application_settings.cache_clear()
-
-        regex = get_frontend_settings().loopback_cors_regex
-
-        assert regex is not None
-        compiled = re.compile(regex)
-        assert compiled.match("http://localhost:3000")
-        assert compiled.match("http://localhost:5173")
-        assert compiled.match("http://127.0.0.1:8080")
-        assert compiled.match("http://[::1]:5000")
-        assert compiled.match("http://localhost")  # default port
-
-    def test_regex_rejects_lookalikes(self, monkeypatch):
-        """The regex must not match localhost-themed lookalike origins."""
-        monkeypatch.setenv("BACKEND_ENV", "development")
-        get_application_settings.cache_clear()
-
-        regex = get_frontend_settings().loopback_cors_regex
-        assert regex is not None
-        compiled = re.compile(regex)
-
-        # Substring/suffix attacks must not slip through.
-        assert not compiled.match("http://evil-localhost.com")
-        assert not compiled.match("http://localhost.attacker.com")
-        assert not compiled.match("http://127.0.0.1.attacker.com")
-        # https on loopback is not honoured (devs serving https locally
-        # would need to register their origin via FRONTEND_URL instead).
-        assert not compiled.match("https://localhost:3000")
-        # Other private ranges are not loopback.
-        assert not compiled.match("http://10.0.0.1:3000")
-        assert not compiled.match("http://192.168.1.1:3000")
 
 
 @pytest.mark.unit

--- a/tests/backend/auth/test_url_utils.py
+++ b/tests/backend/auth/test_url_utils.py
@@ -11,23 +11,15 @@ from unittest.mock import Mock, patch
 import pytest
 
 from rhesis.backend.app.auth.url_utils import build_redirect_url
-from rhesis.backend.app.config.settings import (
-    get_application_settings,
-    get_frontend_settings,
-)
+from rhesis.backend.app.config.settings import get_frontend_settings
 
 
 @pytest.fixture(autouse=True)
 def clean_frontend_settings(monkeypatch):
     monkeypatch.setenv("FRONTEND_URL", "http://localhost:3000")
-    # Pin to production so the loopback dev gate is OFF by default; tests
-    # that exercise the dev branch override BACKEND_ENV explicitly.
-    monkeypatch.setenv("BACKEND_ENV", "production")
     get_frontend_settings.cache_clear()
-    get_application_settings.cache_clear()
     yield
     get_frontend_settings.cache_clear()
-    get_application_settings.cache_clear()
 
 
 def _make_request(original_frontend=None, return_to="/architect"):
@@ -112,142 +104,6 @@ class TestDomainValidation:
         request = _make_request(original_frontend="https://evil-app.rhesis.ai")
         url = build_redirect_url(request, "token123")
         assert "evil-app" not in url
-
-
-@pytest.mark.unit
-class TestLoopbackDevGate:
-    """Loopback origins are accepted only on development backends.
-
-    Regression coverage for the local-dev-against-remote-API workflow:
-    a frontend running on ``http://localhost:3000`` calling a remote
-    dev backend (``FRONTEND_URL=https://dev-app.rhesis.ai``) must end
-    up redirected back to localhost, while a production backend with
-    the same incoming origin must not.
-    """
-
-    @patch(
-        "rhesis.backend.app.auth.token_utils.get_secret_key",
-        return_value="test-secret",
-    )
-    def test_rejects_loopback_in_production(self, _mock_key, monkeypatch):
-        """BACKEND_ENV=production (autouse default in this file) rejects loopback."""
-        monkeypatch.setenv("FRONTEND_URL", "https://app.rhesis.ai")
-        get_frontend_settings.cache_clear()
-        get_application_settings.cache_clear()
-
-        request = _make_request(original_frontend="http://localhost:3000")
-        url = build_redirect_url(request, "token123")
-
-        assert url.startswith("https://app.rhesis.ai/")
-        assert "localhost" not in url
-
-    @patch(
-        "rhesis.backend.app.auth.token_utils.get_secret_key",
-        return_value="test-secret",
-    )
-    def test_accepts_loopback_when_only_environment_is_production(self, _mock_key, monkeypatch):
-        """ENVIRONMENT=production alone no longer gates loopback; only BACKEND_ENV drives it."""
-        monkeypatch.setenv("FRONTEND_URL", "https://app.rhesis.ai")
-        monkeypatch.setenv("BACKEND_ENV", "development")
-        get_frontend_settings.cache_clear()
-        get_application_settings.cache_clear()
-
-        request = _make_request(original_frontend="http://localhost:3000")
-        url = build_redirect_url(request, "token123")
-
-        assert url.startswith("http://localhost:3000/")
-
-    @patch(
-        "rhesis.backend.app.auth.token_utils.get_secret_key",
-        return_value="test-secret",
-    )
-    def test_accepts_loopback_when_backend_env_is_development(self, _mock_key, monkeypatch):
-        """Localhost frontend against a remote dev backend redirects home.
-
-        This is the exact regression scenario: developing the frontend
-        on localhost while pointing the API at dev-api.rhesis.ai (whose
-        FRONTEND_URL is dev-app.rhesis.ai) should still bring the user
-        back to localhost after OAuth.
-        """
-        monkeypatch.setenv("FRONTEND_URL", "https://dev-app.rhesis.ai")
-        monkeypatch.setenv("BACKEND_ENV", "development")
-        get_frontend_settings.cache_clear()
-        get_application_settings.cache_clear()
-
-        request = _make_request(original_frontend="http://localhost:3000")
-        url = build_redirect_url(request, "token123")
-
-        assert url.startswith("http://localhost:3000/")
-
-    @patch(
-        "rhesis.backend.app.auth.token_utils.get_secret_key",
-        return_value="test-secret",
-    )
-    def test_accepts_loopback_when_backend_env_is_local(self, _mock_key, monkeypatch):
-        """BACKEND_ENV=local (Quick Start) is treated as non-production."""
-        monkeypatch.setenv("FRONTEND_URL", "https://dev-app.rhesis.ai")
-        monkeypatch.setenv("BACKEND_ENV", "local")
-        get_frontend_settings.cache_clear()
-        get_application_settings.cache_clear()
-
-        request = _make_request(original_frontend="http://localhost:3000")
-        url = build_redirect_url(request, "token123")
-
-        assert url.startswith("http://localhost:3000/")
-
-    @patch(
-        "rhesis.backend.app.auth.token_utils.get_secret_key",
-        return_value="test-secret",
-    )
-    def test_accepts_127_in_development(self, _mock_key, monkeypatch):
-        """127.0.0.1 with an arbitrary port is accepted in development."""
-        monkeypatch.setenv("FRONTEND_URL", "https://dev-app.rhesis.ai")
-        monkeypatch.setenv("BACKEND_ENV", "development")
-        get_frontend_settings.cache_clear()
-        get_application_settings.cache_clear()
-
-        request = _make_request(original_frontend="http://127.0.0.1:5173")
-        url = build_redirect_url(request, "token123")
-
-        assert url.startswith("http://127.0.0.1:5173/")
-
-    @patch(
-        "rhesis.backend.app.auth.token_utils.get_secret_key",
-        return_value="test-secret",
-    )
-    def test_dev_mode_does_not_relax_lookalike_check(self, _mock_key, monkeypatch):
-        """Even in development, ``evil-localhost.com`` is rejected.
-
-        Dev mode opens an exact-match loopback whitelist; it must never
-        accept substring lookalikes that would also be open redirects.
-        """
-        monkeypatch.setenv("FRONTEND_URL", "https://dev-app.rhesis.ai")
-        monkeypatch.setenv("BACKEND_ENV", "development")
-        get_frontend_settings.cache_clear()
-        get_application_settings.cache_clear()
-
-        request = _make_request(original_frontend="https://evil-localhost.com")
-        url = build_redirect_url(request, "token123")
-
-        assert url.startswith("https://dev-app.rhesis.ai/")
-        assert "evil-localhost.com" not in url
-
-    @patch(
-        "rhesis.backend.app.auth.token_utils.get_secret_key",
-        return_value="test-secret",
-    )
-    def test_dev_mode_rejects_localhost_subdomain_attack(self, _mock_key, monkeypatch):
-        """``localhost.attacker.com`` must not be treated as loopback."""
-        monkeypatch.setenv("FRONTEND_URL", "https://dev-app.rhesis.ai")
-        monkeypatch.setenv("BACKEND_ENV", "development")
-        get_frontend_settings.cache_clear()
-        get_application_settings.cache_clear()
-
-        request = _make_request(original_frontend="https://localhost.attacker.com")
-        url = build_redirect_url(request, "token123")
-
-        assert url.startswith("https://dev-app.rhesis.ai/")
-        assert "attacker.com" not in url
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Purpose

Backend behavior was gated on the environment *name* (`is_development` / `is_production`) in three places rather than on an explicit capability. This decouples security-relevant behavior from `BACKEND_ENV` and makes the same rules apply in every environment, continuing the capability-over-name migration tracked in `playground/env-flags-review.md`.

## What Changed

- **CORS** (`config/settings.py`, `main.py`) — removed the dev-only `loopback_cors_regex`. CORS now honors only the configured `FRONTEND_URL` origin, in every environment.
- **OAuth redirect** (`auth/url_utils.py`) — removed `_is_loopback_dev_origin`. `build_redirect_url` now honors an incoming origin only on an exact netloc match against `FRONTEND_URL`, everywhere.
- **Version info** (`utils/git_utils.py`) — removed `should_show_git_info`. Git branch/commit are now always included in `/` and `/docs` when available.
- Removed the corresponding test coverage for the deleted dev-only branches (`test_settings.py`, `test_url_utils.py`).

## Additional Context

- The fail-secure `quick_start_allowed_by_env` gate (refuses the QUICK_START auth-bypass in prod/GCP) and the ergonomic `logging_config.py` `== "local"` toggle are intentionally left in place.
- Frontend is unchanged, so the frontend `git-utils.ts` still hides git info in prod — the two apps' `/` responses now differ intentionally.

## Behavior / migration notes

- A frontend on a developer's loopback (`http://localhost:3000`) can no longer point at a *remote* dev backend and receive the OAuth redirect back / pass CORS unless its origin is set as `FRONTEND_URL`. Fully-local setups (where `FRONTEND_URL` is already the loopback origin) are unaffected.
- Git branch/commit are now exposed on the public `/` and `/docs` in production. Considered low-sensitivity for self-hosted MIT builds and consistent with docs/OpenAPI already being public.

## Testing

Ruff lint passes on all changed files. The DB-backed pytest suite (`make test`) requires Docker Postgres and was not run in this environment — please confirm `tests/backend/auth/test_url_utils.py` and `tests/backend/app/test_settings.py` are green in CI.