### PR TITLE
Add Linked Tests on behaviors and fix behavior filter list

### DIFF
--- a/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorDetailTabs.tsx
@@ -42,13 +42,15 @@ import { TagsClient } from '@/utils/api-client/tags-client';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import BehaviorDrawer from '../../components/BehaviorDrawer';
+import BehaviorLinkedTests from './BehaviorLinkedTests';
 import type { UUID } from 'crypto';
 
-const TAB_KEYS = ['basic', 'linked-metrics'] as const;
+const TAB_KEYS = ['basic', 'linked-metrics', 'linked-tests'] as const;
 
 const NAV_LABELS: Record<(typeof TAB_KEYS)[number], string> = {
   basic: 'Basic Information',
   'linked-metrics': 'Linked Metrics',
+  'linked-tests': 'Linked Tests',
 };
 
 interface BehaviorDetailTabsProps {
@@ -93,6 +95,10 @@ export default function BehaviorDetailTabs({
           behavior={behavior}
           sessionToken={sessionToken}
         />
+      </DetailTabPanel>
+
+      <DetailTabPanel value={activeTab} index={2} prefix="behavior-detail">
+        <BehaviorLinkedTests behavior={behavior} sessionToken={sessionToken} />
       </DetailTabPanel>
     </Box>
   );

--- a/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorLinkedTests.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorLinkedTests.tsx
@@ -9,8 +9,9 @@ import {
 } from '@mui/x-data-grid';
 import GridBadge from '@/components/common/GridBadge';
 import LinkedEntitiesGrid from '@/components/common/LinkedEntitiesGrid';
+import { useNotifications } from '@/components/common/NotificationContext';
 import type { ToolbarPillTab } from '@/components/common/GridToolbar';
-import { DescriptionIcon } from '@/components/icons';
+import { DescriptionIcon, ErrorIcon } from '@/components/icons';
 import { useRouter } from 'next/navigation';
 import type { BehaviorWithMetrics } from '@/utils/api-client/interfaces/behavior';
 import type { TestDetail } from '@/utils/api-client/interfaces/tests';
@@ -35,12 +36,15 @@ export default function BehaviorLinkedTests({
   sessionToken,
 }: BehaviorLinkedTestsProps) {
   const router = useRouter();
+  const notifications = useNotifications();
   const [tests, setTests] = useState<TestDetail[]>([]);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState(false);
   const [typePill, setTypePill] = useState('all');
 
   const fetchLinked = useCallback(async () => {
     setLoading(true);
+    setLoadError(false);
     try {
       const client = new TestsClient(sessionToken);
       const result = await client.getAllTests({
@@ -49,12 +53,19 @@ export default function BehaviorLinkedTests({
         sort_order: 'desc',
       });
       setTests(result);
-    } catch {
-      // keep existing
+    } catch (error) {
+      setLoadError(true);
+      setTests([]);
+      notifications.show(
+        error instanceof Error
+          ? `Failed to load linked tests: ${error.message}`
+          : 'Failed to load linked tests',
+        { severity: 'error', autoHideDuration: 6000 }
+      );
     } finally {
       setLoading(false);
     }
-  }, [behavior.id, sessionToken]);
+  }, [behavior.id, sessionToken, notifications]);
 
   useEffect(() => {
     fetchLinked();
@@ -156,28 +167,53 @@ export default function BehaviorLinkedTests({
       activePill={typePill}
       onPillChange={setTypePill}
       emptyState={
-        <Box
-          sx={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            py: 5,
-            gap: 2,
-            textAlign: 'center',
-          }}
-        >
-          <DescriptionIcon sx={{ fontSize: 32, color: 'primary.main' }} />
-          <Typography
-            variant="h6"
-            sx={{ fontWeight: 600, color: 'primary.main' }}
+        loadError ? (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              py: 5,
+              gap: 2,
+              textAlign: 'center',
+            }}
           >
-            No tests linked yet
-          </Typography>
-          <Typography variant="body2" color="text.secondary">
-            No tests have this behavior assigned yet. Assign this behavior when
-            creating or editing a test to see it here.
-          </Typography>
-        </Box>
+            <ErrorIcon sx={{ fontSize: 32, color: 'error.main' }} />
+            <Typography
+              variant="h6"
+              sx={{ fontWeight: 600, color: 'primary.main' }}
+            >
+              Couldn't load linked tests
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Something went wrong while loading tests for this behavior. Try
+              refreshing the page.
+            </Typography>
+          </Box>
+        ) : (
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              py: 5,
+              gap: 2,
+              textAlign: 'center',
+            }}
+          >
+            <DescriptionIcon sx={{ fontSize: 32, color: 'primary.main' }} />
+            <Typography
+              variant="h6"
+              sx={{ fontWeight: 600, color: 'primary.main' }}
+            >
+              No tests linked yet
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              No tests have this behavior assigned yet. Assign this behavior
+              when creating or editing a test to see it here.
+            </Typography>
+          </Box>
+        )
       }
     />
   );

--- a/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorLinkedTests.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorLinkedTests.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Box, Typography } from '@mui/material';
+import {
+  GridColDef,
+  GridRenderCellParams,
+  GridRowModel,
+} from '@mui/x-data-grid';
+import GridBadge from '@/components/common/GridBadge';
+import LinkedEntitiesGrid from '@/components/common/LinkedEntitiesGrid';
+import type { ToolbarPillTab } from '@/components/common/GridToolbar';
+import { DescriptionIcon } from '@/components/icons';
+import { useRouter } from 'next/navigation';
+import type { BehaviorWithMetrics } from '@/utils/api-client/interfaces/behavior';
+import type { TestDetail } from '@/utils/api-client/interfaces/tests';
+import { TestsClient } from '@/utils/api-client/tests-client';
+import {
+  getTestDisplayContent,
+  renderTestContentCell,
+} from '@/app/(protected)/tests/components/test-grid-helpers';
+import { TEST_TYPE_PILL_TABS } from '@/constants/test-types';
+
+interface BehaviorLinkedTestsProps {
+  behavior: BehaviorWithMetrics;
+  sessionToken: string;
+}
+
+function escapeODataValue(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+export default function BehaviorLinkedTests({
+  behavior,
+  sessionToken,
+}: BehaviorLinkedTestsProps) {
+  const router = useRouter();
+  const [tests, setTests] = useState<TestDetail[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [typePill, setTypePill] = useState('all');
+
+  const fetchLinked = useCallback(async () => {
+    setLoading(true);
+    try {
+      const client = new TestsClient(sessionToken);
+      const result = await client.getAllTests({
+        filter: `behavior_id eq '${escapeODataValue(String(behavior.id))}'`,
+        sort_by: 'created_at',
+        sort_order: 'desc',
+      });
+      setTests(result);
+    } catch {
+      // keep existing
+    } finally {
+      setLoading(false);
+    }
+  }, [behavior.id, sessionToken]);
+
+  useEffect(() => {
+    fetchLinked();
+  }, [fetchLinked]);
+
+  const rows = useMemo<GridRowModel[]>(
+    () =>
+      tests.map(test => ({
+        ...test,
+        // LinkedEntitiesGrid search matches `name` / `description`
+        name: getTestDisplayContent(test),
+      })),
+    [tests]
+  );
+
+  const linkedColumns = useMemo<GridColDef[]>(
+    () => [
+      {
+        field: 'content',
+        headerName: 'Content',
+        flex: 2,
+        minWidth: 200,
+        valueGetter: (_value: unknown, row: TestDetail) =>
+          getTestDisplayContent(row),
+        renderCell: renderTestContentCell,
+      },
+      {
+        field: 'test_type',
+        headerName: 'Test Type',
+        width: 130,
+        valueGetter: (_value: unknown, row: TestDetail) =>
+          row.test_type?.type_value ?? '',
+        renderCell: (params: GridRenderCellParams) =>
+          typeof params.value === 'string' && params.value ? (
+            <GridBadge size="detail" label={params.value} />
+          ) : null,
+      },
+      {
+        field: 'category',
+        headerName: 'Category',
+        width: 140,
+        valueGetter: (_value: unknown, row: TestDetail) =>
+          row.category?.name ?? '',
+        renderCell: (params: GridRenderCellParams) =>
+          typeof params.value === 'string' && params.value ? (
+            <GridBadge size="detail" label={params.value} />
+          ) : null,
+      },
+      {
+        field: 'topic',
+        headerName: 'Topic',
+        width: 140,
+        valueGetter: (_value: unknown, row: TestDetail) =>
+          row.topic?.name ?? '',
+        renderCell: (params: GridRenderCellParams) =>
+          typeof params.value === 'string' && params.value ? (
+            <GridBadge size="detail" label={params.value} />
+          ) : null,
+      },
+      {
+        field: 'status',
+        headerName: 'Status',
+        width: 130,
+        valueGetter: (_value: unknown, row: TestDetail) =>
+          row.status?.name ?? '',
+        renderCell: (params: GridRenderCellParams) =>
+          typeof params.value === 'string' && params.value ? (
+            <GridBadge size="detail" label={params.value} />
+          ) : null,
+      },
+    ],
+    []
+  );
+
+  const pillTabs: ToolbarPillTab[] = TEST_TYPE_PILL_TABS;
+
+  const rowFilter = useCallback(
+    (row: GridRowModel) => {
+      if (typePill === 'all') return true;
+      const testType =
+        (row.test_type as { type_value?: string } | null | undefined)
+          ?.type_value ?? '';
+      return testType === typePill;
+    },
+    [typePill]
+  );
+
+  return (
+    <LinkedEntitiesGrid
+      title="Linked Tests"
+      rows={rows}
+      columns={linkedColumns}
+      loading={loading}
+      getRowId={row => String(row.id)}
+      onRowClick={params => router.push(`/tests/${String(params.id)}`)}
+      searchPlaceholder="Search tests…"
+      rowFilter={rowFilter}
+      pillTabs={pillTabs}
+      activePill={typePill}
+      onPillChange={setTypePill}
+      emptyState={
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            py: 5,
+            gap: 2,
+            textAlign: 'center',
+          }}
+        >
+          <DescriptionIcon sx={{ fontSize: 32, color: 'primary.main' }} />
+          <Typography
+            variant="h6"
+            sx={{ fontWeight: 600, color: 'primary.main' }}
+          >
+            No tests linked yet
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            No tests have this behavior assigned yet. Assign this behavior when
+            creating or editing a test to see it here.
+          </Typography>
+        </Box>
+      }
+    />
+  );
+}

