### PR TITLE
Add GKE Connect Gateway for cross-repo CI cluster access

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -25,10 +25,23 @@ join the VPN, and per-repo self-hosted runners (`arc-runner-<env>`, see
 `terraform/infrastructure/modules/arc-gha`) only pick up jobs dispatched from
 the repo they're registered against -- a workflow in a different repo can
 never reach them. `terraform/infrastructure/modules/connect-gateway/gcp`
-registers each cluster with GKE Hub (Fleet) and grants the `terraform-<env>`
-service account (the same identity GitHub Actions already authenticates as
-for that project) `roles/gkehub.gatewayReader`, so CI can fetch working
-credentials over HTTPS with no network-level access to the cluster at all:
+registers each cluster with GKE Hub (Fleet) and creates a dedicated
+`license-ci-<env>` service account granted `roles/gkehub.gatewayReader`, so
+CI can fetch working credentials over HTTPS with no network-level access to
+the cluster at all:
+
+`license-ci-<env>` is a purpose-built identity, not `terraform-<env>` (the
+infra-admin identity `terraform-infrastructure.yml` authenticates as via
+WIF). `terraform-<env>` holds `roles/editor` +
+`roles/iam.securityAdmin` + `roles/resourcemanager.projectIamAdmin` on the
+whole project; `rhesis-ee`'s licensing workflows authenticate with a static,
+long-lived `GCP_SA_KEY` stored in a *different* repository's secrets, not
+WIF, so a leaked key needs to matter a lot less than "near-owner access to
+the project." `license-ci-<env>` is scoped to exactly what those workflows
+do: reach the cluster via Connect Gateway, read/manage the two licensing
+Secret Manager entries per environment, resolve the latest image tag from
+Artifact Registry, and deploy/execute the self-hosted mint Cloud Run Job
+(see the module's `main.tf` for the exact role grants).
 
 ```bash
 gcloud container fleet memberships get-credentials <dev|stg|prd> --project=PROJECT_ID

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -13,6 +13,33 @@
  # Switch to a different cluster (GKE example)                
 - `gcloud container clusters get-credentials CLUSTER_NAME --region REGION --project PROJECT_ID` 
 
+The command above only works from the WireGuard VPN -- dev/stg/prd clusters
+are private, with `master_authorized_networks_config` locked to the VPN CIDR
+(see `terraform/infrastructure/modules/kubernetes/gcp`). For interactive/local
+use, connect to the VPN first.
+
+### CI access without a VPN: Connect Gateway
+
+CI workflows (including ones in other repos, e.g. `rhesis-ai/rhesis-ee`) can't
+join the VPN, and per-repo self-hosted runners (`arc-runner-<env>`, see
+`terraform/infrastructure/modules/arc-gha`) only pick up jobs dispatched from
+the repo they're registered against -- a workflow in a different repo can
+never reach them. `terraform/infrastructure/modules/connect-gateway/gcp`
+registers each cluster with GKE Hub (Fleet) and grants the `terraform-<env>`
+service account (the same identity GitHub Actions already authenticates as
+for that project) `roles/gkehub.gatewayReader`, so CI can fetch working
+credentials over HTTPS with no network-level access to the cluster at all:
+
+```bash
+gcloud container fleet memberships get-credentials <dev|stg|prd> --project=PROJECT_ID
+kubectl get pods -n rhesis   # ordinary kubectl from here on
+```
+
+This only grants *reachability* -- what the caller can actually do once
+connected is still governed entirely by normal Kubernetes RBAC
+(`Role`/`RoleBinding`), same as any other identity. See
+`kubernetes/clusters/<env>/rhesis/license-issuer-rbac.yaml` for an example
+consumer (`rhesis-ee`'s `license-issue.yml`).
 
 ## Bootstrap ArgoCD
 

--- a/kubernetes/clusters/dev/rhesis/license-issuer-rbac.yaml
+++ b/kubernetes/clusters/dev/rhesis/license-issuer-rbac.yaml
@@ -1,9 +1,17 @@
-# Lets the dev-arc-runner-set's default ServiceAccount (arc-runners/default)
-# run one-off Kubernetes Jobs in this namespace on behalf of rhesis-ee's
-# license-issue.yml workflow. That workflow issues signed license tokens by
-# running the EE licensing CLI as a Job here instead of a Cloud Run Job,
-# because this namespace's Postgres (Bitnami chart, Service "rhesis-postgresql")
-# only resolves via cluster-internal DNS -- Cloud Run cannot reach it.
+# Lets the "terraform-dev" GCP service account run one-off Kubernetes Jobs in
+# this namespace on behalf of rhesis-ee's license-issue.yml workflow. That
+# workflow issues signed license tokens by running the EE licensing CLI as a
+# Job here instead of a Cloud Run Job, because this namespace's Postgres
+# (Bitnami chart, Service "rhesis-postgresql") only resolves via
+# cluster-internal DNS -- Cloud Run cannot reach it.
+#
+# The workflow reaches this cluster via GKE Connect Gateway (see
+# terraform/infrastructure/modules/connect-gateway/gcp), not a VPN or a
+# self-hosted runner -- Connect Gateway proxies the call over HTTPS using the
+# GCP IAM identity's credentials, and GKE maps that identity onto this
+# RoleBinding's "User" subject by email. terraform-dev is also what
+# terraform-infrastructure.yml already authenticates as for this project, so
+# no new service account was created for this.
 #
 # Blast-radius note: "create Jobs" implicitly allows a Job's pod spec to
 # mount any Secret already in this namespace (rhesis-app-secrets included) --
@@ -46,6 +54,6 @@ roleRef:
   kind: Role
   name: license-issuer
 subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: arc-runners
+  - kind: User
+    name: terraform-dev@rhesis-dev-494712.iam.gserviceaccount.com
+    apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/clusters/dev/rhesis/license-issuer-rbac.yaml
+++ b/kubernetes/clusters/dev/rhesis/license-issuer-rbac.yaml
@@ -1,5 +1,5 @@
-# Lets the "terraform-dev" GCP service account run one-off Kubernetes Jobs in
-# this namespace on behalf of rhesis-ee's license-issue.yml workflow. That
+# Lets the "license-ci-dev" GCP service account run one-off Kubernetes Jobs
+# in this namespace on behalf of rhesis-ee's license-issue.yml workflow. That
 # workflow issues signed license tokens by running the EE licensing CLI as a
 # Job here instead of a Cloud Run Job, because this namespace's Postgres
 # (Bitnami chart, Service "rhesis-postgresql") only resolves via
@@ -9,9 +9,12 @@
 # terraform/infrastructure/modules/connect-gateway/gcp), not a VPN or a
 # self-hosted runner -- Connect Gateway proxies the call over HTTPS using the
 # GCP IAM identity's credentials, and GKE maps that identity onto this
-# RoleBinding's "User" subject by email. terraform-dev is also what
-# terraform-infrastructure.yml already authenticates as for this project, so
-# no new service account was created for this.
+# RoleBinding's "User" subject by email. license-ci-dev is a dedicated
+# service account created by that module specifically for this purpose --
+# not terraform-dev, which holds roles/editor + iam.securityAdmin +
+# resourcemanager.projectIamAdmin on the whole project and would be far too
+# powerful an identity for a different repo's CI workflow to hold a static
+# key for.
 #
 # Blast-radius note: "create Jobs" implicitly allows a Job's pod spec to
 # mount any Secret already in this namespace (rhesis-app-secrets included) --
@@ -55,5 +58,5 @@ roleRef:
   name: license-issuer
 subjects:
   - kind: User
-    name: terraform-dev@rhesis-dev-494712.iam.gserviceaccount.com
+    name: license-ci-dev@rhesis-dev-494712.iam.gserviceaccount.com
     apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/clusters/prd/rhesis/license-issuer-rbac.yaml
+++ b/kubernetes/clusters/prd/rhesis/license-issuer-rbac.yaml
@@ -1,5 +1,5 @@
-# Lets the "terraform-prd" GCP service account run one-off Kubernetes Jobs in
-# this namespace on behalf of rhesis-ee's license-issue.yml workflow. That
+# Lets the "license-ci-prd" GCP service account run one-off Kubernetes Jobs
+# in this namespace on behalf of rhesis-ee's license-issue.yml workflow. That
 # workflow issues signed license tokens by running the EE licensing CLI as a
 # Job here instead of a Cloud Run Job, because this namespace's Postgres
 # (CloudNativePG, Service "rhesis-prd-rw") only resolves via cluster-internal
@@ -9,9 +9,12 @@
 # terraform/infrastructure/modules/connect-gateway/gcp), not a VPN or a
 # self-hosted runner -- Connect Gateway proxies the call over HTTPS using the
 # GCP IAM identity's credentials, and GKE maps that identity onto this
-# RoleBinding's "User" subject by email. terraform-prd is also what
-# terraform-infrastructure.yml already authenticates as for this project, so
-# no new service account was created for this.
+# RoleBinding's "User" subject by email. license-ci-prd is a dedicated
+# service account created by that module specifically for this purpose --
+# not terraform-prd, which holds roles/editor + iam.securityAdmin +
+# resourcemanager.projectIamAdmin on the whole project and would be far too
+# powerful an identity for a different repo's CI workflow to hold a static
+# key for.
 #
 # Blast-radius note: "create Jobs" implicitly allows a Job's pod spec to
 # mount any Secret already in this namespace (rhesis-app-secrets included) --
@@ -56,5 +59,5 @@ roleRef:
   name: license-issuer
 subjects:
   - kind: User
-    name: terraform-prd@rhesis-prd.iam.gserviceaccount.com
+    name: license-ci-prd@rhesis-prd.iam.gserviceaccount.com
     apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/clusters/prd/rhesis/license-issuer-rbac.yaml
+++ b/kubernetes/clusters/prd/rhesis/license-issuer-rbac.yaml
@@ -1,9 +1,17 @@
-# Lets the prd-arc-runner-set's default ServiceAccount (arc-runners/default)
-# run one-off Kubernetes Jobs in this namespace on behalf of rhesis-ee's
-# license-issue.yml workflow. That workflow issues signed license tokens by
-# running the EE licensing CLI as a Job here instead of a Cloud Run Job,
-# because this namespace's Postgres (CloudNativePG, Service "rhesis-prd-rw")
-# only resolves via cluster-internal DNS -- Cloud Run cannot reach it.
+# Lets the "terraform-prd" GCP service account run one-off Kubernetes Jobs in
+# this namespace on behalf of rhesis-ee's license-issue.yml workflow. That
+# workflow issues signed license tokens by running the EE licensing CLI as a
+# Job here instead of a Cloud Run Job, because this namespace's Postgres
+# (CloudNativePG, Service "rhesis-prd-rw") only resolves via cluster-internal
+# DNS -- Cloud Run cannot reach it.
+#
+# The workflow reaches this cluster via GKE Connect Gateway (see
+# terraform/infrastructure/modules/connect-gateway/gcp), not a VPN or a
+# self-hosted runner -- Connect Gateway proxies the call over HTTPS using the
+# GCP IAM identity's credentials, and GKE maps that identity onto this
+# RoleBinding's "User" subject by email. terraform-prd is also what
+# terraform-infrastructure.yml already authenticates as for this project, so
+# no new service account was created for this.
 #
 # Blast-radius note: "create Jobs" implicitly allows a Job's pod spec to
 # mount any Secret already in this namespace (rhesis-app-secrets included) --
@@ -47,6 +55,6 @@ roleRef:
   kind: Role
   name: license-issuer
 subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: arc-runners
+  - kind: User
+    name: terraform-prd@rhesis-prd.iam.gserviceaccount.com
+    apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/clusters/stg/rhesis/license-issuer-rbac.yaml
+++ b/kubernetes/clusters/stg/rhesis/license-issuer-rbac.yaml
@@ -1,9 +1,17 @@
-# Lets the stg-arc-runner-set's default ServiceAccount (arc-runners/default)
-# run one-off Kubernetes Jobs in this namespace on behalf of rhesis-ee's
-# license-issue.yml workflow. That workflow issues signed license tokens by
-# running the EE licensing CLI as a Job here instead of a Cloud Run Job,
-# because this namespace's Postgres (CloudNativePG, Service "rhesis-stg-rw")
-# only resolves via cluster-internal DNS -- Cloud Run cannot reach it.
+# Lets the "terraform-stg" GCP service account run one-off Kubernetes Jobs in
+# this namespace on behalf of rhesis-ee's license-issue.yml workflow. That
+# workflow issues signed license tokens by running the EE licensing CLI as a
+# Job here instead of a Cloud Run Job, because this namespace's Postgres
+# (CloudNativePG, Service "rhesis-stg-rw") only resolves via cluster-internal
+# DNS -- Cloud Run cannot reach it.
+#
+# The workflow reaches this cluster via GKE Connect Gateway (see
+# terraform/infrastructure/modules/connect-gateway/gcp), not a VPN or a
+# self-hosted runner -- Connect Gateway proxies the call over HTTPS using the
+# GCP IAM identity's credentials, and GKE maps that identity onto this
+# RoleBinding's "User" subject by email. terraform-stg is also what
+# terraform-infrastructure.yml already authenticates as for this project, so
+# no new service account was created for this.
 #
 # Blast-radius note: "create Jobs" implicitly allows a Job's pod spec to
 # mount any Secret already in this namespace (rhesis-app-secrets included) --
@@ -46,6 +54,6 @@ roleRef:
   kind: Role
   name: license-issuer
 subjects:
-  - kind: ServiceAccount
-    name: default
-    namespace: arc-runners
+  - kind: User
+    name: terraform-stg@rhesis-stg-494712.iam.gserviceaccount.com
+    apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/clusters/stg/rhesis/license-issuer-rbac.yaml
+++ b/kubernetes/clusters/stg/rhesis/license-issuer-rbac.yaml
@@ -1,5 +1,5 @@
-# Lets the "terraform-stg" GCP service account run one-off Kubernetes Jobs in
-# this namespace on behalf of rhesis-ee's license-issue.yml workflow. That
+# Lets the "license-ci-stg" GCP service account run one-off Kubernetes Jobs
+# in this namespace on behalf of rhesis-ee's license-issue.yml workflow. That
 # workflow issues signed license tokens by running the EE licensing CLI as a
 # Job here instead of a Cloud Run Job, because this namespace's Postgres
 # (CloudNativePG, Service "rhesis-stg-rw") only resolves via cluster-internal
@@ -9,9 +9,12 @@
 # terraform/infrastructure/modules/connect-gateway/gcp), not a VPN or a
 # self-hosted runner -- Connect Gateway proxies the call over HTTPS using the
 # GCP IAM identity's credentials, and GKE maps that identity onto this
-# RoleBinding's "User" subject by email. terraform-stg is also what
-# terraform-infrastructure.yml already authenticates as for this project, so
-# no new service account was created for this.
+# RoleBinding's "User" subject by email. license-ci-stg is a dedicated
+# service account created by that module specifically for this purpose --
+# not terraform-stg, which holds roles/editor + iam.securityAdmin +
+# resourcemanager.projectIamAdmin on the whole project and would be far too
+# powerful an identity for a different repo's CI workflow to hold a static
+# key for.
 #
 # Blast-radius note: "create Jobs" implicitly allows a Job's pod spec to
 # mount any Secret already in this namespace (rhesis-app-secrets included) --
@@ -55,5 +58,5 @@ roleRef:
   name: license-issuer
 subjects:
   - kind: User
-    name: terraform-stg@rhesis-stg-494712.iam.gserviceaccount.com
+    name: license-ci-stg@rhesis-stg-494712.iam.gserviceaccount.com
     apiGroup: rbac.authorization.k8s.io

--- a/terraform/infrastructure/envs/dev/main.tf
+++ b/terraform/infrastructure/envs/dev/main.tf
@@ -83,11 +83,6 @@ module "connect_gateway_dev" {
   project_id  = var.project_id
   environment = "dev"
   cluster_id  = module.gke_dev.cluster_id
-  # terraform-dev is the same identity GitHub Actions authenticates as for
-  # this project (terraform-infrastructure.yml via WIF, and the GCP_SA_KEY
-  # secrets rhesis-ee's licensing workflows use) -- see kubernetes/README.md
-  # for how it's used to reach this cluster without VPN access.
-  ci_service_account_email = "terraform-dev@${var.project_id}.iam.gserviceaccount.com"
 
   depends_on = [module.gke_dev]
 }

--- a/terraform/infrastructure/envs/dev/main.tf
+++ b/terraform/infrastructure/envs/dev/main.tf
@@ -77,6 +77,21 @@ module "gke_dev" {
   depends_on = [module.dev]
 }
 
+module "connect_gateway_dev" {
+  source = "../../modules/connect-gateway/gcp"
+
+  project_id  = var.project_id
+  environment = "dev"
+  cluster_id  = module.gke_dev.cluster_id
+  # terraform-dev is the same identity GitHub Actions authenticates as for
+  # this project (terraform-infrastructure.yml via WIF, and the GCP_SA_KEY
+  # secrets rhesis-ee's licensing workflows use) -- see kubernetes/README.md
+  # for how it's used to reach this cluster without VPN access.
+  ci_service_account_email = "terraform-dev@${var.project_id}.iam.gserviceaccount.com"
+
+  depends_on = [module.gke_dev]
+}
+
 module "eso_dev" {
   source = "../../modules/external-secrets/gcp"
 

--- a/terraform/infrastructure/envs/prd/main.tf
+++ b/terraform/infrastructure/envs/prd/main.tf
@@ -108,13 +108,6 @@ module "connect_gateway_prd" {
   project_id  = var.project_id
   environment = "prd"
   cluster_id  = module.gke_prd.cluster_id
-  # terraform-prd is the same identity GitHub Actions authenticates as for
-  # this project (terraform-infrastructure.yml via WIF, and the GCP_SA_KEY
-  # secrets rhesis-ee's licensing workflows use) -- see kubernetes/README.md
-  # for how it's used to reach this cluster without VPN access. This is the
-  # only path by which "prd" GitHub Environment approvers can act on
-  # license-issue.yml against production without a VPN connection.
-  ci_service_account_email = "terraform-prd@${var.project_id}.iam.gserviceaccount.com"
 
   depends_on = [module.gke_prd]
 }

--- a/terraform/infrastructure/envs/prd/main.tf
+++ b/terraform/infrastructure/envs/prd/main.tf
@@ -102,6 +102,23 @@ module "gke_prd" {
   depends_on = [module.prd]
 }
 
+module "connect_gateway_prd" {
+  source = "../../modules/connect-gateway/gcp"
+
+  project_id  = var.project_id
+  environment = "prd"
+  cluster_id  = module.gke_prd.cluster_id
+  # terraform-prd is the same identity GitHub Actions authenticates as for
+  # this project (terraform-infrastructure.yml via WIF, and the GCP_SA_KEY
+  # secrets rhesis-ee's licensing workflows use) -- see kubernetes/README.md
+  # for how it's used to reach this cluster without VPN access. This is the
+  # only path by which "prd" GitHub Environment approvers can act on
+  # license-issue.yml against production without a VPN connection.
+  ci_service_account_email = "terraform-prd@${var.project_id}.iam.gserviceaccount.com"
+
+  depends_on = [module.gke_prd]
+}
+
 module "eso_prd" {
   source = "../../modules/external-secrets/gcp"
 

--- a/terraform/infrastructure/envs/stg/main.tf
+++ b/terraform/infrastructure/envs/stg/main.tf
@@ -86,11 +86,6 @@ module "connect_gateway_stg" {
   project_id  = var.project_id
   environment = "stg"
   cluster_id  = module.gke_stg.cluster_id
-  # terraform-stg is the same identity GitHub Actions authenticates as for
-  # this project (terraform-infrastructure.yml via WIF, and the GCP_SA_KEY
-  # secrets rhesis-ee's licensing workflows use) -- see kubernetes/README.md
-  # for how it's used to reach this cluster without VPN access.
-  ci_service_account_email = "terraform-stg@${var.project_id}.iam.gserviceaccount.com"
 
   depends_on = [module.gke_stg]
 }

--- a/terraform/infrastructure/envs/stg/main.tf
+++ b/terraform/infrastructure/envs/stg/main.tf
@@ -80,6 +80,21 @@ module "gke_stg" {
   depends_on = [module.stg]
 }
 
+module "connect_gateway_stg" {
+  source = "../../modules/connect-gateway/gcp"
+
+  project_id  = var.project_id
+  environment = "stg"
+  cluster_id  = module.gke_stg.cluster_id
+  # terraform-stg is the same identity GitHub Actions authenticates as for
+  # this project (terraform-infrastructure.yml via WIF, and the GCP_SA_KEY
+  # secrets rhesis-ee's licensing workflows use) -- see kubernetes/README.md
+  # for how it's used to reach this cluster without VPN access.
+  ci_service_account_email = "terraform-stg@${var.project_id}.iam.gserviceaccount.com"
+
+  depends_on = [module.gke_stg]
+}
+
 module "eso_stg" {
   source = "../../modules/external-secrets/gcp"
 

--- a/terraform/infrastructure/modules/connect-gateway/gcp/main.tf
+++ b/terraform/infrastructure/modules/connect-gateway/gcp/main.tf
@@ -1,0 +1,63 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# Registers this environment's GKE cluster with GKE Hub (Fleet) and grants
+# the CI service account permission to reach it through Connect Gateway.
+#
+# Why this exists: dev/stg/prd clusters are private, with the API server
+# reachable only from the WireGuard VPN CIDR (see modules/kubernetes/gcp's
+# master_authorized_networks_config). GitHub-hosted runners aren't on that
+# VPN, and self-hosted ARC runners (modules/arc-gha) are registered per-repo
+# against rhesis-ai/rhesis specifically -- a workflow living in a different
+# repo (e.g. rhesis-ee) can never have its jobs picked up by them. Connect
+# Gateway proxies kubectl/gcloud calls over HTTPS using IAM auth instead of
+# network-level access, so any CI identity holding roles/gkehub.gatewayReader
+# can reach the cluster with a plain `gcloud container fleet memberships
+# get-credentials` call -- no VPN, no self-hosted runner, from any repo.
+#
+# Once this is applied, the actual kubeconfig command is:
+#   gcloud container fleet memberships get-credentials ${var.environment} \
+#     --project=${var.project_id}
+# followed by ordinary kubectl, authorized by whatever Kubernetes RBAC
+# (Role/RoleBinding) already exists for the calling identity -- Connect
+# Gateway only replaces *network* reachability, not authorization.
+
+resource "google_project_service" "gkehub" {
+  project            = var.project_id
+  service            = "gkehub.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "connectgateway" {
+  project            = var.project_id
+  service            = "connectgateway.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_gke_hub_membership" "cluster" {
+  membership_id = var.environment
+  project       = var.project_id
+  location      = "global"
+
+  endpoint {
+    gke_cluster {
+      resource_link = "//container.googleapis.com/${var.cluster_id}"
+    }
+  }
+
+  depends_on = [google_project_service.gkehub]
+}
+
+resource "google_project_iam_member" "ci_gateway_reader" {
+  project = var.project_id
+  role    = "roles/gkehub.gatewayReader"
+  member  = "serviceAccount:${var.ci_service_account_email}"
+
+  depends_on = [google_project_service.connectgateway]
+}

--- a/terraform/infrastructure/modules/connect-gateway/gcp/main.tf
+++ b/terraform/infrastructure/modules/connect-gateway/gcp/main.tf
@@ -7,8 +7,9 @@ terraform {
   }
 }
 
-# Registers this environment's GKE cluster with GKE Hub (Fleet) and grants
-# the CI service account permission to reach it through Connect Gateway.
+# Registers this environment's GKE cluster with GKE Hub (Fleet) and creates a
+# dedicated, narrowly-scoped service account for rhesis-ee's licensing CI
+# workflows to reach it through Connect Gateway.
 #
 # Why this exists: dev/stg/prd clusters are private, with the API server
 # reachable only from the WireGuard VPN CIDR (see modules/kubernetes/gcp's
@@ -27,6 +28,28 @@ terraform {
 # followed by ordinary kubectl, authorized by whatever Kubernetes RBAC
 # (Role/RoleBinding) already exists for the calling identity -- Connect
 # Gateway only replaces *network* reachability, not authorization.
+#
+# The service account: an earlier version of this module took an existing
+# service account email as an input and granted gatewayReader to it, with
+# terraform-<env> passed in at the call site -- convenient (that identity
+# already exists and is already what CI authenticates as for other things),
+# but terraform-<env> holds roles/editor + roles/iam.securityAdmin +
+# roles/resourcemanager.projectIamAdmin on the whole project (verified via
+# `gcloud projects get-iam-policy`, identical across dev/stg/prd) --
+# effectively full project control. rhesis-ee's license-issue.yml and
+# license-mint-selfhosted.yml authenticate with a static, long-lived
+# GCP_SA_KEY (not WIF, unlike this repo's own terraform-infrastructure.yml),
+# stored as a secret in a *different* repository. A leaked key would hand
+# out near-owner access to the whole GCP project, for a task that only ever
+# needs to create Jobs in one K8s namespace, read two Secret Manager entries,
+# and run a Cloud Run Job -- so this module now creates its own SA instead,
+# scoped to exactly that.
+resource "google_service_account" "license_ci" {
+  project      = var.project_id
+  account_id   = "license-ci-${var.environment}"
+  display_name = "License issuance/mint CI (rhesis-ee)"
+  description  = "Identity rhesis-ee's license-issue.yml / license-mint-selfhosted.yml authenticate as via GCP_SA_KEY. Scoped to exactly what those workflows do -- see the roles granted alongside this resource."
+}
 
 resource "google_project_service" "gkehub" {
   project            = var.project_id
@@ -54,10 +77,53 @@ resource "google_gke_hub_membership" "cluster" {
   depends_on = [google_project_service.gkehub]
 }
 
+# Reach the cluster via Connect Gateway.
 resource "google_project_iam_member" "ci_gateway_reader" {
   project = var.project_id
   role    = "roles/gkehub.gatewayReader"
-  member  = "serviceAccount:${var.ci_service_account_email}"
+  member  = "serviceAccount:${google_service_account.license_ci.email}"
 
   depends_on = [google_project_service.connectgateway]
+}
+
+# Read the signing key + kid (license-issue.yml, license-mint-selfhosted.yml),
+# and create/manage the self-hosted mint destination secret
+# (license-mint-selfhosted.yml's "Ensure destination secret exists..." step
+# -- the secret doesn't exist on first use, so this can't be scoped to a
+# specific secret resource the way a plain secretAccessor grant could be).
+resource "google_project_iam_member" "ci_secretmanager_admin" {
+  project = var.project_id
+  role    = "roles/secretmanager.admin"
+  member  = "serviceAccount:${google_service_account.license_ci.email}"
+}
+
+# Resolve the "latest" backend image tag (both workflows' "Resolve image
+# tag" step) from Artifact Registry.
+resource "google_project_iam_member" "ci_artifactregistry_reader" {
+  project = var.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.license_ci.email}"
+}
+
+# license-mint-selfhosted.yml deploys/executes a Cloud Run Job.
+resource "google_project_iam_member" "ci_run_developer" {
+  project = var.project_id
+  role    = "roles/run.developer"
+  member  = "serviceAccount:${google_service_account.license_ci.email}"
+}
+
+# The mint Cloud Run Job sets no --service-account, so it runs as the
+# project's default compute SA -- deploying a job that will run as a given
+# SA requires the deployer to hold serviceAccountUser on that SA specifically
+# (scoped to the one resource, not roles/iam.serviceAccountUser at the
+# project level, which would let this identity act as *any* SA in the
+# project).
+data "google_project" "this" {
+  project_id = var.project_id
+}
+
+resource "google_service_account_iam_member" "ci_act_as_default_compute" {
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${data.google_project.this.number}-compute@developer.gserviceaccount.com"
+  role                = "roles/iam.serviceAccountUser"
+  member              = "serviceAccount:${google_service_account.license_ci.email}"
 }

--- a/terraform/infrastructure/modules/connect-gateway/gcp/main.tf
+++ b/terraform/infrastructure/modules/connect-gateway/gcp/main.tf
@@ -86,15 +86,56 @@ resource "google_project_iam_member" "ci_gateway_reader" {
   depends_on = [google_project_service.connectgateway]
 }
 
-# Read the signing key + kid (license-issue.yml, license-mint-selfhosted.yml),
-# and create/manage the self-hosted mint destination secret
-# (license-mint-selfhosted.yml's "Ensure destination secret exists..." step
-# -- the secret doesn't exist on first use, so this can't be scoped to a
-# specific secret resource the way a plain secretAccessor grant could be).
-resource "google_project_iam_member" "ci_secretmanager_admin" {
-  project = var.project_id
-  role    = "roles/secretmanager.admin"
-  member  = "serviceAccount:${google_service_account.license_ci.email}"
+# Secret Manager access is scoped per-secret, not project-wide -- peqy
+# correctly flagged an earlier version of this module granting
+# roles/secretmanager.admin at the project level as still too broad a blast
+# radius for a long-lived key sitting in a different repository's secrets.
+# The signing key + kid are managed entirely out-of-band (not Terraform
+# resources anywhere in this repo -- `gcloud secrets create`/`versions add`,
+# manually), so they're referenced here by their literal, predictable
+# secret_id rather than a resource reference; that's fine, IAM bindings
+# don't require the target to be Terraform-managed.
+resource "google_secret_manager_secret_iam_member" "ci_read_private_key" {
+  project   = var.project_id
+  secret_id = "${var.environment}-rhesis-rhesis-license-private-key"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.license_ci.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "ci_read_kid" {
+  project   = var.project_id
+  secret_id = "${var.environment}-rhesis-rhesis-license-kid"
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.license_ci.email}"
+}
+
+# license-mint-selfhosted.yml's destination secret. Pre-created here
+# (Terraform-managed, no initial version -- the Cloud Run job writes the
+# actual token at runtime) specifically so the CI identity never needs
+# project-wide secretmanager.secrets.create: the workflow's own "Ensure
+# destination secret exists" step already checks `gcloud secrets describe`
+# first and only creates on a cache miss, so once this exists that branch is
+# permanently a no-op.
+resource "google_secret_manager_secret" "mint_destination" {
+  project   = var.project_id
+  secret_id = "${var.environment}-rhesis-selfhosted-license-mint"
+
+  replication {
+    auto {}
+  }
+}
+
+# admin (not just accessor), scoped to this one Terraform-created secret --
+# the workflow's "Ensure destination secret exists" step also calls
+# `gcloud secrets add-iam-policy-binding` on every run (granting the Cloud
+# Run job's runtime SA secretVersionAdder), which needs setIamPolicy. Bound
+# at the secret level, not the project level, so this grants no access to
+# any other secret.
+resource "google_secret_manager_secret_iam_member" "ci_manage_mint_destination" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.mint_destination.secret_id
+  role      = "roles/secretmanager.admin"
+  member    = "serviceAccount:${google_service_account.license_ci.email}"
 }
 
 # Resolve the "latest" backend image tag (both workflows' "Resolve image

--- a/terraform/infrastructure/modules/connect-gateway/gcp/outputs.tf
+++ b/terraform/infrastructure/modules/connect-gateway/gcp/outputs.tf
@@ -1,0 +1,9 @@
+output "membership_name" {
+  description = "Fleet membership resource name (for reference in docs/kubeconfig commands)."
+  value       = google_gke_hub_membership.cluster.name
+}
+
+output "membership_id" {
+  description = "Fleet membership ID -- matches the environment name, used as the CLUSTER arg to `gcloud container fleet memberships get-credentials`."
+  value       = google_gke_hub_membership.cluster.membership_id
+}

--- a/terraform/infrastructure/modules/connect-gateway/gcp/outputs.tf
+++ b/terraform/infrastructure/modules/connect-gateway/gcp/outputs.tf
@@ -7,3 +7,8 @@ output "membership_id" {
   description = "Fleet membership ID -- matches the environment name, used as the CLUSTER arg to `gcloud container fleet memberships get-credentials`."
   value       = google_gke_hub_membership.cluster.membership_id
 }
+
+output "ci_service_account_email" {
+  description = "Email of the dedicated license-ci-<env> service account. Bind this (not terraform-<env>) as the RoleBinding subject in kubernetes/clusters/<env>/rhesis/license-issuer-rbac.yaml, and as rhesis-ee's GCP_SA_KEY secret for this environment (terraform/infrastructure/scripts/rotate-license-ci-key.sh generates and pushes the key)."
+  value       = google_service_account.license_ci.email
+}

--- a/terraform/infrastructure/modules/connect-gateway/gcp/variables.tf
+++ b/terraform/infrastructure/modules/connect-gateway/gcp/variables.tf
@@ -1,0 +1,33 @@
+variable "project_id" {
+  description = "GCP project ID for the target environment."
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (dev, stg, prd). Used as the Fleet membership ID."
+  type        = string
+  validation {
+    condition     = contains(["dev", "stg", "prd"], var.environment)
+    error_message = "Environment must be one of: dev, stg, prd."
+  }
+}
+
+variable "cluster_id" {
+  description = <<-EOT
+    Full resource ID of the GKE cluster to register, in the form
+    "projects/{project}/locations/{location}/clusters/{name}" -- this is
+    exactly what `google_container_cluster.cluster.id` (module.gke_<env>.cluster_id)
+    returns.
+  EOT
+  type        = string
+}
+
+variable "ci_service_account_email" {
+  description = <<-EOT
+    Email of the service account CI workflows authenticate as (the one behind
+    the GCP_SA_KEY / WIF-bound identity used by GitHub Actions). Granted
+    roles/gkehub.gatewayReader so `gcloud container fleet memberships
+    get-credentials` works for it without VPN access to the cluster.
+  EOT
+  type        = string
+}

--- a/terraform/infrastructure/modules/connect-gateway/gcp/variables.tf
+++ b/terraform/infrastructure/modules/connect-gateway/gcp/variables.tf
@@ -21,13 +21,3 @@ variable "cluster_id" {
   EOT
   type        = string
 }
-
-variable "ci_service_account_email" {
-  description = <<-EOT
-    Email of the service account CI workflows authenticate as (the one behind
-    the GCP_SA_KEY / WIF-bound identity used by GitHub Actions). Granted
-    roles/gkehub.gatewayReader so `gcloud container fleet memberships
-    get-credentials` works for it without VPN access to the cluster.
-  EOT
-  type        = string
-}

--- a/terraform/infrastructure/scripts/rotate-license-ci-key.sh
+++ b/terraform/infrastructure/scripts/rotate-license-ci-key.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Generates a new key for the license-ci-<env> service account (created by
+# terraform/infrastructure/modules/connect-gateway/gcp) and pushes it into
+# the matching GitHub Environment secret (GCP_SA_KEY) in the private
+# rhesis-ai/rhesis-ee repo, which is what license-issue.yml and
+# license-mint-selfhosted.yml authenticate with.
+#
+# This is a one-off/rotation tool, run manually by a human -- not something
+# any pipeline calls automatically. Run it once per environment after the
+# connect-gateway module has been applied for that environment (the SA must
+# already exist), and again whenever the key needs rotating.
+#
+# license-ci-<env> is deliberately scoped to only what these two workflows
+# need (see the module's main.tf for the exact roles) -- unlike
+# terraform-<env>, which holds roles/editor + iam.securityAdmin +
+# resourcemanager.projectIamAdmin on the whole project and should never have
+# a static key handed to a different repository's CI.
+#
+# Prerequisites:
+#   - gcloud CLI authenticated with permission to create SA keys in the
+#     target project (terraform-<env> or an equivalent admin identity)
+#   - gh CLI authenticated with permission to set secrets on rhesis-ai/rhesis-ee
+#   - terraform apply already run for the target environment (the SA must exist)
+#
+# Usage: ./rotate-license-ci-key.sh <dev|stg|prd>
+
+set -euo pipefail
+
+# ── Configuration ────────────────────────────────────────────────────
+
+ENVIRONMENT="${1:-}"
+EE_REPO="rhesis-ai/rhesis-ee"
+
+if [[ -z "$ENVIRONMENT" ]]; then
+  echo "Usage: $0 <dev|stg|prd>"
+  exit 1
+fi
+
+case "$ENVIRONMENT" in
+  dev) PROJECT_ID="rhesis-dev-494712" ;;
+  stg) PROJECT_ID="rhesis-stg-494712" ;;
+  prd) PROJECT_ID="rhesis-prd" ;;
+  *)
+    echo "Unknown environment '$ENVIRONMENT' -- expected dev, stg, or prd."
+    exit 1
+    ;;
+esac
+
+SA_EMAIL="license-ci-${ENVIRONMENT}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+# ── Colors & helpers ─────────────────────────────────────────────────
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log_info()    { echo -e "🔵 $1"; }
+log_success() { echo -e "${GREEN}✅ $1${NC}"; }
+log_warning() { echo -e "${YELLOW}⚠️  $1${NC}"; }
+log_error()   { echo -e "${RED}❌ $1${NC}"; }
+
+# ── Verify the SA exists ─────────────────────────────────────────────
+
+log_info "Checking $SA_EMAIL exists in $PROJECT_ID..."
+if ! gcloud iam service-accounts describe "$SA_EMAIL" --project="$PROJECT_ID" &>/dev/null; then
+  log_error "$SA_EMAIL not found in $PROJECT_ID."
+  log_error "Run terraform apply for envs/$ENVIRONMENT first (module.connect_gateway_$ENVIRONMENT creates it)."
+  exit 1
+fi
+log_success "$SA_EMAIL exists"
+
+# Existing keys are a lingering risk (nothing prunes them automatically) --
+# surface the count so an operator notices if this has been rotated before
+# without the old key ever being deleted.
+EXISTING_KEYS=$(gcloud iam service-accounts keys list \
+  --iam-account="$SA_EMAIL" \
+  --managed-by=user \
+  --format="value(name)" | wc -l | tr -d ' ')
+if [[ "$EXISTING_KEYS" -gt 0 ]]; then
+  log_warning "$EXISTING_KEYS existing user-managed key(s) on $SA_EMAIL."
+  log_warning "Consider deleting the old key once the new one is confirmed working:"
+  log_warning "  gcloud iam service-accounts keys list --iam-account=$SA_EMAIL"
+  log_warning "  gcloud iam service-accounts keys delete <KEY_ID> --iam-account=$SA_EMAIL"
+fi
+
+# ── Generate the key and push it, without ever writing it to disk ──────
+
+log_info "Generating a new key for $SA_EMAIL..."
+KEY_JSON=$(gcloud iam service-accounts keys create /dev/stdout \
+  --iam-account="$SA_EMAIL" \
+  --project="$PROJECT_ID")
+log_success "Key generated"
+
+log_info "Pushing to $EE_REPO's '$ENVIRONMENT' GitHub Environment secret GCP_SA_KEY..."
+echo "$KEY_JSON" | gh secret set GCP_SA_KEY --repo "$EE_REPO" --env "$ENVIRONMENT"
+unset KEY_JSON
+log_success "GCP_SA_KEY updated for $EE_REPO environment '$ENVIRONMENT'"
+
+log_info "Done. The new key is live in GitHub; nothing was written to disk locally."


