### PR TITLE
Fix and declutter tracing-system and connector docs

### DIFF
--- a/docs/content/contribute/connector.mdx
+++ b/docs/content/contribute/connector.mdx
@@ -13,12 +13,12 @@ graph LR
     TargetApp["Target Application<br/><small>Python SDK<br/>@endpoint decorator</small>"]
     Backend["Rhesis Backend<br/><small>ConnectionManager<br/>WebSocket</small>"]
     Workers["Workers<br/><small>Celery<br/>Test Execution</small>"]
-    Redis["Redis<br/><small>Pub/Sub RPC<br/>Message Broker</small>"]
+    Redis["Redis<br/><small>Routing keys + RPC<br/>list/pub-sub</small>"]
     PostgreSQL["PostgreSQL<br/><small>Endpoint Records<br/>Configuration</small>"]
 
     TargetApp <-->|WebSocket<br/>Registration & Execution| Backend
-    Backend <-->|Pub/Sub RPC| Redis
-    Workers <-->|Pub/Sub RPC| Redis
+    Backend <-->|Routing + RPC| Redis
+    Workers <-->|Routing + RPC| Redis
     Backend -->|Store Endpoints| PostgreSQL
     Workers -->|Read Config| PostgreSQL
 ```
@@ -46,20 +46,20 @@ graph LR
 
 **Initial Connection**:
 1. Target app starts → SDK initializes `RhesisClient` with `project_id` and `environment`
-2. SDK establishes WebSocket connection to backend (`/connector/ws`)
-3. SDK sends registration message with function metadata
-4. Backend stores connection and creates endpoint records
+2. SDK establishes an authenticated WebSocket connection to the backend (`/connector/ws`) — project/environment binding happens later, not at connect time
+3. SDK sends a `register` message with function metadata, binding the connection to `project_id`/`environment`
+4. Backend stores the connection routing and creates endpoint records
 
 **Test Execution Flow**:
 1. Worker receives test execution task
-2. Worker publishes RPC request to Redis (`ws:rpc:requests`)
-3. Backend subscribes to Redis and forwards request to SDK via WebSocket
-4. SDK executes function in target app
-5. SDK sends result back via WebSocket
-6. Backend publishes result to Redis (`ws:rpc:response:{test_run_id}`)
-7. Worker subscribes and receives result
+2. Worker looks up which backend instance owns the connection (`ws:routing:{project_id}:{environment}`) and pushes the RPC request onto that instance's queue (`ws:rpc:{worker_id}`)
+3. Backend pops the request and forwards it to the SDK via WebSocket
+4. SDK executes the function in the target app
+5. SDK sends the result back via WebSocket
+6. Backend publishes the result to Redis (`ws:rpc:response:{test_run_id}`)
+7. Worker subscribes to that channel and receives the result
 
-### Connector hardening controls (v0.6.8+)
+### Connector hardening controls
 
 The SDK connector WebSocket endpoint (`/connector/ws`) applies runtime safeguards configurable
 with backend environment variables:
@@ -79,40 +79,48 @@ These limits apply specifically to SDK connector traffic, not to all platform We
 Manages WebSocket connections and RPC routing:
 
 <CodeBlock filename="connection-manager.py" language="python">
-{`from rhesis.backend.app.services.connector.manager import ConnectionManager
+{`from rhesis.backend.app.services.connector.manager import connection_manager
 
-# Store connections (in-memory + Redis)
-await connection_manager.connect(project_id, environment, websocket)
+# Register a connection (project/environment binding happens later, via "register")
+await connection_manager.connect(connection_id, context, websocket)
 
 # Check connection status
 is_connected = await connection_manager.is_connected(project_id, environment)
 
-# Listen for RPC requests from workers
+# Listen for RPC requests from workers (per-instance Redis queue)
 asyncio.create_task(connection_manager._listen_for_rpc_requests())`}
 </CodeBlock>
 
 ### Message Handlers
 
-- **`registration.py`**: Processes SDK function registration, syncs endpoints
-- **`test_result.py`**: Handles test execution results, triggers validation
-- **`pong.py`**: Keepalive message handling
+`SDKMessageHandler` (`services/connector/handler.py`) dispatches each WebSocket message to a specialized handler:
+
+- **`handlers/registration.py`**: processes SDK function registration, syncs endpoints and SDK-registered metrics
+- **`handlers/test_result.py`**: handles test execution results; for validation runs, updates endpoint status (Active/Error)
+- **`handlers/pong.py`**: keepalive message handling
+- **`handlers/metric_sync.py`**: syncs SDK-registered metrics into the `Metric` table
+
+`metric_result` messages are handled inline in `manager.py` rather than through a dedicated handler.
 
 ### Mapping System
 
-4-tier priority for request/response mapping:
+4-tier priority for request/response mapping (`services/connector/mapping/mapper_service.py`):
 
 1. **SDK Manual**: Explicit mappings from `@endpoint` decorator
 2. **Existing DB**: Preserved manual edits from UI
 3. **Auto-Mapping**: Pattern-based heuristics (confidence >= 0.7)
-4. **LLM Fallback**: GPT-4 generates mappings (confidence < 0.7)
+4. **LLM Fallback**: Uses the user's configured generation model (confidence < 0.7)
 
 <CodeBlock filename="mapping-service.py" language="python">
 {`from rhesis.backend.app.services.connector.mapping import MappingService
 
 mapping_service = MappingService()
 result = mapping_service.generate_or_use_existing(
+    db=db,
+    user=user,
+    endpoint=endpoint,
+    sdk_metadata=sdk_metadata,
     function_data=function_data,
-    existing_mappings=endpoint.mappings
 )`}
 </CodeBlock>
 
