### PR TITLE
Fix Architect skill refs missing in Cloud Run image

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -47,8 +47,9 @@ COPY skills/rhesis/references /app/skills/rhesis/references/
 COPY ee/backend /app/ee/backend/
 # sdk/pyproject.toml force-includes this path into the wheel (skill_refs for
 # the architect agent); uv sync fails building rhesis-sdk without it on disk.
-# Build-only: base-runtime never copies /app/skills forward, unlike sdk/
-# penelope/packages-rhesis/ee-backend above.
+# base-runtime also copies /app/skills forward (see below) since rhesis-sdk is
+# installed editable and resolves skill refs from this path at runtime, not
+# from the force-included wheel copy.
 COPY skills/rhesis/references /app/skills/rhesis/references/
 
 # =============================================================================
@@ -132,6 +133,11 @@ COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/apps/backend/src 
 COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/sdk /app/sdk
 COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/penelope /app/penelope
 COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/packages/rhesis /app/packages/rhesis
+# rhesis-sdk is installed editable, so prompt_loader.py resolves skill refs by
+# walking up from its real source path (/app/sdk/src/...) rather than from
+# hatchling's force-included wheel copy. That walk only succeeds if
+# /app/skills/rhesis/references exists in the runtime image too.
+COPY --from=build-backend --chown=rhesis-user:rhesis-user /app/skills/rhesis/references /app/skills/rhesis/references
 # EE editable install resolves via a .pth file pointing at /app/ee/backend/src,
 # so the source tree must exist in the runtime image too. License-based gating
 # decides at runtime which features the bootstrap actually mounts.

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/system_prompt.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/system_prompt.j2
@@ -8,9 +8,9 @@ Operational knowledge loads **per turn** based on your current mode and workflow
 
 {% include "telemachus-guidelines.j2" %}
 
-{% include "odata-patterns.md" %}
+{% include "odata-patterns.md" ignore missing %}
 
-{% include "entity-model.md" %}
+{% include "entity-model.md" ignore missing %}
 
 {% include "telemachus-resolution.j2" %}
 


### PR DESCRIPTION
## Purpose

The Architect (Telemachus) agent throws a raw `odata-patterns.md` `TemplateNotFound` error in the deployed Cloud Run backend, but works fine locally.

## What Changed

- `apps/backend/Dockerfile`: copy `skills/rhesis/references` into the `base-runtime` stage as well. `rhesis-sdk` is installed editable in this image, so `prompt_loader.py` resolves skill references by walking up from its real source path at runtime rather than from hatchling's `force-include` wheel copy — that wheel-copy fallback only gets populated for non-editable installs, so it never covers this image, and the runtime stage was previously dropping `/app/skills` entirely.
- `system_prompt.j2`: mark the `odata-patterns.md` and `entity-model.md` includes `ignore missing`, so a future packaging gap degrades the system prompt instead of crashing the whole agent turn with a raw filename shown to the user.

## Additional Context

Root-caused via the Cloud Run chat UI showing red error bubbles reading `odata-patterns.md`. Confirmed the call chain: `ArchitectAgent.__init__` → `_load_default_system_prompt` → `system_prompt.j2`'s unguarded `{% include %}` → `jinja2.TemplateNotFound` → propagated up through the Celery task as an `ARCHITECT_ERROR` with the raw filename as the error message.

## Testing

- `cd sdk && uv run pytest ../tests/sdk/agents/test_architect_prompt_loader.py ../tests/sdk/agents/test_architect.py -q` — 171 passed.
- Needs a rebuild + redeploy of the backend/worker Cloud Run images to verify the fix in the actual deployed environment.