### PR TITLE
Skip installing unused torch in backend dev image

### DIFF
--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -50,8 +50,10 @@ COPY ee/backend/pyproject.toml ee/backend/README.md /app/ee/backend/
 WORKDIR /app/apps/backend
 COPY apps/backend/uv.lock apps/backend/pyproject.toml apps/backend/README.md ./
 
+# torch comes in via garak but isn't used at runtime; skip installing it.
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --no-install-project --no-install-local --extra all --extra cpu --extra ee
+    uv sync --no-install-project --no-install-local --extra all --extra cpu --extra ee \
+    --no-install-package torch
 
 # Layer 2: full sources, then install local packages
 WORKDIR /app
@@ -67,7 +69,7 @@ COPY apps/backend/src /app/apps/backend/src/
 
 WORKDIR /app/apps/backend
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --extra all --extra cpu --extra ee
+    uv sync --extra all --extra cpu --extra ee --no-install-package torch
 
 
 # ============================================================================


### PR DESCRIPTION
## Purpose

Follow-up to #2262, which removed the wasted torch install from the production backend image. `Dockerfile.dev` still downloads and installs the ~180 MB CPU torch wheel even though torch is only pulled in transitively by `garak` and isn't used at runtime.

## What Changed

- Add `--no-install-package torch` to both `uv sync` calls in `Dockerfile.dev` (the deps-only layer and the full sync). torch stays in the resolution graph so garak's metadata requirement is satisfied and `uv.lock` is unchanged (`--extra cpu` still pins the pytorch-cpu index), but the wheel is never downloaded or installed.

## Additional Context

- Same optimization already merged for the production `Dockerfile` in #2262, where it cut the no-cache `uv sync` step from ~137s to ~103s. This brings the dev image in line.

## Testing

\`\`\`bash
docker build --no-cache -t rhesis-backend-dev:test -f apps/backend/Dockerfile.dev .
docker run --rm --entrypoint sh rhesis-backend-dev:test -c 'ls .venv/lib/python*/site-packages/ | grep -i "^torch" || echo "no torch"'
\`\`\`