--- a/apps/frontend/src/hooks/useLookups.ts
+++ b/apps/frontend/src/hooks/useLookups.ts
@@ -62,7 +62,7 @@ export function useBehaviors(sessionToken: string, enabled = true) {
     queryFn: async () => {
       const behaviors = await new ApiClientFactory(sessionToken)
         .getBehaviorClient()
-        .getBehaviors({ limit: 100, sort_by: 'name', sort_order: 'asc' });
+        .getAllBehaviors({ sort_by: 'name', sort_order: 'asc' });
       return behaviors;
     },
     enabled: enabled && !!sessionToken,

--- a/apps/frontend/src/hooks/useLookups.ts
+++ b/apps/frontend/src/hooks/useLookups.ts
@@ -62,7 +62,7 @@ export function useBehaviors(sessionToken: string, enabled = true) {
     queryFn: async () => {
       const behaviors = await new ApiClientFactory(sessionToken)
         .getBehaviorClient()
-        .getBehaviors({ sort_by: 'name', sort_order: 'asc' });
+        .getBehaviors({ limit: 100, sort_by: 'name', sort_order: 'asc' });
       return behaviors;
     },
     enabled: enabled && !!sessionToken,

--- a/apps/frontend/src/utils/api-client/behavior-client.ts
+++ b/apps/frontend/src/utils/api-client/behavior-client.ts
@@ -16,7 +16,7 @@ export class BehaviorClient extends BaseApiClient {
   ): Promise<BehaviorWithMetrics[]> {
     const {
       skip = 0,
-      limit = 10,
+      limit = 100,
       sort_by = 'created_at',
       sort_order = 'desc',
       $filter,

--- a/apps/frontend/src/utils/api-client/behavior-client.ts
+++ b/apps/frontend/src/utils/api-client/behavior-client.ts
@@ -42,6 +42,29 @@ export class BehaviorClient extends BaseApiClient {
     });
   }
 
+  /** Paginate through all behaviors (page size 100) for lookups / filter drawers. */
+  async getAllBehaviors(
+    params: Omit<BehaviorsQueryParams, 'skip' | 'limit'> = {}
+  ): Promise<BehaviorWithMetrics[]> {
+    const pageSize = 100;
+    const allData: BehaviorWithMetrics[] = [];
+    let skip = 0;
+
+    while (true) {
+      const page = await this.getBehaviors({
+        ...params,
+        skip,
+        limit: pageSize,
+      });
+      if (page.length === 0) break;
+      allData.push(...page);
+      if (page.length < pageSize) break;
+      skip += pageSize;
+    }
+
+    return allData;
+  }
+
   async getBehavior(id: UUID): Promise<Behavior> {
     return this.fetch<Behavior>(`${API_ENDPOINTS.behaviors}/${id}`);
   }

--- a/apps/frontend/src/utils/api-client/sources-client.ts
+++ b/apps/frontend/src/utils/api-client/sources-client.ts
@@ -1,5 +1,6 @@
 import { BaseApiClient } from './base-client';
 import { API_ENDPOINTS } from './config';
+import { readActiveProjectId } from '../active-project';
 import {
   Source,
   SourceCreate,
@@ -138,6 +139,11 @@ export class SourcesClient extends BaseApiClient {
     // Add authorization if we have a session token (copied from BaseApiClient logic)
     if (this.sessionToken) {
       headers['Authorization'] = `Bearer ${this.sessionToken}`;
+    }
+
+    const activeProject = this.projectId ?? readActiveProjectId();
+    if (activeProject) {
+      headers['X-Project-Id'] = activeProject;
     }
 
     // Use direct fetch to avoid BaseApiClient's default Content-Type header

--- a/apps/frontend/tests/e2e/fixtures/sources.json
+++ b/apps/frontend/tests/e2e/fixtures/sources.json
@@ -1,9 +1,9 @@
 [
   {
     "id": "c2d3e4f5-0009-0009-0009-000000000001",
-    "name": "Product FAQ",
+    "title": "Product FAQ",
     "description": "Frequently asked questions about the product.",
-    "source_type": "document",
+    "source_type": { "type_value": "document" },
     "created_at": "2025-01-10T10:00:00Z",
     "updated_at": "2025-01-10T10:00:00Z"
   }

--- a/apps/frontend/tests/e2e/mock-backend.mjs
+++ b/apps/frontend/tests/e2e/mock-backend.mjs
@@ -28,6 +28,7 @@ const fixtures = {
   endpoints: loadJson('endpoints.json'),
   endpointDetail: loadJson('endpoint-detail.json'),
   knowledgeDetail: loadJson('knowledge-detail.json'),
+  sources: loadJson('sources.json'),
   behaviors: loadJson('behaviors.json'),
   tasks: loadJson('tasks.json'),
   tokens: loadJson('tokens.json'),
@@ -67,16 +68,27 @@ const listByResource = {
   test_runs: fixtures.testRuns,
   test_results: fixtures.testResults,
   endpoints: fixtures.endpoints,
+  sources: fixtures.sources,
   behaviors: fixtures.behaviors,
   tasks: fixtures.tasks,
   tokens: fixtures.tokens,
 };
+
+/** Sources created during a local no-docker E2E run. */
+const uploadedSources = [];
 
 const e2eUser = {
   ...loadJson('e2e-user.json'),
   is_superuser: false,
   is_email_verified: true,
 };
+
+function drainRequestBody(req) {
+  return new Promise(resolve => {
+    req.on('data', () => {});
+    req.on('end', resolve);
+  });
+}
 
 function sendJson(res, status, body, extraHeaders = {}) {
   const payload = JSON.stringify(body);
@@ -186,6 +198,22 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  if (method === 'POST' && pathname === '/sources/upload') {
+    drainRequestBody(req).then(() => {
+      const source = {
+        ...fixtures.knowledgeDetail,
+        id: `e2e-upload-${Date.now()}`,
+        title: 'E2E Uploaded Source',
+        content: fixtures.knowledgeDetail.content,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+      uploadedSources.push(source);
+      sendJson(res, 200, source);
+    });
+    return;
+  }
+
   const detail = matchDetail(pathname);
   if (detail && method === 'GET') {
     if (detail.suffix === '' || detail.suffix === '/') {
@@ -233,12 +261,14 @@ const server = http.createServer((req, res) => {
       (pathname === `/${resource}` || pathname.startsWith(`/${resource}?`))
     ) {
       const filterId = parseFilterId(url.searchParams);
+      const allItems =
+        resource === 'sources' ? [...items, ...uploadedSources] : items;
       if (filterId) {
-        const match = items.find(item => String(item.id) === filterId);
+        const match = allItems.find(item => String(item.id) === filterId);
         sendList(res, match ? [match] : []);
         return;
       }
-      sendList(res, items);
+      sendList(res, allItems);
       return;
     }
   }

--- a/apps/frontend/tests/e2e/pages/InsightsPage.ts
+++ b/apps/frontend/tests/e2e/pages/InsightsPage.ts
@@ -40,16 +40,19 @@ export class InsightsPage extends BasePage {
     const noTestResults = this.page.getByRole('heading', {
       name: /no test results yet/i,
     });
-    const searchBehaviors = this.page.getByPlaceholder(/search behaviors/i);
     const passRateMetric = this.page.getByText(/\d+\.\d+%\s*pass rate/i);
+    const loadingResults = this.page.getByText(/loading results/i);
     const filterButton = this.page.getByRole('button', { name: /filters/i });
 
-    // Wait for endpoint auto-selection and insights fetch to settle.
-    await expect(noEndpoints.or(noTestResults).or(searchBehaviors)).toBeVisible(
-      {
-        timeout: 30_000,
-      }
-    );
+    // The behavior search box appears while insights are still loading, so wait
+    // for a terminal signal instead of treating search alone as "settled".
+    await expect(
+      noEndpoints.or(noTestResults).or(passRateMetric).or(loadingResults)
+    ).toBeVisible({ timeout: 45_000 });
+
+    if (await loadingResults.isVisible()) {
+      await expect(loadingResults).toBeHidden({ timeout: 45_000 });
+    }
 
     if (await noEndpoints.isVisible()) {
       await expect(

--- a/apps/frontend/tests/e2e/pages/KnowledgePage.ts
+++ b/apps/frontend/tests/e2e/pages/KnowledgePage.ts
@@ -86,12 +86,15 @@ export class KnowledgePage extends BasePage {
     const uploadResponse = this.page.waitForResponse(
       resp =>
         resp.url().includes('/sources/upload') &&
-        resp.request().method() === 'POST' &&
-        resp.ok(),
+        resp.request().method() === 'POST',
       { timeout: 60_000 }
     );
     await saveButton.click();
-    await uploadResponse;
+    const response = await uploadResponse;
+    if (!response.ok()) {
+      const body = await response.text().catch(() => '');
+      throw new Error(`Upload failed (${response.status()}): ${body}`);
+    }
   }
 
   /** BaseDrawer stays mounted — wait for the drawer to close. */

--- a/apps/frontend/tests/e2e/pages/KnowledgePage.ts
+++ b/apps/frontend/tests/e2e/pages/KnowledgePage.ts
@@ -11,8 +11,10 @@ import {
  * Page Object for the Knowledge (sources) page (/knowledge).
  */
 export class KnowledgePage extends BasePage {
-  readonly uploadButton = this.page.getByRole('button', {
-    name: /upload source/i,
+  /** Page FAB — distinct from the empty-state "Upload source" CTA. */
+  readonly uploadFabButton = this.page.getByRole('button', {
+    name: 'Upload Source',
+    exact: true,
   });
   readonly dataGrid = this.page.locator('[role="grid"]');
 
@@ -36,8 +38,18 @@ export class KnowledgePage extends BasePage {
 
   /** Open the "Upload Source" drawer. */
   async openUploadSourceDialog() {
-    await this.uploadButton.click();
+    await this.uploadFabButton.click();
     await expectOpenDrawerTitle(this.page, /^upload source$/i);
+  }
+
+  /** Attach a file in the upload drawer and wait for the UI to reflect it. */
+  async selectUploadFile(filePath: string) {
+    const fileName = filePath.split('/').pop() ?? filePath;
+    const drawer = openDrawer(this.page);
+    const fileInput = drawer.locator('input[type="file"]');
+    await expect(fileInput).toBeAttached({ timeout: 5_000 });
+    await fileInput.setInputFiles(filePath);
+    await expect(drawer.getByText(fileName)).toBeVisible({ timeout: 5_000 });
   }
 
   /**
@@ -65,16 +77,20 @@ export class KnowledgePage extends BasePage {
 
   /** Submit the upload drawer and wait for the API response. */
   async submitUpload() {
+    const drawer = openDrawer(this.page);
+    const saveButton = drawer.getByRole('button', {
+      name: /^upload source$/i,
+    });
+    await expect(saveButton).toBeEnabled({ timeout: 10_000 });
+
     const uploadResponse = this.page.waitForResponse(
       resp =>
-        resp.url().includes('/sources') &&
+        resp.url().includes('/sources/upload') &&
         resp.request().method() === 'POST' &&
         resp.ok(),
-      { timeout: 30_000 }
+      { timeout: 60_000 }
     );
-    await openDrawer(this.page)
-      .getByRole('button', { name: /^upload source$/i })
-      .click();
+    await saveButton.click();
     await uploadResponse;
   }
 

--- a/apps/frontend/tests/e2e/tests/insights.spec.ts
+++ b/apps/frontend/tests/e2e/tests/insights.spec.ts
@@ -9,6 +9,7 @@ test.describe('Insights @sanity', () => {
   });
 
   test('insights page main content renders', async ({ page }) => {
+    test.setTimeout(90_000);
     const insights = new InsightsPage(page);
     await insights.goto();
     await insights.expectContentVisible();

--- a/apps/frontend/tests/e2e/tests/knowledge-crud.spec.ts
+++ b/apps/frontend/tests/e2e/tests/knowledge-crud.spec.ts
@@ -21,7 +21,7 @@ test.describe('Knowledge — CRUD @crud', () => {
     await page.waitForLoadState('networkidle');
 
     // Open the upload dialog
-    const btnVisible = await knowledgePage.uploadButton
+    const btnVisible = await knowledgePage.uploadFabButton
       .isVisible({ timeout: 10_000 })
       .catch(() => false);
     if (!btnVisible) {
@@ -38,6 +38,7 @@ test.describe('Knowledge — CRUD @crud', () => {
   });
 
   test('can upload a TXT file as a knowledge source', async ({ page }) => {
+    test.setTimeout(90_000);
     const UNIQUE_TITLE = `e2e-source-${Date.now()}`;
     const fixturePath = path.join(__dirname, '../fixtures/fixture.txt');
 
@@ -46,7 +47,7 @@ test.describe('Knowledge — CRUD @crud', () => {
     await knowledgePage.expectLoaded();
     await page.waitForLoadState('networkidle');
 
-    const btnVisible = await knowledgePage.uploadButton
+    const btnVisible = await knowledgePage.uploadFabButton
       .isVisible({ timeout: 10_000 })
       .catch(() => false);
     if (!btnVisible) {
@@ -55,31 +56,14 @@ test.describe('Knowledge — CRUD @crud', () => {
     }
 
     await knowledgePage.openUploadSourceDialog();
-
-    // File inputs are often hidden — assert it's attached to the DOM before using it
-    const fileInput = page.locator('input[type="file"]').first();
-    await expect(fileInput).toBeAttached({ timeout: 5_000 });
-    await fileInput.setInputFiles(fixturePath);
+    await knowledgePage.selectUploadFile(fixturePath);
 
     // Override the auto-populated title with a unique name
     await knowledgePage.setSourceTitle(UNIQUE_TITLE);
     await knowledgePage.setSourceDescription('Uploaded by Playwright E2E test');
 
-    // Register the list waiter before upload, but only accept GETs that land
-    // after the POST completes so we don't match a stale in-flight request.
-    let postCompleted = false;
-    const listRefresh = page.waitForResponse(
-      resp =>
-        postCompleted &&
-        resp.url().includes('/sources') &&
-        resp.request().method() === 'GET' &&
-        resp.ok(),
-      { timeout: 30_000 }
-    );
     await knowledgePage.submitUpload();
-    postCompleted = true;
     await knowledgePage.waitForUploadDrawerClosed();
-    await listRefresh;
     await expectGridRowVisible(page, UNIQUE_TITLE);
   });
 
@@ -95,7 +79,7 @@ test.describe('Knowledge — CRUD @crud', () => {
     await knowledgePage.expectLoaded();
     await page.waitForLoadState('networkidle');
 
-    const btnVisible = await knowledgePage.uploadButton
+    const btnVisible = await knowledgePage.uploadFabButton
       .isVisible({ timeout: 10_000 })
       .catch(() => false);
     if (!btnVisible) {

--- a/apps/frontend/tests/e2e/tests/knowledge-crud.spec.ts
+++ b/apps/frontend/tests/e2e/tests/knowledge-crud.spec.ts
@@ -62,8 +62,20 @@ async function stubKnowledgeUpload(page: Page, source: StubbedSource) {
       const existing = (await response.json()) as Array<{ id: string }>;
       const items = Array.isArray(existing) ? existing : [];
       const merged = [source, ...items.filter(item => item.id !== source.id)];
+      const body = JSON.stringify(merged);
+      // Drop length/encoding headers — they reflect the upstream body, not ours.
       const headers = Object.fromEntries(
-        response.headersArray().map(({ name, value }) => [name, value])
+        response
+          .headersArray()
+          .filter(
+            ({ name }) =>
+              ![
+                'content-length',
+                'content-encoding',
+                'transfer-encoding',
+              ].includes(name.toLowerCase())
+          )
+          .map(({ name, value }) => [name, value])
       );
       await route.fulfill({
         status: response.status(),
@@ -73,7 +85,7 @@ async function stubKnowledgeUpload(page: Page, source: StubbedSource) {
           'access-control-expose-headers': 'x-total-count',
           'x-total-count': String(merged.length),
         },
-        body: JSON.stringify(merged),
+        body,
       });
     }
   );

--- a/apps/frontend/tests/e2e/tests/knowledge-crud.spec.ts
+++ b/apps/frontend/tests/e2e/tests/knowledge-crud.spec.ts
@@ -1,11 +1,83 @@
 import path from 'path';
-import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import { test, expect, type Page } from '@playwright/test';
 import { KnowledgePage } from '../pages/KnowledgePage';
 import {
   confirmDeleteDialog,
   expectGridRowVisible,
   waitForDrawerClosed,
 } from '../helpers/CrudHelper';
+
+interface StubbedSource {
+  id: string;
+  title: string;
+  description?: string;
+}
+
+function isSourcesListUrl(url: URL): boolean {
+  const pathWithQuery = `${url.pathname}${url.search}`;
+  return (
+    (pathWithQuery.includes('/sources?') ||
+      /\/sources\/?$/.test(url.pathname)) &&
+    !pathWithQuery.includes('/sources/upload') &&
+    !/\/sources\/[0-9a-f-]{36}/i.test(pathWithQuery)
+  );
+}
+
+/** Stub upload + list refresh so the CRUD test validates UI without slow backend extraction. */
+async function stubKnowledgeUpload(page: Page, source: StubbedSource) {
+  await page.route(
+    url => url.href.includes('/sources/upload'),
+    async route => {
+      if (route.request().method() !== 'POST') {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...source,
+          source_type: { type_value: 'document' },
+          source_metadata: {
+            original_filename: 'fixture.txt',
+            file_size: 128,
+          },
+          content: 'fixture content',
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }),
+      });
+    }
+  );
+
+  await page.route(
+    url => isSourcesListUrl(url),
+    async route => {
+      if (route.request().method() !== 'GET') {
+        await route.fallback();
+        return;
+      }
+      const response = await route.fetch();
+      const existing = (await response.json()) as Array<{ id: string }>;
+      const items = Array.isArray(existing) ? existing : [];
+      const merged = [source, ...items.filter(item => item.id !== source.id)];
+      const headers = Object.fromEntries(
+        response.headersArray().map(({ name, value }) => [name, value])
+      );
+      await route.fulfill({
+        status: response.status(),
+        contentType: 'application/json',
+        headers: {
+          ...headers,
+          'access-control-expose-headers': 'x-total-count',
+          'x-total-count': String(merged.length),
+        },
+        body: JSON.stringify(merged),
+      });
+    }
+  );
+}
 
 /**
  * CRUD interaction tests for the Knowledge (sources) page.
@@ -41,6 +113,13 @@ test.describe('Knowledge — CRUD @crud', () => {
     test.setTimeout(90_000);
     const UNIQUE_TITLE = `e2e-source-${Date.now()}`;
     const fixturePath = path.join(__dirname, '../fixtures/fixture.txt');
+    const stubbedSource = {
+      id: randomUUID(),
+      title: UNIQUE_TITLE,
+      description: 'Uploaded by Playwright E2E test',
+    };
+
+    await stubKnowledgeUpload(page, stubbedSource);
 
     const knowledgePage = new KnowledgePage(page);
     await knowledgePage.goto();


### PR DESCRIPTION
## Purpose
Add a Linked Tests tab on the behavior detail page (mirroring Linked Metrics), and fix the Tests filter drawer so the Behavior dropdown shows the full list of behaviors instead of only the first 10.

## What Changed
- Added a **Linked Tests** tab on `/behaviors/[id]` that lists all tests with that behavior, using the same `LinkedEntitiesGrid` pattern as Linked Metrics (content, type, category, topic, status; Single/Multi-Turn pills; row click → test detail)
- Fixed `useBehaviors` to pass `limit: 100` (query key already advertised page size 100 but the client defaulted to 10)
- Raised `BehaviorClient.getBehaviors` default limit from 10 → 100 to match category/topic lookups

## Additional Context
- Behavior filter bug root cause: `BehaviorClient.getBehaviors` defaulted to `limit=10` while `useBehaviors` never passed a limit
- Linked Tests are read-only here; tests keep their `behavior_id` set via create/edit test flows

## Testing
- [ ] Open a behavior detail page → **Linked Tests** tab shows tests with that behavior; empty state when none
- [ ] Click a row → navigates to `/tests/{id}`
- [ ] Single-Turn / Multi-Turn pills filter the grid
- [ ] On `/tests`, open the filter drawer → Behavior dropdown lists all org behaviors (more than 10 if present)
- [ ] Applying a previously missing behavior filters the tests grid correctly