### PR TITLE
Fix slow metrics/behaviors list and detail loading

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -390,13 +390,23 @@ def delete_category(
 
 
 # Behavior CRUD
-# Relationships serialized by schemas.Behavior/BehaviorDetail (status, project,
-# organization, user) -- see get_status for the same shape on a simpler model.
+# Both read_behavior and read_behaviors return BehaviorWithMetricsSchema (routers/behavior.py),
+# = schemas.Behavior (tags, status, user) + metrics: List[schemas.Metric] (each needing
+# metric_type, backend_type, tags). organization/project are NOT read by this schema (only
+# BehaviorDetail has them) -- deliberately excluded here. Folding Behavior's own tags chain in
+# here means neither caller needs with_default_derived_field_loads (BehaviorWithMetricsSchema
+# has no counts/comments/tasks field), and metrics.tags is included explicitly since
+# selectinload's default cascade skips many-to-many relations -- omitting it would lazy-load
+# tags per nested metric (N+1). No cartesian product: each hop's own cardinality picks
+# selectinload for collections, joinedload for the final single-valued tag.
 _BEHAVIOR_RELATED_FIELDS = (
     include(models.Behavior.status),
-    include(models.Behavior.project),
-    include(models.Behavior.organization),
     include(models.Behavior.user),
+    include(models.Behavior._tags_relationship, models.TaggedItem.tag),
+    include(models.Behavior.metrics),
+    include(models.Behavior.metrics, models.Metric.metric_type),
+    include(models.Behavior.metrics, models.Metric.backend_type),
+    include(models.Behavior.metrics, models.Metric._tags_relationship, models.TaggedItem.tag),
 )
 
 
@@ -411,7 +421,6 @@ def get_behavior(
         QueryBuilder(db, models.Behavior)
         .with_deleted()
         .with_related(*_BEHAVIOR_RELATED_FIELDS)
-        .with_default_derived_field_loads()
         .with_organization_filter(organization_id)
         .with_visibility_filter(user_id)
         .filter_by_id(behavior_id)
@@ -433,6 +442,50 @@ def get_behaviors(
     return get_items(
         db, models.Behavior, skip, limit, sort_by, sort_order, filter, organization_id, user_id
     )
+
+
+def get_behaviors_detail(
+    db: Session,
+    skip: int = 0,
+    limit: int = 20,
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
+    filter: str | None = None,
+    organization_id: str = None,
+    user_id: str = None,
+) -> List[models.Behavior]:
+    """Get behaviors with related objects for BehaviorWithMetricsSchema, including metrics.
+
+    Runs as two queries, mirroring get_metrics/crud_utils.get_items_detail: a joinless
+    query picks the page's IDs (filter + sort + LIMIT/OFFSET), then a second query
+    eager-loads _BEHAVIOR_RELATED_FIELDS scoped to just those IDs. Without this split,
+    Postgres would have to build every join for every matching row across the org before
+    it can sort and cut down to `limit`.
+    """
+    ordered_ids = (
+        QueryBuilder(db, models.Behavior)
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .with_odata_filter(filter)
+        .with_sorting(sort_by, sort_order)
+        .with_pagination(skip, limit)
+        .ids()
+    )
+    if not ordered_ids:
+        return []
+
+    items = (
+        QueryBuilder(db, models.Behavior)
+        .with_related(*_BEHAVIOR_RELATED_FIELDS)
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .query.filter(models.Behavior.id.in_(ordered_ids))
+        .all()
+    )
+
+    # WHERE id IN (...) does not preserve order -- re-apply the phase-1 sort.
+    items_by_id = {item.id: item for item in items}
+    return [items_by_id[item_id] for item_id in ordered_ids if item_id in items_by_id]
 
 
 def create_behavior(
@@ -3027,8 +3080,20 @@ _METRIC_RELATED_FIELDS = (
     include(models.Metric.user),
     include(models.Metric.organization),
     include(models.Metric.project),
+    # behaviors/test_sets serialize as BehaviorReference/TestSetReference, which
+    # both read `counts` (comments/tasks) and `tags`. with_default_derived_field_loads
+    # only cascades those into many-to-one relations -- it skips many-to-many -- so
+    # without these explicit chains each nested behavior/test_set would lazy-load its
+    # own comments/tasks/tags per row (N+1). include() picks selectinload for each
+    # collection hop and joinedload for the final tag, so no cartesian product.
     include(models.Metric.behaviors),
+    include(models.Metric.behaviors, models.Behavior.comments),
+    include(models.Metric.behaviors, models.Behavior.tasks),
+    include(models.Metric.behaviors, models.Behavior._tags_relationship, models.TaggedItem.tag),
     include(models.Metric.test_sets),
+    include(models.Metric.test_sets, models.TestSet.comments),
+    include(models.Metric.test_sets, models.TestSet.tasks),
+    include(models.Metric.test_sets, models.TestSet._tags_relationship, models.TaggedItem.tag),
 )
 
 
@@ -3057,18 +3122,41 @@ def get_metrics(
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.Metric]:
-    """Get all metrics with their related objects, including many-to-many relationships"""
-    return (
+    """Get all metrics with their related objects, including many-to-many relationships.
+
+    Runs as two queries, mirroring crud_utils.get_items_detail: a joinless
+    query picks the page's IDs (filter + sort + LIMIT/OFFSET), then a second
+    query eager-loads the metric relationships scoped to just those IDs.
+    Without this split, Postgres has to build all nine _METRIC_RELATED_FIELDS
+    joins for every matching row across the org before it can sort and cut
+    down to `limit`, so cost scales with total matching rows rather than
+    page size.
+    """
+    ordered_ids = (
+        QueryBuilder(db, models.Metric)
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .with_odata_filter(filter)
+        .with_sorting(sort_by, sort_order)
+        .with_pagination(skip, limit)
+        .ids()
+    )
+    if not ordered_ids:
+        return []
+
+    items = (
         QueryBuilder(db, models.Metric)
         .with_related(*_METRIC_RELATED_FIELDS)
         .with_default_derived_field_loads()
         .with_organization_filter(organization_id)
         .with_visibility_filter(user_id)
-        .with_odata_filter(filter)
-        .with_pagination(skip, limit)
-        .with_sorting(sort_by, sort_order)
+        .query.filter(models.Metric.id.in_(ordered_ids))
         .all()
     )
+
+    # WHERE id IN (...) does not preserve order -- re-apply the phase-1 sort.
+    items_by_id = {item.id: item for item in items}
+    return [items_by_id[item_id] for item_id in ordered_ids if item_id in items_by_id]
 
 
 def _preprocess_metric_data(

--- a/apps/backend/src/rhesis/backend/app/routers/behavior.py
+++ b/apps/backend/src/rhesis/backend/app/routers/behavior.py
@@ -85,15 +85,13 @@ def read_behaviors(
     """Get all behaviors with automatic session variables for RLS."""
     organization_id, user_id = tenant_context
 
-    results = crud.get_items_detail(
+    results = crud.get_behaviors_detail(
         db=db,
-        model=models.Behavior,
         skip=skip,
         limit=limit,
         sort_by=sort_by,
         sort_order=sort_order,
         filter=filter,
-        nested_relationships={"metrics": ["metric_type", "backend_type"]},
         organization_id=organization_id,
         user_id=user_id,
     )

--- a/tests/backend/utils/test_query_builder_load.py
+++ b/tests/backend/utils/test_query_builder_load.py
@@ -15,7 +15,7 @@ import pytest
 from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app import models
+from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.utils import crud_utils
 from rhesis.backend.app.utils.query_utils import QueryBuilder, include
 from tests.backend.routes.fixtures.data_factories import BehaviorDataFactory, TestDataFactory
@@ -140,3 +140,132 @@ class TestWithRelatedColumnScoping:
         # Behavior.status may be None (not set by the data factory), but the chain
         # itself must compile and execute without error either way.
         assert _is_loaded(result.behavior, "status")
+
+
+@pytest.mark.unit
+@pytest.mark.crud
+class TestMetricBehaviorNestedM2MLoads:
+    """Regression coverage for the N+1 gap in nested many-to-many collections.
+
+    with_default_derived_field_loads() only cascades comments/tasks/tags into
+    joined single-object (many-to-one) relations -- it explicitly skips
+    many-to-many. schemas.MetricDetail.behaviors/test_sets (BehaviorReference/
+    TestSetReference) and schemas.Behavior/BehaviorWithMetricsSchema.metrics
+    (schemas.Metric) both read derived fields on their nested rows, so those
+    extra chains have to be requested explicitly in _METRIC_RELATED_FIELDS/
+    _BEHAVIOR_RELATED_FIELDS -- these tests assert that eager-loading actually
+    reaches those nested rows (no lazy load fires during serialization).
+    """
+
+    def test_get_metrics_loads_nested_behavior_and_test_set_derived_fields(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        from rhesis.backend.app.constants import EntityType
+        from tests.backend.routes.fixtures.data_factories import (
+            BehaviorDataFactory,
+            MetricDataFactory,
+        )
+
+        metric = crud_utils.create_item(
+            test_db,
+            models.Metric,
+            MetricDataFactory.sample_data(),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        behavior = crud_utils.create_item(
+            test_db,
+            models.Behavior,
+            BehaviorDataFactory.sample_data(),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.execute(
+            models.behavior_metric_association.insert().values(
+                metric_id=metric.id,
+                behavior_id=behavior.id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+        )
+        crud.assign_tag(
+            db=test_db,
+            tag=schemas.TagCreate(name="nested-behavior-tag"),
+            entity_id=behavior.id,
+            entity_type=EntityType.BEHAVIOR,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.flush()
+        test_db.expire_all()
+
+        results = crud.get_metrics(db=test_db, skip=0, limit=100, organization_id=test_org_id)
+        result = next(m for m in results if m.id == metric.id)
+
+        assert _is_loaded(result, "behaviors")
+        nested_behavior = next(b for b in result.behaviors if b.id == behavior.id)
+        assert _is_loaded(nested_behavior, "comments")
+        assert _is_loaded(nested_behavior, "tasks")
+        assert _is_loaded(nested_behavior, "_tags_relationship")
+        assert len(nested_behavior.tags) == 1
+        assert nested_behavior.tags[0].name == "nested-behavior-tag"
+
+    def test_get_behavior_and_get_behaviors_detail_load_nested_metric_fields(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        from rhesis.backend.app.constants import EntityType
+        from tests.backend.routes.fixtures.data_factories import (
+            BehaviorDataFactory,
+            MetricDataFactory,
+        )
+
+        behavior = crud_utils.create_item(
+            test_db,
+            models.Behavior,
+            BehaviorDataFactory.sample_data(),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        metric = crud_utils.create_item(
+            test_db,
+            models.Metric,
+            MetricDataFactory.sample_data(),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.execute(
+            models.behavior_metric_association.insert().values(
+                metric_id=metric.id,
+                behavior_id=behavior.id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+        )
+        crud.assign_tag(
+            db=test_db,
+            tag=schemas.TagCreate(name="nested-metric-tag"),
+            entity_id=metric.id,
+            entity_type=EntityType.METRIC,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.flush()
+        test_db.expire_all()
+
+        def _assert_nested_metric_loaded(behavior_result):
+            assert _is_loaded(behavior_result, "metrics")
+            nested_metric = next(m for m in behavior_result.metrics if m.id == metric.id)
+            assert _is_loaded(nested_metric, "metric_type")
+            assert _is_loaded(nested_metric, "backend_type")
+            assert _is_loaded(nested_metric, "_tags_relationship")
+            assert len(nested_metric.tags) == 1
+            assert nested_metric.tags[0].name == "nested-metric-tag"
+
+        single = crud.get_behavior(db=test_db, behavior_id=behavior.id, organization_id=test_org_id)
+        _assert_nested_metric_loaded(single)
+
+        test_db.expire_all()
+        listed = crud.get_behaviors_detail(
+            db=test_db, skip=0, limit=100, organization_id=test_org_id
+        )
+        _assert_nested_metric_loaded(next(b for b in listed if b.id == behavior.id))


### PR DESCRIPTION
## Purpose

The metrics and behaviors pages showed a loading spinner for 1-2s before data appeared. Root cause was two-fold: a join-before-limit query pattern on the metrics list, and two N+1 gaps in nested many-to-many collections that caused per-row lazy loading during response serialization.

## What Changed

- `crud.get_metrics`: split into the id-then-join pattern already used elsewhere in the codebase (a joinless id query does filter+sort+LIMIT, then a join query scoped to just those ids) instead of a single query applying nine joins plus filter/sort/LIMIT together.
- `_METRIC_RELATED_FIELDS`: added explicit `include()` chains for `behaviors`/`test_sets` → `comments`/`tasks`/`tags`. `with_default_derived_field_loads()` only cascades derived-field loads into many-to-one relations, so nested behaviors/test_sets on a metric were lazy-loading their own `counts`/`tags` per row.
- `_BEHAVIOR_RELATED_FIELDS`: rewritten to a single list scoped to exactly what `BehaviorWithMetricsSchema` reads (`status`, `user`, own `tags`, `metrics` → `metric_type`/`backend_type`/`tags`). Drops the `organization`/`project` joins that schema never uses, and closes the missing `metrics.tags` eager load that was causing nested-metric tags to lazy-load per behavior row.
- `get_behavior` (single item) now uses the corrected field list; `get_behaviors_detail` (new) applies the same id-then-join split to the list endpoint, replacing the generic `crud.get_items_detail` call in `routers/behavior.py`.

## Additional Context

No response schema changes -- both endpoints still return `MetricDetail`/`BehaviorWithMetricsSchema` with identical shapes, just eager-loaded more precisely.

## Testing

- Added `TestMetricBehaviorNestedM2MLoads` in `tests/backend/utils/test_query_builder_load.py`, asserting no lazy load fires when serializing nested behaviors/test_sets (for `get_metrics`) and nested metrics (for `get_behavior`/`get_behaviors_detail`). Verified both new tests fail against the pre-fix code and pass against the fix.
- Ran the full affected suite: `tests/backend/utils/test_query_builder_load.py`, `tests/backend/crud/test_metric_crud.py`, `tests/backend/routes/test_behavior.py`, `tests/backend/routes/test_metric.py`, `tests/backend/crud/test_behavior_metric_security.py`, `tests/backend/metrics/` -- 297 passed, 2 pre-existing skips.
- `ruff check` / `ruff format` clean on all changed files.