### PR TITLE
fix(backend): support relationship field sorting

### DIFF
--- a/apps/backend/src/rhesis/backend/app/utils/query_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/query_utils.py
@@ -454,9 +454,20 @@ class QueryBuilder:
             apply_virtual_count_sort,
             is_virtual_count_sort,
         )
+        from rhesis.backend.app.utils.relationship_sort import (
+            apply_virtual_relationship_sort,
+            is_virtual_relationship_sort,
+        )
 
         if self._sort_by and is_virtual_count_sort(self._sort_by):
             self.query = apply_virtual_count_sort(
+                self.query,
+                self.model,
+                self._sort_by,
+                self._sort_order,
+            )
+        elif self._sort_by and is_virtual_relationship_sort(self._sort_by):
+            self.query = apply_virtual_relationship_sort(
                 self.query,
                 self.model,
                 self._sort_by,

--- a/apps/backend/src/rhesis/backend/app/utils/query_validation.py
+++ b/apps/backend/src/rhesis/backend/app/utils/query_validation.py
@@ -8,6 +8,10 @@ from rhesis.backend.app.utils.count_sort import (
     VIRTUAL_COUNT_SORT_FIELDS,
     model_supports_count_sort,
 )
+from rhesis.backend.app.utils.relationship_sort import (
+    VIRTUAL_RELATIONSHIP_SORT_FIELDS,
+    model_supports_relationship_sort,
+)
 
 
 def validate_sort_field(model: Type, sort_by: str) -> None:
@@ -17,6 +21,16 @@ def validate_sort_field(model: Type, sort_by: str) -> None:
             raise HTTPException(
                 status_code=400,
                 detail=f"Invalid sort field: {sort_by}. Model does not support this count sort.",
+            )
+        return
+
+    if sort_by in VIRTUAL_RELATIONSHIP_SORT_FIELDS:
+        if not model_supports_relationship_sort(model, sort_by):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Invalid sort field: {sort_by}. Model does not support this relationship sort."
+                ),
             )
         return
 

--- a/apps/backend/src/rhesis/backend/app/utils/relationship_sort.py
+++ b/apps/backend/src/rhesis/backend/app/utils/relationship_sort.py
@@ -1,0 +1,54 @@
+"""Virtual sort fields backed by related model columns."""
+
+from __future__ import annotations
+
+from sqlalchemy import desc, select
+from sqlalchemy.orm import Query
+
+from rhesis.backend.app.models.behavior import Behavior
+from rhesis.backend.app.models.category import Category
+from rhesis.backend.app.models.topic import Topic
+from rhesis.backend.app.models.type_lookup import TypeLookup
+
+_RELATIONSHIP_SORT_FIELDS = {
+    "behavior.name": (Behavior, "name", "behavior_id"),
+    "topic.name": (Topic, "name", "topic_id"),
+    "category.name": (Category, "name", "category_id"),
+    "test_type.type_value": (TypeLookup, "type_value", "test_type_id"),
+}
+VIRTUAL_RELATIONSHIP_SORT_FIELDS = frozenset(_RELATIONSHIP_SORT_FIELDS)
+
+
+def is_virtual_relationship_sort(sort_by: str | None) -> bool:
+    return sort_by in VIRTUAL_RELATIONSHIP_SORT_FIELDS
+
+
+def model_supports_relationship_sort(model, sort_by: str) -> bool:
+    relationship_sort = _RELATIONSHIP_SORT_FIELDS.get(sort_by)
+    return relationship_sort is not None and hasattr(model, relationship_sort[2])
+
+
+def _relationship_subquery(model, sort_by: str):
+    related_model, related_column, foreign_key = _RELATIONSHIP_SORT_FIELDS[sort_by]
+    return (
+        select(getattr(related_model, related_column))
+        .where(related_model.id == getattr(model, foreign_key))
+        .correlate(model)
+        .scalar_subquery()
+    )
+
+
+def apply_virtual_relationship_sort(
+    query: Query,
+    model,
+    sort_by: str,
+    sort_order: str,
+) -> Query:
+    """Order by a related column, or return the query unchanged if unsupported."""
+    if not model_supports_relationship_sort(model, sort_by):
+        return query
+
+    sort_expression = _relationship_subquery(model, sort_by)
+    if sort_order == "desc":
+        return query.order_by(desc(sort_expression))
+    return query.order_by(sort_expression)

