### PR TITLE
Fix grid crash when combining 2+ filters

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointsGrid.tsx
@@ -138,6 +138,7 @@ export default function EndpointsGrid({
 
   const {
     filterModel,
+    gridFilterModel,
     paginationModel,
     setPaginationModel,
     handlePaginationModelChange,
@@ -156,6 +157,7 @@ export default function EndpointsGrid({
 
         if (drawerFilters.connectionType) {
           drawerItems.push({
+            id: 'connectionType',
             field: 'connectionType',
             operator: 'equals',
             value: drawerFilters.connectionType,
@@ -163,6 +165,7 @@ export default function EndpointsGrid({
         }
         if (drawerFilters.environment) {
           drawerItems.push({
+            id: 'environment',
             field: 'environment',
             operator: 'equals',
             value: drawerFilters.environment,
@@ -170,6 +173,7 @@ export default function EndpointsGrid({
         }
         if (drawerFilters.status) {
           drawerItems.push({
+            id: 'status',
             field: 'status',
             operator: 'equals',
             value: drawerFilters.status,
@@ -403,7 +407,7 @@ export default function EndpointsGrid({
           onPaginationModelChange={handlePaginationModelChange}
           pageSizeOptions={[10, 25, 50]}
           serverSideFiltering={true}
-          filterModel={filterModel}
+          filterModel={gridFilterModel}
           onFilterModelChange={handleFilterModelChange}
           toolbarSlot={EndpointsUnifiedToolbar}
           showToolbar={true}

--- a/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/components/SourcesGrid.tsx
@@ -117,6 +117,7 @@ export default function SourcesGrid({
 
   const {
     filterModel,
+    gridFilterModel,
     paginationModel,
     sortModel,
     setPaginationModel,
@@ -134,6 +135,7 @@ export default function SourcesGrid({
         const drawerItems: typeof prev.items = [];
         if (drawerFilters.sourceType) {
           drawerItems.push({
+            id: 'source_type.type_value',
             field: 'source_type.type_value',
             operator: 'equals',
             value: drawerFilters.sourceType,
@@ -141,6 +143,7 @@ export default function SourcesGrid({
         }
         if (drawerFilters.creator) {
           drawerItems.push({
+            id: 'user.name',
             field: 'user.name',
             operator: 'contains',
             value: drawerFilters.creator,
@@ -148,6 +151,7 @@ export default function SourcesGrid({
         }
         if (drawerFilters.tag) {
           drawerItems.push({
+            id: 'tags',
             field: 'tags',
             operator: 'contains',
             value: drawerFilters.tag,
@@ -520,7 +524,7 @@ export default function SourcesGrid({
             showToolbar={true}
             paginationModel={paginationModel}
             onPaginationModelChange={handlePaginationModelChange}
-            filterModel={filterModel}
+            filterModel={gridFilterModel}
             onFilterModelChange={handleFilterModelChange}
             sortModel={sortModel}
             onSortModelChange={handleSortModelChange}

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -132,6 +132,7 @@ export default function TasksGrid({
 
   const {
     filterModel,
+    gridFilterModel,
     paginationModel,
     sortModel,
     setPaginationModel,
@@ -151,6 +152,7 @@ export default function TasksGrid({
         const drawerItems: typeof prev.items = [];
         if (drawerFilters.status) {
           drawerItems.push({
+            id: 'status',
             field: 'status',
             operator: 'equals',
             value: drawerFilters.status,
@@ -158,6 +160,7 @@ export default function TasksGrid({
         }
         if (drawerFilters.priority) {
           drawerItems.push({
+            id: 'priority',
             field: 'priority',
             operator: 'equals',
             value: drawerFilters.priority,
@@ -165,6 +168,7 @@ export default function TasksGrid({
         }
         if (drawerFilters.assignee) {
           drawerItems.push({
+            id: 'assignee',
             field: 'assignee',
             operator: 'equals',
             value: drawerFilters.assignee,
@@ -384,7 +388,7 @@ export default function TasksGrid({
               getRowId={row => row.id}
               paginationModel={paginationModel}
               onPaginationModelChange={handlePaginationModelChange}
-              filterModel={filterModel}
+              filterModel={gridFilterModel}
               onFilterModelChange={handleFilterModelChange}
               disableRowSelectionOnClick
               onRowClick={handleRowClick}

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -194,6 +194,7 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
       const drawerItems: typeof prev.items = [];
       if (drawerFilters.testSet) {
         drawerItems.push({
+          id: 'test_configuration.test_set.name',
           field: 'test_configuration.test_set.name',
           operator: 'contains',
           value: drawerFilters.testSet,
@@ -201,6 +202,7 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
       }
       if (drawerFilters.executor) {
         drawerItems.push({
+          id: 'user.name',
           field: 'user.name',
           operator: 'contains',
           value: drawerFilters.executor,
@@ -208,6 +210,7 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
       }
       if (drawerFilters.tag) {
         drawerItems.push({
+          id: 'tags',
           field: 'tags',
           operator: 'contains',
           value: drawerFilters.tag,
@@ -228,6 +231,7 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
 
   const {
     filterModel,
+    gridFilterModel,
     paginationModel,
     sortModel,
     setPaginationModel,
@@ -788,7 +792,7 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
             getRowId={row => row.id}
             paginationModel={paginationModel}
             onPaginationModelChange={handlePaginationModelChange}
-            filterModel={filterModel}
+            filterModel={gridFilterModel}
             onFilterModelChange={handleFilterModelChange}
             sortingMode="server"
             sortModel={sortModel}

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -194,6 +194,7 @@ export default function TestSetsGrid({
   // ── Grid state (pagination, filter, sort) via useGridState ──────────────────
   const {
     filterModel,
+    gridFilterModel,
     paginationModel,
     sortModel,
     setPaginationModel,
@@ -213,6 +214,7 @@ export default function TestSetsGrid({
         const drawerItems: typeof prev.items = [];
         if (drawerFilters.testSetType) {
           drawerItems.push({
+            id: 'testSetType',
             field: 'testSetType',
             operator: 'equals',
             value: drawerFilters.testSetType,
@@ -220,6 +222,7 @@ export default function TestSetsGrid({
         }
         if (drawerFilters.status) {
           drawerItems.push({
+            id: 'status.name',
             field: 'status.name',
             operator: 'contains',
             value: drawerFilters.status,
@@ -227,6 +230,7 @@ export default function TestSetsGrid({
         }
         if (drawerFilters.creator) {
           drawerItems.push({
+            id: 'creator',
             field: 'creator',
             operator: 'contains',
             value: drawerFilters.creator,
@@ -234,6 +238,7 @@ export default function TestSetsGrid({
         }
         if (drawerFilters.tag) {
           drawerItems.push({
+            id: 'tags',
             field: 'tags',
             operator: 'contains',
             value: drawerFilters.tag,
@@ -690,7 +695,7 @@ export default function TestSetsGrid({
             totalRows={totalCount}
             pageSizeOptions={[10, 25, 50]}
             serverSideFiltering={true}
-            filterModel={filterModel}
+            filterModel={gridFilterModel}
             onFilterModelChange={handleFilterModelChange}
             sortingMode="server"
             sortModel={sortModel}

--- a/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestsGrid.tsx
@@ -216,6 +216,7 @@ export default function TestsTable({
 
   const {
     filterModel,
+    gridFilterModel,
     paginationModel,
     sortModel,
     setPaginationModel,
@@ -881,7 +882,7 @@ export default function TestsTable({
             totalRows={totalCount}
             pageSizeOptions={[10, 25, 50]}
             serverSideFiltering={true}
-            filterModel={filterModel}
+            filterModel={gridFilterModel}
             onFilterModelChange={handleFilterModelChange}
             sortingMode="server"
             sortModel={sortModel}

--- a/apps/frontend/src/app/(protected)/tests/components/test-filter-model.ts
+++ b/apps/frontend/src/app/(protected)/tests/components/test-filter-model.ts
@@ -20,7 +20,12 @@ export function applyQuickFilterToModel(
   const items = searchQuery
     ? [
         ...otherItems,
-        { field: 'quickFilter', operator: 'contains', value: searchQuery },
+        {
+          id: 'quickFilter',
+          field: 'quickFilter',
+          operator: 'contains',
+          value: searchQuery,
+        },
       ]
     : otherItems;
   return { ...prev, items };
@@ -38,6 +43,7 @@ export function applyTestTypeFilterToModel(
       ? [
           ...otherItems,
           {
+            id: 'test_type.type_value',
             field: 'test_type.type_value',
             operator: 'equals',
             value: typeFilter,
@@ -63,6 +69,7 @@ export function applyTestDrawerFiltersToModel(
 
   if (drawerFilters.testType) {
     drawerItems.push({
+      id: 'test_type.type_value',
       field: 'test_type.type_value',
       operator: 'equals',
       value: drawerFilters.testType,
@@ -70,6 +77,7 @@ export function applyTestDrawerFiltersToModel(
   }
   if (drawerFilters.behavior) {
     drawerItems.push({
+      id: 'behavior.name',
       field: 'behavior.name',
       operator: 'equals',
       value: drawerFilters.behavior,
@@ -77,6 +85,7 @@ export function applyTestDrawerFiltersToModel(
   }
   if (drawerFilters.category) {
     drawerItems.push({
+      id: 'category.name',
       field: 'category.name',
       operator: 'equals',
       value: drawerFilters.category,
@@ -84,6 +93,7 @@ export function applyTestDrawerFiltersToModel(
   }
   if (drawerFilters.topic) {
     drawerItems.push({
+      id: 'topic.name',
       field: 'topic.name',
       operator: 'equals',
       value: drawerFilters.topic,

--- a/apps/frontend/src/components/common/presence-filter.ts
+++ b/apps/frontend/src/components/common/presence-filter.ts
@@ -33,6 +33,7 @@ export function presenceToFilterItem(
 ): GridFilterModel['items'][number] | null {
   if (value === 'all') return null;
   return {
+    id: `${field}-presence`,
     field,
     operator: value === 'with' ? 'isNotEmpty' : 'isEmpty',
     value: true,

--- a/apps/frontend/src/hooks/useGridState.ts
+++ b/apps/frontend/src/hooks/useGridState.ts
@@ -169,10 +169,18 @@ export function useGridState({
     [gridFilterMeta, managedFilterModel, reconciledColumnFilterItems]
   );
 
-  const gridFilterModel = useMemo(
-    () => ({ ...filterModel, items: filterModel.items.slice(0, 1) }),
-    [filterModel]
-  );
+  const gridFilterModel = useMemo(() => {
+    // Prefer a column-driven item (the DataGrid's own filter panel — see
+    // `SortOnlyColumnMenu` in BaseDataGrid.tsx, which currently hides that
+    // panel's entry point, but keep this correct in case it's re-enabled)
+    // over a managed one, so a user-added column filter isn't silently
+    // dropped just because a drawer/search/tab filter is also active.
+    const items = reconciledColumnFilterItems.slice(0, 1);
+    if (items.length === 0 && managedFilterModel.items.length > 0) {
+      items.push(managedFilterModel.items[0]);
+    }
+    return { ...filterModel, items };
+  }, [filterModel, reconciledColumnFilterItems, managedFilterModel]);
 
   useEffect(() => {
     setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));

--- a/apps/frontend/src/hooks/useGridState.ts
+++ b/apps/frontend/src/hooks/useGridState.ts
@@ -21,6 +21,20 @@ export interface UseGridStateOptions {
 
 export interface UseGridStateResult {
   filterModel: GridFilterModel;
+  /**
+   * Community `DataGrid` hard-forces `disableMultipleColumnsFiltering: true`
+   * (see `DATA_GRID_FORCED_PROPS` in `@mui/x-data-grid`), so it silently
+   * truncates any controlled `filterModel` with 2+ items on every render. If
+   * the truncated result differs from the (still multi-item) controlled
+   * prop, DataGrid treats that as a prop change and re-fires
+   * `onFilterModelChange`, which — with our multi-item managed/drawer
+   * filters — creates an infinite `setState` loop (React error #185). Pass
+   * this pre-truncated, single-item-safe model to the `<DataGrid>`
+   * component's `filterModel` prop instead of `filterModel`. Use the full
+   * `filterModel` only for building the server-side filter query, since
+   * actual row filtering happens server-side, not in the grid.
+   */
+  gridFilterModel: GridFilterModel;
   paginationModel: GridPaginationModel;
   sortModel: GridSortModel;
   setFilterModel: (model: GridFilterModel) => void;
@@ -67,7 +81,12 @@ function buildManagedFilterModel(
       ...model,
       items: [
         ...model.items,
-        { field: 'quickFilter', operator: 'contains', value: searchQuery },
+        {
+          id: 'quickFilter',
+          field: 'quickFilter',
+          operator: 'contains',
+          value: searchQuery,
+        },
       ],
     };
   }
@@ -83,7 +102,12 @@ function buildManagedFilterModel(
       ...model,
       items: [
         ...model.items.filter(item => item.field !== typeFilterField),
-        { field: typeFilterField, operator: 'equals', value: typeFilter },
+        {
+          id: typeFilterField,
+          field: typeFilterField,
+          operator: 'equals',
+          value: typeFilter,
+        },
       ],
     };
   }
@@ -145,6 +169,11 @@ export function useGridState({
     [gridFilterMeta, managedFilterModel, reconciledColumnFilterItems]
   );
 
+  const gridFilterModel = useMemo(
+    () => ({ ...filterModel, items: filterModel.items.slice(0, 1) }),
+    [filterModel]
+  );
+
   useEffect(() => {
     setPaginationModel(prev => (prev.page === 0 ? prev : { ...prev, page: 0 }));
   }, [managedFilterModel]);
@@ -161,12 +190,20 @@ export function useGridState({
       const columnItems = stripManagedColumnItems(model.items, managedFields);
 
       setColumnFilterItems(columnItems);
-      setGridFilterMeta({
-        logicOperator: model.logicOperator,
-        quickFilterValues: model.quickFilterValues,
-        quickFilterLogicOperator: model.quickFilterLogicOperator,
-      });
-      setPaginationModel(prev => ({ ...prev, page: 0 }));
+      setGridFilterMeta(prev =>
+        prev.logicOperator === model.logicOperator &&
+        prev.quickFilterValues === model.quickFilterValues &&
+        prev.quickFilterLogicOperator === model.quickFilterLogicOperator
+          ? prev
+          : {
+              logicOperator: model.logicOperator,
+              quickFilterValues: model.quickFilterValues,
+              quickFilterLogicOperator: model.quickFilterLogicOperator,
+            }
+      );
+      setPaginationModel(prev =>
+        prev.page === 0 ? prev : { ...prev, page: 0 }
+      );
     },
     [managedFields]
   );
@@ -185,6 +222,7 @@ export function useGridState({
 
   return {
     filterModel,
+    gridFilterModel,
     paginationModel,
     sortModel,
     setFilterModel,


### PR DESCRIPTION
## Purpose

Selecting two or more simultaneous filters in a grid that uses `useGridState` (e.g. the Tests page drawer: Behavior + Category) crashes the page with React error #185 ("Maximum update depth exceeded").

## What Changed

- Community `@mui/x-data-grid` hard-forces `disableMultipleColumnsFiltering: true`, so it silently truncates any controlled `filterModel` with 2+ items on every render. Since our merged managed/drawer filters could contain 2+ items, the truncated internal state never matched the still-multi-item prop, causing DataGrid to re-fire `onFilterModelChange` forever.
- `useGridState` now exposes a new `gridFilterModel` (capped to at most 1 item) for the `<DataGrid>` component's controlled `filterModel` prop, while the full multi-item `filterModel` is still used to build the server-side filter query (unaffected — filtering itself is server-side).
- Updated all 6 grids that share `useGridState` (Tests, Test Runs, Tasks, Endpoints, Test Sets, Sources) to pass `gridFilterModel` to the grid instead of `filterModel`.
- Also gave every programmatically-built `GridFilterItem` a stable `id` (previously missing), fixing a related but separate churn issue where MUI would assign a new random `id` on each render once 2+ items were present.

## Testing

- `npx tsc --noEmit` passes clean.
- ESLint passes (pre-existing warnings only, no new errors).
- Manually reproduced in the browser: applying Status + Behavior + Category simultaneously in the Tests filter drawer now returns results (or "No rows") with zero console errors, instead of crashing to the error boundary.