### PR TITLE
Add custom JSON schema support for chatbot JSON mode

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/invokers/templating/response_mapper.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/templating/response_mapper.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 from typing import Any, Dict
 
 import jsonpath_ng
@@ -9,9 +10,28 @@ from jinja2 import Template
 
 logger = logging.getLogger(__name__)
 
+# Matches a template that is exactly one bare variable reference, e.g. "{{ message }}"
+# or "{{ metadata.output_mode }}" — no filters, literals, or operators.
+_SIMPLE_VAR_PATTERN = re.compile(r"^\{\{\s*([A-Za-z0-9_.]+)\s*\}\}$")
+
 
 class ResponseMapper:
     """Handles response mapping using Jinja2 templates (with optional JSONPath)."""
+
+    def _resolve_dotted_path(self, response_data: Dict[str, Any], path: str) -> Any:
+        """Resolve a dotted path (e.g. "metadata.id") against response_data.
+
+        Returns None if any segment along the path is missing.
+        """
+        value: Any = response_data
+        for part in path.split("."):
+            if isinstance(value, dict) and part in value:
+                value = value[part]
+            elif hasattr(value, part):
+                value = getattr(value, part)
+            else:
+                return None
+        return value
 
     def _jsonpath_extract(self, response_data: Dict[str, Any], path: str) -> Any:
         """
@@ -44,6 +64,19 @@ class ResponseMapper:
         Returns:
             The mapped value or None if extraction failed
         """
+        # If the template is a single bare variable reference and that value is a
+        # complex type (dict/list/Pydantic model), preserve it as-is instead of
+        # rendering through Jinja2, which would stringify it via Python's repr
+        # (e.g. {'response': 'foo'}) rather than producing valid JSON. This mirrors
+        # TemplateRenderer._parse_rendered_value on the request-mapping side.
+        simple_var_match = _SIMPLE_VAR_PATTERN.match(mapping_value)
+        if simple_var_match:
+            value = self._resolve_dotted_path(response_data, simple_var_match.group(1))
+            if hasattr(value, "model_dump"):
+                return value.model_dump(exclude_none=True)
+            if isinstance(value, (dict, list)):
+                return value
+
         # Step 1: Render as Jinja2 template with response_data as context
         # Also provide jsonpath() function for extracting nested fields
         template = Template(mapping_value)

--- a/apps/chatbot/client.py
+++ b/apps/chatbot/client.py
@@ -454,6 +454,7 @@ class ChatRequest(BaseModel):
     temperature: Optional[float] = None
     max_tokens: Optional[int] = None
     mode: Optional[str] = None  # Output mode: "text" or "json"
+    response_schema: Optional[dict] = None  # Custom JSON Schema, applied when mode == "json"
     context_strategy: Optional[str] = None
     files: Optional[List[FileInput]] = None
     rhesis: Optional[dict] = None
@@ -531,6 +532,9 @@ def extract_file_content(file_input: FileInput) -> dict:
         "temperature": "{{ params.temperature | default(0.7) }}",
         "max_tokens": "{{ params.max_tokens | default(1024) }}",
         "output_mode": "{{ params.output_mode | default(mode | default('text')) }}",
+        # Bare variable reference (no filter) so TemplateRenderer's simple-variable
+        # passthrough preserves the dict as-is instead of stringifying it via Jinja.
+        "response_schema": "{{ params.response_schema }}",
         "context_strategy": "{{ params.context_strategy | default('heuristic') }}",
         "use_case": "{{ params.use_case | default('insurance') }}",
         "conversation_history": "{{ conversation_history | default(none) }}",