@@ -122,14 +130,15 @@ result = mapping_service.generate_or_use_existing(
 
 Workers run in separate processes and cannot access backend's in-memory connection dictionary.
 
-### Solution: Redis Pub/Sub RPC
+### Solution: Redis-Based RPC
 
 **Flow**:
-1. Worker publishes request to Redis channel
-2. Backend subscribes and forwards to WebSocket
-3. SDK executes function and returns result
-4. Backend publishes response to Redis
-5. Worker subscribes and receives result
+1. Worker resolves the owning backend instance via a routing key (`ws:routing:{project_id}:{environment}`)
+2. Worker pushes the request onto that instance's Redis list (`ws:rpc:{worker_id}`)
+3. Backend pops the request (`BLPOP`) and forwards it over the WebSocket
+4. SDK executes the function and returns the result
+5. Backend publishes the response to a per-request pub/sub channel (`ws:rpc:response:{test_run_id}`)
+6. Worker subscribes to that channel and receives the result
 
 <CodeBlock filename="rpc-usage.py" language="python">
 {`from rhesis.backend.app.services.connector.rpc_client import SDKRpcClient
@@ -155,10 +164,16 @@ if await rpc_client.is_connected(project_id, environment):
 
 ### Message Types
 
-- **`register`**: SDK registers functions with metadata
-- **`execute_test`**: Backend requests function execution
-- **`test_result`**: SDK returns execution result
-- **`pong`**: Keepalive response
+| Type | Direction | Purpose |
+|---|---|---|
+| `register` | SDK → backend | Registers functions/metrics, optionally binds `project_id`/`environment` |
+| `connected` | backend → SDK | Sent immediately on connect, before registration |
+| `execute_test` | backend → SDK | Requests function execution |
+| `test_result` | SDK → backend | Returns execution result |
+| `execute_metric` | backend → SDK | Requests metric evaluation |
+| `metric_result` | SDK → backend | Returns metric evaluation result |
+| `pong` | SDK → backend | Keepalive response |
+| `error` | backend → SDK | Oversized, rate-limited, or malformed message |
 
 ### Registration Message
 
@@ -208,23 +223,28 @@ stats = await sync_sdk_endpoints(
     organization_id=org_id,
     user_id=user_id
 )
-# Returns: {"created": 2, "updated": 1, "marked_inactive": 0}`}
+# Returns: {"created": 2, "updated": 1, "marked_inactive": 0, "errors": []}`}
 </CodeBlock>
 
 ## Key Files
 
 **Backend** (`apps/backend/src/rhesis/backend/app/`):
+- `routers/connector.py` - WebSocket and REST endpoints
 - `services/connector/manager.py` - Connection management
-- `services/connector/handlers/` - Message handlers
+- `services/connector/handler.py` - Message dispatch facade
+- `services/connector/handlers/` - Specialized message handlers
+- `services/connector/schemas.py` - Wire protocol message schemas
 - `services/connector/mapping/` - Mapping logic
 - `services/connector/rpc_client.py` - Worker RPC client
 - `services/connector/redis_client.py` - Redis connection
-- `routers/connector.py` - WebSocket and REST endpoints
+- `services/endpoint/sdk_sync.py` - Endpoint synchronization
 
 **SDK** (`sdk/src/rhesis/sdk/`):
+- `clients/rhesis.py` - `RhesisClient`
 - `connector/manager.py` - SDK connector manager
 - `connector/connection.py` - WebSocket connection
-- `decorators.py` - `@endpoint` decorator
+- `connector/executor.py` - Function dispatch
+- `decorators/endpoint.py` - `@endpoint` decorator
 
 ---
 

--- a/docs/content/contribute/tracing-system/architecture.mdx
+++ b/docs/content/contribute/tracing-system/architecture.mdx
@@ -9,20 +9,22 @@ Detailed architecture of the Rhesis tracing system.
 <Mermaid chart={`flowchart TD
     TE["Test Executor<br/>(Celery worker)"]
     SE["SDK Endpoint<br/>(@observe instrumented)"]
-    OT["OpenTelemetry Tracer<br/>(spans with test context)"]
+    OT["OpenTelemetry Tracer"]
     BP["BatchSpanProcessor<br/>(5s batching)"]
     API["Backend API<br/>POST /telemetry/traces"]
-    PG["PostgreSQL<br/>(traces table + JSONB)"]
-    CW["Celery Worker<br/>(cost/anomaly enrichment)"]
+    PG["PostgreSQL<br/>(trace table + JSONB)"]
+    PIL["post_ingest_link<br/>(Celery task)"]
+    CW["enrich_trace_async<br/>(cost/anomaly enrichment)"]
     ED["enriched_data<br/>(JSONB cache)"]
-    QA["Query API<br/>GET /traces/{id}"]
+    QA["Query API<br/>GET /telemetry/traces/{id}"]
 
     TE -->|"invokes"| SE
     SE -->|"creates"| OT
     OT -->|"batches (5s)"| BP
     BP -->|"OTLP/HTTP"| API
-    API -->|"stores + links"| PG
-    PG -->|"enriches"| CW
+    API -->|"stores"| PG
+    API -->|"delay()"| PIL
+    PIL -->|"link + dispatch"| CW
     CW -->|"caches"| ED
     ED -->|"queries"| QA`} />
 
@@ -30,238 +32,148 @@ Detailed architecture of the Rhesis tracing system.
 
 ### OpenTelemetry Integration
 
-The SDK wraps standard OpenTelemetry components:
+The `TracerProvider` and `BatchSpanProcessor` are set up once, in the shared `packages/rhesis/src/rhesis/telemetry/provider.py` package (imported by both the SDK and the backend):
 
-<CodeBlock filename="SDK Tracer Setup" language="python">
-{`from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-
-# Create tracer provider
-provider = TracerProvider(resource=Resource.create({
-    "service.name": "your-service",
+<CodeBlock filename="packages/rhesis/src/rhesis/telemetry/provider.py" language="python">
+{`resource = Resource.create({
+    "service.name": service_name,
+    "service.namespace": "rhesis",
     "deployment.environment": environment,
-}))
+})
 
-# Add batch processor with OTLP exporter
+_TRACER_PROVIDER = TracerProvider(resource=resource)
+exporter = RhesisOTLPExporter(api_key=api_key, base_url=base_url, project_id=project_id, environment=environment)
+
 span_processor = BatchSpanProcessor(
-    RhesisOTLPExporter(api_key, base_url, project_id),
+    exporter,
     max_queue_size=2048,        # Max spans in memory
     max_export_batch_size=512,  # Spans per HTTP request
     schedule_delay_millis=5000, # Export every 5 seconds
 )
-provider.add_span_processor(span_processor)`}
+_TRACER_PROVIDER.add_span_processor(span_processor)`}
 </CodeBlock>
 
-### Decorator Flow
+### Span Creation
 
-When a decorated function executes:
+`@observe` (`sdk/src/rhesis/sdk/decorators/observe.py`) wraps sync, async, and generator functions, starting a span on each call and setting attributes passed to the decorator. `@endpoint` (`sdk/src/rhesis/sdk/decorators/endpoint.py`) does the same and additionally registers the function for remote invocation over WebSocket.
 
-<CodeBlock filename="observe Decorator Flow" language="python">
-{`@wraps(func)
-def wrapper(*args, **kwargs):
-    tracer = trace.get_tracer(__name__)
-
-    with tracer.start_as_current_span(
-        name=final_span_name,
-        kind=SpanKind.INTERNAL,
-    ) as span:
-        # Set attributes from decorator parameters
-        span.set_attribute("function.name", func_name)
-        for key, value in attributes.items():
-            span.set_attribute(key, value)
-
-        try:
-            result = func(*args, **kwargs)
-            span.set_status(Status(StatusCode.OK))
-            return result
-        except Exception as e:
-            span.set_status(Status(StatusCode.ERROR, str(e)))
-            span.record_exception(e)
-            raise`}
-</CodeBlock>
+Span names are validated server-side (`packages/rhesis/src/rhesis/telemetry/schemas.py`) against the pattern `ai.<domain>.<action>` (e.g. `ai.llm.invoke`) or `function.<name>`. The domains `chain`, `workflow`, and `pipeline` are rejected in favor of primitive operations; `agent` is allowed via the dedicated `ai.agent.invoke` / `ai.agent.handoff` operations for multi-agent tracing.
 
 ### OTLP Exporter
 
-The custom exporter sends spans via HTTP POST:
+`RhesisOTLPExporter` (`packages/rhesis/src/rhesis/telemetry/exporter.py`) subclasses OpenTelemetry's `OTLPSpanExporter`:
 
-<CodeBlock filename="OTLP Export" language="python">
-{`class RhesisOTLPExporter(SpanExporter):
-    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
-        # Convert OTEL spans to SDK schemas
-        sdk_spans = [self._convert_span(span) for span in spans]
-
-        # Create batch
-        batch = SpanBatch(spans=sdk_spans)
-
-        # Send via HTTP POST
-        response = self._session.post(
-            f"{self.base_url}/telemetry/traces",
-            json=batch.model_dump(mode="json"),
-            headers={"Authorization": f"Bearer {self.api_key}"},
-            timeout=self._timeout,
-        )
-
-        return SpanExportResult.SUCCESS if response.ok else SpanExportResult.FAILURE`}
+<CodeBlock filename="Exporter Setup" language="python">
+{`class RhesisOTLPExporter(OTLPSpanExporter):
+    def __init__(self, api_key, base_url, project_id, environment,
+                 timeout=10, max_attempts=3, max_chunk_size=100):
+        self.endpoint = f"{base_url.rstrip('/')}/telemetry/traces"
+        super().__init__(endpoint=self.endpoint, timeout=timeout)
+        self._session.headers.update({
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        })`}
 </CodeBlock>
+
+`export()` converts OTEL spans to the shared `OTELSpan` schema, splits batches larger than `max_chunk_size` (100) into separate requests, and retries transient failures (connection errors, timeouts, 408/429/5xx) with exponential-jitter backoff bounded by a wall-clock deadline. Root spans are always placed in the first chunk. After 5 consecutive export failures it logs a warning with the endpoint and success rate.
 
 ## Backend Components
 
 ### Ingestion Endpoint
 
-The `/telemetry/traces` endpoint:
+`ingest_trace()` in `routers/telemetry.py` (`POST /telemetry/traces`):
 
