### PR TITLE
Add catch-all error handling to SSO callback

### DIFF
--- a/ee/backend/src/rhesis/backend/ee/sso/router.py
+++ b/ee/backend/src/rhesis/backend/ee/sso/router.py
@@ -253,42 +253,60 @@ async def sso_callback(
         )
         return RedirectResponse(url=error_redirect, status_code=302)
 
-    # Org-scoped user resolution
+    # Org-scoped user resolution, token creation, and redirect.
+    # Wrapped in a catch-all so unhandled exceptions (DB constraint
+    # violations, missing migrations, etc.) surface as a redirect to
+    # the SSO error page with a logged traceback, not a raw 500.
     try:
-        user = find_or_create_sso_user(db, auth_user, org, sso_config)
-    except SSOLoginError as e:
+        try:
+            user = find_or_create_sso_user(db, auth_user, org, sso_config)
+        except SSOLoginError as e:
+            audit_log(
+                SSOAuditEvent.LOGIN_FAILED,
+                org_id,
+                email=auth_user.email,
+                reason_code=e.reason_code,
+            )
+            return RedirectResponse(url=error_redirect, status_code=302)
+
+        # Create tokens
+        clear_user_logout(str(user.id))
+        session_token = create_session_token(user)
+        refresh_tok = create_refresh_token(db, str(user.id))
+        db.commit()
+
+        # Capture redirect context before session rotation discards it
+        original_frontend = request.session.get("original_frontend", "")
+
+        # Regenerate session (prevents session fixation)
+        regenerate_session(request, {"user_id": str(user.id)})
+        # Restore redirect context for build_redirect_url
+        request.session["return_to"] = state_return_to
+        if original_frontend:
+            request.session["original_frontend"] = original_frontend
+
+        audit_log(
+            SSOAuditEvent.LOGIN_SUCCESS,
+            org_id,
+            email=auth_user.email,
+        )
+
+        redirect_url = await build_redirect_url(request, session_token, refresh_tok)
+        return RedirectResponse(url=redirect_url, status_code=302)
+
+    except Exception:
+        logger.exception(
+            "SSO callback failed for org %s, email %s",
+            org_id,
+            auth_user.email,
+        )
         audit_log(
             SSOAuditEvent.LOGIN_FAILED,
             org_id,
             email=auth_user.email,
-            reason_code=e.reason_code,
+            reason_code="internal_error",
         )
         return RedirectResponse(url=error_redirect, status_code=302)
-
-    # Create tokens
-    clear_user_logout(str(user.id))
-    session_token = create_session_token(user)
-    refresh_tok = create_refresh_token(db, str(user.id))
-    db.commit()
-
-    # Capture redirect context before session rotation discards it
-    original_frontend = request.session.get("original_frontend", "")
-
-    # Regenerate session (prevents session fixation)
-    regenerate_session(request, {"user_id": str(user.id)})
-    # Restore redirect context for build_redirect_url
-    request.session["return_to"] = state_return_to
-    if original_frontend:
-        request.session["original_frontend"] = original_frontend
-
-    audit_log(
-        SSOAuditEvent.LOGIN_SUCCESS,
-        org_id,
-        email=auth_user.email,
-    )
-
-    redirect_url = await build_redirect_url(request, session_token, refresh_tok)
-    return RedirectResponse(url=redirect_url, status_code=302)
 
 
 @router.get("/auth/sso/{org_id}")


### PR DESCRIPTION
## Purpose

Follow-up to #2295. The SSO callback only caught `SSOLoginError`, so any other exception from user provisioning (`IntegrityError`, `ProgrammingError`, etc.) or token creation surfaced as a raw 500 Internal Server Error with no logging. This is the likely cause of the SSO login failures reported by the netgo deployment (v0.10.0) -- the actual root cause is hidden because there's no traceback in the logs.

## What Changed

- Wrapped the post-authentication block (user resolution, token creation, session setup, redirect) in a catch-all `except Exception` that:
  - Logs the full traceback via `logger.exception`
  - Emits an audit event with `reason_code=internal_error`
  - Redirects to the SSO error page instead of returning a 500
- Matches the error handling pattern already used by the regular OAuth callback in `auth.py`

## Additional Context

- The regular OAuth callback wraps everything in `try...except Exception` and returns a 400 with the error message. The SSO callback had no equivalent, so unhandled exceptions became opaque 500s.
- With this change, the next time the error occurs we'll have a full traceback in the logs to identify the root cause.

## Testing

- SSO happy path: login should work as before
- Error path: any exception during user provisioning now redirects to `/auth/sso-error` instead of returning a 500