### PR TITLE
Add Insights summarize via Architect (Telemachus)

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -36,6 +36,8 @@ ENV PATH="/root/.cargo/bin:$PATH"
 COPY sdk /app/sdk/
 COPY penelope /app/penelope/
 COPY packages/rhesis /app/packages/rhesis/
+# Hatch force-includes skill refs into the SDK wheel (see sdk/pyproject.toml).
+COPY skills/rhesis/references /app/skills/rhesis/references/
 # EE source. Deployed images always carry the EE code; runtime activation is
 # decided by the license provider + RHESIS_LICENSE env var, mirroring the
 # QUICK_START pattern (always-on code, env-flipped behavior). The migrate

--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -58,6 +58,8 @@ WORKDIR /app
 COPY sdk /app/sdk/
 COPY penelope /app/penelope/
 COPY packages/rhesis /app/packages/rhesis/
+# Hatch force-includes skill refs into the SDK wheel (see sdk/pyproject.toml).
+COPY skills/rhesis/references /app/skills/rhesis/references/
 COPY ee/backend /app/ee/backend/
 COPY apps/backend/src /app/apps/backend/src/
 

--- a/apps/backend/src/rhesis/backend/app/routers/architect.py
+++ b/apps/backend/src/rhesis/backend/app/routers/architect.py
@@ -34,12 +34,29 @@ def create_session(
     current_user: User = Depends(require_current_user_or_token),
 ):
     organization_id, user_id = tenant_context
