### PR TITLE
Deduplicate Explorer metric aggregation and eligibility filtering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,9 @@ requirements).
 
 ## Git Commits
 
+- **Never commit, push, or open a PR without asking first.** Show what changed, then wait for the
+  user to say go. An approved plan that mentions commits is not the confirmation — ask again when
+  the code is actually ready.
 - **Never commit on `main`.** Check `git branch --show-current` first; if on `main`, create a
   branch before committing: `git fetch origin && git checkout main && git pull origin main &&
 git checkout -b feature/short-description`.

--- a/apps/backend/src/rhesis/backend/app/services/explorer/evaluation.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/evaluation.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
@@ -45,6 +46,61 @@ def build_metrics_summary_for_response(
             row["details"] = det
         out[name] = row
     return out
+
+
+@dataclass(frozen=True)
+class MetricVerdict:
+    """Aggregated outcome of running several metrics on one (input, output) pair."""
+
+    label: str
+    labeler: str
+    model_score: float
+    metrics: Optional[Dict[str, Dict[str, Any]]] = None
+    # Raw valid per-metric results, kept for callers that need a per-metric breakdown.
+    per_metric: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
+    @classmethod
+    def unlabeled(cls) -> "MetricVerdict":
+        """Nothing was evaluated — no output, or no usable metric result."""
+        return cls(label="", labeler="", model_score=0.0)
+
+    @classmethod
+    def error(cls, metric_names: List[str]) -> "MetricVerdict":
+        """Evaluation raised."""
+        return cls(label="error", labeler=", ".join(metric_names), model_score=0.0)
+
+    def as_payload(self) -> Dict[str, Any]:
+        """The four fields every caller writes, whether to an event or to ``test_metadata``."""
+        return {
+            "label": self.label,
+            "labeler": self.labeler,
+            "model_score": self.model_score,
+            "metrics": self.metrics,
+        }
+
+
+def aggregate_metric_verdict(
+    metric_results: Dict[str, Any],
+    metric_names: List[str],
+) -> Optional[MetricVerdict]:
+    """Aggregate raw per-metric results into one verdict.
+
+    Passes only when every metric passed; the score is the mean across metrics. Returns
+    ``None`` when no result is usable, which every caller treats as "no metric results".
+    """
+    valid = {k: v for k, v in metric_results.items() if isinstance(v, dict)}
+    if not valid:
+        return None
+
+    scores = [v.get("score", 0.0) for v in valid.values()]
+    all_passed = all(v.get("is_successful", False) for v in valid.values())
+    return MetricVerdict(
+        label="pass" if all_passed else "fail",
+        labeler=", ".join(metric_names),
+        model_score=sum(scores) / len(scores) if scores else 0.0,
+        metrics=build_metrics_summary_for_response(valid),
+        per_metric=valid,
+    )
 
 
 def _resolve_sdk_metrics(
@@ -271,9 +327,8 @@ async def evaluate_tests_for_explorer_set(
         try:
             metric_results = await _run_metrics_on_text(sdk_metrics, input_text, output_text)
 
-            valid = {k: v for k, v in metric_results.items() if isinstance(v, dict)}
-
-            if not valid:
+            verdict = aggregate_metric_verdict(metric_results, metric_names)
+            if verdict is None:
                 logger.warning(f"No valid metric results for test {test_id_str}")
                 return {
                     "status": "failed",
@@ -281,18 +336,8 @@ async def evaluate_tests_for_explorer_set(
                     "error": "no metric results",
                 }
 
-            all_passed = all(v.get("is_successful", False) for v in valid.values())
-            agg_label = "pass" if all_passed else "fail"
-            agg_labeler = ", ".join(metric_names)
-            scores = [v.get("score", 0.0) for v in valid.values()]
-            agg_score = sum(scores) / len(scores) if scores else 0.0
-            metrics_summary = build_metrics_summary_for_response(valid)
-
             meta = dict(test.test_metadata or {})
-            meta["label"] = agg_label
-            meta["labeler"] = agg_labeler
-            meta["model_score"] = agg_score
-            meta["metrics"] = metrics_summary
+            meta.update(verdict.as_payload())
             if len(sdk_metrics) > 1:
                 meta["evaluation"] = [
                     {
@@ -300,7 +345,7 @@ async def evaluate_tests_for_explorer_set(
                         "labeler": key,
                         "model_score": r.get("score", 0.0),
                     }
-                    for key, r in valid.items()
+                    for key, r in verdict.per_metric.items()
                 ]
             elif "evaluation" in meta:
                 del meta["evaluation"]
@@ -309,10 +354,7 @@ async def evaluate_tests_for_explorer_set(
             return {
                 "status": "ok",
                 "test_id": test_id_str,
-                "label": agg_label,
-                "labeler": agg_labeler,
-                "model_score": agg_score,
-                "metrics": metrics_summary,
+                **verdict.as_payload(),
             }
 
         except Exception as e:
@@ -321,10 +363,8 @@ async def evaluate_tests_for_explorer_set(
                 exc_info=True,
             )
             meta = dict(test.test_metadata or {})
-            meta["label"] = "error"
-            meta["labeler"] = ", ".join(metric_names)
-            meta["model_score"] = 0.0
-            meta.pop("metrics", None)
+            meta.update(MetricVerdict.error(metric_names).as_payload())
+            meta.pop("metrics", None)  # absent, not null — matches what readers expect
             test.test_metadata = meta
             return {
                 "status": "failed",

--- a/apps/backend/src/rhesis/backend/app/services/explorer/responses.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/responses.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
 
-from .utils import _get_test_set_tests_from_db
+from .utils import _build_eligible_tests, _get_test_set_tests_from_db
 
 logger = logging.getLogger(__name__)
 
@@ -78,32 +78,13 @@ async def generate_outputs_for_tests(
 
     tests = _get_test_set_tests_from_db(db, db_test_set.id, organization_id, user_id)
 
-    # Exclude topic markers; only tests with prompt content
+    # Skip tests that already have an output unless overwriting
     eligible = []
     skipped = 0
-    for t in tests:
-        meta = t.test_metadata or {}
-        if meta.get("label") == "topic_marker":
-            continue
-        if not t.prompt or not (t.prompt.content or "").strip():
-            continue
-        if test_ids is not None and t.id not in test_ids:
-            continue
-        # Filter by topic when provided
-        if topic is not None and topic != "":
-            t_topic = (t.topic.name if t.topic and hasattr(t.topic, "name") else "") or ""
-            if include_subtopics:
-                if t_topic != topic and not t_topic.startswith(topic + "/"):
-                    continue
-            else:
-                if t_topic != topic:
-                    continue
-
-        # Filter out tests that already have an output if overwrite is False
-        if not overwrite and meta.get("output", "").strip():
+    for t in _build_eligible_tests(tests, test_ids, topic, include_subtopics):
+        if not overwrite and (t.test_metadata or {}).get("output", "").strip():
             skipped += 1
             continue
-
         eligible.append(t)
 
     updated: List[Dict[str, str]] = []

--- a/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
@@ -13,9 +13,10 @@ from rhesis.backend.app import crud
 
 from .evaluation import (
     _EVAL_MAX_CONCURRENCY,
+    MetricVerdict,
     _resolve_sdk_metrics,
     _run_metrics_on_text,
-    build_metrics_summary_for_response,
+    aggregate_metric_verdict,
 )
 from .utils import _build_eligible_tests, _get_test_set_tests_from_db
 
@@ -473,39 +474,26 @@ async def suggestion_pipeline_stream(
                     input_text,
                     output_text,
                 )
-                valid = {k: v for k, v in metric_results.items() if isinstance(v, dict)}
-                if not valid:
+                verdict = aggregate_metric_verdict(metric_results, metric_names)
+                if verdict is None:
                     await event_queue.put(
                         {
                             "type": "evaluation",
                             "index": index,
                             "input": input_text,
-                            "label": "",
-                            "labeler": "",
-                            "model_score": 0.0,
-                            "metrics": None,
+                            **MetricVerdict.unlabeled().as_payload(),
                             "error": "no metric results",
                         }
                     )
                     evals_failed += 1
                     return
 
-                all_passed = all(v.get("is_successful", False) for v in valid.values())
-                label = "pass" if all_passed else "fail"
-                labeler = ", ".join(metric_names)
-                scores = [v.get("score", 0.0) for v in valid.values()]
-                score = sum(scores) / len(scores) if scores else 0.0
-                metrics_summary = build_metrics_summary_for_response(valid)
-
                 await event_queue.put(
                     {
                         "type": "evaluation",
                         "index": index,
                         "input": input_text,
-                        "label": label,
-                        "labeler": labeler,
-                        "model_score": score,
-                        "metrics": metrics_summary,
+                        **verdict.as_payload(),
                         "error": None,
                     }
                 )
@@ -517,10 +505,7 @@ async def suggestion_pipeline_stream(
                         "type": "evaluation",
                         "index": index,
                         "input": input_text,
-                        "label": "error",
-                        "labeler": ", ".join(metric_names),
-                        "model_score": 0.0,
-                        "metrics": None,
+                        **MetricVerdict.error(metric_names).as_payload(),
                         "error": str(e),
                     }
                 )
@@ -793,10 +778,7 @@ async def evaluate_suggestions_stream(
                 index,
                 {
                     "input": input_text,
-                    "label": "",
-                    "labeler": "",
-                    "model_score": 0.0,
-                    "metrics": None,
+                    **MetricVerdict.unlabeled().as_payload(),
                     "error": "no output to evaluate",
                 },
             )
@@ -804,36 +786,22 @@ async def evaluate_suggestions_stream(
         try:
             metric_results = await _run_metrics_on_text(sdk_metrics, input_text, output_text)
 
-            valid = {k: v for k, v in metric_results.items() if isinstance(v, dict)}
-
-            if not valid:
+            verdict = aggregate_metric_verdict(metric_results, metric_names)
+            if verdict is None:
                 return (
                     index,
                     {
                         "input": input_text,
-                        "label": "",
-                        "labeler": "",
-                        "model_score": 0.0,
-                        "metrics": None,
+                        **MetricVerdict.unlabeled().as_payload(),
                         "error": "no metric results",
                     },
                 )
-
-            all_passed = all(v.get("is_successful", False) for v in valid.values())
-            label = "pass" if all_passed else "fail"
-            labeler = ", ".join(metric_names)
-            scores = [v.get("score", 0.0) for v in valid.values()]
-            score = sum(scores) / len(scores) if scores else 0.0
-            metrics_summary = build_metrics_summary_for_response(valid)
 
             return (
                 index,
                 {
                     "input": input_text,
-                    "label": label,
-                    "labeler": labeler,
-                    "model_score": score,
-                    "metrics": metrics_summary,
+                    **verdict.as_payload(),
                     "error": None,
                 },
             )
@@ -846,10 +814,7 @@ async def evaluate_suggestions_stream(
                 index,
                 {
                     "input": input_text,
-                    "label": "error",
-                    "labeler": ", ".join(metric_names),
-                    "model_score": 0.0,
-                    "metrics": None,
+                    **MetricVerdict.error(metric_names).as_payload(),
                     "error": str(e),
                 },
             )

--- a/tests/backend/services/explorer/test_evaluation.py
+++ b/tests/backend/services/explorer/test_evaluation.py
@@ -10,6 +10,10 @@ from rhesis.backend.app.services.explorer import (
     get_tree_nodes,
     get_tree_tests,
 )
+from rhesis.backend.app.services.explorer.evaluation import (
+    MetricVerdict,
+    aggregate_metric_verdict,
+)
 
 _FACTORY_PATCH = "rhesis.sdk.metrics.factory.MetricFactory.create"
 _RUN_METRICS_PATCH = "rhesis.backend.app.services.explorer.evaluation._run_metrics_on_text"
@@ -34,6 +38,115 @@ def _mock_evaluator_result(metric_name, label, score):
     """Build a MetricEvaluator.evaluate()-shaped return dict."""
     is_successful = label == "pass"
     return {metric_name: {"score": score, "is_successful": is_successful}}
+
+
+@pytest.mark.unit
+class TestMetricVerdict:
+    """Test aggregate_metric_verdict and the MetricVerdict constructors."""
+
+    def test_all_metrics_passing_gives_pass(self):
+        results = {
+            "A": {"score": 1.0, "is_successful": True},
+            "B": {"score": 0.8, "is_successful": True},
+        }
+        verdict = aggregate_metric_verdict(results, ["A", "B"])
+
+        assert verdict is not None
+        assert verdict.label == "pass"
+
+    def test_any_metric_failing_gives_fail(self):
+        results = {
+            "A": {"score": 1.0, "is_successful": True},
+            "B": {"score": 0.2, "is_successful": False},
+        }
+        verdict = aggregate_metric_verdict(results, ["A", "B"])
+
+        assert verdict is not None
+        assert verdict.label == "fail"
+
+    def test_missing_is_successful_counts_as_failure(self):
+        verdict = aggregate_metric_verdict({"A": {"score": 1.0}}, ["A"])
+
+        assert verdict is not None
+        assert verdict.label == "fail"
+
+    def test_model_score_is_the_mean(self):
+        results = {
+            "A": {"score": 1.0, "is_successful": True},
+            "B": {"score": 0.5, "is_successful": True},
+        }
+        verdict = aggregate_metric_verdict(results, ["A", "B"])
+
+        assert verdict is not None
+        assert verdict.model_score == pytest.approx(0.75)
+
+    def test_missing_scores_default_to_zero(self):
+        verdict = aggregate_metric_verdict({"A": {"is_successful": True}}, ["A"])
+
+        assert verdict is not None
+        assert verdict.model_score == 0.0
+
+    def test_labeler_joins_metric_names_in_order(self):
+        results = {"A": {"score": 1.0, "is_successful": True}}
+        verdict = aggregate_metric_verdict(results, ["First", "Second"])
+
+        assert verdict is not None
+        assert verdict.labeler == "First, Second"
+
+    def test_non_dict_results_are_ignored(self):
+        results = {
+            "A": {"score": 0.4, "is_successful": True},
+            "B": "boom",
+            "C": None,
+        }
+        verdict = aggregate_metric_verdict(results, ["A", "B", "C"])
+
+        assert verdict is not None
+        assert verdict.label == "pass"
+        assert verdict.model_score == pytest.approx(0.4)
+        assert set(verdict.per_metric) == {"A"}
+        assert set(verdict.metrics or {}) == {"A"}
+
+    def test_no_usable_results_returns_none(self):
+        assert aggregate_metric_verdict({}, ["A"]) is None
+        assert aggregate_metric_verdict({"A": "boom", "B": None}, ["A", "B"]) is None
+
+    def test_metrics_summary_carries_score_and_reason(self):
+        results = {"A": {"score": 0.9, "is_successful": True, "reason": "looks fine"}}
+        verdict = aggregate_metric_verdict(results, ["A"])
+
+        assert verdict is not None
+        assert verdict.metrics == {
+            "A": {"score": 0.9, "is_successful": True, "reason": "looks fine"}
+        }
+
+    def test_unlabeled_verdict(self):
+        verdict = MetricVerdict.unlabeled()
+
+        assert verdict.as_payload() == {
+            "label": "",
+            "labeler": "",
+            "model_score": 0.0,
+            "metrics": None,
+        }
+        assert verdict.per_metric == {}
+
+    def test_error_verdict_names_the_metrics(self):
+        verdict = MetricVerdict.error(["A", "B"])
+
+        assert verdict.as_payload() == {
+            "label": "error",
+            "labeler": "A, B",
+            "model_score": 0.0,
+            "metrics": None,
+        }
+
+    def test_as_payload_exposes_only_the_four_written_fields(self):
+        results = {"A": {"score": 1.0, "is_successful": True}}
+        verdict = aggregate_metric_verdict(results, ["A"])
+
+        assert verdict is not None
+        assert set(verdict.as_payload()) == {"label", "labeler", "model_score", "metrics"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose

Roadmap item 2.6, bullets 1 and 3 (`playground/explorer-roadmap.md`). Two blocks of copy-pasted
logic in `services/explorer/` that Phase 3 will have to rewrite — every copy is one more place to
edit and one more place to get it wrong.

Pure refactor: no behaviour change, no schema change, no API change.

## What Changed

**Metric aggregation.** The same six lines turning raw per-metric results into one
label/labeler/score/summary appeared verbatim in `evaluation.py` and twice in `suggestions.py`, with
the "no metric results" and "error" fallback payloads duplicated alongside them. Adds
`MetricVerdict` + `aggregate_metric_verdict` next to the metric helpers that already live in
`evaluation.py`, and routes all three sites through them.

`MetricVerdict.per_metric` exists because `evaluate_tests_for_explorer_set` needs the filtered
results to build its multi-metric `evaluation` list. That list is built at one site, so it stays
inline there.

**Eligibility filtering.** `generate_outputs_for_tests` re-implemented `_build_eligible_tests`
line for line (topic-marker skip, empty-prompt skip, `test_ids`, `topic` ± `include_subtopics`),
then added its own `overwrite` tail. Now calls the shared helper. The overwrite/skip loop stays
inline — `evaluation.py`'s equivalent gates on a different metadata key (`label` vs `output`).

**Two behaviour details deliberately preserved:**

- `test_metadata["metrics"]` stays *absent*, not null, on the error path. `as_payload()` would store
  an explicit null, so the `pop` is kept after the `update`.
- NDJSON key order shifts in the two suggestion streams, since the four fields now arrive via a
  spread. Consumers read by key, so this is cosmetic.

## Additional Context

- No router or `crud.py` changes. `routers/explorer.py` has no SQL and reads exactly the keys this
  preserves, so it needed no edit. The 13 hand-rolled DB queries still in the service layer are
  roadmap 2.2's job, deliberately left alone.
- Naming avoids the still-unsettled *explorer* vs *adaptive* vocabulary question (roadmap 2.1).
- Coverage gap worth knowing: only one of the three aggregation sites had any test.
  `evaluate_tests_for_explorer_set` is covered by `test_evaluation.py` and the `/evaluate` route
  tests, but **neither `suggestions.py` site is exercised by any test** — there is no
  `test_suggestions.py`. Hence the new unit tests for the helper itself.

## Testing

New `TestMetricVerdict` unit tests cover all-pass/any-fail, mean score, missing `score` and
`is_successful`, non-dict results filtered out, all-invalid returning `None`, labeler ordering, and
the `unlabeled()`/`error()`/`as_payload()` shapes.

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/explorer/ ../../tests/backend/routes/test_explorer.py -q
```

245 passed locally. `test_responses.py` and the existing `test_evaluation.py` classes pass
untouched, which is the point of running them.

Not covered by any test: the two suggestion streams. Worth a manual check — open an Explorer
session, run Suggestions with metrics configured, confirm rows come back with label/score populated
and a failing metric still renders.