### PR TITLE
Add changelog entries for v0.10 and v0.9.1

### DIFF
--- a/docs/content/changelog.mdx
+++ b/docs/content/changelog.mdx
@@ -10,16 +10,132 @@ This is the aggregated changelog for the entire Rhesis repository. For detailed 
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-07-09
+
+### Platform Release
+
+This release includes the following component versions:
+- **Backend 0.10.0**
+- **Frontend 0.10.0**
+- **SDK 0.10.0**
+
+### Summary
+
+Enterprise Edition gets a **roles and permissions UI** for custom RBAC, including member assignment and scoped API tokens. The SDK adds **Pydantic AI** auto-instrumentation and a Penelope target. List and detail APIs are faster after fixing N+1 query patterns. Test runs pick up a **Reviews** column, and test detail pages show **execution history**.
+
+### Featured Capabilities
+
+**Enterprise RBAC (EE)**
+
+Manage who can do what without leaving Organization Settings:
+
+- **Roles tab**: view built-in roles and create custom ones
+- **Graded permissions**: set access per area (Test Resources, Observability, Infrastructure, Administration) at View / Edit / Manage
+- **Member assignment**: set org and project roles from the team and project member grids
+- **Scoped tokens**: limit API tokens to a role's permissions
+- **Server-driven affordances**: create/edit/delete controls only show when the caller is allowed to use them
+- **Viewer enforcement**: Viewer stays read-only across the UI
+
+See [Roles & Permissions](/docs/organizations/roles).
+
+**Pydantic AI and target updates**
+
+- **Auto-instrumentation**: `PydanticAIIntegration` turns agent runs into Rhesis spans (agent, LLM, tools, handoffs) without `@observe`
+- **Penelope target**: `PydanticAITarget` for multi-turn conversation simulation
+- **Async targets**: native `ainvoke` paths for LangChain and LangGraph
+- **Multimodal attachments**: file / content-block support for LangChain, LangGraph, and Pydantic AI targets
+
+**API performance**
+
+List and detail endpoints were doing far too many round trips (lazy-loaded comments, tasks, tags, files per row). Those N+1 patterns are gone, and a few expensive `ORDER BY` / join paths were split so pages like `/tests` load in a more reasonable time.
+
+**Test run reviews and history**
+
+- Reviews column on the test runs grid, with conflict detection
+- Execution history tab on the test detail page
+
+### Backend Highlights
+- RBAC project/org role scope, precedence, and Viewer read-only enforcement
+- Faster list/detail queries (N+1 fixes, split detail fetches, lookup indexes)
+- Metric–endpoint compatibility preflight check
+- Assorted RBAC onboarding and membership edge-case fixes
+
+### Frontend Highlights
+- EE Roles tab, role editor, member role chips, and token scope picker
+- Affordances-aware UI (actions gated by `permitted_actions`)
+- Reviews column on test runs; execution history on test detail
+- Grids and detail pages moved onto shared React Query hooks
+- Playground endpoint selection and other small UX polish
+
 ### SDK Highlights
+- Pydantic AI integration and native OpenTelemetry span translation
+- `PydanticAITarget` for Penelope
+- Native async send paths for LangChain and LangGraph targets
+- Multimodal file attachments via `FileReference` resolution
+
+## [0.9.1] - 2026-06-25
+
+### Platform Release
+
+This release includes the following component versions:
+- **Backend 0.9.1**
+- **Frontend 0.9.1**
+- **SDK 0.9.1**
+
+### Summary
+
+This release adds **Microsoft Agent Framework (MAF) tracing**, redesigns **Insights** around behavior pass rates, lands the **RBAC backend** (UI follows in 0.10), and expands **MCP tool integrations** (Azure DevOps, Linear, GitLab, Asana, Shortcut). Also includes a Figma-aligned onboarding wizard, vLLM as an LLM provider, and tighter TestSet visibility rules.
+
+### Featured Capabilities
 
 **Microsoft Agent Framework (MAF) tracing**
 
