### PR TITLE
Drop is_running_locally and require SESSION_SECRET_KEY

### DIFF
--- a/apps/backend/src/rhesis/backend/app/config/settings.py
+++ b/apps/backend/src/rhesis/backend/app/config/settings.py
@@ -182,7 +182,7 @@ class AuthSettings(BaseSettings):
     google_client_secret: str | None = Field(default=None, alias="GOOGLE_CLIENT_SECRET")
     github_client_id: str | None = Field(default=None, alias="GH_CLIENT_ID")
     github_client_secret: str | None = Field(default=None, alias="GH_CLIENT_SECRET")
-    session_secret_key: str | None = Field(default=None, alias="SESSION_SECRET_KEY")
+    session_secret_key: str = Field(alias="SESSION_SECRET_KEY")
     jwt_secret_key: str | None = Field(default=None, alias="JWT_SECRET_KEY")
     jwt_algorithm: str = Field(default="HS256", alias="JWT_ALGORITHM")
     jwt_access_token_expire_minutes: int = Field(
@@ -288,7 +288,7 @@ def get_logging_settings() -> LoggingSettings:
 
 @lru_cache
 def get_auth_settings() -> AuthSettings:
-    return AuthSettings()
+    return AuthSettings()  # pyright: ignore[reportCallIssue]
 
 
 @lru_cache

--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -601,16 +601,10 @@ app.add_middleware(
     expose_headers=["X-Total-Count", "X-Test-Header"],
 )
 
-# Get session secret securely without default fallback in production
+# SESSION_SECRET_KEY is a required setting (see AuthSettings), so this fails
+# fast at startup if it is missing — no insecure hardcoded fallback. Run
+# `./rh dev init` to generate one for local development.
 session_secret = get_auth_settings().session_secret_key
-
-from rhesis.backend.app.routers.auth import is_running_locally
-
-if not session_secret:
-    if is_running_locally():
-        session_secret = "fallback-secret-for-development"
-    else:
-        raise ValueError("CRITICAL: SESSION_SECRET_KEY must be set in production environments")
 
 # Add session middleware
 # For OAuth state preservation, we need proper cookie configuration

--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -204,61 +204,35 @@ def _get_api_base_url() -> str:
     return get_application_settings().api_base_url
 
 
-def is_running_locally() -> bool:
-    """Detect local deployment using server-side environment signals only.
-
-    Never uses any request-derived data. Uses two independent signals:
-    1. Quick Start mode (QUICK_START=true + no GCP env vars)
-    2. API_BASE_URL explicitly configured for localhost
-    """
-    # Signal 1: Quick Start mode (env-vars only, no request data)
-    if is_quick_start_enabled():
-        return True
-
-    # Signal 2: API_BASE_URL points to a local address
-    parsed_host = urlparse(_get_api_base_url()).hostname or ""
-    if parsed_host in _LOCAL_HOSTNAMES:
-        return True
-
-    return False
-
-
 def get_callback_url(request: Request, provider: Optional[str] = None) -> str:
-    """Generate the OAuth callback URL.
+    """Generate the OAuth callback URL from the configured API_BASE_URL.
 
-    For local development, uses the request hostname with the server's
-    listening port to preserve session cookie domain alignment. Only
-    whitelisted local hostnames (localhost, 127.0.0.1, ::1) are
-    accepted; any other value falls back to 'localhost'. For
-    production, uses API_BASE_URL.
+    The one exception is loopback aliasing: when API_BASE_URL points at a
+    loopback address, the OAuth session cookie is bound to whichever loopback
+    alias the browser actually used (localhost vs 127.0.0.1 vs ::1), so the
+    callback host is swapped to match — otherwise the cookie set before the
+    redirect is not returned on the callback and state validation fails.
+
+    The swap is gated on the *configured* host being loopback (a trusted,
+    inherently-local value), and only ever selects another loopback alias, so
+    the callback can never point off-box. For real (production) domains the
+    request host is never trusted.
     """
-    if is_running_locally():
-        # Local: use request hostname to match session cookie domain
-        # (e.g., 127.0.0.1 vs localhost). Whitelist ensures that even
-        # if is_running_locally() fires on a misconfigured server,
-        # the callback can only ever point to a local address.
-        hostname = request.url.hostname or "localhost"
-        if hostname not in _LOCAL_HOSTNAMES:
-            hostname = "localhost"
-        server = request.scope.get("server")
-        port = server[1] if server else 8080
-        base_url = f"http://{hostname}:{port}"
+    parsed = urlparse(_get_api_base_url().rstrip("/"))
+
+    if parsed.hostname in _LOCAL_HOSTNAMES:
+        # Loopback: follow the browser's alias (ignoring any non-loopback
+        # request host) and keep the configured scheme — local dev is http.
+        req_host = request.url.hostname
+        host = req_host if req_host in _LOCAL_HOSTNAMES else parsed.hostname
+        port = f":{parsed.port}" if parsed.port else ""
+        base_url = f"{parsed.scheme}://{host}{port}"
     else:
-        # Production: always use configured base URL
-        base_url = _get_api_base_url().rstrip("/")
+        # Real domain: never trust the request host, and always use HTTPS
+        # (guards a misconfigured http:// API_BASE_URL).
+        base_url = f"https://{parsed.netloc}"
 
-    callback_url = f"{base_url}/auth/callback"
-
-    # Ensure HTTPS for non-local URLs
-    if (
-        callback_url.startswith("http://")
-        and "localhost" not in callback_url
-        and "127.0.0.1" not in callback_url
-        and "::1" not in callback_url
-    ):
-        callback_url = "https://" + callback_url[7:]
-
-    return callback_url
+    return f"{base_url}/auth/callback"
 
 
 def _get_frontend_url() -> str:

--- a/ee/backend/src/rhesis/backend/ee/sso/router.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/router.py
@@ -166,19 +166,8 @@ def _generate_pkce() -> tuple:
     return code_verifier, code_challenge
 
 
-def _get_sso_callback_url(request: Request) -> str:
-    """Build the SSO callback URL."""
-    from rhesis.backend.app.routers.auth import is_running_locally
-
-    api_base_url = get_application_settings().api_base_url
-
-    if is_running_locally() and not api_base_url:
-        base_url = str(request.base_url).rstrip("/")
-    elif api_base_url:
-        base_url = api_base_url.rstrip("/")
-    else:
-        base_url = str(request.base_url).rstrip("/")
-
+def _get_sso_callback_url() -> str:
+    base_url = get_application_settings().api_base_url.rstrip("/")
     return f"{base_url}/auth/sso/callback"
 
 
@@ -243,7 +232,7 @@ async def sso_callback(
         logger.warning("SSO callback missing code_verifier in session")
         return RedirectResponse(url=error_redirect, status_code=302)
 
-    redirect_uri = _get_sso_callback_url(request)
+    redirect_uri = _get_sso_callback_url()
 
     # Authenticate with OIDC provider
     provider = OIDCProvider(sso_config)
@@ -346,7 +335,7 @@ async def sso_login(
         request.session["original_frontend"] = original_frontend
     request.session["return_to"] = return_to
 
-    redirect_uri = _get_sso_callback_url(request)
+    redirect_uri = _get_sso_callback_url()
 
     provider = OIDCProvider(sso_config)
     try:

--- a/tests/backend/app/test_settings.py
+++ b/tests/backend/app/test_settings.py
@@ -401,7 +401,9 @@ def test_get_frontend_settings_cache_clear_allows_env_overrides(clean_frontend_e
 
 
 @pytest.mark.unit
-def test_auth_settings_uses_defaults(clean_auth_env):
+def test_auth_settings_uses_defaults(clean_auth_env, monkeypatch):
+    # SESSION_SECRET_KEY is required; provide it so the other defaults can be checked.
+    monkeypatch.setenv("SESSION_SECRET_KEY", "session-secret-key")
     settings = AuthSettings(_env_file=None)
 
     assert settings.email_password_enabled is True
@@ -410,12 +412,18 @@ def test_auth_settings_uses_defaults(clean_auth_env):
     assert settings.google_client_secret is None
     assert settings.github_client_id is None
     assert settings.github_client_secret is None
-    assert settings.session_secret_key is None
+    assert settings.session_secret_key == "session-secret-key"
     assert settings.jwt_secret_key is None
     assert settings.jwt_algorithm == "HS256"
     assert settings.jwt_access_token_expire_minutes == 10080
     assert settings.google_enabled is False
     assert settings.github_enabled is False
+
+
+@pytest.mark.unit
+def test_auth_settings_requires_session_secret_key(clean_auth_env):
+    with pytest.raises(ValidationError, match="SESSION_SECRET_KEY"):
+        AuthSettings(_env_file=None)
 
 
 @pytest.mark.unit
@@ -449,6 +457,7 @@ def test_auth_settings_loads_existing_environment_variables(clean_auth_env, monk
 
 @pytest.mark.unit
 def test_auth_settings_oauth_enabled_requires_client_id_and_secret(clean_auth_env, monkeypatch):
+    monkeypatch.setenv("SESSION_SECRET_KEY", "session-secret-key")
     monkeypatch.setenv("GOOGLE_CLIENT_ID", "google-client-id")
     monkeypatch.setenv("GH_CLIENT_SECRET", "github-client-secret")
 
@@ -460,7 +469,9 @@ def test_auth_settings_oauth_enabled_requires_client_id_and_secret(clean_auth_en
 
 @pytest.mark.unit
 def test_get_auth_settings_cache_clear_allows_env_overrides(clean_auth_env, monkeypatch):
-    assert get_auth_settings().session_secret_key is None
+    # SESSION_SECRET_KEY is required, so it must be set before AuthSettings loads.
+    monkeypatch.setenv("SESSION_SECRET_KEY", "initial-session-secret-key")
+    assert get_auth_settings().session_secret_key == "initial-session-secret-key"
     assert get_auth_settings().jwt_secret_key is None
 
     monkeypatch.setenv("SESSION_SECRET_KEY", "cached-session-secret-key")

--- a/tests/backend/routes/test_auth.py
+++ b/tests/backend/routes/test_auth.py
@@ -1193,13 +1193,19 @@ class TestGetCallbackUrl:
         "rhesis.backend.app.routers.auth.is_quick_start_enabled",
         return_value=True,
     )
-    def test_quick_start_mode_uses_localhost(self, mock_qs):
-        """Quick start mode returns http://localhost:{port}/auth/callback."""
+    @patch(
+        "rhesis.backend.app.routers.auth.get_application_settings",
+        new=_mock_application_settings("local", api_base_url="https://api.rhesis.ai"),
+    )
+    def test_quick_start_does_not_override_remote_api_base_url(self, mock_qs):
+        """QUICK_START does not force a local callback: the callback host is
+        driven solely by API_BASE_URL. With a remote API_BASE_URL the request
+        host is never trusted, even in quick-start mode."""
         from rhesis.backend.app.routers.auth import get_callback_url
 
         request = _make_mock_request(host="localhost", port=8080)
         url = get_callback_url(request)
-        assert url == "http://localhost:8080/auth/callback"
+        assert url == "https://api.rhesis.ai/auth/callback"
 
     @patch(
         "rhesis.backend.app.routers.auth.is_quick_start_enabled",


### PR DESCRIPTION
## Purpose
Follow-up to the env-name-based gating removal (#2171). OAuth/SSO callback URL construction still branched on `is_running_locally()` — a server-side heuristic that inferred "local" from `QUICK_START` + a localhost `API_BASE_URL`. This change removes that indirection and drives callback URLs purely from `API_BASE_URL`. It also removes the insecure hardcoded session-secret fallback.

## What Changed
- **Remove `is_running_locally()`** from `routers/auth.py`. `get_callback_url()` is now driven solely by `API_BASE_URL`, keeping only loopback-alias swapping (localhost vs 127.0.0.1 vs ::1) so the OAuth session cookie set before the redirect is returned on the callback. Real (production) domains never trust the request host and always use HTTPS.
- **Simplify the SSO callback URL** (`ee/.../sso/router.py`) to use `API_BASE_URL` directly instead of the `is_running_locally()` + `request.base_url` fallback chain.
- **Require `SESSION_SECRET_KEY`** (`config/settings.py`): it is now a mandatory setting, so `main.py` no longer falls back to `"fallback-secret-for-development"` when local. Missing it fails fast at startup.
- Update `test_settings.py` and `test_auth.py` to cover the required secret and the API_BASE_URL-driven callback behavior.

## Additional Context
- Depends on local dev setups providing `SESSION_SECRET_KEY` (e.g. via `./rh dev init`).
- Two pre-existing ruff errors (`auth.py` import block, `test_auth.py` E501) originate from #2144 and are intentionally left untouched to keep this PR focused.

## Testing
```bash
cd apps/backend
uv run pytest ../../tests/backend/app/test_settings.py ../../tests/backend/routes/test_auth.py
```