### PR TITLE
Fix Explorer session deletion to match other entities

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -741,6 +741,24 @@ def delete_test_set(
     )
 
 
+def get_test_ids_in_test_sets(
+    db: Session, test_set_ids: List[uuid.UUID], organization_id: str
+) -> List[uuid.UUID]:
+    """Distinct ids of the tests associated with any of the given test sets."""
+    if not test_set_ids:
+        return []
+
+    rows = db.execute(
+        select(test_test_set_association.c.test_id)
+        .where(
+            test_test_set_association.c.test_set_id.in_(test_set_ids),
+            test_test_set_association.c.organization_id == organization_id,
+        )
+        .distinct()
+    ).fetchall()
+    return [row.test_id for row in rows]
+
+
 def get_test_set_by_nano_id_or_slug(
     db: Session, identifier: str, organization_id: str = None, user_id: str = None
 ) -> Optional[models.TestSet]:

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -189,13 +189,37 @@ def _is_explorer_test_set(test_set: models.TestSet) -> bool:
     return ADAPTIVE_TESTING_BEHAVIOR in behaviors
 
 
+def _delete_session_tests(
+    db: Session,
+    test_set_ids: List[UUID],
+    organization_id: str,
+    user_id: str,
+) -> None:
+    """Soft-delete the tests belonging to Explorer sessions that are being deleted.
+
+    Explorer tests -- including the topic-marker rows that carry the tree -- are
+    owned by their session: both import and export copy rows rather than share
+    them, so no other test set references them. Leaving them behind strands them
+    in the global /tests list with no session to reach them from.
+    """
+    test_ids = crud.get_test_ids_in_test_sets(db, test_set_ids, organization_id)
+    if not test_ids:
+        return
+    crud.bulk_delete_tests(
+        db,
+        test_ids,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+
+
 def delete_explorer_test_set(
     db: Session,
     test_set_identifier: str,
     organization_id: str,
     user_id: str,
 ) -> models.TestSet:
-    """Delete a test set that is configured for Explorer.
+    """Delete a test set that is configured for Explorer, along with its tests.
 
     Resolves the test set by UUID, nano_id, or slug. Raises ValueError if the
     set is missing or does not include the Adaptive Testing behavior.
@@ -209,6 +233,8 @@ def delete_explorer_test_set(
     # Build the response payload before deleting to avoid response serialization
     # touching an expired/deleted SQLAlchemy instance after commit.
     payload = schemas.TestSet.model_validate(db_test_set)
+
+    _delete_session_tests(db, [db_test_set.id], organization_id, user_id)
 
     deleted = crud.delete_test_set(
         db,
@@ -227,7 +253,7 @@ def bulk_delete_explorer_test_sets(
     organization_id: str,
     user_id: str,
 ) -> dict:
-    """Delete multiple Explorer test sets at once.
+    """Delete multiple Explorer test sets at once, along with their tests.
 
     Any id that doesn't resolve to a test set with the Adaptive Testing
     behavior is reported back in "not_found_ids" rather than deleted -- same
@@ -244,6 +270,8 @@ def bulk_delete_explorer_test_sets(
         .all()
     )
     valid_ids = [ts.id for ts in candidates if _is_explorer_test_set(ts)]
+
+    _delete_session_tests(db, valid_ids, organization_id, user_id)
 
     result = bulk_delete_by_ids(
         db,

--- a/apps/frontend/src/app/(protected)/explorer/[identifier]/components/ExplorerDetail.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/[identifier]/components/ExplorerDetail.tsx
@@ -40,6 +40,7 @@ import { alpha, useTheme } from '@mui/material/styles';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import { useSession } from 'next-auth/react';
+import { useQueryClient } from '@tanstack/react-query';
 import {
   GridColDef,
   GridPaginationModel,
@@ -51,6 +52,10 @@ import { GridToolbar as AppGridToolbar } from '@/components/common/GridToolbar';
 import BaseDrawer from '@/components/common/BaseDrawer';
 import { PageLayout } from '@/components/layout/PageLayout';
 import { Fab, FabGroup } from '@/components/common/Fab';
+import { DeleteModal } from '@/components/common/DeleteModal';
+import { Can } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+import { explorerKeys } from '@/constants/query-keys';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import FolderIcon from '@mui/icons-material/Folder';
@@ -1962,12 +1967,15 @@ export default function ExplorerDetail({
     string | null
   >(null);
   const [exportSubmitting, setExportSubmitting] = useState(false);
+  const [deleteSessionDialogOpen, setDeleteSessionDialogOpen] = useState(false);
+  const [deleteSessionSubmitting, setDeleteSessionSubmitting] = useState(false);
 
   const theme = useTheme();
   const { status } = useSession();
   const notifications = useNotifications();
   const searchParams = useSearchParams();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const pathname = usePathname();
   const selectedTopicForApi =
     selectedTopic && selectedTopic !== NO_TOPIC_FILTER ? selectedTopic : null;
@@ -2891,6 +2899,28 @@ export default function ExplorerDetail({
     }
   }, [testSetId, notifications, router]);
 
+  const handleDeleteSessionConfirm = useCallback(async () => {
+    setDeleteSessionSubmitting(true);
+    try {
+      const client = new ApiClientFactory().getExplorerClient();
+      await client.deleteExplorerTestSet(testSetId);
+      notifications.show('Session deleted', {
+        severity: 'success',
+        autoHideDuration: 4000,
+      });
+      queryClient.invalidateQueries({ queryKey: explorerKeys.all() });
+      router.push('/explorer');
+    } catch (err) {
+      notifications.show(
+        err instanceof Error ? err.message : 'Failed to delete session.',
+        { severity: 'error', autoHideDuration: 6000 }
+      );
+      setDeleteSessionSubmitting(false);
+    } finally {
+      setDeleteSessionDialogOpen(false);
+    }
+  }, [testSetId, notifications, queryClient, router]);
+
   return (
     <PageLayout
       title={testSetName}
@@ -2901,6 +2931,14 @@ export default function ExplorerDetail({
       ]}
       actions={
         <FabGroup>
+          <Can capability={Capability.Explorer.DELETE}>
+            <Fab
+              icon={<DeleteIcon />}
+              tooltip="Delete session"
+              onClick={() => setDeleteSessionDialogOpen(true)}
+              loading={deleteSessionSubmitting}
+            />
+          </Can>
           <Fab
             icon={<IosShareOutlinedIcon />}
             tooltip="Save to Test Set"
@@ -3309,6 +3347,24 @@ export default function ExplorerDetail({
           }}
           onSubmit={handleRenameTopicSubmit}
           topicPath={renamingTopicPath}
+        />
+
+        {/* Delete Session Confirmation Dialog */}
+        <DeleteModal
+          open={deleteSessionDialogOpen}
+          onClose={() =>
+            !deleteSessionSubmitting && setDeleteSessionDialogOpen(false)
+          }
+          onConfirm={handleDeleteSessionConfirm}
+          isLoading={deleteSessionSubmitting}
+          title="Delete explorer session"
+          message={
+            <>
+              &ldquo;{testSetName}&rdquo; and its tests and topics will be
+              deleted. This cannot be undone.
+            </>
+          }
+          itemType="explorer session"
         />
 
         {/* Delete Test Confirmation Dialog */}

--- a/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
@@ -228,6 +228,7 @@ export default function ExplorerGrid({
   };
 
   const handleDeleteTestSets = () => {
+    setPendingDeleteId(null);
     setDeleteModalOpen(true);
   };
 
@@ -288,7 +289,6 @@ export default function ExplorerGrid({
         { severity: 'success', autoHideDuration: 4000 }
       );
 
-      setPendingDeleteId(null);
       setSelectedRows([]);
       queryClient.invalidateQueries({ queryKey: explorerKeys.all() });
     } catch {
@@ -299,6 +299,8 @@ export default function ExplorerGrid({
     } finally {
       setIsDeleting(false);
       setDeleteModalOpen(false);
+      // Clear here, not on success only: a stale id would retarget the next bulk delete.
+      setPendingDeleteId(null);
     }
   };
 

--- a/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
@@ -37,6 +37,9 @@ import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 import { UserAvatar } from '@/components/common/UserAvatar';
 import { AVATAR_SIZES } from '@/constants/avatar-sizes';
 import type { UserReference } from '@/utils/api-client/interfaces/tests';
+import { createRowActionsColumn } from '@/components/common/createRowActionsColumn';
+import { useCan } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
 
 interface ExplorerGridProps {
   canCreate?: boolean;
@@ -98,8 +101,10 @@ export default function ExplorerGrid({
   });
   const [selectedRows, setSelectedRows] = useState<GridRowSelectionModel>([]);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const canDeleteSession = useCan(Capability.Explorer.DELETE);
 
   const {
     data,
@@ -134,6 +139,11 @@ export default function ExplorerGrid({
     },
     []
   );
+
+  const handleRowDeleteAction = useCallback((id: string) => {
+    setPendingDeleteId(id);
+    setDeleteModalOpen(true);
+  }, []);
 
   const columns = useMemo<GridColDef[]>(
     () => [
@@ -203,8 +213,14 @@ export default function ExplorerGrid({
           );
         },
       },
+      createRowActionsColumn({
+        onDelete: id => handleRowDeleteAction(id),
+        canDelete: () => canDeleteSession,
+        deleteTooltip: 'Delete session',
+        width: 56,
+      }),
     ],
-    []
+    [canDeleteSession, handleRowDeleteAction]
   );
 
   const handleRowClick = (params: GridRowParams) => {
@@ -217,6 +233,7 @@ export default function ExplorerGrid({
 
   const handleDeleteCancel = () => {
     setDeleteModalOpen(false);
+    setPendingDeleteId(null);
   };
 
   const handleExportSelected = useCallback(async () => {
@@ -252,18 +269,26 @@ export default function ExplorerGrid({
   }, [notifications, router, selectedRows]);
 
   const handleDeleteConfirm = async () => {
-    if (selectedRows.length === 0) return;
+    const idsToDelete = pendingDeleteId
+      ? [pendingDeleteId]
+      : selectedRows.map(String);
+    if (idsToDelete.length === 0) return;
 
     try {
       setIsDeleting(true);
       const client = new ApiClientFactory().getExplorerClient();
-      await client.bulkDeleteExplorerTestSets(selectedRows.map(String));
+      if (pendingDeleteId) {
+        await client.deleteExplorerTestSet(pendingDeleteId);
+      } else {
+        await client.bulkDeleteExplorerTestSets(idsToDelete);
+      }
 
       notifications.show(
-        `Successfully deleted ${selectedRows.length} ${selectedRows.length === 1 ? 'session' : 'sessions'}`,
+        `Successfully deleted ${idsToDelete.length} ${idsToDelete.length === 1 ? 'session' : 'sessions'}`,
         { severity: 'success', autoHideDuration: 4000 }
       );
 
+      setPendingDeleteId(null);
       setSelectedRows([]);
       queryClient.invalidateQueries({ queryKey: explorerKeys.all() });
     } catch {
@@ -306,13 +331,15 @@ export default function ExplorerGrid({
       });
     }
 
-    buttons.push({
-      label: selectedRows.length > 1 ? 'Delete sessions' : 'Delete session',
-      icon: <DeleteIcon />,
-      variant: 'outlined' as const,
-      color: 'error' as const,
-      onClick: handleDeleteTestSets,
-    });
+    if (canDeleteSession) {
+      buttons.push({
+        label: selectedRows.length > 1 ? 'Delete sessions' : 'Delete session',
+        icon: <DeleteIcon />,
+        variant: 'outlined' as const,
+        color: 'error' as const,
+        onClick: handleDeleteTestSets,
+      });
+    }
 
     return buttons;
   };
@@ -369,8 +396,16 @@ export default function ExplorerGrid({
               onClose={handleDeleteCancel}
               onConfirm={handleDeleteConfirm}
               isLoading={isDeleting}
-              title="Delete explorer sessions"
-              message={`Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'session' : 'sessions'}? Related tests in the tree will be removed with this record.`}
+              title={
+                pendingDeleteId || selectedRows.length === 1
+                  ? 'Delete explorer session'
+                  : 'Delete explorer sessions'
+              }
+              message={
+                pendingDeleteId
+                  ? 'Are you sure you want to delete this session? Its tests and topics are deleted with it.'
+                  : `Are you sure you want to delete ${selectedRows.length} ${selectedRows.length === 1 ? 'session' : 'sessions'}? Their tests and topics are deleted with them.`
+              }
               itemType="explorer sessions"
             />
           </Box>

--- a/tests/backend/services/explorer/test_tests.py
+++ b/tests/backend/services/explorer/test_tests.py
@@ -5,6 +5,7 @@ from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
+from rhesis.backend.app.database import without_soft_delete_filter
 from rhesis.backend.app.services.explorer import (
     bulk_delete_explorer_test_sets,
     create_explorer_test_set,
@@ -478,6 +479,39 @@ class TestDeleteExplorerTestSet:
         listed = get_explorer_test_sets(db=test_db, organization_id=test_org_id, limit=500)
         assert all(str(ts.id) != created_id for ts in listed)
 
+    def test_delete_cascades_to_session_tests(self, test_db, test_org_id, authenticated_user_id):
+        """Session tests and topic markers are soft-deleted with the session."""
+        created = create_explorer_test_set(
+            db=test_db,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+            name=f"Cascade Delete {uuid.uuid4().hex[:6]}",
+        )
+        create_test_node(
+            db=test_db,
+            test_set_id=created.id,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+            topic="Safety",
+            input="Is this harmful?",
+        )
+        test_ids = crud.get_test_ids_in_test_sets(test_db, [created.id], test_org_id)
+        # The test plus the "Safety" topic marker.
+        assert len(test_ids) == 2
+
+        delete_explorer_test_set(
+            db=test_db,
+            test_set_identifier=str(created.id),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        assert test_db.query(models.Test).filter(models.Test.id.in_(test_ids)).all() == []
+        with without_soft_delete_filter():
+            rows = test_db.query(models.Test).filter(models.Test.id.in_(test_ids)).all()
+        assert len(rows) == 2
+        assert all(row.deleted_at is not None for row in rows)
+
     def test_delete_nonexistent_set(self, test_db, test_org_id, authenticated_user_id):
         """Fake UUID raises ValueError."""
         fake_id = str(uuid.uuid4())
@@ -550,6 +584,63 @@ class TestBulkDeleteExplorerTestSets:
             test_db.query(models.TestSet).filter(models.TestSet.id == regular.id).first()
         )
         assert still_there is not None
+
+    def test_cascades_to_session_tests(self, test_db, test_org_id, authenticated_user_id):
+        """Every deleted session's tests are soft-deleted along with it."""
+        sessions = []
+        for i in range(2):
+            created = create_explorer_test_set(
+                db=test_db,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+                name=f"Bulk Cascade {i} {uuid.uuid4().hex[:6]}",
+            )
+            create_test_node(
+                db=test_db,
+                test_set_id=created.id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+                topic="Safety",
+                input=f"Prompt {i}",
+            )
+            sessions.append(created)
+
+        session_ids = [s.id for s in sessions]
+        test_ids = crud.get_test_ids_in_test_sets(test_db, session_ids, test_org_id)
+        assert len(test_ids) == 4  # 2 tests + 2 topic markers
+
+        bulk_delete_explorer_test_sets(
+            db=test_db,
+            test_set_ids=session_ids,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        assert test_db.query(models.Test).filter(models.Test.id.in_(test_ids)).all() == []
+        with without_soft_delete_filter():
+            rows = test_db.query(models.Test).filter(models.Test.id.in_(test_ids)).all()
+        assert len(rows) == 4
+        assert all(row.deleted_at is not None for row in rows)
+
+    def test_skipped_ids_keep_their_tests(
+        self, test_db, regular_test_set_for_import, test_org_id, authenticated_user_id
+    ):
+        """A non-explorer id is skipped without touching its tests."""
+        regular = regular_test_set_for_import
+        test_ids = crud.get_test_ids_in_test_sets(test_db, [regular.id], test_org_id)
+        assert test_ids
+
+        result = bulk_delete_explorer_test_sets(
+            db=test_db,
+            test_set_ids=[regular.id],
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        assert result["deleted_ids"] == []
+        rows = test_db.query(models.Test).filter(models.Test.id.in_(test_ids)).all()
+        assert len(rows) == len(test_ids)
+        assert all(row.deleted_at is None for row in rows)
 
     def test_empty_ids_is_a_noop(self, test_db, test_org_id, authenticated_user_id):
         result = bulk_delete_explorer_test_sets(


### PR DESCRIPTION
## Purpose

Explorer session deletion is the only entity delete in the app that behaves differently from the
rest, and it had three distinct problems:

1. **No single-row delete.** Every other grid (`TestSetsGrid`, `TestsGrid`, `EndpointsGrid`,
   `TestRunsGrid`, `TasksGrid`, …) has a per-row hover action column and a delete on the detail
   page. `ExplorerGrid` had toolbar bulk-delete only, reachable after ticking a checkbox, and
   `ExplorerDetail` could delete topics and individual tests but never the session.
2. **`explorer:delete` was never checked in the UI.** The capability is defined on both sides
   (`constants/capabilities.ts`, `auth/capabilities.py`) but `ExplorerGrid` only received
   `canCreate`, so the delete button rendered for anyone who could read. The backend *does* enforce
   it (`RhesisRouter` resource stamping + `require_permission` injection in `main.py`), so this was
   a misleading affordance that 403'd on click, not an open door.
3. **The modal text was wrong.** It said *"Related tests in the tree will be removed with this
   record."* They were not — `delete_explorer_test_set` → `crud.delete_test_set` → `delete_item` is
   a soft delete and `cascade_config.py` has no `models.TestSet` entry, so every deleted session
   left its tests *and* its topic-marker rows behind in the global `test` table, still visible in
   `/tests`.

This is item 0.1 of the Explorer roadmap. It also settles the cascade question that Phase 3's
`ON DELETE CASCADE` on `explorer_topic`/`explorer_test` depends on.

## What Changed

**Backend — the cascade is now real.**

- `delete_explorer_test_set` and `bulk_delete_explorer_test_sets` soft-delete the session's tests
  (including topic markers) via a new `_delete_session_tests` helper before deleting the set.
- New `crud.get_test_ids_in_test_sets` resolves the ids off the `test_test_set` association.
- The cascade lives in the service rather than `cascade_config.py` because `Test`↔`TestSet` is M2M
  with no `test_set_id` FK, so the config's `foreign_key` contract can't express it.
- Safe because Explorer tests are session-owned: import and export both *copy* `Test`/`Prompt` rows
  rather than share them, so no other test set references them. `update_test_set_attributes`
  early-returns for Explorer sets, so the recompute can't clobber the `Adaptive Testing` marker.

**Frontend — parity with the other grids.**

- `ExplorerGrid`: per-row hover delete via `createRowActionsColumn`, plus `pendingDeleteId` so one
  `DeleteModal` serves both the single-row and bulk paths. Single deletes now go through
  `DELETE /explorer/{id}` (`deleteExplorerTestSet`, previously an uncalled client method) instead of
  the bulk endpoint.
- Gated on `Capability.Explorer.DELETE` via `useCan` — both the row icon and the toolbar button.
  `useCan` rather than `can(subject, …)` because `TestSet` responses don't carry
  `permitted_actions`.
- `ExplorerDetail`: `<Can>`-gated delete Fab + `DeleteModal`, redirecting to `/explorer`. It
  invalidates `explorerKeys.all()` before navigating — the `QueryClient`'s 5-minute `staleTime`
  would otherwise keep the deleted session in the list.
- Modal title and message now branch on single vs. bulk, and the cascade claim is accurate.

## Additional Context

- Implements 0.1 of the Explorer roadmap; 0.2 and 0.4 are independent and unaffected.
- **Decision recorded for Phase 3:** the cascade is real. Phase 3's `ON DELETE CASCADE` on
  `explorer_topic`/`explorer_test` matches it, but only fires on a hard delete — so the
  service-level cascade stays either way.
- Behaviour change worth flagging: deleting a session now soft-deletes its tests. The tests remain
  in the database (soft delete preserves referential integrity with test runs and results) and
  restore support is unchanged; they simply stop appearing in `/tests`, which is what the UI has
  been promising all along.
- No API contract change — same endpoints, same response shapes.

## Testing

Automated:

```bash
cd apps/backend
make docker-up
uv run pytest ../../tests/backend/services/explorer/ -v      # 103 passed
uv run pytest ../../tests/backend/routes/test_explorer.py -v  #  86 passed
uv run pytest ../../tests/backend/routes/test_test_bulk_delete.py \
              ../../tests/backend/routes/test_test_set_update.py \
              ../../tests/backend/routes/test_test_test_sets.py -v   # 11 passed
```

Three new cases in `tests/backend/services/explorer/test_tests.py`: single-delete cascade,
bulk-delete cascade, and a guard that a skipped non-Explorer id keeps its tests.

Frontend: `npx tsc --noEmit`, `npm run lint` and Prettier are clean on the changed files.

Manual:

1. `/explorer` — hover a session row, confirm the trash icon appears, delete it, confirm the row
   disappears and the toast reads "Successfully deleted 1 session".
2. Open a session with tests under a topic, delete it from the row action, then check `/tests` —
   its tests and topic markers should no longer be listed.
3. Select 2+ sessions, use the toolbar "Delete sessions" button, confirm the modal is plural and
   both are removed.
4. Open a session detail page, delete it via the Fab, confirm it redirects to `/explorer` and the
   session is gone from the list immediately (not after 5 minutes).
5. As a user without `explorer:delete`, confirm neither the row icon, the toolbar button, nor the
   detail-page Fab renders.
