### PR TITLE
Skip installing unused torch in backend image

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -95,11 +95,10 @@ ENV UV_COMPILE_BYTECODE=1 \
     UV_LINK_MODE=copy \
     UV_NO_DEV=1
 
+# torch comes in via garak but isn't used at runtime; skip installing it.
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=cache,target=/root/.cargo/registry \
-    uv sync --extra all --extra cpu --extra ee
-
-RUN uv pip uninstall torch
+    uv sync --extra all --extra cpu --extra ee --no-install-package torch
 
 COPY apps/backend/src ./src
 


### PR DESCRIPTION
## Purpose

The backend build downloads and installs the ~180 MB CPU torch wheel, then immediately uninstalls it. torch is only pulled in transitively by `garak` and isn't used at runtime, so the download is wasted work on every no-cache build.

## What Changed

- Replace the `uv sync ... ` + separate `uv pip uninstall torch` with a single `uv sync --extra all --extra cpu --extra ee --no-install-package torch`.
- torch stays in the resolution graph (garak's metadata requirement is satisfied and `uv.lock` is unchanged, `--extra cpu` still pins the pytorch-cpu index), but the wheel is never downloaded or installed.

## Additional Context

- Measured on a no-cache, cache-pruned build: `uv sync` step dropped from **137.4s → 102.6s** (~36s including the removed 1.5s uninstall step). Package count 418 → 417.
- Final image is byte-for-byte equivalent in outcome: the previous flow already uninstalled torch before the venv was copied into the runtime stage, so image size is unchanged (3.47 GB). This is a build-time win, mainly for CI cold builds.

## Testing

Built the `backend` target with no cache before and after the change:

\`\`\`bash
docker builder prune -af
docker build --no-cache --pull --target backend -t rhesis-backend:test -f apps/backend/Dockerfile .
# verify torch absent:
docker run --rm --entrypoint sh rhesis-backend:test -c 'ls .venv/lib/python*/site-packages/ | grep -i "^torch" || echo "no torch"'
\`\`\`

Confirmed the venv contains no `torch*` package and the app image builds successfully.