### PR TITLE
Add request timeouts to LLM provider calls

### DIFF
--- a/sdk/src/rhesis/sdk/config.py
+++ b/sdk/src/rhesis/sdk/config.py
@@ -4,6 +4,8 @@ from typing import Optional, TypeVar
 # Default values
 DEFAULT_BASE_URL = "https://api.rhesis.ai"
 
+DEFAULT_LLM_TIMEOUT = 300
+
 # Module level variables
 api_key: Optional[str] = None
 base_url: Optional[str] = None

--- a/sdk/src/rhesis/sdk/models/providers/litellm.py
+++ b/sdk/src/rhesis/sdk/models/providers/litellm.py
@@ -6,6 +6,7 @@ import litellm
 from litellm import acompletion, aembedding, batch_completion, embedding
 from pydantic import BaseModel
 
+from rhesis.sdk.config import DEFAULT_LLM_TIMEOUT
 from rhesis.sdk.errors import NO_MODEL_NAME_PROVIDED
 from rhesis.sdk.models.base import BaseEmbedder, BaseLLM, Embedding
 from rhesis.sdk.models.utils import validate_llm_response
@@ -31,6 +32,7 @@ class LiteLLM(BaseLLM):
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
         api_version: Optional[str] = None,
+        timeout: Optional[float] = None,
     ):
         """
         LiteLLM: LiteLLM Provider for Model inference
@@ -46,6 +48,10 @@ class LiteLLM(BaseLLM):
             api_version (Optional[str]): The API version string
                 (e.g. for Azure). If not provided, LiteLLM uses its
                 default or env vars.
+            timeout (Optional[float]): Per-request timeout in seconds. Defaults to
+                ``DEFAULT_LLM_TIMEOUT``. Prevents a hung upstream call from blocking the
+                worker thread indefinitely. A ``timeout`` kwarg passed to a ``generate``
+                call overrides this per request.
 
         Usage:
             >>> llm = LiteLLM(model_name="provider/model", api_key="your_api_key")
@@ -58,6 +64,7 @@ class LiteLLM(BaseLLM):
         self.api_key = api_key
         self.api_base = api_base
         self.api_version = api_version
+        self.timeout = timeout if timeout is not None else DEFAULT_LLM_TIMEOUT
         if not model_name or not isinstance(model_name, str) or model_name.strip() == "":
             raise ValueError(NO_MODEL_NAME_PROVIDED)
         super().__init__(model_name)
@@ -117,6 +124,7 @@ class LiteLLM(BaseLLM):
         # asyncio.run() calls (e.g. Celery tasks), which would cause
         # RuntimeError: Event loop is closed on teardown.
         extra_headers = {"Connection": "close", **(kwargs.pop("extra_headers", None) or {})}
+        timeout = kwargs.pop("timeout", self.timeout)
         response = await acompletion(
             model=self.model_name,
             messages=messages,
@@ -125,6 +133,7 @@ class LiteLLM(BaseLLM):
             api_base=self.api_base,
             api_version=self.api_version,
             extra_headers=extra_headers,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -169,6 +178,7 @@ class LiteLLM(BaseLLM):
         # asyncio.run() calls (e.g. Celery tasks), which would cause
         # RuntimeError: Event loop is closed on teardown.
         extra_headers = {"Connection": "close", **(kwargs.pop("extra_headers", None) or {})}
+        timeout = kwargs.pop("timeout", self.timeout)
         response = await acompletion(
             model=self.model_name,
             messages=messages,
@@ -178,6 +188,7 @@ class LiteLLM(BaseLLM):
             api_base=self.api_base,
             api_version=self.api_version,
             extra_headers=extra_headers,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -224,6 +235,7 @@ class LiteLLM(BaseLLM):
         # Handle schema format for LiteLLM
         response_format = schema
 
+        timeout = kwargs.pop("timeout", self.timeout)
         responses = batch_completion(
             model=self.model_name,
             messages=messages,
@@ -232,6 +244,7 @@ class LiteLLM(BaseLLM):
             api_base=self.api_base,
             api_version=self.api_version,
             n=n,
+            timeout=timeout,
             *args,
             **kwargs,
         )
@@ -295,12 +308,14 @@ class LiteLLMEmbedder(BaseEmbedder):
         model_name: str,
         api_key: Optional[str] = None,
         dimensions: Optional[int] = None,
+        timeout: Optional[float] = None,
     ):
         if not model_name or not isinstance(model_name, str) or model_name.strip() == "":
             raise ValueError(NO_MODEL_NAME_PROVIDED)
         super().__init__(model_name)
         self.api_key = api_key
         self.dimensions = dimensions
+        self.timeout = timeout if timeout is not None else DEFAULT_LLM_TIMEOUT
 
     async def a_generate(self, text: str, **kwargs) -> Embedding:
         """Generate embedding for a single text (async, via LiteLLM)."""
@@ -308,12 +323,14 @@ class LiteLLMEmbedder(BaseEmbedder):
             raise TypeError(f"text must be a string, got {type(text).__name__}")
 
         dimensions = kwargs.pop("dimensions", self.dimensions)
+        timeout = kwargs.pop("timeout", self.timeout)
 
         response = await aembedding(
             model=self.model_name,
             input=[text],
             api_key=self.api_key,
             dimensions=dimensions,
+            timeout=timeout,
             **kwargs,
         )
         return response["data"][0]["embedding"]
@@ -338,12 +355,14 @@ class LiteLLMEmbedder(BaseEmbedder):
 
         # Allow overriding dimensions per call
         dimensions = kwargs.pop("dimensions", self.dimensions)
+        timeout = kwargs.pop("timeout", self.timeout)
 
         response = embedding(
             model=self.model_name,
             input=texts,
             api_key=self.api_key,
             dimensions=dimensions,
+            timeout=timeout,
             **kwargs,
         )
         return [item["embedding"] for item in response["data"]]

--- a/sdk/src/rhesis/sdk/models/providers/litellm_proxy.py
+++ b/sdk/src/rhesis/sdk/models/providers/litellm_proxy.py
@@ -8,6 +8,7 @@ import requests
 from litellm.llms.base_llm.base_utils import type_to_response_format_param
 from pydantic import BaseModel
 
+from rhesis.sdk.config import DEFAULT_LLM_TIMEOUT
 from rhesis.sdk.errors import NO_MODEL_NAME_PROVIDED
 from rhesis.sdk.models.base import BaseLLM
 from rhesis.sdk.models.utils import validate_llm_response
@@ -15,7 +16,7 @@ from rhesis.sdk.models.utils import validate_llm_response
 logger = logging.getLogger(__name__)
 
 DEFAULT_API_BASE = "http://localhost:4000"
-DEFAULT_REQUEST_TIMEOUT = int(os.getenv("LITELLM_PROXY_TIMEOUT", "300"))
+DEFAULT_REQUEST_TIMEOUT = DEFAULT_LLM_TIMEOUT
 
 
 class LiteLLMProxy(BaseLLM):
@@ -94,6 +95,10 @@ class LiteLLMProxy(BaseLLM):
             messages.append({"role": "system", "content": system_prompt})
         messages.append({"role": "user", "content": prompt})
 
+        # Pop the request timeout before building the payload so it configures the
+        # HTTP call rather than leaking into the JSON body sent to the proxy.
+        timeout = kwargs.pop("timeout", DEFAULT_REQUEST_TIMEOUT)
+
         payload: Dict[str, Any] = {
             "model": self.model_name,
             "messages": messages,
@@ -122,7 +127,7 @@ class LiteLLMProxy(BaseLLM):
             url,
             headers=self._build_headers(),
             json=payload,
-            timeout=DEFAULT_REQUEST_TIMEOUT,
+            timeout=timeout,
         )
         response.raise_for_status()
 

--- a/sdk/src/rhesis/sdk/models/providers/native.py
+++ b/sdk/src/rhesis/sdk/models/providers/native.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 from rhesis.sdk.async_utils import run_sync
 from rhesis.sdk.clients import APIClient
+from rhesis.sdk.config import DEFAULT_LLM_TIMEOUT
 from rhesis.sdk.models.base import BaseEmbedder, BaseLLM
 from rhesis.sdk.models.defaults import (
     DEFAULT_EMBEDDING_MODELS,
@@ -22,7 +23,7 @@ DEFAULT_MODEL = DEFAULT_LANGUAGE_MODELS["rhesis"]
 DEFAULT_LANGUAGE_MODEL_NAME = model_name_from_id(DEFAULT_MODEL)
 DEFAULT_EMBEDDING_MODEL_NAME = model_name_from_id(DEFAULT_EMBEDDING_MODELS["rhesis"])
 API_ENDPOINT = "services/generate/content"
-DEFAULT_REQUEST_TIMEOUT = int(os.getenv("RHESIS_LLM_TIMEOUT", "300"))  # 5 minutes
+DEFAULT_REQUEST_TIMEOUT = DEFAULT_LLM_TIMEOUT  # 5 minutes
 
 
 class RhesisLLM(BaseLLM):

--- a/sdk/src/rhesis/sdk/models/providers/polyphemus.py
+++ b/sdk/src/rhesis/sdk/models/providers/polyphemus.py
@@ -10,6 +10,7 @@ import jsonfinder
 import requests
 from pydantic import BaseModel
 
+from rhesis.sdk.config import DEFAULT_LLM_TIMEOUT
 from rhesis.sdk.models.base import BaseLLM
 from rhesis.sdk.models.defaults import DEFAULT_LANGUAGE_MODELS, model_name_from_id
 from rhesis.sdk.models.utils import validate_llm_response
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_MODEL = DEFAULT_LANGUAGE_MODELS["polyphemus"]
 DEFAULT_MODEL_NAME = model_name_from_id(DEFAULT_MODEL)
 DEFAULT_POLYPHEMUS_URL = os.getenv("DEFAULT_POLYPHEMUS_URL") or "https://polyphemus.rhesis.ai"
-DEFAULT_REQUEST_TIMEOUT = int(os.getenv("RHESIS_LLM_TIMEOUT", "300"))  # 5 minutes
+DEFAULT_REQUEST_TIMEOUT = DEFAULT_LLM_TIMEOUT  # 5 minutes
 
 
 class PolyphemusLLM(BaseLLM):

--- a/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
+++ b/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
@@ -234,6 +234,7 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
         credentials: Optional[str] = None,
         location: Optional[str] = None,
         project: Optional[str] = None,
+        timeout: Optional[float] = None,
     ):
         """
         VertexAILLM: Google Vertex AI LLM Provider
