### PR TITLE
fix(backend): put venv bin before system bin in backend image PATH

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -230,7 +230,7 @@ RUN mkdir -p logs && chown rhesis-user:rhesis-user logs
 USER rhesis-user
 
 ENV PYTHONPATH=/app/apps/backend/src \
-    PATH="/usr/local/bin:/app/apps/backend/.venv/bin:$PATH"
+    PATH="/app/apps/backend/.venv/bin:/usr/local/bin:$PATH"
 
 CMD ["./start.sh"]
 

--- a/apps/backend/Dockerfile.dev
+++ b/apps/backend/Dockerfile.dev
@@ -129,7 +129,7 @@ USER rhesis-user
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPATH=/app/apps/backend/src \
-    PATH="/usr/local/bin:/app/apps/backend/.venv/bin:$PATH"
+    PATH="/app/apps/backend/.venv/bin:/usr/local/bin:$PATH"
 
 # Expose port
 EXPOSE 8080


### PR DESCRIPTION
## Summary

Found while actually running `license-issue.yml` and `license-mint-selfhosted.yml` end-to-end against the dev image built from #2107's merge commit — both failed with `ModuleNotFoundError: No module named 'rhesis.backend.ee'`, despite the package being correctly installed and present on disk (confirmed by pulling the image and inspecting `.venv/lib/python3.12/site-packages/` directly).

## Root cause

The `backend` Dockerfile stage sets:
```
PATH="/usr/local/bin:/app/apps/backend/.venv/bin:$PATH"
```
`/usr/local/bin` comes *before* the venv's `bin/`. The base `python:3.12.8-slim` image ships its own `python`/`python3`/`pip` at `/usr/local/bin`, so any bare `python` invocation resolves to the **system** interpreter, not the venv's — silently losing every venv site-package, including the `.pth`-based editable install of `rhesis-backend-ee` that makes `rhesis.backend.ee` importable.

Normal traffic never hits this: `start.sh` launches `uvicorn`/`gunicorn` directly (names that don't collide with anything in `/usr/local/bin`), so PATH order never mattered there. It only surfaces for anything that invokes `python -m ...` directly against this image — which is exactly what the EE license `issue`/`mint` Cloud Run Jobs do.

The `migrate` and `worker` stages already order PATH correctly (`.venv/bin` first) — this brings `backend` in line with them. Applied the same fix to `Dockerfile.dev`.

## Verification

Pulled the affected dev image (`rhesis-backend:8588ff45`) and reproduced directly:
```
$ docker run --rm --entrypoint sh <image> -c 'python -m rhesis.backend.ee.licensing.cli --help'
ModuleNotFoundError: No module named 'rhesis.backend.ee'
```
Then confirmed the fix resolves it by overriding PATH to match the corrected order inside the same (unmodified) image — the CLI's `--help` output prints correctly once `.venv/bin` precedes `/usr/local/bin`.

## Testing

No code changes, no test suite impact — Dockerfile-only. Needs a rebuild + redeploy of the `dev` backend image to actually verify end-to-end (rerunning `license-issue.yml` and `license-mint-selfhosted.yml`).