### PR TITLE
Fix skip T&C modal on onboarding first screen

### DIFF
--- a/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
+++ b/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
@@ -100,7 +100,7 @@ export function ProtectedLayoutClient({
       <FeaturesProvider initialFeatures={initialFeatures}>
         <PermissionsProvider initialPermissions={initialPermissions}>
           <WebSocketProvider>
-            <TermsAcceptanceGate />
+            {!isOnboarding && <TermsAcceptanceGate />}
             {!isOnboarding && !chromeless && <VerificationBanner />}
             {content}
           </WebSocketProvider>


### PR DESCRIPTION
## Purpose

New users landing on onboarding were blocked by the global TermsAcceptanceGate modal, even though step 0 already collects T&C acceptance via an inline checkbox.

## What Changed

- Skip `TermsAcceptanceGate` on `/onboarding` (same gating as `VerificationBanner`) so first-time acceptance happens only through the onboarding checkbox

## Additional Context

- Modal remains active on all other protected routes, including updated-terms re-acceptance for existing users

## Testing

- Log in as a brand-new user with no organization
- Confirm onboarding step 0 shows the inline T&C checkbox and no modal overlay
- Confirm advancing requires checking the box, and terms are recorded via `acceptTerms()`