### PR TITLE
Fix drawer icons forced to body color

### DIFF
--- a/apps/frontend/src/app/(protected)/organizations/team/components/memberCardSx.ts
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/memberCardSx.ts
@@ -47,13 +47,9 @@ export const projectCardItemSx: SxProps<Theme> = {
 /**
  * Selectable project row card (TeamInviteForm).
  *
- * We intentionally do NOT pass `selected` to the ListItemButton so that MUI
- * never adds the Mui-selected class. The Drawer's global Mui-selected rules
- * force color:white and background:#primary on every child (including
- * Typography), which is unreadable on our near-transparent tint.
- *
- * Visual selection state is managed entirely through the `isSelected` JS
- * variable, bypassing all MUI global overrides.
+ * Visual selection state is managed through the `isSelected` JS variable
+ * (border + tint) rather than MUI's `selected` prop, so the row keeps a
+ * subtle tint with readable text instead of a solid primary fill.
  */
 export function getSelectableProjectItemSx(
   isSelected: boolean

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailReviewsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailReviewsTab.tsx
@@ -340,7 +340,7 @@ export default function TestDetailReviewsTab({
           }}
         >
           <Box sx={{ pr: '12px', py: '7px', flexShrink: 0 }}>
-            <WarningAmberIcon sx={{ fontSize: 22, color: '#fff !important' }} />
+            <WarningAmberIcon sx={{ fontSize: 22, color: 'common.white' }} />
           </Box>
           <Box
             sx={{
@@ -620,8 +620,6 @@ function EmptyStateCard({
           onClick={onCreateReview}
           sx={{
             borderRadius: BORDER_RADIUS.md,
-            // Override the MuiDrawer theme rule that sets all icons to body color
-            '& .MuiSvgIcon-root': { color: '#ffffff' },
           }}
         >
           Create review

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
@@ -477,9 +477,7 @@ export default function TestResultDrawer({
             {(test?.test?.id ?? test?.test_id) && (
               <Button
                 variant="outlined"
-                endIcon={
-                  <OpenInNewIcon />
-                }
+                endIcon={<OpenInNewIcon />}
                 component="a"
                 href={`/tests/${test.test?.id ?? test.test_id}`}
                 target="_blank"

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
@@ -478,7 +478,7 @@ export default function TestResultDrawer({
               <Button
                 variant="outlined"
                 endIcon={
-                  <OpenInNewIcon sx={{ color: 'primary.main !important' }} />
+                  <OpenInNewIcon />
                 }
                 component="a"
                 href={`/tests/${test.test?.id ?? test.test_id}`}

--- a/apps/frontend/src/app/(protected)/traces/components/SpanSequenceView.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/SpanSequenceView.tsx
@@ -424,14 +424,7 @@ export default function SpanSequenceView({
                     component={SpanIcon}
                     sx={{
                       fontSize: theme.typography.body1.fontSize,
-                      color: theme => {
-                        const parts = colorPath.split('.');
-                        if (parts.length === 2) {
-                          const [category, shade] = parts;
-                          return `${(theme.palette as unknown as Record<string, Record<string, string>>)[category]?.[shade] || colorPath} !important`;
-                        }
-                        return `${colorPath} !important`;
-                      },
+                      color: colorPath,
                       mb: 0.5,
                     }}
                   />
@@ -690,7 +683,7 @@ export default function SpanSequenceView({
                       component={SpanIcon}
                       sx={{
                         fontSize: theme.typography.caption.fontSize,
-                        color: `${theme.palette.common.white} !important`,
+                        color: 'common.white',
                       }}
                     />
                     <Typography

--- a/apps/frontend/src/app/(protected)/traces/components/SpanTreeView.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/SpanTreeView.tsx
@@ -137,15 +137,7 @@ function SpanTreeNode({
           component={SpanIcon}
           sx={{
             fontSize: theme => theme.spacing(2.25),
-            color: theme => {
-              // Parse theme path (e.g., 'success.main' -> theme.palette.success.main)
-              const parts = colorPath.split('.');
-              if (parts.length === 2) {
-                const [category, shade] = parts;
-                return `${(theme.palette as unknown as Record<string, Record<string, string>>)[category]?.[shade] || colorPath} !important`;
-              }
-              return `${colorPath} !important`;
-            },
+            color: colorPath,
             mr: 1,
             flexShrink: 0,
           }}

--- a/apps/frontend/src/components/comments/CommentItem.tsx
+++ b/apps/frontend/src/components/comments/CommentItem.tsx
@@ -9,7 +9,6 @@ import {
   Button,
   TextField,
   Tooltip,
-  type Theme,
 } from '@mui/material';
 import {
   EditIcon,
@@ -133,13 +132,6 @@ export function CommentItem({
       return formatDistanceToNow(date, { addSuffix: true }).toUpperCase();
     }
     return format(date, 'dd MMM yyyy HH:mm').toUpperCase();
-  };
-
-  const actionIconSx = {
-    p: 0,
-    '& .MuiSvgIcon-root': {
-      color: (theme: Theme) => `${theme.palette.primary.main} !important`,
-    },
   };
 
   return (
@@ -308,8 +300,9 @@ export function CommentItem({
               <Tooltip title="Add reaction">
                 <IconButton
                   size="small"
+                  color="primary"
                   onClick={e => setEmojiAnchorEl(e.currentTarget)}
-                  sx={actionIconSx}
+                  sx={{ p: 0 }}
                 >
                   <EmojiIcon sx={{ fontSize: 20 }} />
                 </IconButton>

--- a/apps/frontend/src/components/common/EntityActionBar.tsx
+++ b/apps/frontend/src/components/common/EntityActionBar.tsx
@@ -50,20 +50,11 @@ export function EntityActionBar<T extends WithPermittedActions>({
             <Box component="span" sx={{ display: 'inline-flex' }}>
               <IconButton
                 size="small"
+                color="primary"
                 aria-label={action.label}
                 disabled={!enabled}
                 onClick={() => subject && action.onSelect(subject)}
-                sx={{
-                  p: 0,
-                  // Match the existing action-icon styling; only force the
-                  // primary tint while enabled so disabled keeps MUI's grey.
-                  ...(enabled && {
-                    '& .MuiSvgIcon-root': {
-                      color: (theme: Theme) =>
-                        `${theme.palette.primary.main} !important`,
-                    },
-                  }),
-                }}
+                sx={{ p: 0 }}
               >
                 {Icon ? <Icon sx={{ fontSize: iconSize }} /> : null}
               </IconButton>

--- a/apps/frontend/src/components/common/FilterButton.tsx
+++ b/apps/frontend/src/components/common/FilterButton.tsx
@@ -46,9 +46,6 @@ export function FilterButton({
         height: 36,
         flexShrink: 0,
         '&:hover': { bgcolor: 'primary.dark' },
-        // The MuiDrawer theme override force-colors `.MuiSvgIcon-root` dark in
-        // light mode; keep this button's icon on its (white) contrast text.
-        '& .MuiSvgIcon-root': { color: 'primary.contrastText' },
         ...sx,
       }}
       {...props}

--- a/apps/frontend/src/components/common/SearchPill.tsx
+++ b/apps/frontend/src/components/common/SearchPill.tsx
@@ -92,12 +92,9 @@ export function SearchPill({
           flexShrink: 0,
           cursor: 'pointer',
           '&:hover': { bgcolor: 'primary.dark' },
-          // The MuiDrawer theme override force-colors `.MuiSvgIcon-root` dark in
-          // light mode; keep this icon on its (white) contrast text.
-          '& .MuiSvgIcon-root': { fontSize: 18, color: 'primary.contrastText' },
         }}
       >
-        <SearchIcon fontSize="small" />
+        <SearchIcon sx={{ fontSize: 18 }} />
       </Box>
     </Box>
   );

--- a/apps/frontend/src/components/tasks/TasksSection.tsx
+++ b/apps/frontend/src/components/tasks/TasksSection.tsx
@@ -219,11 +219,7 @@ export function TasksSection({
     <Can capability={Capability.Task.CREATE}>
       <Button
         variant="outlined"
-        startIcon={
-          <AddIcon
-            sx={{ color: theme => `${theme.palette.primary.main} !important` }}
-          />
-        }
+        startIcon={<AddIcon />}
         onClick={handleCreateTask}
         size="small"
       >
@@ -262,12 +258,7 @@ export function TasksSection({
               textAlign: 'center',
             }}
           >
-            <TasksIcon
-              sx={{
-                fontSize: 32,
-                color: theme => `${theme.palette.primary.main} !important`,
-              }}
-            />
+            <TasksIcon color="primary" sx={{ fontSize: 32 }} />
             <Typography
               variant="h6"
               sx={{ fontWeight: 600, color: 'primary.main' }}
@@ -281,9 +272,8 @@ export function TasksSection({
             <Can capability={Capability.Task.CREATE}>
               <Button
                 variant="contained"
-                startIcon={<AddIcon sx={{ color: 'white !important' }} />}
+                startIcon={<AddIcon />}
                 onClick={handleCreateTask}
-                sx={{ color: 'white' }}
               >
                 Create task
               </Button>

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -294,32 +294,6 @@ const getDesignTokens = (mode: PaletteMode) => {
               color: gs.body,
               boxShadow: mode === 'light' ? ELEVATION.xs : 'none',
             },
-            '& .MuiSvgIcon-root': {
-              color: mode === 'light' ? gs.body : '#FFFFFF',
-            },
-            '& .MuiAvatar-root .MuiSvgIcon-root': {
-              color: 'inherit',
-            },
-            '& .MuiButton-icon .MuiSvgIcon-root, & .MuiButton-startIcon .MuiSvgIcon-root, & .MuiButton-endIcon .MuiSvgIcon-root':
-              {
-                color: 'inherit',
-              },
-            // Drawer sets all icons to body color; keep grid/checkbox selection primary.
-            '& .MuiCheckbox-root, & .MuiDataGrid-checkboxInput': {
-              color: mode === 'light' ? '#0080AF' : '#33A6CB',
-              '&.Mui-checked, &.MuiCheckbox-indeterminate': {
-                color: mode === 'light' ? '#0080AF' : '#33A6CB',
-              },
-            },
-            '& .MuiCheckbox-root .MuiSvgIcon-root, & .MuiDataGrid-checkboxInput .MuiSvgIcon-root':
-              {
-                color: 'inherit',
-              },
-            '& .MuiListItemButton-root.Mui-selected': {
-              backgroundColor: '#0080AF',
-              '& .MuiSvgIcon-root': { color: '#FFFFFF' },
-              '& .MuiTypography-root': { color: '#FFFFFF' },
-            },
             '& .MuiDivider-root': {
               margin: '16px 0',
               borderColor: mode === 'light' ? gs.border : '#2C2C2C',


### PR DESCRIPTION
## Purpose
The global `MuiDrawer` theme override forced every icon inside drawers to body/white color. That broke intentional colors (e.g. primary action icons) and led to `!important` workarounds.

## What Changed
- Removed the blanket `MuiDrawer` `.MuiSvgIcon-root` color override and related compensatory rules from `theme.ts`
- Restored icon colors via MUI component APIs (`IconButton color="primary"`, button start/end icon inheritance, palette paths)
- Dropped drawer-related `!important` / force-color hacks in comments, tasks, filters, traces, and test result drawers

## Additional Context
- Closes #1861
- Navigation sidebar is unaffected (it is not a `MuiDrawer`; icons are styled in `NavItem`)

## Testing
- [ ] Nav sidebar icons still dark (light mode) / white on selected
- [ ] Test result drawer → Tasks & Comments: action icons are primary teal
- [ ] Contained button icons (Create task / Create review) remain white
- [ ] Trace drawer span icons keep semantic colors
- [ ] Filter button / search pill icons stay white on primary backgrounds