### PR TITLE
Reject execution of empty test sets

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_set.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 from uuid import UUID
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
 from rhesis.backend.app import models, schemas
@@ -778,6 +779,8 @@ def execute_test_set_on_endpoint(
     # Check user access permissions
     _validate_user_access(current_user, db_test_set, db_endpoint)
 
+    _validate_test_set_not_empty(db, db_test_set)
+
     # Validate reference test run if provided (output reuse / re-scoring)
     if reference_test_run_id:
         _validate_reference_test_run(db, reference_test_run_id, db_test_set, current_user)
@@ -845,6 +848,30 @@ def execute_test_set_on_endpoint(
     }
     logger.info(f"Successfully initiated test set execution: {response_data}")
     return response_data
+
+
+def count_test_set_tests(db: Session, test_set_id: uuid.UUID) -> int:
+    """Count active tests associated with a test set.
+
+    Join the test table explicitly so stale association rows do not count tests
+    that have been soft-deleted.
+    """
+    return (
+        db.query(func.count(models.Test.id))
+        .select_from(test_test_set_association)
+        .join(models.Test, models.Test.id == test_test_set_association.c.test_id)
+        .filter(
+            test_test_set_association.c.test_set_id == test_set_id,
+            models.Test.deleted_at.is_(None),
+        )
+        .scalar()
+    ) or 0
+
+
+def _validate_test_set_not_empty(db: Session, test_set: models.TestSet) -> None:
+    """Reject execution when a test set has no associated tests."""
+    if count_test_set_tests(db, test_set.id) == 0:
+        raise ValueError("Cannot execute test set with 0 tests. Please add tests before executing.")
 
 
 def _validate_user_access(

--- a/apps/backend/src/rhesis/backend/tasks/execution/orchestration.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/orchestration.py
@@ -12,10 +12,11 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app.models.test_configuration import TestConfiguration
 from rhesis.backend.app.models.test_run import TestRun
-from rhesis.backend.app.services.test_set import get_test_set
+from rhesis.backend.app.services.test_set import count_test_set_tests, get_test_set
 from rhesis.backend.tasks.enums import ExecutionMode
 from rhesis.backend.tasks.execution.batch import execute_tests_as_batch
 from rhesis.backend.tasks.execution.modes import get_execution_mode
+from rhesis.backend.tasks.execution.run import TestExecutionError
 from rhesis.backend.tasks.execution.sequential import execute_tests_sequentially
 
 logger = logging.getLogger(__name__)
@@ -39,16 +40,12 @@ def execute_test_cases(
     """
 
     test_set = get_test_set(session, str(test_config.test_set_id))
-    tests = test_set.tests
+    if count_test_set_tests(session, test_set.id) == 0:
+        raise TestExecutionError(
+            "Cannot execute test set with 0 tests. Please add tests before executing."
+        )
 
-    if not tests:
-        logger.warning(f"No tests found in test set {test_set.id}")
-        return {
-            "test_run_id": str(test_run.id),
-            "test_configuration_id": str(test_config.id),
-            "test_set_id": str(test_config.test_set_id),
-            "total_tests": 0,
-        }
+    tests = test_set.tests
 
     execution_mode = get_execution_mode(test_config)
     logger.info(f"Executing test configuration {test_config.id} in {execution_mode.value} mode")

--- a/tests/backend/routes/test_execute_with_reuse.py
+++ b/tests/backend/routes/test_execute_with_reuse.py
@@ -78,7 +78,7 @@ def _get_or_create_status(db, name, org_id, user_id):
 
 @pytest.fixture
 def db_test_set(test_db, test_org_id, authenticated_user_id):
-    """Create a test set with a test set type."""
+    """Create a test set with one associated test."""
     ts_type = _create_type_lookup(
         test_db,
         "TestSetType",
@@ -93,6 +93,23 @@ def db_test_set(test_db, test_org_id, authenticated_user_id):
         test_set_type_id=ts_type.id,
     )
     test_db.add(test_set)
+    test_db.flush()
+
+    test = models.Test(
+        test_configuration={},
+        organization_id=test_org_id,
+        user_id=authenticated_user_id,
+    )
+    test_db.add(test)
+    test_db.flush()
+    test_db.execute(
+        models.test_test_set_association.insert().values(
+            test_id=test.id,
+            test_set_id=test_set.id,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+    )
     test_db.flush()
     return test_set
 

--- a/tests/backend/services/test_test_set.py
+++ b/tests/backend/services/test_test_set.py
@@ -243,6 +243,10 @@ class TestTestSetExecution:
                 "rhesis.backend.app.services.test_set._validate_user_access"
             ) as mock_validate_access,
             patch(
+                "rhesis.backend.app.services.test_set.count_test_set_tests",
+                return_value=1,
+            ),
+            patch(
                 "rhesis.backend.app.services.test_set._create_test_configuration"
             ) as mock_create_config,
             patch(
@@ -378,6 +382,108 @@ class TestTestSetExecution:
                 db=test_db, test_set_identifier="test_set_id", endpoint_id=None, current_user=user
             )
 
+    def test_count_test_set_tests_excludes_soft_deleted_tests(
+        self, test_db: Session, authenticated_user_id, test_org_id
+    ):
+        """Stale associations to soft-deleted tests do not make a test set executable."""
+        test_set = models.TestSet(
+            **create_test_set_data(),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test = models.Test(
+            **create_test_data(),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.add_all([test_set, test])
+        test_db.flush()
+        test_db.execute(
+            models.test_test_set_association.insert().values(
+                test_id=test.id,
+                test_set_id=test_set.id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+        )
+        test_db.commit()
+
+        assert test_set_service.count_test_set_tests(test_db, test_set.id) == 1
+
+        test.soft_delete()
+        test_db.commit()
+
+        assert test_set_service.count_test_set_tests(test_db, test_set.id) == 0
+
+    def test_execute_test_set_on_endpoint_empty_test_set(
+        self, test_db: Session, authenticated_user_id, test_org_id, db_user, test_organization
+    ):
+        """Empty test sets are rejected before configuration or task submission."""
+        test_set = models.TestSet(
+            **create_test_set_data(),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.add(test_set)
+        test_db.commit()
+
+        project = models.Project(
+            name="Empty Test Set Project",
+            organization_id=test_organization.id,
+            user_id=db_user.id,
+        )
+        test_db.add(project)
+        test_db.commit()
+        test_db.refresh(project)
+
+        endpoint = models.Endpoint(
+            **create_endpoint_data(),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+            project_id=project.id,
+        )
+        test_db.add(endpoint)
+        test_db.commit()
+
+        user = test_db.query(models.User).filter(models.User.id == authenticated_user_id).first()
+
+        with (
+            patch("rhesis.backend.app.crud.resolve_test_set", return_value=test_set),
+            patch("rhesis.backend.app.crud.get_endpoint", return_value=endpoint),
+            patch(
+                "rhesis.backend.app.services.test_set._validate_user_access",
+                return_value=None,
+            ),
+            patch(
+                "rhesis.backend.app.services.test_set._create_test_configuration"
+            ) as mock_create_config,
+            patch(
+                "rhesis.backend.app.services.test_set._submit_test_configuration_for_execution"
+            ) as mock_submit,
+        ):
+            with pytest.raises(ValueError, match="Cannot execute test set with 0 tests"):
+                test_set_service.execute_test_set_on_endpoint(
+                    db=test_db,
+                    test_set_identifier=str(test_set.id),
+                    endpoint_id=endpoint.id,
+                    current_user=user,
+                )
+
+            mock_create_config.assert_not_called()
+            mock_submit.assert_not_called()
+
+    def test_execute_test_set_on_endpoint_empty_returns_http_400(self):
+        """Empty-test ValueError is converted to HTTP 400 by handle_execution_error."""
+        from rhesis.backend.app.utils.execution_validation import handle_execution_error
+
+        error = ValueError(
+            "Cannot execute test set with 0 tests. Please add tests before executing."
+        )
+        result = handle_execution_error(error, operation="execute test set")
+
+        assert result.status_code == 400
+        assert "cannot execute test set with 0 tests" in str(result.detail).lower()
+
     def test_execute_test_set_on_endpoint_with_metrics(
         self, test_db: Session, authenticated_user_id, test_org_id, db_user, test_organization
     ):
@@ -427,6 +533,10 @@ class TestTestSetExecution:
             patch(
                 "rhesis.backend.app.services.test_set._validate_user_access"
             ) as mock_validate_access,
+            patch(
+                "rhesis.backend.app.services.test_set.count_test_set_tests",
+                return_value=1,
+            ),
             patch(
                 "rhesis.backend.app.services.test_set._create_test_configuration"
             ) as mock_create_config,

--- a/tests/backend/tasks/test_pipeline_wiring.py
+++ b/tests/backend/tasks/test_pipeline_wiring.py
@@ -254,6 +254,32 @@ class TestOrchestrationPassthrough:
         call_kwargs = mock_sequential.call_args.kwargs
         assert call_kwargs["reference_test_run_id"] == "ref-run-2"
 
+    def test_empty_test_set_raises_execution_error(self):
+        """execute_test_cases raises TestExecutionError when association count is zero."""
+        mock_test_set = MagicMock()
+        mock_test_set.id = "ts-empty"
+
+        with (
+            patch(
+                "rhesis.backend.tasks.execution.orchestration.get_test_set",
+                return_value=mock_test_set,
+            ),
+            patch(
+                "rhesis.backend.tasks.execution.orchestration.count_test_set_tests",
+                return_value=0,
+            ),
+        ):
+            from rhesis.backend.tasks.execution.orchestration import (
+                execute_test_cases,
+            )
+            from rhesis.backend.tasks.execution.run import TestExecutionError
+
+            with pytest.raises(TestExecutionError, match="Cannot execute test set with 0 tests"):
+                execute_test_cases(
+                    session=MagicMock(),
+                    test_config=MagicMock(test_set_id="ts-empty"),
+                    test_run=MagicMock(),
+                )
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- reject empty test sets before creating execution configuration or scheduling Celery work
- count only active tests, excluding stale associations to soft-deleted records
- retain a worker-side safety check if tests are removed after the request is accepted
- add service and orchestration coverage, including a soft-delete regression test

Closes #674

## Test plan
- [x] `ruff check` on all changed files
- [x] `ruff format --check` on changed service and test files
- [x] `python -m py_compile` on changed files
- [ ] backend integration tests run in project CI because local Docker was unavailable