### PR TITLE
Add Insights time range or test run filter

### DIFF
--- a/apps/frontend/src/app/(protected)/insights/__tests__/types.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/__tests__/types.test.ts
@@ -13,14 +13,32 @@ describe('resolveInsightsTimeRange', () => {
 });
 
 describe('normalizeInsightsFilters', () => {
-  it('migrates legacy months field to 1m', () => {
+  it('migrates legacy months field to time range mode', () => {
     expect(normalizeInsightsFilters({ months: 1, endpointId: 'ep-1' })).toEqual(
       {
-        timeRange: '1m',
         endpointId: 'ep-1',
         behaviorIds: [],
+        runFilterMode: 'timeRange',
+        timeRange: '1m',
+        testRunIds: [],
       }
     );
+  });
+
+  it('migrates legacy useDefaultTestRunWindow to run filter mode', () => {
+    expect(
+      normalizeInsightsFilters({
+        endpointId: 'ep-1',
+        useDefaultTestRunWindow: false,
+        testRunIds: ['run-1'],
+      })
+    ).toEqual({
+      endpointId: 'ep-1',
+      behaviorIds: [],
+      runFilterMode: 'testRuns',
+      timeRange: '1m',
+      testRunIds: ['run-1'],
+    });
   });
 });
 

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsFilterDrawer.tsx
@@ -10,26 +10,44 @@ import {
 } from '@/components/common/FilterDrawer';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import {
+  DEFAULT_INSIGHTS_TIME_RANGE,
+  InsightsFilters,
+  InsightsRunFilterMode,
+  InsightsTimeRange,
+} from '../types';
+import { fetchTestRunsForEndpoint } from '../utils/behavior-insights-utils';
+import {
   behaviorIdsFromCheckedSelection,
   checkedBehaviorIdsFromFilter,
+  checkedTestRunIdsFromFilter,
+  formatInsightsTestRunLabel,
   InsightsBehaviorOption,
+  InsightsTestRunOption,
+  isRunFilterActive,
+  testRunIdsFromCheckedSelection,
 } from '../utils/insights-filter-utils';
 import InsightsBehaviorFilterSection from './InsightsBehaviorFilterSection';
+import InsightsRunFilterSection from './InsightsRunFilterSection';
 
-export interface InsightsDrawerFilters {
-  endpointId: string;
-  behaviorIds: string[];
-}
+export type InsightsDrawerFilters = Pick<
+  InsightsFilters,
+  'endpointId' | 'behaviorIds' | 'runFilterMode' | 'timeRange' | 'testRunIds'
+>;
 
 export const EMPTY_INSIGHTS_DRAWER_FILTERS: InsightsDrawerFilters = {
   endpointId: '',
   behaviorIds: [],
+  runFilterMode: 'timeRange',
+  timeRange: DEFAULT_INSIGHTS_TIME_RANGE,
+  testRunIds: [],
 };
 
 export function hasActiveInsightsDrawerFilters(
   f: InsightsDrawerFilters
 ): boolean {
-  return f.endpointId !== '' || f.behaviorIds.length > 0;
+  return (
+    f.endpointId !== '' || f.behaviorIds.length > 0 || isRunFilterActive(f)
+  );
 }
 
 export function countActiveInsightsDrawerFilters(
@@ -37,6 +55,9 @@ export function countActiveInsightsDrawerFilters(
 ): number {
   let count = f.endpointId !== '' ? 1 : 0;
   if (f.behaviorIds.length > 0) {
+    count += 1;
+  }
+  if (isRunFilterActive(f)) {
     count += 1;
   }
   return count;
@@ -48,6 +69,7 @@ interface InsightsFilterDrawerProps {
   open: boolean;
   onClose: () => void;
   filters: InsightsDrawerFilters;
+  sessionToken: string;
   projectEndpoints: Endpoint[];
   endpointsLoading: boolean;
   behaviorOptions: InsightsBehaviorOption[];
@@ -58,6 +80,7 @@ export default function InsightsFilterDrawer({
   open,
   onClose,
   filters,
+  sessionToken,
   projectEndpoints,
   endpointsLoading,
   behaviorOptions,
@@ -71,15 +94,78 @@ export default function InsightsFilterDrawer({
     onClose
   );
 
+  const [testRunOptions, setTestRunOptions] = React.useState<
+    InsightsTestRunOption[]
+  >([]);
+  const [testRunsLoading, setTestRunsLoading] = React.useState(false);
+
   const allBehaviorIds = React.useMemo(
     () => behaviorOptions.map(option => option.id),
     [behaviorOptions]
+  );
+
+  const allTestRunIds = React.useMemo(
+    () => testRunOptions.map(option => option.id),
+    [testRunOptions]
   );
 
   const checkedBehaviorIds = React.useMemo(
     () => checkedBehaviorIdsFromFilter(allBehaviorIds, draft.behaviorIds),
     [allBehaviorIds, draft.behaviorIds]
   );
+
+  const checkedTestRunIds = React.useMemo(
+    () => checkedTestRunIdsFromFilter(allTestRunIds, draft),
+    [allTestRunIds, draft]
+  );
+
+  React.useEffect(() => {
+    if (
+      !open ||
+      !sessionToken ||
+      !draft.endpointId ||
+      draft.runFilterMode !== 'testRuns'
+    ) {
+      if (!open || draft.runFilterMode !== 'testRuns') {
+        setTestRunOptions([]);
+      }
+      setTestRunsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setTestRunsLoading(true);
+
+    void (async () => {
+      try {
+        const allRuns = await fetchTestRunsForEndpoint(
+          sessionToken,
+          draft.endpointId
+        );
+
+        if (cancelled) return;
+
+        setTestRunOptions(
+          allRuns.map(run => ({
+            id: run.id,
+            label: formatInsightsTestRunLabel(run),
+          }))
+        );
+      } catch {
+        if (!cancelled) {
+          setTestRunOptions([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setTestRunsLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, sessionToken, draft.endpointId, draft.runFilterMode]);
 
   const handleCheckedBehaviorIdsChange = React.useCallback(
     (checkedIds: string[]) => {
@@ -92,6 +178,49 @@ export default function InsightsFilterDrawer({
       }));
     },
     [allBehaviorIds, setDraft]
+  );
+
+  const handleCheckedTestRunIdsChange = React.useCallback(
+    (checkedIds: string[]) => {
+      setDraft(prev => ({
+        ...prev,
+        testRunIds: testRunIdsFromCheckedSelection(allTestRunIds, checkedIds),
+      }));
+    },
+    [allTestRunIds, setDraft]
+  );
+
+  const handleRunFilterModeChange = React.useCallback(
+    (mode: InsightsRunFilterMode) => {
+      setDraft(prev => ({
+        ...prev,
+        runFilterMode: mode,
+        ...(mode === 'timeRange'
+          ? { testRunIds: [] }
+          : { timeRange: DEFAULT_INSIGHTS_TIME_RANGE }),
+      }));
+    },
+    [setDraft]
+  );
+
+  const handleTimeRangeChange = React.useCallback(
+    (timeRange: InsightsTimeRange) => {
+      setDraft(prev => ({ ...prev, timeRange }));
+    },
+    [setDraft]
+  );
+
+  const handleEndpointChange = React.useCallback(
+    (endpointId: string) => {
+      setDraft(prev => ({
+        ...prev,
+        endpointId,
+        testRunIds: [],
+        runFilterMode: 'timeRange',
+        timeRange: DEFAULT_INSIGHTS_TIME_RANGE,
+      }));
+    },
+    [setDraft]
   );
 
   return (
@@ -112,9 +241,7 @@ export default function InsightsFilterDrawer({
             labelId="insights-filter-endpoint-label"
             value={draft.endpointId || ''}
             label="Endpoint"
-            onChange={e =>
-              setDraft(prev => ({ ...prev, endpointId: e.target.value }))
-            }
+            onChange={e => handleEndpointChange(e.target.value)}
             sx={selectSx}
           >
             {projectEndpoints.map(endpoint => (
@@ -125,6 +252,18 @@ export default function InsightsFilterDrawer({
           </Select>
         </FormControl>
       </FilterSection>
+
+      <InsightsRunFilterSection
+        runFilterMode={draft.runFilterMode}
+        timeRange={draft.timeRange}
+        testRunOptions={testRunOptions}
+        checkedTestRunIds={checkedTestRunIds}
+        onRunFilterModeChange={handleRunFilterModeChange}
+        onTimeRangeChange={handleTimeRangeChange}
+        onCheckedTestRunIdsChange={handleCheckedTestRunIdsChange}
+        testRunsLoading={testRunsLoading}
+        disabled={!draft.endpointId}
+      />
 
       <InsightsBehaviorFilterSection
         options={behaviorOptions}

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsPage.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsPage.tsx
@@ -14,6 +14,7 @@ import BehaviorInsightsView from './BehaviorInsightsView';
 import InsightsFailedTestsFab from './InsightsFailedTestsFab';
 import {
   DEFAULT_INSIGHTS_FILTERS,
+  DEFAULT_INSIGHTS_TIME_RANGE,
   normalizeInsightsFilters,
   InsightsFilters,
 } from '../types';
@@ -121,7 +122,9 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
     setExpandedRows(new Set(expandableRowIndices));
   }, [
     filters.endpointId,
+    filters.runFilterMode,
     filters.timeRange,
+    filters.testRunIds,
     filters.behaviorIds,
     expandableRowIndices,
   ]);
@@ -165,7 +168,13 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
     setFilters(prev =>
       prev.endpointId === resolvedId
         ? prev
-        : { ...prev, endpointId: resolvedId }
+        : {
+            ...prev,
+            endpointId: resolvedId,
+            testRunIds: [],
+            runFilterMode: 'timeRange',
+            timeRange: DEFAULT_INSIGHTS_TIME_RANGE,
+          }
     );
   }, [
     endpointsLoading,
@@ -202,6 +211,7 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
   const filterBarProps = {
     filters,
     onFiltersChange: handleFiltersChange,
+    sessionToken,
     projectEndpoints,
     endpointsLoading,
     behaviorOptions,
@@ -215,7 +225,7 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
   return (
     <PageLayout
       title="Insights"
-      description="View pass rates by behavior, metric, and topic for your selected endpoint. Filter by time range or switch endpoints to compare performance."
+      description="View pass rates by behavior, metric, and topic. Filter by time range or pick specific test runs in the filter drawer."
       breadcrumbs={[]}
       actions={
         <InsightsFailedTestsFab

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsRunFilterSection.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsRunFilterSection.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import * as React from 'react';
+import { Box, Typography } from '@mui/material';
+import { FilterSection, filterChipSx } from '@/components/common/FilterDrawer';
+import {
+  INSIGHTS_TIME_RANGE_OPTIONS,
+  InsightsRunFilterMode,
+  InsightsTimeRange,
+  resolveInsightsTimeRange,
+} from '../types';
+import InsightsTestRunFilterSection from './InsightsTestRunFilterSection';
+import { InsightsTestRunOption } from '../utils/insights-filter-utils';
+
+interface InsightsRunFilterSectionProps {
+  runFilterMode: InsightsRunFilterMode;
+  timeRange: InsightsTimeRange;
+  testRunOptions: InsightsTestRunOption[];
+  checkedTestRunIds: string[];
+  onRunFilterModeChange: (mode: InsightsRunFilterMode) => void;
+  onTimeRangeChange: (timeRange: InsightsTimeRange) => void;
+  onCheckedTestRunIdsChange: (ids: string[]) => void;
+  testRunsLoading?: boolean;
+  disabled?: boolean;
+}
+
+const MODE_OPTIONS: { value: InsightsRunFilterMode; label: string }[] = [
+  { value: 'timeRange', label: 'Time range' },
+  { value: 'testRuns', label: 'Test runs' },
+];
+
+export default function InsightsRunFilterSection({
+  runFilterMode,
+  timeRange,
+  testRunOptions,
+  checkedTestRunIds,
+  onRunFilterModeChange,
+  onTimeRangeChange,
+  onCheckedTestRunIdsChange,
+  testRunsLoading = false,
+  disabled = false,
+}: InsightsRunFilterSectionProps) {
+  return (
+    <FilterSection title="Scope">
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <Typography
+            sx={{
+              fontSize: 14,
+              lineHeight: '22px',
+              color: theme => theme.palette.greyscale.body,
+            }}
+          >
+            Filter by
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            {MODE_OPTIONS.map(option => (
+              <Box
+                key={option.value}
+                component="button"
+                type="button"
+                disabled={disabled}
+                onClick={() => onRunFilterModeChange(option.value)}
+                sx={filterChipSx(runFilterMode === option.value)}
+              >
+                {option.label}
+              </Box>
+            ))}
+          </Box>
+        </Box>
+
+        {runFilterMode === 'timeRange' ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+            <Typography
+              sx={{
+                fontSize: 14,
+                lineHeight: '22px',
+                color: theme => theme.palette.greyscale.body,
+              }}
+            >
+              Time range
+            </Typography>
+            <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+              {INSIGHTS_TIME_RANGE_OPTIONS.map(option => (
+                <Box
+                  key={option.value}
+                  component="button"
+                  type="button"
+                  disabled={disabled}
+                  onClick={() => onTimeRangeChange(option.value)}
+                  sx={filterChipSx(
+                    resolveInsightsTimeRange(timeRange) === option.value
+                  )}
+                >
+                  {option.label}
+                </Box>
+              ))}
+            </Box>
+            <Typography
+              sx={{
+                fontSize: 12,
+                lineHeight: '18px',
+                color: 'text.secondary',
+                pt: '3px',
+              }}
+            >
+              Includes all test runs created within the selected window.
+            </Typography>
+          </Box>
+        ) : (
+          <InsightsTestRunFilterSection
+            embedded
+            options={testRunOptions}
+            checkedIds={checkedTestRunIds}
+            onCheckedIdsChange={onCheckedTestRunIdsChange}
+            loading={testRunsLoading}
+            disabled={disabled}
+          />
+        )}
+      </Box>
+    </FilterSection>
+  );
+}

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsTestRunFilterSection.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsTestRunFilterSection.tsx
@@ -34,10 +34,12 @@ interface InsightsTestRunFilterSectionProps {
 function TestRunCheckboxRow({
   option,
   checked,
+  disabled,
   onToggle,
 }: {
   option: InsightsTestRunOption;
   checked: boolean;
+  disabled?: boolean;
   onToggle: () => void;
 }) {
   return (
@@ -51,6 +53,7 @@ function TestRunCheckboxRow({
     >
       <Checkbox
         checked={checked}
+        disabled={disabled}
         onChange={onToggle}
         sx={checkboxSx}
         inputProps={{ 'aria-label': option.label }}
@@ -85,6 +88,7 @@ export default function InsightsTestRunFilterSection({
       : options.slice(0, DEFAULT_VISIBLE_COUNT);
 
   const toggleTestRun = (id: string) => {
+    if (disabled) return;
     onCheckedIdsChange(
       checkedIds.includes(id)
         ? checkedIds.filter(value => value !== id)
@@ -130,6 +134,7 @@ export default function InsightsTestRunFilterSection({
                 key={option.id}
                 option={option}
                 checked={checkedIds.includes(option.id)}
+                disabled={disabled}
                 onToggle={() => toggleTestRun(option.id)}
               />
             ))}
@@ -153,14 +158,19 @@ export default function InsightsTestRunFilterSection({
           component="button"
           type="button"
           underline="always"
-          onClick={() => setShowAll(true)}
+          disabled={disabled}
+          onClick={() => {
+            if (!disabled) setShowAll(true);
+          }}
           sx={{
             alignSelf: 'flex-start',
             fontSize: 14,
             lineHeight: '22px',
             color: theme => theme.palette.greyscale.body,
-            cursor: 'pointer',
+            cursor: disabled ? 'default' : 'pointer',
             textUnderlineOffset: '2px',
+            opacity: disabled ? 0.5 : 1,
+            pointerEvents: disabled ? 'none' : 'auto',
           }}
         >
           Show all

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsTestRunFilterSection.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsTestRunFilterSection.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import * as React from 'react';
+import {
+  Box,
+  Checkbox,
+  CircularProgress,
+  Link,
+  Typography,
+} from '@mui/material';
+import { FilterSection } from '@/components/common/FilterDrawer';
+import { InsightsTestRunOption } from '../utils/insights-filter-utils';
+
+const DEFAULT_VISIBLE_COUNT = 5;
+
+const checkboxSx = {
+  p: '9px',
+  mr: 0,
+  '& .MuiSvgIcon-root': {
+    fontSize: 20,
+  },
+} as const;
+
+interface InsightsTestRunFilterSectionProps {
+  options: InsightsTestRunOption[];
+  checkedIds: string[];
+  onCheckedIdsChange: (ids: string[]) => void;
+  loading?: boolean;
+  disabled?: boolean;
+  /** When true, render only the list (parent supplies section chrome). */
+  embedded?: boolean;
+}
+
+function TestRunCheckboxRow({
+  option,
+  checked,
+  onToggle,
+}: {
+  option: InsightsTestRunOption;
+  checked: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        minHeight: 38,
+        width: '100%',
+      }}
+    >
+      <Checkbox
+        checked={checked}
+        onChange={onToggle}
+        sx={checkboxSx}
+        inputProps={{ 'aria-label': option.label }}
+      />
+      <Typography
+        sx={{
+          fontSize: 14,
+          lineHeight: '22px',
+          color: theme => theme.palette.greyscale.title,
+          wordBreak: 'break-word',
+        }}
+      >
+        {option.label}
+      </Typography>
+    </Box>
+  );
+}
+
+export default function InsightsTestRunFilterSection({
+  options,
+  checkedIds,
+  onCheckedIdsChange,
+  loading = false,
+  disabled = false,
+  embedded = false,
+}: InsightsTestRunFilterSectionProps) {
+  const [showAll, setShowAll] = React.useState(false);
+
+  const visibleOptions =
+    showAll || options.length <= DEFAULT_VISIBLE_COUNT
+      ? options
+      : options.slice(0, DEFAULT_VISIBLE_COUNT);
+
+  const toggleTestRun = (id: string) => {
+    onCheckedIdsChange(
+      checkedIds.includes(id)
+        ? checkedIds.filter(value => value !== id)
+        : [...checkedIds, id]
+    );
+  };
+
+  const content = (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
+      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+        {!embedded ? (
+          <Typography
+            sx={{
+              fontSize: 14,
+              lineHeight: '22px',
+              color: theme => theme.palette.greyscale.body,
+            }}
+          >
+            Test run
+          </Typography>
+        ) : null}
+
+        {loading ? (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 2 }}>
+            <CircularProgress size={24} />
+          </Box>
+        ) : options.length === 0 ? (
+          <Typography
+            sx={{
+              fontSize: 14,
+              lineHeight: '22px',
+              color: 'text.secondary',
+            }}
+          >
+            {disabled
+              ? 'Select an endpoint to view test runs.'
+              : 'No test runs found for this endpoint.'}
+          </Typography>
+        ) : (
+          <Box sx={{ display: 'flex', flexDirection: 'column' }}>
+            {visibleOptions.map(option => (
+              <TestRunCheckboxRow
+                key={option.id}
+                option={option}
+                checked={checkedIds.includes(option.id)}
+                onToggle={() => toggleTestRun(option.id)}
+              />
+            ))}
+          </Box>
+        )}
+
+        <Typography
+          sx={{
+            fontSize: 12,
+            lineHeight: '18px',
+            color: 'text.secondary',
+            pt: '3px',
+          }}
+        >
+          All runs are included by default. Uncheck runs to narrow the view.
+        </Typography>
+      </Box>
+
+      {!loading && !showAll && options.length > DEFAULT_VISIBLE_COUNT ? (
+        <Link
+          component="button"
+          type="button"
+          underline="always"
+          onClick={() => setShowAll(true)}
+          sx={{
+            alignSelf: 'flex-start',
+            fontSize: 14,
+            lineHeight: '22px',
+            color: theme => theme.palette.greyscale.body,
+            cursor: 'pointer',
+            textUnderlineOffset: '2px',
+          }}
+        >
+          Show all
+        </Link>
+      ) : null}
+    </Box>
+  );
+
+  if (embedded) {
+    return content;
+  }
+
+  return <FilterSection title="Test runs">{content}</FilterSection>;
+}

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsTestRunFilterSection.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsTestRunFilterSection.tsx
@@ -149,7 +149,8 @@ export default function InsightsTestRunFilterSection({
             pt: '3px',
           }}
         >
-          All runs are included by default. Uncheck runs to narrow the view.
+          All runs are included by default. Uncheck runs to narrow the
+          view (up to 100 runs can be queried at once).
         </Typography>
       </Box>
 

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsTestRunFilterSection.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsTestRunFilterSection.tsx
@@ -149,8 +149,8 @@ export default function InsightsTestRunFilterSection({
             pt: '3px',
           }}
         >
-          All runs are included by default. Uncheck runs to narrow the
-          view (up to 100 runs can be queried at once).
+          All runs are included by default. Uncheck runs to narrow the view (up
+          to 100 runs can be queried at once).
         </Typography>
       </Box>
 

--- a/apps/frontend/src/app/(protected)/insights/components/TestResultsFilters.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/TestResultsFilters.tsx
@@ -3,17 +3,11 @@
 import React, { useMemo, useState } from 'react';
 import { Box, Button } from '@mui/material';
 import GridToolbar, {
-  ToolbarPillTabs,
   directoryToolbarProps,
 } from '@/components/common/GridToolbar';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import { writeInsightsEndpointId } from '@/utils/insights-endpoint';
-import {
-  INSIGHTS_TIME_RANGE_OPTIONS,
-  InsightsFilters,
-  InsightsTimeRange,
-  resolveInsightsTimeRange,
-} from '../types';
+import { InsightsFilters } from '../types';
 import InsightsFilterDrawer, {
   countActiveInsightsDrawerFilters,
   hasActiveInsightsDrawerFilters,
@@ -24,6 +18,7 @@ import { InsightsBehaviorOption } from '../utils/insights-filter-utils';
 interface TestResultsFiltersProps {
   filters: InsightsFilters;
   onFiltersChange: (filters: InsightsFilters) => void;
+  sessionToken: string;
   projectEndpoints: Endpoint[];
   endpointsLoading: boolean;
   behaviorOptions: InsightsBehaviorOption[];
@@ -33,8 +28,8 @@ interface TestResultsFiltersProps {
   allExpanded?: boolean;
   onToggleAll?: () => void;
   /**
-   * `compact` keeps endpoint/time controls (filter drawer + time range) but
-   * hides behavior search — used on the no-test-results empty state.
+   * `compact` keeps endpoint/test-run controls (filter drawer) but hides
+   * behavior search — used on the no-test-results empty state.
    */
   variant?: 'full' | 'compact';
 }
@@ -42,6 +37,7 @@ interface TestResultsFiltersProps {
 export default function TestResultsFilters({
   filters,
   onFiltersChange,
+  sessionToken,
   projectEndpoints,
   endpointsLoading,
   behaviorOptions,
@@ -59,16 +55,18 @@ export default function TestResultsFilters({
     () => ({
       endpointId: filters.endpointId,
       behaviorIds: filters.behaviorIds,
+      runFilterMode: filters.runFilterMode,
+      timeRange: filters.timeRange,
+      testRunIds: filters.testRunIds,
     }),
-    [filters.endpointId, filters.behaviorIds]
+    [
+      filters.endpointId,
+      filters.behaviorIds,
+      filters.runFilterMode,
+      filters.timeRange,
+      filters.testRunIds,
+    ]
   );
-
-  const handleTimeRangeChange = (value: string) => {
-    onFiltersChange({
-      ...filters,
-      timeRange: value as InsightsTimeRange,
-    });
-  };
 
   const handleDrawerApply = (next: InsightsDrawerFilters) => {
     if (next.endpointId) {
@@ -78,6 +76,9 @@ export default function TestResultsFilters({
       ...filters,
       endpointId: next.endpointId,
       behaviorIds: next.behaviorIds,
+      runFilterMode: next.runFilterMode,
+      timeRange: next.timeRange,
+      testRunIds: next.testRunIds,
     });
   };
 
@@ -93,25 +94,20 @@ export default function TestResultsFilters({
         activeFilterCount={countActiveInsightsDrawerFilters(drawerFilters)}
         {...directoryToolbarProps}
         middleContent={
-          <Box
-            sx={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 1,
-              flexWrap: 'wrap',
-            }}
-          >
-            <ToolbarPillTabs
-              tabs={INSIGHTS_TIME_RANGE_OPTIONS}
-              activeValue={resolveInsightsTimeRange(filters.timeRange)}
-              onChange={handleTimeRangeChange}
-            />
-            {showExpandToggle && onToggleAll && (
+          showExpandToggle && onToggleAll ? (
+            <Box
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 1,
+                flexWrap: 'wrap',
+              }}
+            >
               <Button size="small" variant="text" onClick={onToggleAll}>
                 {allExpanded ? 'Collapse all' : 'Expand all'}
               </Button>
-            )}
-          </Box>
+            </Box>
+          ) : undefined
         }
       />
 
@@ -119,6 +115,7 @@ export default function TestResultsFilters({
         open={filterDrawerOpen}
         onClose={() => setFilterDrawerOpen(false)}
         filters={drawerFilters}
+        sessionToken={sessionToken}
         projectEndpoints={projectEndpoints}
         endpointsLoading={endpointsLoading}
         behaviorOptions={behaviorOptions}

--- a/apps/frontend/src/app/(protected)/insights/components/__tests__/TestResultsFilters.test.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/__tests__/TestResultsFilters.test.tsx
@@ -9,6 +9,43 @@ jest.mock('@/utils/insights-endpoint', () => ({
   writeInsightsEndpointId: jest.fn(),
 }));
 
+jest.mock('../InsightsFilterDrawer', () => ({
+  __esModule: true,
+  default: ({
+    open,
+    onApply,
+  }: {
+    open: boolean;
+    onApply: (filters: {
+      endpointId: string;
+      behaviorIds: string[];
+      runFilterMode: 'timeRange' | 'testRuns';
+      timeRange: '1m' | '7d';
+      testRunIds: string[];
+    }) => void;
+  }) =>
+    open ? (
+      <div role="presentation">
+        <button
+          type="button"
+          onClick={() =>
+            onApply({
+              endpointId: 'ep-2',
+              behaviorIds: [],
+              runFilterMode: 'testRuns',
+              timeRange: '1m',
+              testRunIds: ['run-1'],
+            })
+          }
+        >
+          Apply
+        </button>
+      </div>
+    ) : null,
+  countActiveInsightsDrawerFilters: () => 1,
+  hasActiveInsightsDrawerFilters: () => true,
+}));
+
 import { writeInsightsEndpointId } from '@/utils/insights-endpoint';
 
 function makeEndpoint(id: string, name: string) {
@@ -32,8 +69,12 @@ function renderFilters(
   props: Partial<React.ComponentProps<typeof TestResultsFilters>> = {}
 ) {
   const defaults = {
-    filters: { timeRange: '1m' as const, endpointId: 'ep-1', behaviorIds: [] },
+    filters: {
+      ...DEFAULT_INSIGHTS_FILTERS,
+      endpointId: 'ep-1',
+    },
     onFiltersChange: jest.fn(),
+    sessionToken: 'token',
     projectEndpoints: defaultEndpoints,
     endpointsLoading: false,
     behaviorOptions: [
@@ -59,32 +100,6 @@ afterEach(() => {
 });
 
 describe('TestResultsFilters', () => {
-  it('selects 1M by default', () => {
-    render(
-      <TestResultsFilters
-        filters={DEFAULT_INSIGHTS_FILTERS}
-        onFiltersChange={jest.fn()}
-        projectEndpoints={defaultEndpoints}
-        endpointsLoading={false}
-        searchQuery=""
-        onSearchChange={jest.fn()}
-        behaviorOptions={[]}
-      />
-    );
-
-    expect(screen.getByRole('button', { name: '1M' })).toHaveStyle({
-      color: 'rgb(255, 255, 255)',
-    });
-  });
-
-  it('renders time range pill tabs', () => {
-    renderFilters();
-    expect(screen.getByRole('button', { name: '1D' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '7D' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '1M' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '3M' })).toBeInTheDocument();
-  });
-
   it('renders search input', () => {
     renderFilters();
     expect(
@@ -102,45 +117,29 @@ describe('TestResultsFilters', () => {
     expect(onSearchChange).toHaveBeenCalled();
   });
 
-  it('renders endpoint dropdown in filter drawer', async () => {
+  it('opens the filter drawer', async () => {
     const user = userEvent.setup();
     renderFilters();
     await openFilterDrawer(user);
 
-    const drawer = screen.getByRole('presentation');
-    expect(within(drawer).getByLabelText(/endpoint/i)).toBeInTheDocument();
+    expect(screen.getByRole('presentation')).toBeInTheDocument();
   });
 
-  it('calls onFiltersChange when a time range pill is clicked', async () => {
-    const user = userEvent.setup();
-    const onFiltersChange = jest.fn();
-    renderFilters({ onFiltersChange });
-
-    await user.click(screen.getByRole('button', { name: '7D' }));
-
-    expect(onFiltersChange).toHaveBeenCalledWith({
-      timeRange: '7d',
-      endpointId: 'ep-1',
-      behaviorIds: [],
-    });
-  });
-
-  it('persists endpoint selection to cookie when applied from drawer', async () => {
+  it('persists endpoint and test run selection when applied from drawer', async () => {
     const user = userEvent.setup();
     const onFiltersChange = jest.fn();
     renderFilters({ onFiltersChange });
     await openFilterDrawer(user);
 
     const drawer = screen.getByRole('presentation');
-    await user.click(within(drawer).getByLabelText(/endpoint/i));
-    await user.click(screen.getByRole('option', { name: 'Endpoint Two' }));
     await user.click(within(drawer).getByRole('button', { name: /apply/i }));
 
     expect(writeInsightsEndpointId).toHaveBeenCalledWith('ep-2');
     expect(onFiltersChange).toHaveBeenCalledWith({
-      timeRange: '1m',
+      ...DEFAULT_INSIGHTS_FILTERS,
       endpointId: 'ep-2',
-      behaviorIds: [],
+      runFilterMode: 'testRuns',
+      testRunIds: ['run-1'],
     });
   });
 
@@ -149,19 +148,7 @@ describe('TestResultsFilters', () => {
     expect(screen.getByLabelText(/1 active filters/i)).toBeInTheDocument();
   });
 
-  it('disables endpoint dropdown while loading', async () => {
-    const user = userEvent.setup();
-    renderFilters({ endpointsLoading: true });
-    await openFilterDrawer(user);
-
-    const drawer = screen.getByRole('presentation');
-    expect(within(drawer).getByLabelText(/endpoint/i)).toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
-  });
-
-  it('hides behavior search in compact variant but keeps filters and time range', () => {
+  it('hides behavior search in compact variant but keeps filters', () => {
     renderFilters({ variant: 'compact' });
 
     expect(
@@ -170,6 +157,5 @@ describe('TestResultsFilters', () => {
     expect(
       screen.getByRole('button', { name: /filters/i })
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '1M' })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/(protected)/insights/hooks/__tests__/useBehaviorInsightsData.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/hooks/__tests__/useBehaviorInsightsData.test.ts
@@ -3,7 +3,7 @@ import { DEFAULT_INSIGHTS_FILTERS } from '../../types';
 import { useBehaviorInsightsData } from '../useBehaviorInsightsData';
 
 jest.mock('../../utils/behavior-insights-utils', () => ({
-  fetchTestRunIdsForEndpoint: jest.fn(),
+  resolveInsightsQueryTestRunIds: jest.fn(),
   buildBehaviorColumns: jest.fn(() => []),
 }));
 
@@ -31,16 +31,16 @@ jest.mock('@/utils/api-client/client-factory', () => ({
   })),
 }));
 
-import { fetchTestRunIdsForEndpoint } from '../../utils/behavior-insights-utils';
+import { resolveInsightsQueryTestRunIds } from '../../utils/behavior-insights-utils';
 import { fetchFailedTestIdsForInsights } from '../../utils/insights-failed-tests';
 
-const mockFetchTestRunIds = fetchTestRunIdsForEndpoint as jest.Mock;
+const mockResolveTestRunIds = resolveInsightsQueryTestRunIds as jest.Mock;
 const mockFetchFailedIds = fetchFailedTestIdsForInsights as jest.Mock;
 
 describe('useBehaviorInsightsData', () => {
   beforeEach(() => {
     jest.useFakeTimers();
-    mockFetchTestRunIds.mockReset();
+    mockResolveTestRunIds.mockReset();
     mockFetchFailedIds.mockReset();
   });
 
@@ -49,7 +49,7 @@ describe('useBehaviorInsightsData', () => {
   });
 
   it('resolves deduped failedTestCaseCount when summary has failures', async () => {
-    mockFetchTestRunIds.mockResolvedValue(['run-1', 'run-2']);
+    mockResolveTestRunIds.mockResolvedValue(['run-1', 'run-2']);
     mockFetchFailedIds.mockResolvedValue([
       'test-1',
       'test-2',
@@ -58,12 +58,13 @@ describe('useBehaviorInsightsData', () => {
       'test-5',
     ]);
 
+    const filters = {
+      ...DEFAULT_INSIGHTS_FILTERS,
+      endpointId: 'ep-1',
+    };
+
     const { result } = renderHook(() =>
-      useBehaviorInsightsData('token', {
-        ...DEFAULT_INSIGHTS_FILTERS,
-        endpointId: 'ep-1',
-        timeRange: '1m',
-      })
+      useBehaviorInsightsData('token', filters)
     );
 
     jest.advanceTimersByTime(300);
@@ -78,13 +79,14 @@ describe('useBehaviorInsightsData', () => {
     expect(result.current.summary?.failed).toBe(10);
     expect(mockFetchFailedIds).toHaveBeenCalledWith('token', {
       endpointId: 'ep-1',
+      runFilterMode: 'timeRange',
       timeRange: '1m',
       testRunIds: ['run-1', 'run-2'],
     });
   });
 
   it('finishes main loading before unique failed count resolves', async () => {
-    mockFetchTestRunIds.mockResolvedValue(['run-1']);
+    mockResolveTestRunIds.mockResolvedValue(['run-1']);
     let resolveFailed!: (ids: string[]) => void;
     mockFetchFailedIds.mockImplementation(
       () =>
@@ -97,7 +99,6 @@ describe('useBehaviorInsightsData', () => {
       useBehaviorInsightsData('token', {
         ...DEFAULT_INSIGHTS_FILTERS,
         endpointId: 'ep-1',
-        timeRange: '1m',
       })
     );
 
@@ -115,14 +116,13 @@ describe('useBehaviorInsightsData', () => {
   });
 
   it('still renders insights when unique failed count fetch fails', async () => {
-    mockFetchTestRunIds.mockResolvedValue(['run-1']);
+    mockResolveTestRunIds.mockResolvedValue(['run-1']);
     mockFetchFailedIds.mockRejectedValue(new Error('network'));
 
     const { result } = renderHook(() =>
       useBehaviorInsightsData('token', {
         ...DEFAULT_INSIGHTS_FILTERS,
         endpointId: 'ep-1',
-        timeRange: '1m',
       })
     );
 
@@ -161,7 +161,7 @@ describe('useBehaviorInsightsData', () => {
       }),
     }));
 
-    mockFetchTestRunIds.mockResolvedValue(['run-1']);
+    mockResolveTestRunIds.mockResolvedValue(['run-1']);
 
     const { result } = renderHook(() =>
       useBehaviorInsightsData('token', {
@@ -181,7 +181,7 @@ describe('useBehaviorInsightsData', () => {
   });
 
   it('does not fetch when enabled is false, even with a valid endpointId', async () => {
-    mockFetchTestRunIds.mockResolvedValue(['run-1']);
+    mockResolveTestRunIds.mockResolvedValue(['run-1']);
 
     const { result } = renderHook(() =>
       useBehaviorInsightsData(
@@ -189,7 +189,6 @@ describe('useBehaviorInsightsData', () => {
         {
           ...DEFAULT_INSIGHTS_FILTERS,
           endpointId: 'ep-1',
-          timeRange: '1m',
         },
         false
       )
@@ -199,28 +198,24 @@ describe('useBehaviorInsightsData', () => {
 
     expect(result.current.loading).toBe(false);
     expect(result.current.summary).toBeNull();
-    expect(mockFetchTestRunIds).not.toHaveBeenCalled();
+    expect(mockResolveTestRunIds).not.toHaveBeenCalled();
   });
 
   it('starts fetching once enabled flips from false to true', async () => {
-    mockFetchTestRunIds.mockResolvedValue(['run-1']);
+    mockResolveTestRunIds.mockResolvedValue(['run-1']);
+
+    const filters = {
+      ...DEFAULT_INSIGHTS_FILTERS,
+      endpointId: 'ep-1',
+    };
 
     const { result, rerender } = renderHook(
-      ({ enabled }) =>
-        useBehaviorInsightsData(
-          'token',
-          {
-            ...DEFAULT_INSIGHTS_FILTERS,
-            endpointId: 'ep-1',
-            timeRange: '1m',
-          },
-          enabled
-        ),
+      ({ enabled }) => useBehaviorInsightsData('token', filters, enabled),
       { initialProps: { enabled: false } }
     );
 
     jest.advanceTimersByTime(300);
-    expect(mockFetchTestRunIds).not.toHaveBeenCalled();
+    expect(mockResolveTestRunIds).not.toHaveBeenCalled();
 
     rerender({ enabled: true });
     jest.advanceTimersByTime(300);
@@ -228,6 +223,6 @@ describe('useBehaviorInsightsData', () => {
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
-    expect(mockFetchTestRunIds).toHaveBeenCalledWith('token', 'ep-1', '1m');
+    expect(mockResolveTestRunIds).toHaveBeenCalledWith('token', filters);
   });
 });

--- a/apps/frontend/src/app/(protected)/insights/hooks/useBehaviorInsightsData.ts
+++ b/apps/frontend/src/app/(protected)/insights/hooks/useBehaviorInsightsData.ts
@@ -14,7 +14,7 @@ import {
 import {
   BehaviorInsightColumn,
   buildBehaviorColumns,
-  fetchTestRunIdsForEndpoint,
+  resolveInsightsQueryTestRunIds,
 } from '../utils/behavior-insights-utils';
 import { fetchFailedTestIdsForInsights } from '../utils/insights-failed-tests';
 
@@ -86,10 +86,9 @@ export function useBehaviorInsightsData(
     debounceRef.current = setTimeout(() => {
       void (async () => {
         try {
-          const testRunIds = await fetchTestRunIdsForEndpoint(
+          const testRunIds = await resolveInsightsQueryTestRunIds(
             sessionToken,
-            filters.endpointId,
-            resolveInsightsTimeRange(filters.timeRange)
+            filters
           );
 
           if (!isCurrentRequest(requestId)) return;
@@ -111,10 +110,12 @@ export function useBehaviorInsightsData(
           const behaviorClient = factory.getBehaviorClient();
 
           const statsParams = {
-            ...timeRangeToStatsParams(
-              resolveInsightsTimeRange(filters.timeRange)
-            ),
             test_run_ids: testRunIds,
+            ...(filters.runFilterMode === 'timeRange'
+              ? timeRangeToStatsParams(
+                  resolveInsightsTimeRange(filters.timeRange)
+                )
+              : {}),
           };
 
           const [summaryResult, behaviorResult, behaviors] = await Promise.all([
@@ -183,6 +184,7 @@ export function useBehaviorInsightsData(
                   sessionToken,
                   {
                     endpointId: filters.endpointId,
+                    runFilterMode: filters.runFilterMode,
                     timeRange: resolveInsightsTimeRange(filters.timeRange),
                     testRunIds,
                   }
@@ -212,7 +214,14 @@ export function useBehaviorInsightsData(
         clearTimeout(debounceRef.current);
       }
     };
-  }, [enabled, sessionToken, filters.endpointId, filters.timeRange]);
+  }, [
+    enabled,
+    sessionToken,
+    filters.endpointId,
+    filters.runFilterMode,
+    filters.timeRange,
+    filters.testRunIds,
+  ]);
 
   return {
     summary,

--- a/apps/frontend/src/app/(protected)/insights/types.ts
+++ b/apps/frontend/src/app/(protected)/insights/types.ts
@@ -1,25 +1,32 @@
-import { TestResultsStatsOptions } from '@/utils/api-client/interfaces/common';
-
 export type InsightsTimeRange = '1d' | '7d' | '1m' | '3m';
+export type InsightsRunFilterMode = 'timeRange' | 'testRuns';
 
 export interface InsightsFilters {
-  timeRange: InsightsTimeRange;
   endpointId: string;
   /** Empty means all behaviors are visible. */
   behaviorIds: string[];
+  /** Filter by time window or by explicit test runs — never both. */
+  runFilterMode: InsightsRunFilterMode;
+  timeRange: InsightsTimeRange;
+  /**
+   * Used when `runFilterMode` is `testRuns`. Empty means all test runs for the
+   * endpoint.
+   */
+  testRunIds: string[];
 }
 
 export const DEFAULT_INSIGHTS_TIME_RANGE: InsightsTimeRange = '1m';
 
 export const DEFAULT_INSIGHTS_FILTERS: InsightsFilters = {
-  timeRange: DEFAULT_INSIGHTS_TIME_RANGE,
   endpointId: '',
   behaviorIds: [],
+  runFilterMode: 'timeRange',
+  timeRange: DEFAULT_INSIGHTS_TIME_RANGE,
+  testRunIds: [],
 };
 
 const VALID_TIME_RANGES = new Set<InsightsTimeRange>(['1d', '7d', '1m', '3m']);
 
-/** Ensure the toolbar always has a valid selection (defaults to 1M). */
 export function resolveInsightsTimeRange(
   timeRange: InsightsTimeRange | undefined
 ): InsightsTimeRange {
@@ -30,20 +37,45 @@ export function resolveInsightsTimeRange(
 }
 
 export function normalizeInsightsFilters(
-  filters: Partial<InsightsFilters> & { months?: number }
+  filters: Partial<InsightsFilters> & {
+    months?: number;
+    /** Legacy field from the toolbar-only time range UI. */
+    useDefaultTestRunWindow?: boolean;
+  }
 ): InsightsFilters {
-  let timeRange = filters.timeRange;
-  if (!timeRange && typeof filters.months === 'number') {
+  let runFilterMode = filters.runFilterMode ?? 'timeRange';
+  let timeRange = resolveInsightsTimeRange(filters.timeRange);
+  let testRunIds = filters.testRunIds ?? [];
+
+  if (
+    typeof filters.months === 'number' &&
+    filters.runFilterMode === undefined
+  ) {
     const legacy: Partial<Record<number, InsightsTimeRange>> = {
       1: '1m',
       3: '3m',
     };
-    timeRange = legacy[filters.months];
+    timeRange = legacy[filters.months] ?? DEFAULT_INSIGHTS_TIME_RANGE;
+    runFilterMode = 'timeRange';
+    testRunIds = [];
   }
+
+  if (
+    filters.useDefaultTestRunWindow !== undefined &&
+    filters.runFilterMode === undefined
+  ) {
+    runFilterMode = filters.useDefaultTestRunWindow ? 'timeRange' : 'testRuns';
+    if (runFilterMode === 'timeRange') {
+      testRunIds = [];
+    }
+  }
+
   return {
-    timeRange: resolveInsightsTimeRange(timeRange),
     endpointId: filters.endpointId ?? '',
     behaviorIds: filters.behaviorIds ?? [],
+    runFilterMode,
+    timeRange,
+    testRunIds,
   };
 }
 
@@ -64,7 +96,10 @@ function toIsoDate(date: Date): string {
 /** Map UI time-range pills to stats API query parameters. */
 export function timeRangeToStatsParams(
   timeRange: InsightsTimeRange
-): Pick<TestResultsStatsOptions, 'months' | 'start_date' | 'end_date'> {
+): Pick<
+  import('@/utils/api-client/interfaces/common').TestResultsStatsOptions,
+  'months' | 'start_date' | 'end_date'
+> {
   switch (timeRange) {
     case '1d': {
       const end = new Date();

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/behavior-insights-utils.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/behavior-insights-utils.test.ts
@@ -1,5 +1,7 @@
 import type { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import {
+  assertInsightsTestRunIdsWithinLimit,
+  MAX_INSIGHTS_TEST_RUN_IDS,
   passRatesToItems,
   resolveEndpointId,
   sortBehaviorColumns,

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/behavior-insights-utils.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/behavior-insights-utils.test.ts
@@ -127,7 +127,10 @@ describe('behavior-insights-utils', () => {
     it('allows selections at or below the cap', () => {
       expect(() =>
         assertInsightsTestRunIdsWithinLimit(
-          Array.from({ length: MAX_INSIGHTS_TEST_RUN_IDS }, (_, i) => `run-${i}`)
+          Array.from(
+            { length: MAX_INSIGHTS_TEST_RUN_IDS },
+            (_, i) => `run-${i}`
+          )
         )
       ).not.toThrow();
     });

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/behavior-insights-utils.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/behavior-insights-utils.test.ts
@@ -122,4 +122,25 @@ describe('behavior-insights-utils', () => {
       expect(resolveEndpointId(numericProjectEndpoints, '42')).toBe('ep-1');
     });
   });
+
+  describe('assertInsightsTestRunIdsWithinLimit', () => {
+    it('allows selections at or below the cap', () => {
+      expect(() =>
+        assertInsightsTestRunIdsWithinLimit(
+          Array.from({ length: MAX_INSIGHTS_TEST_RUN_IDS }, (_, i) => `run-${i}`)
+        )
+      ).not.toThrow();
+    });
+
+    it('throws when the allowlist exceeds the cap', () => {
+      expect(() =>
+        assertInsightsTestRunIdsWithinLimit(
+          Array.from(
+            { length: MAX_INSIGHTS_TEST_RUN_IDS + 1 },
+            (_, i) => `run-${i}`
+          )
+        )
+      ).toThrow(/Too many test runs/);
+    });
+  });
 });

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/fetch-failed-test-ids-resolution.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/fetch-failed-test-ids-resolution.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Isolation tests for resolve behavior when `testRunIds` is empty.
+ * Kept separate so we can mock `resolveInsightsQueryTestRunIds` without
+ * affecting URL/format unit tests.
+ */
+jest.mock('../behavior-insights-utils', () => ({
+  resolveInsightsQueryTestRunIds: jest.fn(),
+}));
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getTestResultsClient: () => ({
+      getTestResults: jest.fn().mockResolvedValue({
+        data: [{ test_id: 'test-1' }],
+        pagination: { totalCount: 1 },
+      }),
+    }),
+  })),
+}));
+
+import { resolveInsightsQueryTestRunIds } from '../behavior-insights-utils';
+import { fetchFailedTestIdsForInsights } from '../insights-failed-tests';
+
+const mockResolve = resolveInsightsQueryTestRunIds as jest.Mock;
+
+describe('fetchFailedTestIdsForInsights resolution', () => {
+  beforeEach(() => {
+    mockResolve.mockReset();
+  });
+
+  it('resolves empty testRunIds via resolveInsightsQueryTestRunIds', async () => {
+    mockResolve.mockResolvedValue(['run-a', 'run-b']);
+
+    const ids = await fetchFailedTestIdsForInsights('token', {
+      endpointId: 'ep-1',
+      runFilterMode: 'timeRange',
+      timeRange: '1m',
+      testRunIds: [],
+    });
+
+    expect(mockResolve).toHaveBeenCalledWith('token', {
+      endpointId: 'ep-1',
+      runFilterMode: 'timeRange',
+      timeRange: '1m',
+      testRunIds: [],
+    });
+    expect(ids).toEqual(['test-1']);
+  });
+
+  it('uses provided testRunIds without calling resolve', async () => {
+    const ids = await fetchFailedTestIdsForInsights('token', {
+      endpointId: 'ep-1',
+      runFilterMode: 'testRuns',
+      timeRange: '1m',
+      testRunIds: ['run-1'],
+    });
+
+    expect(mockResolve).not.toHaveBeenCalled();
+    expect(ids).toEqual(['test-1']);
+  });
+});

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-failed-tests.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-failed-tests.test.ts
@@ -1,25 +1,48 @@
 import {
   buildInsightsFailedTestsUrl,
   formatInsightsFailedTestsBanner,
+  formatInsightsRunFilterLabel,
   formatInsightsSummaryDetail,
   formatInsightsTimeRangeLabel,
   parseInsightsFailedTestsSearchParams,
 } from '../insights-failed-tests';
 
 describe('insights-failed-tests', () => {
-  it('builds tests URL with insights context', () => {
+  it('builds tests URL with time range scope', () => {
     expect(
       buildInsightsFailedTestsUrl({
         endpointId: 'ep-1',
+        runFilterMode: 'timeRange',
         timeRange: '1m',
+        testRunIds: [],
       })
-    ).toBe('/tests?failedFromInsights=1&endpointId=ep-1&timeRange=1m');
+    ).toBe(
+      '/tests?failedFromInsights=1&endpointId=ep-1&runFilterMode=timeRange&timeRange=1m'
+    );
+  });
+
+  it('builds tests URL with custom test run scope', () => {
+    expect(
+      buildInsightsFailedTestsUrl({
+        endpointId: 'ep-1',
+        runFilterMode: 'testRuns',
+        timeRange: '1m',
+        testRunIds: ['run-1', 'run-2'],
+      })
+    ).toBe(
+      '/tests?failedFromInsights=1&endpointId=ep-1&runFilterMode=testRuns&testRunIds=run-1%2Crun-2'
+    );
   });
 
   it('builds tests URL with behavior metric scope', () => {
     expect(
       buildInsightsFailedTestsUrl(
-        { endpointId: 'ep-1', timeRange: '1m' },
+        {
+          endpointId: 'ep-1',
+          runFilterMode: 'timeRange',
+          timeRange: '1m',
+          testRunIds: [],
+        },
         {
           behaviorId: 'beh-1',
           behaviorName: 'Safety',
@@ -27,14 +50,19 @@ describe('insights-failed-tests', () => {
         }
       )
     ).toBe(
-      '/tests?failedFromInsights=1&endpointId=ep-1&timeRange=1m&behaviorId=beh-1&behaviorName=Safety&metric=Toxicity'
+      '/tests?failedFromInsights=1&endpointId=ep-1&runFilterMode=timeRange&timeRange=1m&behaviorId=beh-1&behaviorName=Safety&metric=Toxicity'
     );
   });
 
   it('builds tests URL with all-outcome dimension scope', () => {
     expect(
       buildInsightsFailedTestsUrl(
-        { endpointId: 'ep-1', timeRange: '1m' },
+        {
+          endpointId: 'ep-1',
+          runFilterMode: 'timeRange',
+          timeRange: '1m',
+          testRunIds: [],
+        },
         {
           behaviorId: 'beh-1',
           behaviorName: 'Safety',
@@ -43,17 +71,19 @@ describe('insights-failed-tests', () => {
         }
       )
     ).toBe(
-      '/tests?failedFromInsights=1&endpointId=ep-1&timeRange=1m&behaviorId=beh-1&behaviorName=Safety&topic=Claims&outcome=all'
+      '/tests?failedFromInsights=1&endpointId=ep-1&runFilterMode=timeRange&timeRange=1m&behaviorId=beh-1&behaviorName=Safety&topic=Claims&outcome=all'
     );
   });
 
   it('parses insights failed tests search params', () => {
     const params = new URLSearchParams(
-      'failedFromInsights=1&endpointId=ep-1&timeRange=7d&behaviorId=b1&metric=m1&topic=t1&behaviorName=Beh'
+      'failedFromInsights=1&endpointId=ep-1&runFilterMode=testRuns&testRunIds=run-1,run-2&behaviorId=b1&metric=m1&topic=t1&behaviorName=Beh'
     );
     expect(parseInsightsFailedTestsSearchParams(params)).toEqual({
       endpointId: 'ep-1',
-      timeRange: '7d',
+      runFilterMode: 'testRuns',
+      timeRange: '1m',
+      testRunIds: ['run-1', 'run-2'],
       behaviorId: 'b1',
       behaviorName: 'Beh',
       metricName: 'm1',
@@ -62,14 +92,42 @@ describe('insights-failed-tests', () => {
     });
   });
 
+  it('parses legacy timeRange URLs as time range mode', () => {
+    const params = new URLSearchParams(
+      'failedFromInsights=1&endpointId=ep-1&timeRange=7d'
+    );
+    expect(parseInsightsFailedTestsSearchParams(params)).toEqual({
+      endpointId: 'ep-1',
+      runFilterMode: 'timeRange',
+      timeRange: '7d',
+      testRunIds: [],
+      outcome: 'failed',
+    });
+  });
+
   it('returns null when query flag is missing', () => {
-    const params = new URLSearchParams('endpointId=ep-1&timeRange=1m');
+    const params = new URLSearchParams(
+      'endpointId=ep-1&runFilterMode=timeRange&timeRange=1m'
+    );
     expect(parseInsightsFailedTestsSearchParams(params)).toBeNull();
   });
 
-  it('formats time range labels', () => {
+  it('formats run filter labels', () => {
+    expect(
+      formatInsightsRunFilterLabel({
+        runFilterMode: 'timeRange',
+        timeRange: '1m',
+        testRunIds: [],
+      })
+    ).toBe('the last 1 month');
+    expect(
+      formatInsightsRunFilterLabel({
+        runFilterMode: 'testRuns',
+        timeRange: '1m',
+        testRunIds: [],
+      })
+    ).toBe('all test runs');
     expect(formatInsightsTimeRangeLabel('1d')).toBe('1 day');
-    expect(formatInsightsTimeRangeLabel('3m')).toBe('3 months');
   });
 
   it('formats summary detail with test results wording', () => {
@@ -78,24 +136,14 @@ describe('insights-failed-tests', () => {
     );
   });
 
-  it('appends unique failed test case count when it differs from failures', () => {
-    expect(formatInsightsSummaryDetail(10, 20, 10, 5)).toBe(
-      '(10/20 test results passed, 10 failed · 5 unique test cases failed)'
-    );
-  });
-
-  it('omits unique failed test case count when it matches failures', () => {
-    expect(formatInsightsSummaryDetail(7, 10, 3, 3)).toBe(
-      '(7/10 test results passed, 3 failed)'
-    );
-  });
-
   it('formats banner for metric drill-down', () => {
     expect(
       formatInsightsFailedTestsBanner(
         {
           endpointId: 'ep-1',
+          runFilterMode: 'timeRange',
           timeRange: '1m',
+          testRunIds: [],
           behaviorName: 'Safety',
           metricName: 'Toxicity',
         },
@@ -107,7 +155,9 @@ describe('insights-failed-tests', () => {
       formatInsightsFailedTestsBanner(
         {
           endpointId: 'ep-1',
+          runFilterMode: 'timeRange',
           timeRange: '1m',
+          testRunIds: [],
           behaviorName: 'Safety',
           metricName: 'Toxicity',
         },
@@ -122,7 +172,9 @@ describe('insights-failed-tests', () => {
       formatInsightsFailedTestsBanner(
         {
           endpointId: 'ep-1',
+          runFilterMode: 'timeRange',
           timeRange: '1m',
+          testRunIds: [],
           behaviorName: 'Safety',
           topicName: 'Claims',
           outcome: 'all',
@@ -135,7 +187,9 @@ describe('insights-failed-tests', () => {
       formatInsightsFailedTestsBanner(
         {
           endpointId: 'ep-1',
+          runFilterMode: 'testRuns',
           timeRange: '1m',
+          testRunIds: ['run-1'],
           behaviorName: 'Safety',
           metricName: 'Toxicity',
           outcome: 'all',

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-failed-tests.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-failed-tests.test.ts
@@ -34,6 +34,32 @@ describe('insights-failed-tests', () => {
     );
   });
 
+  it('builds tests URL for all test runs with an empty testRunIds param', () => {
+    expect(
+      buildInsightsFailedTestsUrl({
+        endpointId: 'ep-1',
+        runFilterMode: 'testRuns',
+        timeRange: '1m',
+        testRunIds: [],
+      })
+    ).toBe(
+      '/tests?failedFromInsights=1&endpointId=ep-1&runFilterMode=testRuns&testRunIds='
+    );
+  });
+
+  it('parses all-runs testRuns URLs with empty testRunIds', () => {
+    const params = new URLSearchParams(
+      'failedFromInsights=1&endpointId=ep-1&runFilterMode=testRuns&testRunIds='
+    );
+    expect(parseInsightsFailedTestsSearchParams(params)).toEqual({
+      endpointId: 'ep-1',
+      runFilterMode: 'testRuns',
+      timeRange: '1m',
+      testRunIds: [],
+      outcome: 'failed',
+    });
+  });
+
   it('builds tests URL with behavior metric scope', () => {
     expect(
       buildInsightsFailedTestsUrl(

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-filter-utils.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-filter-utils.test.ts
@@ -2,6 +2,7 @@ import {
   behaviorIdsFromCheckedSelection,
   checkedBehaviorIdsFromFilter,
   filterColumnsByBehaviorIds,
+  isRunFilterActive,
 } from '../insights-filter-utils';
 
 describe('insights-filter-utils', () => {
@@ -39,5 +40,37 @@ describe('insights-filter-utils', () => {
     expect(behaviorIdsFromCheckedSelection(['b1', 'b2', 'b3'], ['b2'])).toEqual(
       ['b2']
     );
+  });
+
+  describe('isRunFilterActive', () => {
+    it('is inactive for default time range mode', () => {
+      expect(
+        isRunFilterActive({
+          runFilterMode: 'timeRange',
+          timeRange: '1m',
+          testRunIds: [],
+        })
+      ).toBe(false);
+    });
+
+    it('is active for non-default time ranges', () => {
+      expect(
+        isRunFilterActive({
+          runFilterMode: 'timeRange',
+          timeRange: '7d',
+          testRunIds: [],
+        })
+      ).toBe(true);
+    });
+
+    it('is active for testRuns mode even with empty allowlist', () => {
+      expect(
+        isRunFilterActive({
+          runFilterMode: 'testRuns',
+          timeRange: '1m',
+          testRunIds: [],
+        })
+      ).toBe(true);
+    });
   });
 });

--- a/apps/frontend/src/app/(protected)/insights/utils/behavior-insights-utils.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/behavior-insights-utils.ts
@@ -11,7 +11,13 @@ import {
   writeInsightsEndpointId,
 } from '@/utils/insights-endpoint';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
-import { InsightsTimeRange, timeRangeToStatsParams } from '../types';
+import { TestRun } from '@/utils/api-client/interfaces/test-run';
+import {
+  InsightsFilters,
+  InsightsTimeRange,
+  resolveInsightsTimeRange,
+  timeRangeToStatsParams,
+} from '../types';
 
 function endpointMatchesProject(
   endpoint: Endpoint,
@@ -132,11 +138,11 @@ export function buildEndpointRunFilter(endpointId: string): string {
   return `test_configuration/endpoint_id eq '${endpointId}'`;
 }
 
-export async function fetchTestRunIdsForEndpoint(
+export async function fetchTestRunsForEndpoint(
   sessionToken: string,
   endpointId: string,
   timeRange?: InsightsTimeRange
-): Promise<string[]> {
+): Promise<TestRun[]> {
   const client = new ApiClientFactory(sessionToken).getTestRunsClient();
   const filterParts = [buildEndpointRunFilter(endpointId)];
   if (timeRange) {
@@ -146,7 +152,7 @@ export async function fetchTestRunIdsForEndpoint(
     }
   }
   const filter = filterParts.join(' and ');
-  const ids: string[] = [];
+  const runs: TestRun[] = [];
   let skip = 0;
   const limit = 100;
   let hasMore = true;
@@ -160,13 +166,49 @@ export async function fetchTestRunIdsForEndpoint(
       sort_order: 'desc',
     });
 
-    ids.push(...response.data.map(run => run.id));
+    runs.push(...response.data);
     const total = response.pagination?.totalCount ?? response.data.length;
-    hasMore = ids.length < total;
+    hasMore = runs.length < total;
     skip += limit;
   }
 
-  return ids;
+  return runs;
+}
+
+export async function fetchTestRunIdsForEndpoint(
+  sessionToken: string,
+  endpointId: string,
+  timeRange?: InsightsTimeRange
+): Promise<string[]> {
+  const runs = await fetchTestRunsForEndpoint(
+    sessionToken,
+    endpointId,
+    timeRange
+  );
+  return runs.map(run => run.id);
+}
+
+/** Resolve which test run IDs to query based on Insights filter state. */
+export async function resolveInsightsQueryTestRunIds(
+  sessionToken: string,
+  filters: Pick<
+    InsightsFilters,
+    'endpointId' | 'runFilterMode' | 'timeRange' | 'testRunIds'
+  >
+): Promise<string[]> {
+  if (filters.runFilterMode === 'timeRange') {
+    return fetchTestRunIdsForEndpoint(
+      sessionToken,
+      filters.endpointId,
+      resolveInsightsTimeRange(filters.timeRange)
+    );
+  }
+
+  if (filters.testRunIds.length > 0) {
+    return filters.testRunIds;
+  }
+
+  return fetchTestRunIdsForEndpoint(sessionToken, filters.endpointId);
 }
 
 export function buildBehaviorColumns(

--- a/apps/frontend/src/app/(protected)/insights/utils/behavior-insights-utils.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/behavior-insights-utils.ts
@@ -155,9 +155,8 @@ export async function fetchTestRunsForEndpoint(
   const runs: TestRun[] = [];
   let skip = 0;
   const limit = 100;
-  let hasMore = true;
 
-  while (hasMore) {
+  while (true) {
     const response = await client.getTestRuns({
       filter,
       skip,
@@ -167,8 +166,12 @@ export async function fetchTestRunsForEndpoint(
     });
 
     runs.push(...response.data);
-    const total = response.pagination?.totalCount ?? response.data.length;
-    hasMore = runs.length < total;
+    // Prefer page-size termination over totalCount — some responses omit
+    // x-total-count and totalCount defaults to 0, which would stop after
+    // the first page and silently drop later runs.
+    if (response.data.length < limit) {
+      break;
+    }
     skip += limit;
   }
 
@@ -188,6 +191,20 @@ export async function fetchTestRunIdsForEndpoint(
   return runs.map(run => run.id);
 }
 
+/**
+ * Soft cap for `test_run_ids` query params on `/test_results/stats`.
+ * Beyond this, GET URLs risk proxy/browser length limits.
+ */
+export const MAX_INSIGHTS_TEST_RUN_IDS = 100;
+
+export function assertInsightsTestRunIdsWithinLimit(testRunIds: string[]): void {
+  if (testRunIds.length > MAX_INSIGHTS_TEST_RUN_IDS) {
+    throw new Error(
+      `Too many test runs to query at once (${testRunIds.length}; max ${MAX_INSIGHTS_TEST_RUN_IDS}). Narrow your selection or use a shorter time range.`
+    );
+  }
+}
+
 /** Resolve which test run IDs to query based on Insights filter state. */
 export async function resolveInsightsQueryTestRunIds(
   sessionToken: string,
@@ -196,19 +213,25 @@ export async function resolveInsightsQueryTestRunIds(
     'endpointId' | 'runFilterMode' | 'timeRange' | 'testRunIds'
   >
 ): Promise<string[]> {
+  let testRunIds: string[];
+
   if (filters.runFilterMode === 'timeRange') {
-    return fetchTestRunIdsForEndpoint(
+    testRunIds = await fetchTestRunIdsForEndpoint(
       sessionToken,
       filters.endpointId,
       resolveInsightsTimeRange(filters.timeRange)
     );
+  } else if (filters.testRunIds.length > 0) {
+    testRunIds = filters.testRunIds;
+  } else {
+    testRunIds = await fetchTestRunIdsForEndpoint(
+      sessionToken,
+      filters.endpointId
+    );
   }
 
-  if (filters.testRunIds.length > 0) {
-    return filters.testRunIds;
-  }
-
-  return fetchTestRunIdsForEndpoint(sessionToken, filters.endpointId);
+  assertInsightsTestRunIdsWithinLimit(testRunIds);
+  return testRunIds;
 }
 
 export function buildBehaviorColumns(

--- a/apps/frontend/src/app/(protected)/insights/utils/behavior-insights-utils.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/behavior-insights-utils.ts
@@ -197,7 +197,9 @@ export async function fetchTestRunIdsForEndpoint(
  */
 export const MAX_INSIGHTS_TEST_RUN_IDS = 100;
 
-export function assertInsightsTestRunIdsWithinLimit(testRunIds: string[]): void {
+export function assertInsightsTestRunIdsWithinLimit(
+  testRunIds: string[]
+): void {
   if (testRunIds.length > MAX_INSIGHTS_TEST_RUN_IDS) {
     throw new Error(
       `Too many test runs to query at once (${testRunIds.length}; max ${MAX_INSIGHTS_TEST_RUN_IDS}). Narrow your selection or use a shorter time range.`

--- a/apps/frontend/src/app/(protected)/insights/utils/insights-failed-tests.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/insights-failed-tests.ts
@@ -65,7 +65,8 @@ export function buildInsightsFailedTestsUrl(
       INSIGHTS_TIME_RANGE_PARAM,
       resolveInsightsTimeRange(filters.timeRange)
     );
-  } else if (filters.testRunIds.length > 0) {
+  } else if (filters.runFilterMode === 'testRuns') {
+    // Explicit empty list = all runs for the endpoint (parsed the same way).
     params.set(INSIGHTS_TEST_RUN_IDS_PARAM, filters.testRunIds.join(','));
   }
 
@@ -263,16 +264,19 @@ const TEST_RUN_ID_CHUNK = 15;
  */
 export async function fetchFailedTestIdsForInsights(
   sessionToken: string,
-  filters: InsightsRunContextFilters &
-    InsightsFailedTestsScope & { testRunIds?: string[] }
+  filters: InsightsRunContextFilters & InsightsFailedTestsScope
 ): Promise<string[]> {
   if (!filters.endpointId) {
     return [];
   }
 
+  // Empty `testRunIds` is meaningful: time-range mode and testRuns/"all runs"
+  // both store `[]` and need resolution via `resolveInsightsQueryTestRunIds`.
+  // Do not treat `[]` as missing (`??` would skip resolution).
   const testRunIds =
-    filters.testRunIds ??
-    (await resolveInsightsQueryTestRunIds(sessionToken, filters));
+    filters.testRunIds.length > 0
+      ? filters.testRunIds
+      : await resolveInsightsQueryTestRunIds(sessionToken, filters);
   if (testRunIds.length === 0) {
     return [];
   }

--- a/apps/frontend/src/app/(protected)/insights/utils/insights-failed-tests.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/insights-failed-tests.ts
@@ -3,14 +3,21 @@ import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { TEST_RESULT_STATUS_NAMES } from '@/utils/test-result-status';
 import {
   InsightsFilters,
+  InsightsRunFilterMode,
   InsightsTimeRange,
   resolveInsightsTimeRange,
   timeRangeToStatsParams,
 } from '../types';
-import { fetchTestRunIdsForEndpoint } from './behavior-insights-utils';
+import { resolveInsightsQueryTestRunIds } from './behavior-insights-utils';
 
 export const INSIGHTS_FAILED_TESTS_QUERY = 'failedFromInsights';
 export const INSIGHTS_OUTCOME_ALL = 'all';
+export const INSIGHTS_RUN_FILTER_MODE_PARAM = 'runFilterMode';
+export const INSIGHTS_TIME_RANGE_PARAM = 'timeRange';
+export const INSIGHTS_TEST_RUN_IDS_PARAM = 'testRunIds';
+
+/** @deprecated Legacy URL param — parsed for backward compatibility. */
+export const INSIGHTS_TEST_RUN_SCOPE_PARAM = 'testRunScope';
 
 export type InsightsTestOutcome = 'failed' | 'all';
 
@@ -24,7 +31,9 @@ export interface InsightsFailedTestsScope {
 
 export interface InsightsFailedTestsFilter {
   endpointId: string;
+  runFilterMode: InsightsRunFilterMode;
   timeRange: InsightsTimeRange;
+  testRunIds: string[];
   behaviorId?: string;
   behaviorName?: string;
   metricName?: string;
@@ -38,7 +47,7 @@ function escapeODataValue(value: string): string {
 
 export type InsightsRunContextFilters = Pick<
   InsightsFilters,
-  'endpointId' | 'timeRange'
+  'endpointId' | 'runFilterMode' | 'timeRange' | 'testRunIds'
 >;
 
 export function buildInsightsFailedTestsUrl(
@@ -48,8 +57,17 @@ export function buildInsightsFailedTestsUrl(
   const params = new URLSearchParams({
     [INSIGHTS_FAILED_TESTS_QUERY]: '1',
     endpointId: filters.endpointId,
-    timeRange: filters.timeRange,
+    [INSIGHTS_RUN_FILTER_MODE_PARAM]: filters.runFilterMode,
   });
+
+  if (filters.runFilterMode === 'timeRange') {
+    params.set(
+      INSIGHTS_TIME_RANGE_PARAM,
+      resolveInsightsTimeRange(filters.timeRange)
+    );
+  } else if (filters.testRunIds.length > 0) {
+    params.set(INSIGHTS_TEST_RUN_IDS_PARAM, filters.testRunIds.join(','));
+  }
 
   if (scope?.behaviorId) {
     params.set('behaviorId', scope.behaviorId);
@@ -70,6 +88,69 @@ export function buildInsightsFailedTestsUrl(
   return `/tests?${params.toString()}`;
 }
 
+type LegacyTestRunScope = 'default' | 'all' | 'custom';
+
+function parseLegacyFilters(
+  searchParams: Pick<URLSearchParams, 'get'>
+): Pick<
+  InsightsFailedTestsFilter,
+  'runFilterMode' | 'timeRange' | 'testRunIds'
+> | null {
+  const runFilterMode = searchParams.get(
+    INSIGHTS_RUN_FILTER_MODE_PARAM
+  ) as InsightsRunFilterMode | null;
+  if (runFilterMode === 'timeRange' || runFilterMode === 'testRuns') {
+    const timeRange = searchParams.get(INSIGHTS_TIME_RANGE_PARAM);
+    const rawTestRunIds = searchParams.get(INSIGHTS_TEST_RUN_IDS_PARAM);
+    return {
+      runFilterMode,
+      timeRange: resolveInsightsTimeRange(
+        (timeRange as InsightsTimeRange | null) ?? undefined
+      ),
+      testRunIds:
+        runFilterMode === 'testRuns' && rawTestRunIds
+          ? rawTestRunIds.split(',').filter(Boolean)
+          : [],
+    };
+  }
+
+  const legacyScope = searchParams.get(
+    INSIGHTS_TEST_RUN_SCOPE_PARAM
+  ) as LegacyTestRunScope | null;
+  const legacyTimeRange = searchParams.get(INSIGHTS_TIME_RANGE_PARAM);
+
+  if (legacyScope === 'custom') {
+    const rawTestRunIds = searchParams.get(INSIGHTS_TEST_RUN_IDS_PARAM);
+    return {
+      runFilterMode: 'testRuns',
+      timeRange: DEFAULT_INSIGHTS_TIME_RANGE,
+      testRunIds: rawTestRunIds ? rawTestRunIds.split(',').filter(Boolean) : [],
+    };
+  }
+
+  if (legacyScope === 'all') {
+    return {
+      runFilterMode: 'testRuns',
+      timeRange: DEFAULT_INSIGHTS_TIME_RANGE,
+      testRunIds: [],
+    };
+  }
+
+  if (legacyScope === 'default' || legacyTimeRange) {
+    return {
+      runFilterMode: 'timeRange',
+      timeRange: resolveInsightsTimeRange(
+        (legacyTimeRange as InsightsTimeRange | null) ?? undefined
+      ),
+      testRunIds: [],
+    };
+  }
+
+  return null;
+}
+
+const DEFAULT_INSIGHTS_TIME_RANGE = resolveInsightsTimeRange(undefined);
+
 export function parseInsightsFailedTestsSearchParams(
   searchParams: Pick<URLSearchParams, 'get'>
 ): InsightsFailedTestsFilter | null {
@@ -78,14 +159,18 @@ export function parseInsightsFailedTestsSearchParams(
   }
 
   const endpointId = searchParams.get('endpointId');
-  const timeRange = searchParams.get('timeRange');
-  if (!endpointId || !timeRange) {
+  if (!endpointId) {
+    return null;
+  }
+
+  const runFilters = parseLegacyFilters(searchParams);
+  if (!runFilters) {
     return null;
   }
 
   return {
     endpointId,
-    timeRange: resolveInsightsTimeRange(timeRange as InsightsTimeRange),
+    ...runFilters,
     behaviorId: searchParams.get('behaviorId') || undefined,
     behaviorName: searchParams.get('behaviorName') || undefined,
     metricName: searchParams.get('metric') || undefined,
@@ -173,7 +258,7 @@ async function filterTestIdsByTopic(
 const TEST_RUN_ID_CHUNK = 15;
 
 /**
- * Resolve test case IDs that failed for the endpoint + time window shown on Insights,
+ * Resolve test case IDs that failed for the selected Insights scope,
  * optionally scoped to a behavior, metric, or topic row.
  */
 export async function fetchFailedTestIdsForInsights(
@@ -187,18 +272,17 @@ export async function fetchFailedTestIdsForInsights(
 
   const testRunIds =
     filters.testRunIds ??
-    (await fetchTestRunIdsForEndpoint(
-      sessionToken,
-      filters.endpointId,
-      filters.timeRange
-    ));
+    (await resolveInsightsQueryTestRunIds(sessionToken, filters));
   if (testRunIds.length === 0) {
     return [];
   }
 
   const client = new ApiClientFactory(sessionToken).getTestResultsClient();
   const ids = new Set<string>();
-  const createdAtFilter = buildCreatedAtFilter(filters.timeRange);
+  const createdAtFilter =
+    filters.runFilterMode === 'timeRange'
+      ? buildCreatedAtFilter(resolveInsightsTimeRange(filters.timeRange))
+      : '';
   const failedOnly = filters.outcome !== 'all';
   const statusFilter = `status/name eq '${TEST_RESULT_STATUS_NAMES.FAILED}'`;
 
@@ -307,13 +391,31 @@ export function formatInsightsTimeRangeLabel(
   }
 }
 
+export function formatInsightsRunFilterLabel(
+  filter: Pick<
+    InsightsFailedTestsFilter,
+    'runFilterMode' | 'timeRange' | 'testRunIds'
+  >
+): string {
+  if (filter.runFilterMode === 'timeRange') {
+    return `the last ${formatInsightsTimeRangeLabel(
+      resolveInsightsTimeRange(filter.timeRange)
+    )}`;
+  }
+  if (filter.testRunIds.length === 0) {
+    return 'all test runs';
+  }
+  const count = filter.testRunIds.length;
+  return `${count} selected test run${count === 1 ? '' : 's'}`;
+}
+
 export function formatInsightsFailedTestsBanner(
   filter: InsightsFailedTestsFilter,
   count: number,
   endpointName?: string
 ): string {
   const endpoint = endpointName ?? 'the selected endpoint';
-  const period = formatInsightsTimeRangeLabel(filter.timeRange);
+  const period = formatInsightsRunFilterLabel(filter);
   const noun = `test case${count === 1 ? '' : 's'}`;
 
   const showAll = filter.outcome === 'all';
@@ -326,23 +428,36 @@ export function formatInsightsFailedTestsBanner(
 
   if (filter.metricName && filter.behaviorName) {
     if (showAll) {
-      return `Showing ${count} ${noun} evaluated for "${filter.metricName}" in ${filter.behaviorName} on ${endpoint} in the last ${period}.`;
+      return `Showing ${count} ${noun} evaluated for "${filter.metricName}" in ${filter.behaviorName} on ${endpoint} for ${period}.`;
     }
-    return `Showing ${count} ${noun} where "${filter.metricName}" failed for ${filter.behaviorName} on ${endpoint} in the last ${period}.`;
+    return `Showing ${count} ${noun} where "${filter.metricName}" failed for ${filter.behaviorName} on ${endpoint} for ${period}.`;
   }
 
   if (filter.topicName && filter.behaviorName) {
     if (showAll) {
-      return `Showing ${count} ${noun} for topic "${filter.topicName}" in ${filter.behaviorName} on ${endpoint} in the last ${period}.`;
+      return `Showing ${count} ${noun} for topic "${filter.topicName}" in ${filter.behaviorName} on ${endpoint} for ${period}.`;
     }
-    return `Showing ${count} failed ${noun} for topic "${filter.topicName}" in ${filter.behaviorName} on ${endpoint} in the last ${period}.`;
+    return `Showing ${count} failed ${noun} for topic "${filter.topicName}" in ${filter.behaviorName} on ${endpoint} for ${period}.`;
   }
 
   if (filter.behaviorName) {
     return showAll
-      ? `Showing ${count} ${noun} for ${filter.behaviorName} on ${endpoint} in the last ${period}.`
-      : `Showing ${count} failed ${noun} for ${filter.behaviorName} on ${endpoint} in the last ${period}.`;
+      ? `Showing ${count} ${noun} for ${filter.behaviorName} on ${endpoint} for ${period}.`
+      : `Showing ${count} failed ${noun} for ${filter.behaviorName} on ${endpoint} for ${period}.`;
   }
 
-  return `Showing ${count} failed ${noun} for ${endpoint} in the last ${period}.`;
+  return showAll
+    ? `Showing ${count} ${noun} for ${endpoint} for ${period}.`
+    : `Showing ${count} failed ${noun} for ${endpoint} for ${period}.`;
+}
+
+export function insightsFailedFilterToRunContext(
+  filter: InsightsFailedTestsFilter
+): InsightsRunContextFilters {
+  return {
+    endpointId: filter.endpointId,
+    runFilterMode: filter.runFilterMode,
+    timeRange: filter.timeRange,
+    testRunIds: filter.testRunIds,
+  };
 }

--- a/apps/frontend/src/app/(protected)/insights/utils/insights-filter-utils.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/insights-filter-utils.ts
@@ -51,10 +51,12 @@ export function behaviorIdsFromCheckedSelection(
 export function isRunFilterActive(
   filters: Pick<InsightsFilters, 'runFilterMode' | 'timeRange' | 'testRunIds'>
 ): boolean {
-  if (filters.runFilterMode === 'timeRange') {
-    return filters.timeRange !== DEFAULT_INSIGHTS_TIME_RANGE;
+  // Test-runs mode is always a non-default scope (including empty
+  // testRunIds = "all runs"), even when the allowlist is empty.
+  if (filters.runFilterMode === 'testRuns') {
+    return true;
   }
-  return filters.testRunIds.length > 0;
+  return filters.timeRange !== DEFAULT_INSIGHTS_TIME_RANGE;
 }
 
 export function countActiveInsightsFilters(input: {

--- a/apps/frontend/src/app/(protected)/insights/utils/insights-filter-utils.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/insights-filter-utils.ts
@@ -1,3 +1,10 @@
+import { TestRun } from '@/utils/api-client/interfaces/test-run';
+import {
+  DEFAULT_INSIGHTS_TIME_RANGE,
+  InsightsFilters,
+  InsightsRunFilterMode,
+} from '../types';
+
 export interface InsightsBehaviorOption {
   id: string;
   name: string;
@@ -41,12 +48,27 @@ export function behaviorIdsFromCheckedSelection(
   return checkedIds;
 }
 
+export function isRunFilterActive(
+  filters: Pick<InsightsFilters, 'runFilterMode' | 'timeRange' | 'testRunIds'>
+): boolean {
+  if (filters.runFilterMode === 'timeRange') {
+    return filters.timeRange !== DEFAULT_INSIGHTS_TIME_RANGE;
+  }
+  return filters.testRunIds.length > 0;
+}
+
 export function countActiveInsightsFilters(input: {
   endpointId: string;
   behaviorIds: string[];
+  runFilterMode: InsightsRunFilterMode;
+  timeRange: InsightsFilters['timeRange'];
+  testRunIds: string[];
 }): number {
   let count = input.endpointId ? 1 : 0;
   if (isBehaviorFilterActive(input.behaviorIds)) {
+    count += 1;
+  }
+  if (isRunFilterActive(input)) {
     count += 1;
   }
   return count;
@@ -55,6 +77,55 @@ export function countActiveInsightsFilters(input: {
 export function hasActiveInsightsFilters(input: {
   endpointId: string;
   behaviorIds: string[];
+  runFilterMode: InsightsRunFilterMode;
+  timeRange: InsightsFilters['timeRange'];
+  testRunIds: string[];
 }): boolean {
   return countActiveInsightsFilters(input) > 0;
+}
+
+export interface InsightsTestRunOption {
+  id: string;
+  label: string;
+}
+
+export function formatInsightsTestRunLabel(
+  run: Pick<TestRun, 'id' | 'name' | 'created_at'>
+): string {
+  const name = run.name?.trim() || 'Untitled run';
+  if (!run.created_at) {
+    return name;
+  }
+  const date = new Date(run.created_at).toLocaleString('en-GB', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  return `${name} · ${date}`;
+}
+
+export function checkedTestRunIdsFromFilter(
+  allIds: string[],
+  filters: Pick<InsightsFilters, 'runFilterMode' | 'testRunIds'>
+): string[] {
+  if (filters.runFilterMode !== 'testRuns') {
+    return [];
+  }
+  if (filters.testRunIds.length === 0) {
+    return allIds;
+  }
+  const allowed = new Set(filters.testRunIds);
+  return allIds.filter(id => allowed.has(id));
+}
+
+export function testRunIdsFromCheckedSelection(
+  allIds: string[],
+  checkedIds: string[]
+): string[] {
+  if (checkedIds.length === 0 || checkedIds.length === allIds.length) {
+    return [];
+  }
+  return checkedIds;
 }

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -75,6 +75,7 @@ import { gridSortToApiParams } from '@/utils/grid-sort';
 import {
   fetchFailedTestIdsForInsights,
   formatInsightsFailedTestsBanner,
+  insightsFailedFilterToRunContext,
   type InsightsFailedTestsFilter,
 } from '@/app/(protected)/insights/utils/insights-failed-tests';
 
@@ -333,8 +334,7 @@ export default function TestsTable({
       setInsightsFilterError(null);
       try {
         const ids = await fetchFailedTestIdsForInsights(sessionToken, {
-          endpointId: insightsFailedFilter.endpointId,
-          timeRange: insightsFailedFilter.timeRange,
+          ...insightsFailedFilterToRunContext(insightsFailedFilter),
           behaviorId: insightsFailedFilter.behaviorId,
           behaviorName: insightsFailedFilter.behaviorName,
           metricName: insightsFailedFilter.metricName,
@@ -362,7 +362,9 @@ export default function TestsTable({
     };
   }, [
     insightsFailedFilter?.endpointId,
+    insightsFailedFilter?.runFilterMode,
     insightsFailedFilter?.timeRange,
+    insightsFailedFilter?.testRunIds,
     sessionToken,
     insightsFailedFilter,
   ]);

--- a/apps/frontend/tests/e2e/pages/InsightsPage.ts
+++ b/apps/frontend/tests/e2e/pages/InsightsPage.ts
@@ -42,7 +42,7 @@ export class InsightsPage extends BasePage {
     });
     const searchBehaviors = this.page.getByPlaceholder(/search behaviors/i);
     const passRateMetric = this.page.getByText(/\d+\.\d+%\s*pass rate/i);
-    const timeRange1M = this.page.getByRole('button', { name: '1M' });
+    const filterButton = this.page.getByRole('button', { name: /filters/i });
 
     // Wait for endpoint auto-selection and insights fetch to settle.
     await expect(noEndpoints.or(noTestResults).or(searchBehaviors)).toBeVisible(
@@ -59,12 +59,12 @@ export class InsightsPage extends BasePage {
     }
 
     if (await noTestResults.isVisible()) {
-      await expect(timeRange1M).toBeVisible();
+      await expect(filterButton).toBeVisible();
       return;
     }
 
     await expect(this.page.getByPlaceholder(/search behaviors/i)).toBeVisible();
-    await expect(timeRange1M).toBeVisible();
+    await expect(filterButton).toBeVisible();
     await expect(passRateMetric.first()).toBeVisible({ timeout: 15_000 });
   }
 


### PR DESCRIPTION
## Purpose
Insights previously scoped data only via toolbar time-range pills. Users need to filter by specific test runs **or** by a time window that automatically includes matching runs — not lose the ability to pick a timeframe.

## What Changed
- Moved Insights scope into the filter drawer with mutually exclusive modes: **Time range** (1D / 7D / 1M / 3M) or **Test runs** (multi-select)
- Default remains time range = 1 month
- Empty `testRunIds` in test-run mode means all runs for the endpoint
- Stats and failed-tests drill-down follow the selected mode
- Removed toolbar time-range pills; Expand all stays in the toolbar when relevant
- Soft cap of 100 `test_run_ids` before stats requests (clear error if exceeded) to avoid GET URL length limits
- Test-run pagination no longer relies on optional `totalCount` (avoids dropping pages after the first 100)
- Updated unit tests and e2e Insights page object

## Additional Context
- Backend already supports `test_run_ids` on `/test_results/stats` — no API changes
- Built on a clean branch from `main` (not #2120)
- Follow-up: backend endpoint-scoped stats so “all runs” need not expand to an allowlist

## Testing
- [x] Insights unit tests (`npm test -- --testPathPatterns=insights`)
- [x] Boundary tests for `assertInsightsTestRunIdsWithinLimit` (max / max+1)
- [ ] Manual: open `/insights` → Filters → switch between Time range and Test runs; Apply and confirm chart/summary update
- [ ] Manual: failed-tests FAB / dimension drill-down still opens `/tests` with the correct scope