-- **One-line auto-instrumentation**: `auto_instrument("agent_framework")` (alias `"maf"`) translates MAF GenAI spans into the Rhesis schema - agents, model calls, tools, embeddings, and workflows - with no agent code changes.
-- **Native handoff tracing**: handoffs in `HandoffBuilder` workflows are synthesized into `ai.agent.handoff` spans for the Graph View.
-- **Privacy controls**: `RHESIS_DISABLE_CONTENT_CAPTURE` omits prompt/completion/tool payloads; `RHESIS_MAF_VERBOSE_WORKFLOW_SPANS` keeps full workflow infrastructure spans.
-- **Penelope MAF target**: `MAFTarget` drives any MAF agent through multi-turn conversation simulation.
+- **One-line auto-instrumentation**: `auto_instrument("agent_framework")` (alias `"maf"`) translates MAF GenAI spans into the Rhesis schema — agents, model calls, tools, embeddings, and workflows — with no agent code changes
+- **Native handoff tracing**: handoffs in `HandoffBuilder` workflows become `ai.agent.handoff` spans for the Graph View
+- **Privacy controls**: `RHESIS_DISABLE_CONTENT_CAPTURE` omits prompt/completion/tool payloads; `RHESIS_MAF_VERBOSE_WORKFLOW_SPANS` keeps full workflow infrastructure spans
+- **Penelope MAF target**: `MAFTarget` drives any MAF agent through multi-turn conversation simulation
 
 The legacy `autogen` integration is now a deprecated no-op; use `agent_framework` instead.
+
+See [Microsoft Agent Framework](/docs/tracing/agent-framework).
+
+**Insights redesign**
+
+Insights is now a behavior-centric pass rate view:
+
+- Behavior columns with expandable metric and topic rows
+- Behavior filter and clearer failed-test counts
+- Empty states aligned with the Figma card layout
+
+**RBAC backend (EE)**
+
+Role-based access control lands on the backend: built-in and custom roles, permission catalogs, and project-scoped membership. The authoring UI ships in 0.10.
+
+**MCP tools and knowledge**
+
+- Integrations for Azure DevOps, Linear, GitLab, Asana, and Shortcut
+- `create_endpoint` / `update_endpoint` tools for agent registration
+- Knowledge import from MCP extract providers, scoped by project
+- Tools page redesigned as a provider card grid
+
+### Backend Highlights
+- RBAC policy engine, migrations, and project-scoped token resolution
+- Removed public TestSet visibility (organization and user ownership only)
+- Timezone / `timestamptz` migration and handling fixes
+- Faster test run detail and summary paths
+- vLLM provider support; pass model endpoint as `api_base` to the SDK
+
+### Frontend Highlights
+- Insights behavior-centric redesign and empty-state polish
+- Onboarding wizard aligned with Figma V2
+- Tools page provider grid and endpoint UI improvements
+- Knowledge tool import UX fixes
+
+### SDK Highlights
+- Microsoft Agent Framework telemetry integration and `MAFTarget`
+- MCP inspection tools and additional provider integrations
+- Metric evaluation resilience for weak-JSON models
+- Examples for OpenAI/Anthropic, Pydantic AI, LlamaIndex, and CrewAI telemetry
 
 ## [0.9.0] - 2026-06-11
 

