### PR TITLE
Fix cross-project entity and span resolution under enforced RLS

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -2858,7 +2858,7 @@ def get_project_members(
 
 
 def get_my_projects(db: Session, user_id: uuid.UUID, organization_id: str) -> List[models.Project]:
-    """Return all projects the given user is a member of."""
+    """Return all ACTIVE, non-deleted projects the given user is a member of."""
     from rhesis.backend.app.models.project_membership import ProjectMembership
 
     return (
@@ -2867,6 +2867,8 @@ def get_my_projects(db: Session, user_id: uuid.UUID, organization_id: str) -> Li
         .filter(
             ProjectMembership.user_id == user_id,
             ProjectMembership.organization_id == organization_id,
+            models.Project.deleted_at.is_(None),
+            models.Project.is_active.is_(True),
         )
         .all()
     )

--- a/apps/backend/src/rhesis/backend/app/routers/resolve.py
+++ b/apps/backend/src/rhesis/backend/app/routers/resolve.py
@@ -27,13 +27,12 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import UnmappedClassError
 
-from rhesis.backend.app import models
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.database import temporary_project_scope
 from rhesis.backend.app.dependencies import get_project_context, get_tenant_db_session
 from rhesis.backend.app.models.base import Base
 from rhesis.backend.app.models.user import User
-from rhesis.backend.app.scope import bypass_tenant_filter
+from rhesis.backend.app.services.project_membership import list_other_member_projects
 
 router = APIRouter(prefix="/resolve", tags=["resolve"])
 
@@ -132,28 +131,8 @@ def resolve_entity(
 
     organization_id = str(current_user.organization_id)
     user_id = str(current_user.id)
-    active_project_id = project_id or ""
 
-    # List the caller's projects (id + name) in one org-scoped query. Wrapped
-    # in bypass_tenant_filter() because ProjectMembership carries a project_id
-    # column, so the ORM auto-filter would otherwise pin the result to the
-    # active project. Safe: project_membership has no DB-level project_isolation
-    # policy and both tables keep tenant_isolation (org), so RLS still applies.
-    with bypass_tenant_filter():
-        rows = (
-            db.query(models.Project.id, models.Project.name)
-            .join(
-                models.ProjectMembership,
-                models.ProjectMembership.project_id == models.Project.id,
-            )
-            .filter(
-                models.ProjectMembership.user_id == user_id,
-                models.ProjectMembership.organization_id == organization_id,
-            )
-            .all()
-        )
-
-    candidates = [(str(pid), name) for pid, name in rows if str(pid) != active_project_id]
+    candidates = list_other_member_projects(db, organization_id, user_id, project_id)
 
     # Probe candidate projects one at a time, stopping at the first match. A
     # UUID PK is globally unique, so at most one project can contain the entity.

--- a/apps/backend/src/rhesis/backend/app/routers/resolve.py
+++ b/apps/backend/src/rhesis/backend/app/routers/resolve.py
@@ -1,9 +1,22 @@
 """Cross-project entity resolution endpoint.
 
 When a user follows a shared link to an entity that belongs to a different
-project than their currently active one, the auto-filter returns 404. This
-endpoint lets the frontend discover the entity's actual project so it can
-offer a "switch project" prompt instead of a confusing "Not Found" page.
+project than their currently active one, the auto-filter (and Postgres RLS)
+returns 404. This endpoint discovers which of the caller's *other* projects
+contains the entity so the frontend can offer a "switch project" prompt
+instead of a confusing "Not Found" page.
+
+It probes each project the caller is a member of under that project's own
+scope. Postgres ``FORCE ROW LEVEL SECURITY`` on project-scoped tables cannot
+be bypassed from the non-privileged app role, so the ORM-level
+``bypass_tenant_filter()`` is not sufficient on its own — probing under a real
+project scope is the only cross-project lookup available to the app role.
+
+Probing is sequential with early exit rather than parallel: each probe needs a
+distinct ``app.current_project`` GUC, which is transaction-scoped, so parallel
+probes would need separate connections (fanning out the small engine pool and
+breaking the savepoint-isolated test harness) for no real gain — the lookups
+are indexed primary-key hits on a rare, only-on-404 endpoint.
 """
 
 import uuid
@@ -16,6 +29,7 @@ from sqlalchemy.orm.exc import UnmappedClassError
 
 from rhesis.backend.app import models
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+from rhesis.backend.app.database import temporary_project_scope
 from rhesis.backend.app.dependencies import get_project_context, get_tenant_db_session
 from rhesis.backend.app.models.base import Base
 from rhesis.backend.app.models.user import User
@@ -70,6 +84,29 @@ class ResolvedEntity(BaseModel):
     project_name: str | None = None
 
 
+def _entity_visible_in_project(
+    db: Session,
+    model_cls: type,
+    entity_id: uuid.UUID,
+    organization_id: str,
+    user_id: str,
+    project_id: str,
+) -> bool:
+    """Return True if the entity is visible (and not soft-deleted) with the
+    session temporarily scoped to ``project_id``.
+
+    ``temporary_project_scope`` sets ``app.current_project`` on the request
+    connection and restores the caller's original scope on exit. Scoping to a
+    real project is what makes the lookup correct under RLS: the row is only
+    visible when ``app.current_project`` matches the entity's project.
+    """
+    with temporary_project_scope(db, organization_id, user_id, project_id):
+        query = db.query(model_cls).filter(model_cls.id == entity_id)
+        if hasattr(model_cls, "deleted_at"):
+            query = query.filter(model_cls.deleted_at.is_(None))
+        return query.first() is not None
+
+
 @router.get("", response_model=ResolvedEntity)
 def resolve_entity(
     entity_type: str,
@@ -78,13 +115,13 @@ def resolve_entity(
     project_id: str | None = Depends(get_project_context),
     current_user: User = Depends(require_current_user_or_token),
 ):
-    """Resolve an entity across projects within the caller's organization.
+    """Resolve an entity across the caller's *other* projects.
 
-    Returns one of three resolutions:
-    - ``switchable``: entity is in a different project the caller can access
-    - ``no_access``: entity exists but the caller lacks project membership
-      (project details are withheld)
-    - 404: entity does not exist, is deleted, or belongs to another org
+    Returns ``switchable`` with the target project when the entity lives in a
+    project the caller is a member of; otherwise 404. Entities in projects the
+    caller cannot access are indistinguishable from non-existent ones by
+    design — the app role cannot see them under RLS, and not revealing their
+    existence is the safer behavior.
     """
     model_cls = get_resolvable_entities().get(entity_type)
     if model_cls is None:
@@ -95,63 +132,41 @@ def resolve_entity(
 
     organization_id = str(current_user.organization_id)
     user_id = str(current_user.id)
+    active_project_id = project_id or ""
 
+    # List the caller's projects (id + name) in one org-scoped query. Wrapped
+    # in bypass_tenant_filter() because ProjectMembership carries a project_id
+    # column, so the ORM auto-filter would otherwise pin the result to the
+    # active project. Safe: project_membership has no DB-level project_isolation
+    # policy and both tables keep tenant_isolation (org), so RLS still applies.
     with bypass_tenant_filter():
-        entity = (
-            db.query(model_cls)
-            .filter(
-                model_cls.id == entity_id,
-                model_cls.organization_id == organization_id,
+        rows = (
+            db.query(models.Project.id, models.Project.name)
+            .join(
+                models.ProjectMembership,
+                models.ProjectMembership.project_id == models.Project.id,
             )
-            .first()
-        )
-
-    if entity is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-
-    if hasattr(entity, "deleted_at") and entity.deleted_at is not None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-
-    entity_project_id = str(entity.project_id) if entity.project_id else None
-
-    if entity_project_id is None or entity_project_id == (project_id or ""):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-
-    with bypass_tenant_filter():
-        membership = (
-            db.query(models.ProjectMembership)
             .filter(
                 models.ProjectMembership.user_id == user_id,
-                models.ProjectMembership.project_id == entity_project_id,
                 models.ProjectMembership.organization_id == organization_id,
             )
-            .first()
+            .all()
         )
 
-    if membership is None:
-        return ResolvedEntity(
-            resolution="no_access",
-            entity_type=entity_type,
-            entity_id=str(entity_id),
-        )
+    candidates = [(str(pid), name) for pid, name in rows if str(pid) != active_project_id]
 
-    with bypass_tenant_filter():
-        project = (
-            db.query(models.Project)
-            .filter(
-                models.Project.id == entity_project_id,
-                models.Project.organization_id == organization_id,
+    # Probe candidate projects one at a time, stopping at the first match. A
+    # UUID PK is globally unique, so at most one project can contain the entity.
+    for candidate_project_id, candidate_project_name in candidates:
+        if _entity_visible_in_project(
+            db, model_cls, entity_id, organization_id, user_id, candidate_project_id
+        ):
+            return ResolvedEntity(
+                resolution="switchable",
+                entity_type=entity_type,
+                entity_id=str(entity_id),
+                project_id=candidate_project_id,
+                project_name=candidate_project_name,
             )
-            .first()
-        )
 
-    if project is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
-
-    return ResolvedEntity(
-        resolution="switchable",
-        entity_type=entity_type,
-        entity_id=str(entity_id),
-        project_id=str(project.id),
-        project_name=project.name,
-    )
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -37,6 +37,7 @@ from rhesis.backend.app.schemas.telemetry import (
     TraceType,
 )
 from rhesis.backend.app.services.async_service import BROKER_ERRORS
+from rhesis.backend.app.services.project_membership import list_other_member_projects
 from rhesis.backend.app.services.review import (
     apply_review_resolved,
     authorize_review_action,
@@ -485,14 +486,30 @@ def lookup_span(
     span_db_id: UUID,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
+    scope_project_id: Optional[str] = Depends(get_project_context),
 ):
     """
     Resolve a span's database UUID to its trace_id and project_id.
 
-    Used for navigation from tasks/comments linked to a Trace entity.
+    Used for navigation from tasks/comments linked to a Trace entity. The
+    span's ``trace`` row carries a FORCE-enabled ``project_isolation`` RLS
+    policy, so a lookup scoped to the caller's active project silently misses
+    a span whose trace lives in a different (but accessible) project — probe
+    the caller's other projects before giving up. See ``routers/resolve.py``
+    for the full rationale.
     """
-    organization_id, _ = tenant_context
+    organization_id, user_id = tenant_context
     span = crud.get_trace_by_db_id(db, str(span_db_id), organization_id)
+
+    if not span:
+        for candidate_project_id, _ in list_other_member_projects(
+            db, organization_id, user_id, scope_project_id
+        ):
+            with temporary_project_scope(db, organization_id, user_id, candidate_project_id):
+                span = crud.get_trace_by_db_id(db, str(span_db_id), organization_id)
+            if span:
+                break
+
     if not span:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/apps/backend/src/rhesis/backend/app/services/project_membership.py
+++ b/apps/backend/src/rhesis/backend/app/services/project_membership.py
@@ -1,0 +1,43 @@
+"""Helpers for discovering a caller's project memberships.
+
+Shared by any endpoint that needs to search across a caller's OTHER projects
+under real RLS scope (project_isolation is FORCE-enabled and keyed on the
+`app.current_project` GUC, so a lookup scoped to the active project cannot
+see rows in a different one — see ``routers/resolve.py`` for the full
+rationale). ``project_membership`` carries no ``project_isolation`` policy
+(dropped intentionally in the ``b8c9d0e1f2a3`` migration), so it's queryable
+at org scope; wrapped in ``bypass_tenant_filter()`` only because it *does*
+have a ``project_id`` column that the ORM auto-filter would otherwise pin to
+the active project.
+"""
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.scope import bypass_tenant_filter
+
+
+def list_other_member_projects(
+    db: Session,
+    organization_id: str,
+    user_id: str,
+    exclude_project_id: str | None = None,
+) -> list[tuple[str, str]]:
+    """Return (project_id, project_name) for every project the caller belongs
+    to in this org, excluding ``exclude_project_id`` (typically the active one).
+    """
+    with bypass_tenant_filter():
+        rows = (
+            db.query(models.Project.id, models.Project.name)
+            .join(
+                models.ProjectMembership,
+                models.ProjectMembership.project_id == models.Project.id,
+            )
+            .filter(
+                models.ProjectMembership.user_id == user_id,
+                models.ProjectMembership.organization_id == organization_id,
+            )
+            .all()
+        )
+
+    return [(str(pid), name) for pid, name in rows if str(pid) != (exclude_project_id or "")]

--- a/apps/backend/src/rhesis/backend/app/services/project_membership.py
+++ b/apps/backend/src/rhesis/backend/app/services/project_membership.py
@@ -23,8 +23,9 @@ def list_other_member_projects(
     user_id: str,
     exclude_project_id: str | None = None,
 ) -> list[tuple[str, str]]:
-    """Return (project_id, project_name) for every project the caller belongs
-    to in this org, excluding ``exclude_project_id`` (typically the active one).
+    """Return (project_id, project_name) for every ACTIVE, non-deleted project
+    the caller belongs to in this org, excluding ``exclude_project_id``
+    (typically the active one).
     """
     with bypass_tenant_filter():
         rows = (
@@ -36,6 +37,8 @@ def list_other_member_projects(
             .filter(
                 models.ProjectMembership.user_id == user_id,
                 models.ProjectMembership.organization_id == organization_id,
+                models.Project.deleted_at.is_(None),
+                models.Project.is_active.is_(True),
             )
             .all()
         )

--- a/apps/frontend/src/components/common/CrossProjectAlert.tsx
+++ b/apps/frontend/src/components/common/CrossProjectAlert.tsx
@@ -8,7 +8,6 @@ import { ResolvedEntity } from '@/utils/api-client/resolve-client';
 import { NotFoundEntityData } from '@/utils/entity-error-handler';
 import {
   getResolveEntityIcon,
-  LockOutlinedIcon,
   SwapHorizOutlinedIcon,
 } from '@/utils/entity-detail-icons';
 import { writeActiveProjectId } from '@/utils/active-project';
@@ -30,21 +29,6 @@ export function CrossProjectAlert({
   const displayName =
     entityData.model_name_display || entityData.model_name || 'item';
   const EntityIcon = getResolveEntityIcon(entityData.table_name);
-
-  if (resolvedEntity.resolution === 'no_access') {
-    return (
-      <EntityMessageState
-        icon={LockOutlinedIcon}
-        title={`${displayName} is in another project`}
-        description={`This ${displayName.toLowerCase()} belongs to a project you don't have access to. Contact your administrator to request access.`}
-        secondaryAction={{
-          label: 'Back',
-          onClick: () => window.history.back(),
-          startIcon: <ArrowBackIcon />,
-        }}
-      />
-    );
-  }
 
   const handleSwitch = () => {
     setSwitching(true);

--- a/apps/frontend/src/components/common/DetailNotFoundState.tsx
+++ b/apps/frontend/src/components/common/DetailNotFoundState.tsx
@@ -76,9 +76,7 @@ export default function DetailNotFoundState({
       : getResolveEntityIcon(entityTableName);
 
   const pageTitle = crossProjectData
-    ? crossProjectData.resolution === 'no_access'
-      ? `${displayLabel} — No access`
-      : `${displayLabel} in another project`
+    ? `${displayLabel} in another project`
     : `${displayLabel} not found`;
 
   const contentWrapper = (children: ReactNode) => (

--- a/apps/frontend/src/utils/api-client/resolve-client.ts
+++ b/apps/frontend/src/utils/api-client/resolve-client.ts
@@ -1,7 +1,7 @@
 import { BaseApiClient } from './base-client';
 import { getApiErrorStatus } from './is-not-found-error';
 
-export type EntityResolution = 'switchable' | 'no_access';
+export type EntityResolution = 'switchable';
 
 export interface ResolvedEntity {
   resolution: EntityResolution;

--- a/apps/frontend/src/utils/entity-detail-icons.ts
+++ b/apps/frontend/src/utils/entity-detail-icons.ts
@@ -1,6 +1,5 @@
 import type { SvgIconProps } from '@mui/material/SvgIcon';
 import FolderOffOutlinedIcon from '@mui/icons-material/FolderOffOutlined';
-import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import SwapHorizOutlinedIcon from '@mui/icons-material/SwapHorizOutlined';
 import {
   BehaviorsIcon,
@@ -37,4 +36,4 @@ export function getResolveEntityIcon(
   return RESOLVE_ENTITY_ICONS[tableName] ?? FolderOffOutlinedIcon;
 }
 
-export { FolderOffOutlinedIcon, LockOutlinedIcon, SwapHorizOutlinedIcon };
+export { FolderOffOutlinedIcon, SwapHorizOutlinedIcon };

--- a/tests/backend/routes/test_project_membership.py
+++ b/tests/backend/routes/test_project_membership.py
@@ -210,6 +210,37 @@ class TestProjectListingMembership:
         # assertable here because mine may include more projects than the page holds.
         assert all_ids.issubset(mine_ids)
 
+    def test_mine_excludes_inactive_project(
+        self, authenticated_client, test_db, test_org_id, authenticated_user_id
+    ):
+        """An inactive project the user is enrolled in must not appear in
+        GET /projects/mine — the switcher (and /resolve's candidate probing,
+        which shares this filter) must never offer switching into it."""
+        project = _make_project(test_db, test_org_id)
+        _enroll(test_db, str(authenticated_user_id), str(project.id), test_org_id)
+        project.is_active = False
+        test_db.flush()
+
+        response = authenticated_client.get("/projects/mine")
+        assert response.status_code == status.HTTP_200_OK
+        ids = [p["id"] for p in response.json()]
+        assert str(project.id) not in ids
+
+    def test_mine_excludes_soft_deleted_project(
+        self, authenticated_client, test_db, test_org_id, authenticated_user_id
+    ):
+        """A soft-deleted project the user is enrolled in must not appear in
+        GET /projects/mine."""
+        project = _make_project(test_db, test_org_id)
+        _enroll(test_db, str(authenticated_user_id), str(project.id), test_org_id)
+        project.soft_delete()
+        test_db.flush()
+
+        response = authenticated_client.get("/projects/mine")
+        assert response.status_code == status.HTTP_200_OK
+        ids = [p["id"] for p in response.json()]
+        assert str(project.id) not in ids
+
 
 # ---------------------------------------------------------------------------
 # 2. Creator auto-enrollment on POST /projects/

--- a/tests/backend/routes/test_resolve.py
+++ b/tests/backend/routes/test_resolve.py
@@ -122,6 +122,55 @@ class TestResolveEntityEndpoint:
         assert data["project_id"] == str(other_project.id)
         assert data["project_name"] == other_project.name
 
+    def test_archived_project_not_offered_as_switchable(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_organization,
+        db_user,
+        db_owner_user,
+        db_status,
+        active_project_context,
+        authenticated_user_id,
+    ):
+        """An entity in a project the caller is a member of, but the project is
+        inactive/archived, must not be offered as a switch target — it should
+        404 like any other project the candidate list excludes."""
+        archived_project = self._create_project_with_membership(
+            test_db,
+            test_organization,
+            db_user,
+            db_owner_user,
+            db_status,
+            authenticated_user_id,
+            "archived",
+        )
+        archived_project.is_active = False
+        test_db.flush()
+
+        test_set = TestSet(
+            name="Archived-project test set",
+            description="Belongs to an archived project",
+            user_id=db_user.id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+            project_id=archived_project.id,
+            is_published=False,
+            visibility="organization",
+        )
+        test_db.add(test_set)
+        test_db.flush()
+
+        response = authenticated_client.get(
+            "/resolve",
+            params={
+                "entity_type": "test_set",
+                "entity_id": str(test_set.id),
+            },
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
     def test_not_member_of_entity_project_returns_404(
         self,
         authenticated_client: TestClient,

--- a/tests/backend/routes/test_resolve.py
+++ b/tests/backend/routes/test_resolve.py
@@ -25,9 +25,7 @@ def _override_active_project(project_id: str):
 @pytest.fixture
 def active_project_context(db_project):
     """Pin the active project for resolve endpoint tests."""
-    app.dependency_overrides[get_project_context] = _override_active_project(
-        str(db_project.id)
-    )
+    app.dependency_overrides[get_project_context] = _override_active_project(str(db_project.id))
     yield db_project
     app.dependency_overrides.pop(get_project_context, None)
 
@@ -124,6 +122,58 @@ class TestResolveEntityEndpoint:
         assert data["project_id"] == str(other_project.id)
         assert data["project_name"] == other_project.name
 
+    def test_not_member_of_entity_project_returns_404(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_organization,
+        db_user,
+        db_owner_user,
+        db_status,
+        active_project_context,
+    ):
+        """Entity in a project the caller is NOT a member of resolves to 404.
+
+        The caller can only probe projects they belong to, so a project they
+        cannot access is indistinguishable from a non-existent one — there is no
+        ``no_access`` outcome, and its existence is not revealed.
+        """
+        foreign_project = Project(
+            name="Resolve Project Foreign",
+            description=fake.text(max_nb_chars=100),
+            icon="🚫",
+            is_active=True,
+            user_id=db_user.id,
+            owner_id=db_owner_user.id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+        )
+        test_db.add(foreign_project)
+        test_db.flush()
+
+        test_set = TestSet(
+            name="Foreign-project test set",
+            description="In a project the caller cannot access",
+            user_id=db_user.id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+            project_id=foreign_project.id,
+            is_published=False,
+            visibility="organization",
+        )
+        test_db.add(test_set)
+        test_db.flush()
+
+        response = authenticated_client.get(
+            "/resolve",
+            params={
+                "entity_type": "test_set",
+                "entity_id": str(test_set.id),
+            },
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
     def test_same_project_returns_404(
         self,
         authenticated_client: TestClient,
@@ -193,3 +243,98 @@ class TestResolveEntityEndpoint:
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.integration
+class TestResolveUnderEnforcedRLS:
+    """Guard the premise the resolve endpoint relies on: a project-scoped row is
+    visible only when ``app.current_project`` matches the row's project.
+
+    This exercises real Postgres RLS via a non-BYPASSRLS role, the production
+    scenario. The normal test DB role is a superuser that bypasses RLS entirely
+    — which is exactly why the original ``bypass_tenant_filter()`` approach
+    (ORM-level only) passed tests yet returned 404 in production, where the app
+    role is subject to ``FORCE ROW LEVEL SECURITY``. Because the endpoint's
+    probe runs on the superuser app session, this asserts the RLS behavior at
+    the query layer rather than through the endpoint.
+    """
+
+    def _make_project(self, test_db, test_organization, db_user, db_owner_user, db_status, name):
+        project = Project(
+            name=name,
+            description=fake.text(max_nb_chars=60),
+            icon="🔒",
+            is_active=True,
+            user_id=db_user.id,
+            owner_id=db_owner_user.id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+        )
+        test_db.add(project)
+        test_db.flush()
+        return project
+
+    def test_entity_visible_only_under_its_own_project_scope(
+        self,
+        test_db,
+        test_organization,
+        db_user,
+        db_owner_user,
+        db_status,
+    ):
+        import uuid as _uuid
+
+        from sqlalchemy import text
+
+        org_id = str(test_organization.id)
+
+        project_a = self._make_project(
+            test_db, test_organization, db_user, db_owner_user, db_status, "RLS Project A"
+        )
+        project_b = self._make_project(
+            test_db, test_organization, db_user, db_owner_user, db_status, "RLS Project B"
+        )
+
+        test_set = TestSet(
+            name="RLS cross-project test set",
+            description="Lives in project B",
+            user_id=db_user.id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+            project_id=project_b.id,
+            is_published=False,
+            visibility="organization",
+        )
+        test_db.add(test_set)
+        test_db.flush()
+
+        entity_id = str(test_set.id)
+        probe = f"resolve_rls_probe_{_uuid.uuid4().hex[:8]}"
+
+        test_db.execute(text(f'CREATE ROLE "{probe}" NOLOGIN'))
+        test_db.execute(text(f'GRANT SELECT ON public.test_set TO "{probe}"'))
+        test_db.execute(text(f'SET LOCAL ROLE "{probe}"'))
+        test_db.execute(text("SET LOCAL app.current_organization = :o"), {"o": org_id})
+
+        # Scoped to the WRONG project: RLS hides the row. This is the failure the
+        # old ORM-only bypass could not avoid — the app role never sees it.
+        test_db.execute(text("SET LOCAL app.current_project = :p"), {"p": str(project_a.id)})
+        wrong_scope = test_db.execute(
+            text("SELECT id FROM test_set WHERE id = :id"), {"id": entity_id}
+        ).fetchone()
+        assert wrong_scope is None, (
+            "cross-project entity was visible under the wrong project scope — "
+            "RLS project_isolation is not enforcing"
+        )
+
+        # Scoped to the entity's OWN project: RLS admits the row. This is what
+        # the per-project probe depends on.
+        test_db.execute(text("SET LOCAL app.current_project = :p"), {"p": str(project_b.id)})
+        right_scope = test_db.execute(
+            text("SELECT id FROM test_set WHERE id = :id"), {"id": entity_id}
+        ).fetchone()
+        assert right_scope is not None, (
+            "entity hidden even under its own project scope — the probe would never find it"
+        )
+
+        test_db.execute(text("RESET ROLE"))

--- a/tests/backend/routes/test_telemetry.py
+++ b/tests/backend/routes/test_telemetry.py
@@ -9,10 +9,16 @@ This module tests the OpenTelemetry trace ingestion endpoints including:
 """
 
 import pytest
+from faker import Faker
 from fastapi import status
 from fastapi.testclient import TestClient
 
+from rhesis.backend.app import models
+from rhesis.backend.app.models.project import Project
+from rhesis.backend.app.models.project_membership import ProjectMembership
 from tests.backend.routes.fixtures.data_factories import TraceDataFactory
+
+fake = Faker()
 
 
 @pytest.mark.integration
@@ -180,6 +186,75 @@ class TestTraceAuthentication:
         response = authenticated_client.post("/telemetry/traces", json=trace_batch)
 
         assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.integration
+class TestLookupSpanCrossProject:
+    """A span whose trace lives in a project other than the caller's active
+    one must still resolve via /telemetry/spans/{id}/lookup, not silently
+    404 under project_isolation RLS (same root cause as routers/resolve.py).
+    """
+
+    def test_lookup_span_in_other_member_project(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_organization,
+        db_user,
+        db_owner_user,
+        db_status,
+        db_project,
+        authenticated_user_id,
+    ):
+        other_project = Project(
+            name="Telemetry Other Project",
+            description=fake.text(max_nb_chars=60),
+            icon="📡",
+            is_active=True,
+            user_id=db_user.id,
+            owner_id=db_owner_user.id,
+            organization_id=test_organization.id,
+            status_id=db_status.id,
+        )
+        test_db.add(other_project)
+        test_db.flush()
+        test_db.add(
+            ProjectMembership(
+                project_id=other_project.id,
+                user_id=authenticated_user_id,
+                organization_id=test_organization.id,
+            )
+        )
+        test_db.flush()
+
+        span_data = TraceDataFactory.minimal_data(project_id=str(other_project.id))
+        ingest_response = authenticated_client.post(
+            "/telemetry/traces",
+            json={"spans": [span_data]},
+            headers={"X-Project-Id": str(other_project.id)},
+        )
+        assert ingest_response.status_code == status.HTTP_200_OK
+
+        span_row = (
+            test_db.query(models.Trace).filter(models.Trace.trace_id == span_data["trace_id"]).one()
+        )
+
+        # Active scope is db_project — a different project than the span's own.
+        response = authenticated_client.get(
+            f"/telemetry/spans/{span_row.id}/lookup",
+            headers={"X-Project-Id": str(db_project.id)},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["trace_id"] == span_data["trace_id"]
+        assert data["project_id"] == str(other_project.id)
+
+    def test_lookup_span_not_found(self, authenticated_client: TestClient):
+        response = authenticated_client.get(
+            "/telemetry/spans/123e4567-e89b-12d3-a456-426614174000/lookup"
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Purpose

PR #2147 added a `/resolve` endpoint so that opening a link to an entity in a different project offers a "switch project" prompt instead of a plain 404. In the deployed release, cross-project links still show a generic "Test not found" page.

Root cause: `resolve.py` looked up the entity via `bypass_tenant_filter()`, which only disables the SQLAlchemy ORM auto-filter. It does nothing against Postgres `FORCE ROW LEVEL SECURITY`, which has enforced project-level isolation (`project_isolation`, added in #1880) since five weeks before #2147 merged. The production app connects as a restricted `APP_DB_USER` with no `BYPASSRLS`, so the RLS policy silently hid rows in other projects and the endpoint always fell through to 404. The backend test suite didn't catch this because it runs as a Postgres superuser, which bypasses RLS entirely.

While auditing every entity that should support cross-project resolution, the same root cause turned up in a second, unrelated code path: `GET /telemetry/spans/{id}/lookup` (used for "go to trace" links from tasks/comments) had the identical active-project-only RLS scoping bug — fixed here too.

## What Changed

- **Backend**: `/resolve` now lists the caller's other project memberships and probes each one under its own scope via `temporary_project_scope` (not the ORM-level bypass), stopping at the first match. This is correct under RLS because it sets a real `app.current_project` GUC per probe instead of trying to defeat the policy.
- **Backend**: probing is sequential with early exit rather than parallel — each probe needs a distinct transaction-scoped GUC, so parallelizing would require separate connections, fanning out the small engine pool for a rare, only-on-404, indexed-PK-lookup endpoint.
- **Backend**: the `no_access` resolution is retired. Since the caller can only probe their own projects, "exists in a project you can't access" is now indistinguishable from "doesn't exist" — which also closes a minor existence-leak the old response had.
- **Backend**: extracted `list_other_member_projects()` (`services/project_membership.py`) out of `resolve.py` so the same "list the caller's other projects" query is shared rather than duplicated.
- **Backend**: `lookup_span` now probes the caller's other projects the same way before giving up. The rest of the traces pipeline (`list_traces`, the trace drawer) already handles a resolved cross-project id correctly via `temporary_project_scope` / an explicit `X-Project-Id` header, so this was the only broken link in that chain — no frontend change needed for traces.
- **Frontend**: removed the now-unreachable `no_access` UI branch (`CrossProjectAlert`, `DetailNotFoundState`, `resolve-client.ts`, `entity-detail-icons.ts`).
- **Tests**: added a case for "entity in a project the caller isn't a member of → 404", a dedicated RLS-enforced regression test that creates a real non-`BYPASSRLS` Postgres role and asserts a cross-project row is visible only under its own project scope, and a cross-project `lookup_span` test.

## Additional Context

- No later commit broke this; `git diff` between the #2147 merge commit and this branch's base on the touched files was empty before this PR. The RLS enforcement predates #2147.
- This narrows behavior slightly: entities in projects you have no access to now 404 like any other missing entity, rather than surfacing a distinct "no access" message.
- Audited every project-scoped table for other missing cross-project candidates: none — every other project-scoped model either has no standalone detail page (nothing for `/resolve` to attach to) or is already covered.
- Targets `release/v0.11.0` directly since that's the deployed branch where the bug was reported.

## Testing

```
cd apps/backend && uv run pytest ../../tests/backend/routes/test_resolve.py ../../tests/backend/routes/test_telemetry.py -v
cd apps/frontend && npx tsc --noEmit && npm run lint
```

- [x] `test_switchable_when_entity_in_other_project` — entity in another owned project resolves as switchable
- [x] `test_not_member_of_entity_project_returns_404` — entity in a project the caller isn't a member of 404s (retired `no_access`)
- [x] `test_same_project_returns_404` — entity already visible in the active project isn't re-offered
- [x] `test_entity_visible_only_under_its_own_project_scope` — RLS-enforced: a non-BYPASSRLS role sees the row only when scoped to its actual project
- [x] `test_lookup_span_in_other_member_project` — a span whose trace lives in a different accessible project now resolves instead of 404ing
- [x] Manual: open a test-detail link from a project other than the active one; expect the switch-project card, not "Test not found"