-1. Validates the OTLP JSON payload
-2. Extracts organization/project from API key
-3. Stores spans in PostgreSQL (bulk insert)
-4. Enqueues enrichment (async) or runs sync
-5. Triggers trace linking
+1. Resolves `project_id` — prefers the span's `project_id`, falls back to the request's project scope, otherwise returns 422
+2. Validates the OTLP payload (Pydantic `OTELTraceBatch`, including span-name conventions)
+3. Stores spans via `crud.create_trace_spans()`, commits, and releases the DB session
+4. Dispatches `post_ingest_link.delay(...)` — fire-and-forget
 
-<CodeBlock filename="Ingestion Flow" language="python">
-{`@router.post("/telemetry/traces")
-async def ingest_traces(batch: SpanBatch, db: Session):
-    # 1. Validate spans
-    validated_spans = validate_spans(batch.spans)
+<CodeBlock filename="Dispatch" language="python">
+{`try:
+    post_ingest_link.delay(**dispatch_kwargs)
+except BROKER_ERRORS as broker_err:
+    logger.warning(f"Broker unavailable, post-processing deferred | error={broker_err}")
 
-    # 2. Store in database
-    stored_spans = crud.create_trace_spans(db, validated_spans)
-
-    # 3. Enrich (async or sync)
-    if workers_available():
-        enrich_trace_async.delay(trace_id, project_id)
-    else:
-        enricher.enrich_trace(trace_id, project_id)
-
-    # 4. Link traces (if test context present)
-    linking_service.link_traces_for_incoming_batch(stored_spans)
-
-    return {"status": "ok", "count": len(stored_spans)}`}
+return TraceResponse(status="received", span_count=stored_count, trace_id=trace_id)`}
 </CodeBlock>
+
+If the broker is unreachable, the request still returns 200 — linking and enrichment for that batch simply do not run. This differs from a separate code path used by direct SDK-endpoint invocation (`services/invokers/tracing.py`), which enqueues enrichment via `AsyncService.execute_with_fallback`: it tries the async Celery dispatch first and only falls back to running enrichment synchronously, in-process, when the broker raises a connection error.
+
+The `post_ingest_link` task itself (`tasks/telemetry/post_ingest.py`) performs test-result linking, conversation-id linking, input-file linking, and dispatches an enrichment → evaluation chain per root span. See [Worker: Trace Ingestion Pipeline](/contribute/worker/trace-ingestion-pipeline) for the full breakdown, including metric evaluation.
 
 ### Linking Service
 
-The linking service connects traces to test results using a hybrid strategy:
+`TraceLinkingService` (`services/telemetry/linking_service.py`) has two entry points that share one implementation:
 
 <CodeBlock filename="Linking Service" language="python">
 {`class TraceLinkingService:
     def link_traces_for_test_result(
-        self,
-        test_run_id: str,
-        test_id: str,
-        test_result_id: str,
-        organization_id: str,
-    ):
+        self, test_run_id, test_id, test_configuration_id, test_result_id, organization_id,
+    ) -> int:
         """Called after test result creation (catches slow tests)."""
-        crud.update_traces_with_test_result_id(
-            db=self.db,
-            test_run_id=test_run_id,
-            test_id=test_id,
-            test_result_id=test_result_id,
-            organization_id=organization_id,
-        )
+        return crud.update_traces_with_test_result_id(...)
 
-    def link_traces_for_incoming_batch(
-        self,
-        spans: List[Span],
-        organization_id: str,
-    ):
-        """Called after span ingestion (catches fast tests)."""
-        # Extract test context from span attributes
-        for span in spans:
-            test_run_id = span.attributes.get("rhesis.test.run_id")
-            if test_run_id:
-                # Find corresponding test_result
-                test_result = find_test_result(test_run_id, span.trace_id)
-                if test_result:
-                    crud.update_traces_with_test_result_id(...)`}
+    def link_traces_for_incoming_batch(self, spans, organization_id) -> int:
+        """Called from post_ingest_link (catches fast tests)."""
+        # Extracts test_run_id/test_id/test_configuration_id from the first
+        # span's attributes, finds the matching TestResult, then links.`}
 </CodeBlock>
 
-### Enrichment Service
+### Enrichment
 
-Enrichment calculates costs and detects anomalies:
+`TraceEnricher` (`services/telemetry/enrichment/processor.py`) computes costs, anomalies, and metadata from a trace's spans:
 
-<CodeBlock filename="Enrichment" language="python">
-{`class TraceEnricher:
-    def enrich_trace(self, trace_id: str, project_id: str):
-        # Fetch all spans for trace
-        spans = crud.get_spans_by_trace_id(trace_id)
+- **Costs** — `calculate_token_costs()` uses `litellm.cost_per_token()` on spans with `ai.operation.type = llm.invoke`, in USD and EUR
+- **Anomalies** — `detect_anomalies()` flags spans over 10 seconds (`slow_span`), LLM spans over 10,000 total tokens (`high_token_usage`), and error-status spans (`error`)
+- **Metadata** — `extract_metadata()` collects unique models, tools, and operation types, plus the root span's name
 
-        enriched_data = {
-            "costs": self._calculate_costs(spans),
-            "anomalies": self._detect_anomalies(spans),
-            "metadata": self._extract_metadata(spans),
-            "enriched_at": datetime.utcnow().isoformat(),
-        }
+The result is cached in the `enriched_data` JSONB column:
 
-        # Cache in enriched_data column
-        crud.update_trace_enrichment(trace_id, enriched_data)
-
-    def _calculate_costs(self, spans):
-        """Use LiteLLM for token cost calculation."""
-        total_cost = 0.0
-        for span in spans:
-            if span.span_name == "ai.llm.invoke":
-                model = span.attributes.get("ai.model.name")
-                tokens_in = span.attributes.get("ai.llm.tokens.input", 0)
-                tokens_out = span.attributes.get("ai.llm.tokens.output", 0)
-                cost = litellm.cost_per_token(model, tokens_in, tokens_out)
-                total_cost += cost
-        return {"total_cost_usd": total_cost}`}
+<CodeBlock filename="Enrichment Shape" language="json">
+{`{
+    "costs": {
+        "total_cost_usd": 0.023,
+        "total_cost_eur": 0.021,
+        "breakdown": [
+            { "span_id": "...", "model_name": "gpt-4", "input_tokens": 150,
+              "output_tokens": 80, "total_cost_usd": 0.023, "total_cost_eur": 0.021 }
+        ]
+    },
+    "anomalies": [
+        { "type": "slow_span", "span_id": "...", "span_name": "ai.llm.invoke",
+          "duration_ms": 12340, "message": "Span took 12.3s (threshold: 10s)" }
+    ],
+    "metrics": { "total_duration_ms": 12500, "span_count": 5, "error_count": 0 },
+    "models_used": ["gpt-4"],
+    "tools_used": ["search"],
+    "operation_types": ["llm.invoke", "tool.invoke"],
+    "root_operation": "ai.llm.invoke"
+}`}
 </CodeBlock>
 
-## Enrichment Strategy
-
-### Async-First with Graceful Fallback
-
-<CodeBlock filename="Enrichment Decision" language="python">
-{`if workers_available():
-    # Production path: Async enrichment
-    enrich_trace_async.delay(trace_id, project_id)
-    # → Ingestion returns immediately (~10ms)
-    # → Enrichment happens in background (~50-100ms)
-else:
-    # Development path: Sync enrichment
-    enricher.enrich_trace(trace_id, project_id)
-    # → Enrichment happens inline (~50-100ms)
-    # → Ingestion takes longer but still works`}
-</CodeBlock>
-
-**Benefits:**
-- ✅ Production optimal (async)
-- ✅ Development simple (no workers needed)
-- ✅ Automatic detection (no config)
-- ✅ Graceful degradation (workers crash → sync fallback)
-
-### Enrichment Timing
-
-| Mode | Ingestion | Enrichment | Query |
-|------|-----------|------------|-------|
-| **Async** (production) | ~10ms | Background (~50-100ms) | ~10ms |
-| **Sync** (development) | ~60-110ms | Inline | ~10ms |
-
-Both modes produce the same result, just different timing.
+Re-enrichment is skipped once every span in the trace has a non-null `processed_at` — new child spans (later LLM calls, tool calls) trigger a re-run so multi-turn traces stay up to date as they arrive.
 
 ## Query API
 
 ### Trace Retrieval
 
 <CodeBlock filename="Query Endpoint" language="python">