@@ -559,6 +563,7 @@ async def chat(
     temperature: float = 0.7,
     max_tokens: int = 1024,
     output_mode: str = "text",
+    response_schema: Optional[dict] = None,
     context_strategy: str = "heuristic",
     conversation_history: Optional[List[dict]] = None,
     files: Optional[List[dict]] = None,
@@ -576,6 +581,9 @@ async def chat(
         message: User's message
         session_id: Session identifier (reuse to continue a conversation)
         use_case: Use case for system prompt
+        response_schema: Custom JSON Schema for the assistant's reply. Only
+            applied when ``output_mode == "json"``; when omitted, falls back
+            to the default ``{"response": str}`` schema.
         conversation_history: Explicit conversation history; when ``None``
             the history is looked up from the in-memory session store.
         files: Raw file dicts from the backend (each has filename, content_type,
@@ -595,6 +603,10 @@ async def chat(
     context_strategy = _optional_string(context_strategy) or "heuristic"
     temperature = _float_or_default(temperature, 0.7)
     max_tokens = _int_or_default(max_tokens, 1024)
+    # Guard against the literal "None" string / empty string Jinja2 can render
+    # when the template variable is absent (see conversation_history below).
+    if not isinstance(response_schema, dict) or not response_schema:
+        response_schema = None
 
     # Resolve session – reuse existing or create new
     session_id = session_id or str(uuid.uuid4())
@@ -711,6 +723,7 @@ async def chat(
         temperature=temperature,
         max_tokens=max_tokens,
         context_strategy=context_strategy,
+        response_schema=response_schema,
     )
     tool_calls = []
 
@@ -837,6 +850,7 @@ async def chat_endpoint(
             "temperature": chat_request.temperature,
             "max_tokens": chat_request.max_tokens,
             "context_strategy": chat_request.context_strategy,
+            "response_schema": chat_request.response_schema,
         }
         params.update(
             {
@@ -875,6 +889,7 @@ async def chat_endpoint(
             temperature=params.get("temperature", 0.7),
             max_tokens=params.get("max_tokens", 1024),
             output_mode=output_mode,
+            response_schema=params.get("response_schema"),
             context_strategy=params.get("context_strategy", "heuristic"),
             file_contents=file_contents,
             rhesis=chat_request.rhesis,

--- a/apps/chatbot/endpoint.py
+++ b/apps/chatbot/endpoint.py
@@ -99,6 +99,7 @@ class ResponseGenerator:
         temperature: float = 0.7,
         max_tokens: int = 1024,
         context_strategy: str = "heuristic",
+        response_schema: dict | None = None,
     ):
         """Initialize with SDK model and use case."""
         if model:
@@ -116,6 +117,7 @@ class ResponseGenerator:
         self.temperature = temperature
         self.max_tokens = max_tokens
         self.context_strategy = context_strategy
+        self.response_schema = response_schema
 
         self.use_case_system_prompt = self._load_system_prompt()
 
@@ -192,6 +194,19 @@ class ResponseGenerator:
         messages.append({"role": "user", "content": current_user_content})
         return messages
 
+    @staticmethod
+    def _wrap_json_schema(schema: dict) -> dict:
+        """Wrap a caller-supplied JSON Schema into the structured-output shape
+        SDK model providers expect (OpenAI's json_schema response_format)."""
+        return {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "custom_response",
+                "schema": schema,
+                "strict": True,
+            },
+        }
+
     @observe.llm(
         provider=_provider,
         model=_model_name,
@@ -203,7 +218,11 @@ class ResponseGenerator:
             "max_tokens": self.max_tokens,
         }
         if mode == "json":
-            kwargs["schema"] = ChatResponse
+            kwargs["schema"] = (
+                self._wrap_json_schema(self.response_schema)
+                if self.response_schema
+                else ChatResponse
+            )
 
         return await self.model.a_generate(messages=messages, **kwargs)
 
@@ -534,6 +553,7 @@ def get_response_generator(
     temperature: float = 0.7,
     max_tokens: int = 1024,
     context_strategy: str = "heuristic",
+    response_schema: dict | None = None,
 ) -> ResponseGenerator:
     """Get a ResponseGenerator instance for the specified use case."""
     return ResponseGenerator(
@@ -543,6 +563,7 @@ def get_response_generator(
         temperature=temperature,
         max_tokens=max_tokens,
         context_strategy=context_strategy,
+        response_schema=response_schema,
     )
 
 

--- a/tests/backend/services/invokers/test_response_mapper.py
+++ b/tests/backend/services/invokers/test_response_mapper.py
@@ -165,6 +165,47 @@ class TestResponseMapper:
         assert result["test2"] == "fallback"
         assert result["test3"] == "text"
 
+    def test_map_response_preserves_dict_for_simple_variable_template(self):
+        """A bare {{ var }} template should return the dict itself, not its repr."""
+        mapper = ResponseMapper()
+        response_data = {"message": {"classification": "billing", "confidence": "high"}}
+        mappings = {"output": "{{ message }}"}
+
+        result = mapper.map_response(response_data, mappings)
+
+        assert result["output"] == {"classification": "billing", "confidence": "high"}
+
+    def test_map_response_preserves_list_for_simple_variable_template(self):
+        """A bare {{ var }} template should return the list itself, not its repr."""
+        mapper = ResponseMapper()
+        response_data = {"context": ["a", "b", "c"]}
+        mappings = {"output": "{{ context }}"}
+
+        result = mapper.map_response(response_data, mappings)
+
+        assert result["output"] == ["a", "b", "c"]
+
+    def test_map_response_preserves_nested_dict_via_dotted_path(self):
+        """A bare {{ var.attr }} template should also preserve complex nested values."""
+        mapper = ResponseMapper()
+        response_data = {"metadata": {"intent": {"intent": "support", "confidence": "low"}}}
+        mappings = {"intent": "{{ metadata.intent }}"}
+
+        result = mapper.map_response(response_data, mappings)
+
+        assert result["intent"] == {"intent": "support", "confidence": "low"}
+
+    def test_map_response_still_stringifies_non_simple_dict_template(self):
+        """Templates that aren't a bare variable reference keep prior string behavior."""
+        mapper = ResponseMapper()
+        response_data = {"message": {"a": 1}, "fallback": "text"}
+        mappings = {"output": "{{ message or fallback }}"}
+
+        result = mapper.map_response(response_data, mappings)
+
+        # Not a simple single-variable template, so Jinja2 renders it as a string
+        assert result["output"] == "{'a': 1}"
+
     def test_jsonpath_extract_with_invalid_path(self):
         """Test _jsonpath_extract with invalid JSONPath."""
         mapper = ResponseMapper()


### PR DESCRIPTION
## Purpose

Enable callers to define the exact JSON shape returned by the chatbot when
`mode: "json"` is set, instead of being locked to a hardcoded `{"response": str}`
schema regardless of the system prompt's instructions (e.g. classification
use cases). Uses the SDK's existing structured-output support rather than
adding new infrastructure.

While validating that the new field's output would come back as real JSON
through the platform's remote test-execution path (not just the direct
FastAPI route), found a related bug in the backend's response mapping: bare
single-variable templates like `"{{ message }}"` were stringified through
Jinja2's Python repr (single-quoted, invalid JSON) instead of preserving the
dict/list value, unlike the equivalent request-mapping code path which already
had this passthrough. Fixed as part of this change since the new feature
depends on it.

## What Changed

- `apps/chatbot/client.py`: added `response_schema` field to `ChatRequest`,
  threaded through `chat_endpoint` → `chat()` → `ResponseGenerator`.
- `apps/chatbot/endpoint.py`: `ResponseGenerator` wraps a caller-supplied JSON
  Schema into the OpenAI-style structured-output shape and passes it to
  `model.a_generate(schema=...)` when `mode == "json"`; falls back to the
  original `ChatResponse` schema when no `response_schema` is provided.
- `apps/backend/.../templating/response_mapper.py`: `ResponseMapper` now
  preserves dict/list/Pydantic values for bare single-variable
  `response_mapping` templates instead of stringifying them, mirroring
  `TemplateRenderer`'s existing behavior for `request_mapping`.
- Added tests for the response mapper fix (`tests/backend/services/invokers/test_response_mapper.py`).

## Additional Context

None.

## Testing

- `cd apps/backend && uv run pytest ../../tests/backend/services/invokers/ -v`
  — 213 passed, including 4 new cases covering dict/list passthrough and the
  unchanged stringify behavior for non-simple templates.
- Manually verified against a locally running chatbot service via curl:
  - `mode: "json"` + `response_schema` → `message` returned as the exact
    custom-shaped JSON object (not the default schema).
  - `mode: "json"` with no `response_schema` → unchanged fallback to
    `{"response": "..."}`.
  - `mode: "text"` + `system_prompt` override → unaffected.