### PR TITLE
Remove Status from behavior Linked Tests grid and Tests filter drawer

### DIFF
--- a/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorLinkedTests.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/[identifier]/components/BehaviorLinkedTests.tsx
@@ -123,17 +123,6 @@ export default function BehaviorLinkedTests({
             <GridBadge size="detail" label={params.value} />
           ) : null,
       },
-      {
-        field: 'status',
-        headerName: 'Status',
-        width: 130,
-        valueGetter: (_value: unknown, row: TestDetail) =>
-          row.status?.name ?? '',
-        renderCell: (params: GridRenderCellParams) =>
-          typeof params.value === 'string' && params.value ? (
-            <GridBadge size="detail" label={params.value} />
-          ) : null,
-      },
     ],
     []
   );

--- a/apps/frontend/src/app/(protected)/tests/components/TestFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestFilterDrawer.tsx
@@ -9,14 +9,8 @@ import {
   filterDrawerTextFieldSx,
 } from '@/components/common/FilterDrawer';
 import { filterUniqueValidOptions } from '@/components/common/BaseDrawer';
-import { ENTITY_TYPES } from '@/utils/api-client/config';
 import { TEST_TYPE_FILTER_OPTIONS } from '@/constants/test-types';
-import {
-  useStatuses,
-  useBehaviors,
-  useCategories,
-  useTopics,
-} from '@/hooks/useLookups';
+import { useBehaviors, useCategories, useTopics } from '@/hooks/useLookups';
 import ActivityPresenceFiltersSection from '@/components/common/ActivityPresenceFilters';
 import { EntityType } from '@/types/entity-type';
 import {
@@ -29,8 +23,6 @@ import {
 export interface TestFilters {
   /** test_type/type_value equals: Single-Turn | Multi-Turn | '' */
   testType: string;
-  /** status/name equals */
-  status: string;
   /** behavior/name equals */
   behavior: string;
   /** category/name equals */
@@ -44,7 +36,6 @@ export interface TestFilters {
 
 export const EMPTY_TEST_FILTERS: TestFilters = {
   testType: '',
-  status: '',
   behavior: '',
   category: '',
   topic: '',
@@ -54,7 +45,6 @@ export const EMPTY_TEST_FILTERS: TestFilters = {
 export function hasActiveTestFilters(f: TestFilters): boolean {
   return (
     f.testType !== '' ||
-    f.status !== '' ||
     f.behavior !== '' ||
     f.category !== '' ||
     f.topic !== '' ||
@@ -65,7 +55,6 @@ export function hasActiveTestFilters(f: TestFilters): boolean {
 export function countActiveTestFilters(f: TestFilters): number {
   return (
     (f.testType !== '' ? 1 : 0) +
-    (f.status !== '' ? 1 : 0) +
     (f.behavior !== '' ? 1 : 0) +
     (f.category !== '' ? 1 : 0) +
     (f.topic !== '' ? 1 : 0) +
@@ -90,10 +79,6 @@ export default function TestFilterDrawer({
 }: TestFilterDrawerProps) {
   const [draft, setDraft] = React.useState<TestFilters>(filters);
 
-  const { data: rawStatuses, isLoading: loadingStatuses } = useStatuses(
-    ENTITY_TYPES.test,
-    open
-  );
   const { data: rawBehaviors, isLoading: loadingBehaviors } =
     useBehaviors(open);
   const { data: rawCategories, isLoading: loadingCategories } = useCategories(
@@ -104,13 +89,8 @@ export default function TestFilterDrawer({
     EntityType.TEST,
     open
   );
-  const loadingOptions =
-    loadingStatuses || loadingBehaviors || loadingCategories || loadingTopics;
+  const loadingOptions = loadingBehaviors || loadingCategories || loadingTopics;
 
-  const statusOptions = React.useMemo(
-    () => filterUniqueValidOptions(rawStatuses ?? []).map(s => s.name),
-    [rawStatuses]
-  );
   const behaviorOptions = React.useMemo(
     () => filterUniqueValidOptions(rawBehaviors ?? []).map(b => b.name),
     [rawBehaviors]
@@ -137,10 +117,7 @@ export default function TestFilterDrawer({
 
   const renderAutocomplete = (
     title: string,
-    field: keyof Pick<
-      TestFilters,
-      'status' | 'behavior' | 'category' | 'topic'
-    >,
+    field: keyof Pick<TestFilters, 'behavior' | 'category' | 'topic'>,
     options: string[],
     placeholder: string
   ) => (
@@ -191,7 +168,6 @@ export default function TestFilterDrawer({
         </Box>
       </FilterSection>
 
-      {renderAutocomplete('Status', 'status', statusOptions, 'Select status…')}
       {renderAutocomplete(
         'Behavior',
         'behavior',

--- a/apps/frontend/src/app/(protected)/tests/components/test-filter-model.ts
+++ b/apps/frontend/src/app/(protected)/tests/components/test-filter-model.ts
@@ -7,7 +7,6 @@ import {
 
 export const TEST_DRAWER_FILTER_FIELDS = [
   'test_type.type_value',
-  'status.name',
   'behavior.name',
   'category.name',
   'topic.name',
@@ -67,13 +66,6 @@ export function applyTestDrawerFiltersToModel(
       field: 'test_type.type_value',
       operator: 'equals',
       value: drawerFilters.testType,
-    });
-  }
-  if (drawerFilters.status) {
-    drawerItems.push({
-      field: 'status.name',
-      operator: 'equals',
-      value: drawerFilters.status,
     });
   }
   if (drawerFilters.behavior) {

--- a/apps/frontend/src/hooks/__tests__/useGridState.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useGridState.test.ts
@@ -7,7 +7,7 @@ import { combineTestFiltersToOData } from '@/utils/odata-filter';
 
 describe('useGridState', () => {
   it('keeps search when drawer filters are applied first', () => {
-    const drawerFilters = { ...EMPTY_TEST_FILTERS, status: 'Active' };
+    const drawerFilters = { ...EMPTY_TEST_FILTERS, behavior: 'Active' };
 
     const { result, rerender } = renderHook(
       ({
@@ -32,7 +32,7 @@ describe('useGridState', () => {
 
     expect(result.current.filterModel.items).toEqual([
       {
-        field: 'status.name',
+        field: 'behavior.name',
         operator: 'equals',
         value: 'Active',
       },
@@ -48,7 +48,7 @@ describe('useGridState', () => {
           value: 'refund',
         },
         {
-          field: 'status.name',
+          field: 'behavior.name',
           operator: 'equals',
           value: 'Active',
         },
@@ -130,7 +130,7 @@ describe('useGridState', () => {
   });
 
   it('drops stale column filters when the same field becomes toolbar-managed', () => {
-    const drawerFilters = { ...EMPTY_TEST_FILTERS, status: 'Active' };
+    const drawerFilters = { ...EMPTY_TEST_FILTERS, behavior: 'Active' };
 
     const { result, rerender } = renderHook(
       ({
@@ -157,7 +157,7 @@ describe('useGridState', () => {
       result.current.handleFilterModelChange({
         items: [
           {
-            field: 'status.name',
+            field: 'behavior.name',
             operator: 'equals',
             value: 'Draft',
           },
@@ -167,7 +167,7 @@ describe('useGridState', () => {
 
     expect(result.current.filterModel.items).toEqual([
       {
-        field: 'status.name',
+        field: 'behavior.name',
         operator: 'equals',
         value: 'Draft',
       },
@@ -177,7 +177,7 @@ describe('useGridState', () => {
 
     expect(result.current.filterModel.items).toEqual([
       {
-        field: 'status.name',
+        field: 'behavior.name',
         operator: 'equals',
         value: 'Active',
       },
@@ -188,7 +188,7 @@ describe('useGridState', () => {
     const drawerFilters = {
       ...EMPTY_TEST_FILTERS,
       behavior: 'Accuracy Testing',
-      status: 'New',
+      category: 'New',
     };
 
     const { result } = renderHook(() =>


### PR DESCRIPTION
## Purpose

The "Status" surface is being removed from two places in the Tests area:
1. The Linked Tests grid on the behavior detail page had a "Status" column that isn't needed there.
2. The Tests page filter drawer (`/tests`) had a "Status" filter option that is being removed as well.

Closes #2248

## What Changed

- `BehaviorLinkedTests.tsx`: removed the `status` column definition from `linkedColumns`.
- `TestFilterDrawer.tsx`: removed the `status` field from `TestFilters`, `EMPTY_TEST_FILTERS`, the active-filter helpers, the `useStatuses` hook + `statusOptions`, and the "Status" autocomplete section (plus now-unused `useStatuses` / `ENTITY_TYPES` imports).
- `test-filter-model.ts`: removed `status.name` from `TEST_DRAWER_FILTER_FIELDS` and the status OData mapping.
- `useGridState.test.ts`: updated specs that constructed a `status` drawer filter / asserted `status.name` items to use the still-valid `behavior`/`category` fields.

## Additional Context

- Related issue: #2248
- The filter-drawer removal is intentional and now called out here (per review feedback).

## Testing

1. Open a behavior detail page → "Linked Tests" tab; confirm no "Status" column (Content, Test Type, Category, Topic remain).
2. Open `/tests` → filter drawer; confirm no "Status" filter (Test Type, Behavior, Category, Topic, and activity/presence filters remain).
3. `npx tsc --noEmit`, Prettier, ESLint, and the `useGridState` unit tests pass.