--- a/docs/content/docs/integrations.mdx
+++ b/docs/content/docs/integrations.mdx
@@ -17,8 +17,8 @@ Beyond those four layers, Rhesis also bundles **evaluation frameworks** (DeepEva
 
 Your application emits spans through the Rhesis SDK; spans are batched and sent to Rhesis over HTTP using OpenTelemetry conventions. The integration mechanism depends on the framework:
 
-- **LangChain** and **LangGraph** are auto-instrumented end-to-end with a single `auto_instrument()` call — no per-function decorators required.
-- Other Python frameworks (CrewAI, OpenAI Agents SDK, LlamaIndex, AutoGen, …) are traced with the `@observe.*` decorators, applied to the functions, tools, or agents you want to capture.
+- **LangChain**, **LangGraph**, **Microsoft Agent Framework**, and **Pydantic AI** are auto-instrumented with a single `auto_instrument()` call — no per-function decorators required.
+- Other Python frameworks (CrewAI, OpenAI Agents SDK, LlamaIndex, …) are traced with the `@observe.*` decorators, applied to the functions, tools, or agents you want to capture.
 - Any OpenTelemetry-compatible exporter can target the Rhesis ingestion endpoint directly. See [Tracing setup](/docs/tracing/setup) for the exact endpoint and headers.
 
 See: [Tracing overview](/docs/tracing) · [Auto-instrumentation](/docs/tracing/auto-instrumentation) · [Decorators](/docs/tracing/decorators) · [Multi-agent tracing](/docs/tracing/multi-agent)

--- a/docs/content/docs/tracing/auto-instrumentation.mdx
+++ b/docs/content/docs/tracing/auto-instrumentation.mdx
@@ -2,7 +2,7 @@ import { CodeBlock } from "@/components/CodeBlock";
 
 # Auto-Instrumentation
 
-Zero-config tracing for LangChain and LangGraph applications.
+Zero-config tracing for LangChain, LangGraph, Microsoft Agent Framework, and Pydantic AI applications.
 
 ## Overview
 
@@ -12,10 +12,12 @@ Auto-instrumentation automatically traces all LLM calls, tool invocations, and c
     AI["auto_instrument()"] --> LC["LangChain"]
     AI --> LG["LangGraph"]
     AI --> MAF["Microsoft Agent Framework"]
+    AI --> PAI["Pydantic AI"]
 
     LC --> T["Automatic Traces"]
     LG --> T
-    MAF --> T`} />
+    MAF --> T
+    PAI --> T`} />
 
 ## API at a glance
 
@@ -239,9 +241,10 @@ disable_auto_instrument()`}
 | LangChain | Auto-instrument (callback + tool patch) | `langchain` | Supported |
 | LangGraph | Auto-instrument (callback + graph patch) | `langgraph` | Supported |
 | Microsoft Agent Framework | Auto-instrument (OTel span translation) | `agent-framework` | Supported |
-| Other Python frameworks (CrewAI, OpenAI Agents SDK, LlamaIndex, AutoGen, …) | `@observe.*` decorators | n/a | Use [Decorators](/tracing/decorators) |
+| Pydantic AI | Auto-instrument (OTel span translation) | `pydantic-ai` | Supported |
+| Other Python frameworks (CrewAI, OpenAI Agents SDK, LlamaIndex, …) | `@observe.*` decorators | n/a | Use [Decorators](/tracing/decorators) |
 
-Microsoft Agent Framework has its own dedicated guide - see [Microsoft Agent Framework](/tracing/agent-framework) for installation, handoff tracing, and content-capture options.
+Microsoft Agent Framework has its own dedicated guide - see [Microsoft Agent Framework](/tracing/agent-framework) for installation, handoff tracing, and content-capture options. For Pydantic AI, call `auto_instrument("pydantic_ai")` after creating `RhesisClient`.
 
 For frameworks not in the auto-instrument list, wrap the functions, tools, or agents you want to trace with `@observe.llm`, `@observe.tool`, `@observe.retrieval`, etc. Without decorators only top-level inputs and outputs are captured.
 

--- a/docs/content/docs/tracing/auto-instrumentation.mdx
+++ b/docs/content/docs/tracing/auto-instrumentation.mdx
@@ -29,6 +29,8 @@ The full auto-instrumentation surface lives in `rhesis.sdk.telemetry`:
 auto_instrument()                              # auto-detect installed frameworks
 auto_instrument("langchain")                   # explicit single framework
 auto_instrument("langchain", "langgraph")      # explicit multiple frameworks
+auto_instrument("agent_framework")             # Microsoft Agent Framework (alias: "maf")
+auto_instrument("pydantic_ai")                 # Pydantic AI
 disable_auto_instrument()                      # turn everything off`}
 </CodeBlock>
 
@@ -42,7 +44,7 @@ The function returns the list of frameworks it actually instrumented, so you can
 
 <CodeBlock filename="bootstrap.py" language="python">
 {`enabled = auto_instrument()
-print(f"Tracing enabled for: {enabled}")  # e.g. ['langchain', 'langgraph']`}
+print(f"Tracing enabled for: {enabled}")  # e.g. ['langchain', 'langgraph', 'agent_framework', 'pydantic_ai']`}
 </CodeBlock>
 
 ## LangChain
