### PR TITLE
Add ./rh secrets command and document self-hosting secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,14 @@ SESSION_SECRET_KEY=
 # AUTH_REGISTRATION_ENABLED=true
 
 # =============================================================================
+# ENTERPRISE FEATURES
+# =============================================================================
+# Only needed with the Enterprise package installed.
+
+# SSO_ENCRYPTION_KEY=      # SSO; keep stable. Generate: openssl rand -base64 32 | tr '+/' '-_'
+# AUDIT_HASH_KEY=          # API Clients. Generate: openssl rand -hex 32
+
+# =============================================================================
 # SMTP
 # =============================================================================
 # SMTP_HOST=smtp.example.com

--- a/docs/content/docs/deployment/docker-compose.mdx
+++ b/docs/content/docs/deployment/docker-compose.mdx
@@ -27,15 +27,19 @@ cd rhesis
 # 2. Copy environment variables
 cp .env.example .env.docker
 
-# 3. Generate the four required secrets and paste each into .env.docker
-openssl rand -base64 32 | tr '+/' '-_'   # DB_ENCRYPTION_KEY
-openssl rand -hex 32                      # JWT_SECRET_KEY
-openssl rand -hex 32                      # NEXTAUTH_SECRET
-openssl rand -hex 32                      # SESSION_SECRET_KEY
+# 3. Generate the four required secrets into .env.docker
+#    (DB_ENCRYPTION_KEY, JWT_SECRET_KEY, NEXTAUTH_SECRET, SESSION_SECRET_KEY)
+./rh secrets
 
 # 4. Start all services
 docker compose --env-file .env.docker up -d`}
 </CodeBlock>
+
+<Callout type="warning">
+Changing `DB_ENCRYPTION_KEY` on an existing deployment makes data already encrypted with the old
+key (such as stored provider credentials) permanently undecryptable. Back it up and keep it stable.
+The other three secrets can be rotated safely.
+</Callout>
 
 ### Access the applications
 
@@ -106,15 +110,19 @@ The variables above get a deployment running. Everything else is optional — se
 
 ### Enterprise Features
 
-Enterprise Edition features are discovered at runtime through `GET /features`. The endpoint returns license metadata and enabled feature names for the current organization. Frontend pages hide gated UI until the feature appears in that response.
+Enterprise Edition features are discovered at runtime through `GET /features`; the frontend hides gated UI until a feature appears there. Without the Enterprise package, Rhesis runs in Community mode and all three are unavailable.
 
-| Feature | Feature name | Related docs |
-|---|---|---|
-| Role-Based Access Control | `rbac` | [Roles & Permissions](/docs/organizations/roles) |
-| Single Sign-On | `sso` | [Single Sign-On](/docs/organizations/sso) |
-| API Clients | `api_clients` | [API Clients](/docs/organizations/api-clients) |
+Two features need their own secret — set it in `.env.docker` (see [Enterprise features](/docs/deployment/environment-variables#enterprise-features) for how to generate each). The feature stays disabled until its secret is present and valid.
 
-When the Enterprise package is not installed, Rhesis runs in Community mode and these features are unavailable.
+| Feature | Feature name | Secret | Docs |
+|---|---|---|---|
+| Role-Based Access Control | `rbac` | — | [Roles & Permissions](/docs/organizations/roles) |
+| Single Sign-On | `sso` | `SSO_ENCRYPTION_KEY` | [Single Sign-On](/docs/organizations/sso) |
+| API Clients | `api_clients` | `AUDIT_HASH_KEY` | [API Clients](/docs/organizations/api-clients) |
+
+<Callout type="warning">
+Keep `SSO_ENCRYPTION_KEY` stable once set — like `DB_ENCRYPTION_KEY`, changing it makes already-stored SSO credentials undecryptable.
+</Callout>
 
 ## Telemetry & Privacy
 

--- a/docs/content/docs/deployment/environment-variables.mdx
+++ b/docs/content/docs/deployment/environment-variables.mdx
@@ -118,6 +118,17 @@ Email (notifications, invitations) is disabled until `SMTP_HOST` is set.
 | `STORAGE_SERVICE_ACCOUNT_KEY` | Base64 service-account credentials for GCS | *(unset)* |
 | `LOCAL_STORAGE_PATH` | Filesystem path for the `file://` backend | `/tmp/rhesis-files` |
 
