### PR TITLE
Fix: hide test-set assign controls for viewers

### DIFF
--- a/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
+++ b/apps/frontend/src/components/tests/LinkedTestSetsSection.tsx
@@ -19,6 +19,8 @@ import { TestSet } from '@/utils/api-client/interfaces/test-set';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { formatDate } from '@/utils/date';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { useCan } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
 
 interface LinkedTestSetsSectionProps {
   testId: string;
@@ -29,6 +31,7 @@ export default function LinkedTestSetsSection({
 }: LinkedTestSetsSectionProps) {
   const { show: showNotification } = useNotifications();
   const { status } = useSession();
+  const canEditTest = useCan(Capability.TestSet.UPDATE);
 
   const [testSets, setTestSets] = useState<TestSet[]>([]);
   const [totalCount, setTotalCount] = useState(0);
@@ -219,15 +222,19 @@ export default function LinkedTestSetsSection({
               No test sets assigned yet
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              Assign this test to a test set to group related cases together.
+              {canEditTest
+                ? 'Assign this test to a test set to group related cases together.'
+                : 'This test has no linked test sets yet.'}
             </Typography>
-            <Button
-              variant="contained"
-              startIcon={<AddIcon />}
-              onClick={handleAssignClick}
-            >
-              Assign to test set
-            </Button>
+            {canEditTest && (
+              <Button
+                variant="contained"
+                startIcon={<AddIcon />}
+                onClick={handleAssignClick}
+              >
+                Assign to test set
+              </Button>
+            )}
           </Box>
         </Paper>
       ) : (
@@ -249,13 +256,15 @@ export default function LinkedTestSetsSection({
             >
               Linked Test Sets ({totalCount})
             </Typography>
-            <Button
-              variant="outlined"
-              startIcon={<AddIcon />}
-              onClick={handleAssignClick}
-            >
-              Assign
-            </Button>
+            {canEditTest && (
+              <Button
+                variant="outlined"
+                startIcon={<AddIcon />}
+                onClick={handleAssignClick}
+              >
+                Assign
+              </Button>
+            )}
           </Box>
 
           <BaseDataGrid
@@ -275,17 +284,19 @@ export default function LinkedTestSetsSection({
         </Paper>
       )}
 
-      <AssignEntityDrawer
-        open={assignOpen}
-        onClose={() => setAssignOpen(false)}
-        title="Assign Test Set"
-        rows={availableFiltered}
-        columns={drawerColumns}
-        loading={loadingAvailable}
-        getRowId={row => String(row.id)}
-        onAssign={handleAssign}
-        searchPlaceholder="Search test sets…"
-      />
+      {canEditTest && (
+        <AssignEntityDrawer
+          open={assignOpen}
+          onClose={() => setAssignOpen(false)}
+          title="Assign Test Set"
+          rows={availableFiltered}
+          columns={drawerColumns}
+          loading={loadingAvailable}
+          getRowId={row => String(row.id)}
+          onAssign={handleAssign}
+          searchPlaceholder="Search test sets…"
+        />
+      )}
     </>
   );
 }

--- a/apps/frontend/src/components/tests/__tests__/LinkedTestSetsSection.test.tsx
+++ b/apps/frontend/src/components/tests/__tests__/LinkedTestSetsSection.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import LinkedTestSetsSection from '../LinkedTestSetsSection';
 
 let mockCanEdit = true;
@@ -37,10 +38,13 @@ jest.mock('@/utils/api-client/test-sets-client', () => ({
   })),
 }));
 
+// Always render a marker (regardless of `open`) so tests can distinguish
+// "component gated out of the tree entirely" from "mounted but closed".
 jest.mock('@/components/common/AssignEntityDrawer', () => ({
   __esModule: true,
-  default: ({ open }: { open: boolean }) =>
-    open ? <div data-testid="assign-drawer" /> : null,
+  default: ({ open }: { open: boolean }) => (
+    <div data-testid="assign-drawer" data-open={String(open)} />
+  ),
 }));
 
 describe('LinkedTestSetsSection', () => {
@@ -65,7 +69,10 @@ describe('LinkedTestSetsSection', () => {
     expect(
       screen.queryByRole('button', { name: /assign to test set/i })
     ).not.toBeInTheDocument();
-    expect(screen.getByText('This test has no linked test sets yet.')).toBeInTheDocument();
+    expect(
+      screen.getByText('This test has no linked test sets yet.')
+    ).toBeInTheDocument();
+    // Drawer is gated out of the tree entirely for viewers, not just closed.
     expect(screen.queryByTestId('assign-drawer')).not.toBeInTheDocument();
   });
 
@@ -94,7 +101,7 @@ describe('LinkedTestSetsSection', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('shows Assign controls for Member/Admin/Owner', async () => {
+  it('shows Assign controls for Member/Admin/Owner and opens the drawer on click', async () => {
     mockCanEdit = true;
     mockGetLinkedTestSets.mockResolvedValue({
       data: [],
@@ -103,10 +110,23 @@ describe('LinkedTestSetsSection', () => {
 
     render(<LinkedTestSetsSection testId="test-1" />);
 
+    const assignButton = await screen.findByRole('button', {
+      name: /assign to test set/i,
+    });
+
+    // Drawer is mounted (gating allows it) but closed until clicked.
+    expect(screen.getByTestId('assign-drawer')).toHaveAttribute(
+      'data-open',
+      'false'
+    );
+
+    await userEvent.click(assignButton);
+
     await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: /assign to test set/i })
-      ).toBeInTheDocument()
+      expect(screen.getByTestId('assign-drawer')).toHaveAttribute(
+        'data-open',
+        'true'
+      )
     );
   });
 });

--- a/apps/frontend/src/components/tests/__tests__/LinkedTestSetsSection.test.tsx
+++ b/apps/frontend/src/components/tests/__tests__/LinkedTestSetsSection.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import LinkedTestSetsSection from '../LinkedTestSetsSection';
+
+let mockCanEdit = true;
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => mockCanEdit,
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => mockCanEdit,
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ status: 'authenticated' }),
+}));
+
+const mockShowNotification = jest.fn();
+
+jest.mock('@/components/common/NotificationContext', () => ({
+  useNotifications: () => ({ show: mockShowNotification }),
+}));
+
+const mockGetLinkedTestSets = jest.fn();
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getTestsClient: () => ({
+      getLinkedTestSets: mockGetLinkedTestSets,
+    }),
+  })),
+}));
+
+jest.mock('@/utils/api-client/test-sets-client', () => ({
+  TestSetsClient: jest.fn().mockImplementation(() => ({
+    getTestSets: jest.fn().mockResolvedValue({ data: [] }),
+    associateTestsWithTestSet: jest.fn(),
+  })),
+}));
+
+jest.mock('@/components/common/AssignEntityDrawer', () => ({
+  __esModule: true,
+  default: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="assign-drawer" /> : null,
+}));
+
+describe('LinkedTestSetsSection', () => {
+  beforeEach(() => {
+    mockCanEdit = true;
+    mockGetLinkedTestSets.mockReset();
+  });
+
+  it('hides Assign controls for Viewer (empty state)', async () => {
+    mockCanEdit = false;
+    mockGetLinkedTestSets.mockResolvedValue({
+      data: [],
+      pagination: { totalCount: 0 },
+    });
+
+    render(<LinkedTestSetsSection testId="test-1" />);
+
+    await waitFor(() =>
+      expect(screen.getByText('No test sets assigned yet')).toBeInTheDocument()
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /assign to test set/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('This test has no linked test sets yet.')).toBeInTheDocument();
+    expect(screen.queryByTestId('assign-drawer')).not.toBeInTheDocument();
+  });
+
+  it('hides Assign button for Viewer when test sets are linked', async () => {
+    mockCanEdit = false;
+    mockGetLinkedTestSets.mockResolvedValue({
+      data: [
+        {
+          id: 'ts-1',
+          name: 'Test Set 1',
+          description: 'desc',
+          created_at: '2024-01-01T00:00:00Z',
+        },
+      ],
+      pagination: { totalCount: 1 },
+    });
+
+    render(<LinkedTestSetsSection testId="test-1" />);
+
+    await waitFor(() =>
+      expect(screen.getByText('Linked Test Sets (1)')).toBeInTheDocument()
+    );
+
+    expect(
+      screen.queryByRole('button', { name: /^assign$/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows Assign controls for Member/Admin/Owner', async () => {
+    mockCanEdit = true;
+    mockGetLinkedTestSets.mockResolvedValue({
+      data: [],
+      pagination: { totalCount: 0 },
+    });
+
+    render(<LinkedTestSetsSection testId="test-1" />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /assign to test set/i })
+      ).toBeInTheDocument()
+    );
+  });
+});


