### PR TITLE
Fix docs Docker build broken by deleted theme.config.jsx (v0.11.0)

### DIFF
--- a/docs/src/Dockerfile
+++ b/docs/src/Dockerfile
@@ -26,7 +26,7 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 
 # Copy source files needed for build
-COPY src/package.json src/package-lock.json src/next.config.mjs src/mdx-components.js src/theme.config.jsx ./
+COPY src/package.json src/package-lock.json src/next.config.mjs src/mdx-components.js ./
 COPY src/public ./public
 COPY src/app ./app
 COPY src/components ./components
@@ -67,7 +67,7 @@ RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
 # Copy package files
-COPY src/package.json src/package-lock.json src/next.config.mjs src/mdx-components.js src/theme.config.jsx ./
+COPY src/package.json src/package-lock.json src/next.config.mjs src/mdx-components.js ./
 
 COPY --from=builder  /app/public ./public
 


### PR DESCRIPTION
## Purpose

Same fix as #2305, for the `v0.11.0` release branch.

The backport (#2303) carried over the `theme.config.jsx` deletion from #2293, but the Dockerfile on
this branch still `COPY`s that file by name, so the docs image build fails:

```
ERROR: failed to compute cache key:
  failed to calculate checksum of ref ...: "/src/theme.config.jsx": not found
```

The docs deploy on `release/v0.11.0` has already failed once on `77268ef22`. #2303 was merged before
this was caught, so it needs a follow-up rather than an amend.

## What Changed

Cherry-pick of `1d80b2a29` from #2305: removes `src/theme.config.jsx` from the two `COPY` lines in
`docs/src/Dockerfile` (builder stage line 29, runner stage line 70). Nothing else.

## Additional Context

`theme.config.jsx` was dead code — nothing has imported it since the Nextra 4 app-router migration —
so only the Dockerfile reference needed removing, not the deletion reverted.

The other files #2293/#2303 deleted are safe: `GitHubStarBanner.jsx` and `ThemeAwareLogo.jsx` sit
under `src/components`, and the removed TTF directories under `src/public`; both are copied wholesale
rather than by name.

Merge order does not matter — #2305 and this PR touch different branches and don't interact.

## Testing

Verified on this branch, not inherited from #2305:

- Every explicitly named `COPY` source in the Dockerfile resolves on disk
- `docker build -f src/Dockerfile .` — exit 0
- Ran the container: `GET /docs` → 200, no errors in the container log, and the served HTML carries
  `rhesis-footer`, `rhesis-navlogo`, `rhesis-backdrop`, and the "Structured feedback and evals for AI
  agents" copy