### PR TITLE
Run no-await async routes on the sync threadpool

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -273,7 +273,7 @@ def _resolve_org_by_id_or_slug(db: Session, org: str):
 
 
 @router.get("/providers", response_model=ProvidersResponse)
-async def get_providers(
+def get_providers(
     request: Request,
     org: Optional[str] = None,
     db: Session = Depends(get_db_session),
@@ -324,7 +324,7 @@ async def get_providers(
 
 @router.get("/terms-status", response_model=TermsStatusResponse)
 @limiter.limit(AUTH_TERMS_STATUS_LIMIT)
-async def get_terms_status(
+def get_terms_status(
     request: Request,
     current_user: User = Depends(require_current_user_or_token_without_context),
 ):
@@ -345,7 +345,7 @@ async def get_terms_status(
 
 
 @router.post("/accept-terms")
-async def accept_terms(
+def accept_terms(
     db: Session = Depends(get_db_session),
     current_user: User = Depends(require_current_user_or_token_without_context),
 ):
@@ -746,7 +746,7 @@ async def verify_email(
 
 @router.post("/resend-verification")
 @limiter.limit(AUTH_RESEND_VERIFICATION_LIMIT)
-async def resend_verification(
+def resend_verification(
     request: Request,
     body: ResendVerificationRequest,
     db: Session = Depends(get_db_session),
@@ -787,7 +787,7 @@ async def resend_verification(
 
 @router.post("/forgot-password")
 @limiter.limit(AUTH_FORGOT_PASSWORD_LIMIT)
-async def forgot_password(
+def forgot_password(
     request: Request,
     body: ForgotPasswordRequest,
     db: Session = Depends(get_db_session),
@@ -898,7 +898,7 @@ _MAGIC_LINK_SUCCESS_RESPONSE = {
 
 @router.post("/magic-link")
 @limiter.limit(AUTH_MAGIC_LINK_LIMIT)
-async def request_magic_link(
+def request_magic_link(
     request: Request,
     body: MagicLinkRequest,
     db: Session = Depends(get_db_session),
@@ -1091,7 +1091,7 @@ def _refresh_invalid() -> HTTPException:
 
 
 @router.post("/refresh")
-async def refresh_tokens(
+def refresh_tokens(
     body: RefreshTokenRequest,
     request: Request,
     db: Session = Depends(get_db_session),
@@ -1222,7 +1222,7 @@ async def refresh_tokens(
 
 
 @router.get("/logout")
-async def logout(
+def logout(
     request: Request,
     post_logout: bool = False,
     session_token: str = None,
@@ -1325,7 +1325,7 @@ async def logout(
 
 
 @router.post("/verify")
-async def verify_auth(
+def verify_auth(
     request: Request,
     body: VerifyTokenRequest,
     secret_key: str = Depends(get_secret_key),

--- a/apps/backend/src/rhesis/backend/app/routers/connector.py
+++ b/apps/backend/src/rhesis/backend/app/routers/connector.py
@@ -291,7 +291,7 @@ async def trigger_test(
 
 
 @router.get("/status/{project_id}", response_model=ConnectionStatusResponse)
-async def get_status(
+def get_status(
     project_id: str,
     environment: str = "development",
     current_user: User = Depends(require_current_user_or_token),
@@ -320,7 +320,7 @@ async def get_status(
 
 
 @router.post("/trace", response_model=TraceResponse)
-async def receive_trace(
+def receive_trace(
     trace: ExecutionTrace,
     current_user: User = Depends(require_current_user_or_token),
 ):

--- a/apps/backend/src/rhesis/backend/app/routers/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/routers/endpoint.py
@@ -388,7 +388,7 @@ async def invoke_endpoint(
     response_model=ExploreEndpointResponse,
     dependencies=[Depends(validate_generation_model)],
 )
-async def explore_endpoint_route(
+def explore_endpoint_route(
     endpoint_id: uuid.UUID,
     request: ExploreEndpointRequest,
     db: Session = Depends(get_tenant_db_session),

--- a/apps/backend/src/rhesis/backend/app/routers/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/routers/explorer.py
@@ -823,7 +823,7 @@ async def generate_suggestions_endpoint(
 @router.post(
     "/{test_set_identifier}/generate_suggestion_outputs",
 )
-async def generate_suggestion_outputs_endpoint(
+def generate_suggestion_outputs_endpoint(
     test_set_identifier: str,
     body: GenerateSuggestionOutputsRequest,
     db: Session = Depends(get_tenant_db_session),
@@ -871,7 +871,7 @@ async def generate_suggestion_outputs_endpoint(
 @router.post(
     "/{test_set_identifier}/suggestion_pipeline",
 )
-async def suggestion_pipeline_endpoint(
+def suggestion_pipeline_endpoint(
     test_set_identifier: str,
     body: SuggestionPipelineRequest,
     db: Session = Depends(get_tenant_db_session),
@@ -931,7 +931,7 @@ async def suggestion_pipeline_endpoint(
 @router.post(
     "/{test_set_identifier}/evaluate_suggestions",
 )
-async def evaluate_suggestions_endpoint(
+def evaluate_suggestions_endpoint(
     test_set_identifier: str,
     body: EvaluateSuggestionsRequest,
     db: Session = Depends(get_tenant_db_session),

--- a/apps/backend/src/rhesis/backend/app/routers/file_import.py
+++ b/apps/backend/src/rhesis/backend/app/routers/file_import.py
@@ -115,7 +115,7 @@ async def analyze_file(
     "/{import_id}/parse",
     response_model=ParseResponse,
 )
-async def parse_file(
+def parse_file(
     import_id: str,
     request: ParseRequest,
     current_user: User = Depends(require_current_user_or_token),
@@ -153,7 +153,7 @@ async def parse_file(
     "/{import_id}/preview",
     response_model=PreviewPage,
 )
-async def preview_data(
+def preview_data(
     import_id: str,
     page: int = Query(1, ge=1, description="Page number (1-based)"),
     page_size: int = Query(50, ge=1, le=200, description="Rows per page"),
@@ -175,7 +175,7 @@ async def preview_data(
 
 
 @router.post("/{import_id}/confirm")
-async def confirm_import(
+def confirm_import(
     import_id: str,
     request: ConfirmRequest,
     db: Session = Depends(get_tenant_db_session),
@@ -230,7 +230,7 @@ async def confirm_import(
 
 
 @router.delete("/{import_id}")
-async def cancel_import(
+def cancel_import(
     import_id: str,
     current_user: User = Depends(require_current_user_or_token),
 ):
@@ -248,7 +248,7 @@ async def cancel_import(
     "/{import_id}/remap",
     response_model=RemapResponse,
 )
-async def remap_with_llm(
+def remap_with_llm(
     import_id: str,
     db: Session = Depends(get_tenant_db_session),
     current_user: User = Depends(require_current_user_or_token),

--- a/apps/backend/src/rhesis/backend/app/routers/garak.py
+++ b/apps/backend/src/rhesis/backend/app/routers/garak.py
@@ -138,7 +138,7 @@ async def list_probe_modules(
 
 
 @router.get("/probes/{module_name}", response_model=GarakProbeDetailResponse)
-async def get_probe_module_detail(
+def get_probe_module_detail(
     module_name: str,
     db: Session = Depends(get_tenant_db_session),
     current_user: User = Depends(require_current_user_or_token),
@@ -256,7 +256,7 @@ async def preview_import(
 
 
 @router.post("/import", response_model=GarakImportTaskResponse, status_code=202)
-async def import_probes(
+def import_probes(
     request: GarakImportRequest,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
@@ -353,7 +353,7 @@ async def preview_sync(
 
 
 @router.post("/sync/{test_set_id}", response_model=GarakSyncTaskResponse, status_code=202)
-async def sync_test_set(
+def sync_test_set(
     test_set_id: str,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
@@ -407,7 +407,7 @@ async def sync_test_set(
 
 
 @router.post("/generate", response_model=GarakGenerateResponse, status_code=202)
-async def generate_dynamic_probe(
+def generate_dynamic_probe(
     request: GarakGenerateRequest,
     current_user: User = Depends(require_current_user_or_token),
     probe_service: GarakProbeService = Depends(get_probe_service),

--- a/apps/backend/src/rhesis/backend/app/routers/home.py
+++ b/apps/backend/src/rhesis/backend/app/routers/home.py
@@ -9,7 +9,7 @@ router = APIRouter(prefix="/home", tags=["home"])
 
 
 @router.get("/")
-async def home(request: Request, current_user: Optional[User] = Depends(get_current_user)):
+def home(request: Request, current_user: Optional[User] = Depends(get_current_user)):
     # Public endpoint, user is optional
     base_url = str(request.base_url).rstrip("/")
     if current_user:
@@ -19,5 +19,5 @@ async def home(request: Request, current_user: Optional[User] = Depends(get_curr
 
 
 @router.get("/protected")
-async def protected(current_user: User = Depends(require_current_user)):
+def protected(current_user: User = Depends(require_current_user)):
     return {"message": f"Welcome, {current_user.display_name}!"}

--- a/apps/backend/src/rhesis/backend/app/routers/organization.py
+++ b/apps/backend/src/rhesis/backend/app/routers/organization.py
@@ -42,7 +42,7 @@ router = RhesisRouter(
 @handle_database_exceptions(
     entity_name="organization", custom_unique_message="Organization with this name already exists"
 )
-async def create_organization(
+def create_organization(
     organization: schemas.OrganizationCreate,
     db: Session = Depends(get_db_session),
     current_user: User = Depends(require_current_user_or_token_without_context),
@@ -54,7 +54,7 @@ async def create_organization(
 
 @router.get("/", response_model=list[schemas.Organization])
 @with_count_header(model=models.Organization)
-async def read_organizations(
+def read_organizations(
     response: Response,
     skip: int = 0,
     limit: int = 10,
@@ -135,7 +135,7 @@ def update_organization(
     response_model=dict,
     **capability(Permission.Organization.UPDATE),
 )
-async def initialize_organization_data(
+def initialize_organization_data(
     organization_id: uuid.UUID,
     db: Session = Depends(get_tenant_db_session),
     current_user: User = Depends(require_current_user_or_token),
@@ -271,7 +271,7 @@ async def initialize_organization_data(
     response_model=dict,
     **capability(Permission.Organization.UPDATE),
 )
-async def rollback_organization_data(
+def rollback_organization_data(
     organization_id: uuid.UUID,
     db: Session = Depends(get_tenant_db_session),
     current_user: User = Depends(require_current_user_or_token),

--- a/apps/backend/src/rhesis/backend/app/routers/project.py
+++ b/apps/backend/src/rhesis/backend/app/routers/project.py
@@ -30,7 +30,7 @@ router = RhesisRouter(
 @handle_database_exceptions(
     entity_name="project", custom_unique_message="Project with this name already exists"
 )
-async def create_project(
+def create_project(
     project: schemas.ProjectCreate,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
@@ -80,7 +80,7 @@ def read_my_projects(
 
 
 @router.get("/", response_model=list[schemas.ProjectDetail])
-async def read_projects(
+def read_projects(
     response: Response,
     skip: int = 0,
     limit: int = 10,

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -71,7 +71,7 @@ def _handle_generation_error(error: Exception) -> None:
 
 
 @router.get("/github/contents")
-async def get_github_contents(repo_url: str):
+def get_github_contents(repo_url: str):
     """
     Get the contents of a GitHub repository.
 
@@ -155,7 +155,7 @@ async def generate_content_endpoint(
 
 
 @router.post("/generate/embedding")
-async def generate_embedding_endpoint(
+def generate_embedding_endpoint(
     request: GenerateEmbeddingRequest,
     db: Session = Depends(get_tenant_db_session),
     current_user: User = Depends(require_current_user_or_token),
@@ -313,7 +313,7 @@ async def generate_multiturn_tests_endpoint(
 
 
 @router.post("/generate/test_pipeline")
-async def test_pipeline_endpoint(
+def test_pipeline_endpoint(
     request: TestPipelineRequest,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),

--- a/apps/backend/src/rhesis/backend/app/routers/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_run.py
@@ -512,7 +512,7 @@ def cancel_test_run(
 
 
 @router.post("/{test_run_id}/rescore", **capability(Permission.TestRun.UPDATE))
-async def rescore_test_run_endpoint(
+def rescore_test_run_endpoint(
     test_run_id: UUID,
     request: schemas.TestRunRescoreRequest = None,
     db: Session = Depends(get_tenant_db_session),
@@ -606,7 +606,7 @@ def download_test_run_results(
 
 
 @router.get("/{test_run_id}/traces", response_model=TraceListResponse)
-async def get_test_run_traces(
+def get_test_run_traces(
     test_run_id: UUID,
     limit: int = Query(100, ge=1, le=1000, description="Results per page"),
     offset: int = Query(0, ge=0, description="Pagination offset"),

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -100,7 +100,7 @@ def resolve_test_set_or_raise(identifier: str, db: Session, organization_id: str
 @router.post(
     "/generate", response_model=TestSetGenerationResponse, **capability(Permission.TestSet.GENERATE)
 )
-async def generate_test_set(
+def generate_test_set(
     request: services_schemas.GenerateTestsRequest,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
@@ -229,7 +229,7 @@ async def generate_test_set(
 
 
 @router.post("/bulk", response_model=schemas.TestSetBulkResponse)
-async def create_test_set_bulk(
+def create_test_set_bulk(
     test_set_data: schemas.TestSetBulkCreate,
     db: Session = Depends(get_tenant_db_session),
     current_user: User = Depends(require_current_user_or_token),
@@ -303,7 +303,7 @@ async def create_test_set_bulk(
 @handle_database_exceptions(
     entity_name="test set", custom_unique_message="Test set with this name already exists"
 )
-async def create_test_set(
+def create_test_set(
     test_set: schemas.TestSetCreate,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
@@ -318,7 +318,7 @@ async def create_test_set(
 
 @router.get("/", response_model=list[schemas.TestSetDetail])
 @with_count_header(model=models.TestSet)
-async def read_test_sets(
+def read_test_sets(
     response: Response,
     skip: int = 0,
     limit: int = 10,
@@ -409,7 +409,7 @@ def generate_test_set_stats(
 
 
 @router.get("/{test_set_identifier}", response_model=schemas.TestSetDetail)
-async def read_test_set(
+def read_test_set(
     test_set_identifier: str,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
@@ -420,7 +420,7 @@ async def read_test_set(
 
 
 @router.delete("/{test_set_id}", response_model=schemas.TestSet)
-async def delete_test_set(
+def delete_test_set(
     test_set_id: uuid.UUID,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
@@ -439,7 +439,7 @@ async def delete_test_set(
 @handle_database_exceptions(
     entity_name="test set", custom_unique_message="Test set with this name already exists"
 )
-async def update_test_set(
+def update_test_set(
     test_set_identifier: str,
     test_set: schemas.TestSetUpdate,
     db: Session = Depends(get_tenant_db_session),
@@ -527,7 +527,7 @@ def get_test_set_prompts(
 
 
 @router.get("/{test_set_identifier}/tests", response_model=list[schemas.TestDetail])
-async def get_test_set_tests(
+def get_test_set_tests(
     test_set_identifier: str,
     response: Response,
     skip: int = 0,
@@ -559,7 +559,7 @@ async def get_test_set_tests(
 @router.post(
     "/{test_set_identifier}/execute/{endpoint_id}", **capability(Permission.TestSet.EXECUTE)
 )
-async def execute_test_set(
+def execute_test_set(
     test_set_identifier: str,
     endpoint_id: uuid.UUID,
     test_configuration_attributes: schemas.TestSetExecutionRequest = None,
@@ -748,7 +748,7 @@ def download_test_set_prompts_csv(
     response_model=schemas.TestSetBulkAssociateResponse,
     **capability(Permission.TestSet.UPDATE),
 )
-async def associate_tests_with_test_set(
+def associate_tests_with_test_set(
     test_set_id: uuid.UUID,
     request: schemas.TestSetBulkAssociateRequest,
     db: Session = Depends(get_tenant_db_session),
@@ -777,7 +777,7 @@ async def associate_tests_with_test_set(
     response_model=schemas.TestSetBulkDisassociateResponse,
     **capability(Permission.TestSet.UPDATE),
 )
-async def disassociate_tests_from_test_set(
+def disassociate_tests_from_test_set(
     test_set_id: uuid.UUID,
     request: schemas.TestSetBulkDisassociateRequest,
     db: Session = Depends(get_tenant_db_session),

--- a/apps/backend/src/rhesis/backend/app/routers/token.py
+++ b/apps/backend/src/rhesis/backend/app/routers/token.py
@@ -197,7 +197,7 @@ def current_token_info(
 
 
 @router.get("/", response_model=List[TokenRead])
-async def read_tokens(
+def read_tokens(
     response: Response,
     skip: int = 0,
     limit: int = 100,

--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -92,7 +92,7 @@ router = RhesisRouter(
 @handle_database_exceptions(
     entity_name="user", custom_unique_message="User with this email already exists"
 )
-async def create_user(
+def create_user(
     request: Request,
     user: schemas.UserCreate,
     db: Session = Depends(get_tenant_db_session),
@@ -200,7 +200,7 @@ async def create_user(
 
 @router.get("/", response_model=list[schemas.User])
 @with_count_header(model=models.User)
-async def read_users(
+def read_users(
     response: Response,
     skip: int = 0,
     limit: int = 10,

--- a/apps/backend/src/rhesis/backend/app/routers/websocket.py
+++ b/apps/backend/src/rhesis/backend/app/routers/websocket.py
@@ -45,7 +45,7 @@ class WebSocketTokenResponse(BaseModel):
 
 
 @router.post("/ws/token", response_model=WebSocketTokenResponse)
-async def get_websocket_token(
+def get_websocket_token(
     request: Request,
     current_user: User = Depends(require_current_user_or_token),
 ) -> WebSocketTokenResponse:

--- a/tests/backend/ee/sso/test_sso_slug_resolution.py
+++ b/tests/backend/ee/sso/test_sso_slug_resolution.py
@@ -130,13 +130,9 @@ class TestAuthProvidersOrgParam:
         db = MagicMock()
         db.query.return_value = _FakeQuery(org)
 
-        import asyncio
-
         from rhesis.backend.app.routers.auth import get_providers
 
-        result = asyncio.get_event_loop().run_until_complete(
-            get_providers(request=_make_mock_request(), org=str(org_id), db=db)
-        )
+        result = get_providers(request=_make_mock_request(), org=str(org_id), db=db)
 
         sso_providers = [p for p in result.providers if p.name == "sso"]
         assert len(sso_providers) == 1
@@ -149,13 +145,9 @@ class TestAuthProvidersOrgParam:
         db = MagicMock()
         db.query.return_value = _FakeQuery(org)
 
-        import asyncio
-
         from rhesis.backend.app.routers.auth import get_providers
 
-        result = asyncio.get_event_loop().run_until_complete(
-            get_providers(request=_make_mock_request(), org="acme-corp", db=db)
-        )
+        result = get_providers(request=_make_mock_request(), org="acme-corp", db=db)
 
         sso_providers = [p for p in result.providers if p.name == "sso"]
         assert len(sso_providers) == 1
@@ -169,13 +161,9 @@ class TestAuthProvidersOrgParam:
         db = MagicMock()
         db.query.return_value = _FakeQuery(org)
 
-        import asyncio
-
         from rhesis.backend.app.routers.auth import get_providers
 
-        result = asyncio.get_event_loop().run_until_complete(
-            get_providers(request=_make_mock_request(), org=str(org_id), db=db)
-        )
+        result = get_providers(request=_make_mock_request(), org=str(org_id), db=db)
 
         sso_providers = [p for p in result.providers if p.name == "sso"]
         assert len(sso_providers) == 1
@@ -185,13 +173,9 @@ class TestAuthProvidersOrgParam:
         """When no org param, SSO should never appear."""
         db = MagicMock()
 
-        import asyncio
-
         from rhesis.backend.app.routers.auth import get_providers
 
-        result = asyncio.get_event_loop().run_until_complete(
-            get_providers(request=_make_mock_request(), org=None, db=db)
-        )
+        result = get_providers(request=_make_mock_request(), org=None, db=db)
 
         sso_providers = [p for p in result.providers if p.name == "sso"]
         assert len(sso_providers) == 0

--- a/tests/backend/routes/test_garak_async_dispatch.py
+++ b/tests/backend/routes/test_garak_async_dispatch.py
@@ -53,7 +53,7 @@ class TestImportProbesDispatch:
         with patch("rhesis.backend.app.routers.garak.task_launcher") as mock_launcher:
             mock_launcher.return_value = MagicMock(id="task-abc-123")
 
-            response = await import_probes(
+            response = import_probes(
                 request=request,
                 db=mock_db,
                 tenant_context=(str(current_user.organization_id), str(current_user.id)),
@@ -91,7 +91,7 @@ class TestImportProbesDispatch:
         with patch("rhesis.backend.app.routers.garak.task_launcher") as mock_launcher:
             mock_launcher.return_value = MagicMock(id="task-abc-123")
 
-            await import_probes(
+            import_probes(
                 request=request,
                 db=MagicMock(),
                 tenant_context=(str(current_user.organization_id), str(current_user.id)),
@@ -120,7 +120,7 @@ class TestSyncTestSetDispatch:
             mock_sync_cls.return_value.resolve_sync_target.return_value = {"dan": ["Dan_11_0"]}
             mock_launcher.return_value = MagicMock(id="task-xyz-789")
 
-            response = await sync_test_set(
+            response = sync_test_set(
                 test_set_id=test_set_id,
                 db=MagicMock(),
                 tenant_context=(str(current_user.organization_id), str(current_user.id)),
@@ -150,7 +150,7 @@ class TestSyncTestSetDispatch:
             from fastapi import HTTPException
 
             with pytest.raises(HTTPException) as exc_info:
-                await sync_test_set(
+                sync_test_set(
                     test_set_id="nope",
                     db=MagicMock(),
                     tenant_context=(str(current_user.organization_id), str(current_user.id)),

--- a/tests/backend/services/test_rescore.py
+++ b/tests/backend/services/test_rescore.py
@@ -269,15 +269,16 @@ class TestRescoreEndpoint:
 
     def test_endpoint_calls_service(self):
         """Endpoint delegates to rescore_test_run service."""
-        # Verify the router function signature and wiring
-        # Verify the endpoint exists and is async
+        # Verify the router function signature and wiring.
+        # The endpoint is sync (no await inside), running in the threadpool
+        # rather than the event loop, matching the rest of the sync DB layer.
         import inspect
 
         from rhesis.backend.app.routers.test_run import (
             rescore_test_run_endpoint,
         )
 
-        assert inspect.iscoroutinefunction(rescore_test_run_endpoint)
+        assert not inspect.iscoroutinefunction(rescore_test_run_endpoint)
 
     def test_endpoint_converts_metrics_to_dicts(self):
         """The endpoint converts ExecutionMetric schema objects to dicts."""

--- a/tests/backend/services/websocket/test_ws_token_auth_guard.py
+++ b/tests/backend/services/websocket/test_ws_token_auth_guard.py
@@ -33,7 +33,7 @@ async def test_ws_token_denied_for_token_auth():
     user = SimpleNamespace(id=uuid.uuid4(), organization_id=uuid.uuid4())
 
     with pytest.raises(HTTPException) as exc:
-        await get_websocket_token(request=request, current_user=user)
+        get_websocket_token(request=request, current_user=user)
     assert exc.value.status_code == 403
 
 
@@ -50,7 +50,7 @@ async def test_ws_token_allowed_for_session_auth():
         WS_TOKEN_TTL_SECONDS=60,
     )
     with patch.object(ws_router, "get_ws_token_service", return_value=stub):
-        resp = await ws_router.get_websocket_token(request=request, current_user=user)
+        resp = ws_router.get_websocket_token(request=request, current_user=user)
 
     assert resp.token == "ws-token-xyz"
     assert resp.expires_in == 60


### PR DESCRIPTION
## Purpose

52 FastAPI route handlers across 15 router files were declared `async def` but never `await`ed anything. Since the backend's DB layer is 100% sync SQLAlchemy (`Session`, not `AsyncSession`), these handlers ran their sync CRUD/Celery/service work directly on the single event loop instead of FastAPI's threadpool, blocking other concurrent requests (including genuinely async work like WebSocket messages, `a_generate` LLM calls, and MCP/tool invocations) for the duration of each call.

## What Changed

- Converted the 52 no-await `async def` handlers to plain `def` across `auth.py`, `connector.py`, `endpoint.py`, `explorer.py`, `file_import.py`, `garak.py`, `home.py`, `organization.py`, `project.py`, `services.py`, `test_run.py`, `test_set.py`, `token.py`, `user.py`, and `websocket.py`. No logic changes — purely mechanical, since none of these functions contained an `await`.
- Updated 4 test files that called the affected handlers as coroutines (`asyncio.run_until_complete`, `await ...`, or an `inspect.iscoroutinefunction` assertion) to match the new sync signatures.
- Left untouched: the 43 routes with genuine `await` (WebSockets, `a_generate`, `httpx.AsyncClient`, `asyncio.to_thread` streaming in `file.py`), and `routers/job.py`'s 9 async-no-await handlers, whose `@router...` decorators are already commented out (dead/disabled code, not live endpoints).

## Additional Context

Investigation found the backend is ~73% sync / 27% async routes overall, with the DB layer (`database.py`) using a sync `create_engine` + `Session` exclusively. FastAPI runs plain `def` routes in the anyio threadpool and `async def` routes on the event loop, so misdeclaring a sync-only handler as `async def` risks blocking the loop with no benefit.

## Testing

- Full backend suite: `cd apps/backend && uv run pytest ../../tests/backend/ -v` — 6455 passed, 82 skipped, 1 xfailed (skips/xfail pre-existing, unrelated to this change).
- `uvx ruff check` / `uvx ruff format --check` on all changed files — no new issues (pre-existing import-order/unused-import findings in a few router files confirmed present on `main` before this change).