### PR DESCRIPTION
## Purpose

Viewers could still assign tests to test sets from the test detail page, breaking the read-only RBAC contract for the Viewer role. Fixes #2247.

## What Changed

- Gate the Assign button (both empty-state and populated-state) and the Assign drawer in `LinkedTestSetsSection.tsx` (test detail page's Linked Test Sets tab) behind `useCan(Capability.TestSet.UPDATE)`, mirroring the existing pattern already used in `TestSetLinkedTestsSection.tsx` (test-set detail page) and the `/tests` page FAB.
- Adjust the empty-state copy for read-only viewers ("This test has no linked test sets yet.").
- Add `LinkedTestSetsSection.test.tsx` covering: Viewer sees no Assign button (empty and populated states), Member/Admin/Owner still sees it.

## Additional Context

- Backend was already correctly gated: `POST /test_sets/{id}/associate` and `/disassociate` both require `Permission.TestSet.UPDATE`, with existing `test_viewer_cannot_associate_tests` / `test_member_can_associate_tests` tests passing (verified locally, 7/7 green in `tests/backend/ee/rbac/test_test_set_export_authz.py`). This was purely a frontend gap.
- Related prior work: #2158 (Enforce Viewer read-only RBAC across platform), #2159 (Gate trial test run for viewers).
- Other Assign surfaces (`/tests` FAB, test-set detail page) were already gated and required no changes.

## Testing

- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- New frontend tests (3) pass; full frontend suite passes except one pre-existing, unrelated flake in `TestsGrid.test.tsx` (reproduces identically on `release/v0.11.0` without this change)
- Backend authz tests for associate/disassociate — 7/7 passing

Manual verification steps:
1. Sign in as a Viewer, open a test's detail page, go to the "Test Sets" tab.
2. Confirm no "Assign"/"Assign to test set" button is shown.
3. Sign in as Member/Admin/Owner and confirm Assign still works as before.