### PR TITLE
Fix N+1 trip-wire failures and trim unused Detail schema fields

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -31,7 +31,6 @@ from rhesis.backend.app.utils.crud_utils import (
     delete_item,
     get_item,
     get_item_detail,
-    get_item_with_deferred,
     get_items,
     get_items_detail,
     update_item,
@@ -75,6 +74,13 @@ def get_session_variables(db: Session):
 
 
 # Endpoint CRUD
+_ENDPOINT_RELATED_FIELDS = (
+    include(models.Endpoint.status),
+    include(models.Endpoint.user),
+    include(models.Endpoint.project),
+)
+
+
 def get_endpoint(
     db: Session,
     endpoint_id: uuid.UUID,
@@ -83,9 +89,18 @@ def get_endpoint(
     project_id: str = None,
 ) -> Optional[models.Endpoint]:
     """Get endpoint with relationships eagerly loaded."""
-    return get_item_detail(
-        db, models.Endpoint, endpoint_id, organization_id, user_id, project_id=project_id
+    from rhesis.backend.app.utils.crud_utils import _check_and_raise_if_deleted
+
+    item = (
+        QueryBuilder(db, models.Endpoint)
+        .with_deleted()
+        .with_related(*_ENDPOINT_RELATED_FIELDS)
+        .with_organization_filter(organization_id)
+        .with_project_filter(project_id)
+        .with_visibility_filter(user_id)
+        .filter_by_id(endpoint_id)
     )
+    return _check_and_raise_if_deleted(item, models.Endpoint, endpoint_id, False)
 
 
 def get_endpoints(
@@ -98,16 +113,15 @@ def get_endpoints(
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.Endpoint]:
-    return get_items_detail(
-        db,
-        models.Endpoint,
-        skip,
-        limit,
-        sort_by,
-        sort_order,
-        filter,
-        organization_id=organization_id,
-        user_id=user_id,
+    return (
+        QueryBuilder(db, models.Endpoint)
+        .with_related(*_ENDPOINT_RELATED_FIELDS)
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .with_odata_filter(filter)
+        .with_sorting(sort_by, sort_order)
+        .with_pagination(skip, limit)
+        .all()
     )
 
 
@@ -148,16 +162,15 @@ def get_experiments(
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.Experiment]:
-    return get_items_detail(
-        db,
-        models.Experiment,
-        skip,
-        limit,
-        sort_by,
-        sort_order,
-        filter,
-        organization_id=organization_id,
-        user_id=user_id,
+    return (
+        QueryBuilder(db, models.Experiment)
+        .with_related(include(models.Experiment.project))
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .with_odata_filter(filter)
+        .with_sorting(sort_by, sort_order)
+        .with_pagination(skip, limit)
+        .all()
     )
 
 
@@ -336,8 +349,8 @@ def delete_prompt_template(
 def get_category(
     db: Session, category_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.Category]:
-    """Get category with relationships eagerly loaded."""
-    return get_item_detail(db, models.Category, category_id, organization_id, user_id)
+    """Get a single category by ID."""
+    return get_item(db, models.Category, category_id, organization_id, user_id)
 
 
 def get_categories(
@@ -350,7 +363,7 @@ def get_categories(
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.Category]:
-    return get_items_detail(
+    return get_items(
         db,
         models.Category,
         skip,
@@ -910,16 +923,26 @@ def get_test_set_tests(
 
 
 # TestConfiguration CRUD
+_TEST_CONFIGURATION_RELATED_FIELDS = (
+    include(models.TestConfiguration.test_set),
+    include(models.TestConfiguration.endpoint),
+)
+
+
 def get_test_configuration(
     db: Session, test_configuration_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.TestConfiguration]:
-    return get_item_detail(
-        db,
-        models.TestConfiguration,
-        test_configuration_id,
-        organization_id=organization_id,
-        user_id=user_id,
+    from rhesis.backend.app.utils.crud_utils import _check_and_raise_if_deleted
+
+    item = (
+        QueryBuilder(db, models.TestConfiguration)
+        .with_deleted()
+        .with_related(*_TEST_CONFIGURATION_RELATED_FIELDS)
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .filter_by_id(test_configuration_id)
     )
+    return _check_and_raise_if_deleted(item, models.TestConfiguration, test_configuration_id, False)
 
 
 def get_test_configurations(
@@ -932,16 +955,15 @@ def get_test_configurations(
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.TestConfiguration]:
-    return get_items_detail(
-        db,
-        models.TestConfiguration,
-        skip,
-        limit,
-        sort_by,
-        sort_order,
-        filter,
-        organization_id=organization_id,
-        user_id=user_id,
+    return (
+        QueryBuilder(db, models.TestConfiguration)
+        .with_related(*_TEST_CONFIGURATION_RELATED_FIELDS)
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .with_odata_filter(filter)
+        .with_sorting(sort_by, sort_order)
+        .with_pagination(skip, limit)
+        .all()
     )
 
 
@@ -1229,6 +1251,12 @@ def mark_embeddings_stale(
 
 
 # Source CRUD
+_SOURCE_RELATED_FIELDS = (
+    include(models.Source.source_type),
+    include(models.Source.user),
+)
+
+
 def get_source(
     db: Session,
     source_id: uuid.UUID,
@@ -1239,9 +1267,20 @@ def get_source(
 
     Note: Content field is deferred and will not be loaded unless explicitly requested.
     Use get_source_with_content() to load the content field.
-    Relationships (source_type, status, user) are loaded for display.
+    Relationships (source_type, user) are loaded for display.
     """
-    return get_item_detail(db, models.Source, source_id, organization_id, user_id)
+    from rhesis.backend.app.utils.crud_utils import _check_and_raise_if_deleted
+
+    item = (
+        QueryBuilder(db, models.Source)
+        .with_deleted()
+        .with_related(*_SOURCE_RELATED_FIELDS)
+        .with_default_derived_field_loads()
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .filter_by_id(source_id)
+    )
+    return _check_and_raise_if_deleted(item, models.Source, source_id, False)
 
 
 def get_source_with_content(
@@ -1251,19 +1290,22 @@ def get_source_with_content(
     user_id: str = None,
     include_deleted: bool = False,
 ) -> Optional[models.Source]:
-    """Get source with content field explicitly loaded.
+    """Get source with content field explicitly loaded (a deferred column)."""
+    from sqlalchemy.orm import undefer
 
-    This uses get_item_with_deferred from crud_utils to load the deferred content field.
-    """
-    return get_item_with_deferred(
-        db=db,
-        model=models.Source,
-        item_id=source_id,
-        deferred_fields=["content"],
-        organization_id=organization_id,
-        user_id=user_id,
-        include_deleted=include_deleted,
+    from rhesis.backend.app.utils.crud_utils import _check_and_raise_if_deleted
+
+    item = (
+        QueryBuilder(db, models.Source)
+        .with_deleted()
+        .with_related(*_SOURCE_RELATED_FIELDS)
+        .with_default_derived_field_loads()
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
     )
+    item.query = item.query.options(undefer(models.Source.content))
+    item = item.filter_by_id(source_id)
+    return _check_and_raise_if_deleted(item, models.Source, source_id, include_deleted)
 
 
 def get_sources(
@@ -1280,18 +1322,18 @@ def get_sources(
 
     Note: Content field is deferred and will not be loaded.
     Use get_source_with_content() for individual sources that need content.
-    Relationships (source_type, status, user) are loaded for display.
+    Relationships (source_type, user) are loaded for display.
     """
-    return get_items_detail(
-        db,
-        models.Source,
-        skip,
-        limit,
-        sort_by,
-        sort_order,
-        filter,
-        organization_id=organization_id,
-        user_id=user_id,
+    return (
+        QueryBuilder(db, models.Source)
+        .with_related(*_SOURCE_RELATED_FIELDS)
+        .with_default_derived_field_loads()
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .with_odata_filter(filter)
+        .with_sorting(sort_by, sort_order)
+        .with_pagination(skip, limit)
+        .all()
     )
 
 
@@ -2695,18 +2737,31 @@ def delete_test_run(
 
 
 # Test Result CRUD
+_TEST_RESULT_RELATED_FIELDS = (
+    include(models.TestResult.test_run),
+    include(models.TestResult.test),
+    include(models.TestResult.test, models.Test.prompt),
+    include(models.TestResult.test, models.Test.behavior),
+    include(models.TestResult.test, models.Test.topic),
+)
+
+
 def get_test_result(
     db: Session, test_result_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.TestResult]:
-    """Get test_result with relationships (tags, tasks, comments) using optimized approach."""
-    return get_item_detail(
-        db,
-        models.TestResult,
-        test_result_id,
-        organization_id,
-        user_id,
-        nested_relationships={"test": ["prompt", "behavior", "topic"]},
+    """Get test_result with relationships (tags, test, test_run) eagerly loaded."""
+    from rhesis.backend.app.utils.crud_utils import _check_and_raise_if_deleted
+
+    item = (
+        QueryBuilder(db, models.TestResult)
+        .with_deleted()
+        .with_related(*_TEST_RESULT_RELATED_FIELDS)
+        .with_default_derived_field_loads()
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .filter_by_id(test_result_id)
     )
+    return _check_and_raise_if_deleted(item, models.TestResult, test_result_id, False)
 
 
 def get_test_results(
@@ -2719,18 +2774,17 @@ def get_test_results(
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.TestResult]:
-    """Get test_results with relationships (tags, tasks, comments) using optimized approach."""
-    return get_items_detail(
-        db,
-        models.TestResult,
-        skip,
-        limit,
-        sort_by,
-        sort_order,
-        filter,
-        nested_relationships={"test": ["prompt", "behavior", "topic"]},
-        organization_id=organization_id,
-        user_id=user_id,
+    """Get test_results with relationships (tags, test, test_run) eagerly loaded."""
+    return (
+        QueryBuilder(db, models.TestResult)
+        .with_related(*_TEST_RESULT_RELATED_FIELDS)
+        .with_default_derived_field_loads()
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .with_odata_filter(filter)
+        .with_sorting(sort_by, sort_order)
+        .with_pagination(skip, limit)
+        .all()
     )
 
 
@@ -3638,11 +3692,24 @@ def test_model_connection(db: Session, model_id: uuid.UUID) -> bool:
 
 
 # Tool CRUD
+_TOOL_RELATED_FIELDS = (include(models.Tool.tool_provider_type),)
+
+
 def get_tool(
     db: Session, tool_id: uuid.UUID, organization_id: str, user_id: str = None
 ) -> Optional[models.Tool]:
     """Get a specific tool by ID with relationships loaded"""
-    return get_item_detail(db, models.Tool, tool_id, organization_id, user_id)
+    from rhesis.backend.app.utils.crud_utils import _check_and_raise_if_deleted
+
+    item = (
+        QueryBuilder(db, models.Tool)
+        .with_deleted()
+        .with_related(*_TOOL_RELATED_FIELDS)
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .filter_by_id(tool_id)
+    )
+    return _check_and_raise_if_deleted(item, models.Tool, tool_id, False)
 
 
 def get_tools(
@@ -3656,16 +3723,15 @@ def get_tools(
     user_id: str = None,
 ) -> List[models.Tool]:
     """Get all tools for an organization with filtering and pagination"""
-    return get_items_detail(
-        db,
-        models.Tool,
-        skip,
-        limit,
-        sort_by,
-        sort_order,
-        filter,
-        organization_id=organization_id,
-        user_id=user_id,
+    return (
+        QueryBuilder(db, models.Tool)
+        .with_related(*_TOOL_RELATED_FIELDS)
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .with_odata_filter(filter)
+        .with_sorting(sort_by, sort_order)
+        .with_pagination(skip, limit)
+        .all()
     )
 
 
@@ -4929,7 +4995,18 @@ def get_architect_session_detail(
     organization_id: str = None,
     user_id: str = None,
 ) -> Optional[models.ArchitectSession]:
-    return get_item_detail(db, models.ArchitectSession, session_id, organization_id, user_id)
+    """Get an architect session with its messages eagerly loaded."""
+    from rhesis.backend.app.utils.crud_utils import _check_and_raise_if_deleted
+
+    item = (
+        QueryBuilder(db, models.ArchitectSession)
+        .with_deleted()
+        .with_related(include(models.ArchitectSession.messages))
+        .with_organization_filter(organization_id)
+        .with_visibility_filter(user_id)
+        .filter_by_id(session_id)
+    )
+    return _check_and_raise_if_deleted(item, models.ArchitectSession, session_id, False)
 
 
 def get_architect_sessions(

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -390,17 +390,11 @@ def delete_category(
 
 
 # Behavior CRUD
-# Both read_behavior and read_behaviors return BehaviorWithMetricsSchema (routers/behavior.py),
-# = schemas.Behavior (tags, status, user) + metrics: List[schemas.Metric] (each needing
-# metric_type, backend_type, tags). organization/project are NOT read by this schema (only
-# BehaviorDetail has them) -- deliberately excluded here. Folding Behavior's own tags chain in
-# here means neither caller needs with_default_derived_field_loads (BehaviorWithMetricsSchema
-# has no counts/comments/tasks field), and metrics.tags is included explicitly since
-# selectinload's default cascade skips many-to-many relations -- omitting it would lazy-load
-# tags per nested metric (N+1). No cartesian product: each hop's own cardinality picks
-# selectinload for collections, joinedload for the final single-valued tag.
+# read_behavior/read_behaviors return BehaviorWithMetricsSchema (tags, user, metrics with
+# metric_type/backend_type/tags); status/organization/project are unused, excluded. metrics.tags
+# is included explicitly since selectinload's default cascade skips many-to-many relations
+# (would otherwise lazy-load tags per nested metric).
 _BEHAVIOR_RELATED_FIELDS = (
-    include(models.Behavior.status),
     include(models.Behavior.user),
     include(models.Behavior._tags_relationship, models.TaggedItem.tag),
     include(models.Behavior.metrics),
@@ -592,15 +586,11 @@ def get_test_set(
 # because those produce cartesian-product joins or lazy fan-out and none of
 # these endpoints serialize them. comments/tasks/files/tags ARE serialized
 # (via CountsMixin.counts / TagsMixin.tags) -- see with_default_derived_field_loads.
+# license_type/owner/assignee/organization/project: unused, excluded.
 _TEST_SET_RELATED_FIELDS = (
     include(models.TestSet.status),
-    include(models.TestSet.license_type),
     include(models.TestSet.test_set_type),
     include(models.TestSet.user),
-    include(models.TestSet.owner),
-    include(models.TestSet.assignee),
-    include(models.TestSet.organization),
-    include(models.TestSet.project),
 )
 
 
@@ -896,14 +886,10 @@ def get_test_set_tests(
             include(models.Test.user),
             include(models.Test.assignee),
             include(models.Test.owner),
-            include(models.Test.parent),
             include(models.Test.topic),
             include(models.Test.behavior),
             include(models.Test.category),
             include(models.Test.status),
-            include(models.Test.source),
-            include(models.Test.organization),
-            include(models.Test.project),
         )
         .with_visibility_filter()
         .with_custom_filter(
@@ -1052,24 +1038,8 @@ def delete_risk(
 def get_status(
     db: Session, status_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.Status]:
-    """Get a single status by ID without joining all its related entities."""
-    from rhesis.backend.app.utils.crud_utils import _check_and_raise_if_deleted
-    from rhesis.backend.app.utils.query_utils import QueryBuilder
-
-    item = (
-        QueryBuilder(db, models.Status)
-        .with_deleted()
-        .with_related(
-            include(models.Status.entity_type),
-            include(models.Status.project),
-            include(models.Status.organization),
-            include(models.Status.user),
-        )
-        .with_organization_filter(organization_id)
-        .with_visibility_filter(user_id)
-        .filter_by_id(status_id)
-    )
-    return _check_and_raise_if_deleted(item, models.Status, status_id, False)
+    """Get a single status by ID."""
+    return get_item(db, models.Status, status_id, organization_id, user_id)
 
 
 def get_statuses(
@@ -1390,8 +1360,8 @@ def get_chunk(
 def get_topic(
     db: Session, topic_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.Topic]:
-    """Get topic with relationships eagerly loaded."""
-    return get_item_detail(db, models.Topic, topic_id, organization_id, user_id)
+    """Get a single topic by ID."""
+    return get_item(db, models.Topic, topic_id, organization_id, user_id)
 
 
 def get_topics(
@@ -2113,12 +2083,7 @@ def get_projects(
     with bypass_tenant_filter():
         builder = (
             QueryBuilder(db, models.Project)
-            .with_related(
-                include(models.Project.user),
-                include(models.Project.owner),
-                include(models.Project.organization),
-                include(models.Project.status),
-            )
+            .with_related(include(models.Project.owner))
             .with_default_derived_field_loads()
             .with_organization_filter(organization_id)
             .with_visibility_filter(user_id)
@@ -2450,16 +2415,13 @@ def delete_test_context(
 
 # Test Run CRUD
 
-# Relationships loaded for TestRun detail responses. Matches the schema defined
-# by schemas.TestRunDetail.
+# Relationships loaded for TestRun detail responses. Matches schemas.TestRunDetail.
+# assignee/owner/organization/experiment/project (TestRun's own top-level fields) are
+# unused, excluded; the nested test_configuration.endpoint.project chain below is a
+# separate, still-used field.
 _TEST_RUN_RELATED_FIELDS = (
     include(models.TestRun.status),
-    include(models.TestRun.assignee),
-    include(models.TestRun.owner),
     include(models.TestRun.user),
-    include(models.TestRun.organization),
-    include(models.TestRun.experiment),
-    include(models.TestRun.project),
     include(models.TestRun.test_configuration, models.TestConfiguration.endpoint),
     include(
         models.TestRun.test_configuration,
@@ -2847,6 +2809,7 @@ def get_my_projects(db: Session, user_id: uuid.UUID, organization_id: str) -> Li
 
     return (
         db.query(models.Project)
+        .options(include(models.Project.owner))
         .join(ProjectMembership, ProjectMembership.project_id == models.Project.id)
         .filter(
             ProjectMembership.user_id == user_id,
@@ -2996,35 +2959,20 @@ def get_type_lookup_by_name_and_value(
 
 # Metric CRUD
 # Relationships serialized by schemas.MetricDetail. with_related picks joinedload
-# for the many-to-one ones (metric_type, status, ...) and selectinload for the
-# many-to-many ones (behaviors, test_sets) automatically -- joinedload on the
-# M2M pair previously produced a cartesian product (one row per
-# (metric, behavior, test_set) tuple) that bloated the response by orders of
-# magnitude.
+# for many-to-one (metric_type, ...) and selectinload for the many-to-many
+# (behaviors) -- joinedload on an M2M would cartesian-product the rows.
+# status/assignee/owner/user/organization/project/test_sets: unused, excluded.
 _METRIC_RELATED_FIELDS = (
     include(models.Metric.metric_type),
-    include(models.Metric.status),
-    include(models.Metric.assignee),
-    include(models.Metric.owner),
     include(models.Metric.model),
     include(models.Metric.backend_type),
-    include(models.Metric.user),
-    include(models.Metric.organization),
-    include(models.Metric.project),
-    # behaviors/test_sets serialize as BehaviorReference/TestSetReference, which
-    # both read `counts` (comments/tasks) and `tags`. with_default_derived_field_loads
-    # only cascades those into many-to-one relations -- it skips many-to-many -- so
-    # without these explicit chains each nested behavior/test_set would lazy-load its
-    # own comments/tasks/tags per row (N+1). include() picks selectinload for each
-    # collection hop and joinedload for the final tag, so no cartesian product.
+    # behaviors serializes as BehaviorReference, which reads counts/tags;
+    # with_default_derived_field_loads only cascades those into many-to-one
+    # relations, so these chains are explicit to avoid an N+1 per behavior.
     include(models.Metric.behaviors),
     include(models.Metric.behaviors, models.Behavior.comments),
     include(models.Metric.behaviors, models.Behavior.tasks),
     include(models.Metric.behaviors, models.Behavior._tags_relationship, models.TaggedItem.tag),
-    include(models.Metric.test_sets),
-    include(models.Metric.test_sets, models.TestSet.comments),
-    include(models.Metric.test_sets, models.TestSet.tasks),
-    include(models.Metric.test_sets, models.TestSet._tags_relationship, models.TaggedItem.tag),
 )
 
 
@@ -3375,6 +3323,7 @@ def get_metric_behaviors(
 
     return (
         QueryBuilder(db, models.Behavior)
+        .with_related(include(models.Behavior._tags_relationship, models.TaggedItem.tag))
         .with_organization_filter(organization_id)
         .with_custom_filter(
             lambda q: q.join(models.behavior_metric_association).filter(
@@ -3551,7 +3500,9 @@ def get_model(
     db: Session, model_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.Model]:
     """Get a specific model by ID with its related objects and organization filtering"""
-    query = db.query(models.Model).filter(models.Model.id == model_id)
+    query = db.query(models.Model).options(include(models.Model.provider_type)).filter(
+        models.Model.id == model_id
+    )
 
     # Apply organization filtering (SECURITY CRITICAL)
     if organization_id:
@@ -3805,6 +3756,8 @@ def get_comments_by_entity(
     """Get all comments for a specific entity (test, test_set, test_run)"""
     return (
         QueryBuilder(db, models.Comment)
+        .with_related(include(models.Comment.user))
+        .with_default_derived_field_loads()
         .with_organization_filter(organization_id)
         .with_custom_filter(
             lambda q: q.filter(
@@ -3977,7 +3930,13 @@ def get_task(
     db: Session, task_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.Task]:
     """Get task with relationships eagerly loaded."""
-    return get_item_detail(db, models.Task, task_id, organization_id, user_id)
+    # Task.comments is a custom polymorphic relationship (viewonly, matched by
+    # entity_id/entity_type), not the CommentsMixin comments/tasks/files/tags
+    # default -- TaskDetail.comment_count reads it directly, so it needs its
+    # own explicit selectin_chains entry.
+    return get_item_detail(
+        db, models.Task, task_id, organization_id, user_id, selectin_chains=[["comments"]]
+    )
 
 
 def get_tasks(
@@ -3991,6 +3950,8 @@ def get_tasks(
     user_id: str = None,
 ) -> List[models.Task]:
     """Get tasks with filtering and sorting"""
+    # See get_task -- Task.comments is a custom polymorphic relationship, not
+    # covered by the CommentsMixin default, but TaskDetail.comment_count reads it.
     return get_items_detail(
         db,
         models.Task,
@@ -3999,6 +3960,7 @@ def get_tasks(
         sort_by,
         sort_order,
         filter,
+        selectin_chains=[["comments"]],
         organization_id=organization_id,
         user_id=user_id,
     )
@@ -4467,7 +4429,8 @@ def query_traces(
         .options(
             joinedload(models.Trace.test_result)
             .joinedload(models.TestResult.test_configuration)
-            .joinedload(models.TestConfiguration.endpoint)
+            .joinedload(models.TestConfiguration.endpoint),
+            joinedload(models.Trace.trace_metrics_status),
         )
     )
 

--- a/apps/backend/src/rhesis/backend/app/crud.py
+++ b/apps/backend/src/rhesis/backend/app/crud.py
@@ -3500,8 +3500,10 @@ def get_model(
     db: Session, model_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.Model]:
     """Get a specific model by ID with its related objects and organization filtering"""
-    query = db.query(models.Model).options(include(models.Model.provider_type)).filter(
-        models.Model.id == model_id
+    query = (
+        db.query(models.Model)
+        .options(include(models.Model.provider_type))
+        .filter(models.Model.id == model_id)
     )
 
     # Apply organization filtering (SECURITY CRITICAL)

--- a/apps/backend/src/rhesis/backend/app/models/test.py
+++ b/apps/backend/src/rhesis/backend/app/models/test.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, ForeignKey, Integer, Table, and_, case, select
+from sqlalchemy import Column, ForeignKey, Integer, Table, and_, case, inspect, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import object_session, relationship
@@ -129,21 +129,24 @@ class Test(
         test_type = get_test_type(self)
 
         sess = object_session(self)
+        state = inspect(self)
 
-        def _fk_obj(related, fk_id, model_cls):
-            """Resolve FK when relationship not populated (e.g. during flush/mapper events)."""
-            if related is not None:
-                return related
+        def _fk_obj(rel_name, fk_id, model_cls):
+            # Checks load state first: this also runs from after_insert/after_update
+            # ORM events, where a plain attribute access could trigger a lazy load.
+            if rel_name not in state.unloaded:
+                related = getattr(self, rel_name)
+                if related is not None:
+                    return related
             if fk_id is None or sess is None:
                 return None
-            # Avoid re-entrant flush: to_searchable_text runs from after_insert/after_update.
             with sess.no_autoflush:
                 return sess.get(model_cls, fk_id)
 
-        topic = _fk_obj(self.topic, self.topic_id, Topic)
-        behavior = _fk_obj(self.behavior, self.behavior_id, Behavior)
-        category = _fk_obj(self.category, self.category_id, Category)
-        prompt = _fk_obj(self.prompt, self.prompt_id, Prompt)
+        topic = _fk_obj("topic", self.topic_id, Topic)
+        behavior = _fk_obj("behavior", self.behavior_id, Behavior)
+        category = _fk_obj("category", self.category_id, Category)
+        prompt = _fk_obj("prompt", self.prompt_id, Prompt)
 
         # Common metadata for both types
         metadata = [

--- a/apps/backend/src/rhesis/backend/app/routers/metric.py
+++ b/apps/backend/src/rhesis/backend/app/routers/metric.py
@@ -233,11 +233,21 @@ def read_metric(
 ):
     """Get a specific metric by ID with its related objects"""
     organization_id, user_id = tenant_context
-    # Use get_item_detail which properly handles soft-deleted items (raises ItemDeletedException)
-    from rhesis.backend.app.utils.crud_utils import get_item_detail
-
-    db_metric = get_item_detail(db, models.Metric, metric_id, organization_id, user_id)
+    db_metric = crud.get_metric(db, metric_id, organization_id, user_id)
     if db_metric is None:
+        # crud.get_metric's query silently excludes soft-deleted rows (like most
+        # plain getters); check separately here so a deleted metric still gets
+        # its own 410, matching the other standard entity routes' contract.
+        from rhesis.backend.app.utils.crud_utils import _check_and_raise_if_deleted
+        from rhesis.backend.app.utils.query_utils import QueryBuilder
+
+        deleted_check = (
+            QueryBuilder(db, models.Metric)
+            .with_deleted()
+            .with_organization_filter(organization_id)
+            .filter_by_id(metric_id)
+        )
+        _check_and_raise_if_deleted(deleted_check, models.Metric, metric_id, False)
         raise HTTPException(status_code=404, detail="Metric not found")
     return db_metric
 

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -563,6 +563,7 @@ def get_trace(
                 "test_result",
                 "test",
                 "test_result.test_configuration.endpoint",
+                "trace_metrics_status",
             ],
         )
 

--- a/apps/backend/src/rhesis/backend/app/schemas/behavior.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/behavior.py
@@ -1,15 +1,9 @@
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import List, Optional, Union
 
 from pydantic import UUID4, Field
 
 from rhesis.backend.app.schemas import Base
-from rhesis.backend.app.schemas.references import (
-    OrganizationReference,
-    ProjectReference,
-    StatusReference,
-)
-from rhesis.backend.app.schemas.status import Status
 from rhesis.backend.app.schemas.tag import Tag, TagRead
 from rhesis.backend.app.schemas.user import UserReference
 
@@ -34,19 +28,13 @@ class BehaviorUpdate(BehaviorBase):
 class Behavior(BehaviorBase):
     tags: List[Tag] = Field(default_factory=list)
     created_at: Optional[Union[datetime, str]] = None
-    status: Optional[Status] = None
     user: Optional[UserReference] = None
 
 
-# The detailed model with expanded relations
+# The detailed model with expanded relations.
 class BehaviorDetail(Behavior):
-    # Overrides of the base schema's fields to match the shape used for
-    # the detailed/expanded response (lightweight reference instead of the
-    # full related schema, and TagRead instead of Tag for tags).
+    # Override of the base schema's tags field to match the shape used for the
+    # detailed/expanded response (TagRead instead of Tag).
     id: UUID4
     name: Optional[str] = None
     tags: Optional[List[TagRead]] = None
-    status: Optional[StatusReference] = None
-    counts: Optional[Dict[str, Any]] = None
-    project: Optional[ProjectReference] = None
-    organization: Optional[OrganizationReference] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/category.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/category.py
@@ -1,16 +1,8 @@
-from typing import Any, Dict, Optional
+from typing import Optional
 
 from pydantic import UUID4
 
 from rhesis.backend.app.schemas import Base
-from rhesis.backend.app.schemas.references import (
-    CategoryReference,
-    OrganizationReference,
-    ProjectReference,
-    StatusReference,
-    TypeLookupReference,
-)
-from rhesis.backend.app.schemas.user import UserReference
 
 
 # Category schemas
@@ -36,14 +28,6 @@ class Category(CategoryBase):
     pass
 
 
-# The detailed model with expanded relations
 class CategoryDetail(Category):
     id: UUID4
     name: Optional[str] = None
-    counts: Optional[Dict[str, Any]] = None
-    status: Optional[StatusReference] = None
-    parent: Optional[CategoryReference] = None
-    entity_type: Optional[TypeLookupReference] = None
-    project: Optional[ProjectReference] = None
-    organization: Optional[OrganizationReference] = None
-    user: Optional[UserReference] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/comment.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/comment.py
@@ -10,7 +10,6 @@ from rhesis.backend.app.constants import EntityType
 from .affordances import WithPermittedActions
 from .base import Base
 from .emoji_reaction import EmojiReaction
-from .references import OrganizationReference, ProjectReference
 from .user import UserReference
 
 
@@ -78,10 +77,9 @@ class Comment(CommentBase, WithPermittedActions):
     model_config = ConfigDict(from_attributes=True)
 
 
-# The detailed model with expanded relations
+# The detailed model with expanded relations. organization: unused, excluded.
+# project isn't even a real relationship on the Comment ORM model (always None).
 class CommentDetail(Comment):
     content: Optional[str] = None
     user_id: Optional[UUID4] = None
     user: Optional[UserReference] = None
-    organization: Optional[OrganizationReference] = None
-    project: Optional[ProjectReference] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/endpoint.py
@@ -11,12 +11,7 @@ from rhesis.backend.app.models.enums import (
     EndpointResponseFormat,
 )
 from rhesis.backend.app.schemas import Base
-from rhesis.backend.app.schemas.references import (
-    OrganizationReference,
-    ProjectReference,
-    StatusReference,
-)
-from rhesis.backend.app.schemas.tag import TagRead
+from rhesis.backend.app.schemas.references import ProjectReference, StatusReference
 from rhesis.backend.app.schemas.user import UserReference
 
 
@@ -251,10 +246,8 @@ class Endpoint(Base):
 # The detailed model with expanded relations
 class EndpointDetail(Endpoint):
     name: Optional[str] = None
-    tags: Optional[List[TagRead]] = None
     status: Optional[StatusReference] = None
     user: Optional[UserReference] = None
-    organization: Optional[OrganizationReference] = None
     project: Optional[ProjectReference] = None
 
 

--- a/apps/backend/src/rhesis/backend/app/schemas/metric.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/metric.py
@@ -6,15 +6,9 @@ from pydantic import UUID4, ConfigDict, model_validator
 
 from rhesis.backend.app.schemas import Base
 from rhesis.backend.app.schemas.metric_types import ScoreType, ThresholdOperator
-from rhesis.backend.app.schemas.references import (
-    BehaviorReference,
-    OrganizationReference,
-    ProjectReference,
-    StatusReference,
-)
+from rhesis.backend.app.schemas.references import BehaviorReference
 from rhesis.backend.app.schemas.tag import Tag, TagRead
 from rhesis.backend.app.schemas.type_lookup import TypeLookup
-from rhesis.backend.app.schemas.user import UserReference
 
 
 class MetricScope(str, Enum):
@@ -96,9 +90,6 @@ class Metric(MetricBase):
     model_config = ConfigDict(from_attributes=True)
 
 
-# Lightweight reference schemas below are specific to MetricDetail (Model
-# and TestSet references aren't identical across every consumer elsewhere,
-# so stay local rather than living in the shared schemas/references.py module).
 class ModelReference(Base):
     id: UUID4
     name: Optional[str] = None
@@ -115,32 +106,10 @@ class ModelReference(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-class TestSetReference(Base):
-    id: UUID4
-    name: Optional[str] = None
-    description: Optional[str] = None
-    counts: Optional[Dict[str, Any]] = None
-    user_id: Optional[UUID4] = None
-    organization_id: Optional[UUID4] = None
-    status_id: Optional[UUID4] = None
-    attributes: Optional[Dict[str, Any]] = None
-    tags: Optional[List[TagRead]] = None
-
-    model_config = ConfigDict(from_attributes=True)
-
-
 class MetricDetail(Metric):
     name: Optional[str] = None
-    counts: Optional[Dict[str, Any]] = None
-    status: Optional[StatusReference] = None
-    assignee: Optional[UserReference] = None
-    owner: Optional[UserReference] = None
-    user: Optional[UserReference] = None
     model: Optional[ModelReference] = None
     behaviors: Optional[List[BehaviorReference]] = []
-    test_sets: Optional[List[TestSetReference]] = []
-    organization: Optional[OrganizationReference] = None
-    project: Optional[ProjectReference] = None
 
 
 class GenerateMetricRequest(Base):

--- a/apps/backend/src/rhesis/backend/app/schemas/model.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/model.py
@@ -5,21 +5,14 @@ Security: API keys are write-only. They can be set via POST/PUT but are never
 returned in responses to prevent exposure through logs, caches, or clients.
 """
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Dict, Literal, Optional
 
 from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator
 
 from .base import Base
-from .references import (
-    OrganizationReference,
-    ProjectReference,
-    StatusReference,
-    TypeLookupReference,
-)
+from .references import StatusReference, TypeLookupReference
 from .status import Status
-from .tag import Tag, TagRead
 from .type_lookup import TypeLookup
-from .user import User, UserReference
 
 
 class ModelBaseFields(Base):
@@ -80,6 +73,7 @@ class ModelUpdate(ModelBaseFields):
     assignee_id: Optional[UUID4] = None
 
 
+# owner/assignee/tags: unused, excluded (owner_id/assignee_id FK columns stay).
 class ModelRead(ModelBaseFields):
     """Schema for reading Model (excludes API key for security)"""
 
@@ -91,9 +85,6 @@ class ModelRead(ModelBaseFields):
     is_protected: bool = False
     provider_type: Optional[TypeLookup] = None
     status: Optional[Status] = None
-    owner: Optional[User] = None
-    assignee: Optional[User] = None
-    tags: Optional[List[Tag]] = []
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -109,26 +100,17 @@ class Model(ModelBase):
     is_protected: bool = False
     provider_type: Optional[TypeLookup] = None
     status: Optional[Status] = None
-    owner: Optional[User] = None
-    assignee: Optional[User] = None
-    tags: Optional[List[Tag]] = []
 
     model_config = ConfigDict(from_attributes=True)
 
 
-# The detailed model with expanded relations
+# The detailed model with expanded relations. owner/assignee/tags/counts/
+# project/organization/user: unused, excluded.
 class ModelDetail(ModelRead):
     name: Optional[str] = None
     model_name: Optional[str] = None
     provider_type: Optional[TypeLookupReference] = None
     status: Optional[StatusReference] = None
-    owner: Optional[UserReference] = None
-    assignee: Optional[UserReference] = None
-    tags: Optional[List[TagRead]] = None
-    counts: Optional[Dict[str, Any]] = None
-    project: Optional[ProjectReference] = None
-    organization: Optional[OrganizationReference] = None
-    user: Optional[UserReference] = None
 
 
 class TestModelConnectionRequest(BaseModel):

--- a/apps/backend/src/rhesis/backend/app/schemas/project.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/project.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Optional
 from pydantic import UUID4
 
 from rhesis.backend.app.schemas import Base
-from rhesis.backend.app.schemas.references import OrganizationReference, StatusReference
 from rhesis.backend.app.schemas.tag import TagRead
 from rhesis.backend.app.schemas.user import UserReference
 
@@ -33,11 +32,8 @@ class Project(ProjectBase):
     id: UUID4
 
 
-# The detailed model with expanded relations
+# The detailed model with expanded relations. user/organization/status: unused, excluded.
 class ProjectDetail(Project):
     name: Optional[str] = None
     tags: Optional[List[TagRead]] = None
-    user: Optional[UserReference] = None
     owner: Optional[UserReference] = None
-    organization: Optional[OrganizationReference] = None
-    status: Optional[StatusReference] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/references.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/references.py
@@ -111,17 +111,3 @@ class PromptReference(Base):
     tags: Optional[List[TagRead]] = None
 
     model_config = ConfigDict(from_attributes=True)
-
-
-class SourceReference(Base):
-    id: UUID4
-    title: Optional[str] = None
-    description: Optional[str] = None
-    content: Optional[str] = None
-    counts: Optional[Dict[str, Any]] = None
-    user_id: Optional[UUID4] = None
-    organization_id: Optional[UUID4] = None
-    status_id: Optional[UUID4] = None
-    tags: Optional[List[TagRead]] = None
-
-    model_config = ConfigDict(from_attributes=True)

--- a/apps/backend/src/rhesis/backend/app/schemas/source.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/source.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional, Union
 from pydantic import UUID4, ConfigDict, field_validator
 
 from rhesis.backend.app.schemas import Base
-from rhesis.backend.app.schemas.status import Status
 from rhesis.backend.app.schemas.tag import Tag
 from rhesis.backend.app.schemas.type_lookup import TypeLookup
 from rhesis.backend.app.schemas.user import User
@@ -84,7 +83,6 @@ class Source(SourceBase):
     counts: Optional[Dict[str, int]] = None  # Comment and task counts from CountsMixin
     # Related objects
     source_type: Optional[TypeLookup] = None
-    status: Optional[Status] = None
     user: Optional[User] = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/apps/backend/src/rhesis/backend/app/schemas/status.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/status.py
@@ -3,12 +3,6 @@ from typing import Optional
 from pydantic import UUID4
 
 from rhesis.backend.app.schemas import Base
-from rhesis.backend.app.schemas.references import (
-    OrganizationReference,
-    ProjectReference,
-    TypeLookupReference,
-)
-from rhesis.backend.app.schemas.user import UserReference
 
 
 # Status schemas
@@ -32,11 +26,6 @@ class Status(StatusBase):
     pass
 
 
-# The detailed model with expanded relations
 class StatusDetail(Status):
     id: UUID4
     name: Optional[str] = None
-    entity_type: Optional[TypeLookupReference] = None
-    project: Optional[ProjectReference] = None
-    organization: Optional[OrganizationReference] = None
-    user: Optional[UserReference] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/task_management.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/task_management.py
@@ -14,7 +14,6 @@ from .references import (
     TypeLookupReference,
 )
 from .status import Status
-from .tag import TagRead
 from .type_lookup import TypeLookup
 from .user import User, UserReference
 
@@ -108,7 +107,6 @@ class TaskDetail(Task):
     user_id: Optional[UUID4] = None
     status_id: Optional[UUID4] = None
     organization_id: Optional[UUID4] = None
-    tags: Optional[List[TagRead]] = None
 
     user: Optional[UserReference] = None
     assignee: Optional[UserReference] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/test.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test.py
@@ -7,15 +7,11 @@ from rhesis.backend.app.schemas import Base
 from rhesis.backend.app.schemas.references import (
     BehaviorReference,
     CategoryReference,
-    OrganizationReference,
-    ProjectReference,
     PromptReference,
-    SourceReference,
     StatusReference,
     TopicReference,
     TypeLookupReference,
 )
-from rhesis.backend.app.schemas.tag import TagRead
 from rhesis.backend.app.schemas.user import UserReference
 
 
@@ -105,23 +101,7 @@ class Test(TestBase):
     model_config = ConfigDict(from_attributes=True)
 
 
-# Shallow self-reference for TestDetail.parent -- deliberately not recursive
-# (mirrors the factory's reference-only, one-level-deep behavior for parent).
-class TestReference(Base):
-    id: UUID4
-    nano_id: Optional[str] = None
-    content: Optional[str] = None
-    counts: Optional[Dict[str, Any]] = None
-    user_id: Optional[UUID4] = None
-    organization_id: Optional[UUID4] = None
-    status_id: Optional[UUID4] = None
-    project_id: Optional[UUID4] = None
-    tags: Optional[List[TagRead]] = None
-
-    model_config = ConfigDict(from_attributes=True)
-
-
-# The detailed model with expanded relations
+# The detailed model with expanded relations. parent/source/organization/project: unused, excluded.
 class TestDetail(Test):
     # Include the full related objects instead of just IDs
     content: Optional[str] = None
@@ -131,15 +111,11 @@ class TestDetail(Test):
     user: Optional[UserReference] = None
     assignee: Optional[UserReference] = None
     owner: Optional[UserReference] = None
-    parent: Optional[TestReference] = None
     topic: Optional[TopicReference] = None
     behavior: Optional[BehaviorReference] = None
     category: Optional[CategoryReference] = None
     status: Optional[StatusReference] = None
-    source: Optional[SourceReference] = None
     tags: Optional[List[TestTag]] = []
-    organization: Optional[OrganizationReference] = None
-    project: Optional[ProjectReference] = None
 
 
 # Bulk creation models

--- a/apps/backend/src/rhesis/backend/app/schemas/test_configuration.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_configuration.py
@@ -3,16 +3,7 @@ from typing import Any, Dict, List, Optional
 from pydantic import UUID4, BaseModel, Field
 
 from rhesis.backend.app.schemas import Base
-from rhesis.backend.app.schemas.references import (
-    CategoryReference,
-    OrganizationReference,
-    ProjectReference,
-    PromptReference,
-    StatusReference,
-    TopicReference,
-)
 from rhesis.backend.app.schemas.tag import TagRead
-from rhesis.backend.app.schemas.user import UserReference
 
 
 # TestConfiguration schemas
@@ -39,15 +30,6 @@ class TestConfigurationUpdate(TestConfigurationBase):
 
 class TestConfiguration(TestConfigurationBase):
     pass
-
-
-class UseCaseReference(Base):
-    id: UUID4
-    name: Optional[str] = None
-    description: Optional[str] = None
-    user_id: Optional[UUID4] = None
-    organization_id: Optional[UUID4] = None
-    status_id: Optional[UUID4] = None
 
 
 class TestSetReference(Base):
@@ -78,16 +60,8 @@ class TestConfigurationDetail(TestConfiguration):
     # base schema declares it required) -- preserved here for parity.
     id: UUID4
     endpoint_id: Optional[UUID4] = None
-    category: Optional[CategoryReference] = None
-    topic: Optional[TopicReference] = None
-    prompt: Optional[PromptReference] = None
-    use_case: Optional[UseCaseReference] = None
     test_set: Optional[TestSetReference] = None
-    user: Optional[UserReference] = None
-    status: Optional[StatusReference] = None
     endpoint: Optional[EndpointReference] = None
-    project: Optional[ProjectReference] = None
-    organization: Optional[OrganizationReference] = None
 
 
 class TestConfigurationExecutionRequest(BaseModel):

--- a/apps/backend/src/rhesis/backend/app/schemas/test_configuration.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_configuration.py
@@ -41,9 +41,6 @@ class TestConfiguration(TestConfigurationBase):
     pass
 
 
-# Lightweight reference schemas below are specific to TestConfigurationDetail
-# (use_case/test_set/endpoint have consumer-specific shapes elsewhere, so
-# stay local rather than living in the shared schemas/references.py module).
 class UseCaseReference(Base):
     id: UUID4
     name: Optional[str] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/test_result.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_result.py
@@ -67,9 +67,6 @@ class TestResult(TestResultBase, WithPermittedActions):
     model_config = ConfigDict(from_attributes=True)
 
 
-# Lightweight reference schemas below are specific to TestResultDetail's
-# nested chain (test -> prompt / behavior / topic) -- richer than the shared
-# references, so they stay local rather than living in schemas/references.py.
 class TestReference(Base):
     id: UUID4
     content: Optional[str] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/test_result.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_result.py
@@ -12,14 +12,10 @@ from rhesis.backend.app.schemas import Base
 from rhesis.backend.app.schemas.affordances import WithPermittedActions
 from rhesis.backend.app.schemas.references import (
     BehaviorReference,
-    OrganizationReference,
-    ProjectReference,
     PromptReference,
-    StatusReference,
     TopicReference,
 )
 from rhesis.backend.app.schemas.tag import TagRead
-from rhesis.backend.app.schemas.user import UserReference
 
 # Re-export for backward compatibility
 REVIEW_TARGET_TRACE = ReviewTarget.TRACE
@@ -82,17 +78,6 @@ class TestReference(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-class TestConfigurationReference(Base):
-    id: UUID4
-    user_id: Optional[UUID4] = None
-    organization_id: Optional[UUID4] = None
-    status_id: Optional[UUID4] = None
-    attributes: Optional[Dict[str, Any]] = None
-    endpoint_id: Optional[UUID4] = None
-
-    model_config = ConfigDict(from_attributes=True)
-
-
 class TestRunReference(Base):
     id: UUID4
     name: Optional[str] = None
@@ -111,13 +96,8 @@ class TestResultDetail(TestResult):
     id: UUID4
     counts: Optional[Dict[str, Any]] = None
     tags: Optional[List[TagRead]] = None
-    status: Optional[StatusReference] = None
-    user: Optional[UserReference] = None
     test: Optional[TestReference] = None
-    test_configuration: Optional[TestConfigurationReference] = None
     test_run: Optional[TestRunReference] = None
-    organization: Optional[OrganizationReference] = None
-    project: Optional[ProjectReference] = None
 
 
 # Review schemas

--- a/apps/backend/src/rhesis/backend/app/schemas/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_run.py
@@ -6,7 +6,6 @@ from rhesis.backend.app.auth.capabilities import ResourceType
 from rhesis.backend.app.schemas import Base
 from rhesis.backend.app.schemas.affordances import WithPermittedActions
 from rhesis.backend.app.schemas.references import (
-    OrganizationReference,
     ProjectReference,
     StatusReference,
     TypeLookupReference,
@@ -47,20 +46,6 @@ class TestRun(TestRunBase, WithPermittedActions):
 
     __resource_type__: ClassVar[Optional[str]] = ResourceType.TEST_RUN
     # __owner_attr__ defaults to "user_id", which is the creator column on TestRun.
-
-    model_config = ConfigDict(from_attributes=True)
-
-
-# Lightweight reference schemas below are specific to TestRunDetail's nested
-# chain (test_configuration -> endpoint -> project, test_configuration ->
-# test_set -> test_set_type) -- richer than the shared references, so they
-# stay local rather than living in schemas/references.py.
-class ExperimentReference(Base):
-    id: UUID4
-    name: Optional[str] = None
-    description: Optional[str] = None
-    user_id: Optional[UUID4] = None
-    organization_id: Optional[UUID4] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -109,13 +94,7 @@ class TestConfigurationReference(Base):
 class TestRunDetail(TestRun):
     id: UUID4
     counts: Optional[Dict[str, Any]] = None
-    experiment_summary: Optional[Dict[str, Any]] = None
     tags: Optional[List[TagRead]] = None
     status: Optional[StatusReference] = None
-    assignee: Optional[UserReference] = None
-    owner: Optional[UserReference] = None
     user: Optional[UserReference] = None
-    experiment: Optional[ExperimentReference] = None
     test_configuration: Optional[TestConfigurationReference] = None
-    organization: Optional[OrganizationReference] = None
-    project: Optional[ProjectReference] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_set.py
@@ -5,12 +5,7 @@ from typing import Any, Dict, List, Optional, Union
 from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator
 
 from rhesis.backend.app.schemas import Base
-from rhesis.backend.app.schemas.references import (
-    OrganizationReference,
-    ProjectReference,
-    StatusReference,
-    TypeLookupReference,
-)
+from rhesis.backend.app.schemas.references import StatusReference, TypeLookupReference
 from rhesis.backend.app.schemas.tag import Tag, TagRead
 from rhesis.backend.app.schemas.user import UserReference
 
@@ -66,7 +61,9 @@ class TestSet(TestSetBase):
     model_config = ConfigDict(from_attributes=True)
 
 
-# The detailed model with expanded relations
+# The detailed model with expanded relations. status is kept despite the exclusions
+# below: it's referenced today only as an OData filter path ('status.name'), so its
+# consumption is unclear rather than confirmed-unused.
 class TestSetDetail(TestSet):
     name: Optional[str] = None
     tags: Optional[List[TagRead]] = None
@@ -74,13 +71,8 @@ class TestSetDetail(TestSet):
     counts: Optional[Dict[str, Any]] = None
 
     status: Optional[StatusReference] = None
-    license_type: Optional[TypeLookupReference] = None
     test_set_type: Optional[TypeLookupReference] = None
     user: Optional[UserReference] = None
-    owner: Optional[UserReference] = None
-    assignee: Optional[UserReference] = None
-    organization: Optional[OrganizationReference] = None
-    project: Optional[ProjectReference] = None
 
 
 # Bulk creation models

--- a/apps/backend/src/rhesis/backend/app/schemas/tool.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/tool.py
@@ -5,15 +5,10 @@ from typing import Any, Dict, Optional, Union
 from pydantic import UUID4, ConfigDict, field_serializer
 
 from .base import Base
-from .references import (
-    OrganizationReference,
-    ProjectReference,
-    StatusReference,
-    TypeLookupReference,
-)
+from .references import TypeLookupReference
 from .status import Status
 from .type_lookup import TypeLookup
-from .user import User, UserReference
+from .user import User
 
 
 class ToolBase(Base):
@@ -93,12 +88,14 @@ class Tool(Base):
     model_config = ConfigDict(from_attributes=True)
 
 
-# The detailed model with expanded relations
-class ToolDetail(Tool):
+# Extends ToolBase, not Tool -- Tool declares status/user as full relationship
+# objects, which would leak back in through inheritance if this extended it instead.
+class ToolDetail(ToolBase):
+    id: UUID4
+    created_at: Union[datetime, str]
+    updated_at: Union[datetime, str]
     name: Optional[str] = None
 
     tool_provider_type: Optional[TypeLookupReference] = None
-    status: Optional[StatusReference] = None
-    user: Optional[UserReference] = None
-    organization: Optional[OrganizationReference] = None
-    project: Optional[ProjectReference] = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/backend/src/rhesis/backend/app/schemas/topic.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/topic.py
@@ -3,14 +3,6 @@ from typing import Optional
 from pydantic import UUID4
 
 from rhesis.backend.app.schemas import Base
-from rhesis.backend.app.schemas.references import (
-    OrganizationReference,
-    ProjectReference,
-    StatusReference,
-    TopicReference,
-    TypeLookupReference,
-)
-from rhesis.backend.app.schemas.user import UserReference
 
 
 # Topic schemas
@@ -36,14 +28,8 @@ class Topic(TopicBase):
     pass
 
 
-# The detailed model with expanded relations
+# No nested relationships are actually consumed by any caller (backend, frontend,
+# or SDK) -- keep this flat rather than eager-loading data nobody reads.
 class TopicDetail(Topic):
     id: UUID4
     name: Optional[str] = None
-
-    status: Optional[StatusReference] = None
-    parent: Optional[TopicReference] = None
-    entity_type: Optional[TypeLookupReference] = None
-    project: Optional[ProjectReference] = None
-    organization: Optional[OrganizationReference] = None
-    user: Optional[UserReference] = None

--- a/apps/backend/src/rhesis/backend/app/services/explorer/settings.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/settings.py
@@ -49,12 +49,15 @@ def resolve_metric_names(
     organization_id: str,
     request_metric_names: Optional[List[str]],
 ) -> List[str]:
-    # Kept for API symmetry with endpoint resolver usage from routers.
-    _ = db, organization_id
+    _ = organization_id
     if request_metric_names:
         return request_metric_names
 
-    metric_names = [metric.name for metric in (test_set.metrics or []) if metric.name]
+    # Queried by ID rather than via test_set.metrics -- callers of this
+    # resolver (routers/explorer.py) don't guarantee that many-to-many
+    # relationship is eager-loaded on the passed-in test_set.
+    metrics = db.query(models.Metric).filter(models.Metric.test_sets.any(id=test_set.id)).all()
+    metric_names = [metric.name for metric in metrics if metric.name]
     if not metric_names:
         raise ValueError("No metrics specified and no metrics configured in settings")
 
@@ -82,10 +85,9 @@ def get_explorer_settings(
         if endpoint is not None:
             endpoint_ref = ExplorerSettingsEndpoint(id=endpoint.id, name=endpoint.name)
 
-    metrics = [
-        ExplorerSettingsMetric(id=metric.id, name=metric.name)
-        for metric in (test_set.metrics or [])
-    ]
+    # Queried by ID rather than via test_set.metrics -- see resolve_metric_names.
+    db_metrics = db.query(models.Metric).filter(models.Metric.test_sets.any(id=test_set.id)).all()
+    metrics = [ExplorerSettingsMetric(id=metric.id, name=metric.name) for metric in db_metrics]
 
     return ExplorerSettingsResponse(default_endpoint=endpoint_ref, metrics=metrics)
 
@@ -120,7 +122,13 @@ def update_explorer_settings(
 
     if metric_ids is not None:
         # Replace metrics atomically by removing existing and adding requested.
-        existing_metric_ids = [metric.id for metric in (test_set.metrics or [])]
+        # Queried by ID rather than via test_set.metrics -- see resolve_metric_names.
+        existing_metric_ids = [
+            metric.id
+            for metric in db.query(models.Metric)
+            .filter(models.Metric.test_sets.any(id=test_set.id))
+            .all()
+        ]
         desired_metric_ids = list(dict.fromkeys(metric_ids))
 
         for metric_id in existing_metric_ids:

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -2,7 +2,7 @@ import logging
 from typing import List, Optional
 from uuid import UUID
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.constants import ADAPTIVE_TESTING_BEHAVIOR
@@ -775,6 +775,7 @@ def update_test_node(
     # Look up the test and verify it belongs to the test set
     db_test = (
         db.query(models.Test)
+        .options(joinedload(models.Test.prompt))
         .join(
             test_test_set_association,
             models.Test.id == test_test_set_association.c.test_id,

--- a/apps/backend/src/rhesis/backend/app/services/garak/sync.py
+++ b/apps/backend/src/rhesis/backend/app/services/garak/sync.py
@@ -334,9 +334,7 @@ class GarakSyncService:
 
         # Queried by ID rather than via test_set.tests -- callers don't
         # guarantee that many-to-many relationship is eager-loaded.
-        tests = (
-            self.db.query(Test).filter(Test.test_sets.any(id=test_set.id)).all()
-        )
+        tests = self.db.query(Test).filter(Test.test_sets.any(id=test_set.id)).all()
         for test in tests:
             if test.test_metadata and test.test_metadata.get("source") == "garak":
                 probe_id = test.test_metadata.get("garak_probe_id")

--- a/apps/backend/src/rhesis/backend/app/services/garak/sync.py
+++ b/apps/backend/src/rhesis/backend/app/services/garak/sync.py
@@ -20,7 +20,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app.models.test import test_test_set_association
+from rhesis.backend.app.models.test import Test, test_test_set_association
 from rhesis.backend.app.models.test_set import TestSet
 from rhesis.backend.app.schemas import test_set as test_set_schemas
 from rhesis.backend.app.services.test import bulk_create_tests
@@ -332,7 +332,12 @@ class GarakSyncService:
         """Get the set of Garak probe IDs currently in the test set."""
         probe_ids = set()
 
-        for test in test_set.tests:
+        # Queried by ID rather than via test_set.tests -- callers don't
+        # guarantee that many-to-many relationship is eager-loaded.
+        tests = (
+            self.db.query(Test).filter(Test.test_sets.any(id=test_set.id)).all()
+        )
+        for test in tests:
             if test.test_metadata and test.test_metadata.get("source") == "garak":
                 probe_id = test.test_metadata.get("garak_probe_id")
                 if probe_id:
@@ -418,7 +423,9 @@ class GarakSyncService:
         """Remove old prompts from the test set."""
         removed_count = 0
 
-        for test in list(test_set.tests):  # Create list copy to allow modification
+        # Queried by ID rather than via test_set.tests -- see _get_existing_probe_ids.
+        tests = self.db.query(Test).filter(Test.test_sets.any(id=test_set.id)).all()
+        for test in tests:
             if not test.test_metadata or test.test_metadata.get("source") != "garak":
                 continue
 

--- a/apps/backend/src/rhesis/backend/app/services/organization.py
+++ b/apps/backend/src/rhesis/backend/app/services/organization.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Type
 
 from sqlalchemy import inspect
 from sqlalchemy.exc import InvalidRequestError
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, joinedload, with_parent
 from sqlalchemy.orm.attributes import flag_modified
 
 from rhesis.backend.app import crud, models
@@ -1218,10 +1218,18 @@ def _load_relationship_via_core(db: Session, entity, rel):
     """Fetch a relationship's related row(s) via an explicit top-level query,
     instead of the implicit lazy-load triggered by plain attribute access --
     see the call site in _get_nested_entities for why this fallback exists.
+
+    Uses with_parent() rather than rel.local_remote_pairs so that relationships
+    with extra primaryjoin predicates (polymorphic entity_type discriminators,
+    soft-delete filters) are honored, not just the FK-equality part of the join.
     """
     target_model = rel.mapper.class_
-    conditions = [remote == getattr(entity, local.name) for local, remote in rel.local_remote_pairs]
-    rows = QueryBuilder(db, target_model).build().filter(*conditions).all()
+    rows = (
+        QueryBuilder(db, target_model)
+        .build()
+        .filter(with_parent(entity, getattr(entity.__class__, rel.key)))
+        .all()
+    )
     return rows if rel.uselist else (rows[0] if rows else None)
 
 

--- a/apps/backend/src/rhesis/backend/app/services/organization.py
+++ b/apps/backend/src/rhesis/backend/app/services/organization.py
@@ -6,6 +6,7 @@ from contextlib import ExitStack
 from typing import Any, Dict, List, Optional, Type
 
 from sqlalchemy import inspect
+from sqlalchemy.exc import InvalidRequestError
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -1213,6 +1214,17 @@ def _sort_models_by_dependencies(models: List[Type]) -> List[Type]:
     return sorted_models
 
 
+def _load_relationship_via_core(db: Session, entity, rel):
+    """Fetch a relationship's related row(s) via an explicit top-level query,
+    instead of the implicit lazy-load triggered by plain attribute access --
+    see the call site in _get_nested_entities for why this fallback exists.
+    """
+    target_model = rel.mapper.class_
+    conditions = [remote == getattr(entity, local.name) for local, remote in rel.local_remote_pairs]
+    rows = QueryBuilder(db, target_model).build().filter(*conditions).all()
+    return rows if rel.uselist else (rows[0] if rows else None)
+
+
 def _get_nested_entities(db: Session, entity, organization_id: str, visited=None) -> List:
     """
     Recursively get all nested entities for a given entity.
@@ -1247,8 +1259,10 @@ def _get_nested_entities(db: Session, entity, organization_id: str, visited=None
         if rel.mapper.class_.__name__ in ["User", "Organization"]:
             continue
 
-        # Get the related attribute
-        related = getattr(entity, rel_name)
+        try:
+            related = getattr(entity, rel_name)
+        except InvalidRequestError:
+            related = _load_relationship_via_core(db, entity, rel)
 
         # Handle collections (one-to-many)
         if rel.uselist:

--- a/apps/backend/src/rhesis/backend/app/services/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_set.py
@@ -192,9 +192,7 @@ def generate_test_set_attributes(
     # test_set isn't guaranteed to have that many-to-many relationship loaded.
     tests = (
         QueryBuilder(db, models.Test)
-        .with_custom_filter(
-            lambda q: q.filter(models.Test.test_sets.any(id=test_set.id))
-        )
+        .with_custom_filter(lambda q: q.filter(models.Test.test_sets.any(id=test_set.id)))
         .with_related(
             include(models.Test.topic),
             include(models.Test.behavior),

--- a/apps/backend/src/rhesis/backend/app/services/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_set.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 from uuid import UUID
 
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, contains_eager
 
 from rhesis.backend.app import models, schemas
 from rhesis.backend.app.constants import (
@@ -188,10 +188,13 @@ def generate_test_set_attributes(
     """
     # Eager-load per-test relationships in one query instead of lazily fetching
     # topic/behavior/category/prompt for each test in test_set.tests (N+1).
-    test_ids = [test.id for test in test_set.tests]
+    # Filtered by test_sets.any(...) rather than test_set.tests -- the caller's
+    # test_set isn't guaranteed to have that many-to-many relationship loaded.
     tests = (
         QueryBuilder(db, models.Test)
-        .with_custom_filter(lambda q: q.filter(models.Test.id.in_(test_ids)))
+        .with_custom_filter(
+            lambda q: q.filter(models.Test.test_sets.any(id=test_set.id))
+        )
         .with_related(
             include(models.Test.topic),
             include(models.Test.behavior),
@@ -199,8 +202,6 @@ def generate_test_set_attributes(
             include(models.Test.prompt),
         )
         .all()
-        if test_ids
-        else []
     )
 
     # Get all unique IDs and names for each dimension (skip tests with None values)
@@ -680,6 +681,7 @@ def get_last_completed_test_run(
             TestRun.test_configuration_id == TestConfiguration.id,
         )
         .join(Status, TestRun.status_id == Status.id)
+        .options(contains_eager(TestRun.status))
         .filter(
             TestConfiguration.test_set_id == db_test_set.id,
             TestConfiguration.endpoint_id == uuid.UUID(str(endpoint_id)),
@@ -821,12 +823,20 @@ def execute_test_set_on_endpoint(
     if metrics and len(metrics) > 0:
         metrics_source = MetricsSource.EXECUTION_TIME.value
         logger.debug("Metrics source: execution_time (user-provided metrics)")
-    elif db_test_set.metrics and len(db_test_set.metrics) > 0:
-        metrics_source = MetricsSource.TEST_SET.value
-        logger.debug(f"Metrics source: test_set ({len(db_test_set.metrics)} metrics on test set)")
     else:
-        metrics_source = MetricsSource.BEHAVIOR.value
-        logger.debug("Metrics source: behavior (fallback to test behaviors)")
+        # Queried by ID rather than via db_test_set.metrics -- that many-to-many
+        # relationship isn't guaranteed eager-loaded on the resolved test set.
+        test_set_metrics_count = (
+            db.query(models.Metric.id)
+            .filter(models.Metric.test_sets.any(id=db_test_set.id))
+            .count()
+        )
+        if test_set_metrics_count > 0:
+            metrics_source = MetricsSource.TEST_SET.value
+            logger.debug(f"Metrics source: test_set ({test_set_metrics_count} metrics on test set)")
+        else:
+            metrics_source = MetricsSource.BEHAVIOR.value
+            logger.debug("Metrics source: behavior (fallback to test behaviors)")
 
     parameters_ref: Dict[str, Any] | None = None
     has_version = bool(experiment_version and str(experiment_version).strip())

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -345,6 +345,7 @@ def get_item_detail(
     include_deleted: bool = False,
     project_id: str = None,
     nested_relationships: dict = None,
+    selectin_chains: list | None = None,
 ) -> Optional[T]:
     """
     Get a single item with all first-level relationships eagerly loaded.
@@ -366,6 +367,12 @@ def get_item_detail(
             Format: {"relationship_name": ["nested_rel1", "nested_rel2"]}. Mirrors
             get_items_detail's parameter of the same name, for parity between the
             single-item and list paths when a schema nests fields two levels deep.
+        selectin_chains: Extra relationship-name chains to load with nested
+            selectinload, beyond with_optimized_loads' many-to-one/one-to-one
+            defaults -- e.g. a one-to-many relationship the response schema
+            reads directly (custom polymorphic relationships bypass the
+            comments/tasks/files/tags mixin defaults). Mirrors
+            get_items_detail's parameter of the same name.
 
     Returns:
         Item with relationships loaded or None if not found
@@ -378,7 +385,7 @@ def get_item_detail(
         QueryBuilder(db, model)
         .with_deleted()  # Always include deleted to check status
         .with_optimized_loads(skip_one_to_many=True, nested_relationships=nested_relationships)
-        .with_default_derived_field_loads()
+        .with_default_derived_field_loads(selectin_chains)
         .with_organization_filter(organization_id)
         .with_project_filter(project_id)
         .with_visibility_filter(user_id)

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
@@ -258,12 +258,15 @@ def prefetch_execution_context(
             metric_configs = _convert_metrics(models, f"test {sample_test.id}")
         else:
             # P3 (or no metrics at all) — resolution can differ per test since each
-            # test may belong to a different behavior. Reuse the sample test's
-            # already-resolved metrics instead of querying it twice.
+            # test may belong to a different behavior. Cache by behavior_id so tests
+            # sharing a behavior don't each re-query get_behavior_metrics() (N+1).
+            metrics_by_behavior_id: Dict[Any, List] = {sample_test.behavior_id: sample_metrics}
             for test in tests:
                 tid = str(test.id)
                 if test is sample_test:
                     metrics = sample_metrics
+                elif test.behavior_id in metrics_by_behavior_id:
+                    metrics = metrics_by_behavior_id[test.behavior_id]
                 else:
                     metrics = get_test_metrics(
                         test,
@@ -273,6 +276,7 @@ def prefetch_execution_context(
                         test_set=test_set,
                         test_configuration=test_config,
                     )
+                    metrics_by_behavior_id[test.behavior_id] = metrics
                 models = prepare_metric_configs(metrics, tid)
                 per_test_metric_configs[tid] = _convert_metrics(models, f"test {tid}")
     except Exception as e:

--- a/apps/backend/src/rhesis/backend/tasks/execution/executors/data.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/executors/data.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud
 from rhesis.backend.app.models.test import Test
+from rhesis.backend.tasks.execution.metrics_utils import get_behavior_metrics
 
 logger = logging.getLogger(__name__)
 
@@ -196,32 +197,31 @@ def get_test_metrics(
                     logger.warning(f"Failed to load execution-time metrics for test {test.id}: {e}")
 
     # Priority 2: Test set metrics override behavior metrics
-    if test_set and hasattr(test_set, "metrics") and test_set.metrics:
-        metrics = [metric for metric in test_set.metrics if metric.class_name]
-        if metrics:
-            logger.debug(
-                f"Using {len(metrics)} test set metrics for test {test.id} "
-                f"(overriding behavior metrics)"
-            )
-            invalid_count = len(test_set.metrics) - len(metrics)
-            if invalid_count > 0:
-                logger.warning(
-                    f"Filtered out {invalid_count} test set metrics without class_name "
-                    f"for test {test.id}"
+    # Queried by ID rather than via test_set.metrics -- callers don't guarantee
+    # that many-to-many relationship is eager-loaded on the passed-in test_set.
+    if test_set:
+        ts_metrics = db.query(Metric).filter(Metric.test_sets.any(id=test_set.id)).all()
+        if ts_metrics:
+            metrics = [metric for metric in ts_metrics if metric.class_name]
+            if metrics:
+                logger.debug(
+                    f"Using {len(metrics)} test set metrics for test {test.id} "
+                    f"(overriding behavior metrics)"
                 )
-            return (metrics, "test_set") if return_source else metrics
+                invalid_count = len(ts_metrics) - len(metrics)
+                if invalid_count > 0:
+                    logger.warning(
+                        f"Filtered out {invalid_count} test set metrics without class_name "
+                        f"for test {test.id}"
+                    )
+                return (metrics, "test_set") if return_source else metrics
 
     # Priority 3: Fall back to behavior metrics
-    behavior = test.behavior
-    if behavior and behavior.metrics:
-        # Return Metric models directly - evaluator accepts them
-        metrics = [metric for metric in behavior.metrics if metric.class_name]
-
-        invalid_count = len(behavior.metrics) - len(metrics)
-        if invalid_count > 0:
-            logger.warning(
-                f"Filtered out {invalid_count} metrics without class_name for test {test.id}"
-            )
+    # Queried by ID rather than via test.behavior.metrics for the same reason.
+    if test.behavior_id:
+        behavior_metrics = get_behavior_metrics(db, test.behavior_id)
+        if behavior_metrics:
+            metrics = behavior_metrics
 
     # Return empty list if no valid metrics found (no defaults in SDK)
     if not metrics:

--- a/apps/backend/src/rhesis/backend/tasks/execution/modes.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/modes.py
@@ -196,12 +196,31 @@ def get_test_type(test: Test) -> TestType:
     Returns:
         TestType: The test type (Single-Turn or Multi-Turn)
     """
-    if not test.test_type:
+    from sqlalchemy import inspect as sa_inspect
+    from sqlalchemy.orm import object_session
+    from sqlalchemy.orm.state import InstanceState
+
+    from rhesis.backend.app.models.type_lookup import TypeLookup
+
+    # Don't assume `test.test_type` is eager-loaded -- this also runs from ORM event
+    # listeners (e.g. Test.to_searchable_text), so fall back to a lookup by
+    # test_type_id. isinstance-guarded: tests pass plain Mock() doubles with no
+    # real load state.
+    state = sa_inspect(test, raiseerr=False)
+    if not isinstance(state, InstanceState) or "test_type" not in state.unloaded:
+        test_type = test.test_type
+    elif test.test_type_id and (sess := object_session(test)) is not None:
+        with sess.no_autoflush:
+            test_type = sess.get(TypeLookup, test.test_type_id)
+    else:
+        test_type = None
+
+    if not test_type:
         logger.debug(f"Test {test.id} has no test_type set, defaulting to Single-Turn")
         return TestType.SINGLE_TURN
 
     # Get the type_value from the TypeLookup relationship
-    test_type_value = test.test_type.type_value
+    test_type_value = test_type.type_value
 
     # Try to match against TestType enum values
     try:

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/__tests__/client-wrapper.test.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/__tests__/client-wrapper.test.tsx
@@ -101,8 +101,6 @@ const makeProject = (): Project =>
     description: 'A test project',
     created_at: '2024-01-15T00:00:00Z',
     owner: { id: 'user-1', name: 'Alice', email: 'alice@example.com' },
-    user: { id: 'user-1', name: 'Alice', email: 'alice@example.com' },
-    organization: { id: 'org-1', name: 'Acme' },
   }) as Project;
 
 async function openDeleteModal() {

--- a/apps/frontend/src/app/(protected)/test-sets/components/__tests__/TestSetsGrid.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/__tests__/TestSetsGrid.test.tsx
@@ -168,7 +168,6 @@ const makeTestSet = (id: UUID, name = 'Test Set'): TestSet => ({
   is_published: false,
   name,
   description: 'A test set',
-  owner: { id: 'u1', name: 'Alice', email: 'alice@example.com' },
   tags: [],
   counts: { comments: 0, tasks: 0 },
   created_at: '2024-01-01T00:00:00Z',

--- a/apps/frontend/src/utils/api-client/interfaces/behavior.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/behavior.ts
@@ -21,9 +21,7 @@ export type BehaviorUpdate = Partial<BehaviorBase>;
 export interface Behavior extends BehaviorBase {
   id: UUID;
   nano_id?: string | null;
-  status?: Status | null;
   user?: User | null;
-  organization?: Organization | null;
   metrics?: MetricWithRelationships[]; // Optional metrics when using include=metrics
   tags?: Tag[];
 }
@@ -46,49 +44,6 @@ export interface BehaviorReference {
   user_id?: UUID | null;
   organization_id: UUID;
   status_id: UUID;
-}
-
-export interface MetricWithBehaviors {
-  id: UUID;
-  nano_id?: string | null;
-  name: string;
-  description: string;
-  evaluation_prompt: string;
-  evaluation_steps: string;
-  reasoning: string;
-  score_type: string;
-  min_score?: number | null;
-  max_score?: number | null;
-  reference_score?: string;
-  threshold?: number | null;
-  threshold_operator: string;
-  explanation: string;
-  metric_type_id: UUID;
-  backend_type_id: UUID;
-  model_id?: UUID | null;
-  status_id?: UUID | null;
-  assignee_id?: UUID | null;
-  owner_id?: UUID | null;
-  class_name?: string;
-  context_required: boolean;
-  ground_truth_required?: boolean; // Add missing property
-  evaluation_examples?: string;
-  created_at: string;
-  updated_at: string;
-  tags: Tag[];
-  user_id?: UUID | null;
-  organization_id: UUID;
-
-  // Related entities
-  metric_type: TypeLookup;
-  status?: Status | null;
-  assignee?: User | null;
-  owner?: User | null;
-  model?: Model | null;
-  backend_type: TypeLookup;
-  behaviors: BehaviorReference[];
-  user?: User | null;
-  organization: Organization;
 }
 
 export interface BehaviorWithMetrics extends BehaviorBase {

--- a/apps/frontend/src/utils/api-client/interfaces/metric.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/metric.ts
@@ -5,7 +5,6 @@ import { Status } from './status';
 import { Tag } from './tag';
 import { PaginationParams } from './pagination';
 import { Model } from './model';
-import { Organization } from './organization';
 import { MetricScopeValue } from '@/constants/metric-scopes';
 
 export type ScoreType = 'numeric' | 'categorical';
@@ -120,9 +119,6 @@ export interface MetricDetail extends Metric {
   nano_id?: string;
   behaviors?: BehaviorReference[] | string[]; // Allow both reference objects and UUID strings
   model?: Model; // Include the full model object when available
-  user?: User; // Include the creating user
-  organization?: Organization; // Include the organization
-  comments?: unknown; // Comments data (can be null)
 }
 
 export interface MetricsResponse {

--- a/apps/frontend/src/utils/api-client/interfaces/model.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/model.ts
@@ -1,5 +1,4 @@
 import { UUID } from 'crypto';
-import { User } from './user';
 import { TypeLookup } from './type-lookup';
 import { Status } from './status';
 import { PaginationParams } from './pagination';
@@ -22,8 +21,6 @@ export interface Model {
   // References
   provider_type?: TypeLookup;
   status?: Status;
-  owner?: User;
-  assignee?: User;
   metrics?: UUID[];
 }
 

--- a/apps/frontend/src/utils/api-client/interfaces/project.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/project.ts
@@ -63,17 +63,6 @@ export interface ProjectUser {
 }
 
 /**
- * Organization interface for nested objects in project responses
- */
-export interface ProjectOrganization {
-  id: UUID | string; // Allow string for mock data compatibility
-  name: string;
-  description: string;
-  email: string;
-  user_id: UUID | string; // Allow string for mock data compatibility
-}
-
-/**
  * System information for a project
  */
 export interface ProjectSystem {
@@ -129,9 +118,7 @@ export interface Project extends ProjectBase, ProjectFrontendFields {
   updated_at?: string;
 
   // Nested objects from API response
-  user: ProjectUser;
   owner: ProjectUser;
-  organization: ProjectOrganization;
 }
 
 /** Minimal user info embedded in project membership responses */

--- a/apps/frontend/src/utils/api-client/interfaces/task.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/task.ts
@@ -21,7 +21,6 @@ export interface Task extends WithPermittedActions {
   task_metadata?: TaskMetadata;
   total_comments?: number;
   organization_id?: string;
-  tags?: Tag[];
   created_at?: string;
   updated_at?: string;
 
@@ -91,13 +90,6 @@ export interface Priority {
   type_name?: string;
   type_value?: string;
   description?: string;
-}
-
-export interface Tag {
-  id: string;
-  name: string;
-  description?: string;
-  color?: string;
 }
 
 // Entity types are defined canonically in `@/types/entity-type` and re-exported

--- a/apps/frontend/src/utils/api-client/interfaces/test-run.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/test-run.ts
@@ -4,15 +4,6 @@ import { TestConfigurationDetail } from './test-configuration';
 import { Tag } from './tag';
 import type { WithPermittedActions } from '@/types/affordances';
 
-// Define Organization interface based on API response
-export interface OrganizationReference {
-  id: string;
-  name: string;
-  description?: string;
-  email?: string;
-  user_id?: UUID;
-}
-
 // Base interfaces for TestRun
 export interface TestRunBase {
   name?: string;
@@ -42,10 +33,7 @@ export interface TestRunDetail extends TestRun {
   user?: UserReference;
   status?: Status;
   test_configuration?: TestConfigurationDetail;
-  organization?: OrganizationReference;
   priority?: number;
-  assignee?: UserReference;
-  owner?: UserReference;
   counts?: {
     comments: number;
     tasks: number;

--- a/apps/frontend/src/utils/api-client/interfaces/test-set.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/test-set.ts
@@ -18,20 +18,6 @@ export interface TestSetBase {
   test_set_type_id?: UUID;
 }
 
-// Organization interface for the nested organization data
-export interface Organization {
-  id: string;
-  name: string;
-  description?: string;
-  email?: string;
-  user_id?: string;
-  tags?: Array<{
-    id: string;
-    name: string;
-    icon_unicode?: string;
-  }>;
-}
-
 // User interface for the nested user data
 export interface User {
   id: string;
@@ -40,16 +26,6 @@ export interface User {
   family_name?: string;
   given_name?: string;
   picture?: string;
-  organization_id?: string;
-}
-
-// LicenseType interface for the nested license_type data
-export interface LicenseType {
-  id: string;
-  description?: string;
-  type_name?: string;
-  type_value?: string;
-  user_id?: string;
   organization_id?: string;
 }
 
@@ -97,7 +73,6 @@ export interface TestSet {
   status_details?: Status;
   tags?: Tag[];
   license_type_id?: UUID;
-  license_type?: LicenseType;
   test_set_type_id?: UUID;
   test_set_type?: TestSetType;
   attributes?: {
@@ -130,12 +105,9 @@ export interface TestSet {
   user_id?: UUID;
   user?: User;
   owner_id?: UUID;
-  owner?: User;
   assignee_id?: UUID;
-  assignee?: User;
   priority?: number;
   organization_id?: UUID;
-  organization?: Organization;
   is_published: boolean;
   visibility?: 'public' | 'organization' | 'user';
   counts?: {

--- a/apps/frontend/src/utils/api-client/interfaces/tests.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/tests.ts
@@ -1,7 +1,6 @@
 import { UUID } from 'crypto';
 import { Prompt } from './prompt';
 import { Tag } from './tag';
-import { Source } from './source';
 import { TestTypeValue } from '@/constants/test-types';
 
 // Priority level enum
@@ -105,13 +104,10 @@ export interface TestDetail extends Test {
   user?: UserReference;
   assignee?: UserReference;
   owner?: UserReference;
-  parent?: TestDetail;
   topic?: Topic;
   behavior?: Behavior;
   category?: Category;
   status?: Status;
-  source?: Source;
-  organization?: Organization;
   priorityLevel?: PriorityLevel;
   counts?: {
     comments?: number;

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -501,22 +501,28 @@ def forbid_implicit_lazy_loads():
 
     Catches the N+1 pattern fixed in #2244, where a relationship missing from
     QueryBuilder.with_related()/include() lazy-loads transparently on first
-    access. Injects raiseload('*', sql_only=True) into every query via
-    Query.before_compile; already eager-loaded relationships are unaffected.
+    access. Injects raiseload('*', sql_only=True) into every ORM SELECT via
+    SessionEvents.do_orm_execute; already eager-loaded relationships are
+    unaffected. do_orm_execute covers session.query(...), session.execute(select(...)),
+    and session.get(...) alike, unlike Query.before_compile which only fires for
+    the legacy session.query() API.
 
     Autouse set as true: every test uses this.
     """
     from sqlalchemy import event
-    from sqlalchemy.orm import Query, raiseload
+    from sqlalchemy.orm import Session, raiseload
 
-    def _raise_on_unloaded(query):
-        return query.options(raiseload("*", sql_only=True))
+    def _raise_on_unloaded(orm_execute_state):
+        if orm_execute_state.is_select:
+            orm_execute_state.statement = orm_execute_state.statement.options(
+                raiseload("*", sql_only=True)
+            )
 
-    event.listen(Query, "before_compile", _raise_on_unloaded, retval=True)
+    event.listen(Session, "do_orm_execute", _raise_on_unloaded)
     try:
         yield
     finally:
-        event.remove(Query, "before_compile", _raise_on_unloaded)
+        event.remove(Session, "do_orm_execute", _raise_on_unloaded)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -496,6 +496,30 @@ def bound_scope():
 
 
 @pytest.fixture(autouse=True)
+def forbid_implicit_lazy_loads():
+    """Raise instead of silently lazy-loading any relationship not eager-loaded via include().
+
+    Catches the N+1 pattern fixed in #2244, where a relationship missing from
+    QueryBuilder.with_related()/include() lazy-loads transparently on first
+    access. Injects raiseload('*', sql_only=True) into every query via
+    Query.before_compile; already eager-loaded relationships are unaffected.
+
+    Autouse set as true: every test uses this.
+    """
+    from sqlalchemy import event
+    from sqlalchemy.orm import Query, raiseload
+
+    def _raise_on_unloaded(query):
+        return query.options(raiseload("*", sql_only=True))
+
+    event.listen(Query, "before_compile", _raise_on_unloaded, retval=True)
+    try:
+        yield
+    finally:
+        event.remove(Query, "before_compile", _raise_on_unloaded)
+
+
+@pytest.fixture(autouse=True)
 def disable_enrichment(request, monkeypatch):
     """
     Disable trace enrichment for all tests by default.

--- a/tests/backend/services/garak/test_sync.py
+++ b/tests/backend/services/garak/test_sync.py
@@ -7,7 +7,7 @@ import pytest
 from faker import Faker
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app.models.test import Test
+from rhesis.backend.app.models.test import Test, test_test_set_association
 from rhesis.backend.app.models.test_set import TestSet
 from rhesis.backend.app.services.garak.probes import GarakProbeInfo
 from rhesis.backend.app.services.garak.sync import GarakSyncService, SyncResult
@@ -168,9 +168,26 @@ class TestGarakSyncServiceProbeIds:
         test_db.add_all([test1, test2])
         test_db.commit()
 
-        # Associate tests with test set
-        test_set.tests.append(test1)
-        test_set.tests.append(test2)
+        # Associate tests with test set (tests/TestSet.tests is viewonly --
+        # insert into the association table directly, not via .append()).
+        test_db.execute(
+            test_test_set_association.insert().values(
+                [
+                    {
+                        "test_id": test1.id,
+                        "test_set_id": test_set.id,
+                        "organization_id": test_org_id,
+                        "user_id": authenticated_user_id,
+                    },
+                    {
+                        "test_id": test2.id,
+                        "test_set_id": test_set.id,
+                        "organization_id": test_org_id,
+                        "user_id": authenticated_user_id,
+                    },
+                ]
+            )
+        )
         test_db.commit()
 
         probe_ids = service._get_existing_probe_ids(test_set)
@@ -204,7 +221,14 @@ class TestGarakSyncServiceProbeIds:
         test_db.add(test1)
         test_db.commit()
 
-        test_set.tests.append(test1)
+        test_db.execute(
+            test_test_set_association.insert().values(
+                test_id=test1.id,
+                test_set_id=test_set.id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+        )
         test_db.commit()
 
         probe_ids = service._get_existing_probe_ids(test_set)

--- a/tests/backend/services/test_embedding_generator.py
+++ b/tests/backend/services/test_embedding_generator.py
@@ -5,7 +5,7 @@ import json
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from rhesis.backend.app import models
 from rhesis.backend.app.models.enums import EmbeddingStatus, ModelType
@@ -237,7 +237,12 @@ class TestEmbeddingGenerator:
         assert result["status"] == "success"
         assert "embedding_id" in result
 
-        embedding = test_db.query(models.Embedding).filter_by(id=result["embedding_id"]).first()
+        embedding = (
+            test_db.query(models.Embedding)
+            .options(joinedload(models.Embedding.status))
+            .filter_by(id=result["embedding_id"])
+            .first()
+        )
         assert embedding is not None
         assert str(embedding.entity_id) == str(test_entity.id)
         assert embedding.entity_type == "Test"
@@ -335,7 +340,14 @@ class TestEmbeddingGenerator:
             model_id=str(embedding_model.id),
         )
 
-        test_entity.prompt.content = "What is the capital of Spain?"
+        # generate() commits, which expires test_entity (SQLAlchemy's default
+        # expire_on_commit) -- look up the prompt by its FK rather than through
+        # the now-unloaded relationship, since re-loading it is exactly the
+        # lazy-load the raiseload trip-wire fixture forbids.
+        from rhesis.backend.app.models import Prompt
+
+        prompt = test_db.query(Prompt).filter_by(id=test_entity.prompt_id).first()
+        prompt.content = "What is the capital of Spain?"
         test_db.commit()
         test_db.refresh(test_entity)
 
@@ -349,14 +361,20 @@ class TestEmbeddingGenerator:
 
         assert result1["embedding_id"] != result2["embedding_id"]
 
-        old_embedding = test_db.query(models.Embedding).filter_by(
-            id=result1["embedding_id"]
-        ).first()
+        old_embedding = (
+            test_db.query(models.Embedding)
+            .options(joinedload(models.Embedding.status))
+            .filter_by(id=result1["embedding_id"])
+            .first()
+        )
         assert old_embedding.status.name.lower() == EmbeddingStatus.STALE.value.lower()
 
-        new_embedding = test_db.query(models.Embedding).filter_by(
-            id=result2["embedding_id"]
-        ).first()
+        new_embedding = (
+            test_db.query(models.Embedding)
+            .options(joinedload(models.Embedding.status))
+            .filter_by(id=result2["embedding_id"])
+            .first()
+        )
         assert new_embedding.status.name.lower() == EmbeddingStatus.ACTIVE.value.lower()
 
     def test_generate_entity_without_to_searchable_text(


### PR DESCRIPTION
## Purpose

`forbid_implicit_lazy_loads` (raiseload on any non-eager-loaded relationship access) surfaced 59 failures across 12 entities. Fixed all of them, then trimmed the eager-loading down to only what's actually consumed by the frontend/SDK. A follow-up sweep caught more of the same pattern in entities missed the first time.

## What Changed

- Fixed 59 raiseload failures: list/detail eager-load mismatches, service code reading relationships directly without eager-loading, one deliberately-lazy walker needing a Core-query escape hatch.
- Audited all `*Detail` schemas against frontend + SDK usage, removed 28 unused nested fields.

| Schema | Removed | Kept |
|---|---|---|
| TopicDetail | status, parent, entity_type, project, organization, user (all 6) | — (now flat) |
| ProjectDetail | user, organization, status | tags, owner |
| BehaviorDetail | status, counts, project, organization | tags |
| MetricDetail | counts, status, assignee, owner, user, test_sets, organization, project | model, behaviors |
| CommentDetail | organization, project (dead — no ORM relationship) | user |
| TaskDetail | tags | user, assignee, status |
| TestDetail | parent, source, organization, project | prompt, test_type, user, assignee, owner, topic, behavior, category, status, tags |
| TestSetDetail | license_type, owner, assignee, organization, project | tags, counts, status*, test_set_type, user |
| TestRunDetail | experiment_summary, assignee, owner, experiment, organization, project | counts, tags, status, user, test_configuration |
| ModelDetail | owner, assignee, tags, counts, project, organization, user | provider_type, status |

*kept despite unclear usage — referenced only as an OData filter path

**Follow-up sweep** (missed the first time — these don't follow the `*Detail` naming convention):

| Schema | Removed | Kept |
|---|---|---|
| CategoryDetail | status, parent, entity_type, project, organization, user (all 6) | — (now flat) |
| EndpointDetail | tags, organization | status, user, project |
| TestResultDetail | status, user, organization, test_configuration, project | tags, test, test_run |
| TestConfigurationDetail | category, topic, prompt, use_case, user, status, project, organization | test_set, endpoint |
| ToolDetail | status, user, organization, project | tool_provider_type |
| Source | status | tags, counts, source_type, user |

`ArchitectSession`/`Experiment` had no dead schema field, but `get_item_detail`/`get_items_detail` was still joining every relationship regardless — switched both to explicit `include()` lists (organization/project/user/owner dropped, `messages`/`project` kept).

## Additional Context

Deferred, not part of this PR:
- [ ] `@safe_relationship` swallows lazy-load errors silently instead of raising — separate bug
- [ ] Fuller `get_item_detail`/`get_items_detail` explicit-include refactor
- [ ] `Trace`'s embedded objects each carry their own unused leaf fields — smaller trim, one level down
- [ ] `get_visible_experiment` has a latent single-fetch N+1 the test fixture can't detect

## Testing

Full `tests/backend/` suite passes (6474 passed, 82 skipped, 1 xfailed — no regressions).