### PR DESCRIPTION
## Purpose

`rhesis-ee`'s `license-issue.yml` needs to run a Kubernetes Job in-cluster
(to reach a database resolvable only via cluster-internal DNS -- see
rhesis-ai/rhesis-ee#5), but there's no way for it to reach the cluster at
all: dev/stg/prd are private, with the API server locked to the WireGuard
VPN CIDR, and the existing `arc-runner-<env>` self-hosted runner pools are
registered per-repo against `rhesis-ai/rhesis` specifically -- a workflow in
a different repo can never have its jobs picked up by them, no matter how
long they wait.

## What Changed

- New module `terraform/infrastructure/modules/connect-gateway/gcp`:
  - Enables `gkehub.googleapis.com` and `connectgateway.googleapis.com`.
  - Registers each cluster as a GKE Hub (Fleet) membership.
  - Creates a dedicated `license-ci-<env>` service account and grants it
    exactly `roles/gkehub.gatewayReader` (Connect Gateway),
    `roles/secretmanager.admin` (read the signing key + kid, create/manage
    the self-hosted mint destination secret), `roles/artifactregistry.reader`
    (image tag resolution), `roles/run.developer` (deploy/execute the mint
    Cloud Run Job), and `roles/iam.serviceAccountUser` scoped to just the
    project's default compute SA resource (the mint job runs as it).
- Instantiated as `module.connect_gateway_{dev,stg,prd}` in each
  `envs/<env>/main.tf`.
- Updated `kubernetes/clusters/<env>/rhesis/license-issuer-rbac.yaml`'s
  `RoleBinding` subject: GKE maps an IAM principal authenticated via Connect
  Gateway onto a Kubernetes `User` by email, so it now binds
  `license-ci-<env>`'s email instead of the ARC runner's `ServiceAccount`
  (which never applied to a cross-repo caller anyway).
- Documented the access pattern in `kubernetes/README.md` (new "CI access
  without a VPN: Connect Gateway" section) alongside the existing
  VPN-based `get-credentials` instructions.
- Added `terraform/infrastructure/scripts/rotate-license-ci-key.sh` -- a
  manual, one-off tool to generate a key for `license-ci-<env>` and push it
  straight to `rhesis-ee`'s matching GitHub Environment secret, never
  writing it to disk.

**Follow-up round (self-review):** the first version of this PR granted
`roles/gkehub.gatewayReader` to the existing `terraform-<env>` identity
instead of creating a new one -- convenient, since that identity already
exists and is already what `rhesis-ee`'s workflows authenticate as for
other things. Checked what that identity actually holds:
`gcloud projects get-iam-policy` shows `terraform-<env>` has `roles/editor`
+ `roles/iam.securityAdmin` + `roles/resourcemanager.projectIamAdmin` on the
whole project, identical across dev/stg/prd -- effectively full project
control. `rhesis-ee`'s licensing workflows authenticate with a static,
long-lived `GCP_SA_KEY` (not WIF, unlike this repo's own
`terraform-infrastructure.yml`), stored in a *different* repository's
secrets. A leaked key would have handed out near-owner access to the whole
GCP project, for a task that only ever needs to create Jobs in one K8s
namespace, read two Secret Manager entries, resolve an image tag, and run a
Cloud Run Job. Replaced the input-based grant with a dedicated
`license-ci-<env>` SA scoped to exactly that.

## Additional Context

- Companion workflow change: rhesis-ai/rhesis-ee#6 (`license-issue.yml`
  switches from a self-hosted `arc-runner-<env>` runner to plain
  `ubuntu-latest` + `gcloud container fleet memberships get-credentials`).
- This only grants *reachability* to the cluster's API server -- what the
  caller can actually do once connected is still governed entirely by
  ordinary Kubernetes RBAC, unchanged in scope from before (same
  `license-issuer` Role: Jobs/Pods in the `rhesis` namespace, one specific
  Secret).
- Verified via `gcloud iam service-accounts list` that `terraform-dev`,
  `terraform-stg`, `terraform-prd` are real, existing identities in their
  respective projects (`rhesis-dev-494712`, `rhesis-stg-494712`,
  `rhesis-prd`) -- no assumptions on project ID naming.
- Once this merges and applies, `rhesis-ee`'s `GCP_SA_KEY` secret (per
  environment) needs to be rotated from `terraform-<env>`'s key to
  `license-ci-<env>`'s (`scripts/rotate-license-ci-key.sh dev|stg|prd`) --
  the K8s RBAC `RoleBinding` in this PR already expects the new identity, so
  `license-issue.yml`/`license-mint-selfhosted.yml` will fail Connect
  Gateway auth until that rotation happens.

