### PR TITLE
fix(notifications): thread project_id into email deep links for cross-project navigation

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/task_notification.py
+++ b/apps/backend/src/rhesis/backend/app/services/task_notification.py
@@ -70,6 +70,11 @@ def send_task_assignment_notification(
             "entity_type": task.entity_type,
             "entity_id": str(task.entity_id) if task.entity_id else None,
             "entity_name": entity_name,
+            # Thread the task's owning project_id into the deep link so the
+            # frontend can switch projects before fetching the task (see #2133).
+            # May be None for tasks without a project — the template guards
+            # with `{% if project_id %}`.
+            "project_id": str(task.project_id) if task.project_id else None,
             "created_at": task.created_at.strftime("%Y-%m-%d %H:%M:%S")
             if task.created_at
             else "N/A",

--- a/apps/backend/src/rhesis/backend/notifications/email/template_service.py
+++ b/apps/backend/src/rhesis/backend/notifications/email/template_service.py
@@ -59,7 +59,12 @@ class TemplateService:
                 "execution_time",
                 "error_message",
                 "frontend_url",
-                # Note: test_run_id and test_set_id are optional (task-specific)
+                # Note: test_run_id, test_set_id, and project_id are optional
+                # (task-specific). project_id is intentionally NOT in this set
+                # so _prepare_context leaves it as None/Undefined when absent,
+                # which the template's `{% if project_id %}` guard correctly
+                # evaluates to False (issue #2133). Adding it here would set
+                # missing values to 'N/A' (truthy) and produce ?project_id=N/A.
             },
             EmailTemplate.TEST_EXECUTION_SUMMARY: {
                 "recipient_name",
@@ -78,6 +83,7 @@ class TemplateService:
                 "endpoint_name",
                 "endpoint_url",
                 "project_name",
+                # project_id is optional — see TASK_COMPLETION note above.
             },
             EmailTemplate.TEAM_INVITATION: {
                 "recipient_name",
@@ -102,6 +108,7 @@ class TemplateService:
                 "created_at",
                 "task_metadata",
                 "frontend_url",
+                # project_id is optional — see TASK_COMPLETION note above.
             },
             EmailTemplate.WELCOME: {
                 "recipient_name",

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/task_assignment.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/task_assignment.html.jinja2
@@ -101,10 +101,17 @@
 
     {%- if frontend_url %}
     <div style="text-align: center; margin: 30px 0;">
-        <a href="{{ frontend_url }}/tasks/{{ task_id }}" 
+        {%- if project_id %}
+        <a href="{{ frontend_url }}/tasks/{{ task_id }}?project_id={{ project_id }}"
            style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
             View Task
         </a>
+        {%- else %}
+        <a href="{{ frontend_url }}/tasks/{{ task_id }}"
+           style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
+            View Task
+        </a>
+        {%- endif %}
     </div>
     {%- endif %}
     

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/task_completion.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/task_completion.html.jinja2
@@ -92,17 +92,31 @@
     {%- if frontend_url %}
         {%- if test_run_id and test_run_id != "N/A" %}
         <div style="text-align: center; margin: 30px 0;">
-            <a href="{{ frontend_url }}/test-runs/{{ test_run_id }}" 
+            {%- if project_id %}
+            <a href="{{ frontend_url }}/test-runs/{{ test_run_id }}?project_id={{ project_id }}"
                style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
                 View Test Run
             </a>
+            {%- else %}
+            <a href="{{ frontend_url }}/test-runs/{{ test_run_id }}"
+               style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
+                View Test Run
+            </a>
+            {%- endif %}
         </div>
         {%- elif test_set_id and test_set_id != "N/A" %}
         <div style="text-align: center; margin: 30px 0;">
-            <a href="{{ frontend_url }}/test-sets/{{ test_set_id }}" 
+            {%- if project_id %}
+            <a href="{{ frontend_url }}/test-sets/{{ test_set_id }}?project_id={{ project_id }}"
                style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
                 View Test Set
             </a>
+            {%- else %}
+            <a href="{{ frontend_url }}/test-sets/{{ test_set_id }}"
+               style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
+                View Test Set
+            </a>
+            {%- endif %}
         </div>
         {%- endif %}
     {%- endif %}

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/test_execution_summary.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/test_execution_summary.html.jinja2
@@ -115,10 +115,17 @@
 
     {%- if frontend_url and test_run_id %}
     <div style="text-align: center; margin: 30px 0;">
+        {%- if project_id %}
+        <a href="{{ frontend_url }}/test-runs/{{ test_run_id }}?project_id={{ project_id }}"
+           style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
+            View Test Run
+        </a>
+        {%- else %}
         <a href="{{ frontend_url }}/test-runs/{{ test_run_id }}"
            style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
             View Test Run
         </a>
+        {%- endif %}
     </div>
     {%- endif %}
 

--- a/apps/backend/src/rhesis/backend/tasks/execution/result_processor.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/result_processor.py
@@ -336,6 +336,17 @@ def get_test_context(test_configuration) -> Tuple[str, str, str, str]:
     return test_set_name, endpoint_name, endpoint_url, project_name
 
 
+def get_test_run_project_id(test_run) -> Optional[str]:
+    """
+    Return the test run's project_id as a string, or None.
+
+    Used by email deep-link rendering so the frontend can switch to the
+    owning project before fetching the test run (see issue #2133).
+    """
+    project_id = getattr(test_run, "project_id", None)
+    return str(project_id) if project_id else None
+
+
 def calculate_execution_time(
     test_run: TestRun, completion_time: datetime, logger_func
 ) -> Optional[str]:
@@ -519,6 +530,7 @@ def build_summary_data(
     endpoint_url: str,
     project_name: str,
     completion_time: datetime,
+    project_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Build the summary data dictionary to return from the task.
@@ -537,6 +549,10 @@ def build_summary_data(
         endpoint_url: URL of the endpoint
         project_name: Name of the project
         completion_time: Completion timestamp
+        project_id: UUID string of the test run's owning project. Threaded into
+            email deep links so the frontend can switch to the owning project
+            before fetching the test run (see issue #2133). ``None`` when the
+            test run has no project_id — templates guard with ``{% if project_id %}``.
 
     Returns:
         Dictionary containing test execution summary
@@ -555,6 +571,7 @@ def build_summary_data(
         "endpoint_name": endpoint_name,
         "endpoint_url": endpoint_url,
         "project_name": project_name,
+        "project_id": project_id,
         "completed_at": completion_time.strftime("%Y-%m-%d %H:%M:%S"),
     }
 
@@ -614,6 +631,7 @@ class TestRunProcessor:
                 "",
                 "",
                 completion_time,
+                project_id=get_test_run_project_id(test_run),
             )
 
         # Calculate test statistics using SQL aggregation
@@ -665,4 +683,5 @@ class TestRunProcessor:
             endpoint_url,
             project_name,
             completion_time,
+            project_id=get_test_run_project_id(test_run),
         )

--- a/apps/backend/src/rhesis/backend/tasks/test_set.py
+++ b/apps/backend/src/rhesis/backend/tasks/test_set.py
@@ -220,7 +220,15 @@ def _build_task_result(
     org_id: str,
     user_id: str,
 ) -> dict:
-    """Build the comprehensive task result dictionary."""
+    """Build the comprehensive task result dictionary.
+
+    The returned dict is forwarded to the email template (TASK_COMPLETION) by
+    BaseTask.on_success → _send_task_completion_email. ``project_id`` is
+    included so the "View Test Set" deep link can switch the frontend to the
+    owning project before fetching the test set (see issue #2133). It is
+    ``None`` when the test set has no project — the template guards with
+    ``{% if project_id %}``.
+    """
     return {
         "test_set_id": str(db_test_set.id),
         "test_set_name": db_test_set.name,
@@ -234,6 +242,9 @@ def _build_task_result(
         "metadata": db_test_set.attributes.get("metadata", {}) if db_test_set.attributes else {},
         "organization_id": org_id,
         "user_id": user_id,
+        # Thread the test set's project_id into the email deep link so the
+        # frontend can switch projects before fetching the test set (#2133).
+        "project_id": str(db_test_set.project_id) if db_test_set.project_id else None,
         "save_successful": True,
     }
 

--- a/apps/frontend/middleware.ts
+++ b/apps/frontend/middleware.ts
@@ -1,0 +1,11 @@
+// Next.js middleware entrypoint.
+//
+// The middleware logic itself lives in `./src/proxy.ts` (so it can be unit-tested
+// in isolation), but Next.js only invokes middleware from a top-level
+// `middleware.ts` file at the project root. Without this entrypoint the proxy
+// is dead code.
+//
+// `export { proxy as middleware }` is the canonical Next.js pattern for
+// re-exporting a middleware function from a non-default file. `config` is
+// the matcher configuration consumed by Next.js.
+export { proxy as middleware, config } from './src/proxy';

--- a/apps/frontend/src/__tests__/middleware.test.ts
+++ b/apps/frontend/src/__tests__/middleware.test.ts
@@ -90,6 +90,19 @@ describe('applyProjectDeepLink — project deep-link switching (issue 2133)', ()
       expect(res).toBeNull();
       expect(req.cookies.get(ACTIVE_PROJECT_COOKIE)?.value).toBe(OTHER_UUID);
     });
+
+    it('returns null when path is outside the email deep-link scope (e.g. /traces)', () => {
+      // /traces legitimately carries ?project_id= as a list filter, not a
+      // cross-project navigation cue — silently switching the cookie there
+      // would surprise the user. See peqy's "Also" note in rev_01KY3WFCZWWWGH3EBN7W13WTGH.
+      const req = buildRequest('/traces', {
+        project_id: TARGET_UUID,
+        cookies: { [ACTIVE_PROJECT_COOKIE]: OTHER_UUID },
+      });
+      const res = applyProjectDeepLink(req);
+      expect(res).toBeNull();
+      expect(req.cookies.get(ACTIVE_PROJECT_COOKIE)?.value).toBe(OTHER_UUID);
+    });
   });
 
   describe('cookie switching (returns NextResponse with Set-Cookie)', () => {

--- a/apps/frontend/src/__tests__/middleware.test.ts
+++ b/apps/frontend/src/__tests__/middleware.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @jest-environment node
+ *
+ * Project deep-link switching (issue 2133) tests.
+ *
+ * The deep-link logic lives in `applyProjectDeepLink` in `src/proxy.ts` —
+ * extracted from the legacy `src/middleware.ts` (removed when the repo
+ * migrated to Next.js's `proxy.ts` pattern in #2183). The full `proxy()`
+ * function's auth/session contract is covered by `proxy.test.ts`; this
+ * suite pins down only the deep-link switching branch.
+ *
+ * Runs in the node environment because NextRequest/NextResponse need the
+ * fetch-API globals (Request, Headers) that jest-environment-jsdom strips.
+ */
+import { NextRequest } from 'next/server';
+import { applyProjectDeepLink } from '../proxy';
+import { ACTIVE_PROJECT_COOKIE } from '../utils/active-project';
+
+// Fixed UUIDs for deterministic tests. Both match the UUID pattern in
+// proxy.ts so the validation branch is exercised honestly.
+const TARGET_UUID = '12345678-1234-1234-1234-123456789abc';
+const OTHER_UUID = '87654321-4321-4321-4321-210987654321';
+
+/**
+ * Build a NextRequest as proxy() would receive it: a path, optional
+ * `?project_id=` query param, and optional incoming cookies.
+ *
+ * Cookies are set via the `Cookie` request header (the same wire format
+ * the browser sends) rather than via a cookies API so we exercise the
+ * real NextRequest parsing path.
+ */
+function buildRequest(
+  path: string,
+  opts: {
+    project_id?: string;
+    cookies?: Record<string, string>;
+  } = {}
+): NextRequest {
+  const url = new URL(path, 'http://localhost:3000');
+  if (opts.project_id !== undefined) {
+    url.searchParams.set('project_id', opts.project_id);
+  }
+  const headers = new Headers();
+  if (opts.cookies) {
+    const cookieHeader = Object.entries(opts.cookies)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('; ');
+    if (cookieHeader) headers.set('cookie', cookieHeader);
+  }
+  return new NextRequest(url, { headers });
+}
+
+describe('applyProjectDeepLink — project deep-link switching (issue 2133)', () => {
+  describe('no-op branches (returns null)', () => {
+    it('returns null when project_id is absent', () => {
+      const req = buildRequest('/test-runs/abc');
+      const res = applyProjectDeepLink(req);
+      expect(res).toBeNull();
+      // Request cookies must be untouched.
+      expect(req.cookies.get(ACTIVE_PROJECT_COOKIE)?.value).toBeUndefined();
+    });
+
+    it('returns null when project_id is not a UUID', () => {
+      const req = buildRequest('/test-runs/abc', {
+        project_id: 'not-a-uuid',
+      });
+      const res = applyProjectDeepLink(req);
+      expect(res).toBeNull();
+      // A malformed value must NOT overwrite an existing cookie.
+      expect(req.cookies.get(ACTIVE_PROJECT_COOKIE)?.value).toBeUndefined();
+    });
+
+    it('returns null when project_id matches the current cookie', () => {
+      const req = buildRequest('/test-runs/abc', {
+        project_id: TARGET_UUID,
+        cookies: { [ACTIVE_PROJECT_COOKIE]: TARGET_UUID },
+      });
+      const res = applyProjectDeepLink(req);
+      expect(res).toBeNull();
+      // No mutation needed when already on the target project.
+      expect(req.cookies.get(ACTIVE_PROJECT_COOKIE)?.value).toBe(TARGET_UUID);
+    });
+
+    it('does not clobber an existing different project cookie when project_id is malformed', () => {
+      const req = buildRequest('/test-runs/abc', {
+        project_id: 'literally-anything',
+        cookies: { [ACTIVE_PROJECT_COOKIE]: OTHER_UUID },
+      });
+      const res = applyProjectDeepLink(req);
+      expect(res).toBeNull();
+      expect(req.cookies.get(ACTIVE_PROJECT_COOKIE)?.value).toBe(OTHER_UUID);
+    });
+  });
+
+  describe('cookie switching (returns NextResponse with Set-Cookie)', () => {
+    it('sets the project cookie on the response when no current cookie exists', () => {
+      const req = buildRequest('/test-runs/abc', {
+        project_id: TARGET_UUID,
+      });
+      const res = applyProjectDeepLink(req);
+      expect(res).not.toBeNull();
+      const setCookie = res!.headers.get('set-cookie');
+      expect(setCookie).not.toBeNull();
+      expect(setCookie).toContain(`${ACTIVE_PROJECT_COOKIE}=${TARGET_UUID}`);
+      expect(setCookie).toMatch(/Path=\/(?:;|$)/i);
+      expect(setCookie).toMatch(/SameSite=Lax/i);
+      // max-age must match writeActiveProjectId (1 year) so the server-
+      // and client-side writes produce identical cookies.
+      expect(setCookie).toMatch(/Max-Age=31536000/i);
+    });
+
+    it('sets the project cookie on the response when a different cookie exists', () => {
+      const req = buildRequest('/test-runs/abc', {
+        project_id: TARGET_UUID,
+        cookies: { [ACTIVE_PROJECT_COOKIE]: OTHER_UUID },
+      });
+      const res = applyProjectDeepLink(req);
+      expect(res).not.toBeNull();
+      const setCookie = res!.headers.get('set-cookie');
+      expect(setCookie).not.toBeNull();
+      expect(setCookie).toContain(`${ACTIVE_PROJECT_COOKIE}=${TARGET_UUID}`);
+      // The OLD value must NOT also be present.
+      expect(setCookie).not.toContain(`${ACTIVE_PROJECT_COOKIE}=${OTHER_UUID}`);
+    });
+  });
+
+  describe('C1 regression — request cookie propagation', () => {
+    // The whole point of the deep-link switch is that the FIRST server-
+    // rendered fetch sees the new project_id. `response.cookies.set()`
+    // only adds a `Set-Cookie` response header (browser stores it for
+    // the NEXT navigation). Server components' `cookies()` reads the
+    // CURRENT request's `Cookie` header — so the helper must also mutate
+    // the incoming request's cookies via `request.cookies.set()`.
+    //
+    // Without this fix the deep-linked page would still 404 on first hit
+    // because the server fetch runs with the OLD project_id cookie.
+    it('mutates the INCOMING request cookies so downstream cookies() sees the new project_id', () => {
+      const req = buildRequest('/test-runs/abc', {
+        project_id: TARGET_UUID,
+        cookies: { [ACTIVE_PROJECT_COOKIE]: OTHER_UUID },
+      });
+      // Pre-condition: cookie starts as OTHER_UUID.
+      expect(req.cookies.get(ACTIVE_PROJECT_COOKIE)?.value).toBe(OTHER_UUID);
+      applyProjectDeepLink(req);
+      // Post-condition: cookie on the REQUEST is now TARGET_UUID.
+      expect(req.cookies.get(ACTIVE_PROJECT_COOKIE)?.value).toBe(TARGET_UUID);
+    });
+
+    it('mutates the request Cookie header (downstream reads via headers, not cookies API)', () => {
+      const req = buildRequest('/test-runs/abc', {
+        project_id: TARGET_UUID,
+        cookies: { [ACTIVE_PROJECT_COOKIE]: OTHER_UUID },
+      });
+      applyProjectDeepLink(req);
+      // The Cookie header itself must reflect the new value — this is
+      // what gets forwarded via NextResponse.next({ request: { headers } }).
+      const cookieHeader = req.headers.get('cookie') ?? '';
+      expect(cookieHeader).toContain(`${ACTIVE_PROJECT_COOKIE}=${TARGET_UUID}`);
+      expect(cookieHeader).not.toContain(
+        `${ACTIVE_PROJECT_COOKIE}=${OTHER_UUID}`
+      );
+    });
+
+    it('also sets the response Set-Cookie for browser persistence (both paths covered)', () => {
+      const req = buildRequest('/test-runs/abc', {
+        project_id: TARGET_UUID,
+        cookies: { [ACTIVE_PROJECT_COOKIE]: OTHER_UUID },
+      });
+      const res = applyProjectDeepLink(req);
+      // C1 fix: request-side mutation.
+      expect(req.cookies.get(ACTIVE_PROJECT_COOKIE)?.value).toBe(TARGET_UUID);
+      // Browser persistence: response-side Set-Cookie.
+      expect(res!.headers.get('set-cookie')).toContain(
+        `${ACTIVE_PROJECT_COOKIE}=${TARGET_UUID}`
+      );
+    });
+  });
+
+  describe('matcher coverage', () => {
+    // The matcher in proxy.ts covers all non-static paths; the deep-link
+    // helper itself is URL-agnostic and would handle each project-scoped
+    // detail path identically. These tests document that intent.
+    it.each([
+      '/test-runs/abc',
+      '/test-sets/abc',
+      '/tasks/abc',
+      '/test-runs/abc/compare', // trailing sub-route
+    ])('switches project on matched path %s', path => {
+      const req = buildRequest(path, {
+        project_id: TARGET_UUID,
+        cookies: { [ACTIVE_PROJECT_COOKIE]: OTHER_UUID },
+      });
+      const res = applyProjectDeepLink(req);
+      expect(res).not.toBeNull();
+      expect(res!.headers.get('set-cookie')).toContain(
+        `${ACTIVE_PROJECT_COOKIE}=${TARGET_UUID}`
+      );
+      expect(req.cookies.get(ACTIVE_PROJECT_COOKIE)?.value).toBe(TARGET_UUID);
+    });
+  });
+});

--- a/apps/frontend/src/proxy.ts
+++ b/apps/frontend/src/proxy.ts
@@ -14,6 +14,7 @@ import {
   getServerBackendUrl,
   shouldUseSecureCookies,
 } from './utils/url-resolver';
+import { ACTIVE_PROJECT_COOKIE } from './utils/active-project';
 
 const decodeBase64 =
   globalThis.atob ??
@@ -144,7 +145,102 @@ async function createSessionClearingResponse(
   return response;
 }
 
+// UUID pattern for `?project_id=<uuid>` deep links from backend email
+// notifications. See `applyProjectDeepLink` below.
+const UUID_PATTERN =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+// Cookie max-age must match writeActiveProjectId() so server- and
+// client-side writes produce identical cookies (no shadowing).
+const PROJECT_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+/**
+ * Proactively switch the active project when a project-scoped detail page is
+ * reached via a deep link carrying `?project_id=<uuid>`.
+ *
+ * Backend email notifications thread the entity's owning project_id into
+ * every project-scoped deep link (see issue 2133). Without this switch, the
+ * target page's server component would fetch with the currently selected
+ * project's cookie, 404 against the project-scoped API, and fall through to
+ * `notFound()` before any client-side switcher could run.
+ *
+ * Running here — before the auth/session checks — lets us set the
+ * `rh_active_project_id` cookie so `getServerActiveProjectId()` returns the
+ * owning project on the very first server-rendered fetch. Auth still runs
+ * afterwards on the (now project-correct) request.
+ *
+ * Returns `null` when no switching is needed so the caller can fall through
+ * to the rest of the proxy logic.
+ */
+export function applyProjectDeepLink(
+  request: NextRequest
+): NextResponse | null {
+  const projectId = request.nextUrl.searchParams.get('project_id');
+
+  // No project_id in URL — normal navigation, no-op.
+  if (!projectId) {
+    return null;
+  }
+
+  // Reject malformed project_id — don't blindly trust a query param.
+  // A non-UUID value would otherwise overwrite the cookie with garbage and
+  // break the user's session.
+  if (!UUID_PATTERN.test(projectId)) {
+    return null;
+  }
+
+  const currentProjectId = request.cookies.get(ACTIVE_PROJECT_COOKIE)?.value;
+
+  // Already on the correct project — no-op, avoids a Set-Cookie header on
+  // every intra-project navigation that happens to carry ?project_id.
+  if (currentProjectId === projectId) {
+    return null;
+  }
+
+  // Mutate the INCOMING request's Cookie header FIRST.
+  //
+  // `response.cookies.set()` only adds a `Set-Cookie` response header —
+  // the browser stores it for the NEXT navigation, but `cookies()` from
+  // `next/headers` reads the CURRENT request's `Cookie` header, which is
+  // unchanged. The server component on this same request would still see
+  // the OLD project_id cookie and 404 against the project-scoped API.
+  //
+  // `NextRequest.cookies` is a `RequestCookies` whose `set()` mutates the
+  // underlying `Cookie` header on `request.headers`. Then we forward that
+  // modified headers object via `NextResponse.next({ request: { headers } })`,
+  // which is how middleware propagates header changes to downstream server
+  // components in a single request (no extra round-trip, no 404 flash).
+  //
+  // See: https://nextjs.org/docs/app/api-reference/functions/next-request#cookies
+  request.cookies.set(ACTIVE_PROJECT_COOKIE, projectId);
+
+  const response = NextResponse.next({
+    request: {
+      headers: request.headers,
+    },
+  });
+
+  // ALSO set on the response so the browser persists it for future
+  // navigations (otherwise the cookie would only live for this single
+  // request and the next navigation would lose the project switch).
+  response.cookies.set(ACTIVE_PROJECT_COOKIE, projectId, {
+    path: '/',
+    maxAge: PROJECT_COOKIE_MAX_AGE,
+    sameSite: 'lax',
+  });
+
+  return response;
+}
+
 export async function proxy(request: NextRequest) {
+  // Apply project deep-link switching before auth/session checks so the
+  // first server-rendered fetch sees the correct project. Auth still runs
+  // on the (now project-correct) request via the fall-through below.
+  const deepLinkResponse = applyProjectDeepLink(request);
+  if (deepLinkResponse) {
+    return deepLinkResponse;
+  }
+
   const pathname = request.nextUrl.pathname;
 
   // At the top of the middleware function, after pathname declaration

--- a/apps/frontend/src/proxy.ts
+++ b/apps/frontend/src/proxy.ts
@@ -150,6 +150,13 @@ async function createSessionClearingResponse(
 const UUID_PATTERN =
   /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
 
+// Email deep-link detail routes — the only paths whose `?project_id=` is a
+// cross-project navigation cue (backend templates always link to a specific
+// entity under one of these prefixes). Other routes may legitimately carry
+// `?project_id=` as a filter (e.g. /traces) where silently switching the
+// active project cookie would be surprising, so scope the switch here.
+const DEEP_LINK_PATH_PREFIXES = ['/test-runs/', '/test-sets/', '/tasks/'];
+
 // Cookie max-age must match writeActiveProjectId() so server- and
 // client-side writes produce identical cookies (no shadowing).
 const PROJECT_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
@@ -186,6 +193,15 @@ export function applyProjectDeepLink(
   // A non-UUID value would otherwise overwrite the cookie with garbage and
   // break the user's session.
   if (!UUID_PATTERN.test(projectId)) {
+    return null;
+  }
+
+  // Scope the switch to email deep-link detail routes only. Other paths may
+  // carry a valid `?project_id=<uuid>` for a different purpose (e.g. /traces
+  // uses it as a list filter), where silently switching the active project
+  // would surprise the user.
+  const pathname = request.nextUrl.pathname;
+  if (!DEEP_LINK_PATH_PREFIXES.some(prefix => pathname.startsWith(prefix))) {
     return null;
   }
 

--- a/tests/backend/notifications/__init__.py
+++ b/tests/backend/notifications/__init__.py
@@ -1,0 +1,8 @@
+"""
+Notifications testing module for Rhesis backend.
+
+This module contains tests for notification-related functionality including:
+- Email template rendering
+- Deep link generation with project context
+- Template variable threading
+"""

--- a/tests/backend/notifications/test_email_project_id_deep_link.py
+++ b/tests/backend/notifications/test_email_project_id_deep_link.py
@@ -1,0 +1,200 @@
+"""
+Unit tests for project_id deep-link rendering in email templates (issue #2133).
+
+These tests verify that the three project-scoped email templates
+(TEST_EXECUTION_SUMMARY, TASK_COMPLETION, TASK_ASSIGNMENT) emit
+``?project_id=<uuid>`` in their deep links when a project_id is supplied,
+and omit the query param entirely when project_id is None/undefined.
+
+The tests render the actual Jinja2 templates via TemplateService, so they
+catch regressions in both the template markup and the
+``_prepare_context`` plumbing (project_id must NOT be in the required
+variables set, otherwise missing values become 'N/A' (truthy) and the
+guard fails — see template_service.py).
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from rhesis.backend.notifications.email.template_service import (
+    EmailTemplate,
+    TemplateService,
+)
+
+# All templates deep-link to ``{frontend_url}`` and require a non-empty
+# value — passing a placeholder keeps the assertion focused on the
+# project_id query param rather than the URL itself.
+_FRONTEND_URL = "https://app.example.test"
+
+
+def _base_summary_vars(**overrides):
+    """Minimum variables for TEST_EXECUTION_SUMMARY to render without N/A noise."""
+    base = {
+        "recipient_name": "Tester",
+        "task_name": "Run #1",
+        "task_id": "task-1",
+        "status": "success",
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "total_tests": 10,
+        "tests_passed": 8,
+        "tests_failed": 2,
+        "execution_time": "1m",
+        "test_run_id": "tr-1",
+        "status_details": "8 passed, 2 failed",
+        "test_set_name": "Smoke",
+        "endpoint_name": "Prod",
+        "endpoint_url": "https://endpoint.example.test",
+        "project_name": "Demo",
+        "frontend_url": _FRONTEND_URL,
+    }
+    base.update(overrides)
+    return base
+
+
+def _base_completion_vars(**overrides):
+    """Minimum variables for TASK_COMPLETION (test_run_id path) to render."""
+    base = {
+        "recipient_name": "Tester",
+        "task_name": "Run #1",
+        "task_id": "task-1",
+        "status": "success",
+        "completed_at": datetime.now(timezone.utc).isoformat(),
+        "execution_time": "1m",
+        "error_message": "",
+        "frontend_url": _FRONTEND_URL,
+        "test_run_id": "tr-1",
+    }
+    base.update(overrides)
+    return base
+
+
+def _base_assignment_vars(**overrides):
+    """Minimum variables for TASK_ASSIGNMENT to render."""
+    base = {
+        "assignee_name": "Alice",
+        "assigner_name": "Bob",
+        "task_title": "Review",
+        "task_description": "Please review",
+        "task_id": "task-1",
+        "status_name": "In Progress",
+        "priority_name": "High",
+        "entity_type": "test_run",
+        "entity_id": "tr-1",
+        "entity_name": "Run #1",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "task_metadata": {},
+        "frontend_url": _FRONTEND_URL,
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture(scope="module")
+def template_service():
+    """Module-scoped fixture — TemplateService loads templates from disk once."""
+    return TemplateService()
+
+
+@pytest.mark.unit
+class TestTestExecutionSummaryDeepLink:
+    """TEST_EXECUTION_SUMMARY deep link includes ?project_id when set."""
+
+    def test_includes_project_id_when_set(self, template_service):
+        project_id = str(uuid.uuid4())
+        html = template_service.render_template(
+            EmailTemplate.TEST_EXECUTION_SUMMARY,
+            _base_summary_vars(project_id=project_id),
+        )
+        # Must include the query param with the exact project_id value.
+        assert f"?project_id={project_id}" in html
+        # And must NOT include the bare deep link (no query param) — the
+        # {% if project_id %} branch must win over the {% else %} branch.
+        assert 'href="https://app.example.test/test-runs/tr-1"' not in html
+
+    def test_omits_project_id_when_none(self, template_service):
+        # project_id explicitly None (test run without a project) → the
+        # {% else %} branch must render the bare deep link with no query param.
+        html = template_service.render_template(
+            EmailTemplate.TEST_EXECUTION_SUMMARY,
+            _base_summary_vars(project_id=None),
+        )
+        assert "?project_id=" not in html
+        assert 'href="https://app.example.test/test-runs/tr-1"' in html
+
+    def test_omits_project_id_when_omitted(self, template_service):
+        # Backward compat: when project_id is not in the variables dict at
+        # all (legacy caller), _prepare_context leaves it Undefined → the
+        # {% else %} branch must render the bare deep link.
+        html = template_service.render_template(
+            EmailTemplate.TEST_EXECUTION_SUMMARY,
+            _base_summary_vars(),  # no project_id key
+        )
+        assert "?project_id=" not in html
+        assert 'href="https://app.example.test/test-runs/tr-1"' in html
+
+
+@pytest.mark.unit
+class TestTaskCompletionDeepLink:
+    """TASK_COMPLETION deep link switches between test_run_id and test_set_id."""
+
+    def test_test_run_path_includes_project_id(self, template_service):
+        project_id = str(uuid.uuid4())
+        html = template_service.render_template(
+            EmailTemplate.TASK_COMPLETION,
+            _base_completion_vars(project_id=project_id),
+        )
+        assert f"/test-runs/tr-1?project_id={project_id}" in html
+
+    def test_test_run_path_omits_project_id_when_none(self, template_service):
+        html = template_service.render_template(
+            EmailTemplate.TASK_COMPLETION,
+            _base_completion_vars(project_id=None),
+        )
+        assert "?project_id=" not in html
+        assert 'href="https://app.example.test/test-runs/tr-1"' in html
+
+    def test_test_set_path_includes_project_id(self, template_service):
+        # When test_run_id is absent/None but test_set_id is present, the
+        # deep link points at /test-sets/<id> — project_id must thread
+        # through that branch too.
+        project_id = str(uuid.uuid4())
+        vars_ = _base_completion_vars(
+            project_id=project_id,
+            test_run_id=None,
+            test_set_id="ts-1",
+        )
+        html = template_service.render_template(EmailTemplate.TASK_COMPLETION, vars_)
+        assert f"/test-sets/ts-1?project_id={project_id}" in html
+
+    def test_test_set_path_omits_project_id_when_none(self, template_service):
+        vars_ = _base_completion_vars(
+            project_id=None,
+            test_run_id=None,
+            test_set_id="ts-1",
+        )
+        html = template_service.render_template(EmailTemplate.TASK_COMPLETION, vars_)
+        assert "?project_id=" not in html
+        assert 'href="https://app.example.test/test-sets/ts-1"' in html
+
+
+@pytest.mark.unit
+class TestTaskAssignmentDeepLink:
+    """TASK_ASSIGNMENT deep link includes ?project_id when set."""
+
+    def test_includes_project_id_when_set(self, template_service):
+        project_id = str(uuid.uuid4())
+        html = template_service.render_template(
+            EmailTemplate.TASK_ASSIGNMENT,
+            _base_assignment_vars(project_id=project_id),
+        )
+        assert f"/tasks/task-1?project_id={project_id}" in html
+
+    def test_omits_project_id_when_none(self, template_service):
+        html = template_service.render_template(
+            EmailTemplate.TASK_ASSIGNMENT,
+            _base_assignment_vars(project_id=None),
+        )
+        assert "?project_id=" not in html
+        assert 'href="https://app.example.test/tasks/task-1"' in html

--- a/tests/backend/tasks/_heavy_import_stubs.py
+++ b/tests/backend/tasks/_heavy_import_stubs.py
@@ -1,0 +1,143 @@
+"""Install sys.meta_path stubs for the SDK's heavy optional dependencies.
+
+The ``rhesis.backend.tasks`` package eagerly imports ``embedding``,
+``endpoint``, ``execution``, ``example_task``, etc. Each of those
+transitively pulls in ``rhesis.backend.metrics`` → ``rhesis.sdk.metrics``
+→ ``ragas`` / ``deepeval`` / ``langchain_core`` / ... — a
+deep tree of optional SDK deps that aren't installed in the lightweight
+backend test venv.
+
+The pure data-transformation functions under test (``build_summary_data``,
+``get_test_run_project_id``, ``_build_task_result``) don't actually call
+into any of these — so stubbing the missing modules lets the import chain
+complete without forcing a full SDK install (torch, langchain, etc.) just
+to run a unit test.
+
+``litellm`` is intentionally NOT stubbed even though the SDK's metrics
+module imports it: litellm IS installed in the backend test venv (it's a
+direct dependency of ``rhesis.backend``), and stubbing it leaks into
+every other test in the session via ``sys.meta_path`` — the dummy class
+returned by the stub is missing real litellm's
+``LiteLLMProxyChatConfig._should_use_litellm_proxy_by_default`` attribute,
+which causes unrelated ``tests/backend/services/telemetry/test_enrichment.py``
+tests to fail with ``AttributeError``. Only truly-absent deps are stubbed.
+
+Usage:
+    Just import this module at the top of a test file:
+
+        from tests.backend.tasks._heavy_import_stubs import _  # noqa: F401
+
+    The import has the side effect of installing the meta path finder.
+
+Design notes:
+    A ``sys.meta_path`` finder is used rather than a static
+    ``sys.modules`` stub list because the SDK's lazy ``__getattr__``
+    import pattern pulls in new submodules at runtime (e.g.
+    ``ragas.llms``, ``deepeval.test_case``). The finder catches every
+    ``ModuleNotFoundError`` for the known-heavy dependency trees and
+    returns a stub module whose ``__getattr__`` yields dummy classes,
+    so ``from ragas.metrics import AnswerAccuracy`` resolves whether or
+    not the real ``ragas`` package is installed.
+"""
+
+import importlib.abc
+import importlib.machinery
+import sys
+import types
+
+# Top-level packages (and dotted prefixes) we're willing to stub.
+# Anything starting with one of these prefixes will be stubbed on first
+# import. Rhesis's own packages (``rhesis.backend``, ``rhesis.sdk``) are
+# NOT in this list — those must come from the real source tree.
+_STUBBABLE_PREFIXES = (
+    "ragas",
+    "deepeval",
+    "deepteam",
+    "langchain",
+    "langchain_core",
+    "langchain_google_genai",
+)
+
+
+class _StubModule(types.ModuleType):
+    """Module stub that returns dummy attributes for any name access."""
+
+    # Mark as a package so ``from <stub>.submod import X`` resolves to a
+    # stub child instead of triggering a real filesystem search.
+    __path__: list = []
+
+    def __getattr__(self, name):
+        # Return a dummy class so ``class Foo(StubbedClass):`` style
+        # imports (if any) also don't crash. Instantiations are never
+        # reached because the functions under test don't invoke metric
+        # code paths.
+        return type(name, (), {})
+
+
+class _StubLoader(importlib.abc.Loader):
+    def create_module(self, spec):
+        return _StubModule(spec.name)
+
+    def exec_module(self, module):
+        # No-op: the stub is fully populated by ``__getattr__`` at
+        # attribute-access time. We don't need to execute any real code.
+        pass
+
+
+class _StubFinder(importlib.abc.MetaPathFinder):
+    """Meta path finder that returns stub loaders for heavy deps.
+
+    Only matches modules whose dotted name starts with one of
+    ``_STUBBABLE_PREFIXES``. Other imports fall through to the standard
+    finders, so genuine ``ModuleNotFoundError`` (e.g. a typo'd rhesis
+    module) still surfaces.
+
+    Even when a prefix matches, the finder FIRST defers to
+    ``importlib.machinery.PathFinder.find_spec()`` to check whether the
+    real package is actually installed on ``sys.path``. Only when the
+    real package truly isn't available does it return a stub ``ModuleSpec``.
+    This prevents the stub from shadowing a real install — without this
+    check, inserting the finder at ``sys.meta_path[0]`` would stub
+    ``langchain``/``langchain_core``/etc. even in venvs where those
+    packages are present, and the dummy ``_StubModule.__getattr__`` class
+    would leak into every other test in the same pytest session (see peqy
+    review rev_01KY3T1YY0NK0SC81Z3BZH8XFD, and the ``litellm`` write-up
+    above for the failure mode this guards against).
+    """
+
+    def find_spec(self, fullname, path, target=None):
+        if not any(
+            fullname == prefix or fullname.startswith(prefix + ".")
+            for prefix in _STUBBABLE_PREFIXES
+        ):
+            return None
+        # Defer to the standard path finder FIRST. If the real package is
+        # installed on sys.path, return None so the import machinery falls
+        # through to the standard finders and resolves to the genuine module.
+        # ``PathFinder.find_spec`` is a static method that walks sys.path
+        # directly (it doesn't recurse into sys.meta_path), so this won't
+        # re-enter our finder.
+        real_spec = importlib.machinery.PathFinder.find_spec(fullname, path)
+        if real_spec is not None:
+            return None
+        # Real package truly isn't available — stub it so the SDK's eager
+        # import chain completes without forcing a full install of
+        # torch/langchain/ragas just to run a unit test.
+        return importlib.machinery.ModuleSpec(
+            fullname,
+            _StubLoader(),
+            is_package=True,
+        )
+
+
+# Insert at the front of sys.meta_path so we get first crack at every
+# import. ``find_spec`` only stubs modules whose prefix is in
+# ``_STUBBABLE_PREFIXES`` AND whose real package can't be found via
+# ``PathFinder.find_spec()`` — so inserting at the front is safe even
+# for stubbable prefixes that ARE installed (the check short-circuits
+# and lets the standard finders handle them normally).
+#
+# Idempotent: skip if already installed (e.g. when multiple test modules
+# import this stub helper in the same session).
+if not any(isinstance(f, _StubFinder) for f in sys.meta_path):
+    sys.meta_path.insert(0, _StubFinder())

--- a/tests/backend/tasks/test_result_processor_project_id.py
+++ b/tests/backend/tasks/test_result_processor_project_id.py
@@ -1,0 +1,187 @@
+"""
+Unit tests for project_id threading through email deep links (issue #2133).
+
+These tests verify that:
+1. ``build_summary_data`` carries ``project_id`` into the template context.
+2. ``get_test_run_project_id`` converts the TestRun's project_id to a string
+   (or None) so Jinja2's truthiness guard works correctly.
+3. The TestSet task result builder (``_build_task_result``) threads the test
+   set's ``project_id`` so the TASK_COMPLETION email deep link can switch
+   projects.
+
+The tests are intentionally DB-free — they exercise pure data-transformation
+functions with a MagicMock TestRun/TestSet, so they run in milliseconds and
+don't require the testcontainers stack.
+"""
+
+# Side-effect import: installs a sys.meta_path finder that stubs out the
+# SDK's heavy optional deps (ragas, deepeval, litellm, langchain, ...) so
+# the ``rhesis.backend.tasks`` package's eager imports complete without
+# pulling in torch/langchain just to run a unit test. See
+# _heavy_import_stubs.py for the rationale and the stubbed module list.
+#
+# MUST run before any ``from rhesis.backend...`` import. We do it via
+# ``importlib.import_module`` (rather than a top-level ``import``) so ruff's
+# isort doesn't reorder it after the rhesis imports — isort doesn't treat
+# runtime ``importlib.import_module`` calls as module-level imports.
+import importlib as _importlib
+
+_importlib.import_module("tests.backend.tasks._heavy_import_stubs")
+
+import uuid  # noqa: E402
+from datetime import datetime  # noqa: E402
+from unittest.mock import MagicMock  # noqa: E402
+
+import pytest  # noqa: E402
+
+from rhesis.backend.tasks import test_set as test_set_module  # noqa: E402
+from rhesis.backend.tasks.execution.result_processor import (  # noqa: E402
+    build_summary_data,
+    get_test_run_project_id,
+)
+
+
+def _make_summary_kwargs(**overrides):
+    """Build the minimum kwargs build_summary_data accepts, with overrides."""
+    base = {
+        "test_run_id": "tr-1",
+        "email_status": "success",
+        "execution_status": "Complete",
+        "total_tests": 10,
+        "tests_passed": 8,
+        "tests_failed": 2,
+        "execution_errors": 0,
+        "execution_time": "1m 30s",
+        "test_set_name": "Smoke",
+        "endpoint_name": "Prod",
+        "endpoint_url": "https://example.com",
+        "project_name": "Demo",
+        "completion_time": datetime(2026, 1, 1, 12, 0, 0),
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.unit
+class TestBuildSummaryDataProjectId:
+    """build_summary_data must thread project_id into the returned dict."""
+
+    def test_returns_project_id_when_provided(self):
+        project_id = str(uuid.uuid4())
+        result = build_summary_data(**_make_summary_kwargs(project_id=project_id))
+        assert result["project_id"] == project_id
+
+    def test_defaults_project_id_to_none_when_omitted(self):
+        # When the caller doesn't pass project_id at all (e.g. legacy code
+        # paths that haven't been updated), it must default to None — NOT
+        # be missing from the dict — so the Jinja2 template's
+        # `{% if project_id %}` guard evaluates to False rather than
+        # raising UndefinedError.
+        result = build_summary_data(**_make_summary_kwargs())
+        assert result["project_id"] is None
+
+    def test_defaults_project_id_to_none_when_explicitly_none(self):
+        # Test runs without a project should pass None explicitly via
+        # get_test_run_project_id(); the function must preserve None
+        # rather than coercing to a string.
+        result = build_summary_data(**_make_summary_kwargs(project_id=None))
+        assert result["project_id"] is None
+
+    def test_preserves_all_other_keys(self):
+        # Regression guard: adding project_id must not displace any
+        # existing key — downstream consumers (email subject line, status
+        # details) still need to read them.
+        project_id = str(uuid.uuid4())
+        result = build_summary_data(**_make_summary_kwargs(project_id=project_id))
+        for key in (
+            "test_run_id",
+            "status",
+            "execution_status",
+            "total_tests",
+            "tests_passed",
+            "tests_failed",
+            "execution_errors",
+            "execution_time",
+            "status_details",
+            "test_set_name",
+            "endpoint_name",
+            "endpoint_url",
+            "project_name",
+            "completed_at",
+        ):
+            assert key in result, f"project_id addition dropped {key}"
+
+
+@pytest.mark.unit
+class TestGetTestRunProjectId:
+    """get_test_run_project_id converts the model's UUID to a string for Jinja2."""
+
+    def test_returns_string_when_project_id_set(self):
+        project_id = uuid.uuid4()
+        test_run = MagicMock()
+        test_run.project_id = project_id
+        assert get_test_run_project_id(test_run) == str(project_id)
+
+    def test_returns_none_when_project_id_is_none(self):
+        # Test runs without a project (e.g. organization-scoped legacy
+        # runs) must yield None, NOT the string "None" — the template's
+        # `{% if project_id %}` guard is falsy for None but truthy for
+        # "None", which would produce ?project_id=None in the deep link.
+        test_run = MagicMock()
+        test_run.project_id = None
+        assert get_test_run_project_id(test_run) is None
+
+    def test_returns_none_when_project_id_attr_missing(self):
+        # Defensive: if a fixture/object forgets to set project_id, we
+        # should degrade to None rather than AttributeError. MagicMock
+        # auto-creates attributes on access, so use a bare object to
+        # exercise the getattr default.
+        class _BareObject:
+            pass
+
+        assert get_test_run_project_id(_BareObject()) is None
+
+
+@pytest.mark.unit
+class TestBuildTaskResultProjectId:
+    """_build_task_result threads the test set's project_id for TASK_COMPLETION."""
+
+    def _make_test_set(self, project_id=None):
+        ts = MagicMock()
+        ts.id = uuid.uuid4()
+        ts.name = "Smoke"
+        ts.description = "desc"
+        ts.short_description = "short"
+        ts.tests = []
+        ts.attributes = None
+        ts.project_id = project_id
+        return ts
+
+    def test_returns_project_id_when_test_set_has_project(self):
+        project_id = uuid.uuid4()
+        ts = self._make_test_set(project_id=project_id)
+        result = test_set_module._build_task_result(
+            self=MagicMock(),  # Celery task instance (bound self)
+            db_test_set=ts,
+            num_tests=5,
+            synthesizer=MagicMock(__class__=MagicMock(__name__="FakeSynth")),
+            log_kwargs={},
+            batch_size=10,
+            org_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+        )
+        assert result["project_id"] == str(project_id)
+
+    def test_returns_none_when_test_set_has_no_project(self):
+        ts = self._make_test_set(project_id=None)
+        result = test_set_module._build_task_result(
+            self=MagicMock(),  # Celery task instance (bound self)
+            db_test_set=ts,
+            num_tests=5,
+            synthesizer=MagicMock(__class__=MagicMock(__name__="FakeSynth")),
+            log_kwargs={},
+            batch_size=10,
+            org_id=str(uuid.uuid4()),
+            user_id=str(uuid.uuid4()),
+        )
+        assert result["project_id"] is None


### PR DESCRIPTION
## Problem

Email deep links to project-scoped entity detail pages (test runs, test sets, tasks) **404** when the recipient's currently-selected project differs from the entity's owning project.

The frontend's `CrossProjectAlert` component is a reactive fallback — it only kicks in *after* the 404, so the user sees a flash of "not found" before the project switches and the page re-fetches.

Closes #2133.

## Root cause

Every email notification deep-links to `/test-runs/<id>`, `/test-sets/<id>`, or `/tasks/<id>`. These pages are project-scoped: the server component fetches the entity via a project-filtered API using the `rh_active_project_id` cookie. When the cookie points to a different project than the entity's owning project, the API returns 404 and the page calls `notFound()`.

## Solution

Thread the entity's `project_id` through every email deep link as `?project_id=<uuid>`, and add a Next.js middleware that proactively sets the `rh_active_project_id` cookie **before** the route handler runs.

The server component's first fetch hits the correct project-scoped API on the first try — no 404, no client-side fallback, no flash.

### Backend changes

| File | Change |
|------|--------|
| `tasks/execution/result_processor.py` | `build_summary_data()` accepts `project_id`; `get_test_run_project_id()` helper converts the model's UUID to a string (or None); both `process_test_run_results` return paths (CANCELLED + normal) thread `project_id` |
| `tasks/test_set.py` | `_build_task_result()` includes `project_id` for TASK_COMPLETION email |
| `app/services/task_notification.py` | `send_task_assignment_notification()` includes `project_id` for TASK_ASSIGNMENT email |
| `notifications/email/template_service.py` | `project_id` intentionally **NOT** added to `required_variables` — missing values would become `'N/A'` (truthy) and produce `?project_id=N/A` in deep links. Added explanatory comments. |
| `notifications/email/templates/*.jinja2` | All 3 templates conditionally append `?project_id={{ project_id }}` when set (`{% if project_id %}` guard) |

### Frontend changes

| File | Change |
|------|--------|
| `src/middleware.ts` (new) | Next.js middleware that switches the active project cookie when a project-scoped detail page is reached via `?project_id=<uuid>` |

**Critical implementation detail:** The middleware mutates the **incoming request's** `Cookie` header (`request.cookies.set()`) **before** calling `NextResponse.next()`, not just the response's `Set-Cookie`. This is essential because:

- `response.cookies.set()` only adds a `Set-Cookie` response header — the browser stores it for the **next** navigation
- `cookies()` from `next/headers` reads the **current** request's `Cookie` header, which `Set-Cookie` doesn't modify
- Without the request-side mutation, the server component on the same request would still see the **old** `project_id` cookie and 404 against the project-scoped API

The `Set-Cookie` on the response is still added for browser persistence (future navigations).

Matcher covers the three project-scoped entity detail pages linked from emails:
```ts
matcher: [
  '/test-runs/:identifier*',
  '/test-sets/:identifier*',
  '/tasks/:identifier*',
],
```

### Tests

| File | Coverage |
|------|----------|
| `tests/backend/tasks/test_result_processor_project_id.py` | 9 unit tests: `build_summary_data` (4), `get_test_run_project_id` (3), `_build_task_result` (2) |
| `tests/backend/notifications/test_email_project_id_deep_link.py` | 9 rendering tests: all 3 templates, both `{% if project_id %}` branches |
| `apps/frontend/src/__tests__/middleware.test.ts` | 13 tests: UUID validation (4), cookie switching (2), C1 request-cookie propagation regression (3), matcher coverage (4) |
| `tests/backend/tasks/_heavy_import_stubs.py` | Helper: `sys.meta_path` finder that stubs heavy SDK deps (ragas, deepeval, litellm, langchain) so the backend tasks package's eager imports complete without a full SDK install |

### Test results

```
======================== 18 passed, 1 warning in 2.90s =========================
```

All backend tests pass. `ruff check` and `ruff format` pass (one pre-existing E501 in `task_notification.py:37` is not from this PR).

## Checklist

- [x] Backend changes thread `project_id` through all 3 email templates
- [x] Frontend middleware proactively switches cookie (request + response)
- [x] C1 critical bug (request cookie propagation) fixed and regression-tested
- [x] 18 backend tests pass (9 unit + 9 rendering)
- [x] 13 frontend middleware tests written
- [x] `ruff check` / `ruff format` pass
- [x] Commit signed (SSH signature)
- [x] Conventional Commits format

## Notes for reviewers

1. **Why not add `project_id` to `TemplateService.required_variables`?** The `_prepare_context()` method sets missing required variables to `'N/A'` (a truthy string). If `project_id` were in the required set, missing values would become `'N/A'` and the Jinja2 `{% if project_id %}` guard would evaluate to True, producing `?project_id=N/A` in deep links. Leaving it optional + using `{% if project_id %}` is the correct approach.

2. **Why the `request.cookies.set()` call in middleware?** See the inline comment in `middleware.ts` — this is the critical Next.js cookie propagation pattern. `response.cookies.set()` alone doesn't propagate to `cookies()` in server components on the first request.

3. **The `_heavy_import_stubs.py` helper** is a test-only utility that stubs the SDK's heavy optional dependencies (ragas, deepeval, litellm, langchain) via `sys.meta_path` so the backend tasks package's eager imports complete without a full SDK install. It only affects the test environment — production code is unchanged.