### PR TITLE
Declutter worker contributing docs

### DIFF
--- a/docs/content/contribute/worker/README.mdx
+++ b/docs/content/contribute/worker/README.mdx
@@ -1,88 +1,25 @@
-import { CodeBlock } from '@/components/CodeBlock'
+# Worker
 
-# Rhesis Worker Documentation
+The Rhesis worker runs background processing on Celery with Redis as the broker and result
+backend: test execution, trace ingestion, metric evaluation, and Architect chat turns.
 
-This directory contains documentation related to the Rhesis worker system, which handles background processing, task queues, and asynchronous operations using **Redis as the message broker**.
+## Design and internals
 
-## Contents
+- [Architecture](/contribute/worker/architecture): how the worker relates to the backend, SDK, database, and broker.
+- [Multi-Worker RPC](/contribute/worker/multi-worker-rpc): routing RPC requests to the worker that holds an SDK's WebSocket connection.
+- [Background Tasks](/contribute/worker/background-tasks): Celery configuration, the `BaseTask` base class, tenant context, and the task launcher.
+- [Architect Background Tasks](/contribute/worker/architect-background-tasks): Architect chat execution and async resume.
+- [Trace Ingestion Pipeline](/contribute/worker/trace-ingestion-pipeline): how traces flow through storage, linking, enrichment, and metric evaluation.
+- [Test Execution](/contribute/worker/test-execution): the executor architecture and async batch engine.
+- [Test Types](/contribute/worker/test-types): single-turn vs. multi-turn tests.
+- [Execution Modes](/contribute/worker/execution-modes): parallel vs. sequential test runs.
 
-- [Background Tasks and Processing](background-tasks.md): Detailed information about Redis-based Celery configuration, task management, tenant context handling, error recovery, and troubleshooting.
-- [Troubleshooting Guide](troubleshooting.md): Solutions for common issues with workers, tasks, and the Celery processing system.
-- [GKE Troubleshooting Guide](gke-troubleshooting.md): **NEW** - Comprehensive guide for diagnosing and fixing worker issues in Google Kubernetes Engine.
-- [Logging Guide](logging.md): **NEW** - Complete guide to worker logging, log analysis, and monitoring.
-- [Trace Ingestion Pipeline](trace-ingestion-pipeline.md): How traces flow through storage, enrichment, and metric evaluation after ingestion via `POST /telemetry/traces`.
-- [Architecture and Dependencies](architecture.md): Explanation of how the worker system integrates with the backend and SDK components.
+## Operations
 
-## Topics Covered
+- [Logging](/contribute/worker/logging): log sources, configuration, and analysis.
+- [Troubleshooting](/contribute/worker/troubleshooting): stuck tasks, tenant-context errors, broker connectivity, and worker registration.
+- [GKE Troubleshooting](/contribute/worker/gke-troubleshooting): diagnosing workers in Google Kubernetes Engine.
 
-- **Redis-based Celery configuration** with TLS support
-- Worker deployment and scaling in **GKE (Google Kubernetes Engine)**
-- Task management and organization
-- **Async batch execution and cooperative cancellation**
-- Multi-tenancy in background tasks
-- Error handling and recovery
-- Task monitoring and observability
-- **GKE troubleshooting with kubectl**
-- **Comprehensive logging and log analysis**
-- Redis connection diagnostics
+## Related
 
