### PR TITLE
Fix Explorer empty state and first-load session list

### DIFF
--- a/apps/frontend/src/app/(protected)/explorer/ExplorerClient.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/ExplorerClient.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import { useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import FileUploadIcon from '@mui/icons-material/FileUploadOutlined';
 import { useSession } from 'next-auth/react';
@@ -11,10 +10,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { explorerKeys } from '@/constants/query-keys';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabAddIcon, FabGroup } from '@/components/common/Fab';
-import EntityEmptyState from '@/components/common/EntityEmptyState';
-import { AccountTreeIcon } from '@/components/icons';
 import { useDocumentTitle } from '@/hooks/useDocumentTitle';
-import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import { Can, useCan, useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
@@ -31,7 +27,6 @@ export default function ExplorerClient() {
   const queryClient = useQueryClient();
   const notifications = useNotifications();
 
-  const [sessionCount, setSessionCount] = React.useState<number | null>(null);
   const [createDialogOpen, setCreateDialogOpen] = React.useState(false);
   const [importDialogOpen, setImportDialogOpen] = React.useState(false);
 
@@ -106,29 +101,10 @@ export default function ExplorerClient() {
         }
       >
         <Box sx={{ mt: 2, mb: 2 }}>
-          {sessionCount === 0 ? (
-            <EntityEmptyState
-              icon={AccountTreeIcon}
-              title="No explorer sessions yet"
-              description="Start a new session to explore behaviors and generate tests, or load an existing test set."
-              actionLabel={canCreateSession ? 'New session' : undefined}
-              onAction={
-                canCreateSession ? () => setCreateDialogOpen(true) : undefined
-              }
-            />
-          ) : (
-            <Paper
-              sx={{
-                width: '100%',
-                borderRadius: BORDER_RADIUS.md,
-                boxShadow: ELEVATION.xs,
-                border: theme => `1px solid ${theme.palette.greyscale.border}`,
-                overflow: 'hidden',
-              }}
-            >
-              <ExplorerGrid onTotalCountChange={setSessionCount} />
-            </Paper>
-          )}
+          <ExplorerGrid
+            canCreate={canCreateSession}
+            onCreateClick={() => setCreateDialogOpen(true)}
+          />
         </Box>
       </PageLayout>
 

--- a/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
@@ -18,14 +18,16 @@ import {
 } from '@mui/x-data-grid';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
-import BaseDataGrid from '@/components/common/BaseDataGrid';
+import BaseDataGrid, { GRID_PAPER_SX } from '@/components/common/BaseDataGrid';
 import GridToolbar from '@/components/common/GridToolbar';
+import GridStateGate from '@/components/common/GridStateGate';
+import EntityEmptyState from '@/components/common/EntityEmptyState';
+import { AccountTreeIcon } from '@/components/icons';
 import { useRouter } from 'next/navigation';
-import { Box, Typography } from '@mui/material';
+import { Box, Paper, Typography } from '@mui/material';
 import GridBadge from '@/components/common/GridBadge';
 import DeleteIcon from '@mui/icons-material/Delete';
 import IosShareOutlinedIcon from '@mui/icons-material/IosShareOutlined';
-import type { ExplorerTestSet } from '@/utils/api-client/interfaces/explorer';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import { useNotifications } from '@/components/common/NotificationContext';
@@ -34,7 +36,8 @@ import { explorerKeys } from '@/constants/query-keys';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 
 interface ExplorerGridProps {
-  onTotalCountChange?: (count: number) => void;
+  canCreate?: boolean;
+  onCreateClick?: () => void;
 }
 
 interface ExplorerToolbarState {
@@ -67,7 +70,8 @@ function ExplorerUnifiedToolbar() {
 }
 
 export default function ExplorerGrid({
-  onTotalCountChange,
+  canCreate,
+  onCreateClick,
 }: ExplorerGridProps) {
   const router = useRouter();
   const { status } = useSession();
@@ -83,16 +87,18 @@ export default function ExplorerGrid({
   const [isDeleting, setIsDeleting] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
 
-  const { data: allRows = [], isLoading: loading } = useQuery({
+  const {
+    data,
+    isLoading: loading,
+    error,
+  } = useQuery({
     queryKey: explorerKeys.all(),
     queryFn: () =>
       new ApiClientFactory().getExplorerClient().getExplorerTestSets(),
     enabled: isAuthenticated(status),
   });
 
-  useEffect(() => {
-    onTotalCountChange?.(allRows.length);
-  }, [allRows.length, onTotalCountChange]);
+  const allRows = data ?? [];
 
   useEffect(() => {
     setPaginationModel(prev => ({ ...prev, page: 0 }));
@@ -278,39 +284,59 @@ export default function ExplorerGrid({
   };
 
   return (
-    <ExplorerToolbarContext.Provider value={{ searchQuery, setSearchQuery }}>
-      <Box>
-        <BaseDataGrid
-          columns={columns}
-          rows={rows}
-          loading={loading}
-          getRowId={row => row.id}
-          showToolbar={true}
-          toolbarSlot={ExplorerUnifiedToolbar}
-          actionButtons={getActionButtons()}
-          onRowClick={handleRowClick}
-          paginationModel={paginationModel}
-          onPaginationModelChange={handlePaginationModelChange}
-          serverSidePagination={false}
-          totalRows={rows.length}
-          pageSizeOptions={[10, 25, 50]}
-          disablePaperWrapper={true}
-          persistState
-          checkboxSelection
-          disableRowSelectionOnClick
-          onRowSelectionModelChange={setSelectedRows}
-          rowSelectionModel={selectedRows}
+    <GridStateGate
+      data={data}
+      error={error ? 'Failed to load explorer sessions' : null}
+      isEmpty={allRows.length === 0 && !searchQuery.trim()}
+      emptyState={
+        <EntityEmptyState
+          card
+          icon={AccountTreeIcon}
+          title="No explorer sessions yet"
+          description="Start a new session to explore behaviors and generate tests, or load an existing test set."
+          actionLabel={canCreate ? 'New session' : undefined}
+          onAction={canCreate ? onCreateClick : undefined}
         />
-        <DeleteModal
-          open={deleteModalOpen}
-          onClose={handleDeleteCancel}
-          onConfirm={handleDeleteConfirm}
-          isLoading={isDeleting}
-          title="Delete explorer sessions"
-          message={`Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'session' : 'sessions'}? Related tests in the tree will be removed with this record.`}
-          itemType="explorer sessions"
-        />
-      </Box>
-    </ExplorerToolbarContext.Provider>
+      }
+    >
+      <Paper sx={GRID_PAPER_SX}>
+        <ExplorerToolbarContext.Provider
+          value={{ searchQuery, setSearchQuery }}
+        >
+          <Box>
+            <BaseDataGrid
+              columns={columns}
+              rows={rows}
+              loading={loading}
+              getRowId={row => row.id}
+              showToolbar={true}
+              toolbarSlot={ExplorerUnifiedToolbar}
+              actionButtons={getActionButtons()}
+              onRowClick={handleRowClick}
+              paginationModel={paginationModel}
+              onPaginationModelChange={handlePaginationModelChange}
+              serverSidePagination={false}
+              totalRows={rows.length}
+              pageSizeOptions={[10, 25, 50]}
+              disablePaperWrapper={true}
+              persistState
+              checkboxSelection
+              disableRowSelectionOnClick
+              onRowSelectionModelChange={setSelectedRows}
+              rowSelectionModel={selectedRows}
+            />
+            <DeleteModal
+              open={deleteModalOpen}
+              onClose={handleDeleteCancel}
+              onConfirm={handleDeleteConfirm}
+              isLoading={isDeleting}
+              title="Delete explorer sessions"
+              message={`Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'session' : 'sessions'}? Related tests in the tree will be removed with this record.`}
+              itemType="explorer sessions"
+            />
+          </Box>
+        </ExplorerToolbarContext.Provider>
+      </Paper>
+    </GridStateGate>
   );
 }


### PR DESCRIPTION
## Purpose

The Explorer list had a first-load bug: opening `/explorer` after logging in showed the "No explorer sessions yet" empty state even when the organization already had sessions. Only after creating and saving a new session did the previously-existing sessions appear in the grid, making it look like old sessions were leaking in. Separately, the empty state was not rendered on a Paper card like every other list page.

Root cause: `ExplorerClient` toggled between the empty state and the grid based on a `sessionCount` pushed up from `ExplorerGrid`. The grid's query defaulted `data` to `[]`, so before the first fetch settled it reported a count of `0`, the parent flipped to the empty state and **unmounted the grid**, aborting the in-flight fetch. The grid only recovered once a cache invalidation (e.g. after creating a session) forced a refetch — at which point all existing org sessions appeared at once.

## What Changed

- `ExplorerGrid` now owns the loading/empty/populated decision via `GridStateGate`, gating on the query's `data` (i.e. real loading) instead of a default empty array, so the grid stays mounted until the first fetch settles.
- Empty state now uses `EntityEmptyState card` on a `Paper` (`GRID_PAPER_SX`), matching Test Sets, Knowledge, Test Runs, etc.
- `ExplorerGrid` takes `canCreate` / `onCreateClick` props (replacing `onTotalCountChange`); `ExplorerClient` always renders the grid and no longer tracks `sessionCount`.
- Removed a pre-existing unused `ExplorerTestSet` type import.

## Additional Context

- Follows the exact pattern already used by `TestSetsGrid`, `SourcesGrid`, and `TestRunsGrid`.
- Not in scope: the backend `GET /explorer/` filters by organization but does not apply the per-user visibility filter that `GET /test_sets` uses. If Explorer should scope to the current user or respect per-session visibility, that's a separate backend change.

## Testing

1. Log in fresh and open `/explorer` — with existing org sessions, the grid loads directly (spinner → grid), no false empty state.
2. In an org with no sessions, the empty state renders on a Paper card with the "New session" action.
3. Create a new session, return to `/explorer` — the full session list shows as expected with no flash of the empty state.