### PR TITLE
Make self-hosted telemetry opt-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,7 +104,7 @@ SESSION_SECRET_KEY=
 # =============================================================================
 # On by default for self-hosted deployments.
 
-# OTEL_RHESIS_TELEMETRY_ENABLED=false
+# OTEL_RHESIS_TELEMETRY_ENABLED=true
 
 # =============================================================================
 # ADVANCED TUNING

--- a/apps/backend/src/rhesis/backend/app/config/settings.py
+++ b/apps/backend/src/rhesis/backend/app/config/settings.py
@@ -158,11 +158,20 @@ class TelemetrySettings(BaseSettings):
         alias="OTEL_EXPORTER_OTLP_ENDPOINT",
     )
     service_name: str = Field(default="rhesis", alias="OTEL_SERVICE_NAME")
-    deployment_type: str = Field(default="self-hosted", alias="OTEL_DEPLOYMENT_TYPE")
+    deployment_type: Literal["cloud", "self-hosted"] = Field(
+        default="self-hosted", alias="OTEL_DEPLOYMENT_TYPE"
+    )
     rhesis_telemetry_enabled: bool = Field(
-        default=True,
+        default=False,
         alias="OTEL_RHESIS_TELEMETRY_ENABLED",
     )
+
+    @property
+    def is_telemetry_enabled(self) -> bool:
+        """Cloud is always on; self-hosted is opt-in via OTEL_RHESIS_TELEMETRY_ENABLED."""
+        if self.deployment_type == "cloud":
+            return True
+        return self.rhesis_telemetry_enabled  # self-hosted
 
 
 class LoggingSettings(BaseSettings):