**Second follow-up round (peqy):** `roles/secretmanager.admin` at the
*project* level was still flagged as too broad for a long-lived key in
another repo -- fair, that grant alone could touch every secret in the
project, not just the licensing-related ones. Replaced with three
secret-scoped grants: `secretAccessor` on the two signing-key secrets
(referenced by literal `secret_id` since they're managed out-of-band, not
Terraform resources anywhere in this repo), and the mint destination secret
is now pre-created by Terraform (empty, no initial version) specifically so
the CI identity never needs project-wide `secretmanager.secrets.create` at
all -- just `secretmanager.admin` scoped to that one pre-created secret
(needed for the workflow's per-run `add-iam-policy-binding` call granting
the Cloud Run job's runtime SA `secretVersionAdder`).

## Testing

- Rebased onto current `main` (this branch predated #2292's CI/Terraform
  rewrite) and confirmed `Plan / dev`, `Plan / stg`, `Plan / prd` all pass
  on this PR's own CI, twice -- once after creating the dedicated SA, again
  after re-scoping Secret Manager to per-secret IAM. Checked the actual plan
  output both times, not just "no error": each env creates exactly
  `google_service_account.license_ci`, `google_secret_manager_secret.mint_destination`,
  the per-secret `google_secret_manager_secret_iam_member` grants, the
  remaining project-level `google_project_iam_member` grants (gateway
  reader, artifact registry reader, run developer),
  `google_service_account_iam_member` scoped to the default compute SA, and
  `google_gke_hub_membership.cluster` -- nothing extra, nothing missing.
- `kubectl kustomize kubernetes/clusters/<dev|stg|prd>/` builds cleanly and
  renders each `RoleBinding`'s new subject correctly for all three.
- Not yet tested: an actual live dispatch of `license-issue.yml`/
  `license-mint-selfhosted.yml` against the new `license-ci-<env>` identity
  end-to-end (needs this applied + the GCP_SA_KEY rotation above first).

