### PR TITLE
Remove deprecated @mui/lab dependency

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rhesis-app",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhesis-app",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "hasInstallScript": true,
       "dependencies": {
         "@emotion/react": "^11",
@@ -14,7 +14,6 @@
         "@icons-pack/react-simple-icons": "^13.12.0",
         "@monaco-editor/react": "^4.7.0",
         "@mui/icons-material": "^7",
-        "@mui/lab": "^7.0.0",
         "@mui/material": "^7",
         "@mui/material-nextjs": "^7",
         "@mui/x-charts": "^8.19.0",
@@ -2996,48 +2995,6 @@
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mui/lab": {
-      "version": "7.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "@mui/system": "^7.3.3",
-        "@mui/types": "^7.4.7",
-        "@mui/utils": "^7.3.3",
-        "clsx": "^2.1.1",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mui-org"
-      },
-      "peerDependencies": {
-        "@emotion/react": "^11.5.0",
-        "@emotion/styled": "^11.3.0",
-        "@mui/material": "^7.3.3",
-        "@mui/material-pigment-css": "^7.3.3",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/react": {
-          "optional": true
-        },
-        "@emotion/styled": {
-          "optional": true
-        },
-        "@mui/material-pigment-css": {
-          "optional": true
-        },
         "@types/react": {
           "optional": true
         }

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -36,7 +36,6 @@
     "@icons-pack/react-simple-icons": "^13.12.0",
     "@monaco-editor/react": "^4.7.0",
     "@mui/icons-material": "^7",
-    "@mui/lab": "^7.0.0",
     "@mui/material": "^7",
     "@mui/material-nextjs": "^7",
     "@mui/x-charts": "^8.19.0",

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { LoadingButton } from '@mui/lab';
+import { Button } from '@mui/material';
 import { PlayArrowIcon } from '@/components/icons';
 import { SectionCard } from '@/components/common/SectionCard';
 import { useEndpointDetailContext } from './EndpointDetailContext';
@@ -137,7 +137,7 @@ export default function EndpointTestTab() {
       subtitle="Fire a live request and see exactly what your API returns and how Rhesis maps it."
       actions={
         canInvoke ? (
-          <LoadingButton
+          <Button
             variant="contained"
             onClick={handleTest}
             loading={isTestingEndpoint}
@@ -145,7 +145,7 @@ export default function EndpointTestTab() {
             startIcon={<PlayArrowIcon />}
           >
             Check connection
-          </LoadingButton>
+          </Button>
         ) : undefined
       }
     >

--- a/apps/frontend/src/app/(protected)/endpoints/components/MappingEditor.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/MappingEditor.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
 import {
   Box,
+  Button,
   Typography,
   Popover,
   List,
@@ -10,7 +11,6 @@ import {
   ListItemText,
   Link,
 } from '@mui/material';
-import { LoadingButton } from '@mui/lab';
 import { PlayArrowIcon } from '@/components/icons';
 import RequestBodyEditor from './RequestBodyEditor';
 import FormSectionDivider from '@/components/common/FormSectionDivider';
@@ -304,7 +304,7 @@ export default function MappingEditor({
             headline="Request body"
             descriptiveText="Define the JSON body Rhesis sends with each test. Place {{ input }} where your API expects the prompt."
           />
-          <LoadingButton
+          <Button
             variant="contained"
             onClick={handleQuickTest}
             loading={isTestingEndpoint}
@@ -313,7 +313,7 @@ export default function MappingEditor({
             sx={{ ...sectionContainedButtonSx, flexShrink: 0, mt: 0.5 }}
           >
             Check connection
-          </LoadingButton>
+          </Button>
         </Box>
         <RequestBodyEditor
           value={requestTemplate}

--- a/apps/frontend/src/app/(protected)/endpoints/components/TabTest.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/TabTest.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { LoadingButton } from '@mui/lab';
+import { Button } from '@mui/material';
 import { PlayArrowIcon } from '@/components/icons';
 import { SectionCard } from '@/components/common/SectionCard';
 import EndpointTestWorkbench from './EndpointTestWorkbench';
@@ -138,7 +138,7 @@ export default function TabTest({
       title="Test"
       subtitle="Fire a live request and see exactly what your API returns and how Rhesis maps it."
       actions={
-        <LoadingButton
+        <Button
           variant="contained"
           onClick={handleTest}
           loading={isTestingEndpoint}
@@ -146,7 +146,7 @@ export default function TabTest({
           startIcon={<PlayArrowIcon />}
         >
           Check connection
-        </LoadingButton>
+        </Button>
       }
     >
       <EndpointTestWorkbench


### PR DESCRIPTION
## Purpose
Remove the deprecated `@mui/lab@7.0.0` dependency that triggers npm install warnings and is not intended for production use.

## What Changed
- Replaced `LoadingButton` from `@mui/lab` with `Button` from `@mui/material` (same `loading` / `loadingPosition` API) in endpoint test UI
- Removed `@mui/lab` from frontend dependencies

## Additional Context
- Closes #927

## Testing
- [ ] Confirm endpoint "Check connection" buttons still show loading state while testing
- [ ] `npm ci` in `apps/frontend` no longer warns about deprecated `@mui/lab`