### PR TITLE
Stop duplicating settings.py defaults in docker-compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,8 @@ SESSION_SECRET_KEY=
 # =============================================================================
 # SMTP
 # =============================================================================
+# Email notifications are disabled unless SMTP_HOST, SMTP_USER and SMTP_PASSWORD are all set.
+
 # SMTP_HOST=smtp.example.com
 # SMTP_PORT=587
 # SMTP_USER=your-smtp-username

--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,7 @@ SESSION_SECRET_KEY=
 # GH_CLIENT_ID=your-github-client-id
 # GH_CLIENT_SECRET=your-github-client-secret
 # AUTH_REGISTRATION_ENABLED=true
+# AUTH_EMAIL_PASSWORD_ENABLED=true
 
 # =============================================================================
 # ENTERPRISE FEATURES
@@ -100,6 +101,7 @@ SESSION_SECRET_KEY=
 
 # STORAGE_SERVICE_URI=file:///app/storage
 # STORAGE_SERVICE_ACCOUNT_KEY=your-base64-service-account-key
+# LOCAL_STORAGE_PATH=/tmp/rhesis-files
 
 # =============================================================================
 # TELEMETRY
@@ -115,3 +117,4 @@ SESSION_SECRET_KEY=
 # QUICK_START=false
 # CELERY_WORKER_CONCURRENCY=8
 # CELERY_WORKER_PREFETCH_MULTIPLIER=4
