### PR TITLE
Add Summarize FAB on test run detail page

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailHeader.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunDetailHeader.tsx
@@ -10,6 +10,7 @@ import { DownloadIcon } from '@/components/icons';
 import { formatDate } from '@/utils/date';
 import { getTestRunDisplayTimestamp } from '@/utils/test-run-utils';
 import { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
+import TestRunSummarizeFab from './TestRunSummarizeFab';
 
 interface TestRunDetailHeaderProps {
   testRun: TestRunDetail;
@@ -86,6 +87,7 @@ export default function TestRunDetailHeader({
       </Box>
 
       <FabGroup>
+        <TestRunSummarizeFab testRun={testRun} />
         <Fab
           icon={<CompareArrowsOutlinedIcon />}
           tooltip={

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunSummarizeFab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunSummarizeFab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { Fab } from '@/components/common/Fab';
 import { Can } from '@/components/common/Can';
 import { useNotifications } from '@/components/common/NotificationContext';
@@ -21,12 +21,15 @@ export default function TestRunSummarizeFab({
   testRun,
 }: TestRunSummarizeFabProps) {
   const [creating, setCreating] = useState(false);
+  const creatingRef = useRef(false);
   const { show: showNotification } = useNotifications();
 
   const isDisabled = creating || !testRun.id;
 
   const handleClick = useCallback(async () => {
-    if (isDisabled) return;
+    // Ref guard so a double-click before re-render cannot open multiple sessions.
+    if (creatingRef.current || !testRun.id) return;
+    creatingRef.current = true;
     setCreating(true);
     try {
       const testRunName = testRun.name || 'Test Run';
@@ -49,9 +52,10 @@ export default function TestRunSummarizeFab({
         severity: 'error',
       });
     } finally {
+      creatingRef.current = false;
       setCreating(false);
     }
-  }, [isDisabled, showNotification, testRun]);
+  }, [showNotification, testRun]);
 
   return (
     <Can capability={Capability.Architect.CREATE}>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunSummarizeFab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestRunSummarizeFab.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+import { Fab } from '@/components/common/Fab';
+import { Can } from '@/components/common/Can';
+import { useNotifications } from '@/components/common/NotificationContext';
+import { Capability } from '@/constants/capabilities';
+import { EngineeringIcon } from '@/components/icons';
+import { createAndOpenArchitectSession } from '@/utils/architect-handoff';
+import type { TestRunDetail } from '@/utils/api-client/interfaces/test-run';
+import {
+  buildTestRunSummarizePrompt,
+  buildTestRunSummarizeSessionTitle,
+} from '../utils/test-run-summarize-prompt';
+
+interface TestRunSummarizeFabProps {
+  testRun: TestRunDetail;
+}
+
+export default function TestRunSummarizeFab({
+  testRun,
+}: TestRunSummarizeFabProps) {
+  const [creating, setCreating] = useState(false);
+  const { show: showNotification } = useNotifications();
+
+  const isDisabled = creating || !testRun.id;
+
+  const handleClick = useCallback(async () => {
+    if (isDisabled) return;
+    setCreating(true);
+    try {
+      const testRunName = testRun.name || 'Test Run';
+      const endpointName = testRun.test_configuration?.endpoint?.name;
+      const testSetName = testRun.test_configuration?.test_set?.name;
+      const title = buildTestRunSummarizeSessionTitle({ testRunName });
+      const initialMessage = buildTestRunSummarizePrompt({
+        testRunId: String(testRun.id),
+        testRunName,
+        endpointName,
+        testSetName,
+      });
+      await createAndOpenArchitectSession({
+        title,
+        initialMessage,
+      });
+    } catch (error) {
+      console.error('Failed to open test run summary in Architect:', error);
+      showNotification('Could not open Architect summary. Please try again.', {
+        severity: 'error',
+      });
+    } finally {
+      setCreating(false);
+    }
+  }, [isDisabled, showNotification, testRun]);
+
+  return (
+    <Can capability={Capability.Architect.CREATE}>
+      <Fab
+        icon={<EngineeringIcon />}
+        tooltip="Summarize test run"
+        aria-label="Summarize test run"
+        onClick={handleClick}
+        disabled={isDisabled}
+        loading={creating}
+      />
+    </Can>
+  );
+}

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/utils/__tests__/test-run-summarize-prompt.test.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/utils/__tests__/test-run-summarize-prompt.test.ts
@@ -1,0 +1,49 @@
+import {
+  buildTestRunSummarizePrompt,
+  buildTestRunSummarizeSessionTitle,
+} from '../test-run-summarize-prompt';
+
+describe('buildTestRunSummarizeSessionTitle', () => {
+  it('includes the test run name', () => {
+    expect(
+      buildTestRunSummarizeSessionTitle({ testRunName: 'Nightly Safety' })
+    ).toBe('Test run summary — Nightly Safety');
+  });
+
+  it('falls back when the name is blank', () => {
+    expect(buildTestRunSummarizeSessionTitle({ testRunName: '  ' })).toBe(
+      'Test run summary — Test Run'
+    );
+  });
+});
+
+describe('buildTestRunSummarizePrompt', () => {
+  it('includes run identity, endpoint, test set, and handoff guardrails', () => {
+    const prompt = buildTestRunSummarizePrompt({
+      testRunId: 'run-abc',
+      testRunName: 'Nightly Safety',
+      endpointName: 'Chatbot',
+      testSetName: 'Safety Suite',
+    });
+
+    expect(prompt).toContain('Summarize this test run');
+    expect(prompt).toContain('Test Run handoff');
+    expect(prompt).toContain('do not show the menu');
+    expect(prompt).toContain('Test run: Nightly Safety');
+    expect(prompt).toContain('Test run ID: run-abc');
+    expect(prompt).toContain('Endpoint: Chatbot');
+    expect(prompt).toContain('Test set: Safety Suite');
+    expect(prompt).toContain('re-fetch stats');
+  });
+
+  it('uses unknown fallbacks when endpoint/test set are missing', () => {
+    const prompt = buildTestRunSummarizePrompt({
+      testRunId: 'run-xyz',
+      testRunName: '',
+    });
+
+    expect(prompt).toContain('Test run: unnamed');
+    expect(prompt).toContain('Endpoint: unknown');
+    expect(prompt).toContain('Test set: unknown');
+  });
+});

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/utils/test-run-summarize-prompt.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/utils/test-run-summarize-prompt.ts
@@ -1,0 +1,34 @@
+export function buildTestRunSummarizeSessionTitle(input: {
+  testRunName: string;
+}): string {
+  const name = input.testRunName.trim() || 'Test Run';
+  return `Test run summary — ${name}`;
+}
+
+export interface BuildTestRunSummarizePromptInput {
+  testRunId: string;
+  testRunName: string;
+  endpointName?: string;
+  testSetName?: string;
+}
+
+export function buildTestRunSummarizePrompt(
+  input: BuildTestRunSummarizePromptInput
+): string {
+  const lines = [
+    'Summarize this test run for me.',
+    '',
+    'This is a Test Run handoff — analyze these test results; do not show the menu',
+    'and do not start exploration or create entities.',
+    '',
+    `Test run: ${input.testRunName.trim() || 'unnamed'}`,
+    `Test run ID: ${input.testRunId}`,
+    `Endpoint: ${input.endpointName?.trim() || 'unknown'}`,
+    `Test set: ${input.testSetName?.trim() || 'unknown'}`,
+    '',
+    'Please re-fetch stats for this run, summarize overall and by behavior/metric,',
+    'then sample a few failed results and call out patterns and next steps.',
+  ];
+
+  return lines.join('\n');
+}


### PR DESCRIPTION
## Purpose

Harry Cruz asked to mirror the Insights “Summarize insights” Architect FAB on the test run detail view so users can open a pre-seeded Architect session from a single run.

## What Changed

- Added `TestRunSummarizeFab` that creates an Architect session and opens `/architect?session=<id>` with a handoff prompt for the current run
- Added prompt/title builders for the test-run handoff
- Wired the FAB into the test run detail header `FabGroup` (first in the group)
- Added unit tests for the prompt builders

## Additional Context

- Reuses the shared `createAndOpenArchitectSession` handoff and `Capability.Architect.CREATE` gate
- Scope is the whole test run (header is tab-agnostic); Test Cases-tab client filters are not included in the prompt

## Testing

- [ ] Open a test run detail page with `architect:create`
- [ ] Confirm the Summarize FAB appears in the header
- [ ] Click it and verify a new Architect tab opens with a session summarizing that run
- [ ] Confirm users without `architect:create` do not see the FAB