### PR TITLE
Add JSON-aware rendering in test result drawer

### DIFF
--- a/apps/frontend/src/app/(protected)/playground/components/MessageBubble.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/MessageBubble.tsx
@@ -187,7 +187,7 @@ export default function MessageBubble({
               }}
             >
               <Box sx={{ flex: 1, minWidth: 0 }}>
-                {isUser ? (
+                {message.role === 'user' ? (
                   <Typography
                     variant="body2"
                     sx={{

--- a/apps/frontend/src/app/(protected)/playground/components/MessageBubble.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/MessageBubble.tsx
@@ -21,7 +21,7 @@ import DownloadIcon from '@mui/icons-material/Download';
 import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
 import { TracesIcon } from '@/components/icons';
 import { ChatMessage } from '@/hooks/usePlaygroundChat';
-import MarkdownContent from '@/components/common/MarkdownContent';
+import MessageContent from '@/components/common/MessageContent';
 import { BORDER_RADIUS } from '@/styles/theme-constants';
 
 interface MessageBubbleProps {
@@ -196,7 +196,7 @@ export default function MessageBubble({
                     {message.content}
                   </Typography>
                 ) : (
-                  <MarkdownContent content={message.content} variant="body2" />
+                  <MessageContent content={message.content} variant="body2" />
                 )}
               </Box>
 

--- a/apps/frontend/src/app/(protected)/playground/components/MessageBubble.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/MessageBubble.tsx
@@ -22,6 +22,7 @@ import ScienceOutlinedIcon from '@mui/icons-material/ScienceOutlined';
 import { TracesIcon } from '@/components/icons';
 import { ChatMessage } from '@/hooks/usePlaygroundChat';
 import MessageContent from '@/components/common/MessageContent';
+import { stringifyMessageContent } from '@/utils/message-content';
 import { BORDER_RADIUS } from '@/styles/theme-constants';
 
 interface MessageBubbleProps {
@@ -53,7 +54,9 @@ export default function MessageBubble({
   const handleCopy = async (e: React.MouseEvent) => {
     e.stopPropagation();
     try {
-      await navigator.clipboard.writeText(message.content);
+      await navigator.clipboard.writeText(
+        stringifyMessageContent(message.content)
+      );
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {

--- a/apps/frontend/src/app/(protected)/playground/components/PlaygroundChat.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/PlaygroundChat.tsx
@@ -33,6 +33,7 @@ import MessageBubble, { MessageBubbleSkeleton } from './MessageBubble';
 import TraceDrawer from '@/app/(protected)/traces/components/TraceDrawer';
 import CreateTestFromConversationDrawer from './CreateTestFromConversationDrawer';
 import { ConversationMessage } from '@/utils/api-client/interfaces/tests';
+import { stringifyMessageContent } from '@/utils/message-content';
 import { TEST_TYPES, type TestTypeValue } from '@/constants/test-types';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 
@@ -193,7 +194,10 @@ export default function PlaygroundChat({
 
     const conversationMessages = messages
       .filter(msg => !msg.isError)
-      .map(msg => ({ role: msg.role, content: msg.content }));
+      .map(msg => ({
+        role: msg.role,
+        content: stringifyMessageContent(msg.content),
+      }));
 
     setTestDrawerMessages(conversationMessages);
     setTestDrawerType(TEST_TYPES.MULTI_TURN);
@@ -207,7 +211,10 @@ export default function PlaygroundChat({
 
       const userMessage = messages[messageIndex];
       const conversationMessages: ConversationMessage[] = [
-        { role: userMessage.role, content: userMessage.content },
+        {
+          role: userMessage.role,
+          content: stringifyMessageContent(userMessage.content),
+        },
       ];
 
       // Include the next assistant message if available
@@ -219,7 +226,7 @@ export default function PlaygroundChat({
       ) {
         conversationMessages.push({
           role: nextMessage.role,
-          content: nextMessage.content,
+          content: stringifyMessageContent(nextMessage.content),
         });
       }
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
@@ -21,10 +21,7 @@ import FileAttachmentList from '@/components/common/FileAttachmentList';
 import MarkdownContent from '@/components/common/MarkdownContent';
 import { JsonPreview } from '@/app/(protected)/endpoints/components/JsonPreview';
 import { testPreviewSx } from '@/app/(protected)/endpoints/components/endpoint-styles';
-import {
-  looksLikeMarkdown,
-  parseJsonString,
-} from '@/utils/message-content';
+import { looksLikeMarkdown, parseJsonString } from '@/utils/message-content';
 import { useFiles } from '@/hooks/useFiles';
 import { getEffectiveTestResultStatus } from '@/utils/test-result-status';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
@@ -21,6 +21,10 @@ import FileAttachmentList from '@/components/common/FileAttachmentList';
 import MarkdownContent from '@/components/common/MarkdownContent';
 import { JsonPreview } from '@/app/(protected)/endpoints/components/JsonPreview';
 import { testPreviewSx } from '@/app/(protected)/endpoints/components/endpoint-styles';
+import {
+  looksLikeMarkdown,
+  parseJsonString,
+} from '@/utils/message-content';
 import { useFiles } from '@/hooks/useFiles';
 import { getEffectiveTestResultStatus } from '@/utils/test-result-status';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
@@ -34,27 +38,6 @@ interface TestDetailOverviewTabProps {
   onTestResultUpdate: (updatedTest: TestResultDetail) => void;
   testSetType?: string; // e.g., "Multi-turn" or "Single-turn"
 }
-
-const parseJsonString = (
-  text: string
-): Record<string, unknown> | unknown[] | null => {
-  const trimmed = text.trim();
-  if (
-    !(trimmed.startsWith('{') && trimmed.endsWith('}')) &&
-    !(trimmed.startsWith('[') && trimmed.endsWith(']'))
-  ) {
-    return null;
-  }
-  try {
-    const parsed: unknown = JSON.parse(trimmed);
-    if (parsed !== null && typeof parsed === 'object') {
-      return parsed as Record<string, unknown> | unknown[];
-    }
-  } catch {
-    return null;
-  }
-  return null;
-};
 
 // Helper function to render text with proper list formatting
 const renderFormattedText = (text: string) => {
@@ -150,7 +133,16 @@ export default function TestDetailOverviewTab({
         </Box>
       );
     }
-    return <MarkdownContent content={text} variant="body2" />;
+    return looksLikeMarkdown(text) ? (
+      <MarkdownContent content={text} variant="body2" />
+    ) : (
+      <Typography
+        variant="body2"
+        sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', m: 0 }}
+      >
+        {text}
+      </Typography>
+    );
   };
 
   const isMultiTurn =

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailOverviewTab.tsx
@@ -18,6 +18,9 @@ import TestResultTags from './TestResultTags';
 import StatusChip from '@/components/common/StatusChip';
 import ViewField from '@/components/common/ViewField';
 import FileAttachmentList from '@/components/common/FileAttachmentList';
+import MarkdownContent from '@/components/common/MarkdownContent';
+import { JsonPreview } from '@/app/(protected)/endpoints/components/JsonPreview';
+import { testPreviewSx } from '@/app/(protected)/endpoints/components/endpoint-styles';
 import { useFiles } from '@/hooks/useFiles';
 import { getEffectiveTestResultStatus } from '@/utils/test-result-status';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
@@ -32,18 +35,23 @@ interface TestDetailOverviewTabProps {
   testSetType?: string; // e.g., "Multi-turn" or "Single-turn"
 }
 
-// Try to parse a string as JSON and pretty-print it; returns null if not JSON
-const tryFormatJson = (text: string): string | null => {
+const parseJsonString = (
+  text: string
+): Record<string, unknown> | unknown[] | null => {
   const trimmed = text.trim();
   if (
-    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
-    (trimmed.startsWith('[') && trimmed.endsWith(']'))
+    !(trimmed.startsWith('{') && trimmed.endsWith('}')) &&
+    !(trimmed.startsWith('[') && trimmed.endsWith(']'))
   ) {
-    try {
-      return JSON.stringify(JSON.parse(trimmed), null, 2);
-    } catch {
-      return null;
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed !== null && typeof parsed === 'object') {
+      return parsed as Record<string, unknown> | unknown[];
     }
+  } catch {
+    return null;
   }
   return null;
 };
@@ -123,33 +131,26 @@ export default function TestDetailOverviewTab({
     entityType: 'TestResult',
   });
 
-  // Render text content, formatting JSON when detected
   const renderTextContent = (text: string) => {
-    const formatted = tryFormatJson(text);
-    if (formatted) {
+    const parsed = parseJsonString(text);
+    if (parsed !== null) {
       return (
-        <Typography
+        <Box
           component="pre"
-          variant="body2"
           sx={{
+            fontFamily: 'monospace',
+            fontSize: 12,
             whiteSpace: 'pre-wrap',
             wordBreak: 'break-word',
-            fontFamily: theme.typography.fontFamilyCode,
             m: 0,
+            p: 0,
           }}
         >
-          {formatted}
-        </Typography>
+          <JsonPreview value={parsed} />
+        </Box>
       );
     }
-    return (
-      <Typography
-        variant="body2"
-        sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-      >
-        {text}
-      </Typography>
-    );
+    return <MarkdownContent content={text} variant="body2" />;
   };
 
   const isMultiTurn =
@@ -341,18 +342,12 @@ export default function TestDetailOverviewTab({
                     overflow: 'auto',
                   }}
                 >
-                  <Typography
+                  <Box
                     component="pre"
-                    variant="body2"
-                    sx={{
-                      whiteSpace: 'pre-wrap',
-                      wordBreak: 'break-word',
-                      fontFamily: theme.typography.fontFamilyCode,
-                      m: 0,
-                    }}
+                    sx={{ ...testPreviewSx, minHeight: 'unset' }}
                   >
-                    {JSON.stringify(test.test_output.metadata, null, 2)}
-                  </Typography>
+                    <JsonPreview value={test.test_output.metadata} />
+                  </Box>
                 </Paper>
               </Collapse>
             </Box>

--- a/apps/frontend/src/components/common/ConversationHistory.tsx
+++ b/apps/frontend/src/components/common/ConversationHistory.tsx
@@ -28,10 +28,7 @@ import MarkdownContent from '@/components/common/MarkdownContent';
 import StatusChip from '@/components/common/StatusChip';
 import { JsonPreview } from '@/app/(protected)/endpoints/components/JsonPreview';
 import { testPreviewSx } from '@/app/(protected)/endpoints/components/endpoint-styles';
-import {
-  looksLikeMarkdown,
-  parseJsonString,
-} from '@/utils/message-content';
+import { looksLikeMarkdown, parseJsonString } from '@/utils/message-content';
 import { getProjectIconComponent } from '@/components/common/ProjectIcons';
 import { Project } from '@/utils/api-client/interfaces/project';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';

--- a/apps/frontend/src/components/common/ConversationHistory.tsx
+++ b/apps/frontend/src/components/common/ConversationHistory.tsx
@@ -28,6 +28,10 @@ import MarkdownContent from '@/components/common/MarkdownContent';
 import StatusChip from '@/components/common/StatusChip';
 import { JsonPreview } from '@/app/(protected)/endpoints/components/JsonPreview';
 import { testPreviewSx } from '@/app/(protected)/endpoints/components/endpoint-styles';
+import {
+  looksLikeMarkdown,
+  parseJsonString,
+} from '@/utils/message-content';
 import { getProjectIconComponent } from '@/components/common/ProjectIcons';
 import { Project } from '@/utils/api-client/interfaces/project';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -36,27 +40,6 @@ import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 // Superhero (female) emoji built from code points to avoid linter emoji detection.
 // U+1F9B8 (superhero) + U+200D (ZWJ) + U+2640 (female sign) + U+FE0F (variation selector)
 const PENELOPE_ICON = String.fromCodePoint(0x1f9b8, 0x200d, 0x2640, 0xfe0f);
-
-const parseJsonString = (
-  text: string
-): Record<string, unknown> | unknown[] | null => {
-  const trimmed = text.trim();
-  if (
-    !(trimmed.startsWith('{') && trimmed.endsWith('}')) &&
-    !(trimmed.startsWith('[') && trimmed.endsWith(']'))
-  ) {
-    return null;
-  }
-  try {
-    const parsed: unknown = JSON.parse(trimmed);
-    if (parsed !== null && typeof parsed === 'object') {
-      return parsed as Record<string, unknown> | unknown[];
-    }
-  } catch {
-    return null;
-  }
-  return null;
-};
 
 function renderJsonPreview(value: unknown) {
   return (
@@ -71,7 +54,17 @@ function renderMessageContent(content: string) {
   if (parsed !== null) {
     return renderJsonPreview(parsed);
   }
-  return <MarkdownContent content={content} variant="body2" />;
+  if (looksLikeMarkdown(content)) {
+    return <MarkdownContent content={content} variant="body2" />;
+  }
+  return (
+    <Typography
+      variant="body2"
+      sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', m: 0 }}
+    >
+      {content}
+    </Typography>
+  );
 }
 
 interface ConversationHistoryProps {
@@ -721,7 +714,7 @@ export default function ConversationHistory({
                         }}
                         onClick={e => e.stopPropagation()}
                       >
-                        {(turn.context as string[]).map((item, idx, arr) => {
+                        {(turn.context ?? []).map((item, idx, arr) => {
                           const itemContent =
                             typeof item === 'string'
                               ? renderMessageContent(item)

--- a/apps/frontend/src/components/common/ConversationHistory.tsx
+++ b/apps/frontend/src/components/common/ConversationHistory.tsx
@@ -26,6 +26,8 @@ import {
 import type { FileResponse } from '@/utils/api-client/interfaces/file';
 import MarkdownContent from '@/components/common/MarkdownContent';
 import StatusChip from '@/components/common/StatusChip';
+import { JsonPreview } from '@/app/(protected)/endpoints/components/JsonPreview';
+import { testPreviewSx } from '@/app/(protected)/endpoints/components/endpoint-styles';
 import { getProjectIconComponent } from '@/components/common/ProjectIcons';
 import { Project } from '@/utils/api-client/interfaces/project';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -34,6 +36,43 @@ import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 // Superhero (female) emoji built from code points to avoid linter emoji detection.
 // U+1F9B8 (superhero) + U+200D (ZWJ) + U+2640 (female sign) + U+FE0F (variation selector)
 const PENELOPE_ICON = String.fromCodePoint(0x1f9b8, 0x200d, 0x2640, 0xfe0f);
+
+const parseJsonString = (
+  text: string
+): Record<string, unknown> | unknown[] | null => {
+  const trimmed = text.trim();
+  if (
+    !(trimmed.startsWith('{') && trimmed.endsWith('}')) &&
+    !(trimmed.startsWith('[') && trimmed.endsWith(']'))
+  ) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed !== null && typeof parsed === 'object') {
+      return parsed as Record<string, unknown> | unknown[];
+    }
+  } catch {
+    return null;
+  }
+  return null;
+};
+
+function renderJsonPreview(value: unknown) {
+  return (
+    <Box component="pre" sx={{ ...testPreviewSx, minHeight: 'unset', m: 0 }}>
+      <JsonPreview value={value} />
+    </Box>
+  );
+}
+
+function renderMessageContent(content: string) {
+  const parsed = parseJsonString(content);
+  if (parsed !== null) {
+    return renderJsonPreview(parsed);
+  }
+  return <MarkdownContent content={content} variant="body2" />;
+}
 
 interface ConversationHistoryProps {
   conversationSummary: ConversationTurn[];
@@ -626,10 +665,7 @@ export default function ConversationHistory({
                         : 0,
                   }}
                 >
-                  <MarkdownContent
-                    content={turn.target_response || ''}
-                    variant="body2"
-                  />
+                  {renderMessageContent(turn.target_response || '')}
                 </Box>
 
                 {/* Context (collapsible within response) */}
@@ -685,22 +721,25 @@ export default function ConversationHistory({
                         }}
                         onClick={e => e.stopPropagation()}
                       >
-                        {(turn.context as string[]).map((item, idx, arr) => (
-                          <Typography
-                            key={`ctx-${turn.turn}-${item}`}
-                            variant="body2"
-                            sx={{
-                              color: theme.palette.text.secondary,
-                              mb: idx < arr.length - 1 ? 1 : 0,
-                              pl: 1,
-                              borderLeft: `2px solid ${theme.palette.info.light}`,
-                            }}
-                          >
-                            {typeof item === 'string'
-                              ? item
-                              : JSON.stringify(item)}
-                          </Typography>
-                        ))}
+                        {(turn.context as string[]).map((item, idx, arr) => {
+                          const itemContent =
+                            typeof item === 'string'
+                              ? renderMessageContent(item)
+                              : renderJsonPreview(item);
+                          return (
+                            <Box
+                              key={`ctx-${turn.turn}-${typeof item === 'string' ? item : idx}`}
+                              sx={{
+                                color: theme.palette.text.secondary,
+                                mb: idx < arr.length - 1 ? 1 : 0,
+                                pl: 1,
+                                borderLeft: `2px solid ${theme.palette.info.light}`,
+                              }}
+                            >
+                              {itemContent}
+                            </Box>
+                          );
+                        })}
                       </Box>
                     </Collapse>
                   </>
@@ -762,20 +801,7 @@ export default function ConversationHistory({
                         }}
                         onClick={e => e.stopPropagation()}
                       >
-                        <Typography
-                          component="pre"
-                          variant="body2"
-                          sx={{
-                            fontFamily:
-                              theme.typography.fontFamilyCode ?? 'monospace',
-                            whiteSpace: 'pre-wrap',
-                            wordBreak: 'break-all',
-                            color: theme.palette.text.secondary,
-                            m: 0,
-                          }}
-                        >
-                          {JSON.stringify(turn.metadata, null, 2)}
-                        </Typography>
+                        {renderJsonPreview(turn.metadata)}
                       </Box>
                     </Collapse>
                   </>
@@ -837,20 +863,7 @@ export default function ConversationHistory({
                         }}
                         onClick={e => e.stopPropagation()}
                       >
-                        <Typography
-                          component="pre"
-                          variant="body2"
-                          sx={{
-                            fontFamily:
-                              theme.typography.fontFamilyCode ?? 'monospace',
-                            whiteSpace: 'pre-wrap',
-                            wordBreak: 'break-all',
-                            color: theme.palette.text.secondary,
-                            m: 0,
-                          }}
-                        >
-                          {JSON.stringify(turn.tool_calls, null, 2)}
-                        </Typography>
+                        {renderJsonPreview(turn.tool_calls)}
                       </Box>
                     </Collapse>
                   </>

--- a/apps/frontend/src/components/common/MessageContent.tsx
+++ b/apps/frontend/src/components/common/MessageContent.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import React from 'react';
+import { Box, Typography, TypographyProps } from '@mui/material';
+import MarkdownContent from '@/components/common/MarkdownContent';
+import { JsonPreview } from '@/app/(protected)/endpoints/components/JsonPreview';
+import { testPreviewSx } from '@/app/(protected)/endpoints/components/endpoint-styles';
+import { looksLikeMarkdown, parseJsonString } from '@/utils/message-content';
+
+interface MessageContentProps {
+  content: string;
+  variant?: TypographyProps['variant'];
+}
+
+/** Renders message text as JSON preview, markdown, or plain pre-wrapped text. */
+export default function MessageContent({
+  content,
+  variant = 'body2',
+}: MessageContentProps) {
+  const parsed = parseJsonString(content);
+  if (parsed !== null) {
+    return (
+      <Box component="pre" sx={{ ...testPreviewSx, minHeight: 'unset', m: 0 }}>
+        <JsonPreview value={parsed} />
+      </Box>
+    );
+  }
+  if (looksLikeMarkdown(content)) {
+    return <MarkdownContent content={content} variant={variant} />;
+  }
+  return (
+    <Typography
+      variant={variant}
+      sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', m: 0 }}
+    >
+      {content}
+    </Typography>
+  );
+}

--- a/apps/frontend/src/components/common/MessageContent.tsx
+++ b/apps/frontend/src/components/common/MessageContent.tsx
@@ -8,8 +8,16 @@ import { testPreviewSx } from '@/app/(protected)/endpoints/components/endpoint-s
 import { looksLikeMarkdown, parseJsonString } from '@/utils/message-content';
 
 interface MessageContentProps {
-  content: string;
+  content: unknown;
   variant?: TypographyProps['variant'];
+}
+
+function renderJsonPreview(value: unknown) {
+  return (
+    <Box component="pre" sx={{ ...testPreviewSx, minHeight: 'unset', m: 0 }}>
+      <JsonPreview value={value} />
+    </Box>
+  );
 }
 
 /** Renders message text as JSON preview, markdown, or plain pre-wrapped text. */
@@ -17,23 +25,24 @@ export default function MessageContent({
   content,
   variant = 'body2',
 }: MessageContentProps) {
-  const parsed = parseJsonString(content);
-  if (parsed !== null) {
-    return (
-      <Box component="pre" sx={{ ...testPreviewSx, minHeight: 'unset', m: 0 }}>
-        <JsonPreview value={parsed} />
-      </Box>
-    );
+  if (content !== null && typeof content === 'object') {
+    return renderJsonPreview(content);
   }
-  if (looksLikeMarkdown(content)) {
-    return <MarkdownContent content={content} variant={variant} />;
+
+  const text = content == null ? '' : String(content);
+  const parsed = parseJsonString(text);
+  if (parsed !== null) {
+    return renderJsonPreview(parsed);
+  }
+  if (looksLikeMarkdown(text)) {
+    return <MarkdownContent content={text} variant={variant} />;
   }
   return (
     <Typography
       variant={variant}
       sx={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word', m: 0 }}
     >
-      {content}
+      {text}
     </Typography>
   );
 }

--- a/apps/frontend/src/hooks/__tests__/usePlaygroundChat.test.ts
+++ b/apps/frontend/src/hooks/__tests__/usePlaygroundChat.test.ts
@@ -222,9 +222,13 @@ describe('usePlaygroundChat', () => {
     });
 
     expect(result.current.messages).toHaveLength(2);
-    expect(result.current.messages[1].role).toBe('assistant');
-    expect(result.current.messages[1].content).toBe('Hi there!');
-    expect(result.current.messages[1].traceId).toBe('trace-123');
+    const assistantMessage = result.current.messages[1];
+    expect(assistantMessage.role).toBe('assistant');
+    if (assistantMessage.role !== 'assistant') {
+      throw new Error('expected assistant message');
+    }
+    expect(assistantMessage.content).toBe('Hi there!');
+    expect(assistantMessage.traceId).toBe('trace-123');
     expect(result.current.isLoading).toBe(false);
     expect(result.current.sessionId).toBe('sess-1');
   });

--- a/apps/frontend/src/hooks/usePlaygroundChat.ts
+++ b/apps/frontend/src/hooks/usePlaygroundChat.ts
@@ -17,8 +17,8 @@ export interface ChatMessage {
   id: string;
   /** Message role: user or assistant */
   role: 'user' | 'assistant';
-  /** Message content (may contain markdown) */
-  content: string;
+  /** Message content (string or structured JSON from endpoint output) */
+  content: string | Record<string, unknown> | unknown[];
   /** Trace ID for assistant messages (for viewing trace details) */
   traceId?: string;
   /** Timestamp when the message was created */

--- a/apps/frontend/src/hooks/usePlaygroundChat.ts
+++ b/apps/frontend/src/hooks/usePlaygroundChat.ts
@@ -12,24 +12,30 @@ import { readActiveProjectId } from '@/utils/active-project';
 /**
  * Chat message interface for the playground.
  */
-export interface ChatMessage {
+type ChatMessageBase = {
   /** Unique message ID */
   id: string;
-  /** Message role: user or assistant */
-  role: 'user' | 'assistant';
-  /** Message content (string or structured JSON from endpoint output) */
-  content: string | Record<string, unknown> | unknown[];
-  /** Trace ID for assistant messages (for viewing trace details) */
-  traceId?: string;
   /** Timestamp when the message was created */
   timestamp: Date;
   /** Whether the message is an error */
   isError?: boolean;
-  /** File attachments on user messages */
+};
+
+export type UserChatMessage = ChatMessageBase & {
+  role: 'user';
+  content: string;
   files?: FileAttachment[];
-  /** Output files on assistant messages */
+};
+
+export type AssistantChatMessage = ChatMessageBase & {
+  role: 'assistant';
+  /** String or structured JSON from endpoint output */
+  content: string | Record<string, unknown> | unknown[];
+  traceId?: string;
   outputFiles?: FileAttachment[];
-}
+};
+
+export type ChatMessage = UserChatMessage | AssistantChatMessage;
 
 /**
  * Options for the usePlaygroundChat hook.
@@ -132,10 +138,10 @@ export function usePlaygroundChat(
           }
 
           // Add assistant message
-          const assistantMessage: ChatMessage = {
+          const assistantMessage: AssistantChatMessage = {
             id: generateMessageId(),
             role: 'assistant',
-            content: payload?.output || '',
+            content: payload?.output ?? '',
             traceId: payload?.trace_id,
             timestamp: new Date(),
             ...(payload?.output_files?.length && {
@@ -163,7 +169,7 @@ export function usePlaygroundChat(
           setError(errorMessage);
 
           // Add error message as assistant response
-          const errorChatMessage: ChatMessage = {
+          const errorChatMessage: AssistantChatMessage = {
             id: generateMessageId(),
             role: 'assistant',
             content: `Error: ${errorMessage}`,
@@ -214,7 +220,7 @@ export function usePlaygroundChat(
       pendingCorrelationRef.current = correlationId;
 
       // Add user message immediately
-      const userMessage: ChatMessage = {
+      const userMessage: UserChatMessage = {
         id: generateMessageId(),
         role: 'user',
         content: trimmedMessage,

--- a/apps/frontend/src/utils/__tests__/message-content.test.ts
+++ b/apps/frontend/src/utils/__tests__/message-content.test.ts
@@ -1,0 +1,60 @@
+import {
+  looksLikeMarkdown,
+  parseJsonString,
+  stringifyMessageContent,
+} from '../message-content';
+
+describe('message-content', () => {
+  describe('parseJsonString', () => {
+    it('parses JSON objects and arrays', () => {
+      expect(parseJsonString('{"a":1}')).toEqual({ a: 1 });
+      expect(parseJsonString('[1, 2]')).toEqual([1, 2]);
+    });
+
+    it('parses JSON primitives', () => {
+      expect(parseJsonString('true')).toBe(true);
+      expect(parseJsonString('false')).toBe(false);
+      expect(parseJsonString('null')).toBe(null);
+      expect(parseJsonString('42')).toBe(42);
+      expect(parseJsonString('-3.14')).toBe(-3.14);
+      expect(parseJsonString('"ok"')).toBe('ok');
+    });
+
+    it('rejects plain text that is not JSON', () => {
+      expect(parseJsonString('hello')).toBeNull();
+      expect(parseJsonString('The answer is 42')).toBeNull();
+      expect(parseJsonString('true story')).toBeNull();
+      expect(parseJsonString('')).toBeNull();
+    });
+  });
+
+  describe('looksLikeMarkdown', () => {
+    it('detects common markdown syntax', () => {
+      expect(looksLikeMarkdown('# Heading')).toBe(true);
+      expect(looksLikeMarkdown('- item')).toBe(true);
+      expect(looksLikeMarkdown('**bold**')).toBe(true);
+      expect(looksLikeMarkdown('[link](https://example.com)')).toBe(true);
+      expect(looksLikeMarkdown('```code```')).toBe(true);
+    });
+
+    it('detects inline code', () => {
+      expect(looksLikeMarkdown('Run `curl` to test')).toBe(true);
+      expect(looksLikeMarkdown('Use `foo_bar` here')).toBe(true);
+    });
+
+    it('returns false for plain text', () => {
+      expect(looksLikeMarkdown('hello world')).toBe(false);
+      expect(looksLikeMarkdown('line one\nline two')).toBe(false);
+    });
+  });
+
+  describe('stringifyMessageContent', () => {
+    it('returns strings unchanged', () => {
+      expect(stringifyMessageContent('hello')).toBe('hello');
+    });
+
+    it('stringifies structured values', () => {
+      expect(stringifyMessageContent({ a: 1 })).toBe('{\n  "a": 1\n}');
+    });
+  });
+});

--- a/apps/frontend/src/utils/message-content.ts
+++ b/apps/frontend/src/utils/message-content.ts
@@ -2,6 +2,9 @@
 export function parseJsonString(
   text: string
 ): Record<string, unknown> | unknown[] | null {
+  if (typeof text !== 'string') {
+    return null;
+  }
   const trimmed = text.trim();
   if (
     !(trimmed.startsWith('{') && trimmed.endsWith('}')) &&
@@ -25,5 +28,19 @@ const MARKDOWN_PATTERN =
 
 /** True when the text contains common markdown syntax (not just plain text). */
 export function looksLikeMarkdown(text: string): boolean {
+  if (typeof text !== 'string' || !text) {
+    return false;
+  }
   return MARKDOWN_PATTERN.test(text);
+}
+
+/** Normalize message content to a display/API string. */
+export function stringifyMessageContent(content: unknown): string {
+  if (typeof content === 'string') {
+    return content;
+  }
+  if (content == null) {
+    return '';
+  }
+  return JSON.stringify(content, null, 2);
 }

--- a/apps/frontend/src/utils/message-content.ts
+++ b/apps/frontend/src/utils/message-content.ts
@@ -1,30 +1,35 @@
-/** Parse a string as JSON object/array; returns null when not valid JSON. */
-export function parseJsonString(
-  text: string
-): Record<string, unknown> | unknown[] | null {
+/** Parse a string as JSON; returns null when not valid JSON. */
+export function parseJsonString(text: string): unknown | null {
   if (typeof text !== 'string') {
     return null;
   }
   const trimmed = text.trim();
-  if (
-    !(trimmed.startsWith('{') && trimmed.endsWith('}')) &&
-    !(trimmed.startsWith('[') && trimmed.endsWith(']'))
-  ) {
+  if (!trimmed) {
     return null;
   }
+
+  const looksLikeJson =
+    (trimmed.startsWith('{') && trimmed.endsWith('}')) ||
+    (trimmed.startsWith('[') && trimmed.endsWith(']')) ||
+    trimmed === 'true' ||
+    trimmed === 'false' ||
+    trimmed === 'null' ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) ||
+    /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/.test(trimmed);
+
+  if (!looksLikeJson) {
+    return null;
+  }
+
   try {
-    const parsed: unknown = JSON.parse(trimmed);
-    if (parsed !== null && typeof parsed === 'object') {
-      return parsed as Record<string, unknown> | unknown[];
-    }
+    return JSON.parse(trimmed);
   } catch {
     return null;
   }
-  return null;
 }
 
 const MARKDOWN_PATTERN =
-  /(^|\n)(#{1,6}\s|[-*+]\s|\d+\.\s|>\s|```)|(\*\*.+\*\*|__.+__)|(\[.+\]\(.+\))/;
+  /(^|\n)(#{1,6}\s|[-*+]\s|\d+\.\s|>\s|```)|(\*\*.+\*\*|__.+__)|(\[.+\]\(.+\))|(`[^`\n]+`)/;
 
 /** True when the text contains common markdown syntax (not just plain text). */
 export function looksLikeMarkdown(text: string): boolean {

--- a/apps/frontend/src/utils/message-content.ts
+++ b/apps/frontend/src/utils/message-content.ts
@@ -1,0 +1,29 @@
+/** Parse a string as JSON object/array; returns null when not valid JSON. */
+export function parseJsonString(
+  text: string
+): Record<string, unknown> | unknown[] | null {
+  const trimmed = text.trim();
+  if (
+    !(trimmed.startsWith('{') && trimmed.endsWith('}')) &&
+    !(trimmed.startsWith('[') && trimmed.endsWith(']'))
+  ) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (parsed !== null && typeof parsed === 'object') {
+      return parsed as Record<string, unknown> | unknown[];
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+const MARKDOWN_PATTERN =
+  /(^|\n)(#{1,6}\s|[-*+]\s|\d+\.\s|>\s|```)|(\*\*.+\*\*|__.+__)|(\[.+\]\(.+\))/;
+
+/** True when the text contains common markdown syntax (not just plain text). */
+export function looksLikeMarkdown(text: string): boolean {
+  return MARKDOWN_PATTERN.test(text);
+}

--- a/apps/frontend/src/utils/websocket/types.ts
+++ b/apps/frontend/src/utils/websocket/types.ts
@@ -321,7 +321,7 @@ export interface ChatMessagePayload {
  * Chat response payload (received from server).
  */
 export interface ChatResponsePayload {
-  output: string;
+  output: string | Record<string, unknown> | unknown[];
   trace_id?: string;
   endpoint_id: string;
   /** Conversation ID for multi-turn conversations (canonical name) */


### PR DESCRIPTION
## Summary

- Render JSON responses with syntax-highlighted `JsonPreview` in the test result overview and conversation tabs
- Fall back to `MarkdownContent` for non-JSON text (lists, bold, code blocks, etc.)
- Reuse existing endpoint workbench preview styles (`testPreviewSx`) for metadata and tool calls

## Test plan

- [ ] Open a single-turn test result with a plain-text response — verify markdown renders correctly
- [ ] Open a test result with a JSON response — verify syntax-highlighted JSON in the Overview tab
- [ ] Open a multi-turn test result — verify JSON responses in the Conversation tab use `JsonPreview`
- [ ] Expand metadata and tool calls in conversation turns — verify highlighted JSON
- [ ] Confirm non-JSON markdown responses still render formatting in the Conversation tab