@@ -236,15 +238,15 @@ disable_auto_instrument()`}
 
 ## Supported Frameworks
 
-| Framework | Mechanism | Extra | Status |
-|---|---|---|---|
-| LangChain | Auto-instrument (callback + tool patch) | `langchain` | Supported |
-| LangGraph | Auto-instrument (callback + graph patch) | `langgraph` | Supported |
-| Microsoft Agent Framework | Auto-instrument (OTel span translation) | `agent-framework` | Supported |
-| Pydantic AI | Auto-instrument (OTel span translation) | `pydantic-ai` | Supported |
-| Other Python frameworks (CrewAI, OpenAI Agents SDK, LlamaIndex, …) | `@observe.*` decorators | n/a | Use [Decorators](/tracing/decorators) |
+| Framework | Mechanism | `auto_instrument` key | pip extra | Status |
+|---|---|---|---|---|
+| LangChain | Auto-instrument (callback + tool patch) | `langchain` | `langchain` | Supported |
+| LangGraph | Auto-instrument (callback + graph patch) | `langgraph` | `langgraph` | Supported |
+| Microsoft Agent Framework | Auto-instrument (OTel span translation) | `agent_framework` (alias `maf`) | `agent-framework` | Supported |
+| Pydantic AI | Auto-instrument (OTel span translation) | `pydantic_ai` | `pydantic-ai` | Supported |
+| Other Python frameworks (CrewAI, OpenAI Agents SDK, LlamaIndex, …) | `@observe.*` decorators | n/a | n/a | Use [Decorators](/docs/tracing/decorators) |
 
-Microsoft Agent Framework has its own dedicated guide - see [Microsoft Agent Framework](/tracing/agent-framework) for installation, handoff tracing, and content-capture options. For Pydantic AI, call `auto_instrument("pydantic_ai")` after creating `RhesisClient`.
+Microsoft Agent Framework has its own dedicated guide — see [Microsoft Agent Framework](/docs/tracing/agent-framework) for installation, handoff tracing, and content-capture options. For Pydantic AI, call `auto_instrument("pydantic_ai")` after creating `RhesisClient`.
 
 For frameworks not in the auto-instrument list, wrap the functions, tools, or agents you want to trace with `@observe.llm`, `@observe.tool`, `@observe.retrieval`, etc. Without decorators only top-level inputs and outputs are captured.
 
@@ -254,10 +256,10 @@ To add a new framework to the auto-instrument list, see [Contributing: SDK Integ
 
 <Callout type="info">
   **Related:**
-  - [Setup](/tracing/setup) - Initial configuration
-  - [Decorators](/tracing/decorators) - `@observe` and `@endpoint`
-  - [Multi-Agent Tracing](/tracing/multi-agent) - Agent and handoff spans
-  - [Microsoft Agent Framework](/tracing/agent-framework) - Native agent and handoff tracing for MAF
+  - [Setup](/docs/tracing/setup) - Initial configuration
+  - [Decorators](/docs/tracing/decorators) - `@observe` and `@endpoint`
+  - [Multi-Agent Tracing](/docs/tracing/multi-agent) - Agent and handoff spans
+  - [Microsoft Agent Framework](/docs/tracing/agent-framework) - Native agent and handoff tracing for MAF
   - [Integrations](/docs/integrations) - The four integration layers at a glance
   - [Connector](/sdk/connector) - Register functions as endpoints
 </Callout>


### PR DESCRIPTION
## Purpose
The docs changelog was missing platform releases 0.9.1 and 0.10.0, and still listed Microsoft Agent Framework tracing under Unreleased.

## What Changed
- Added `0.10.0` and `0.9.1` sections to `docs/content/changelog.mdx`
- Moved MAF notes out of Unreleased into 0.9.1, with a link to the MAF tracing guide
- Updated integrations and auto-instrumentation docs so MAF and Pydantic AI appear in the supported-framework lists

## Additional Context
- Roles link: `/docs/organizations/roles`
- MAF link: `/docs/tracing/agent-framework`
- Component changelogs in-repo for 0.10 are still truncated; docs entry was reconstructed from release commits and the SDK changelog

## Testing
- [ ] Preview changelog page renders both new sections
- [ ] Confirm Roles and MAF links resolve
- [ ] Spot-check auto-instrumentation / integrations pages for Pydantic AI + MAF wording