### PR TITLE
Fix grid loading/empty-state flicker

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/__tests__/page.test.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/__tests__/page.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import EndpointsPage from '../page';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    refresh: jest.fn(),
+  }),
+  usePathname: () => '/endpoints',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { session_token: 'tok', user: { id: 'u1', name: 'Alice' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+// EndpointsGrid owns the query and the loading/empty/populated decision
+// itself — the page's only job is to wire `canCreate` and `onCreateClick`
+// through to it correctly.
+jest.mock('../components/EndpointsGrid', () => {
+  return function MockEndpointsGrid({
+    canCreate,
+    onCreateClick,
+  }: {
+    canCreate?: boolean;
+    onCreateClick?: () => void;
+  }) {
+    return (
+      <button onClick={onCreateClick} disabled={!canCreate}>
+        mock-create-endpoint
+      </button>
+    );
+  };
+});
+
+jest.mock('../components/EndpointCreateDrawer', () => {
+  return function MockEndpointCreateDrawer({ open }: { open: boolean }) {
+    return open ? <div data-testid="endpoint-create-drawer" /> : null;
+  };
+});
+
+describe('EndpointsPage', () => {
+  it('passes canCreate through to the grid', () => {
+    render(<EndpointsPage />);
+    expect(screen.getByText('mock-create-endpoint')).toBeEnabled();
+  });
+
+  it('opens the create drawer when the grid invokes onCreateClick', async () => {
+    render(<EndpointsPage />);
+    await userEvent.click(screen.getByText('mock-create-endpoint'));
+    expect(screen.getByTestId('endpoint-create-drawer')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -8,7 +8,7 @@ import React, {
   useMemo,
 } from 'react';
 import { useRouter } from 'next/navigation';
-import { Box, Typography, useTheme, Alert } from '@mui/material';
+import { Box, Typography, useTheme, Alert, Paper } from '@mui/material';
 import GridBadge from '@/components/common/GridBadge';
 import GridToolbar from '@/components/common/GridToolbar';
 import {
@@ -18,7 +18,7 @@ import {
   GridToolbarDensitySelector,
   GridToolbarExport,
 } from '@mui/x-data-grid';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
+import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
 import { Project } from '@/utils/api-client/interfaces/project';
 import { useSession } from 'next-auth/react';
@@ -44,10 +44,22 @@ import { endpointKeys } from '@/constants/query-keys';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import GridStateGate from '@/components/common/GridStateGate';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
+import EndpointsIcon from '@/components/EndpointsIcon';
 
 interface EndpointsGridProps {
-  onTotalCountChange?: (count: number) => void;
   projectId?: string;
+  /**
+   * Only supplied by the top-level Endpoints list page. When present, the
+   * grid renders a full loading/empty-state experience of its own; when
+   * absent (e.g. the embedded Project > Endpoints tab), it renders exactly
+   * as before — BaseDataGrid's own loading skeleton and no-rows overlay,
+   * unchanged.
+   */
+  canCreate?: boolean;
+  onCreateClick?: () => void;
 }
 
 interface EndpointsToolbarState {
@@ -101,8 +113,9 @@ function EndpointsUnifiedToolbar() {
 }
 
 export default function EndpointsGrid({
-  onTotalCountChange,
   projectId,
+  canCreate,
+  onCreateClick,
 }: EndpointsGridProps) {
   const theme = useTheme();
   const router = useRouter();
@@ -209,22 +222,6 @@ export default function EndpointsGrid({
 
   const endpoints = endpointsData?.data ?? [];
   const totalCount = endpointsData?.pagination.totalCount ?? 0;
-
-  useEffect(() => {
-    if (!endpointsData) return;
-    const filtersActive =
-      filterModel.items.length > 0 ||
-      !!searchQuery ||
-      hasActiveEndpointFilters(drawerFilters);
-    if (!filtersActive) onTotalCountChange?.(totalCount);
-  }, [
-    endpointsData,
-    filterModel.items.length,
-    searchQuery,
-    drawerFilters,
-    onTotalCountChange,
-    totalCount,
-  ]);
 
   useEffect(() => {
     const fetchProjects = async () => {
@@ -377,7 +374,13 @@ export default function EndpointsGrid({
     [searchQuery, hasActiveDrawerFilters, activeFilterCount]
   );
 
-  return (
+  // Only the top-level Endpoints page passes `onCreateClick` — that's when
+  // this grid owns its own loading/empty presentation and Paper wrapper.
+  const isStandalone = onCreateClick !== undefined;
+  const filtersActive =
+    filterModel.items.length > 0 || !!searchQuery || hasActiveDrawerFilters;
+
+  const content = (
     <EndpointsToolbarContext.Provider value={toolbarContextValue}>
       {error && (
         <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
@@ -430,5 +433,27 @@ export default function EndpointsGrid({
         onApply={setDrawerFilters}
       />
     </EndpointsToolbarContext.Provider>
+  );
+
+  return (
+    <GridStateGate
+      active={isStandalone}
+      data={endpointsData}
+      error={error}
+      isEmpty={totalCount === 0 && !filtersActive}
+      emptyState={
+        <EntityEmptyState
+          card
+          icon={EndpointsIcon}
+          title="No endpoints yet"
+          description="Create your first endpoint to connect your application under test and start running tests and evaluations."
+          actionLabel={canCreate ? 'Create endpoint' : undefined}
+          onAction={canCreate ? onCreateClick : undefined}
+          enrichment={getEntityEmptyStateEnrichment('endpoints')}
+        />
+      }
+    >
+      {isStandalone ? <Paper sx={GRID_PAPER_SX}>{content}</Paper> : content}
+    </GridStateGate>
   );
 }

--- a/apps/frontend/src/app/(protected)/endpoints/components/__tests__/EndpointsGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/__tests__/EndpointsGrid.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { render, screen } from '@/test-utils';
+import '@testing-library/jest-dom';
+import EndpointsGrid from '../EndpointsGrid';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+  usePathname: () => '/endpoints',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { session_token: 'tok', user: { id: 'u1', name: 'Alice' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('@/components/common/NotificationContext', () => ({
+  useNotifications: () => ({ show: jest.fn(), close: jest.fn() }),
+  NotificationProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+const mockGetEndpoints = jest.fn();
+const mockGetProjects = jest.fn();
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getEndpointsClient: () => ({ getEndpoints: mockGetEndpoints }),
+    getProjectsClient: () => ({ getProjects: mockGetProjects }),
+  })),
+}));
+
+jest.mock('@/components/common/BaseDataGrid', () => {
+  return function MockBaseDataGrid({
+    rows,
+    loading,
+  }: {
+    rows: Array<Record<string, unknown>>;
+    loading?: boolean;
+  }) {
+    if (loading) return <div data-testid="grid-loading">Loading…</div>;
+    return (
+      <div data-testid="base-data-grid">
+        {rows.map(row => (
+          <div key={String(row.id)} data-testid={`row-${row.id}`} />
+        ))}
+      </div>
+    );
+  };
+});
+
+jest.mock('@/components/common/DeleteModal', () => ({
+  DeleteModal: () => null,
+}));
+
+const makePaginatedResponse = <T,>(data: T[], total?: number) => ({
+  data,
+  pagination: {
+    totalCount: total ?? data.length,
+    skip: 0,
+    limit: 10,
+    currentPage: 0,
+    pageSize: 10,
+    totalPages: 1,
+  },
+});
+
+const makeEndpoint = (id: string, name = 'Endpoint') => ({
+  id,
+  name,
+  status: { name: 'Active' },
+});
+
+describe('EndpointsGrid', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetProjects.mockResolvedValue([]);
+    // Default: one row, so tests that don't care about emptiness exercise the
+    // populated (grid) branch rather than the empty-state branch.
+    mockGetEndpoints.mockResolvedValue(
+      makePaginatedResponse([makeEndpoint('e-0')])
+    );
+  });
+
+  it('renders the grid directly (no full-page loading/empty logic) when used without onCreateClick, e.g. embedded in a project tab', async () => {
+    render(<EndpointsGrid projectId="p1" />);
+    expect(await screen.findByTestId('base-data-grid')).toBeInTheDocument();
+  });
+
+  it('shows a loading state while the first fetch is in flight', () => {
+    mockGetEndpoints.mockReturnValue(new Promise(() => {}));
+    render(<EndpointsGrid canCreate onCreateClick={jest.fn()} />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state directly, without ever mounting the grid, when there are zero endpoints', async () => {
+    mockGetEndpoints.mockResolvedValue(makePaginatedResponse([]));
+    render(<EndpointsGrid canCreate onCreateClick={jest.fn()} />);
+    expect(await screen.findByText('No endpoints yet')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('renders the grid, not the empty state, when endpoints exist', async () => {
+    render(<EndpointsGrid canCreate onCreateClick={jest.fn()} />);
+    expect(await screen.findByTestId('row-e-0')).toBeInTheDocument();
+    expect(screen.queryByText('No endpoints yet')).not.toBeInTheDocument();
+  });
+
+  it('shows the error alert instead of the empty state when the fetch fails', async () => {
+    mockGetEndpoints.mockRejectedValue(new Error('Network error'));
+    render(<EndpointsGrid canCreate onCreateClick={jest.fn()} />);
+    expect(await screen.findByText(/network error/i)).toBeInTheDocument();
+    expect(screen.queryByText('No endpoints yet')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/endpoints/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/page.tsx
@@ -3,20 +3,15 @@
 import * as React from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { useSession } from 'next-auth/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { endpointKeys } from '@/constants/query-keys';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
-import EntityEmptyState from '@/components/common/EntityEmptyState';
-import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
-import EndpointsIcon from '@/components/EndpointsIcon';
 import EndpointsGrid from './components/EndpointsGrid';
 import EndpointCreateDrawer from './components/EndpointCreateDrawer';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
@@ -32,7 +27,6 @@ export default function EndpointsPage() {
     Capability.Endpoint.READ
   );
   const canCreate = useCan(Capability.Endpoint.CREATE);
-  const [endpointCount, setEndpointCount] = React.useState<number | null>(null);
   const [createDrawerOpen, setCreateDrawerOpen] = React.useState(false);
   const [createProjectId, setCreateProjectId] = React.useState<
     string | undefined
@@ -103,29 +97,7 @@ export default function EndpointsPage() {
         }
       >
         <Box sx={{ mt: 2, mb: 2 }}>
-          {endpointCount === 0 ? (
-            <EntityEmptyState
-              card
-              icon={EndpointsIcon}
-              title="No endpoints yet"
-              description="Create your first endpoint to connect your application under test and start running tests and evaluations."
-              actionLabel={canCreate ? 'Create endpoint' : undefined}
-              onAction={canCreate ? handleCreate : undefined}
-              enrichment={getEntityEmptyStateEnrichment('endpoints')}
-            />
-          ) : (
-            <Paper
-              sx={{
-                width: '100%',
-                borderRadius: BORDER_RADIUS.md,
-                boxShadow: ELEVATION.xs,
-                border: theme => `1px solid ${theme.palette.greyscale.border}`,
-                overflow: 'hidden',
-              }}
-            >
-              <EndpointsGrid onTotalCountChange={setEndpointCount} />
-            </Paper>
-          )}
+          <EndpointsGrid canCreate={canCreate} onCreateClick={handleCreate} />
         </Box>
       </PageLayout>
 

--- a/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
@@ -46,6 +46,7 @@ import { can } from '@/utils/affordances';
 import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
+import GridStateGate from '@/components/common/GridStateGate';
 import { BiotechIcon } from '@/components/icons';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { useNotifications } from '@/components/common/NotificationContext';
@@ -412,20 +413,26 @@ export default function ExperimentsClientWrapper() {
         </FabGroup>
       }
     >
-      {loading ? null : experiments.length === 0 &&
-        !searchQuery.trim() &&
-        !visibilityFilter ? (
-        <EntityEmptyState
-          card
-          icon={BiotechIcon}
-          title="No experiments yet"
-          description="Experiments let you bundle parameter values into versioned configurations. Create one to start tracking how different settings affect your test results."
-          actionLabel={canCreateExperiment ? 'New Experiment' : undefined}
-          onAction={canCreateExperiment ? () => setCreateOpen(true) : undefined}
-          actionDisabled={!activeProject}
-          enrichment={getEntityEmptyStateEnrichment('experiments')}
-        />
-      ) : (
+      <GridStateGate
+        data={loading ? null : experiments}
+        isEmpty={
+          experiments.length === 0 && !searchQuery.trim() && !visibilityFilter
+        }
+        emptyState={
+          <EntityEmptyState
+            card
+            icon={BiotechIcon}
+            title="No experiments yet"
+            description="Experiments let you bundle parameter values into versioned configurations. Create one to start tracking how different settings affect your test results."
+            actionLabel={canCreateExperiment ? 'New Experiment' : undefined}
+            onAction={
+              canCreateExperiment ? () => setCreateOpen(true) : undefined
+            }
+            actionDisabled={!activeProject}
+            enrichment={getEntityEmptyStateEnrichment('experiments')}
+          />
+        }
+      >
         <ExperimentsToolbarContext.Provider
           value={{
             searchQuery,
@@ -455,7 +462,7 @@ export default function ExperimentsClientWrapper() {
             sx={rowActionsHoverSx}
           />
         </ExperimentsToolbarContext.Provider>
-      )}
+      </GridStateGate>
 
       <CreateExperimentDialog
         open={createOpen}

--- a/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/components/ExperimentsClientWrapper.tsx
@@ -412,10 +412,9 @@ export default function ExperimentsClientWrapper() {
         </FabGroup>
       }
     >
-      {!loading &&
-      experiments.length === 0 &&
-      !searchQuery.trim() &&
-      !visibilityFilter ? (
+      {loading ? null : experiments.length === 0 &&
+        !searchQuery.trim() &&
+        !visibilityFilter ? (
         <EntityEmptyState
           card
           icon={BiotechIcon}

--- a/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/KnowledgeClientWrapper.tsx
@@ -4,7 +4,7 @@ import React, { useState, useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
 import { sourceKeys } from '@/constants/query-keys';
-import { Box, Alert, Paper } from '@mui/material';
+import { Box, Alert } from '@mui/material';
 import UploadIcon from '@mui/icons-material/Upload';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabGroup } from '@/components/common/Fab';
@@ -16,7 +16,6 @@ import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { MenuBookIcon } from '@/components/icons';
 import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import SourcesGrid from './SourcesGrid';
 import UploadSourceDrawer from './UploadSourceDrawer';
 import ToolImportDrawer from './ToolImportDrawer';
@@ -29,30 +28,20 @@ export default function KnowledgeClientWrapper() {
   const canCreateSource = useCan(Capability.Source.CREATE);
   const { status } = useSession();
   const queryClient = useQueryClient();
-  const [sourceCount, setSourceCount] = useState<number | null>(null);
   const [uploadDrawerOpen, setUploadDrawerOpen] = useState(false);
   const [toolImportDrawerOpen, setToolImportDrawerOpen] = useState(false);
 
   useDocumentTitle('Knowledge');
 
-  const remountSourcesGridAfterCreate = useCallback(() => {
-    // Empty state uses `sourceCount === 0`, which unmounts SourcesGrid. Reset to
-    // `null` (initial load state) so the grid remounts and `onTotalCountChange`
-    // can set the real count once the refetch succeeds.
-    setSourceCount(prev => (prev === 0 ? null : prev));
-  }, []);
-
   const handleUploadSuccess = useCallback(() => {
     setUploadDrawerOpen(false);
-    remountSourcesGridAfterCreate();
     queryClient.invalidateQueries({ queryKey: sourceKeys.all() });
-  }, [queryClient, remountSourcesGridAfterCreate]);
+  }, [queryClient]);
 
   const handleMcpImportSuccess = useCallback(() => {
     setToolImportDrawerOpen(false);
-    remountSourcesGridAfterCreate();
     queryClient.invalidateQueries({ queryKey: sourceKeys.all() });
-  }, [queryClient, remountSourcesGridAfterCreate]);
+  }, [queryClient]);
 
   if (!isAuthenticated(status)) {
     return (
@@ -104,31 +93,10 @@ export default function KnowledgeClientWrapper() {
         }
       >
         <Box sx={{ mt: 2, mb: 2 }}>
-          {sourceCount === 0 ? (
-            <EntityEmptyState
-              card
-              icon={MenuBookIcon}
-              title="No knowledge sources yet"
-              description="Upload files or import from tool connections to use as context for test generation and evaluation."
-              actionLabel={canCreateSource ? 'Upload source' : undefined}
-              onAction={
-                canCreateSource ? () => setUploadDrawerOpen(true) : undefined
-              }
-            />
-          ) : (
-            <Paper
-              sx={{
-                width: '100%',
-                borderRadius: BORDER_RADIUS.md,
-                boxShadow: ELEVATION.xs,
-                border: theme => `1px solid ${theme.palette.greyscale.border}`,
-                overflow: 'hidden',
-                position: 'relative',
-              }}
-            >
-              <SourcesGrid onTotalCountChange={setSourceCount} />
-            </Paper>
-          )}
+          <SourcesGrid
+            canCreate={canCreateSource}
+            onCreateClick={() => setUploadDrawerOpen(true)}
+          />
         </Box>
       </PageLayout>
 

--- a/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-import React, {
-  useEffect,
-  useState,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react';
+import React, { useState, useCallback, useContext, useMemo } from 'react';
 import {
   GridColDef,
   GridFilterModel,
@@ -15,11 +9,11 @@ import {
   GridToolbarDensitySelector,
   GridToolbarExport,
 } from '@mui/x-data-grid';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
+import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { Source } from '@/utils/api-client/interfaces/source';
-import { Box, Chip, Typography } from '@mui/material';
+import { Box, Chip, Typography, Paper } from '@mui/material';
 import GridToolbar from '@/components/common/GridToolbar';
 import GridBadge from '@/components/common/GridBadge';
 import {
@@ -33,7 +27,7 @@ import { useNotifications } from '@/components/common/NotificationContext';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import styles from '@/styles/Knowledge.module.css';
 import { combineSourceFiltersToOData } from '@/utils/odata-filter';
-import { ChatIcon } from '@/components/icons';
+import { ChatIcon, MenuBookIcon } from '@/components/icons';
 import { formatFileSize, getFileExtension } from '@/constants/knowledge';
 import { formatDate } from '@/utils/date';
 import SourceFilterDrawer, {
@@ -47,9 +41,12 @@ import { sourceKeys } from '@/constants/query-keys';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import GridStateGate from '@/components/common/GridStateGate';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
 
 interface SourcesGridProps {
-  onTotalCountChange?: (count: number) => void;
+  canCreate?: boolean;
+  onCreateClick?: () => void;
 }
 
 interface SourcesToolbarState {
@@ -98,7 +95,10 @@ function SourcesUnifiedToolbar() {
   );
 }
 
-export default function SourcesGrid({ onTotalCountChange }: SourcesGridProps) {
+export default function SourcesGrid({
+  canCreate,
+  onCreateClick,
+}: SourcesGridProps) {
   const router = useRouter();
   const { status } = useSession();
   const notifications = useNotifications();
@@ -192,22 +192,6 @@ export default function SourcesGrid({ onTotalCountChange }: SourcesGridProps) {
 
   const sources = sourcesData?.data ?? [];
   const totalCount = sourcesData?.pagination.totalCount ?? 0;
-
-  useEffect(() => {
-    if (!sourcesData) return;
-    const filtersActive =
-      filterModel.items.length > 0 ||
-      !!searchQuery ||
-      hasActiveSourceFilters(drawerFilters);
-    if (!filtersActive) onTotalCountChange?.(totalCount);
-  }, [
-    sourcesData,
-    filterModel.items.length,
-    searchQuery,
-    drawerFilters,
-    onTotalCountChange,
-    totalCount,
-  ]);
 
   // Handle row click to navigate to preview
   const handleRowClick = useCallback(
@@ -505,48 +489,71 @@ export default function SourcesGrid({ onTotalCountChange }: SourcesGridProps) {
     );
   }
 
+  const filtersActive =
+    filterModel.items.length > 0 ||
+    !!searchQuery ||
+    hasActiveSourceFilters(drawerFilters);
+
   return (
-    <SourcesToolbarContext.Provider value={toolbarContextValue}>
-      <BaseDataGrid
-        columns={columns}
-        rows={sources}
-        loading={loading}
-        getRowId={row => row.id}
-        showToolbar={true}
-        paginationModel={paginationModel}
-        onPaginationModelChange={handlePaginationModelChange}
-        filterModel={filterModel}
-        onFilterModelChange={handleFilterModelChange}
-        sortModel={sortModel}
-        onSortModelChange={handleSortModelChange}
-        serverSidePagination={true}
-        serverSideFiltering={true}
-        sortingMode="server"
-        totalRows={totalCount}
-        pageSizeOptions={[10, 25, 50]}
-        disablePaperWrapper={true}
-        onRowClick={handleRowClick}
-        toolbarSlot={SourcesUnifiedToolbar}
-        persistState
-        sx={rowActionsHoverSx}
-      />
+    <GridStateGate
+      data={sourcesData}
+      error={error}
+      isEmpty={totalCount === 0 && !filtersActive}
+      emptyState={
+        <EntityEmptyState
+          card
+          icon={MenuBookIcon}
+          title="No knowledge sources yet"
+          description="Upload files or import from tool connections to use as context for test generation and evaluation."
+          actionLabel={canCreate ? 'Upload source' : undefined}
+          onAction={canCreate ? onCreateClick : undefined}
+        />
+      }
+    >
+      <Paper sx={GRID_PAPER_SX}>
+        <SourcesToolbarContext.Provider value={toolbarContextValue}>
+          <BaseDataGrid
+            columns={columns}
+            rows={sources}
+            loading={loading}
+            getRowId={row => row.id}
+            showToolbar={true}
+            paginationModel={paginationModel}
+            onPaginationModelChange={handlePaginationModelChange}
+            filterModel={filterModel}
+            onFilterModelChange={handleFilterModelChange}
+            sortModel={sortModel}
+            onSortModelChange={handleSortModelChange}
+            serverSidePagination={true}
+            serverSideFiltering={true}
+            sortingMode="server"
+            totalRows={totalCount}
+            pageSizeOptions={[10, 25, 50]}
+            disablePaperWrapper={true}
+            onRowClick={handleRowClick}
+            toolbarSlot={SourcesUnifiedToolbar}
+            persistState
+            sx={rowActionsHoverSx}
+          />
 
-      <DeleteModal
-        open={deleteModalOpen}
-        onClose={handleDeleteCancel}
-        onConfirm={handleDeleteConfirm}
-        isLoading={isDeleting}
-        title="Delete Source"
-        message="Are you sure you want to delete this source? This action cannot be undone."
-        itemType="source"
-      />
+          <DeleteModal
+            open={deleteModalOpen}
+            onClose={handleDeleteCancel}
+            onConfirm={handleDeleteConfirm}
+            isLoading={isDeleting}
+            title="Delete Source"
+            message="Are you sure you want to delete this source? This action cannot be undone."
+            itemType="source"
+          />
 
-      <SourceFilterDrawer
-        open={filterDrawerOpen}
-        onClose={() => setFilterDrawerOpen(false)}
-        filters={drawerFilters}
-        onApply={f => setDrawerFilters(f)}
-      />
-    </SourcesToolbarContext.Provider>
+          <SourceFilterDrawer
+            open={filterDrawerOpen}
+            onClose={() => setFilterDrawerOpen(false)}
+            filters={drawerFilters}
+            onApply={f => setDrawerFilters(f)}
+          />
+        </SourcesToolbarContext.Provider>
+      </Paper>
+    </GridStateGate>
   );
 }

--- a/apps/frontend/src/app/(protected)/knowledge/components/__tests__/KnowledgeClientWrapper.test.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/__tests__/KnowledgeClientWrapper.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import KnowledgeClientWrapper from '../KnowledgeClientWrapper';
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { session_token: 'tok', user: { id: 'u1', name: 'Alice' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+// SourcesGrid owns the query and the loading/empty/populated decision
+// itself — the wrapper's only job is to wire `canCreate`/`onCreateClick`
+// through to it correctly.
+jest.mock('../SourcesGrid', () => {
+  return function MockSourcesGrid({
+    canCreate,
+    onCreateClick,
+  }: {
+    canCreate?: boolean;
+    onCreateClick?: () => void;
+  }) {
+    return (
+      <button onClick={onCreateClick} disabled={!canCreate}>
+        mock-upload-source
+      </button>
+    );
+  };
+});
+
+jest.mock('../UploadSourceDrawer', () => {
+  return function MockUploadSourceDrawer({ open }: { open: boolean }) {
+    return open ? <div data-testid="upload-source-drawer" /> : null;
+  };
+});
+
+jest.mock('../ToolImportDrawer', () => {
+  return function MockToolImportDrawer() {
+    return null;
+  };
+});
+
+describe('KnowledgeClientWrapper', () => {
+  it('passes canCreate through to the grid', () => {
+    render(<KnowledgeClientWrapper />);
+    expect(screen.getByText('mock-upload-source')).toBeEnabled();
+  });
+
+  it('opens the upload drawer when the grid invokes onCreateClick', async () => {
+    render(<KnowledgeClientWrapper />);
+    await userEvent.click(screen.getByText('mock-upload-source'));
+    expect(screen.getByTestId('upload-source-drawer')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/knowledge/components/__tests__/SourcesGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/__tests__/SourcesGrid.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, screen } from '@/test-utils';
+import '@testing-library/jest-dom';
+import SourcesGrid from '../SourcesGrid';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+  usePathname: () => '/knowledge',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { session_token: 'tok', user: { id: 'u1', name: 'Alice' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('@/components/common/NotificationContext', () => ({
+  useNotifications: () => ({ show: jest.fn(), close: jest.fn() }),
+  NotificationProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+const mockGetSources = jest.fn();
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getSourcesClient: () => ({ getSources: mockGetSources }),
+  })),
+}));
+
+jest.mock('@/components/common/BaseDataGrid', () => {
+  return function MockBaseDataGrid({
+    rows,
+    loading,
+  }: {
+    rows: Array<Record<string, unknown>>;
+    loading?: boolean;
+  }) {
+    if (loading) return <div data-testid="grid-loading">Loading…</div>;
+    return (
+      <div data-testid="base-data-grid">
+        {rows.map(row => (
+          <div key={String(row.id)} data-testid={`row-${row.id}`} />
+        ))}
+      </div>
+    );
+  };
+});
+
+jest.mock('@/components/common/DeleteModal', () => ({
+  DeleteModal: () => null,
+}));
+
+const makePaginatedResponse = <T,>(data: T[], total?: number) => ({
+  data,
+  pagination: {
+    totalCount: total ?? data.length,
+    skip: 0,
+    limit: 25,
+    currentPage: 0,
+    pageSize: 25,
+    totalPages: 1,
+  },
+});
+
+const makeSource = (id: string, title = 'Source') => ({
+  id,
+  title,
+});
+
+describe('SourcesGrid', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: one row, so tests that don't care about emptiness exercise the
+    // populated (grid) branch rather than the empty-state branch.
+    mockGetSources.mockResolvedValue(
+      makePaginatedResponse([makeSource('s-0')])
+    );
+  });
+
+  it('shows a loading state while the first fetch is in flight', () => {
+    mockGetSources.mockReturnValue(new Promise(() => {}));
+    render(<SourcesGrid canCreate onCreateClick={jest.fn()} />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state directly, without ever mounting the grid, when there are zero sources', async () => {
+    mockGetSources.mockResolvedValue(makePaginatedResponse([]));
+    render(<SourcesGrid canCreate onCreateClick={jest.fn()} />);
+    expect(
+      await screen.findByText('No knowledge sources yet')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('renders the grid, not the empty state, when sources exist', async () => {
+    render(<SourcesGrid canCreate onCreateClick={jest.fn()} />);
+    expect(await screen.findByTestId('row-s-0')).toBeInTheDocument();
+    expect(
+      screen.queryByText('No knowledge sources yet')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the error message instead of the empty state when the fetch fails', async () => {
+    mockGetSources.mockRejectedValue(new Error('Network error'));
+    render(<SourcesGrid canCreate onCreateClick={jest.fn()} />);
+    expect(await screen.findByText(/network error/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText('No knowledge sources yet')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/tasks/__tests__/page.test.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/__tests__/page.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import TasksPage from '../page';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    refresh: jest.fn(),
+  }),
+  usePathname: () => '/tasks',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { session_token: 'tok', user: { id: 'u1', name: 'Alice' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+// TasksGrid owns the query and the loading/empty/populated decision itself —
+// the page's only job is to wire `canCreate`/`onCreateClick` through to it.
+jest.mock('../components/TasksGrid', () => {
+  return function MockTasksGrid({
+    canCreate,
+    onCreateClick,
+  }: {
+    canCreate?: boolean;
+    onCreateClick?: () => void;
+  }) {
+    return (
+      <button onClick={onCreateClick} disabled={!canCreate}>
+        mock-create-task
+      </button>
+    );
+  };
+});
+
+jest.mock('../components/TaskDrawer', () => {
+  return function MockTaskDrawer({ open }: { open: boolean }) {
+    return open ? <div data-testid="task-drawer" /> : null;
+  };
+});
+
+describe('TasksPage', () => {
+  it('passes canCreate through to the grid', () => {
+    render(<TasksPage />);
+    expect(screen.getByText('mock-create-task')).toBeEnabled();
+  });
+
+  it('opens the create drawer when the grid invokes onCreateClick', async () => {
+    render(<TasksPage />);
+    await userEvent.click(screen.getByText('mock-create-task'));
+    expect(screen.getByTestId('task-drawer')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-import React, {
-  useEffect,
-  useState,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react';
+import React, { useState, useCallback, useContext, useMemo } from 'react';
 import {
   GridColDef,
   GridFilterModel,
@@ -15,13 +9,14 @@ import {
   GridToolbarDensitySelector,
   GridToolbarExport,
 } from '@mui/x-data-grid';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
+import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { Task } from '@/utils/api-client/interfaces/task';
 import { can } from '@/utils/affordances';
 import { Capability } from '@/constants/capabilities';
-import { Typography, Box, Alert, Avatar } from '@mui/material';
+import { Typography, Box, Alert, Avatar, Paper } from '@mui/material';
+import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined';
 import GridToolbar, { ToolbarPillTabs } from '@/components/common/GridToolbar';
 import GridBadge from '@/components/common/GridBadge';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -44,9 +39,12 @@ import { taskKeys } from '@/constants/query-keys';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import GridStateGate from '@/components/common/GridStateGate';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
 
 interface TasksGridProps {
-  onTotalCountChange?: (count: number) => void;
+  canCreate?: boolean;
+  onCreateClick?: () => void;
 }
 
 const STATUS_PILL_TABS = [
@@ -114,7 +112,10 @@ function TasksUnifiedToolbar() {
   );
 }
 
-export default function TasksGrid({ onTotalCountChange }: TasksGridProps) {
+export default function TasksGrid({
+  canCreate,
+  onCreateClick,
+}: TasksGridProps) {
   const router = useRouter();
   const notifications = useNotifications();
   const queryClient = useQueryClient();
@@ -210,22 +211,6 @@ export default function TasksGrid({ onTotalCountChange }: TasksGridProps) {
   });
   const tasks: Task[] = tasksData?.data ?? [];
   const totalCount = tasksData?.totalCount ?? 0;
-
-  useEffect(() => {
-    if (!tasksData) return;
-    const filtersActive =
-      filterModel.items.length > 0 ||
-      !!searchQuery ||
-      hasActiveTaskFilters(drawerFilters);
-    if (!filtersActive) onTotalCountChange?.(totalCount);
-  }, [
-    tasksData,
-    filterModel.items.length,
-    searchQuery,
-    drawerFilters,
-    onTotalCountChange,
-    totalCount,
-  ]);
 
   const handleRowClick = useCallback(
     (params: GridRowParams) => {
@@ -353,76 +338,98 @@ export default function TasksGrid({ onTotalCountChange }: TasksGridProps) {
     ];
   }, [router, handleRowDeleteAction]);
 
+  const filtersActive =
+    filterModel.items.length > 0 ||
+    !!searchQuery ||
+    hasActiveTaskFilters(drawerFilters);
+
   return (
-    <TasksToolbarContext.Provider
-      value={{
-        searchQuery,
-        setSearchQuery,
-        statusFilter,
-        setStatusFilter,
-        openFilterDrawer: () => setFilterDrawerOpen(true),
-        hasActiveDrawerFilters: hasActiveTaskFilters(drawerFilters),
-        activeFilterCount: countActiveTaskFilters(drawerFilters),
-      }}
+    <GridStateGate
+      data={tasksData}
+      error={error}
+      isEmpty={totalCount === 0 && !filtersActive}
+      emptyState={
+        <EntityEmptyState
+          icon={AssignmentOutlinedIcon}
+          title="No tasks yet"
+          description="Create tasks to track follow-ups, issues, and action items from tests and evaluations."
+          actionLabel={canCreate ? 'Create task' : undefined}
+          onAction={canCreate ? onCreateClick : undefined}
+        />
+      }
     >
-      <Box sx={{ position: 'relative' }}>
-        {error && (
-          <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
-            {error}
-          </Alert>
-        )}
-
-        <BaseDataGrid
-          rows={tasks}
-          columns={columns}
-          loading={loading}
-          getRowId={row => row.id}
-          paginationModel={paginationModel}
-          onPaginationModelChange={handlePaginationModelChange}
-          filterModel={filterModel}
-          onFilterModelChange={handleFilterModelChange}
-          disableRowSelectionOnClick
-          onRowClick={handleRowClick}
-          serverSidePagination={true}
-          totalRows={totalCount}
-          pageSizeOptions={[10, 25, 50, 100]}
-          serverSideFiltering={true}
-          showToolbar={true}
-          toolbarSlot={TasksUnifiedToolbar}
-          disablePaperWrapper={true}
-          persistState
-          sx={{
-            ...rowActionsHoverSx,
-            '& .MuiDataGrid-row': {
-              cursor: 'pointer',
-            },
+      <Paper sx={GRID_PAPER_SX}>
+        <TasksToolbarContext.Provider
+          value={{
+            searchQuery,
+            setSearchQuery,
+            statusFilter,
+            setStatusFilter,
+            openFilterDrawer: () => setFilterDrawerOpen(true),
+            hasActiveDrawerFilters: hasActiveTaskFilters(drawerFilters),
+            activeFilterCount: countActiveTaskFilters(drawerFilters),
           }}
-        />
+        >
+          <Box sx={{ position: 'relative' }}>
+            {error && (
+              <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
+                {error}
+              </Alert>
+            )}
 
-        <DeleteModal
-          open={deleteModalOpen}
-          onClose={handleDeleteCancel}
-          onConfirm={handleDeleteConfirm}
-          isLoading={isDeleting}
-          title="Delete Task"
-          message="Are you sure you want to delete this task? This action cannot be undone."
-          itemType="task"
-        />
+            <BaseDataGrid
+              rows={tasks}
+              columns={columns}
+              loading={loading}
+              getRowId={row => row.id}
+              paginationModel={paginationModel}
+              onPaginationModelChange={handlePaginationModelChange}
+              filterModel={filterModel}
+              onFilterModelChange={handleFilterModelChange}
+              disableRowSelectionOnClick
+              onRowClick={handleRowClick}
+              serverSidePagination={true}
+              totalRows={totalCount}
+              pageSizeOptions={[10, 25, 50, 100]}
+              serverSideFiltering={true}
+              showToolbar={true}
+              toolbarSlot={TasksUnifiedToolbar}
+              disablePaperWrapper={true}
+              persistState
+              sx={{
+                ...rowActionsHoverSx,
+                '& .MuiDataGrid-row': {
+                  cursor: 'pointer',
+                },
+              }}
+            />
 
-        <TaskFilterDrawer
-          open={filterDrawerOpen}
-          onClose={() => setFilterDrawerOpen(false)}
-          filters={drawerFilters}
-          onApply={f => {
-            setDrawerFilters(f);
-            if (f.status) {
-              setStatusFilter(f.status);
-            } else if (!drawerFilters.status) {
-              setStatusFilter('all');
-            }
-          }}
-        />
-      </Box>
-    </TasksToolbarContext.Provider>
+            <DeleteModal
+              open={deleteModalOpen}
+              onClose={handleDeleteCancel}
+              onConfirm={handleDeleteConfirm}
+              isLoading={isDeleting}
+              title="Delete Task"
+              message="Are you sure you want to delete this task? This action cannot be undone."
+              itemType="task"
+            />
+
+            <TaskFilterDrawer
+              open={filterDrawerOpen}
+              onClose={() => setFilterDrawerOpen(false)}
+              filters={drawerFilters}
+              onApply={f => {
+                setDrawerFilters(f);
+                if (f.status) {
+                  setStatusFilter(f.status);
+                } else if (!drawerFilters.status) {
+                  setStatusFilter('all');
+                }
+              }}
+            />
+          </Box>
+        </TasksToolbarContext.Provider>
+      </Paper>
+    </GridStateGate>
   );
 }

--- a/apps/frontend/src/app/(protected)/tasks/components/__tests__/TasksGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/__tests__/TasksGrid.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, screen } from '@/test-utils';
+import '@testing-library/jest-dom';
+import TasksGrid from '../TasksGrid';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+  usePathname: () => '/tasks',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { session_token: 'tok', user: { id: 'u1', name: 'Alice' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('@/components/common/NotificationContext', () => ({
+  useNotifications: () => ({ show: jest.fn(), close: jest.fn() }),
+  NotificationProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+const mockGetTasks = jest.fn();
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getTasksClient: () => ({ getTasks: mockGetTasks }),
+  })),
+}));
+
+jest.mock('@/components/common/BaseDataGrid', () => {
+  return function MockBaseDataGrid({
+    rows,
+    loading,
+  }: {
+    rows: Array<Record<string, unknown>>;
+    loading?: boolean;
+  }) {
+    if (loading) return <div data-testid="grid-loading">Loading…</div>;
+    return (
+      <div data-testid="base-data-grid">
+        {rows.map(row => (
+          <div key={String(row.id)} data-testid={`row-${row.id}`} />
+        ))}
+      </div>
+    );
+  };
+});
+
+jest.mock('@/components/common/DeleteModal', () => ({
+  DeleteModal: () => null,
+}));
+
+const makeTasksResponse = (
+  data: Array<Record<string, unknown>>,
+  total?: number
+) => ({
+  data,
+  totalCount: total ?? data.length,
+});
+
+const makeTask = (id: string, title = 'Task') => ({
+  id,
+  title,
+  status: { name: 'Open' },
+});
+
+describe('TasksGrid', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: one row, so tests that don't care about emptiness exercise the
+    // populated (grid) branch rather than the empty-state branch.
+    mockGetTasks.mockResolvedValue(makeTasksResponse([makeTask('t-0')]));
+  });
+
+  it('shows a loading state while the first fetch is in flight', () => {
+    mockGetTasks.mockReturnValue(new Promise(() => {}));
+    render(<TasksGrid canCreate onCreateClick={jest.fn()} />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state directly, without ever mounting the grid, when there are zero tasks', async () => {
+    mockGetTasks.mockResolvedValue(makeTasksResponse([]));
+    render(<TasksGrid canCreate onCreateClick={jest.fn()} />);
+    expect(await screen.findByText('No tasks yet')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+  });
+
+  it('renders the grid, not the empty state, when tasks exist', async () => {
+    render(<TasksGrid canCreate onCreateClick={jest.fn()} />);
+    expect(await screen.findByTestId('row-t-0')).toBeInTheDocument();
+    expect(screen.queryByText('No tasks yet')).not.toBeInTheDocument();
+  });
+
+  it('shows the error alert instead of the empty state when the fetch fails', async () => {
+    mockGetTasks.mockRejectedValue(new Error('Network error'));
+    render(<TasksGrid canCreate onCreateClick={jest.fn()} />);
+    expect(await screen.findByText(/network error/i)).toBeInTheDocument();
+    expect(screen.queryByText('No tasks yet')).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/tasks/page.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/page.tsx
@@ -2,16 +2,13 @@
 
 import * as React from 'react';
 import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import AssignmentOutlinedIcon from '@mui/icons-material/AssignmentOutlined';
 import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { taskKeys } from '@/constants/query-keys';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
-import EntityEmptyState from '@/components/common/EntityEmptyState';
 import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
@@ -21,7 +18,6 @@ import TaskDrawer, {
   type TaskDrawerInitialEntity,
 } from './components/TaskDrawer';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import { EntityType } from '@/types/tasks';
 import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
 
@@ -33,7 +29,6 @@ export default function TasksPage() {
   );
   const canCreateTask = useCan(Capability.Task.CREATE);
   const searchParams = useSearchParams();
-  const [taskCount, setTaskCount] = React.useState<number | null>(null);
   const [createDrawerOpen, setCreateDrawerOpen] = React.useState(false);
   const [initialEntity, setInitialEntity] = React.useState<
     TaskDrawerInitialEntity | undefined
@@ -131,34 +126,13 @@ export default function TasksPage() {
         }
       >
         <Box sx={{ mt: 2, mb: 2 }}>
-          {taskCount === 0 ? (
-            <EntityEmptyState
-              icon={AssignmentOutlinedIcon}
-              title="No tasks yet"
-              description="Create tasks to track follow-ups, issues, and action items from tests and evaluations."
-              actionLabel={canCreateTask ? 'Create task' : undefined}
-              onAction={
-                canCreateTask
-                  ? () => {
-                      setInitialEntity(undefined);
-                      setCreateDrawerOpen(true);
-                    }
-                  : undefined
-              }
-            />
-          ) : (
-            <Paper
-              sx={{
-                width: '100%',
-                borderRadius: BORDER_RADIUS.md,
-                boxShadow: ELEVATION.xs,
-                border: theme => `1px solid ${theme.palette.greyscale.border}`,
-                overflow: 'hidden',
-              }}
-            >
-              <TasksGrid onTotalCountChange={setTaskCount} />
-            </Paper>
-          )}
+          <TasksGrid
+            canCreate={canCreateTask}
+            onCreateClick={() => {
+              setInitialEntity(undefined);
+              setCreateDrawerOpen(true);
+            }}
+          />
         </Box>
       </PageLayout>
 

--- a/apps/frontend/src/app/(protected)/test-runs/__tests__/page.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/__tests__/page.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import TestRunsPage from '../page';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    refresh: jest.fn(),
+  }),
+  usePathname: () => '/test-runs',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { session_token: 'tok', user: { id: 'u1', name: 'Alice' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+// TestRunsGrid owns the query and the loading/empty/populated decision
+// itself — the page's only job is to wire `canCreate`/`onCreateClick`
+// through to it correctly.
+jest.mock('../components/TestRunsGrid', () => {
+  return function MockTestRunsGrid({
+    canCreate,
+    onCreateClick,
+  }: {
+    canCreate?: boolean;
+    onCreateClick?: () => void;
+  }) {
+    return (
+      <button onClick={onCreateClick} disabled={!canCreate}>
+        mock-create-test-run
+      </button>
+    );
+  };
+});
+
+jest.mock('@/components/common/RunDrawer', () => {
+  return function MockRunDrawer({ open }: { open: boolean }) {
+    return open ? <div data-testid="run-drawer" /> : null;
+  };
+});
+
+describe('TestRunsPage', () => {
+  it('passes canCreate through to the grid', () => {
+    render(<TestRunsPage />);
+    expect(screen.getByText('mock-create-test-run')).toBeEnabled();
+  });
+
+  it('opens the create drawer when the grid invokes onCreateClick', async () => {
+    render(<TestRunsPage />);
+    await userEvent.click(screen.getByText('mock-create-test-run'));
+    expect(screen.getByTestId('run-drawer')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-import React, {
-  useEffect,
-  useState,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react';
+import React, { useState, useCallback, useContext, useMemo } from 'react';
 import { useSession } from 'next-auth/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { testRunKeys } from '@/constants/query-keys';
@@ -24,7 +18,7 @@ import {
   GridToolbarDensitySelector,
   GridToolbarExport,
 } from '@mui/x-data-grid';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
+import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import { useRouter } from 'next/navigation';
 import {
   Typography,
@@ -35,12 +29,14 @@ import {
   Button,
   ButtonGroup,
   Tooltip,
+  Paper,
 } from '@mui/material';
 import {
   ChatIcon,
   DescriptionIcon,
   ScienceIcon,
   BiotechIcon,
+  PlayArrowIcon,
 } from '@/components/icons';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import PersonIcon from '@mui/icons-material/Person';
@@ -68,8 +64,16 @@ import {
   rowActionsHoverSx,
 } from '@/components/common/createRowActionsColumn';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import GridStateGate from '@/components/common/GridStateGate';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 
 type RunKindFilter = 'all' | 'tests' | 'experiments';
+
+interface TestRunsGridProps {
+  canCreate?: boolean;
+  onCreateClick?: () => void;
+}
 
 function formatReviewTooltip(reviewed: number, corrected: number): string {
   const reviewedLabel = `${reviewed} test${reviewed === 1 ? '' : 's'} reviewed`;
@@ -150,11 +154,7 @@ function TestRunsUnifiedToolbar() {
 
 // ── Grid component ────────────────────────────────────────────────────────────
 
-interface TestRunsGridProps {
-  onTotalCountChange?: (count: number) => void;
-}
-
-function TestRunsGrid({ onTotalCountChange }: TestRunsGridProps) {
+function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
   const { status } = useSession();
   const queryClient = useQueryClient();
   const router = useRouter();
@@ -284,24 +284,6 @@ function TestRunsGrid({ onTotalCountChange }: TestRunsGridProps) {
 
   const testRuns = testRunsData?.data ?? [];
   const totalCount = testRunsData?.pagination.totalCount ?? 0;
-
-  // ── Side effect: notify parent of total count ─────────────────────────────
-
-  useEffect(() => {
-    if (!testRunsData) return;
-    const filtersActive =
-      filterModel.items.length > 0 ||
-      !!searchQuery ||
-      hasActiveTestRunFilters(drawerFilters);
-    if (!filtersActive) onTotalCountChange?.(totalCount);
-  }, [
-    testRunsData,
-    filterModel.items.length,
-    searchQuery,
-    drawerFilters,
-    onTotalCountChange,
-    totalCount,
-  ]);
 
   // ── Row action handlers ────────────────────────────────────────────────────
 
@@ -759,83 +741,107 @@ function TestRunsGrid({ onTotalCountChange }: TestRunsGridProps) {
     [runKindFilter, handleRunKindFilterChange]
   );
 
+  const filtersActive =
+    filterModel.items.length > 0 ||
+    !!searchQuery ||
+    hasActiveTestRunFilters(drawerFilters);
+
   return (
-    <TestRunsToolbarContext.Provider
-      value={{
-        searchQuery,
-        setSearchQuery,
-        statusFilter,
-        setStatusFilter,
-        openFilterDrawer: () => setFilterDrawerOpen(true),
-        hasActiveDrawerFilters: hasActiveTestRunFilters(drawerFilters),
-        activeFilterCount: countActiveTestRunFilters(drawerFilters),
-      }}
+    <GridStateGate
+      data={testRunsData}
+      error={error}
+      isEmpty={totalCount === 0 && !filtersActive}
+      emptyState={
+        <EntityEmptyState
+          card
+          icon={PlayArrowIcon}
+          title="No test runs yet"
+          description="Execute a test set against an AI endpoint to start your first test run. Test runs measure quality, safety, and reliability of your AI endpoints."
+          actionLabel={canCreate ? 'Create test run' : undefined}
+          onAction={canCreate ? onCreateClick : undefined}
+          enrichment={getEntityEmptyStateEnrichment('test-runs')}
+        />
+      }
     >
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
-          {error}
-        </Alert>
-      )}
+      <Paper sx={GRID_PAPER_SX}>
+        <TestRunsToolbarContext.Provider
+          value={{
+            searchQuery,
+            setSearchQuery,
+            statusFilter,
+            setStatusFilter,
+            openFilterDrawer: () => setFilterDrawerOpen(true),
+            hasActiveDrawerFilters: hasActiveTestRunFilters(drawerFilters),
+            activeFilterCount: countActiveTestRunFilters(drawerFilters),
+          }}
+        >
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
+              {error}
+            </Alert>
+          )}
 
-      <BaseDataGrid
-        rows={testRuns}
-        columns={columns}
-        loading={loading}
-        getRowId={row => row.id}
-        paginationModel={paginationModel}
-        onPaginationModelChange={handlePaginationModelChange}
-        filterModel={filterModel}
-        onFilterModelChange={handleFilterModelChange}
-        sortingMode="server"
-        sortModel={sortModel}
-        onSortModelChange={handleSortModelChange}
-        serverSideFiltering={true}
-        onRowClick={handleRowClick}
-        getRowUrl={row => `/test-runs/${row.id}`}
-        serverSidePagination={true}
-        totalRows={totalCount}
-        pageSizeOptions={[10, 25, 50]}
-        gridToolbarExtra={runKindToolbar}
-        disablePaperWrapper={true}
-        showToolbar={true}
-        toolbarSlot={TestRunsUnifiedToolbar}
-        persistState
-        storageKey="test-runs-grid-v2"
-        sx={rowActionsHoverSx}
-      />
+          <BaseDataGrid
+            rows={testRuns}
+            columns={columns}
+            loading={loading}
+            getRowId={row => row.id}
+            paginationModel={paginationModel}
+            onPaginationModelChange={handlePaginationModelChange}
+            filterModel={filterModel}
+            onFilterModelChange={handleFilterModelChange}
+            sortingMode="server"
+            sortModel={sortModel}
+            onSortModelChange={handleSortModelChange}
+            serverSideFiltering={true}
+            onRowClick={handleRowClick}
+            getRowUrl={row => `/test-runs/${row.id}`}
+            serverSidePagination={true}
+            totalRows={totalCount}
+            pageSizeOptions={[10, 25, 50]}
+            gridToolbarExtra={runKindToolbar}
+            disablePaperWrapper={true}
+            showToolbar={true}
+            toolbarSlot={TestRunsUnifiedToolbar}
+            persistState
+            storageKey="test-runs-grid-v2"
+            sx={rowActionsHoverSx}
+          />
 
-      <DeleteModal
-        open={deleteModalOpen}
-        onClose={handleDeleteCancel}
-        onConfirm={handleDeleteConfirm}
-        isLoading={isDeleting}
-        title="Delete Test Run"
-        message="Are you sure you want to delete this test run? Related data will not be deleted."
-        itemType="test runs"
-      />
+          <DeleteModal
+            open={deleteModalOpen}
+            onClose={handleDeleteCancel}
+            onConfirm={handleDeleteConfirm}
+            isLoading={isDeleting}
+            title="Delete Test Run"
+            message="Are you sure you want to delete this test run? Related data will not be deleted."
+            itemType="test runs"
+          />
 
-      <DeleteModal
-        open={cancelModalOpen}
-        onClose={handleCancelClose}
-        onConfirm={handleCancelConfirm}
-        isLoading={isCancelling}
-        title="Cancel Test Run"
-        message="Are you sure you want to cancel this test run? It will be stopped and marked as Cancelled."
-        itemType="test run"
-        confirmButtonText={isCancelling ? 'Cancelling...' : 'Cancel Run'}
-        cancelButtonText="Keep Running"
-      />
+          <DeleteModal
+            open={cancelModalOpen}
+            onClose={handleCancelClose}
+            onConfirm={handleCancelConfirm}
+            isLoading={isCancelling}
+            title="Cancel Test Run"
+            message="Are you sure you want to cancel this test run? It will be stopped and marked as Cancelled."
+            itemType="test run"
+            confirmButtonText={isCancelling ? 'Cancelling...' : 'Cancel Run'}
+            cancelButtonText="Keep Running"
+          />
 
-      {/* Filter drawer */}
-      <TestRunFilterDrawer
-        open={filterDrawerOpen}
-        onClose={() => setFilterDrawerOpen(false)}
-        filters={drawerFilters}
-        onApply={f => {
-          setDrawerFilters(f);
-        }}
-      />
-    </TestRunsToolbarContext.Provider>
+          {/* Filter drawer */}
+          <TestRunFilterDrawer
+            open={filterDrawerOpen}
+            onClose={() => setFilterDrawerOpen(false)}
+            filters={drawerFilters}
+            onApply={f => {
+              setDrawerFilters(f);
+            }}
+          />
+        </TestRunsToolbarContext.Provider>
+      </Paper>
+    </GridStateGate>
   );
 }
 

--- a/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/__tests__/TestRunsGrid.test.tsx
@@ -170,21 +170,32 @@ const makePaginatedResponse = <T,>(data: T[], total?: number) => ({
 describe('TestRunsGrid', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetTestRuns.mockResolvedValue(makePaginatedResponse([]));
+    // Default: one row, so tests that don't care about emptiness exercise
+    // the populated (grid) branch rather than the empty-state branch.
+    mockGetTestRuns.mockResolvedValue(
+      makePaginatedResponse([makeTestRun('r-0')])
+    );
     mockGetProject.mockResolvedValue({ id: 'p1', name: 'Project A' });
   });
 
-  it('shows loading state while fetching', () => {
+  it('shows a loading state while the first fetch is in flight', () => {
     mockGetTestRuns.mockReturnValue(new Promise(() => {}));
     render(<TestRunsGrid />);
-    expect(screen.getByTestId('grid-loading')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state directly, without ever mounting the grid, when there are zero test runs', async () => {
+    mockGetTestRuns.mockResolvedValue(makePaginatedResponse([]));
+    render(<TestRunsGrid />);
+    expect(await screen.findByText('No test runs yet')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
   it('does NOT render a "New Test Run" action button (creation moved to page FAB)', async () => {
     render(<TestRunsGrid />);
-    await waitFor(() =>
-      expect(screen.queryByTestId('grid-loading')).not.toBeInTheDocument()
-    );
+    await screen.findByTestId('base-data-grid');
     expect(screen.queryByTestId('action-New Test Run')).not.toBeInTheDocument();
   });
 
@@ -322,21 +333,9 @@ describe('TestRunsGrid', () => {
     );
   });
 
-  it('calls onTotalCountChange with the total count', async () => {
-    mockGetTestRuns.mockResolvedValue(
-      makePaginatedResponse([makeTestRun('r-1'), makeTestRun('r-2')], 42)
-    );
-    const onTotalCountChange = jest.fn();
-    render(<TestRunsGrid onTotalCountChange={onTotalCountChange} />);
-    await waitFor(() => expect(onTotalCountChange).toHaveBeenCalledWith(42));
-  });
-
   it('passes showToolbar and toolbarSlot props to BaseDataGrid', async () => {
     render(<TestRunsGrid />);
-    await waitFor(() =>
-      expect(screen.queryByTestId('grid-loading')).not.toBeInTheDocument()
-    );
     // The grid renders without error, confirming toolbarSlot prop is accepted
-    expect(screen.getByTestId('base-data-grid')).toBeInTheDocument();
+    expect(await screen.findByTestId('base-data-grid')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/(protected)/test-runs/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/page.tsx
@@ -2,7 +2,6 @@
 
 import * as React from 'react';
 import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { useSession } from 'next-auth/react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -13,13 +12,9 @@ import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
-import EntityEmptyState from '@/components/common/EntityEmptyState';
-import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
-import { PlayArrowIcon } from '@/components/icons';
 import TestRunsGrid from './components/TestRunsGrid';
 import RunDrawer from '@/components/common/RunDrawer';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
 
 export default function TestRunsPage() {
@@ -29,7 +24,6 @@ export default function TestRunsPage() {
     Capability.TestRun.READ
   );
   const canCreateTestRun = useCan(Capability.TestRun.CREATE);
-  const [testRunCount, setTestRunCount] = React.useState<number | null>(null);
   const [createDrawerOpen, setCreateDrawerOpen] = React.useState(false);
 
   useDocumentTitle('Test Runs');
@@ -81,31 +75,10 @@ export default function TestRunsPage() {
         }
       >
         <Box sx={{ mt: 2, mb: 2 }}>
-          {testRunCount === 0 ? (
-            <EntityEmptyState
-              card
-              icon={PlayArrowIcon}
-              title="No test runs yet"
-              description="Execute a test set against an AI endpoint to start your first test run. Test runs measure quality, safety, and reliability of your AI endpoints."
-              actionLabel={canCreateTestRun ? 'Create test run' : undefined}
-              onAction={
-                canCreateTestRun ? () => setCreateDrawerOpen(true) : undefined
-              }
-              enrichment={getEntityEmptyStateEnrichment('test-runs')}
-            />
-          ) : (
-            <Paper
-              sx={{
-                width: '100%',
-                borderRadius: BORDER_RADIUS.md,
-                boxShadow: ELEVATION.xs,
-                border: theme => `1px solid ${theme.palette.greyscale.border}`,
-                overflow: 'hidden',
-              }}
-            >
-              <TestRunsGrid onTotalCountChange={setTestRunCount} />
-            </Paper>
-          )}
+          <TestRunsGrid
+            canCreate={canCreateTestRun}
+            onCreateClick={() => setCreateDrawerOpen(true)}
+          />
         </Box>
       </PageLayout>
 

--- a/apps/frontend/src/app/(protected)/test-sets/__tests__/page.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/__tests__/page.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import TestSetsPage from '../page';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    refresh: jest.fn(),
+  }),
+  usePathname: () => '/test-sets',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { session_token: 'tok', user: { id: 'u1', name: 'Alice' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+jest.mock('@/components/common/NotificationContext', () => ({
+  useNotifications: () => ({ show: jest.fn(), close: jest.fn() }),
+  NotificationProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+// TestSetsGrid owns the query and the loading/empty/populated decision
+// itself (see TestSetsGrid.test.tsx for that behavior) — the page's only
+// job is to wire `canCreate` and `onCreateClick` through to it correctly.
+jest.mock('../components/TestSetsGrid', () => {
+  return function MockTestSetsGrid({
+    canCreate,
+    onCreateClick,
+  }: {
+    canCreate?: boolean;
+    onCreateClick?: () => void;
+  }) {
+    return (
+      <button onClick={onCreateClick} disabled={!canCreate}>
+        mock-create-test-set
+      </button>
+    );
+  };
+});
+
+jest.mock('../components/TestSetDrawer', () => {
+  return function MockTestSetDrawer({ open }: { open: boolean }) {
+    return open ? <div data-testid="test-set-drawer" /> : null;
+  };
+});
+
+jest.mock('../components/FileImportDrawer', () => {
+  return function MockFileImportDrawer() {
+    return null;
+  };
+});
+
+jest.mock('../components/GarakImportDrawer', () => {
+  return function MockGarakImportDrawer() {
+    return null;
+  };
+});
+
+describe('TestSetsPage', () => {
+  it('passes canCreate through to the grid', () => {
+    render(<TestSetsPage />);
+    expect(screen.getByText('mock-create-test-set')).toBeEnabled();
+  });
+
+  it('opens the create drawer when the grid invokes onCreateClick', async () => {
+    render(<TestSetsPage />);
+    await userEvent.click(screen.getByText('mock-create-test-set'));
+    expect(screen.getByTestId('test-set-drawer')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -1,12 +1,6 @@
 'use client';
 
-import React, {
-  useEffect,
-  useState,
-  useCallback,
-  useContext,
-  useMemo,
-} from 'react';
+import React, { useState, useCallback, useContext, useMemo } from 'react';
 import {
   GridColDef,
   GridRowParams,
@@ -16,7 +10,7 @@ import {
   GridToolbarDensitySelector,
   GridToolbarExport,
 } from '@mui/x-data-grid';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
+import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import { useRouter } from 'next/navigation';
 import { combineTestSetFiltersToOData } from '@/utils/odata-filter';
 import {
@@ -26,8 +20,20 @@ import {
 import { gridSortToApiParams } from '@/utils/grid-sort';
 import { TestSet } from '@/utils/api-client/interfaces/test-set';
 import { Tag } from '@/utils/api-client/interfaces/tag';
-import { Box, Tooltip, Typography, Avatar, Alert, Chip } from '@mui/material';
-import { ChatIcon, DescriptionIcon } from '@/components/icons';
+import {
+  Box,
+  Tooltip,
+  Typography,
+  Avatar,
+  Alert,
+  Chip,
+  Paper,
+} from '@mui/material';
+import {
+  ChatIcon,
+  DescriptionIcon,
+  HorizontalSplitIcon,
+} from '@/components/icons';
 import InsertDriveFileOutlined from '@mui/icons-material/InsertDriveFileOutlined';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import DeleteIcon from '@mui/icons-material/DeleteOutlined';
@@ -58,9 +64,13 @@ import { testSetKeys } from '@/constants/query-keys';
 import { useGridState } from '@/hooks/useGridState';
 import { useGridQuery } from '@/hooks/useGridQuery';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import GridStateGate from '@/components/common/GridStateGate';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 
 interface TestSetsGridProps {
-  onTotalCountChange?: (count: number) => void;
+  canCreate?: boolean;
+  onCreateClick?: () => void;
 }
 
 // ─── Toolbar context ────────────────────────────────────────────────────────────
@@ -156,7 +166,8 @@ const ChipContainer = ({ items }: { items: string[] }) => {
 };
 
 export default function TestSetsGrid({
-  onTotalCountChange,
+  canCreate,
+  onCreateClick,
 }: TestSetsGridProps) {
   const router = useRouter();
   const { status } = useSession();
@@ -268,23 +279,6 @@ export default function TestSetsGrid({
   });
   const testSets = testSetsData?.data ?? [];
   const totalCount = testSetsData?.pagination.totalCount ?? 0;
-
-  // ── onTotalCountChange side effect ───────────────────────────────────────────
-  useEffect(() => {
-    if (!testSetsData) return;
-    const filtersActive =
-      filterModel.items.length > 0 ||
-      !!searchQuery ||
-      hasActiveTestSetFilters(drawerFilters);
-    if (!filtersActive) onTotalCountChange?.(totalCount);
-  }, [
-    testSetsData,
-    filterModel.items.length,
-    searchQuery,
-    drawerFilters,
-    onTotalCountChange,
-    totalCount,
-  ]);
 
   // ── Row + selection handlers ─────────────────────────────────────────────────
 
@@ -623,112 +617,136 @@ export default function TestSetsGrid({
     ];
   }, [handleRowEditAction, handleRowDeleteAction]);
 
-  return (
-    <TestSetsToolbarContext.Provider
-      value={{
-        searchQuery,
-        setSearchQuery,
-        typeFilter,
-        setTypeFilter,
-        openFilterDrawer: () => setFilterDrawerOpen(true),
-        hasActiveDrawerFilters: hasActiveTestSetFilters(drawerFilters),
-        activeFilterCount: countActiveTestSetFilters(drawerFilters),
-      }}
-    >
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
-          {error}
-        </Alert>
-      )}
+  const filtersActive =
+    filterModel.items.length > 0 ||
+    !!searchQuery ||
+    hasActiveTestSetFilters(drawerFilters);
 
-      {selectedRows.length > 0 && (
-        <Box
-          sx={{
-            px: 2,
-            py: 1,
-            display: 'flex',
-            alignItems: 'center',
-            gap: 2,
-            borderBottom: theme =>
-              `1px solid ${theme.palette.greyscale.border}`,
+  return (
+    <GridStateGate
+      data={testSetsData}
+      error={error}
+      isEmpty={totalCount === 0 && !filtersActive}
+      emptyState={
+        <EntityEmptyState
+          card
+          icon={HorizontalSplitIcon}
+          title="No test sets yet"
+          description="Group related tests into a test set to version, share, and run them together."
+          actionLabel={canCreate ? 'Create test set' : undefined}
+          onAction={canCreate ? onCreateClick : undefined}
+          enrichment={getEntityEmptyStateEnrichment('test-sets')}
+        />
+      }
+    >
+      <Paper sx={GRID_PAPER_SX}>
+        <TestSetsToolbarContext.Provider
+          value={{
+            searchQuery,
+            setSearchQuery,
+            typeFilter,
+            setTypeFilter,
+            openFilterDrawer: () => setFilterDrawerOpen(true),
+            hasActiveDrawerFilters: hasActiveTestSetFilters(drawerFilters),
+            activeFilterCount: countActiveTestSetFilters(drawerFilters),
           }}
         >
-          <Typography variant="subtitle1" color="primary">
-            {selectedRows.length} selected
-          </Typography>
-        </Box>
-      )}
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
+              {error}
+            </Alert>
+          )}
 
-      <BaseDataGrid
-        columns={columns}
-        rows={processedTestSets}
-        loading={loading}
-        getRowId={row => row.id}
-        showToolbar={true}
-        onRowClick={handleRowClick}
-        getRowUrl={row => `/test-sets/${row.id}`}
-        paginationModel={paginationModel}
-        onPaginationModelChange={handlePaginationModelChange}
-        actionButtons={getActionButtons()}
-        serverSidePagination={true}
-        totalRows={totalCount}
-        pageSizeOptions={[10, 25, 50]}
-        serverSideFiltering={true}
-        filterModel={filterModel}
-        onFilterModelChange={handleFilterModelChange}
-        sortingMode="server"
-        sortModel={sortModel}
-        onSortModelChange={handleSortModelChange}
-        toolbarSlot={TestSetsUnifiedToolbar}
-        disablePaperWrapper={true}
-        persistState
-        initialState={{
-          columns: {
-            columnVisibilityModel: {
-              sources: false,
-            },
-          },
-        }}
-        sx={rowActionsHoverSx}
-      />
+          {selectedRows.length > 0 && (
+            <Box
+              sx={{
+                px: 2,
+                py: 1,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 2,
+                borderBottom: theme =>
+                  `1px solid ${theme.palette.greyscale.border}`,
+              }}
+            >
+              <Typography variant="subtitle1" color="primary">
+                {selectedRows.length} selected
+              </Typography>
+            </Box>
+          )}
 
-      {/* Test Run Drawer */}
-      {isAuthenticated(status) && (
-        <>
-          <RunDrawer
-            mode="createFromGrid"
-            open={testRunDrawerOpen}
-            onClose={() => setTestRunDrawerOpen(false)}
-            data={{ selectedTestSetIds: selectedRows as string[] }}
-            onSuccess={() => setTestRunDrawerOpen(false)}
+          <BaseDataGrid
+            columns={columns}
+            rows={processedTestSets}
+            loading={loading}
+            getRowId={row => row.id}
+            showToolbar={true}
+            onRowClick={handleRowClick}
+            getRowUrl={row => `/test-sets/${row.id}`}
+            paginationModel={paginationModel}
+            onPaginationModelChange={handlePaginationModelChange}
+            actionButtons={getActionButtons()}
+            serverSidePagination={true}
+            totalRows={totalCount}
+            pageSizeOptions={[10, 25, 50]}
+            serverSideFiltering={true}
+            filterModel={filterModel}
+            onFilterModelChange={handleFilterModelChange}
+            sortingMode="server"
+            sortModel={sortModel}
+            onSortModelChange={handleSortModelChange}
+            toolbarSlot={TestSetsUnifiedToolbar}
+            disablePaperWrapper={true}
+            persistState
+            initialState={{
+              columns: {
+                columnVisibilityModel: {
+                  sources: false,
+                },
+              },
+            }}
+            sx={rowActionsHoverSx}
           />
-          <DeleteModal
-            open={deleteModalOpen}
-            onClose={handleDeleteCancel}
-            onConfirm={handleDeleteConfirm}
-            isLoading={isDeleting}
-            title={pendingDeleteId ? 'Delete Test Set' : 'Delete Test Sets'}
-            message={
-              pendingDeleteId
-                ? 'Are you sure you want to delete this test set? Related data will not be deleted.'
-                : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'test set' : 'test sets'}? Don't worry, related data will not be deleted, only ${selectedRows.length === 1 ? 'this record' : 'these records'}.`
-            }
-            itemType="test sets"
-          />
-        </>
-      )}
 
-      {/* Filter drawer */}
-      <TestSetFilterDrawer
-        open={filterDrawerOpen}
-        onClose={() => setFilterDrawerOpen(false)}
-        filters={drawerFilters}
-        onApply={f => {
-          setDrawerFilters(f);
-          if (f.testSetType) setTypeFilter(f.testSetType);
-          else if (!drawerFilters.testSetType) setTypeFilter('all');
-        }}
-      />
-    </TestSetsToolbarContext.Provider>
+          {/* Test Run Drawer */}
+          {isAuthenticated(status) && (
+            <>
+              <RunDrawer
+                mode="createFromGrid"
+                open={testRunDrawerOpen}
+                onClose={() => setTestRunDrawerOpen(false)}
+                data={{ selectedTestSetIds: selectedRows as string[] }}
+                onSuccess={() => setTestRunDrawerOpen(false)}
+              />
+              <DeleteModal
+                open={deleteModalOpen}
+                onClose={handleDeleteCancel}
+                onConfirm={handleDeleteConfirm}
+                isLoading={isDeleting}
+                title={pendingDeleteId ? 'Delete Test Set' : 'Delete Test Sets'}
+                message={
+                  pendingDeleteId
+                    ? 'Are you sure you want to delete this test set? Related data will not be deleted.'
+                    : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'test set' : 'test sets'}? Don't worry, related data will not be deleted, only ${selectedRows.length === 1 ? 'this record' : 'these records'}.`
+                }
+                itemType="test sets"
+              />
+            </>
+          )}
+
+          {/* Filter drawer */}
+          <TestSetFilterDrawer
+            open={filterDrawerOpen}
+            onClose={() => setFilterDrawerOpen(false)}
+            filters={drawerFilters}
+            onApply={f => {
+              setDrawerFilters(f);
+              if (f.testSetType) setTypeFilter(f.testSetType);
+              else if (!drawerFilters.testSetType) setTypeFilter('all');
+            }}
+          />
+        </TestSetsToolbarContext.Provider>
+      </Paper>
+    </GridStateGate>
   );
 }

--- a/apps/frontend/src/app/(protected)/test-sets/components/__tests__/TestSetsGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/__tests__/TestSetsGrid.test.tsx
@@ -199,14 +199,28 @@ async function waitForGrid() {
 describe('TestSetsGrid', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Default: fetch returns empty so tests that don't care about rows stay fast
-    mockGetTestSets.mockResolvedValue(makePaginatedResponse([]));
+    // Default: one row, so tests that don't care about emptiness exercise the
+    // populated (grid) branch rather than the empty-state branch.
+    mockGetTestSets.mockResolvedValue(
+      makePaginatedResponse([
+        makeTestSet('00000000-0000-0000-0000-000000000000' as UUID),
+      ])
+    );
   });
 
-  it('shows loading state while fetching', () => {
+  it('shows a loading state while the first fetch is in flight', () => {
     mockGetTestSets.mockReturnValue(new Promise(() => {}));
     render(<TestSetsGrid />);
-    expect(screen.getByTestId('grid-loading')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state directly, without ever mounting the grid, when there are zero test sets', async () => {
+    mockGetTestSets.mockResolvedValue(makePaginatedResponse([]));
+    render(<TestSetsGrid />);
+    expect(await screen.findByText('No test sets yet')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
   it('renders rows returned by the fetch', async () => {

--- a/apps/frontend/src/app/(protected)/test-sets/page.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/page.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import { useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { useQueryClient } from '@tanstack/react-query';
 import { testSetKeys } from '@/constants/query-keys';
@@ -13,15 +12,11 @@ import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh';
 import { useSession } from 'next-auth/react';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
-import EntityEmptyState from '@/components/common/EntityEmptyState';
-import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
-import { HorizontalSplitIcon } from '@/components/icons';
 import TestSetsGrid from './components/TestSetsGrid';
 import TestSetDrawer from './components/TestSetDrawer';
 import FileImportDrawer from './components/FileImportDrawer';
 import GarakImportDrawer from './components/GarakImportDrawer';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
@@ -40,7 +35,6 @@ export default function TestSetsPage() {
   const canCreate = useCan(Capability.TestSet.CREATE);
   const canGenerate = useCan(Capability.TestSet.GENERATE);
 
-  const [testSetCount, setTestSetCount] = React.useState<number | null>(null);
   const [createDrawerOpen, setCreateDrawerOpen] = React.useState(false);
   const [fileImportDrawerOpen, setFileImportDrawerOpen] = React.useState(false);
   const [garakImportDrawerOpen, setGarakImportDrawerOpen] =
@@ -143,29 +137,10 @@ export default function TestSetsPage() {
         }
       >
         <Box sx={{ mt: 2, mb: 2 }}>
-          {testSetCount === 0 ? (
-            <EntityEmptyState
-              card
-              icon={HorizontalSplitIcon}
-              title="No test sets yet"
-              description="Group related tests into a test set to version, share, and run them together."
-              actionLabel={canCreate ? 'Create test set' : undefined}
-              onAction={canCreate ? () => setCreateDrawerOpen(true) : undefined}
-              enrichment={getEntityEmptyStateEnrichment('test-sets')}
-            />
-          ) : (
-            <Paper
-              sx={{
-                width: '100%',
-                borderRadius: BORDER_RADIUS.md,
-                boxShadow: ELEVATION.xs,
-                border: theme => `1px solid ${theme.palette.greyscale.border}`,
-                overflow: 'hidden',
-              }}
-            >
-              <TestSetsGrid onTotalCountChange={setTestSetCount} />
-            </Paper>
-          )}
+          <TestSetsGrid
+            canCreate={canCreate}
+            onCreateClick={() => setCreateDrawerOpen(true)}
+          />
         </Box>
       </PageLayout>
 

--- a/apps/frontend/src/app/(protected)/tests/__tests__/page.test.tsx
+++ b/apps/frontend/src/app/(protected)/tests/__tests__/page.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import TestsPage from '../page';
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: jest.fn(), refresh: jest.fn() }),
+  usePathname: () => '/tests',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { session_token: 'tok', user: { id: 'u1', name: 'Alice' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+jest.mock('@/components/common/NotificationContext', () => ({
+  useNotifications: () => ({ show: jest.fn(), close: jest.fn() }),
+  NotificationProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+jest.mock('@/contexts/OnboardingContext', () => ({
+  useOnboarding: () => ({ activeTour: null, startTour: jest.fn() }),
+}));
+
+jest.mock('@/hooks/useEndpoints', () => ({
+  useEndpoint: () => ({ data: undefined }),
+}));
+
+// TestsGrid owns the query and the loading/empty/populated decision itself —
+// the page's only job is to wire `canCreate`/`onNewTest` through to it.
+jest.mock('../components/TestsGrid', () => {
+  return function MockTestsGrid({
+    canCreate,
+    onNewTest,
+  }: {
+    canCreate?: boolean;
+    onNewTest?: () => void;
+  }) {
+    return (
+      <button onClick={onNewTest} disabled={!canCreate}>
+        mock-create-test
+      </button>
+    );
+  };
+});
+
+jest.mock('@/app/(protected)/test-sets/components/FileImportDrawer', () => {
+  return function MockFileImportDrawer() {
+    return null;
+  };
+});
+
+describe('TestsPage', () => {
+  it('passes canCreate through to the grid', () => {
+    render(<TestsPage />);
+    expect(screen.getByText('mock-create-test')).toBeEnabled();
+  });
+
+  it('navigates to the manual test flow when the grid invokes onNewTest', async () => {
+    render(<TestsPage />);
+    await userEvent.click(screen.getByText('mock-create-test'));
+    expect(mockPush).toHaveBeenCalledWith('/tests/new-manual');
+  });
+});

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -25,7 +25,7 @@ import {
   GridToolbarDensitySelector,
   GridToolbarExport,
 } from '@mui/x-data-grid';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
+import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import { useRouter } from 'next/navigation';
 import { TestDetail } from '@/utils/api-client/interfaces/tests';
 import { Tag } from '@/utils/api-client/interfaces/tag';
@@ -36,9 +36,15 @@ import {
   Chip,
   FormControlLabel,
   Switch,
+  Paper,
 } from '@mui/material';
 import GridBadge from '@/components/common/GridBadge';
-import { AttachFileIcon, ChatIcon, DescriptionIcon } from '@/components/icons';
+import {
+  AttachFileIcon,
+  ChatIcon,
+  DescriptionIcon,
+  ScienceIcon,
+} from '@/components/icons';
 import InsertDriveFileOutlined from '@mui/icons-material/InsertDriveFileOutlined';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useSession } from 'next-auth/react';
@@ -80,13 +86,16 @@ import {
   type InsightsFailedTestsFilter,
 } from '@/app/(protected)/insights/utils/insights-failed-tests';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import GridStateGate from '@/components/common/GridStateGate';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
 
 interface TestsTableProps {
   onNewTest?: () => void;
   disableAddButton?: boolean;
+  canCreate?: boolean;
   insightsFailedFilter?: InsightsFailedTestsFilter | null;
   insightsEndpointName?: string;
-  onTotalCountChange?: (count: number) => void;
   onBulkActionsChange?: (actions: TestsBulkActionsState) => void;
 }
 
@@ -184,11 +193,11 @@ function TestsUnifiedToolbar() {
 }
 
 export default function TestsTable({
-  onNewTest: _onNewTest,
-  disableAddButton: _disableAddButton = false,
+  onNewTest,
+  disableAddButton = false,
+  canCreate,
   insightsFailedFilter = null,
   insightsEndpointName,
-  onTotalCountChange,
   onBulkActionsChange,
 }: TestsTableProps) {
   const router = useRouter();
@@ -300,23 +309,6 @@ export default function TestsTable({
         typeValues.size === 1 ? ([...typeValues][0] ?? undefined) : undefined,
     };
   }, [selectedRows, tests]);
-
-  useEffect(() => {
-    if (!testsData) return;
-    const filtersActive =
-      filterModel.items.length > 0 ||
-      !!searchQuery ||
-      hasActiveTestFilters(drawerFilters) ||
-      !!insightsFailedFilter;
-    if (!filtersActive) onTotalCountChange?.(testsData.pagination.totalCount);
-  }, [
-    testsData,
-    filterModel.items.length,
-    searchQuery,
-    drawerFilters,
-    insightsFailedFilter,
-    onTotalCountChange,
-  ]);
 
   // Apply Insights failed-test filter from URL params
   useEffect(() => {
@@ -780,6 +772,12 @@ export default function TestsTable({
     }
   }, [queryClient, paginationModel.page]);
 
+  const filtersActive =
+    filterModel.items.length > 0 ||
+    !!searchQuery ||
+    hasActiveTestFilters(drawerFilters) ||
+    !!insightsFailedFilter;
+
   const showSelectionActions = checkboxSelectionMode && selectedRows.length > 0;
 
   const bulkHandlersRef = useRef({
@@ -812,120 +810,140 @@ export default function TestsTable({
   }, [onBulkActionsChange]);
 
   return (
-    <TestsToolbarContext.Provider
-      value={{
-        searchQuery,
-        setSearchQuery,
-        typeFilter,
-        setTypeFilter,
-        openFilterDrawer: () => setFilterDrawerOpen(true),
-        hasActiveDrawerFilters: hasActiveTestFilters(drawerFilters),
-        activeFilterCount: countActiveTestFilters(drawerFilters),
-        checkboxSelectionMode,
-        setCheckboxSelectionMode: handleCheckboxSelectionModeChange,
-      }}
+    <GridStateGate
+      data={testsData}
+      error={error}
+      isEmpty={totalCount === 0 && !filtersActive}
+      emptyState={
+        <EntityEmptyState
+          card
+          icon={ScienceIcon}
+          title="No test yet"
+          description="Create your first test to start evaluating your AI endpoints. Tests let you measure quality, safety, and reliability across single-turn and multi-turn interactions."
+          actionLabel={canCreate ? 'Create test' : undefined}
+          onAction={canCreate ? onNewTest : undefined}
+          actionDisabled={disableAddButton}
+          enrichment={getEntityEmptyStateEnrichment('tests')}
+        />
+      }
     >
-      {error && (
-        <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
-          {error}
-        </Alert>
-      )}
+      <Paper sx={GRID_PAPER_SX}>
+        <TestsToolbarContext.Provider
+          value={{
+            searchQuery,
+            setSearchQuery,
+            typeFilter,
+            setTypeFilter,
+            openFilterDrawer: () => setFilterDrawerOpen(true),
+            hasActiveDrawerFilters: hasActiveTestFilters(drawerFilters),
+            activeFilterCount: countActiveTestFilters(drawerFilters),
+            checkboxSelectionMode,
+            setCheckboxSelectionMode: handleCheckboxSelectionModeChange,
+          }}
+        >
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }} onClose={dismissError}>
+              {error}
+            </Alert>
+          )}
 
-      {insightsFailedFilter && (
-        <Alert severity="info" sx={{ mb: 2 }}>
-          {insightsFilterLoading
-            ? 'Loading test cases from Insights…'
-            : insightsFilterError ||
-              formatInsightsFailedTestsBanner(
-                insightsFailedFilter,
-                insightsFailedTestIds?.length ?? 0,
-                insightsEndpointName
-              )}
-        </Alert>
-      )}
+          {insightsFailedFilter && (
+            <Alert severity="info" sx={{ mb: 2 }}>
+              {insightsFilterLoading
+                ? 'Loading test cases from Insights…'
+                : insightsFilterError ||
+                  formatInsightsFailedTestsBanner(
+                    insightsFailedFilter,
+                    insightsFailedTestIds?.length ?? 0,
+                    insightsEndpointName
+                  )}
+            </Alert>
+          )}
 
-      <BaseDataGrid
-        rows={tests}
-        columns={columns}
-        loading={loading}
-        getRowId={row => row.id}
-        paginationModel={paginationModel}
-        onPaginationModelChange={handlePaginationModelChange}
-        checkboxSelection={checkboxSelectionMode}
-        disableRowSelectionOnClick={checkboxSelectionMode || undefined}
-        onRowSelectionModelChange={
-          checkboxSelectionMode ? handleSelectionChange : undefined
-        }
-        rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
-        onRowClick={checkboxSelectionMode ? undefined : handleRowClick}
-        getRowUrl={
-          checkboxSelectionMode ? undefined : row => `/tests/${row.id}`
-        }
-        serverSidePagination={true}
-        totalRows={totalCount}
-        pageSizeOptions={[10, 25, 50]}
-        serverSideFiltering={true}
-        filterModel={filterModel}
-        onFilterModelChange={handleFilterModelChange}
-        sortingMode="server"
-        sortModel={sortModel}
-        onSortModelChange={handleSortModelChange}
-        toolbarSlot={TestsUnifiedToolbar}
-        showToolbar={true}
-        disablePaperWrapper={true}
-        persistState={!insightsFailedFilter}
-        initialState={{
-          columns: {
-            columnVisibilityModel: {
-              'test_metadata.sources': false,
-            },
-          },
-        }}
-        sx={rowActionsHoverSx}
-      />
-
-      {isAuthenticated(status) && (
-        <>
-          <TestDrawer
-            open={drawerOpen}
-            onClose={handleDrawerClose}
-            test={selectedTest}
-            onSuccess={handleTestSaved}
-          />
-          <TestSetSelectionDrawer
-            open={testSetDrawerOpen}
-            onClose={() => setTestSetDrawerOpen(false)}
-            onSelect={handleTestSetsAssign}
-            testTypeValue={selectedTestTypes.commonTypeValue}
-          />
-          <DeleteModal
-            open={deleteModalOpen}
-            onClose={handleDeleteCancel}
-            onConfirm={handleDeleteConfirm}
-            isLoading={isDeleting}
-            title={pendingDeleteId ? 'Delete Test' : 'Delete Tests'}
-            message={
-              pendingDeleteId
-                ? 'Are you sure you want to delete this test? Related data will not be deleted.'
-                : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'test' : 'tests'}? Don't worry, related data will not be deleted, only ${selectedRows.length === 1 ? 'this record' : 'these records'}.`
+          <BaseDataGrid
+            rows={tests}
+            columns={columns}
+            loading={loading}
+            getRowId={row => row.id}
+            paginationModel={paginationModel}
+            onPaginationModelChange={handlePaginationModelChange}
+            checkboxSelection={checkboxSelectionMode}
+            disableRowSelectionOnClick={checkboxSelectionMode || undefined}
+            onRowSelectionModelChange={
+              checkboxSelectionMode ? handleSelectionChange : undefined
             }
-            itemType="tests"
+            rowSelectionModel={checkboxSelectionMode ? selectedRows : []}
+            onRowClick={checkboxSelectionMode ? undefined : handleRowClick}
+            getRowUrl={
+              checkboxSelectionMode ? undefined : row => `/tests/${row.id}`
+            }
+            serverSidePagination={true}
+            totalRows={totalCount}
+            pageSizeOptions={[10, 25, 50]}
+            serverSideFiltering={true}
+            filterModel={filterModel}
+            onFilterModelChange={handleFilterModelChange}
+            sortingMode="server"
+            sortModel={sortModel}
+            onSortModelChange={handleSortModelChange}
+            toolbarSlot={TestsUnifiedToolbar}
+            showToolbar={true}
+            disablePaperWrapper={true}
+            persistState={!insightsFailedFilter}
+            initialState={{
+              columns: {
+                columnVisibilityModel: {
+                  'test_metadata.sources': false,
+                },
+              },
+            }}
+            sx={rowActionsHoverSx}
           />
-        </>
-      )}
 
-      {/* Filter drawer */}
-      <TestFilterDrawer
-        open={filterDrawerOpen}
-        onClose={() => setFilterDrawerOpen(false)}
-        filters={drawerFilters}
-        onApply={f => {
-          setDrawerFilters(f);
-          // If drawer sets a test type, sync the pill tab too
-          if (f.testType) setTypeFilter(f.testType);
-          else if (!drawerFilters.testType) setTypeFilter('all');
-        }}
-      />
-    </TestsToolbarContext.Provider>
+          {isAuthenticated(status) && (
+            <>
+              <TestDrawer
+                open={drawerOpen}
+                onClose={handleDrawerClose}
+                test={selectedTest}
+                onSuccess={handleTestSaved}
+              />
+              <TestSetSelectionDrawer
+                open={testSetDrawerOpen}
+                onClose={() => setTestSetDrawerOpen(false)}
+                onSelect={handleTestSetsAssign}
+                testTypeValue={selectedTestTypes.commonTypeValue}
+              />
+              <DeleteModal
+                open={deleteModalOpen}
+                onClose={handleDeleteCancel}
+                onConfirm={handleDeleteConfirm}
+                isLoading={isDeleting}
+                title={pendingDeleteId ? 'Delete Test' : 'Delete Tests'}
+                message={
+                  pendingDeleteId
+                    ? 'Are you sure you want to delete this test? Related data will not be deleted.'
+                    : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'test' : 'tests'}? Don't worry, related data will not be deleted, only ${selectedRows.length === 1 ? 'this record' : 'these records'}.`
+                }
+                itemType="tests"
+              />
+            </>
+          )}
+
+          {/* Filter drawer */}
+          <TestFilterDrawer
+            open={filterDrawerOpen}
+            onClose={() => setFilterDrawerOpen(false)}
+            filters={drawerFilters}
+            onApply={f => {
+              setDrawerFilters(f);
+              // If drawer sets a test type, sync the pill tab too
+              if (f.testType) setTypeFilter(f.testType);
+              else if (!drawerFilters.testType) setTypeFilter('all');
+            }}
+          />
+        </TestsToolbarContext.Provider>
+      </Paper>
+    </GridStateGate>
   );
 }

--- a/apps/frontend/src/app/(protected)/tests/components/__tests__/TestsGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/__tests__/TestsGrid.test.tsx
@@ -262,20 +262,29 @@ function TestsTableHarness(props: React.ComponentProps<typeof TestsTable>) {
 describe('TestsTable', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetTests.mockResolvedValue(makePaginatedResponse([]));
+    // Default: one row, so tests that don't care about emptiness exercise
+    // the populated (grid) branch rather than the empty-state branch.
+    mockGetTests.mockResolvedValue(makePaginatedResponse([makeTest('t-0')]));
   });
 
-  it('shows loading state while fetching', () => {
+  it('shows a loading state while the first fetch is in flight', () => {
     mockGetTests.mockReturnValue(new Promise(() => {}));
     render(<TestsTableHarness />);
-    expect(screen.getByTestId('grid-loading')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state directly, without ever mounting the grid, when there are zero tests', async () => {
+    mockGetTests.mockResolvedValue(makePaginatedResponse([]));
+    render(<TestsTableHarness />);
+    expect(await screen.findByText('No test yet')).toBeInTheDocument();
+    expect(screen.queryByTestId('base-data-grid')).not.toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
 
   it('renders no action buttons when no rows are selected', async () => {
     render(<TestsTableHarness />);
-    await waitFor(() =>
-      expect(screen.queryByTestId('grid-loading')).not.toBeInTheDocument()
-    );
+    await screen.findByTestId('base-data-grid');
     expect(screen.queryByTestId('action-Add Tests')).not.toBeInTheDocument();
   });
 

--- a/apps/frontend/src/app/(protected)/tests/page.tsx
+++ b/apps/frontend/src/app/(protected)/tests/page.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
 import { useSession } from 'next-auth/react';
 import { useQueryClient } from '@tanstack/react-query';
 import EditNoteIcon from '@mui/icons-material/EditNote';
@@ -12,13 +11,10 @@ import DownloadOutlinedIcon from '@mui/icons-material/DownloadOutlined';
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabGroup } from '@/components/common/Fab';
-import EntityEmptyState from '@/components/common/EntityEmptyState';
-import { getEntityEmptyStateEnrichment } from '@/constants/entity-empty-state-env';
-import { CategoryIcon, ScienceIcon } from '@/components/icons';
+import { CategoryIcon } from '@/components/icons';
 import TestsGrid, { type TestsBulkActionsState } from './components/TestsGrid';
 import FileImportDrawer from '@/app/(protected)/test-sets/components/FileImportDrawer';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import { useOnboarding } from '@/contexts/OnboardingContext';
 import { parseInsightsFailedTestsSearchParams } from '@/app/(protected)/insights/utils/insights-failed-tests';
 import { useEndpoint } from '@/hooks/useEndpoints';
@@ -36,7 +32,6 @@ export default function TestsPage() {
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const notifications = useNotifications();
-  const [testCount, setTestCount] = React.useState<number | null>(null);
   const [fileImportDrawerOpen, setFileImportDrawerOpen] = React.useState(false);
   const [bulkActions, setBulkActions] = React.useState<
     Pick<TestsBulkActionsState, 'visible' | 'assignDisabled'>
@@ -212,46 +207,14 @@ export default function TestsPage() {
         }
       >
         <Box sx={{ mt: 2, mb: 2 }}>
-          <Paper
-            sx={{
-              width: '100%',
-              borderRadius: BORDER_RADIUS.md,
-              boxShadow: ELEVATION.xs,
-              border: theme => `1px solid ${theme.palette.greyscale.border}`,
-              overflow: 'hidden',
-              position: 'relative',
-            }}
-          >
-            <TestsGrid
-              onNewTest={handleCreateManual}
-              disableAddButton={shouldDisableAddButton}
-              insightsFailedFilter={insightsFailedFilter}
-              insightsEndpointName={insightsEndpointName}
-              onTotalCountChange={setTestCount}
-              onBulkActionsChange={handleBulkActionsChange}
-            />
-            {testCount === 0 && (
-              <Box
-                sx={{
-                  position: 'absolute',
-                  inset: 0,
-                  zIndex: 1,
-                  bgcolor: 'background.paper',
-                }}
-              >
-                <EntityEmptyState
-                  card
-                  icon={ScienceIcon}
-                  title="No test yet"
-                  description="Create your first test to start evaluating your AI endpoints. Tests let you measure quality, safety, and reliability across single-turn and multi-turn interactions."
-                  actionLabel={canCreate ? 'Create test' : undefined}
-                  onAction={canCreate ? handleCreateManual : undefined}
-                  actionDisabled={shouldDisableAddButton}
-                  enrichment={getEntityEmptyStateEnrichment('tests')}
-                />
-              </Box>
-            )}
-          </Paper>
+          <TestsGrid
+            onNewTest={handleCreateManual}
+            disableAddButton={shouldDisableAddButton}
+            canCreate={canCreate}
+            insightsFailedFilter={insightsFailedFilter}
+            insightsEndpointName={insightsEndpointName}
+            onBulkActionsChange={handleBulkActionsChange}
+          />
         </Box>
       </PageLayout>
 

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -1,6 +1,7 @@
 import React, {
   useState,
   useEffect,
+  useLayoutEffect,
   useCallback,
   ReactNode,
   useRef,
@@ -67,6 +68,21 @@ import {
   useRowActionsGridRootProps,
 } from '@/components/common/createRowActionsColumn';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
+
+/**
+ * Shared "grid card" look — the bordered, rounded, shadowed Paper every grid
+ * page wraps its toolbar + DataGrid (+ alerts, selection banners, etc.) in.
+ * Exported so grid components that need more inside the card than just the
+ * DataGrid (and so pass `disablePaperWrapper`) can reuse the exact same sx
+ * instead of re-declaring it.
+ */
+export const GRID_PAPER_SX = {
+  width: '100%',
+  borderRadius: BORDER_RADIUS.md,
+  boxShadow: ELEVATION.xs,
+  border: (theme: Theme) => `1px solid ${theme.palette.greyscale.border}`,
+  overflow: 'hidden',
+} as const;
 
 interface FilterOption {
   value: string;
@@ -724,18 +740,15 @@ export default function BaseDataGrid({
   const isMountedRef = useRef(false);
   const [isInitialized, setIsInitialized] = useState(false);
 
-  // Initialization effect
-  useEffect(() => {
+  // Initialization effect — runs before paint (useLayoutEffect) so the
+  // ready-gate below never actually reaches the screen on a normal mount;
+  // a setTimeout(0)-delayed useEffect would let the browser paint the
+  // fallback spinner first, then swap to the grid, causing a visible flash.
+  useLayoutEffect(() => {
     isMountedRef.current = true;
-    // Delay DataGrid initialization to prevent state update on unmounted component
-    const initTimer = setTimeout(() => {
-      if (isMountedRef.current) {
-        setIsInitialized(true);
-      }
-    }, 0);
+    setIsInitialized(true);
 
     return () => {
-      clearTimeout(initTimer);
       isMountedRef.current = false;
     };
   }, []);
@@ -1421,17 +1434,7 @@ export default function BaseDataGrid({
                 </PaginationSizeContext.Provider>
               </HideRowsPerPageBelowContext.Provider>
             ) : (
-              <Paper
-                elevation={0}
-                sx={{
-                  width: '100%',
-                  borderRadius: BORDER_RADIUS.md,
-                  border: theme =>
-                    `1px solid ${theme.palette.greyscale.border}`,
-                  boxShadow: ELEVATION.xs,
-                  overflow: 'hidden',
-                }}
-              >
+              <Paper elevation={0} sx={GRID_PAPER_SX}>
                 <HideRowsPerPageBelowContext.Provider
                   value={hideRowsPerPageBelow}
                 >

--- a/apps/frontend/src/components/common/GridStateGate.tsx
+++ b/apps/frontend/src/components/common/GridStateGate.tsx
@@ -38,7 +38,7 @@ export default function GridStateGate({
   children,
 }: GridStateGateProps) {
   if (!active) return <>{children}</>;
-  if (!data && !error) return <PageLoadingState />;
+  if (data == null && !error) return <PageLoadingState />;
   if (isEmpty && !error) return <>{emptyState}</>;
   return <>{children}</>;
 }

--- a/apps/frontend/src/components/common/GridStateGate.tsx
+++ b/apps/frontend/src/components/common/GridStateGate.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React from 'react';
+import PageLoadingState from './PageLoadingState';
+
+interface GridStateGateProps {
+  /**
+   * Set to false to bypass all gating and always render `children` — for
+   * grids embedded in another page (e.g. a project's Endpoints tab) that
+   * never owned a full-page loading/empty presentation to begin with.
+   */
+  active?: boolean;
+  /** The query's data object — gates on `data`, not `isLoading`, so a query
+   *  that hasn't started yet (e.g. still waiting on session auth) is treated
+   *  the same as one that's actively fetching. */
+  data: unknown;
+  error?: string | null;
+  isEmpty: boolean;
+  emptyState: React.ReactNode;
+  children: React.ReactNode;
+}
+
+/**
+ * Centralizes the loading → empty-state → content decision every grid page
+ * makes: show a spinner until the first fetch settles, show a dedicated
+ * empty-state card if that fetch came back with nothing, otherwise render
+ * the grid. An error always falls through to `children` so the caller's own
+ * error `Alert` (rendered alongside the grid) gets a chance to show —
+ * fetch failures leave `data` undefined forever, so without this the error
+ * would be masked by a permanent loading spinner.
+ */
+export default function GridStateGate({
+  active = true,
+  data,
+  error = null,
+  isEmpty,
+  emptyState,
+  children,
+}: GridStateGateProps) {
+  if (!active) return <>{children}</>;
+  if (!data && !error) return <PageLoadingState />;
+  if (isEmpty && !error) return <>{emptyState}</>;
+  return <>{children}</>;
+}

--- a/apps/frontend/src/hooks/useGridStateStorage.ts
+++ b/apps/frontend/src/hooks/useGridStateStorage.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { usePathname } from 'next/navigation';
 import type { GridApi, GridInitialState } from '@mui/x-data-grid';
 
@@ -132,8 +138,10 @@ export function useGridStateStorage(
     GridInitialState | undefined
   >(undefined);
 
-  // Load state on mount (client-side only, runs once after hydration)
-  useEffect(() => {
+  // Load state on mount (client-side only, runs once after hydration).
+  // useLayoutEffect so this resolves before paint — a passive useEffect
+  // would let the browser paint the "not loaded yet" fallback first.
+  useLayoutEffect(() => {
     const savedState = loadState(storageKey);
     if (savedState) {
       setInitialState(savedState);

--- a/apps/frontend/tests/e2e/helpers/CrudHelper.ts
+++ b/apps/frontend/tests/e2e/helpers/CrudHelper.ts
@@ -41,9 +41,19 @@ export async function expectGridRowVisible(page: Page, text: string) {
   await expect(row).toBeVisible({ timeout: 15_000 });
 }
 
-/** Locator for the currently open MUI drawer (BaseDrawer titles are plain Typography). */
-export function openDrawer(page: Page) {
-  return page.locator('.MuiDrawer-root:not([aria-hidden="true"])');
+/**
+ * Locator for an open MUI drawer (BaseDrawer titles are plain Typography).
+ * Pass `title` to scope to one specific drawer — required whenever more
+ * than one drawer can be mounted on the page (even closed), since a
+ * just-closed drawer's `aria-hidden` attribute can lag its mount by a
+ * frame, which otherwise trips Playwright's strict-mode "resolved to N
+ * elements" check against the unscoped locator.
+ */
+export function openDrawer(page: Page, title?: string | RegExp) {
+  const drawers = page.locator('.MuiDrawer-root:not([aria-hidden="true"])');
+  if (title === undefined) return drawers;
+  // BaseDrawer title is Typography — avoid matching the footer save button.
+  return drawers.filter({ has: page.getByRole('paragraph', { name: title }) });
 }
 
 /** Wait until the open drawer shows the expected title text. */
@@ -60,9 +70,16 @@ export async function expectOpenDrawerTitle(
   ).toBeVisible({ timeout });
 }
 
-/** Wait until no drawer is open. */
-export async function waitForDrawerClosed(page: Page, timeout = 15_000) {
-  await openDrawer(page).waitFor({ state: 'hidden', timeout });
+/**
+ * Wait until no drawer is open. Pass `title` to scope to one specific
+ * drawer when other drawers may be mounted-but-closed on the page.
+ */
+export async function waitForDrawerClosed(
+  page: Page,
+  opts: { title?: string | RegExp; timeout?: number } = {}
+) {
+  const { title, timeout = 15_000 } = opts;
+  await openDrawer(page, title).waitFor({ state: 'hidden', timeout });
 }
 
 /** Wait until a drawer heading is no longer visible (BaseDrawer uses role=presentation). */
@@ -71,7 +88,7 @@ export async function waitForDrawerHeadingHidden(
   title: string | RegExp,
   timeout = 15_000
 ) {
-  await waitForDrawerClosed(page, timeout);
+  await waitForDrawerClosed(page, { title, timeout });
 }
 
 /** UUID that is valid but unlikely to exist in Quick Start seed data. */

--- a/apps/frontend/tests/e2e/pages/KnowledgePage.ts
+++ b/apps/frontend/tests/e2e/pages/KnowledgePage.ts
@@ -99,7 +99,7 @@ export class KnowledgePage extends BasePage {
 
   /** BaseDrawer stays mounted — wait for the drawer to close. */
   async waitForUploadDrawerClosed() {
-    await waitForDrawerClosed(this.page, 20_000);
+    await waitForDrawerClosed(this.page, { timeout: 20_000 });
   }
 
   /** Delete a row via the hover-revealed row-actions delete icon. */

--- a/apps/frontend/tests/e2e/tests/tasks-crud.spec.ts
+++ b/apps/frontend/tests/e2e/tests/tasks-crud.spec.ts
@@ -52,7 +52,7 @@ test.describe('Tasks — CRUD @crud', () => {
 
     await expect(saveBtn).toBeEnabled({ timeout: 15_000 });
     await saveBtn.click();
-    await waitForDrawerClosed(page, 20_000);
+    await waitForDrawerClosed(page, { timeout: 20_000 });
 
     await page.waitForLoadState('networkidle');
     await tasksPage.expectTaskVisible(title);

--- a/apps/frontend/tests/e2e/tests/test-sets-crud.spec.ts
+++ b/apps/frontend/tests/e2e/tests/test-sets-crud.spec.ts
@@ -49,7 +49,10 @@ test.describe('Test Sets — CRUD @crud', () => {
 
     // Save (button text from BaseDrawer default is "Save Changes")
     await drawer.getByRole('button', { name: /save changes/i }).click();
-    await waitForDrawerClosed(page);
+    // Scoped by title: the grid's own RunDrawer/TestSetFilterDrawer can be
+    // mounted-but-closed here too, and an unscoped wait would strict-mode
+    // violate against whichever of them hasn't yet settled aria-hidden.
+    await waitForDrawerClosed(page, { title: 'New Test Set' });
 
     // The new test set should appear in the list
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Purpose

Grid pages (Tests, Tasks, TestRuns, TestSets, Sources, Endpoints, Experiments) briefly flashed a "No X yet" empty-state card, or a fully blank bordered box, before settling on the real content. This PR fixes the underlying causes and removes the duplication that made the bug easy to introduce in the first place.

## What Changed

- Fixed a race where the empty-state check was gated on `loading && !data`. React Query's `isLoading` is `false` while a query is still disabled (e.g. waiting on session auth to resolve), so on first render the grid fell through to the empty-state branch before any data had actually arrived. Now gated on `!data` alone.
- Fixed the real root cause of the blank-box flash: `BaseDataGrid` gated its first paint on an `isInitialized` flag that was set inside a `useEffect` wrapped in an artificial `setTimeout(0)`. Since `useEffect` runs after the browser's first paint, that fallback box was genuinely visible for a frame on every single grid mount, regardless of any data state. The same pattern existed in `useGridStateStorage`'s persisted-state load. Both are now set inside `useLayoutEffect`, which runs before paint, so the fallback never reaches the screen on a normal mount.
- Applied the equivalent fix to `ExperimentsClientWrapper`, which uses manual `useState`-based fetching rather than React Query and had the same class of bug.
- Centralized what had become ~15 lines of duplicated loading/empty/content branching, repeated nearly identically across six grid components, into a single shared `GridStateGate` component.
- Centralized a byte-for-byte identical Paper style block (border, radius, shadow, overflow) that was copy-pasted in seven places into one exported `GRID_PAPER_SX` constant in `BaseDataGrid`.

## Additional Context

No behavior change for the populated, error, or filtered-empty states — this only affects the brief window between "page loads" and "first fetch resolves." All six grid components and their page-level wiring were re-verified against Jest suites covering the loading, empty, populated, and error states for each grid.

## Testing

- `npx jest` across all six grid component suites and their corresponding page suites: 56/56 passing
- `npx tsc --noEmit` clean on every touched file
- `npx eslint` clean (0 errors) on every touched file