-    return crud.create_architect_session(
+    initial_message = (session.initial_message or "").strip() or None
+
+    db_session = crud.create_architect_session(
         db=db,
         session=session,
         organization_id=organization_id,
         user_id=user_id,
     )
+
+    if initial_message:
+        from rhesis.backend.app.services.architect.session_start import (
+            start_session_with_message,
+        )
+
+        start_session_with_message(
+            db=db,
+            db_session=db_session,
+            user_message=initial_message,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+
+    return db_session
 
 
 @router.get("/", response_model=list[schemas.ArchitectSession])

--- a/apps/backend/src/rhesis/backend/app/schemas/architect.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/architect.py
@@ -35,7 +35,14 @@ class ArchitectSessionBase(Base):
 
 
 class ArchitectSessionCreate(ArchitectSessionBase):
-    pass
+    """Create an Architect session.
+
+    When ``initial_message`` is set, the backend persists it as the first user
+    message and dispatches the Celery chat task in the same request so the
+    session is already processing when the client opens it.
+    """
+
+    initial_message: Optional[str] = None
 
 
 class ArchitectSessionUpdate(ArchitectSessionBase):

--- a/apps/backend/src/rhesis/backend/app/services/architect/session_start.py
+++ b/apps/backend/src/rhesis/backend/app/services/architect/session_start.py
@@ -17,7 +17,12 @@ def start_session_with_message(
     organization_id: str,
     user_id: str,
 ) -> None:
-    """Persist the first user turn and dispatch the Architect Celery task."""
+    """Persist the first user turn and dispatch the Architect Celery task.
+
+    Commits before enqueue so the worker can see the session and user message
+    (same ordering as the WebSocket handler, which exits its DB context before
+    ``apply_async``).
+    """
     session_id = str(db_session.id)
     project_id = str(db_session.project_id) if db_session.project_id else None
 
@@ -32,6 +37,10 @@ def start_session_with_message(
         organization_id=organization_id,
         user_id=user_id,
     )
+
+    # Flush alone is not enough — create_item only flushes; the request
+    # context manager commits on exit. Enqueue only after the rows are durable.
+    db.commit()
 
     from rhesis.backend.tasks.architect import architect_chat_task
 

--- a/apps/backend/src/rhesis/backend/app/services/architect/session_start.py
+++ b/apps/backend/src/rhesis/backend/app/services/architect/session_start.py
@@ -1,0 +1,51 @@
+"""Start an Architect turn from REST (contextual handoffs).
+
+Mirrors the WebSocket ``handle_architect_message`` path so Insights and other
+entry points reuse the same Celery runner and Redis pub/sub channel.
+"""
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import crud, models, schemas
+
+
+def start_session_with_message(
+    *,
+    db: Session,
+    db_session: models.ArchitectSession,
+    user_message: str,
+    organization_id: str,
+    user_id: str,
+) -> None:
+    """Persist the first user turn and dispatch the Architect Celery task."""
+    session_id = str(db_session.id)
+    project_id = str(db_session.project_id) if db_session.project_id else None
+
+    crud.create_architect_message(
+        db=db,
+        message=schemas.ArchitectMessageCreate(
+            session_id=db_session.id,
+            role="user",
+            content=user_message,
+            project_id=project_id,
+        ),
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+
+    from rhesis.backend.tasks.architect import architect_chat_task
+
+    task_headers = {
+        "organization_id": organization_id,
+        "user_id": user_id,
+    }
+    if project_id:
+        task_headers["project_id"] = project_id
+
+    architect_chat_task.apply_async(
+        kwargs={
+            "session_id": session_id,
+            "user_message": user_message,
+        },
+        headers=task_headers,
+    )

--- a/apps/chatbot/Dockerfile
+++ b/apps/chatbot/Dockerfile
@@ -33,6 +33,8 @@ COPY apps/chatbot/pyproject.toml apps/chatbot/uv.lock ./
 # SDK and rhesis meta-package (SDK depends on rhesis[telemetry])
 COPY sdk /app/sdk/
 COPY packages/rhesis /app/packages/rhesis/
+# Hatch force-includes skill refs into the SDK wheel (see sdk/pyproject.toml).
+COPY skills/rhesis/references /app/skills/rhesis/references/
 
 ENV UV_COMPILE_BYTECODE=1 \
     UV_NO_MANAGED_PYTHON=1 \

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
@@ -80,10 +80,7 @@ export default function ArchitectClient() {
           if (!data.some(s => s.id === sessionFromQuery)) {
             try {
               const detail = await client.getSession(sessionFromQuery);
-              nextSessions = [
-                detail,
-                ...data.filter(s => s.id !== detail.id),
-              ];
+              nextSessions = [detail, ...data.filter(s => s.id !== detail.id)];
             } catch (err) {
               console.error('Failed to load session from query:', err);
             }

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
@@ -50,6 +50,8 @@ export default function ArchitectClient() {
     [activeProject?.id]
   );
 
+  const sessionFromQuery = searchParams.get('session');
+
   const clearSessionQueryParam = useCallback(() => {
     if (!searchParams.has('session')) return;
     const params = new URLSearchParams(searchParams.toString());
@@ -62,45 +64,30 @@ export default function ArchitectClient() {
   // shows only sessions belonging to the current project. The backend already
   // filters by project via RLS (X-Project-Id header); we just need to re-fetch
   // when the project scope switches.
-  // Prefer ?session= over the resume hint (contextual handoffs from Insights etc.).
   useEffect(() => {
     const loadSessions = async () => {
       if (permsLoading || !canRead) return;
       const client = getClient();
       if (!client) return;
       setIsLoadingSessions(true);
-      setActiveSessionId(null);
+      // Keep a pending ?session= selection while the list reloads.
+      if (!searchParams.get('session')) {
+        setActiveSessionId(null);
+      }
       setSessions([]);
       try {
         const data = await client.getSessions();
-        let nextSessions = data;
-        const sessionFromQuery = searchParams.get('session');
-
-        if (sessionFromQuery) {
-          if (!data.some(s => s.id === sessionFromQuery)) {
-            try {
-              const detail = await client.getSession(sessionFromQuery);
-              nextSessions = [detail, ...data.filter(s => s.id !== detail.id)];
-            } catch (err) {
-              console.error('Failed to load session from query:', err);
-            }
-          }
-          setSessions(nextSessions);
-          const exists = nextSessions.some(s => s.id === sessionFromQuery);
-          setActiveSessionId(exists ? sessionFromQuery : null);
-          if (exists) {
-            touchResumeHint(sessionFromQuery);
-          }
-          clearSessionQueryParam();
+        setSessions(data);
+        // Skip resume when a ?session= handoff is pending — the query effect
+        // prefers that id over the resume hint.
+        if (searchParams.get('session')) {
+          return;
+        }
+        const projectId = activeProject?.id;
+        if (projectId) {
+          setActiveSessionId(pickResumableSessionId(projectId, data));
         } else {
-          setSessions(nextSessions);
-          const projectId = activeProject?.id;
-          if (projectId) {
-            const resumeSessionId = pickResumableSessionId(projectId, data);
-            setActiveSessionId(resumeSessionId);
-          } else {
-            setActiveSessionId(null);
-          }
+          setActiveSessionId(null);
         }
       } catch (err) {
         console.error('Failed to load architect sessions:', err);
@@ -110,10 +97,60 @@ export default function ArchitectClient() {
       }
     };
     loadSessions();
-    // Intentionally omit searchParams from deps after first load for a given
-    // project — clearing ?session= must not re-trigger a full reload loop.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- project/token drive reload
   }, [getClient, activeProject?.id, permsLoading, canRead]);
+
+  // Prefer ?session= over resume (contextual handoffs). Separate from the list
+  // reload so in-app navigations to /architect?session= still work without a
+  // remount (peqy).
+  useEffect(() => {
+    if (!sessionFromQuery || permsLoading || !canRead) return;
+
+    let cancelled = false;
+
+    const selectFromQuery = async () => {
+      const client = getClient();
+      if (!client) return;
+
+      setActiveSessionId(sessionFromQuery);
+      touchResumeHint(sessionFromQuery);
+
+      const alreadyListed = sessions.some(s => s.id === sessionFromQuery);
+      if (!alreadyListed) {
+        try {
+          const detail = await client.getSession(sessionFromQuery);
+          if (cancelled) return;
+          setSessions(prev => [
+            detail,
+            ...prev.filter(s => s.id !== detail.id),
+          ]);
+        } catch (err) {
+          console.error('Failed to load session from query:', err);
+          if (!cancelled) {
+            setActiveSessionId(null);
+          }
+          return;
+        }
+      }
+
+      clearSessionQueryParam();
+    };
+
+    selectFromQuery();
+    return () => {
+      cancelled = true;
+    };
+    // sessions intentionally omitted — we only need the id from the URL;
+    // re-running on every list change would clear the param twice.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- query-driven select
+  }, [
+    sessionFromQuery,
+    permsLoading,
+    canRead,
+    getClient,
+    touchResumeHint,
+    clearSessionQueryParam,
+  ]);
 
   // Bump last-activity when navigating away mid-conversation.
   useEffect(() => {

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Box } from '@mui/material';
 import { useSession } from 'next-auth/react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { ArchitectSession } from '@/utils/api-client/architect-client';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
@@ -22,6 +23,9 @@ import ArchitectWelcome from './ArchitectWelcome';
 export default function ArchitectClient() {
   const { data: session } = useSession();
   const { activeProject } = useActiveProject();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
     Capability.Architect.READ
   );
@@ -46,10 +50,19 @@ export default function ArchitectClient() {
     [activeProject?.id]
   );
 
+  const clearSessionQueryParam = useCallback(() => {
+    if (!searchParams.has('session')) return;
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete('session');
+    const qs = params.toString();
+    router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
+  }, [pathname, router, searchParams]);
+
   // Reload sessions whenever the active project changes so the sidebar always
   // shows only sessions belonging to the current project. The backend already
   // filters by project via RLS (X-Project-Id header); we just need to re-fetch
   // when the project scope switches.
+  // Prefer ?session= over the resume hint (contextual handoffs from Insights etc.).
   useEffect(() => {
     const loadSessions = async () => {
       if (permsLoading || !canRead) return;
@@ -60,14 +73,37 @@ export default function ArchitectClient() {
       setSessions([]);
       try {
         const data = await client.getSessions();
-        setSessions(data);
+        let nextSessions = data;
+        const sessionFromQuery = searchParams.get('session');
 
-        const projectId = activeProject?.id;
-        if (projectId) {
-          const resumeSessionId = pickResumableSessionId(projectId, data);
-          setActiveSessionId(resumeSessionId);
+        if (sessionFromQuery) {
+          if (!data.some(s => s.id === sessionFromQuery)) {
+            try {
+              const detail = await client.getSession(sessionFromQuery);
+              nextSessions = [
+                detail,
+                ...data.filter(s => s.id !== detail.id),
+              ];
+            } catch (err) {
+              console.error('Failed to load session from query:', err);
+            }
+          }
+          setSessions(nextSessions);
+          const exists = nextSessions.some(s => s.id === sessionFromQuery);
+          setActiveSessionId(exists ? sessionFromQuery : null);
+          if (exists) {
+            touchResumeHint(sessionFromQuery);
+          }
+          clearSessionQueryParam();
         } else {
-          setActiveSessionId(null);
+          setSessions(nextSessions);
+          const projectId = activeProject?.id;
+          if (projectId) {
+            const resumeSessionId = pickResumableSessionId(projectId, data);
+            setActiveSessionId(resumeSessionId);
+          } else {
+            setActiveSessionId(null);
+          }
         }
       } catch (err) {
         console.error('Failed to load architect sessions:', err);
@@ -77,6 +113,9 @@ export default function ArchitectClient() {
       }
     };
     loadSessions();
+    // Intentionally omit searchParams from deps after first load for a given
+    // project — clearing ?session= must not re-trigger a full reload loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- project/token drive reload
   }, [getClient, activeProject?.id, permsLoading, canRead]);
 
   // Bump last-activity when navigating away mid-conversation.

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsFailedTestsFab.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsFailedTestsFab.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { useRouter } from 'next/navigation';
-import { Fab, FabGroup } from '@/components/common/Fab';
+import { Fab } from '@/components/common/Fab';
 import { ScienceIcon } from '@/components/icons';
 import { InsightsFilters } from '../types';
 import { buildInsightsFailedTestsUrl } from '../utils/insights-failed-tests';
@@ -31,18 +31,16 @@ export default function InsightsFailedTestsFab({
   };
 
   return (
-    <FabGroup>
-      <Fab
-        icon={<ScienceIcon />}
-        tooltip={
-          failedCount > 0
-            ? `View ${failedCount} failed test case${failedCount === 1 ? '' : 's'}`
-            : 'No failed test cases in this view'
-        }
-        aria-label="View failed test cases"
-        onClick={handleClick}
-        disabled={isDisabled}
-      />
-    </FabGroup>
+    <Fab
+      icon={<ScienceIcon />}
+      tooltip={
+        failedCount > 0
+          ? `View ${failedCount} failed test case${failedCount === 1 ? '' : 's'}`
+          : 'No failed test cases in this view'
+      }
+      aria-label="View failed test cases"
+      onClick={handleClick}
+      disabled={isDisabled}
+    />
   );
 }

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsPage.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsPage.tsx
@@ -12,6 +12,8 @@ import { PageLayout } from '@/components/layout/PageLayout';
 import TestResultsFilters from './TestResultsFilters';
 import BehaviorInsightsView from './BehaviorInsightsView';
 import InsightsFailedTestsFab from './InsightsFailedTestsFab';
+import InsightsSummarizeFab from './InsightsSummarizeFab';
+import { FabGroup } from '@/components/common/Fab';
 import {
   DEFAULT_INSIGHTS_FILTERS,
   DEFAULT_INSIGHTS_TIME_RANGE,
@@ -193,6 +195,11 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
     [projectEndpoints, filters.endpointId]
   );
 
+  const visibleBehaviorNames = useMemo(
+    () => filteredColumns.map(column => column.name),
+    [filteredColumns]
+  );
+
   const fabLoading =
     endpointsLoading ||
     insightsLoading ||
@@ -228,12 +235,22 @@ export default function InsightsPage({ sessionToken }: InsightsPageProps) {
       description="View pass rates by behavior, metric, and topic. Filter by time range or pick specific test runs in the filter drawer."
       breadcrumbs={[]}
       actions={
-        <InsightsFailedTestsFab
-          filters={filters}
-          failedCount={failedTestCaseCount ?? 0}
-          loading={fabLoading}
-          disabled={projectEndpoints.length === 0}
-        />
+        <FabGroup>
+          <InsightsSummarizeFab
+            sessionToken={sessionToken}
+            filters={filters}
+            endpointName={selectedEndpointName}
+            visibleBehaviorNames={visibleBehaviorNames}
+            loading={fabLoading}
+            disabled={projectEndpoints.length === 0}
+          />
+          <InsightsFailedTestsFab
+            filters={filters}
+            failedCount={failedTestCaseCount ?? 0}
+            loading={fabLoading}
+            disabled={projectEndpoints.length === 0}
+          />
+        </FabGroup>
       }
     >
       <Box

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsSummarizeFab.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsSummarizeFab.tsx
@@ -34,7 +34,7 @@ export default function InsightsSummarizeFab({
 }: InsightsSummarizeFabProps) {
   const [creating, setCreating] = useState(false);
 
-  // Enabled regardless of failedCount (including 0) — peqy / #2178
+  // Enabled regardless of failedCount (including 0)
   const isDisabled =
     disabled || loading || creating || !filters.endpointId || !sessionToken;
 
@@ -70,13 +70,7 @@ export default function InsightsSummarizeFab({
     } finally {
       setCreating(false);
     }
-  }, [
-    endpointName,
-    filters,
-    isDisabled,
-    sessionToken,
-    visibleBehaviorNames,
-  ]);
+  }, [endpointName, filters, isDisabled, sessionToken, visibleBehaviorNames]);
 
   return (
     <Can capability={Capability.Architect.CREATE}>

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsSummarizeFab.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsSummarizeFab.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { Fab } from '@/components/common/Fab';
+import { Can } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+import { EngineeringIcon } from '@/components/icons';
+import { createAndOpenArchitectSession } from '@/utils/architect-handoff';
+import { InsightsFilters } from '../types';
+import { resolveInsightsQueryTestRunIds } from '../utils/behavior-insights-utils';
+import {
+  buildInsightsSummarizePrompt,
+  buildInsightsSummarizeSessionTitle,
+  capArchitectInsightsTestRunIds,
+} from '../utils/insights-summarize-prompt';
+
+interface InsightsSummarizeFabProps {
+  sessionToken: string;
+  filters: InsightsFilters;
+  endpointName?: string;
+  /** Behavior names currently visible (multi-select ∩ search). */
+  visibleBehaviorNames: string[];
+  loading?: boolean;
+  disabled?: boolean;
+}
+
+export default function InsightsSummarizeFab({
+  sessionToken,
+  filters,
+  endpointName = '',
+  visibleBehaviorNames,
+  loading = false,
+  disabled = false,
+}: InsightsSummarizeFabProps) {
+  const [creating, setCreating] = useState(false);
+
+  // Enabled regardless of failedCount (including 0) — peqy / #2178
+  const isDisabled =
+    disabled || loading || creating || !filters.endpointId || !sessionToken;
+
+  const handleClick = useCallback(async () => {
+    if (isDisabled) return;
+    setCreating(true);
+    try {
+      const resolvedIds = await resolveInsightsQueryTestRunIds(
+        sessionToken,
+        filters
+      );
+      const { ids, truncated, totalMatched } =
+        capArchitectInsightsTestRunIds(resolvedIds);
+      const title = buildInsightsSummarizeSessionTitle({
+        endpointName,
+        filters,
+      });
+      const initialMessage = buildInsightsSummarizePrompt({
+        endpointName,
+        filters,
+        visibleBehaviorNames,
+        testRunIds: ids,
+        truncated,
+        totalMatched,
+      });
+      await createAndOpenArchitectSession({
+        sessionToken,
+        title,
+        initialMessage,
+      });
+    } catch (error) {
+      console.error('Failed to open Insights summary in Architect:', error);
+    } finally {
+      setCreating(false);
+    }
+  }, [
+    endpointName,
+    filters,
+    isDisabled,
+    sessionToken,
+    visibleBehaviorNames,
+  ]);
+
+  return (
+    <Can capability={Capability.Architect.CREATE}>
+      <Fab
+        icon={<EngineeringIcon />}
+        tooltip="Summarize insights"
+        aria-label="Summarize insights"
+        onClick={handleClick}
+        disabled={isDisabled}
+        loading={creating}
+      />
+    </Can>
+  );
+}

--- a/apps/frontend/src/app/(protected)/insights/components/InsightsSummarizeFab.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/InsightsSummarizeFab.tsx
@@ -3,6 +3,7 @@
 import React, { useCallback, useState } from 'react';
 import { Fab } from '@/components/common/Fab';
 import { Can } from '@/components/common/Can';
+import { useNotifications } from '@/components/common/NotificationContext';
 import { Capability } from '@/constants/capabilities';
 import { EngineeringIcon } from '@/components/icons';
 import { createAndOpenArchitectSession } from '@/utils/architect-handoff';
@@ -33,6 +34,7 @@ export default function InsightsSummarizeFab({
   disabled = false,
 }: InsightsSummarizeFabProps) {
   const [creating, setCreating] = useState(false);
+  const { show: showNotification } = useNotifications();
 
   // Enabled regardless of failedCount (including 0)
   const isDisabled =
@@ -67,10 +69,20 @@ export default function InsightsSummarizeFab({
       });
     } catch (error) {
       console.error('Failed to open Insights summary in Architect:', error);
+      showNotification('Could not open Architect summary. Please try again.', {
+        severity: 'error',
+      });
     } finally {
       setCreating(false);
     }
-  }, [endpointName, filters, isDisabled, sessionToken, visibleBehaviorNames]);
+  }, [
+    endpointName,
+    filters,
+    isDisabled,
+    sessionToken,
+    showNotification,
+    visibleBehaviorNames,
+  ]);
 
   return (
     <Can capability={Capability.Architect.CREATE}>

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-summarize-prompt.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-summarize-prompt.test.ts
@@ -1,0 +1,114 @@
+import {
+  MAX_ARCHITECT_INSIGHTS_TEST_RUN_IDS,
+  buildInsightsSummarizePrompt,
+  buildInsightsSummarizeSessionTitle,
+  capArchitectInsightsTestRunIds,
+  formatInsightsPeriodLabel,
+} from '../insights-summarize-prompt';
+import { DEFAULT_INSIGHTS_FILTERS, InsightsFilters } from '../../types';
+
+function filters(
+  overrides: Partial<InsightsFilters> = {}
+): InsightsFilters {
+  return { ...DEFAULT_INSIGHTS_FILTERS, ...overrides };
+}
+
+describe('capArchitectInsightsTestRunIds', () => {
+  it('returns all ids when under the cap', () => {
+    const ids = ['a', 'b', 'c'];
+    expect(capArchitectInsightsTestRunIds(ids)).toEqual({
+      ids,
+      truncated: false,
+      totalMatched: 3,
+    });
+  });
+
+  it('takes the first 50 preserving order when over the cap', () => {
+    const ids = Array.from({ length: 60 }, (_, i) => `run-${i}`);
+    const result = capArchitectInsightsTestRunIds(ids);
+    expect(result.truncated).toBe(true);
+    expect(result.totalMatched).toBe(60);
+    expect(result.ids).toHaveLength(MAX_ARCHITECT_INSIGHTS_TEST_RUN_IDS);
+    expect(result.ids[0]).toBe('run-0');
+    expect(result.ids[49]).toBe('run-49');
+  });
+});
+
+describe('formatInsightsPeriodLabel', () => {
+  it('uses time-range labels', () => {
+    expect(
+      formatInsightsPeriodLabel(filters({ timeRange: '7d' }))
+    ).toBe('7D');
+  });
+
+  it('uses run count for explicit selection', () => {
+    expect(
+      formatInsightsPeriodLabel(
+        filters({
+          runFilterMode: 'testRuns',
+          testRunIds: ['1', '2', '3'],
+        })
+      )
+    ).toBe('3 runs');
+  });
+});
+
+describe('buildInsightsSummarizeSessionTitle', () => {
+  it('includes endpoint and period', () => {
+    expect(
+      buildInsightsSummarizeSessionTitle({
+        endpointName: 'Chatbot',
+        filters: filters({ timeRange: '1m' }),
+      })
+    ).toBe('Insights summary — Chatbot — 1M');
+  });
+});
+
+describe('buildInsightsSummarizePrompt', () => {
+  it('includes RUN_ANALYZE / Insights signals and visible behaviors', () => {
+    const prompt = buildInsightsSummarizePrompt({
+      endpointName: 'Chatbot',
+      filters: filters({ timeRange: '7d' }),
+      visibleBehaviorNames: ['Safety', 'Tone'],
+      testRunIds: ['run-1', 'run-2'],
+      truncated: false,
+      totalMatched: 2,
+    });
+
+    expect(prompt).toContain('Summarize insights');
+    expect(prompt).toContain('test results');
+    expect(prompt).toContain('Insights handoff');
+    expect(prompt).toContain('Endpoint: Chatbot');
+    expect(prompt).toContain('Behaviors in scope: Safety, Tone');
+    expect(prompt).toContain('run-1, run-2');
+    expect(prompt).not.toContain('Note:');
+  });
+
+  it('discloses truncation for time-range (most recent)', () => {
+    const prompt = buildInsightsSummarizePrompt({
+      endpointName: 'API',
+      filters: filters({ runFilterMode: 'timeRange', timeRange: '3m' }),
+      visibleBehaviorNames: [],
+      testRunIds: ['a'],
+      truncated: true,
+      totalMatched: 80,
+    });
+    expect(prompt).toContain('80 runs matched');
+    expect(prompt).toContain('most recent');
+  });
+
+  it('discloses truncation for explicit selection (first 50 in order)', () => {
+    const prompt = buildInsightsSummarizePrompt({
+      endpointName: 'API',
+      filters: filters({
+        runFilterMode: 'testRuns',
+        testRunIds: Array.from({ length: 60 }, (_, i) => `id-${i}`),
+      }),
+      visibleBehaviorNames: [],
+      testRunIds: ['id-0'],
+      truncated: true,
+      totalMatched: 60,
+    });
+    expect(prompt).toContain('first 50 in selection order');
+  });
+});

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-summarize-prompt.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-summarize-prompt.test.ts
@@ -7,9 +7,7 @@ import {
 } from '../insights-summarize-prompt';
 import { DEFAULT_INSIGHTS_FILTERS, InsightsFilters } from '../../types';
 
-function filters(
-  overrides: Partial<InsightsFilters> = {}
-): InsightsFilters {
+function filters(overrides: Partial<InsightsFilters> = {}): InsightsFilters {
   return { ...DEFAULT_INSIGHTS_FILTERS, ...overrides };
 }
 
@@ -36,9 +34,7 @@ describe('capArchitectInsightsTestRunIds', () => {
 
 describe('formatInsightsPeriodLabel', () => {
   it('uses time-range labels', () => {
-    expect(
-      formatInsightsPeriodLabel(filters({ timeRange: '7d' }))
-    ).toBe('7D');
+    expect(formatInsightsPeriodLabel(filters({ timeRange: '7d' }))).toBe('7D');
   });
 
   it('uses run count for explicit selection', () => {

--- a/apps/frontend/src/app/(protected)/insights/utils/insights-summarize-prompt.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/insights-summarize-prompt.ts
@@ -17,7 +17,7 @@ export interface CapArchitectInsightsTestRunIdsResult {
  * Cap run IDs for the Architect handoff.
  *
  * - Time-range mode: IDs are already recency-ordered (newest first) — take first 50.
- * - Explicit selection: preserve user-provided order — take first 50 (peqy / #2178).
+ * - Explicit selection: preserve user-provided order — take first 50.
  */
 export function capArchitectInsightsTestRunIds(
   testRunIds: string[]

--- a/apps/frontend/src/app/(protected)/insights/utils/insights-summarize-prompt.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/insights-summarize-prompt.ts
@@ -1,0 +1,107 @@
+import {
+  InsightsFilters,
+  InsightsTimeRange,
+  INSIGHTS_TIME_RANGE_OPTIONS,
+} from '../types';
+
+/** Hard cap for Architect handoff — agent tool cost scales with run count. */
+export const MAX_ARCHITECT_INSIGHTS_TEST_RUN_IDS = 50;
+
+export interface CapArchitectInsightsTestRunIdsResult {
+  ids: string[];
+  truncated: boolean;
+  totalMatched: number;
+}
+
+/**
+ * Cap run IDs for the Architect handoff.
+ *
+ * - Time-range mode: IDs are already recency-ordered (newest first) — take first 50.
+ * - Explicit selection: preserve user-provided order — take first 50 (peqy / #2178).
+ */
+export function capArchitectInsightsTestRunIds(
+  testRunIds: string[]
+): CapArchitectInsightsTestRunIdsResult {
+  const totalMatched = testRunIds.length;
+  if (totalMatched <= MAX_ARCHITECT_INSIGHTS_TEST_RUN_IDS) {
+    return { ids: testRunIds, truncated: false, totalMatched };
+  }
+  return {
+    ids: testRunIds.slice(0, MAX_ARCHITECT_INSIGHTS_TEST_RUN_IDS),
+    truncated: true,
+    totalMatched,
+  };
+}
+
+export function formatInsightsPeriodLabel(
+  filters: Pick<InsightsFilters, 'runFilterMode' | 'timeRange' | 'testRunIds'>
+): string {
+  if (filters.runFilterMode === 'testRuns') {
+    const n = filters.testRunIds.length;
+    return n > 0 ? `${n} runs` : 'all runs';
+  }
+  const option = INSIGHTS_TIME_RANGE_OPTIONS.find(
+    o => o.value === filters.timeRange
+  );
+  return option?.label ?? filters.timeRange.toUpperCase();
+}
+
+export function buildInsightsSummarizeSessionTitle(input: {
+  endpointName: string;
+  filters: Pick<InsightsFilters, 'runFilterMode' | 'timeRange' | 'testRunIds'>;
+}): string {
+  const endpoint = input.endpointName.trim() || 'endpoint';
+  const period = formatInsightsPeriodLabel(input.filters);
+  return `Insights summary — ${endpoint} — ${period}`;
+}
+
+export interface BuildInsightsSummarizePromptInput {
+  endpointName: string;
+  filters: InsightsFilters;
+  /** Behavior names currently visible (multi-select ∩ search). */
+  visibleBehaviorNames: string[];
+  testRunIds: string[];
+  truncated: boolean;
+  totalMatched: number;
+  timeRange?: InsightsTimeRange;
+}
+
+export function buildInsightsSummarizePrompt(
+  input: BuildInsightsSummarizePromptInput
+): string {
+  const period = formatInsightsPeriodLabel(input.filters);
+  const behaviors =
+    input.visibleBehaviorNames.length > 0
+      ? input.visibleBehaviorNames.join(', ')
+      : 'all visible';
+
+  const truncationNote = input.truncated
+    ? input.filters.runFilterMode === 'testRuns'
+      ? `Note: ${input.totalMatched} runs matched; using the first ${MAX_ARCHITECT_INSIGHTS_TEST_RUN_IDS} in selection order.`
+      : `Note: ${input.totalMatched} runs matched; using the ${MAX_ARCHITECT_INSIGHTS_TEST_RUN_IDS} most recent.`
+    : null;
+
+  const lines = [
+    'Summarize insights for the Insights page view I was looking at.',
+    '',
+    'This is an Insights handoff — analyze these test results; do not show the menu',
+    'and do not start exploration or create entities.',
+    '',
+    `Endpoint: ${input.endpointName.trim() || 'unknown'}`,
+    `Period / runs: ${period}`,
+    `Behaviors in scope: ${behaviors}`,
+    `Test run IDs (max ${MAX_ARCHITECT_INSIGHTS_TEST_RUN_IDS}): ${input.testRunIds.join(', ') || '(none)'}`,
+  ];
+
+  if (truncationNote) {
+    lines.push(truncationNote);
+  }
+
+  lines.push(
+    '',
+    'Please re-fetch stats for this scope, summarize overall and by behavior/metric,',
+    'then sample a few failed results and call out patterns and next steps.'
+  );
+
+  return lines.join('\n');
+}

--- a/apps/frontend/src/utils/__tests__/architect-handoff.test.ts
+++ b/apps/frontend/src/utils/__tests__/architect-handoff.test.ts
@@ -1,0 +1,73 @@
+import { createAndOpenArchitectSession } from '../architect-handoff';
+
+const createSession = jest.fn();
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getArchitectClient: () => ({
+      createSession,
+    }),
+  })),
+}));
+
+describe('createAndOpenArchitectSession', () => {
+  beforeEach(() => {
+    createSession.mockReset();
+    createSession.mockResolvedValue({ id: 'sess-123', title: 'T' });
+  });
+
+  it('opens about:blank sync, creates session with initial_message, then navigates', async () => {
+    const tab = { closed: false, location: { href: '' } };
+    const openWindow = jest.fn().mockReturnValue(tab);
+    const navigate = jest.fn();
+
+    await createAndOpenArchitectSession({
+      sessionToken: 'token',
+      title: 'Insights summary — Bot — 1M',
+      initialMessage: 'Summarize insights\ntest results',
+      openWindow,
+      navigate,
+    });
+
+    expect(openWindow).toHaveBeenCalledWith('about:blank', '_blank');
+    expect(createSession).toHaveBeenCalledWith({
+      title: 'Insights summary — Bot — 1M',
+      initial_message: 'Summarize insights\ntest results',
+    });
+    expect(tab.location.href).toBe('/architect?session=sess-123');
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to same-tab navigation when popup is blocked', async () => {
+    const openWindow = jest.fn().mockReturnValue(null);
+    const navigate = jest.fn();
+
+    await createAndOpenArchitectSession({
+      sessionToken: 'token',
+      title: 'Title',
+      initialMessage: 'Message',
+      openWindow,
+      navigate,
+    });
+
+    expect(navigate).toHaveBeenCalledWith('/architect?session=sess-123');
+  });
+
+  it('closes the placeholder tab if create fails', async () => {
+    const tab = { closed: false, close: jest.fn(), location: { href: '' } };
+    const openWindow = jest.fn().mockReturnValue(tab);
+    createSession.mockRejectedValue(new Error('boom'));
+
+    await expect(
+      createAndOpenArchitectSession({
+        sessionToken: 'token',
+        title: 'Title',
+        initialMessage: 'Message',
+        openWindow,
+        navigate: jest.fn(),
+      })
+    ).rejects.toThrow('boom');
+
+    expect(tab.close).toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/utils/api-client/architect-client.ts
+++ b/apps/frontend/src/utils/api-client/architect-client.ts
@@ -31,6 +31,11 @@ export interface ArchitectMessageResponse {
 
 export interface ArchitectSessionCreateRequest {
   title?: string;
+  /**
+   * When set, the backend persists this as the first user message and starts
+   * the Architect Celery task immediately (contextual handoff).
+   */
+  initial_message?: string;
 }
 
 export class ArchitectClient extends BaseApiClient {

--- a/apps/frontend/src/utils/architect-handoff.ts
+++ b/apps/frontend/src/utils/architect-handoff.ts
@@ -20,7 +20,7 @@ export interface CreateAndOpenArchitectSessionOptions {
  * then navigate to `/architect?session=<id>`.
  *
  * Opens `about:blank` synchronously on the click gesture so browsers do not
- * popup-block the tab after the async create call (peqy / #2178).
+ * popup-block the tab after the async create call.
  */
 export async function createAndOpenArchitectSession(
   options: CreateAndOpenArchitectSessionOptions

--- a/apps/frontend/src/utils/architect-handoff.ts
+++ b/apps/frontend/src/utils/architect-handoff.ts
@@ -1,0 +1,68 @@
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type {
+  ArchitectSession,
+  ArchitectSessionCreateRequest,
+} from '@/utils/api-client/architect-client';
+
+export interface CreateAndOpenArchitectSessionOptions {
+  sessionToken: string;
+  title: string;
+  initialMessage: string;
+  /** Open in a new tab (default true). Falls back to same-tab if blocked. */
+  newTab?: boolean;
+  /** Test seams */
+  openWindow?: (url?: string, target?: string) => Window | null;
+  navigate?: (url: string) => void;
+}
+
+/**
+ * Create an Architect session with an initial message already processing,
+ * then navigate to `/architect?session=<id>`.
+ *
+ * Opens `about:blank` synchronously on the click gesture so browsers do not
+ * popup-block the tab after the async create call (peqy / #2178).
+ */
+export async function createAndOpenArchitectSession(
+  options: CreateAndOpenArchitectSessionOptions
+): Promise<ArchitectSession> {
+  const { sessionToken, title, initialMessage } = options;
+  const newTab = options.newTab !== false;
+  const openWindow =
+    options.openWindow ??
+    (typeof window !== 'undefined' ? window.open.bind(window) : undefined);
+  const navigate =
+    options.navigate ??
+    (typeof window !== 'undefined'
+      ? (url: string) => {
+          window.location.assign(url);
+        }
+      : undefined);
+
+  let tab: Window | null = null;
+  if (newTab && openWindow) {
+    tab = openWindow('about:blank', '_blank');
+  }
+
+  try {
+    const client = new ApiClientFactory(sessionToken).getArchitectClient();
+    const payload: ArchitectSessionCreateRequest = {
+      title,
+      initial_message: initialMessage,
+    };
+    const session = await client.createSession(payload);
+    const url = `/architect?session=${encodeURIComponent(session.id)}`;
+
+    if (tab && !tab.closed) {
+      tab.location.href = url;
+    } else if (navigate) {
+      navigate(url);
+    }
+
+    return session;
+  } catch (error) {
+    if (tab && !tab.closed) {
+      tab.close();
+    }
+    throw error;
+  }
+}

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_loader.py
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_loader.py
@@ -89,6 +89,7 @@ def phase_include_names(mode: AgentMode, workflow_path: WorkflowPath) -> List[st
                     "phases/execution.md",
                     "phases/analysis.md",
                     "result-analysis.md",
+                    "insights-summary.md",
                 ]
             )
         elif wp == WorkflowPath.DIRECT:

--- a/sdk/src/rhesis/sdk/agents/architect/workflow.py
+++ b/sdk/src/rhesis/sdk/agents/architect/workflow.py
@@ -36,6 +36,9 @@ _RUN_ANALYZE_SIGNALS = (
     "analyze run",
     "run analyze",
     "past runs",
+    "summarize insights",
+    "insights summary",
+    "insights page",
 )
 
 _DIRECT_SIGNALS = (

--- a/skills/rhesis/references/insights-summary.md
+++ b/skills/rhesis/references/insights-summary.md
@@ -1,0 +1,38 @@
+# Insights summary handoff
+
+Use this when the user message is an **Insights handoff** (phrases like "summarize insights", "insights summary", "Insights page view").
+
+## Intent
+
+- Do **not** show the four-path menu.
+- Do **not** start exploration or create entities.
+- Re-fetch stats for the listed scope; do not trust pasted pass-rate numbers (there should be none).
+
+## Scope from the prompt
+
+Honor:
+
+- Endpoint name
+- Period / run selection
+- Behavior names listed as in scope (client-side Insights filters)
+- Test run IDs (already capped at ≤50)
+
+If the prompt notes truncation (50 of N), mention that briefly in your reply.
+
+## Tool sequence
+
+1. Prefer `get_test_result_stats` with the provided `test_run_ids` (and/or the same date window Insights used). Start with overall aggregates, then by behavior / metric.
+2. Identify weak behaviors and metrics.
+3. Failures: `list_test_results` with Failed status + behavior scope; minimal `$select`. Call `get_test_result` only for a few samples.
+4. Present: overall → by behavior → by metric → 2–3 failure examples → links to runs/tests.
+5. Suggest concrete next steps (narrow filters, re-run weak behaviors, open failed cases).
+
+## Nested run budget (inside ≤50 IDs)
+
+| Runs in scope | Strategy |
+|---|---|
+| ≤ 10 | Aggregate stats + optional per-run `mode=all` on up to 3 weakest runs |
+| 11–30 | Aggregate only; sample failures across scope (cap ~10 result details) |
+| 31–50 | Aggregate + top 3 weakest behaviors; **no** per-run full-stats loop |
+
+Never analyze more than the IDs listed in the handoff prompt.

--- a/skills/rhesis/references/phases/analysis.md
+++ b/skills/rhesis/references/phases/analysis.md
@@ -15,3 +15,7 @@ Present: overall pass rate → by behavior → by metric → 2–3 failure examp
 Operational volume: `get_test_run_stats`.
 
 Details: `result-analysis.md`.
+
+## Insights handoff
+
+When the user message is an Insights summarize handoff, also follow `insights-summary.md` (no four-path menu; respect listed behaviors and ≤50 run IDs).

--- a/skills/rhesis/references/result-analysis.md
+++ b/skills/rhesis/references/result-analysis.md
@@ -185,6 +185,12 @@ Returns: full prompt, full response, expected response, metric scores with indiv
 
 ---
 
+## Insights handoff
+
+When the message is an Insights page summarize handoff, follow `insights-summary.md`: skip the menu, re-fetch with the listed `test_run_ids` / behaviors, enforce the nested ≤50-run budget, then present aggregates and a few failure samples.
+
+---
+
 ## Offering next steps after analysis
 
 After presenting results, proactively offer relevant follow-ups:

--- a/skills/rhesis/references/workflow-index.md
+++ b/skills/rhesis/references/workflow-index.md
@@ -23,7 +23,7 @@ Details: `phases/creation.md`, `entity-model.md`, `metric-scope.md`.
 | Vague `/rhesis` or "help me test" | This file → `SKILL.md` intake | Matching path below | — |
 | Named endpoint + explore/test | `phases/discovery.md` | `exploration-strategies.md` → `phases/planning.md` | Requirements workflow |
 | Pasted PRD / spec / FRs | `requirements-workflow.md` | `use-case-bracketfeld.md` (target shape) → `metric-scope.md` | `explore_endpoint` unless user asks |
-| "Run tests" / "analyze" / "compare runs" | `phases/execution.md` → `phases/analysis.md` | `result-analysis.md` | New plan |
+| "Run tests" / "analyze" / "compare runs" / Insights summarize | `phases/execution.md` → `phases/analysis.md` | `result-analysis.md`, `insights-summary.md` (Insights handoff) | New plan |
 | Single action ("list test sets", "fix metric X") | `phases/direct-requests.md` | `tool-catalog.md` if needed | Full phases |
 | Entity / OData / tool questions | `entity-model.md` | `odata-patterns.md`, `tool-catalog.md` | — |
 | Terminology / "what is X?" | [Glossary](https://docs.rhesis.ai/glossary.md) (`glossary/<id>.md`) | `definitions.md` if concepts are mixed up | — |
@@ -36,7 +36,7 @@ Details: `phases/creation.md`, `entity-model.md`, `metric-scope.md`.
 |---|---|
 | PRD paste, numbered FRs, "requirements doc" | Requirements → test foundation |
 | Endpoint name + "test" / "explore" | Exploration (Quick unless they said comprehensive) |
-| Test run id, "compare runs", "last run" | Run / analyze |
+| Test run id, "compare runs", "last run", "summarize insights" | Run / analyze |
 | OpenAPI, `AGENTS.md`, agent code in repo | Quick exploration of implied endpoint |
 | None of the above | Four-path menu below |
 
@@ -85,6 +85,7 @@ Skip the menu when intent is already clear. Requirements and run/analyze paths s
 | `phases/direct-requests.md` | One-off commands |
 | `odata-patterns.md` | `$filter`, `$select`, batch lookups |
 | `result-analysis.md` | Stats modes and presentation |
+| `insights-summary.md` | Insights page → Telemachus handoff |
 | `tool-catalog.md` | MCP tool listing |
 
 ---

--- a/tests/backend/services/architect/test_session_start.py
+++ b/tests/backend/services/architect/test_session_start.py
@@ -60,7 +60,12 @@ class TestStartSessionWithMessage:
             assert str(message_arg.session_id) == str(session_id)
             assert str(message_arg.project_id) == str(project_id)
 
+            db.commit.assert_called_once()
             mock_task.apply_async.assert_called_once()
+            # Commit must precede enqueue (worker races otherwise).
+            assert db.commit.call_count == 1
+            assert db.mock_calls.index(("commit", (), {})) < len(db.mock_calls)
+
             kwargs = mock_task.apply_async.call_args.kwargs["kwargs"]
             assert kwargs["session_id"] == str(session_id)
             assert "Summarize insights" in kwargs["user_message"]

--- a/tests/backend/services/architect/test_session_start.py
+++ b/tests/backend/services/architect/test_session_start.py
@@ -1,0 +1,68 @@
+"""Tests for Architect session create with optional initial_message."""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from rhesis.backend.app.schemas.architect import ArchitectSessionCreate
+from rhesis.backend.app.services.architect.session_start import (
+    start_session_with_message,
+)
+
+
+@pytest.mark.unit
+class TestArchitectSessionCreateSchema:
+    def test_initial_message_optional(self):
+        create = ArchitectSessionCreate(title="Hello")
+        assert create.initial_message is None
+
+    def test_initial_message_accepted(self):
+        create = ArchitectSessionCreate(
+            title="Insights summary",
+            initial_message="Summarize insights for the Insights page",
+        )
+        assert create.initial_message.startswith("Summarize insights")
+
+
+@pytest.mark.unit
+class TestStartSessionWithMessage:
+    def test_persists_message_and_dispatches_celery(self):
+        db = MagicMock()
+        session_id = uuid4()
+        project_id = uuid4()
+        db_session = MagicMock()
+        db_session.id = session_id
+        db_session.project_id = project_id
+
+        with (
+            patch(
+                "rhesis.backend.app.services.architect.session_start.crud"
+            ) as mock_crud,
+            patch(
+                "rhesis.backend.tasks.architect.architect_chat_task"
+            ) as mock_task,
+        ):
+            start_session_with_message(
+                db=db,
+                db_session=db_session,
+                user_message="Summarize insights\ntest results",
+                organization_id=str(uuid4()),
+                user_id=str(uuid4()),
+            )
+
+            mock_crud.create_architect_message.assert_called_once()
+            message_arg = mock_crud.create_architect_message.call_args.kwargs[
+                "message"
+            ]
+            assert message_arg.role == "user"
+            assert message_arg.content.startswith("Summarize insights")
+            assert str(message_arg.session_id) == str(session_id)
+            assert str(message_arg.project_id) == str(project_id)
+
+            mock_task.apply_async.assert_called_once()
+            kwargs = mock_task.apply_async.call_args.kwargs["kwargs"]
+            assert kwargs["session_id"] == str(session_id)
+            assert "Summarize insights" in kwargs["user_message"]
+            headers = mock_task.apply_async.call_args.kwargs["headers"]
+            assert headers["project_id"] == str(project_id)

--- a/tests/sdk/agents/test_architect_prompt_loader.py
+++ b/tests/sdk/agents/test_architect_prompt_loader.py
@@ -45,6 +45,14 @@ class TestInferWorkflowPath:
     def test_ambiguous_returns_none(self):
         assert infer_workflow_path("hello") is None
 
+    def test_insights_summarize_signals(self):
+        assert (
+            infer_workflow_path("Summarize insights for the Insights page view")
+            == WorkflowPath.RUN_ANALYZE
+        )
+        assert infer_workflow_path("insights summary — Chatbot") == WorkflowPath.RUN_ANALYZE
+
+
 
 @pytest.mark.unit
 class TestResolveWorkflowPathUpdate:
@@ -89,6 +97,12 @@ class TestPhaseIncludeNames:
 
     def test_executing_has_analysis(self):
         names = phase_include_names(AgentMode.EXECUTING, WorkflowPath.EXPLORE)
+        assert "phases/analysis.md" in names
+
+    def test_run_analyze_discovery_includes_insights_summary(self):
+        names = phase_include_names(AgentMode.DISCOVERY, WorkflowPath.RUN_ANALYZE)
+        assert "insights-summary.md" in names
+        assert "result-analysis.md" in names
         assert "phases/analysis.md" in names
 
 


### PR DESCRIPTION
## Purpose

Add a **Summarize insights** FAB on `/insights` that opens a new Architect (Telemachus) session in a **new tab** and asks it to re-fetch and summarize the same filtered view — aggregates first, then sample failures.

This PR contains the **full implementation** (not a design/proposal follow-up). Design was locked in the review thread (Harry + peqy): no in-repo proposal file, no `localStorage`, shared handoff via `initial_message` on session create.

## What Changed

- **Backend:** optional `initial_message` on `POST /architect/sessions` — persist user message and dispatch Celery in the same request
- **Race fix (critical):** commit the session/message **before** `architect_chat_task.apply_async` so the worker cannot race ahead of the DB write (WS path already did this; REST path now matches)
- **Frontend:** shared `createAndOpenArchitectSession` (blank tab sync on click → `/architect?session=`), Insights FAB, prompt/title utils with **50-run cap**
- **ArchitectClient:** prefer `?session=` over resume hint; clear param after select; dedicated effect so query-only navigations while already on `/architect` still select the session
- **UX:** Insights summarize FAB surfaces failures with a toast (not `console.error` only)
- **Skill:** `insights-summary.md` + `RUN_ANALYZE` signals (`summarize insights`, etc.)

## Locked decisions (from review)

| Topic | Decision |
|---|---|
| Nav | New tab (blank tab sync on click; same-tab if blocked) |
| Enable | Regardless of `failedCount` (including `0`) |
| Payload | Filters/IDs only — Telemachus re-fetches |
| Run cap | 50; time-range = most recent; explicit selection = preserve order, first 50 |
| Handoff | `initial_message` on create — no localStorage |

## Dependency

Built on **#2120** (merged).

## Testing

- Backend: `tests/backend/services/architect/test_session_start.py`
- Frontend: handoff + prompt unit tests
- SDK: Insights `RUN_ANALYZE` signal + phase include tests
- Manual: Insights (with filters) → FAB → new Architect tab → analysis without four-path menu

## Additional Context

- Implementation landed in this PR after the design thread; supersedes the earlier design-only / follow-up framing
- Post-review corrections from peqy: commit-before-enqueue, `searchParams` session effect, error toast
- Design discussion: https://github.com/rhesis-ai/rhesis/pull/2178#issuecomment-5016376737