### PR TITLE
Fix 500 on GET /users/ for orgs with terms-accepted members

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -26,7 +26,11 @@ from rhesis.backend.app.schemas.polyphemus import (
     PolyphemusAccessRequest,
     PolyphemusAccessResponse,
 )
-from rhesis.backend.app.schemas.user import UserSettings, UserSettingsRead, UserSettingsUpdate
+from rhesis.backend.app.schemas.user import (
+    UserSettingsOutput,
+    UserSettingsRead,
+    UserSettingsUpdate,
+)
 from rhesis.backend.app.services import polyphemus as polyphemus_service
 from rhesis.backend.app.utils.database_exceptions import handle_database_exceptions
 from rhesis.backend.app.utils.decorators import with_count_header
@@ -242,7 +246,7 @@ def get_user_settings(
     return _user_settings_read_payload(db_user, request, current_user, db)
 
 
-@router.patch("/settings", response_model=UserSettings)
+@router.patch("/settings", response_model=UserSettingsOutput)
 @handle_database_exceptions(entity_name="user settings")
 def update_user_settings(
     settings_update: UserSettingsUpdate,

--- a/apps/backend/src/rhesis/backend/app/schemas/user.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/user.py
@@ -144,13 +144,24 @@ class UserSettings(BaseModel):
     is_verified: Optional[bool] = Field(None, description="User verification status")
 
 
-class UserSettingsRead(UserSettings):
-    """GET /users/settings — includes server-resolved affordances for self-service actions."""
+class UserSettingsOutput(UserSettings):
+    """user_settings as returned in user-serializing responses (e.g. GET /users/, GET /users/{id}).
+
+    Adds the server-managed ``terms`` field so users whose settings contain it don't fail
+    response validation. Distinct from the writable ``UserSettings`` (still forbids ``terms``
+    on input) and from ``UserSettingsRead`` (adds ``permitted_actions`` for the dedicated
+    GET /users/settings endpoint).
+    """
 
     terms: Optional[dict] = Field(
         None,
         description="Server-managed terms acceptance metadata (read-only for users)",
     )
+
+
+class UserSettingsRead(UserSettingsOutput):
+    """GET /users/settings — includes server-resolved affordances for self-service actions."""
+
     permitted_actions: list[str] = Field(
         default_factory=list,
         description="Capabilities the caller may exercise on their own settings "
@@ -221,7 +232,10 @@ class UserUpdate(UserBase):
 
 
 class User(UserBase):
-    pass
+    user_settings: Optional[UserSettingsOutput] = Field(
+        default_factory=lambda: UserSettingsOutput(version=1),
+        description="User preferences and settings",
+    )
 
 
 # For use in responses where we need minimal user info

--- a/tests/backend/routes/test_user_settings.py
+++ b/tests/backend/routes/test_user_settings.py
@@ -470,6 +470,38 @@ class TestUserSettingsRoutes:
 
         assert data["ui"]["theme"] == "dark", "JSONB mutation was not persisted"
 
+    def test_patch_settings_for_terms_accepted_user_returns_200(
+        self, authenticated_client, settings_endpoint, test_db, authenticated_user_id
+    ):
+        """✅ PATCH /users/settings must not 500 when user_settings already has `terms`.
+
+        Regression test for the response-model bug where `terms` (written by
+        auth/terms.py on T&C acceptance) failed response validation against the
+        strict `UserSettings` schema (extra="forbid", no `terms` field).
+        """
+        from datetime import datetime, timezone
+
+        from rhesis.backend.app import models
+
+        db_user = (
+            test_db.query(models.User).filter(models.User.id == authenticated_user_id).first()
+        )
+        db_user.user_settings = {
+            **(db_user.user_settings or {}),
+            "terms": {
+                "accepted_at": datetime.now(timezone.utc).isoformat(),
+                "version": "1.0",
+            },
+        }
+        test_db.commit()
+
+        response = authenticated_client.patch(settings_endpoint, json={"ui": {"theme": "dark"}})
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["ui"]["theme"] == "dark"
+        assert data["terms"]["version"] == "1.0"
+
 
 # Export test class for pytest discovery
 __all__ = ["TestUserSettingsRoutes"]


### PR DESCRIPTION
## Purpose

`GET /users/` returned a 500 for any organization containing a member who had accepted the terms & conditions. The response schema for the user list serialized `user_settings` through `UserSettings`, which has `extra=\"forbid\"` and no `terms` field — but `auth/terms.py` writes a `terms` key into that same JSONB column on acceptance. One teammate accepting T&C broke the Team tab for the whole org.

## What Changed

- Added `UserSettingsOutput(UserSettings)` — adds the `terms` field for response serialization
  only.
- `User` (the `GET /users/` and `GET /users/{id}` response schema) now types `user_settings` as  `UserSettingsOutput` instead of the writable `UserSettings`.
- Left the writable `UserSettings` (used by `UserCreate`/`UserUpdate` via `UserBase`) unchanged  and still `extra=\"forbid\"` with no `terms` field, so `PUT /users/{id}` still rejects  client-supplied `terms` (verified by the existing
  `test_update_user_rejects_user_settings_terms` test).
- `UserSettingsRead` (dedicated `GET /users/settings` schema) now extends `UserSettingsOutput`  instead of duplicating the `terms` field.

## Additional Context

- Root cause: `auth/terms.py`'s `record_terms_acceptance` (introduced in #2144) writes `terms` into `user_settings`, but only `UserSettingsRead` (used by `GET /users/settings`) accounted for it — the list/detail schema didn't.
- No detailed traceback was visible in Cloud Logging because FastAPI's response-model validation errors aren't logged by the app's exception handling; only the access-log 500 line showed up.

## Testing

- `uvx ruff check` / `ruff format --check` on the changed file.
- `uv run pytest ../../tests/backend/auth/test_terms.py ../../tests/backend/routes/test_auth.py ../../tests/backend/routes/test_user_settings.py -q` — all pass (104 passed), including the security regression test for `PUT /users/{id}` rejecting client-supplied `terms`.
- `uv run pytest ../../tests/backend/ -q -k "user"` — 333 passed, 31 skipped (pre-existing skips unrelated to this change).