--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -57,6 +57,7 @@ from rhesis.backend.app.auth.user_utils import (
 from rhesis.backend.app.config.settings import (
     get_application_settings,
     get_frontend_settings,
+    get_telemetry_settings,
 )
 from rhesis.backend.app.dependencies import (
     get_db_session,
@@ -74,7 +75,6 @@ from rhesis.backend.app.utils.rate_limit import (
 )
 from rhesis.backend.app.utils.redact import redact_email
 from rhesis.backend.telemetry import (
-    is_telemetry_enabled,
     set_telemetry_enabled,
     track_user_activity,
 )
@@ -477,7 +477,7 @@ async def auth_callback(request: Request, db: Session = Depends(get_db_session))
         request.session["return_to"] = return_to
 
         # Track login activity
-        if is_telemetry_enabled():
+        if get_telemetry_settings().is_telemetry_enabled:
             set_telemetry_enabled(
                 enabled=True,
                 user_id=str(user.id),
@@ -553,7 +553,7 @@ async def login_with_email(
         auth_code = await create_auth_code(access_token, refresh_tok)
 
         # Track login activity
-        if is_telemetry_enabled():
+        if get_telemetry_settings().is_telemetry_enabled:
             set_telemetry_enabled(
                 enabled=True,
                 user_id=str(user.id),
@@ -666,7 +666,7 @@ async def register_with_email(
             logger.warning(f"Failed to send verification email: {email_err}")
 
         # Track registration activity
-        if is_telemetry_enabled():
+        if get_telemetry_settings().is_telemetry_enabled:
             set_telemetry_enabled(
                 enabled=True,
                 user_id=str(user.id),
@@ -1023,7 +1023,7 @@ async def verify_magic_link(
     auth_code = await create_auth_code(access_token, refresh_tok)
 
     # Track login activity
-    if is_telemetry_enabled():
+    if get_telemetry_settings().is_telemetry_enabled:
         set_telemetry_enabled(
             enabled=True,
             user_id=str(user.id),
@@ -1273,7 +1273,7 @@ def logout(
                         logger.warning("Failed to bust permission cache on logout: %s", cache_err)
 
                 # Track logout activity
-                if is_telemetry_enabled():
+                if get_telemetry_settings().is_telemetry_enabled:
                     org_id = user_info.get("organization_id")
                     set_telemetry_enabled(
                         enabled=True,
@@ -1430,7 +1430,7 @@ async def local_login(request: Request, db: Session = Depends(get_db_session)):
             redact_email(user.email),
         )
 
-        if is_telemetry_enabled():
+        if get_telemetry_settings().is_telemetry_enabled:
             set_telemetry_enabled(
                 enabled=True,
                 user_id=str(user.id),

--- a/apps/backend/src/rhesis/backend/app/routers/task_management.py
+++ b/apps/backend/src/rhesis/backend/app/routers/task_management.py
@@ -9,7 +9,7 @@ from rhesis.backend.app.auth.capabilities import Permission
 from rhesis.backend.app.auth.principal import resolve_principal_from_request
 from rhesis.backend.app.auth.rbac import authorize_object, project_id_from_scope
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
-from rhesis.backend.app.config.settings import get_frontend_settings
+from rhesis.backend.app.config.settings import get_frontend_settings, get_telemetry_settings
 from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
@@ -19,7 +19,6 @@ from rhesis.backend.app.services.task_management import validate_task_organizati
 from rhesis.backend.app.services.task_notification import send_task_assignment_notification
 from rhesis.backend.app.utils.decorators import with_count_header
 from rhesis.backend.telemetry import (
-    is_telemetry_enabled,
     set_telemetry_enabled,
     track_feature_usage,
 )
@@ -45,7 +44,7 @@ def create_task(
     """Create a new task"""
     try:
         # Set telemetry context for this request (if telemetry is enabled)
-        if is_telemetry_enabled() and current_user:
+        if get_telemetry_settings().is_telemetry_enabled and current_user:
             set_telemetry_enabled(
                 enabled=True,
                 user_id=str(current_user.id) if current_user.id else None,
@@ -184,7 +183,7 @@ def update_task(
     """Update a task"""
     try:
         # Set telemetry context for this request (if telemetry is enabled)
-        if is_telemetry_enabled() and current_user:
+        if get_telemetry_settings().is_telemetry_enabled and current_user:
             set_telemetry_enabled(
                 enabled=True,
                 user_id=str(current_user.id) if current_user.id else None,

--- a/apps/backend/src/rhesis/backend/telemetry/__init__.py
+++ b/apps/backend/src/rhesis/backend/telemetry/__init__.py
@@ -8,7 +8,6 @@ from .instrumentation import (
     _set_telemetry_enabled_for_testing,
     get_tracer,
     initialize_telemetry,
-    is_telemetry_enabled,
     set_telemetry_enabled,
     track_feature_usage,
     track_user_activity,
@@ -17,7 +16,6 @@ from .instrumentation import (
 __all__ = [
     "initialize_telemetry",
     "get_tracer",
-    "is_telemetry_enabled",
     "set_telemetry_enabled",
     "track_user_activity",
     "track_feature_usage",

--- a/apps/backend/src/rhesis/backend/telemetry/instrumentation.py
+++ b/apps/backend/src/rhesis/backend/telemetry/instrumentation.py
@@ -152,21 +152,21 @@ def initialize_telemetry():
 
     Environment Variables:
         OTEL_DEPLOYMENT_TYPE: "cloud" or "self-hosted"
-        OTEL_RHESIS_TELEMETRY_ENABLED: "true" or "false" (self-hosted only, defaults to true)
+        OTEL_RHESIS_TELEMETRY_ENABLED: "true" or "false" (self-hosted only, defaults to false)
         OTEL_EXPORTER_OTLP_ENDPOINT: Telemetry collector endpoint URL
         OTEL_SERVICE_NAME: Service identifier (default: "rhesis")
         OTEL_PROCESSOR_ENDPOINT: Telemetry processor endpoint (default: telemetry-processor:4317)
         OTEL_API_KEY: API key for telemetry authentication
 
-    See is_telemetry_enabled() docstring for detailed information about
-    data collection practices and privacy protections.
+    See TelemetrySettings.is_telemetry_enabled in app.config.settings for the
+    enablement rules; https://rhesis.ai/privacy-policy for data practices.
     """
     global _TELEMETRY_GLOBALLY_ENABLED
 
     settings = get_telemetry_settings()
 
     # Check if telemetry is enabled based on deployment type
-    _TELEMETRY_GLOBALLY_ENABLED = is_telemetry_enabled()
+    _TELEMETRY_GLOBALLY_ENABLED = settings.is_telemetry_enabled
 
     if not _TELEMETRY_GLOBALLY_ENABLED:
         logger.info(f"Telemetry disabled for deployment_type={settings.deployment_type}")
@@ -233,79 +233,6 @@ def initialize_telemetry():
 
     except Exception as e:
         logger.error(f"Failed to initialize telemetry: {e}")
-
-
-def is_telemetry_enabled() -> bool:
-    """
-    Check if telemetry is enabled based on deployment type.
-
-    CLOUD DEPLOYMENTS:
-    - Telemetry is always enabled
-    - User consent collected via agreement to Terms & Conditions
-    - See https://www.rhesis.ai/terms-conditions for full details
-
-    SELF-HOSTED DEPLOYMENTS:
-    - Telemetry is ENABLED by default (opt-out)
-    - Opt-out by setting OTEL_RHESIS_TELEMETRY_ENABLED=false
-
-    IMPORTANT FOR SELF-HOSTED ADMINISTRATORS:
-    Telemetry is enabled by default to help improve Rhesis.
-    You can disable it anytime by setting OTEL_RHESIS_TELEMETRY_ENABLED=false.
-
-    Data Collected:
-    - Login/logout events with hashed user IDs (SHA-256, irreversible, 16-char truncated)
-    - API endpoint usage and response times
-    - Feature interaction patterns (e.g., "test created", "report viewed")
-    - Deployment type tag ("cloud" or "self-hosted")
-    - Service version information
-
-    Data NOT Collected:
-    - No email addresses, names, or personally identifiable information
-    - No test data, prompts, or LLM responses
-    - No API keys, tokens, passwords, or credentials
-    - No IP addresses or organization names
-    - No file contents or source code
-
-    Privacy & Security:
-    - All user/organization IDs are pseudonymized via SHA-256 hashing
-    - Data is transmitted over encrypted connections (HTTPS/gRPC with TLS)
-    - Sensitive metadata keys are automatically filtered (passwords, tokens, etc.)
-    - No data is shared with third parties
-
-    All data is sent to Rhesis's telemetry servers for product improvement.
-    For full privacy details, see: https://rhesis.ai/privacy-policy
-
-    You may disable telemetry at any time by setting OTEL_RHESIS_TELEMETRY_ENABLED=false.
-
-    Returns:
-        bool: True if telemetry should be collected
-
-    Examples:
-        # Self-hosted: Enabled by default (opt-out)
-        OTEL_DEPLOYMENT_TYPE=self-hosted
-        # OTEL_RHESIS_TELEMETRY_ENABLED not set -> defaults to true
-
-        # Self-hosted: Explicitly disable telemetry (opt-out)
-        OTEL_DEPLOYMENT_TYPE=self-hosted
-        OTEL_RHESIS_TELEMETRY_ENABLED=false
-
-        # Cloud: Always enabled
-        OTEL_DEPLOYMENT_TYPE=cloud
-    """
-    settings = get_telemetry_settings()
-    deployment_type = settings.deployment_type
-
-    # Cloud users: Always enabled (user consent collected via Terms & Conditions agreement)
-    if deployment_type == "cloud":
-        return True
-
-    # Self-hosted users: Enabled by default (opt-out)
-    # Users can disable by setting OTEL_RHESIS_TELEMETRY_ENABLED=false
-    if deployment_type == "self-hosted":
-        return settings.rhesis_telemetry_enabled
-
-    # Unknown deployment type: Disable telemetry for safety
-    return False
 
 
 def _set_telemetry_enabled_for_testing(enabled: bool):

--- a/apps/backend/src/rhesis/backend/telemetry/middleware.py
+++ b/apps/backend/src/rhesis/backend/telemetry/middleware.py
@@ -9,11 +9,11 @@ from typing import Callable
 from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from rhesis.backend.app.config.settings import get_telemetry_settings
 from rhesis.backend.telemetry.instrumentation import (
     _telemetry_org_id,
     _telemetry_user_id,
     get_tracer,
-    is_telemetry_enabled,
     set_telemetry_enabled,
 )
 
@@ -46,7 +46,7 @@ class TelemetryMiddleware(BaseHTTPMiddleware):
                 return await call_next(request)
 
         # Check if telemetry is globally enabled (based on deployment type + env var)
-        telemetry_enabled = is_telemetry_enabled()
+        telemetry_enabled = get_telemetry_settings().is_telemetry_enabled
 
         if not telemetry_enabled:
             # Telemetry disabled, just process request normally

--- a/tests/backend/app/test_settings.py
+++ b/tests/backend/app/test_settings.py
@@ -772,9 +772,7 @@ def test_application_settings_api_base_url_validation(clean_application_env, mon
 
 
 @pytest.mark.unit
-def test_get_application_settings_api_base_url_cache_clear(
-    minimal_application_env, monkeypatch
-):
+def test_get_application_settings_api_base_url_cache_clear(minimal_application_env, monkeypatch):
     assert get_application_settings().api_base_url == "https://api.example.com"
 
     monkeypatch.setenv("API_BASE_URL", "https://cached-api.example.com")
@@ -822,7 +820,7 @@ def test_telemetry_settings_uses_system_defaults(clean_telemetry_env):
     assert settings.otlp_endpoint == "https://telemetry.rhesis.ai"
     assert settings.service_name == "rhesis"
     assert settings.deployment_type == "self-hosted"
-    assert settings.rhesis_telemetry_enabled is True
+    assert settings.rhesis_telemetry_enabled is False
 
 
 @pytest.mark.unit

--- a/tests/backend/test_telemetry_fixtures.py
+++ b/tests/backend/test_telemetry_fixtures.py
@@ -6,10 +6,10 @@ telemetry state in tests and ensure proper test isolation.
 """
 
 import pytest
+from pydantic import ValidationError
 
 from rhesis.backend.app.config.settings import get_telemetry_settings
 from rhesis.backend.telemetry import (
-    is_telemetry_enabled,
     track_feature_usage,
     track_user_activity,
 )
@@ -99,15 +99,15 @@ class TestTelemetryDeploymentTypes:
         monkeypatch.setenv("OTEL_DEPLOYMENT_TYPE", "cloud")
         get_telemetry_settings.cache_clear()
 
-        assert is_telemetry_enabled() is True
+        assert get_telemetry_settings().is_telemetry_enabled is True
 
-    def test_self_hosted_default_enabled(self, monkeypatch):
-        """Test that self-hosted deployment has telemetry enabled by default"""
+    def test_self_hosted_default_disabled(self, monkeypatch):
+        """Test that self-hosted deployment has telemetry disabled by default (opt-in)"""
         monkeypatch.setenv("OTEL_DEPLOYMENT_TYPE", "self-hosted")
         monkeypatch.delenv("OTEL_RHESIS_TELEMETRY_ENABLED", raising=False)
         get_telemetry_settings.cache_clear()
 
-        assert is_telemetry_enabled() is True
+        assert get_telemetry_settings().is_telemetry_enabled is False
 
     def test_self_hosted_can_enable(self, monkeypatch):
         """Test that self-hosted deployment can enable telemetry via env var"""
@@ -115,7 +115,7 @@ class TestTelemetryDeploymentTypes:
         monkeypatch.setenv("OTEL_RHESIS_TELEMETRY_ENABLED", "true")
         get_telemetry_settings.cache_clear()
 
-        assert is_telemetry_enabled() is True
+        assert get_telemetry_settings().is_telemetry_enabled is True
 
     def test_self_hosted_can_disable(self, monkeypatch):
         """Test that self-hosted deployment can disable telemetry via env var"""
@@ -123,14 +123,15 @@ class TestTelemetryDeploymentTypes:
         monkeypatch.setenv("OTEL_RHESIS_TELEMETRY_ENABLED", "false")
         get_telemetry_settings.cache_clear()
 
-        assert is_telemetry_enabled() is False
+        assert get_telemetry_settings().is_telemetry_enabled is False
 
-    def test_unknown_deployment_disabled(self, monkeypatch):
-        """Test that unknown deployment types have telemetry disabled"""
+    def test_unknown_deployment_type_rejected(self, monkeypatch):
+        """Test that an unknown deployment type is a load-time validation error"""
         monkeypatch.setenv("OTEL_DEPLOYMENT_TYPE", "unknown")
         get_telemetry_settings.cache_clear()
 
-        assert is_telemetry_enabled() is False
+        with pytest.raises(ValidationError):
+            get_telemetry_settings()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Purpose

Developer and bare-process backend runs were emitting telemetry tagged as `self-hosted`, polluting our self-hosting analytics. Any process started without telemetry env vars fell through to the code defaults (`deployment_type=self-hosted`, telemetry `True`) and looked like a real self-hosted install.

This flips self-hosted telemetry to **opt-in**, so only deployments that explicitly enable it emit. It also centralizes the enablement decision and hardens the config so misconfiguration fails loudly instead of silently.

## What Changed

- **Default off for self-hosted:** `TelemetrySettings.rhesis_telemetry_enabled` default `True → False`. Self-hosted now opts in via `OTEL_RHESIS_TELEMETRY_ENABLED=true`. Cloud is unchanged (always on, T&C consent).
- **Single source of truth:** moved the gate onto `TelemetrySettings.is_telemetry_enabled` as a `@property`; removed the standalone `is_telemetry_enabled()` function and its re-export from the `telemetry` package. All callers (`auth.py`, `task_management.py`, `middleware.py`, `instrumentation.py`, tests) now read `get_telemetry_settings().is_telemetry_enabled`.
- **Typo-proof config:** `deployment_type` is now `Literal["cloud", "self-hosted"]`, so an invalid value is a load-time `ValidationError` rather than a silent disable. Empty/unset still resolves to the `self-hosted` default (`env_ignore_empty=True`).
- **Docs:** `.env.example` telemetry example comment updated.
- **Tests:** self-hosted default now asserts off; unknown deployment type now asserts `ValidationError`; default-value assertion flipped.

## Additional Context

- **Real self-hosting is unaffected.** `docker-compose.yml` explicitly passes `OTEL_RHESIS_TELEMETRY_ENABLED=${...:-true}` + `OTEL_DEPLOYMENT_TYPE=self-hosted`, so the shipped self-hosting stack stays telemetry-on by default. Cloud CI/Helm set their vars explicitly too. Only *unconfigured* processes (dev, bare runs) change behavior.
- **Deploy heads-up:** because `deployment_type` is now validated, a deployment whose `OTEL_DEPLOYMENT_TYPE` secret (or Helm `config.otelDeploymentType`) is set to something outside `cloud`/`self-hosted` will now fail to boot instead of silently disabling telemetry. Unset → `|| 'cloud'` remains valid. Worth confirming that secret's value before rollout.
- The Celery worker never emitted this product-usage telemetry (it doesn't call `initialize_telemetry()`), so it needs no telemetry config and is unaffected.

## Testing

From `apps/backend`:

```bash
uv run pytest ../../tests/backend/test_telemetry_fixtures.py ../../tests/backend/app/test_settings.py -v
```

Covers: cloud always on, self-hosted off by default, self-hosted opt-in via env var, and invalid `deployment_type` raising `ValidationError`. Verified the gate logic directly (cloud → True; self-hosted default → False; self-hosted+true → True) and that all edited files compile.