### PR TITLE
Show session creator in Explorer sessions grid

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -680,6 +680,41 @@ def get_test_sets(
     return query_builder.all()
 
 
+def get_explorer_test_sets(
+    db: Session,
+    organization_id: str,
+    skip: int = 0,
+    limit: int = 100,
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
+) -> List[models.TestSet]:
+    """
+    Get Explorer test sets -- the inverse of get_test_sets' exclusion clause.
+
+    Eager-loads what TestSetDetail serializes, since GET /explorer/ returns that schema.
+    """
+    explorer_marker = cast([ADAPTIVE_TESTING_BEHAVIOR], JSONB)
+
+    def only_explorer_test_sets(query):
+        return query.filter(
+            models.TestSet.attributes["metadata"]["behaviors"].contains(explorer_marker)
+        )
+
+    # Paginated outside the builder on purpose: with_pagination caps limit at 100
+    # (validate_pagination) and this endpoint has never capped. with_sorting already
+    # appends id ASC as a tiebreaker, so pagination stays stable.
+    query = (
+        QueryBuilder(db, models.TestSet)
+        .with_related(*_TEST_SET_RELATED_FIELDS)
+        .with_default_derived_field_loads()
+        .with_organization_filter(organization_id)
+        .with_custom_filter(only_explorer_test_sets)
+        .with_sorting(sort_by, sort_order)
+        .build()
+    )
+    return query.offset(skip).limit(limit).all()
+
+
 def create_test_set(
     db: Session, test_set: schemas.TestSetCreate, organization_id: str = None, user_id: str = None
 ) -> models.TestSet:

--- a/apps/backend/src/rhesis/backend/app/routers/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/routers/explorer.py
@@ -199,7 +199,7 @@ def export_regular_test_set_from_explorer_endpoint(
 
 @router.get(
     "/",
-    response_model=List[schemas.TestSet],
+    response_model=List[schemas.TestSetDetail],
 )
 def list_explorer_test_sets(
     skip: int = 0,

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -2,8 +2,6 @@ import logging
 from typing import List, Optional
 from uuid import UUID
 
-from sqlalchemy import cast
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
@@ -108,24 +106,14 @@ def get_explorer_test_sets(
     List[models.TestSet]
         Test sets configured for Explorer (Adaptive Testing behavior)
     """
-    target = cast(
-        [ADAPTIVE_TESTING_BEHAVIOR],
-        JSONB,
+    test_sets = crud.get_explorer_test_sets(
+        db=db,
+        organization_id=organization_id,
+        skip=skip,
+        limit=limit,
+        sort_by=sort_by,
+        sort_order=sort_order,
     )
-    query = (
-        db.query(models.TestSet)
-        .filter(models.TestSet.organization_id == organization_id)
-        .filter(models.TestSet.attributes["metadata"]["behaviors"].contains(target))
-    )
-
-    # Apply sorting with id tiebreaker for stable pagination
-    sort_column = getattr(models.TestSet, sort_by, models.TestSet.created_at)
-    if sort_order == "asc":
-        query = query.order_by(sort_column.asc(), models.TestSet.id.asc())
-    else:
-        query = query.order_by(sort_column.desc(), models.TestSet.id.asc())
-
-    test_sets = query.offset(skip).limit(limit).all()
 
     logger.info(f"Found {len(test_sets)} explorer test sets for organization={organization_id}")
 

--- a/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/components/ExplorerGrid.tsx
@@ -34,6 +34,9 @@ import { useNotifications } from '@/components/common/NotificationContext';
 import { formatDate } from '@/utils/date';
 import { explorerKeys } from '@/constants/query-keys';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { UserAvatar } from '@/components/common/UserAvatar';
+import { AVATAR_SIZES } from '@/constants/avatar-sizes';
+import type { UserReference } from '@/utils/api-client/interfaces/tests';
 
 interface ExplorerGridProps {
   canCreate?: boolean;
@@ -66,6 +69,17 @@ function ExplorerUnifiedToolbar() {
         </>
       }
     />
+  );
+}
+
+/** Same name cascade the other grids use, so sorting and export match the cell. */
+function userDisplayName(user?: UserReference): string {
+  if (!user) return '';
+  return (
+    user.name ||
+    `${user.given_name || ''} ${user.family_name || ''}`.trim() ||
+    user.email ||
+    ''
   );
 }
 
@@ -152,10 +166,10 @@ export default function ExplorerGrid({
         field: 'status',
         headerName: 'Status',
         width: 120,
+        valueGetter: (_, row) => row.status?.name || '',
         renderCell: params => {
-          const status = params.value;
-          if (!status) return '-';
-          return <GridBadge label={status} />;
+          if (!params.value) return '-';
+          return <GridBadge label={params.value} />;
         },
       },
       {
@@ -166,6 +180,26 @@ export default function ExplorerGrid({
           if (!params.value) return '-';
           return (
             <Typography variant="body2">{formatDate(params.value)}</Typography>
+          );
+        },
+      },
+      {
+        field: 'user',
+        headerName: 'Creator',
+        width: 160,
+        minWidth: 120,
+        valueGetter: (_, row) => userDisplayName(row.user),
+        renderCell: params => {
+          if (!params.value) return '-';
+          return (
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <UserAvatar
+                userName={params.value}
+                userPicture={params.row.user?.picture}
+                size={AVATAR_SIZES.SMALL}
+              />
+              <Typography variant="body2">{params.value}</Typography>
+            </Box>
           );
         },
       },

--- a/apps/frontend/src/utils/api-client/explorer-client.ts
+++ b/apps/frontend/src/utils/api-client/explorer-client.ts
@@ -12,6 +12,7 @@ import {
   ExplorerSettings,
   ExplorerSettingsUpdateRequest,
   ExplorerTestSet,
+  ExplorerTestSetDetail,
   ExportExplorerTestSetResponse,
   GenerateOutputsRequest,
   GenerateOutputsResponse,
@@ -92,14 +93,14 @@ export class ExplorerClient extends BaseApiClient {
     limit: number = 100,
     sortBy: string = 'created_at',
     sortOrder: string = 'desc'
-  ): Promise<ExplorerTestSet[]> {
+  ): Promise<ExplorerTestSetDetail[]> {
     const params = new URLSearchParams({
       skip: skip.toString(),
       limit: limit.toString(),
       sort_by: sortBy,
       sort_order: sortOrder,
     });
-    return this.fetch<ExplorerTestSet[]>(
+    return this.fetch<ExplorerTestSetDetail[]>(
       `${API_ENDPOINTS.explorer}/?${params.toString()}`,
       { cache: 'no-store' }
     );

--- a/apps/frontend/src/utils/api-client/interfaces/explorer.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/explorer.ts
@@ -3,10 +3,15 @@
  * Matches the backend schemas in apps/backend/src/rhesis/backend/app/schemas/explorer.py
  */
 
+import { Status } from './status';
+import { Tag } from './tag';
+import { UserReference } from './tests';
+
 // =============================================================================
 // Explorer test set (TestSet JSON from GET /explorer)
 // =============================================================================
 
+/** Bare schemas.TestSet -- what create, detail, import and export return. */
 export interface ExplorerTestSet {
   id: string;
   name: string;
@@ -14,11 +19,24 @@ export interface ExplorerTestSet {
   slug?: string;
   nano_id?: string;
   status_id?: string;
-  status?: string;
   test_set_type_id?: string;
   attributes?: Record<string, unknown>;
   created_at?: string;
   updated_at?: string;
+}
+
+/** schemas.TestSetDetail -- only GET /explorer/ expands these relations. */
+export interface ExplorerTestSetDetail extends ExplorerTestSet {
+  user?: UserReference;
+  owner?: UserReference;
+  assignee?: UserReference;
+  status?: Status;
+  tags?: Tag[];
+  counts?: {
+    comments?: number;
+    tasks?: number;
+    files?: number;
+  };
 }
 
 /** Response from POST /explorer/import/{source_test_set_id} */

--- a/tests/backend/routes/test_explorer.py
+++ b/tests/backend/routes/test_explorer.py
@@ -400,6 +400,25 @@ class TestListExplorerTestSetsEndpoint:
         for item in data:
             assert expected_fields.issubset(item.keys())
 
+    def test_returns_expanded_creator(
+        self,
+        authenticated_client: TestClient,
+        explorer_and_regular_test_sets,
+        authenticated_user_id,
+    ):
+        """`user` must be expanded -- the sessions grid renders a Creator column from it.
+
+        Only TestSetDetail carries it; the bare TestSet schema would drop the key.
+        """
+        response = authenticated_client.get("/explorer")
+
+        assert response.status_code == status.HTTP_200_OK
+        explorer_id = str(explorer_and_regular_test_sets["explorer_1"].id)
+        item = next(i for i in response.json() if i["id"] == explorer_id)
+
+        assert item["user"] is not None
+        assert item["user"]["id"] == str(authenticated_user_id)
+
     def test_pagination_limit(
         self,
         authenticated_client: TestClient,

--- a/tests/backend/services/explorer/test_tests.py
+++ b/tests/backend/services/explorer/test_tests.py
@@ -1,6 +1,7 @@
 import uuid
 
 import pytest
+from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
@@ -294,6 +295,30 @@ class TestGetExplorerTestSets:
         )
 
         assert all(isinstance(ts, models.TestSet) for ts in result)
+
+    def test_eager_loads_creator(
+        self,
+        test_db,
+        explorer_and_regular_test_sets,
+        test_org_id,
+        authenticated_user_id,
+    ):
+        """`user` must come back already loaded -- GET /explorer/ serializes it.
+
+        Asserts it is not in `unloaded`, so a lazy fallback (N+1 per row) fails here
+        rather than silently working.
+        """
+        result = get_explorer_test_sets(
+            db=test_db,
+            organization_id=test_org_id,
+        )
+
+        explorer_id = str(explorer_and_regular_test_sets["explorer_1"].id)
+        test_set = next(ts for ts in result if str(ts.id) == explorer_id)
+
+        assert "user" not in sa_inspect(test_set).unloaded
+        assert test_set.user is not None
+        assert str(test_set.user.id) == str(authenticated_user_id)
 
     def test_pagination_skip_and_limit(
         self,


### PR DESCRIPTION
## Purpose

Explorer roadmap item **0.2 — Session owner not shown** (`playground/explorer-roadmap.md`).

The Explorer sessions grid couldn't show who created a session. The cause was the response model,
not the UI: `GET /explorer/` declared `response_model=List[schemas.TestSet]`, and `schemas.TestSet`
is the bare model — `user`, `owner` and `assignee` only exist on `TestSetDetail`. `GET /test_sets/`
already returns `TestSetDetail`, which is why `TestSetsGrid` could render a Creator column and
`ExplorerGrid` could not.

## What Changed

**Backend**

- `GET /explorer/` now returns `List[schemas.TestSetDetail]`.
- New `crud.get_explorer_test_sets` — the inverse of `get_test_sets`' Explorer exclusion clause.
  The query moved out of `services/explorer/tests.py` so it can reuse `_TEST_SET_RELATED_FIELDS`
  and `with_default_derived_field_loads()`, which eager-load the relations and counts
  `TestSetDetail` serializes. Without them the response N+1s across `user`, one query per row.
  The service function keeps its signature and delegates.
- Pagination is applied outside `QueryBuilder` on purpose: `with_pagination` enforces a 100-item
  cap via `validate_pagination`, and this endpoint has never capped. `with_sorting` already
  appends `id ASC`, so the previous tiebreaker behaviour is preserved.

**Frontend**

- Creator column on `ExplorerGrid`, mirroring `TestSetsGrid`'s name cascade
  (`name` → `given_name family_name` → `email`) so sorting and CSV export match the rendered cell.
  Rendered with the shared `UserAvatar` rather than a fourth hand-rolled `Avatar` + initial block.
- New `ExplorerTestSetDetail` interface, kept separate from `ExplorerTestSet` because only the list
  endpoint returns the detail shape — create, detail, import and export still return the bare schema.
- Fixed the Status column, which passed the raw value to `GridBadge`'s `label`. It was dead before
  (the bare schema never sent `status`) but would have received an object once the endpoint started
  expanding it. Now reads `status?.name`.

## Additional Context

- **Deliberately out of scope: the roadmap's "drawer filter".** `ExplorerGrid` loads all rows
  client-side and `getExplorerTestSets()` defaults to `limit: 100`, so a client-side Creator filter
  would silently filter only the newest 100 sessions — inheriting the truncation that already
  affects search rather than fixing it. A Creator filter belongs with a server-side `$filter` +
  `useGridQuery` migration for the whole grid, which is its own change. Sorting by Creator works.
- **One intentional behaviour change:** an invalid `sort_by` now returns 400
  (`validate_sort_field`) instead of silently falling back to `created_at`. This matches
  `GET /test_sets/`.
- Roadmap item 0.2 also prepays one of Phase 2.2's 14 service-layer DB-access sites.
- Not touched, both pre-existing on `main`: an unused `APIRouter` import in `routers/explorer.py`
  (F401) and a ruff-format deviation at `tests/backend/services/explorer/test_tests.py:546`.

## Testing

Two new tests, one per layer, asserting the actual change:

- `test_eager_loads_creator` — `user` is not in `sa_inspect(test_set).unloaded`, so a lazy fallback
  (N+1 per row) fails the test rather than silently working.
- `test_returns_expanded_creator` — the HTTP response contains a populated `user` object.

```bash
cd apps/backend
make docker-up
uv run pytest ../../tests/backend/services/explorer/ ../../tests/backend/routes/test_explorer.py
```

188 passed (101 service + 87 route).

```bash
cd apps/frontend
npx prettier --check <touched> && npx eslint <touched> && npx tsc --noEmit
```

Clean. (`tsc` reports 8 pre-existing errors in stale `.next/` generated types for a removed `mcp`
route; none in `src/`.)

**Manual:** open `/explorer` and confirm each session row shows an avatar + creator name, the
Creator header sorts, and Status renders `-` rather than crashing.
