### PR TITLE
Fix organization_member RLS policy crashing SSO auto-provisioning

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/c5d6e7f8a9b0_fix_organization_member_rls_empty_uuid.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/c5d6e7f8a9b0_fix_organization_member_rls_empty_uuid.py
@@ -1,0 +1,61 @@
+"""Fix organization_member RLS policy crash on empty GUC
+
+The tenant_isolation policy on organization_member (added in
+6c7d8e9f0a1b) casts current_setting('app.current_organization')
+directly to ::uuid.  When no tenant GUC is set (e.g. SSO callback,
+migrations, seeding), the setting defaults to '' and the cast fails
+with ``invalid input syntax for type uuid: ""``.
+
+The hardened policies on role and role_permission (a0b1c2d3e4f5)
+already use NULLIF(..., '')::uuid and a trusted-context escape.
+This migration applies the same pattern to organization_member:
+
+- USING: trusted context (empty GUC) sees all rows; tenant context
+  is scoped to its own org.
+- WITH CHECK: trusted context may write any row; tenant context may
+  only write its own org.
+
+Revision ID: c5d6e7f8a9b0
+Revises: b4b371a45639
+Create Date: 2026-07-30
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "c5d6e7f8a9b0"
+down_revision: Union[str, None] = "b4b371a45639"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS tenant_isolation ON organization_member")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON organization_member
+            USING (
+                NULLIF(current_setting('app.current_organization', true), '') IS NULL
+                OR organization_id = NULLIF(
+                    current_setting('app.current_organization', true), ''
+                )::uuid
+            )
+            WITH CHECK (
+                NULLIF(current_setting('app.current_organization', true), '') IS NULL
+                OR organization_id = NULLIF(
+                    current_setting('app.current_organization', true), ''
+                )::uuid
+            )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS tenant_isolation ON organization_member")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON organization_member
+            USING (organization_id = current_setting('app.current_organization')::uuid)
+        """
+    )


### PR DESCRIPTION
## Purpose

The RLS policy on `organization_member` casts `current_setting('app.current_organization')` directly to `::uuid`. When no tenant GUC is set (SSO callback uses `get_db_session`, not `get_tenant_db_session`), the setting defaults to `''` and the cast fails:

```
psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type uuid: ""
```

This crashes SSO auto-provisioning for new users. `assign_default_org_role` queries `organization_member` to check for an existing row, the RLS policy fires with the empty GUC, and the entire callback 500s.

Existing SSO users are unaffected because they skip the auto-provisioning path (found by email in the org, profile updated, no `organization_member` query).

## What Changed

- New migration replaces the `organization_member` RLS policy with the `NULLIF(..., '')::uuid` pattern already used by `role` and `role_permission` (from `a0b1c2d3e4f5`)
- Empty GUC (trusted context: migrations, SSO callback, seeding) sees all rows
- Non-empty GUC (tenant request) is scoped to its own org

## Additional Context

- Root cause confirmed from production logs (traceback included in the investigation)
- The auto-RLS trigger template (`d4e5f6a7b8c3`) uses the same bare `::uuid` cast for ~14 other tables. Those have the same latent bug but are not triggered by the SSO flow. A follow-up PR should harden those policies too.
- Related: #2295 (await fix), #2296 (catch-all error handling that surfaced this traceback)

## Testing

- SSO login with a new user (auto-provisioned) should complete without error
- Existing user SSO login unaffected
- Run migration up/down to verify policy replacement