-## Quick Start Guides
-
-### For Worker Registration Issues
-If workers aren't processing tasks or seem disconnected:
-
-1. **Check Worker Status**: Create and run `check_workers.py` (see [Worker Registration](troubleshooting.md#worker-registration-and-status-checking))
-2. **Quick Status**:
-
-<CodeBlock language="python" isTerminal={false}>
-{`python -c "from rhesis.backend.worker import app; print('Workers:', list(app.control.inspect().active().keys()) if app.control.inspect().active() else 'None')"`}
-</CodeBlock>
-
-3. **Test Redis Connection**: Verify broker connectivity
-4. **Scale Workers** (for GKE):
-
-<CodeBlock language="bash" isTerminal={true}>
-{`kubectl scale deployment rhesis-worker --replicas=0/2 -n <namespace>`}
-</CodeBlock>
-
-### For GKE Worker Issues
-If you're experiencing deployment or connectivity issues:
-
-1. **Connect to Cluster**: Follow [GKE Setup](gke-troubleshooting.md#quick-start-connect-to-your-cluster)
-2. **Check Pod Status**:
-
-<CodeBlock language="bash" isTerminal={true}>
-{`kubectl get pods -n <namespace>`}
-</CodeBlock>
-
-3. **Check Logs**:
-
-<CodeBlock language="bash" isTerminal={true}>
-{`kubectl logs <pod> -c worker -n <namespace> --tail=100`}
-</CodeBlock>
-
-4. **Test Health Endpoints**:
-
-<CodeBlock language="bash" isTerminal={true}>
-{`kubectl exec -it <pod> -- curl localhost:8080/debug`}
-</CodeBlock>
-
-5. **Check Worker Registration**: Use [Worker Registration Checking](gke-troubleshooting.md#worker-registration-checking)
-6. **Full Diagnostics**: See [GKE Troubleshooting Guide](gke-troubleshooting.md) and [Logging Guide](logging.md)
-
-### For Current Test Execution Issues (Async Batch Engine)
-If test runs are stuck or not progressing as expected:
-
-1. **Inspect active tasks**:
-
-<CodeBlock language="bash" isTerminal={true}>
-{`celery -A rhesis.backend.worker inspect active`}
-</CodeBlock>
-
-2. **Check worker logs** for batch runner and cancellation-watchdog events.
-3. **Review execution internals**: [Test Execution](test-execution.md) and [Execution Modes](execution-modes.md)
-4. **Use troubleshooting playbooks**: [Troubleshooting Guide](troubleshooting.md)
-
-## Related Documentation
-
-- [Backend API Documentation](https://docs.rhesis.ai/contribute/backend): Information about the API services that queue background tasks
+- [Backend](/contribute/backend): the API services that queue background tasks.

--- a/docs/content/contribute/worker/architecture.mdx
+++ b/docs/content/contribute/worker/architecture.mdx
@@ -2,11 +2,10 @@ import { CodeBlock } from '@/components/CodeBlock'
 
 # Worker Architecture and Dependencies
 
-This document explains the relationships and dependencies between the Rhesis worker system, the backend API, and the SDK components.
+The worker shares code, models, and the database with the backend API, connected through a Redis
+broker.
 
 ## Component Relationships
-
-The Rhesis platform consists of several interrelated components:
 
 <CodeBlock language="text" isTerminal={false}>
 {`┌───────────┐     ┌───────────┐     ┌───────────┐
@@ -93,14 +92,6 @@ CELERY_RESULT_BACKEND=rediss://:password@redis-host:6378/1?ssl_cert_reqs=CERT_NO
 CELERY_WORKER_CONCURRENCY=8
 CELERY_WORKER_PREFETCH_MULTIPLIER=4`}
 </CodeBlock>
-
-### Development Workflow
-
-When developing tasks, you need to:
-
-1. Write code in the backend repository
-2. Ensure both backend and worker containers have access to the latest code
-3. Test tasks using both API-triggered execution and direct worker execution
 
 ## Managing Circular Dependencies
 

--- a/docs/content/contribute/worker/background-tasks.mdx
+++ b/docs/content/contribute/worker/background-tasks.mdx
@@ -1,77 +1,48 @@
 import { CodeBlock } from '@/components/CodeBlock'
 
-# Worker Tasks and Background Processing
+# Background Tasks
 
-## Overview
+The backend offloads long-running work to Celery: test execution, trace enrichment, metric
+evaluation, and Architect chat turns. Tasks carry tenant context (organization and user) so they
+run with the same isolation as an API request.
 
-The Rhesis backend uses Celery to handle asynchronous background tasks. This allows the API to offload time-consuming operations and improve responsiveness. The task processing system is designed to be scalable, fault-tolerant, and context-aware.
+## Celery configuration
 
-## Celery Configuration
+The Celery app is created in `celery/core.py`, which applies `CELERY_CONFIG` from
+`celery/config.py` and auto-discovers tasks under `rhesis.backend.tasks`:
 
-The Celery application is configured in `worker.py`:
-
-<CodeBlock language="python" filename="worker.py" isTerminal={false}>
-{`import os
-from celery import Celery
-from dotenv import load_dotenv
-
-# Load environment variables from .env file
-load_dotenv()
-
-# Create the Celery app
-app = Celery("rhesis")
-
-# Configure Celery
-app.conf.update(
-    broker_url=os.getenv("BROKER_URL"),
-    result_backend=os.getenv("CELERY_RESULT_BACKEND"),
-    task_serializer="json",
-    result_serializer="json",
-    accept_content=["json"],
-    timezone="UTC",
-    enable_utc=True,
-)
-
-# Auto-discover tasks without loading config files
+<CodeBlock language="python" filename="celery/core.py" isTerminal={false}>
+{`app = Celery("rhesis")
+app.conf.update(CELERY_CONFIG)
 app.autodiscover_tasks(["rhesis.backend.tasks"], force=True)`}
 </CodeBlock>
 
-The application uses Redis as both the broker and result backend with TLS support:
+Redis serves as both broker and result backend. Use `rediss://` for TLS; the
+`ssl_cert_reqs=CERT_NONE` parameter connects to managed Redis services that use self-signed
+certificates.
 
 <CodeBlock language="bash" filename=".env" isTerminal={false}>
-{`# Development (local Redis)
+{`# Local
 BROKER_URL=redis://localhost:6379/0
 CELERY_RESULT_BACKEND=redis://localhost:6379/1
 
 # Production (Redis with TLS)
 BROKER_URL=rediss://:password@redis-host:6378/0?ssl_cert_reqs=CERT_NONE
-CELERY_RESULT_BACKEND=rediss://:password@redis-host:6378/1?ssl_cert_reqs=CERT_NONE
-
-# Model API Keys (required for evaluation tasks)
-GEMINI_API_KEY=your_gemini_api_key
-GEMINI_MODEL_NAME=gemini-1.5-pro
-AZURE_OPENAI_ENDPOINT=https://your-endpoint.openai.azure.com/
-AZURE_OPENAI_API_KEY=your_azure_openai_key
-AZURE_OPENAI_DEPLOYMENT_NAME=your-deployment-name
-AZURE_OPENAI_API_VERSION=2024-02-01`}
+CELERY_RESULT_BACKEND=rediss://:password@redis-host:6378/1?ssl_cert_reqs=CERT_NONE`}
 </CodeBlock>
 
-**Note:** The `rediss://` protocol indicates Redis with TLS/SSL encryption. The `ssl_cert_reqs=CERT_NONE` parameter is used when connecting to managed Redis services that use self-signed certificates.
+`CELERY_CONFIG` sets Redis-oriented defaults: `result_expires=3600`, `result_compression="gzip"`,
+broker connection retries, and transport options with 30-second socket timeouts for TLS
+connections.
 
-## Base Task Class
+## Base task class
 
-All tasks inherit from a `BaseTask` class that provides retry logic, error handling, and most importantly, context awareness for multi-tenant operations:
+Tasks inherit from `BaseTask`, which adds retry settings and tenant-context management. It reads
+`organization_id` and `user_id` from task kwargs when the task is queued, stores them in the task
+headers, and restores them onto the request before the task starts:
 
 <CodeBlock language="python" filename="tasks/base.py" isTerminal={false}>
-{`from celery import Task
-from contextlib import contextmanager
-
-from rhesis.backend.app.database import get_db_with_tenant_variables
-
-class BaseTask(Task):
-    """Base task class with retry settings and tenant context management."""
-
-    # Retry settings
+{`class BaseTask(Task):
     autoretry_for = (Exception,)
     max_retries = 3
     retry_backoff = True
@@ -80,211 +51,71 @@ class BaseTask(Task):
 
     @contextmanager
     def get_db_session(self):
-        """Get a database session with the proper tenant context."""
         request = getattr(self, 'request', None)
         org_id = getattr(request, 'organization_id', None) or ''
         user_id = getattr(request, 'user_id', None) or ''
         project_id = getattr(request, 'project_id', None) or ''
-
         with get_db_with_tenant_variables(org_id, user_id, project_id) as db:
-            yield db
-
-    def apply_async(self, args=None, kwargs=None, **options):
-        """Store org_id and user_id in task context when task is queued."""
-        args = args or ()
-        kwargs = kwargs or {}
-
-        # Extract context from kwargs and store in headers
-        if kwargs and ('organization_id' in kwargs or 'user_id' in kwargs):
-            headers = options.get('headers', {})
-
-            if 'organization_id' in kwargs:
-                headers['organization_id'] = kwargs.pop('organization_id')
-
-            if 'user_id' in kwargs:
-                headers['user_id'] = kwargs.pop('user_id')
-
-            options['headers'] = headers
-
-        return super().apply_async(args, kwargs, **options)
-
-    def before_start(self, task_id, args, kwargs):
-        """Add organization_id and user_id to task request context."""
-        # Try to get from kwargs first, then headers (which take precedence)
-        if 'organization_id' in kwargs:
-            self.request.organization_id = kwargs.pop('organization_id')
-        if 'user_id' in kwargs:
-            self.request.user_id = kwargs.pop('user_id')
-
-        headers = getattr(self.request, 'headers', {}) or {}
-        if headers:
-            if 'organization_id' in headers:
-                self.request.organization_id = headers['organization_id']
-            if 'user_id' in headers:
-                self.request.user_id = headers['user_id']`}
+            yield db`}
 </CodeBlock>
 
-This enhanced `BaseTask` ensures that:
-- Tasks have access to organization_id and user_id for proper multi-tenant operations
-- Context is automatically propagated through the task execution
-- Error handling and retry logic are standardized
-- Logging and monitoring include context information
+## Tenant context decorator
 
-## Tenant Context Decorator
-
-A task decorator is provided to automatically handle database sessions with proper tenant context:
+`with_tenant_context` opens a database session with the task's tenant context and passes it to the
+function as `db`:
 
 <CodeBlock language="python" filename="tasks/decorators.py" isTerminal={false}>
-{`from functools import wraps
-
-def with_tenant_context(func):
-    """
-    Decorator to automatically maintain tenant context in task functions.
-    This ensures all database operations use the proper tenant context.
-    """
+{`def with_tenant_context(func):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
-        # Get task request for context
-        request = getattr(self, 'request', None)
-        organization_id = getattr(request, 'organization_id', None)
-        user_id = getattr(request, 'user_id', None)
-
-        # Get a database session
         with self.get_db_session() as db:
-            # Add db to kwargs and execute the task function
             kwargs['db'] = db
             return func(self, *args, **kwargs)
-
     return wrapper`}
 </CodeBlock>
 
-Using this decorator simplifies working with database operations in tasks:
+## Task launcher
 
-<CodeBlock language="python" filename="tasks/example_task.py" isTerminal={false}>
-{`@app.task(base=BaseTask, name="rhesis.backend.tasks.count_test_sets")
-@with_tenant_context
-def count_test_sets(self, db=None):
-    """
-    Task that counts total test sets.
-    The db parameter is automatically provided with tenant context.
-    """
-    # Access context from task request
-    org_id = getattr(self.request, 'organization_id', 'unknown')
-    user_id = getattr(self.request, 'user_id', 'unknown')
-
-    # The db session already has tenant context set
-    test_sets = crud.get_test_sets(db)
-    count = len(test_sets)
-
-    return {
-        "count": count,
-        "organization_id": org_id,
-        "user_id": user_id
-    }`}
-</CodeBlock>
-
-## Task Launcher Utility
-
-A `task_launcher` utility method is provided to easily launch tasks with proper context from FastAPI routes:
+`task_launcher` launches a task from a FastAPI route, pulling `organization_id` and `user_id` off
+`current_user` so callers don't pass them explicitly:
 
 <CodeBlock language="python" filename="tasks/launcher.py" isTerminal={false}>
 {`def task_launcher(task: Callable, *args: Any, current_user=None, **kwargs: Any):
-    """
-    Launch a task with proper context from a FastAPI route.
-
-    This helper automatically adds organization_id and user_id from current_user
-    to the task context, removing the need to pass them explicitly.
-    """
-    # Add user context if available and not already specified
     if current_user is not None:
-        if hasattr(current_user, 'id') and current_user.id is not None:
+        if getattr(current_user, 'id', None) is not None:
             kwargs.setdefault('user_id', str(current_user.id))
-
-        if hasattr(current_user, 'organization_id') and current_user.organization_id is not None:
+        if getattr(current_user, 'organization_id', None) is not None:
             kwargs.setdefault('organization_id', str(current_user.organization_id))
-
-    # Launch the task
     return task.delay(*args, **kwargs)`}
 </CodeBlock>
 
-## Task Organization
+## Writing tasks
 
-Tasks are organized in the `tasks/` directory:
-
-<CodeBlock language="text" isTerminal={false}>
-{`tasks/
-├── __init__.py
-├── base.py
-├── example_task.py
-├── test_configuration.py
-└── test_set.py`}
-</CodeBlock>
-
-## Creating Tasks
-
-When creating a task, you no longer need to explicitly require organization_id and user_id as parameters. The context system handles this automatically:
-
-### Simple Task without Database Access
-
-<CodeBlock language="python" filename="tasks/echo.py" isTerminal={false}>
-{`@app.task(base=BaseTask, name="rhesis.backend.tasks.echo")
-def echo(message: str):
-    """Echo task for testing context."""
-    task = echo.request
-    org_id = getattr(task, 'organization_id', 'unknown')
-    user_id = getattr(task, 'user_id', 'unknown')
-
-    print(f"Task executed for organization: {org_id}, by user: {user_id}")
-    return f"Message: {message}, Organization: {org_id}, User: {user_id}"`}
-</CodeBlock>
-
-### Task with Automatic Database Context
+You do not pass `organization_id` and `user_id` as explicit parameters — the context system
+propagates them. Use `@with_tenant_context` when the task needs a database session:
 
 <CodeBlock language="python" filename="tasks/test_configuration.py" isTerminal={false}>
 {`@app.task(base=BaseTask, name="rhesis.backend.tasks.get_test_configuration")
 @with_tenant_context
 def get_test_configuration(test_configuration_id: str, db=None):
-    """
-    Get a test configuration with proper tenant context.
-
-    The @with_tenant_context decorator automatically:
-    1. Creates a database session
-    2. Sets the tenant context from task headers
-    3. Passes the session to the function
-    4. Closes the session when done
-    """
-    # Convert string ID to UUID
     config_id = UUID(test_configuration_id)
-
-    # Use existing crud functions with proper tenant context
     test_config = crud.get_test_configuration(db, test_configuration_id=config_id)
-
-    return {
-        "found": test_config is not None,
-        "id": str(test_config.id) if test_config else None
-    }`}
+    return {"found": test_config is not None,
+            "id": str(test_config.id) if test_config else None}`}
 </CodeBlock>
 
-### Task with Manual Database Session Control
+Without the decorator, open a session manually via `self.get_db_session()`, which already carries
+tenant context:
 
 <CodeBlock language="python" filename="tasks/manual_example.py" isTerminal={false}>
 {`@app.task(base=BaseTask, name="rhesis.backend.tasks.manual_db_example")
 def manual_db_example():
-    """Example of manually managing database sessions."""
-    results = {}
-
-    # Use the context manager to get a properly configured session
     with manual_db_example.get_db_session() as db:
-        # The session already has tenant context set
         test_sets = crud.get_test_sets(db)
-        results["test_set_count"] = len(test_sets)
-
-    return results`}
+        return {"test_set_count": len(test_sets)}`}
 </CodeBlock>
 
-## Using Tasks in FastAPI Routes
-
-The most common way to launch tasks is from FastAPI route handlers:
+Launch tasks from a route with `task_launcher`:
 
 <CodeBlock language="python" filename="routers/test_configuration.py" isTerminal={false}>
 {`from rhesis.backend.tasks import task_launcher, execute_test_configuration
@@ -292,106 +123,48 @@ The most common way to launch tasks is from FastAPI route handlers:
 @router.post("/{test_configuration_id}/execute")
 def execute_test_configuration_endpoint(
     test_configuration_id: UUID,
-    current_user: schemas.User = Depends(require_current_user_or_token)
+    current_user: schemas.User = Depends(require_current_user_or_token),
 ):
-    # Schedule the task with automatic context handling
     result = task_launcher(
         execute_test_configuration,
         str(test_configuration_id),
-        current_user=current_user
+        current_user=current_user,
     )
-
-    # Return the task ID for checking status later
     return {"task_id": result.id}`}
 </CodeBlock>
 
-## Worker Configuration
+## Running workers
 
-Celery workers are configured with Redis-optimized performance settings:
+`apps/worker/start.sh` runs two Celery workers against the same broker:
 
-<CodeBlock language="dockerfile" filename="Dockerfile" isTerminal={false}>
-{`# Default Celery configuration optimized for Redis
-ENV CELERY_WORKER_CONCURRENCY=8 \
-    CELERY_WORKER_PREFETCH_MULTIPLIER=4 \
-    CELERY_WORKER_MAX_TASKS_PER_CHILD=1000 \
-    LOG_LEVEL=INFO \
-    CELERY_WORKER_LOGLEVEL=INFO \
-    CELERY_WORKER_OPTS=""`}
+- a **main** worker on the `celery`, `execution`, and `telemetry` queues
+- an **architect** worker on the `architect` queue
+
+Both use the thread pool. Concurrency and prefetch are set through environment variables
+(`CELERY_WORKER_CONCURRENCY`, `CELERY_WORKER_PREFETCH_MULTIPLIER`, and the `CELERY_ARCHITECT_*`
+equivalents):
+
+<CodeBlock language="bash" filename="start.sh" isTerminal={true}>
+{`celery -A rhesis.backend.worker.app worker \\
+    --pool threads -n main@%h \\
+    --queues=celery,execution,telemetry \\
+    --loglevel="$CELERY_WORKER_LOGLEVEL" \\
+    --concurrency="$CELERY_WORKER_CONCURRENCY" \\
+    --prefetch-multiplier="$CELERY_WORKER_PREFETCH_MULTIPLIER" \\
+    --optimization=fair -E`}
 </CodeBlock>
 
-### Redis-Specific Configuration
+`LOG_LEVEL` controls application logs; `CELERY_WORKER_LOGLEVEL` controls Celery's own
+task-lifecycle messages and defaults to `LOG_LEVEL`. Set `ENABLE_FLOWER=yes` to run the Flower
+monitoring UI on port 5555.
 
-The Celery app includes Redis-optimized settings:
+## Monitoring task status
 
-<CodeBlock language="python" filename="worker.py" isTerminal={false}>
-{`app.conf.update(
-    # Redis configuration with TLS support
-    broker_url=os.getenv("BROKER_URL", "redis://localhost:6379/0"),
-    result_backend=os.getenv("CELERY_RESULT_BACKEND", "redis://localhost:6379/1"),
-
-    # Redis-optimized settings
-    result_expires=3600,  # 1 hour - shorter for Redis efficiency
-    result_compression="gzip",
-
-    # Connection settings for Redis reliability
-    broker_connection_retry_on_startup=True,
-    broker_connection_retry=True,
-    broker_connection_max_retries=10,
-
-    # Redis transport options for TLS connections
-    broker_transport_options={
-        'retry_on_timeout': True,
-        'connection_pool_kwargs': {
-            'retry_on_timeout': True,
-            'socket_connect_timeout': 30,
-            'socket_timeout': 30,
-        }
-    },
-
-    result_backend_transport_options={
-        'retry_on_timeout': True,
-        'connection_pool_kwargs': {
-            'retry_on_timeout': True,
-            'socket_connect_timeout': 30,
-            'socket_timeout': 30,
-        }
-    },
-)`}
-</CodeBlock>
-
-The worker startup script applies these configurations. `LOG_LEVEL` controls
-application logs; Celery's own task-lifecycle messages are controlled
-separately by `CELERY_WORKER_LOGLEVEL`, which defaults to `LOG_LEVEL` but can
-be overridden independently:
-
-<CodeBlock language="bash" filename="start-worker.sh" isTerminal={true}>
-{`# Start Celery worker with Redis-optimized settings
-celery -A rhesis.backend.worker.app worker \
-    --queues=celery,execution,telemetry \
-    --loglevel=\${CELERY_WORKER_LOGLEVEL:-INFO} \
-    --concurrency=\${CELERY_WORKER_CONCURRENCY:-8} \
-    --prefetch-multiplier=\${CELERY_WORKER_PREFETCH_MULTIPLIER:-4} \
-    --max-tasks-per-child=\${CELERY_WORKER_MAX_TASKS_PER_CHILD:-1000} \
-    \${CELERY_WORKER_OPTS}`}
-</CodeBlock>
-
-Optional monitoring is available through Flower:
-
-<CodeBlock language="bash" isTerminal={true}>
-{`# Enable Flower monitoring
-docker run -e ENABLE_FLOWER=yes -p 5555:5555 your-worker-image`}
-</CodeBlock>
-
-## Task Monitoring
-
-Task status can be monitored through several interfaces:
-
-### API Endpoint
+Query a task's status through the result backend:
 
 <CodeBlock language="python" filename="routers/tasks.py" isTerminal={false}>
 {`@router.get("/tasks/{task_id}")
 async def get_task_status(task_id: str):
-    """Get the status of a task."""
     result = AsyncResult(task_id, app=celery_app)
     return {
         "task_id": task_id,
@@ -401,31 +174,10 @@ async def get_task_status(task_id: str):
     }`}
 </CodeBlock>
 
-### Flower Dashboard
+## Error handling
 
-Access the Flower web UI at `http://localhost:5555` when enabled.
+`BaseTask` logs exceptions with tenant context, retries failed tasks with exponential backoff up to
+`max_retries`, and records the final error in the result backend once retries are exhausted.
 
-## Error Handling
-
-The enhanced BaseTask provides improved error handling:
-
-1. Exceptions are logged with tenant context information
-2. Failed tasks are automatically retried with exponential backoff
-3. After maximum retries, the error is recorded in the result backend
-4. Both success and failure callbacks include context information
-5. Task execution time and other metrics are tracked automatically
-
-## Troubleshooting
-
-For detailed information about troubleshooting common worker issues, including:
-
-- Dealing with stuck tasks and async batch execution failures
-- Fixing tenant context errors
-- Connection problems with the broker
-- Task execution failures
-
-Please refer to the [Worker Troubleshooting Guide](troubleshooting.md).
-
-## Task Monitoring
-
-Task status can be monitored through several interfaces:
+For stuck tasks, broker connectivity, and tenant-context errors, see
+[Troubleshooting](/contribute/worker/troubleshooting).

--- a/docs/content/contribute/worker/execution-modes.mdx
+++ b/docs/content/contribute/worker/execution-modes.mdx
@@ -10,7 +10,8 @@ When executing a test configuration (a set of tests against an endpoint), Rhesis
 
 ### Description
 
-Tests are executed simultaneously using multiple Celery workers. This is the default mode and provides the fastest execution time.
+A single Celery task runs the tests concurrently through an async batch engine. This is the default
+mode and the fastest.
 
 ### How It Works
 
@@ -33,21 +34,11 @@ Collect Results`}
 
 ### Use Cases
 
-✅ **Best for:**
+**Best for:** independent tests against endpoints that handle concurrent requests without rate
+limits, and large test suites where speed matters.
 
-- Endpoints that can handle concurrent requests
-- Independent tests (no dependencies)
-- Fast execution needed
-- Scalable endpoints without rate limits
-- High-performance testing scenarios
-- Large test suites
-
-⚠️ **Considerations:**
-
-- May overwhelm endpoints
-- Harder to debug concurrent failures
-- Requires adequate system resources
-- May hit rate limits
+**Considerations:** may overwhelm an endpoint or hit rate limits, and concurrent failures are
+harder to debug.
 
 ### Configuration
 
@@ -103,20 +94,10 @@ Collect Results`}
 
 ### Use Cases
 
-✅ **Best for:**
+**Best for:** rate-limited or stateful endpoints, tests with dependencies on each other, and
+debugging (one test at a time is easier to trace).
 
-- Endpoints with rate limiting
-- Endpoints that can't handle concurrent load
-- Tests with dependencies on each other
-- Debugging test execution issues
-- Limited endpoint resources
-- Stateful testing scenarios
-
-⚠️ **Considerations:**
-
-- Slower overall execution time
-- Less efficient resource utilization
-- Longer wait times for results
+**Considerations:** slower overall, with longer waits for results.
 
 ### Configuration
 
@@ -244,46 +225,8 @@ Example with 20 tests, 5s average test time:
 
 | Mode                 | Execution Time | Resource Usage |
 | -------------------- | -------------- | -------------- |
-| Parallel (5 workers) | ~20-25 seconds | High           |
+| Parallel (concurrency 5) | ~20-25 seconds | High       |
 | Sequential           | ~100 seconds   | Low            |
-
----
-
-## Utilities
-
-### Get Current Mode
-
-<CodeBlock language="python" filename="get_mode.py" isTerminal={false}>
-{`from rhesis.backend.tasks.execution.modes import get_execution_mode
-
-mode = get_execution_mode(test_config)
-# Returns: ExecutionMode.PARALLEL or ExecutionMode.SEQUENTIAL`}
-</CodeBlock>
-
-### Get Mode Description
-
-<CodeBlock language="python" filename="get_description.py" isTerminal={false}>
-{`from rhesis.backend.tasks.execution.modes import get_mode_description
-
-description = get_mode_description(ExecutionMode.PARALLEL)
-# Returns: "Tests are executed simultaneously using multiple workers..."`}
-</CodeBlock>
-
-### Get Recommendations
-
-<CodeBlock language="python" filename="get_recommendations.py" isTerminal={false}>
-{`from rhesis.backend.tasks.execution.modes import get_mode_recommendations
-
-recommendations = get_mode_recommendations()
-# Returns: {
-#   ExecutionMode.SEQUENTIAL: {
-#     "use_when": [...],
-#     "pros": [...],
-#     "cons": [...]
-#   },
-#   ...
-# }`}
-</CodeBlock>
 
 ---
 

--- a/docs/content/contribute/worker/gke-troubleshooting.mdx
+++ b/docs/content/contribute/worker/gke-troubleshooting.mdx
@@ -38,162 +38,11 @@ The worker includes several debugging endpoints:
 
 ## Worker Registration Checking
 
-### Check Registered Workers with Python Script
+To verify workers are registered with the broker from inside a pod, run the `check_workers.py`
+script from [Troubleshooting](/contribute/worker/troubleshooting#worker-registration-and-status-checking):
 
-Create a Python script to check registered Celery workers and Redis connectivity:
-
-<CodeBlock language="python" isTerminal={false}>
-{`#!/usr/bin/env python3
-"""
-Script to check registered Celery workers
-"""
-import os
-import sys
-import json
-from datetime import datetime
-
-# Add the backend source to Python path
-sys.path.insert(0, 'apps/backend/src')
-
-try:
-    from celery import Celery
-    from rhesis.backend.worker import app as celery_app
-    import redis
-    from urllib.parse import urlparse
-except ImportError as e:
-    print(f"❌ Import error: {e}")
-    print("Make sure you're in the project root and have the required packages installed")
-    sys.exit(1)
-
-def parse_redis_url(url):
-    """Parse Redis URL and return connection parameters"""
-    parsed = urlparse(url)
-    use_ssl = parsed.scheme == 'rediss'
-
-    return {
-        'host': parsed.hostname,
-        'port': parsed.port or (6379 if not use_ssl else 6380),
-        'password': parsed.password,
-        'db': int(parsed.path.lstrip('/')) if parsed.path else 0,
-        'ssl': use_ssl,
-        'ssl_cert_reqs': None if use_ssl else None,
-        'decode_responses': True
-    }
-
-def check_celery_workers():
-    """Check Celery workers using the app's inspect functionality"""
-    print("\n" + "="*50)
-    print("🔍 CHECKING CELERY WORKERS")
-    print("="*50)
-
-    try:
-        inspect = celery_app.control.inspect()
-
-        # Check active workers
-        print("\n📋 Active Workers:")
-        active = inspect.active()
-        if active:
-            for worker_name, tasks in active.items():
-                print(f"  ✅ {worker_name}: {len(tasks)} active tasks")
-        else:
-            print("  ❌ No active workers found")
-
-        # Check registered workers
-        print("\n📋 Registered Workers:")
-        registered = inspect.registered()
-        if registered:
-            for worker_name, tasks in registered.items():
-                print(f"  ✅ {worker_name}: {len(tasks)} registered tasks")
-        else:
-            print("  ❌ No registered workers found")
-
-        # Check worker stats
-        print("\n📊 Worker Statistics:")
-        stats = inspect.stats()
-        if stats:
-            for worker_name, worker_stats in stats.items():
-                print(f"  📈 {worker_name}:")
-                print(f"    - Pool: {worker_stats.get('pool', {}).get('max-concurrency', 'unknown')} max concurrency")
-                print(f"    - Total tasks: {worker_stats.get('total', 'unknown')}")
-        else:
-            print("  ❌ No worker statistics available")
-
-        return True
-
-    except Exception as e:
-        print(f"❌ Error checking Celery workers: {e}")
-        return False
-
-def main():
-    print("🚀 CELERY WORKER CHECKER")
-    print("=" * 50)
-    print(f"⏰ Timestamp: {datetime.now().isoformat()}")
-
-    broker_url = os.getenv('BROKER_URL')
-    if not broker_url:
-        print("\n❌ BROKER_URL not found in environment")
-        return
-
-    print(f"🔗 Broker URL: {broker_url.split('@')[0]}@***")
-
-    # Check Celery workers
-    workers_found = check_celery_workers()
-
-    print("\n" + "="*50)
-    if workers_found:
-        print("✅ WORKER CHECK COMPLETED - Workers found")
-    else:
-        print("⚠️  WORKER CHECK COMPLETED - No workers found")
-    print("="*50)
-
-if __name__ == "__main__":
-    main()`}
-</CodeBlock>
-
-**Usage:**
 <CodeBlock language="bash" isTerminal={true}>
-{`# Save as check_workers.py in project root
-chmod +x check_workers.py
-python check_workers.py`}
-</CodeBlock>
-
-**Expected Output (with workers running):**
-<CodeBlock language="text" isTerminal={false}>
-{`🚀 CELERY WORKER CHECKER
-==================================================
-⏰ Timestamp: 2025-06-14T10:57:41.278363
-🔗 Broker URL: rediss://:***@***
-
-==================================================
-🔍 CHECKING CELERY WORKERS
-==================================================
-
-📋 Active Workers:
-  ✅ celery@rhesis-worker-6d9bcd9c6f-abc123: 0 active tasks
-
-📋 Registered Workers:
-  ✅ celery@rhesis-worker-6d9bcd9c6f-abc123: 12 registered tasks
-
-📊 Worker Statistics:
-  📈 celery@rhesis-worker-6d9bcd9c6f-abc123:
-    - Pool: 8 max concurrency
-    - Total tasks: 0
-
-==================================================
-✅ WORKER CHECK COMPLETED - Workers found
-==================================================`}
-</CodeBlock>
-
-**Expected Output (no workers):**
-<CodeBlock language="text" isTerminal={false}>
-{`📋 Active Workers:
-  ❌ No active workers found
-
-📋 Registered Workers:
-  ❌ No registered workers found
-
-📊 Worker Statistics:
-  ❌ No worker statistics available`}
+{`kubectl exec -it <pod-name> -n <namespace> -- python check_workers.py`}
 </CodeBlock>
 
 ### Cluster Management Commands
@@ -321,13 +170,12 @@ rhesis-worker-586659994f-lldfn   1/2     Running   167        13h`}
 }`}
 </CodeBlock>
 
-**Note:** As of the latest update, the main `/health` endpoint uses a **lightweight check** that doesn't ping workers. If you're still seeing timeouts:
+The `/health` endpoint runs a lightweight check that does not ping workers, so timeouts there
+usually point to Redis rather than worker startup.
 
 **Solutions:**
 - Check Redis connectivity specifically: `curl localhost:8080/debug/redis`
-- Use detailed health check to test worker ping: `curl localhost:8080/debug/detailed`
-- The `/health` endpoint should now be much faster since it doesn't wait for worker responses
-- If `/health` is still slow, it's likely a Redis connection issue, not worker startup
+- Use the detailed health check to test worker ping: `curl localhost:8080/debug/detailed`
 
 #### C. Environment Configuration
 <CodeBlock language="bash" isTerminal={true}>
@@ -564,5 +412,3 @@ When reporting issues, include:
    ```bash
    kubectl get deployment rhesis-worker -n <namespace> -o yaml
    ```
-
-This comprehensive information will help quickly identify and resolve issues.

--- a/docs/content/contribute/worker/logging.mdx
+++ b/docs/content/contribute/worker/logging.mdx
@@ -331,149 +331,15 @@ kubectl logs <pod-name> -c worker -n <namespace> --since=10m | grep -i "connecti
 kubectl logs <pod-name> -c worker -n <namespace> --since=1h | grep "GET /health" | grep -c "200 OK"`}
 </CodeBlock>
 
-#### Log-based Health Check
-<CodeBlock language="bash" isTerminal={true}>
-{`#!/bin/bash
-# Simple health check based on logs
-NAMESPACE="rhesis-worker-dev"
-POD=$(kubectl get pods -n $NAMESPACE -l app=rhesis-worker -o jsonpath='{.items[0].metadata.name}')
-
-# Check for recent errors
-ERROR_COUNT=$(kubectl logs $POD -c worker -n $NAMESPACE --tail=50 | grep -c ERROR)
-if [ $ERROR_COUNT -gt 5 ]; then
-    echo "WARNING: $ERROR_COUNT errors found in recent logs"
-fi
-
-# Check for Redis connectivity
-REDIS_ERRORS=$(kubectl logs $POD -c worker -n $NAMESPACE --since=5m | grep -c "Redis\|connection")
-if [ $REDIS_ERRORS -gt 0 ]; then
-    echo "WARNING: Redis connection issues detected"
-fi`}
-</CodeBlock>
-
 ## Debugging with Logs
 
-### Step-by-Step Debugging Process
-
-1. **Identify the Problem**
-
-<CodeBlock language="bash" isTerminal={true}>
-{`# Check pod status
-kubectl get pods -n <namespace>
-
-# Look for restart indicators
-kubectl describe pod <pod-name> -n <namespace>`}
-</CodeBlock>
-
-2. **Get Recent Logs**
+Correlate logs with the worker's health endpoints when diagnosing a problem: `/debug` shows system
+status including recent errors, and `/debug/redis` shows Redis connectivity details.
 
 <CodeBlock language="bash" isTerminal={true}>
-{`# Get current logs
-kubectl logs <pod-name> -c worker -n <namespace> --tail=100
-
-# Get crash logs if restarted
-kubectl logs <pod-name> -c worker -n <namespace> --previous`}
+{`kubectl exec -it <pod-name> -n <namespace> -- curl localhost:8080/debug | jq`}
 </CodeBlock>
 
-3. **Search for Specific Issues**
-
-<CodeBlock language="bash" isTerminal={true}>
-{`# Connection problems
-kubectl logs <pod-name> -c worker -n <namespace> | grep -i "connection\|redis\|timeout"
-
-# Task problems
-kubectl logs <pod-name> -c worker -n <namespace> | grep -i "task\|error\|failed"`}
-</CodeBlock>
-
-4. **Correlate with Health Endpoints**
-
-<CodeBlock language="bash" isTerminal={true}>
-{`# Check current system state
-kubectl exec -it <pod-name> -n <namespace> -- curl localhost:8080/debug | jq`}
-</CodeBlock>
-
-### Common Debugging Scenarios
-
-#### Scenario 1: Pod Won't Start
-
-<CodeBlock language="bash" isTerminal={true}>
-{`# Check startup logs
-kubectl logs <pod-name> -c worker -n <namespace>
-
-# Look for import errors, connection failures, configuration issues
-kubectl logs <pod-name> -c worker -n <namespace> | grep -E "(❌|ERROR|Failed)"`}
-</CodeBlock>
-
-#### Scenario 2: Health Checks Failing
-
-<CodeBlock language="bash" isTerminal={true}>
-{`# Check health endpoint logs
-kubectl logs <pod-name> -c worker -n <namespace> | grep -E "(GET /health|500|timeout)"
-
-# Test health endpoint directly
-kubectl exec -it <pod-name> -n <namespace> -- curl -w "%{time_total}" localhost:8080/health`}
-</CodeBlock>
-
-#### Scenario 3: Tasks Not Processing
-
-<CodeBlock language="bash" isTerminal={true}>
-{`# Check for task reception
-kubectl logs <pod-name> -c worker -n <namespace> | grep "Received task"
-
-# Check for task failures
-kubectl logs <pod-name> -c worker -n <namespace> | grep -E "(failed|exception|error)"
-
-# Check worker status
-kubectl exec -it <pod-name> -n <namespace> -- curl localhost:8080/debug | jq '.celery_status'`}
-</CodeBlock>
-
-## Best Practices
-
-### 1. Log Retention
-- Keep logs for at least 7 days for troubleshooting
-- Archive important logs before pod restarts
-- Use log aggregation systems for production
-
-### 2. Log Levels
-- Use `INFO` for production (balance of detail vs. noise)
-- Use `DEBUG` for development and troubleshooting
-- Use `ERROR` only for actual errors that need attention
-
-### 3. Structured Logging
-- Include relevant context (organization_id, user_id, task_id)
-- Use consistent log formats across tasks
-- Include timing information for performance monitoring
-
-### 4. Log Monitoring
-- Set up alerts for error rate increases
-- Monitor health check failure patterns
-- Track connection timeout frequencies
-
-### 5. Performance Considerations
-- Avoid excessive logging in tight loops
-- Use appropriate log levels to control verbosity
-- Consider log sampling for high-volume operations
-
-## Integration with Other Tools
-
-### Health Endpoints
-The logging system integrates with the health endpoints:
-- `/debug`: Shows system status including recent errors
-- `/debug/redis`: Shows Redis connectivity with error details
-- All endpoints log their usage for monitoring
-
-### Monitoring Systems
-Logs can be integrated with:
-- **Prometheus**: Metric extraction from log patterns
-- **Grafana**: Log visualization and dashboards
-- **ELK Stack**: Centralized log aggregation and search
-- **Google Cloud Logging**: Native GKE log collection
-
-### Alert Integration
-Example alert conditions based on logs:
-- Error rate > 10% over 5 minutes
-- Health check failure rate > 20% over 2 minutes
-- No successful task processing for 10 minutes
-- Redis connection timeouts > 5 in 5 minutes
-
-This comprehensive logging system provides visibility into all aspects of worker operation, from startup through task processing to health monitoring.
+For pod-level debugging scenarios (won't start, health checks failing, tasks not processing), see
+[GKE Troubleshooting](/contribute/worker/gke-troubleshooting) and
+[Troubleshooting](/contribute/worker/troubleshooting).

--- a/docs/content/contribute/worker/multi-worker-rpc.mdx
+++ b/docs/content/contribute/worker/multi-worker-rpc.mdx
@@ -249,19 +249,3 @@ To verify multi-worker routing:
 6. Backend worker forwards request to SDK via WebSocket
 7. SDK result is published to response channel
 8. Celery worker receives result and returns it
-
-## Benefits of Direct Routing
-
-**Compared to broadcast-based approaches:**
-
-- **Efficiency**: Only the relevant worker receives requests (no wasted processing)
-- **Fail-fast**: Immediate error if SDK is disconnected (no timeout waiting)
-- **No race conditions**: Single source of truth for which worker has the connection
-- **Scalability**: O(1) routing lookup regardless of number of workers
-- **Simplicity**: No complex coordination logic or connection location checking
-
-**Reliability:**
-- Heartbeat keeps routing fresh (30s TTL, 10s refresh)
-- Stale entries expire automatically
-- BLPOP queuing ensures no dropped requests
-- Worker-specific queues prevent message interference

--- a/docs/content/contribute/worker/test-execution.mdx
+++ b/docs/content/contribute/worker/test-execution.mdx
@@ -2,13 +2,14 @@ import { CodeBlock } from '@/components/CodeBlock'
 
 # Test Execution System
 
-## Overview
-
-The Rhesis test execution system provides a flexible and extensible architecture for running tests against endpoints. It supports multiple test types and execution modes, enabling you to test everything from simple API responses to complex multi-turn conversations.
+Tests run against endpoints through executors selected by test type, coordinated by an async batch
+engine. This page covers the executor architecture; for single-turn vs. multi-turn tests see
+[Test Types](/contribute/worker/test-types), and for parallel vs. sequential runs see
+[Execution Modes](/contribute/worker/execution-modes).
 
 ## Architecture
 
-The system uses the **Strategy Pattern** to route tests to appropriate executors based on their type:
+A factory routes each test to an executor based on its type:
 
 <CodeBlock language="text" isTerminal={false}>
 {`Test → Factory → Executor → Results
@@ -182,55 +183,15 @@ class TestType(str, Enum):
     IMAGE = "Image"  # New type`}
 </CodeBlock>
 
-## Design Principles
+## Async Batch Engine
 
-### Modularity
-
-Each executor is self-contained (~150-200 lines) and handles one test type.
-
-### Loose Coupling
-
-- Executors don't depend on each other
-- Multi-turn executor preserves Penelope trace as-is
-- No tight coupling to external frameworks
-
-### Backward Compatibility
-
-- Public API (`execute_test()`) unchanged
-- Helper functions re-exported for existing code
-- All existing tests work without modifications
-
-### Extensibility (Open/Closed Principle)
-
-- Add new test types without modifying existing code
-- Factory pattern enables clean routing
-- Easy to test executors independently
-
-## Performance Considerations
-
-### Execution Time Tracking
-
-All executors track execution time in milliseconds for monitoring and optimization.
-
-### Caching
-
-The system checks for existing results to avoid duplicate test execution.
-
-### Parallel Processing
-
-Use parallel execution mode for independent tests to maximize throughput.
-
-### Parallel Engine Notes (v0.6.12+)
-
-The parallel path now uses an internal async batch runner instead of Celery chord fan-out:
+The parallel path uses an internal async batch runner rather than Celery chord fan-out:
 
 - `execute_test_configuration` creates a single worker task per test run
 - `execute_tests_as_batch` prefetches execution context and runs `run_batch(...)`
-- `run_batch` uses `asyncio` tasks with semaphore-limited concurrency
+- `run_batch` runs each test as an `asyncio` task with semaphore-limited concurrency
 - cancellation is cooperative via Celery revoke checks and task cancellation
-- default per-test timeout is `1800` seconds (`30` minutes)
-
-This model reduces worker orchestration overhead and improves reliability for large runs.
+- per-test timeout defaults to `1800` seconds (30 minutes); batch concurrency defaults to `10`
 
 ## Module Location
 

--- a/docs/content/contribute/worker/test-types.mdx
+++ b/docs/content/contribute/worker/test-types.mdx
@@ -2,9 +2,8 @@ import { CodeBlock } from '@/components/CodeBlock'
 
 # Test Types
 
-## Overview
-
-Rhesis supports multiple test types, each designed for different testing scenarios. The test type determines how the test is executed and evaluated.
+The test type determines how a test is executed and evaluated. Rhesis supports single-turn and
+multi-turn tests.
 
 ## Single-Turn Tests
 
@@ -175,28 +174,6 @@ The complete Penelope trace is stored, including:
 
 ---
 
-## Future Test Types
-
-The system is designed to easily support additional test types:
-
-### Image/Multimodal Tests
-
-Testing vision-capable models with images, diagrams, or mixed media.
-
-### Adversarial Tests
-
-Security and robustness testing with jailbreak attempts and edge cases.
-
-### Synthetic Tests
-
-Automatically generated test cases for broader coverage.
-
-### Performance Tests
-
-Load testing and stress testing endpoints under various conditions.
-
----
-
 ## Test Type Detection
 
 The system automatically routes tests to the appropriate executor:
@@ -217,26 +194,6 @@ if is_multi_turn_test(test):
 if test_type == TestType.MULTI_TURN:
     # ...`}
 </CodeBlock>
-
----
-
-## Choosing a Test Type
-
-### Use Single-Turn When:
-
-- ✅ Testing specific API responses
-- ✅ Simple input-output validation needed
-- ✅ Running regression tests at scale
-- ✅ Performance benchmarking required
-- ✅ Testing isolated functionality
-
-### Use Multi-Turn When:
-
-- ✅ Testing conversational interfaces
-- ✅ Validating complex user journeys
-- ✅ Checking context retention
-- ✅ Testing goal-oriented behavior
-- ✅ Evaluating dialogue quality
 
 ---
 

--- a/docs/content/contribute/worker/troubleshooting.mdx
+++ b/docs/content/contribute/worker/troubleshooting.mdx
@@ -4,7 +4,7 @@ import { CodeBlock } from '@/components/CodeBlock'
 
 This document covers common issues you may encounter with the Rhesis worker system and how to resolve them.
 
-Test runs use the **async batch engine** (one Celery task per run with internal `asyncio` fan-out). For how that works and how to debug it, see [Test Execution](test-execution.md), [Execution Modes](execution-modes.md), and [Background Tasks](background-tasks.md).
+Test runs use the **async batch engine** (one Celery task per run with internal `asyncio` fan-out). For how that works and how to debug it, see [Test Execution](/contribute/worker/test-execution), [Execution Modes](/contribute/worker/execution-modes), and [Background Tasks](/contribute/worker/background-tasks).
 
 ## Dealing with Stuck Tasks
 
@@ -32,7 +32,7 @@ celery -A rhesis.backend.worker control revoke <task_id>`}
 {`celery -A rhesis.backend.worker purge -f`}
 </CodeBlock>
 
-Celery configuration for brokers, retries, and execution task time limits lives in `apps/backend/src/rhesis/backend/celery/config.py`. For test-run-specific behavior (cancellation watchdog, batch concurrency), see [Test Execution](test-execution.md).
+Celery configuration for brokers, retries, and execution task time limits lives in `apps/backend/src/rhesis/backend/celery/config.py`. For test-run-specific behavior (cancellation watchdog, batch concurrency), see [Test Execution](/contribute/worker/test-execution).
 
 ## Tenant Context Issues
 
@@ -75,7 +75,7 @@ organization_id = organization_id or request_org_id`}
 3. For TLS connections (`rediss://`), ensure `ssl_cert_reqs=CERT_NONE` parameter is included
 4. Test Redis connectivity: `redis-cli -u "$BROKER_URL" ping`
 5. Check firewall rules if running in a cloud environment
-6. For GKE deployments, see the [GKE Troubleshooting Guide](gke-troubleshooting.md)
+6. For GKE deployments, see the [GKE Troubleshooting Guide](/contribute/worker/gke-troubleshooting)
 
 ### Error: Missing API Keys for Model Evaluation
 
@@ -277,6 +277,6 @@ Include broker reachability and worker liveness (for example HTTP `/health` or `
 
 ## Related Documentation
 
-- **[GKE Troubleshooting Guide](gke-troubleshooting.md)**: Debugging workers in Google Kubernetes Engine
-- [Background Tasks and Processing](./background-tasks.md): General task management information
-- [Architecture and Dependencies](architecture.md): System integration details
+- [GKE Troubleshooting Guide](/contribute/worker/gke-troubleshooting): Debugging workers in Google Kubernetes Engine
+- [Background Tasks](/contribute/worker/background-tasks): Celery configuration and task patterns
+- [Architecture](/contribute/worker/architecture): System integration details

--- a/docs/decluttering-rules.md
+++ b/docs/decluttering-rules.md
@@ -185,7 +185,7 @@ Check off pages/sections as they are done.
       Test Run Status, OData Query Guide, Architect Chat System, Environment Configuration,
       Security Features, Security Improvements, Database Field Encryption,
       Encryption Troubleshooting, Development Workflow, Deployment
-- [ ] Worker — Overview, Architecture, Multi-Worker RPC, Background Tasks,
+- [x] Worker — Overview, Architecture, Multi-Worker RPC, Background Tasks,
       Architect Background Tasks, Trace Ingestion Pipeline, Test Execution, Test Types,
       Execution Modes, Logging, Troubleshooting, GKE Troubleshooting
 - [x] SDK — Getting Started, Architect Agent, Integrations


### PR DESCRIPTION
## Purpose

Declutter the **Worker** subsection of the Contribute docs (`docs/content/contribute/worker/`,
12 pages) per `docs/decluttering-rules.md`. The pages had accumulated hype, cross-page
duplication, and several claims that no longer matched the code.

Net: **~3,526 → ~2,725 lines**, docs build passes, all internal links resolve.

## What Changed

### Deleted content (and why)

- **README "Topics Covered" + "Quick Start Guides" sections** — the Topics list restated the page
  contents; the three Quick Start blocks duplicated the troubleshooting/GKE/execution pages they
  linked to (rules 5–7). README is now a short hub of annotated links.
- **`background-tasks.mdx`: duplicate config block and a dangling trailing "Task Monitoring"
  heading** — the Celery config was shown twice and the file ended with an empty duplicate section.
- **`check_workers.py` script duplicated across `troubleshooting.mdx` and `gke-troubleshooting.mdx`**
  (~100 lines each) — kept one canonical copy in troubleshooting; GKE now links to it (rule 6).
- **`logging.mdx`: "Debugging with Logs" scenarios, "Best Practices", "Integration with Other
  Tools"** — the debugging scenarios duplicated `gke-troubleshooting`; Best Practices and the
  Prometheus/Grafana/ELK list were generic, non-Rhesis boilerplate (rules 6, 9, 17).
- **`test-types.mdx`: "Future Test Types" roadmap and the ✅-emoji "Choosing a Test Type" section**
  — speculative content and a duplicate of the per-type Use Cases (rules 4, 5, 16).
- **`test-execution.mdx`: "Design Principles" (SOLID lecture) and thin "Performance
  Considerations"**, plus a `(v0.6.12+)` version tag (rules 9, 16).
- **`multi-worker-rpc.mdx`: trailing duplicate "Benefits of Direct Routing" section** (rule 5).
- Decorative emojis in prose/headings, hype words, and "As of the latest update" phrasing across
  the section. (Emoji in log-output examples were kept — they reproduce what `start.sh` actually
  prints.)

### Factual fixes (verified against `apps/backend/` + `apps/worker/`)

- Celery config lives in `celery/core.py` + `celery/config.py`, **not** `worker.py`.
- Corrected the worker start command: two thread-pool workers (main on `celery,execution,telemetry`;
  architect on `architect`), no `--max-tasks-per-child` flag.
- `execution-modes`: parallel mode is a single task with an async batch engine, not "multiple
  Celery workers".
- Converted all broken `.md`-suffixed links to the absolute extensionless convention.

## Additional Context

- Part of the ongoing docs decluttering tracked in `docs/decluttering-rules.md` (Worker section
  checked off).
- Companion PR: **backend** subsection (`docs/declutter-backend`) — disjoint files, independent.

## Testing

- `cd docs/src && npm run build` — compiles all pages, no MDX/link errors.
- Verified no remaining `.md` links, decorative emojis, or banned words; all internal
  `/contribute/worker/...` links resolve to existing files.
