### PR TITLE
Fix owners/admins unable to re-run test runs

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunMainView.tsx
@@ -23,7 +23,7 @@ import { FilterState } from './TestRunFilterBar';
 import { TestResultDetail } from '@/utils/api-client/interfaces/test-results';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 import { useNotifications } from '@/components/common/NotificationContext';
-import { can } from '@/utils/affordances';
+import { can, useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useTestRunDetailData } from '../hooks/useTestRunDetailData';
@@ -509,16 +509,16 @@ export default function TestRunMainView({
     'aria-controls': `test-run-tabpanel-${index}`,
   }));
 
-  const canCreateRerun = can(testRun, Capability.TestRun.CREATE);
+  const canExecute = useCan(Capability.TestSet.EXECUTE);
   const canRerun =
     Boolean(testRun.test_configuration_id) &&
-    canCreateRerun &&
+    canExecute &&
     testSetExists !== false;
 
   const rerunTooltip =
     testSetExists === false
       ? 'The test set for this run no longer exists'
-      : !canCreateRerun
+      : !canExecute
         ? 'You do not have permission to re-run tests'
         : !testRun.test_configuration_id
           ? 'Cannot re-run: No test configuration found'


### PR DESCRIPTION
## Purpose

Organization/project owners and admins could not re-run test runs. The
re-run button was always disabled regardless of role.

## What Changed

- `TestRunMainView.tsx` re-run gate switched from
  `can(testRun, Capability.TestRun.CREATE)` (an object-level affordance
  check) to `useCan(Capability.TestSet.EXECUTE)` (an ambient scope
  check).
- The object-level check was always `false`: the backend's
  `permitted_actions_for` deliberately excludes `create`/`read` from
  any object's `permitted_actions`, since those are collection-scoped
  actions, not properties of an existing object. So
  `test_run:create` never appeared in a test run's `permitted_actions`
  for any user.
- The re-run action's actual backend call
  (`POST /test_sets/{id}/execute/{endpoint_id}`) is gated by
  `Permission.TestSet.EXECUTE` (`test_set:execute`), which is what the
  fresh "Run test set" button already checks. The new frontend check
  now matches that.

## Additional Context

Owner, Admin, and Member roles all hold `test_set:execute`; Viewer does
not, so the button now correctly enables/disables based on role.

## Testing

- `npx tsc --noEmit` passes
- `npx eslint` passes on the changed file
- Manually traced the permission resolution path:
  `permitted_actions_for` in
  `apps/backend/src/rhesis/backend/app/auth/capabilities.py` and the
  `test_set:execute` capability decorator on the execute route in
  `apps/backend/src/rhesis/backend/app/routers/test_set.py`