### PR TITLE
Test: harmless annotation to verify stg promotion pin holds

### DIFF
--- a/kubernetes/clusters/stg/rhesis/namespace.yaml
+++ b/kubernetes/clusters/stg/rhesis/namespace.yaml
@@ -6,3 +6,4 @@ metadata:
   name: rhesis
   annotations:
     argocd.argoproj.io/sync-wave: "0"
+    rhesis.ai/promotion-gate-test: "should-not-auto-deploy"


### PR DESCRIPTION
## Purpose

Verification step for the prd promotion-gate fix (`feat/argocd-prd-promotion-gate`).
`stg-base` is currently pinned to a fixed commit SHA (via the throwaway
`test-promote-stg-config.yml` workflow) to test the pin-by-commit mechanism.

## What Changed

- Add a harmless annotation (`rhesis.ai/promotion-gate-test`) to the `rhesis`
  Namespace in `kubernetes/clusters/stg/rhesis/namespace.yaml`.

## Additional Context

Expected: after this merges to `main`, `stg-base` in ArgoCD should **stay
Synced at its currently-pinned commit** and NOT pick up this change — proving
that pinning `targetRevision` to a commit (instead of tracking `main`) stops
unrelated merges from auto-deploying to an environment. We'll then manually
re-run the test workflow to explicitly promote stg to this new commit and
confirm the annotation *does* land once promoted.

This annotation and the test workflow will both be reverted/removed once
validated.

## Testing

Manual, via ArgoCD UI/CLI — see PR #2310 and the parent branch for context.