-{`@router.get("/traces/{trace_id}")
-async def get_trace(trace_id: str, db: Session):
-    # 1. Fetch all spans for trace_id
-    spans = crud.get_spans_by_trace_id(db, trace_id)
-
-    # 2. Build span tree (parent-child relationships)
-    span_tree = build_span_tree(spans)
-
-    # 3. Return with cached enrichment
-    root_span = spans[0]
-    return {
-        "trace_id": trace_id,
-        "spans": span_tree,
-        "enriched_data": root_span.enriched_data,
-        "test_result_id": root_span.test_result_id,
-    }`}
+{`@router.get("/traces/{trace_id}", response_model=TraceDetailResponse)
+def get_trace(trace_id: str, project_id: str, db: Session, tenant_context):
+    spans = crud.get_trace_by_id(db, trace_id, project_id, organization_id,
+                                  eager_load=["project", "test_run", "test_result", "test"])
+    root_spans = build_span_tree(spans)
+    ...`}
 </CodeBlock>
+
+`GET /telemetry/traces/{trace_id}` (`project_id` is a required query param) returns the span tree plus trace-level rollups and linked entities:
+
+| Field | Description |
+|-------|-------------|
+| `root_spans` | Spans arranged as a parent-child tree |
+| `span_count`, `error_count`, `total_tokens`, `total_cost_usd` | Computed across all spans in the trace |
+| `trace_metrics_status`, `trace_reviews` | LLM-based metric evaluation status and human review state |
+| `project`, `endpoint`, `test_run`, `test_result`, `test` | Linked entities, populated where applicable |
 
 ## Configuration
 
@@ -278,24 +190,35 @@ async def get_trace(trace_id: str, db: Session):
 ### Environment Variables
 
 <CodeBlock filename=".env" language="bash">
