### PR TITLE
Move Explorer tree types from SDK into backend

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/routers/explorer.py
@@ -11,7 +11,7 @@ import logging
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from fastapi import Body, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
@@ -45,6 +45,8 @@ from rhesis.backend.app.schemas.explorer import (
     ImportExplorerTestSetResponse,
     SuggestedTest,
     SuggestionPipelineRequest,
+    TestTreeNode,
+    TopicNode,
 )
 from rhesis.backend.app.services.explorer import (
     bulk_delete_explorer_test_sets,
@@ -73,7 +75,6 @@ from rhesis.backend.app.services.explorer import (
     update_test_node,
     update_topic_node,
 )
-from rhesis.sdk.adaptive_testing.schemas import TestTreeNode, TopicNode
 
 logger = logging.getLogger(__name__)
 

--- a/apps/backend/src/rhesis/backend/app/schemas/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/explorer.py
@@ -1,11 +1,85 @@
 """Schemas for Explorer API (generate outputs, evaluate, etc.)."""
 
-from typing import Any, Dict, List, Optional
+import uuid
+from functools import cached_property
+from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import UUID4, BaseModel, ConfigDict, Field
+from pydantic import UUID4, BaseModel, ConfigDict, Field, computed_field
 
 from rhesis.backend.app.schemas import Base
 from rhesis.backend.app.schemas.test_set import TestSet as TestSetSchema
+
+# ---------------------------------------------------------------------------
+# Tree nodes — the response contract for the /explorer tree endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestTreeNode(BaseModel):
+    """A single node in an Explorer test tree — either a test or a topic marker."""
+
+    id: str = Field(default_factory=lambda: uuid.uuid4().hex)
+    topic: str = ""
+    input: str = ""
+    output: str = ""
+    # "error" is written by the evaluation path when a metric raises.
+    label: Literal["", "topic_marker", "pass", "fail", "error"] = ""
+    labeler: str = ""
+    to_eval: bool = True
+    model_score: float = 0.0
+    metrics: Optional[Dict[str, Any]] = None
+
+
+class TopicNode(BaseModel):
+    """A hierarchical topic in an Explorer test tree, identified by its slash path."""
+
+    path: str  # Full path like "Safety/Violence"
+
+    model_config = {"frozen": True}  # Make it hashable
+
+    @computed_field
+    @cached_property
+    def name(self) -> str:
+        """The leaf name, e.g. 'Violence'."""
+        if not self.path:
+            return ""
+        return self.path.rsplit("/", 1)[-1]
+
+    @computed_field
+    @cached_property
+    def parent_path(self) -> Optional[str]:
+        """Parent path, or None for root-level topics."""
+        if "/" in self.path:
+            return self.path.rsplit("/", 1)[0]
+        return None
+
+    @computed_field
+    @cached_property
+    def depth(self) -> int:
+        """How deep in the hierarchy (0 = root level)."""
+        if not self.path:
+            return -1  # Root itself
+        return self.path.count("/")
+
+    def __str__(self) -> str:
+        return self.path
+
+    def __repr__(self) -> str:
+        return f"TopicNode(path={self.path!r})"
+
+    def get_all_parents(self) -> list["TopicNode"]:
+        """Get all parent TopicNodes from immediate parent up to the root.
+
+        ``TopicNode(path="A/B/C").get_all_parents()`` returns
+        ``[TopicNode(path="A/B"), TopicNode(path="A")]``.
+        """
+        parents: list["TopicNode"] = []
+        current = self
+        while current.parent_path is not None:
+            parent = TopicNode(path=current.parent_path)
+            parents.append(parent)
+            current = parent
+        return parents
+
 
 # ---------------------------------------------------------------------------
 # Create / update explorer test nodes

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.constants import ADAPTIVE_TESTING_BEHAVIOR
 from rhesis.backend.app.models.test import test_test_set_association
+from rhesis.backend.app.schemas.explorer import TestTreeNode, TopicNode
 from rhesis.backend.app.services.test import create_test_set_associations
 from rhesis.backend.app.utils.crud_utils import (
     bulk_delete_by_ids,
@@ -15,10 +16,9 @@ from rhesis.backend.app.utils.crud_utils import (
     get_or_create_type_lookup,
 )
 from rhesis.backend.app.utils.query_utils import QueryBuilder
-from rhesis.sdk.adaptive_testing.schemas import TestTreeNode, TopicNode
 
 from .topics import create_topic_node
-from .utils import _db_test_to_node, convert_to_sdk_tree
+from .utils import _db_test_to_node, build_test_tree
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ def get_tree_nodes(
 
     Returns the complete tree as a flat list of TestTreeNode objects.
     """
-    tree_data = convert_to_sdk_tree(db, test_set_id, organization_id, user_id)
+    tree_data = build_test_tree(db, test_set_id, organization_id, user_id)
     return list(tree_data)
 
 
@@ -51,7 +51,7 @@ def get_tree_tests(
     topic : str, optional
         If provided, only returns tests under this topic path.
     """
-    tree_data = convert_to_sdk_tree(db, test_set_id, organization_id, user_id)
+    tree_data = build_test_tree(db, test_set_id, organization_id, user_id)
 
     if topic:
         return tree_data.topics.get_tests(TopicNode(path=topic), recursive=True)
@@ -69,7 +69,7 @@ def get_tree_topics(
 
     Returns the hierarchical topic structure derived from topic markers.
     """
-    tree_data = convert_to_sdk_tree(db, test_set_id, organization_id, user_id)
+    tree_data = build_test_tree(db, test_set_id, organization_id, user_id)
     return tree_data.topics.get_all()
 
 

--- a/apps/backend/src/rhesis/backend/app/services/explorer/topics.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/topics.py
@@ -6,11 +6,11 @@ from sqlalchemy.orm import Session, contains_eager
 
 from rhesis.backend.app import crud, models
 from rhesis.backend.app.models.test import test_test_set_association
+from rhesis.backend.app.schemas.explorer import TopicNode
 from rhesis.backend.app.services.test import create_test_set_associations
 from rhesis.backend.app.utils.crud_utils import get_or_create_topic
-from rhesis.sdk.adaptive_testing.schemas import TopicNode
 
-from .utils import convert_to_sdk_tree
+from .utils import build_test_tree
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ def create_topic_node(
         The created (or already existing) topic node
     """
     # Build the current tree to check which markers already exist
-    tree_data = convert_to_sdk_tree(db, test_set_id, organization_id, user_id)
+    tree_data = build_test_tree(db, test_set_id, organization_id, user_id)
 
     # Collect paths that still need a topic_marker
     topic_node = TopicNode(path=topic)
@@ -154,13 +154,13 @@ def update_topic_node(
     if "/" in new_name:
         raise ValueError("new_name must not contain '/'")
 
-    # Build the SDK tree to validate the topic exists
-    tree_data = convert_to_sdk_tree(db, test_set_id, organization_id, user_id)
+    # Build the tree to validate the topic exists
+    tree_data = build_test_tree(db, test_set_id, organization_id, user_id)
     existing_topic = tree_data.topics.get(topic_path)
     if existing_topic is None:
         return None
 
-    # Compute the new path using the SDK helper
+    # Compute the new path using the topic-tree helper
     old_topic = TopicNode(path=topic_path)
     new_topic = tree_data.topics.rename(old_topic, new_name)
     new_path = new_topic.path
@@ -246,7 +246,7 @@ def remove_topic_node(
     bool
         True if the topic existed and was removed, False if not found.
     """
-    tree_data = convert_to_sdk_tree(db, test_set_id, organization_id, user_id)
+    tree_data = build_test_tree(db, test_set_id, organization_id, user_id)
     existing = tree_data.topics.get(topic_path)
     if existing is None:
         return False

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tree.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tree.py
@@ -1,0 +1,135 @@
+"""In-memory view over an Explorer test set's tests.
+
+``TestTreeData`` holds the flat node collection built by :mod:`.utils`; ``TopicTree`` derives
+the topic hierarchy from the ``topic_marker`` nodes inside it. Both are read-only helpers —
+persistence lives in the service modules and ``crud``.
+"""
+
+from typing import Iterator, List, Optional
+
+from rhesis.backend.app.schemas.explorer import TestTreeNode, TopicNode
+
+
+class TestTreeData:
+    """Collection of TestTreeNodes keyed by node id."""
+
+    def __init__(self, nodes: Optional[List[TestTreeNode]] = None):
+        self._nodes: dict[str, TestTreeNode] = {}
+        if nodes:
+            for node in nodes:
+                self._nodes[node.id] = node
+
+    def __iter__(self) -> Iterator[TestTreeNode]:
+        return iter(self._nodes.values())
+
+    @property
+    def topics(self) -> "TopicTree":
+        """Get the TopicTree view for this test tree."""
+        if not hasattr(self, "_topic_tree"):
+            self._topic_tree = TopicTree(self)
+        return self._topic_tree
+
+    def get_tests(self) -> List[TestTreeNode]:
+        """Get all actual test nodes (non-topic markers)."""
+        return [node for node in self if node.label != "topic_marker"]
+
+
+class TopicTree:
+    """A view over TestTreeData that provides topic-oriented operations.
+
+    This doesn't store topics separately - it derives them from topic_marker nodes
+    in the underlying TestTreeData.
+    """
+
+    def __init__(self, test_tree_data: "TestTreeData"):
+        self._data = test_tree_data
+        self._topic_cache: dict[str, TopicNode] = {}
+
+    def _get_or_create_topic(self, path: str) -> TopicNode:
+        """Get cached TopicNode or create new one"""
+        if path not in self._topic_cache:
+            self._topic_cache[path] = TopicNode(path=path)
+        return self._topic_cache[path]
+
+    def _is_real_topic(self, path: str) -> bool:
+        """Filter out suggestion pseudo-topics"""
+        return "__suggestions__" not in path
+
+    # --- Query methods ---
+
+    def get(self, path: str) -> TopicNode | None:
+        """Get a topic by path, or None if no topic_marker exists for it."""
+        for node in self._data:
+            if node.topic == path and node.label == "topic_marker":
+                return self._get_or_create_topic(path)
+        return None
+
+    def get_all(self) -> list[TopicNode]:
+        """Get all topics (excludes __suggestions__ pseudo-topics)."""
+        topics = []
+        seen = set()
+        for node in self._data:
+            if (
+                node.label == "topic_marker"
+                and self._is_real_topic(node.topic)
+                and node.topic not in seen
+            ):
+                seen.add(node.topic)
+                topics.append(self._get_or_create_topic(node.topic))
+        return topics
+
+    def get_tests(
+        self, topic: TopicNode | None = None, recursive: bool = False
+    ) -> list[TestTreeNode]:
+        """Get test nodes (non-topic-markers) under a topic."""
+        tests = []
+        topic_path = topic.path if topic else ""
+
+        for node in self._data:
+            if node.label == "topic_marker":
+                continue
+            if "__suggestions__" in node.topic:
+                continue
+
+            if not topic_path:
+                # No topic filter - get all
+                tests.append(node)
+            elif recursive:
+                # Include topic and all descendants
+                if node.topic == topic_path or node.topic.startswith(topic_path + "/"):
+                    tests.append(node)
+            else:
+                # Direct children only
+                if node.topic == topic_path:
+                    tests.append(node)
+
+        return tests
+
+    # --- Mutation methods ---
+
+    def rename(self, topic: TopicNode, new_name: str) -> TopicNode:
+        """Rename a topic (changes the last segment of path).
+
+        Updates all nodes under this topic.
+        """
+        if "/" in topic.path:
+            new_path = topic.path.rsplit("/", 1)[0] + "/" + new_name
+        else:
+            new_path = new_name
+
+        return self.move(topic, new_path)
+
+    def move(self, topic: TopicNode, new_path: str) -> TopicNode:
+        """Move a topic to a new path.
+
+        Updates all nodes under this topic.
+        """
+        old_path = topic.path
+
+        for node in self._data:
+            if node.topic == old_path:
+                node.topic = new_path
+            elif node.topic.startswith(old_path + "/"):
+                node.topic = new_path + node.topic[len(old_path) :]
+
+        return self._get_or_create_topic(new_path)

--- a/apps/backend/src/rhesis/backend/app/services/explorer/utils.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/utils.py
@@ -5,7 +5,9 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
-from rhesis.sdk.adaptive_testing.schemas import TestTreeData, TestTreeNode
+from rhesis.backend.app.schemas.explorer import TestTreeNode
+
+from .tree import TestTreeData
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +15,7 @@ logger = logging.getLogger(__name__)
 def _db_test_to_node(db_test: models.Test) -> TestTreeNode | None:
     """Convert a backend Test model to a TestTreeNode.
 
-    Maps DB fields to the SDK node format:
+    Maps DB fields to the node format:
     - test.topic.name -> node.topic
     - test.prompt.content -> node.input
     - test.test_metadata -> output, label, labeler, model_score, metrics
@@ -82,7 +84,7 @@ def _get_test_set_tests_from_db(
     return all_tests
 
 
-def convert_to_sdk_tree(
+def build_test_tree(
     db: Session,
     test_set_id: UUID,
     organization_id: str,

--- a/apps/frontend/src/utils/api-client/interfaces/explorer.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/explorer.ts
@@ -72,7 +72,8 @@ export interface TestNode {
   topic: string;
   input: string;
   output: string;
-  label: '' | 'topic_marker' | 'pass' | 'fail';
+  /** 'error' is set by the backend when a metric raises during evaluation. */
+  label: '' | 'topic_marker' | 'pass' | 'fail' | 'error';
   labeler: string;
   to_eval: boolean;
   model_score: number;

--- a/tests/backend/routes/test_explorer.py
+++ b/tests/backend/routes/test_explorer.py
@@ -857,6 +857,44 @@ class TestExplorerTreeEndpoint:
         for node in nodes:
             assert expected_fields.issubset(node.keys())
 
+    def test_get_tree_with_error_label(
+        self,
+        authenticated_client: TestClient,
+        explorer_test_set,
+        test_db: Session,
+        test_org_id,
+        authenticated_user_id,
+    ):
+        """A test labelled 'error' by a failed evaluation must not break the tree read."""
+        errored = _create_test_with_metadata(
+            db=test_db,
+            topic_name="Safety",
+            prompt_content="Prompt whose evaluation raised",
+            metadata={
+                "label": "error",
+                "output": "some output",
+                "labeler": "answer_relevancy",
+                "model_score": 0.0,
+            },
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        test_db.execute(
+            test_test_set_association.insert().values(
+                test_id=errored.id,
+                test_set_id=explorer_test_set.id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+        )
+        test_db.commit()
+
+        response = authenticated_client.get(f"/explorer/{explorer_test_set.id}/tree")
+
+        assert response.status_code == status.HTTP_200_OK
+        labels = [node["label"] for node in response.json()]
+        assert "error" in labels
+
     def test_get_tree_not_found(
         self,
         authenticated_client: TestClient,

--- a/tests/backend/routes/test_websocket.py
+++ b/tests/backend/routes/test_websocket.py
@@ -180,9 +180,7 @@ class TestAuthenticateWebSocketToken:
             # Mock websocket
             mock_ws = MagicMock()
 
-            result = asyncio.get_event_loop().run_until_complete(
-                authenticate_websocket_token(mock_ws, "valid_token")
-            )
+            result = asyncio.run(authenticate_websocket_token(mock_ws, "valid_token"))
 
             # Returns a (user, Principal) tuple so token scopes reach channel authz.
             assert result is not None
@@ -199,9 +197,7 @@ class TestAuthenticateWebSocketToken:
 
         mock_ws = MagicMock()
 
-        result = asyncio.get_event_loop().run_until_complete(
-            authenticate_websocket_token(mock_ws, None)
-        )
+        result = asyncio.run(authenticate_websocket_token(mock_ws, None))
 
         assert result is None
 
@@ -218,9 +214,7 @@ class TestAuthenticateWebSocketToken:
 
             mock_ws = MagicMock()
 
-            result = asyncio.get_event_loop().run_until_complete(
-                authenticate_websocket_token(mock_ws, "invalid_token")
-            )
+            result = asyncio.run(authenticate_websocket_token(mock_ws, "invalid_token"))
 
             assert result is None
 

--- a/tests/backend/services/explorer/test_tests.py
+++ b/tests/backend/services/explorer/test_tests.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
 from rhesis.backend.app.database import without_soft_delete_filter
+from rhesis.backend.app.schemas.explorer import TestTreeNode, TopicNode
 from rhesis.backend.app.services.explorer import (
     bulk_delete_explorer_test_sets,
     create_explorer_test_set,
@@ -20,7 +21,6 @@ from rhesis.backend.app.services.explorer import (
     import_explorer_test_set_from_source,
     update_test_node,
 )
-from rhesis.sdk.adaptive_testing.schemas import TestTreeNode, TopicNode
 
 # ============================================================================
 # Helpers and Fixtures for get_explorer_test_sets
@@ -580,9 +580,7 @@ class TestBulkDeleteExplorerTestSets:
         assert set(result["not_found_ids"]) == {str(regular.id), str(fake_id)}
 
         # The regular (non-explorer) test set must still exist, untouched.
-        still_there = (
-            test_db.query(models.TestSet).filter(models.TestSet.id == regular.id).first()
-        )
+        still_there = test_db.query(models.TestSet).filter(models.TestSet.id == regular.id).first()
         assert still_there is not None
 
     def test_cascades_to_session_tests(self, test_db, test_org_id, authenticated_user_id):

--- a/tests/backend/services/explorer/test_topics.py
+++ b/tests/backend/services/explorer/test_topics.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models
 from rhesis.backend.app.database import without_soft_delete_filter
+from rhesis.backend.app.schemas.explorer import TopicNode
 from rhesis.backend.app.services.explorer import (
     create_topic_node,
     get_tree_nodes,
@@ -13,7 +14,6 @@ from rhesis.backend.app.services.explorer import (
     remove_topic_node,
     update_topic_node,
 )
-from rhesis.sdk.adaptive_testing.schemas import TopicNode
 
 from .conftest import _associate_tests_with_test_set, _create_test_with_metadata
 

--- a/tests/backend/services/explorer/test_tree.py
+++ b/tests/backend/services/explorer/test_tree.py
@@ -1,0 +1,317 @@
+"""Unit tests for the Explorer in-memory tree.
+
+Ported from the SDK's ``tests/sdk/adaptive_testing/test_schemas.py`` when
+``TestTreeNode``/``TopicNode`` moved into ``app.schemas.explorer`` and
+``TestTreeData``/``TopicTree`` into ``app.services.explorer.tree``. Only the surface the
+backend actually calls is covered — the unused SDK methods were dropped in the same move.
+"""
+
+import pytest
+
+from rhesis.backend.app.schemas.explorer import TestTreeNode, TopicNode
+from rhesis.backend.app.services.explorer.tree import TestTreeData, TopicTree
+
+
+class TestTestTreeNode:
+    """Tests for the TestTreeNode model."""
+
+    def test_default_values(self):
+        """Should have correct default values."""
+        node = TestTreeNode(input="test")
+        assert node.topic == ""
+        assert node.output == ""
+        assert node.label == ""
+        assert node.labeler == ""
+        assert node.to_eval is True
+        assert node.model_score == 0.0
+        assert node.metrics is None
+
+    def test_auto_generates_unique_id(self):
+        """Should auto-generate unique IDs."""
+        node1 = TestTreeNode(input="test1")
+        node2 = TestTreeNode(input="test2")
+        assert node1.id != node2.id
+        assert len(node1.id) == 32  # UUID hex length
+
+    def test_create_with_all_fields(self):
+        """Should create node with all fields specified."""
+        node = TestTreeNode(
+            id="custom-id",
+            topic="Safety",
+            input="Is this safe?",
+            output="Yes",
+            label="pass",
+            labeler="user",
+            to_eval=False,
+            model_score=0.95,
+            metrics={"answer_relevancy": {"score": 0.95, "is_successful": True}},
+        )
+        assert node.id == "custom-id"
+        assert node.topic == "Safety"
+        assert node.input == "Is this safe?"
+        assert node.output == "Yes"
+        assert node.label == "pass"
+        assert node.labeler == "user"
+        assert node.to_eval is False
+        assert node.model_score == 0.95
+        assert node.metrics == {"answer_relevancy": {"score": 0.95, "is_successful": True}}
+
+    def test_missing_input_uses_default(self):
+        """Should use empty string as default for input."""
+        node = TestTreeNode()
+        assert node.input == ""
+
+    def test_topic_preserved_as_given(self):
+        """Topic is stored exactly as provided, spaces and all."""
+        node = TestTreeNode(input="test", topic="Safety Topic/Sub Topic")
+        assert node.topic == "Safety Topic/Sub Topic"
+
+    @pytest.mark.parametrize("label", ["", "topic_marker", "pass", "fail", "error"])
+    def test_accepts_every_persisted_label(self, label):
+        """All labels the services write must be constructible.
+
+        ``error`` is written by ``evaluation.py`` when a metric raises; before it was added
+        to the Literal, any tree read after a failed evaluation raised ValidationError.
+        """
+        assert TestTreeNode(input="test", label=label).label == label
+
+    def test_rejects_unknown_label(self):
+        """Labels outside the Literal are still rejected."""
+        with pytest.raises(ValueError):
+            TestTreeNode(input="test", label="banana")
+
+
+class TestTestTreeData:
+    """Tests for the TestTreeData collection."""
+
+    @pytest.fixture
+    def sample_nodes(self):
+        return [
+            TestTreeNode(id="node1", input="input1"),
+            TestTreeNode(id="node2", input="input2"),
+            TestTreeNode(id="node3", input="input3"),
+        ]
+
+    def test_init_empty(self):
+        """Should initialize with no nodes."""
+        assert list(TestTreeData()) == []
+
+    def test_iter_returns_same_nodes_in_order(self, sample_nodes):
+        """Should iterate over the same node objects in insertion order."""
+        data = TestTreeData(sample_nodes)
+        nodes = list(data)
+        assert len(nodes) == len(sample_nodes)
+        for iterated, original in zip(nodes, sample_nodes):
+            assert iterated is original
+
+    def test_init_deduplicates_by_id(self):
+        """Nodes are keyed by id, so a repeated id keeps only the last one."""
+        data = TestTreeData(
+            [
+                TestTreeNode(id="dup", input="first"),
+                TestTreeNode(id="dup", input="second"),
+            ]
+        )
+        nodes = list(data)
+        assert len(nodes) == 1
+        assert nodes[0].input == "second"
+
+    def test_topics_property_returns_topic_tree(self):
+        """Should expose a TopicTree view."""
+        data = TestTreeData()
+        assert isinstance(data.topics, TopicTree)
+
+    def test_topics_property_cached(self):
+        """Should return the same TopicTree instance on repeated access."""
+        data = TestTreeData()
+        assert data.topics is data.topics
+
+    def test_get_tests_excludes_topic_markers(self):
+        """Should return only non-marker nodes."""
+        data = TestTreeData(
+            [
+                TestTreeNode(id="m1", topic="Safety", label="topic_marker"),
+                TestTreeNode(id="t1", topic="Safety", input="test1", label="pass"),
+                TestTreeNode(id="t2", topic="Safety", input="test2", label="fail"),
+            ]
+        )
+        tests = data.get_tests()
+        assert {t.id for t in tests} == {"t1", "t2"}
+
+
+class TestTopicTree:
+    """Tests for the TopicTree view."""
+
+    @pytest.fixture
+    def data_with_topics(self):
+        nodes = [
+            TestTreeNode(id="m1", topic="Safety", label="topic_marker"),
+            TestTreeNode(id="m2", topic="Safety/Violence", label="topic_marker"),
+            TestTreeNode(id="m3", topic="Safety/Privacy", label="topic_marker"),
+            TestTreeNode(id="m4", topic="Performance", label="topic_marker"),
+            TestTreeNode(id="t1", topic="Safety", input="test1", label="pass"),
+            TestTreeNode(id="t2", topic="Safety/Violence", input="test2", label="fail"),
+            TestTreeNode(id="t3", topic="Safety/Violence", input="test3", label="pass"),
+        ]
+        return TestTreeData(nodes)
+
+    def test_get_existing_topic(self, data_with_topics):
+        """Should return a TopicNode for an existing path."""
+        topic = data_with_topics.topics.get("Safety")
+        assert topic is not None
+        assert topic.path == "Safety"
+
+    def test_get_nonexistent_topic(self, data_with_topics):
+        """Should return None when no topic_marker exists for the path."""
+        assert data_with_topics.topics.get("NonExistent") is None
+
+    def test_get_ignores_paths_that_only_have_tests(self, data_with_topics):
+        """A path with tests but no marker is not a topic."""
+        data = TestTreeData([TestTreeNode(id="t1", topic="Orphan", input="x", label="pass")])
+        assert data.topics.get("Orphan") is None
+
+    def test_get_all_topics(self, data_with_topics):
+        """Should return every marker path once."""
+        paths = {t.path for t in data_with_topics.topics.get_all()}
+        assert paths == {"Safety", "Safety/Violence", "Safety/Privacy", "Performance"}
+
+    def test_get_all_excludes_suggestions(self):
+        """Should exclude __suggestions__ pseudo-topics."""
+        data = TestTreeData(
+            [
+                TestTreeNode(id="m1", topic="Safety", label="topic_marker"),
+                TestTreeNode(id="m2", topic="Safety/__suggestions__", label="topic_marker"),
+            ]
+        )
+        paths = {t.path for t in data.topics.get_all()}
+        assert paths == {"Safety"}
+
+    def test_get_tests_direct(self, data_with_topics):
+        """Should return direct tests only when recursive=False."""
+        tree = data_with_topics.topics
+        tests = tree.get_tests(tree.get("Safety"), recursive=False)
+        assert [t.id for t in tests] == ["t1"]
+
+    def test_get_tests_recursive(self, data_with_topics):
+        """Should include subtopic tests when recursive=True."""
+        tree = data_with_topics.topics
+        tests = tree.get_tests(tree.get("Safety"), recursive=True)
+        assert {t.id for t in tests} == {"t1", "t2", "t3"}
+
+    def test_get_tests_all(self, data_with_topics):
+        """Should return all tests when topic is None."""
+        assert len(data_with_topics.topics.get_tests(None)) == 3
+
+    def test_get_tests_excludes_suggestions(self):
+        """Should exclude tests in __suggestions__ topics."""
+        data = TestTreeData(
+            [
+                TestTreeNode(id="m1", topic="Safety", label="topic_marker"),
+                TestTreeNode(id="t1", topic="Safety", input="test1", label="pass"),
+                TestTreeNode(id="t2", topic="Safety/__suggestions__", input="s", label=""),
+            ]
+        )
+        tests = data.topics.get_tests(None)
+        assert [t.id for t in tests] == ["t1"]
+
+    def test_rename_nested_topic(self, data_with_topics):
+        """Should replace the last path segment and move its tests."""
+        tree = data_with_topics.topics
+        new_topic = tree.rename(tree.get("Safety/Violence"), "Aggression")
+
+        assert new_topic.path == "Safety/Aggression"
+        assert tree.get("Safety/Violence") is None
+        assert tree.get("Safety/Aggression") is not None
+        assert len(tree.get_tests(new_topic)) == 2
+
+    def test_rename_root_level_topic(self):
+        """Should rename a root-level topic."""
+        data = TestTreeData(
+            [
+                TestTreeNode(id="m1", topic="Safety", label="topic_marker"),
+                TestTreeNode(id="t1", topic="Safety", input="test", label="pass"),
+            ]
+        )
+        tree = data.topics
+        new_topic = tree.rename(tree.get("Safety"), "Security")
+
+        assert new_topic.path == "Security"
+        assert tree.get("Safety") is None
+        assert tree.get("Security") is not None
+
+    def test_move_topic(self, data_with_topics):
+        """Should move a topic to an unrelated path."""
+        tree = data_with_topics.topics
+        new_topic = tree.move(tree.get("Safety/Violence"), "Performance/Violence")
+
+        assert new_topic.path == "Performance/Violence"
+        assert tree.get("Safety/Violence") is None
+        assert tree.get("Performance/Violence") is not None
+
+    def test_move_topic_updates_descendants(self):
+        """Should re-path child topics and their tests."""
+        data = TestTreeData(
+            [
+                TestTreeNode(id="m1", topic="A", label="topic_marker"),
+                TestTreeNode(id="m2", topic="A/B", label="topic_marker"),
+                TestTreeNode(id="m3", topic="A/B/C", label="topic_marker"),
+                TestTreeNode(id="m4", topic="X", label="topic_marker"),
+                TestTreeNode(id="t1", topic="A/B/C", input="test", label="pass"),
+            ]
+        )
+        tree = data.topics
+        tree.move(tree.get("A/B"), "X/B")
+
+        assert tree.get("A/B") is None
+        assert tree.get("A/B/C") is None
+        assert tree.get("X/B") is not None
+        assert tree.get("X/B/C") is not None
+        assert len(tree.get_tests(tree.get("X/B/C"))) == 1
+
+
+class TestTopicNode:
+    """Tests for the TopicNode model."""
+
+    def test_name_is_leaf_segment(self):
+        assert TopicNode(path="Safety/Violence").name == "Violence"
+
+    def test_name_root_level(self):
+        assert TopicNode(path="Safety").name == "Safety"
+
+    def test_name_empty_path(self):
+        assert TopicNode(path="").name == ""
+
+    def test_parent_path(self):
+        assert TopicNode(path="Safety/Violence/Weapons").parent_path == "Safety/Violence"
+
+    def test_parent_path_root_level_is_none(self):
+        assert TopicNode(path="Safety").parent_path is None
+
+    def test_depth_counts_separators(self):
+        assert TopicNode(path="Safety").depth == 0
+        assert TopicNode(path="Safety/Violence").depth == 1
+        assert TopicNode(path="Safety/Violence/Weapons").depth == 2
+
+    def test_depth_empty_path_is_root(self):
+        assert TopicNode(path="").depth == -1
+
+    def test_is_hashable(self):
+        """Frozen model, so it can be used in sets and dict keys."""
+        assert len({TopicNode(path="Safety"), TopicNode(path="Safety")}) == 1
+
+    def test_get_all_parents(self):
+        """Should return parents from immediate parent up to the root."""
+        parents = TopicNode(path="A/B/C").get_all_parents()
+        assert [p.path for p in parents] == ["A/B", "A"]
+
+    def test_get_all_parents_root_level(self):
+        assert TopicNode(path="A").get_all_parents() == []
+
+    def test_serialized_fields(self):
+        """The computed fields are part of the API response shape."""
+        assert TopicNode(path="Safety/Violence").model_dump() == {
+            "path": "Safety/Violence",
+            "name": "Violence",
+            "parent_path": "Safety",
+            "depth": 1,
+        }

--- a/tests/backend/services/garak/test_probes.py
+++ b/tests/backend/services/garak/test_probes.py
@@ -540,8 +540,7 @@ class TestGarakProbeServiceEnumerateCachedConcurrency:
             assert modules == []
             assert probes_by_module == {}
 
-    @pytest.mark.asyncio
-    async def test_lock_survives_across_different_event_loops(self):
+    def test_lock_survives_across_different_event_loops(self):
         """Regression test flagged in PR review: a bare module-level
         asyncio.Lock() binds to whichever event loop first genuinely contends
         on it (waits, not just uncontended acquire/release), and raises
@@ -550,7 +549,12 @@ class TestGarakProbeServiceEnumerateCachedConcurrency:
         (function-scoped), so two different tests contending on the same
         process-wide single-flight lock would hit exactly this in CI.
         _get_enumeration_lock() must hand back a fresh, working lock whenever
-        the running loop differs from the one it was last bound to."""
+        the running loop differs from the one it was last bound to.
+
+        Deliberately a sync test driving two loops in sequence: the pair of
+        loops is the whole point, and running one from inside the other would
+        need nest_asyncio.
+        """
 
         async def _contend():
             lock = _get_enumeration_lock()
@@ -565,16 +569,12 @@ class TestGarakProbeServiceEnumerateCachedConcurrency:
 
             await asyncio.gather(holder(), waiter())
 
-        # Contends on the lock in the current (pytest-asyncio) event loop —
-        # this is what binds a bare asyncio.Lock() internally.
-        await _contend()
-
-        # Simulate a second, independent test function getting its own fresh
-        # event loop (exactly what pytest-asyncio's function-scoped loops do)
-        # and also contending on the same process-wide lock. Without the fix,
-        # this raises "... is bound to a different event loop".
-        new_loop = asyncio.new_event_loop()
-        try:
-            new_loop.run_until_complete(_contend())
-        finally:
-            new_loop.close()
+        # Two independent loops, exactly what pytest-asyncio's function-scoped
+        # loops give two consecutive tests. Contending in the second one raises
+        # "... is bound to a different event loop" without the rebinding fix.
+        for _ in range(2):
+            loop = asyncio.new_event_loop()
+            try:
+                loop.run_until_complete(_contend())
+            finally:
+                loop.close()


### PR DESCRIPTION
## Purpose

The Explorer tree endpoints depended on `rhesis.sdk.adaptive_testing.schemas` for their response
contract, so the backend's public API shape was owned by the SDK. This is the first prep step of the
Explorer roadmap: the backend now owns these types, which unblocks changing the tree representation
without an SDK release.

## What Changed

- Move `TestTreeNode` and `TopicNode` into `app.schemas.explorer`, and `TestTreeData` / `TopicTree`
  into a new `services/explorer/tree.py`.
- Drop the `rhesis.sdk.adaptive_testing.schemas` import from the explorer router, services and utils.
- Rename `convert_to_sdk_tree` to `build_test_tree` (nothing SDK-shaped is being converted anymore).
- Allow `label="error"` on tree nodes in both the backend schema and the frontend `TestNode`
  interface — the evaluation path already writes it when a metric raises, so the previous union was
  wrong.
- Replace `get_event_loop().run_until_complete()` with `asyncio.run()` in the websocket auth tests,
  and make the garak lock-rebinding test a plain sync test driving two fresh loops in sequence.

## Additional Context

- No behavior change to the tree endpoints; the JSON shape is identical apart from `"error"` now
  being a documented label value.
- The SDK schemas are left in place — nothing here removes them.

## Testing

```bash
cd apps/backend && uv run pytest ../../tests/backend/services/explorer ../../tests/backend/routes/test_explorer.py ../../tests/backend/routes/test_websocket.py ../../tests/backend/services/garak/test_probes.py
```

New `tests/backend/services/explorer/test_tree.py` covers `TestTreeData` / `TopicTree` directly
(topic derivation, recursive test lookup, `__suggestions__` filtering, rename/move). A route test in
`test_explorer.py` covers the `error` label round-tripping through the API.
