### PR TITLE
Fix docs Docker build broken by deleted theme.config.jsx

### DIFF
--- a/docs/src/Dockerfile
+++ b/docs/src/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 
 # Copy source files needed for build
-COPY src/package.json src/package-lock.json src/next.config.mjs src/mdx-components.js src/theme.config.jsx ./
+COPY src/package.json src/package-lock.json src/next.config.mjs src/mdx-components.js ./
 COPY src/public ./public
 COPY src/app ./app
 COPY src/components ./components
@@ -67,7 +67,7 @@ RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
 # Copy package files
-COPY src/package.json src/package-lock.json src/next.config.mjs src/mdx-components.js src/theme.config.jsx ./
+COPY src/package.json src/package-lock.json src/next.config.mjs src/mdx-components.js ./
 
 COPY --from=builder  /app/public ./public
 


### PR DESCRIPTION
## Purpose

The docs deploy has been failing on `main` since #2293 merged (`f8538e807`), and on every commit
since. That PR deleted `docs/src/theme.config.jsx` as dead code — nothing has imported it since the
Nextra 4 app-router migration — but the Dockerfile still `COPY`s it by name, so the image build
cannot resolve it:

```
ERROR: failed to compute cache key:
  failed to calculate checksum of ref ...: "/src/theme.config.jsx": not found
```

This is my regression from #2293 and it blocks the docs deploy.

## What Changed

Removed `src/theme.config.jsx` from the two `COPY` lines in `docs/src/Dockerfile` — the builder stage
(line 29) and the runner stage (line 70). Nothing else.

## Additional Context

Why CI didn't catch it: the deploy job is `SKIPPED` on pull requests, so the Docker build only runs
after merge. On my side I verified `make lint` and `npm run build`, neither of which reads the
Dockerfile — the gap was mine.

The other files #2293 deleted are safe: `GitHubStarBanner.jsx` and `ThemeAwareLogo.jsx` live under
`src/components`, and the removed TTF directories under `src/public`, both of which are copied
wholesale rather than by name. I checked every explicitly named `COPY` source in the Dockerfile
resolves on disk, so there is no second instance of this waiting.

A matching fix is needed on `release/v0.11.0`; I'm applying it to the backport PR (#2303) as well.

## Testing

This time I built the image rather than relying on `next build`:

- `docker build -f src/Dockerfile .` — exit 0
- Ran the container and hit it: `GET /docs` → 200, no errors in the container log
- Confirmed the served HTML carries the new design — `rhesis-footer`, `rhesis-navlogo`,
  `rhesis-backdrop`, and the "Structured feedback and evals for AI agents" copy — and that no banner
  element renders (the `nextra-banner` string in the HTML is only inside Nextra's own conditional
  selectors, not a rendered div)