### PR TITLE
Fix sidebar collapse toggle crowding the project name

### DIFF
--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -121,7 +121,10 @@ export function Sidebar() {
         justifyContent: 'space-between',
         bgcolor: theme => theme.palette.greyscale.surface1,
         px: collapsed ? '12px' : '26px',
-        py: '30px',
+        // Top padding lives on the scrolling section below, not here, so the
+        // collapse toggle can be pulled up into it without being clipped.
+        pt: 0,
+        pb: '30px',
         transition: 'width 0.2s ease, padding 0.2s ease',
         overflowX: 'hidden',
         boxSizing: 'border-box',
@@ -134,6 +137,7 @@ export function Sidebar() {
           flexDirection: 'column',
           gap: '28px',
           flex: 1,
+          pt: '30px',
           overflowY: 'auto',
           overflowX: 'hidden',
           scrollbarWidth: 'none',
@@ -225,8 +229,11 @@ export function Sidebar() {
                 gap: '8px',
                 flex: 1,
                 minWidth: 0,
-                // Reclaim ~2 characters of width (chevron removed) before ellipsis
-                mr: '-2ch',
+                // The toggle now sits a full icon height above this row, so the
+                // name can run under it. Reclaim most of its footprint but stop
+                // short of the sidebar's right padding — the full 44px pushed
+                // the ellipsis past the edge, where overflowX hid it.
+                mr: '-28px',
                 borderRadius: BORDER_RADIUS.pill,
                 '&:hover': {
                   bgcolor: theme => theme.palette.greyscale.surface2,
@@ -256,9 +263,9 @@ export function Sidebar() {
                 {activeProject && (
                   <Typography
                     sx={{
-                      fontSize: 18,
+                      fontSize: 14,
                       fontWeight: 700,
-                      lineHeight: '25px',
+                      lineHeight: '20px',
                       color: theme => theme.palette.greyscale.title,
                       whiteSpace: 'nowrap',
                       overflow: 'hidden',
@@ -285,8 +292,19 @@ export function Sidebar() {
                 </Typography>
               </Box>
             </ButtonBase>
-            {/* Collapse toggle — inline, right of brand row */}
-            <Box sx={{ alignSelf: 'flex-start', flexShrink: 0 }}>
+            {/* Collapse toggle — inline, right of brand row.
+                -30px = the IconButton's own 6px padding plus a full 24px icon
+                height, lifting the glyph clear of the project name into the
+                section's top padding. -8px right eats into the sidebar's 26px
+                side padding. */}
+            <Box
+              sx={{
+                alignSelf: 'flex-start',
+                flexShrink: 0,
+                mt: '-30px',
+                mr: '-8px',
+              }}
+            >
               <Tooltip title="Collapse sidebar" placement="right">
                 <IconButton
                   onClick={toggle}

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -56,9 +56,19 @@ const LEFT_PANEL_PATH =
   'M8 19V5H5.30775C5.23075 5 5.16025 5.03208 5.09625 5.09625C5.03208 5.16025 5 5.23075 5 5.30775V18.6923C5 18.7692 5.03208 18.8398 5.09625 18.9038C5.16025 18.9679 5.23075 19 5.30775 19H8Z' +
   'M9.5 19H18.6923C18.7692 19 18.8398 18.9679 18.9038 18.9038C18.9679 18.8398 19 18.7692 19 18.6923V5.30775C19 5.23075 18.9679 5.16025 18.9038 5.09625C18.8398 5.03208 18.7692 5 18.6923 5H9.5V19Z';
 
+// Collapse-toggle geometry. TOGGLE_LIFT_PX pulls the expanded toggle out of the
+// brand row by its own full height so it clears the project name — it is derived
+// from the two values below rather than hard-coded, and both are applied to the
+// icon and the button, so the alignment holds if either changes.
+const TOGGLE_ICON_PX = 24;
+const TOGGLE_BUTTON_PADDING_PX = 6;
+const TOGGLE_LIFT_PX = TOGGLE_ICON_PX + TOGGLE_BUTTON_PADDING_PX;
+// Nudge toward the sidebar edge, into its 26px side padding.
+const TOGGLE_NUDGE_RIGHT_PX = 8;
+
 function LeftPanelCloseIcon() {
   return (
-    <SvgIcon viewBox="0 0 24 24">
+    <SvgIcon viewBox="0 0 24 24" sx={{ fontSize: TOGGLE_ICON_PX }}>
       <path d={LEFT_PANEL_PATH} fill="currentColor" />
     </SvgIcon>
   );
@@ -67,7 +77,10 @@ function LeftPanelCloseIcon() {
 function LeftPanelOpenIcon() {
   // Mirror horizontally: arrow now points right, indicating "open left panel"
   return (
-    <SvgIcon viewBox="0 0 24 24" sx={{ transform: 'scaleX(-1)' }}>
+    <SvgIcon
+      viewBox="0 0 24 24"
+      sx={{ fontSize: TOGGLE_ICON_PX, transform: 'scaleX(-1)' }}
+    >
       <path d={LEFT_PANEL_PATH} fill="currentColor" />
     </SvgIcon>
   );
@@ -165,7 +178,7 @@ export function Sidebar() {
                 size="small"
                 aria-label="Expand sidebar"
                 sx={{
-                  p: '6px',
+                  p: `${TOGGLE_BUTTON_PADDING_PX}px`,
                   borderRadius: BORDER_RADIUS.md,
                   color: theme => theme.palette.greyscale.label,
                   '&:hover': {
@@ -292,17 +305,15 @@ export function Sidebar() {
                 </Typography>
               </Box>
             </ButtonBase>
-            {/* Collapse toggle — inline, right of brand row.
-                -30px = the IconButton's own 6px padding plus a full 24px icon
-                height, lifting the glyph clear of the project name into the
-                section's top padding. -8px right eats into the sidebar's 26px
-                side padding. */}
+            {/* Collapse toggle — inline, right of brand row. Lifted a full icon
+                height clear of the project name, into the scrolling section's
+                top padding. */}
             <Box
               sx={{
                 alignSelf: 'flex-start',
                 flexShrink: 0,
-                mt: '-30px',
-                mr: '-8px',
+                mt: `-${TOGGLE_LIFT_PX}px`,
+                mr: `-${TOGGLE_NUDGE_RIGHT_PX}px`,
               }}
             >
               <Tooltip title="Collapse sidebar" placement="right">
@@ -311,7 +322,7 @@ export function Sidebar() {
                   size="small"
                   aria-label="Collapse sidebar"
                   sx={{
-                    p: '6px',
+                    p: `${TOGGLE_BUTTON_PADDING_PX}px`,
                     borderRadius: BORDER_RADIUS.md,
                     color: theme => theme.palette.greyscale.label,
                     '&:hover': {


### PR DESCRIPTION
## Purpose

In the expanded sidebar the collapse toggle sat inline beside the project name, crowding it and forcing long names to ellipsis early — "Travel Agent" truncated to "Travel Ag…" with visible space left over.

## What Changed

- Lift the collapse toggle a full icon height (`mt: -30px` — 6px button padding + 24px glyph) above the brand row and nudge it 8px toward the sidebar edge, clear of the project name.
- Move the sidebar's 30px top padding from the outer container onto the scrolling section below it. The toggle previously sat flush against the top of a `overflowY: auto` container with zero headroom, so pulling it up would have clipped the glyph; as padding on the scroll container, that 30px becomes visible space the toggle can occupy.
- Project name drops from 18px/25px to 14px/20px.
- Brand block reclaims 28px of the toggle's former footprint (`mr: -2ch` → `-28px`) so the name truncates later. Stops short of the full 44px, which pushed the ellipsis past the sidebar edge where `overflowX: hidden` cut it off.

## Additional Context

- Expanded state only — the collapsed rail lays the toggle and logo out vertically and is untouched.
- No behaviour change: same click target, tooltip, and `aria-label`.

## Testing

Manual, in local dev (`./rh dev up` + `./rh dev backend` + `./rh dev frontend`):

1. Open any page with a project selected and confirm the toggle sits above the project name, near the right edge, with the full `…` visible on a long name.
2. Collapse and expand the sidebar — the rail layout and the toggle's return position should be unchanged.
3. Check both light and dark mode; the toggle uses `greyscale.label` with a `surface2` hover, unchanged.

`npx tsc --noEmit` and `npm run lint` pass (lint's 6 warnings are pre-existing in `ee/frontend`); Prettier clean.
