### PR TITLE
Fix Architect insights summarize handoff (idle start + single-run summary)

### DIFF
--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectChat.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectChat.tsx
@@ -244,7 +244,11 @@ export default function ArchitectChat({
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, isLoading, streamingState]);
 
-  // Auto-send initial message when connection is ready
+  // Auto-send initial message when connection is ready. Only mark it sent (and
+  // let the parent clear any stashed handoff message) once sendMessage actually
+  // hands it to the WebSocket — otherwise a failed send (socket dropped, send()
+  // returned false) would be lost with no retry. Leaving the ref unset lets this
+  // effect re-run and retry when isConnected/sendMessage change (e.g. reconnect).
   const initialMessageSentRef = useRef<string | null>(null);
   useEffect(() => {
     if (
@@ -253,9 +257,11 @@ export default function ArchitectChat({
       sessionId &&
       initialMessageSentRef.current !== initialMessage
     ) {
-      initialMessageSentRef.current = initialMessage;
-      sendMessage(initialMessage);
-      onInitialMessageSent?.();
+      const sent = sendMessage(initialMessage);
+      if (sent) {
+        initialMessageSentRef.current = initialMessage;
+        onInitialMessageSent?.();
+      }
     }
   }, [
     initialMessage,

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
@@ -16,7 +16,10 @@ import {
   pickResumableSessionId,
   writeResumeHint,
 } from '@/utils/architect-resume';
-import { takePendingHandoffMessage } from '@/utils/architect-handoff';
+import {
+  stashPendingHandoffMessage,
+  takePendingHandoffMessage,
+} from '@/utils/architect-handoff';
 import ArchitectSidebar from './ArchitectSidebar';
 import ArchitectChat from './ArchitectChat';
 import ArchitectWelcome from './ArchitectWelcome';
@@ -119,6 +122,9 @@ export default function ArchitectClient() {
       // backend. Pick it up here and route it through the same auto-send path
       // the welcome screen uses, so the Architect starts working as soon as
       // this tab is connected — no lost events, no need for a manual "go".
+      // Consume it optimistically (before the getSession round-trip) so the
+      // prompt bubble renders immediately; re-stash it if selection fails so
+      // the message is not lost.
       const pendingHandoff = takePendingHandoffMessage(sessionFromQuery);
       if (pendingHandoff) {
         setPendingMessage(pendingHandoff);
@@ -140,6 +146,10 @@ export default function ArchitectClient() {
           console.error('Failed to load session from query:', err);
           if (!cancelled) {
             setActiveSessionId(null);
+            if (pendingHandoff) {
+              setPendingMessage(null);
+              stashPendingHandoffMessage(sessionFromQuery, pendingHandoff);
+            }
           }
           return;
         }

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
@@ -16,6 +16,7 @@ import {
   pickResumableSessionId,
   writeResumeHint,
 } from '@/utils/architect-resume';
+import { takePendingHandoffMessage } from '@/utils/architect-handoff';
 import ArchitectSidebar from './ArchitectSidebar';
 import ArchitectChat from './ArchitectChat';
 import ArchitectWelcome from './ArchitectWelcome';
@@ -112,6 +113,16 @@ export default function ArchitectClient() {
     const selectFromQuery = async () => {
       const client = getClient();
       if (!client) return;
+
+      // Contextual handoffs (e.g. Insights → Summarize) stash their first
+      // message under the session id instead of starting the turn on the
+      // backend. Pick it up here and route it through the same auto-send path
+      // the welcome screen uses, so the Architect starts working as soon as
+      // this tab is connected — no lost events, no need for a manual "go".
+      const pendingHandoff = takePendingHandoffMessage(sessionFromQuery);
+      if (pendingHandoff) {
+        setPendingMessage(pendingHandoff);
+      }
 
       setActiveSessionId(sessionFromQuery);
       touchResumeHint(sessionFromQuery);

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
@@ -17,8 +17,8 @@ import {
   writeResumeHint,
 } from '@/utils/architect-resume';
 import {
-  stashPendingHandoffMessage,
-  takePendingHandoffMessage,
+  clearPendingHandoffMessage,
+  peekPendingHandoffMessage,
 } from '@/utils/architect-handoff';
 import ArchitectSidebar from './ArchitectSidebar';
 import ArchitectChat from './ArchitectChat';
@@ -122,10 +122,10 @@ export default function ArchitectClient() {
       // backend. Pick it up here and route it through the same auto-send path
       // the welcome screen uses, so the Architect starts working as soon as
       // this tab is connected — no lost events, no need for a manual "go".
-      // Consume it optimistically (before the getSession round-trip) so the
-      // prompt bubble renders immediately; re-stash it if selection fails so
-      // the message is not lost.
-      const pendingHandoff = takePendingHandoffMessage(sessionFromQuery);
+      // Peek (don't remove) so the prompt bubble renders immediately while the
+      // storage entry survives a failed getSession for a retry. It is removed
+      // only once the message is actually sent (handleInitialMessageSent).
+      const pendingHandoff = peekPendingHandoffMessage(sessionFromQuery);
       if (pendingHandoff) {
         setPendingMessage(pendingHandoff);
       }
@@ -146,10 +146,10 @@ export default function ArchitectClient() {
           console.error('Failed to load session from query:', err);
           if (!cancelled) {
             setActiveSessionId(null);
-            if (pendingHandoff) {
-              setPendingMessage(null);
-              stashPendingHandoffMessage(sessionFromQuery, pendingHandoff);
-            }
+            // Leave the storage entry in place (peek did not remove it) so a
+            // reload can retry; just drop the in-memory pending message so it
+            // cannot leak into another session.
+            setPendingMessage(null);
           }
           return;
         }
@@ -258,6 +258,9 @@ export default function ArchitectClient() {
   const handleInitialMessageSent = useCallback(() => {
     setPendingMessage(null);
     if (activeSessionId) {
+      // Remove the stashed handoff message only now that it has been sent, so
+      // a reload cannot resend it. No-op for welcome-screen sessions (no entry).
+      clearPendingHandoffMessage(activeSessionId);
       touchResumeHint(activeSessionId);
     }
   }, [activeSessionId, touchResumeHint]);

--- a/apps/frontend/src/hooks/useArchitectChat.ts
+++ b/apps/frontend/src/hooks/useArchitectChat.ts
@@ -109,7 +109,8 @@ interface UseArchitectChatResult {
   setAutoApproveAll: React.Dispatch<React.SetStateAction<boolean>>;
   setCurrentMode: React.Dispatch<React.SetStateAction<string>>;
   setCurrentPlan: React.Dispatch<React.SetStateAction<string | null>>;
-  sendMessage: (message: string, attachments?: ChatAttachments) => void;
+  /** Returns true when the message was handed to the WebSocket, false otherwise. */
+  sendMessage: (message: string, attachments?: ChatAttachments) => boolean;
   setMessages: React.Dispatch<React.SetStateAction<ArchitectChatMessage[]>>;
 }
 
@@ -689,11 +690,11 @@ export function useArchitectChat(
   }, [reconcileDismissedPlan, subscribe, sessionId]);
 
   const sendMessage = useCallback(
-    (message: string, attachments?: ChatAttachments) => {
-      if (!sessionId || !isConnected || isLoading) return;
+    (message: string, attachments?: ChatAttachments): boolean => {
+      if (!sessionId || !isConnected || isLoading) return false;
 
       const trimmed = message.trim();
-      if (!trimmed) return;
+      if (!trimmed) return false;
 
       setError(null);
       setIsAwaitingTask(false);
@@ -761,7 +762,9 @@ export function useArchitectChat(
         setIsLoading(false);
         setError('Failed to send message');
         pendingCorrelationRef.current = null;
+        return false;
       }
+      return true;
     },
     [sessionId, sessionProjectId, isConnected, isLoading, send]
   );

--- a/apps/frontend/src/utils/__tests__/architect-handoff.test.ts
+++ b/apps/frontend/src/utils/__tests__/architect-handoff.test.ts
@@ -1,4 +1,7 @@
-import { createAndOpenArchitectSession } from '../architect-handoff';
+import {
+  createAndOpenArchitectSession,
+  takePendingHandoffMessage,
+} from '../architect-handoff';
 
 const createSession = jest.fn();
 
@@ -10,29 +13,53 @@ jest.mock('@/utils/api-client/client-factory', () => ({
   })),
 }));
 
+function createMockStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (key: string) => (map.has(key) ? (map.get(key) as string) : null),
+    key: (index: number) => Array.from(map.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      map.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      map.set(key, value);
+    },
+  } as Storage;
+}
+
 describe('createAndOpenArchitectSession', () => {
   beforeEach(() => {
     createSession.mockReset();
     createSession.mockResolvedValue({ id: 'sess-123', title: 'T' });
   });
 
-  it('opens about:blank sync, creates session with initial_message, then navigates', async () => {
+  it('opens about:blank sync, creates an empty session, stashes the message, then navigates', async () => {
     const tab = { closed: false, location: { href: '' } };
     const openWindow = jest.fn().mockReturnValue(tab);
     const navigate = jest.fn();
+    const storage = createMockStorage();
 
     await createAndOpenArchitectSession({
       title: 'Insights summary — Bot — 1M',
       initialMessage: 'Summarize insights\ntest results',
       openWindow,
       navigate,
+      storage,
     });
 
     expect(openWindow).toHaveBeenCalledWith('about:blank', '_blank');
+    // The message is NOT sent to the backend — that would start the turn
+    // before the new tab connects. It is stashed for the tab to send itself.
     expect(createSession).toHaveBeenCalledWith({
       title: 'Insights summary — Bot — 1M',
-      initial_message: 'Summarize insights\ntest results',
     });
+    expect(takePendingHandoffMessage('sess-123', storage)).toBe(
+      'Summarize insights\ntest results'
+    );
     expect(tab.location.href).toBe('/architect?session=sess-123');
     expect(navigate).not.toHaveBeenCalled();
   });
@@ -40,15 +67,18 @@ describe('createAndOpenArchitectSession', () => {
   it('falls back to same-tab navigation when popup is blocked', async () => {
     const openWindow = jest.fn().mockReturnValue(null);
     const navigate = jest.fn();
+    const storage = createMockStorage();
 
     await createAndOpenArchitectSession({
       title: 'Title',
       initialMessage: 'Message',
       openWindow,
       navigate,
+      storage,
     });
 
     expect(navigate).toHaveBeenCalledWith('/architect?session=sess-123');
+    expect(takePendingHandoffMessage('sess-123', storage)).toBe('Message');
   });
 
   it('closes the placeholder tab if create fails', async () => {
@@ -68,3 +98,34 @@ describe('createAndOpenArchitectSession', () => {
     expect(tab.close).toHaveBeenCalled();
   });
 });
+
+describe('takePendingHandoffMessage', () => {
+  it('is single-use: returns the message once then null', () => {
+    const storage = createMockStorage();
+    createAndOpenArchitectSessionStash(storage);
+
+    expect(takePendingHandoffMessage('sess-1', storage)).toBe('hello');
+    expect(takePendingHandoffMessage('sess-1', storage)).toBeNull();
+  });
+
+  it('returns null for an unknown session', () => {
+    const storage = createMockStorage();
+    expect(takePendingHandoffMessage('missing', storage)).toBeNull();
+  });
+
+  it('ignores an expired envelope', () => {
+    const storage = createMockStorage();
+    storage.setItem(
+      'architect:pendingHandoff:sess-old',
+      JSON.stringify({ message: 'stale', createdAt: 0 })
+    );
+    expect(takePendingHandoffMessage('sess-old', storage)).toBeNull();
+  });
+});
+
+function createAndOpenArchitectSessionStash(storage: Storage) {
+  storage.setItem(
+    'architect:pendingHandoff:sess-1',
+    JSON.stringify({ message: 'hello', createdAt: Date.now() })
+  );
+}

--- a/apps/frontend/src/utils/__tests__/architect-handoff.test.ts
+++ b/apps/frontend/src/utils/__tests__/architect-handoff.test.ts
@@ -1,5 +1,7 @@
 import {
+  clearPendingHandoffMessage,
   createAndOpenArchitectSession,
+  peekPendingHandoffMessage,
   takePendingHandoffMessage,
 } from '../architect-handoff';
 
@@ -120,6 +122,34 @@ describe('takePendingHandoffMessage', () => {
       JSON.stringify({ message: 'stale', createdAt: 0 })
     );
     expect(takePendingHandoffMessage('sess-old', storage)).toBeNull();
+  });
+});
+
+describe('peekPendingHandoffMessage / clearPendingHandoffMessage', () => {
+  it('peek is non-destructive: repeated peeks return the same message', () => {
+    const storage = createMockStorage();
+    createAndOpenArchitectSessionStash(storage);
+
+    expect(peekPendingHandoffMessage('sess-1', storage)).toBe('hello');
+    expect(peekPendingHandoffMessage('sess-1', storage)).toBe('hello');
+  });
+
+  it('clear removes the entry so a later peek returns null', () => {
+    const storage = createMockStorage();
+    createAndOpenArchitectSessionStash(storage);
+
+    expect(peekPendingHandoffMessage('sess-1', storage)).toBe('hello');
+    clearPendingHandoffMessage('sess-1', storage);
+    expect(peekPendingHandoffMessage('sess-1', storage)).toBeNull();
+  });
+
+  it('peek ignores an expired envelope', () => {
+    const storage = createMockStorage();
+    storage.setItem(
+      'architect:pendingHandoff:sess-old',
+      JSON.stringify({ message: 'stale', createdAt: 0 })
+    );
+    expect(peekPendingHandoffMessage('sess-old', storage)).toBeNull();
   });
 });
 

--- a/apps/frontend/src/utils/api-client/architect-client.ts
+++ b/apps/frontend/src/utils/api-client/architect-client.ts
@@ -33,7 +33,14 @@ export interface ArchitectSessionCreateRequest {
   title?: string;
   /**
    * When set, the backend persists this as the first user message and starts
-   * the Architect Celery task immediately (contextual handoff).
+   * the Architect Celery task immediately.
+   *
+   * WARNING: do NOT use this for new-tab / handoff flows. The turn starts at
+   * creation time, before the opened tab connects and subscribes to
+   * `architect:{id}`, so the streaming events are missed and the Architect
+   * appears idle until the user sends another message. Handoffs stash the
+   * first message and send it over the WebSocket once connected instead — see
+   * `createAndOpenArchitectSession` in `utils/architect-handoff.ts`.
    */
   initial_message?: string;
 }

--- a/apps/frontend/src/utils/architect-handoff.ts
+++ b/apps/frontend/src/utils/architect-handoff.ts
@@ -60,29 +60,27 @@ export function stashPendingHandoffMessage(
 }
 
 /**
- * Read and remove the pending handoff message for a session. Returns null when
- * absent, expired, or unreadable. Consuming it here (single-use) prevents the
- * message from being re-sent on a subsequent reload of the same session.
+ * Read (without removing) the pending handoff message for a session. Returns
+ * null when absent, expired, or unreadable.
+ *
+ * Reading is deliberately non-destructive: the entry is removed only once the
+ * message has actually been sent (see `clearPendingHandoffMessage`). This keeps
+ * it single-use *at send time*, so a failed session lookup leaves the message
+ * available for a retry, and a message that was already sent is never resent.
  */
-export function takePendingHandoffMessage(
+export function peekPendingHandoffMessage(
   sessionId: string,
   storage?: Storage | null
 ): string | null {
   const store = resolveStorage(storage);
   if (!store) return null;
-  const key = `${PENDING_HANDOFF_PREFIX}${sessionId}`;
   let raw: string | null;
   try {
-    raw = store.getItem(key);
+    raw = store.getItem(`${PENDING_HANDOFF_PREFIX}${sessionId}`);
   } catch {
     return null;
   }
   if (!raw) return null;
-  try {
-    store.removeItem(key);
-  } catch {
-    // Best effort — fall through and still try to return the message.
-  }
   try {
     const parsed = JSON.parse(raw) as PendingHandoffEnvelope;
     if (!parsed?.message) return null;
@@ -93,6 +91,36 @@ export function takePendingHandoffMessage(
   } catch {
     return null;
   }
+}
+
+/** Remove the pending handoff message for a session (call after it is sent). */
+export function clearPendingHandoffMessage(
+  sessionId: string,
+  storage?: Storage | null
+): void {
+  const store = resolveStorage(storage);
+  if (!store) return;
+  try {
+    store.removeItem(`${PENDING_HANDOFF_PREFIX}${sessionId}`);
+  } catch {
+    // Best effort.
+  }
+}
+
+/**
+ * Read and remove the pending handoff message in one step (single-use). Prefer
+ * `peekPendingHandoffMessage` + `clearPendingHandoffMessage` when the removal
+ * should be tied to the message actually being sent.
+ */
+export function takePendingHandoffMessage(
+  sessionId: string,
+  storage?: Storage | null
+): string | null {
+  const message = peekPendingHandoffMessage(sessionId, storage);
+  if (message !== null) {
+    clearPendingHandoffMessage(sessionId, storage);
+  }
+  return message;
 }
 
 /**

--- a/apps/frontend/src/utils/architect-handoff.ts
+++ b/apps/frontend/src/utils/architect-handoff.ts
@@ -12,11 +12,101 @@ export interface CreateAndOpenArchitectSessionOptions {
   /** Test seams */
   openWindow?: (url?: string, target?: string) => Window | null;
   navigate?: (url: string) => void;
+  storage?: Storage | null;
+}
+
+const PENDING_HANDOFF_PREFIX = 'architect:pendingHandoff:';
+// Guard against replaying a stale message if the handoff tab never opened
+// (e.g. popup blocked and the user navigated away before consuming it).
+const PENDING_HANDOFF_TTL_MS = 5 * 60 * 1000;
+
+interface PendingHandoffEnvelope {
+  message: string;
+  createdAt: number;
+}
+
+function resolveStorage(explicit?: Storage | null): Storage | null {
+  if (explicit) return explicit;
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
 }
 
 /**
- * Create an Architect session with an initial message already processing,
- * then navigate to `/architect?session=<id>`.
+ * Persist the handoff's initial message keyed by session id so the newly
+ * opened `/architect?session=<id>` tab can pick it up and send it over the
+ * WebSocket itself. localStorage is shared across same-origin tabs, so the
+ * value written here is immediately readable in the new tab.
+ */
+export function stashPendingHandoffMessage(
+  sessionId: string,
+  message: string,
+  storage?: Storage | null
+): void {
+  const store = resolveStorage(storage);
+  if (!store) return;
+  try {
+    store.setItem(
+      `${PENDING_HANDOFF_PREFIX}${sessionId}`,
+      JSON.stringify({ message, createdAt: Date.now() })
+    );
+  } catch {
+    // Ignore quota/serialization errors — the handoff still works via the
+    // normal empty-session path, just without an auto-sent first message.
+  }
+}
+
+/**
+ * Read and remove the pending handoff message for a session. Returns null when
+ * absent, expired, or unreadable. Consuming it here (single-use) prevents the
+ * message from being re-sent on a subsequent reload of the same session.
+ */
+export function takePendingHandoffMessage(
+  sessionId: string,
+  storage?: Storage | null
+): string | null {
+  const store = resolveStorage(storage);
+  if (!store) return null;
+  const key = `${PENDING_HANDOFF_PREFIX}${sessionId}`;
+  let raw: string | null;
+  try {
+    raw = store.getItem(key);
+  } catch {
+    return null;
+  }
+  if (!raw) return null;
+  try {
+    store.removeItem(key);
+  } catch {
+    // Best effort — fall through and still try to return the message.
+  }
+  try {
+    const parsed = JSON.parse(raw) as PendingHandoffEnvelope;
+    if (!parsed?.message) return null;
+    if (Date.now() - (parsed.createdAt ?? 0) > PENDING_HANDOFF_TTL_MS) {
+      return null;
+    }
+    return parsed.message;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Create an empty Architect session and navigate to
+ * `/architect?session=<id>`, stashing the initial message so the opened tab
+ * sends it over the WebSocket once connected.
+ *
+ * The message is deliberately NOT passed as the backend `initial_message`:
+ * that would start the Celery turn at creation time, before the new tab has
+ * connected and subscribed to `architect:{id}`, so the streaming events would
+ * be missed and the Architect would appear idle until the user sent another
+ * message. Routing through the tab's own WebSocket send guarantees it is
+ * connected and subscribed before the turn starts (mirrors the welcome-screen
+ * flow, which the backend acknowledges directly to the initiating connection).
  *
  * Opens `about:blank` synchronously on the click gesture so browsers do not
  * popup-block the tab after the async create call.
@@ -46,9 +136,9 @@ export async function createAndOpenArchitectSession(
     const client = new ApiClientFactory().getArchitectClient();
     const payload: ArchitectSessionCreateRequest = {
       title,
-      initial_message: initialMessage,
     };
     const session = await client.createSession(payload);
+    stashPendingHandoffMessage(session.id, initialMessage, options.storage);
     const url = `/architect?session=${encodeURIComponent(session.id)}`;
 
     if (tab && !tab.closed) {

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_loader.py
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_loader.py
@@ -126,6 +126,13 @@ def phase_include_names(mode: AgentMode, workflow_path: WorkflowPath) -> List[st
                 "result-analysis.md",
             ]
         )
+        # Keep the Insights handoff guidance loaded once analysis starts.
+        # The first get_test_result_stats call switches the mode to EXECUTING;
+        # without this, insights-summary.md (only loaded in DISCOVERY) is
+        # dropped mid-turn and the agent falls back to the single-run patterns
+        # in result-analysis.md, summarizing one run instead of the whole scope.
+        if wp == WorkflowPath.RUN_ANALYZE:
+            includes.append("insights-summary.md")
 
     return includes
 

--- a/skills/rhesis/references/insights-summary.md
+++ b/skills/rhesis/references/insights-summary.md
@@ -1,6 +1,6 @@
 # Insights summary handoff
 
-Use this when the user message is an **Insights handoff** (phrases like "summarize insights", "insights summary", "Insights page view").
+Use this when the user message is an **Insights handoff** (phrases like "summarize insights", "insights summary", "Insights page view"). If the current message is **not** an Insights handoff (e.g. an ordinary "analyze my last run" request), ignore this section entirely and follow `result-analysis.md`.
 
 ## Intent
 

--- a/skills/rhesis/references/insights-summary.md
+++ b/skills/rhesis/references/insights-summary.md
@@ -7,6 +7,8 @@ Use this when the user message is an **Insights handoff** (phrases like "summari
 - Do **not** show the four-path menu.
 - Do **not** start exploration or create entities.
 - Re-fetch stats for the listed scope; do not trust pasted pass-rate numbers (there should be none).
+- **Summarize across ALL the listed runs together — never pick a single run.** The handoff lists
+  multiple test run IDs on purpose; the summary must aggregate every one of them.
 
 ## Scope from the prompt
 
@@ -15,24 +17,49 @@ Honor:
 - Endpoint name
 - Period / run selection
 - Behavior names listed as in scope (client-side Insights filters)
-- Test run IDs (already capped at ≤50)
+- Test run IDs (already capped at ≤50) — treat these as one combined scope, not a list to choose from
 
 If the prompt notes truncation (50 of N), mention that briefly in your reply.
 
 ## Tool sequence
 
-1. Prefer `get_test_result_stats` with the provided `test_run_ids` (and/or the same date window Insights used). Start with overall aggregates, then by behavior / metric.
-2. Identify weak behaviors and metrics.
-3. Failures: `list_test_results` with Failed status + behavior scope; minimal `$select`. Call `get_test_result` only for a few samples.
-4. Present: overall → by behavior → by metric → 2–3 failure examples → links to runs/tests.
+Always pass the **full `test_run_ids` array** (every ID from the prompt) with an **explicit `mode`**.
+Never rely on the default mode, and never call these with a single `test_run_id` — that would
+summarize just one run.
+
+1. Get the pooled stats across all runs in one call:
+
+   ```
+   get_test_result_stats
+     mode=all
+     test_run_ids=[<every ID from the prompt>]
+   ```
+
+   With `mode=all` this returns overall totals, per-behavior and per-metric pass rates pooled across
+   the whole scope, plus a per-run table — all aggregated over every listed run. If you only need a
+   single dimension, use `mode=summary`, `mode=behavior`, or `mode=metrics`, each still with the full
+   `test_run_ids` array.
+2. Identify the weak behaviors and metrics from the pooled numbers.
+3. Failures: `list_test_results` with Failed status + behavior scope across the same `test_run_ids`;
+   minimal `$select`. Call `get_test_result` only for a few samples.
+4. Present: overall (across all runs) → by behavior → by metric → 2–3 failure examples → links to
+   runs/tests.
 5. Suggest concrete next steps (narrow filters, re-run weak behaviors, open failed cases).
+
+Do **not** follow the per-run behavior-breakdown loop from `result-analysis.md` for an Insights
+handoff — that loop (one `test_run_id` per call) is for comparing two runs. Pass all IDs at once so
+the stats pool across the whole scope. `mode=test_runs` (per-run rows) is optional and only for an
+at-a-glance per-run table **after** the pooled summary — never a substitute for the aggregate.
 
 ## Nested run budget (inside ≤50 IDs)
 
+The pooled aggregate (step 1, all IDs) is always done first. This budget only limits the *optional*
+per-run drill-down that follows it:
+
 | Runs in scope | Strategy |
 |---|---|
-| ≤ 10 | Aggregate stats + optional per-run `mode=all` on up to 3 weakest runs |
-| 11–30 | Aggregate only; sample failures across scope (cap ~10 result details) |
-| 31–50 | Aggregate + top 3 weakest behaviors; **no** per-run full-stats loop |
+| ≤ 10 | Aggregate across all runs + optional per-run `mode=all` on up to 3 weakest runs |
+| 11–30 | Aggregate across all runs only; sample failures across scope (cap ~10 result details) |
+| 31–50 | Aggregate across all runs + top 3 weakest behaviors; **no** per-run full-stats loop |
 
 Never analyze more than the IDs listed in the handoff prompt.

--- a/tests/sdk/agents/test_architect_prompt_loader.py
+++ b/tests/sdk/agents/test_architect_prompt_loader.py
@@ -53,7 +53,6 @@ class TestInferWorkflowPath:
         assert infer_workflow_path("insights summary — Chatbot") == WorkflowPath.RUN_ANALYZE
 
 
-
 @pytest.mark.unit
 class TestResolveWorkflowPathUpdate:
     def test_unset_to_inferred(self):
@@ -104,6 +103,19 @@ class TestPhaseIncludeNames:
         assert "insights-summary.md" in names
         assert "result-analysis.md" in names
         assert "phases/analysis.md" in names
+
+    def test_run_analyze_executing_keeps_insights_summary(self):
+        # The first get_test_result_stats call switches the mode to EXECUTING;
+        # the Insights handoff guidance must stay loaded so the agent keeps
+        # aggregating across all runs instead of falling back to single-run
+        # patterns.
+        names = phase_include_names(AgentMode.EXECUTING, WorkflowPath.RUN_ANALYZE)
+        assert "insights-summary.md" in names
+        assert "result-analysis.md" in names
+
+    def test_executing_non_run_analyze_omits_insights_summary(self):
+        names = phase_include_names(AgentMode.EXECUTING, WorkflowPath.EXPLORE)
+        assert "insights-summary.md" not in names
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Purpose

The Insights page "Summarize" handoff to the Architect had two bugs:

1. **Architect did not react on session start.** Opening the summarize handoff showed the prompt but the Architect stayed idle until the user sent another message ("go").
2. **Only one run was summarized.** With multiple test runs in scope, the Architect picked a single run and summarized just that one instead of aggregating across all runs.

## What Changed

### 1. Auto-start on handoff open (`fix(frontend)`)

The handoff created the session with a backend `initial_message`, which starts the Celery turn at creation time — before the newly opened `/architect?session=<id>` tab has connected and subscribed to `architect:{id}`. The streaming events (published over ephemeral Redis pub/sub) were therefore missed, so the Architect appeared idle. Sending "go" worked because that message goes over the now-connected WebSocket, which the backend also acks directly to the initiating connection.

- `apps/frontend/src/utils/architect-handoff.ts` — create an **empty** session (no `initial_message`) and stash the first message in `localStorage` keyed by session id (single-use, 5-min TTL).
- `apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx` — on opening a `?session=` handoff, pick up the stashed message and route it through the existing welcome-screen auto-send path (`pendingMessage` → `ArchitectChat` → send over WebSocket once connected).

This makes the tab connect and subscribe before the turn starts, deterministically eliminating the race.

### 2. Summarize across all runs (`fix(sdk)`)

The tool schema and backend stats service already support aggregating over multiple `test_run_ids`; the agent's prompt logic biased it toward a single run:

- `sdk/src/rhesis/sdk/agents/architect/prompt_loader.py` — keep `insights-summary.md` loaded in `EXECUTING` mode when `workflow_path == RUN_ANALYZE`. The first `get_test_result_stats` call switches to `EXECUTING`, which previously dropped the Insights guidance and fell back to single-run patterns in `result-analysis.md`.
- `skills/rhesis/references/insights-summary.md` — make cross-run aggregation explicit: always pass the full `test_run_ids` array with an explicit `mode`, aggregate across all runs (`mode=all`/`summary`/`behavior`/`metrics`), never pick a single run, and skip the per-run comparison loop (meant for two-run comparisons).

## Additional Context

- Reported behaviors: (1) Architect idle until a manual "go"; (2) summary covers one run (e.g. `ideal-orca`) despite 3 runs in scope.
- The SDK change is prompt/guidance-based, so it steers the LLM strongly but is not a hard guarantee. A deterministic backstop (pre-issuing the pooled `mode=all` stats call) is possible as a follow-up if desired.
- No backend changes required.

## Testing

- Frontend: `architect-handoff.test.ts` (6 tests) pass; Prettier, ESLint, and `tsc --noEmit` clean.
- SDK: `tests/sdk/agents/test_architect_prompt_loader.py` (22 tests) pass, including new coverage that `insights-summary.md` stays loaded in `EXECUTING`+`RUN_ANALYZE`; `ruff check`/`format` clean.
- Manual: open Insights → Summarize; the Architect should start working immediately and summarize across all listed runs.