### PR TITLE
Show app version in support drawer

### DIFF
--- a/apps/frontend/src/components/navigation/SupportDrawer.tsx
+++ b/apps/frontend/src/components/navigation/SupportDrawer.tsx
@@ -11,6 +11,7 @@ import EmailOutlinedIcon from '@mui/icons-material/EmailOutlined';
 import { FilterDrawerShell } from '@/components/common/FilterDrawer';
 import { BORDER_RADIUS } from '@/styles/theme';
 import DiscordIcon from '@/components/DiscordIcon';
+import AppVersion from '@/components/common/AppVersion';
 
 interface SupportDrawerProps {
   open: boolean;
@@ -129,7 +130,14 @@ export default function SupportDrawer({ open, onClose }: SupportDrawerProps) {
       title="Support"
       anchor="right"
     >
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '40px' }}>
+      <Box
+        sx={{
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '40px',
+        }}
+      >
         <SupportSection
           title="Docs"
           description="Explore guides, API references, and examples to get the most out of Rhesis."
@@ -203,6 +211,14 @@ export default function SupportDrawer({ open, onClose }: SupportDrawerProps) {
             />
           </Box>
         </SupportSection>
+
+        <AppVersion
+          sx={{
+            mt: 'auto',
+            fontSize: 12,
+            color: theme => theme.palette.greyscale.subtitle,
+          }}
+        />
       </Box>
     </FilterDrawerShell>
   );


### PR DESCRIPTION
## Purpose

The app used to show version info (version, and in dev mode also git commit hash and branch) in the UI. This was silently dropped during the Figma UI revamp (#1780), which removed the `toolbarActions`/`sidebarFooter` slots from the old `DashboardLayout` without re-wiring the version display anywhere in the new `AppShell`.

## What Changed

- Render the existing `AppVersion` component at the bottom of the Support drawer (`SupportDrawer.tsx`).
- No new build-time plumbing needed: `next.config.mjs` and `src/utils/git-utils.ts` already inject `APP_VERSION`/`NEXT_PUBLIC_GIT_BRANCH`/`NEXT_PUBLIC_GIT_COMMIT` and were untouched by the revamp.

## Additional Context

- In production, shows `v0.10.0`. In dev/staging, shows `v0.10.0 (branch@commit)`.

## Testing

- Open the app, click the Support icon to open the drawer, confirm the version line appears pinned to the bottom.
- `npx tsc --noEmit` and `npm run lint` pass clean on the changed file.