### PR TITLE
docs: add telemetry configuration guide with mode subguides

### DIFF
--- a/docs/content/guides/_meta.tsx
+++ b/docs/content/guides/_meta.tsx
@@ -6,6 +6,7 @@ const meta: MetaRecord = {
   'custom-metrics': 'Building Custom Metrics with the Rhesis SDK',
   'ci-cd-integration': 'Integrating Rhesis SDK into CI/CD',
   'testing-user-journeys': 'Testing User Journeys of AI Agents',
+  'telemetry-configuration': 'Configuring Telemetry for Your AI Application',
 }
 
 export default meta

--- a/docs/content/guides/index.mdx
+++ b/docs/content/guides/index.mdx
@@ -46,6 +46,13 @@ Step-by-step guides to help you get the most out of Rhesis. Whether you're just 
     link="/guides/testing-user-journeys"
     linkText="User journeys →"
   />
+  <NextStepCard
+    emoji="📡"
+    title="Configuring Telemetry for Your AI Application"
+    description="Pick the right way to instrument your app — auto-instrumentation, decorators, raw OpenTelemetry, or the GenAI semantic conventions."
+    link="/guides/telemetry-configuration"
+    linkText="Configure telemetry →"
+  />
 </NextStepCardGrid>
 
 ## All guides (at a glance)
@@ -54,6 +61,7 @@ Step-by-step guides to help you get the most out of Rhesis. Whether you're just 
 - **Building Custom Metrics with the Rhesis SDK** — Judges, scorers, and conversational metrics in code.
 - **Integrating Rhesis SDK into CI/CD** — Run evaluations from GitHub Actions and similar systems.
 - **Testing User Journeys of AI Agents** — Goal-based checks for agentic workflows.
+- **Configuring Telemetry for Your AI Application** — Choose a mode and wire up tracing: [auto-instrumentation](/guides/telemetry-configuration/auto-instrumentation), [decorators](/guides/telemetry-configuration/decorators), [raw OpenTelemetry](/guides/telemetry-configuration/raw-opentelemetry), or [GenAI semantic conventions](/guides/telemetry-configuration/genai-conventions).
 
 ## Need Help?
 

--- a/docs/content/guides/index.mdx
+++ b/docs/content/guides/index.mdx
@@ -49,7 +49,7 @@ Step-by-step guides to help you get the most out of Rhesis. Whether you're just 
   <NextStepCard
     emoji="📡"
     title="Configuring Telemetry for Your AI Application"
-    description="Pick the right way to instrument your app — auto-instrumentation, decorators, raw OpenTelemetry, or the GenAI semantic conventions."
+    description="Pick the right way to instrument your app: auto-instrumentation, decorators, raw OpenTelemetry, or the GenAI semantic conventions."
     link="/guides/telemetry-configuration"
     linkText="Configure telemetry →"
   />
@@ -61,7 +61,7 @@ Step-by-step guides to help you get the most out of Rhesis. Whether you're just 
 - **Building Custom Metrics with the Rhesis SDK** — Judges, scorers, and conversational metrics in code.
 - **Integrating Rhesis SDK into CI/CD** — Run evaluations from GitHub Actions and similar systems.
 - **Testing User Journeys of AI Agents** — Goal-based checks for agentic workflows.
-- **Configuring Telemetry for Your AI Application** — Choose a mode and wire up tracing: [auto-instrumentation](/guides/telemetry-configuration/auto-instrumentation), [decorators](/guides/telemetry-configuration/decorators), [raw OpenTelemetry](/guides/telemetry-configuration/raw-opentelemetry), or [GenAI semantic conventions](/guides/telemetry-configuration/genai-conventions).
+- **Configuring Telemetry for Your AI Application**: Choose a mode and wire up tracing: [auto-instrumentation](/guides/telemetry-configuration/auto-instrumentation), [decorators](/guides/telemetry-configuration/decorators), [raw OpenTelemetry](/guides/telemetry-configuration/raw-opentelemetry), or [GenAI semantic conventions](/guides/telemetry-configuration/genai-conventions).
 
 ## Need Help?
 

--- a/docs/content/guides/telemetry-configuration/_meta.tsx
+++ b/docs/content/guides/telemetry-configuration/_meta.tsx
@@ -1,0 +1,11 @@
+import type { MetaRecord } from 'nextra'
+
+const meta: MetaRecord = {
+  index: 'Overview',
+  'auto-instrumentation': 'Telemetry: Auto-Instrumentation',
+  decorators: 'Telemetry: Decorators',
+  'raw-opentelemetry': 'Telemetry: Raw OpenTelemetry',
+  'genai-conventions': 'Telemetry: GenAI Semantic Conventions',
+}
+
+export default meta

