### PR TITLE
Fix rhesis plugin entry to use source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,17 +5,15 @@
     "url": "https://rhesis.ai"
   },
   "metadata": {
-    "description": "Rhesis AI plugin marketplace — AI testing tools and skills",
-    "pluginRoot": "./skills"
+    "description": "Rhesis AI plugin marketplace — AI testing tools and skills"
   },
   "plugins": [
     {
       "name": "rhesis",
-      "source": "rhesis",
+      "source": "./skills/rhesis",
       "description": "Design, run, and analyze AI test suites on the Rhesis platform",
       "category": "testing",
-      "tags": ["ai-testing", "mcp", "evaluation", "llm-testing"],
-      "skills": ["./skills/rhesis"]
+      "tags": ["ai-testing", "mcp", "evaluation", "llm-testing"]
     }
   ]
 }


### PR DESCRIPTION
## Purpose
The plugin entry in the marketplace manifest used the deprecated `pluginRoot` + `skills` array shape. This updates it to the standard `source` path so the plugin resolves correctly.

## What Changed
- Drop `pluginRoot` from `metadata`
- Set plugin `source` to `./skills/rhesis`
- Remove the redundant `skills` array (covered by `source`)

## Testing
Verify the `rhesis` plugin loads from the marketplace and its skills/MCP resolve.