### PR TITLE
Add agent rules for test runs and plain-language answers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,17 @@ Read natively by Cursor and imported by Claude Code (`CLAUDE.md` → `@AGENTS.md
 rules that apply repo-wide. Scoped rules live in each area's own `AGENTS.md`:
 `apps/backend/AGENTS.md`, `apps/frontend/AGENTS.md`, `sdk/AGENTS.md`, `docs/AGENTS.md`.
 
+## Answering
+
+Write answers in simple, plain language. Short sentences, everyday words. Say what you did and what
+it means — skip the buildup.
+
+Technical terms are fine when they're the real name for something: codebase names
+(`bind_scope_to_session`, test set, affordances), everyday dev words (endpoint, migration, fixture,
+race condition), and framework/infra terms (GUC, RLS policy, `ContextVar`, Celery worker). Avoid
+abstract engineering-speak that carries no information — "leverage the abstraction", "surface area",
+"idiomatic", "orthogonal concerns", "non-trivial", "first-class citizen".
+
 ## Technology Stack
 
 Backend and Python SDK: Python 3.10+, `uv` with `pyproject.toml`, Pydantic 2.x, pytest.

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -14,6 +14,10 @@ See root `AGENTS.md` for repo-wide rules (commits, PRs, testing overview, tech s
 
 ## Testing
 
+**Ask the user before running the whole backend suite.** It takes a very long time. Default to the
+narrowest selection that covers the change (single test, class, or file); only run
+`../../tests/backend/` in full once the user says to.
+
 Backend tests must run from `apps/backend` — its `pyproject.toml` sets
 `testpaths = ["../../tests/backend"]` and `pythonpath = ["src"]`, so paths/imports only resolve
 from that directory. Never run `uv run pytest tests/backend/...` from the repo root.
@@ -24,6 +28,10 @@ uv run pytest ../../tests/backend/ -v
 # single test class:
 uv run pytest ../../tests/backend/services/explorer/test_tests.py::TestCreateExplorerTestSet -v
 ```
+
+Backend tests need Docker running (they use a real database). If tests fail with connection or
+container errors, stop and ask the user to start Docker instead of trying to work around it or
+debug the test code.
 
 ## Debugging
 

--- a/sdk/AGENTS.md
+++ b/sdk/AGENTS.md
@@ -29,3 +29,6 @@ docker compose -f ../tests/docker-compose.test.yml --profile sdk logs sdk-test-b
 # run a single test:
 uv run pytest ../tests/sdk/integration/test_entities.py::test_endpoint
 ```
+
+Integration tests need Docker running. If they fail with connection or container errors, stop and
+ask the user to start Docker instead of trying to work around it or debug the test code.


### PR DESCRIPTION
## Purpose

Two recurring annoyances when working with coding agents in this repo:

1. Agents kick off the full backend test suite unprompted, which takes a very long time, and when it
   fails because Docker isn't running they try to debug the test code instead of saying what's wrong.
2. Agent answers are harder to read than they need to be — lots of abstract engineering-speak.

## What Changed

- `AGENTS.md` — new "Answering" section: plain language, short sentences. Real technical names are
  fine (codebase names, common dev words, framework/infra terms); abstract filler like "leverage the
  abstraction" or "non-trivial" is not.
- `apps/backend/AGENTS.md` — ask before running the whole backend suite; default to the narrowest
  selection. Tests need Docker; on connection/container errors, stop and ask the user to start it.
- `sdk/AGENTS.md` — same Docker rule for SDK integration tests.

## Additional Context

- Docs only, no code changes. Applies to Claude Code (via `CLAUDE.md` → `@AGENTS.md`) and Cursor,
  which reads `AGENTS.md` natively.

## Testing

Nothing to run. The scoped files load automatically when an agent reads files in `apps/backend/` or
`sdk/`.
