### PR TITLE
Add RBAC for license-issue.yml's in-cluster Job (dev/stg/prd)

### DIFF
--- a/kubernetes/clusters/dev/kustomization.yaml
+++ b/kubernetes/clusters/dev/kustomization.yaml
@@ -22,5 +22,7 @@ resources:
   - rhesis/namespace.yaml
   # rhesis-app-secrets: see clusters/dev/external-secrets/kustomization.yaml (same sync tree as ESO)
   - rhesis/rhesis-application.yaml
+  # RBAC for rhesis-ee's license-issue.yml workflow (arc-runner-dev -> one-off Jobs here)
+  - rhesis/license-issuer-rbac.yaml
   # ARC self-hosted runner: gives deploy jobs VPC-internal access to ArgoCD
   - arc.yaml

--- a/kubernetes/clusters/dev/rhesis/license-issuer-rbac.yaml
+++ b/kubernetes/clusters/dev/rhesis/license-issuer-rbac.yaml
@@ -1,0 +1,51 @@
+# Lets the dev-arc-runner-set's default ServiceAccount (arc-runners/default)
+# run one-off Kubernetes Jobs in this namespace on behalf of rhesis-ee's
+# license-issue.yml workflow. That workflow issues signed license tokens by
+# running the EE licensing CLI as a Job here instead of a Cloud Run Job,
+# because this namespace's Postgres (Bitnami chart, Service "rhesis-postgresql")
+# only resolves via cluster-internal DNS -- Cloud Run cannot reach it.
+#
+# Blast-radius note: "create Jobs" implicitly allows a Job's pod spec to
+# mount any Secret already in this namespace (rhesis-app-secrets included) --
+# Kubernetes RBAC has no way to grant Job-creation without that. The real
+# access boundary is who can dispatch license-issue.yml in the private
+# rhesis-ee repo, not this Role.
+#
+# secrets get/update/delete are scoped via resourceNames to the one Secret
+# the workflow actually manages. Kubernetes RBAC cannot apply resourceNames
+# to "create" (the object doesn't exist yet at authorization time), so this
+# Role can still create a Secret under any name -- it just can't read,
+# change, or remove anything other than "license-issue-signing" afterward.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: license-issuer
+  namespace: rhesis
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["license-issue-signing"]
+    verbs: ["create", "get", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: license-issuer
+  namespace: rhesis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: license-issuer
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: arc-runners

--- a/kubernetes/clusters/prd/kustomization.yaml
+++ b/kubernetes/clusters/prd/kustomization.yaml
@@ -24,5 +24,7 @@ resources:
   - cnpg-cluster-application.yaml
   # rhesis-app-secrets: see clusters/prd/external-secrets/rhesis-app-secrets.yaml
   - rhesis/rhesis-application.yaml
+  # RBAC for rhesis-ee's license-issue.yml workflow (arc-runner-prd -> one-off Jobs here)
+  - rhesis/license-issuer-rbac.yaml
   # ARC self-hosted runner: gives deploy jobs VPC-internal access to ArgoCD
   - arc.yaml

--- a/kubernetes/clusters/prd/rhesis/license-issuer-rbac.yaml
+++ b/kubernetes/clusters/prd/rhesis/license-issuer-rbac.yaml
@@ -1,0 +1,52 @@
+# Lets the prd-arc-runner-set's default ServiceAccount (arc-runners/default)
+# run one-off Kubernetes Jobs in this namespace on behalf of rhesis-ee's
+# license-issue.yml workflow. That workflow issues signed license tokens by
+# running the EE licensing CLI as a Job here instead of a Cloud Run Job,
+# because this namespace's Postgres (CloudNativePG, Service "rhesis-prd-rw")
+# only resolves via cluster-internal DNS -- Cloud Run cannot reach it.
+#
+# Blast-radius note: "create Jobs" implicitly allows a Job's pod spec to
+# mount any Secret already in this namespace (rhesis-app-secrets included) --
+# Kubernetes RBAC has no way to grant Job-creation without that. The real
+# access boundary is who can dispatch license-issue.yml in the private
+# rhesis-ee repo, not this Role -- for prd, that's gated by required
+# reviewer approval on the "prd" GitHub Environment (see license-issue.yml).
+#
+# secrets get/update/delete are scoped via resourceNames to the one Secret
+# the workflow actually manages. Kubernetes RBAC cannot apply resourceNames
+# to "create" (the object doesn't exist yet at authorization time), so this
+# Role can still create a Secret under any name -- it just can't read,
+# change, or remove anything other than "license-issue-signing" afterward.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: license-issuer
+  namespace: rhesis
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["license-issue-signing"]
+    verbs: ["create", "get", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: license-issuer
+  namespace: rhesis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: license-issuer
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: arc-runners

--- a/kubernetes/clusters/stg/kustomization.yaml
+++ b/kubernetes/clusters/stg/kustomization.yaml
@@ -24,5 +24,7 @@ resources:
   - cnpg-cluster-application.yaml
   # rhesis-app-secrets: see clusters/stg/external-secrets/rhesis-app-secrets.yaml
   - rhesis/rhesis-application.yaml
+  # RBAC for rhesis-ee's license-issue.yml workflow (arc-runner-stg -> one-off Jobs here)
+  - rhesis/license-issuer-rbac.yaml
   # ARC self-hosted runner: gives deploy jobs VPC-internal access to ArgoCD
   - arc.yaml

--- a/kubernetes/clusters/stg/rhesis/license-issuer-rbac.yaml
+++ b/kubernetes/clusters/stg/rhesis/license-issuer-rbac.yaml
@@ -1,0 +1,51 @@
+# Lets the stg-arc-runner-set's default ServiceAccount (arc-runners/default)
+# run one-off Kubernetes Jobs in this namespace on behalf of rhesis-ee's
+# license-issue.yml workflow. That workflow issues signed license tokens by
+# running the EE licensing CLI as a Job here instead of a Cloud Run Job,
+# because this namespace's Postgres (CloudNativePG, Service "rhesis-stg-rw")
+# only resolves via cluster-internal DNS -- Cloud Run cannot reach it.
+#
+# Blast-radius note: "create Jobs" implicitly allows a Job's pod spec to
+# mount any Secret already in this namespace (rhesis-app-secrets included) --
+# Kubernetes RBAC has no way to grant Job-creation without that. The real
+# access boundary is who can dispatch license-issue.yml in the private
+# rhesis-ee repo, not this Role.
+#
+# secrets get/update/delete are scoped via resourceNames to the one Secret
+# the workflow actually manages. Kubernetes RBAC cannot apply resourceNames
+# to "create" (the object doesn't exist yet at authorization time), so this
+# Role can still create a Secret under any name -- it just can't read,
+# change, or remove anything other than "license-issue-signing" afterward.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: license-issuer
+  namespace: rhesis
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["create", "get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["license-issue-signing"]
+    verbs: ["create", "get", "update", "delete"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: license-issuer
+  namespace: rhesis
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: license-issuer
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: arc-runners


### PR DESCRIPTION
## Purpose

`license-issue.yml` in the private rhesis-ee repo currently runs the EE
licensing CLI as a Cloud Run Job, which fails in every environment: the
application database is never reachable from Cloud Run. dev runs a
self-hosted Postgres (Bitnami chart) inside the cluster's private pod
network; stg/prd run CloudNativePG, also inside the cluster's private pod
network. Both are reachable only via cluster-internal DNS. The workflow is
being reworked to run the CLI as a one-off Kubernetes Job in the `rhesis`
namespace instead, reusing the same networking the backend/worker
Deployments already rely on.

## What Changed

- Added `kubernetes/clusters/<dev|stg|prd>/rhesis/license-issuer-rbac.yaml`:
  a namespaced `Role`/`RoleBinding` per cluster letting that cluster's
  `arc-runner-set`'s default ServiceAccount (`arc-runners/default`)
  create/get/list/watch/delete Jobs and Pods, read pod logs, and manage one
  specific Secret (`license-issue-signing`) in the `rhesis` namespace.
- Registered each manifest in its cluster's `kubernetes/clusters/<env>/kustomization.yaml`.

## Additional Context

- Companion workflow change is in `rhesis-ai/rhesis-ee` (`license-issue.yml`
  reworked to deploy/run a K8s Job via `kubectl` from `arc-runner-<env>`
  instead of `gcloud run jobs`, with environment-specific DB-credential
  wiring since dev and stg/prd source those differently).
- Blast-radius note (also in each manifest's comments): granting "create
  Jobs in this namespace" implicitly allows a Job's pod spec to mount any
  other Secret already there (`rhesis-app-secrets` included) — Kubernetes
  RBAC has no way to grant Job-creation without that. The real access
  boundary is who can dispatch `license-issue.yml` in the private
  rhesis-ee repo — for `prd` specifically, that's the required-reviewer gate
  already on the workflow's `prd` GitHub Environment. `secrets` verbs are
  scoped via `resourceNames` to `license-issue-signing` for
  get/update/delete; `resourceNames` cannot restrict `create` (a Kubernetes
  RBAC limitation), so this Role could still create a Secret under an
  arbitrary name, just not read/modify/delete it afterward.

## Testing

Validated locally: `kubectl kustomize kubernetes/clusters/<dev|stg|prd>/`
builds cleanly for all three and renders each `Role`/`RoleBinding` as
expected. Full validation is re-running `license-issue.yml` against dev
once this merges and ArgoCD syncs it — stg/prd validation follows whenever
those environments are next exercised.