### PR TITLE
Harden SSO admin authz defense-in-depth, add HTTP-level tests

### DIFF
--- a/ee/backend/src/rhesis/backend/ee/sso/router.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/router.py
@@ -384,12 +384,25 @@ class SSOTestResponse(BaseModel):
     message: str
 
 
-async def _require_org_admin(request: Request, org_id: str):
-    """Verify the current user is an admin of the specified org.
+async def _require_org_admin(request: Request, org_id: str, db: Session):
+    """Verify the current user may manage SSO for the specified org.
 
-    Supports both session cookies and Bearer token authentication
-    to work with the frontend API client.
+    Supports both session cookies and Bearer token authentication to work with
+    the frontend API client. Two distinct checks, both required:
+
+    1. **Same-org guard**: the caller's own ``organization_id`` must match the
+       ``org_id`` path parameter. The org-scoped ``sso:manage`` capability
+       (below) is evaluated against the caller's *own* org context — it says
+       nothing about the arbitrary ``org_id`` in this URL — so without this
+       guard an owner of org A could read/overwrite org B's SSO config
+       (including its ``client_secret``) simply by changing the path.
+    2. **Role check** via the RBAC PDP (``Permission.SSO.MANAGE``, owner-only
+       even in EE): defense-in-depth alongside the ``@capability(...)``-driven
+       authz backstop (``apply_authz_backstop`` in ``main.py``) already wired
+       on these routes, kept here so this function is correct standalone.
     """
+    from rhesis.backend.app.auth.principal import resolve_principal_from_request
+    from rhesis.backend.app.auth.rbac import authorize
     from rhesis.backend.app.auth.user_utils import (
         bearer_scheme,
         get_authenticated_user_with_context,
@@ -411,6 +424,13 @@ async def _require_org_admin(request: Request, org_id: str):
             detail="Not authorized to manage this organization's SSO",
         )
 
+    principal = resolve_principal_from_request(user, request)
+    if not authorize(principal, Permission.SSO.MANAGE, project_id=None, db=db):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to manage this organization's SSO",
+        )
+
     return user
 
 
@@ -423,7 +443,7 @@ async def get_sso_config(
 ):
     """Get SSO configuration for an organization (client_secret masked)."""
     # Authorization side-effect; the returned user isn't used in the response body.
-    await _require_org_admin(request, org_id)
+    await _require_org_admin(request, org_id, db)
 
     if not check_sso_available():
         raise HTTPException(
@@ -455,7 +475,7 @@ async def update_sso_config(
     db: Session = Depends(get_db_session),
 ):
     """Set or update SSO configuration for an organization."""
-    user = await _require_org_admin(request, org_id)
+    user = await _require_org_admin(request, org_id, db)
 
     if not check_sso_available():
         raise HTTPException(
@@ -577,7 +597,7 @@ async def delete_sso_config(
     Unlike get/update, delete intentionally works even when SSO encryption
     is unavailable so that admins can always clean up broken configurations.
     """
-    user = await _require_org_admin(request, org_id)
+    user = await _require_org_admin(request, org_id, db)
 
     org = _get_org_or_404(db, org_id)
     org.sso_config = None
@@ -602,7 +622,7 @@ async def test_sso_connection(
 ):
     """Test OIDC discovery for an org's SSO configuration."""
     # Authorization side-effect; the returned user isn't used in the response body.
-    await _require_org_admin(request, org_id)
+    await _require_org_admin(request, org_id, db)
 
     if not check_sso_available():
         return SSOTestResponse(success=False, message="SSO is not available")

