### PR TITLE
Fix duplicated behavior metrics in test run batch execution

### DIFF
--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
@@ -47,7 +47,11 @@ class ExecutionContext:
     execution_model: Any = None
     evaluation_model: Any = None
     # SDK MetricConfig objects built while the DB session is open (ORM-safe after close).
+    # Shared list used when all tests share the same metrics (Priority 1/2).
     metric_configs: List[MetricConfig] = field(default_factory=list)
+    # Per-test metric configs for behavior-mapped metrics (Priority 3) where each
+    # test may have a different behavior with different metrics.
+    per_test_metric_configs: Dict[str, List[MetricConfig]] = field(default_factory=dict)
     test_data: Dict[str, Any] = field(default_factory=dict)
     input_files: Dict[str, List] = field(default_factory=dict)
     existing_result_ids: Set[str] = field(default_factory=set)
@@ -66,6 +70,21 @@ class ExecutionContext:
     # Snapshot of test_data taken before the main pass, used to persist error
     # records after the batch for tests that failed without a DB row.
     test_data_snapshot: Dict[str, Any] = field(default_factory=dict)
+
+    def get_metric_configs_for_test(self, test_id: str) -> List[MetricConfig]:
+        """Return metric configs for a specific test.
+
+        Uses per-test configs when available (behavior-mapped metrics),
+        otherwise falls back to the shared list (test_set / execution-time).
+        """
+        if self.per_test_metric_configs:
+            return self.per_test_metric_configs.get(test_id, [])
+        return self.metric_configs
+
+    @property
+    def has_metrics(self) -> bool:
+        """True if any test has metric configs to evaluate."""
+        return bool(self.metric_configs) or bool(self.per_test_metric_configs)
 
 
 def prefetch_execution_context(
@@ -172,31 +191,68 @@ def prefetch_execution_context(
     # Pre-fetch metrics: convert ORM -> MetricConfig before session closes.  Async
     # evaluation runs after session.close(); detached Metric rows would raise on
     # lazy loads (e.g. backend_type) in metric_model_to_config.
+    #
+    # Metric resolution follows a 3-level priority (see executors/data.py):
+    #   P1 execution-time, P2 test-set, P3 behavior.
+    # P1 and P2 produce the same metrics for every test, so a single resolution
+    # from any sample test is correct.  P3 (behavior) can differ per test because
+    # each test may belong to a different behavior with different metrics.
+    # Detect which priority applies and resolve accordingly.
     metric_configs: List[MetricConfig] = []
-    try:
-        sample_test = tests[0] if tests else None
-        if sample_test:
-            metrics = get_test_metrics(
-                sample_test,
-                session,
-                organization_id,
-                user_id,
-                test_set=test_set,
-                test_configuration=test_config,
-            )
-            from rhesis.backend.tasks.execution.executors.metrics import (
-                prepare_metric_configs,
-            )
+    per_test_metric_configs: Dict[str, List[MetricConfig]] = {}
 
-            metric_models = prepare_metric_configs(metrics, str(sample_test.id))
+    try:
+        from rhesis.backend.tasks.execution.executors.metrics import (
+            prepare_metric_configs,
+        )
+
+        def _convert_metrics(metric_models, label):
+            configs = []
             for m in metric_models:
                 try:
-                    metric_configs.append(metric_model_to_config(m))
+                    configs.append(metric_model_to_config(m))
                 except Exception as conv_err:
                     logger.warning(
-                        f"Failed to convert metric {getattr(m, 'id', '?')} to "
-                        f"MetricConfig for test {sample_test.id}: {conv_err}"
+                        f"Failed to convert metric {getattr(m, 'id', '?')} "
+                        f"to MetricConfig for {label}: {conv_err}"
                     )
+            return configs
+
+        # Check whether P1 or P2 apply (shared metrics for all tests).
+        attrs = test_config.attributes or {}
+        has_execution_time_metrics = bool(attrs.get("metrics"))
+        has_test_set_metrics = bool(
+            test_set and hasattr(test_set, "metrics") and test_set.metrics
+        )
+
+        if has_execution_time_metrics or has_test_set_metrics:
+            # P1 / P2: metrics are the same for every test; resolve once.
+            sample_test = tests[0] if tests else None
+            if sample_test:
+                metrics = get_test_metrics(
+                    sample_test,
+                    session,
+                    organization_id,
+                    user_id,
+                    test_set=test_set,
+                    test_configuration=test_config,
+                )
+                models = prepare_metric_configs(metrics, str(sample_test.id))
+                metric_configs = _convert_metrics(models, f"test {sample_test.id}")
+        else:
+            # P3: behavior metrics — resolve per test.
+            for test in tests:
+                tid = str(test.id)
+                metrics = get_test_metrics(
+                    test,
+                    session,
+                    organization_id,
+                    user_id,
+                    test_set=test_set,
+                    test_configuration=test_config,
+                )
+                models = prepare_metric_configs(metrics, tid)
+                per_test_metric_configs[tid] = _convert_metrics(models, f"test {tid}")
     except Exception as e:
         logger.warning(f"Failed to pre-fetch metrics: {e}")
 
@@ -270,6 +326,7 @@ def prefetch_execution_context(
         execution_model=execution_model,
         evaluation_model=evaluation_model,
         metric_configs=metric_configs,
+        per_test_metric_configs=per_test_metric_configs,
         test_data=test_data,
         existing_result_ids=existing_result_ids,
         batch_concurrency=batch_concurrency,

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
@@ -221,9 +221,7 @@ def prefetch_execution_context(
         # Check whether P1 or P2 apply (shared metrics for all tests).
         attrs = test_config.attributes or {}
         has_execution_time_metrics = bool(attrs.get("metrics"))
-        has_test_set_metrics = bool(
-            test_set and hasattr(test_set, "metrics") and test_set.metrics
-        )
+        has_test_set_metrics = bool(test_set and hasattr(test_set, "metrics") and test_set.metrics)
 
         if has_execution_time_metrics or has_test_set_metrics:
             # P1 / P2: metrics are the same for every test; resolve once.

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
@@ -194,10 +194,13 @@ def prefetch_execution_context(
     #
     # Metric resolution follows a 3-level priority (see executors/data.py):
     #   P1 execution-time, P2 test-set, P3 behavior.
-    # P1 and P2 produce the same metrics for every test, so a single resolution
-    # from any sample test is correct.  P3 (behavior) can differ per test because
-    # each test may belong to a different behavior with different metrics.
-    # Detect which priority applies and resolve accordingly.
+    # P1 and P2 come from shared config (test_configuration.attributes / test_set.metrics)
+    # and resolve identically for every test, so a single resolution is correct — but
+    # only when one of them actually wins. get_test_metrics() can fall through past a
+    # *configured* P1/P2 to P3 if it resolves to zero valid metrics (missing/invalid IDs,
+    # or every candidate filtered out for lacking a class_name), and that fallback can
+    # differ per test. So resolve the sample test first and branch on the priority that
+    # actually won, not on whether P1/P2 config is merely present.
     metric_configs: List[MetricConfig] = []
     per_test_metric_configs: Dict[str, List[MetricConfig]] = {}
 
@@ -218,37 +221,41 @@ def prefetch_execution_context(
                     )
             return configs
 
-        # Check whether P1 or P2 apply (shared metrics for all tests).
-        attrs = test_config.attributes or {}
-        has_execution_time_metrics = bool(attrs.get("metrics"))
-        has_test_set_metrics = bool(test_set and hasattr(test_set, "metrics") and test_set.metrics)
-
-        if has_execution_time_metrics or has_test_set_metrics:
-            # P1 / P2: metrics are the same for every test; resolve once.
-            sample_test = tests[0] if tests else None
-            if sample_test:
-                metrics = get_test_metrics(
-                    sample_test,
-                    session,
-                    organization_id,
-                    user_id,
-                    test_set=test_set,
-                    test_configuration=test_config,
-                )
-                models = prepare_metric_configs(metrics, str(sample_test.id))
-                metric_configs = _convert_metrics(models, f"test {sample_test.id}")
+        sample_test = tests[0] if tests else None
+        if sample_test:
+            sample_metrics, sample_source = get_test_metrics(
+                sample_test,
+                session,
+                organization_id,
+                user_id,
+                test_set=test_set,
+                test_configuration=test_config,
+                return_source=True,
+            )
         else:
-            # P3: behavior metrics — resolve per test.
+            sample_metrics, sample_source = [], "none"
+
+        if sample_source in ("execution_time", "test_set"):
+            # P1 / P2 actually won: shared config, safe to reuse for every test.
+            models = prepare_metric_configs(sample_metrics, str(sample_test.id))
+            metric_configs = _convert_metrics(models, f"test {sample_test.id}")
+        else:
+            # P3 (or no metrics at all) — resolution can differ per test since each
+            # test may belong to a different behavior. Reuse the sample test's
+            # already-resolved metrics instead of querying it twice.
             for test in tests:
                 tid = str(test.id)
-                metrics = get_test_metrics(
-                    test,
-                    session,
-                    organization_id,
-                    user_id,
-                    test_set=test_set,
-                    test_configuration=test_config,
-                )
+                if test is sample_test:
+                    metrics = sample_metrics
+                else:
+                    metrics = get_test_metrics(
+                        test,
+                        session,
+                        organization_id,
+                        user_id,
+                        test_set=test_set,
+                        test_configuration=test_config,
+                    )
                 models = prepare_metric_configs(metrics, tid)
                 per_test_metric_configs[tid] = _convert_metrics(models, f"test {tid}")
     except Exception as e:

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/evaluation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/evaluation.py
@@ -37,9 +37,14 @@ async def evaluate_metrics(
         return {}
 
     metrics_results = dict(penelope_metrics)
+    test_metric_configs = ctx.get_metric_configs_for_test(test_id)
     try:
         if is_multi_turn:
-            metrics_results.update(await _evaluate_multi_turn_metrics(ctx, evaluator, test, output))
+            metrics_results.update(
+                await _evaluate_multi_turn_metrics(
+                    ctx, evaluator, test, output, test_metric_configs
+                )
+            )
         else:
             metrics_results.update(
                 await _evaluate_single_turn_metrics(
@@ -49,6 +54,7 @@ async def evaluate_metrics(
                     output,
                     prompt_content,
                     expected_response,
+                    test_metric_configs,
                 )
             )
     except Exception as e:
@@ -57,10 +63,11 @@ async def evaluate_metrics(
 
 
 async def _evaluate_multi_turn_metrics(
-    ctx: ExecutionContext,
+    _ctx: ExecutionContext,
     evaluator: Any,
     test: Test,
     output: Dict[str, Any],
+    metric_configs: list,
 ) -> Dict[str, Any]:
     from rhesis.backend.tasks.execution.constants import CONVERSATION_SUMMARY_KEY
     from rhesis.backend.tasks.execution.evaluation import _build_conversation_history
@@ -73,7 +80,7 @@ async def _evaluate_multi_turn_metrics(
     goal = test_config_data.get("goal", "")
 
     filtered_configs = [
-        mc for mc in ctx.metric_configs if mc.class_name not in PENELOPE_EVALUATED_METRICS
+        mc for mc in metric_configs if mc.class_name not in PENELOPE_EVALUATED_METRICS
     ]
 
     if not filtered_configs:
@@ -96,12 +103,13 @@ async def _evaluate_multi_turn_metrics(
 
 
 async def _evaluate_single_turn_metrics(
-    ctx: ExecutionContext,
+    _ctx: ExecutionContext,
     evaluator: Any,
     test: Any,
     output: Dict[str, Any],
     prompt_content: str,
     expected_response: str,
+    metric_configs: list,
 ) -> Dict[str, Any]:
     from rhesis.backend.tasks.execution.response_extractor import (
         extract_response_with_fallback,
@@ -118,7 +126,7 @@ async def _evaluate_single_turn_metrics(
     # directly into the metric configs so the metric has them at construction time.
     # This avoids threading probe context through the generic evaluator interface.
     garak_notes = (test.test_metadata or {}).get("garak_notes") if test else None
-    metric_configs = _inject_probe_notes(ctx.metric_configs, garak_notes)
+    metric_configs = _inject_probe_notes(metric_configs, garak_notes)
 
     # Drop metrics that are scoped exclusively to Multi-Turn — they require
     # conversation_history which is not available for single-turn tests.

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/runner.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/runner.py
@@ -169,7 +169,7 @@ async def run_batch(
 
     # Create a single MetricEvaluator for the batch (stateless, safe to share).
     evaluator = None
-    if ctx.metric_configs:
+    if ctx.has_metrics:
         from rhesis.backend.metrics.evaluator import MetricEvaluator
 
         evaluator = MetricEvaluator(
@@ -323,7 +323,7 @@ async def _execute_single_test(
                 # Discard Penelope goal metrics when the first target call was HTTP error.
                 metrics_results = {}
                 logger.info(f"[BATCH] HTTP error for test {test_id}; skipping metrics")
-            elif evaluator and ctx.metric_configs:
+            elif evaluator and ctx.get_metric_configs_for_test(test_id):
                 metrics_results = await evaluate_metrics(
                     ctx,
                     evaluator,

--- a/apps/backend/src/rhesis/backend/tasks/execution/executors/data.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/executors/data.py
@@ -1,7 +1,7 @@
 """Data retrieval utilities for test execution."""
 
 import logging
-from typing import TYPE_CHECKING, List, Optional, Tuple
+from typing import TYPE_CHECKING, List, Literal, Optional, Tuple, Union, overload
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -77,6 +77,10 @@ def get_test_and_prompt(
         return test, prompt.content, prompt.expected_response or ""
 
 
+MetricSource = Literal["execution_time", "test_set", "behavior", "none"]
+
+
+@overload
 def get_test_metrics(
     test: Test,
     db: Session,
@@ -84,7 +88,32 @@ def get_test_metrics(
     user_id: Optional[str] = None,
     test_set: Optional["TestSet"] = None,
     test_configuration: Optional["TestConfiguration"] = None,
-) -> List:
+    return_source: Literal[False] = False,
+) -> List: ...
+
+
+@overload
+def get_test_metrics(
+    test: Test,
+    db: Session,
+    organization_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    test_set: Optional["TestSet"] = None,
+    test_configuration: Optional["TestConfiguration"] = None,
+    *,
+    return_source: Literal[True],
+) -> Tuple[List, MetricSource]: ...
+
+
+def get_test_metrics(
+    test: Test,
+    db: Session,
+    organization_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    test_set: Optional["TestSet"] = None,
+    test_configuration: Optional["TestConfiguration"] = None,
+    return_source: bool = False,
+) -> "Union[List, Tuple[List, MetricSource]]":
     """
     Retrieve and validate metrics for a test.
 
@@ -99,6 +128,13 @@ def get_test_metrics(
     - Garak-imported test sets to use their detector metrics
     - Default behavior-level metrics as fallback
 
+    Note that a configured priority level (e.g. execution-time metrics present in
+    test_configuration.attributes) can still fall through to a lower priority if it
+    resolves to zero valid metrics (missing/invalid IDs, or every candidate filtered
+    out for lacking a class_name). Callers that need to know which level actually won
+    (e.g. to decide whether metrics are shared across a batch or vary per test) should
+    pass return_source=True rather than inferring it from raw config presence.
+
     Args:
         test: Test model instance
         db: Database session (needed for RLS context and metric queries)
@@ -106,9 +142,11 @@ def get_test_metrics(
         user_id: User ID for RLS policies
         test_set: Optional TestSet model instance for metric override
         test_configuration: Optional TestConfiguration for execution-time metric override
+        return_source: If True, return (metrics, source) where source is one of
+            "execution_time", "test_set", "behavior", or "none".
 
     Returns:
-        List of valid Metric models
+        List of valid Metric models, or (metrics, source) if return_source is True.
     """
     from rhesis.backend.app.models.metric import Metric
 
@@ -153,7 +191,7 @@ def get_test_metrics(
                             f"Using {len(metrics)} execution-time metrics for test {test.id} "
                             f"(overriding test set and behavior metrics)"
                         )
-                        return metrics
+                        return (metrics, "execution_time") if return_source else metrics
                 except Exception as e:
                     logger.warning(f"Failed to load execution-time metrics for test {test.id}: {e}")
 
@@ -171,7 +209,7 @@ def get_test_metrics(
                     f"Filtered out {invalid_count} test set metrics without class_name "
                     f"for test {test.id}"
                 )
-            return metrics
+            return (metrics, "test_set") if return_source else metrics
 
     # Priority 3: Fall back to behavior metrics
     behavior = test.behavior
@@ -188,6 +226,6 @@ def get_test_metrics(
     # Return empty list if no valid metrics found (no defaults in SDK)
     if not metrics:
         logger.warning(f"No valid metrics found for test {test.id}, returning empty list")
-        return []
+        return ([], "none") if return_source else []
 
-    return metrics
+    return (metrics, "behavior") if return_source else metrics

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailMetricsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailMetricsTab.tsx
@@ -118,8 +118,14 @@ export default function TestDetailMetricsTab({
       !isMultiTurn;
 
     if (useBehaviorGrouping) {
-      // Handle behavior-based metrics (single-turn tests with behavior source)
-      behaviors.forEach(behavior => {
+      // Filter to only the behavior belonging to this test result to avoid
+      // duplicating metrics shared across different behaviors in the run.
+      const testBehaviorId = test.test?.behavior?.id;
+      const relevantBehaviors = testBehaviorId
+        ? behaviors.filter(b => b.id === testBehaviorId)
+        : behaviors;
+
+      relevantBehaviors.forEach(behavior => {
         behavior.metrics.forEach(metric => {
           const metricResult = testMetrics[metric.name];
           if (metricResult) {

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailMetricsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailMetricsTab.tsx
@@ -41,6 +41,7 @@ import {
   MetricsSource,
   getMetricsSourceLabel,
 } from '@/utils/api-client/interfaces/test-configuration';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
 
 interface TestDetailMetricsTabProps {
   test: TestResultDetail;
@@ -333,7 +334,7 @@ export default function TestDetailMetricsTab({
             onChange={handleFilterChange}
             aria-label="metric status filter"
             sx={{
-              borderRadius: '999px',
+              borderRadius: BORDER_RADIUS.pill,
               border: '1px solid',
               borderColor: 'primary.main',
               overflow: 'hidden',
@@ -346,7 +347,7 @@ export default function TestDetailMetricsTab({
                 px: 2,
                 py: 1,
                 fontWeight: 700,
-                fontSize: '14px',
+                fontSize: theme.typography.body2.fontSize,
                 lineHeight: '22px',
                 textTransform: 'none',
                 color: 'primary.main',
@@ -392,9 +393,9 @@ export default function TestDetailMetricsTab({
           <Card
             variant="outlined"
             sx={{
-              borderRadius: '12px',
+              borderRadius: BORDER_RADIUS.md,
               borderColor: 'divider',
-              boxShadow: '0px 2px 2px rgba(84,90,101,0.25)',
+              boxShadow: ELEVATION.xs,
             }}
           >
             <CardContent>
@@ -422,9 +423,9 @@ export default function TestDetailMetricsTab({
               <Card
                 variant="outlined"
                 sx={{
-                  borderRadius: '12px',
+                  borderRadius: BORDER_RADIUS.md,
                   borderColor: 'divider',
-                  boxShadow: '0px 2px 2px rgba(84,90,101,0.25)',
+                  boxShadow: ELEVATION.xs,
                 }}
               >
                 <CardContent>
@@ -458,9 +459,9 @@ export default function TestDetailMetricsTab({
               <Card
                 variant="outlined"
                 sx={{
-                  borderRadius: '12px',
+                  borderRadius: BORDER_RADIUS.md,
                   borderColor: 'divider',
-                  boxShadow: '0px 2px 2px rgba(84,90,101,0.25)',
+                  boxShadow: ELEVATION.xs,
                 }}
               >
                 <CardContent>
@@ -495,9 +496,9 @@ export default function TestDetailMetricsTab({
             <Card
               variant="outlined"
               sx={{
-                borderRadius: '12px',
+                borderRadius: BORDER_RADIUS.md,
                 borderColor: 'divider',
-                boxShadow: '0px 2px 2px rgba(84,90,101,0.25)',
+                boxShadow: ELEVATION.xs,
               }}
             >
               <CardContent>
@@ -533,9 +534,9 @@ export default function TestDetailMetricsTab({
             <Card
               sx={{
                 mb: 3,
-                borderRadius: '12px',
+                borderRadius: BORDER_RADIUS.md,
                 borderColor: 'divider',
-                boxShadow: '0px 2px 2px rgba(84,90,101,0.25)',
+                boxShadow: ELEVATION.xs,
                 ...(goalIsOverruled && {
                   borderLeft: `${theme.spacing(0.375)} solid ${theme.palette.warning.main}`,
                 }),
@@ -853,9 +854,9 @@ export default function TestDetailMetricsTab({
         <Paper
           variant="outlined"
           sx={{
-            borderRadius: '12px',
+            borderRadius: BORDER_RADIUS.md,
             borderColor: 'divider',
-            boxShadow: '0px 2px 2px rgba(84,90,101,0.25)',
+            boxShadow: ELEVATION.xs,
             bgcolor: 'background.paper',
             overflow: 'hidden',
           }}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailMetricsTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailMetricsTab.tsx
@@ -121,10 +121,13 @@ export default function TestDetailMetricsTab({
     if (useBehaviorGrouping) {
       // Filter to only the behavior belonging to this test result to avoid
       // duplicating metrics shared across different behaviors in the run.
+      // If this test has no known behavior, don't fall back to the full run-wide
+      // behaviors list either — that would reintroduce the same duplication for
+      // this test. The direct-metrics branch below picks up the slack instead.
       const testBehaviorId = test.test?.behavior?.id;
       const relevantBehaviors = testBehaviorId
         ? behaviors.filter(b => b.id === testBehaviorId)
-        : behaviors;
+        : [];
 
       relevantBehaviors.forEach(behavior => {
         behavior.metrics.forEach(metric => {

--- a/tests/backend/metrics/test_garak_pipeline.py
+++ b/tests/backend/metrics/test_garak_pipeline.py
@@ -382,7 +382,7 @@ class TestEvaluateSingleTurnGarakNotes:
         output = {"response": "safe response", "metadata": None, "tool_calls": None}
 
         await _evaluate_single_turn_metrics(
-            ctx, mock_evaluator, mock_test, output, "test prompt", ""
+            ctx, mock_evaluator, mock_test, output, "test prompt", "", ctx.metric_configs
         )
 
         mock_evaluator.a_evaluate.assert_called_once()
@@ -414,7 +414,7 @@ class TestEvaluateSingleTurnGarakNotes:
         output = {"response": "safe", "metadata": None, "tool_calls": None}
 
         await _evaluate_single_turn_metrics(
-            ctx, mock_evaluator, mock_test, output, "test", ""
+            ctx, mock_evaluator, mock_test, output, "test", "", ctx.metric_configs
         )
 
         call_kwargs = mock_evaluator.a_evaluate.call_args
@@ -442,7 +442,7 @@ class TestEvaluateSingleTurnGarakNotes:
         output = {"response": "safe", "metadata": None, "tool_calls": None}
 
         await _evaluate_single_turn_metrics(
-            ctx, mock_evaluator, mock_test, output, "test", ""
+            ctx, mock_evaluator, mock_test, output, "test", "", ctx.metric_configs
         )
 
         call_kwargs = mock_evaluator.a_evaluate.call_args

--- a/tests/backend/tasks/test_batch_per_test_metrics.py
+++ b/tests/backend/tasks/test_batch_per_test_metrics.py
@@ -162,11 +162,15 @@ class TestPrefetchMetricResolution:
             "t2", "Behavior B", "Metric B", "JudgeB"
         )
 
-        # get_test_metrics returns different metrics per test
+        # get_test_metrics returns different metrics per test; the sample-test
+        # call passes return_source=True and expects a (metrics, source) tuple.
         def side_effect(test, *args, **kwargs):
-            return {str(test_1.id): [metric_1], str(test_2.id): [metric_2]}[
+            metrics = {str(test_1.id): [metric_1], str(test_2.id): [metric_2]}[
                 str(test.id)
             ]
+            if kwargs.get("return_source"):
+                return metrics, "behavior"
+            return metrics
 
         mock_get_metrics.side_effect = side_effect
 
@@ -262,8 +266,9 @@ class TestPrefetchMetricResolution:
         shared_metric.class_name = "SharedJudge"
         shared_metric.id = uuid4()
 
-        # get_test_metrics returns the shared metric (from test_set, P2)
-        mock_get_metrics.return_value = [shared_metric]
+        # get_test_metrics returns the shared metric (from test_set, P2); the
+        # sample-test call passes return_source=True and expects a tuple back.
+        mock_get_metrics.return_value = ([shared_metric], "test_set")
 
         def to_config(m):
             cfg = MagicMock()
@@ -338,6 +343,134 @@ class TestPrefetchMetricResolution:
         # Both tests should get the same shared configs
         assert ctx.get_metric_configs_for_test(str(test_1.id)) == ctx.metric_configs
         assert ctx.get_metric_configs_for_test(str(test_2.id)) == ctx.metric_configs
+
+
+class TestPrefetchFallthroughToPerTest:
+    """Regression test: a *configured* P1 (execution-time) override that
+    resolves to zero valid metrics must fall through to per-test P3
+    resolution, not be treated as shared just because
+    test_configuration.attributes['metrics'] is merely present."""
+
+    def _make_test(self, test_id, behavior_name, metric_name, metric_class):
+        metric = MagicMock()
+        metric.name = metric_name
+        metric.class_name = metric_class
+        metric.id = uuid4()
+        metric.metric_scope = ["Single-Turn"]
+
+        behavior = MagicMock()
+        behavior.name = behavior_name
+        behavior.metrics = [metric]
+
+        test = MagicMock()
+        test.id = uuid4() if test_id is None else test_id
+        test.behavior = behavior
+        test.behavior_id = uuid4()
+        test.project_id = None
+        test.prompt = MagicMock()
+        test.prompt.content = "test prompt"
+        test.prompt.expected_response = "expected"
+        test.test_type = None
+        test.test_configuration = None
+        test.test_metadata = None
+        return test, metric
+
+    @patch("rhesis.backend.metrics.metric_config.metric_model_to_config")
+    @patch("rhesis.backend.tasks.execution.executors.data.get_test_metrics")
+    def test_configured_but_invalid_execution_time_metrics_falls_back_per_test(
+        self, mock_get_metrics, mock_to_config
+    ):
+        test_1, metric_1 = self._make_test("t1", "Behavior A", "Metric A", "JudgeA")
+        test_2, metric_2 = self._make_test("t2", "Behavior B", "Metric B", "JudgeB")
+
+        # get_test_metrics reports that P1 (execution_time) was configured but
+        # resolved to nothing valid, so it fell through to P3 (behavior) —
+        # which differs per test.
+        def side_effect(test, *args, **kwargs):
+            metrics = {str(test_1.id): [metric_1], str(test_2.id): [metric_2]}[
+                str(test.id)
+            ]
+            if kwargs.get("return_source"):
+                return metrics, "behavior"
+            return metrics
+
+        mock_get_metrics.side_effect = side_effect
+
+        def to_config(m):
+            cfg = MagicMock()
+            cfg.name = m.name
+            cfg.class_name = m.class_name
+            return cfg
+
+        mock_to_config.side_effect = to_config
+
+        test_set = MagicMock()
+        test_set.metrics = []
+        test_set.id = uuid4()
+
+        test_config = MagicMock()
+        # P1 is *configured* (non-empty) but, per the mocked source above,
+        # resolves to nothing valid and falls through to P3 internally.
+        test_config.attributes = {"metrics": [{"id": str(uuid4())}]}
+        test_config.organization_id = uuid4()
+        test_config.user_id = uuid4()
+        test_config.project_id = None
+        test_config.test_set_id = test_set.id
+        test_config.endpoint_id = uuid4()
+
+        test_run = MagicMock()
+        test_run.id = uuid4()
+
+        endpoint = MagicMock()
+        endpoint.id = test_config.endpoint_id
+        endpoint.project_id = None
+        endpoint.environment = None
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = endpoint
+
+        with (
+            patch("rhesis.backend.app.database.bind_scope_to_session"),
+            patch(
+                "rhesis.backend.app.services.test_set.get_test_set",
+                return_value=test_set,
+            ),
+            patch(
+                "rhesis.backend.app.services.invokers.auth.manager"
+                ".AuthenticationManager"
+            ),
+            patch("rhesis.backend.app.config.settings.get_model_settings"),
+            patch(
+                "rhesis.backend.tasks.execution.executors.data"
+                ".get_test_and_prompt",
+                side_effect=lambda s, tid, org: (
+                    test_1 if tid == str(test_1.id) else test_2,
+                    "prompt",
+                    "expected",
+                ),
+            ),
+        ):
+            from rhesis.backend.tasks.execution.batch.context import (
+                prefetch_execution_context,
+            )
+
+            ctx = prefetch_execution_context(
+                session, test_config, test_run, [test_1, test_2]
+            )
+
+        # Even though P1 config was present, it didn't actually win — the
+        # per-test path must be used, not a single shared resolution from
+        # tests[0].
+        assert ctx.metric_configs == []
+        assert str(test_1.id) in ctx.per_test_metric_configs
+        assert str(test_2.id) in ctx.per_test_metric_configs
+
+        configs_1 = ctx.per_test_metric_configs[str(test_1.id)]
+        configs_2 = ctx.per_test_metric_configs[str(test_2.id)]
+        assert len(configs_1) == 1
+        assert len(configs_2) == 1
+        assert configs_1[0].class_name == "JudgeA"
+        assert configs_2[0].class_name == "JudgeB"
 
 
 # ============================================================================

--- a/tests/backend/tasks/test_batch_per_test_metrics.py
+++ b/tests/backend/tasks/test_batch_per_test_metrics.py
@@ -1,0 +1,417 @@
+"""
+Tests for per-test metric resolution in batch execution.
+
+Covers the fix for the bug where batch execution resolved metrics from only
+tests[0] and applied them to all tests, ignoring per-test behavior metrics.
+
+Scenarios:
+- Behavior-mapped metrics (Priority 3) are resolved per-test
+- Test-set metrics (Priority 2) remain shared across all tests
+- Execution-time metrics (Priority 1) remain shared across all tests
+- ExecutionContext.get_metric_configs_for_test returns correct configs
+- Batch evaluation uses per-test configs
+"""
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from rhesis.backend.tasks.execution.batch.context import ExecutionContext
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _make_metric_config(name: str, class_name: str) -> MagicMock:
+    mc = MagicMock()
+    mc.name = name
+    mc.class_name = class_name
+    return mc
+
+
+def _make_execution_context(**overrides) -> ExecutionContext:
+    """Build a minimal ExecutionContext with sensible defaults."""
+    defaults = dict(
+        test_config=MagicMock(),
+        test_run=MagicMock(),
+        test_set=MagicMock(),
+        endpoint=MagicMock(),
+        organization_id="org-1",
+        user_id="user-1",
+    )
+    defaults.update(overrides)
+    return ExecutionContext(**defaults)
+
+
+# ============================================================================
+# ExecutionContext.get_metric_configs_for_test
+# ============================================================================
+
+
+class TestGetMetricConfigsForTest:
+    """Tests for the per-test metric lookup method on ExecutionContext."""
+
+    def test_returns_shared_when_no_per_test(self):
+        """Falls back to shared metric_configs when per_test_metric_configs is empty."""
+        shared = [_make_metric_config("Shared", "SharedJudge")]
+        ctx = _make_execution_context(metric_configs=shared)
+
+        assert ctx.get_metric_configs_for_test("any-test-id") == shared
+
+    def test_returns_per_test_configs(self):
+        """Returns per-test configs when available."""
+        mc_a = [_make_metric_config("MetricA", "JudgeA")]
+        mc_b = [_make_metric_config("MetricB", "JudgeB")]
+        ctx = _make_execution_context(
+            per_test_metric_configs={"test-1": mc_a, "test-2": mc_b},
+        )
+
+        assert ctx.get_metric_configs_for_test("test-1") == mc_a
+        assert ctx.get_metric_configs_for_test("test-2") == mc_b
+
+    def test_returns_empty_for_unknown_test(self):
+        """Returns empty list for a test ID not in per_test_metric_configs."""
+        mc_a = [_make_metric_config("MetricA", "JudgeA")]
+        ctx = _make_execution_context(
+            per_test_metric_configs={"test-1": mc_a},
+        )
+
+        assert ctx.get_metric_configs_for_test("unknown-id") == []
+
+    def test_per_test_takes_precedence_over_shared(self):
+        """per_test_metric_configs is preferred when populated, even if
+        metric_configs is also set."""
+        shared = [_make_metric_config("Shared", "SharedJudge")]
+        per_test = [_make_metric_config("PerTest", "PerTestJudge")]
+        ctx = _make_execution_context(
+            metric_configs=shared,
+            per_test_metric_configs={"test-1": per_test},
+        )
+
+        assert ctx.get_metric_configs_for_test("test-1") == per_test
+
+
+class TestHasMetrics:
+    """Tests for the has_metrics property."""
+
+    def test_false_when_empty(self):
+        ctx = _make_execution_context()
+        assert ctx.has_metrics is False
+
+    def test_true_with_shared(self):
+        ctx = _make_execution_context(
+            metric_configs=[_make_metric_config("M", "J")]
+        )
+        assert ctx.has_metrics is True
+
+    def test_true_with_per_test(self):
+        ctx = _make_execution_context(
+            per_test_metric_configs={"t1": [_make_metric_config("M", "J")]}
+        )
+        assert ctx.has_metrics is True
+
+
+# ============================================================================
+# prefetch_execution_context: per-test vs shared metrics
+# ============================================================================
+
+
+class TestPrefetchMetricResolution:
+    """Tests that prefetch_execution_context resolves metrics correctly
+    based on the active priority level."""
+
+    def _make_test(self, test_id, behavior_name, metric_name, metric_class):
+        """Create a mock Test with a behavior and one metric."""
+        metric = MagicMock()
+        metric.name = metric_name
+        metric.class_name = metric_class
+        metric.id = uuid4()
+        metric.metric_scope = ["Single-Turn"]
+
+        behavior = MagicMock()
+        behavior.name = behavior_name
+        behavior.metrics = [metric]
+
+        test = MagicMock()
+        test.id = uuid4() if test_id is None else test_id
+        test.behavior = behavior
+        test.behavior_id = uuid4()
+        test.project_id = None
+        test.prompt = MagicMock()
+        test.prompt.content = "test prompt"
+        test.prompt.expected_response = "expected"
+        test.test_type = None
+        test.test_configuration = None
+        test.test_metadata = None
+        return test, metric
+
+    @patch("rhesis.backend.metrics.metric_config.metric_model_to_config")
+    @patch(
+        "rhesis.backend.tasks.execution.executors.data.get_test_metrics"
+    )
+    def test_behavior_metrics_resolved_per_test(
+        self, mock_get_metrics, mock_to_config
+    ):
+        """When using behavior metrics (P3), each test gets its own configs."""
+        test_1, metric_1 = self._make_test(
+            "t1", "Behavior A", "Metric A", "JudgeA"
+        )
+        test_2, metric_2 = self._make_test(
+            "t2", "Behavior B", "Metric B", "JudgeB"
+        )
+
+        # get_test_metrics returns different metrics per test
+        def side_effect(test, *args, **kwargs):
+            return {str(test_1.id): [metric_1], str(test_2.id): [metric_2]}[
+                str(test.id)
+            ]
+
+        mock_get_metrics.side_effect = side_effect
+
+        # metric_model_to_config returns a mock config with the name
+        def to_config(m):
+            cfg = MagicMock()
+            cfg.name = m.name
+            cfg.class_name = m.class_name
+            return cfg
+
+        mock_to_config.side_effect = to_config
+
+        # Test set with NO direct metrics (triggers P3)
+        test_set = MagicMock()
+        test_set.metrics = []
+        test_set.id = uuid4()
+
+        test_config = MagicMock()
+        test_config.attributes = {}
+        test_config.organization_id = uuid4()
+        test_config.user_id = uuid4()
+        test_config.project_id = None
+        test_config.test_set_id = test_set.id
+        test_config.endpoint_id = uuid4()
+
+        test_run = MagicMock()
+        test_run.id = uuid4()
+
+        endpoint = MagicMock()
+        endpoint.id = test_config.endpoint_id
+        endpoint.project_id = None
+        endpoint.environment = None
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = endpoint
+
+        with (
+            patch(
+                "rhesis.backend.app.database.bind_scope_to_session"
+            ),
+            patch(
+                "rhesis.backend.app.services.test_set.get_test_set",
+                return_value=test_set,
+            ),
+            patch(
+                "rhesis.backend.app.services.invokers.auth.manager"
+                ".AuthenticationManager"
+            ),
+            patch(
+                "rhesis.backend.app.config.settings.get_model_settings"
+            ),
+            patch(
+                "rhesis.backend.tasks.execution.executors.data"
+                ".get_test_and_prompt",
+                side_effect=lambda s, tid, org: (
+                    test_1 if tid == str(test_1.id) else test_2,
+                    "prompt",
+                    "expected",
+                ),
+            ),
+        ):
+            from rhesis.backend.tasks.execution.batch.context import (
+                prefetch_execution_context,
+            )
+
+            ctx = prefetch_execution_context(
+                session, test_config, test_run, [test_1, test_2]
+            )
+
+        # Shared should be empty; per-test should have entries
+        assert ctx.metric_configs == []
+        assert str(test_1.id) in ctx.per_test_metric_configs
+        assert str(test_2.id) in ctx.per_test_metric_configs
+
+        configs_1 = ctx.per_test_metric_configs[str(test_1.id)]
+        configs_2 = ctx.per_test_metric_configs[str(test_2.id)]
+        assert len(configs_1) == 1
+        assert len(configs_2) == 1
+        assert configs_1[0].class_name == "JudgeA"
+        assert configs_2[0].class_name == "JudgeB"
+
+    @patch("rhesis.backend.metrics.metric_config.metric_model_to_config")
+    @patch(
+        "rhesis.backend.tasks.execution.executors.data.get_test_metrics"
+    )
+    def test_test_set_metrics_shared(self, mock_get_metrics, mock_to_config):
+        """When using test_set metrics (P2), all tests share the same configs."""
+        test_1, _ = self._make_test("t1", "Behavior A", "Metric A", "JudgeA")
+        test_2, _ = self._make_test("t2", "Behavior B", "Metric B", "JudgeB")
+
+        shared_metric = MagicMock()
+        shared_metric.name = "Shared Metric"
+        shared_metric.class_name = "SharedJudge"
+        shared_metric.id = uuid4()
+
+        # get_test_metrics returns the shared metric (from test_set, P2)
+        mock_get_metrics.return_value = [shared_metric]
+
+        def to_config(m):
+            cfg = MagicMock()
+            cfg.name = m.name
+            cfg.class_name = m.class_name
+            return cfg
+
+        mock_to_config.side_effect = to_config
+
+        # Test set WITH direct metrics (triggers P2)
+        test_set = MagicMock()
+        test_set.metrics = [shared_metric]
+        test_set.id = uuid4()
+
+        test_config = MagicMock()
+        test_config.attributes = {}
+        test_config.organization_id = uuid4()
+        test_config.user_id = uuid4()
+        test_config.project_id = None
+        test_config.test_set_id = test_set.id
+        test_config.endpoint_id = uuid4()
+
+        test_run = MagicMock()
+        test_run.id = uuid4()
+
+        endpoint = MagicMock()
+        endpoint.id = test_config.endpoint_id
+        endpoint.project_id = None
+        endpoint.environment = None
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.first.return_value = endpoint
+
+        with (
+            patch(
+                "rhesis.backend.app.database.bind_scope_to_session"
+            ),
+            patch(
+                "rhesis.backend.app.services.test_set.get_test_set",
+                return_value=test_set,
+            ),
+            patch(
+                "rhesis.backend.app.services.invokers.auth.manager"
+                ".AuthenticationManager"
+            ),
+            patch(
+                "rhesis.backend.app.config.settings.get_model_settings"
+            ),
+            patch(
+                "rhesis.backend.tasks.execution.executors.data"
+                ".get_test_and_prompt",
+                side_effect=lambda s, tid, org: (
+                    test_1 if tid == str(test_1.id) else test_2,
+                    "prompt",
+                    "expected",
+                ),
+            ),
+        ):
+            from rhesis.backend.tasks.execution.batch.context import (
+                prefetch_execution_context,
+            )
+
+            ctx = prefetch_execution_context(
+                session, test_config, test_run, [test_1, test_2]
+            )
+
+        # Shared should be populated; per-test should be empty
+        assert len(ctx.metric_configs) == 1
+        assert ctx.metric_configs[0].class_name == "SharedJudge"
+        assert ctx.per_test_metric_configs == {}
+
+        # Both tests should get the same shared configs
+        assert ctx.get_metric_configs_for_test(str(test_1.id)) == ctx.metric_configs
+        assert ctx.get_metric_configs_for_test(str(test_2.id)) == ctx.metric_configs
+
+
+# ============================================================================
+# Batch evaluation uses per-test configs
+# ============================================================================
+
+
+class TestBatchEvaluationPerTestMetrics:
+    """Tests that batch evaluation passes the correct per-test metrics."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_uses_per_test_configs(self):
+        """evaluate_metrics passes per-test configs to the evaluator, not shared."""
+        mc_a = _make_metric_config("MetricA", "JudgeA")
+        mc_b = _make_metric_config("MetricB", "JudgeB")
+
+        ctx = _make_execution_context(
+            per_test_metric_configs={
+                "test-1": [mc_a],
+                "test-2": [mc_b],
+            },
+        )
+
+        mock_evaluator = MagicMock()
+        mock_evaluator.a_evaluate = MagicMock(
+            return_value={"MetricA": {"is_successful": True}}
+        )
+        # Make it awaitable
+        import asyncio
+
+        future = asyncio.Future()
+        future.set_result({"MetricA": {"is_successful": True}})
+        mock_evaluator.a_evaluate.return_value = future
+
+        test = MagicMock()
+        test.test_metadata = None
+
+        with (
+            patch(
+                "rhesis.backend.tasks.execution.response_extractor"
+                ".extract_response_with_fallback",
+                return_value="response text",
+            ),
+            patch(
+                "rhesis.backend.tasks.execution.response_extractor"
+                ".normalize_context_to_list",
+                return_value=[],
+            ),
+            patch(
+                "rhesis.backend.tasks.execution.evaluation._is_multi_turn_only",
+                return_value=False,
+            ),
+        ):
+            from rhesis.backend.tasks.execution.batch.evaluation import (
+                evaluate_metrics,
+            )
+
+            await evaluate_metrics(
+                ctx=ctx,
+                evaluator=mock_evaluator,
+                test=test,
+                test_id="test-1",
+                output={"output": "response text"},
+                prompt_content="prompt",
+                expected_response="expected",
+                is_multi_turn=False,
+                penelope_metrics={},
+            )
+
+        # The evaluator should have been called with test-1's metric (MetricA),
+        # not test-2's (MetricB) or an empty shared list.
+        call_kwargs = mock_evaluator.a_evaluate.call_args
+        metrics_passed = call_kwargs.kwargs.get("metrics") or call_kwargs[1].get(
+            "metrics"
+        )
+        assert len(metrics_passed) == 1
+        assert metrics_passed[0].class_name == "JudgeA"


### PR DESCRIPTION
## Purpose

Behavior-mapped metrics were duplicated across all tests in a test run's Metrics tab. Batch execution resolved metrics once from `tests[0]` and shared that result across every test, so any test whose behavior differed from `tests[0]`'s behavior displayed the wrong (duplicated) metric.

## What Changed

- `ExecutionContext` now supports per-test metric configs (`per_test_metric_configs`) in addition to the existing shared `metric_configs`, with a `get_metric_configs_for_test()` helper and `has_metrics` property.
- `prefetch_execution_context()` detects whether Priority 1 (execution-time) or Priority 2 (test-set) metrics apply — these are shared across all tests, so they're resolved once. Otherwise (Priority 3, behavior-mapped), metrics are resolved per-test.
- `evaluate_metrics()` and the batch runner now look up metrics per-test instead of reading a single shared list.
- Frontend `TestDetailMetricsTab` now filters the rendered behaviors down to the current test's own behavior, instead of iterating over every behavior in the run.
- Added test coverage for the new `ExecutionContext` helpers, per-test vs shared metric resolution in `prefetch_execution_context`, and per-test config usage in `evaluate_metrics`.

## Additional Context

Custom metrics assigned directly (not via behavior mapping) were unaffected by this bug, since those resolve via Priority 1/2 and were already shared correctly.

## Testing

- New tests in `tests/backend/tasks/test_batch_per_test_metrics.py` cover: `get_metric_configs_for_test` fallback/precedence, `has_metrics`, per-test resolution for behavior metrics (P3), shared resolution for test-set metrics (P2), and `evaluate_metrics` passing per-test configs to the evaluator.
- Existing batch execution tests pass unchanged.
- Manual repro: create a test run with multiple behaviors, each mapped to a distinct metric, and confirm the Metrics tab for each test shows only that test's own behavior's metric.