+# CELERY_WORKER_LOGLEVEL=       # defaults to LOG_LEVEL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,16 @@ x-host:
   api_base_url:  &api_base_url  ${API_BASE_URL:-http://localhost:8080}
   frontend_url:  &frontend_url  ${FRONTEND_URL:-http://localhost:3000}
 
+# Non-secret defaults are owned by settings.py: pass ${VAR:-} so an unset var
+# arrives empty and env_ignore_empty falls back to the application default.
 x-common-storage: &common-storage
-  STORAGE_SERVICE_URI: ${STORAGE_SERVICE_URI:-file:///app/storage}
+  STORAGE_SERVICE_URI: ${STORAGE_SERVICE_URI:-}
   STORAGE_SERVICE_ACCOUNT_KEY: ${STORAGE_SERVICE_ACCOUNT_KEY:-}
-  LOCAL_STORAGE_PATH: ${LOCAL_STORAGE_PATH:-/tmp/rhesis-files}
+  LOCAL_STORAGE_PATH: ${LOCAL_STORAGE_PATH:-}
 
 x-common-auth: &common-auth
-  AUTH_EMAIL_PASSWORD_ENABLED: ${AUTH_EMAIL_PASSWORD_ENABLED:-true}
-  AUTH_REGISTRATION_ENABLED: ${AUTH_REGISTRATION_ENABLED:-true}
+  AUTH_EMAIL_PASSWORD_ENABLED: ${AUTH_EMAIL_PASSWORD_ENABLED:-}
+  AUTH_REGISTRATION_ENABLED: ${AUTH_REGISTRATION_ENABLED:-}
   # Google OAuth (optional)
   GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
   GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
@@ -21,11 +23,12 @@ x-common-auth: &common-auth
   SESSION_SECRET_KEY: ${SESSION_SECRET_KEY:?SESSION_SECRET_KEY is required, no safe default}
 
 
+# No placeholder host/credentials: email stays disabled until SMTP_HOST is set.
 x-common-smtp: &common-smtp
-  SMTP_HOST: ${SMTP_HOST:-smtp.example.com}
-  SMTP_PORT: ${SMTP_PORT:-587}
-  SMTP_USER: ${SMTP_USER:-user@example.com}
-  SMTP_PASSWORD: ${SMTP_PASSWORD:-your-smtp-password}
+  SMTP_HOST: ${SMTP_HOST:-}
+  SMTP_PORT: ${SMTP_PORT:-}
+  SMTP_USER: ${SMTP_USER:-}
+  SMTP_PASSWORD: ${SMTP_PASSWORD:-}
   FROM_EMAIL: ${FROM_EMAIL:-noreply@example.com}
 
 x-common-jwt: &common-jwt
@@ -35,20 +38,20 @@ x-common-environment: &common-environment
   BACKEND_ENV: local
   FRONTEND_ENV: local
   WORKER_ENV: local
-  LOG_LEVEL: ${LOG_LEVEL:-INFO}
-  QUICK_START: ${QUICK_START:-false}
+  LOG_LEVEL: ${LOG_LEVEL:-}
+  QUICK_START: ${QUICK_START:-}
 
 x-rhesis-config: &rhesis-config
   API_BASE_URL: *api_base_url
-  RHESIS_BASE_URL: https://api.rhesis.ai
-  RHESIS_API_KEY: ${RHESIS_API_KEY:-your-rhesis-api-key}
+  RHESIS_BASE_URL: ${RHESIS_BASE_URL:-}
+  RHESIS_API_KEY: ${RHESIS_API_KEY:-}
   RHESIS_CONNECTOR_DISABLED: true
   FRONTEND_URL: *frontend_url
   BACKEND_URL: http://backend:8080
-  DEFAULT_GENERATION_MODEL: ${DEFAULT_GENERATION_MODEL:-rhesis/rhesis-default}
-  DEFAULT_EVALUATION_MODEL: ${DEFAULT_EVALUATION_MODEL:-rhesis/rhesis-default}
-  DEFAULT_EXECUTION_MODEL: ${DEFAULT_EXECUTION_MODEL:-rhesis/rhesis-default}
-  DEFAULT_EMBEDDING_MODEL: ${DEFAULT_EMBEDDING_MODEL:-rhesis/rhesis-embedding}
+  DEFAULT_GENERATION_MODEL: ${DEFAULT_GENERATION_MODEL:-}
+  DEFAULT_EVALUATION_MODEL: ${DEFAULT_EVALUATION_MODEL:-}
+  DEFAULT_EXECUTION_MODEL: ${DEFAULT_EXECUTION_MODEL:-}
+  DEFAULT_EMBEDDING_MODEL: ${DEFAULT_EMBEDDING_MODEL:-}
 
 x-telemetry-config: &telemetry-config
   OTEL_RHESIS_TELEMETRY_ENABLED: ${OTEL_RHESIS_TELEMETRY_ENABLED:-true}  # Self-hosted: opt-out via env var
@@ -98,8 +101,9 @@ services:
       <<: [*common-auth, *common-smtp, *common-jwt, *common-environment, *rhesis-config, *telemetry-config, *common-storage]
       # DB/Redis default to the built-in postgres/redis services above; set
       # these in your .env file to point at an external database or Redis.
+      # DB_NAME keeps a literal default because migrate.sh reads $DB_NAME directly.
       DB_HOST: ${DB_HOST:-postgres}
-      DB_PORT: ${DB_PORT:-5432}
+      DB_PORT: ${DB_PORT:-}
       DB_NAME: ${DB_NAME:-rhesis-db}
       APP_DB_USER: ${APP_DB_USER:-rhesis-user}
       APP_DB_PASS: ${APP_DB_PASS:-rhesis-password}
@@ -143,8 +147,9 @@ services:
       <<: [*common-auth,  *common-smtp, *common-jwt, *common-environment, *rhesis-config, *common-storage]
       # DB/Redis default to the built-in postgres/redis services above; set
       # these in your .env file to point at an external database or Redis.
+      # DB_NAME keeps a literal default because migrate.sh reads $DB_NAME directly.
       DB_HOST: ${DB_HOST:-postgres}
-      DB_PORT: ${DB_PORT:-5432}
+      DB_PORT: ${DB_PORT:-}
       DB_NAME: ${DB_NAME:-rhesis-db}
       APP_DB_USER: ${APP_DB_USER:-rhesis-user}
       APP_DB_PASS: ${APP_DB_PASS:-rhesis-password}
@@ -153,10 +158,10 @@ services:
       DB_ENCRYPTION_KEY: ${DB_ENCRYPTION_KEY:?DB_ENCRYPTION_KEY is required, no safe default}
       BROKER_URL: ${BROKER_URL:-redis://:rhesis-redis-pass@redis:6379/0}
       CELERY_RESULT_BACKEND: ${CELERY_RESULT_BACKEND:-redis://:rhesis-redis-pass@redis:6379/1}
-      LOG_LEVEL: ${LOG_LEVEL:-INFO}
       CELERY_WORKER_CONCURRENCY: ${CELERY_WORKER_CONCURRENCY:-8}
       CELERY_WORKER_PREFETCH_MULTIPLIER: ${CELERY_WORKER_PREFETCH_MULTIPLIER:-4}
-      CELERY_WORKER_LOGLEVEL: ${CELERY_WORKER_LOGLEVEL:-INFO}
+      # Unset falls back to LOG_LEVEL in apps/worker/start.sh.
+      CELERY_WORKER_LOGLEVEL: ${CELERY_WORKER_LOGLEVEL:-}
       ENABLE_FLOWER: no
     volumes:
       - rhesis-storage:/app/storage

--- a/docs/content/docs/deployment/environment-variables.mdx
+++ b/docs/content/docs/deployment/environment-variables.mdx
@@ -153,7 +153,7 @@ Rarely changed; the defaults are correct for most deployments.
 | Variable | Description | Default |
 |---|---|---|
 | `JWT_ALGORITHM` | JWT signing algorithm | `HS256` |
-| `JWT_ACCESS_TOKEN_EXPIRE_MINUTES` | Access-token lifetime (minutes) | `10080` |
+| `JWT_ACCESS_TOKEN_EXPIRE_MINUTES` | Access-token lifetime (minutes); refreshed automatically, and the window in which a deactivated user's token stays valid | `15` |
 | `RHESIS_BASE_URL` | Base URL for Rhesis-hosted models | `https://api.rhesis.ai` |
 | `DB_DRIVER` | SQLAlchemy database driver | `postgresql` |
 | `BROKER_READ_URL` | Optional read-replica broker URL | *(unset)* |

--- a/docs/content/docs/organizations/api-clients.mdx
+++ b/docs/content/docs/organizations/api-clients.mdx
@@ -81,7 +81,7 @@ Successful responses follow the OAuth token response shape:
   "access_token": "<rhesis-jwt>",
   "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
   "token_type": "Bearer",
-  "expires_in": 604800,
+  "expires_in": 900,
   "scope": "read offline_access",
   "refresh_token": "<refresh-token>",
   "refresh_expires_in": 604800

--- a/sdk/src/rhesis/sdk/clients/rhesis.py
+++ b/sdk/src/rhesis/sdk/clients/rhesis.py
@@ -210,8 +210,8 @@ class RhesisClient:
         return cls(
             project_id=os.getenv("RHESIS_PROJECT_ID"),
             api_key=os.getenv("RHESIS_API_KEY"),
-            environment=os.getenv("RHESIS_ENVIRONMENT", "development"),
-            base_url=os.getenv("RHESIS_BASE_URL", "http://localhost:8080"),
+            environment=os.getenv("RHESIS_ENVIRONMENT") or "development",
+            base_url=os.getenv("RHESIS_BASE_URL") or "http://localhost:8080",
         )
 
     def _init_telemetry(self) -> None:

--- a/sdk/src/rhesis/sdk/clients/rhesis.py
+++ b/sdk/src/rhesis/sdk/clients/rhesis.py
@@ -208,8 +208,8 @@ class RhesisClient:
             return DisabledClient()
 
         return cls(
-            project_id=os.getenv("RHESIS_PROJECT_ID"),
-            api_key=os.getenv("RHESIS_API_KEY"),
+            project_id=os.getenv("RHESIS_PROJECT_ID") or None,
+            api_key=os.getenv("RHESIS_API_KEY") or None,
             environment=os.getenv("RHESIS_ENVIRONMENT") or "development",
             base_url=os.getenv("RHESIS_BASE_URL") or "http://localhost:8080",
         )

--- a/sdk/src/rhesis/sdk/clients/rhesis.py
+++ b/sdk/src/rhesis/sdk/clients/rhesis.py
@@ -207,9 +207,21 @@ class RhesisClient:
             logger.info("Connector explicitly disabled (RHESIS_CONNECTOR_DISABLED=true)")
             return DisabledClient()
 
+        project_id = os.getenv("RHESIS_PROJECT_ID") or None
+        api_key = os.getenv("RHESIS_API_KEY") or None
+
+        # Gate before construction: __init__ eagerly installs the OTEL provider and
+        # starts exporting, so a missing key would ship spans with "Bearer None".
+        if not api_key or not project_id:
+            logger.info(
+                "RHESIS_API_KEY/RHESIS_PROJECT_ID not set; using DisabledClient. "
+                "Traces will NOT be shipped to the backend."
+            )
+            return DisabledClient()
+
         return cls(
-            project_id=os.getenv("RHESIS_PROJECT_ID") or None,
-            api_key=os.getenv("RHESIS_API_KEY") or None,
+            project_id=project_id,
+            api_key=api_key,
             environment=os.getenv("RHESIS_ENVIRONMENT") or "development",
             base_url=os.getenv("RHESIS_BASE_URL") or "http://localhost:8080",
         )

--- a/sdk/src/rhesis/sdk/models/providers/native.py
+++ b/sdk/src/rhesis/sdk/models/providers/native.py
@@ -60,7 +60,7 @@ class RhesisLLM(BaseLLM):
         self.api_key = api_key or os.getenv("RHESIS_API_KEY")
         self.base_url = base_url or os.getenv("RHESIS_BASE_URL")
 
-        if self.api_key is None:
+        if not self.api_key:
             raise ValueError("RHESIS_API_KEY is not set")
 
         super().__init__(model_name, **kwargs)
@@ -257,7 +257,7 @@ class RhesisEmbedder(BaseEmbedder):
         self.api_key = api_key or os.getenv("RHESIS_API_KEY")
         self.base_url = base_url or os.getenv("RHESIS_BASE_URL")
 
-        if self.api_key is None:
+        if not self.api_key:
             raise ValueError("RHESIS_API_KEY is not set")
 
         self.client = APIClient(api_key=self.api_key, base_url=self.base_url)

--- a/tests/sdk/test_client.py
+++ b/tests/sdk/test_client.py
@@ -291,6 +291,49 @@ def test_normal_client_when_connector_enabled(monkeypatch):
     importlib.reload(rhesis.sdk.clients.rhesis)
 
 
+@pytest.mark.parametrize(
+    "env",
+    [
+        pytest.param({}, id="both-missing"),
+        pytest.param({"RHESIS_API_KEY": "test_key"}, id="project-id-missing"),
+        pytest.param({"RHESIS_PROJECT_ID": "test_project"}, id="api-key-missing"),
+        pytest.param(
+            {"RHESIS_API_KEY": "", "RHESIS_PROJECT_ID": ""},
+            id="both-empty",
+        ),
+        pytest.param(
+            {"RHESIS_API_KEY": "test_key", "RHESIS_PROJECT_ID": ""},
+            id="project-id-empty",
+        ),
+    ],
+)
+def test_disabled_client_when_credentials_missing(monkeypatch, env):
+    """from_environment() returns a DisabledClient when either credential is unset or empty.
+
+    Gating happens before construction: RhesisClient.__init__ installs the OTEL
+    provider and starts exporting, so a missing key would ship "Bearer None".
+    """
+    monkeypatch.delenv("RHESIS_CONNECTOR_DISABLED", raising=False)
+    for name in ("RHESIS_API_KEY", "RHESIS_PROJECT_ID"):
+        monkeypatch.delenv(name, raising=False)
+    for name, value in env.items():
+        monkeypatch.setenv(name, value)
+
+    import importlib
+
+    import rhesis.sdk.clients.rhesis
+
+    importlib.reload(rhesis.sdk.clients.rhesis)
+    from rhesis.sdk.clients.rhesis import DisabledClient, RhesisClient
+
+    client = RhesisClient.from_environment()
+
+    assert isinstance(client, DisabledClient)
+    assert client.is_disabled is True
+
+    importlib.reload(rhesis.sdk.clients.rhesis)
+
+
 @pytest.mark.asyncio
 async def test_connect_raises_when_event_loop_running(monkeypatch):
     """connect() raises RuntimeError when called from a context with a running event loop."""


### PR DESCRIPTION
## Purpose

`docker-compose.yml` repeated `settings.py` defaults for non-secret configuration via
`${VAR:-default}`, so the same value lived in two places and could drift. Some of those Compose
values were placeholders that changed behavior rather than merely duplicating it — a fake SMTP host
made the backend believe email was configured.

## What Changed

- **Compose owns topology, `settings.py` owns non-secret defaults.** Storage, auth toggles,
  `SMTP_PORT`, `LOG_LEVEL`, `QUICK_START`, all four `DEFAULT_*_MODEL`, `RHESIS_BASE_URL`, `DB_PORT`
  and `CELERY_WORKER_LOGLEVEL` now pass `${VAR:-}`. An unset var arrives empty and
  `env_ignore_empty=True` falls back to the application default.
  - `${VAR:-}` rather than bare `${VAR}`: bare interpolation makes Compose print
    `variable is not set, defaulting to a blank string` for every one of them on each `up`.
- **Placeholder non-secrets removed.** `SMTP_HOST`/`SMTP_USER`/`SMTP_PASSWORD` injected
  `smtp.example.com` plus fake credentials, so `SMTPService.is_configured` was `True` and every send
  attempt hit a 30s socket timeout instead of reporting email as disabled. `RHESIS_API_KEY` injected
  `your-rhesis-api-key`.
- **`RHESIS_BASE_URL` is now overridable** — it was hardcoded to `https://api.rhesis.ai`.
- **`LOG_LEVEL=DEBUG` now reaches Celery.** `CELERY_WORKER_LOGLEVEL: ${...:-INFO}` was masking the
  `:="$LOG_LEVEL"` derivation in `apps/worker/start.sh`. The worker's redundant `LOG_LEVEL` line
  (already supplied by the `common-environment` anchor) is gone.
- **SDK reads empty env vars as unset** on the two paths outside pydantic-settings: the
  `RhesisLLM`/`RhesisEmbedder` guard was `api_key is None`, so an empty key passed it and sent
  `Bearer ` for a 401 instead of raising the actionable `RHESIS_API_KEY is not set`;
  `RhesisClient.from_env` used `os.getenv(name, default)`, whose default only applies when the var
  is absent.
- **Docs: two stale JWT lifetimes.** Both predate the move to short-lived access tokens behind the
  refresh flow. `environment-variables.mdx` listed the `JWT_ACCESS_TOKEN_EXPIRE_MINUTES` default as
  `10080`; it is `15`. `api-clients.mdx` showed `expires_in: 604800` while calling those values the
  defaults; `exchange.py:531` returns `jwt_access_token_expire_minutes * 60`, so `900`.

### Two Compose values deliberately kept literal

- `DB_NAME` — `apps/backend/migrate.sh` reads bare `$DB_NAME` for `pg_isready`/`psql -d` with no
  shell fallback, so an empty value breaks migrations on startup. `DB_PORT` was safe to strip only
  because migrate.sh writes `${DB_PORT:-5432}`.
- `OTEL_RHESIS_TELEMETRY_ENABLED` — not duplication. #2271 flipped the *code* default to off so
  bare-process dev runs stop reporting, with docker-compose opting in explicitly. Stripping it would
  have silently reversed that decision.

## Additional Context

- Follows #2271, which flipped the self-hosted telemetry default.
- No behavior change for any var a user already sets; overrides pass through unchanged.
- The `10080` in the docs is exactly 7 days — the old pre-refresh session lifetime, which now lives
  on as the refresh token's TTL (`JWT_REFRESH_TOKEN_EXPIRE_DAYS`). That's the tell that
  `10080 → 1440 → 15` was one architectural migration rather than config rot.

## Testing

```bash
# Renders clean, zero "variable is not set" warnings; every stripped var resolves to ""
docker compose --env-file .env.docker config

# Overrides still pass through (LOG_LEVEL=DEBUG, SMTP_HOST=..., DB_PORT=6543, ...)
docker compose --env-file .env.docker config | grep -E "LOG_LEVEL|SMTP_HOST|DB_PORT"

cd apps/backend && uv run pytest ../../tests/backend/app/test_settings.py -q   # 61 passed
cd sdk && uv run pytest ../tests/sdk/models ../tests/sdk/test_client.py ../tests/sdk/connector -q  # 391 passed
cd docs/src && npm run build   # 270 pages
```

Loaded every settings group with the stripped vars set to empty and compared against what Compose
used to inject: all values identical except the two intended changes — SMTP host/user/password and
`RHESIS_API_KEY` are now `None`, so `SMTPService.is_configured` is `False` and logs
"SMTP configuration incomplete" instead of timing out against `smtp.example.com`.