--- a/tests/backend/ee/sso/test_sso_admin_authz_http.py
+++ b/tests/backend/ee/sso/test_sso_admin_authz_http.py
@@ -1,0 +1,167 @@
+"""End-to-end authz enforcement for the SSO admin endpoints over HTTP.
+
+GitHub issue #1748: the SSO admin endpoints (``GET/PUT/DELETE
+/organizations/{org_id}/sso``, ``POST .../sso/test``) must be reachable only
+by an org admin/owner, not any org member — the config includes the IdP
+``client_secret``. Two things gate these routes and both are exercised here:
+
+1. The ``@capability(Permission.SSO.MANAGE)``-driven authz backstop
+   (``apply_authz_backstop`` in ``main.py``), which denies non-owners before
+   the route handler body runs at all.
+2. ``_require_org_admin`` in ``ee/backend/.../sso/router.py``, which adds a
+   same-org guard (the backstop's capability check is evaluated against the
+   caller's *own* org, not the ``org_id`` path parameter — without this guard
+   an owner of org A could reach org B's SSO config) plus a redundant PDP
+   role check so the function is correct standalone.
+
+Run with:
+    cd apps/backend
+    uv run pytest ../../tests/backend/ee/sso/test_sso_admin_authz_http.py -v
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+import pytest
+
+from tests.backend.ee.rbac._rbac_helpers import _assign_org_role, _ee_provider_active
+from tests.backend.fixtures.test_setup import create_test_organization_and_user
+
+VALID_SSO_BODY = {
+    "issuer_url": "https://idp.example.com",
+    "client_id": "test-client",
+    "client_secret": "test-secret",
+}
+
+
+def _ee_active():
+    return _ee_provider_active()
+
+
+def _context(test_db, role_name: str):
+    """Create a fresh org + user + token, assigned the given built-in org role."""
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    suffix = uuid.uuid4().hex[:8]
+    org, user, token = create_test_organization_and_user(
+        test_db,
+        f"SSO AuthZ {role_name} {ts}_{suffix}",
+        f"sso_authz_{role_name.lower()}_{suffix}@rhesis-test.com",
+        f"SSO AuthZ {role_name} User",
+    )
+    if role_name != "Owner":
+        org.owner_id = None
+        test_db.flush()
+        _assign_org_role(test_db, org.id, user.id, role_name)
+    test_db.commit()
+    return org, user, token
+
+
+def _auth(token) -> dict:
+    return {"Authorization": f"Bearer {token.token}"}
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+@pytest.mark.security
+class TestSsoAdminDeniedForNonOwners:
+    """A plain Member or non-Owner Admin must get 403 on every SSO admin route."""
+
+    @pytest.mark.parametrize("role_name", ["Member", "Admin", "Viewer"])
+    def test_get_sso_config_denied(self, client, test_db, role_name):
+        org, _user, token = _context(test_db, role_name)
+        with _ee_active():
+            resp = client.get(f"/organizations/{org.id}/sso", headers=_auth(token))
+        assert resp.status_code == 403, resp.text
+        assert resp.headers.get("X-Accepted-Permissions") == "sso:manage"
+
+    @pytest.mark.parametrize("role_name", ["Member", "Admin", "Viewer"])
+    def test_update_sso_config_denied(self, client, test_db, role_name):
+        org, _user, token = _context(test_db, role_name)
+        with _ee_active():
+            resp = client.put(
+                f"/organizations/{org.id}/sso",
+                json=VALID_SSO_BODY,
+                headers=_auth(token),
+            )
+        assert resp.status_code == 403, resp.text
+
+    @pytest.mark.parametrize("role_name", ["Member", "Admin", "Viewer"])
+    def test_delete_sso_config_denied(self, client, test_db, role_name):
+        org, _user, token = _context(test_db, role_name)
+        with _ee_active():
+            resp = client.delete(f"/organizations/{org.id}/sso", headers=_auth(token))
+        assert resp.status_code == 403, resp.text
+
+    @pytest.mark.parametrize("role_name", ["Member", "Admin", "Viewer"])
+    def test_test_connection_denied(self, client, test_db, role_name):
+        org, _user, token = _context(test_db, role_name)
+        with _ee_active():
+            resp = client.post(f"/organizations/{org.id}/sso/test", headers=_auth(token))
+        assert resp.status_code == 403, resp.text
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+@pytest.mark.security
+class TestSsoAdminAllowedForOwner:
+    """The org Owner is allowed through the authz gate on every SSO admin route."""
+
+    def test_get_sso_config_allowed(self, client, test_db):
+        org, _user, token = _context(test_db, "Owner")
+        with _ee_active():
+            resp = client.get(f"/organizations/{org.id}/sso", headers=_auth(token))
+        assert resp.status_code != 403, resp.text
+
+    def test_update_sso_config_allowed(self, client, test_db):
+        org, _user, token = _context(test_db, "Owner")
+        with _ee_active():
+            resp = client.put(
+                f"/organizations/{org.id}/sso",
+                json=VALID_SSO_BODY,
+                headers=_auth(token),
+            )
+        assert resp.status_code != 403, resp.text
+
+    def test_delete_sso_config_allowed(self, client, test_db):
+        org, _user, token = _context(test_db, "Owner")
+        with _ee_active():
+            resp = client.delete(f"/organizations/{org.id}/sso", headers=_auth(token))
+        assert resp.status_code != 403, resp.text
+
+    def test_test_connection_allowed(self, client, test_db):
+        org, _user, token = _context(test_db, "Owner")
+        with _ee_active():
+            resp = client.post(f"/organizations/{org.id}/sso/test", headers=_auth(token))
+        assert resp.status_code != 403, resp.text
+
+
+@pytest.mark.ee
+@pytest.mark.integration
+@pytest.mark.security
+class TestSsoAdminCrossOrgDenied:
+    """An Owner of org A must not reach org B's SSO config via the path param.
+
+    The ``sso:manage`` capability check is evaluated against the caller's own
+    org context, not the ``org_id`` in the URL — only ``_require_org_admin``'s
+    same-org guard catches a mismatched path parameter.
+    """
+
+    def test_owner_cannot_read_other_orgs_sso_config(self, client, test_db):
+        _owner_org, _owner_user, owner_token = _context(test_db, "Owner")
+        other_org, _other_user, _other_token = _context(test_db, "Owner")
+        with _ee_active():
+            resp = client.get(f"/organizations/{other_org.id}/sso", headers=_auth(owner_token))
+        assert resp.status_code == 403, resp.text
+
+    def test_owner_cannot_update_other_orgs_sso_config(self, client, test_db):
+        _owner_org, _owner_user, owner_token = _context(test_db, "Owner")
+        other_org, _other_user, _other_token = _context(test_db, "Owner")
+        with _ee_active():
+            resp = client.put(
+                f"/organizations/{other_org.id}/sso",
+                json=VALID_SSO_BODY,
+                headers=_auth(owner_token),
+            )
+        assert resp.status_code == 403, resp.text

--- a/tests/backend/ee/sso/test_sso_admin_authz_http.py
+++ b/tests/backend/ee/sso/test_sso_admin_authz_http.py
@@ -165,3 +165,19 @@ class TestSsoAdminCrossOrgDenied:
                 headers=_auth(owner_token),
             )
         assert resp.status_code == 403, resp.text
+
+    def test_owner_cannot_delete_other_orgs_sso_config(self, client, test_db):
+        _owner_org, _owner_user, owner_token = _context(test_db, "Owner")
+        other_org, _other_user, _other_token = _context(test_db, "Owner")
+        with _ee_active():
+            resp = client.delete(f"/organizations/{other_org.id}/sso", headers=_auth(owner_token))
+        assert resp.status_code == 403, resp.text
+
+    def test_owner_cannot_test_connection_on_other_orgs_sso_config(self, client, test_db):
+        _owner_org, _owner_user, owner_token = _context(test_db, "Owner")
+        other_org, _other_user, _other_token = _context(test_db, "Owner")
+        with _ee_active():
+            resp = client.post(
+                f"/organizations/{other_org.id}/sso/test", headers=_auth(owner_token)
+            )
+        assert resp.status_code == 403, resp.text


### PR DESCRIPTION
## Purpose

Closes #1748. The issue reported that `_require_org_admin` in the SSO admin router only checked org membership (`user.organization_id == org_id`), not an actual admin role, so any org member could allegedly read/overwrite an org's SSO config including the `client_secret`.

Investigation found the underlying vulnerability was already closed by the RBAC authz backstop from PR #1917: every route carrying `@capability(Permission.SSO.MANAGE)` gets a `require_permission("sso:manage")` dependency injected ahead of the handler body, and `sso:manage` is owner-only (denied even for EE Admin). So a plain member already got 403 before `_require_org_admin`'s body ever ran. What remained legitimately open: the helper itself was still misleadingly named/implemented, and there was no HTTP-level test proving the 403 behavior.

## What Changed

- `_require_org_admin` now performs two explicit checks instead of one:
  - the existing same-org guard (still required — the `sso:manage` capability check is evaluated against the caller's own org, not the `org_id` path parameter, so this is the only thing stopping an owner of org A from reaching org B's SSO config)
  - an explicit RBAC PDP check (`authorize(..., Permission.SSO.MANAGE, ...)`), so the function is correct standalone rather than relying entirely on the backstop
- Added `tests/backend/ee/sso/test_sso_admin_authz_http.py`: HTTP-level integration tests asserting Member/Admin/Viewer get 403 on all four SSO admin routes, Owner is allowed through, and cross-org path-parameter access is denied.

## Additional Context

- Issue: #1748
- Related: #1736 (original SSO integration), #1917 (RBAC implementation that added the authz backstop)

## Testing

```
cd apps/backend
uv run pytest ../../tests/backend/ee/sso/ ../../tests/backend/ee/rbac/ ../../tests/backend/security/ -v
```
1523 passed, 3 skipped (pre-existing, unrelated skips).

`uvx ruff check` / `uvx ruff format --check` pass on both changed files.