### PR TITLE
Prefer RHESIS_API_KEY over Polyphemus delegation tokens

### DIFF
--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -12,7 +12,7 @@ from typing import Union
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud
-from rhesis.backend.app.config.settings import get_model_settings
+from rhesis.backend.app.config.settings import get_model_settings, get_rhesis_settings
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 from rhesis.sdk.models.base import BaseEmbedder, BaseLLM
@@ -428,9 +428,21 @@ def _fetch_and_configure_model(
     if _is_rhesis_system_model(provider, api_key):
         return default_model
 
-    # Special handling for Polyphemus models without API keys (use delegation tokens)
-    if provider == "polyphemus" and not api_key and user:
-        return _call_polyphemus_with_delegation(user, model_name)
+    # Special handling for Polyphemus models without a stored API key.
+    #
+    # - Self-hosted deployments configure a real RHESIS_API_KEY and call
+    #   Polyphemus directly with it (same path as any other provider below).
+    # - Rhesis-hosted (SaaS) deployments have no such key configured, so we
+    #   mint a short-lived delegation token on the user's behalf instead.
+    #   Delegation only validates because the backend and Polyphemus share
+    #   the same JWT_SECRET_KEY there; a self-hosted backend's secret would
+    #   be meaningless to the externally-hosted Polyphemus service, so a
+    #   configured RHESIS_API_KEY always takes precedence when present.
+    if provider == "polyphemus" and not api_key:
+        if get_rhesis_settings().api_key:
+            logger.debug("Using configured RHESIS_API_KEY for Polyphemus (self-hosted mode)")
+        elif user:
+            return _call_polyphemus_with_delegation(user, model_name)
 
     # Use SDK's get_model to create configured instance with error handling
     try:

--- a/tests/backend/utils/test_llm_delegation.py
+++ b/tests/backend/utils/test_llm_delegation.py
@@ -12,6 +12,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from rhesis.backend.app.config.settings import get_rhesis_settings
 from rhesis.backend.app.models.user import User
 
 
@@ -142,6 +143,14 @@ class TestPolyphemusDelegation:
 class TestPolyphemusModelConfiguration:
     """Test Polyphemus model configuration flow."""
 
+    @pytest.fixture(autouse=True)
+    def clean_rhesis_api_key(self, monkeypatch):
+        """Ensure RHESIS_API_KEY is unset by default and settings cache is reset."""
+        monkeypatch.delenv("RHESIS_API_KEY", raising=False)
+        get_rhesis_settings.cache_clear()
+        yield
+        get_rhesis_settings.cache_clear()
+
     @pytest.fixture
     def test_user(self):
         """Create a mock user for testing."""
@@ -172,7 +181,8 @@ class TestPolyphemusModelConfiguration:
     def test_polyphemus_model_uses_delegation(
         self, mock_get_model, mock_polyphemus_class, test_user, mock_polyphemus_model
     ):
-        """Test that Polyphemus models without API keys use delegation tokens."""
+        """Without a configured RHESIS_API_KEY, Polyphemus models without a stored
+        API key use per-user delegation tokens (Rhesis-hosted/SaaS mode)."""
         from sqlalchemy.orm import Session
 
         from rhesis.backend.app.utils.user_model_utils import _fetch_and_configure_model
@@ -200,6 +210,81 @@ class TestPolyphemusModelConfiguration:
         assert len(call_kwargs["api_key"]) > 0
         # JWT tokens don't start with rh-
         assert not call_kwargs["api_key"].startswith("rh-")
+
+    @patch("rhesis.sdk.models.providers.polyphemus.PolyphemusLLM")
+    @patch("rhesis.backend.app.utils.user_model_utils.crud.get_model")
+    @patch("rhesis.backend.app.utils.user_model_utils._call_polyphemus_with_delegation")
+    def test_polyphemus_model_prefers_env_api_key_over_delegation(
+        self,
+        mock_delegate,
+        mock_get_model,
+        mock_polyphemus_class,
+        test_user,
+        mock_polyphemus_model,
+        monkeypatch,
+    ):
+        """A configured RHESIS_API_KEY (self-hosted mode) takes precedence over
+        minting a delegation token, even when a user is available."""
+        from sqlalchemy.orm import Session
+
+        from rhesis.backend.app.utils.user_model_utils import _fetch_and_configure_model
+
+        monkeypatch.setenv("RHESIS_API_KEY", "rh-self-hosted-key")
+        get_rhesis_settings.cache_clear()
+
+        mock_db = Mock(spec=Session)
+        mock_get_model.return_value = mock_polyphemus_model
+
+        _fetch_and_configure_model(
+            db=mock_db,
+            model_id="model-789",
+            organization_id="org-456",
+            default_model="gpt-4",
+            user=test_user,
+        )
+
+        # Delegation must not be used when a real API key is configured
+        mock_delegate.assert_not_called()
+
+        # PolyphemusLLM is reached via the generic SDK factory path, with
+        # api_key=None so the SDK provider picks up RHESIS_API_KEY itself
+        mock_polyphemus_class.assert_called_once()
+        call_kwargs = mock_polyphemus_class.call_args[1]
+        assert call_kwargs["api_key"] is None
+
+    @patch("rhesis.sdk.models.providers.polyphemus.PolyphemusLLM")
+    @patch("rhesis.backend.app.utils.user_model_utils.crud.get_model")
+    @patch("rhesis.backend.app.utils.user_model_utils._call_polyphemus_with_delegation")
+    def test_polyphemus_model_uses_env_api_key_without_user(
+        self,
+        mock_delegate,
+        mock_get_model,
+        mock_polyphemus_class,
+        mock_polyphemus_model,
+        monkeypatch,
+    ):
+        """A configured RHESIS_API_KEY resolves the model even with no user
+        available (e.g. background jobs), without requiring delegation."""
+        from sqlalchemy.orm import Session
+
+        from rhesis.backend.app.utils.user_model_utils import _fetch_and_configure_model
+
+        monkeypatch.setenv("RHESIS_API_KEY", "rh-self-hosted-key")
+        get_rhesis_settings.cache_clear()
+
+        mock_db = Mock(spec=Session)
+        mock_get_model.return_value = mock_polyphemus_model
+
+        _fetch_and_configure_model(
+            db=mock_db,
+            model_id="model-789",
+            organization_id="org-456",
+            default_model="gpt-4",
+            user=None,
+        )
+
+        mock_delegate.assert_not_called()
+        mock_polyphemus_class.assert_called_once()
 
 
 class TestModelEndpointConfiguration:


### PR DESCRIPTION
## Purpose

Self-hosted deployments have their own independent `JWT_SECRET_KEY`, so any
`service_delegation` JWT they mint is meaningless to the externally-hosted
Polyphemus service and would be rejected. Self-hosted operators should
instead configure a real `RHESIS_API_KEY` and have it used directly.

## What Changed

- `_fetch_and_configure_model` now checks `get_rhesis_settings().api_key`
  (i.e. `RHESIS_API_KEY`) before minting a per-user delegation token for
  keyless Polyphemus models.
  - If an env key is configured (self-hosted mode), it falls through to the
    existing generic `get_model(...)` call, which passes `api_key=None` to
    `PolyphemusLLM`; the SDK provider then picks up `RHESIS_API_KEY` from
    the environment itself.
  - If no env key is configured (Rhesis-hosted/SaaS mode), it mints a
    short-lived delegation token on the user's behalf as before.
- Added tests covering: env key takes precedence over delegation when a
  user is present, and env key resolves the model even with no user (e.g.
  background jobs).

## Additional Context

No SDK or `apps/polyphemus` changes are needed — `PolyphemusLLM` already
falls back to `os.getenv("RHESIS_API_KEY")` when no explicit key is passed,
and Polyphemus's auth already validates real `rh-*` tokens directly.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/utils/test_llm_delegation.py -v
uv run pytest ../../tests/backend/auth/test_delegation_tokens.py ../../tests/backend/app/test_settings.py -v
```

All 13 delegation tests and 67 settings/delegation-token tests pass.
`ruff check` / `ruff format --check` are clean on the changed files.