### PR TITLE
Add server-driven pagination and initial fetch for metrics/behaviors

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -3054,10 +3054,7 @@ def _apply_metric_scope_filter(builder: QueryBuilder, metric_scope: str | None) 
     scopes = [s.strip() for s in metric_scope.split(",") if s.strip()]
     if scopes:
         builder.query = builder.query.filter(
-            or_(*[
-                models.Metric.metric_scope.op("@>")(cast([s], PG_JSONB))
-                for s in scopes
-            ])
+            or_(*[models.Metric.metric_scope.op("@>")(cast([s], PG_JSONB)) for s in scopes])
         )
 
 

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -3043,6 +3043,24 @@ def get_metric(
     )
 
 
+def _apply_metric_scope_filter(builder: QueryBuilder, metric_scope: str | None) -> None:
+    """Parse a comma-separated metric_scope string and apply a JSONB @> filter."""
+    if not metric_scope:
+        return
+    from sqlalchemy import or_
+    from sqlalchemy.dialects.postgresql import JSONB as PG_JSONB
+    from sqlalchemy.sql.expression import cast
+
+    scopes = [s.strip() for s in metric_scope.split(",") if s.strip()]
+    if scopes:
+        builder.query = builder.query.filter(
+            or_(*[
+                models.Metric.metric_scope.op("@>")(cast([s], PG_JSONB))
+                for s in scopes
+            ])
+        )
+
+
 def get_metrics(
     db: Session,
     skip: int = 0,
@@ -3050,6 +3068,7 @@ def get_metrics(
     sort_by: str = "created_at",
     sort_order: str = "desc",
     filter: str | None = None,
+    metric_scope: str | None = None,
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.Metric]:
@@ -3063,15 +3082,18 @@ def get_metrics(
     down to `limit`, so cost scales with total matching rows rather than
     page size.
     """
-    ordered_ids = (
+    builder = (
         QueryBuilder(db, models.Metric)
         .with_organization_filter(organization_id)
         .with_visibility_filter(user_id)
         .with_odata_filter(filter)
         .with_sorting(sort_by, sort_order)
         .with_pagination(skip, limit)
-        .ids()
     )
+
+    _apply_metric_scope_filter(builder, metric_scope)
+
+    ordered_ids = builder.ids()
     if not ordered_ids:
         return []
 

--- a/apps/backend/src/rhesis/backend/app/routers/metric.py
+++ b/apps/backend/src/rhesis/backend/app/routers/metric.py
@@ -202,6 +202,10 @@ def read_metrics(
         alias="$select",
         description="Comma-separated list of fields to return",
     ),
+    metric_scope: str | None = Query(
+        None,
+        description="Comma-separated metric scopes to filter by (JSONB array contains)",
+    ),
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
@@ -215,9 +219,26 @@ def read_metrics(
         sort_by=sort_by,
         sort_order=sort_order,
         filter=filter,
+        metric_scope=metric_scope,
         organization_id=organization_id,
         user_id=user_id,
     )
+
+    # The @with_count_header decorator computes a count using only the OData
+    # $filter.  When metric_scope is also active, override the header with an
+    # accurate count that includes the JSONB filter.
+    if metric_scope:
+        from rhesis.backend.app.utils.query_utils import QueryBuilder
+
+        cb = (
+            QueryBuilder(db, models.Metric)
+            .with_organization_filter(organization_id)
+            .with_visibility_filter(user_id)
+            .with_odata_filter(filter)
+        )
+        crud._apply_metric_scope_filter(cb, metric_scope)
+        response.headers["X-Total-Count"] = str(cb.count())
+
     if select:
         serialized = jsonable_encoder(results)
         return JSONResponse(content=apply_select(serialized, select))

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -648,11 +648,6 @@ export default function BehaviorsClient({
             },
             gap: theme.spacing(3),
             mb: 4,
-            opacity: isLoading ? theme.palette.action.disabledOpacity : 1,
-            pointerEvents: isLoading ? 'none' : 'auto',
-            transition: theme.transitions.create('opacity', {
-              duration: theme.transitions.duration.short,
-            }),
           })}
         >
           {behaviors.map(behavior => (

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -142,6 +142,7 @@ export default function BehaviorsClient({
     filterFingerprint,
     initialData,
     initialTotalCount,
+    enabled: !permsLoading && canRead,
     onData: data => {
       data.forEach(behavior => {
         (behavior.tags ?? []).forEach(tag => tagNamesRef.current.add(tag.name));

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import * as React from 'react';
+import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import CircularProgress from '@mui/material/CircularProgress';
+import LinearProgress from '@mui/material/LinearProgress';
 import Alert from '@mui/material/Alert';
+import TablePagination from '@mui/material/TablePagination';
 import GridToolbar, {
   ToolbarPillTabs,
   directoryToolbarProps,
@@ -37,29 +40,54 @@ import BehaviorFilterDrawer, {
   countActiveBehaviorFilters,
 } from './BehaviorFilterDrawer';
 import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
+import { buildBehaviorODataFilter } from '@/utils/odata-filter';
 
 interface BehaviorsClientProps {
   organizationId: UUID;
   userId?: UUID;
-  sessionStatus?: 'loading' | 'authenticated' | 'unauthenticated';
+  /** Server-fetched first page — when present, skips the initial client fetch. */
+  initialData?: BehaviorWithMetrics[];
+  initialTotalCount?: number;
 }
 
 export default function BehaviorsClient({
   organizationId,
   userId,
-  sessionStatus,
+  initialData,
+  initialTotalCount = 0,
 }: BehaviorsClientProps) {
   const router = useRouter();
   const notifications = useNotifications();
+  const { status: sessionStatus } = useSession();
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
     Capability.Behavior.READ
   );
   const canCreateBehavior = useCan(Capability.Behavior.CREATE);
 
-  // Data state
-  const [behaviors, setBehaviors] = React.useState<BehaviorWithMetrics[]>([]);
-  const [isLoading, setIsLoading] = React.useState(true);
+  // Accumulate tag names seen across page navigations for the filter drawer
+  const tagNamesRef = React.useRef(new Set<string>());
+
+  // Data state — seeded from the server-fetched first page when available
+  const [behaviors, setBehaviors] = React.useState<BehaviorWithMetrics[]>(
+    initialData ?? []
+  );
+  const [totalCount, setTotalCount] = React.useState(initialTotalCount);
+  const [isLoading, setIsLoading] = React.useState(initialData === undefined);
   const [error, setError] = React.useState<string | null>(null);
+
+  // Pagination
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(25);
+
+  const [availableTagNames, setAvailableTagNames] = React.useState<string[]>(
+    () => {
+      if (!initialData) return [];
+      initialData.forEach(behavior => {
+        (behavior.tags ?? []).forEach(tag => tagNamesRef.current.add(tag.name));
+      });
+      return Array.from(tagNamesRef.current).sort((a, b) => a.localeCompare(b));
+    }
+  );
 
   // Drawer state
   const [drawerOpen, setDrawerOpen] = React.useState(false);
@@ -90,9 +118,46 @@ export default function BehaviorsClient({
   // Refresh key for manual refresh
   const [refreshKey, setRefreshKey] = React.useState(0);
 
-  const hasFetchedRef = React.useRef(false);
+  // Reset to page 0 whenever filters change
+  const filterFingerprint = React.useMemo(
+    () =>
+      JSON.stringify([
+        searchQuery,
+        metricCountFilter,
+        drawerFilters.tagNames,
+      ]),
+    [searchQuery, metricCountFilter, drawerFilters.tagNames]
+  );
+
+  // Identifies the request whose result is currently reflected in
+  // `behaviors`/`totalCount`. Seeded with the server-fetched first page's
+  // signature (page 0, default size, no filters, refreshKey 0 -- exactly
+  // what `page`/`rowsPerPage`/`filterFingerprint`/`refreshKey` hold on this
+  // first render) when the server provided initial data. The fetch effect
+  // below compares against this on every run rather than consuming a
+  // one-shot flag, so it stays correct under React 18 Strict Mode's dev-only
+  // double-invoke of mount effects -- both invocations compute the same
+  // signature and both no-op, instead of the second one slipping through a
+  // "consumed" ref.
+  const loadedRequestKeyRef = React.useRef<string | null>(
+    initialData !== undefined
+      ? `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}`
+      : null
+  );
 
   React.useEffect(() => {
+    setPage(0);
+  }, [filterFingerprint]);
+
+  React.useEffect(() => {
+    const requestKey = `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}`;
+    if (loadedRequestKeyRef.current === requestKey) {
+      return;
+    }
+    loadedRequestKeyRef.current = requestKey;
+
+    let cancelled = false;
+
     const fetchBehaviors = async () => {
       if (!isAuthenticated(sessionStatus)) {
         // Keep spinner while session is still loading; stop it on auth failure
@@ -102,32 +167,68 @@ export default function BehaviorsClient({
         return;
       }
 
-      if (refreshKey === 0 && hasFetchedRef.current) {
-        return;
-      }
-
       try {
         setIsLoading(true);
         setError(null);
 
         const behaviorClient = new BehaviorClient();
-        const behaviorsList = await behaviorClient.getBehaviorsWithMetrics({
-          limit: 100,
+        const odataFilter = buildBehaviorODataFilter({
+          search: searchQuery,
+          metricCount: metricCountFilter,
+          tagNames: drawerFilters.tagNames,
         });
 
-        setBehaviors(behaviorsList);
-        hasFetchedRef.current = true;
-      } catch (err) {
-        setError(
-          err instanceof Error ? err.message : 'Failed to fetch behaviors'
+        const response = await behaviorClient.getBehaviorsPage({
+          skip: page * rowsPerPage,
+          limit: rowsPerPage,
+          sort_by: 'name',
+          sort_order: 'asc',
+          $filter: odataFilter,
+        });
+
+        if (cancelled) return;
+
+        setBehaviors(response.data);
+        setTotalCount(response.pagination.totalCount);
+
+        response.data.forEach(behavior => {
+          (behavior.tags ?? []).forEach(tag => tagNamesRef.current.add(tag.name));
+        });
+        setAvailableTagNames(
+          Array.from(tagNamesRef.current).sort((a, b) => a.localeCompare(b))
         );
+      } catch (err) {
+        if (cancelled) return;
+        const errorMessage =
+          err instanceof Error ? err.message : 'Failed to fetch behaviors';
+        setError(errorMessage);
+        notifications.show('Failed to load behaviors data', {
+          severity: 'error',
+          autoHideDuration: 4000,
+        });
       } finally {
-        setIsLoading(false);
+        if (!cancelled) {
+          setIsLoading(false);
+        }
       }
     };
 
     fetchBehaviors();
-  }, [refreshKey, sessionStatus]);
+    return () => {
+      cancelled = true;
+    };
+    // filterFingerprint captures search/metricCount/tagNames; no need to list them individually
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, rowsPerPage, filterFingerprint, refreshKey, sessionStatus, notifications]);
+
+  // Clamp page when the result set shrinks below the current page (e.g. after delete)
+  React.useEffect(() => {
+    if (totalCount === 0) return;
+    const lastPage = Math.max(0, Math.ceil(totalCount / rowsPerPage) - 1);
+    if (page > lastPage) {
+      setPage(lastPage);
+    }
+  }, [totalCount, rowsPerPage, page]);
 
   const handleAddNewBehavior = () => {
     setEditingBehavior({ id: null, name: '', description: '', tagNames: [] });
@@ -233,11 +334,10 @@ export default function BehaviorsClient({
           }
         }
 
-        const createdWithMetrics = await behaviorClient.getBehaviorWithMetrics(
-          created.id
-        );
-
-        setBehaviors(prev => [...prev, createdWithMetrics]);
+        // Re-fetch the current page rather than splicing the new item into
+        // local state -- with server-side pagination/sorting, the new
+        // behavior may not belong on the page the user is viewing.
+        handleRefresh();
 
         notifications.show(
           tagSyncFailed
@@ -251,7 +351,7 @@ export default function BehaviorsClient({
       } else if (editingBehavior && editingBehavior.id) {
         const editingId = editingBehavior.id;
         const existing = behaviors.find(b => b.id === editingId);
-        const updated = await behaviorClient.updateBehavior(editingId, {
+        await behaviorClient.updateBehavior(editingId, {
           name: name.trim(),
           description: description?.trim() || null,
         });
@@ -262,21 +362,7 @@ export default function BehaviorsClient({
           tagSyncFailed = true;
         }
 
-        const refreshed =
-          await behaviorClient.getBehaviorWithMetrics(editingId);
-
-        setBehaviors(prev =>
-          prev.map(b =>
-            b.id === editingId
-              ? {
-                  ...b,
-                  name: updated.name,
-                  description: updated.description,
-                  tags: refreshed.tags ?? [],
-                }
-              : b
-          )
-        );
+        handleRefresh();
 
         notifications.show(
           tagSyncFailed
@@ -310,17 +396,13 @@ export default function BehaviorsClient({
 
       const behaviorClient = new BehaviorClient();
 
-      const created = await behaviorClient.createBehavior({
+      await behaviorClient.createBehavior({
         name: generateCopyName(name),
         description: description || null,
         organization_id: organizationId,
       });
 
-      const createdWithMetrics = await behaviorClient.getBehaviorWithMetrics(
-        created.id
-      );
-
-      setBehaviors(prev => [...prev, createdWithMetrics]);
+      handleRefresh();
 
       notifications.show('Behavior duplicated successfully', {
         severity: 'success',
@@ -359,7 +441,7 @@ export default function BehaviorsClient({
 
         await behaviorClient.deleteBehavior(editingBehavior.id);
 
-        setBehaviors(prev => prev.filter(b => b.id !== editingBehavior.id));
+        handleRefresh();
 
         notifications.show('Behavior deleted successfully', {
           severity: 'success',
@@ -423,57 +505,6 @@ export default function BehaviorsClient({
     }
   };
 
-  /** Unique tag names across all loaded behaviors. Reused for drawer
-   *  suggestions and filter chips so users group across behaviors. */
-  const availableTagNames = React.useMemo(
-    () =>
-      Array.from(
-        new Set(behaviors.flatMap(b => (b.tags ?? []).map(t => t.name)))
-      ).sort((a, b) => a.localeCompare(b)),
-    [behaviors]
-  );
-
-  const filteredBehaviors = React.useMemo(() => {
-    let filtered = behaviors;
-
-    if (metricCountFilter !== 'all') {
-      filtered = filtered.filter(behavior => {
-        const hasMetrics = behavior.metrics && behavior.metrics.length > 0;
-        if (metricCountFilter === 'has_metrics') return hasMetrics;
-        if (metricCountFilter === 'no_metrics') return !hasMetrics;
-        return true;
-      });
-    }
-
-    if (drawerFilters.tagNames.length > 0) {
-      const selected = new Set(drawerFilters.tagNames);
-      filtered = filtered.filter(behavior =>
-        (behavior.tags ?? []).some(t => selected.has(t.name))
-      );
-    }
-
-    if (searchQuery.trim()) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(behavior => {
-        const nameMatch = behavior.name.toLowerCase().includes(query);
-        const descriptionMatch = behavior.description
-          ?.toLowerCase()
-          .includes(query);
-        const metricMatch = behavior.metrics?.some(
-          metric =>
-            metric.name?.toLowerCase().includes(query) ||
-            metric.description?.toLowerCase().includes(query)
-        );
-        const tagMatch = (behavior.tags ?? []).some(t =>
-          t.name?.toLowerCase().includes(query)
-        );
-        return nameMatch || descriptionMatch || metricMatch || tagMatch;
-      });
-    }
-
-    return filtered;
-  }, [behaviors, searchQuery, metricCountFilter, drawerFilters]);
-
   const hasActiveFilters =
     searchQuery.trim() !== '' ||
     metricCountFilter !== 'all' ||
@@ -492,8 +523,10 @@ export default function BehaviorsClient({
     { value: 'no_metrics', label: 'No Metrics' },
   ];
 
-  // Loading state
-  if (isLoading) {
+  // First load — no data at all yet, show a full-page spinner
+  const isInitialLoad = isLoading && behaviors.length === 0 && totalCount === 0;
+
+  if (isInitialLoad) {
     return (
       <PageLayout title="Behaviors" breadcrumbs={[]}>
         <Box
@@ -573,8 +606,18 @@ export default function BehaviorsClient({
         </Alert>
       )}
 
+      {/* Subtle loading indicator for subsequent fetches — always
+          mounted so its height never shifts the grid below */}
+      <LinearProgress
+        sx={{
+          mb: 1,
+          borderRadius: theme => theme.shape.borderRadius,
+          visibility: isLoading ? 'visible' : 'hidden',
+        }}
+      />
+
       {/* Behaviors grid / empty states */}
-      {filteredBehaviors.length === 0 ? (
+      {behaviors.length === 0 ? (
         hasActiveFilters ? (
           <EntityEmptyState
             icon={PsychologyIcon}
@@ -596,44 +639,63 @@ export default function BehaviorsClient({
         )
       ) : (
         <Box
-          sx={{
+          sx={theme => ({
             display: 'grid',
             gridTemplateColumns: {
               xs: '1fr',
               sm: '1fr 1fr',
               md: 'repeat(3, 1fr)',
             },
-            gap: '24px',
+            gap: theme.spacing(3),
             mb: 4,
-          }}
+            opacity: isLoading ? theme.palette.action.disabledOpacity : 1,
+            pointerEvents: isLoading ? 'none' : 'auto',
+            transition: theme.transitions.create('opacity', {
+              duration: theme.transitions.duration.short,
+            }),
+          })}
         >
-          {filteredBehaviors
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map(behavior => (
-              <BehaviorCard
-                key={behavior.id}
-                behavior={behavior}
-                onClick={() => router.push(`/behaviors/${behavior.id}`)}
-                onEdit={() =>
-                  handleEditBehavior(
-                    behavior.id,
-                    behavior.name,
-                    behavior.description || '',
-                    (behavior.tags ?? []).map(t => t.name)
-                  )
-                }
-                onDuplicate={() =>
-                  handleDuplicateBehavior(
-                    behavior.id,
-                    behavior.name,
-                    behavior.description || ''
-                  )
-                }
-                onViewMetrics={() => handleViewMetrics(behavior)}
-                onRefresh={handleRefresh}
-              />
-            ))}
+          {behaviors.map(behavior => (
+            <BehaviorCard
+              key={behavior.id}
+              behavior={behavior}
+              onClick={() => router.push(`/behaviors/${behavior.id}`)}
+              onEdit={() =>
+                handleEditBehavior(
+                  behavior.id,
+                  behavior.name,
+                  behavior.description || '',
+                  (behavior.tags ?? []).map(t => t.name)
+                )
+              }
+              onDuplicate={() =>
+                handleDuplicateBehavior(
+                  behavior.id,
+                  behavior.name,
+                  behavior.description || ''
+                )
+              }
+              onViewMetrics={() => handleViewMetrics(behavior)}
+              onRefresh={handleRefresh}
+            />
+          ))}
         </Box>
+      )}
+      {totalCount > 0 && (
+        <TablePagination
+          component="div"
+          count={totalCount}
+          page={page}
+          onPageChange={(_event, newPage) => setPage(newPage)}
+          rowsPerPage={rowsPerPage}
+          onRowsPerPageChange={event => {
+            setRowsPerPage(parseInt(event.target.value, 10));
+            setPage(0);
+          }}
+          rowsPerPageOptions={[25, 50, 100]}
+          labelRowsPerPage="Behaviors per page:"
+          sx={{ mb: 2 }}
+        />
       )}
 
       {/* Behavior Edit Drawer */}

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -166,13 +166,25 @@ export default function BehaviorsClient({
    * just-created item -- with server-side pagination, its name may sort
    * outside whatever page the user happens to be viewing.
    */
+  /**
+   * Only optimistically splices the new row into the *rendered* page when
+   * we're on page 0: with server-side name sorting, a row created/duplicated
+   * while viewing another page may not actually belong there, and we don't
+   * have the adjacent pages' boundary names to know where it really sorts.
+   * Elsewhere we still bump `totalCount` (so pagination controls reflect the
+   * new row existing) and rely on the next real fetch to reveal it. Slicing
+   * to `rowsPerPage` after inserting keeps the rendered page from exceeding
+   * what the pagination controls advertise.
+   */
   const insertBehaviorSorted = (behavior: BehaviorWithMetrics) => {
-    setBehaviors(prev => {
-      const next = [...prev, behavior];
-      next.sort((a, b) => a.name.localeCompare(b.name));
-      return next;
-    });
     setTotalCount(prev => prev + 1);
+    if (page !== 0) return;
+    setBehaviors(prev => {
+      const next = [...prev, behavior].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      );
+      return next.slice(0, rowsPerPage);
+    });
   };
 
   const handleAddNewBehavior = () => {

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -42,7 +42,6 @@ import BehaviorFilterDrawer, {
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 import { usePaginatedList } from '@/hooks/usePaginatedList';
 import { buildBehaviorODataFilter } from '@/utils/odata-filter';
-import { BEHAVIORS_READ_CAPABILITY } from './behaviors-constants';
 
 interface BehaviorsClientProps {
   organizationId: UUID;
@@ -62,7 +61,7 @@ export default function BehaviorsClient({
   const notifications = useNotifications();
   const { status: sessionStatus } = useSession();
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
-    BEHAVIORS_READ_CAPABILITY
+    Capability.Behavior.READ
   );
   const canCreateBehavior = useCan(Capability.Behavior.CREATE);
 

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -42,6 +42,7 @@ import BehaviorFilterDrawer, {
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 import { usePaginatedList } from '@/hooks/usePaginatedList';
 import { buildBehaviorODataFilter } from '@/utils/odata-filter';
+import { BEHAVIORS_READ_CAPABILITY } from './behaviors-constants';
 
 interface BehaviorsClientProps {
   organizationId: UUID;
@@ -61,7 +62,7 @@ export default function BehaviorsClient({
   const notifications = useNotifications();
   const { status: sessionStatus } = useSession();
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
-    Capability.Behavior.READ
+    BEHAVIORS_READ_CAPABILITY
   );
   const canCreateBehavior = useCan(Capability.Behavior.CREATE);
 

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -139,9 +139,14 @@ export default function BehaviorsClient({
   // double-invoke of mount effects -- both invocations compute the same
   // signature and both no-op, instead of the second one slipping through a
   // "consumed" ref.
+  //
+  // `sessionStatus` is part of the key so a run that lands while the session
+  // is still `loading` doesn't "claim" the same key a later `authenticated`
+  // run would use -- otherwise that later run would see a match and skip the
+  // fetch entirely, leaving the page stuck.
   const loadedRequestKeyRef = React.useRef<string | null>(
     initialData !== undefined
-      ? `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}`
+      ? `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}`
       : null
   );
 
@@ -150,7 +155,7 @@ export default function BehaviorsClient({
   }, [filterFingerprint]);
 
   React.useEffect(() => {
-    const requestKey = `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}`;
+    const requestKey = `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}`;
     if (loadedRequestKeyRef.current === requestKey) {
       return;
     }

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -121,11 +121,7 @@ export default function BehaviorsClient({
   // Reset to page 0 whenever filters change
   const filterFingerprint = React.useMemo(
     () =>
-      JSON.stringify([
-        searchQuery,
-        metricCountFilter,
-        drawerFilters.tagNames,
-      ]),
+      JSON.stringify([searchQuery, metricCountFilter, drawerFilters.tagNames]),
     [searchQuery, metricCountFilter, drawerFilters.tagNames]
   );
 
@@ -197,7 +193,9 @@ export default function BehaviorsClient({
         setTotalCount(response.pagination.totalCount);
 
         response.data.forEach(behavior => {
-          (behavior.tags ?? []).forEach(tag => tagNamesRef.current.add(tag.name));
+          (behavior.tags ?? []).forEach(tag =>
+            tagNamesRef.current.add(tag.name)
+          );
         });
         setAvailableTagNames(
           Array.from(tagNamesRef.current).sort((a, b) => a.localeCompare(b))
@@ -224,7 +222,14 @@ export default function BehaviorsClient({
     };
     // filterFingerprint captures search/metricCount/tagNames; no need to list them individually
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page, rowsPerPage, filterFingerprint, refreshKey, sessionStatus, notifications]);
+  }, [
+    page,
+    rowsPerPage,
+    filterFingerprint,
+    refreshKey,
+    sessionStatus,
+    notifications,
+  ]);
 
   // Clamp page when the result set shrinks below the current page (e.g. after delete)
   React.useEffect(() => {

--- a/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/components/BehaviorsClient.tsx
@@ -39,7 +39,8 @@ import BehaviorFilterDrawer, {
   hasActiveBehaviorFilters,
   countActiveBehaviorFilters,
 } from './BehaviorFilterDrawer';
-import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
+import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { usePaginatedList } from '@/hooks/usePaginatedList';
 import { buildBehaviorODataFilter } from '@/utils/odata-filter';
 
 interface BehaviorsClientProps {
@@ -66,18 +67,6 @@ export default function BehaviorsClient({
 
   // Accumulate tag names seen across page navigations for the filter drawer
   const tagNamesRef = React.useRef(new Set<string>());
-
-  // Data state — seeded from the server-fetched first page when available
-  const [behaviors, setBehaviors] = React.useState<BehaviorWithMetrics[]>(
-    initialData ?? []
-  );
-  const [totalCount, setTotalCount] = React.useState(initialTotalCount);
-  const [isLoading, setIsLoading] = React.useState(initialData === undefined);
-  const [error, setError] = React.useState<string | null>(null);
-
-  // Pagination
-  const [page, setPage] = React.useState(0);
-  const [rowsPerPage, setRowsPerPage] = React.useState(25);
 
   const [availableTagNames, setAvailableTagNames] = React.useState<string[]>(
     () => {
@@ -115,9 +104,6 @@ export default function BehaviorsClient({
     EMPTY_BEHAVIOR_FILTERS
   );
 
-  // Refresh key for manual refresh
-  const [refreshKey, setRefreshKey] = React.useState(0);
-
   // Reset to page 0 whenever filters change
   const filterFingerprint = React.useMemo(
     () =>
@@ -125,120 +111,68 @@ export default function BehaviorsClient({
     [searchQuery, metricCountFilter, drawerFilters.tagNames]
   );
 
-  // Identifies the request whose result is currently reflected in
-  // `behaviors`/`totalCount`. Seeded with the server-fetched first page's
-  // signature (page 0, default size, no filters, refreshKey 0 -- exactly
-  // what `page`/`rowsPerPage`/`filterFingerprint`/`refreshKey` hold on this
-  // first render) when the server provided initial data. The fetch effect
-  // below compares against this on every run rather than consuming a
-  // one-shot flag, so it stays correct under React 18 Strict Mode's dev-only
-  // double-invoke of mount effects -- both invocations compute the same
-  // signature and both no-op, instead of the second one slipping through a
-  // "consumed" ref.
-  //
-  // `sessionStatus` is part of the key so a run that lands while the session
-  // is still `loading` doesn't "claim" the same key a later `authenticated`
-  // run would use -- otherwise that later run would see a match and skip the
-  // fetch entirely, leaving the page stuck.
-  const loadedRequestKeyRef = React.useRef<string | null>(
-    initialData !== undefined
-      ? `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}`
-      : null
-  );
-
-  React.useEffect(() => {
-    setPage(0);
-  }, [filterFingerprint]);
-
-  React.useEffect(() => {
-    const requestKey = `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}`;
-    if (loadedRequestKeyRef.current === requestKey) {
-      return;
-    }
-    loadedRequestKeyRef.current = requestKey;
-
-    let cancelled = false;
-
-    const fetchBehaviors = async () => {
-      if (!isAuthenticated(sessionStatus)) {
-        // Keep spinner while session is still loading; stop it on auth failure
-        if (!isSessionLoading(sessionStatus)) {
-          setIsLoading(false);
-        }
-        return;
-      }
-
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        const behaviorClient = new BehaviorClient();
-        const odataFilter = buildBehaviorODataFilter({
-          search: searchQuery,
-          metricCount: metricCountFilter,
-          tagNames: drawerFilters.tagNames,
-        });
-
-        const response = await behaviorClient.getBehaviorsPage({
-          skip: page * rowsPerPage,
-          limit: rowsPerPage,
-          sort_by: 'name',
-          sort_order: 'asc',
-          $filter: odataFilter,
-        });
-
-        if (cancelled) return;
-
-        setBehaviors(response.data);
-        setTotalCount(response.pagination.totalCount);
-
-        response.data.forEach(behavior => {
-          (behavior.tags ?? []).forEach(tag =>
-            tagNamesRef.current.add(tag.name)
-          );
-        });
-        setAvailableTagNames(
-          Array.from(tagNamesRef.current).sort((a, b) => a.localeCompare(b))
-        );
-      } catch (err) {
-        if (cancelled) return;
-        const errorMessage =
-          err instanceof Error ? err.message : 'Failed to fetch behaviors';
-        setError(errorMessage);
-        notifications.show('Failed to load behaviors data', {
-          severity: 'error',
-          autoHideDuration: 4000,
-        });
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    fetchBehaviors();
-    return () => {
-      cancelled = true;
-    };
-    // filterFingerprint captures search/metricCount/tagNames; no need to list them individually
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
+  const {
+    data: behaviors,
+    setData: setBehaviors,
+    totalCount,
+    setTotalCount,
+    isLoading,
+    error,
     page,
     rowsPerPage,
+    onPageChange: setPage,
+    onRowsPerPageChange: handleRowsPerPageChange,
+    refresh: handleRefresh,
+  } = usePaginatedList<BehaviorWithMetrics>({
+    fetchPage: ({ skip, limit }) => {
+      const behaviorClient = new BehaviorClient();
+      const odataFilter = buildBehaviorODataFilter({
+        search: searchQuery,
+        metricCount: metricCountFilter,
+        tagNames: drawerFilters.tagNames,
+      });
+      return behaviorClient.getBehaviorsPage({
+        skip,
+        limit,
+        sort_by: 'name',
+        sort_order: 'asc',
+        $filter: odataFilter,
+      });
+    },
     filterFingerprint,
-    refreshKey,
-    sessionStatus,
-    notifications,
-  ]);
+    initialData,
+    initialTotalCount,
+    onData: data => {
+      data.forEach(behavior => {
+        (behavior.tags ?? []).forEach(tag => tagNamesRef.current.add(tag.name));
+      });
+      setAvailableTagNames(
+        Array.from(tagNamesRef.current).sort((a, b) => a.localeCompare(b))
+      );
+    },
+    onError: () => {
+      notifications.show('Failed to load behaviors data', {
+        severity: 'error',
+        autoHideDuration: 4000,
+      });
+    },
+  });
 
-  // Clamp page when the result set shrinks below the current page (e.g. after delete)
-  React.useEffect(() => {
-    if (totalCount === 0) return;
-    const lastPage = Math.max(0, Math.ceil(totalCount / rowsPerPage) - 1);
-    if (page > lastPage) {
-      setPage(lastPage);
-    }
-  }, [totalCount, rowsPerPage, page]);
+  /**
+   * Inserts a behavior into the current page in name order (matching the
+   * directory's default sort) rather than relying on a re-fetch to reveal
+   * it. A re-fetch of the current page can't be trusted to surface a
+   * just-created item -- with server-side pagination, its name may sort
+   * outside whatever page the user happens to be viewing.
+   */
+  const insertBehaviorSorted = (behavior: BehaviorWithMetrics) => {
+    setBehaviors(prev => {
+      const next = [...prev, behavior];
+      next.sort((a, b) => a.name.localeCompare(b.name));
+      return next;
+    });
+    setTotalCount(prev => prev + 1);
+  };
 
   const handleAddNewBehavior = () => {
     setEditingBehavior({ id: null, name: '', description: '', tagNames: [] });
@@ -344,10 +278,10 @@ export default function BehaviorsClient({
           }
         }
 
-        // Re-fetch the current page rather than splicing the new item into
-        // local state -- with server-side pagination/sorting, the new
-        // behavior may not belong on the page the user is viewing.
-        handleRefresh();
+        const createdWithMetrics = await behaviorClient.getBehaviorWithMetrics(
+          created.id
+        );
+        insertBehaviorSorted(createdWithMetrics);
 
         notifications.show(
           tagSyncFailed
@@ -361,7 +295,7 @@ export default function BehaviorsClient({
       } else if (editingBehavior && editingBehavior.id) {
         const editingId = editingBehavior.id;
         const existing = behaviors.find(b => b.id === editingId);
-        await behaviorClient.updateBehavior(editingId, {
+        const updated = await behaviorClient.updateBehavior(editingId, {
           name: name.trim(),
           description: description?.trim() || null,
         });
@@ -372,7 +306,22 @@ export default function BehaviorsClient({
           tagSyncFailed = true;
         }
 
-        handleRefresh();
+        const refreshed =
+          await behaviorClient.getBehaviorWithMetrics(editingId);
+        setBehaviors(prev =>
+          prev
+            .map(b =>
+              b.id === editingId
+                ? {
+                    ...b,
+                    name: updated.name,
+                    description: updated.description,
+                    tags: refreshed.tags ?? [],
+                  }
+                : b
+            )
+            .sort((a, b) => a.name.localeCompare(b.name))
+        );
 
         notifications.show(
           tagSyncFailed
@@ -406,13 +355,16 @@ export default function BehaviorsClient({
 
       const behaviorClient = new BehaviorClient();
 
-      await behaviorClient.createBehavior({
+      const created = await behaviorClient.createBehavior({
         name: generateCopyName(name),
         description: description || null,
         organization_id: organizationId,
       });
 
-      handleRefresh();
+      const createdWithMetrics = await behaviorClient.getBehaviorWithMetrics(
+        created.id
+      );
+      insertBehaviorSorted(createdWithMetrics);
 
       notifications.show('Behavior duplicated successfully', {
         severity: 'success',
@@ -451,7 +403,8 @@ export default function BehaviorsClient({
 
         await behaviorClient.deleteBehavior(editingBehavior.id);
 
-        handleRefresh();
+        setBehaviors(prev => prev.filter(b => b.id !== editingBehavior.id));
+        setTotalCount(prev => Math.max(0, prev - 1));
 
         notifications.show('Behavior deleted successfully', {
           severity: 'success',
@@ -467,10 +420,6 @@ export default function BehaviorsClient({
     } else {
       setDrawerOpen(false);
     }
-  };
-
-  const handleRefresh = () => {
-    setRefreshKey(prev => prev + 1);
   };
 
   const handleViewMetrics = (behavior: BehaviorWithMetrics) => {
@@ -511,7 +460,7 @@ export default function BehaviorsClient({
         return prev;
       });
     } else {
-      setRefreshKey(prev => prev + 1);
+      handleRefresh();
     }
   };
 
@@ -693,10 +642,9 @@ export default function BehaviorsClient({
           page={page}
           onPageChange={(_event, newPage) => setPage(newPage)}
           rowsPerPage={rowsPerPage}
-          onRowsPerPageChange={event => {
-            setRowsPerPage(parseInt(event.target.value, 10));
-            setPage(0);
-          }}
+          onRowsPerPageChange={event =>
+            handleRowsPerPageChange(parseInt(event.target.value, 10))
+          }
           rowsPerPageOptions={[25, 50, 100]}
           labelRowsPerPage="Behaviors per page:"
           sx={{ mb: 2 }}

--- a/apps/frontend/src/app/(protected)/behaviors/components/behaviors-constants.ts
+++ b/apps/frontend/src/app/(protected)/behaviors/components/behaviors-constants.ts
@@ -1,0 +1,2 @@
+/** Default page size for the behaviors directory grid. */
+export const DEFAULT_BEHAVIORS_PAGE_SIZE = 25;

--- a/apps/frontend/src/app/(protected)/behaviors/components/behaviors-constants.ts
+++ b/apps/frontend/src/app/(protected)/behaviors/components/behaviors-constants.ts
@@ -1,2 +1,12 @@
+import { Capability } from '@/constants/capabilities';
+
 /** Default page size for the behaviors directory grid. */
 export const DEFAULT_BEHAVIORS_PAGE_SIZE = 25;
+
+/**
+ * Read capability gating the behaviors directory. Shared between the server
+ * component's `prefetchList` call and the client component's
+ * `useCanWithStatus` check so the two gates can't drift onto different
+ * capability values.
+ */
+export const BEHAVIORS_READ_CAPABILITY = Capability.Behavior.READ;

--- a/apps/frontend/src/app/(protected)/behaviors/components/behaviors-constants.ts
+++ b/apps/frontend/src/app/(protected)/behaviors/components/behaviors-constants.ts
@@ -1,12 +1,2 @@
-import { Capability } from '@/constants/capabilities';
-
 /** Default page size for the behaviors directory grid. */
 export const DEFAULT_BEHAVIORS_PAGE_SIZE = 25;
-
-/**
- * Read capability gating the behaviors directory. Shared between the server
- * component's `prefetchList` call and the client component's
- * `useCanWithStatus` check so the two gates can't drift onto different
- * capability values.
- */
-export const BEHAVIORS_READ_CAPABILITY = Capability.Behavior.READ;

--- a/apps/frontend/src/app/(protected)/behaviors/page.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/page.tsx
@@ -1,9 +1,11 @@
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { Capability } from '@/constants/capabilities';
 import BehaviorsClient from './components/BehaviorsClient';
-import { DEFAULT_BEHAVIORS_PAGE_SIZE } from './components/behaviors-constants';
+import {
+  DEFAULT_BEHAVIORS_PAGE_SIZE,
+  BEHAVIORS_READ_CAPABILITY,
+} from './components/behaviors-constants';
 import type { UUID } from 'crypto';
 
 /**
@@ -23,7 +25,7 @@ export default async function BehaviorsPage() {
   const client = (await createServerApiFactory()).getBehaviorClient();
 
   const { initialData, initialTotalCount } = await prefetchList(
-    Capability.Behavior.READ,
+    BEHAVIORS_READ_CAPABILITY,
     () =>
       client.getBehaviorsPage({
         skip: 0,

--- a/apps/frontend/src/app/(protected)/behaviors/page.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/page.tsx
@@ -1,27 +1,54 @@
-'use client';
-
-import * as React from 'react';
-import { useSession } from 'next-auth/react';
+import { auth } from '@/auth';
+import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import BehaviorsClient from './components/BehaviorsClient';
+import { DEFAULT_BEHAVIORS_PAGE_SIZE } from './components/behaviors-constants';
 import type { UUID } from 'crypto';
 
-export default function BehaviorsPage() {
-  const { data: session, status } = useSession();
+/**
+ * Server component: fetches the first page of behaviors before rendering so
+ * the page arrives with content already in place -- no client-side spinner
+ * on first load. Permission gating (`useCan`) stays client-side since it
+ * depends on the `PermissionsContext` seeded by `(protected)/layout.tsx`,
+ * which resolves synchronously on first render.
+ */
+export default async function BehaviorsPage() {
+  const session = await auth();
 
-  const organizationId = React.useMemo(
-    () => session?.user?.organization_id as UUID,
-    [session?.user?.organization_id]
-  );
-  const userId = React.useMemo(
-    () => (session?.user?.id as UUID | undefined) ?? undefined,
-    [session?.user?.id]
-  );
+  if (!session || session.error) {
+    throw new Error('Authentication required');
+  }
+
+  const organizationId = session.user?.organization_id as UUID;
+  const userId = (session.user?.id as UUID | undefined) ?? undefined;
+
+  const client = (await createServerApiFactory()).getBehaviorClient();
+
+  let initialData;
+  let initialTotalCount = 0;
+  try {
+    const response = await client.getBehaviorsPage({
+      skip: 0,
+      limit: DEFAULT_BEHAVIORS_PAGE_SIZE,
+      sort_by: 'name',
+      sort_order: 'asc',
+    });
+    initialData = response.data;
+    initialTotalCount = response.pagination.totalCount;
+  } catch {
+    // Fall back to client-side fetching on the initial mount.
+    initialData = undefined;
+  }
+
+  const serializedInitialData = initialData
+    ? JSON.parse(JSON.stringify(initialData))
+    : undefined;
 
   return (
     <BehaviorsClient
       organizationId={organizationId}
       userId={userId}
-      sessionStatus={status}
+      initialData={serializedInitialData}
+      initialTotalCount={initialTotalCount}
     />
   );
 }

--- a/apps/frontend/src/app/(protected)/behaviors/page.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/page.tsx
@@ -1,5 +1,7 @@
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { hasServerCapability } from '@/utils/server-permissions';
+import { Capability } from '@/constants/capabilities';
 import BehaviorsClient from './components/BehaviorsClient';
 import { DEFAULT_BEHAVIORS_PAGE_SIZE } from './components/behaviors-constants';
 import type { UUID } from 'crypto';
@@ -7,9 +9,12 @@ import type { UUID } from 'crypto';
 /**
  * Server component: fetches the first page of behaviors before rendering so
  * the page arrives with content already in place -- no client-side spinner
- * on first load. Permission gating (`useCan`) stays client-side since it
- * depends on the `PermissionsContext` seeded by `(protected)/layout.tsx`,
- * which resolves synchronously on first render.
+ * on first load.
+ *
+ * The `Behavior.READ` check runs here, server-side, before the prefetch: an
+ * unauthorized user's client-side `useCan` gate in `BehaviorsClient` renders
+ * an AccessDenied screen, but that alone doesn't stop real data from being
+ * serialized into the page's initial payload -- this check does.
  */
 export default async function BehaviorsPage() {
   const session = await auth();
@@ -20,23 +25,26 @@ export default async function BehaviorsPage() {
 
   const organizationId = session.user?.organization_id as UUID;
   const userId = (session.user?.id as UUID | undefined) ?? undefined;
+  const canRead = await hasServerCapability(Capability.Behavior.READ);
 
   const client = (await createServerApiFactory()).getBehaviorClient();
 
   let initialData;
   let initialTotalCount = 0;
-  try {
-    const response = await client.getBehaviorsPage({
-      skip: 0,
-      limit: DEFAULT_BEHAVIORS_PAGE_SIZE,
-      sort_by: 'name',
-      sort_order: 'asc',
-    });
-    initialData = response.data;
-    initialTotalCount = response.pagination.totalCount;
-  } catch {
-    // Fall back to client-side fetching on the initial mount.
-    initialData = undefined;
+  if (canRead) {
+    try {
+      const response = await client.getBehaviorsPage({
+        skip: 0,
+        limit: DEFAULT_BEHAVIORS_PAGE_SIZE,
+        sort_by: 'name',
+        sort_order: 'asc',
+      });
+      initialData = response.data;
+      initialTotalCount = response.pagination.totalCount;
+    } catch {
+      // Fall back to client-side fetching on the initial mount.
+      initialData = undefined;
+    }
   }
 
   const serializedInitialData = initialData

--- a/apps/frontend/src/app/(protected)/behaviors/page.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/page.tsx
@@ -1,11 +1,9 @@
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
+import { Capability } from '@/constants/capabilities';
 import BehaviorsClient from './components/BehaviorsClient';
-import {
-  DEFAULT_BEHAVIORS_PAGE_SIZE,
-  BEHAVIORS_READ_CAPABILITY,
-} from './components/behaviors-constants';
+import { DEFAULT_BEHAVIORS_PAGE_SIZE } from './components/behaviors-constants';
 import type { UUID } from 'crypto';
 
 /**
@@ -25,7 +23,7 @@ export default async function BehaviorsPage() {
   const client = (await createServerApiFactory()).getBehaviorClient();
 
   const { initialData, initialTotalCount } = await prefetchList(
-    BEHAVIORS_READ_CAPABILITY,
+    Capability.Behavior.READ,
     () =>
       client.getBehaviorsPage({
         skip: 0,

--- a/apps/frontend/src/app/(protected)/behaviors/page.tsx
+++ b/apps/frontend/src/app/(protected)/behaviors/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
-import { hasServerCapability } from '@/utils/server-permissions';
+import { prefetchList } from '@/utils/server-prefetch';
 import { Capability } from '@/constants/capabilities';
 import BehaviorsClient from './components/BehaviorsClient';
 import { DEFAULT_BEHAVIORS_PAGE_SIZE } from './components/behaviors-constants';
@@ -9,12 +9,7 @@ import type { UUID } from 'crypto';
 /**
  * Server component: fetches the first page of behaviors before rendering so
  * the page arrives with content already in place -- no client-side spinner
- * on first load.
- *
- * The `Behavior.READ` check runs here, server-side, before the prefetch: an
- * unauthorized user's client-side `useCan` gate in `BehaviorsClient` renders
- * an AccessDenied screen, but that alone doesn't stop real data from being
- * serialized into the page's initial payload -- this check does.
+ * on first load. See `prefetchList` for the permission-gating rationale.
  */
 export default async function BehaviorsPage() {
   const session = await auth();
@@ -25,37 +20,24 @@ export default async function BehaviorsPage() {
 
   const organizationId = session.user?.organization_id as UUID;
   const userId = (session.user?.id as UUID | undefined) ?? undefined;
-  const canRead = await hasServerCapability(Capability.Behavior.READ);
-
   const client = (await createServerApiFactory()).getBehaviorClient();
 
-  let initialData;
-  let initialTotalCount = 0;
-  if (canRead) {
-    try {
-      const response = await client.getBehaviorsPage({
+  const { initialData, initialTotalCount } = await prefetchList(
+    Capability.Behavior.READ,
+    () =>
+      client.getBehaviorsPage({
         skip: 0,
         limit: DEFAULT_BEHAVIORS_PAGE_SIZE,
         sort_by: 'name',
         sort_order: 'asc',
-      });
-      initialData = response.data;
-      initialTotalCount = response.pagination.totalCount;
-    } catch {
-      // Fall back to client-side fetching on the initial mount.
-      initialData = undefined;
-    }
-  }
-
-  const serializedInitialData = initialData
-    ? JSON.parse(JSON.stringify(initialData))
-    : undefined;
+      })
+  );
 
   return (
     <BehaviorsClient
       organizationId={organizationId}
       userId={userId}
-      initialData={serializedInitialData}
+      initialData={initialData}
       initialTotalCount={initialTotalCount}
     />
   );

--- a/apps/frontend/src/app/(protected)/layout.tsx
+++ b/apps/frontend/src/app/(protected)/layout.tsx
@@ -1,17 +1,23 @@
 import { auth, getFreshAccessToken } from '@/auth';
 import { headers } from 'next/headers';
-import { createServerApiFactory } from '@/utils/api-client/server-factory';
-import { getServerActiveProjectId } from '@/utils/server-active-project';
 import { FeatureName } from '@/constants/features';
 import type { FeaturesResponse } from '@/utils/api-client/features-client';
 import { fetchTermsStatusServer } from '@/utils/api-client/auth-client.server';
 import type { TermsStatus } from '@/utils/api-client/auth-client';
+import {
+  getServerFeatures,
+  getServerPermissions,
+} from '@/utils/server-permissions';
 import { ProtectedLayoutClient } from './ProtectedLayoutClient';
 
 /**
  * Server-side layout that seeds `FeaturesProvider`, `PermissionsProvider`, and
  * `TermsAcceptanceGate` with data so they don't need a client-side fetch on
- * mount. Failures are swallowed — client providers fall back to fetching.
+ * mount. Failures are swallowed -- client providers fall back to fetching.
+ *
+ * Uses `getServerFeatures`/`getServerPermissions` (React.cache-wrapped) so
+ * nested server components (page.tsx via prefetchList/hasServerCapability)
+ * share the same responses without issuing duplicate requests.
  */
 export default async function ProtectedLayout({
   children,
@@ -25,15 +31,12 @@ export default async function ProtectedLayout({
   let initialTermsStatus: TermsStatus | null = null;
 
   if (session && !session.error) {
-    const [projectId, { accessToken }] = await Promise.all([
-      getServerActiveProjectId(),
-      getFreshAccessToken({ headers: await headers() }),
-    ]);
-
-    const factory = await createServerApiFactory();
+    const { accessToken } = await getFreshAccessToken({
+      headers: await headers(),
+    });
 
     const [featuresResult, termsResult] = await Promise.allSettled([
-      factory.getFeaturesClient().getFeatures(),
+      getServerFeatures(),
       accessToken ? fetchTermsStatusServer(accessToken) : Promise.resolve(null),
     ]);
 
@@ -42,11 +45,9 @@ export default async function ProtectedLayout({
 
       if (initialFeatures.enabled.includes(FeatureName.RBAC)) {
         try {
-          initialPermissions = await factory
-            .getPermissionsClient()
-            .getMyPermissions(projectId);
+          initialPermissions = await getServerPermissions();
         } catch {
-          // Ignore — PermissionsProvider falls back to fetching on mount.
+          // Ignore -- PermissionsProvider falls back to fetching on mount.
         }
       }
     }

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -66,51 +66,53 @@ interface MetricsClientProps {
   initialTotalCount?: number;
 }
 
+interface MetricsOptionMaps {
+  behaviors: Map<string, ApiBehavior>;
+  backendTypes: Map<string, { type_value: string }>;
+  metricTypes: Map<string, { type_value: string; description: string }>;
+}
+
 /**
  * Extracts the behavior/backend/type dropdown options a page of metrics
- * contributes. Used both to seed state from the server-fetched first page
- * and to update state after each subsequent client-side fetch.
+ * contributes and merges them into the running accumulator maps. Mutating
+ * maps that persist across fetches -- rather than deriving from just the
+ * current page -- matters because pages are server-filtered: filtering by
+ * one backend type would otherwise make that fetch's response (and thus the
+ * dropdown) contain only that value, making every other option vanish from
+ * the filter UI the moment it's applied.
  */
-function deriveMetricsPageOptions(
-  data: MetricDetail[],
-  behaviorMap: Map<string, ApiBehavior>
-) {
+function deriveMetricsPageOptions(data: MetricDetail[], maps: MetricsOptionMaps) {
   data.forEach(metric => {
     metric.behaviors?.forEach(behavior => {
       if (behavior && typeof behavior !== 'string' && behavior.id) {
-        behaviorMap.set(behavior.id, {
+        maps.behaviors.set(behavior.id, {
           id: behavior.id,
           name: behavior.name || 'Unnamed Behavior',
           description: behavior.description ?? undefined,
         } as ApiBehavior);
       }
     });
-  });
-  const behaviorsData = Array.from(behaviorMap.values());
-  const behaviorOptions = behaviorsData.map(b => ({ id: b.id, name: b.name }));
-
-  const uniqueBackendTypes = new Map<string, { type_value: string }>();
-  const uniqueMetricTypes = new Map<
-    string,
-    { type_value: string; description: string }
-  >();
-
-  data.forEach(metric => {
     if (metric.backend_type) {
       const val = metric.backend_type.type_value;
-      uniqueBackendTypes.set(val, {
+      maps.backendTypes.set(val, {
         type_value: val.charAt(0).toUpperCase() + val.slice(1),
       });
     }
     if (metric.metric_type) {
-      uniqueMetricTypes.set(metric.metric_type.type_value, {
+      maps.metricTypes.set(metric.metric_type.type_value, {
         type_value: metric.metric_type.type_value,
         description: metric.metric_type.description || '',
       });
     }
   });
 
-  return { behaviorsData, behaviorOptions, uniqueBackendTypes, uniqueMetricTypes };
+  const behaviorsData = Array.from(maps.behaviors.values());
+  return {
+    behaviorsData,
+    behaviorOptions: behaviorsData.map(b => ({ id: b.id, name: b.name })),
+    backendTypeOptions: Array.from(maps.backendTypes.values()),
+    metricTypeOptions: Array.from(maps.metricTypes.values()),
+  };
 }
 
 export default function MetricsClientComponent({
@@ -124,14 +126,19 @@ export default function MetricsClientComponent({
 
   const assignMode = searchParams.get('assignMode') === 'true';
 
-  // Accumulate unique behaviors across page navigations for the dropdown
-  const behaviorMapRef = React.useRef(new Map<string, ApiBehavior>());
+  // Accumulate dropdown options across page/filter navigations (see
+  // deriveMetricsPageOptions) so filtering to one value doesn't erase the
+  // other options from the dropdowns.
+  const optionMapsRef = React.useRef<MetricsOptionMaps>({
+    behaviors: new Map(),
+    backendTypes: new Map(),
+    metricTypes: new Map(),
+  });
 
   // Data state — seeded from the server-fetched first page when available
   const [behaviors, setBehaviors] = React.useState<ApiBehavior[]>(() =>
     initialData
-      ? deriveMetricsPageOptions(initialData, behaviorMapRef.current)
-          .behaviorsData
+      ? deriveMetricsPageOptions(initialData, optionMapsRef.current).behaviorsData
       : []
   );
   const [_behaviorsWithMetrics, setBehaviorsWithMetrics] = React.useState<
@@ -151,22 +158,13 @@ export default function MetricsClientComponent({
   const [filterOptions, setFilterOptions] = React.useState<FilterOptions>(
     () => {
       if (!initialData) return initialFilterOptions;
-      const { behaviorOptions, uniqueBackendTypes, uniqueMetricTypes } =
-        deriveMetricsPageOptions(initialData, behaviorMapRef.current);
+      const { behaviorOptions, backendTypeOptions, metricTypeOptions } =
+        deriveMetricsPageOptions(initialData, optionMapsRef.current);
       return {
         ...initialFilterOptions,
-        backend:
-          uniqueBackendTypes.size > 0
-            ? Array.from(uniqueBackendTypes.values())
-            : initialFilterOptions.backend,
-        type:
-          uniqueMetricTypes.size > 0
-            ? Array.from(uniqueMetricTypes.values())
-            : initialFilterOptions.type,
-        behavior:
-          behaviorOptions.length > 0
-            ? behaviorOptions
-            : initialFilterOptions.behavior,
+        backend: backendTypeOptions,
+        type: metricTypeOptions,
+        behavior: behaviorOptions,
       };
     }
   );
@@ -253,22 +251,15 @@ export default function MetricsClientComponent({
         setMetrics(response.data);
         setTotalCount(response.pagination.totalCount);
 
-        const { behaviorsData, behaviorOptions, uniqueBackendTypes, uniqueMetricTypes } =
-          deriveMetricsPageOptions(response.data, behaviorMapRef.current);
+        const { behaviorsData, behaviorOptions, backendTypeOptions, metricTypeOptions } =
+          deriveMetricsPageOptions(response.data, optionMapsRef.current);
         setBehaviors(behaviorsData);
 
         setFilterOptions(prev => ({
           ...prev,
-          backend:
-            uniqueBackendTypes.size > 0
-              ? Array.from(uniqueBackendTypes.values())
-              : prev.backend,
-          type:
-            uniqueMetricTypes.size > 0
-              ? Array.from(uniqueMetricTypes.values())
-              : prev.type,
-          behavior:
-            behaviorOptions.length > 0 ? behaviorOptions : prev.behavior,
+          backend: backendTypeOptions,
+          type: metricTypeOptions,
+          behavior: behaviorOptions,
         }));
       } catch (err) {
         if (cancelled) return;

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -13,8 +13,9 @@ import type {
 import type { UUID } from 'crypto';
 import { TEST_TYPES } from '@/constants/test-types';
 import { buildMetricODataFilter } from '@/utils/odata-filter';
-import { METRICS_SELECT, METRICS_READ_CAPABILITY } from './metrics-constants';
+import { METRICS_SELECT } from './metrics-constants';
 import { useCanWithStatus } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
 import { usePaginatedList } from '@/hooks/usePaginatedList';
@@ -128,7 +129,7 @@ export default function MetricsClientComponent({
   const searchParams = useSearchParams();
   const notifications = useNotifications();
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
-    METRICS_READ_CAPABILITY
+    Capability.Metric.READ
   );
 
   const assignMode = searchParams.get('assignMode') === 'true';

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import * as React from 'react';
+import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { useNotifications } from '@/components/common/NotificationContext';
 import ErrorBoundary from '@/components/common/ErrorBoundary';
-import { BehaviorClient } from '@/utils/api-client/behavior-client';
 import { MetricsClient } from '@/utils/api-client/metrics-client';
 import { MetricDetail } from '@/utils/api-client/interfaces/metric';
 import type {
@@ -13,6 +13,8 @@ import type {
 } from '@/utils/api-client/interfaces/behavior';
 import type { UUID } from 'crypto';
 import { TEST_TYPES } from '@/constants/test-types';
+import { buildMetricODataFilter } from '@/utils/odata-filter';
+import { METRICS_SELECT } from './metrics-constants';
 
 import MetricsDirectoryTab, { type FilterState } from './MetricsDirectoryTab';
 import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
@@ -59,44 +61,166 @@ interface BehaviorMetrics {
 
 interface MetricsClientProps {
   organizationId: UUID;
-  sessionStatus?: 'loading' | 'authenticated' | 'unauthenticated';
+  /** Server-fetched first page — when present, skips the initial client fetch. */
+  initialData?: MetricDetail[];
+  initialTotalCount?: number;
+}
+
+/**
+ * Extracts the behavior/backend/type dropdown options a page of metrics
+ * contributes. Used both to seed state from the server-fetched first page
+ * and to update state after each subsequent client-side fetch.
+ */
+function deriveMetricsPageOptions(
+  data: MetricDetail[],
+  behaviorMap: Map<string, ApiBehavior>
+) {
+  data.forEach(metric => {
+    metric.behaviors?.forEach(behavior => {
+      if (behavior && typeof behavior !== 'string' && behavior.id) {
+        behaviorMap.set(behavior.id, {
+          id: behavior.id,
+          name: behavior.name || 'Unnamed Behavior',
+          description: behavior.description ?? undefined,
+        } as ApiBehavior);
+      }
+    });
+  });
+  const behaviorsData = Array.from(behaviorMap.values());
+  const behaviorOptions = behaviorsData.map(b => ({ id: b.id, name: b.name }));
+
+  const uniqueBackendTypes = new Map<string, { type_value: string }>();
+  const uniqueMetricTypes = new Map<
+    string,
+    { type_value: string; description: string }
+  >();
+
+  data.forEach(metric => {
+    if (metric.backend_type) {
+      const val = metric.backend_type.type_value;
+      uniqueBackendTypes.set(val, {
+        type_value: val.charAt(0).toUpperCase() + val.slice(1),
+      });
+    }
+    if (metric.metric_type) {
+      uniqueMetricTypes.set(metric.metric_type.type_value, {
+        type_value: metric.metric_type.type_value,
+        description: metric.metric_type.description || '',
+      });
+    }
+  });
+
+  return { behaviorsData, behaviorOptions, uniqueBackendTypes, uniqueMetricTypes };
 }
 
 export default function MetricsClientComponent({
   organizationId,
-  sessionStatus,
+  initialData,
+  initialTotalCount = 0,
 }: MetricsClientProps) {
   const searchParams = useSearchParams();
   const notifications = useNotifications();
+  const { status: sessionStatus } = useSession();
 
-  // Check if we're in assign mode (coming from behaviors page)
   const assignMode = searchParams.get('assignMode') === 'true';
 
-  // Data state
-  const [behaviors, setBehaviors] = React.useState<ApiBehavior[]>([]);
+  // Accumulate unique behaviors across page navigations for the dropdown
+  const behaviorMapRef = React.useRef(new Map<string, ApiBehavior>());
+
+  // Data state — seeded from the server-fetched first page when available
+  const [behaviors, setBehaviors] = React.useState<ApiBehavior[]>(() =>
+    initialData
+      ? deriveMetricsPageOptions(initialData, behaviorMapRef.current)
+          .behaviorsData
+      : []
+  );
   const [_behaviorsWithMetrics, setBehaviorsWithMetrics] = React.useState<
     BehaviorWithMetrics[]
   >([]);
-  const [metrics, setMetrics] = React.useState<MetricDetail[]>([]);
+  const [metrics, setMetrics] = React.useState<MetricDetail[]>(
+    initialData ?? []
+  );
+  const [totalCount, setTotalCount] = React.useState(initialTotalCount);
 
-  // Loading states
-  const [isLoading, setIsLoading] = React.useState(true);
+  // Loading / error — no initial spinner when the server already provided data
+  const [isLoading, setIsLoading] = React.useState(initialData === undefined);
   const [error, setError] = React.useState<string | null>(null);
 
   // Filter state
   const [filters, setFilters] = React.useState<FilterState>(initialFilterState);
-  const [filterOptions, setFilterOptions] =
-    React.useState<FilterOptions>(initialFilterOptions);
+  const [filterOptions, setFilterOptions] = React.useState<FilterOptions>(
+    () => {
+      if (!initialData) return initialFilterOptions;
+      const { behaviorOptions, uniqueBackendTypes, uniqueMetricTypes } =
+        deriveMetricsPageOptions(initialData, behaviorMapRef.current);
+      return {
+        ...initialFilterOptions,
+        backend:
+          uniqueBackendTypes.size > 0
+            ? Array.from(uniqueBackendTypes.values())
+            : initialFilterOptions.backend,
+        type:
+          uniqueMetricTypes.size > 0
+            ? Array.from(uniqueMetricTypes.values())
+            : initialFilterOptions.type,
+        behavior:
+          behaviorOptions.length > 0
+            ? behaviorOptions
+            : initialFilterOptions.behavior,
+      };
+    }
+  );
   const [_behaviorMetrics, setBehaviorMetrics] =
     React.useState<BehaviorMetrics>({});
 
-  // Refresh key for manual refresh
-  const [refreshKey] = React.useState(0);
+  // Pagination (owned here so filter/page changes trigger a single re-fetch)
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(25);
+  const [refreshKey, setRefreshKey] = React.useState(0);
 
-  const hasFetchedRef = React.useRef(false);
+  // Reset page to 0 whenever filters change
+  const filterFingerprint = React.useMemo(
+    () =>
+      JSON.stringify([
+        filters.search,
+        filters.backend,
+        filters.type,
+        filters.scoreType,
+        filters.metricScope,
+        filters.behavior,
+      ]),
+    [filters]
+  );
 
-  // Fetch behaviors, metrics, and filter options - using same pattern as test runs
+  // Identifies the request whose result is currently reflected in `metrics`/
+  // `totalCount`. Seeded with the server-fetched first page's signature
+  // (page 0, default size, no filters, refreshKey 0 -- exactly what `page`/
+  // `rowsPerPage`/`filterFingerprint`/`refreshKey` hold on this first render)
+  // when the server provided initial data. The fetch effect below compares
+  // against this on every run rather than consuming a one-shot flag, so it
+  // stays correct under React 18 Strict Mode's dev-only double-invoke of
+  // mount effects -- both invocations compute the same signature and both
+  // no-op, instead of the second one slipping through a "consumed" ref.
+  const loadedRequestKeyRef = React.useRef<string | null>(
+    initialData !== undefined
+      ? `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}`
+      : null
+  );
+
   React.useEffect(() => {
+    setPage(0);
+  }, [filterFingerprint]);
+
+  // Main data-fetching effect — runs on page, rowsPerPage, or filter change
+  React.useEffect(() => {
+    const requestKey = `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}`;
+    if (loadedRequestKeyRef.current === requestKey) {
+      return;
+    }
+    loadedRequestKeyRef.current = requestKey;
+
+    let cancelled = false;
+
     const fetchData = async () => {
       if (!isAuthenticated(sessionStatus)) {
         if (!isSessionLoading(sessionStatus)) {
@@ -105,112 +229,49 @@ export default function MetricsClientComponent({
         return;
       }
 
-      const isRefresh = refreshKey > 0;
-      const isFirstLoad = !hasFetchedRef.current;
-
-      if (!isRefresh && !isFirstLoad) {
-        return;
-      }
-
-      hasFetchedRef.current = true;
-
       try {
         setIsLoading(true);
         setError(null);
 
-        const behaviorClient = new BehaviorClient();
         const metricsClient = new MetricsClient();
+        const odataFilter = buildMetricODataFilter(filters);
 
-        const [behaviorsWithMetricsData, allMetricsData] = await Promise.all([
-          behaviorClient.getBehaviorsWithMetrics({
-            skip: 0,
-            limit: 100,
-            sort_by: 'created_at',
-            sort_order: 'desc',
+        const response = await metricsClient.getMetrics({
+          skip: page * rowsPerPage,
+          limit: rowsPerPage,
+          sort_by: 'created_at',
+          sort_order: 'desc',
+          $filter: odataFilter,
+          $select: METRICS_SELECT,
+          ...(filters.metricScope.length > 0 && {
+            metric_scope: filters.metricScope.join(','),
           }),
-          metricsClient.getAllMetrics({
-            sort_by: 'created_at',
-            sort_order: 'desc',
-          }),
-        ]);
-
-        // Extract behaviors from the optimized response
-        const behaviorsData = behaviorsWithMetricsData;
-
-        // Use all metrics from the dedicated metrics endpoint
-        const metricsData = allMetricsData;
-
-        // Add behavior IDs to each metric for compatibility
-        const metricsWithBehaviors = metricsData.map(metric => {
-          const behaviorIds = behaviorsWithMetricsData
-            .filter(behavior => behavior.metrics?.some(m => m.id === metric.id))
-            .map(behavior => behavior.id);
-
-          return {
-            ...metric,
-            behaviors: behaviorIds,
-          };
         });
 
-        // Set the data
-        setBehaviorsWithMetrics(behaviorsWithMetricsData);
+        if (cancelled) return;
+
+        setMetrics(response.data);
+        setTotalCount(response.pagination.totalCount);
+
+        const { behaviorsData, behaviorOptions, uniqueBackendTypes, uniqueMetricTypes } =
+          deriveMetricsPageOptions(response.data, behaviorMapRef.current);
         setBehaviors(behaviorsData);
-        setMetrics(metricsWithBehaviors as MetricDetail[]);
-
-        // Initialize behavior metrics state
-        const initialBehaviorMetrics: BehaviorMetrics = {};
-        behaviorsWithMetricsData.forEach(behavior => {
-          initialBehaviorMetrics[behavior.id] = {
-            metrics: (behavior.metrics || []) as MetricDetail[],
-            isLoading: false,
-            error: null,
-          };
-        });
-        setBehaviorMetrics(initialBehaviorMetrics);
-
-        // Extract backend types and metric types from the metrics in the response
-        const uniqueBackendTypes = new Map<string, { type_value: string }>();
-        const uniqueMetricTypes = new Map<
-          string,
-          { type_value: string; description: string }
-        >();
-
-        metricsWithBehaviors.forEach(metric => {
-          // Extract backend types from metric.backend_type
-          if (metric.backend_type) {
-            const backendTypeValue =
-              metric.backend_type.type_value.charAt(0).toUpperCase() +
-              metric.backend_type.type_value.slice(1);
-            uniqueBackendTypes.set(metric.backend_type.type_value, {
-              type_value: backendTypeValue,
-            });
-          }
-
-          // Extract metric types from metric.metric_type
-          if (metric.metric_type) {
-            uniqueMetricTypes.set(metric.metric_type.type_value, {
-              type_value: metric.metric_type.type_value,
-              description: metric.metric_type.description || '',
-            });
-          }
-        });
-
-        const backendTypes = Array.from(uniqueBackendTypes.values());
-        const metricTypes = Array.from(uniqueMetricTypes.values());
-
-        // Create behavior filter options
-        const behaviorOptions = behaviorsWithMetricsData.map(behavior => ({
-          id: behavior.id,
-          name: behavior.name,
-        }));
 
         setFilterOptions(prev => ({
           ...prev,
-          backend: backendTypes,
-          type: metricTypes,
-          behavior: behaviorOptions,
+          backend:
+            uniqueBackendTypes.size > 0
+              ? Array.from(uniqueBackendTypes.values())
+              : prev.backend,
+          type:
+            uniqueMetricTypes.size > 0
+              ? Array.from(uniqueMetricTypes.values())
+              : prev.type,
+          behavior:
+            behaviorOptions.length > 0 ? behaviorOptions : prev.behavior,
         }));
       } catch (err) {
+        if (cancelled) return;
         const errorMessage =
           err instanceof Error ? err.message : 'An error occurred';
         setError(errorMessage);
@@ -219,12 +280,41 @@ export default function MetricsClientComponent({
           autoHideDuration: 4000,
         });
       } finally {
-        setIsLoading(false);
+        if (!cancelled) {
+          setIsLoading(false);
+        }
       }
     };
 
     fetchData();
-  }, [refreshKey, notifications, sessionStatus]);
+    return () => {
+      cancelled = true;
+    };
+    // filterFingerprint captures all filter state; no need to list individual fields
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, rowsPerPage, filterFingerprint, refreshKey, sessionStatus, notifications]);
+
+  // Clamp page when the result set shrinks below the current page (e.g. after delete)
+  React.useEffect(() => {
+    if (totalCount === 0) return;
+    const lastPage = Math.max(0, Math.ceil(totalCount / rowsPerPage) - 1);
+    if (page > lastPage) {
+      setPage(lastPage);
+    }
+  }, [totalCount, rowsPerPage, page]);
+
+  const handleRefresh = React.useCallback(() => {
+    setRefreshKey(prev => prev + 1);
+  }, []);
+
+  const handlePageChange = React.useCallback((newPage: number) => {
+    setPage(newPage);
+  }, []);
+
+  const handleRowsPerPageChange = React.useCallback((newSize: number) => {
+    setRowsPerPage(newSize);
+    setPage(0);
+  }, []);
 
   return (
     <ErrorBoundary>
@@ -232,6 +322,12 @@ export default function MetricsClientComponent({
         organizationId={organizationId}
         behaviors={behaviors}
         metrics={metrics}
+        totalCount={totalCount}
+        page={page}
+        rowsPerPage={rowsPerPage}
+        onPageChange={handlePageChange}
+        onRowsPerPageChange={handleRowsPerPageChange}
+        onRefresh={handleRefresh}
         filters={filters}
         filterOptions={filterOptions}
         isLoading={isLoading}

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import * as React from 'react';
-import { useSession } from 'next-auth/react';
 import { useSearchParams } from 'next/navigation';
 import { useNotifications } from '@/components/common/NotificationContext';
 import ErrorBoundary from '@/components/common/ErrorBoundary';
@@ -19,9 +18,9 @@ import { useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
+import { usePaginatedList } from '@/hooks/usePaginatedList';
 
 import MetricsDirectoryTab, { type FilterState } from './MetricsDirectoryTab';
-import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
 
 const initialFilterState: FilterState = {
   search: '',
@@ -129,7 +128,6 @@ export default function MetricsClientComponent({
 }: MetricsClientProps) {
   const searchParams = useSearchParams();
   const notifications = useNotifications();
-  const { status: sessionStatus } = useSession();
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
     Capability.Metric.READ
   );
@@ -145,7 +143,6 @@ export default function MetricsClientComponent({
     metricTypes: new Map(),
   });
 
-  // Data state — seeded from the server-fetched first page when available
   const [behaviors, setBehaviors] = React.useState<ApiBehavior[]>(() =>
     initialData
       ? deriveMetricsPageOptions(initialData, optionMapsRef.current)
@@ -155,14 +152,6 @@ export default function MetricsClientComponent({
   const [_behaviorsWithMetrics, setBehaviorsWithMetrics] = React.useState<
     BehaviorWithMetrics[]
   >([]);
-  const [metrics, setMetrics] = React.useState<MetricDetail[]>(
-    initialData ?? []
-  );
-  const [totalCount, setTotalCount] = React.useState(initialTotalCount);
-
-  // Loading / error — no initial spinner when the server already provided data
-  const [isLoading, setIsLoading] = React.useState(initialData === undefined);
-  const [error, setError] = React.useState<string | null>(null);
 
   // Filter state
   const [filters, setFilters] = React.useState<FilterState>(initialFilterState);
@@ -182,12 +171,6 @@ export default function MetricsClientComponent({
   const [_behaviorMetrics, setBehaviorMetrics] =
     React.useState<BehaviorMetrics>({});
 
-  // Pagination (owned here so filter/page changes trigger a single re-fetch)
-  const [page, setPage] = React.useState(0);
-  const [rowsPerPage, setRowsPerPage] = React.useState(25);
-  const [refreshKey, setRefreshKey] = React.useState(0);
-
-  // Reset page to 0 whenever filters change
   const filterFingerprint = React.useMemo(
     () =>
       JSON.stringify([
@@ -201,138 +184,59 @@ export default function MetricsClientComponent({
     [filters]
   );
 
-  // Identifies the request whose result is currently reflected in `metrics`/
-  // `totalCount`. Seeded with the server-fetched first page's signature
-  // (page 0, default size, no filters, refreshKey 0 -- exactly what `page`/
-  // `rowsPerPage`/`filterFingerprint`/`refreshKey` hold on this first render)
-  // when the server provided initial data. The fetch effect below compares
-  // against this on every run rather than consuming a one-shot flag, so it
-  // stays correct under React 18 Strict Mode's dev-only double-invoke of
-  // mount effects -- both invocations compute the same signature and both
-  // no-op, instead of the second one slipping through a "consumed" ref.
-  //
-  // `sessionStatus` is part of the key so a run that lands while the session
-  // is still `loading` doesn't "claim" the same key a later `authenticated`
-  // run would use -- otherwise that later run would see a match and skip the
-  // fetch entirely, leaving the page stuck.
-  const loadedRequestKeyRef = React.useRef<string | null>(
-    initialData !== undefined
-      ? `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}`
-      : null
-  );
-
-  React.useEffect(() => {
-    setPage(0);
-  }, [filterFingerprint]);
-
-  // Main data-fetching effect — runs on page, rowsPerPage, or filter change
-  React.useEffect(() => {
-    const requestKey = `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}`;
-    if (loadedRequestKeyRef.current === requestKey) {
-      return;
-    }
-    loadedRequestKeyRef.current = requestKey;
-
-    let cancelled = false;
-
-    const fetchData = async () => {
-      if (!isAuthenticated(sessionStatus)) {
-        if (!isSessionLoading(sessionStatus)) {
-          setIsLoading(false);
-        }
-        return;
-      }
-
-      try {
-        setIsLoading(true);
-        setError(null);
-
-        const metricsClient = new MetricsClient();
-        const odataFilter = buildMetricODataFilter(filters);
-
-        const response = await metricsClient.getMetrics({
-          skip: page * rowsPerPage,
-          limit: rowsPerPage,
-          sort_by: 'created_at',
-          sort_order: 'desc',
-          $filter: odataFilter,
-          $select: METRICS_SELECT,
-          ...(filters.metricScope.length > 0 && {
-            metric_scope: filters.metricScope.join(','),
-          }),
-        });
-
-        if (cancelled) return;
-
-        setMetrics(response.data);
-        setTotalCount(response.pagination.totalCount);
-
-        const {
-          behaviorsData,
-          behaviorOptions,
-          backendTypeOptions,
-          metricTypeOptions,
-        } = deriveMetricsPageOptions(response.data, optionMapsRef.current);
-        setBehaviors(behaviorsData);
-
-        setFilterOptions(prev => ({
-          ...prev,
-          backend: backendTypeOptions,
-          type: metricTypeOptions,
-          behavior: behaviorOptions,
-        }));
-      } catch (err) {
-        if (cancelled) return;
-        const errorMessage =
-          err instanceof Error ? err.message : 'An error occurred';
-        setError(errorMessage);
-        notifications.show('Failed to load metrics data', {
-          severity: 'error',
-          autoHideDuration: 4000,
-        });
-      } finally {
-        if (!cancelled) {
-          setIsLoading(false);
-        }
-      }
-    };
-
-    fetchData();
-    return () => {
-      cancelled = true;
-    };
-    // filterFingerprint captures all filter state; no need to list individual fields
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
+  const {
+    data: metrics,
+    setData: setMetrics,
+    totalCount,
+    isLoading,
+    error,
     page,
     rowsPerPage,
+    onPageChange: handlePageChange,
+    onRowsPerPageChange: handleRowsPerPageChange,
+    refresh: handleRefresh,
+  } = usePaginatedList<MetricDetail>({
+    fetchPage: ({ skip, limit }) => {
+      const metricsClient = new MetricsClient();
+      const odataFilter = buildMetricODataFilter(filters);
+      return metricsClient.getMetrics({
+        skip,
+        limit,
+        sort_by: 'created_at',
+        sort_order: 'desc',
+        $filter: odataFilter,
+        $select: METRICS_SELECT,
+        ...(filters.metricScope.length > 0 && {
+          metric_scope: filters.metricScope.join(','),
+        }),
+      });
+    },
     filterFingerprint,
-    refreshKey,
-    sessionStatus,
-    notifications,
-  ]);
+    initialData,
+    initialTotalCount,
+    onData: data => {
+      const {
+        behaviorsData,
+        behaviorOptions,
+        backendTypeOptions,
+        metricTypeOptions,
+      } = deriveMetricsPageOptions(data, optionMapsRef.current);
+      setBehaviors(behaviorsData);
 
-  // Clamp page when the result set shrinks below the current page (e.g. after delete)
-  React.useEffect(() => {
-    if (totalCount === 0) return;
-    const lastPage = Math.max(0, Math.ceil(totalCount / rowsPerPage) - 1);
-    if (page > lastPage) {
-      setPage(lastPage);
-    }
-  }, [totalCount, rowsPerPage, page]);
-
-  const handleRefresh = React.useCallback(() => {
-    setRefreshKey(prev => prev + 1);
-  }, []);
-
-  const handlePageChange = React.useCallback((newPage: number) => {
-    setPage(newPage);
-  }, []);
-
-  const handleRowsPerPageChange = React.useCallback((newSize: number) => {
-    setRowsPerPage(newSize);
-    setPage(0);
-  }, []);
+      setFilterOptions(prev => ({
+        ...prev,
+        backend: backendTypeOptions,
+        type: metricTypeOptions,
+        behavior: behaviorOptions,
+      }));
+    },
+    onError: () => {
+      notifications.show('Failed to load metrics data', {
+        severity: 'error',
+        autoHideDuration: 4000,
+      });
+    },
+  });
 
   if (permsLoading) return <PageLoadingState />;
   if (!canRead) return <AccessDenied resource="metrics" />;

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -13,9 +13,8 @@ import type {
 import type { UUID } from 'crypto';
 import { TEST_TYPES } from '@/constants/test-types';
 import { buildMetricODataFilter } from '@/utils/odata-filter';
-import { METRICS_SELECT } from './metrics-constants';
+import { METRICS_SELECT, METRICS_READ_CAPABILITY } from './metrics-constants';
 import { useCanWithStatus } from '@/components/common/Can';
-import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
 import { usePaginatedList } from '@/hooks/usePaginatedList';
@@ -129,7 +128,7 @@ export default function MetricsClientComponent({
   const searchParams = useSearchParams();
   const notifications = useNotifications();
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
-    Capability.Metric.READ
+    METRICS_READ_CAPABILITY
   );
 
   const assignMode = searchParams.get('assignMode') === 'true';

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -85,7 +85,10 @@ interface MetricsOptionMaps {
  * dropdown) contain only that value, making every other option vanish from
  * the filter UI the moment it's applied.
  */
-function deriveMetricsPageOptions(data: MetricDetail[], maps: MetricsOptionMaps) {
+function deriveMetricsPageOptions(
+  data: MetricDetail[],
+  maps: MetricsOptionMaps
+) {
   data.forEach(metric => {
     metric.behaviors?.forEach(behavior => {
       if (behavior && typeof behavior !== 'string' && behavior.id) {
@@ -145,7 +148,8 @@ export default function MetricsClientComponent({
   // Data state — seeded from the server-fetched first page when available
   const [behaviors, setBehaviors] = React.useState<ApiBehavior[]>(() =>
     initialData
-      ? deriveMetricsPageOptions(initialData, optionMapsRef.current).behaviorsData
+      ? deriveMetricsPageOptions(initialData, optionMapsRef.current)
+          .behaviorsData
       : []
   );
   const [_behaviorsWithMetrics, setBehaviorsWithMetrics] = React.useState<
@@ -263,8 +267,12 @@ export default function MetricsClientComponent({
         setMetrics(response.data);
         setTotalCount(response.pagination.totalCount);
 
-        const { behaviorsData, behaviorOptions, backendTypeOptions, metricTypeOptions } =
-          deriveMetricsPageOptions(response.data, optionMapsRef.current);
+        const {
+          behaviorsData,
+          behaviorOptions,
+          backendTypeOptions,
+          metricTypeOptions,
+        } = deriveMetricsPageOptions(response.data, optionMapsRef.current);
         setBehaviors(behaviorsData);
 
         setFilterOptions(prev => ({
@@ -295,7 +303,14 @@ export default function MetricsClientComponent({
     };
     // filterFingerprint captures all filter state; no need to list individual fields
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page, rowsPerPage, filterFingerprint, refreshKey, sessionStatus, notifications]);
+  }, [
+    page,
+    rowsPerPage,
+    filterFingerprint,
+    refreshKey,
+    sessionStatus,
+    notifications,
+  ]);
 
   // Clamp page when the result set shrinks below the current page (e.g. after delete)
   React.useEffect(() => {

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -214,6 +214,7 @@ export default function MetricsClientComponent({
     filterFingerprint,
     initialData,
     initialTotalCount,
+    enabled: !permsLoading && canRead,
     onData: data => {
       const {
         behaviorsData,

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -15,6 +15,10 @@ import type { UUID } from 'crypto';
 import { TEST_TYPES } from '@/constants/test-types';
 import { buildMetricODataFilter } from '@/utils/odata-filter';
 import { METRICS_SELECT } from './metrics-constants';
+import { useCanWithStatus } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+import AccessDenied from '@/components/common/AccessDenied';
+import PageLoadingState from '@/components/common/PageLoadingState';
 
 import MetricsDirectoryTab, { type FilterState } from './MetricsDirectoryTab';
 import { isAuthenticated, isSessionLoading } from '@/hooks/useIsAuthenticated';
@@ -123,6 +127,9 @@ export default function MetricsClientComponent({
   const searchParams = useSearchParams();
   const notifications = useNotifications();
   const { status: sessionStatus } = useSession();
+  const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
+    Capability.Metric.READ
+  );
 
   const assignMode = searchParams.get('assignMode') === 'true';
 
@@ -199,9 +206,14 @@ export default function MetricsClientComponent({
   // stays correct under React 18 Strict Mode's dev-only double-invoke of
   // mount effects -- both invocations compute the same signature and both
   // no-op, instead of the second one slipping through a "consumed" ref.
+  //
+  // `sessionStatus` is part of the key so a run that lands while the session
+  // is still `loading` doesn't "claim" the same key a later `authenticated`
+  // run would use -- otherwise that later run would see a match and skip the
+  // fetch entirely, leaving the page stuck.
   const loadedRequestKeyRef = React.useRef<string | null>(
     initialData !== undefined
-      ? `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}`
+      ? `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}`
       : null
   );
 
@@ -211,7 +223,7 @@ export default function MetricsClientComponent({
 
   // Main data-fetching effect — runs on page, rowsPerPage, or filter change
   React.useEffect(() => {
-    const requestKey = `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}`;
+    const requestKey = `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}`;
     if (loadedRequestKeyRef.current === requestKey) {
       return;
     }
@@ -306,6 +318,9 @@ export default function MetricsClientComponent({
     setRowsPerPage(newSize);
     setPage(0);
   }, []);
+
+  if (permsLoading) return <PageLoadingState />;
+  if (!canRead) return <AccessDenied resource="metrics" />;
 
   return (
     <ErrorBoundary>

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
+import LinearProgress from '@mui/material/LinearProgress';
 import TablePagination from '@mui/material/TablePagination';
 import GridToolbar, {
   PrimarySegmentedPills,
@@ -24,10 +25,7 @@ import MetricCard from './MetricCard';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { MetricsClient } from '@/utils/api-client/metrics-client';
-import {
-  MetricDetail,
-  MetricScope,
-} from '@/utils/api-client/interfaces/metric';
+import { MetricDetail } from '@/utils/api-client/interfaces/metric';
 import type {
   Behavior as ApiBehavior,
   BehaviorWithMetrics,
@@ -67,6 +65,12 @@ interface MetricsDirectoryTabProps {
   organizationId: UUID;
   behaviors: ApiBehavior[];
   metrics: MetricDetail[];
+  totalCount: number;
+  page: number;
+  rowsPerPage: number;
+  onPageChange: (page: number) => void;
+  onRowsPerPageChange: (size: number) => void;
+  onRefresh: () => void;
   filters: FilterState;
   filterOptions: FilterOptions;
   isLoading: boolean;
@@ -77,7 +81,7 @@ interface MetricsDirectoryTabProps {
   setBehaviorsWithMetrics: React.Dispatch<
     React.SetStateAction<BehaviorWithMetrics[]>
   >;
-  assignMode?: boolean; // Whether we're in assign mode (coming from behaviors page)
+  assignMode?: boolean;
 }
 
 // Add type guard function
@@ -96,6 +100,12 @@ export default function MetricsDirectoryTab({
   organizationId: _organizationId,
   behaviors,
   metrics,
+  totalCount,
+  page,
+  rowsPerPage,
+  onPageChange,
+  onRowsPerPageChange,
+  onRefresh,
   filters,
   filterOptions,
   isLoading,
@@ -127,14 +137,10 @@ export default function MetricsDirectoryTab({
     React.useState<{ id: string; name: string } | null>(null);
   const [isDeletingMetric, setIsDeletingMetric] = React.useState(false);
 
-  // Pagination state
-  const [page, setPage] = React.useState(0);
-  const [rowsPerPage, setRowsPerPage] = React.useState(25);
-
   // Advanced filters drawer state
   const [filterDrawerOpen, setFilterDrawerOpen] = React.useState(false);
 
-  // Filter handlers
+  // Filter handlers — parent resets page to 0 when filters change
   const handleFilterChange = (
     filterType: keyof FilterState,
     value: string | string[]
@@ -143,7 +149,6 @@ export default function MetricsDirectoryTab({
       ...prev,
       [filterType]: value,
     }));
-    setPage(0);
   };
 
   // Count active advanced filters
@@ -155,84 +160,12 @@ export default function MetricsDirectoryTab({
     filters.metricScope.length +
     (behaviorStr.trim() !== '' ? 1 : 0);
 
+  // True empty = server returned zero results and no filters are active
   const isTrueEmpty =
-    metrics.length === 0 &&
+    totalCount === 0 &&
     !filters.search &&
     filters.backend.length === 0 &&
     activeAdvancedFilterCount === 0;
-
-  // Filter metrics based on search and filter criteria
-  const getFilteredMetrics = () => {
-    return metrics.filter(metric => {
-      // Search filter
-      const searchMatch =
-        !filters.search ||
-        (metric.name || '')
-          .toLowerCase()
-          .includes(filters.search.toLowerCase()) ||
-        (metric.description || '')
-          .toLowerCase()
-          .includes(filters.search.toLowerCase()) ||
-        (metric.metric_type?.type_value || '')
-          .toLowerCase()
-          .includes(filters.search.toLowerCase());
-
-      // Backend filter
-      const backendMatch =
-        filters.backend.length === 0 ||
-        (metric.backend_type &&
-          filters.backend.includes(
-            metric.backend_type.type_value.toLowerCase()
-          ));
-
-      // Type filter
-      const typeMatch =
-        filters.type.length === 0 ||
-        (metric.metric_type?.type_value &&
-          filters.type.includes(metric.metric_type.type_value));
-
-      // Score type filter
-      const scoreTypeMatch =
-        !filters.scoreType ||
-        filters.scoreType.length === 0 ||
-        (metric.score_type && filters.scoreType.includes(metric.score_type));
-
-      // Metric scope filter
-      const metricScopeMatch =
-        !filters.metricScope ||
-        filters.metricScope.length === 0 ||
-        (metric.metric_scope &&
-          filters.metricScope.some(scope =>
-            metric.metric_scope?.includes(scope as MetricScope)
-          ));
-
-      // Behavior filter — text match against assigned behavior names
-      const behaviorFilter =
-        typeof filters.behavior === 'string' ? filters.behavior : '';
-      const metricBehaviorIds = Array.isArray(metric.behaviors)
-        ? metric.behaviors.map((b: string | { id?: string }) =>
-            typeof b === 'string' ? b : b.id
-          )
-        : [];
-      const metricBehaviorNames = behaviors
-        .filter(b => metricBehaviorIds.includes(b.id as string))
-        .map(b => b.name || '');
-      const behaviorMatch =
-        behaviorFilter.trim() === '' ||
-        metricBehaviorNames.some(
-          name => name.toLowerCase() === behaviorFilter.toLowerCase()
-        );
-
-      return (
-        searchMatch &&
-        backendMatch &&
-        typeMatch &&
-        scoreTypeMatch &&
-        metricScopeMatch &&
-        behaviorMatch
-      );
-    });
-  };
 
   // Function to assign a metric to a behavior
   const handleAssignMetricToBehavior = async (
@@ -423,10 +356,7 @@ export default function MetricsDirectoryTab({
       const metricClient = new MetricsClient();
       await metricClient.deleteMetric(metricToDeleteCompletely.id as UUID);
 
-      // Remove the metric from local state
-      setMetrics(prevMetrics =>
-        prevMetrics.filter(m => m.id !== metricToDeleteCompletely.id)
-      );
+      onRefresh();
 
       notifications.show('Metric deleted successfully', {
         severity: 'success',
@@ -449,21 +379,12 @@ export default function MetricsDirectoryTab({
     setMetricToDeleteCompletely(null);
   };
 
-  const filteredMetrics = getFilteredMetrics();
   const activeBehaviors = behaviors.filter(b => b.name && b.name.trim() !== '');
 
-  // Clamp page when list shrinks (e.g. after delete/duplicate)
-  React.useEffect(() => {
-    const lastPage = Math.max(
-      0,
-      Math.ceil(filteredMetrics.length / rowsPerPage) - 1
-    );
-    if (page > lastPage) {
-      setPage(lastPage);
-    }
-  }, [filteredMetrics.length, rowsPerPage, page]);
+  // First load — no data at all yet, show a full-page spinner
+  const isInitialLoad = isLoading && metrics.length === 0 && totalCount === 0;
 
-  if (isLoading) {
+  if (isInitialLoad) {
     return (
       <PageLayout title="Metrics" breadcrumbs={[]}>
         <Box
@@ -484,7 +405,7 @@ export default function MetricsDirectoryTab({
     );
   }
 
-  if (error) {
+  if (error && metrics.length === 0) {
     return (
       <PageLayout title="Metrics" breadcrumbs={[]}>
         <Box sx={{ display: 'flex', justifyContent: 'center', p: 4 }}>
@@ -606,26 +527,38 @@ export default function MetricsDirectoryTab({
                 metricScope: drawerFilters.metricScope,
                 behavior: drawerFilters.behavior,
               }));
-              setPage(0);
+            }}
+          />
+
+          {/* Subtle loading indicator for subsequent fetches — always
+              mounted so its height never shifts the grid below */}
+          <LinearProgress
+            sx={{
+              mb: 1,
+              borderRadius: theme => theme.shape.borderRadius,
+              visibility: isLoading ? 'visible' : 'hidden',
             }}
           />
 
           {/* Metrics grid */}
           <Box
-            sx={{
+            sx={theme => ({
               display: 'grid',
               gridTemplateColumns: {
                 xs: '1fr',
                 sm: '1fr 1fr',
                 md: 'repeat(3, 1fr)',
               },
-              gap: '24px',
+              gap: theme.spacing(3),
               mb: 4,
-            }}
+              opacity: isLoading ? theme.palette.action.disabledOpacity : 1,
+              pointerEvents: isLoading ? 'none' : 'auto',
+              transition: theme.transitions.create('opacity', {
+                duration: theme.transitions.duration.short,
+              }),
+            })}
           >
-            {filteredMetrics
-              .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-              .map(metric => {
+            {metrics.map(metric => {
                 const assignedBehaviors = activeBehaviors.filter(b => {
                   if (!Array.isArray(metric.behaviors)) return false;
                   // Check if behaviors is an array of strings (UUIDs) or BehaviorReference objects
@@ -679,16 +612,15 @@ export default function MetricsDirectoryTab({
                 );
               })}
           </Box>
-          {filteredMetrics.length > 0 && (
+          {totalCount > 0 && (
             <TablePagination
               component="div"
-              count={filteredMetrics.length}
+              count={totalCount}
               page={page}
-              onPageChange={(_event, newPage) => setPage(newPage)}
+              onPageChange={(_event, newPage) => onPageChange(newPage)}
               rowsPerPage={rowsPerPage}
               onRowsPerPageChange={event => {
-                setRowsPerPage(parseInt(event.target.value, 10));
-                setPage(0);
+                onRowsPerPageChange(parseInt(event.target.value, 10));
               }}
               rowsPerPageOptions={[25, 50, 100]}
               labelRowsPerPage="Metrics per page:"

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
@@ -551,11 +551,6 @@ export default function MetricsDirectoryTab({
               },
               gap: theme.spacing(3),
               mb: 4,
-              opacity: isLoading ? theme.palette.action.disabledOpacity : 1,
-              pointerEvents: isLoading ? 'none' : 'auto',
-              transition: theme.transitions.create('opacity', {
-                duration: theme.transitions.duration.short,
-              }),
             })}
           >
             {metrics.map(metric => {

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
@@ -554,58 +554,57 @@ export default function MetricsDirectoryTab({
             })}
           >
             {metrics.map(metric => {
-                const assignedBehaviors = activeBehaviors.filter(b => {
-                  if (!Array.isArray(metric.behaviors)) return false;
-                  // Check if behaviors is an array of strings (UUIDs) or BehaviorReference objects
-                  const behaviorIds = metric.behaviors.map(behavior =>
-                    typeof behavior === 'string' ? behavior : behavior.id
-                  );
-                  return behaviorIds.includes(b.id as string);
-                });
-                const behaviorNames = assignedBehaviors.map(
-                  b => b.name || 'Unnamed Behavior'
+              const assignedBehaviors = activeBehaviors.filter(b => {
+                if (!Array.isArray(metric.behaviors)) return false;
+                // Check if behaviors is an array of strings (UUIDs) or BehaviorReference objects
+                const behaviorIds = metric.behaviors.map(behavior =>
+                  typeof behavior === 'string' ? behavior : behavior.id
                 );
+                return behaviorIds.includes(b.id as string);
+              });
+              const behaviorNames = assignedBehaviors.map(
+                b => b.name || 'Unnamed Behavior'
+              );
 
-                const isCustomMetric =
-                  metric.backend_type?.type_value?.toLowerCase() === 'custom';
+              const isCustomMetric =
+                metric.backend_type?.type_value?.toLowerCase() === 'custom';
 
-                return (
-                  <MetricCard
-                    key={metric.id}
-                    type={
-                      isValidMetricType(metric.metric_type?.type_value)
-                        ? metric.metric_type.type_value
+              return (
+                <MetricCard
+                  key={metric.id}
+                  type={
+                    isValidMetricType(metric.metric_type?.type_value)
+                      ? metric.metric_type.type_value
+                      : undefined
+                  }
+                  title={metric.name}
+                  description={metric.description}
+                  backend={metric.backend_type?.type_value}
+                  metricType={metric.metric_type?.type_value}
+                  scoreType={metric.score_type}
+                  metricScope={metric.metric_scope}
+                  usedIn={behaviorNames}
+                  showUsage={true}
+                  onClick={
+                    assignMode
+                      ? () => {
+                          setSelectedMetric(metric);
+                          setAssignDialogOpen(true);
+                        }
+                      : isCustomMetric
+                        ? () => router.push(`/metrics/${metric.id}`)
                         : undefined
-                    }
-                    title={metric.name}
-                    description={metric.description}
-                    backend={metric.backend_type?.type_value}
-                    metricType={metric.metric_type?.type_value}
-                    scoreType={metric.score_type}
-                    metricScope={metric.metric_scope}
-                    usedIn={behaviorNames}
-                    showUsage={true}
-                    onClick={
-                      assignMode
-                        ? () => {
-                            setSelectedMetric(metric);
-                            setAssignDialogOpen(true);
-                          }
-                        : isCustomMetric
-                          ? () => router.push(`/metrics/${metric.id}`)
-                          : undefined
-                    }
-                    onDelete={
-                      canDelete &&
-                      assignedBehaviors.length === 0 &&
-                      metric.backend_type?.type_value?.toLowerCase() ===
-                        'custom'
-                        ? () => handleDeleteMetric(metric.id, metric.name)
-                        : undefined
-                    }
-                  />
-                );
-              })}
+                  }
+                  onDelete={
+                    canDelete &&
+                    assignedBehaviors.length === 0 &&
+                    metric.backend_type?.type_value?.toLowerCase() === 'custom'
+                      ? () => handleDeleteMetric(metric.id, metric.name)
+                      : undefined
+                  }
+                />
+              );
+            })}
           </Box>
           {totalCount > 0 && (
             <TablePagination

--- a/apps/frontend/src/app/(protected)/metrics/components/metrics-constants.ts
+++ b/apps/frontend/src/app/(protected)/metrics/components/metrics-constants.ts
@@ -1,3 +1,5 @@
+import { Capability } from '@/constants/capabilities';
+
 /**
  * OData $select expression for the metrics directory list -- trims the
  * response to only the fields the grid/filters render. Shared between the
@@ -9,3 +11,11 @@ export const METRICS_SELECT =
 
 /** Default page size for the metrics directory grid. */
 export const DEFAULT_METRICS_PAGE_SIZE = 25;
+
+/**
+ * Read capability gating the metrics directory. Shared between the server
+ * component's `prefetchList` call and the client component's
+ * `useCanWithStatus` check so the two gates can't drift onto different
+ * capability values.
+ */
+export const METRICS_READ_CAPABILITY = Capability.Metric.READ;

--- a/apps/frontend/src/app/(protected)/metrics/components/metrics-constants.ts
+++ b/apps/frontend/src/app/(protected)/metrics/components/metrics-constants.ts
@@ -1,5 +1,3 @@
-import { Capability } from '@/constants/capabilities';
-
 /**
  * OData $select expression for the metrics directory list -- trims the
  * response to only the fields the grid/filters render. Shared between the
@@ -11,11 +9,3 @@ export const METRICS_SELECT =
 
 /** Default page size for the metrics directory grid. */
 export const DEFAULT_METRICS_PAGE_SIZE = 25;
-
-/**
- * Read capability gating the metrics directory. Shared between the server
- * component's `prefetchList` call and the client component's
- * `useCanWithStatus` check so the two gates can't drift onto different
- * capability values.
- */
-export const METRICS_READ_CAPABILITY = Capability.Metric.READ;

--- a/apps/frontend/src/app/(protected)/metrics/components/metrics-constants.ts
+++ b/apps/frontend/src/app/(protected)/metrics/components/metrics-constants.ts
@@ -1,0 +1,11 @@
+/**
+ * OData $select expression for the metrics directory list -- trims the
+ * response to only the fields the grid/filters render. Shared between the
+ * server component (initial page fetch) and the client component
+ * (subsequent pagination/filter fetches) so both request the same shape.
+ */
+export const METRICS_SELECT =
+  'name,description,score_type,metric_scope,metric_type,backend_type,behaviors';
+
+/** Default page size for the metrics directory grid. */
+export const DEFAULT_METRICS_PAGE_SIZE = 25;

--- a/apps/frontend/src/app/(protected)/metrics/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/page.tsx
@@ -1,5 +1,7 @@
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { hasServerCapability } from '@/utils/server-permissions';
+import { Capability } from '@/constants/capabilities';
 import MetricsClientComponent from './components/MetricsClient';
 import type { UUID } from 'crypto';
 import { METRICS_SELECT, DEFAULT_METRICS_PAGE_SIZE } from './components/metrics-constants';
@@ -7,9 +9,13 @@ import { METRICS_SELECT, DEFAULT_METRICS_PAGE_SIZE } from './components/metrics-
 /**
  * Server component: fetches the first page of metrics before rendering so
  * the page arrives with content already in place -- no client-side spinner
- * on first load. Permission gating (`useCan`) stays client-side since it
- * depends on the `PermissionsContext` seeded by `(protected)/layout.tsx`,
- * which resolves synchronously on first render.
+ * on first load.
+ *
+ * The `Metric.READ` check runs here, server-side, before the prefetch: it's
+ * not just a render gate, it decides whether metrics data is fetched and
+ * embedded in the response at all. `MetricsClientComponent` still resolves
+ * `useCan` client-side too, so a user whose permissions change mid-session
+ * gets a consistent client-side AccessDenied without a full reload.
  */
 export default async function MetricsPage() {
   const session = await auth();
@@ -19,24 +25,27 @@ export default async function MetricsPage() {
   }
 
   const organizationId = session.user?.organization_id as UUID;
+  const canRead = await hasServerCapability(Capability.Metric.READ);
 
   const client = (await createServerApiFactory()).getMetricsClient();
 
   let initialData;
   let initialTotalCount = 0;
-  try {
-    const response = await client.getMetrics({
-      skip: 0,
-      limit: DEFAULT_METRICS_PAGE_SIZE,
-      sort_by: 'created_at',
-      sort_order: 'desc',
-      $select: METRICS_SELECT,
-    });
-    initialData = response.data;
-    initialTotalCount = response.pagination.totalCount;
-  } catch {
-    // Fall back to client-side fetching on the initial mount.
-    initialData = undefined;
+  if (canRead) {
+    try {
+      const response = await client.getMetrics({
+        skip: 0,
+        limit: DEFAULT_METRICS_PAGE_SIZE,
+        sort_by: 'created_at',
+        sort_order: 'desc',
+        $select: METRICS_SELECT,
+      });
+      initialData = response.data;
+      initialTotalCount = response.pagination.totalCount;
+    } catch {
+      // Fall back to client-side fetching on the initial mount.
+      initialData = undefined;
+    }
   }
 
   const serializedInitialData = initialData

--- a/apps/frontend/src/app/(protected)/metrics/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/page.tsx
@@ -1,32 +1,53 @@
-'use client';
-
-import * as React from 'react';
-import { useSession } from 'next-auth/react';
+import { auth } from '@/auth';
+import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import MetricsClientComponent from './components/MetricsClient';
 import type { UUID } from 'crypto';
-import { useCanWithStatus } from '@/components/common/Can';
-import { Capability } from '@/constants/capabilities';
-import AccessDenied from '@/components/common/AccessDenied';
-import PageLoadingState from '@/components/common/PageLoadingState';
+import { METRICS_SELECT, DEFAULT_METRICS_PAGE_SIZE } from './components/metrics-constants';
 
-export default function MetricsPage() {
-  const { data: session, status } = useSession();
-  const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
-    Capability.Metric.READ
-  );
+/**
+ * Server component: fetches the first page of metrics before rendering so
+ * the page arrives with content already in place -- no client-side spinner
+ * on first load. Permission gating (`useCan`) stays client-side since it
+ * depends on the `PermissionsContext` seeded by `(protected)/layout.tsx`,
+ * which resolves synchronously on first render.
+ */
+export default async function MetricsPage() {
+  const session = await auth();
 
-  const organizationId = React.useMemo(
-    () => session?.user?.organization_id as UUID,
-    [session?.user?.organization_id]
-  );
+  if (!session || session.error) {
+    throw new Error('Authentication required');
+  }
 
-  if (permsLoading) return <PageLoadingState />;
-  if (!canRead) return <AccessDenied resource="metrics" />;
+  const organizationId = session.user?.organization_id as UUID;
+
+  const client = (await createServerApiFactory()).getMetricsClient();
+
+  let initialData;
+  let initialTotalCount = 0;
+  try {
+    const response = await client.getMetrics({
+      skip: 0,
+      limit: DEFAULT_METRICS_PAGE_SIZE,
+      sort_by: 'created_at',
+      sort_order: 'desc',
+      $select: METRICS_SELECT,
+    });
+    initialData = response.data;
+    initialTotalCount = response.pagination.totalCount;
+  } catch {
+    // Fall back to client-side fetching on the initial mount.
+    initialData = undefined;
+  }
+
+  const serializedInitialData = initialData
+    ? JSON.parse(JSON.stringify(initialData))
+    : undefined;
 
   return (
     <MetricsClientComponent
       organizationId={organizationId}
-      sessionStatus={status}
+      initialData={serializedInitialData}
+      initialTotalCount={initialTotalCount}
     />
   );
 }

--- a/apps/frontend/src/app/(protected)/metrics/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/page.tsx
@@ -1,6 +1,6 @@
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
-import { hasServerCapability } from '@/utils/server-permissions';
+import { prefetchList } from '@/utils/server-prefetch';
 import { Capability } from '@/constants/capabilities';
 import MetricsClientComponent from './components/MetricsClient';
 import type { UUID } from 'crypto';
@@ -12,13 +12,7 @@ import {
 /**
  * Server component: fetches the first page of metrics before rendering so
  * the page arrives with content already in place -- no client-side spinner
- * on first load.
- *
- * The `Metric.READ` check runs here, server-side, before the prefetch: it's
- * not just a render gate, it decides whether metrics data is fetched and
- * embedded in the response at all. `MetricsClientComponent` still resolves
- * `useCan` client-side too, so a user whose permissions change mid-session
- * gets a consistent client-side AccessDenied without a full reload.
+ * on first load. See `prefetchList` for the permission-gating rationale.
  */
 export default async function MetricsPage() {
   const session = await auth();
@@ -28,37 +22,24 @@ export default async function MetricsPage() {
   }
 
   const organizationId = session.user?.organization_id as UUID;
-  const canRead = await hasServerCapability(Capability.Metric.READ);
-
   const client = (await createServerApiFactory()).getMetricsClient();
 
-  let initialData;
-  let initialTotalCount = 0;
-  if (canRead) {
-    try {
-      const response = await client.getMetrics({
+  const { initialData, initialTotalCount } = await prefetchList(
+    Capability.Metric.READ,
+    () =>
+      client.getMetrics({
         skip: 0,
         limit: DEFAULT_METRICS_PAGE_SIZE,
         sort_by: 'created_at',
         sort_order: 'desc',
         $select: METRICS_SELECT,
-      });
-      initialData = response.data;
-      initialTotalCount = response.pagination.totalCount;
-    } catch {
-      // Fall back to client-side fetching on the initial mount.
-      initialData = undefined;
-    }
-  }
-
-  const serializedInitialData = initialData
-    ? JSON.parse(JSON.stringify(initialData))
-    : undefined;
+      })
+  );
 
   return (
     <MetricsClientComponent
       organizationId={organizationId}
-      initialData={serializedInitialData}
+      initialData={initialData}
       initialTotalCount={initialTotalCount}
     />
   );

--- a/apps/frontend/src/app/(protected)/metrics/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/page.tsx
@@ -1,12 +1,12 @@
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
+import { Capability } from '@/constants/capabilities';
 import MetricsClientComponent from './components/MetricsClient';
 import type { UUID } from 'crypto';
 import {
   METRICS_SELECT,
   DEFAULT_METRICS_PAGE_SIZE,
-  METRICS_READ_CAPABILITY,
 } from './components/metrics-constants';
 
 /**
@@ -25,7 +25,7 @@ export default async function MetricsPage() {
   const client = (await createServerApiFactory()).getMetricsClient();
 
   const { initialData, initialTotalCount } = await prefetchList(
-    METRICS_READ_CAPABILITY,
+    Capability.Metric.READ,
     () =>
       client.getMetrics({
         skip: 0,

--- a/apps/frontend/src/app/(protected)/metrics/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/page.tsx
@@ -4,7 +4,10 @@ import { hasServerCapability } from '@/utils/server-permissions';
 import { Capability } from '@/constants/capabilities';
 import MetricsClientComponent from './components/MetricsClient';
 import type { UUID } from 'crypto';
-import { METRICS_SELECT, DEFAULT_METRICS_PAGE_SIZE } from './components/metrics-constants';
+import {
+  METRICS_SELECT,
+  DEFAULT_METRICS_PAGE_SIZE,
+} from './components/metrics-constants';
 
 /**
  * Server component: fetches the first page of metrics before rendering so

--- a/apps/frontend/src/app/(protected)/metrics/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/page.tsx
@@ -1,12 +1,12 @@
 import { auth } from '@/auth';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { prefetchList } from '@/utils/server-prefetch';
-import { Capability } from '@/constants/capabilities';
 import MetricsClientComponent from './components/MetricsClient';
 import type { UUID } from 'crypto';
 import {
   METRICS_SELECT,
   DEFAULT_METRICS_PAGE_SIZE,
+  METRICS_READ_CAPABILITY,
 } from './components/metrics-constants';
 
 /**
@@ -25,7 +25,7 @@ export default async function MetricsPage() {
   const client = (await createServerApiFactory()).getMetricsClient();
 
   const { initialData, initialTotalCount } = await prefetchList(
-    Capability.Metric.READ,
+    METRICS_READ_CAPABILITY,
     () =>
       client.getMetrics({
         skip: 0,

--- a/apps/frontend/src/hooks/usePaginatedList.ts
+++ b/apps/frontend/src/hooks/usePaginatedList.ts
@@ -1,0 +1,184 @@
+'use client';
+
+import * as React from 'react';
+import { useSession } from 'next-auth/react';
+import type { PaginatedResponse } from '@/utils/api-client/interfaces/pagination';
+import { isAuthenticated, isSessionLoading } from './useIsAuthenticated';
+
+export interface UsePaginatedListOptions<T> {
+  /** Fetches one page for the given offset/size. Should close over any active filters. */
+  fetchPage: (params: {
+    skip: number;
+    limit: number;
+  }) => Promise<PaginatedResponse<T>>;
+  /**
+   * Stable string capturing all active filter state. Changing it resets the
+   * page to 0 and triggers a re-fetch, same as changing `page`/`rowsPerPage`.
+   */
+  filterFingerprint: string;
+  /** Server-fetched first page, when present skips the initial client fetch. */
+  initialData?: T[];
+  initialTotalCount?: number;
+  defaultPageSize?: number;
+  /**
+   * Called with each successful page's data, in addition to `data` being
+   * updated. Use this to accumulate filter-dropdown options or other
+   * derived state that shouldn't reset every fetch.
+   */
+  onData?: (data: T[]) => void;
+  /** Called with the raw error on fetch failure, e.g. to show a toast. */
+  onError?: (error: unknown) => void;
+}
+
+export interface UsePaginatedListResult<T> {
+  data: T[];
+  setData: React.Dispatch<React.SetStateAction<T[]>>;
+  totalCount: number;
+  /** Escape hatch for optimistic create/delete: adjust the count shown by pagination controls without a re-fetch. */
+  setTotalCount: React.Dispatch<React.SetStateAction<number>>;
+  isLoading: boolean;
+  error: string | null;
+  page: number;
+  rowsPerPage: number;
+  onPageChange: (page: number) => void;
+  onRowsPerPageChange: (size: number) => void;
+  refresh: () => void;
+}
+
+/**
+ * Owns the client-side half of the server-pagination pattern shared by
+ * directory-style pages (metrics, behaviors, ...): page/rowsPerPage state,
+ * resetting to page 0 on filter change, clamping the page when the result
+ * set shrinks (e.g. after a delete), and re-fetching on page/filter/refresh
+ * changes.
+ *
+ * Fetches are keyed by a request signature (page, rowsPerPage,
+ * filterFingerprint, refreshKey, sessionStatus) rather than a one-shot
+ * "skip the first fetch" flag, so it stays correct under React 18 Strict
+ * Mode's dev-only double-invoke of mount effects: both invocations compute
+ * the same signature and both no-op, instead of the second slipping through
+ * a "consumed" ref. `sessionStatus` is part of the key so a run that lands
+ * while the session is still `loading` doesn't "claim" the same key a later
+ * `authenticated` run would use.
+ */
+export function usePaginatedList<T>({
+  fetchPage,
+  filterFingerprint,
+  initialData,
+  initialTotalCount = 0,
+  defaultPageSize = 25,
+  onData,
+  onError,
+}: UsePaginatedListOptions<T>): UsePaginatedListResult<T> {
+  const { status: sessionStatus } = useSession();
+
+  const [data, setData] = React.useState<T[]>(initialData ?? []);
+  const [totalCount, setTotalCount] = React.useState(initialTotalCount);
+  const [isLoading, setIsLoading] = React.useState(initialData === undefined);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(defaultPageSize);
+  const [refreshKey, setRefreshKey] = React.useState(0);
+
+  const loadedRequestKeyRef = React.useRef<string | null>(
+    initialData !== undefined
+      ? `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}`
+      : null
+  );
+
+  React.useEffect(() => {
+    setPage(0);
+  }, [filterFingerprint]);
+
+  React.useEffect(() => {
+    const requestKey = `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}`;
+    if (loadedRequestKeyRef.current === requestKey) {
+      return;
+    }
+    loadedRequestKeyRef.current = requestKey;
+
+    let cancelled = false;
+
+    const run = async () => {
+      if (!isAuthenticated(sessionStatus)) {
+        if (!isSessionLoading(sessionStatus)) {
+          setIsLoading(false);
+        }
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const response = await fetchPage({
+          skip: page * rowsPerPage,
+          limit: rowsPerPage,
+        });
+
+        if (cancelled) return;
+
+        setData(response.data);
+        setTotalCount(response.pagination.totalCount);
+        onData?.(response.data);
+      } catch (err) {
+        if (cancelled) return;
+        const message =
+          err instanceof Error ? err.message : 'An error occurred';
+        setError(message);
+        onError?.(err);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    run();
+    return () => {
+      cancelled = true;
+    };
+    // fetchPage/onData/onError are recreated every render; the request-key
+    // check above (not this array) is what governs whether a fetch actually
+    // fires, so omitting them here is intentional -- adding them would only
+    // cause spurious re-runs on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [page, rowsPerPage, filterFingerprint, refreshKey, sessionStatus]);
+
+  // Clamp page when the result set shrinks below the current page (e.g. after delete)
+  React.useEffect(() => {
+    if (totalCount === 0) return;
+    const lastPage = Math.max(0, Math.ceil(totalCount / rowsPerPage) - 1);
+    if (page > lastPage) {
+      setPage(lastPage);
+    }
+  }, [totalCount, rowsPerPage, page]);
+
+  const refresh = React.useCallback(() => {
+    setRefreshKey(prev => prev + 1);
+  }, []);
+
+  const onPageChange = React.useCallback((newPage: number) => {
+    setPage(newPage);
+  }, []);
+
+  const onRowsPerPageChange = React.useCallback((newSize: number) => {
+    setRowsPerPage(newSize);
+    setPage(0);
+  }, []);
+
+  return {
+    data,
+    setData,
+    totalCount,
+    setTotalCount,
+    isLoading,
+    error,
+    page,
+    rowsPerPage,
+    onPageChange,
+    onRowsPerPageChange,
+    refresh,
+  };
+}

--- a/apps/frontend/src/hooks/usePaginatedList.ts
+++ b/apps/frontend/src/hooks/usePaginatedList.ts
@@ -21,6 +21,13 @@ export interface UsePaginatedListOptions<T> {
   initialTotalCount?: number;
   defaultPageSize?: number;
   /**
+   * Gates fetching, e.g. `!permsLoading && canRead`. Defaults to `true`.
+   * While `false`, no request is issued and `isLoading` is cleared -- use
+   * this so a user who will render `<AccessDenied />` never triggers a
+   * list request (and resulting 403 + error toast) in the first place.
+   */
+  enabled?: boolean;
+  /**
    * Called with each successful page's data, in addition to `data` being
    * updated. Use this to accumulate filter-dropdown options or other
    * derived state that shouldn't reset every fetch.
@@ -53,13 +60,13 @@ export interface UsePaginatedListResult<T> {
  * changes.
  *
  * Fetches are keyed by a request signature (page, rowsPerPage,
- * filterFingerprint, refreshKey, sessionStatus) rather than a one-shot
- * "skip the first fetch" flag, so it stays correct under React 18 Strict
- * Mode's dev-only double-invoke of mount effects: both invocations compute
- * the same signature and both no-op, instead of the second slipping through
- * a "consumed" ref. `sessionStatus` is part of the key so a run that lands
- * while the session is still `loading` doesn't "claim" the same key a later
- * `authenticated` run would use.
+ * filterFingerprint, refreshKey, sessionStatus, enabled) rather than a
+ * one-shot "skip the first fetch" flag, so it stays correct under React 18
+ * Strict Mode's dev-only double-invoke of mount effects: both invocations
+ * compute the same signature and both no-op, instead of the second slipping
+ * through a "consumed" ref. `sessionStatus` is part of the key so a run that
+ * lands while the session is still `loading` doesn't "claim" the same key a
+ * later `authenticated` run would use.
  */
 export function usePaginatedList<T>({
   fetchPage,
@@ -67,6 +74,7 @@ export function usePaginatedList<T>({
   initialData,
   initialTotalCount = 0,
   defaultPageSize = 25,
+  enabled = true,
   onData,
   onError,
 }: UsePaginatedListOptions<T>): UsePaginatedListResult<T> {
@@ -83,7 +91,7 @@ export function usePaginatedList<T>({
 
   const loadedRequestKeyRef = React.useRef<string | null>(
     initialData !== undefined
-      ? `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}`
+      ? `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}|${enabled}`
       : null
   );
 
@@ -92,7 +100,15 @@ export function usePaginatedList<T>({
   }, [filterFingerprint]);
 
   React.useEffect(() => {
-    const requestKey = `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}`;
+    if (!enabled) {
+      // Don't record a request key while disabled: leaves the last real
+      // signature in place so the fetch fires as soon as `enabled` flips
+      // back to `true`, rather than being treated as already-satisfied.
+      setIsLoading(false);
+      return;
+    }
+
+    const requestKey = `${page}|${rowsPerPage}|${filterFingerprint}|${refreshKey}|${sessionStatus}|${enabled}`;
     if (loadedRequestKeyRef.current === requestKey) {
       return;
     }
@@ -144,7 +160,14 @@ export function usePaginatedList<T>({
     // fires, so omitting them here is intentional -- adding them would only
     // cause spurious re-runs on every render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [page, rowsPerPage, filterFingerprint, refreshKey, sessionStatus]);
+  }, [
+    page,
+    rowsPerPage,
+    filterFingerprint,
+    refreshKey,
+    sessionStatus,
+    enabled,
+  ]);
 
   // Clamp page when the result set shrinks below the current page (e.g. after delete)
   React.useEffect(() => {

--- a/apps/frontend/src/utils/api-client/behavior-client.ts
+++ b/apps/frontend/src/utils/api-client/behavior-client.ts
@@ -7,10 +7,40 @@ import {
   BehaviorsQueryParams,
   BehaviorWithMetrics,
 } from './interfaces/behavior';
+import { PaginatedResponse } from './interfaces/pagination';
 import { UUID } from 'crypto';
 import { MetricDetail } from './interfaces/metric';
 
 export class BehaviorClient extends BaseApiClient {
+  /**
+   * Fetch a single page of behaviors along with the total matching count
+   * (via the X-Total-Count header). Use this for server-side pagination
+   * instead of getAllBehaviors()/getBehaviors(), which fetch everything.
+   */
+  async getBehaviorsPage(
+    params: BehaviorsQueryParams = {}
+  ): Promise<PaginatedResponse<BehaviorWithMetrics>> {
+    const {
+      skip = 0,
+      limit = 25,
+      sort_by = 'created_at',
+      sort_order = 'desc',
+      $filter,
+    } = params;
+
+    return this.fetchPaginated<BehaviorWithMetrics>(
+      API_ENDPOINTS.behaviors,
+      {
+        skip,
+        limit,
+        sort_by,
+        sort_order,
+        $filter,
+      },
+      { cache: 'no-store' }
+    );
+  }
+
   async getBehaviors(
     params: BehaviorsQueryParams = {}
   ): Promise<BehaviorWithMetrics[]> {

--- a/apps/frontend/src/utils/api-client/interfaces/behavior.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/behavior.ts
@@ -157,7 +157,7 @@ export interface BehaviorsQueryParams {
   skip?: number;
   limit?: number;
   sort_by?: string;
-  sort_order?: string;
+  sort_order?: 'asc' | 'desc';
   $filter?: string;
-  include?: string; // New: for including relationships like 'metrics'
+  include?: string;
 }

--- a/apps/frontend/src/utils/api-client/interfaces/metric.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/metric.ts
@@ -133,4 +133,15 @@ export interface MetricsResponse {
 export interface MetricQueryParams extends PaginationParams {
   status?: string;
   type?: string;
+  /**
+   * OData $select expression -- comma-separated top-level field names to
+   * return (id is always included). Trims the response to only what the
+   * caller renders; see backend utils/odata.py::apply_select.
+   */
+  $select?: string;
+  /**
+   * Comma-separated metric scopes (JSONB array contains filter).
+   * Matches metrics whose metric_scope array contains any of the values.
+   */
+  metric_scope?: string;
 }

--- a/apps/frontend/src/utils/api-client/server-factory.ts
+++ b/apps/frontend/src/utils/api-client/server-factory.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react';
 import { headers } from 'next/headers';
 import { ApiClientFactory } from './client-factory';
 import { getServerActiveProjectId } from '../server-active-project';
@@ -24,11 +25,17 @@ import { getFreshAccessToken } from '@/auth';
  * a Route Handler or Server Action can), so a refresh performed here can't be
  * persisted — the next `/api/backend` proxy call (or navigation) catches the
  * cookie up. See `getFreshAccessToken()`'s docstring.
+ *
+ * Wrapped in `React.cache()` so multiple server components in the same RSC
+ * render pass (e.g. layout.tsx + page.tsx) share a single token refresh and
+ * factory instance.
  */
-export async function createServerApiFactory(): Promise<ApiClientFactory> {
-  const [{ accessToken }, projectId] = await Promise.all([
-    getFreshAccessToken({ headers: await headers() }),
-    getServerActiveProjectId(),
-  ]);
-  return new ApiClientFactory(accessToken ?? undefined, projectId);
-}
+export const createServerApiFactory = cache(
+  async (): Promise<ApiClientFactory> => {
+    const [{ accessToken }, projectId] = await Promise.all([
+      getFreshAccessToken({ headers: await headers() }),
+      getServerActiveProjectId(),
+    ]);
+    return new ApiClientFactory(accessToken ?? undefined, projectId);
+  }
+);

--- a/apps/frontend/src/utils/odata-filter.ts
+++ b/apps/frontend/src/utils/odata-filter.ts
@@ -1373,23 +1373,27 @@ export function buildMetricODataFilter(
     );
   }
 
-  pushOrConditions(parts, f.backend, b =>
-    `tolower(backend_type/type_value) eq '${escapeODataValue(b)}'`
+  pushOrConditions(
+    parts,
+    f.backend,
+    b => `tolower(backend_type/type_value) eq '${escapeODataValue(b)}'`
   );
 
-  pushOrConditions(parts, f.type, t =>
-    `tolower(metric_type/type_value) eq tolower('${escapeODataValue(t)}')`
+  pushOrConditions(
+    parts,
+    f.type,
+    t => `tolower(metric_type/type_value) eq tolower('${escapeODataValue(t)}')`
   );
 
-  pushOrConditions(parts, f.scoreType, s =>
-    `tolower(score_type) eq tolower('${escapeODataValue(s)}')`
+  pushOrConditions(
+    parts,
+    f.scoreType,
+    s => `tolower(score_type) eq tolower('${escapeODataValue(s)}')`
   );
 
   if (f.behavior.trim()) {
     const b = escapeODataValue(f.behavior.trim());
-    parts.push(
-      `behaviors/any(b: tolower(b/name) eq tolower('${b}'))`
-    );
+    parts.push(`behaviors/any(b: tolower(b/name) eq tolower('${b}'))`);
   }
 
   return joinODataParts(parts);
@@ -1430,8 +1434,11 @@ export function buildBehaviorODataFilter(
     parts.push('not metrics/any()');
   }
 
-  pushOrConditions(parts, f.tagNames, t =>
-    `_tags_relationship/any(tg: tolower(tg/tag/name) eq tolower('${escapeODataValue(t)}'))`
+  pushOrConditions(
+    parts,
+    f.tagNames,
+    t =>
+      `_tags_relationship/any(tg: tolower(tg/tag/name) eq tolower('${escapeODataValue(t)}'))`
   );
 
   return joinODataParts(parts);

--- a/apps/frontend/src/utils/odata-filter.ts
+++ b/apps/frontend/src/utils/odata-filter.ts
@@ -1315,6 +1315,128 @@ export function buildEndpointListFilter(
   return `(${parts.join(') and (')})`;
 }
 
+// ── Shared directory-filter helpers ───────────────────────────────────────────
+
+/**
+ * Joins an array of OData filter parts with `and`.
+ * Returns undefined when the array is empty (no active filters).
+ */
+function joinODataParts(parts: string[]): string | undefined {
+  if (parts.length === 0) return undefined;
+  if (parts.length === 1) return parts[0];
+  return parts.map(p => `(${p})`).join(' and ');
+}
+
+/**
+ * Pushes a multi-value OR condition onto `parts`.
+ * Each value is mapped to an OData expression via `toExpr`; if the result
+ * is a single expression it is added unwrapped, otherwise they are grouped
+ * inside parentheses with ` or `.
+ */
+function pushOrConditions(
+  parts: string[],
+  values: string[],
+  toExpr: (v: string) => string
+): void {
+  if (values.length === 0) return;
+  const conds = values.map(toExpr);
+  parts.push(conds.length === 1 ? conds[0] : `(${conds.join(' or ')})`);
+}
+
+// ── Metric directory filters ──────────────────────────────────────────────────
+
+export interface MetricDirectoryFilters {
+  search: string;
+  backend: string[];
+  type: string[];
+  scoreType: string[];
+  behavior: string;
+}
+
+/**
+ * Builds an OData $filter string for the metric list endpoint.
+ * Returns undefined when no filters are active.
+ *
+ * Note: `metricScope` is NOT handled here — it uses a dedicated backend
+ * query parameter because OData cannot filter Postgres JSONB arrays.
+ */
+export function buildMetricODataFilter(
+  f: MetricDirectoryFilters
+): string | undefined {
+  const parts: string[] = [];
+
+  const search = f.search.trim();
+  if (search) {
+    const q = escapeODataValue(search);
+    parts.push(
+      `(contains(tolower(name),tolower('${q}')) or contains(tolower(description),tolower('${q}')))`
+    );
+  }
+
+  pushOrConditions(parts, f.backend, b =>
+    `tolower(backend_type/type_value) eq '${escapeODataValue(b)}'`
+  );
+
+  pushOrConditions(parts, f.type, t =>
+    `tolower(metric_type/type_value) eq tolower('${escapeODataValue(t)}')`
+  );
+
+  pushOrConditions(parts, f.scoreType, s =>
+    `tolower(score_type) eq tolower('${escapeODataValue(s)}')`
+  );
+
+  if (f.behavior.trim()) {
+    const b = escapeODataValue(f.behavior.trim());
+    parts.push(
+      `behaviors/any(b: tolower(b/name) eq tolower('${b}'))`
+    );
+  }
+
+  return joinODataParts(parts);
+}
+
+// ── Behavior directory filters ────────────────────────────────────────────────
+
+export type BehaviorMetricCountFilter = 'all' | 'has_metrics' | 'no_metrics';
+
+export interface BehaviorDirectoryFilters {
+  search: string;
+  metricCount: BehaviorMetricCountFilter;
+  tagNames: string[];
+}
+
+/**
+ * Builds an OData $filter string for the behavior list endpoint.
+ * Returns undefined when no filters are active.
+ */
+export function buildBehaviorODataFilter(
+  f: BehaviorDirectoryFilters
+): string | undefined {
+  const parts: string[] = [];
+
+  const search = f.search.trim();
+  if (search) {
+    const q = escapeODataValue(search);
+    parts.push(
+      `(contains(tolower(name),tolower('${q}')) or contains(tolower(description),tolower('${q}')) or ` +
+        `metrics/any(m: contains(tolower(m/name),tolower('${q}')) or contains(tolower(m/description),tolower('${q}'))) or ` +
+        `_tags_relationship/any(tg: contains(tolower(tg/tag/name),tolower('${q}'))))`
+    );
+  }
+
+  if (f.metricCount === 'has_metrics') {
+    parts.push('metrics/any()');
+  } else if (f.metricCount === 'no_metrics') {
+    parts.push('not metrics/any()');
+  }
+
+  pushOrConditions(parts, f.tagNames, t =>
+    `_tags_relationship/any(tg: tolower(tg/tag/name) eq tolower('${escapeODataValue(t)}'))`
+  );
+
+  return joinODataParts(parts);
+}
+
 // ── Team member filters (organization team page) ─────────────────────────────
 
 export interface TeamFilters {

--- a/apps/frontend/src/utils/server-permissions.ts
+++ b/apps/frontend/src/utils/server-permissions.ts
@@ -1,32 +1,51 @@
+import { cache } from 'react';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { getServerActiveProjectId } from '@/utils/server-active-project';
 import { FeatureName } from '@/constants/features';
+import type { FeaturesResponse } from '@/utils/api-client/features-client';
+
+/**
+ * Cached server-side fetchers for features and permissions. `React.cache()`
+ * deduplicates within a single RSC render pass, so `layout.tsx` and
+ * `page.tsx` (via `prefetchList` / `hasServerCapability`) share one
+ * `GET /features` and one `GET /me/permissions` call instead of two each.
+ */
+export const getServerFeatures = cache(
+  async (): Promise<FeaturesResponse> => {
+    const factory = await createServerApiFactory();
+    return factory.getFeaturesClient().getFeatures();
+  }
+);
+
+export const getServerPermissions = cache(
+  async (): Promise<string[]> => {
+    const factory = await createServerApiFactory();
+    const projectId = await getServerActiveProjectId();
+    return factory.getPermissionsClient().getMyPermissions(projectId);
+  }
+);
 
 /**
  * Server-side counterpart of `useCan`/`useCanWithStatus` for gating a page's
  * initial server-rendered fetch, not just its client-side render.
  *
- * Mirrors `(protected)/layout.tsx`'s RBAC bootstrap: when the RBAC feature is
- * off, every ambient check is a permissive no-op (matches `useCan`'s
- * behavior); when it's on, checks membership in `GET /me/permissions` for the
- * active project. Fails closed (returns `false`) on any error, since the
- * caller uses this to decide whether it's safe to fetch and expose data.
+ * When the RBAC feature is off, every ambient check is a permissive no-op
+ * (matches `useCan`'s behavior); when it's on, checks membership in
+ * `GET /me/permissions` for the active project. Fails closed (returns
+ * `false`) on any error, since the caller uses this to decide whether it's
+ * safe to fetch and expose data.
  */
 export async function hasServerCapability(
   capability: string
 ): Promise<boolean> {
   try {
-    const factory = await createServerApiFactory();
-    const features = await factory.getFeaturesClient().getFeatures();
+    const features = await getServerFeatures();
 
     if (!features.enabled.includes(FeatureName.RBAC)) {
       return true;
     }
 
-    const projectId = await getServerActiveProjectId();
-    const permissions = await factory
-      .getPermissionsClient()
-      .getMyPermissions(projectId);
+    const permissions = await getServerPermissions();
     return permissions.includes(capability);
   } catch {
     return false;

--- a/apps/frontend/src/utils/server-permissions.ts
+++ b/apps/frontend/src/utils/server-permissions.ts
@@ -3,6 +3,7 @@ import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { getServerActiveProjectId } from '@/utils/server-active-project';
 import { FeatureName } from '@/constants/features';
 import type { FeaturesResponse } from '@/utils/api-client/features-client';
+import { can } from '@/utils/affordances';
 
 /**
  * Cached server-side fetchers for features and permissions. `React.cache()`
@@ -10,20 +11,16 @@ import type { FeaturesResponse } from '@/utils/api-client/features-client';
  * `page.tsx` (via `prefetchList` / `hasServerCapability`) share one
  * `GET /features` and one `GET /me/permissions` call instead of two each.
  */
-export const getServerFeatures = cache(
-  async (): Promise<FeaturesResponse> => {
-    const factory = await createServerApiFactory();
-    return factory.getFeaturesClient().getFeatures();
-  }
-);
+export const getServerFeatures = cache(async (): Promise<FeaturesResponse> => {
+  const factory = await createServerApiFactory();
+  return factory.getFeaturesClient().getFeatures();
+});
 
-export const getServerPermissions = cache(
-  async (): Promise<string[]> => {
-    const factory = await createServerApiFactory();
-    const projectId = await getServerActiveProjectId();
-    return factory.getPermissionsClient().getMyPermissions(projectId);
-  }
-);
+export const getServerPermissions = cache(async (): Promise<string[]> => {
+  const factory = await createServerApiFactory();
+  const projectId = await getServerActiveProjectId();
+  return factory.getPermissionsClient().getMyPermissions(projectId);
+});
 
 /**
  * Server-side counterpart of `useCan`/`useCanWithStatus` for gating a page's
@@ -31,9 +28,11 @@ export const getServerPermissions = cache(
  *
  * When the RBAC feature is off, every ambient check is a permissive no-op
  * (matches `useCan`'s behavior); when it's on, checks membership in
- * `GET /me/permissions` for the active project. Fails closed (returns
- * `false`) on any error, since the caller uses this to decide whether it's
- * safe to fetch and expose data.
+ * `GET /me/permissions` for the active project via the same `can()`
+ * primitive `useCan`/`useCanWithStatus` use client-side, so server and client
+ * can't independently drift on what "has this capability" means. Fails
+ * closed (returns `false`) on any error, since the caller uses this to
+ * decide whether it's safe to fetch and expose data.
  */
 export async function hasServerCapability(
   capability: string
@@ -46,7 +45,7 @@ export async function hasServerCapability(
     }
 
     const permissions = await getServerPermissions();
-    return permissions.includes(capability);
+    return can({ permitted_actions: permissions }, capability);
   } catch {
     return false;
   }

--- a/apps/frontend/src/utils/server-permissions.ts
+++ b/apps/frontend/src/utils/server-permissions.ts
@@ -12,7 +12,9 @@ import { FeatureName } from '@/constants/features';
  * active project. Fails closed (returns `false`) on any error, since the
  * caller uses this to decide whether it's safe to fetch and expose data.
  */
-export async function hasServerCapability(capability: string): Promise<boolean> {
+export async function hasServerCapability(
+  capability: string
+): Promise<boolean> {
   try {
     const factory = await createServerApiFactory();
     const features = await factory.getFeaturesClient().getFeatures();

--- a/apps/frontend/src/utils/server-permissions.ts
+++ b/apps/frontend/src/utils/server-permissions.ts
@@ -1,0 +1,32 @@
+import { createServerApiFactory } from '@/utils/api-client/server-factory';
+import { getServerActiveProjectId } from '@/utils/server-active-project';
+import { FeatureName } from '@/constants/features';
+
+/**
+ * Server-side counterpart of `useCan`/`useCanWithStatus` for gating a page's
+ * initial server-rendered fetch, not just its client-side render.
+ *
+ * Mirrors `(protected)/layout.tsx`'s RBAC bootstrap: when the RBAC feature is
+ * off, every ambient check is a permissive no-op (matches `useCan`'s
+ * behavior); when it's on, checks membership in `GET /me/permissions` for the
+ * active project. Fails closed (returns `false`) on any error, since the
+ * caller uses this to decide whether it's safe to fetch and expose data.
+ */
+export async function hasServerCapability(capability: string): Promise<boolean> {
+  try {
+    const factory = await createServerApiFactory();
+    const features = await factory.getFeaturesClient().getFeatures();
+
+    if (!features.enabled.includes(FeatureName.RBAC)) {
+      return true;
+    }
+
+    const projectId = await getServerActiveProjectId();
+    const permissions = await factory
+      .getPermissionsClient()
+      .getMyPermissions(projectId);
+    return permissions.includes(capability);
+  } catch {
+    return false;
+  }
+}

--- a/apps/frontend/src/utils/server-prefetch.ts
+++ b/apps/frontend/src/utils/server-prefetch.ts
@@ -1,0 +1,46 @@
+import { hasServerCapability } from './server-permissions';
+import type { PaginatedResponse } from './api-client/interfaces/pagination';
+
+export interface PrefetchListResult<T> {
+  /** Undefined when unauthorized or the fetch failed -- caller falls back to a client fetch. */
+  initialData?: T[];
+  initialTotalCount: number;
+}
+
+/**
+ * Server-side counterpart of `usePaginatedList`: fetches a directory page's
+ * first page during server rendering so the page arrives with content
+ * already in place, with no client-side spinner on first load.
+ *
+ * The capability check runs here, before the fetch: it's not just a render
+ * gate, it decides whether the entity's data is fetched and embedded in the
+ * server-rendered payload at all. Callers should still gate the client
+ * render with the matching `useCanWithStatus` check, so a user whose
+ * permissions change mid-session gets a consistent client-side
+ * `AccessDenied` without a full reload.
+ *
+ * Fails open to "no initial data" (never throws) so a permission-check or
+ * upstream API error just falls back to the existing client-side fetch
+ * instead of breaking the page.
+ */
+export async function prefetchList<T>(
+  capability: string,
+  fetchFirstPage: () => Promise<PaginatedResponse<T>>
+): Promise<PrefetchListResult<T>> {
+  const canRead = await hasServerCapability(capability);
+  if (!canRead) {
+    return { initialData: undefined, initialTotalCount: 0 };
+  }
+
+  try {
+    const response = await fetchFirstPage();
+    return {
+      // Server components pass data as props: strip class instances / non-plain
+      // values so this doesn't blow up when serialized across the RSC boundary.
+      initialData: JSON.parse(JSON.stringify(response.data)),
+      initialTotalCount: response.pagination.totalCount,
+    };
+  } catch {
+    return { initialData: undefined, initialTotalCount: 0 };
+  }
+}

--- a/tests/backend/utils/test_query_builder_load.py
+++ b/tests/backend/utils/test_query_builder_load.py
@@ -269,3 +269,85 @@ class TestMetricBehaviorNestedM2MLoads:
             db=test_db, skip=0, limit=100, organization_id=test_org_id
         )
         _assert_nested_metric_loaded(next(b for b in listed if b.id == behavior.id))
+
+
+@pytest.mark.unit
+@pytest.mark.crud
+class TestODataAnyNavigationFilter:
+    """Regression coverage for OData $filter expressions that navigate a
+    many-to-many relationship with `any(...)`, e.g. the frontend's
+    `behaviors/any(b: tolower(b/name) eq tolower('...'))` used to filter the
+    metrics directory by behavior name. `odata_query`'s SQLAlchemy backend
+    compiles this to an `EXISTS` subquery through the association table --
+    this test locks in that it actually returns the right rows rather than
+    raising or silently matching everything.
+    """
+
+    def test_get_metrics_filters_by_behavior_name_via_any(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        from tests.backend.routes.fixtures.data_factories import (
+            BehaviorDataFactory,
+            MetricDataFactory,
+        )
+
+        matching_behavior = crud_utils.create_item(
+            test_db,
+            models.Behavior,
+            {**BehaviorDataFactory.sample_data(), "name": "Toxicity"},
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        other_behavior = crud_utils.create_item(
+            test_db,
+            models.Behavior,
+            {**BehaviorDataFactory.sample_data(), "name": "Relevance"},
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        matching_metric = crud_utils.create_item(
+            test_db,
+            models.Metric,
+            MetricDataFactory.sample_data(),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        other_metric = crud_utils.create_item(
+            test_db,
+            models.Metric,
+            MetricDataFactory.sample_data(),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.execute(
+            models.behavior_metric_association.insert().values(
+                metric_id=matching_metric.id,
+                behavior_id=matching_behavior.id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+        )
+        test_db.execute(
+            models.behavior_metric_association.insert().values(
+                metric_id=other_metric.id,
+                behavior_id=other_behavior.id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+        )
+        test_db.flush()
+        test_db.expire_all()
+
+        odata_filter = "behaviors/any(b: tolower(b/name) eq tolower('Toxicity'))"
+        results = crud.get_metrics(
+            db=test_db,
+            skip=0,
+            limit=100,
+            filter=odata_filter,
+            organization_id=test_org_id,
+        )
+        result_ids = {m.id for m in results}
+
+        assert matching_metric.id in result_ids
+        assert other_metric.id not in result_ids

--- a/tests/backend/utils/test_query_builder_load.py
+++ b/tests/backend/utils/test_query_builder_load.py
@@ -346,6 +346,7 @@ class TestODataAnyNavigationFilter:
             limit=100,
             filter=odata_filter,
             organization_id=test_org_id,
+            user_id=authenticated_user_id,
         )
         result_ids = {m.id for m in results}
 


### PR DESCRIPTION
## Purpose

Follow-up to #2265. After that merge, performance improved but the metrics/behaviors directories still showed a loading spinner on every interaction: the frontend made redundant full-collection fetches for client-side filtering, over-fetched relationship data, and flashed the entire page (with layout shift) on every search keystroke, filter change, or page navigation.

## What Changed

- **Server-side pagination and filtering**: replaced client-side `getAllMetrics()`/`getBehaviors()` (which paginated through every row for local filtering) with paged, OData-filtered requests (`buildMetricODataFilter`, `buildBehaviorODataFilter`) scoped to `skip`/`limit`. Behaviors gains pagination for the first time.
- **No more full-page flash on refetch**: replaced the full-page spinner shown on every search/filter/page change with a fixed-height `LinearProgress` bar (no dimming/opacity — the bar alone signals an in-flight fetch), so the toolbar and pagination controls stay visible and nothing shifts.
- **Server-side initial fetch (BFF)**: converted `metrics/page.tsx` and `behaviors/page.tsx` into server components that fetch the first page via `createServerApiFactory()` and pass it as props, so the first paint already has data — no client spinner on initial load. The prefetch is gated server-side on the relevant `*.READ` capability via `hasServerCapability()` so unauthorized users never get list data serialized into the initial payload.
- **Reusable primitives**: extracted the pagination/prefetch boilerplate shared by both directories into `usePaginatedList` (client hook: page/rowsPerPage state, filter-triggered page reset, page clamping on shrink, idempotent fetch via a request-signature ref that's robust to React Strict Mode's double-invoked mount effects) and `prefetchList` (server helper: capability-gated first-page fetch). Both take an `enabled`/capability gate so a user who will render `<AccessDenied />` never issues the underlying list request.
- **CRUD consistency**: metrics create/update/delete refresh from the server (correct under server-side pagination). Behaviors uses optimistic local updates instead (`insertBehaviorSorted`) since it's sorted by name — a blind refetch could hide a just-created row that doesn't land on page 0; the optimistic insert only splices into the current page when viewing page 0 and caps the result to `rowsPerPage`, otherwise the row surfaces on the next real fetch. Page-clamping resets the page automatically when a delete shrinks the result set below it.
- **Backend DRY**: extracted `_apply_metric_scope_filter()` to remove duplicated JSONB `metric_scope` filter logic between `crud.get_metrics()` and the router's count-header override.
- **Backend regression coverage**: added a test exercising the OData `behaviors/any(b: tolower(b/name) eq ...)` navigation filter end-to-end against real `Metric`/`Behavior` rows, scoped to the authenticated user.

## Additional Context

- Follow-up to #2265 (server-side query/relationship-loading optimization).
- No API contract changes beyond the existing `metric_scope` query param and `$select` support added in #2265.
- Follow-up plan for rolling this pattern out to the rest of the app: #2268.

## Testing

- `tsc --noEmit`, `eslint`, `prettier`, and the frontend jest suite for `metrics`/`behaviors`/`odata-filter`/`usePaginatedList` (116 tests) all pass.
- `ruff check`/`ruff format` pass on the touched backend files; all 9 tests in `tests/backend/utils/test_query_builder_load.py` pass, including the new `any()` navigation-filter regression test.
- Manually verified in dev: metrics/behaviors pages render with data on first load (no spinner), searching/filtering/paginating no longer flashes the page, create/update/delete keep the directory consistent, and users lacking `Metric.READ`/`Behavior.READ` get no list data in the initial payload and no client-side list requests.
