### PR TITLE
Fix mapping tab staleness, missing created by/on, and silent test errors

### DIFF
--- a/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import UUID4, BaseModel, ConfigDict, field_validator
@@ -228,6 +229,9 @@ class Endpoint(Base):
     status_id: Optional[UUID4] = None
     user_id: Optional[UUID4] = None
     organization_id: Optional[UUID4] = None
+
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
 
     # Tracing control
     disable_tracing: bool = False

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
@@ -112,12 +112,13 @@ export default function EndpointTestTab() {
         );
       }
       const result = await invokeEndpoint(endpoint.id, inputData);
+      if (!result.success) {
+        throw new Error(result.error ?? 'Test failed');
+      }
       const data = result.data as Record<string, unknown>;
       const raw = data?.raw_response ?? data;
       setRawResponse(raw);
-      setStatusCode(
-        String(data?.status_code ?? (result.success ? '200' : 'error'))
-      );
+      setStatusCode(String(data?.status_code ?? '200'));
       if (responseMapping.conversation_id) {
         const convId = applyJsonPath(raw, responseMapping.conversation_id);
         if (typeof convId === 'string') {

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
@@ -130,7 +130,9 @@ export default function EndpointTestTab() {
           (typeof data.output === 'string' && data.output) ||
           'Endpoint invocation failed';
         setStatusCode(
-          typeof data.status_code === 'number' ? String(data.status_code) : ''
+          typeof data.status_code === 'number'
+            ? String(data.status_code)
+            : 'error'
         );
         setError(message);
         return;

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointTestTab.tsx
@@ -118,6 +118,24 @@ export default function EndpointTestTab() {
       const data = result.data as Record<string, unknown>;
       const raw = data?.raw_response ?? data;
       setRawResponse(raw);
+
+      // The backend returns HTTP 200 even when the endpoint invocation
+      // itself failed (e.g. a connection error to the target URL) — the
+      // failure is encoded in the body as `error: true` instead of the
+      // HTTP status, so it must be checked explicitly rather than assumed
+      // to be a 200 success just because the request reached the server.
+      if (data?.error === true) {
+        const message =
+          (typeof data.message === 'string' && data.message) ||
+          (typeof data.output === 'string' && data.output) ||
+          'Endpoint invocation failed';
+        setStatusCode(
+          typeof data.status_code === 'number' ? String(data.status_code) : ''
+        );
+        setError(message);
+        return;
+      }
+
       setStatusCode(String(data?.status_code ?? '200'));
       if (responseMapping.conversation_id) {
         const convId = applyJsonPath(raw, responseMapping.conversation_id);

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/useEndpointDetail.ts
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/useEndpointDetail.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 import { useTheme } from '@mui/material/styles';
 import { useSession } from 'next-auth/react';
 import {
@@ -13,6 +14,7 @@ import { createEndpoint } from '@/actions/endpoints';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { BORDER_RADIUS } from '@/styles/theme-constants';
+import { endpointKeys } from '@/constants/query-keys';
 import { patchEndpointFields } from './endpointPatch';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 
@@ -21,6 +23,7 @@ export function useEndpointDetail(initialEndpoint: Endpoint) {
   const router = useRouter();
   const { data: session, status } = useSession();
   const notifications = useNotifications();
+  const queryClient = useQueryClient();
 
   const [endpoint, setEndpoint] = useState<Endpoint>(initialEndpoint);
   const [isDuplicating, setIsDuplicating] = useState(false);
@@ -80,7 +83,7 @@ export function useEndpointDetail(initialEndpoint: Endpoint) {
       try {
         await patchEndpointFields(endpoint.id, payload);
         const { auth_token, ...rest } = payload;
-        setEndpoint(prev => {
+        const applyUpdate = (prev: Endpoint) => {
           const next: Endpoint = { ...prev, ...rest };
           // auth_token is write-only; keep the derived has_auth_token flag in
           // sync so the UI reflects a newly set or removed token without a
@@ -90,7 +93,15 @@ export function useEndpointDetail(initialEndpoint: Endpoint) {
               typeof auth_token === 'string' && auth_token.trim() !== '';
           }
           return next;
-        });
+        };
+        setEndpoint(applyUpdate);
+        // Keep the React Query cache in sync too — otherwise switching tabs
+        // (which re-reads the cached endpoint into local state) reverts the
+        // just-saved change until a full page reload refetches from the server.
+        queryClient.setQueryData<Endpoint>(
+          endpointKeys.detail(endpoint.id),
+          prev => (prev ? applyUpdate(prev) : prev)
+        );
         notifications.show('Endpoint updated successfully', {
           severity: 'success',
         });
@@ -102,7 +113,7 @@ export function useEndpointDetail(initialEndpoint: Endpoint) {
         throw error;
       }
     },
-    [endpoint.id, notifications]
+    [endpoint.id, notifications, queryClient]
   );
 
   const duplicateEndpoint = useCallback(async () => {

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/page.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/page.tsx
@@ -136,14 +136,11 @@ export default function EndpointPage({ params }: PageProps) {
   const metadataStrip = (
     <DetailMetadataStrip
       items={[
-        { label: 'created by:', value: '—' },
+        { label: 'created by:', value: endpoint.user?.name || '—' },
         {
           label: 'created on:',
-          value: endpoint.endpoint_metadata?.created_at
-            ? format(
-                new Date(endpoint.endpoint_metadata.created_at),
-                'dd/MM/yyyy'
-              )
+          value: endpoint.created_at
+            ? format(new Date(endpoint.created_at), 'dd/MM/yyyy')
             : '—',
         },
       ]}

--- a/apps/frontend/src/utils/api-client/interfaces/endpoint.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/endpoint.ts
@@ -65,6 +65,9 @@ export interface Endpoint {
   organization_id?: string;
   project_id?: string;
 
+  created_at?: string;
+  updated_at?: string;
+
   // Nested project object (when included in response)
   project?: {
     id?: string;
@@ -75,6 +78,13 @@ export interface Endpoint {
 
   // Nested status object (when included in response)
   status?: Status;
+
+  // Nested user object (when included in the detail response)
+  user?: {
+    id?: string;
+    name?: string;
+    email?: string;
+  };
 
   has_auth_token?: boolean;
 


### PR DESCRIPTION
## Purpose

Fixes three bugs on the endpoint detail page reported by a user testing staging.

## What Changed

- Sync the saved endpoint into the React Query cache after a mapping edit, so switching tabs and back no longer reverts to stale cached data (previously only local state was updated, not the cache).
- Expose `created_at`/`updated_at` on the backend `Endpoint` schema and wire up `endpoint.user`/`endpoint.created_at` on the frontend so "Created by"/"Created on" render instead of a hardcoded placeholder / wrong metadata field.
- Surface real error details on the Test tab's "Test connection" action: the server action can resolve with `{ success: false, error }` without throwing, and the backend can also return HTTP 200 with an in-band `error: true` payload (e.g. on a connection failure) — neither case was previously checked, so failures silently showed a `200` with no message.

## Additional Context

- Backend intentionally returns 200 for some invocation failures (`rest_invoker.py`) to preserve full request/response context for tracing; the frontend now checks the payload's `error` field explicitly instead of inferring success from HTTP status.

## Testing

- `npx tsc --noEmit` and `npx eslint` clean on all changed frontend files.
- `uvx ruff check` / `uvx ruff format` clean on the changed backend file.
- Not manually verified against a running local stack (requires full backend + DB + auth); please exercise the mapping tab, endpoint overview metadata, and Test tab error path on staging before merging.