### PR TITLE
Show Azure AI Foundry name in model provider picker

### DIFF
--- a/apps/frontend/src/app/(protected)/models/components/ConnectionForm.tsx
+++ b/apps/frontend/src/app/(protected)/models/components/ConnectionForm.tsx
@@ -43,6 +43,7 @@ import {
   LOCAL_PROVIDERS,
   PROVIDERS_WITH_OPTIONAL_API_KEY,
   providerSupportsModelListing,
+  getProviderDisplayName,
 } from '@/config/model-providers';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
@@ -488,7 +489,7 @@ export const ConnectionForm = forwardRef<
         try {
           const modelData: ModelCreate = {
             name,
-            description: `${isCustomProvider ? providerName : provider.description} Connection`,
+            description: `${isCustomProvider ? providerName : getProviderDisplayName(provider)} Connection`,
             icon: provider.type_value,
             model_name: modelName,
             model_type: modelType,

--- a/apps/frontend/src/app/(protected)/models/components/ProviderSelectionPanel.tsx
+++ b/apps/frontend/src/app/(protected)/models/components/ProviderSelectionPanel.tsx
@@ -17,6 +17,7 @@ import {
   LOCAL_PROVIDERS,
   EMBEDDING_PROVIDERS,
   PROVIDER_ICONS,
+  getProviderDisplayName,
 } from '@/config/model-providers';
 
 interface ProviderItem {
@@ -74,7 +75,7 @@ function buildModelProviderItems(
 
     return {
       provider,
-      name: provider.description || provider.type_value,
+      name: getProviderDisplayName(provider),
       icon: PROVIDER_ICONS[provider.type_value] || (
         <SmartToyIcon sx={{ fontSize: theme => theme.iconSizes.large }} />
       ),

--- a/apps/frontend/src/config/model-providers.tsx
+++ b/apps/frontend/src/config/model-providers.tsx
@@ -153,6 +153,27 @@ export const PROVIDER_ICONS: Record<string, React.ReactNode> = {
   azure: <CloudIcon sx={{ fontSize: theme => theme.iconSizes.large }} />,
 };
 
+// User-facing display names keyed by provider type_value. Overrides the
+// backend-provided description where the stored text uses outdated branding
+// (e.g. "Azure AI Studio" was renamed by Microsoft to "Azure AI Foundry").
+export const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
+  azure_ai: 'Azure AI Foundry',
+  azure: 'Azure OpenAI',
+};
+
+// Resolve the label to show for a provider: display-name override first, then
+// the backend description, then the raw type_value as a last resort.
+export function getProviderDisplayName(provider: {
+  type_value: string;
+  description?: string;
+}): string {
+  return (
+    PROVIDER_DISPLAY_NAMES[provider.type_value] ||
+    provider.description ||
+    provider.type_value
+  );
+}
+
 // Provider information interface
 export interface ProviderInfo {
   id: string;


### PR DESCRIPTION
## Purpose

Microsoft renamed **Azure AI Studio → Azure AI Foundry**, but the model provider picker still displayed the outdated brand name. The label shown to users is derived from the backend `type_lookup` description (`provider.description`), which is seeded as `"Azure AI Studio model provider"`. This is a frontend-only fix so the UI presents the current, correct branding without a backend/data migration.

## What Changed

- Add `PROVIDER_DISPLAY_NAMES` map and a `getProviderDisplayName()` helper in `src/config/model-providers.tsx`:
  - `azure_ai` → **Azure AI Foundry**
  - `azure` → **Azure OpenAI**
  - Falls back to the backend description, then `type_value`, so all other providers are unchanged.
- Use the helper in `ProviderSelectionPanel` (the provider picker label) and in `ConnectionForm`'s auto-generated connection description.

## Additional Context

- Refs #1287 — Azure OpenAI and Azure AI Foundry are already wired end-to-end (SDK, backend, migrations, frontend); this cleans up the last cosmetic issue, the outdated "Azure AI Studio" brand name.
- Scope intentionally limited to the frontend name only. The backend `initial_data.json` description and a migration to refresh existing orgs' descriptions are left as a separate follow-up.

## Testing

- `npm run format`, `npx tsc --noEmit`, `npm run lint` — no new errors from the changed files (pre-existing `.next/` `/mcp` type staleness and `ee/frontend` warnings are unrelated).
- Manual: open the model connection drawer / provider picker and confirm the Azure providers show "Azure AI Foundry" and "Azure OpenAI".