### PR TITLE
Fix assigned test not appearing in Test Set list

### DIFF
--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectChat.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectChat.tsx
@@ -96,7 +96,9 @@ function planDataToMarkdown(data: Record<string, unknown>): string {
     lines.push('');
   }
   const mappings = data.behavior_metric_mappings as
-    PlanSpec[] | Record<string, string[]> | undefined;
+    | PlanSpec[]
+    | Record<string, string[]>
+    | undefined;
   if (mappings) {
     lines.push('## Behavior-Metric Mappings', '');
     if (Array.isArray(mappings)) {

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
@@ -287,7 +287,9 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
           input_data: inputData,
           endpoint_path: formData.endpoint_path || undefined,
           response_format: (formData.response_format || 'json') as
-            'json' | 'xml' | 'text',
+            | 'json'
+            | 'xml'
+            | 'text',
         });
 
         const r = result as Record<string, unknown>;

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentVersionsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentVersionsGrid.tsx
@@ -185,7 +185,8 @@ export default function ExperimentVersionsGrid({
           row.values[field.name] ?? null,
         renderCell: (params: GridRenderCellParams<ExperimentVersion>) => {
           const val = params.row.values[field.name] as
-            ParameterValue | undefined;
+            | ParameterValue
+            | undefined;
           return (
             <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
               {val !== undefined ? (

--- a/apps/frontend/src/app/(protected)/organizations/settings/components/OrganizationSettingsTabs.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/components/OrganizationSettingsTabs.tsx
@@ -68,13 +68,15 @@ export default function OrganizationSettingsTabs({
   const allTabs: MergedTab[] = useMemo(() => {
     const merged: MergedTab[] = [
       ...BUILT_IN_TABS,
-      ...dynamicTabs.map((t): DynamicTab => ({
-        id: t.id,
-        label: t.title,
-        order: t.order,
-        dynamic: true,
-        component: t.component,
-      })),
+      ...dynamicTabs.map(
+        (t): DynamicTab => ({
+          id: t.id,
+          label: t.title,
+          order: t.order,
+          dynamic: true,
+          component: t.component,
+        })
+      ),
     ];
     return merged.sort((a, b) => a.order - b.order);
   }, [dynamicTabs]);

--- a/apps/frontend/src/app/(protected)/tasks/components/TaskDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TaskDrawer.tsx
@@ -150,7 +150,8 @@ export default function TaskDrawer({
 
   const entityType = initialEntity?.entityType;
   const commentId = initialEntity?.task_metadata?.comment_id as
-    string | undefined;
+    | string
+    | undefined;
 
   return (
     <BaseDrawer

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -439,7 +439,8 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
             (params.row.attributes?.parameter_experiment_name as string) ||
             undefined;
           const version = params.row.attributes?.parameter_version as
-            string | undefined;
+            | string
+            | undefined;
 
           if (!name && !version) return null;
 

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetLinkedTestsSection.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetLinkedTestsSection.tsx
@@ -11,6 +11,7 @@ import {
 import AddIcon from '@mui/icons-material/Add';
 import PlaylistAddIcon from '@mui/icons-material/PlaylistAdd';
 import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import AssignTestsDrawer from './AssignTestsDrawer';
 import EmbeddingTestsPanel from './EmbeddingTestsPanel';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
@@ -18,6 +19,7 @@ import { TestDetail } from '@/utils/api-client/interfaces/tests';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
+import { testSetKeys } from '@/constants/query-keys';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import type { Theme } from '@mui/material/styles';
 
@@ -46,6 +48,7 @@ export default function TestSetLinkedTestsSection({
   const { show: showNotification } = useNotifications();
   const canEditTestSet = useCan(Capability.TestSet.UPDATE);
   const router = useRouter();
+  const queryClient = useQueryClient();
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [refreshKey, setRefreshKey] = useState(0);
   const [totalCount, setTotalCount] = useState(initialTestCount);
@@ -116,7 +119,17 @@ export default function TestSetLinkedTestsSection({
         { severity: 'success', autoHideDuration: 4000 }
       );
       setDrawerOpen(false);
+      // Optimistically grow the count so the empty state gives way to the grid
+      // immediately after the first assignment.
+      setTotalCount(prev => prev + tests.length);
+      // Drop cached test-list pages so the grid refetches with the new rows
+      // (React Query keeps them fresh for 5 min otherwise).
+      await queryClient.invalidateQueries({
+        queryKey: [...testSetKeys.detail(testSetId), 'tests'],
+      });
       handleRefresh();
+      // Sync the server-rendered testCount prop for this page.
+      router.refresh();
     } catch (error) {
       const msg = error instanceof Error ? error.message : '';
       if (msg.includes('already associated')) {

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/ChipGroup.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/ChipGroup.tsx
@@ -35,7 +35,11 @@ export default function ChipGroup({
     };
 
     return colorMap[chip.colorVariant || 'blue'] as
-      'primary' | 'secondary' | 'warning' | 'success' | undefined;
+      | 'primary'
+      | 'secondary'
+      | 'warning'
+      | 'success'
+      | undefined;
   };
 
   const getChipSx = (chip: ChipConfig) => {

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/SelectionModal.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/SelectionModal.tsx
@@ -26,7 +26,12 @@ export interface SelectionCardConfig {
   buttonLabel: string;
   buttonVariant: 'contained' | 'outlined';
   buttonColor?:
-    'primary' | 'secondary' | 'warning' | 'error' | 'info' | 'success';
+    | 'primary'
+    | 'secondary'
+    | 'warning'
+    | 'error'
+    | 'info'
+    | 'success';
   onClick: () => void;
   preview?: ReactNode;
 }

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/types.ts
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/types.ts
@@ -178,4 +178,8 @@ export interface FlowState {
  * Document processing status
  */
 export type DocumentStatus =
-  'uploading' | 'extracting' | 'generating' | 'completed' | 'error';
+  | 'uploading'
+  | 'extracting'
+  | 'generating'
+  | 'completed'
+  | 'error';

--- a/apps/frontend/src/app/(protected)/tests/components/TestDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestDrawer.tsx
@@ -29,7 +29,8 @@ export default function TestDrawer({
   const { data: session } = useSession();
   const getCurrentUserId = () =>
     session?.user?.id as
-      `${string}-${string}-${string}-${string}-${string}` | undefined;
+      | `${string}-${string}-${string}-${string}-${string}`
+      | undefined;
 
   const handleSave = async () => {
     try {

--- a/apps/frontend/src/app/(protected)/traces/components/ConversationTraceView.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/ConversationTraceView.tsx
@@ -47,7 +47,8 @@ function getPerTurnOverrides(
   rootSpans: SpanNode[]
 ): Record<number, TurnOverrideEntry> {
   const traceMetrics = rootSpans.find(s => s.trace_metrics)?.trace_metrics as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   if (!traceMetrics) return {};
 
   const turnOverrides = traceMetrics.turn_overrides as

--- a/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
@@ -249,14 +249,17 @@ export default function TraceDrawer({
 
   const mentionableMetrics: MentionOption[] = useMemo(() => {
     const traceMetrics = selectedSpan?.trace_metrics as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     if (!traceMetrics) return [];
     const names: string[] = [];
     for (const section of ['turn_metrics', 'conversation_metrics']) {
       const sectionData = traceMetrics[section] as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       const metrics = sectionData?.metrics as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       if (metrics) {
         names.push(...Object.keys(metrics));
       }
@@ -304,15 +307,18 @@ export default function TraceDrawer({
   const handleReviewMetric = useCallback(
     (metricName: string) => {
       const traceMetrics = selectedSpan?.trace_metrics as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       if (!traceMetrics) return;
 
       let isSuccessful = false;
       for (const section of ['turn_metrics', 'conversation_metrics']) {
         const sectionData = traceMetrics[section] as
-          Record<string, unknown> | undefined;
+          | Record<string, unknown>
+          | undefined;
         const metrics = sectionData?.metrics as
-          Record<string, { is_successful?: boolean }> | undefined;
+          | Record<string, { is_successful?: boolean }>
+          | undefined;
         if (metrics?.[metricName]) {
           isSuccessful = !!metrics[metricName].is_successful;
           break;
@@ -366,7 +372,8 @@ export default function TraceDrawer({
         const testRun = await testRunsClient.getTestRun(trace.test_run.id);
         if (testRun?.experiment_id) {
           const attrs = testRun.attributes as
-            Record<string, unknown> | undefined;
+            | Record<string, unknown>
+            | undefined;
           setExperimentInfo({
             id: testRun.experiment_id,
             name: (attrs?.parameter_experiment_name as string) || 'Unknown',

--- a/apps/frontend/src/app/(protected)/traces/components/TraceMetricsTab.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceMetricsTab.tsx
@@ -287,7 +287,8 @@ export default function TraceMetricsTab({
   const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
 
   const traceMetrics = selectedSpan?.trace_metrics as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
 
   const turnMetrics = useMemo(() => {
     if (!traceMetrics?.turn_metrics) return null;

--- a/apps/frontend/src/app/(protected)/traces/components/TraceReviewDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceReviewDrawer.tsx
@@ -59,7 +59,8 @@ function getAllTraceMetrics(
   const result: Record<string, MetricEntry> = {};
   for (const section of ['turn_metrics', 'conversation_metrics']) {
     const sectionData = traceMetrics[section] as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     const metrics = (sectionData?.metrics ?? {}) as Record<string, MetricEntry>;
     Object.assign(result, metrics);
   }
@@ -128,13 +129,16 @@ export default function TraceReviewDrawer({
 
   const getTurnMetricsAutomatedStatus = useCallback((): 'passed' | 'failed' => {
     const traceMetrics = selectedSpan?.trace_metrics as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     const turnSection = traceMetrics?.turn_metrics as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     if (!turnSection) return 'failed';
 
     const metrics = turnSection.metrics as
-      Record<string, { is_successful?: boolean }> | undefined;
+      | Record<string, { is_successful?: boolean }>
+      | undefined;
     if (metrics && Object.keys(metrics).length > 0) {
       return Object.values(metrics).every(m => m?.is_successful)
         ? 'passed'

--- a/apps/frontend/src/app/(protected)/traces/components/TraceReviewsTab.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceReviewsTab.tsx
@@ -260,7 +260,8 @@ export default function TraceReviewsTab({
 
     for (const section of ['turn_metrics', 'conversation_metrics']) {
       const sectionData = traceMetrics[section] as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       const metrics = (sectionData?.metrics ?? {}) as Record<
         string,
         { is_successful?: boolean }

--- a/apps/frontend/src/components/common/NotificationContext.tsx
+++ b/apps/frontend/src/components/common/NotificationContext.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { Snackbar, Alert, useTheme } from '@mui/material';
 
 export type NotificationSeverity =
-  'success' | 'info' | 'warning' | 'error' | 'neutral';
+  | 'success'
+  | 'info'
+  | 'warning'
+  | 'error'
+  | 'neutral';
 
 interface NotificationOptions {
   severity?: NotificationSeverity;

--- a/apps/frontend/src/components/common/TestRunStatus.tsx
+++ b/apps/frontend/src/components/common/TestRunStatus.tsx
@@ -11,7 +11,11 @@ import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import BlockIcon from '@mui/icons-material/Block';
 
 export type TestRunStatusColor =
-  'success' | 'error' | 'warning' | 'info' | 'default';
+  | 'success'
+  | 'error'
+  | 'warning'
+  | 'info'
+  | 'default';
 
 /**
  * Get the color for a test run status

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -102,10 +102,12 @@ export function Sidebar() {
   const groups = groupNavItems(navigation);
 
   const mainGroups = groups.filter(g => g.type !== 'footer-links') as (
-    StandaloneGroup | SectionGroup
+    | StandaloneGroup
+    | SectionGroup
   )[];
   const footerGroup = groups.find(g => g.type === 'footer-links') as
-    FooterLinksGroup | undefined;
+    | FooterLinksGroup
+    | undefined;
 
   const sidebarWidth = collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_WIDTH;
 

--- a/apps/frontend/src/components/tasks/TasksSection.tsx
+++ b/apps/frontend/src/components/tasks/TasksSection.tsx
@@ -178,7 +178,11 @@ export function TasksSection({
             label={params.row.status?.name || 'Unknown'}
             color={
               getStatusColor(params.row.status?.name) as
-                'warning' | 'primary' | 'success' | 'error' | 'default'
+                | 'warning'
+                | 'primary'
+                | 'success'
+                | 'error'
+                | 'default'
             }
             size="small"
           />

--- a/apps/frontend/src/config/onboarding-tours.ts
+++ b/apps/frontend/src/config/onboarding-tours.ts
@@ -166,7 +166,9 @@ export const driverConfig = {
   prevBtnText: 'Back',
   doneBtnText: 'Got it!',
   showButtons: ['next', 'previous', 'close'] as (
-    'next' | 'previous' | 'close'
+    | 'next'
+    | 'previous'
+    | 'close'
   )[],
   allowClose: true,
   overlayClickNext: false,

--- a/apps/frontend/src/hooks/useArchitectChat.ts
+++ b/apps/frontend/src/hooks/useArchitectChat.ts
@@ -657,7 +657,8 @@ export function useArchitectChat(
     unsubs.push(
       subscribe(EventType.SUBSCRIPTION_ERROR, (msg: WebSocketMessage) => {
         const payload = msg.payload as
-          { channel?: string; error?: string } | undefined;
+          | { channel?: string; error?: string }
+          | undefined;
         const deniedChannel = payload?.channel ?? msg.channel;
         if (deniedChannel !== `architect:${sessionId}`) return;
 

--- a/apps/frontend/src/hooks/useWebSocket.ts
+++ b/apps/frontend/src/hooks/useWebSocket.ts
@@ -15,7 +15,8 @@ import { EventType, WebSocketMessage, EventHandler } from '@/utils/websocket';
  * `preflight:{id}`) can use the plain string form.
  */
 export type ChannelSubscription =
-  string | { channel: string; projectId?: string | null };
+  | string
+  | { channel: string; projectId?: string | null };
 
 /**
  * Options for the useWebSocket hook.

--- a/apps/frontend/src/utils/api-client/interfaces/embedding.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/embedding.ts
@@ -26,4 +26,5 @@ export interface EmbeddingGraphComputeResponse {
 }
 
 export type EmbeddingGraphGetResponse =
-  { status: 'pending' } | { status: 'ready'; graph: Scatter2DGraph };
+  | { status: 'pending' }
+  | { status: 'ready'; graph: Scatter2DGraph };

--- a/apps/frontend/src/utils/api-client/interfaces/explorer.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/explorer.ts
@@ -255,7 +255,8 @@ export interface SuggestionOutputStreamSummaryEvent {
 }
 
 export type SuggestionOutputStreamEvent =
-  SuggestionOutputStreamItemEvent | SuggestionOutputStreamSummaryEvent;
+  | SuggestionOutputStreamItemEvent
+  | SuggestionOutputStreamSummaryEvent;
 
 // =============================================================================
 // Evaluate Suggestions (non-persisted)
@@ -289,7 +290,8 @@ export interface SuggestionEvalStreamSummaryEvent {
 }
 
 export type SuggestionEvalStreamEvent =
-  SuggestionEvalStreamItemEvent | SuggestionEvalStreamSummaryEvent;
+  | SuggestionEvalStreamItemEvent
+  | SuggestionEvalStreamSummaryEvent;
 
 // =============================================================================
 // Unified Suggestion Pipeline (single stream)

--- a/apps/frontend/src/utils/conversation-from-spans.ts
+++ b/apps/frontend/src/utils/conversation-from-spans.ts
@@ -7,15 +7,18 @@ import type {
 
 function getAutomatedTurnSuccess(rootSpans: SpanNode[]): boolean | undefined {
   const traceMetrics = rootSpans.find(s => s.trace_metrics)?.trace_metrics as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   if (!traceMetrics) return undefined;
 
   const turnSection = traceMetrics.turn_metrics as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   if (!turnSection) return undefined;
 
   const metrics = turnSection.metrics as
-    Record<string, { is_successful?: boolean }> | undefined;
+    | Record<string, { is_successful?: boolean }>
+    | undefined;
   if (metrics && Object.keys(metrics).length > 0) {
     return Object.values(metrics).every(m => m?.is_successful);
   }

--- a/apps/frontend/src/utils/websocket/client.ts
+++ b/apps/frontend/src/utils/websocket/client.ts
@@ -323,7 +323,8 @@ export class WebSocketClient {
     // Handle connection confirmation
     if (message.type === EventType.CONNECTED) {
       const payload = message.payload as unknown as
-        ConnectedPayload | undefined;
+        | ConnectedPayload
+        | undefined;
       this.state.connectionId = payload?.connection_id;
     }
 


### PR DESCRIPTION
## Purpose

Fixes #2234. When assigning a test from the **Tests** tab of a Test Set, the newly assigned test did not appear in the test list table.

## What Changed

- `TestSetLinkedTestsSection.tsx`: after a successful `associateTestsWithTestSet` call, the component now:
  - optimistically bumps the local `totalCount` so an empty test set immediately transitions from the "No tests yet" empty state to the grid (the grid was never mounted while `totalCount === 0`, so the previous `refreshKey` remount had no effect);
  - invalidates the `test-sets / detail / <id> / tests` React Query cache so the grid refetches instead of showing stale rows (app-wide `staleTime` is 5 min);
  - calls `router.refresh()` to sync the server-rendered `testCount` prop.

## Additional Context

- Root cause: the assign handler only incremented a `refreshKey` used as a `key` on a component that isn't mounted when the set is empty, and never invalidated the query cache, so populated sets showed stale data and empty sets never rendered the grid.

## Testing

1. Open a Test Set with no tests, go to the **Tests** tab.
2. Assign one or more tests — the grid now appears immediately with the new tests.
3. Repeat on a Test Set that already has tests — newly assigned tests appear without a manual reload.