### PR TITLE
Fix flaky type lookup long values test

### DIFF
--- a/tests/backend/routes/fixtures/data_factories.py
+++ b/tests/backend/routes/fixtures/data_factories.py
@@ -1891,7 +1891,7 @@ class TypeLookupDataFactory(BaseDataFactory):
         elif case_type == "long_values":
             return {
                 "type_name": f"long_type_{fake.word()}",
-                "type_value": fake.text(max_nb_chars=200).replace("\n", " "),
+                "type_value": f"long_value_{'x' * 150}_{fake.word()}",
                 "description": fake.paragraph(nb_sentences=3),
             }
         elif case_type == "special_characters":


### PR DESCRIPTION
## Purpose

Fix intermittently failing test `test_create_type_lookup_with_long_values`.

## What Changed

- Replaced `fake.text(max_nb_chars=200)` with a deterministic string in `TypeLookupDataFactory.edge_case_data("long_values")`. `fake.text()` only guarantees an upper bound on length, so it can produce strings under 100 characters, failing the `assert len(...) > 100` check.

## Additional Context

- Failed run: https://github.com/rhesis-ai/rhesis/actions/runs/30538835584/job/90858515116
- Error: `AssertionError: assert 93 > 100` (Faker generated a 93-char string)

## Testing

The fix is deterministic. The generated string is always 160+ characters.