### PR TITLE
Reduce frontend bootstrap and duplicate client fetches

### DIFF
--- a/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
+++ b/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
@@ -14,6 +14,7 @@ import { Sidebar } from '@/components/navigation/Sidebar';
 import { WebSocketProvider } from '@/contexts/WebSocketContext';
 import NoProjectAccess from '@/components/common/NoProjectAccess';
 import TermsAcceptanceGate from '@/components/auth/TermsAcceptanceGate';
+import type { TermsStatus } from '@/utils/api-client/auth-client';
 
 interface ExtendedUser {
   id: string;
@@ -70,12 +71,15 @@ export function ProtectedLayoutClient({
   children,
   initialFeatures,
   initialPermissions,
+  initialTermsStatus,
 }: {
   children: React.ReactNode;
   /** Server-fetched `GET /features` result, seeds FeaturesProvider so nav-gating capabilities are known on first paint (no client-side loading window). Null on fetch failure — client falls back to its own fetch. */
   initialFeatures: FeaturesResponse | null;
   /** Server-fetched `GET /me/permissions` result for the active project, seeds PermissionsProvider for the same reason. Null when RBAC is off or the fetch failed. */
   initialPermissions: string[] | null;
+  /** Server-fetched `GET /auth/terms-status` result, passed to `TermsAcceptanceGate` so it can decide without its own client-side fetch. Null on fetch failure — the gate falls back to fetching on mount. */
+  initialTermsStatus: TermsStatus | null;
 }) {
   const { data: session } = useSession();
   const pathname = usePathname();
@@ -100,7 +104,9 @@ export function ProtectedLayoutClient({
       <FeaturesProvider initialFeatures={initialFeatures}>
         <PermissionsProvider initialPermissions={initialPermissions}>
           <WebSocketProvider>
-            {!isOnboarding && <TermsAcceptanceGate />}
+            {!isOnboarding && (
+              <TermsAcceptanceGate initialTermsStatus={initialTermsStatus} />
+            )}
             {!isOnboarding && !chromeless && <VerificationBanner />}
             {content}
           </WebSocketProvider>

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
@@ -1,14 +1,16 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { Box } from '@mui/material';
 import { useSession } from 'next-auth/react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { ArchitectSession } from '@/utils/api-client/architect-client';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
+import { architectSessionKeys } from '@/constants/query-keys';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
 import {
@@ -23,10 +25,12 @@ import {
 import ArchitectSidebar from './ArchitectSidebar';
 import ArchitectChat from './ArchitectChat';
 import ArchitectWelcome from './ArchitectWelcome';
-import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
 
 export default function ArchitectClient() {
   const { status } = useSession();
+  const userScope = useUserScope();
+  const queryClient = useQueryClient();
   const { activeProject } = useActiveProject();
   const router = useRouter();
   const pathname = usePathname();
@@ -34,12 +38,31 @@ export default function ArchitectClient() {
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
     Capability.Architect.READ
   );
-  const [sessions, setSessions] = useState<ArchitectSession[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
-  const [isLoadingSessions, setIsLoadingSessions] = useState(true);
   const [pendingMessage, setPendingMessage] = useState<string | null>(null);
   const [isCreatingSession, setIsCreatingSession] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
+
+  const projectKey = activeProject?.id ?? '';
+  const sessionsQueryKey = architectSessionKeys.list(userScope, projectKey);
+
+  const updateSessions = useCallback(
+    (updater: (prev: ArchitectSession[]) => ArchitectSession[]) => {
+      queryClient.setQueryData<ArchitectSession[]>(sessionsQueryKey, prev =>
+        updater(prev ?? [])
+      );
+    },
+    [queryClient, sessionsQueryKey]
+  );
+
+  // react-query dedupes Strict Mode remounts and project-scoped refetches.
+  const { data: sessions = [], isLoading: isLoadingSessions } = useQuery({
+    queryKey: sessionsQueryKey,
+    queryFn: () => new ApiClientFactory().getArchitectClient().getSessions(),
+    enabled:
+      !permsLoading && canRead && isAuthenticated(status) && !!userScope,
+    staleTime: 30_000,
+  });
 
   const getClient = useCallback(() => {
     if (!isAuthenticated(status)) return null;
@@ -65,45 +88,30 @@ export default function ArchitectClient() {
     router.replace(qs ? `${pathname}?${qs}` : pathname, { scroll: false });
   }, [pathname, router, searchParams]);
 
-  // Reload sessions whenever the active project changes so the sidebar always
-  // shows only sessions belonging to the current project. The backend already
-  // filters by project via RLS (X-Project-Id header); we just need to re-fetch
-  // when the project scope switches.
+  // When the project scope changes (or the list first resolves), clear / resume
+  // selection. Skip while a ?session= handoff is pending — that effect wins.
+  const resumeForProjectRef = useRef<string | null>(null);
   useEffect(() => {
-    const loadSessions = async () => {
-      if (permsLoading || !canRead) return;
-      const client = getClient();
-      if (!client) return;
-      setIsLoadingSessions(true);
-      // Keep a pending ?session= selection while the list reloads.
-      if (!searchParams.get('session')) {
-        setActiveSessionId(null);
-      }
-      setSessions([]);
-      try {
-        const data = await client.getSessions();
-        setSessions(data);
-        // Skip resume when a ?session= handoff is pending — the query effect
-        // prefers that id over the resume hint.
-        if (searchParams.get('session')) {
-          return;
-        }
-        const projectId = activeProject?.id;
-        if (projectId) {
-          setActiveSessionId(pickResumableSessionId(projectId, data));
-        } else {
-          setActiveSessionId(null);
-        }
-      } catch (err) {
-        console.error('Failed to load architect sessions:', err);
-        setActiveSessionId(null);
-      } finally {
-        setIsLoadingSessions(false);
-      }
-    };
-    loadSessions();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- project/token drive reload
-  }, [getClient, activeProject?.id, permsLoading, canRead]);
+    if (sessionFromQuery) return;
+
+    // Project switched — drop the previous selection until the new list resolves.
+    if (resumeForProjectRef.current !== projectKey) {
+      setActiveSessionId(null);
+    }
+
+    if (permsLoading || !canRead || isLoadingSessions) return;
+    if (resumeForProjectRef.current === projectKey) return;
+    resumeForProjectRef.current = projectKey;
+
+    if (projectKey) {
+      setActiveSessionId(pickResumableSessionId(projectKey, sessions));
+    } else {
+      setActiveSessionId(null);
+    }
+    // sessions read once when the project key first resolves — intentionally
+    // not a dep, so title/create/delete cache writes don't re-run resume.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectKey, permsLoading, canRead, isLoadingSessions, sessionFromQuery]);
 
   // Prefer ?session= over resume (contextual handoffs). Separate from the list
   // reload so in-app navigations to /architect?session= still work without a
@@ -132,13 +140,14 @@ export default function ArchitectClient() {
 
       setActiveSessionId(sessionFromQuery);
       touchResumeHint(sessionFromQuery);
+      resumeForProjectRef.current = projectKey;
 
       const alreadyListed = sessions.some(s => s.id === sessionFromQuery);
       if (!alreadyListed) {
         try {
           const detail = await client.getSession(sessionFromQuery);
           if (cancelled) return;
-          setSessions(prev => [
+          updateSessions(prev => [
             detail,
             ...prev.filter(s => s.id !== detail.id),
           ]);
@@ -172,6 +181,8 @@ export default function ArchitectClient() {
     getClient,
     touchResumeHint,
     clearSessionQueryParam,
+    projectKey,
+    updateSessions,
   ]);
 
   // Bump last-activity when navigating away mid-conversation.
@@ -190,13 +201,13 @@ export default function ArchitectClient() {
     if (!client) return;
     try {
       const newSession = await client.createSession();
-      setSessions(prev => [newSession, ...prev]);
+      updateSessions(prev => [newSession, ...prev]);
       setActiveSessionId(newSession.id);
       touchResumeHint(newSession.id);
     } catch (err) {
       console.error('Failed to create session:', err);
     }
-  }, [getClient, touchResumeHint]);
+  }, [getClient, touchResumeHint, updateSessions]);
 
   const handleNewSessionWithMessage = useCallback(
     async (message: string) => {
@@ -206,7 +217,7 @@ export default function ArchitectClient() {
       setIsCreatingSession(true);
       try {
         const newSession = await client.createSession();
-        setSessions(prev => [newSession, ...prev]);
+        updateSessions(prev => [newSession, ...prev]);
         setPendingMessage(message);
         setActiveSessionId(newSession.id);
         touchResumeHint(newSession.id);
@@ -215,7 +226,7 @@ export default function ArchitectClient() {
         setIsCreatingSession(false);
       }
     },
-    [getClient, touchResumeHint]
+    [getClient, touchResumeHint, updateSessions]
   );
 
   const handleSelectSession = useCallback(
@@ -232,7 +243,7 @@ export default function ArchitectClient() {
       if (!client) return;
       try {
         await client.deleteSession(id);
-        setSessions(prev => prev.filter(s => s.id !== id));
+        updateSessions(prev => prev.filter(s => s.id !== id));
         if (activeSessionId === id) {
           setActiveSessionId(null);
           if (activeProject?.id) {
@@ -243,16 +254,16 @@ export default function ArchitectClient() {
         console.error('Failed to delete session:', err);
       }
     },
-    [getClient, activeSessionId, activeProject?.id]
+    [getClient, activeSessionId, activeProject?.id, updateSessions]
   );
 
   const handleSessionTitleUpdate = useCallback(
     (sessionId: string, title: string) => {
-      setSessions(prev =>
+      updateSessions(prev =>
         prev.map(s => (s.id === sessionId ? { ...s, title } : s))
       );
     },
-    []
+    [updateSessions]
   );
 
   const handleInitialMessageSent = useCallback(() => {

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
@@ -59,8 +59,7 @@ export default function ArchitectClient() {
   const { data: sessions = [], isLoading: isLoadingSessions } = useQuery({
     queryKey: sessionsQueryKey,
     queryFn: () => new ApiClientFactory().getArchitectClient().getSessions(),
-    enabled:
-      !permsLoading && canRead && isAuthenticated(status) && !!userScope,
+    enabled: !permsLoading && canRead && isAuthenticated(status) && !!userScope,
     staleTime: 30_000,
   });
 

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, {
+  useState,
+  useEffect,
+  useCallback,
+  useRef,
+  useMemo,
+} from 'react';
 import { Box } from '@mui/material';
 import { useSession } from 'next-auth/react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -44,7 +50,12 @@ export default function ArchitectClient() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
 
   const projectKey = activeProject?.id ?? '';
-  const sessionsQueryKey = architectSessionKeys.list(userScope, projectKey);
+  // Memoize so `updateSessions` (and the ?session= effect that depends on it)
+  // stay stable across renders while scope/project are unchanged.
+  const sessionsQueryKey = useMemo(
+    () => architectSessionKeys.list(userScope, projectKey),
+    [userScope, projectKey]
+  );
 
   const updateSessions = useCallback(
     (updater: (prev: ArchitectSession[]) => ArchitectSession[]) => {
@@ -59,7 +70,12 @@ export default function ArchitectClient() {
   const { data: sessions = [], isLoading: isLoadingSessions } = useQuery({
     queryKey: sessionsQueryKey,
     queryFn: () => new ApiClientFactory().getArchitectClient().getSessions(),
-    enabled: !permsLoading && canRead && isAuthenticated(status) && !!userScope,
+    enabled:
+      !permsLoading &&
+      canRead &&
+      isAuthenticated(status) &&
+      !!userScope &&
+      !!projectKey,
     staleTime: 30_000,
   });
 
@@ -116,7 +132,15 @@ export default function ArchitectClient() {
   // reload so in-app navigations to /architect?session= still work without a
   // remount (peqy).
   useEffect(() => {
-    if (!sessionFromQuery || permsLoading || !canRead) return;
+    if (
+      !sessionFromQuery ||
+      permsLoading ||
+      !canRead ||
+      !userScope ||
+      !projectKey
+    ) {
+      return;
+    }
 
     let cancelled = false;
 
@@ -177,10 +201,11 @@ export default function ArchitectClient() {
     sessionFromQuery,
     permsLoading,
     canRead,
+    userScope,
+    projectKey,
     getClient,
     touchResumeHint,
     clearSessionQueryParam,
-    projectKey,
     updateSessions,
   ]);
 

--- a/apps/frontend/src/app/(protected)/layout.tsx
+++ b/apps/frontend/src/app/(protected)/layout.tsx
@@ -34,9 +34,7 @@ export default async function ProtectedLayout({
 
     const [featuresResult, termsResult] = await Promise.allSettled([
       factory.getFeaturesClient().getFeatures(),
-      accessToken
-        ? fetchTermsStatusServer(accessToken)
-        : Promise.resolve(null),
+      accessToken ? fetchTermsStatusServer(accessToken) : Promise.resolve(null),
     ]);
 
     if (featuresResult.status === 'fulfilled') {

--- a/apps/frontend/src/app/(protected)/layout.tsx
+++ b/apps/frontend/src/app/(protected)/layout.tsx
@@ -1,21 +1,17 @@
-import { auth } from '@/auth';
+import { auth, getFreshAccessToken } from '@/auth';
+import { headers } from 'next/headers';
 import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { getServerActiveProjectId } from '@/utils/server-active-project';
 import { FeatureName } from '@/constants/features';
 import type { FeaturesResponse } from '@/utils/api-client/features-client';
+import { fetchTermsStatusServer } from '@/utils/api-client/auth-client.server';
+import type { TermsStatus } from '@/utils/api-client/auth-client';
 import { ProtectedLayoutClient } from './ProtectedLayoutClient';
 
 /**
- * Server-side counterpart of `ProtectedLayoutClient`. Fetches `GET /features`
- * and, when RBAC is on, `GET /me/permissions` for the active project — the
- * same two calls `FeaturesProvider`/`PermissionsProvider` would otherwise make
- * on mount — so the nav-gating capability set is already known on first paint.
- * Without this, `useCan` reports "unknown" (fail-closed) for one round trip on
- * every hard load, hiding every gated nav item until the client fetch resolves.
- *
- * Mirrors the `initialActiveProject`/`initialOrganization` seeding already
- * done in the root `app/layout.tsx`. Failures here are swallowed — the client
- * providers fall back to fetching normally, same as that existing pattern.
+ * Server-side layout that seeds `FeaturesProvider`, `PermissionsProvider`, and
+ * `TermsAcceptanceGate` with data so they don't need a client-side fetch on
+ * mount. Failures are swallowed — client providers fall back to fetching.
  */
 export default async function ProtectedLayout({
   children,
@@ -26,21 +22,39 @@ export default async function ProtectedLayout({
 
   let initialFeatures: FeaturesResponse | null = null;
   let initialPermissions: string[] | null = null;
+  let initialTermsStatus: TermsStatus | null = null;
 
   if (session && !session.error) {
-    try {
-      const projectId = await getServerActiveProjectId();
-      const factory = await createServerApiFactory();
+    const [projectId, { accessToken }] = await Promise.all([
+      getServerActiveProjectId(),
+      getFreshAccessToken({ headers: await headers() }),
+    ]);
 
-      initialFeatures = await factory.getFeaturesClient().getFeatures();
+    const factory = await createServerApiFactory();
+
+    const [featuresResult, termsResult] = await Promise.allSettled([
+      factory.getFeaturesClient().getFeatures(),
+      accessToken
+        ? fetchTermsStatusServer(accessToken)
+        : Promise.resolve(null),
+    ]);
+
+    if (featuresResult.status === 'fulfilled') {
+      initialFeatures = featuresResult.value;
 
       if (initialFeatures.enabled.includes(FeatureName.RBAC)) {
-        initialPermissions = await factory
-          .getPermissionsClient()
-          .getMyPermissions(projectId);
+        try {
+          initialPermissions = await factory
+            .getPermissionsClient()
+            .getMyPermissions(projectId);
+        } catch {
+          // Ignore — PermissionsProvider falls back to fetching on mount.
+        }
       }
-    } catch {
-      // Ignore — client providers will fetch on mount.
+    }
+
+    if (termsResult.status === 'fulfilled') {
+      initialTermsStatus = termsResult.value;
     }
   }
 
@@ -48,6 +62,7 @@ export default async function ProtectedLayout({
     <ProtectedLayoutClient
       initialFeatures={initialFeatures}
       initialPermissions={initialPermissions}
+      initialTermsStatus={initialTermsStatus}
     >
       {children}
     </ProtectedLayoutClient>

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -39,6 +39,7 @@ import { handleSignIn, handleSignOut } from '../actions/auth';
 import { LayoutContent } from '../components/layout/LayoutContent';
 import { createServerApiFactory } from '../utils/api-client/server-factory';
 import { getServerActiveProjectId } from '../utils/server-active-project';
+import { fetchQuickStartEnabledServer } from '../utils/quick_start.server';
 import {
   type NavigationItem,
   type BrandingProps,
@@ -46,6 +47,7 @@ import {
 } from '../types/navigation';
 import { type Project } from '../utils/api-client/interfaces/project';
 import { type Organization } from '../utils/api-client/interfaces/organization';
+import { type UserSettings } from '../utils/api-client/interfaces/user';
 import { type Session } from 'next-auth';
 import ThemeContextProvider from '../components/providers/ThemeProvider';
 import { Capability } from '../constants/capabilities';
@@ -292,20 +294,46 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
     apiBaseUrl: process.env.API_BASE_URL ?? 'http://localhost:8080',
   }).replace(/</g, '\\u003c')};`;
 
-  // Fetch the active project server-side so the sidebar can render the
-  // project name on first paint without a flash.
+  // Fetch the active project, and the full member-project list for the
+  // switcher, server-side so the sidebar/switcher render on first paint
+  // without a flash. Without `initialProjects`, `ActiveProjectProvider`
+  // always issued a client-side `GET /projects/mine` on mount even though
+  // the active project itself was already known here — this seeds that list
+  // too so the client effect can skip the network round trip entirely on
+  // the common case (falling back to fetching itself if this failed).
   let initialActiveProject: Project | null = null;
+  let initialProjects: Project[] | null = null;
+  // Seeds `useUserSettings`'s cache too (see `ActiveProjectProvider`), so
+  // the `default_project` fallback lookup it otherwise does with a client
+  // `GET /users/settings` — needed whenever there's no active-project cookie
+  // yet, e.g. a brand-new session — is already answered.
+  let initialUserSettings: UserSettings | null = null;
   const projectId = await getServerActiveProjectId();
-  if (projectId && session && !session.error) {
-    try {
-      const factory = await createServerApiFactory();
-      initialActiveProject = await factory
-        .getProjectsClient()
-        .getProject(projectId);
-    } catch {
-      // Ignore — client will fetch on mount
+  if (session && !session.error && session.user?.organization_id) {
+    const factory = await createServerApiFactory();
+    const [projectsResult, settingsResult] = await Promise.allSettled([
+      factory.getProjectsClient().getMyProjects(),
+      factory.getUsersClient().getUserSettings(),
+    ]);
+
+    if (projectsResult.status === 'fulfilled') {
+      initialProjects = projectsResult.value;
+      if (projectId) {
+        initialActiveProject =
+          projectsResult.value.find(p => String(p.id) === projectId) ?? null;
+      }
+    }
+    if (settingsResult.status === 'fulfilled') {
+      initialUserSettings = settingsResult.value;
     }
   }
+
+  // Fetched once here (unauthenticated `GET /auth/providers`) and threaded
+  // down via `QuickStartProvider` — see `fetchQuickStartEnabledServer`'s
+  // docstring for why this replaced two separate client-side `/api/auth-config`
+  // calls (one from `LayoutContent`, one from whichever consumer — the
+  // landing page or `TermsAcceptanceGate` — was also mounted).
+  const initialQuickStart = await fetchQuickStartEnabledServer();
 
   return (
     <html lang="en" suppressHydrationWarning data-theme-mode={initialThemeMode}>
@@ -323,7 +351,10 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
             branding={branding}
             authentication={AUTHENTICATION}
             initialActiveProject={initialActiveProject}
+            initialProjects={initialProjects}
+            initialUserSettings={initialUserSettings}
             initialOrganization={organization}
+            initialQuickStart={initialQuickStart}
           >
             {props.children}
           </LayoutContent>

--- a/apps/frontend/src/app/page.tsx
+++ b/apps/frontend/src/app/page.tsx
@@ -9,7 +9,7 @@ import LoginSection from '../components/auth/LoginSection';
 import AuthPageShell from '../components/auth/AuthPageShell';
 import { getClientApiBaseUrl } from '../utils/url-resolver';
 import RocketLaunchIcon from '@mui/icons-material/RocketLaunchOutlined';
-import { fetchQuickStartEnabled } from '@/utils/quick_start';
+import { useQuickStart } from '@/contexts/QuickStartContext';
 import {
   isAuthenticated,
   isSessionLoading,
@@ -24,27 +24,10 @@ export default function LandingPage() {
     boolean | null
   >(null);
   const [autoLoggingIn, setAutoLoggingIn] = useState(false);
-  const [isQuickStartMode, setIsQuickStartMode] = useState(false);
-  const [quickStartLoaded, setQuickStartLoaded] = useState(false);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    fetchQuickStartEnabled().then(enabled => {
-      if (!cancelled) {
-        setIsQuickStartMode(enabled);
-        setQuickStartLoaded(true);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const isQuickStartMode = useQuickStart();
 
   useEffect(() => {
     if (
-      quickStartLoaded &&
       isQuickStartMode &&
       isSessionUnauthenticated(status) &&
       !autoLoggingIn
@@ -80,7 +63,7 @@ export default function LandingPage() {
           });
       }
     }
-  }, [quickStartLoaded, isQuickStartMode, status, autoLoggingIn]);
+  }, [isQuickStartMode, status, autoLoggingIn]);
 
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);

--- a/apps/frontend/src/components/auth/TermsAcceptanceGate.tsx
+++ b/apps/frontend/src/components/auth/TermsAcceptanceGate.tsx
@@ -13,8 +13,17 @@ import {
 } from '@mui/material';
 import { useSession } from 'next-auth/react';
 import TermsAcceptanceField from './TermsAcceptanceField';
-import { acceptTerms, fetchTermsStatus } from '@/utils/api-client/auth-client';
-import { fetchQuickStartEnabled } from '@/utils/quick_start';
+import {
+  acceptTerms,
+  fetchTermsStatus,
+  type TermsStatus,
+} from '@/utils/api-client/auth-client';
+import { useQuickStart } from '@/contexts/QuickStartContext';
+
+interface TermsAcceptanceGateProps {
+  /** Server-fetched terms status (see `fetchTermsStatusServer`), seeded from the `(protected)` layout so no client-side fetch is needed on the happy path. Null when the server fetch failed/was skipped — falls back to a client fetch. */
+  initialTermsStatus?: TermsStatus | null;
+}
 
 /**
  * Global post-login gate: if the active terms version changed since the user last
@@ -22,42 +31,37 @@ import { fetchQuickStartEnabled } from '@/utils/quick_start';
  *
  * Skipped in Quick Start mode — local dev auto-login should not be blocked.
  */
-export default function TermsAcceptanceGate() {
+export default function TermsAcceptanceGate({
+  initialTermsStatus = null,
+}: TermsAcceptanceGateProps) {
   const { status } = useSession();
+  const quickStart = useQuickStart();
 
-  const [quickStart, setQuickStart] = React.useState<boolean | null>(null);
-  const [loading, setLoading] = React.useState(true);
-  const [open, setOpen] = React.useState(false);
+  const [loading, setLoading] = React.useState(!initialTermsStatus);
+  const [open, setOpen] = React.useState(
+    initialTermsStatus ? !initialTermsStatus.terms_accepted : false
+  );
   const [checked, setChecked] = React.useState(false);
   const [submitting, setSubmitting] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
   const [showWarning, setShowWarning] = React.useState(false);
-  const [hasPriorAcceptance, setHasPriorAcceptance] = React.useState(false);
+  const [hasPriorAcceptance, setHasPriorAcceptance] = React.useState(
+    initialTermsStatus?.has_prior_acceptance ?? false
+  );
 
   React.useEffect(() => {
-    let cancelled = false;
-
-    fetchQuickStartEnabled().then(enabled => {
-      if (!cancelled) {
-        setQuickStart(enabled);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  React.useEffect(() => {
-    if (quickStart === true) {
+    if (quickStart) {
       setLoading(false);
       return;
     }
 
-    if (quickStart === null || status !== 'authenticated') {
-      if (quickStart !== null) {
-        setLoading(false);
-      }
+    // Already seeded server-side — skip the client-side round trip entirely.
+    if (initialTermsStatus) {
+      setLoading(false);
+      return;
+    }
+
+    if (status !== 'authenticated') {
       return;
     }
 
@@ -83,14 +87,9 @@ export default function TermsAcceptanceGate() {
     return () => {
       cancelled = true;
     };
-  }, [status, quickStart]);
+  }, [status, quickStart, initialTermsStatus]);
 
-  if (
-    loading ||
-    quickStart === null ||
-    quickStart ||
-    status !== 'authenticated'
-  ) {
+  if (loading || quickStart || status !== 'authenticated') {
     return null;
   }
 

--- a/apps/frontend/src/components/auth/TermsAcceptanceGate.tsx
+++ b/apps/frontend/src/components/auth/TermsAcceptanceGate.tsx
@@ -55,8 +55,11 @@ export default function TermsAcceptanceGate({
       return;
     }
 
-    // Already seeded server-side — skip the client-side round trip entirely.
+    // Seeded server-side — sync local state when the prop is present/updates
+    // (layout refetch, navigation) and skip the client-side round trip.
     if (initialTermsStatus) {
+      setHasPriorAcceptance(initialTermsStatus.has_prior_acceptance);
+      setOpen(!initialTermsStatus.terms_accepted);
       setLoading(false);
       return;
     }

--- a/apps/frontend/src/components/layout/LayoutContent.tsx
+++ b/apps/frontend/src/components/layout/LayoutContent.tsx
@@ -14,8 +14,9 @@ import OnboardingChecklist from '../onboarding/OnboardingChecklist';
 import { type NavigationItem, type LayoutProps } from '../../types/navigation';
 import { ActiveProjectProvider } from '@/contexts/ActiveProjectContext';
 import { OrganizationProvider } from '@/contexts/OrganizationContext';
-import { fetchQuickStartEnabled } from '@/utils/quick_start';
+import { QuickStartProvider } from '@/contexts/QuickStartContext';
 import { useSessionGuard } from '@/hooks/useSessionGuard';
+import { userSettingsKeys } from '@/constants/query-keys';
 // Side-effect import: pulls ee_bootstrap into the *client* bundle so
 // EE feature registrations land in the client-side registry as well as
 // the server-side one. Layout.tsx imports the same module for the
@@ -47,22 +48,32 @@ export function LayoutContent({
   branding,
   authentication,
   initialActiveProject = null,
+  initialProjects = null,
+  initialUserSettings = null,
   initialOrganization = null,
+  initialQuickStart = false,
 }: Omit<LayoutProps, 'theme'>) {
   const theme = useTheme();
   const pathname = usePathname();
-  const [queryClient] = React.useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 5 * 60_000,
-            gcTime: 30 * 60_000,
-            refetchOnWindowFocus: false,
-          },
+  const [queryClient] = React.useState(() => {
+    const qc = new QueryClient({
+      defaultOptions: {
+        queries: {
+          staleTime: 5 * 60_000,
+          gcTime: 30 * 60_000,
+          refetchOnWindowFocus: false,
         },
-      })
-  );
+      },
+    });
+    // Pre-seed the user settings cache so useUserSettings and
+    // ActiveProjectProvider's default_project lookup hit the cache instead
+    // of issuing a redundant client-side GET /users/settings.
+    const userScope = session?.user?.id ?? '';
+    if (userScope && initialUserSettings) {
+      qc.setQueryData(userSettingsKeys.all(userScope), initialUserSettings);
+    }
+    return qc;
+  });
   const protectedSegments = React.useMemo(
     () => getAllSegments(navigation),
     [navigation]
@@ -78,24 +89,6 @@ export function LayoutContent({
     );
   }, [pathname, protectedSegments]);
 
-  // Use state to avoid hydration mismatch - start with false (matches server)
-  const [isQuickStartMode, setIsQuickStartMode] = React.useState(false);
-
-  // Check Quick Start mode after mount (client-side only)
-  React.useEffect(() => {
-    let cancelled = false;
-
-    fetchQuickStartEnabled().then(enabled => {
-      if (!cancelled) {
-        setIsQuickStartMode(enabled);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   // Build sx prop conditionally
   const boxSx = React.useMemo(() => {
     const baseStyles = {
@@ -104,7 +97,7 @@ export function LayoutContent({
       minHeight: '100vh',
     };
 
-    if (isQuickStartMode) {
+    if (initialQuickStart) {
       return {
         ...baseStyles,
         // Hide the account menu button when Quick Start mode is enabled
@@ -129,7 +122,7 @@ export function LayoutContent({
     }
 
     return baseStyles;
-  }, [isQuickStartMode]);
+  }, [initialQuickStart]);
 
   return (
     <SessionProvider session={session} refetchOnWindowFocus={false}>
@@ -137,28 +130,33 @@ export function LayoutContent({
         <AppRouterCacheProvider options={{ enableCssLayer: true }}>
           <CssBaseline />
           <QueryClientProvider client={queryClient}>
-            <ActiveProjectProvider initialActiveProject={initialActiveProject}>
-              <OrganizationProvider initialOrganization={initialOrganization}>
-                <NotificationProvider>
-                  <OnboardingProvider>
-                    <Box sx={boxSx}>
-                      <Box sx={{ flex: 1 }}>
-                        <NavigationProvider
-                          navigation={navigation}
-                          branding={branding}
-                          session={session}
-                          authentication={authentication}
-                          theme={theme}
-                        >
-                          {children}
-                        </NavigationProvider>
+            <QuickStartProvider value={initialQuickStart}>
+              <ActiveProjectProvider
+                initialActiveProject={initialActiveProject}
+                initialProjects={initialProjects}
+              >
+                <OrganizationProvider initialOrganization={initialOrganization}>
+                  <NotificationProvider>
+                    <OnboardingProvider>
+                      <Box sx={boxSx}>
+                        <Box sx={{ flex: 1 }}>
+                          <NavigationProvider
+                            navigation={navigation}
+                            branding={branding}
+                            session={session}
+                            authentication={authentication}
+                            theme={theme}
+                          >
+                            {children}
+                          </NavigationProvider>
+                        </Box>
                       </Box>
-                    </Box>
-                    {session && isProtectedRoute && <OnboardingChecklist />}
-                  </OnboardingProvider>
-                </NotificationProvider>
-              </OrganizationProvider>
-            </ActiveProjectProvider>
+                      {session && isProtectedRoute && <OnboardingChecklist />}
+                    </OnboardingProvider>
+                  </NotificationProvider>
+                </OrganizationProvider>
+              </ActiveProjectProvider>
+            </QuickStartProvider>
           </QueryClientProvider>
         </AppRouterCacheProvider>
       </SessionGuard>

--- a/apps/frontend/src/constants/query-keys.ts
+++ b/apps/frontend/src/constants/query-keys.ts
@@ -81,3 +81,8 @@ export const permissionKeys = {
 export const userSettingsKeys = {
   all: (userScope: string) => ['user-settings', userScope] as const,
 };
+
+export const architectSessionKeys = {
+  list: (userScope: string, projectId: string) =>
+    ['architect-sessions', userScope, projectId] as const,
+};

--- a/apps/frontend/src/contexts/ActiveProjectContext.tsx
+++ b/apps/frontend/src/contexts/ActiveProjectContext.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/utils/active-project';
 import type { UUID } from 'crypto';
 import { Project } from '@/utils/api-client/interfaces/project';
-import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
 
 interface ActiveProjectContextValue {
   /** Projects the current user is a member of. */
@@ -52,27 +52,33 @@ const ActiveProjectContext = createContext<ActiveProjectContextValue>({
 export function ActiveProjectProvider({
   children,
   initialActiveProject = null,
+  initialProjects = null,
 }: {
   children: React.ReactNode;
   initialActiveProject?: Project | null;
+  /** Server-fetched `GET /projects/mine` result. When present, the initial mount effect reuses it instead of re-fetching client-side. */
+  initialProjects?: Project[] | null;
 }) {
   const { data: session, status } = useSession();
   const queryClient = useQueryClient();
-  const userScope = session?.user?.id ?? '';
+  const userScope = useUserScope();
   const pathname = usePathname();
   const pathnameRef = useRef(pathname);
   pathnameRef.current = pathname;
   const [projects, setProjects] = useState<Project[]>(
-    initialActiveProject ? [initialActiveProject] : []
+    initialProjects ?? (initialActiveProject ? [initialActiveProject] : [])
   );
   const [activeProject, setActiveProjectState] = useState<Project | null>(
     initialActiveProject
   );
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!initialProjects);
+  // Only the very first mount effect run may reuse the server-seeded list —
+  // any later call (org switch, explicit refresh()) must hit the network.
+  const hasConsumedInitialRef = useRef(false);
 
   const fetchProjects = useCallback(
     async (options?: { listOnly?: boolean }) => {
-      if (!isAuthenticated(status)) return;
+      if (!isAuthenticated(status) || !userScope) return;
       if (
         pathnameRef.current.startsWith('/onboarding') ||
         !session?.user?.organization_id
@@ -82,11 +88,21 @@ export function ActiveProjectProvider({
         setLoading(false);
         return;
       }
+
+      const canReuseInitialProjects =
+        initialProjects !== null && !hasConsumedInitialRef.current;
+      hasConsumedInitialRef.current = true;
+
       setLoading(true);
       try {
-        const factory = new ApiClientFactory();
-        const projectsClient = factory.getProjectsClient();
-        const data = await projectsClient.getMyProjects();
+        let data: Project[];
+        if (canReuseInitialProjects) {
+          data = initialProjects as Project[];
+        } else {
+          const factory = new ApiClientFactory();
+          const projectsClient = factory.getProjectsClient();
+          data = await projectsClient.getMyProjects();
+        }
         setProjects(data);
 
         if (options?.listOnly) {
@@ -152,7 +168,7 @@ export function ActiveProjectProvider({
         setLoading(false);
       }
     },
-    [session?.user?.organization_id, queryClient, userScope, status]
+    [session?.user?.organization_id, queryClient, userScope, status, initialProjects]
   );
 
   useEffect(() => {
@@ -168,7 +184,7 @@ export function ActiveProjectProvider({
         writeActiveProjectId(nextId as string);
 
         // Persist as default_project so the selection survives logout/login.
-        if (isAuthenticated(status)) {
+        if (isAuthenticated(status) && userScope) {
           try {
             const factory = new ApiClientFactory();
             const updated = await factory.getUsersClient().updateUserSettings({

--- a/apps/frontend/src/contexts/ActiveProjectContext.tsx
+++ b/apps/frontend/src/contexts/ActiveProjectContext.tsx
@@ -168,7 +168,13 @@ export function ActiveProjectProvider({
         setLoading(false);
       }
     },
-    [session?.user?.organization_id, queryClient, userScope, status, initialProjects]
+    [
+      session?.user?.organization_id,
+      queryClient,
+      userScope,
+      status,
+      initialProjects,
+    ]
   );
 
   useEffect(() => {

--- a/apps/frontend/src/contexts/FeaturesContext.tsx
+++ b/apps/frontend/src/contexts/FeaturesContext.tsx
@@ -27,7 +27,7 @@ import type {
 import { useQuery } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
-import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
 
 interface FeaturesState {
   license: LicenseInfo | null;
@@ -61,13 +61,16 @@ export function FeaturesProvider({
    */
   initialFeatures?: FeaturesResponse | null;
 }) {
-  const { data: session, status } = useSession();
-  const userScope = session?.user?.id ?? '';
+  const { status } = useSession();
+  const userScope = useUserScope();
 
   const { data, isLoading, error } = useQuery({
     queryKey: featureKeys.all(userScope),
     queryFn: () => new ApiClientFactory().getFeaturesClient().getFeatures(),
-    enabled: isAuthenticated(status),
+    // `!!userScope` closes the gap where `status` flips to 'authenticated'
+    // before `userScope` reflects the real user id — without it the query
+    // could run (and cache) under the `''` scope key.
+    enabled: isAuthenticated(status) && !!userScope,
     staleTime: 5 * 60_000,
     ...(initialFeatures ? { initialData: initialFeatures } : {}),
   });

--- a/apps/frontend/src/contexts/OnboardingContext.tsx
+++ b/apps/frontend/src/contexts/OnboardingContext.tsx
@@ -24,7 +24,7 @@ import {
   mergeProgress,
 } from '@/utils/onboarding-service';
 import { getTourSteps, driverConfig } from '@/config/onboarding-tours';
-import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
 
 const OnboardingContext = createContext<OnboardingContextValue | undefined>(
   undefined
@@ -53,7 +53,7 @@ interface OnboardingProviderProps {
 export function OnboardingProvider({ children }: OnboardingProviderProps) {
   const { data: session, status } = useSession();
   const queryClient = useQueryClient();
-  const userScope = session?.user?.id ?? '';
+  const userScope = useUserScope();
   // Initialize with localStorage data immediately to avoid flash
   const [progress, setProgress] = useState<OnboardingProgress>(() => {
     // Load synchronously during initialization to prevent flash
@@ -85,6 +85,7 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
     // the org-attach step) has none yet, and the fetch would 403.
     if (
       !isAuthenticated(status) ||
+      !userScope ||
       !session?.user?.organization_id ||
       loadStartedRef.current
     ) {
@@ -142,7 +143,7 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
 
     saveProgress(progress);
 
-    if (!dbLoadedRef.current || !isAuthenticated(status)) return;
+    if (!dbLoadedRef.current || !isAuthenticated(status) || !userScope) return;
 
     // Skip the write when progress already matches what the database holds.
     // This suppresses the redundant PATCH the initial load's merge would
@@ -381,7 +382,7 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
   }, [driverInstance]);
 
   const forceSyncToDatabase = useCallback(async () => {
-    if (isAuthenticated(status) && session?.user?.organization_id) {
+    if (isAuthenticated(status) && userScope && session?.user?.organization_id) {
       try {
         await syncProgressToDatabase(queryClient, userScope, progress);
       } catch (error) {

--- a/apps/frontend/src/contexts/OnboardingContext.tsx
+++ b/apps/frontend/src/contexts/OnboardingContext.tsx
@@ -382,7 +382,11 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
   }, [driverInstance]);
 
   const forceSyncToDatabase = useCallback(async () => {
-    if (isAuthenticated(status) && userScope && session?.user?.organization_id) {
+    if (
+      isAuthenticated(status) &&
+      userScope &&
+      session?.user?.organization_id
+    ) {
       try {
         await syncProgressToDatabase(queryClient, userScope, progress);
       } catch (error) {

--- a/apps/frontend/src/contexts/PermissionsContext.tsx
+++ b/apps/frontend/src/contexts/PermissionsContext.tsx
@@ -32,7 +32,10 @@ import { useQuery } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 import type { WithPermittedActions } from '@/types/affordances';
-import { isAuthenticated as checkIsAuthenticated } from '@/hooks/useIsAuthenticated';
+import {
+  isAuthenticated as checkIsAuthenticated,
+  useUserScope,
+} from '@/hooks/useIsAuthenticated';
 
 export interface AmbientPermissions extends WithPermittedActions {
   permitted_actions: string[];
@@ -79,7 +82,7 @@ export function PermissionsProvider({
    */
   initialPermissions?: string[] | null;
 }) {
-  const { data: session, status } = useSession();
+  const { status } = useSession();
   const { activeProject } = useActiveProject();
   const { loading: featuresLoading } = useFeaturesState();
   const rbacEnabled = useFeature(FeatureName.RBAC);
@@ -87,7 +90,7 @@ export function PermissionsProvider({
   // Scope the cache key by user id — the access token no longer reaches this
   // client component (BFF proxy injects it), so it can't double as a scope
   // key here anymore.
-  const userScope = session?.user?.id ?? '';
+  const userScope = useUserScope();
 
   const { data, isLoading, error, isSuccess } = useQuery({
     queryKey: permissionKeys.all(userScope, activeProject?.id ?? ''),
@@ -95,7 +98,9 @@ export function PermissionsProvider({
       new ApiClientFactory()
         .getPermissionsClient()
         .getMyPermissions(activeProject?.id ?? undefined),
-    enabled: !featuresLoading && rbacEnabled && isAuthenticated,
+    // `!!userScope` closes the gap where `status` flips to 'authenticated'
+    // before `userScope` reflects the real user id.
+    enabled: !featuresLoading && rbacEnabled && isAuthenticated && !!userScope,
     staleTime: 5 * 60_000,
     ...(initialPermissions ? { initialData: initialPermissions } : {}),
   });

--- a/apps/frontend/src/contexts/QuickStartContext.tsx
+++ b/apps/frontend/src/contexts/QuickStartContext.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import * as React from 'react';
+
+const QuickStartContext = React.createContext<boolean>(false);
+
+/**
+ * Provides the Quick Start mode flag app-wide from a single server-fetched
+ * value (see `fetchQuickStartEnabledServer` in `@/utils/quick_start`),
+ * seeded once in the root layout. Consumers (`TermsAcceptanceGate`, the
+ * landing page, etc.) read it via `useQuickStart()` instead of each making
+ * their own `GET /api/auth-config` call on mount — which was the source of
+ * duplicate auth-config requests on every page load.
+ */
+export function QuickStartProvider({
+  value,
+  children,
+}: {
+  value: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <QuickStartContext.Provider value={value}>
+      {children}
+    </QuickStartContext.Provider>
+  );
+}
+
+export function useQuickStart(): boolean {
+  return React.useContext(QuickStartContext);
+}

--- a/apps/frontend/src/contexts/WebSocketContext.tsx
+++ b/apps/frontend/src/contexts/WebSocketContext.tsx
@@ -76,6 +76,29 @@ function makeWsTokenProvider(): () => Promise<string> {
 }
 
 /**
+ * Survive React Strict Mode's mount → unmount → remount without minting a
+ * second `POST /ws/token`: keep one client and defer disconnect by a tick so
+ * the remount can cancel teardown. Real unmount/logout still disconnects.
+ */
+let sharedClient: WebSocketClient | null = null;
+let teardownTimer: ReturnType<typeof setTimeout> | null = null;
+let onConnectionChange: ((connected: boolean) => void) | null = null;
+
+function clearTeardownTimer(): void {
+  if (teardownTimer) {
+    clearTimeout(teardownTimer);
+    teardownTimer = null;
+  }
+}
+
+function disposeSharedClient(): void {
+  clearTeardownTimer();
+  sharedClient?.disconnect();
+  sharedClient = null;
+  onConnectionChange = null;
+}
+
+/**
  * WebSocket provider component.
  *
  * This provider manages a WebSocket connection to the backend and
@@ -83,74 +106,65 @@ function makeWsTokenProvider(): () => Promise<string> {
  *
  * The connection is automatically established when a user session
  * is available and torn down on logout.
- *
- * @example
- * ```tsx
- * // In your app layout
- * <WebSocketProvider>
- *   <YourApp />
- * </WebSocketProvider>
- *
- * // In a component
- * const { isConnected, subscribe, subscribeToChannel } = useWebSocketContext();
- * ```
  */
 export function WebSocketProvider({ children }: WebSocketProviderProps) {
   const { status } = useSession();
   const [isConnected, setIsConnected] = useState(false);
   const [connectionId, setConnectionId] = useState<string | undefined>();
   const clientRef = useRef<WebSocketClient | null>(null);
+  const connectionIdHandlerRef = useRef<(id?: string) => void>(() => {});
 
-  // Initialize WebSocket client when session is available
+  connectionIdHandlerRef.current = id => setConnectionId(id);
+
   useEffect(() => {
-    // Don't connect if no session or still loading
     if (!isAuthenticated(status)) {
-      return;
-    }
-
-    const wsUrl = getWebSocketUrl();
-
-    // Create WebSocket client. The tokenProvider fetches a fresh short-lived
-    // WS token before each connection attempt (including auto-reconnects) via
-    // the BFF proxy. There's no static access token to fall back to here —
-    // this client never holds one — so a provider failure fails the
-    // connection attempt cleanly instead of reusing a stale credential.
-    const client = new WebSocketClient({
-      url: wsUrl,
-      token: '',
-      tokenProvider: makeWsTokenProvider(),
-      onConnectionChange: connected => {
-        setIsConnected(connected);
-        if (!connected) {
-          setConnectionId(undefined);
-        }
-      },
-    });
-
-    // Subscribe to connected event to capture connection ID
-    client.subscribe(EventType.CONNECTED, msg => {
-      const payload = msg.payload as { connection_id?: string } | undefined;
-      if (payload?.connection_id) {
-        setConnectionId(payload.connection_id);
-      }
-    });
-
-    // Connect
-    client.connect();
-    clientRef.current = client;
-
-    // Cleanup on unmount or session change
-    return () => {
-      client.disconnect();
+      // Logout / session loss: drop the shared socket immediately.
+      disposeSharedClient();
       clientRef.current = null;
       setIsConnected(false);
       setConnectionId(undefined);
+      return;
+    }
+
+    clearTeardownTimer();
+
+    onConnectionChange = connected => {
+      setIsConnected(connected);
+      if (!connected) setConnectionId(undefined);
+    };
+
+    if (!sharedClient) {
+      sharedClient = new WebSocketClient({
+        url: getWebSocketUrl(),
+        token: '',
+        tokenProvider: makeWsTokenProvider(),
+        onConnectionChange: connected => onConnectionChange?.(connected),
+      });
+      sharedClient.connect();
+    }
+
+    clientRef.current = sharedClient;
+    setIsConnected(sharedClient.isConnected);
+    if (sharedClient.connectionId) {
+      setConnectionId(sharedClient.connectionId);
+    }
+
+    const unsubscribe = sharedClient.subscribe(EventType.CONNECTED, msg => {
+      const payload = msg.payload as { connection_id?: string } | undefined;
+      connectionIdHandlerRef.current(payload?.connection_id);
+    });
+
+    return () => {
+      unsubscribe();
+      clientRef.current = null;
+      // Defer so Strict Mode remount can reuse `sharedClient` instead of
+      // disconnecting and minting another token.
+      teardownTimer = setTimeout(() => {
+        disposeSharedClient();
+      }, 0);
     };
   }, [status]);
 
-  /**
-   * Send a message to the WebSocket server.
-   */
   const send = useCallback((message: WebSocketMessage): boolean => {
     if (!clientRef.current) {
       console.warn('WebSocket client not initialized');
@@ -159,9 +173,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     return clientRef.current.send(message);
   }, []);
 
-  /**
-   * Subscribe to a specific event type.
-   */
   const subscribe = useCallback(
     (eventType: EventType | string, handler: EventHandler): (() => void) => {
       if (!clientRef.current) {
@@ -173,9 +184,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     []
   );
 
-  /**
-   * Subscribe to a backend channel.
-   */
   const subscribeToChannel = useCallback(
     (channel: string, projectId?: string | null): void => {
       if (!clientRef.current) {
@@ -187,9 +195,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     []
   );
 
-  /**
-   * Unsubscribe from a backend channel.
-   */
   const unsubscribeFromChannel = useCallback((channel: string): void => {
     if (!clientRef.current) {
       console.warn('WebSocket client not initialized');
@@ -198,10 +203,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     clientRef.current.unsubscribeFromChannel(channel);
   }, []);
 
-  /**
-   * Manually trigger a reconnection attempt.
-   * Resets the reconnection counter and attempts to connect.
-   */
   const reconnect = useCallback((): void => {
     if (!clientRef.current) {
       console.warn('WebSocket client not initialized');
@@ -249,18 +250,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
  * Hook to access the WebSocket context.
  *
  * @throws Error if used outside of WebSocketProvider
- *
- * @example
- * ```tsx
- * const { isConnected, subscribe, subscribeToChannel } = useWebSocketContext();
- *
- * useEffect(() => {
- *   const unsubscribe = subscribe(EventType.MESSAGE, (msg) => {
- *     console.log('Received:', msg);
- *   });
- *   return unsubscribe;
- * }, [subscribe]);
- * ```
  */
 export function useWebSocketContext(): WebSocketContextValue {
   const context = useContext(WebSocketContext);

--- a/apps/frontend/src/contexts/__tests__/ActiveProjectContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/ActiveProjectContext.test.tsx
@@ -1,22 +1,31 @@
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   ActiveProjectProvider,
   useActiveProject,
 } from '@/contexts/ActiveProjectContext';
 import type { Project } from '@/utils/api-client/interfaces/project';
 
+let mockSession: { data: unknown; status: string } = {
+  data: null,
+  status: 'unauthenticated',
+};
+
 jest.mock('next-auth/react', () => ({
-  useSession: () => ({ data: null }),
+  useSession: () => mockSession,
 }));
 
 jest.mock('next/navigation', () => ({
   usePathname: () => '/projects/proj-1',
 }));
 
+const getMyProjects = jest.fn();
 jest.mock('@/utils/api-client/client-factory', () => ({
-  ApiClientFactory: jest.fn(),
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getProjectsClient: () => ({ getMyProjects }),
+  })),
 }));
 
 function Probe() {
@@ -112,5 +121,63 @@ describe('ActiveProjectProvider.syncProject', () => {
     });
 
     expect(screen.getByTestId('project-list')).toHaveTextContent('New Name');
+  });
+});
+
+describe('ActiveProjectProvider server-seeded initial data', () => {
+  beforeEach(() => {
+    getMyProjects.mockClear();
+    document.cookie = 'rh_active_project_id=; path=/; SameSite=Lax; max-age=0';
+    mockSession = {
+      data: {
+        user: { id: 'user-1', organization_id: 'org-1' },
+      },
+      status: 'authenticated',
+    };
+  });
+
+  afterEach(() => {
+    mockSession = { data: null, status: 'unauthenticated' };
+  });
+
+  it('reuses the server-seeded project list instead of fetching /projects/mine', async () => {
+    const seededProject = { id: 'proj-1', name: 'Seeded Project' } as Project;
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ActiveProjectProvider
+          initialActiveProject={seededProject}
+          initialProjects={[seededProject]}
+        >
+          <Probe />
+        </ActiveProjectProvider>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('active-name')).toHaveTextContent(
+        'Seeded Project'
+      )
+    );
+    expect(getMyProjects).not.toHaveBeenCalled();
+  });
+
+  it('falls back to fetching /projects/mine when no initial data was seeded', async () => {
+    getMyProjects.mockResolvedValue([{ id: 'proj-9', name: 'Fetched' }]);
+    const queryClient = new QueryClient();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ActiveProjectProvider>
+          <Probe />
+        </ActiveProjectProvider>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(getMyProjects).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(screen.getByTestId('active-name')).toHaveTextContent('Fetched')
+    );
   });
 });

--- a/apps/frontend/src/hooks/useIsAuthenticated.ts
+++ b/apps/frontend/src/hooks/useIsAuthenticated.ts
@@ -39,3 +39,24 @@ export function useIsAuthenticated(): boolean {
   const { status } = useSession();
   return isAuthenticated(status);
 }
+
+/**
+ * The `session.user.id`-based cache-scope key used by every context that
+ * scopes a react-query cache/`QueryClient` entry by user (`FeaturesContext`,
+ * `PermissionsContext`, `OnboardingContext`, `ActiveProjectContext`) — the
+ * access token no longer reaches client components (BFF proxy injects it
+ * server-side), so it can't double as a scope key here anymore.
+ *
+ * Falls back to `''` when the id isn't known yet (session still resolving,
+ * or unauthenticated). Callers MUST additionally gate on
+ * `isAuthenticated(status) && userScope !== ''` — a shared query `enabled`
+ * check or effect guard — before using this as a query key or passing it to
+ * `fetchQuery`/`setQueryData`. Centralized here so every consumer derives it
+ * identically instead of re-deriving `session?.user?.id ?? ''` inline, which
+ * previously invited call sites to gate on `isAuthenticated(status)` alone
+ * and skip the `userScope` emptiness check.
+ */
+export function useUserScope(): string {
+  const { data: session } = useSession();
+  return session?.user?.id ?? '';
+}

--- a/apps/frontend/src/hooks/useUserSettings.ts
+++ b/apps/frontend/src/hooks/useUserSettings.ts
@@ -5,24 +5,25 @@ import { useSession } from 'next-auth/react';
 import { userSettingsKeys } from '@/constants/query-keys';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { UserSettings } from '@/utils/api-client/interfaces/user';
-import { isAuthenticated as checkIsAuthenticated } from '@/hooks/useIsAuthenticated';
+import {
+  isAuthenticated as checkIsAuthenticated,
+  useUserScope,
+} from '@/hooks/useIsAuthenticated';
 
 /**
  * Cached current-user settings from GET /users/settings.
  *
- * Scoped by user id (falling back to the session token) so the cache never
- * bleeds across login/logout or user switches, matching the pattern used by
- * `featureKeys`/`permissionKeys`.
+ * Scoped by user id so the cache never bleeds across login/logout or user
+ * switches, matching the pattern used by `featureKeys`/`permissionKeys`.
  */
 export function useUserSettings(enabled = true) {
-  const { data: session, status } = useSession();
-  const isAuthenticated = checkIsAuthenticated(status);
-  const userScope = session?.user?.id ?? '';
+  const { status } = useSession();
+  const userScope = useUserScope();
 
   return useQuery<UserSettings>({
     queryKey: userSettingsKeys.all(userScope),
     queryFn: () => new ApiClientFactory().getUsersClient().getUserSettings(),
-    enabled: enabled && isAuthenticated,
+    enabled: enabled && checkIsAuthenticated(status) && !!userScope,
     staleTime: 5 * 60_000,
   });
 }

--- a/apps/frontend/src/types/navigation.ts
+++ b/apps/frontend/src/types/navigation.ts
@@ -3,6 +3,7 @@ import { type Theme } from '@mui/material/styles';
 import { type Session } from 'next-auth';
 import { type Project } from '@/utils/api-client/interfaces/project';
 import { type Organization } from '@/utils/api-client/interfaces/organization';
+import { type UserSettings } from '@/utils/api-client/interfaces/user';
 
 export interface NavigationPageItem {
   kind: 'page';
@@ -81,5 +82,11 @@ export interface LayoutProps {
   authentication: AuthenticationProps;
   theme: Theme;
   initialActiveProject?: Project | null;
+  /** Server-fetched `GET /projects/mine` result — seeds `ActiveProjectProvider` so the switcher list and active-project resolution don't need a client-side fetch on mount. */
+  initialProjects?: Project[] | null;
+  /** Server-fetched `GET /users/settings` result — seeds the `useUserSettings` cache and the `default_project` fallback lookup inside `ActiveProjectProvider`. */
+  initialUserSettings?: UserSettings | null;
   initialOrganization?: Organization | null;
+  /** Server-fetched Quick Start flag — see `fetchQuickStartEnabledServer`. */
+  initialQuickStart?: boolean;
 }

--- a/apps/frontend/src/utils/__tests__/quick_start.test.ts
+++ b/apps/frontend/src/utils/__tests__/quick_start.test.ts
@@ -2,7 +2,8 @@ import { fetchQuickStartEnabled } from '../quick_start';
 import { fetchQuickStartEnabledServer } from '../quick_start.server';
 
 jest.mock('../server-fetch', () => ({
-  serverFetch: (path: string) => global.fetch(`http://backend.internal:8080${path}`),
+  serverFetch: (path: string) =>
+    global.fetch(`http://backend.internal:8080${path}`),
 }));
 
 function makeResponse(body: unknown, ok = true): Response {
@@ -74,7 +75,9 @@ describe('quick_start', () => {
 
       await expect(fetchQuickStartEnabledServer()).resolves.toBe(true);
       const [target] = fetchMock.mock.calls[0];
-      expect(String(target)).toBe('http://backend.internal:8080/auth/providers');
+      expect(String(target)).toBe(
+        'http://backend.internal:8080/auth/providers'
+      );
     });
 
     it('returns false when the backend request fails', async () => {

--- a/apps/frontend/src/utils/__tests__/quick_start.test.ts
+++ b/apps/frontend/src/utils/__tests__/quick_start.test.ts
@@ -1,4 +1,9 @@
 import { fetchQuickStartEnabled } from '../quick_start';
+import { fetchQuickStartEnabledServer } from '../quick_start.server';
+
+jest.mock('../server-fetch', () => ({
+  serverFetch: (path: string) => global.fetch(`http://backend.internal:8080${path}`),
+}));
 
 function makeResponse(body: unknown, ok = true): Response {
   return {
@@ -49,6 +54,39 @@ describe('quick_start', () => {
       fetchMock.mockRejectedValue(new Error('network unavailable'));
 
       await expect(fetchQuickStartEnabled()).resolves.toBe(false);
+    });
+  });
+
+  describe('fetchQuickStartEnabledServer', () => {
+    let fetchMock: jest.Mock;
+
+    beforeEach(() => {
+      fetchMock = jest.fn();
+      global.fetch = fetchMock;
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('hits the backend directly instead of the same-origin proxy', async () => {
+      fetchMock.mockResolvedValue(makeResponse({ quick_start: true }));
+
+      await expect(fetchQuickStartEnabledServer()).resolves.toBe(true);
+      const [target] = fetchMock.mock.calls[0];
+      expect(String(target)).toBe('http://backend.internal:8080/auth/providers');
+    });
+
+    it('returns false when the backend request fails', async () => {
+      fetchMock.mockResolvedValue(makeResponse({}, false));
+
+      await expect(fetchQuickStartEnabledServer()).resolves.toBe(false);
+    });
+
+    it('returns false when the backend request throws', async () => {
+      fetchMock.mockRejectedValue(new Error('network unavailable'));
+
+      await expect(fetchQuickStartEnabledServer()).resolves.toBe(false);
     });
   });
 });

--- a/apps/frontend/src/utils/api-client/auth-client.server.ts
+++ b/apps/frontend/src/utils/api-client/auth-client.server.ts
@@ -1,0 +1,25 @@
+import { serverFetch } from '../server-fetch';
+import type { TermsStatus } from './auth-client';
+
+/**
+ * Server-side fetch of `GET /auth/terms-status`. Called once from the
+ * `(protected)` layout so `TermsAcceptanceGate` can render its decision on
+ * first paint without a client-side round trip.
+ *
+ * Returns `null` on any failure — the client falls back to its own fetch.
+ */
+export async function fetchTermsStatusServer(
+  accessToken: string
+): Promise<TermsStatus | null> {
+  try {
+    const response = await serverFetch('/auth/terms-status', { accessToken });
+    if (!response.ok) return null;
+    const data = await response.json();
+    return {
+      terms_accepted: Boolean(data.terms_accepted),
+      has_prior_acceptance: Boolean(data.has_prior_acceptance),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/frontend/src/utils/quick_start.server.ts
+++ b/apps/frontend/src/utils/quick_start.server.ts
@@ -1,0 +1,24 @@
+import { serverFetch } from './server-fetch';
+
+interface AuthConfigResponse {
+  quick_start?: boolean;
+}
+
+/**
+ * Server-side fetch of the Quick Start flag from `GET /auth/providers`.
+ * Called once from the root layout so the result can be threaded down via
+ * `QuickStartProvider`, eliminating duplicate client-side `/api/auth-config`
+ * calls that previously fired on every page load.
+ *
+ * Unauthenticated — no token needed.
+ */
+export async function fetchQuickStartEnabledServer(): Promise<boolean> {
+  try {
+    const response = await serverFetch('/auth/providers');
+    if (!response.ok) return false;
+    const data = (await response.json()) as AuthConfigResponse;
+    return data.quick_start === true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/frontend/src/utils/server-fetch.ts
+++ b/apps/frontend/src/utils/server-fetch.ts
@@ -1,21 +1,30 @@
 import { getServerBackendUrl } from './url-resolver';
 
+type ServerFetchOptions = RequestInit & {
+  accessToken?: string;
+};
+
 /**
  * Minimal server-side fetch wrapper for backend API calls from Server
- * Components. Resolves the backend URL, sets `cache: 'no-store'`, and
- * optionally injects an Authorization header.
+ * Components. Resolves the backend URL, defaults `cache` to `'no-store'`,
+ * and optionally injects an Authorization header. Remaining `RequestInit`
+ * fields (method, body, signal, extra headers, …) are forwarded as-is.
  *
  * Returns the raw `Response` — callers handle JSON parsing and error mapping
  * themselves (keeps this layer thin and composable).
  */
 export function serverFetch(
   path: string,
-  options?: { accessToken?: string }
+  options: ServerFetchOptions = {}
 ): Promise<Response> {
-  const url = new URL(path, getServerBackendUrl());
-  const headers: Record<string, string> = {};
-  if (options?.accessToken) {
-    headers['Authorization'] = `Bearer ${options.accessToken}`;
+  const { accessToken, headers: initHeaders, cache, ...init } = options;
+  const headers = new Headers(initHeaders);
+  if (accessToken) {
+    headers.set('Authorization', `Bearer ${accessToken}`);
   }
-  return fetch(url, { headers, cache: 'no-store' });
+  return fetch(new URL(path, getServerBackendUrl()), {
+    ...init,
+    headers,
+    cache: cache ?? 'no-store',
+  });
 }

--- a/apps/frontend/src/utils/server-fetch.ts
+++ b/apps/frontend/src/utils/server-fetch.ts
@@ -1,0 +1,21 @@
+import { getServerBackendUrl } from './url-resolver';
+
+/**
+ * Minimal server-side fetch wrapper for backend API calls from Server
+ * Components. Resolves the backend URL, sets `cache: 'no-store'`, and
+ * optionally injects an Authorization header.
+ *
+ * Returns the raw `Response` — callers handle JSON parsing and error mapping
+ * themselves (keeps this layer thin and composable).
+ */
+export function serverFetch(
+  path: string,
+  options?: { accessToken?: string }
+): Promise<Response> {
+  const url = new URL(path, getServerBackendUrl());
+  const headers: Record<string, string> = {};
+  if (options?.accessToken) {
+    headers['Authorization'] = `Bearer ${options.accessToken}`;
+  }
+  return fetch(url, { headers, cache: 'no-store' });
+}


### PR DESCRIPTION
## Purpose

Protected pages were making redundant client-side fetches for bootstrap data (`auth-config`/quick-start, terms status, projects/mine, user settings) and Strict Mode remounts were doubling architect sessions and websocket token calls.

## What Changed

- Seed quick-start, projects, user settings, features/permissions, and terms status from server layouts and thread them into providers/gates
- Add `serverFetch` helper and `.server.ts` fetch helpers for backend calls from Server Components
- Centralize `useUserScope()` and gate queries on a non-empty scope
- Dedupe architect sessions via react-query; reuse one WebSocket client across Strict Mode remounts so `/ws/token` mints once

## Additional Context

- Server seeding for architect sessions / websocket token left for a later pass
- Unrelated `agents/dr-rhesis/uv.lock` changes were intentionally excluded

## Testing

- [ ] Hard-refresh `/architect` and confirm a single `sessions` and single `/api/backend/ws/token` request
- [ ] Confirm no duplicate client `auth-config` / terms-status / projects/mine / users/settings on happy-path load
- [ ] Terms gate still blocks when terms are unaccepted; skipped in quick-start
- [ ] Project switcher still lists projects and restores active project from cookie/default