### PR TITLE
Add throwaway workflow to test ArgoCD revision pinning

### DIFF
--- a/.github/workflows/test-promote-stg-config.yml
+++ b/.github/workflows/test-promote-stg-config.yml
@@ -1,0 +1,61 @@
+name: "[TEST] Promote stg-base config (throwaway)"
+
+# TEMPORARY workflow to validate the prd promotion-gate mechanism (pin targetRevision
+# to a commit SHA, then move it via `argocd app set --revision`) against stg before
+# trusting it in prd. Mirrors the `promote-prd-config` job in publish-release.yml,
+# targeting stg-base instead. Delete this file (and revert kubernetes/clusters/stg/base.yaml)
+# once the test is confirmed.
+
+on:
+  workflow_dispatch:
+    inputs:
+      revision:
+        description: 'Commit SHA to pin stg-base to (default: this run''s commit)'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  promote-stg-config:
+    runs-on: arc-runner-stg
+    permissions:
+      contents: none
+    steps:
+      - name: Resolve revision
+        id: resolve-revision
+        run: |
+          REVISION="${{ inputs.revision }}"
+          if [ -z "$REVISION" ]; then
+            REVISION="$GITHUB_SHA"
+          fi
+          echo "revision=$REVISION" >> "$GITHUB_OUTPUT"
+          echo "Pinning stg-base to: $REVISION"
+
+      - name: Install ArgoCD CLI
+        run: |
+          ARGOCD_VERSION="v2.14.4"
+          ARGOCD_SHA256="ed774771701f8e5a9330918e4f905f2f171e2181906aec792c9ff6907a4c480f"
+          mkdir -p "$HOME/bin"
+          curl -sSL -o "$HOME/bin/argocd" \
+            "https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-amd64"
+          echo "${ARGOCD_SHA256}  $HOME/bin/argocd" | sha256sum -c -
+          chmod +x "$HOME/bin/argocd"
+          echo "$HOME/bin" >> "$GITHUB_PATH"
+
+      - name: Pin stg-base to the resolved commit and sync
+        env:
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER_STG }}
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN_STG }}
+          REVISION: ${{ steps.resolve-revision.outputs.revision }}
+        run: |
+          argocd app set stg-base --revision "$REVISION" \
+            --server "$ARGOCD_SERVER" --auth-token "$ARGOCD_AUTH_TOKEN" --grpc-web
+          argocd app sync stg-base \
+            --server "$ARGOCD_SERVER" --auth-token "$ARGOCD_AUTH_TOKEN" --grpc-web --timeout 300
+
+      - name: Show resulting app state
+        env:
+          ARGOCD_SERVER: ${{ secrets.ARGOCD_SERVER_STG }}
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_AUTH_TOKEN_STG }}
+        run: |
+          argocd app get stg-base --server "$ARGOCD_SERVER" --auth-token "$ARGOCD_AUTH_TOKEN" --grpc-web


### PR DESCRIPTION
## Purpose

Preparation for the prd promotion-gate fix in `feat/argocd-prd-promotion-gate`.
`workflow_dispatch` only fires for workflow files present on the default
branch, so this needs to land on `main` before it can be run — even though
it's just test tooling.

## What Changed

- Add `.github/workflows/test-promote-stg-config.yml`: manual-dispatch-only,
  pins `stg-base`'s ArgoCD `targetRevision` to a given (or current) commit SHA
  and syncs. No push/schedule trigger — inert until someone runs it.

## Additional Context

- This validates the mechanism behind the prd fix (pin `targetRevision` to a
  commit instead of a release branch, to avoid dangling refs after
  `delete_branch_on_merge`) against stg before trusting it in prd.
- This file will be removed in a follow-up PR once testing is done, and
  `stg-base`'s live ArgoCD tracking will be reset back to `main`.

## Testing

Manual — will be run via `gh workflow run test-promote-stg-config.yml --ref main`
after merge to confirm ArgoCD's `stg-base` app can be re-pointed to a pinned
commit and back.