--- a/tests/backend/utils/test_relationship_sort.py
+++ b/tests/backend/utils/test_relationship_sort.py
@@ -1,0 +1,125 @@
+import pytest
+from fastapi import HTTPException
+
+from rhesis.backend.app.models.behavior import Behavior
+from rhesis.backend.app.models.test import Test
+from rhesis.backend.app.utils.query_utils import QueryBuilder
+from rhesis.backend.app.utils.query_validation import validate_sort_field
+from rhesis.backend.app.utils.relationship_sort import (
+    apply_virtual_relationship_sort,
+    is_virtual_relationship_sort,
+    model_supports_relationship_sort,
+)
+
+
+@pytest.mark.parametrize(
+    "sort_by",
+    [
+        "behavior.name",
+        "topic.name",
+        "category.name",
+        "test_type.type_value",
+    ],
+)
+def test_virtual_relationship_sort_detection(sort_by):
+    assert is_virtual_relationship_sort(sort_by)
+    assert not is_virtual_relationship_sort("behavior_id")
+
+
+@pytest.mark.parametrize(
+    "sort_by",
+    [
+        "behavior.name",
+        "topic.name",
+        "category.name",
+        "test_type.type_value",
+    ],
+)
+def test_model_supports_relationship_sort_for_test(sort_by):
+    assert model_supports_relationship_sort(Test, sort_by)
+    assert not model_supports_relationship_sort(Behavior, sort_by)
+
+
+@pytest.mark.parametrize(
+    "sort_by",
+    [
+        "behavior.name",
+        "topic.name",
+        "category.name",
+        "test_type.type_value",
+    ],
+)
+def test_validate_sort_field_accepts_relationship_sort_for_test(sort_by):
+    validate_sort_field(Test, sort_by)
+
+
+@pytest.mark.parametrize(
+    "sort_by",
+    [
+        "behavior.name",
+        "topic.name",
+        "category.name",
+        "test_type.type_value",
+    ],
+)
+def test_validate_sort_field_rejects_relationship_sort_for_other_models(sort_by):
+    with pytest.raises(HTTPException) as exc_info:
+        validate_sort_field(Behavior, sort_by)
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.parametrize(
+    ("sort_by", "related_column", "foreign_key"),
+    [
+        ("behavior.name", "behavior.name", "test.behavior_id"),
+        ("topic.name", "topic.name", "test.topic_id"),
+        ("category.name", "category.name", "test.category_id"),
+        (
+            "test_type.type_value",
+            "type_lookup.type_value",
+            "test.test_type_id",
+        ),
+    ],
+)
+@pytest.mark.parametrize("sort_order", ["asc", "desc"])
+def test_apply_relationship_sort_builds_correlated_subquery(
+    test_db, sort_by, related_column, foreign_key, sort_order
+):
+    query = test_db.query(Test)
+    sorted_query = apply_virtual_relationship_sort(query, Test, sort_by, sort_order)
+
+    compiled = str(sorted_query.statement.compile(compile_kwargs={"literal_binds": True})).lower()
+    related_table = related_column.split(".", maxsplit=1)[0]
+    assert f"select {related_column}" in compiled
+    assert f"{related_table}.id = {foreign_key}" in compiled
+    assert "order by" in compiled
+    if sort_order == "desc":
+        assert " desc" in compiled
+
+
+@pytest.mark.parametrize(
+    ("sort_by", "related_column", "foreign_key"),
+    [
+        ("behavior.name", "behavior.name", "test.behavior_id"),
+        ("topic.name", "topic.name", "test.topic_id"),
+        ("category.name", "category.name", "test.category_id"),
+        (
+            "test_type.type_value",
+            "type_lookup.type_value",
+            "test.test_type_id",
+        ),
+    ],
+)
+def test_query_builder_dispatches_relationship_sort(test_db, sort_by, related_column, foreign_key):
+    query = QueryBuilder(test_db, Test).with_sorting(sort_by, "asc").build()
+
+    compiled = str(query.statement.compile(compile_kwargs={"literal_binds": True})).lower()
+    related_table = related_column.split(".", maxsplit=1)[0]
+    assert f"select {related_column}" in compiled
+    assert f"{related_table}.id = {foreign_key}" in compiled
+
+
+def test_apply_relationship_sort_keeps_query_unchanged_when_unsupported(test_db):
+    query = test_db.query(Behavior)
+
+    assert apply_virtual_relationship_sort(query, Behavior, "topic.name", "asc") is query


### PR DESCRIPTION
## Summary

Adds backend support for sorting Tests by relationship-backed fields using correlated scalar subqueries, following the existing virtual count-sort pattern.

## Changes

- support `behavior.name`, `topic.name`, `category.name`, and `test_type.type_value`
- validate relationship sort fields against the requested model
- dispatch supported fields through a shared relationship-sort helper
- add focused coverage for detection, validation, SQL generation, ordering, and QueryBuilder dispatch

Closes #2254.

## Validation

- GitHub Actions: Lint Check, Secret Scanning, Security Scanning (Trivy), and Backend Tests passed
- direct query and SQL matrix passed for all four fields in ascending and descending order
- Ruff format check passed
- Ruff check passed
- `git diff --check` passed