@@ -252,6 +253,9 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
             project (Optional[str]): GCP project ID (usually auto-extracted from credentials)
                 - Priority: init parameter > VERTEX_AI_PROJECT env var > credentials file
                 - If not provided, will be extracted from credentials file automatically
+            timeout (Optional[float]): Per-request timeout in seconds passed through to LiteLLM.
+                Defaults to ``DEFAULT_LLM_TIMEOUT`` so a hung Vertex AI call fails loudly
+                instead of blocking the worker thread indefinitely.
 
         Environment Variables (used as fallback):
             GOOGLE_APPLICATION_CREDENTIALS: Service account credentials
@@ -280,7 +284,7 @@ class VertexAILLM(VertexAICredentialsMixin, LiteLLM):
 
         # Initialize parent LiteLLM with vertex_ai prefix
         # Don't pass api_key as Vertex AI uses credentials
-        super().__init__(f"{self.PROVIDER}/{model_name}", api_key=None)
+        super().__init__(f"{self.PROVIDER}/{model_name}", api_key=None, timeout=timeout)
 
     def load_model(self) -> dict:
         """
@@ -452,6 +456,7 @@ class VertexAIEmbedder(VertexAICredentialsMixin, LiteLLMEmbedder):
         location: Optional[str] = None,
         project: Optional[str] = None,
         dimensions: Optional[int] = None,
+        timeout: Optional[float] = None,
     ):
         self._init_vertex_credentials(credentials, location, project)
         self._vertex_config = self._load_vertex_config()
@@ -462,6 +467,7 @@ class VertexAIEmbedder(VertexAICredentialsMixin, LiteLLMEmbedder):
             model_name=f"{self.PROVIDER}/{model_name}",
             api_key=None,
             dimensions=dimensions,
+            timeout=timeout,
         )
 
     def _with_vertex_credentials(self, func, *args, **kwargs):

--- a/tests/sdk/models/providers/test_azure_ai.py
+++ b/tests/sdk/models/providers/test_azure_ai.py
@@ -94,6 +94,7 @@ class TestAzureAILLMGenerate:
             api_base="https://endpoint.inference.ai.azure.com/",
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -120,6 +121,7 @@ class TestAzureAILLMGenerate:
             api_base="https://endpoint.inference.ai.azure.com/",
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -182,6 +184,7 @@ class TestAzureAILLMGenerate:
             api_base="https://endpoint.inference.ai.azure.com/",
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -205,6 +208,7 @@ class TestAzureAILLMGenerate:
             api_base="https://endpoint.inference.ai.azure.com/",
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
             temperature=0.7,
             max_tokens=100,
         )

--- a/tests/sdk/models/providers/test_azure_openai.py
+++ b/tests/sdk/models/providers/test_azure_openai.py
@@ -116,6 +116,7 @@ class TestAzureOpenAILLMGenerate:
             api_base="https://resource.openai.azure.com/",
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -142,6 +143,7 @@ class TestAzureOpenAILLMGenerate:
             api_base="https://resource.openai.azure.com/",
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -204,6 +206,7 @@ class TestAzureOpenAILLMGenerate:
             api_base="https://resource.openai.azure.com/",
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -227,6 +230,7 @@ class TestAzureOpenAILLMGenerate:
             api_base="https://resource.openai.azure.com/",
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
             temperature=0.7,
             max_tokens=100,
         )

--- a/tests/sdk/models/providers/test_gemini.py
+++ b/tests/sdk/models/providers/test_gemini.py
@@ -71,6 +71,7 @@ class TestGeminiLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -107,6 +108,7 @@ class TestGeminiLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -151,6 +153,7 @@ class TestGeminiLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
             temperature=0.7,
             max_tokens=100,
         )
@@ -177,4 +180,5 @@ class TestGeminiLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )

--- a/tests/sdk/models/providers/test_litellm.py
+++ b/tests/sdk/models/providers/test_litellm.py
@@ -3,7 +3,9 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from pydantic import BaseModel
 
+from rhesis.sdk.config import DEFAULT_LLM_TIMEOUT
 from rhesis.sdk.models import LiteLLM
+from rhesis.sdk.models.providers.litellm import LiteLLMEmbedder
 
 
 class TestLiteLLM:
@@ -52,6 +54,7 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -79,6 +82,7 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -116,6 +120,7 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -154,6 +159,7 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -200,6 +206,7 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
             temperature=0.7,
             max_tokens=100,
         )
@@ -238,6 +245,7 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             n=1,
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.batch_completion")
@@ -264,6 +272,7 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             n=1,
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.batch_completion")
@@ -295,6 +304,7 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             n=1,
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.batch_completion")
@@ -336,6 +346,7 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             n=1,
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.batch_completion")
@@ -367,6 +378,7 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             n=2,
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.batch_completion")
@@ -441,6 +453,7 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             n=1,
+            timeout=300,
             temperature=0.7,
             max_tokens=100,
         )
@@ -465,6 +478,7 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             n=1,
+            timeout=300,
         )
 
     # Tests for Connection: close injection in async paths
@@ -567,4 +581,78 @@ class TestLiteLLM:
             api_base=None,
             api_version=None,
             n=1,
+            timeout=300,
         )
+
+
+class TestLiteLLMTimeout:
+    """A hung upstream call must not block a worker thread forever: every LiteLLM call
+    carries a request timeout (default DEFAULT_LLM_TIMEOUT), overridable per instance
+    and per call."""
+
+    def test_default_timeout(self):
+        assert LiteLLM("provider/model").timeout == DEFAULT_LLM_TIMEOUT
+
+    def test_explicit_instance_timeout(self):
+        assert LiteLLM("provider/model", timeout=5).timeout == 5
+
+    @patch("rhesis.sdk.models.providers.litellm.acompletion")
+    def test_default_timeout_passed_to_acompletion(self, mock_completion):
+        mock_completion.return_value = Mock(choices=[Mock(message=Mock(content="ok"))])
+        LiteLLM("provider/model").generate("hi")
+        assert mock_completion.call_args.kwargs["timeout"] == DEFAULT_LLM_TIMEOUT
+
+    @patch("rhesis.sdk.models.providers.litellm.acompletion")
+    def test_instance_timeout_passed_to_acompletion(self, mock_completion):
+        mock_completion.return_value = Mock(choices=[Mock(message=Mock(content="ok"))])
+        LiteLLM("provider/model", timeout=7).generate("hi")
+        assert mock_completion.call_args.kwargs["timeout"] == 7
+
+    @patch("rhesis.sdk.models.providers.litellm.acompletion")
+    def test_per_call_timeout_overrides_instance(self, mock_completion):
+        mock_completion.return_value = Mock(choices=[Mock(message=Mock(content="ok"))])
+        LiteLLM("provider/model", timeout=7).generate("hi", timeout=1)
+        assert mock_completion.call_args.kwargs["timeout"] == 1
+
+    @patch("rhesis.sdk.models.providers.litellm.batch_completion")
+    def test_timeout_passed_to_batch_completion(self, mock_batch):
+        mock_batch.return_value = [Mock(choices=[Mock(message=Mock(content="ok"))])]
+        LiteLLM("provider/model", timeout=8).generate_batch(["hi"])
+        assert mock_batch.call_args.kwargs["timeout"] == 8
+
+    @patch("rhesis.sdk.models.providers.litellm.acompletion")
+    def test_subclass_enforces_default_timeout(self, mock_completion):
+        """Thin LiteLLM subclasses (OpenAI, Gemini, …) inherit the default timeout on
+        every call, so a hung upstream call can never block indefinitely."""
+        from rhesis.sdk.models.providers.openai import OpenAILLM
+
+        mock_completion.return_value = Mock(choices=[Mock(message=Mock(content="ok"))])
+        OpenAILLM("gpt-4o", api_key="x").generate("hi")
+        assert mock_completion.call_args.kwargs["timeout"] == DEFAULT_LLM_TIMEOUT
+
+    @patch("rhesis.sdk.models.providers.litellm.acompletion")
+    def test_subclass_per_call_timeout_override(self, mock_completion):
+        """A per-call timeout overrides the default on any provider, including subclasses."""
+        from rhesis.sdk.models.providers.openai import OpenAILLM
+
+        mock_completion.return_value = Mock(choices=[Mock(message=Mock(content="ok"))])
+        OpenAILLM("gpt-4o", api_key="x").generate("hi", timeout=2)
+        assert mock_completion.call_args.kwargs["timeout"] == 2
+
+
+class TestLiteLLMEmbedderTimeout:
+    def test_default_timeout(self):
+        assert LiteLLMEmbedder("provider/embed").timeout == DEFAULT_LLM_TIMEOUT
+
+    @patch("rhesis.sdk.models.providers.litellm.embedding")
+    def test_timeout_passed_to_embedding(self, mock_embedding):
+        mock_embedding.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
+        LiteLLMEmbedder("provider/embed", timeout=9).generate_batch(["hi"])
+        assert mock_embedding.call_args.kwargs["timeout"] == 9
+
+    @pytest.mark.asyncio
+    @patch("rhesis.sdk.models.providers.litellm.aembedding", new_callable=AsyncMock)
+    async def test_timeout_passed_to_aembedding(self, mock_aembedding):
+        mock_aembedding.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
+        await LiteLLMEmbedder("provider/embed", timeout=4).a_generate("hi")
+        assert mock_aembedding.call_args.kwargs["timeout"] == 4

--- a/tests/sdk/models/providers/test_openrouter.py
+++ b/tests/sdk/models/providers/test_openrouter.py
@@ -65,6 +65,7 @@ class TestOpenRouterLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -101,6 +102,7 @@ class TestOpenRouterLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -145,6 +147,7 @@ class TestOpenRouterLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
             temperature=0.7,
             max_tokens=100,
         )
@@ -171,6 +174,7 @@ class TestOpenRouterLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.providers.litellm.acompletion")
@@ -198,4 +202,5 @@ class TestOpenRouterLLM:
             api_base=None,
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )

--- a/tests/sdk/models/providers/test_vllm.py
+++ b/tests/sdk/models/providers/test_vllm.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import Mock, patch
 
 import pytest
@@ -61,6 +60,7 @@ class TestVllmLLM:
             api_base="http://localhost:8000",
             api_version=None,
             extra_headers={"Connection": "close"},
+            timeout=300,
         )
 
     @patch("rhesis.sdk.models.factory._create_from_spec")


### PR DESCRIPTION
## Purpose

The LiteLLM provider family (Vertex AI, OpenAI, Gemini, Anthropic, Azure, etc.) made outbound calls with **no request timeout**, so a stuck upstream call could block a Celery worker thread indefinitely.

Observed in staging: a test-generation task started `synthesizer.generate()` on `vertex_ai/gemini-3.1-flash-lite` and **never returned** — no completion, no error, no retry. It hung for ~2h15m until a rolling deploy recycled the pod. The identical model/code path succeeded in ~3s once Vertex recovered, confirming the call itself was fine — only the missing timeout turned a transient upstream blip into a multi-hour silent hang.

Celery `time_limit`/`soft_time_limit` cannot cover this: the workers run `--pool threads`, and Celery time limits are only supported on the prefork/gevent pools. The reliable fix is a timeout on the I/O call itself.

## What Changed

- `config.py`: new hardcoded `DEFAULT_LLM_TIMEOUT = 300` constant (single source of truth, no env var).
- `litellm.py`: `timeout` param on `LiteLLM` and `LiteLLMEmbedder` constructors; `timeout` threaded into all 5 LiteLLM calls (`acompletion` ×2, `batch_completion`, `aembedding`, `embedding`). A per-call `timeout=` overrides the instance default.
- `vertex_ai.py`: `timeout` param on `VertexAILLM` / `VertexAIEmbedder` constructors (they lacked `**kwargs`), forwarded to `super().__init__`.
- `native.py`, `polyphemus.py`, `litellm_proxy.py`: consolidated onto `DEFAULT_LLM_TIMEOUT` (previously read `RHESIS_LLM_TIMEOUT` / `LITELLM_PROXY_TIMEOUT` env vars — those overrides are removed); proxy now honors a per-call `timeout` instead of leaking it into the request body.

A stuck call now raises `litellm.Timeout` → propagates to the caller → the task fails loudly and `BaseTask` autoretry handles it, instead of hanging until pod recycle.

## Additional Context

- The default 300s and per-call `timeout=` override apply to **all** providers. Per-instance override via `get_model(..., timeout=X)` works for Vertex + direct construction; the thin subclasses (OpenAI/Gemini/etc.) still drop constructor `**kwargs`, so wiring per-instance override through all 15 is left as a follow-up (not needed to fix the hang).
- **Out of scope / separate issue:** the Vertex embedding 404s (`text-embedding-005` in `locations/eu`) are a `VERTEX_AI_LOCATION=eu` deployment misconfig, not addressed here.

## Testing

- Added 9 timeout tests in `test_litellm.py` (default, instance override, per-call override, batch, embedder sync+async, thin-subclass default+override).
- Updated exact-kwarg assertions across 6 provider test files to include `timeout=300`.
- `cd sdk && uv run pytest ../tests/sdk/models/ ../tests/sdk/synthesizers/` → all pass (309 + 38). Ruff check + format clean.