### PR TITLE
Publish GHCR images on platform tag with version labels

### DIFF
--- a/.github/workflows/publish-ghcr-images.yml
+++ b/.github/workflows/publish-ghcr-images.yml
@@ -1,6 +1,9 @@
 name: "[Build] Docker GitHub Container Registry"
 
 on:
+  push:
+    tags:
+      - 'v*'  # Trigger on platform version tags (e.g., v0.10.0)
   workflow_dispatch:
 
 permissions:
@@ -243,14 +246,30 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute image tags
+        id: tags
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}"
+          # Release (platform tag e.g. v0.10.0): publish :latest + :<version>.
+          # Manual dispatch: publish :dev only, so ad-hoc builds never touch :latest.
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+            TAG_ARGS="-t ${IMAGE}:latest -t ${IMAGE}:${VERSION}"
+            PRIMARY_REF="${IMAGE}:${VERSION}"
+          else
+            TAG_ARGS="-t ${IMAGE}:dev"
+            PRIMARY_REF="${IMAGE}:dev"
+          fi
+          echo "tag_args=${TAG_ARGS}" >> "$GITHUB_OUTPUT"
+          echo "primary_ref=${PRIMARY_REF}" >> "$GITHUB_OUTPUT"
+
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
         run: |
           docker buildx imagetools create \
-            -t ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:latest \
+            ${{ steps.tags.outputs.tag_args }} \
             $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:latest
+          docker buildx imagetools inspect ${{ steps.tags.outputs.primary_ref }}


### PR DESCRIPTION
## Purpose

Publish the GHCR container images (backend, worker, frontend, chatbot) automatically as part of the release flow, instead of only via a manual run. This mirrors the SDK/PyPI mechanism (`publish-pypi.yml`), which auto-triggers on version-tag pushes.

## What Changed

- **Trigger on the platform version tag.** Added a `push` trigger on `v*` tags (e.g. `v0.10.0`) alongside the existing `workflow_dispatch`. Platform tags are `v<version>` while component tags are prefixed (`sdk-v*`, `backend-v*`, …), so `v*` matches only platform releases.
- **Label images with the version.** The `merge` job now tags images per trigger:
  - **Release (tag `v0.10.0`)** → `:latest` + `:0.10.0`
  - **Manual dispatch** → `:dev` only — ad-hoc builds never overwrite `:latest`
- Manifest create/inspect steps use the computed tags.

## Additional Context

- `:latest` is only ever written by a release-tag push, so a bare `docker pull …/backend` always resolves to the newest release (Docker defaults an untagged pull to `:latest`, never `:dev`).
- Note: `:latest` won't exist until the first `v*` tag is pushed; a manual dispatch alone will not create it (by design).

## Testing

- Push a platform tag `vX.Y.Z` (or let Release step 3 create it) and confirm the images publish as `:latest` and `:X.Y.Z`.
- Run the workflow manually via `workflow_dispatch` and confirm it publishes `:dev` and leaves `:latest` untouched.
