### PR TITLE
Add bulk delete for tests and explorer test sets

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -2365,22 +2365,14 @@ def bulk_delete_tests(
     if not test_ids:
         return {"deleted_ids": [], "not_found_ids": []}
 
-    # Distinct test sets containing ANY of the tests being deleted, resolved once
-    # for the whole batch (contrast with delete_test's per-test lookup above).
-    # This is a Core-style db.execute(select(...)) query, which the ambient
-    # tenant-filter listener does NOT auto-scope (ORM Query only) -- explicit
-    # organization_id filter required, since this runs against the raw
-    # caller-supplied test_ids before bulk_delete_by_ids has a chance to
-    # resolve which ones actually belong to this organization.
-    rows = db.execute(
-        test_test_set_association.select().where(
-            test_test_set_association.c.test_id.in_(test_ids),
-            test_test_set_association.c.organization_id == organization_id,
-        )
-    ).fetchall()
-    affected_test_set_ids = {row.test_set_id for row in rows}
-
-    def _recompute_affected_test_sets(_deleted_ids: List[uuid.UUID]) -> None:
+    def _recompute_affected_test_sets(deleted_ids: List[uuid.UUID]) -> None:
+        rows = db.execute(
+            test_test_set_association.select().where(
+                test_test_set_association.c.test_id.in_(deleted_ids),
+                test_test_set_association.c.organization_id == organization_id,
+            )
+        ).fetchall()
+        affected_test_set_ids = {row.test_set_id for row in rows}
         for test_set_id in affected_test_set_ids:
             update_test_set_attributes(
                 db=db,

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -26,6 +26,7 @@ from rhesis.backend.app.schemas.telemetry import (
     TraceType,
 )
 from rhesis.backend.app.utils.crud_utils import (
+    bulk_delete_by_ids,
     create_item,
     delete_item,
     get_item,
@@ -2341,6 +2342,53 @@ def delete_test(
 
     # Return the soft-deleted test
     return db_test
+
+
+def bulk_delete_tests(
+    db: Session,
+    test_ids: List[uuid.UUID],
+    organization_id: str,
+    user_id: str,
+) -> Dict[str, List[str]]:
+    """
+    Soft delete multiple tests in one transaction and recompute test-set
+    attributes once per distinct affected test set (not once per deleted test).
+
+    Deleting the same 25 tests one at a time (25 DELETE /tests/{id} requests)
+    recomputes -- and re-UPDATEs -- a shared test set's attributes up to 25
+    times, and those concurrent UPDATEs to the same row serialize at the
+    database. Resolving the affected test sets across the whole batch up
+    front and recomputing each exactly once avoids both problems.
+    """
+    from rhesis.backend.app.services.test_set import update_test_set_attributes
+
+    if not test_ids:
+        return {"deleted_ids": [], "not_found_ids": []}
+
+    # Distinct test sets containing ANY of the tests being deleted, resolved once
+    # for the whole batch (contrast with delete_test's per-test lookup above).
+    rows = db.execute(
+        test_test_set_association.select().where(test_test_set_association.c.test_id.in_(test_ids))
+    ).fetchall()
+    affected_test_set_ids = {row.test_set_id for row in rows}
+
+    def _recompute_affected_test_sets(_deleted_ids: List[uuid.UUID]) -> None:
+        for test_set_id in affected_test_set_ids:
+            update_test_set_attributes(
+                db=db,
+                test_set_id=str(test_set_id),
+                organization_id=organization_id,
+                user_id=user_id,
+            )
+
+    return bulk_delete_by_ids(
+        db,
+        models.Test,
+        test_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+        on_deleted=_recompute_affected_test_sets,
+    )
 
 
 # TestContext CRUD

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -2367,8 +2367,16 @@ def bulk_delete_tests(
 
     # Distinct test sets containing ANY of the tests being deleted, resolved once
     # for the whole batch (contrast with delete_test's per-test lookup above).
+    # This is a Core-style db.execute(select(...)) query, which the ambient
+    # tenant-filter listener does NOT auto-scope (ORM Query only) -- explicit
+    # organization_id filter required, since this runs against the raw
+    # caller-supplied test_ids before bulk_delete_by_ids has a chance to
+    # resolve which ones actually belong to this organization.
     rows = db.execute(
-        test_test_set_association.select().where(test_test_set_association.c.test_id.in_(test_ids))
+        test_test_set_association.select().where(
+            test_test_set_association.c.test_id.in_(test_ids),
+            test_test_set_association.c.organization_id == organization_id,
+        )
     ).fetchall()
     affected_test_set_ids = {row.test_set_id for row in rows}
 

--- a/apps/backend/src/rhesis/backend/app/routers/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/routers/explorer.py
@@ -12,7 +12,6 @@ from typing import List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
-from rhesis.backend.app.routers.base import RhesisRouter
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
@@ -23,6 +22,7 @@ from rhesis.backend.app.dependencies import (
     get_tenant_db_session,
 )
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.explorer import (
     CreateExplorerTestBody,
     EvaluateFailedItem,
@@ -32,6 +32,8 @@ from rhesis.backend.app.schemas.explorer import (
     EvaluateSuggestionsRequest,
     ExplorerSettingsResponse,
     ExplorerSettingsUpdate,
+    ExplorerTestSetBulkDeleteRequest,
+    ExplorerTestSetBulkDeleteResponse,
     ExportExplorerTestSetResponse,
     GenerateOutputsFailedItem,
     GenerateOutputsRequest,
@@ -45,6 +47,7 @@ from rhesis.backend.app.schemas.explorer import (
     SuggestionPipelineRequest,
 )
 from rhesis.backend.app.services.explorer import (
+    bulk_delete_explorer_test_sets,
     create_explorer_test_set,
     create_test_node,
     create_topic_node,
@@ -219,6 +222,31 @@ def list_explorer_test_sets(
         limit=limit,
         sort_by=sort_by,
         sort_order=sort_order,
+    )
+
+
+@router.delete("/bulk", response_model=ExplorerTestSetBulkDeleteResponse)
+def bulk_delete_explorer_test_sets_endpoint(
+    request: ExplorerTestSetBulkDeleteRequest,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Delete multiple Explorer test sets at once.
+
+    Ids that don't resolve to a test set with the Adaptive Testing behavior
+    are reported in `not_found_ids` rather than deleted.
+
+    Registered before /{test_set_identifier} below -- FastAPI matches routes
+    in registration order, so a literal /bulk path must come first or the
+    identifier-shaped route would swallow it (treating "bulk" as an identifier).
+    """
+    organization_id, user_id = tenant_context
+    return bulk_delete_explorer_test_sets(
+        db=db,
+        test_set_ids=request.test_set_ids,
+        organization_id=str(organization_id),
+        user_id=str(user_id),
     )
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/test.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test.py
@@ -133,6 +133,28 @@ def create_tests_bulk(
             )
 
 
+@router.delete("/bulk", response_model=schemas.TestBulkDeleteResponse)
+def bulk_delete_tests(
+    request: schemas.TestBulkDeleteRequest,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Delete multiple tests at once.
+
+    Soft-deletes every test in one transaction and recomputes each affected
+    test set's attributes once, rather than once per deleted test.
+
+    Registered before /{test_id} routes below -- FastAPI matches routes in
+    registration order, so a literal /bulk path must come first or a
+    /{test_id}-shaped route would swallow it (treating "bulk" as an id).
+    """
+    organization_id, user_id = tenant_context
+    return crud.bulk_delete_tests(
+        db=db, test_ids=request.test_ids, organization_id=organization_id, user_id=user_id
+    )
+
+
 @router.post(
     "/from-conversation",
     response_model=schemas.ConversationToTestResponse,

--- a/apps/backend/src/rhesis/backend/app/schemas/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/__init__.py
@@ -144,6 +144,8 @@ from .test import (
     TestBulkCreate,
     TestBulkCreateRequest,
     TestBulkCreateResponse,
+    TestBulkDeleteRequest,
+    TestBulkDeleteResponse,
     TestBulkResponse,
     TestCreate,
     TestDetail,

--- a/apps/backend/src/rhesis/backend/app/schemas/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/explorer.py
@@ -60,6 +60,24 @@ class ExportExplorerTestSetResponse(Base):
 
 
 # ---------------------------------------------------------------------------
+# Bulk delete
+# ---------------------------------------------------------------------------
+
+
+class ExplorerTestSetBulkDeleteRequest(BaseModel):
+    """Request for DELETE /explorer/bulk."""
+
+    test_set_ids: List[UUID4]
+
+
+class ExplorerTestSetBulkDeleteResponse(BaseModel):
+    """Response for DELETE /explorer/bulk."""
+
+    deleted_ids: List[str]
+    not_found_ids: List[str]
+
+
+# ---------------------------------------------------------------------------
 # Generate outputs
 # ---------------------------------------------------------------------------
 

--- a/apps/backend/src/rhesis/backend/app/schemas/test.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test.py
@@ -234,6 +234,15 @@ class TestBulkCreateResponse(BaseModel):
     message: str
 
 
+class TestBulkDeleteRequest(BaseModel):
+    test_ids: List[UUID4]
+
+
+class TestBulkDeleteResponse(BaseModel):
+    deleted_ids: List[str]
+    not_found_ids: List[str]
+
+
 # In-place test execution schemas
 class TestExecuteRequest(BaseModel):
     """

--- a/apps/backend/src/rhesis/backend/app/services/cascade.py
+++ b/apps/backend/src/rhesis/backend/app/services/cascade.py
@@ -18,7 +18,7 @@ Usage:
 
 import logging
 from datetime import datetime, timezone
-from typing import Optional, Type
+from typing import List, Optional, Type
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -89,6 +89,71 @@ def cascade_soft_delete(
 
         except Exception as e:
             logger.error(f"Error cascading soft delete to {rel.child_model.__name__}: {e}")
+            raise
+
+    return total_deleted
+
+
+def cascade_soft_delete_bulk(
+    db: Session,
+    parent_model: Type,
+    parent_ids: List[UUID],
+    organization_id: Optional[str] = None,
+) -> int:
+    """
+    Cascade soft delete to all configured child relationships for many parents at once.
+
+    Same configuration and per-relationship bulk UPDATE as cascade_soft_delete(),
+    but issues one UPDATE per relationship for the whole batch of parent_ids
+    instead of one per parent_id -- for bulk_delete_by_ids() in crud_utils.py.
+
+    Args:
+        db: Database session
+        parent_model: The parent model class (e.g., models.Test)
+        parent_ids: IDs of the parent records being deleted
+        organization_id: Optional organization ID for tenant filtering
+
+    Returns:
+        Total number of child records soft deleted across all relationships
+
+    Note:
+        This function does NOT commit - the caller is responsible for transaction management.
+    """
+    if not parent_ids:
+        return 0
+
+    total_deleted = 0
+    relationships = get_cascade_relationships(parent_model)
+
+    for rel in relationships:
+        if not rel.cascade_delete:
+            continue
+
+        try:
+            query = db.query(rel.child_model).filter(
+                getattr(rel.child_model, rel.foreign_key).in_(parent_ids)
+            )
+
+            for key, value in rel.extra_filters.items():
+                query = query.filter(getattr(rel.child_model, key) == value)
+
+            if organization_id and hasattr(rel.child_model, "organization_id"):
+                query = query.filter(rel.child_model.organization_id == organization_id)
+
+            count = query.update(
+                {"deleted_at": datetime.now(timezone.utc)}, synchronize_session=False
+            )
+
+            total_deleted += count
+
+            if count > 0:
+                logger.info(
+                    f"Bulk cascade soft delete: {count} {rel.child_model.__name__} "
+                    f"records for {len(parent_ids)} {parent_model.__name__} row(s)"
+                )
+
+        except Exception as e:
+            logger.error(f"Error bulk cascading soft delete to {rel.child_model.__name__}: {e}")
             raise
 
     return total_deleted

--- a/apps/backend/src/rhesis/backend/app/services/explorer/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/__init__.py
@@ -26,6 +26,7 @@ from .suggestions import (
     suggestion_pipeline_stream,
 )
 from .tests import (
+    bulk_delete_explorer_test_sets,
     create_explorer_test_set,
     create_test_node,
     delete_explorer_test_set,
@@ -47,6 +48,7 @@ from .topics import (
 __all__ = [
     "a_generate_embedding_vectors_batch",
     "create_test_embedding",
+    "bulk_delete_explorer_test_sets",
     "create_explorer_test_set",
     "create_test_node",
     "create_topic_node",

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -11,10 +11,12 @@ from rhesis.backend.app.constants import ADAPTIVE_TESTING_BEHAVIOR
 from rhesis.backend.app.models.test import test_test_set_association
 from rhesis.backend.app.services.test import create_test_set_associations
 from rhesis.backend.app.utils.crud_utils import (
+    bulk_delete_by_ids,
     get_or_create_behavior,
     get_or_create_topic,
     get_or_create_type_lookup,
 )
+from rhesis.backend.app.utils.query_utils import QueryBuilder
 from rhesis.sdk.adaptive_testing.schemas import TestTreeNode, TopicNode
 
 from .topics import create_topic_node
@@ -229,6 +231,43 @@ def delete_explorer_test_set(
     if deleted is None:
         raise ValueError("Test set not found with provided identifier")
     return payload
+
+
+def bulk_delete_explorer_test_sets(
+    db: Session,
+    test_set_ids: List[UUID],
+    organization_id: str,
+    user_id: str,
+) -> dict:
+    """Delete multiple Explorer test sets at once.
+
+    Any id that doesn't resolve to a test set with the Adaptive Testing
+    behavior is reported back in "not_found_ids" rather than deleted -- same
+    guard delete_explorer_test_set() enforces per-item, applied to the batch
+    up front so bulk_delete_by_ids() only ever touches valid ids.
+    """
+    if not test_set_ids:
+        return {"deleted_ids": [], "not_found_ids": []}
+
+    candidates = (
+        QueryBuilder(db, models.TestSet)
+        .with_organization_filter(organization_id)
+        .with_custom_filter(lambda q: q.filter(models.TestSet.id.in_(test_set_ids)))
+        .all()
+    )
+    valid_ids = [ts.id for ts in candidates if _is_explorer_test_set(ts)]
+
+    result = bulk_delete_by_ids(
+        db,
+        models.TestSet,
+        valid_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    valid_id_strs = {str(i) for i in valid_ids}
+    skipped_ids = [str(i) for i in test_set_ids if str(i) not in valid_id_strs]
+    result["not_found_ids"] = result["not_found_ids"] + skipped_ids
+    return result
 
 
 def _unique_explorer_import_name(db: Session, organization_id: str, base_name: str) -> str:

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -4,7 +4,8 @@ Utility functions for CRUD operations with improved readability and maintainabil
 
 import logging
 import uuid
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
 from pydantic import BaseModel
 from sqlalchemy import inspect
@@ -701,6 +702,78 @@ def delete_item(
     except Exception:
         db.rollback()
         raise
+
+
+def bulk_delete_by_ids(
+    db: Session,
+    model: Type[T],
+    item_ids: List[uuid.UUID],
+    organization_id: str = None,
+    user_id: str = None,
+    on_deleted: Optional[Callable[[List[uuid.UUID]], None]] = None,
+) -> Dict[str, List[str]]:
+    """
+    Soft delete multiple items by ID in a single transaction.
+
+    Generic bulk counterpart to delete_item(): instead of one round trip per
+    id, resolves which ids exist/are visible, cascades and soft-deletes the
+    whole batch with one UPDATE per table (see cascade_soft_delete_bulk()),
+    and commits once. Use this instead of looping delete_item() per id when a
+    resource needs a real bulk-delete endpoint -- a loop still opens one
+    transaction per id and gains nothing over 25 individual requests.
+
+    Args:
+        db: Database session
+        model: SQLAlchemy model class
+        item_ids: IDs of items to delete
+        organization_id: Organization ID for tenant filtering
+        user_id: User ID for visibility filtering
+        on_deleted: Optional callback invoked once, after commit, with the
+            list of ids actually deleted. Use this for bespoke post-delete
+            side effects that should run once per batch rather than once per
+            id (e.g. Test's test-set-attribute recompute, keyed by the
+            *distinct* affected test sets, not by each deleted test).
+
+    Returns:
+        Dict with "deleted_ids" and "not_found_ids" (both lists of str ids).
+    """
+    from rhesis.backend.app.services import cascade as cascade_service
+
+    if not item_ids:
+        return {"deleted_ids": [], "not_found_ids": []}
+
+    existing_ids = {
+        row.id
+        for row in QueryBuilder(db, model)
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .with_custom_filter(lambda q: q.filter(model.id.in_(item_ids)))
+        .all()
+    }
+    deleted_ids = [i for i in item_ids if i in existing_ids]
+    not_found_ids = [i for i in item_ids if i not in existing_ids]
+
+    if deleted_ids:
+        try:
+            cascade_service.cascade_soft_delete_bulk(db, model, deleted_ids, organization_id)
+
+            query = db.query(model).filter(model.id.in_(deleted_ids))
+            if organization_id and hasattr(model, "organization_id"):
+                query = query.filter(model.organization_id == organization_id)
+            query.update({"deleted_at": datetime.now(timezone.utc)}, synchronize_session=False)
+
+            db.commit()
+        except Exception:
+            db.rollback()
+            raise
+
+        if on_deleted:
+            on_deleted(deleted_ids)
+
+    return {
+        "deleted_ids": [str(i) for i in deleted_ids],
+        "not_found_ids": [str(i) for i in not_found_ids],
+    }
 
 
 def get_deleted_items(

--- a/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
@@ -217,9 +217,7 @@ export default function ExplorerGrid({
     try {
       setIsDeleting(true);
       const client = new ApiClientFactory().getExplorerClient();
-      await Promise.all(
-        selectedRows.map(id => client.deleteExplorerTestSet(String(id)))
-      );
+      await client.bulkDeleteExplorerTestSets(selectedRows.map(String));
 
       notifications.show(
         `Successfully deleted ${selectedRows.length} ${selectedRows.length === 1 ? 'session' : 'sessions'}`,

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -722,7 +722,7 @@ export default function TestsTable({
       const clientFactory = new ApiClientFactory();
       const testsClient = clientFactory.getTestsClient();
 
-      await Promise.all(idsToDelete.map(id => testsClient.deleteTest(id)));
+      await testsClient.bulkDeleteTests(idsToDelete);
 
       notifications.show(
         `Successfully deleted ${idsToDelete.length} ${idsToDelete.length === 1 ? 'test' : 'tests'}`,

--- a/apps/frontend/src/utils/api-client/explorer-client.ts
+++ b/apps/frontend/src/utils/api-client/explorer-client.ts
@@ -1,6 +1,7 @@
 import { BaseApiClient } from './base-client';
 import { API_ENDPOINTS } from './config';
 import { joinUrl } from '@/utils/url';
+import { BulkDeleteResponse } from './interfaces/common';
 import {
   DeleteTopicResponse,
   DeleteTestResponse,
@@ -129,6 +130,19 @@ export class ExplorerClient extends BaseApiClient {
   async deleteExplorerTestSet(testSetId: string): Promise<void> {
     return this.fetch<void>(`${API_ENDPOINTS.explorer}/${testSetId}`, {
       method: 'DELETE',
+    });
+  }
+
+  /**
+   * Delete multiple explorer test sets at once.
+   * @param testSetIds Test set IDs to delete
+   */
+  async bulkDeleteExplorerTestSets(
+    testSetIds: string[]
+  ): Promise<BulkDeleteResponse> {
+    return this.fetch<BulkDeleteResponse>(`${API_ENDPOINTS.explorer}/bulk`, {
+      method: 'DELETE',
+      body: JSON.stringify({ test_set_ids: testSetIds }),
     });
   }
 

--- a/apps/frontend/src/utils/api-client/interfaces/common.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/common.ts
@@ -18,6 +18,12 @@ export interface StatsOptions {
   mode?: StatsMode; // Default is 'entity' if not specified
 }
 
+// Shared shape for POST .../bulk-delete endpoints (see schemas/bulk.py on the backend)
+export interface BulkDeleteResponse {
+  deleted_ids: string[];
+  not_found_ids: string[];
+}
+
 // Comprehensive options for test results stats
 export interface TestResultsStatsOptions {
   // Data mode selection

--- a/apps/frontend/src/utils/api-client/tests-client.ts
+++ b/apps/frontend/src/utils/api-client/tests-client.ts
@@ -16,7 +16,7 @@ import {
   PriorityLevel,
 } from './interfaces/tests';
 import { TestSet } from './interfaces/test-set';
-import { StatsOptions } from './interfaces/common';
+import { BulkDeleteResponse, StatsOptions } from './interfaces/common';
 import { PaginatedResponse, PaginationParams } from './interfaces/pagination';
 import {
   IndividualTestStats,
@@ -170,6 +170,13 @@ export class TestsClient extends BaseApiClient {
   async deleteTest(id: string): Promise<Test> {
     return this.fetch<Test>(`${API_ENDPOINTS.tests}/${id}`, {
       method: 'DELETE',
+    });
+  }
+
+  async bulkDeleteTests(testIds: string[]): Promise<BulkDeleteResponse> {
+    return this.fetch<BulkDeleteResponse>(`${API_ENDPOINTS.tests}/bulk`, {
+      method: 'DELETE',
+      body: JSON.stringify({ test_ids: testIds }),
     });
   }
 

--- a/tests/backend/crud/test_test_crud.py
+++ b/tests/backend/crud/test_test_crud.py
@@ -218,3 +218,106 @@ class TestTestOperations:
         assert reloaded_explorer_test_set.attributes["metadata"]["behaviors"] == [
             ADAPTIVE_TESTING_BEHAVIOR
         ]
+
+
+@pytest.mark.unit
+@pytest.mark.crud
+class TestBulkDeleteTests:
+    """🧪 crud.bulk_delete_tests"""
+
+    def _make_test(self, test_db, test_org_id, authenticated_user_id, behavior_id, test_set_id):
+        db_test = models.Test(
+            behavior_id=behavior_id,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.add(db_test)
+        test_db.flush()
+        test_db.execute(
+            test_test_set_association.insert().values(
+                test_id=db_test.id,
+                test_set_id=test_set_id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+        )
+        test_db.flush()
+        return db_test
+
+    def test_recomputes_each_affected_test_set_exactly_once(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        """Deleting several tests spread across 2 test sets recomputes each
+        test set's attributes exactly once, not once per deleted test."""
+        behavior = models.Behavior(
+            name="Compliance", organization_id=test_org_id, user_id=authenticated_user_id
+        )
+        test_db.add(behavior)
+        test_db.flush()
+
+        test_set_a = models.TestSet(
+            name="Set A", organization_id=test_org_id, user_id=authenticated_user_id
+        )
+        test_set_b = models.TestSet(
+            name="Set B", organization_id=test_org_id, user_id=authenticated_user_id
+        )
+        test_db.add_all([test_set_a, test_set_b])
+        test_db.flush()
+
+        # 2 tests in set A, 1 test in set B
+        tests_a = [
+            self._make_test(test_db, test_org_id, authenticated_user_id, behavior.id, test_set_a.id)
+            for _ in range(2)
+        ]
+        test_b = self._make_test(
+            test_db, test_org_id, authenticated_user_id, behavior.id, test_set_b.id
+        )
+        all_ids = [t.id for t in tests_a] + [test_b.id]
+
+        with patch(
+            "rhesis.backend.app.services.test_set.update_test_set_attributes"
+        ) as mock_refresh:
+            result = crud.bulk_delete_tests(
+                db=test_db,
+                test_ids=all_ids,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+
+        assert set(result["deleted_ids"]) == {str(i) for i in all_ids}
+        assert result["not_found_ids"] == []
+
+        # Exactly one recompute call per distinct affected test set, not per test.
+        assert mock_refresh.call_count == 2
+        recomputed_test_set_ids = {
+            call.kwargs["test_set_id"] for call in mock_refresh.call_args_list
+        }
+        assert recomputed_test_set_ids == {str(test_set_a.id), str(test_set_b.id)}
+
+        for test_id in all_ids:
+            deleted_test = test_db.query(models.Test).filter(models.Test.id == test_id).first()
+            assert deleted_test is None
+
+    def test_reports_not_found_ids(
+        self, test_db: Session, db_test_minimal, test_org_id: str, authenticated_user_id: str
+    ):
+        """A nonexistent id in the batch is reported back, not silently dropped."""
+        fake_id = uuid.uuid4()
+
+        result = crud.bulk_delete_tests(
+            db=test_db,
+            test_ids=[db_test_minimal.id, fake_id],
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        assert result["deleted_ids"] == [str(db_test_minimal.id)]
+        assert result["not_found_ids"] == [str(fake_id)]
+
+    def test_empty_ids_is_a_noop(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        result = crud.bulk_delete_tests(
+            db=test_db, test_ids=[], organization_id=test_org_id, user_id=authenticated_user_id
+        )
+        assert result == {"deleted_ids": [], "not_found_ids": []}

--- a/tests/backend/crud/test_test_crud.py
+++ b/tests/backend/crud/test_test_crud.py
@@ -321,3 +321,79 @@ class TestBulkDeleteTests:
             db=test_db, test_ids=[], organization_id=test_org_id, user_id=authenticated_user_id
         )
         assert result == {"deleted_ids": [], "not_found_ids": []}
+
+    def test_foreign_org_test_set_is_never_recomputed(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        """🔒 SECURITY: a guessed/foreign test id must not leak its org's test
+        set into the recompute set, even though it's reported as not_found.
+
+        The affected-test-sets lookup in bulk_delete_tests is a Core-style
+        db.execute(select(...)) query, which the ambient tenant-filter
+        listener does not auto-scope -- it must filter by organization_id
+        explicitly or a foreign org's test_set_id can leak into the batch.
+        """
+        other_org_id = str(uuid.uuid4())
+        test_db.add(models.Organization(id=uuid.UUID(other_org_id), name="Other Org"))
+        test_db.flush()
+
+        behavior = models.Behavior(
+            name="Compliance", organization_id=test_org_id, user_id=authenticated_user_id
+        )
+        test_db.add(behavior)
+        test_db.flush()
+
+        own_test_set = models.TestSet(
+            name="Own Set", organization_id=test_org_id, user_id=authenticated_user_id
+        )
+        foreign_test_set = models.TestSet(
+            name="Foreign Set", organization_id=other_org_id, user_id=authenticated_user_id
+        )
+        test_db.add_all([own_test_set, foreign_test_set])
+        test_db.flush()
+
+        own_test = self._make_test(
+            test_db, test_org_id, authenticated_user_id, behavior.id, own_test_set.id
+        )
+
+        foreign_test = models.Test(
+            behavior_id=behavior.id,
+            organization_id=other_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.add(foreign_test)
+        test_db.flush()
+        test_db.execute(
+            test_test_set_association.insert().values(
+                test_id=foreign_test.id,
+                test_set_id=foreign_test_set.id,
+                organization_id=other_org_id,
+                user_id=authenticated_user_id,
+            )
+        )
+        test_db.flush()
+
+        with patch(
+            "rhesis.backend.app.services.test_set.update_test_set_attributes"
+        ) as mock_refresh:
+            result = crud.bulk_delete_tests(
+                db=test_db,
+                test_ids=[own_test.id, foreign_test.id],
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+
+        # Foreign test is invisible to this org -- reported not_found, not deleted.
+        assert result["deleted_ids"] == [str(own_test.id)]
+        assert result["not_found_ids"] == [str(foreign_test.id)]
+
+        # And its test set must never be touched -- only the caller's own set.
+        recomputed_test_set_ids = {
+            call.kwargs["test_set_id"] for call in mock_refresh.call_args_list
+        }
+        assert recomputed_test_set_ids == {str(own_test_set.id)}
+
+        # The foreign test/test set must remain untouched in the database.
+        still_there = test_db.query(models.Test).filter(models.Test.id == foreign_test.id).first()
+        assert still_there is not None
+        assert still_there.deleted_at is None

--- a/tests/backend/routes/test_explorer.py
+++ b/tests/backend/routes/test_explorer.py
@@ -758,6 +758,47 @@ class TestDeleteExplorerTestSetEndpoint:
 
 @pytest.mark.integration
 @pytest.mark.routes
+class TestBulkDeleteExplorerTestSetsEndpoint:
+    """Test DELETE /explorer/bulk"""
+
+    def test_bulk_delete_returns_deleted_and_not_found_ids(
+        self,
+        authenticated_client: TestClient,
+        explorer_and_regular_test_sets,
+    ):
+        explorer_1_id = str(explorer_and_regular_test_sets["explorer_1"].id)
+        explorer_2_id = str(explorer_and_regular_test_sets["explorer_2"].id)
+        regular_id = str(explorer_and_regular_test_sets["regular"].id)
+        fake_id = str(uuid.uuid4())
+
+        response = authenticated_client.request(
+            "DELETE",
+            "/explorer/bulk",
+            json={"test_set_ids": [explorer_1_id, explorer_2_id, regular_id, fake_id]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert set(data["deleted_ids"]) == {explorer_1_id, explorer_2_id}
+        assert set(data["not_found_ids"]) == {regular_id, fake_id}
+
+        list_resp = authenticated_client.get("/explorer")
+        ids = {item["id"] for item in list_resp.json()}
+        assert explorer_1_id not in ids
+        assert explorer_2_id not in ids
+
+    def test_bulk_delete_unauthenticated(self, client: TestClient):
+        response = client.request(
+            "DELETE", "/explorer/bulk", json={"test_set_ids": [str(uuid.uuid4())]}
+        )
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+
+@pytest.mark.integration
+@pytest.mark.routes
 class TestExplorerTreeEndpoint:
     """Test GET /explorer/{test_set_id}/tree"""
 

--- a/tests/backend/routes/test_test_bulk_delete.py
+++ b/tests/backend/routes/test_test_bulk_delete.py
@@ -1,0 +1,39 @@
+"""
+Tests for DELETE /tests/bulk endpoint.
+
+Registered before /{test_id} in routers/test.py -- these tests exist mainly to
+guard against that route-ordering regression (a /{test_id}-shaped route
+registered first would swallow "/tests/bulk", treating "bulk" as an id).
+"""
+
+import uuid
+
+from fastapi import status
+from fastapi.testclient import TestClient
+
+
+class TestBulkDeleteTestsEndpoint:
+    """Tests for DELETE /tests/bulk"""
+
+    def test_bulk_delete_returns_deleted_and_not_found_ids(
+        self, authenticated_client: TestClient, db_test_minimal
+    ):
+        fake_id = str(uuid.uuid4())
+
+        response = authenticated_client.request(
+            "DELETE",
+            "/tests/bulk",
+            json={"test_ids": [str(db_test_minimal.id), fake_id]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["deleted_ids"] == [str(db_test_minimal.id)]
+        assert data["not_found_ids"] == [fake_id]
+
+    def test_bulk_delete_unauthenticated(self, client: TestClient):
+        response = client.request("DELETE", "/tests/bulk", json={"test_ids": [str(uuid.uuid4())]})
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]

--- a/tests/backend/services/explorer/test_tests.py
+++ b/tests/backend/services/explorer/test_tests.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
 from rhesis.backend.app.services.explorer import (
+    bulk_delete_explorer_test_sets,
     create_explorer_test_set,
     create_test_node,
     delete_explorer_test_set,
@@ -475,6 +476,61 @@ class TestDeleteExplorerTestSet:
                 organization_id=test_org_id,
                 user_id=authenticated_user_id,
             )
+
+
+class TestBulkDeleteExplorerTestSets:
+    """Test bulk_delete_explorer_test_sets - deletes several at once, skips non-explorer ids."""
+
+    def test_deletes_valid_explorer_sets(
+        self, test_db, explorer_and_regular_test_sets, test_org_id, authenticated_user_id
+    ):
+        explorer_1 = explorer_and_regular_test_sets["explorer_1"]
+        explorer_2 = explorer_and_regular_test_sets["explorer_2"]
+
+        result = bulk_delete_explorer_test_sets(
+            db=test_db,
+            test_set_ids=[explorer_1.id, explorer_2.id],
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        assert set(result["deleted_ids"]) == {str(explorer_1.id), str(explorer_2.id)}
+        assert result["not_found_ids"] == []
+        listed_ids = {
+            str(ts.id)
+            for ts in get_explorer_test_sets(db=test_db, organization_id=test_org_id, limit=500)
+        }
+        assert str(explorer_1.id) not in listed_ids
+        assert str(explorer_2.id) not in listed_ids
+
+    def test_skips_non_explorer_and_nonexistent_ids(
+        self, test_db, explorer_and_regular_test_sets, test_org_id, authenticated_user_id
+    ):
+        explorer_1 = explorer_and_regular_test_sets["explorer_1"]
+        regular = explorer_and_regular_test_sets["regular"]
+        fake_id = uuid.uuid4()
+
+        result = bulk_delete_explorer_test_sets(
+            db=test_db,
+            test_set_ids=[explorer_1.id, regular.id, fake_id],
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        assert result["deleted_ids"] == [str(explorer_1.id)]
+        assert set(result["not_found_ids"]) == {str(regular.id), str(fake_id)}
+
+        # The regular (non-explorer) test set must still exist, untouched.
+        still_there = (
+            test_db.query(models.TestSet).filter(models.TestSet.id == regular.id).first()
+        )
+        assert still_there is not None
+
+    def test_empty_ids_is_a_noop(self, test_db, test_org_id, authenticated_user_id):
+        result = bulk_delete_explorer_test_sets(
+            db=test_db, test_set_ids=[], organization_id=test_org_id, user_id=authenticated_user_id
+        )
+        assert result == {"deleted_ids": [], "not_found_ids": []}
 
 
 # ============================================================================


### PR DESCRIPTION
## Purpose

Bulk-deleting tests from the UI fired one `DELETE` request per selected row, and each one independently recomputed its test set's attributes — when many deleted tests shared a test set, that row got recomputed and updated up to N times, with concurrent writes serializing at the database.

## What Changed

- Added a generic `bulk_delete_by_ids()` core (`utils/crud_utils.py`) that soft-deletes many ids in one transaction, with cascade support (`cascade_soft_delete_bulk`) and an optional post-delete hook for resource-specific side effects.
- `DELETE /tests/bulk`: resolves all test sets affected by the whole batch once, and recomputes each exactly once instead of once per deleted test.
- `DELETE /explorer/bulk`: same generic core, no hook needed (explorer test set deletion has no bespoke side effects).
- Frontend: `TestsGrid` and `ExplorerGrid` now fire one bulk request instead of `Promise.all(N individual deletes)`.

## Additional Context

- Both routes are registered before their `/{id}`-shaped counterparts — FastAPI matches routes in registration order, so a literal `/bulk` path must come first or the identifier-shaped route swallows it.
- Scope intentionally limited to Test and Explorer test sets — the only two resources with a live multi-select-delete UI today.

## Testing

- Backend: `cd apps/backend && RHESIS_SKIP_MIGRATIONS=1 uv run pytest ../../tests/backend/ -q` — full suite passes (one pre-existing, unrelated failure).
- New tests cover: bulk delete recomputing each affected test set exactly once (not once per test), not-found id reporting, explorer non-adaptive/nonexistent id skipping, and route-level HTTP checks for both endpoints (including the route-ordering regression).
- Frontend: `npx tsc --noEmit` and `eslint` clean on all touched files.