### PR TITLE
Fix backend N+1 queries in test/test-set eager loading

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -36,7 +36,7 @@ from rhesis.backend.app.utils.crud_utils import (
     update_item,
 )
 from rhesis.backend.app.utils.name_generator import generate_memorable_name
-from rhesis.backend.app.utils.query_utils import QueryBuilder, _resolve_chain, include
+from rhesis.backend.app.utils.query_utils import QueryBuilder, include, resolve_chain
 
 logger = logging.getLogger(__name__)
 
@@ -4210,7 +4210,7 @@ def get_trace_by_id(
     # Add eager loading if specified
     if eager_load:
         options = [
-            include(*_resolve_chain(models.Trace, relationship.split(".")))
+            include(*resolve_chain(models.Trace, relationship.split(".")))
             for relationship in eager_load
         ]
         builder = builder.with_related(*options)

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -36,7 +36,7 @@ from rhesis.backend.app.utils.crud_utils import (
     update_item,
 )
 from rhesis.backend.app.utils.name_generator import generate_memorable_name
-from rhesis.backend.app.utils.query_utils import QueryBuilder, include
+from rhesis.backend.app.utils.query_utils import QueryBuilder, _resolve_chain, include
 
 logger = logging.getLogger(__name__)
 
@@ -4184,32 +4184,38 @@ def get_trace_by_id(
         trace_id: OpenTelemetry trace ID
         project_id: Project ID for access control
         organization_id: Organization ID for multi-tenant security
-        eager_load: Optional list of relationship names to eager load
+        eager_load: Optional list of relationship names to eager load. Each
+            entry may be a single name ("test_result") or a dotted chain
+            ("test_result.test_configuration.endpoint") to eager-load a
+            nested relationship in the same query.
 
     Returns:
         List of Trace models ordered by start_time
     """
     from uuid import UUID
 
-    from sqlalchemy.orm import joinedload
-
     # Convert organization_id to UUID
     org_uuid = UUID(organization_id)
 
-    query = db.query(models.Trace).filter(
-        and_(
-            models.Trace.trace_id == trace_id,
-            models.Trace.project_id == project_id,
-            models.Trace.organization_id == org_uuid,
+    builder = QueryBuilder(db, models.Trace).with_custom_filter(
+        lambda q: q.filter(
+            and_(
+                models.Trace.trace_id == trace_id,
+                models.Trace.project_id == project_id,
+                models.Trace.organization_id == org_uuid,
+            )
         )
     )
 
     # Add eager loading if specified
     if eager_load:
-        for relationship in eager_load:
-            query = query.options(joinedload(getattr(models.Trace, relationship)))
+        options = [
+            include(*_resolve_chain(models.Trace, relationship.split(".")))
+            for relationship in eager_load
+        ]
+        builder = builder.with_related(*options)
 
-    return query.order_by(models.Trace.start_time).all()
+    return builder.with_sorting(sort_by="start_time").all()
 
 
 def get_trace_id_for_conversation(

--- a/apps/backend/src/rhesis/backend/app/routers/preflight.py
+++ b/apps/backend/src/rhesis/backend/app/routers/preflight.py
@@ -5,7 +5,6 @@ import logging
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
-from rhesis.backend.app.routers.base import RhesisRouter
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
@@ -14,6 +13,7 @@ from rhesis.backend.app.constants import TestSetType
 from rhesis.backend.app.dependencies import get_tenant_db_session
 from rhesis.backend.app.models.test_set import TestSet
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.preflight import (
     PreflightCheckInfo,
     PreflightCheckRequest,
@@ -33,6 +33,7 @@ from rhesis.backend.app.services.preflight import (
     compute_summary,
     run_preflight_checks_multi,
 )
+from rhesis.backend.app.utils.query_utils import QueryBuilder, include
 
 logger = logging.getLogger(__name__)
 
@@ -200,8 +201,14 @@ async def run_preflight(
     db: Session = Depends(get_tenant_db_session),
     current_user: User = Depends(require_current_user_or_token),
 ):
-    # Query all requested test sets
-    db_test_sets = db.query(TestSet).filter(TestSet.id.in_(request.test_set_ids)).all()
+    # Query all requested test sets, eager-loading test_set_type so
+    # _is_multi_turn() below doesn't lazy-load it once per test set.
+    db_test_sets = (
+        QueryBuilder(db, TestSet)
+        .with_custom_filter(lambda q: q.filter(TestSet.id.in_(request.test_set_ids)))
+        .with_related(include(TestSet.test_set_type))
+        .all()
+    )
 
     found_ids = {ts.id for ts in db_test_sets}
     missing = [str(tid) for tid in request.test_set_ids if tid not in found_ids]

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -533,36 +533,21 @@ def get_trace(
     organization_id, user_id = tenant_context
 
     try:
-        # Fetch all spans for trace with eager loading of relationships
-        from sqlalchemy.orm import joinedload
-
+        # Fetch all spans for trace with eager loading of relationships, including
+        # the nested test_result.test_configuration.endpoint chain in the same query
         spans = crud.get_trace_by_id(
             db=db,
             trace_id=trace_id,
             project_id=project_id,
             organization_id=organization_id,
-            eager_load=["project", "test_run", "test_result", "test"],
+            eager_load=[
+                "project",
+                "test_run",
+                "test_result",
+                "test",
+                "test_result.test_configuration.endpoint",
+            ],
         )
-
-        # Additional eager load for endpoint via test_result.test_configuration.endpoint
-        # This is done separately since it's a nested relationship
-        if spans and spans[0].test_result_id:
-            from rhesis.backend.app.models.test_configuration import TestConfiguration
-            from rhesis.backend.app.models.test_result import TestResult
-
-            # Fetch test_result with nested eager loading and explicitly update the relationship
-            test_result_with_endpoint = (
-                db.query(TestResult)
-                .filter(TestResult.id == spans[0].test_result_id)
-                .options(
-                    joinedload(TestResult.test_configuration).joinedload(TestConfiguration.endpoint)
-                )
-                .first()
-            )
-
-            # Explicitly update the relationship instead of relying on identity map
-            if test_result_with_endpoint:
-                spans[0].test_result = test_result_with_endpoint
 
         if not spans:
             raise HTTPException(

--- a/apps/backend/src/rhesis/backend/app/services/explorer/embeddings.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/embeddings.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from uuid import UUID as UUIDType
 
 import numpy as np
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.models.embedding import EmbeddingConfig
@@ -20,6 +20,7 @@ from rhesis.backend.app.models.user import User
 from rhesis.backend.app.services.explorer.diversity_strategies import (
     DEFAULT_EMBEDDING_DIVERSITY_STRATEGY,
 )
+from rhesis.backend.app.utils.query_utils import QueryBuilder, include
 from rhesis.backend.app.utils.user_model_utils import get_user_embedding_model
 from rhesis.sdk.models.factory import get_model
 
@@ -260,15 +261,17 @@ async def a_generate_embedding_vectors_batch(
 def load_test_for_embedding(db: Session, test_id: str, organization_id: str) -> Optional[Test]:
     """Load a Test with relationships required for ``to_searchable_text()``."""
     return (
-        db.query(Test)
-        .options(
-            joinedload(Test.prompt),
-            joinedload(Test.topic),
-            joinedload(Test.behavior),
-            joinedload(Test.category),
-            joinedload(Test.test_type),
+        QueryBuilder(db, Test)
+        .with_custom_filter(
+            lambda q: q.filter(Test.id == test_id, Test.organization_id == organization_id)
         )
-        .filter(Test.id == test_id, Test.organization_id == organization_id)
+        .with_related(
+            include(Test.prompt),
+            include(Test.topic),
+            include(Test.behavior),
+            include(Test.category),
+            include(Test.test_type),
+        )
         .first()
     )
 

--- a/apps/backend/src/rhesis/backend/app/services/explorer/topics.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/topics.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 from uuid import UUID
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, contains_eager
 
 from rhesis.backend.app import crud, models
 from rhesis.backend.app.models.test import test_test_set_association
@@ -179,6 +179,7 @@ def update_topic_node(
             models.Test.id == test_test_set_association.c.test_id,
         )
         .join(models.Topic, models.Test.topic_id == models.Topic.id)
+        .options(contains_eager(models.Test.topic))
         .filter(
             test_test_set_association.c.test_set_id == test_set_id,
             models.Test.organization_id == organization_id,
@@ -260,6 +261,7 @@ def remove_topic_node(
             models.Test.id == test_test_set_association.c.test_id,
         )
         .join(models.Topic, models.Test.topic_id == models.Topic.id)
+        .options(contains_eager(models.Test.topic))
         .filter(
             test_test_set_association.c.test_set_id == test_set_id,
             models.Test.organization_id == organization_id,

--- a/apps/backend/src/rhesis/backend/app/services/stats/test.py
+++ b/apps/backend/src/rhesis/backend/app/services/stats/test.py
@@ -3,9 +3,10 @@
 from datetime import datetime, timezone
 from typing import Dict
 
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models
+from rhesis.backend.app.utils.query_utils import QueryBuilder, include
 
 from .calculator import StatsCalculator
 from .common import build_pass_rate_stats, parse_date_range
@@ -84,30 +85,36 @@ def get_individual_test_stats(
         start_date_obj, end_date_obj = parse_date_range(start_date, end_date, months_val)
 
     # Base query for test results with eager loading
-    base_query = (
-        db.query(models.TestResult)
-        .options(
-            joinedload(models.TestResult.test_run),  # Eager load test run info
-            joinedload(models.TestResult.status),  # Eager load status for evaluation
+    builder = (
+        QueryBuilder(db, models.TestResult)
+        .with_custom_filter(lambda q: q.filter(models.TestResult.test_id == test_id))
+        .with_related(
+            include(models.TestResult.test_run),  # Eager load test run info
+            include(models.TestResult.status),  # Eager load status for evaluation
         )
-        .filter(models.TestResult.test_id == test_id)
     )
 
     # Apply organization filter (SECURITY CRITICAL)
     if organization_id:
-        base_query = base_query.filter(models.TestResult.organization_id == organization_id)
+        builder = builder.with_custom_filter(
+            lambda q: q.filter(models.TestResult.organization_id == organization_id)
+        )
 
     # Apply date range filters if specified
     if start_date_obj:
-        base_query = base_query.filter(models.TestResult.created_at >= start_date_obj)
+        builder = builder.with_custom_filter(
+            lambda q: q.filter(models.TestResult.created_at >= start_date_obj)
+        )
     if end_date_obj:
-        base_query = base_query.filter(models.TestResult.created_at <= end_date_obj)
+        builder = builder.with_custom_filter(
+            lambda q: q.filter(models.TestResult.created_at <= end_date_obj)
+        )
 
     # Order by created_at descending for recent runs
-    base_query = base_query.order_by(models.TestResult.created_at.desc())
+    builder = builder.with_sorting(sort_by="created_at", sort_order="desc")
 
     # Execute query
-    test_results = base_query.all()
+    test_results = builder.all()
 
     if not test_results:
         return _empty_individual_test_stats(

--- a/apps/backend/src/rhesis/backend/app/services/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_set.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 from uuid import UUID
 
 from sqlalchemy import func
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models, schemas
 from rhesis.backend.app.constants import (
@@ -23,6 +23,7 @@ from rhesis.backend.app.models.test import test_test_set_association
 from rhesis.backend.app.services.stats import StatsCalculator
 from rhesis.backend.app.services.test import bulk_create_test_set_associations, bulk_create_tests
 from rhesis.backend.app.utils.crud_utils import get_or_create_status, get_or_create_type_lookup
+from rhesis.backend.app.utils.query_utils import QueryBuilder, include
 from rhesis.backend.app.utils.uuid_utils import (
     ensure_owner_id,
     sanitize_uuid_field,
@@ -35,19 +36,23 @@ logger = logging.getLogger(__name__)
 
 def get_test_set(db: Session, test_set_id: uuid.UUID, organization_id: str = None):
     """Get test set by ID with organization filtering for security"""
-    query = (
-        db.query(TestSet)
-        .filter(TestSet.id == test_set_id)
-        .options(
-            joinedload(TestSet.prompts).joinedload(Prompt.demographic),
-            joinedload(TestSet.prompts).joinedload(Prompt.category),
-            joinedload(TestSet.prompts).joinedload(Prompt.attack_category),
-            joinedload(TestSet.prompts).joinedload(Prompt.topic),
-            joinedload(TestSet.prompts).joinedload(Prompt.behavior),
+    builder = (
+        QueryBuilder(db, TestSet)
+        .with_custom_filter(lambda q: q.filter(TestSet.id == test_set_id))
+        .with_related(
+            # TestSet.prompts is one-to-many -- include() picks selectinload for
+            # it automatically, avoiding the cartesian-product blowup a plain
+            # joinedload(TestSet.prompts) would cause once fanned out across
+            # six nested joinedload(Prompt.*) chains.
+            include(TestSet.prompts, Prompt.demographic),
+            include(TestSet.prompts, Prompt.category),
+            include(TestSet.prompts, Prompt.attack_category),
+            include(TestSet.prompts, Prompt.topic),
+            include(TestSet.prompts, Prompt.behavior),
             # Temporarily disabled due to entity_type column issue
-            # joinedload(TestSet.prompts).joinedload(Prompt.source),
-            joinedload(TestSet.prompts).joinedload(Prompt.status),
-            joinedload(TestSet.prompts).joinedload(Prompt.user),
+            # include(TestSet.prompts, Prompt.source),
+            include(TestSet.prompts, Prompt.status),
+            include(TestSet.prompts, Prompt.user),
         )
     )
 
@@ -55,9 +60,11 @@ def get_test_set(db: Session, test_set_id: uuid.UUID, organization_id: str = Non
     if organization_id:
         from uuid import UUID as UUIDType
 
-        query = query.filter(TestSet.organization_id == UUIDType(organization_id))
+        builder = builder.with_custom_filter(
+            lambda q: q.filter(TestSet.organization_id == UUIDType(organization_id))
+        )
 
-    return query.first()
+    return builder.first()
 
 
 def create_pending_test_set(
@@ -180,33 +187,48 @@ def generate_test_set_attributes(
     Returns:
         Dict containing the complete attributes structure
     """
+    # Eager-load per-test relationships in one query instead of lazily fetching
+    # topic/behavior/category/prompt for each test in test_set.tests (N+1).
+    test_ids = [test.id for test in test_set.tests]
+    tests = (
+        QueryBuilder(db, models.Test)
+        .with_custom_filter(lambda q: q.filter(models.Test.id.in_(test_ids)))
+        .with_related(
+            include(models.Test.topic),
+            include(models.Test.behavior),
+            include(models.Test.category),
+            include(models.Test.prompt),
+        )
+        .all()
+        if test_ids
+        else []
+    )
+
     # Get all unique IDs and names for each dimension (skip tests with None values)
-    topics = list(set(str(test.topic_id) for test in test_set.tests if test.topic_id))
-    behaviors = list(set(str(test.behavior_id) for test in test_set.tests if test.behavior_id))
-    categories = list(set(str(test.category_id) for test in test_set.tests if test.category_id))
+    topics = list(set(str(test.topic_id) for test in tests if test.topic_id))
+    behaviors = list(set(str(test.behavior_id) for test in tests if test.behavior_id))
+    categories = list(set(str(test.category_id) for test in tests if test.category_id))
 
     # Get all unique names for metadata (skip tests with None relationships)
-    topic_names = list(set(test.topic.name for test in test_set.tests if test.topic))
-    behavior_names = list(set(test.behavior.name for test in test_set.tests if test.behavior))
-    category_names = list(set(test.category.name for test in test_set.tests if test.category))
+    topic_names = list(set(test.topic.name for test in tests if test.topic))
+    behavior_names = list(set(test.behavior.name for test in tests if test.behavior))
+    category_names = list(set(test.category.name for test in tests if test.category))
 
     # Get a random prompt's content for the sample (now through tests)
     sample = None
-    if test_set.tests:
+    if tests:
         # Filter tests that have prompts with content
-        tests_with_prompts = [
-            test for test in test_set.tests if test.prompt and test.prompt.content
-        ]
+        tests_with_prompts = [test for test in tests if test.prompt and test.prompt.content]
         if tests_with_prompts:
             sample = random.choice(tests_with_prompts).prompt.content
 
     # Count unique prompts (in case multiple tests reference the same prompt)
-    unique_prompt_ids = set(str(test.prompt_id) for test in test_set.tests if test.prompt_id)
+    unique_prompt_ids = set(str(test.prompt_id) for test in tests if test.prompt_id)
     total_prompts = len(unique_prompt_ids)
 
     # Extract unique documents from test metadata
     documents_dict = {}
-    for test in test_set.tests:
+    for test in tests:
         if test.test_metadata and "sources" in test.test_metadata:
             for source in test.test_metadata["sources"]:
                 if "source" in source and source["source"] not in documents_dict:
@@ -223,7 +245,7 @@ def generate_test_set_attributes(
         "categories": category_names,
         "license_type": license_type.type_value,
         "total_prompts": total_prompts,
-        "total_tests": len(test_set.tests),
+        "total_tests": len(tests),
     }
 
     if documents_dict:

--- a/apps/backend/src/rhesis/backend/app/utils/query_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/query_utils.py
@@ -25,7 +25,7 @@ T = TypeVar("T")
 _MAX_EAGER_LOADS_WARN = 12
 
 
-def _resolve_chain(model: Type, names: list) -> tuple:
+def resolve_chain(model: Type, names: list) -> tuple:
     """Resolve a runtime ``[name, ...]`` relationship-name chain into a tuple of
     real attributes, one per hop, starting from ``model``.
 
@@ -178,12 +178,12 @@ class QueryBuilder:
             if issubclass(self.model, mixin):
                 _add(list(chain))
         for chain in chains:
-            # _resolve_chain turns the runtime [name, ...] chain into a tuple of
+            # resolve_chain turns the runtime [name, ...] chain into a tuple of
             # real attributes; include() picks joinedload vs. selectinload per hop
             # from each one's own cardinality, whether the chain is a single hop
             # (comments/tasks/files/tags) or multi-hop (_tags_relationship -> tag)
             # -- no special-casing needed for either length.
-            self.with_related(include(*_resolve_chain(self.model, chain)))
+            self.with_related(include(*resolve_chain(self.model, chain)))
 
         # Cascade one level into joined-in single-object relations (the ones
         # with_optimized_loads/with_related eager-load via joinedload) whose

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
@@ -98,7 +98,9 @@ def prefetch_execution_context(
     """Pre-fetch all shared data in a single session before async execution."""
     from rhesis.backend.app import crud
     from rhesis.backend.app.database import bind_scope_to_session
+    from rhesis.backend.app.models.behavior import Behavior
     from rhesis.backend.app.services.test_set import get_test_set
+    from rhesis.backend.app.utils.query_utils import QueryBuilder, include
     from rhesis.backend.tasks.execution.executors.data import get_test_metrics
 
     organization_id = str(test_config.organization_id) if test_config.organization_id else ""
@@ -167,6 +169,21 @@ def prefetch_execution_context(
             execution_model = model_settings.execution_model
         if evaluation_model is None:
             evaluation_model = model_settings.evaluation_model
+
+    # Warm the session identity map with prompt/behavior/behavior.metrics eager-loaded
+    # for every test in the batch, in one query. get_test_and_prompt/get_test_metrics
+    # below re-fetch each test by id from this same session -- SQLAlchemy's identity
+    # map returns the very same instance per row, so once these relationships are
+    # already populated here, those per-test lookups find them already loaded instead
+    # of issuing one extra lazy-load query per test per relationship (N+1).
+    test_ids = [test.id for test in tests]
+    if test_ids:
+        QueryBuilder(session, Test).with_custom_filter(
+            lambda q: q.filter(Test.id.in_(test_ids))
+        ).with_related(
+            include(Test.prompt),
+            include(Test.behavior, Behavior.metrics),
+        ).all()
 
     # Pre-fetch per-test data
     test_data: Dict[str, Any] = {}


### PR DESCRIPTION
## Purpose

Several backend code paths issued one extra query per row instead of eager-loading related data, causing N+1 query patterns under load.

## What Changed

- Replaced lazy relationship traversal and manual `joinedload` chains with `QueryBuilder` + `include()` across:
  - test/test-set attribute generation (`services/test_set.py`)
  - trace lookup (`routers/preflight.py`, `routers/telemetry.py`)
  - explorer topic rename/remove (`services/explorer/topics.py`, `services/explorer/embeddings.py`)
  - stats (`services/stats/test.py`)
  - batch execution prefetch (`tasks/execution/batch/context.py`)
  - shared query helpers (`crud.py`)

## Additional Context

- No behavior change intended — same data returned, fewer queries issued per request.

## Testing

Existing backend test suite; no new query-count assertions added.