-{`# Backend
-DATABASE_URL=postgresql://user:pass@localhost:5432/rhesis
-CELERY_BROKER_URL=redis://localhost:6379/0
+{`# Backend database (component vars, not a single DATABASE_URL)
+DB_HOST=localhost
+DB_NAME=rhesis-db
+APP_DB_USER=app-user
+APP_DB_PASS=secure-password
 
-# Enrichment
+# Celery broker
+BROKER_URL=redis://localhost:6379/0
+CELERY_RESULT_BACKEND=redis://localhost:6379/1
+
+# Enrichment (fallback rate; a live rate is fetched and cached normally)
 USD_TO_EUR_RATE=0.92
 
 # SDK
 RHESIS_API_KEY=your_api_key
-RHESIS_BACKEND_URL=http://localhost:8080`}
+RHESIS_BASE_URL=http://localhost:8080
+RHESIS_PROJECT_ID=your_project_id   # fallback when no project-scoped token is used`}
 </CodeBlock>
+
+See [Environment Variables](/contribute/environment-variables) for the full reference.
 
 ### Celery Workers
 
-<CodeBlock filename="Start Workers" language="bash">
-{`# Start workers
-celery -A rhesis.backend.app.main worker --concurrency=4
+Traces are processed by the same worker(s) that run test execution — see [Worker: Background Tasks](/contribute/worker/background-tasks) for queue and concurrency configuration.
 
-# Autoscale
-celery -A rhesis.backend.app.main worker --autoscale=10,2`}
+<CodeBlock filename="Start Workers" language="bash">
+{`celery -A rhesis.backend.worker.app worker --pool threads -n main@%h \\
+  --queues=celery,execution,telemetry \\
+  --concurrency=$CELERY_WORKER_CONCURRENCY \\
+  --prefetch-multiplier=$CELERY_WORKER_PREFETCH_MULTIPLIER \\
+  --optimization=fair`}
 </CodeBlock>

--- a/docs/content/contribute/tracing-system/data-structures.mdx
+++ b/docs/content/contribute/tracing-system/data-structures.mdx
@@ -6,9 +6,9 @@ Schemas, database design, and data formats for the tracing system.
 
 ## Span Structure
 
-### OTLP Span Format
+### Canonical Span Schema
 
-Spans sent from SDK to backend follow the OTLP/JSON format:
+Spans sent from SDK to backend follow the shared `OTELSpan` schema (`packages/rhesis/src/rhesis/telemetry/schemas.py`), serialized as JSON:
 
 <CodeBlock filename="Span Payload" language="json">
 {`{
@@ -17,6 +17,7 @@ Spans sent from SDK to backend follow the OTLP/JSON format:
     "parent_span_id": null,
     "project_id": "my-project",
     "environment": "development",
+    "conversation_id": null,
     "span_name": "ai.llm.invoke",
     "span_kind": "CLIENT",
     "start_time": "2024-01-01T00:00:00.000000Z",
@@ -57,6 +58,8 @@ Spans sent from SDK to backend follow the OTLP/JSON format:
 }`}
 </CodeBlock>
 
+`span_name` must match `ai.<domain>.<action>` (domains `chain`, `workflow`, `pipeline` rejected) or `function.<name>`.
+
 ### Test Execution Context
 
 Context attributes added to spans during test execution:
@@ -66,104 +69,106 @@ Context attributes added to spans during test execution:
     "rhesis.test.run_id": "uuid",              # Which test run
     "rhesis.test.id": "uuid",                  # Which test definition
     "rhesis.test.configuration_id": "uuid",    # Which configuration
-    # test_result_id is linked after creation
+    # rhesis.test.result_id is linked after creation
 }`}
 </CodeBlock>
 
 ## Database Schema
 
-### traces Table
+### trace Table
 
-<CodeBlock filename="SQL Schema" language="sql">
-{`CREATE TABLE traces (
-    -- Identity
-    id UUID PRIMARY KEY,
-    trace_id VARCHAR(32) NOT NULL,      -- OTEL trace ID
-    span_id VARCHAR(16) NOT NULL,       -- OTEL span ID
-    parent_span_id VARCHAR(16),
+<CodeBlock filename="SQLAlchemy Model" language="python">
+{`class Trace(Base, EmbeddableMixin, TagsMixin, CommentsMixin, TasksMixin, FilesMixin, ReviewsMixin):
+    __tablename__ = "trace"
 
-    -- Span data
-    span_name VARCHAR(255) NOT NULL,
-    start_time TIMESTAMP WITH TIME ZONE NOT NULL,
-    end_time TIMESTAMP WITH TIME ZONE NOT NULL,
-    duration_ms FLOAT NOT NULL,
-    status_code VARCHAR(50) NOT NULL,
+    # id, nano_id, created_at, updated_at, deleted_at come from Base
 
-    -- Multi-tenancy
-    organization_id UUID NOT NULL REFERENCES organization(id),
-    project_id UUID NOT NULL REFERENCES project(id),
+    trace_id = Column(String(32), nullable=False, index=True)      # OTEL trace ID
+    span_id = Column(String(16), nullable=False, index=True)       # OTEL span ID
+    parent_span_id = Column(String(16), nullable=True, index=True)
 
-    -- Test execution (FKs for linking)
-    test_run_id UUID REFERENCES test_run(id) ON DELETE SET NULL,
-    test_result_id UUID REFERENCES test_result(id) ON DELETE SET NULL,
-    test_id UUID REFERENCES test(id) ON DELETE SET NULL,
+    project_id = Column(GUID(), ForeignKey("project.id", ondelete="CASCADE"), nullable=False, index=True)
+    organization_id = Column(GUID(), nullable=False, index=True)    # not a FK
+    environment = Column(String(50), nullable=False, index=True)
+    conversation_id = Column(String(255), nullable=True)
 
-    -- JSONB columns (flexible schema)
-    attributes JSONB NOT NULL DEFAULT '{}',
-    events JSONB NOT NULL DEFAULT '[]',
-    enriched_data JSONB,                -- Cached enrichment
+    test_run_id = Column(GUID(), ForeignKey("test_run.id", ondelete="SET NULL"), nullable=True, index=True)
+    test_result_id = Column(GUID(), ForeignKey("test_result.id", ondelete="SET NULL"), nullable=True, index=True)
+    test_id = Column(GUID(), ForeignKey("test.id", ondelete="SET NULL"), nullable=True, index=True)
 
-    -- Timestamps
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
-);`}
+    span_name = Column(String(255), nullable=False, index=True)
+    span_kind = Column(String(20), nullable=False)
+
+    start_time = Column(DateTime(timezone=True), nullable=False, index=True)
+    end_time = Column(DateTime(timezone=True), nullable=False)
+    duration_ms = Column(Float, nullable=False)
+
+    status_code = Column(String(20), nullable=False, index=True)
+    status_message = Column(Text, nullable=True)
+
+    attributes = Column(JSONB, nullable=False, default=dict)
+    events = Column(JSONB, nullable=False, default=list)
+    links = Column(JSONB, nullable=False, default=list)
+    resource = Column(JSONB, nullable=False, default=dict)
+
+    processed_at = Column(DateTime(timezone=True), nullable=True)  # set once enrichment runs
+    enriched_data = Column(JSONB, default=dict)
+
+    trace_metrics = Column(JSONB, nullable=True)                   # LLM-based metric evaluation
+    trace_metrics_status_id = Column(GUID(), ForeignKey("status.id"), nullable=True, index=True)
+    trace_metrics_processed_at = Column(DateTime(timezone=True), nullable=True)
+
+    trace_reviews = Column(JSONB, nullable=True)                   # human review state`}
 </CodeBlock>
 
 ### Column Details
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `id` | UUID | Primary key (internal) |
+| `id` | UUID | Primary key |
 | `trace_id` | VARCHAR(32) | OpenTelemetry trace ID (groups spans) |
 | `span_id` | VARCHAR(16) | OpenTelemetry span ID (unique per span) |
 | `parent_span_id` | VARCHAR(16) | Parent span for hierarchy |
+| `project_id` | UUID | Project isolation, FK with `ON DELETE CASCADE` |
+| `organization_id` | UUID | Multi-tenancy isolation (no FK) |
+| `environment` | VARCHAR(50) | e.g. `development`, `production` |
+| `conversation_id` | VARCHAR(255) | Groups turns of a multi-turn conversation |
+| `test_run_id` / `test_result_id` / `test_id` | UUID | Linked test execution entities |
 | `span_name` | VARCHAR(255) | Operation name (`ai.llm.invoke`) |
-| `start_time` | TIMESTAMP | Span start time |
-| `end_time` | TIMESTAMP | Span end time |
+| `span_kind` | VARCHAR(20) | OTEL span kind (`CLIENT`, `INTERNAL`, ...) |
 | `duration_ms` | FLOAT | Calculated duration |
-| `status_code` | VARCHAR(50) | OK, ERROR, UNSET |
-| `organization_id` | UUID | Multi-tenancy isolation |
-| `project_id` | UUID | Project isolation |
-| `test_run_id` | UUID | Linked test run |
-| `test_result_id` | UUID | Linked test result |
-| `test_id` | UUID | Linked test definition |
-| `attributes` | JSONB | Span attributes |
-| `events` | JSONB | Span events (prompts, completions) |
+| `status_code` | VARCHAR(20) | `OK`, `ERROR`, `UNSET` |
+| `attributes` / `events` / `links` / `resource` | JSONB | Span data |
+| `processed_at` | TIMESTAMP | Set when enrichment last ran; `NULL` triggers re-enrichment |
 | `enriched_data` | JSONB | Cached enrichment results |
+| `trace_metrics` / `trace_metrics_status_id` / `trace_metrics_processed_at` | JSONB / UUID / TIMESTAMP | LLM-based metric evaluation results and status |
+| `trace_reviews` | JSONB | Human review annotations |
 
 ## Indexes
 
 <CodeBlock filename="Critical Indexes" language="sql">
-{`-- Get all spans for a trace (primary query)
-CREATE INDEX idx_trace_trace_id ON traces(trace_id, start_time DESC);
-
--- Test execution queries
-CREATE INDEX idx_trace_test_run ON traces(test_run_id, start_time DESC);
-CREATE INDEX idx_trace_test_result ON traces(test_result_id);
+{`CREATE INDEX idx_trace_trace_id ON trace(trace_id, start_time);       -- get all spans for a trace
+CREATE INDEX idx_trace_project_time ON trace(project_id, start_time DESC);
+CREATE INDEX idx_trace_org_time ON trace(organization_id, start_time DESC);
+CREATE INDEX idx_trace_span_name_time ON trace(span_name, start_time DESC);
+CREATE INDEX idx_trace_environment_time ON trace(environment, start_time DESC);
+CREATE INDEX idx_trace_status_time ON trace(status_code, start_time DESC);
+CREATE INDEX idx_trace_test_run ON trace(test_run_id, start_time DESC);
+CREATE INDEX idx_trace_test_result ON trace(test_result_id);
+CREATE INDEX idx_trace_test ON trace(test_id);
+CREATE INDEX idx_trace_conversation ON trace(conversation_id, start_time DESC);
 
 -- JSONB attribute queries
-CREATE INDEX idx_trace_attributes ON traces USING GIN(attributes jsonb_path_ops);
+CREATE INDEX idx_trace_attributes ON trace USING GIN(attributes jsonb_path_ops);
 
--- Organization/project filtering
-CREATE INDEX idx_trace_org_project ON traces(organization_id, project_id, created_at DESC);
-
--- Status code filtering
-CREATE INDEX idx_trace_status ON traces(status_code, created_at DESC);`}
+-- Partial indexes for background workers scanning unprocessed rows
+CREATE INDEX idx_trace_unprocessed ON trace(created_at) WHERE processed_at IS NULL;
+CREATE INDEX idx_trace_metrics_unprocessed ON trace(created_at) WHERE trace_metrics_processed_at IS NULL;`}
 </CodeBlock>
-
-### Index Usage
-
-| Query | Index Used |
-|-------|------------|
-| Get spans by trace_id | `idx_trace_trace_id` |
-| Get traces for test run | `idx_trace_test_run` |
-| Query by attribute (model, provider) | `idx_trace_attributes` |
-| Filter by organization | `idx_trace_org_project` |
-| Find error traces | `idx_trace_status` |
 
 ## Enrichment Data
 
-The `enriched_data` JSONB column caches computed values:
+The `enriched_data` JSONB column caches computed values (`EnrichedTraceData`, `schemas/enrichment.py`):
 
 <CodeBlock filename="Enrichment Structure" language="json">
 {`{
@@ -173,33 +178,32 @@ The `enriched_data` JSONB column caches computed values:
         "breakdown": [
             {
                 "span_id": "1234567890abcdef",
-                "model": "gpt-4",
-                "tokens_input": 150,
-                "tokens_output": 80,
-                "cost_usd": 0.023,
-                "cost_eur": 0.021
+                "model_name": "gpt-4",
+                "input_tokens": 150,
+                "output_tokens": 80,
+                "total_cost_usd": 0.023,
+                "total_cost_eur": 0.021
             }
         ]
     },
     "anomalies": [
         {
-            "type": "high_latency",
+            "type": "slow_span",
             "span_id": "1234567890abcdef",
-            "threshold_ms": 1000,
-            "actual_ms": 2340,
-            "severity": "warning"
+            "span_name": "ai.llm.invoke",
+            "duration_ms": 12340,
+            "message": "Span took 12.3s (threshold: 10s)"
         }
     ],
-    "metadata": {
-        "models_used": ["gpt-4"],
-        "total_tokens_input": 150,
-        "total_tokens_output": 80,
-        "total_tokens": 230,
+    "metrics": {
+        "total_duration_ms": 12500,
         "span_count": 5,
-        "llm_call_count": 2,
-        "tool_call_count": 1
+        "error_count": 0
     },
-    "enriched_at": "2025-01-01T10:00:00Z"
+    "models_used": ["gpt-4"],
+    "tools_used": ["search"],
+    "operation_types": ["llm.invoke", "tool.invoke"],
+    "root_operation": "ai.llm.invoke"
 }`}
 </CodeBlock>
 
@@ -207,21 +211,19 @@ The `enriched_data` JSONB column caches computed values:
 
 | Field | Description |
 |-------|-------------|
-| `costs.total_cost_usd` | Total cost in USD |
-| `costs.total_cost_eur` | Total cost in EUR |
+| `costs.total_cost_usd` / `total_cost_eur` | Total cost across all LLM spans |
 | `costs.breakdown` | Per-span cost breakdown |
-| `anomalies` | Detected anomalies |
-| `metadata.models_used` | Unique models in trace |
-| `metadata.total_tokens` | Sum of all tokens |
-| `metadata.span_count` | Number of spans |
-| `enriched_at` | Enrichment timestamp |
+| `anomalies` | Detected anomalies: `slow_span` (>10s), `high_token_usage` (>10,000 tokens), `error` |
+| `metrics` | Trace-level duration, span count, error count |
+| `models_used` / `tools_used` / `operation_types` | Unique values seen across the trace's spans |
+| `root_operation` | The root span's `span_name` |
 
 ## Common Query Patterns
 
 ### Get Trace by ID
 
 <CodeBlock filename="Query" language="sql">
-{`SELECT * FROM traces
+{`SELECT * FROM trace
 WHERE trace_id = 'abc123...'
 ORDER BY start_time ASC;
 -- Uses: idx_trace_trace_id`}
@@ -231,7 +233,7 @@ ORDER BY start_time ASC;
 
 <CodeBlock filename="Query" language="sql">
 {`SELECT DISTINCT trace_id, MIN(start_time) as trace_start
-FROM traces
+FROM trace
 WHERE test_run_id = 'uuid'
 GROUP BY trace_id
 ORDER BY trace_start DESC;
@@ -241,7 +243,7 @@ ORDER BY trace_start DESC;
 ### Get LLM Calls with Specific Model
 
 <CodeBlock filename="Query" language="sql">
-{`SELECT * FROM traces
+{`SELECT * FROM trace
 WHERE attributes @> '{"ai.model.name": "gpt-4"}'
   AND project_id = 'uuid'
 ORDER BY created_at DESC;
@@ -252,12 +254,12 @@ ORDER BY created_at DESC;
 
 <CodeBlock filename="Query" language="sql">
 {`SELECT DISTINCT trace_id, span_name, status_code
-FROM traces
+FROM trace
 WHERE status_code = 'ERROR'
   AND project_id = 'uuid'
 ORDER BY created_at DESC
 LIMIT 100;
--- Uses: idx_trace_status`}
+-- Uses: idx_trace_status_time`}
 </CodeBlock>
 
 ### Get High-Cost Traces
@@ -265,8 +267,8 @@ LIMIT 100;
 <CodeBlock filename="Query" language="sql">
 {`SELECT trace_id,
        enriched_data->'costs'->>'total_cost_usd' as cost_usd,
-       enriched_data->'metadata'->>'models_used' as models
-FROM traces
+       enriched_data->>'models_used' as models
+FROM trace
 WHERE enriched_data IS NOT NULL
   AND (enriched_data->'costs'->>'total_cost_usd')::float > 0.10
   AND project_id = 'uuid'
@@ -302,10 +304,10 @@ Content-Type: application/json`}
 
 | Status | Meaning | Action |
 |--------|---------|--------|
-| 200 | Success | Spans ingested |
+| 200 | Success | Spans ingested (post-processing dispatched separately) |
 | 401 | Unauthorized | Check API key |
-| 422 | Validation Error | Fix span names/attributes |
-| 500 | Server Error | Retry with backoff |
+| 422 | Validation error, or no `project_id` could be resolved | Fix span format, or pass a project-scoped token / `X-Project-Id` header |
+| 500 | Server error | Retry with backoff |
 
 ### Validation Errors
 
@@ -316,7 +318,7 @@ Common 422 errors:
     "detail": [
         {
             "loc": ["spans", 0, "span_name"],
-            "msg": "span_name cannot use framework concept 'agent'. Use primitive operations: llm, tool, retrieval, embedding",
+            "msg": "span_name cannot use framework concept 'chain'. Use primitive operations: llm, tool, retrieval, embedding",
             "type": "value_error"
         }
     ]

--- a/docs/content/contribute/tracing-system/index.mdx
+++ b/docs/content/contribute/tracing-system/index.mdx
@@ -19,26 +19,23 @@ The tracing system captures OpenTelemetry-compliant traces from SDK-instrumented
 
 <Mermaid chart={`flowchart TD
     subgraph SDK["SDK (Client)"]
-        D["@endpoint / @observe"]
+        D["@observe / @endpoint"]
         T["OpenTelemetry Tracer"]
         B["BatchSpanProcessor<br/>(5s batching)"]
-        E["OTLP Exporter"]
+        E["RhesisOTLPExporter"]
     end
 
     subgraph Backend["Backend (Server)"]
         I["POST /telemetry/traces"]
-        S["PostgreSQL"]
-        L["Linking Service"]
-        EN["Enrichment"]
+        S["PostgreSQL (trace table)"]
+        P["post_ingest_link<br/>(Celery task)"]
     end
 
     D --> T --> B --> E
     E -->|"OTLP/HTTP"| I
     I --> S
-    I --> L
-    I --> EN
-    EN --> S
-    L --> S`} />
+    I -->|"delay()"| P
+    P -->|"link + enrich"| S`} />
 
 ## Key Technologies
 
@@ -46,10 +43,10 @@ The tracing system captures OpenTelemetry-compliant traces from SDK-instrumented
 |-----------|------------|---------|
 | SDK Tracer | OpenTelemetry Python | Span creation with AI semantic conventions |
 | Batch Processor | OTEL BatchSpanProcessor | Batches spans, exports every 5 seconds |
-| Transport | OTLP/HTTP | JSON payload to `/telemetry/traces` |
-| Storage | PostgreSQL + JSONB | Flexible span storage with full-text search |
-| Enrichment | Celery + LiteLLM | Cost calculation, anomaly detection |
-| Linking | Service Layer | Hybrid strategy for test context linking |
+| Transport | OTLP/HTTP | Chunked (100 spans/request), retried with backoff, to `/telemetry/traces` |
+| Storage | PostgreSQL + JSONB | Flexible span storage, GIN-indexed attributes |
+| Post-processing | Celery | Test-result linking, cost/anomaly enrichment, metric evaluation |
+| Linking | Service layer | Hybrid strategy for test-context linking |
 
 ## Communication Channels
 
@@ -62,8 +59,8 @@ The SDK uses **two independent channels**:
 
 <Mermaid chart={`flowchart TD
     subgraph App["Your Application"]
-        O["@observe()<br/>trace_only()"]
-        E["@endpoint()<br/>remote_testable()"]
+        O["@observe()"]
+        E["@endpoint()"]
     end
 
     subgraph Backend["Backend (localhost:8080)"]
@@ -78,11 +75,11 @@ The SDK uses **two independent channels**:
 ## Design Principles
 
 1. **OpenTelemetry Standard** - Industry-standard OTLP protocol for interoperability
-2. **Async-First with Sync Fallback** - Optimal in production, works without workers in development
-3. **Hybrid Linking** - Two strategic linking points to handle race conditions
-4. **Idempotent Operations** - Safe to call linking multiple times
-5. **Cache Enrichment** - Compute once, query fast
-6. **Graceful Degradation** - System works even when components fail
+2. **Hybrid Linking** - Two strategic linking points to handle race conditions
+3. **Idempotent Operations** - Safe to call linking multiple times
+4. **Cache Enrichment** - Enrichment is skipped when every span in a trace is already processed
+5. **Async Post-Processing** - Ingestion never blocks on linking, enrichment, or metric evaluation
+6. **Fire-and-Forget Dispatch** - If the Celery broker is unreachable at dispatch time, ingestion still succeeds; post-processing for that batch is skipped and logged as a warning
 
 ## Performance Characteristics
 
@@ -91,8 +88,8 @@ The SDK uses **two independent channels**:
 | Span creation (SDK) | ~0.1ms | Per span, negligible overhead |
 | BatchProcessor delay | 5000ms | Fixed by OpenTelemetry design |
 | Span export (OTLP) | ~10ms | Network call |
-| Backend ingestion | ~10-20ms | With async enrichment |
-| Enrichment calculation | ~50-100ms | Background (Celery) |
+| Backend ingestion | ~10-20ms | Spans stored before async dispatch |
+| Linking + enrichment | ~50-100ms | Background (Celery, `post_ingest_link`) |
 | Trace query | ~10ms | Cached enrichment |
 | **End-to-end** | **~5 seconds** | Test start to queryable trace |
 
@@ -102,9 +99,11 @@ The SDK uses **two independent channels**:
 
 | File | Purpose |
 |------|---------|
-| `sdk/src/rhesis/sdk/telemetry/tracer.py` | Core `Tracer` class |
-| `sdk/src/rhesis/sdk/telemetry/exporter.py` | OTLP HTTP exporter |
-| `sdk/src/rhesis/sdk/telemetry/attributes.py` | AI semantic conventions |
+| `sdk/src/rhesis/sdk/telemetry/tracer.py` | `Tracer` class — creates spans via the shared OTEL provider |
+| `packages/rhesis/src/rhesis/telemetry/provider.py` | `TracerProvider` + `BatchSpanProcessor` setup |
+| `packages/rhesis/src/rhesis/telemetry/exporter.py` | `RhesisOTLPExporter` — chunked, retrying OTLP HTTP export |
+| `packages/rhesis/src/rhesis/telemetry/schemas.py` | Canonical span schema, span-name validation |
+| `sdk/src/rhesis/sdk/telemetry/attributes.py` | AI semantic convention attribute constants |
 | `sdk/src/rhesis/sdk/decorators/observe.py` | `@observe` decorator |
 | `sdk/src/rhesis/sdk/decorators/endpoint.py` | `@endpoint` decorator |
 
@@ -112,11 +111,12 @@ The SDK uses **two independent channels**:
 
 | File | Purpose |
 |------|---------|
-| `apps/backend/.../routers/telemetry.py` | Ingestion endpoint |
-| `apps/backend/.../services/telemetry/linking_service.py` | Hybrid linking logic |
-| `apps/backend/.../services/telemetry/enricher.py` | Cost/anomaly enrichment |
-| `apps/backend/.../tasks/execution/executors/results.py` | Test result processing |
-| `apps/backend/.../crud.py` | `create_trace_spans()`, `update_traces_with_test_result_id()` |
+| `apps/backend/.../routers/telemetry.py` | Ingestion (`POST /telemetry/traces`) and query endpoints |
+| `apps/backend/.../tasks/telemetry/post_ingest.py` | `post_ingest_link` — linking + enrichment dispatch |
+| `apps/backend/.../services/telemetry/linking_service.py` | `TraceLinkingService` |
+| `apps/backend/.../services/telemetry/enrichment/` | Cost/anomaly enrichment (`core.py`, `processor.py`) |
+| `apps/backend/.../models/trace.py` | `Trace` SQLAlchemy model |
+| `apps/backend/.../crud.py` | `create_trace_spans()`, `update_traces_with_test_result_id()`, `get_trace_by_id()`, `mark_trace_processed()` |
 
 ## Next Steps
 

--- a/docs/content/contribute/tracing-system/lifecycle.mdx
+++ b/docs/content/contribute/tracing-system/lifecycle.mdx
@@ -11,13 +11,13 @@ This page covers the complete trace lifecycle, including the race condition prob
 <CodeBlock filename="Fast Test Timeline" language="text">
 {`T=0ms     Test starts
 T=2000ms  Test completes → create test_result
-T=2010ms  Linking attempt #1 → Finds 0 traces ❌ (not exported yet)
+T=2010ms  Linking attempt #1 → Finds 0 traces (not exported yet)
 T=5000ms  BatchSpanProcessor exports spans → backend receives
 T=5015ms  Spans stored in database
-T=5020ms  Linking attempt #2 → Finds test_result, links traces ✅
-T=5030ms  Enrichment queued (Celery) or runs sync
+T=5020ms  post_ingest_link dispatched → linking attempt #2 finds test_result
+T=5030ms  Enrichment chain dispatched (Celery)
 T=5080ms  Enrichment cached
-T=5090ms  User queries trace → 10ms (cached) ✅
+T=5090ms  User queries trace → 10ms (cached)
 
 Total: ~5 seconds from test start to queryable enriched trace`}
 </CodeBlock>
@@ -45,16 +45,15 @@ Total: ~5 seconds from test start to queryable enriched trace`}
     subgraph Phase4["4. Backend Processing"]
         I["Validate OTLP format"]
         J["Store in PostgreSQL"]
-        K["Trigger linking #2"]
-        L["Enqueue enrichment"]
+        K["Dispatch post_ingest_link"]
+        L["Linking + enrichment"]
     end
 
     A --> B --> C
     B --> D --> E --> F
     F --> G --> H
     H --> I --> J
-    J --> K
-    J --> L`} />
+    J --> K --> L`} />
 
 ## The Race Condition Problem
 
@@ -100,50 +99,48 @@ T=10s: test_result created ← Too late for linking attempt #2!`}
 
 ### Point #1: After Test Result Creation
 
-**Location**: `results.py` → `link_traces_for_test_result()`
+**Location**: `tasks/execution/executors/results.py` → `link_traces_for_test_result()`
 
 **Purpose**: Catch traces that arrived BEFORE test result (slow tests)
 
 <CodeBlock filename="Linking Point #1" language="python">
-{`# After creating test_result in results.py
+{`linking_service = TraceLinkingService(db)
 linking_service.link_traces_for_test_result(
     test_run_id=test_run_id,
     test_id=test_id,
+    test_configuration_id=test_config_id,
     test_result_id=str(result_id),
     organization_id=organization_id,
-)
-# This catches traces from slow tests (>5s)
-# where spans arrived before the test result was created`}
+)`}
 </CodeBlock>
 
 ### Point #2: After Span Ingestion
 
-**Location**: `telemetry.py` → `link_traces_for_incoming_batch()`
+**Location**: `tasks/telemetry/post_ingest.py` → `link_traces_for_incoming_batch()`, run inside the async `post_ingest_link` task dispatched by the ingestion endpoint
 
 **Purpose**: Catch traces that arrived AFTER test result (fast tests)
 
 <CodeBlock filename="Linking Point #2" language="python">
-{`# After storing spans in telemetry.py
-linking_service.link_traces_for_incoming_batch(
+{`linking_service.link_traces_for_incoming_batch(
     spans=stored_spans,
     organization_id=organization_id,
 )
-# This catches traces from fast tests (<5s)
-# where test result was created before spans arrived`}
+# Extracts test_run_id/test_id/test_configuration_id from the first span's
+# attributes, finds the matching test result, then links.`}
 </CodeBlock>
 
 ## Idempotency
 
-Both linking points use the same CRUD operation with **idempotency check**:
+Both linking points call `crud.update_traces_with_test_result_id()`, which only updates traces that aren't linked yet:
 
-<CodeBlock filename="Idempotent Update" language="sql">
-{`-- Only update traces where test_result_id is NULL
-UPDATE traces
-SET test_result_id = :new_test_result_id
-WHERE test_run_id = :test_run_id
-  AND test_id = :test_id
-  AND test_result_id IS NULL  -- Idempotency check
-  AND organization_id = :organization_id`}
+<CodeBlock filename="Idempotent Update" language="python">
+{`db.query(models.Trace).filter(
+    models.Trace.test_run_id == test_run_uuid,
+    models.Trace.test_id == test_id_uuid,
+    models.Trace.organization_id == org_uuid,
+    models.Trace.attributes["rhesis.test.configuration_id"].astext == str(test_config_uuid),
+    models.Trace.test_result_id.is_(None),  # Idempotency check
+).update({"test_result_id": test_result_uuid})`}
 </CodeBlock>
 
 **Safe to call multiple times:**
@@ -185,7 +182,7 @@ This context is stored as span attributes:
 | BatchSpanProcessor delay | 5 seconds | Largest delay, unavoidable |
 | Test execution | Variable | Determines which scenario |
 | Span ingestion | ~10-20ms | Fast |
-| Enrichment | ~50-100ms | Background |
+| Linking + enrichment | ~50-100ms | Background (Celery) |
 | Query | ~10ms | Cached |
 
 ### Why 5 Seconds?
@@ -207,23 +204,29 @@ OpenTelemetry's default of 5 seconds optimizes for **production efficiency** ove
 
 ## Error Handling
 
-### Workers Unavailable
+### Broker Unreachable at Dispatch
 
-**Detection**: `celery_app.control.inspect()`
+**Detection**: `post_ingest_link.delay(...)` raises a broker error (Redis/kombu unreachable)
 
-**Fallback**: Sync enrichment
+**Handling**: Caught and logged as a warning; ingestion still returns 200
 
-**Impact**: Slower ingestion, no data loss
+**Impact**: Linking and enrichment are skipped for that batch — this is fire-and-forget, not retried by the ingestion request itself
+
+### Task Failure After Dispatch
+
+**Handling**: `post_ingest_link` retries up to 3 times (`max_retries=3`, 30s delay) on uncaught exceptions
+
+**Impact**: Transient failures (e.g. a momentarily locked row) self-heal; exhausted retries are logged
 
 ### Database Failure
 
 **Handling**: Return 500 error
 
-**Impact**: Spans lost (SDK retries once)
+**Impact**: Spans lost (SDK retries the export)
 
 ### Linking Failure
 
-**Handling**: Log error, don't fail ingestion
+**Handling**: Log error, don't fail the task
 
 **Impact**: Traces stored but not linked
 
@@ -239,13 +242,13 @@ OpenTelemetry's default of 5 seconds optimizes for **production efficiency** ove
 
 1. Check SDK export: Is `BatchSpanProcessor` configured?
 2. Check backend: Is `/telemetry/traces` receiving requests?
-3. Check database: Are spans stored in `traces` table?
+3. Check database: Are spans stored in the `trace` table?
 4. Wait 5 seconds for batching delay
 
 ### Traces Not Linked to Test Results?
 
 1. Check test context: Are spans created with `rhesis.test.*` attributes?
-2. Check linking logs: Are both linking attempts running?
+2. Check Celery: Is `post_ingest_link` running (broker reachable)?
 3. Check database: Is `test_result_id` NULL or set?
 
 <CodeBlock filename="Debug Query" language="sql">
@@ -253,7 +256,7 @@ OpenTelemetry's default of 5 seconds optimizes for **production efficiency** ove
 SELECT trace_id, span_name,
        attributes->>'rhesis.test.run_id' as test_run_id,
        test_result_id
-FROM traces
+FROM trace
 WHERE attributes->>'rhesis.test.run_id' IS NOT NULL
   AND test_result_id IS NULL
 ORDER BY created_at DESC
@@ -263,15 +266,15 @@ LIMIT 10;`}
 ### Enrichment Not Happening?
 
 1. Check workers: Are Celery workers running?
-2. Check logs: Is enrichment being queued or run sync?
-3. Check database: Is `enriched_data` column populated?
+2. Check logs: Did `post_ingest_link` dispatch successfully?
+3. Check database: Is `enriched_data` populated and `processed_at` set?
 
 <CodeBlock filename="Check Enrichment" language="sql">
 {`-- Check enrichment status
 SELECT trace_id,
        enriched_data IS NOT NULL as is_enriched,
-       enriched_data->>'enriched_at' as enriched_at
-FROM traces
+       processed_at
+FROM trace
 WHERE created_at > NOW() - INTERVAL '1 hour'
 ORDER BY created_at DESC
 LIMIT 10;`}

--- a/docs/decluttering-rules.md
+++ b/docs/decluttering-rules.md
@@ -194,7 +194,7 @@ Check off pages/sections as they are done.
 - [x] Connector (`contribute/connector.mdx`)
 
 **Reference**
-- [ ] Environment Variables (`contribute/environment-variables.mdx`)
+- [x] Environment Variables (`contribute/environment-variables.mdx`)
 - [x] Telemetry
 
 ### Other

--- a/docs/decluttering-rules.md
+++ b/docs/decluttering-rules.md
@@ -189,7 +189,7 @@ Check off pages/sections as they are done.
       Architect Background Tasks, Trace Ingestion Pipeline, Test Execution, Test Types,
       Execution Modes, Logging, Troubleshooting, GKE Troubleshooting
 - [x] SDK — Getting Started, Architect Agent, Integrations
-- [ ] Tracing System — Overview, Architecture, Trace Lifecycle, Data Structures
+- [x] Tracing System — Overview, Architecture, Trace Lifecycle, Data Structures
 - [ ] Polyphemus
 - [ ] Connector (`contribute/connector.mdx`)
 

--- a/docs/decluttering-rules.md
+++ b/docs/decluttering-rules.md
@@ -191,7 +191,7 @@ Check off pages/sections as they are done.
 - [x] SDK — Getting Started, Architect Agent, Integrations
 - [x] Tracing System — Overview, Architecture, Trace Lifecycle, Data Structures
 - [ ] Polyphemus
-- [ ] Connector (`contribute/connector.mdx`)
+- [x] Connector (`contribute/connector.mdx`)
 
 **Reference**
 - [ ] Environment Variables (`contribute/environment-variables.mdx`)


### PR DESCRIPTION
## Purpose

Continues the docs decluttering pass tracked in `docs/decluttering-rules.md`. While applying the tone/redundancy rules to `contribute/tracing-system/` (4 pages) and `contribute/connector.mdx`, a code-verification pass found the pages had drifted significantly from the actual implementation — this PR fixes both the prose and the factual content.

## What Changed

- **Tracing System** (`contribute/tracing-system/{index,architecture,lifecycle,data-structures}.mdx`):
  - Removed a fictional `workers_available()` synchronous-fallback path for trace ingestion (the real ingestion endpoint always dispatches async and just logs a warning if the broker is unreachable)
  - Fixed SDK file paths (`TracerProvider`/`BatchSpanProcessor`/`RhesisOTLPExporter`/span validation live in `packages/rhesis/src/rhesis/telemetry/`, not `sdk/.../telemetry/`)
  - Fixed the `enriched_data` JSON shape (`costs`/`anomalies`/`metrics`/`models_used`/`tools_used`/`operation_types`/`root_operation`, no `metadata` wrapper or `enriched_at`)
  - Fixed the database schema (table is `trace`, not `traces`; corrected columns, indexes, and FKs)
  - Fixed env var names (`BROKER_URL`, `RHESIS_BASE_URL`, component `DB_*`/`APP_DB_*` vars)
  - Fixed the Celery worker start command and the span-name validation example (`agent` is now allowed; `chain`/`workflow`/`pipeline` are rejected)
- **Connector** (`contribute/connector.mdx`):
  - Fixed `ConnectionManager.connect()` signature and the RPC transport description (per-instance Redis list + routing-key lookup, not a shared `ws:rpc:requests` channel)
  - Fixed `MappingService.generate_or_use_existing()` signature and the LLM-fallback model claim (uses the user's configured generation model, not hardcoded GPT-4)
  - Filled in missing WebSocket message types (`execute_metric`, `metric_result`, `connected`, `error`)
  - Fixed a Key Files entry pointing at a non-existent `decorators.py`
  - Dropped a stray version annotation per decluttering rule 16
- Marked "Tracing System" and "Connector" done in `docs/decluttering-rules.md`, plus a bookkeeping checkbox for "Environment Variables" left over from an earlier uncommitted pass

## Additional Context

Every claim (function/class names, signatures, env vars, Redis keys, DB columns/indexes, HTTP routes) was checked directly against the source before being rewritten. `contribute/worker/trace-ingestion-pipeline.mdx` has the same stale "workers available" narrative but is out of scope here — it belongs to the not-yet-started "Worker" checklist item.

## Testing

`pnpm build` in `docs/src` succeeds (277 static pages generated, including all 5 changed pages).