--- a/docs/content/guides/telemetry-configuration/auto-instrumentation.mdx
+++ b/docs/content/guides/telemetry-configuration/auto-instrumentation.mdx
@@ -1,0 +1,146 @@
+import { CodeBlock } from '@/components/CodeBlock'
+import { Table } from '@/components/Table'
+
+# Configure Telemetry: Auto-Instrumentation
+
+Auto-instrumentation traces every LLM call, tool invocation, and chain or graph execution in supported frameworks without touching your application code. If you're building on LangChain, LangGraph, Microsoft Agent Framework, or Pydantic AI, this is the fastest path to a working trace.
+
+## What You'll Achieve
+
+- Traces for every LLM call, tool call, and (for LangGraph/MAF) agent/graph step
+- No decorators, no manual span creation
+- One line of code: `auto_instrument()`
+
+## Prerequisites
+
+- `RhesisClient` initialized — see [Configuring Telemetry](/guides/telemetry-configuration#prerequisites)
+- The pip extra for your framework installed
+
+## Supported Frameworks
+
+<Table
+  headers={['Framework', 'auto_instrument key', 'pip extra', 'Mechanism']}
+  rows={[
+    ['LangChain', '`langchain`', '`langchain`', 'Callback handler + tool patching'],
+    ['LangGraph', '`langgraph`', '`langgraph`', 'Shared LangChain callback + graph method patching'],
+    ['Microsoft Agent Framework', '`agent_framework` (alias `maf`)', '`agent-framework`', 'OTel span translation (gen_ai.* → ai.*)'],
+    ['Pydantic AI', '`pydantic_ai`', '`pydantic-ai`', 'OTel span translation'],
+  ]}
+/>
+
+Using a different framework? Auto-instrumentation won't cover it — go to [Decorators](/guides/telemetry-configuration/decorators) instead.
+
+## Setup
+
+<Steps>
+
+### Install the framework extra
+
+<CodeBlock filename="terminal" language="bash">
+{`pip install "rhesis-sdk[langchain]>=0.6.0"
+# or: [langgraph], [agent-framework], [pydantic-ai]`}
+</CodeBlock>
+
+### Initialize the client
+
+<CodeBlock filename="app.py" language="python">
+{`from rhesis.sdk import RhesisClient
+
+client = RhesisClient(
+    api_key="your-api-key",
+    project_id="your-project-id",
+)`}
+</CodeBlock>
+
+### Enable auto-instrumentation
+
+<CodeBlock filename="app.py" language="python">
+{`from rhesis.sdk.telemetry import auto_instrument
+
+# Auto-detect every installed framework
+enabled = auto_instrument()
+print(f"Tracing enabled for: {enabled}")
+
+# Or be explicit
+auto_instrument("langchain", "langgraph")
+auto_instrument("agent_framework")   # alias: "maf"
+auto_instrument("pydantic_ai")`}
+</CodeBlock>
+
+<Callout type="info">
+Call `auto_instrument()` once, right after creating `RhesisClient`, before your framework code runs. It patches the framework's entry points, so anything constructed beforehand (e.g. a chain built at import time) is still traced — the patching targets invocation, not construction.
+</Callout>
+
+### Use your framework normally
+
+<CodeBlock filename="app.py" language="python">
+{`from langchain_google_genai import ChatGoogleGenerativeAI
+
+llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash-exp")
+response = llm.invoke("Explain quantum computing")
+# Traced automatically — no changes to this call`}
+</CodeBlock>
+
+### Verify traces are arriving
+
+Open the Rhesis dashboard's trace view for your project. A single `llm.invoke` call should appear as an `ai.llm.invoke` span with model name, provider, and token counts populated within a few seconds (traces flush every 5s by default).
+
+</Steps>
+
+## How It Works
+
+```mermaid
+flowchart LR
+    subgraph Callback-based
+        LC[LangChain] --> CB[Global callback handler]
+        LG[LangGraph] --> CB
+        CB --> Spans1["ai.llm.invoke / ai.tool.invoke<br/>spans, properly nested"]
+    end
+    subgraph Span-translating
+        MAF[Microsoft Agent Framework] --> TR[Translating exporter]
+        PAI[Pydantic AI] --> TR
+        TR --> Spans2["gen_ai.* rewritten to<br/>ai.* on export"]
+    end
+```
+
+**Callback-based (LangChain/LangGraph):** the SDK registers a global callback handler that intercepts `on_chat_model_start`, `on_tool_start`, `on_chain_start`, and equivalents, creating properly-nested Rhesis-convention spans directly. LangGraph reuses the LangChain callback rather than creating its own, so `auto_instrument("langgraph")` alone already covers chains, tools, and LLM calls invoked from graph nodes.
+
+**Span-translating (MAF/Pydantic AI):** these frameworks already emit standard OpenTelemetry GenAI spans (`gen_ai.*`). The SDK wraps the OTLP exporter with a translating exporter that rewrites span names and attributes into the Rhesis `ai.*` schema at export time, and synthesizes `ai.agent.handoff` spans from `handoff_to_*` tool-call patterns.
+
+## Combining with Decorators
+
+Auto-instrumentation and `@observe`/`@endpoint` work together — the SDK deduplicates so you never get two spans for the same LLM call:
+
+<CodeBlock filename="app.py" language="python">
+{`from rhesis.sdk import RhesisClient, endpoint
+from rhesis.sdk.telemetry import auto_instrument
+
+client = RhesisClient()
+auto_instrument()
+
+@endpoint()
+def chat_handler(input: str) -> dict:
+    # This function traced by @endpoint as the root span
+    # Internal LangChain calls traced by auto-instrumentation
+    chain = prompt | llm
+    return {"output": chain.invoke({"message": input})}`}
+</CodeBlock>
+
+## Disabling
+
+<CodeBlock filename="teardown.py" language="python">
+{`from rhesis.sdk.telemetry import disable_auto_instrument
+
+disable_auto_instrument()  # turns off every previously-enabled framework`}
+</CodeBlock>
+
+<Callout type="success">
+**You have working traces.** Multi-agent system? See [Multi-Agent Tracing](/docs/tracing/multi-agent). Multi-turn chat? See [Tracking Multi-Turn Conversations](/guides/telemetry-configuration#tracking-multi-turn-conversations).
+</Callout>
+
+<Callout type="info">
+  **Related:**
+  - [Auto-Instrumentation Reference](/docs/tracing/auto-instrumentation) — full API surface and per-framework examples
+  - [Microsoft Agent Framework](/docs/tracing/agent-framework) — handoff tracing and content-capture options
+  - [Configuring Telemetry](/guides/telemetry-configuration) — back to the mode overview
+</Callout>

--- a/docs/content/guides/telemetry-configuration/auto-instrumentation.mdx
+++ b/docs/content/guides/telemetry-configuration/auto-instrumentation.mdx
@@ -13,7 +13,7 @@ Auto-instrumentation traces every LLM call, tool invocation, and chain or graph 
 
 ## Prerequisites
 
-- `RhesisClient` initialized — see [Configuring Telemetry](/guides/telemetry-configuration#prerequisites)
+- `RhesisClient` initialized: see [Configuring Telemetry](/guides/telemetry-configuration#prerequisites)
 - The pip extra for your framework installed
 
 ## Supported Frameworks
@@ -28,7 +28,7 @@ Auto-instrumentation traces every LLM call, tool invocation, and chain or graph 
   ]}
 />
 
-Using a different framework? Auto-instrumentation won't cover it — go to [Decorators](/guides/telemetry-configuration/decorators) instead.
+Using a different framework? Auto-instrumentation won't cover it. Go to [Decorators](/guides/telemetry-configuration/decorators) instead.
 
 ## Setup
 
@@ -68,7 +68,7 @@ auto_instrument("pydantic_ai")`}
 </CodeBlock>
 
 <Callout type="info">
-Call `auto_instrument()` once, right after creating `RhesisClient`, before your framework code runs. It patches the framework's entry points, so anything constructed beforehand (e.g. a chain built at import time) is still traced — the patching targets invocation, not construction.
+Call `auto_instrument()` once, right after creating `RhesisClient`, before your framework code runs. It patches the framework's entry points, so anything constructed beforehand (e.g. a chain built at import time) is still traced: the patching targets invocation, not construction.
 </Callout>
 
 ### Use your framework normally
@@ -78,7 +78,7 @@ Call `auto_instrument()` once, right after creating `RhesisClient`, before your 
 
 llm = ChatGoogleGenerativeAI(model="gemini-2.0-flash-exp")
 response = llm.invoke("Explain quantum computing")
-# Traced automatically — no changes to this call`}
+# Traced automatically, no changes to this call`}
 </CodeBlock>
 
 ### Verify traces are arriving
@@ -109,7 +109,7 @@ flowchart LR
 
 ## Combining with Decorators
 
-Auto-instrumentation and `@observe`/`@endpoint` work together — the SDK deduplicates so you never get two spans for the same LLM call:
+Auto-instrumentation and `@observe`/`@endpoint` work together: the SDK deduplicates so you never get two spans for the same LLM call:
 
 <CodeBlock filename="app.py" language="python">
 {`from rhesis.sdk import RhesisClient, endpoint
@@ -140,7 +140,7 @@ disable_auto_instrument()  # turns off every previously-enabled framework`}
 
 <Callout type="info">
   **Related:**
-  - [Auto-Instrumentation Reference](/docs/tracing/auto-instrumentation) — full API surface and per-framework examples
-  - [Microsoft Agent Framework](/docs/tracing/agent-framework) — handoff tracing and content-capture options
-  - [Configuring Telemetry](/guides/telemetry-configuration) — back to the mode overview
+  - [Auto-Instrumentation Reference](/docs/tracing/auto-instrumentation) - full API surface and per-framework examples
+  - [Microsoft Agent Framework](/docs/tracing/agent-framework) - handoff tracing and content-capture options
+  - [Configuring Telemetry](/guides/telemetry-configuration) - back to the mode overview
 </Callout>

--- a/docs/content/guides/telemetry-configuration/decorators.mdx
+++ b/docs/content/guides/telemetry-configuration/decorators.mdx
@@ -1,0 +1,206 @@
+import { CodeBlock } from '@/components/CodeBlock'
+import { Table } from '@/components/Table'
+
+# Configure Telemetry: Decorators
+
+Decorators are the sweet spot between zero-code auto-instrumentation and manual span creation. Wrap any function with `@observe` (or a typed variant) and the SDK handles span naming, I/O capture, and attribute stamping for you. Use this mode for frameworks not covered by [auto-instrumentation](/guides/telemetry-configuration/auto-instrumentation) — CrewAI, OpenAI Agents SDK, or your own hand-rolled pipeline.
+
+## What You'll Achieve
+
+- A traced entry point (`@endpoint`) that's also registered for remote testing
+- Typed spans (`ai.llm.invoke`, `ai.tool.invoke`, `ai.retrieval`, …) around your internal functions
+- Correct parent-child nesting with zero manual OpenTelemetry code
+
+## Prerequisites
+
+- `RhesisClient` initialized — see [Configuring Telemetry](/guides/telemetry-configuration#prerequisites)
+
+## Setup
+
+<Steps>
+
+### Decorate your entry point
+
+`@endpoint` registers the function for remote testing via the Rhesis connector and traces it as the root span:
+
+<CodeBlock filename="app.py" language="python">
+{`from rhesis.sdk import RhesisClient, endpoint
+
+client = RhesisClient()
+
+@endpoint()
+def chat(input: str) -> dict:
+    context = build_context(input)
+    response = generate(input, context)
+    return {"output": response}`}
+</CodeBlock>
+
+### Decorate internal steps with typed spans
+
+Each typed decorator maps to a specific span name and stamps the matching semantic attributes:
+
+<CodeBlock filename="app.py" language="python">
+{`from rhesis.sdk import observe
+
+@observe.retrieval(backend="chroma", top_k=5)
+def build_context(query: str) -> list:
+    return vectorstore.similarity_search(query, k=5)
+
+@observe.llm(provider="anthropic", model="claude-sonnet-4-20250514")
+def generate(query: str, context: list) -> str:
+    return anthropic.messages.create(
+        model="claude-sonnet-4-20250514",
+        messages=[{"role": "user", "content": f"Context: {context}\\n\\nQuestion: {query}"}]
+    ).content[0].text`}
+</CodeBlock>
+
+### Verify the trace tree
+
+Run the endpoint once and check the dashboard. You should see:
+
+<CodeBlock filename="trace" language="text">
+{`function.chat (root)
+├── ai.retrieval (build_context)
+└── ai.llm.invoke (generate)`}
+</CodeBlock>
+
+</Steps>
+
+## Typed Decorator Reference
+
+<Table
+  headers={['Decorator', 'Span Name', 'Required Params']}
+  rows={[
+    ['`@observe()`', '`function.<name>`', 'none'],
+    ['`@observe.llm()`', '`ai.llm.invoke`', '`provider`, `model`'],
+    ['`@observe.tool()`', '`ai.tool.invoke`', '`name`, `tool_type`'],
+    ['`@observe.retrieval()`', '`ai.retrieval`', '`backend`'],
+    ['`@observe.embedding()`', '`ai.embedding.generate`', '`model`'],
+    ['`@observe.rerank()`', '`ai.rerank`', '`model`'],
+    ['`@observe.agent()`', '`ai.agent.invoke`', '`name`'],
+    ['`@observe.evaluation()`', '`ai.evaluation`', '`metric`, `evaluator`'],
+    ['`@observe.guardrail()`', '`ai.guardrail`', '`guardrail_type`, `provider`'],
+    ['`@observe.transform()`', '`ai.transform`', '`transform_type`, `operation`'],
+    ['`@endpoint()`', '`function.<name>`', 'none'],
+  ]}
+/>
+
+## Multi-Agent Example
+
+Agent handoffs are ordinary nested spans plus an explicit `ai.agent.handoff` span:
+
+<CodeBlock filename="agents.py" language="python">
+{`from rhesis.sdk import observe, endpoint
+from opentelemetry import trace
+
+tracer = trace.get_tracer("multi-agent")
+
+@endpoint()
+def run(task: str) -> dict:
+    return orchestrator(task)
+
+@observe.agent(name="orchestrator")
+def orchestrator(task: str) -> dict:
+    plan = plan_task(task)
+
+    if plan["needs_research"]:
+        with tracer.start_as_current_span("ai.agent.handoff") as span:
+            span.set_attribute("ai.agent.handoff.from", "orchestrator")
+            span.set_attribute("ai.agent.handoff.to", "researcher")
+            research = researcher(plan["research_query"])
+    else:
+        research = None
+
+    return synthesize(task, plan, research)
+
+@observe.agent(name="researcher")
+def researcher(query: str) -> dict:
+    docs = search_knowledge_base(query)
+    return {"docs": docs, "summary": summarize(query, docs)}`}
+</CodeBlock>
+
+```mermaid
+graph TD
+    A[function.run — root] --> B[ai.agent.invoke: orchestrator]
+    B --> C[ai.llm.invoke: plan_task]
+    B --> D[ai.agent.handoff]
+    D --> E[ai.agent.invoke: researcher]
+    E --> F[ai.retrieval: search_knowledge_base]
+    E --> G[ai.llm.invoke: summarize]
+    B --> H[ai.llm.invoke: synthesize]
+
+    style D fill:#fff3e0,stroke:#f57c00,stroke-width:2px
+```
+
+For frameworks with native handoff support, see [Multi-Agent Tracing](/docs/tracing/multi-agent).
+
+## Tracking Multi-Turn Conversations
+
+If you're instrumenting a custom chat server (not using `@endpoint`'s automatic `session_id` handling), manage conversation context explicitly so turns are grouped into one trace:
+
+<CodeBlock filename="chat_server.py" language="python">
+{`from rhesis.sdk import observe
+from rhesis.sdk.telemetry.context import (
+    set_conversation_id,
+    set_conversation_trace_id,
+    set_conversation_mapped_input,
+    get_root_trace_id,
+    set_root_trace_id,
+)
+
+sessions = {}  # session_id -> trace_id
+
+@observe()
+def handle_message(session_id: str, user_message: str) -> str:
+    set_conversation_id(session_id)
+    set_conversation_mapped_input(user_message)
+
+    if session_id in sessions:
+        set_conversation_trace_id(sessions[session_id])
+
+    try:
+        return generate_response(user_message, session_id)
+    finally:
+        trace_id = get_root_trace_id()
+        if trace_id and session_id not in sessions:
+            sessions[session_id] = trace_id
+
+        set_conversation_id(None)
+        set_conversation_trace_id(None)
+        set_conversation_mapped_input(None)
+        set_root_trace_id(None)`}
+</CodeBlock>
+
+<Callout type="tip">
+Prefer `@endpoint()` with a returned `session_id` field when you can — the Rhesis connector manages this context for you automatically. Manual context management is only needed for custom chat servers outside the connector.
+</Callout>
+
+## Combining with Auto-Instrumentation
+
+<CodeBlock filename="app.py" language="python">
+{`from rhesis.sdk import RhesisClient, endpoint
+from rhesis.sdk.telemetry import auto_instrument
+
+client = RhesisClient()
+auto_instrument("langchain")
+
+@endpoint()
+def chat(input: str) -> dict:
+    # This function traced by @endpoint
+    # Internal LangChain LLM/tool calls traced by auto-instrumentation
+    chain = prompt | llm | output_parser
+    return {"output": chain.invoke({"message": input})}`}
+</CodeBlock>
+
+The SDK deduplicates automatically — `@observe.llm()` sets a context flag that tells the auto-instrumentation callback to skip creating a duplicate span for the same call.
+
+<Callout type="success">
+**You have working traces.** Need finer control over attributes or events than the typed decorators expose? See [Raw OpenTelemetry](/guides/telemetry-configuration/raw-opentelemetry).
+</Callout>
+
+<Callout type="info">
+  **Related:**
+  - [Decorators Reference](/docs/tracing/decorators) — full `@observe` and `@endpoint` API
+  - [Conversation Tracing](/docs/tracing/conversation-tracing) — deep reference on turn management
+  - [Configuring Telemetry](/guides/telemetry-configuration) — back to the mode overview
+</Callout>

--- a/docs/content/guides/telemetry-configuration/decorators.mdx
+++ b/docs/content/guides/telemetry-configuration/decorators.mdx
@@ -3,7 +3,7 @@ import { Table } from '@/components/Table'
 
 # Configure Telemetry: Decorators
 
-Decorators are the sweet spot between zero-code auto-instrumentation and manual span creation. Wrap any function with `@observe` (or a typed variant) and the SDK handles span naming, I/O capture, and attribute stamping for you. Use this mode for frameworks not covered by [auto-instrumentation](/guides/telemetry-configuration/auto-instrumentation) — CrewAI, OpenAI Agents SDK, or your own hand-rolled pipeline.
+Decorators are the sweet spot between zero-code auto-instrumentation and manual span creation. Wrap any function with `@observe` (or a typed variant) and the SDK handles span naming, I/O capture, and attribute stamping for you. Use this mode for frameworks not covered by [auto-instrumentation](/guides/telemetry-configuration/auto-instrumentation): CrewAI, OpenAI Agents SDK, or your own hand-rolled pipeline.
 
 ## What You'll Achieve
 
@@ -13,7 +13,7 @@ Decorators are the sweet spot between zero-code auto-instrumentation and manual 
 
 ## Prerequisites
 
-- `RhesisClient` initialized — see [Configuring Telemetry](/guides/telemetry-configuration#prerequisites)
+- `RhesisClient` initialized: see [Configuring Telemetry](/guides/telemetry-configuration#prerequisites)
 
 ## Setup
 
@@ -121,7 +121,7 @@ def researcher(query: str) -> dict:
 
 ```mermaid
 graph TD
-    A[function.run — root] --> B[ai.agent.invoke: orchestrator]
+    A["function.run (root)"] --> B[ai.agent.invoke: orchestrator]
     B --> C[ai.llm.invoke: plan_task]
     B --> D[ai.agent.handoff]
     D --> E[ai.agent.invoke: researcher]
@@ -172,7 +172,7 @@ def handle_message(session_id: str, user_message: str) -> str:
 </CodeBlock>
 
 <Callout type="tip">
-Prefer `@endpoint()` with a returned `session_id` field when you can — the Rhesis connector manages this context for you automatically. Manual context management is only needed for custom chat servers outside the connector.
+Prefer `@endpoint()` with a returned `session_id` field when you can: the Rhesis connector manages this context for you automatically. Manual context management is only needed for custom chat servers outside the connector.
 </Callout>
 
 ## Combining with Auto-Instrumentation
@@ -192,7 +192,7 @@ def chat(input: str) -> dict:
     return {"output": chain.invoke({"message": input})}`}
 </CodeBlock>
 
-The SDK deduplicates automatically — `@observe.llm()` sets a context flag that tells the auto-instrumentation callback to skip creating a duplicate span for the same call.
+The SDK deduplicates automatically: `@observe.llm()` sets a context flag that tells the auto-instrumentation callback to skip creating a duplicate span for the same call.
 
 <Callout type="success">
 **You have working traces.** Need finer control over attributes or events than the typed decorators expose? See [Raw OpenTelemetry](/guides/telemetry-configuration/raw-opentelemetry).
@@ -200,7 +200,7 @@ The SDK deduplicates automatically — `@observe.llm()` sets a context flag that
 
 <Callout type="info">
   **Related:**
-  - [Decorators Reference](/docs/tracing/decorators) — full `@observe` and `@endpoint` API
-  - [Conversation Tracing](/docs/tracing/conversation-tracing) — deep reference on turn management
-  - [Configuring Telemetry](/guides/telemetry-configuration) — back to the mode overview
+  - [Decorators Reference](/docs/tracing/decorators) - full `@observe` and `@endpoint` API
+  - [Conversation Tracing](/docs/tracing/conversation-tracing) - deep reference on turn management
+  - [Configuring Telemetry](/guides/telemetry-configuration) - back to the mode overview
 </Callout>

--- a/docs/content/guides/telemetry-configuration/genai-conventions.mdx
+++ b/docs/content/guides/telemetry-configuration/genai-conventions.mdx
@@ -1,0 +1,209 @@
+import { CodeBlock } from '@/components/CodeBlock'
+import { Table } from '@/components/Table'
+
+# Configure Telemetry: OTel GenAI Semantic Conventions
+
+If you're building a framework, orchestrator, or agent runtime, implement the [OpenTelemetry Semantic Conventions for GenAI](https://github.com/open-telemetry/semantic-conventions-genai) directly instead of coupling to the Rhesis SDK. Rhesis already ships a translation layer that consumes `gen_ai.*` spans and maps them into the Rhesis `ai.*` schema — this is exactly how the Microsoft Agent Framework and Pydantic AI integrations work today.
+
+## Who This Is For
+
+- You're building a framework other people will use, and don't want them coupled to Rhesis
+- You want telemetry that works with any OTel-compatible backend (Jaeger, Honeycomb, Datadog, …) *and* Rhesis
+- You already emit OTel spans and want to align with the emerging standard
+
+If you're building an *application* rather than a framework, use [Auto-Instrumentation](/guides/telemetry-configuration/auto-instrumentation) or [Decorators](/guides/telemetry-configuration/decorators) instead — they're less setup for the same result.
+
+## Operation Mapping
+
+The spec defines several GenAI operation types. Here's how each maps to Rhesis today:
+
+<Table
+  headers={['GenAI Operation', 'Span Name Pattern', 'Rhesis Translation', 'Status']}
+  rows={[
+    ['`chat`', '`chat {model}`', '`ai.llm.invoke`', 'Fully supported'],
+    ['`invoke_agent`', '`invoke_agent {agent_name}`', '`ai.agent.invoke`', 'Fully supported'],
+    ['`create_agent`', '`create_agent {agent_name}`', '`ai.agent.invoke`', 'Fully supported'],
+    ['`execute_tool`', '`execute_tool {tool_name}`', '`ai.tool.invoke`', 'Fully supported'],
+    ['`embeddings`', '`embeddings {model}`', '`ai.embedding.generate`', 'Fully supported'],
+    ['`invoke_workflow`', '`invoke_workflow {name}`', '`function.{framework}.*`', 'Fallback — no semantic mapping yet'],
+    ['`plan`', '`plan {agent_name}`', '`function.{framework}.*`', 'Fallback — no semantic mapping yet'],
+  ]}
+/>
+
+`chat`, `invoke_agent`, `create_agent`, `execute_tool`, and `embeddings` translate fully — correct attribute mapping, token extraction, and prompt/completion event synthesis included. `invoke_workflow` and `plan` land under a `function.*` fallback name: visible in traces, but without semantic interpretation yet.
+
+## Attribute Mapping
+
+The translation layer maps `gen_ai.*` attributes to `ai.*` and preserves the originals — both coexist on the exported span:
+
+<Table
+  headers={['GenAI Attribute', 'Rhesis Attribute', 'Notes']}
+  rows={[
+    ['`gen_ai.operation.name`', '`ai.operation.type`', 'chat→llm.invoke, invoke_agent→agent.invoke, execute_tool→tool.invoke, embeddings→embedding.create'],
+    ['`gen_ai.request.model`', '`ai.model.name`', 'Preferred over response.model when both present'],
+    ['`gen_ai.response.model`', '`ai.model.name`', 'Used when request model is absent'],
+    ['`gen_ai.provider.name`', '`ai.model.provider`', ''],
+    ['`gen_ai.system`', '`ai.model.provider`', 'Legacy alias, same target'],
+    ['`gen_ai.usage.input_tokens`', '`ai.llm.tokens.input`', ''],
+    ['`gen_ai.usage.output_tokens`', '`ai.llm.tokens.output`', ''],
+    ['(computed)', '`ai.llm.tokens.total`', 'input + output, synthesized'],
+    ['`gen_ai.request.temperature`', '`ai.llm.temperature`', ''],
+    ['`gen_ai.request.max_tokens`', '`ai.llm.max_tokens`', ''],
+    ['`gen_ai.response.finish_reasons`', '`ai.llm.finish_reason`', ''],
+    ['`gen_ai.tool.name`', '`ai.tool.name`', ''],
+    ['`gen_ai.tool.type`', '`ai.tool.type`', ''],
+    ['`gen_ai.agent.name`', '`ai.agent.name`', ''],
+    ['`gen_ai.conversation.id`', '`ai.session.id`', ''],
+  ]}
+/>
+
+## Content Capture
+
+The GenAI spec stores message content as structured JSON attributes:
+
+<CodeBlock filename="attributes" language="text">
+{`gen_ai.system_instructions -> [{"type": "text", "content": "You are a helpful assistant"}]
+gen_ai.input.messages      -> [{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}]
+gen_ai.output.messages     -> [{"role": "assistant", "parts": [{"type": "text", "content": "Hi!"}]}]`}
+</CodeBlock>
+
+Rhesis translates these into `ai.prompt` and `ai.completion` span events rendered in the trace UI. Tool I/O attributes (`gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`) translate similarly into `ai.tool.input` / `ai.tool.output` events.
+
+<Callout type="tip">
+Populate these attributes — they're what makes traces useful in the Rhesis UI (actual prompts and completions inline, not just span names). Privacy-sensitive deployments can opt out with `RHESIS_DISABLE_CONTENT_CAPTURE=true`.
+</Callout>
+
+## Agent Handoffs
+
+Rhesis synthesizes `ai.agent.handoff` spans from two patterns:
+
+1. **Tool-call pattern** — an `execute_tool` span where `gen_ai.tool.name` starts with `handoff_to_`. The target agent is parsed from the suffix (`handoff_to_researcher` → `researcher`); the source agent is resolved by walking the span's parent chain.
+2. **Message pattern** — a `chat` span whose `gen_ai.output.messages` contains a `tool_call` part named `handoff_to_*`. This covers frameworks (like MAF) where handoff middleware short-circuits before a tool-execution span is created.
+
+<Callout type="tip">
+If your framework supports agent-to-agent delegation, name your handoff tools `handoff_to_{target_agent}`. That's the convention Microsoft Agent Framework uses, and it's enough signal for Rhesis to draw handoff edges in the graph view with zero Rhesis-specific instrumentation.
+</Callout>
+
+## Setup
+
+<Steps>
+
+### Initialize the Rhesis client and enable translation
+
+If your framework is already in the auto-instrument list:
+
+<CodeBlock filename="app.py" language="python">
+{`from rhesis.sdk import RhesisClient
+from rhesis.sdk.telemetry import auto_instrument
+
+client = RhesisClient()
+auto_instrument("agent_framework")  # or "pydantic_ai", or auto-detect`}
+</CodeBlock>
+
+This wraps the OTLP exporter with a translating exporter that rewrites `gen_ai.*` spans into the Rhesis schema before export.
+
+### Emit the minimum viable span set
+
+If you're building a new framework, this is what to emit for full Rhesis compatibility:
+
+<CodeBlock filename="minimal_instrumentation.py" language="python">
+{`from opentelemetry import trace
+import json
+
+tracer = trace.get_tracer("my-framework", "1.0.0")
+
+# 1. Agent invocation
+with tracer.start_as_current_span(
+    "invoke_agent my-agent",
+    kind=trace.SpanKind.INTERNAL,
+    attributes={
+        "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.agent.name": "my-agent",
+    },
+) as agent_span:
+
+    # 2. LLM call (child of agent)
+    with tracer.start_as_current_span(
+        "chat gpt-4o",
+        kind=trace.SpanKind.CLIENT,
+        attributes={
+            "gen_ai.operation.name": "chat",
+            "gen_ai.request.model": "gpt-4o",
+            "gen_ai.provider.name": "openai",
+        },
+    ) as chat_span:
+        # Make the LLM call...
+        chat_span.set_attribute("gen_ai.usage.input_tokens", 150)
+        chat_span.set_attribute("gen_ai.usage.output_tokens", 80)
+
+        chat_span.set_attribute("gen_ai.input.messages", json.dumps([
+            {"role": "user", "parts": [{"type": "text", "content": "What is ML?"}]}
+        ]))
+        chat_span.set_attribute("gen_ai.output.messages", json.dumps([
+            {"role": "assistant", "parts": [{"type": "text", "content": "ML is..."}]}
+        ]))
+
+    # 3. Tool execution (child of agent)
+    with tracer.start_as_current_span(
+        "execute_tool calculator",
+        kind=trace.SpanKind.INTERNAL,
+        attributes={
+            "gen_ai.operation.name": "execute_tool",
+            "gen_ai.tool.name": "calculator",
+            "gen_ai.tool.type": "function",
+        },
+    ) as tool_span:
+        tool_span.set_attribute("gen_ai.tool.call.arguments", '{"expression": "2+2"}')
+        tool_span.set_attribute("gen_ai.tool.call.result", "4")
+
+    # 4. Agent handoff (as a tool call)
+    with tracer.start_as_current_span(
+        "execute_tool handoff_to_specialist",
+        kind=trace.SpanKind.INTERNAL,
+        attributes={
+            "gen_ai.operation.name": "execute_tool",
+            "gen_ai.tool.name": "handoff_to_specialist",
+        },
+    ) as handoff_span:
+        # Rhesis translates this into ai.agent.handoff automatically
+        pass`}
+</CodeBlock>
+
+</Steps>
+
+These spans work with any OTel-compatible backend (they follow the standard) and Rhesis translates them automatically into `ai.llm.invoke`, `ai.agent.invoke`, `ai.tool.invoke`, and `ai.agent.handoff` with full attribute mapping.
+
+## What Is Not Yet Translated
+
+These GenAI spec features land in Rhesis as passthrough attributes — preserved on the span, shipped to the backend, but not yet rendered specially in the UI:
+
+<Table
+  headers={['GenAI Feature', 'Status', 'What Happens Today']}
+  rows={[
+    ['`invoke_workflow` operation', 'Fallback', 'Lands as `function.{framework}.*`, visible but uninterpreted'],
+    ['`plan` operation', 'Fallback', 'Lands as `function.{framework}.*`, visible but uninterpreted'],
+    ['`gen_ai.plan.reasoning` / `gen_ai.plan.steps`', 'Passthrough', 'Preserved as raw attributes'],
+    ['`gen_ai.workflow.name` / `gen_ai.workflow.id`', 'Passthrough', 'Preserved as raw attributes'],
+    ['`gen_ai.data_source.id`', 'Passthrough', 'Preserved as raw attributes'],
+    ['`gen_ai.output.type`', 'Passthrough', 'Preserved as raw attributes'],
+    ['`gen_ai.usage.cache_creation.input_tokens`', 'Passthrough', 'Preserved as raw attributes'],
+    ['`gen_ai.usage.cache_read.input_tokens`', 'Passthrough', 'Preserved as raw attributes'],
+    ['Memory operations (`create_memory`, `search_memory`, …)', 'Passthrough', 'Not yet emitted by any framework we integrate with'],
+  ]}
+/>
+
+<Callout type="info">
+Passthrough means the data is queryable but the Rhesis UI doesn't render it specially yet — no plan visualization, no workflow grouping, no cache-hit indicators. As the GenAI spec stabilizes and frameworks adopt these operations, we'll add semantic mappings.
+</Callout>
+
+<Callout type="success">
+**Your framework now emits spec-native telemetry.** Any application built on it gets Rhesis traces automatically, with zero Rhesis-specific code in the framework itself.
+</Callout>
+
+<Callout type="info">
+  **Related:**
+  - [OTel GenAI Semantic Conventions Spec](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md)
+  - [Microsoft Agent Framework](/docs/tracing/agent-framework) — a working example of this pattern
+  - [Semantic Conventions Reference](/docs/tracing/semantic-conventions) — the Rhesis `ai.*` schema these spans translate into
+  - [Configuring Telemetry](/guides/telemetry-configuration) — back to the mode overview
+</Callout>

--- a/docs/content/guides/telemetry-configuration/genai-conventions.mdx
+++ b/docs/content/guides/telemetry-configuration/genai-conventions.mdx
@@ -15,10 +15,10 @@ If you're building an *application* rather than a framework, use [Auto-Instrumen
 
 ## Operation Mapping
 
-The spec defines several GenAI operation types. Here's how each maps to Rhesis today:
+The spec defines several GenAI operation types. Here's how each maps to Rhesis today — the "Rhesis Translation" column is the exported span's **name**, which is distinct from its `ai.operation.type` attribute value (see [Attribute Mapping](#attribute-mapping) below):
 
 <Table
-  headers={['GenAI Operation', 'Span Name Pattern', 'Rhesis Translation', 'Status']}
+  headers={['GenAI Operation', 'Span Name Pattern', 'Rhesis Span Name', 'Status']}
   rows={[
     ['`chat`', '`chat {model}`', '`ai.llm.invoke`', 'Fully supported'],
     ['`invoke_agent`', '`invoke_agent {agent_name}`', '`ai.agent.invoke`', 'Fully supported'],
@@ -31,6 +31,10 @@ The spec defines several GenAI operation types. Here's how each maps to Rhesis t
 />
 
 `chat`, `invoke_agent`, `create_agent`, `execute_tool`, and `embeddings` translate fully — correct attribute mapping, token extraction, and prompt/completion event synthesis included. `invoke_workflow` and `plan` land under a `function.*` fallback name: visible in traces, but without semantic interpretation yet.
+
+<Callout type="info">
+Span name and `ai.operation.type` are two different fields, and they don't always match textually. An `embeddings` span is named `ai.embedding.generate`, but its `ai.operation.type` attribute is set to `embedding.create` — both refer to the same operation, just via different naming (the span name follows the `ai.<domain>.<action>` convention; the attribute value tracks the GenAI spec's own operation vocabulary more closely).
+</Callout>
 
 ## Attribute Mapping
 

--- a/docs/content/guides/telemetry-configuration/genai-conventions.mdx
+++ b/docs/content/guides/telemetry-configuration/genai-conventions.mdx
@@ -3,7 +3,7 @@ import { Table } from '@/components/Table'
 
 # Configure Telemetry: OTel GenAI Semantic Conventions
 
-If you're building a framework, orchestrator, or agent runtime, implement the [OpenTelemetry Semantic Conventions for GenAI](https://github.com/open-telemetry/semantic-conventions-genai) directly instead of coupling to the Rhesis SDK. Rhesis already ships a translation layer that consumes `gen_ai.*` spans and maps them into the Rhesis `ai.*` schema — this is exactly how the Microsoft Agent Framework and Pydantic AI integrations work today.
+If you're building a framework, orchestrator, or agent runtime, implement the [OpenTelemetry Semantic Conventions for GenAI](https://github.com/open-telemetry/semantic-conventions-genai) directly instead of coupling to the Rhesis SDK. Rhesis already ships a translation layer that consumes `gen_ai.*` spans and maps them into the Rhesis `ai.*` schema: this is exactly how the Microsoft Agent Framework and Pydantic AI integrations work today.
 
 ## Who This Is For
 
@@ -11,11 +11,11 @@ If you're building a framework, orchestrator, or agent runtime, implement the [O
 - You want telemetry that works with any OTel-compatible backend (Jaeger, Honeycomb, Datadog, …) *and* Rhesis
 - You already emit OTel spans and want to align with the emerging standard
 
-If you're building an *application* rather than a framework, use [Auto-Instrumentation](/guides/telemetry-configuration/auto-instrumentation) or [Decorators](/guides/telemetry-configuration/decorators) instead — they're less setup for the same result.
+If you're building an *application* rather than a framework, use [Auto-Instrumentation](/guides/telemetry-configuration/auto-instrumentation) or [Decorators](/guides/telemetry-configuration/decorators) instead: they're less setup for the same result.
 
 ## Operation Mapping
 
-The spec defines several GenAI operation types. Here's how each maps to Rhesis today — the "Rhesis Translation" column is the exported span's **name**, which is distinct from its `ai.operation.type` attribute value (see [Attribute Mapping](#attribute-mapping) below):
+The spec defines several GenAI operation types. Here's how each maps to Rhesis today. The "Rhesis Translation" column is the exported span's **name**, which is distinct from its `ai.operation.type` attribute value (see [Attribute Mapping](#attribute-mapping) below):
 
 <Table
   headers={['GenAI Operation', 'Span Name Pattern', 'Rhesis Span Name', 'Status']}
@@ -25,20 +25,20 @@ The spec defines several GenAI operation types. Here's how each maps to Rhesis t
     ['`create_agent`', '`create_agent {agent_name}`', '`ai.agent.invoke`', 'Fully supported'],
     ['`execute_tool`', '`execute_tool {tool_name}`', '`ai.tool.invoke`', 'Fully supported'],
     ['`embeddings`', '`embeddings {model}`', '`ai.embedding.generate`', 'Fully supported'],
-    ['`invoke_workflow`', '`invoke_workflow {name}`', '`function.{framework}.*`', 'Fallback — no semantic mapping yet'],
-    ['`plan`', '`plan {agent_name}`', '`function.{framework}.*`', 'Fallback — no semantic mapping yet'],
+    ['`invoke_workflow`', '`invoke_workflow {name}`', '`function.{framework}.*`', 'Fallback: no semantic mapping yet'],
+    ['`plan`', '`plan {agent_name}`', '`function.{framework}.*`', 'Fallback: no semantic mapping yet'],
   ]}
 />
 
-`chat`, `invoke_agent`, `create_agent`, `execute_tool`, and `embeddings` translate fully — correct attribute mapping, token extraction, and prompt/completion event synthesis included. `invoke_workflow` and `plan` land under a `function.*` fallback name: visible in traces, but without semantic interpretation yet.
+`chat`, `invoke_agent`, `create_agent`, `execute_tool`, and `embeddings` translate fully: correct attribute mapping, token extraction, and prompt/completion event synthesis included. `invoke_workflow` and `plan` land under a `function.*` fallback name: visible in traces, but without semantic interpretation yet.
 
 <Callout type="info">
-Span name and `ai.operation.type` are two different fields, and they don't always match textually. An `embeddings` span is named `ai.embedding.generate`, but its `ai.operation.type` attribute is set to `embedding.create` — both refer to the same operation, just via different naming (the span name follows the `ai.<domain>.<action>` convention; the attribute value tracks the GenAI spec's own operation vocabulary more closely).
+Span name and `ai.operation.type` are two different fields, and they don't always match textually. An `embeddings` span is named `ai.embedding.generate`, but its `ai.operation.type` attribute is set to `embedding.create`: both refer to the same operation, just via different naming (the span name follows the `ai.<domain>.<action>` convention; the attribute value tracks the GenAI spec's own operation vocabulary more closely).
 </Callout>
 
 ## Attribute Mapping
 
-The translation layer maps `gen_ai.*` attributes to `ai.*` and preserves the originals — both coexist on the exported span:
+The translation layer maps `gen_ai.*` attributes to `ai.*` and preserves the originals, so both coexist on the exported span:
 
 <Table
   headers={['GenAI Attribute', 'Rhesis Attribute', 'Notes']}
@@ -74,15 +74,15 @@ gen_ai.output.messages     -> [{"role": "assistant", "parts": [{"type": "text", 
 Rhesis translates these into `ai.prompt` and `ai.completion` span events rendered in the trace UI. Tool I/O attributes (`gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`) translate similarly into `ai.tool.input` / `ai.tool.output` events.
 
 <Callout type="tip">
-Populate these attributes — they're what makes traces useful in the Rhesis UI (actual prompts and completions inline, not just span names). Privacy-sensitive deployments can opt out with `RHESIS_DISABLE_CONTENT_CAPTURE=true`.
+Populate these attributes: they're what makes traces useful in the Rhesis UI (actual prompts and completions inline, not just span names). Privacy-sensitive deployments can opt out with `RHESIS_DISABLE_CONTENT_CAPTURE=true`.
 </Callout>
 
 ## Agent Handoffs
 
 Rhesis synthesizes `ai.agent.handoff` spans from two patterns:
 
-1. **Tool-call pattern** — an `execute_tool` span where `gen_ai.tool.name` starts with `handoff_to_`. The target agent is parsed from the suffix (`handoff_to_researcher` → `researcher`); the source agent is resolved by walking the span's parent chain.
-2. **Message pattern** — a `chat` span whose `gen_ai.output.messages` contains a `tool_call` part named `handoff_to_*`. This covers frameworks (like MAF) where handoff middleware short-circuits before a tool-execution span is created.
+1. **Tool-call pattern**: an `execute_tool` span where `gen_ai.tool.name` starts with `handoff_to_`. The target agent is parsed from the suffix (`handoff_to_researcher` → `researcher`); the source agent is resolved by walking the span's parent chain.
+2. **Message pattern**: a `chat` span whose `gen_ai.output.messages` contains a `tool_call` part named `handoff_to_*`. This covers frameworks (like MAF) where handoff middleware short-circuits before a tool-execution span is created.
 
 <Callout type="tip">
 If your framework supports agent-to-agent delegation, name your handoff tools `handoff_to_{target_agent}`. That's the convention Microsoft Agent Framework uses, and it's enough signal for Rhesis to draw handoff edges in the graph view with zero Rhesis-specific instrumentation.
@@ -179,7 +179,7 @@ These spans work with any OTel-compatible backend (they follow the standard) and
 
 ## What Is Not Yet Translated
 
-These GenAI spec features land in Rhesis as passthrough attributes — preserved on the span, shipped to the backend, but not yet rendered specially in the UI:
+These GenAI spec features land in Rhesis as passthrough attributes, preserved on the span and shipped to the backend, but not yet rendered specially in the UI:
 
 <Table
   headers={['GenAI Feature', 'Status', 'What Happens Today']}
@@ -197,7 +197,7 @@ These GenAI spec features land in Rhesis as passthrough attributes — preserved
 />
 
 <Callout type="info">
-Passthrough means the data is queryable but the Rhesis UI doesn't render it specially yet — no plan visualization, no workflow grouping, no cache-hit indicators. As the GenAI spec stabilizes and frameworks adopt these operations, we'll add semantic mappings.
+Passthrough means the data is queryable but the Rhesis UI doesn't render it specially yet: no plan visualization, no workflow grouping, no cache-hit indicators. As the GenAI spec stabilizes and frameworks adopt these operations, we'll add semantic mappings.
 </Callout>
 
 <Callout type="success">
@@ -207,7 +207,7 @@ Passthrough means the data is queryable but the Rhesis UI doesn't render it spec
 <Callout type="info">
   **Related:**
   - [OTel GenAI Semantic Conventions Spec](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-agent-spans.md)
-  - [Microsoft Agent Framework](/docs/tracing/agent-framework) — a working example of this pattern
-  - [Semantic Conventions Reference](/docs/tracing/semantic-conventions) — the Rhesis `ai.*` schema these spans translate into
-  - [Configuring Telemetry](/guides/telemetry-configuration) — back to the mode overview
+  - [Microsoft Agent Framework](/docs/tracing/agent-framework) - a working example of this pattern
+  - [Semantic Conventions Reference](/docs/tracing/semantic-conventions) - the Rhesis `ai.*` schema these spans translate into
+  - [Configuring Telemetry](/guides/telemetry-configuration) - back to the mode overview
 </Callout>

--- a/docs/content/guides/telemetry-configuration/index.mdx
+++ b/docs/content/guides/telemetry-configuration/index.mdx
@@ -43,19 +43,21 @@ Already using the SDK to run tests? `RhesisClient()` is likely initialized somew
 
 ```mermaid
 flowchart TD
-    Q1{Building a framework<br/>others will use?}
-    Q1 -->|Yes| GENAI[Emit gen_ai.* spans<br/>per OTel GenAI conventions]
-    Q1 -->|No| Q2{Framework supported by<br/>auto_instrument?}
-    Q2 -->|"Yes: LangChain, LangGraph,<br/>MAF, Pydantic AI"| AUTO[auto_instrument]
-    Q2 -->|No| Q3{Can you decorate the<br/>functions you want traced?}
-    Q3 -->|Yes| DEC["@observe / @endpoint"]
-    Q3 -->|"No: third-party code,<br/>dynamic dispatch"| RAW[Raw OpenTelemetry]
+    Q1{Building a<br/>framework?}
+    Q1 -->|Yes| GENAI[GenAI Semantic<br/>Conventions]
+    Q1 -->|No| Q2{Framework has<br/>auto_instrument?}
+    Q2 -->|Yes| AUTO[Auto-Instrumentation]
+    Q2 -->|No| Q3{Can you decorate<br/>the code?}
+    Q3 -->|Yes| DEC[Decorators]
+    Q3 -->|No| RAW[Raw OpenTelemetry]
 
     style GENAI fill:#e3f2fd,stroke:#1976d2,stroke-width:2px
     style AUTO fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
     style DEC fill:#fff3e0,stroke:#f57c00,stroke-width:2px
     style RAW fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
 ```
+
+The table below has the full detail (which frameworks, which code changes); the diagram only needs to carry the decision logic.
 
 | Mode | Best for | Code changes | Guide |
 |---|---|---|---|

--- a/docs/content/guides/telemetry-configuration/index.mdx
+++ b/docs/content/guides/telemetry-configuration/index.mdx
@@ -8,7 +8,7 @@ Rhesis traces every LLM call, tool invocation, retrieval, and agent handoff your
 ## What You'll Achieve
 
 - **A working trace pipeline** from your application to the Rhesis dashboard
-- **The right level of abstraction** for your stack — zero-code, decorator-based, fully manual, or spec-native
+- **The right level of abstraction** for your stack: zero-code, decorator-based, fully manual, or spec-native
 - **Multi-turn conversation tracking**, if your application is a chat or agent loop rather than single-shot calls
 
 ## Prerequisites
@@ -33,10 +33,10 @@ export RHESIS_PROJECT_ID="your-project-id"
 export RHESIS_ENVIRONMENT="development"`}
 </CodeBlock>
 
-Initializing `RhesisClient` wires up the full export pipeline behind the scenes — see [How Telemetry Flows](#how-telemetry-flows) below.
+Initializing `RhesisClient` wires up the full export pipeline behind the scenes: see [How Telemetry Flows](#how-telemetry-flows) below.
 
 <Callout type="info">
-Already using the SDK to run tests? `RhesisClient()` is likely initialized somewhere already. You do not need a second instance for telemetry — the same client wires up tracing.
+Already using the SDK to run tests? `RhesisClient()` is likely initialized somewhere already. You do not need a second instance for telemetry; the same client wires up tracing.
 </Callout>
 
 ## Which Mode Fits Your Stack?
@@ -65,7 +65,7 @@ flowchart TD
 | **GenAI semantic conventions** | Framework/runtime authors who want backend-neutral telemetry | Emit `gen_ai.*` spans | [GenAI Semantic Conventions](/guides/telemetry-configuration/genai-conventions) |
 
 <Callout type="tip">
-These modes compose. Most real applications mix at least two — for example `auto_instrument("langchain")` for the framework layer plus `@observe.guardrail()` around a hand-rolled safety check.
+These modes compose. Most real applications mix at least two: for example `auto_instrument("langchain")` for the framework layer plus `@observe.guardrail()` around a hand-rolled safety check.
 </Callout>
 
 ## How Telemetry Flows
@@ -78,16 +78,16 @@ Regardless of which mode you pick, every span ends up funneled through the same 
     Exp --> API["POST /telemetry/traces"]
     API --> UI["Rhesis Dashboard"]`} />
 
-`RhesisClient()` creates this pipeline once as a process-wide singleton (`get_tracer_provider()`), registers it as the global OpenTelemetry `TracerProvider`, and every `trace.get_tracer(...)` call afterward feeds into it automatically. You only need to set this up manually if you skip `RhesisClient()` entirely — see [Raw OpenTelemetry](/guides/telemetry-configuration/raw-opentelemetry#the-export-pipeline).
+`RhesisClient()` creates this pipeline once as a process-wide singleton (`get_tracer_provider()`), registers it as the global OpenTelemetry `TracerProvider`, and every `trace.get_tracer(...)` call afterward feeds into it automatically. You only need to set this up manually if you skip `RhesisClient()` entirely: see [Raw OpenTelemetry](/guides/telemetry-configuration/raw-opentelemetry#the-export-pipeline).
 
 ## Tracking Multi-Turn Conversations
 
-Single-shot calls need no extra configuration — each gets its own trace. Chat and agent applications that span multiple turns need two additional pieces of context so the dashboard groups turns into one conversation:
+Single-shot calls need no extra configuration: each gets its own trace. Chat and agent applications that span multiple turns need two additional pieces of context so the dashboard groups turns into one conversation:
 
-- **`conversation_id`** — a stable identifier shared across turns (your session ID)
-- **`conversation_trace_id`** — the shared `trace_id` all turns reuse, so the whole conversation renders as a single trace with turn markers
+- **`conversation_id`**: a stable identifier shared across turns (your session ID)
+- **`conversation_trace_id`**: the shared `trace_id` all turns reuse, so the whole conversation renders as a single trace with turn markers
 
-The easiest path is returning a `session_id` from an `@endpoint`-decorated function — the Rhesis connector manages trace continuity for you automatically. Manual context management (for `@observe` or raw OTel) is covered in each subguide's conversation section. For the full reference, see [Conversation Tracing](/docs/tracing/conversation-tracing).
+The easiest path is returning a `session_id` from an `@endpoint`-decorated function: the Rhesis connector manages trace continuity for you automatically. Manual context management (for `@observe` or raw OTel) is covered in each subguide's conversation section. For the full reference, see [Conversation Tracing](/docs/tracing/conversation-tracing).
 
 ## Next Steps
 
@@ -124,7 +124,7 @@ The easiest path is returning a `session_id` from an `@endpoint`-decorated funct
 
 <Callout type="info">
   **Related:**
-  - [Tracing Overview](/docs/tracing) — concepts and terminology
-  - [Multi-Agent Tracing](/docs/tracing/multi-agent) — agent and handoff spans
-  - [Semantic Conventions Reference](/docs/tracing/semantic-conventions) — full `ai.*` attribute reference
+  - [Tracing Overview](/docs/tracing) - concepts and terminology
+  - [Multi-Agent Tracing](/docs/tracing/multi-agent) - agent and handoff spans
+  - [Semantic Conventions Reference](/docs/tracing/semantic-conventions) - full `ai.*` attribute reference
 </Callout>

--- a/docs/content/guides/telemetry-configuration/index.mdx
+++ b/docs/content/guides/telemetry-configuration/index.mdx
@@ -1,0 +1,130 @@
+import { CodeBlock } from '@/components/CodeBlock'
+import { NextStepCard, NextStepCardGrid } from '@/components/NextStepCard'
+
+# Configuring Telemetry for Your AI Application
+
+Rhesis traces every LLM call, tool invocation, retrieval, and agent handoff your application makes, then renders them as a navigable trace tree in the dashboard. This guide helps you pick the right way to wire that up and points you to a focused subguide for each mode.
+
+## What You'll Achieve
+
+- **A working trace pipeline** from your application to the Rhesis dashboard
+- **The right level of abstraction** for your stack — zero-code, decorator-based, fully manual, or spec-native
+- **Multi-turn conversation tracking**, if your application is a chat or agent loop rather than single-shot calls
+
+## Prerequisites
+
+Every mode below builds on the same client initialization:
+
+<CodeBlock filename="app.py" language="python">
+{`from rhesis.sdk import RhesisClient
+
+client = RhesisClient(
+    api_key="your-api-key",
+    project_id="your-project-id",
+    environment="development",
+)`}
+</CodeBlock>
+
+Or via environment variables, so `RhesisClient()` needs no arguments:
+
+<CodeBlock filename="terminal" language="bash">
+{`export RHESIS_API_KEY="your-api-key"
+export RHESIS_PROJECT_ID="your-project-id"
+export RHESIS_ENVIRONMENT="development"`}
+</CodeBlock>
+
+Initializing `RhesisClient` wires up the full export pipeline behind the scenes — see [How Telemetry Flows](#how-telemetry-flows) below.
+
+<Callout type="info">
+Already using the SDK to run tests? `RhesisClient()` is likely initialized somewhere already. You do not need a second instance for telemetry — the same client wires up tracing.
+</Callout>
+
+## Which Mode Fits Your Stack?
+
+```mermaid
+flowchart TD
+    Q1{Building a framework<br/>others will use?}
+    Q1 -->|Yes| GENAI[Emit gen_ai.* spans<br/>per OTel GenAI conventions]
+    Q1 -->|No| Q2{Framework supported by<br/>auto_instrument?}
+    Q2 -->|"Yes: LangChain, LangGraph,<br/>MAF, Pydantic AI"| AUTO[auto_instrument]
+    Q2 -->|No| Q3{Can you decorate the<br/>functions you want traced?}
+    Q3 -->|Yes| DEC["@observe / @endpoint"]
+    Q3 -->|"No: third-party code,<br/>dynamic dispatch"| RAW[Raw OpenTelemetry]
+
+    style GENAI fill:#e3f2fd,stroke:#1976d2,stroke-width:2px
+    style AUTO fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px
+    style DEC fill:#fff3e0,stroke:#f57c00,stroke-width:2px
+    style RAW fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px
+```
+
+| Mode | Best for | Code changes | Guide |
+|---|---|---|---|
+| **Auto-instrumentation** | LangChain, LangGraph, Microsoft Agent Framework, Pydantic AI apps | None | [Auto-Instrumentation](/guides/telemetry-configuration/auto-instrumentation) |
+| **Decorators** | Custom code, unsupported frameworks (CrewAI, OpenAI Agents SDK, …) | Add `@observe` / `@endpoint` | [Decorators](/guides/telemetry-configuration/decorators) |
+| **Raw OpenTelemetry** | Third-party code you can't decorate, or full control over span attributes | Manual span creation | [Raw OpenTelemetry](/guides/telemetry-configuration/raw-opentelemetry) |
+| **GenAI semantic conventions** | Framework/runtime authors who want backend-neutral telemetry | Emit `gen_ai.*` spans | [GenAI Semantic Conventions](/guides/telemetry-configuration/genai-conventions) |
+
+<Callout type="tip">
+These modes compose. Most real applications mix at least two — for example `auto_instrument("langchain")` for the framework layer plus `@observe.guardrail()` around a hand-rolled safety check.
+</Callout>
+
+## How Telemetry Flows
+
+Regardless of which mode you pick, every span ends up funneled through the same pipeline:
+
+<Mermaid chart={`flowchart LR
+    App["Your application<br/>(spans)"] --> BSP["BatchSpanProcessor<br/>(queue: 2048, batch: 512, flush: 5s)"]
+    BSP --> Exp["RhesisOTLPExporter<br/>(JSON over HTTP, authenticated)"]
+    Exp --> API["POST /telemetry/traces"]
+    API --> UI["Rhesis Dashboard"]`} />
+
+`RhesisClient()` creates this pipeline once as a process-wide singleton (`get_tracer_provider()`), registers it as the global OpenTelemetry `TracerProvider`, and every `trace.get_tracer(...)` call afterward feeds into it automatically. You only need to set this up manually if you skip `RhesisClient()` entirely — see [Raw OpenTelemetry](/guides/telemetry-configuration/raw-opentelemetry#the-export-pipeline).
+
+## Tracking Multi-Turn Conversations
+
+Single-shot calls need no extra configuration — each gets its own trace. Chat and agent applications that span multiple turns need two additional pieces of context so the dashboard groups turns into one conversation:
+
+- **`conversation_id`** — a stable identifier shared across turns (your session ID)
+- **`conversation_trace_id`** — the shared `trace_id` all turns reuse, so the whole conversation renders as a single trace with turn markers
+
+The easiest path is returning a `session_id` from an `@endpoint`-decorated function — the Rhesis connector manages trace continuity for you automatically. Manual context management (for `@observe` or raw OTel) is covered in each subguide's conversation section. For the full reference, see [Conversation Tracing](/docs/tracing/conversation-tracing).
+
+## Next Steps
+
+<NextStepCardGrid>
+  <NextStepCard
+    emoji="⚡"
+    title="Auto-Instrumentation"
+    description="Zero-code tracing for LangChain, LangGraph, Microsoft Agent Framework, and Pydantic AI."
+    link="/guides/telemetry-configuration/auto-instrumentation"
+    linkText="Set up auto-instrumentation →"
+  />
+  <NextStepCard
+    emoji="🎯"
+    title="Decorators"
+    description="Trace custom code and unsupported frameworks with @observe and @endpoint."
+    link="/guides/telemetry-configuration/decorators"
+    linkText="Set up decorators →"
+  />
+  <NextStepCard
+    emoji="🔧"
+    title="Raw OpenTelemetry"
+    description="Full control over span creation for third-party code and advanced cases."
+    link="/guides/telemetry-configuration/raw-opentelemetry"
+    linkText="Set up raw OpenTelemetry →"
+  />
+  <NextStepCard
+    emoji="📡"
+    title="GenAI Semantic Conventions"
+    description="Building a framework? Emit spec-native spans Rhesis translates automatically."
+    link="/guides/telemetry-configuration/genai-conventions"
+    linkText="Implement the spec →"
+  />
+</NextStepCardGrid>
+
+<Callout type="info">
+  **Related:**
+  - [Tracing Overview](/docs/tracing) — concepts and terminology
+  - [Multi-Agent Tracing](/docs/tracing/multi-agent) — agent and handoff spans
+  - [Semantic Conventions Reference](/docs/tracing/semantic-conventions) — full `ai.*` attribute reference
+</Callout>

--- a/docs/content/guides/telemetry-configuration/raw-opentelemetry.mdx
+++ b/docs/content/guides/telemetry-configuration/raw-opentelemetry.mdx
@@ -2,7 +2,7 @@ import { CodeBlock } from '@/components/CodeBlock'
 
 # Configure Telemetry: Raw OpenTelemetry
 
-For cases where you can't decorate functions — third-party code, dynamic dispatch — or need fine-grained control over span attributes and events, use the OpenTelemetry tracer directly with Rhesis's semantic constants.
+For cases where you can't decorate functions (third-party code, dynamic dispatch) or need fine-grained control over span attributes and events, use the OpenTelemetry tracer directly with Rhesis's semantic constants.
 
 ## What You'll Achieve
 
@@ -12,10 +12,10 @@ For cases where you can't decorate functions — third-party code, dynamic dispa
 
 ## Prerequisites
 
-- `RhesisClient` initialized — see [Configuring Telemetry](/guides/telemetry-configuration#prerequisites)
+- `RhesisClient` initialized: see [Configuring Telemetry](/guides/telemetry-configuration#prerequisites)
 
 <Callout type="info">
-If you initialize `RhesisClient()`, the export pipeline below is already wired up for you — skip to [Creating Spans Manually](#creating-spans-manually). The manual pipeline setup is only needed if you're bypassing `RhesisClient()` entirely.
+If you initialize `RhesisClient()`, the export pipeline below is already wired up for you: skip to [Creating Spans Manually](#creating-spans-manually). The manual pipeline setup is only needed if you're bypassing `RhesisClient()` entirely.
 </Callout>
 
 ## The Export Pipeline
@@ -245,12 +245,12 @@ def handle_turn(session_id: str, user_message: str) -> str:
 For the full attribute reference (`rhesis.conversation.*`) and the shared-vs-separate trace_id tradeoff, see [Conversation Tracing](/docs/tracing/conversation-tracing).
 
 <Callout type="success">
-**You have full control over span creation.** For most applications, [Decorators](/guides/telemetry-configuration/decorators) cover the same ground with far less code — reach for raw OpenTelemetry only when you genuinely need it.
+**You have full control over span creation.** For most applications, [Decorators](/guides/telemetry-configuration/decorators) cover the same ground with far less code: reach for raw OpenTelemetry only when you genuinely need it.
 </Callout>
 
 <Callout type="info">
   **Related:**
-  - [Custom Spans Reference](/docs/tracing/custom-spans) — every attribute and event in depth
-  - [Semantic Conventions Reference](/docs/tracing/semantic-conventions) — the complete `ai.*` schema
-  - [Configuring Telemetry](/guides/telemetry-configuration) — back to the mode overview
+  - [Custom Spans Reference](/docs/tracing/custom-spans) - every attribute and event in depth
+  - [Semantic Conventions Reference](/docs/tracing/semantic-conventions) - the complete `ai.*` schema
+  - [Configuring Telemetry](/guides/telemetry-configuration) - back to the mode overview
 </Callout>

--- a/docs/content/guides/telemetry-configuration/raw-opentelemetry.mdx
+++ b/docs/content/guides/telemetry-configuration/raw-opentelemetry.mdx
@@ -1,0 +1,256 @@
+import { CodeBlock } from '@/components/CodeBlock'
+
+# Configure Telemetry: Raw OpenTelemetry
+
+For cases where you can't decorate functions — third-party code, dynamic dispatch — or need fine-grained control over span attributes and events, use the OpenTelemetry tracer directly with Rhesis's semantic constants.
+
+## What You'll Achieve
+
+- Full control over span names, attributes, and events
+- An understanding of the export pipeline so you can wire it manually if needed
+- Correctly-shaped spans that pass Rhesis's span-name validation
+
+## Prerequisites
+
+- `RhesisClient` initialized — see [Configuring Telemetry](/guides/telemetry-configuration#prerequisites)
+
+<Callout type="info">
+If you initialize `RhesisClient()`, the export pipeline below is already wired up for you — skip to [Creating Spans Manually](#creating-spans-manually). The manual pipeline setup is only needed if you're bypassing `RhesisClient()` entirely.
+</Callout>
+
+## The Export Pipeline
+
+`RhesisClient()` calls `get_tracer_provider()`, which creates a singleton `TracerProvider` with a `BatchSpanProcessor` wrapping a `RhesisOTLPExporter`, and registers it as the global OpenTelemetry provider. After that, any `trace.get_tracer(...)` call returns a tracer that feeds into this pipeline:
+
+<Mermaid chart={`sequenceDiagram
+    participant App as Your code
+    participant Tracer as OTel Tracer
+    participant BSP as BatchSpanProcessor
+    participant Exp as RhesisOTLPExporter
+    participant API as Rhesis Backend
+
+    App->>Tracer: start_as_current_span(...)
+    Tracer->>BSP: span ends, queued
+    Note over BSP: buffers up to 2048 spans,<br/>flushes every 5s or at 512 spans
+    BSP->>Exp: export(batch)
+    Exp->>API: POST /telemetry/traces (JSON, authenticated)
+    Exp-->>BSP: retry with backoff on 408/429/5xx`} />
+
+### Setting up the pipeline manually
+
+If you skip `RhesisClient()` and wire things yourself:
+
+<CodeBlock filename="telemetry_setup.py" language="python">
+{`from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from rhesis.telemetry.exporter import RhesisOTLPExporter
+
+# 1. Create the exporter (authenticated JSON-over-HTTP to your backend)
+exporter = RhesisOTLPExporter(
+    api_key="your-api-key",
+    base_url="https://api.rhesis.ai",  # or your self-hosted URL
+    project_id="your-project-id",
+    environment="production",
+)
+
+# 2. Create a TracerProvider with resource metadata
+resource = Resource.create({
+    "service.name": "my-app",
+    "service.namespace": "rhesis",
+    "deployment.environment": "production",
+})
+provider = TracerProvider(resource=resource)
+
+# 3. Wire the exporter through a BatchSpanProcessor
+provider.add_span_processor(
+    BatchSpanProcessor(
+        exporter,
+        max_queue_size=2048,        # spans buffered in memory
+        max_export_batch_size=512,  # spans per HTTP request
+        schedule_delay_millis=5000, # flush interval (5 seconds)
+    )
+)
+
+# 4. Register as global provider
+trace.set_tracer_provider(provider)
+
+# Now trace.get_tracer("my-app") works
+tracer = trace.get_tracer("my-app")`}
+</CodeBlock>
+
+`RhesisOTLPExporter` handles authentication, retry with exponential backoff jitter (on 408/429/5xx and connection errors), chunking for batches over `max_chunk_size` (default 100), conversation context propagation, and span-name validation.
+
+At the end of your process, flush pending spans:
+
+<CodeBlock filename="teardown.py" language="python">
+{`from rhesis.telemetry.provider import shutdown_tracer_provider
+
+shutdown_tracer_provider()  # flushes buffered spans and shuts down`}
+</CodeBlock>
+
+## The Semantic Layer
+
+<Callout type="warning">
+All spans must be named `ai.<domain>.<action>` or `function.<name>`. Names like `chain`, `workflow`, or `pipeline` are rejected by the backend with HTTP 422.
+</Callout>
+
+<CodeBlock filename="constants.py" language="python">
+{`from rhesis.sdk.telemetry import AIAttributes, AIEvents
+from rhesis.telemetry.schemas import AIOperationType
+
+# Span names (use as span_name)
+AIOperationType.LLM_INVOKE          # "ai.llm.invoke"
+AIOperationType.TOOL_INVOKE         # "ai.tool.invoke"
+AIOperationType.RETRIEVAL           # "ai.retrieval"
+AIOperationType.EMBEDDING_GENERATE  # "ai.embedding.generate"
+AIOperationType.RERANK              # "ai.rerank"
+AIOperationType.EVALUATION          # "ai.evaluation"
+AIOperationType.GUARDRAIL           # "ai.guardrail"
+AIOperationType.TRANSFORM           # "ai.transform"
+AIOperationType.AGENT_INVOKE        # "ai.agent.invoke"
+AIOperationType.AGENT_HANDOFF       # "ai.agent.handoff"
+
+# Attribute keys
+AIAttributes.MODEL_PROVIDER        # "ai.model.provider"
+AIAttributes.MODEL_NAME            # "ai.model.name"
+AIAttributes.LLM_TOKENS_INPUT      # "ai.llm.tokens.input"
+AIAttributes.LLM_TOKENS_OUTPUT     # "ai.llm.tokens.output"
+AIAttributes.TOOL_NAME             # "ai.tool.name"
+AIAttributes.TOOL_TYPE             # "ai.tool.type"
+AIAttributes.AGENT_NAME            # "ai.agent.name"
+
+# Event names (for prompt/completion capture)
+AIEvents.PROMPT       # "ai.prompt"
+AIEvents.COMPLETION   # "ai.completion"
+AIEvents.TOOL_INPUT   # "ai.tool.input"
+AIEvents.TOOL_OUTPUT  # "ai.tool.output"`}
+</CodeBlock>
+
+See the [Semantic Conventions Reference](/docs/tracing/semantic-conventions) for the complete list.
+
+## Creating Spans Manually
+
+<Steps>
+
+### Trace an LLM call
+
+<CodeBlock filename="llm_span.py" language="python">
+{`from opentelemetry import trace
+from rhesis.sdk.telemetry import AIAttributes, AIEvents
+from rhesis.telemetry.schemas import AIOperationType
+
+tracer = trace.get_tracer("my-app")
+
+def call_llm(prompt: str) -> str:
+    with tracer.start_as_current_span(AIOperationType.LLM_INVOKE) as span:
+        span.set_attribute(AIAttributes.MODEL_PROVIDER, "openai")
+        span.set_attribute(AIAttributes.MODEL_NAME, "gpt-4o")
+
+        span.add_event(AIEvents.PROMPT, attributes={
+            AIAttributes.PROMPT_ROLE: "user",
+            AIAttributes.PROMPT_CONTENT: prompt,
+        })
+
+        response = openai.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        result = response.choices[0].message.content
+
+        span.add_event(AIEvents.COMPLETION, attributes={
+            AIAttributes.COMPLETION_CONTENT: result,
+        })
+        span.set_attribute(AIAttributes.LLM_TOKENS_INPUT, response.usage.prompt_tokens)
+        span.set_attribute(AIAttributes.LLM_TOKENS_OUTPUT, response.usage.completion_tokens)
+
+        return result`}
+</CodeBlock>
+
+### Trace a tool call
+
+<CodeBlock filename="tool_span.py" language="python">
+{`def execute_tool(tool_name: str, tool_input: dict) -> dict:
+    with tracer.start_as_current_span(AIOperationType.TOOL_INVOKE) as span:
+        span.set_attribute(AIAttributes.TOOL_NAME, tool_name)
+        span.set_attribute(AIAttributes.TOOL_TYPE, "function")
+
+        span.add_event(AIEvents.TOOL_INPUT, attributes={"ai.tool.input": str(tool_input)})
+        result = tool_registry[tool_name](**tool_input)
+        span.add_event(AIEvents.TOOL_OUTPUT, attributes={"ai.tool.output": str(result)})
+
+        return result`}
+</CodeBlock>
+
+### Trace an agent handoff
+
+<CodeBlock filename="agent_span.py" language="python">
+{`def run_agent(agent_name: str, input_text: str) -> str:
+    with tracer.start_as_current_span(AIOperationType.AGENT_INVOKE) as span:
+        span.set_attribute(AIAttributes.AGENT_NAME, agent_name)
+
+        result = call_llm(input_text)
+
+        if should_handoff(result):
+            with tracer.start_as_current_span(AIOperationType.AGENT_HANDOFF) as handoff_span:
+                handoff_span.set_attribute(AIAttributes.AGENT_HANDOFF_FROM, agent_name)
+                handoff_span.set_attribute(AIAttributes.AGENT_HANDOFF_TO, "specialist")
+                result = run_agent("specialist", result)
+
+        return result`}
+</CodeBlock>
+
+</Steps>
+
+<Callout type="tip">
+Building attribute dicts by hand? `create_llm_attributes(...)` and `create_tool_attributes(...)` in `rhesis.sdk.telemetry` save you from remembering every constant name.
+</Callout>
+
+## Tracking Multi-Turn Conversations
+
+At the lowest level, you build the synthetic parent context yourself so subsequent turns share a `trace_id`:
+
+<CodeBlock filename="conversation_span.py" language="python">
+{`from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+
+conversations = {}  # session_id -> {"trace_id": str, "turn": int}
+
+def handle_turn(session_id: str, user_message: str) -> str:
+    parent_context = None
+
+    if session_id in conversations:
+        conv = conversations[session_id]
+        trace_id_int = int(conv["trace_id"], 16)
+        synthetic_span_ctx = SpanContext(
+            trace_id=trace_id_int,
+            span_id=0x00000000CAFECAFE,  # placeholder, stripped by exporter
+            is_remote=True,
+            trace_flags=TraceFlags(TraceFlags.SAMPLED),
+        )
+        parent_context = trace.set_span_in_context(NonRecordingSpan(synthetic_span_ctx))
+
+    with tracer.start_as_current_span("function.chat", context=parent_context) as span:
+        span.set_attribute("rhesis.conversation.is_turn_root", True)
+        span.set_attribute("rhesis.conversation.id", session_id)
+        span.set_attribute("rhesis.conversation.input", user_message[:10000])
+
+        if session_id not in conversations:
+            trace_id = format(span.get_span_context().trace_id, "032x")
+            conversations[session_id] = {"trace_id": trace_id, "turn": 1}
+
+        return call_llm(user_message)`}
+</CodeBlock>
+
+For the full attribute reference (`rhesis.conversation.*`) and the shared-vs-separate trace_id tradeoff, see [Conversation Tracing](/docs/tracing/conversation-tracing).
+
+<Callout type="success">
+**You have full control over span creation.** For most applications, [Decorators](/guides/telemetry-configuration/decorators) cover the same ground with far less code — reach for raw OpenTelemetry only when you genuinely need it.
+</Callout>
+
+<Callout type="info">
+  **Related:**
+  - [Custom Spans Reference](/docs/tracing/custom-spans) — every attribute and event in depth
+  - [Semantic Conventions Reference](/docs/tracing/semantic-conventions) — the complete `ai.*` schema
+  - [Configuring Telemetry](/guides/telemetry-configuration) — back to the mode overview
+</Callout>

--- a/docs/content/guides/telemetry-configuration/raw-opentelemetry.mdx
+++ b/docs/content/guides/telemetry-configuration/raw-opentelemetry.mdx
@@ -176,9 +176,9 @@ def call_llm(prompt: str) -> str:
         span.set_attribute(AIAttributes.TOOL_NAME, tool_name)
         span.set_attribute(AIAttributes.TOOL_TYPE, "function")
 
-        span.add_event(AIEvents.TOOL_INPUT, attributes={"ai.tool.input": str(tool_input)})
+        span.add_event(AIEvents.TOOL_INPUT, attributes={AIAttributes.TOOL_INPUT_CONTENT: str(tool_input)})
         result = tool_registry[tool_name](**tool_input)
-        span.add_event(AIEvents.TOOL_OUTPUT, attributes={"ai.tool.output": str(result)})
+        span.add_event(AIEvents.TOOL_OUTPUT, attributes={AIAttributes.TOOL_OUTPUT_CONTENT: str(result)})
 
         return result`}
 </CodeBlock>


### PR DESCRIPTION
## Purpose
Developers instrumenting their AI application with Rhesis had no single guide walking through which telemetry mode to use and how to set it up. This adds that guide to the Guides section, nested with a subguide per mode.

## What Changed
- New guide `Configuring Telemetry for Your AI Application` (`/guides/telemetry-configuration`) — decision tree, prerequisites, export pipeline overview, and multi-turn conversation tracking summary
- Nested subguides, one per mode:
  - `auto-instrumentation` — zero-code setup for LangChain, LangGraph, Microsoft Agent Framework, Pydantic AI
  - `decorators` — `@observe` / `@endpoint` setup and reference
  - `raw-opentelemetry` — manual pipeline wiring and span creation with `AIAttributes`
  - `genai-conventions` — recommendation for framework authors to emit `gen_ai.*` spans, with full mapping/gap tables
- Updated `docs/content/guides/_meta.tsx` and `index.mdx` to register and surface the new guide
- Structure mirrors the existing `/docs/tracing` folder pattern (folder + `_meta.tsx` + `index.mdx` rendered as a collapsible sidebar group)

## Additional Context
Uses the existing MDX component set (`CodeBlock`, `Callout`, `Steps`, `Table`, `Mermaid`, `NextStepCard`) for consistency with other guides.

## Testing
- `npm run build` in `docs/src` completes with no MDX errors (279 static pages generated)
- Verified via local dev server that all 5 new routes return 200 and the sidebar nests the 4 subguides under the main guide