### PR TITLE
Fix SSO callback missing await on build_redirect_url

### DIFF
--- a/ee/backend/src/rhesis/backend/ee/sso/router.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/router.py
@@ -287,7 +287,7 @@ async def sso_callback(
         email=auth_user.email,
     )
 
-    redirect_url = build_redirect_url(request, session_token, refresh_tok)
+    redirect_url = await build_redirect_url(request, session_token, refresh_tok)
     return RedirectResponse(url=redirect_url, status_code=302)
 
 


### PR DESCRIPTION
## Purpose

When `build_redirect_url` was changed from sync to async (to support storing auth-code tokens in Redis server-side), the regular OAuth callback in `auth.py` was updated to use `await`, but the EE SSO callback in `sso/router.py` was missed. Without `await`, the redirect URL variable holds a coroutine object instead of a string, breaking all new SSO logins with an Internal Server Error.

## What Changed

- Added missing `await` to `build_redirect_url()` call in the SSO callback endpoint

## Additional Context

- The regression was introduced in `8f08eb2db` ("fix(auth): store auth-code tokens server-side")
- The OAuth callback at `apps/backend/src/rhesis/backend/app/routers/auth.py:494` was correctly updated; only the EE SSO path was missed
- Affects all SSO logins on versions after v0.10.0. Existing sessions are unaffected since they bypass the callback.

## Testing

- Verify SSO login flow completes successfully after Keycloak authentication
- Confirm the redirect lands on `/auth/signin?code=...&return_to=...` as expected