+## Enterprise features
+
+Only used when the Enterprise package is installed (see
+[Enterprise Features](/docs/deployment/docker-compose#enterprise-features)). Each feature stays
+disabled until its secret is set and valid.
+
+| Variable | Description | Generate with |
+|---|---|---|
+| `SSO_ENCRYPTION_KEY` | Encrypts stored SSO `client_secret`s; required for Single Sign-On. Must stay stable once set — changing it makes stored SSO credentials undecryptable | `openssl rand -base64 32 \| tr '+/' '-_'` |
+| `AUDIT_HASH_KEY` | HMAC key for hashing emails in API-client audit logs; required for API Clients | `openssl rand -hex 32` |
+
 ## Telemetry
 
 | Variable | Description | Default |
@@ -182,8 +193,6 @@ The empty-state pair exists for each of `TESTS`, `PROJECTS`, `TEST_SETS`, `TEST_
 
 | Variable | Purpose |
 |---|---|
-| `AUDIT_HASH_KEY` | Hashing key for API-client audit logs (Enterprise) |
-| `SSO_ENCRYPTION_KEY` | Encryption key for SSO configuration (Enterprise) |
 | `AUTH_SECRET`, `DATABASE_URL` | Hosted frontend auth secret and direct database URL |
 | `VERTEX_AI_LOCATION`, `VERTEX_AI_PROJECT`, `GOOGLE_APPLICATION_CREDENTIALS` | Vertex AI / GCP model access |
 | `PERSPECTIVE_API_KEY`, `CHATBOT_API_KEY` | Hosted third-party API keys |

--- a/docs/content/docs/deployment/quick-start.mdx
+++ b/docs/content/docs/deployment/quick-start.mdx
@@ -62,7 +62,7 @@ Use the `./rh` CLI for easy service management:
 </CodeBlock>
 ### Enable Test Generation
 
-Test generation needs an AI provider. Quick Start can use Rhesis-hosted models, or you can configure your own provider in the platform. `./rh start` prompts for a Rhesis API key when one is missing.
+Test generation needs an AI provider. Quick Start can use Rhesis-hosted models, or you can configure your own provider [in the platform](/docs/models). `./rh start` prompts for a Rhesis API key when one is missing.
 
 1. Get a key from [app.rhesis.ai/tokens](https://app.rhesis.ai/tokens).
 2. Run `./rh start` in an interactive terminal and paste the key when prompted.

--- a/rh
+++ b/rh
@@ -38,6 +38,7 @@ show_help() {
     echo -e "  ${GREEN}./rh restart --build${NC}   - Restart and rebuild images locally"
     echo -e "  ${GREEN}./rh logs${NC}              - View logs from all services"
     echo -e "  ${GREEN}./rh delete${NC}            - Delete all services, images, volumes, and data"
+    echo -e "  ${GREEN}./rh secrets${NC}           - Generate the required secrets in .env.docker"
     echo ""
     echo -e "${YELLOW}Local Development:${NC}"
     echo -e "  ${GREEN}./rh dev init${NC}          - Initialize env files (one-time setup)"
@@ -160,6 +161,61 @@ ensure_env_secret() {
         echo "${var_name}=${value}" >> .env.docker.local
     fi
     echo -e "${GREEN}✅ ${var_name} generated${NC}"
+}
+
+# Set VAR_NAME=value in .env.docker, replacing an existing line or appending one.
+# Portable across macOS (BSD sed) and Linux (GNU sed).
+set_docker_secret() {
+    local var_name="$1"
+    local value="$2"
+    if grep -q "^${var_name}=" .env.docker 2>/dev/null; then
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "s|^${var_name}=.*|${var_name}=${value}|" .env.docker
+        else
+            sed -i "s|^${var_name}=.*|${var_name}=${value}|" .env.docker
+        fi
+    else
+        echo "${var_name}=${value}" >> .env.docker
+    fi
+}
+
+# Fill the four required secrets in an existing .env.docker (production flow).
+# DB_ENCRYPTION_KEY is guarded: rotating it makes data already encrypted with the
+# old key undecryptable, so it is overwritten only on explicit confirmation
+# (default no). The other three are safe to rotate and are set unconditionally.
+generate_docker_secrets() {
+    if [ ! -f ".env.docker" ]; then
+        echo -e "${RED}❌ .env.docker not found${NC}"
+        echo -e "${YELLOW}   Create it first: ${GREEN}cp .env.example .env.docker${NC}"
+        exit 1
+    fi
+
+    if grep -qE "^DB_ENCRYPTION_KEY=[^[:space:]]" .env.docker 2>/dev/null; then
+        echo -e "${YELLOW}⚠️  DB_ENCRYPTION_KEY is already set in .env.docker.${NC}"
+        echo -e "${WHITE}   Overwriting it makes data already encrypted with the old key"
+        echo -e "   (such as stored provider credentials) permanently undecryptable.${NC}"
+        local reply=""
+        if [ -t 0 ]; then
+            read -r -p "$(echo -e ${YELLOW}Overwrite DB_ENCRYPTION_KEY? [y/N]: ${NC})" reply
+        fi
+        if [[ "$reply" =~ ^[Yy]$ ]]; then
+            set_docker_secret "DB_ENCRYPTION_KEY" "$(generate_encryption_key)"
+            echo -e "${GREEN}✅ DB_ENCRYPTION_KEY regenerated${NC}"
+        else
+            echo -e "${WHITE}   Kept existing DB_ENCRYPTION_KEY.${NC}"
+        fi
+    else
+        set_docker_secret "DB_ENCRYPTION_KEY" "$(generate_encryption_key)"
+        echo -e "${GREEN}✅ DB_ENCRYPTION_KEY generated${NC}"
+    fi
+
+    set_docker_secret "JWT_SECRET_KEY" "$(generate_hex_secret)"
+    set_docker_secret "SESSION_SECRET_KEY" "$(generate_hex_secret)"
+    set_docker_secret "NEXTAUTH_SECRET" "$(generate_hex_secret)"
+    echo -e "${GREEN}✅ JWT_SECRET_KEY, SESSION_SECRET_KEY, NEXTAUTH_SECRET set${NC}"
+
+    chmod 600 .env.docker
+    echo -e "${GREEN}✅ Secrets written to .env.docker${NC}"
 }
 
 # Prompt for a host port, accepting a default when the user just presses Enter.
@@ -1412,6 +1468,9 @@ case "$1" in
                 exit 1
                 ;;
         esac
+        ;;
+    "secrets")
+        generate_docker_secrets
         ;;
     "stop")
         stop_all


### PR DESCRIPTION
## Purpose

Manager feedback on the self-hosting docs surfaced three gaps and one rough edge:

- The production Docker Compose guide asked users to hand-run four `openssl` commands and paste each into `.env.docker` — awkward, and appending duplicated the empty keys already shipped in `.env.example`.
- No guidance that `DB_ENCRYPTION_KEY` must stay stable (rotating it orphans encrypted data).
- `SSO_ENCRYPTION_KEY` (needed for self-hosted SSO) was undocumented and mis-filed as cloud-only.
- The quick-start's "configure in the platform" had no link.

## What Changed

- **`./rh secrets`** (new command): fills the four required secrets into an existing `.env.docker`, in place (no duplicate lines). `DB_ENCRYPTION_KEY` is overwrite-guarded with a `[y/N]` prompt defaulting to **no**; the other three are set unconditionally (safe to rotate).
- **docker-compose.mdx**: step 3 is now `./rh secrets`; added a warning about `DB_ENCRYPTION_KEY` stability; consolidated the Enterprise Features section into one table listing each feature's required secret (`SSO_ENCRYPTION_KEY`, `AUDIT_HASH_KEY`).
- **environment-variables.mdx**: moved `SSO_ENCRYPTION_KEY`/`AUDIT_HASH_KEY` out of the cloud-only table into a self-hosting **Enterprise features** section with generate commands.
- **quick-start.mdx**: linked "configure in the platform" to the Models docs.
- **.env.example**: added commented `SSO_ENCRYPTION_KEY` and `AUDIT_HASH_KEY`.

## Testing

Exercised `./rh secrets` end-to-end (`bash -n rh` passes):
- Fresh `.env.docker` → all four filled, no prompt, no duplicate lines.
- Re-run (DB key present), declined/non-interactive → DB key kept, others rotated.
- Re-run, interactive `y` (via PTY) → DB key rotated.
- Missing `.env.docker` → clean error + `cp .env.example .env.docker` hint, exit 1.

## Notes

Following the repo's existing `[ -t 0 ]` convention, the overwrite prompt is skipped when stdin isn't a TTY and defaults to no — so a DB-key overwrite can't be forced non-interactively. Happy to add a `--force` flag if wanted.