### PR TITLE
Move Explorer read queries into crud/explorer.py

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/crud/__init__.py
@@ -683,41 +683,6 @@ def get_test_sets(
     return query_builder.all()
 
 
-def get_explorer_test_sets(
-    db: Session,
-    organization_id: str,
-    skip: int = 0,
-    limit: int = 100,
-    sort_by: str = "created_at",
-    sort_order: str = "desc",
-) -> List[models.TestSet]:
-    """
-    Get Explorer test sets -- the inverse of get_test_sets' exclusion clause.
-
-    Eager-loads what TestSetDetail serializes, since GET /explorer/ returns that schema.
-    """
-    explorer_marker = cast([ADAPTIVE_TESTING_BEHAVIOR], JSONB)
-
-    def only_explorer_test_sets(query):
-        return query.filter(
-            models.TestSet.attributes["metadata"]["behaviors"].contains(explorer_marker)
-        )
-
-    # Paginated outside the builder on purpose: with_pagination caps limit at 100
-    # (validate_pagination) and this endpoint has never capped. with_sorting already
-    # appends id ASC as a tiebreaker, so pagination stays stable.
-    query = (
-        QueryBuilder(db, models.TestSet)
-        .with_related(*_TEST_SET_RELATED_FIELDS)
-        .with_default_derived_field_loads()
-        .with_organization_filter(organization_id)
-        .with_custom_filter(only_explorer_test_sets)
-        .with_sorting(sort_by, sort_order)
-        .build()
-    )
-    return query.offset(skip).limit(limit).all()
-
-
 def create_test_set(
     db: Session, test_set: schemas.TestSetCreate, organization_id: str = None, user_id: str = None
 ) -> models.TestSet:
@@ -742,24 +707,6 @@ def delete_test_set(
     return delete_item(
         db, models.TestSet, test_set_id, organization_id=organization_id, user_id=user_id
     )
-
-
-def get_test_ids_in_test_sets(
-    db: Session, test_set_ids: List[uuid.UUID], organization_id: str
-) -> List[uuid.UUID]:
-    """Distinct ids of the tests associated with any of the given test sets."""
-    if not test_set_ids:
-        return []
-
-    rows = db.execute(
-        select(test_test_set_association.c.test_id)
-        .where(
-            test_test_set_association.c.test_set_id.in_(test_set_ids),
-            test_test_set_association.c.organization_id == organization_id,
-        )
-        .distinct()
-    ).fetchall()
-    return [row.test_id for row in rows]
 
 
 def get_test_set_by_nano_id_or_slug(

--- a/apps/backend/src/rhesis/backend/app/crud/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/crud/explorer.py
@@ -3,16 +3,287 @@
 Part of the incremental split of the ``crud`` monolith: ``crud/__init__.py`` still holds
 the bulk of the functions, and per-entity modules like this one take over as the code
 around them is touched.
+
+Every function here flushes and never commits -- the request session owns the commit
+(see ``get_db_with_tenant_variables`` in ``database.py``).
 """
 
 import logging
-from typing import Dict, List
+import uuid
+from typing import Dict, List, Optional
 
-from sqlalchemy.orm import Session
+from sqlalchemy import cast, select
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Session, contains_eager, joinedload
 
 from rhesis.backend.app import models
+from rhesis.backend.app.constants import ADAPTIVE_TESTING_BEHAVIOR
+
+# _TEST_SET_RELATED_FIELDS is imported rather than relocated: three other functions in
+# the monolith use the same tuple, and moving it would mean deciding a new home for a
+# TestSet-wide constant while this module only owns the Explorer slice.
+# crud/__init__.py never imports this module, so the parent-package import is cycle-free.
+from rhesis.backend.app.crud import _TEST_SET_RELATED_FIELDS
+from rhesis.backend.app.models.enums import ModelType
+from rhesis.backend.app.models.test import test_test_set_association
+from rhesis.backend.app.utils.query_utils import QueryBuilder, include
 
 logger = logging.getLogger(__name__)
+
+
+# --- Test sets ---------------------------------------------------------------------
+
+
+def get_explorer_test_sets(
+    db: Session,
+    organization_id: str,
+    skip: int = 0,
+    limit: int = 100,
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
+) -> List[models.TestSet]:
+    """Get Explorer test sets -- the inverse of ``get_test_sets``' exclusion clause.
+
+    Eager-loads what ``TestSetDetail`` serializes, since ``GET /explorer/`` returns
+    that schema.
+
+    Parameters
+    ----------
+    db : Session
+        Database session
+    organization_id : str
+        Organization ID for tenant isolation
+    skip : int
+        Number of records to skip (pagination offset)
+    limit : int
+        Maximum number of records to return
+    sort_by : str
+        Field to sort by
+    sort_order : str
+        Sort direction ('asc' or 'desc')
+
+    Returns
+    -------
+    list of models.TestSet
+        Test sets carrying the Adaptive Testing behavior.
+    """
+    explorer_marker = cast([ADAPTIVE_TESTING_BEHAVIOR], JSONB)
+
+    def only_explorer_test_sets(query):
+        return query.filter(
+            models.TestSet.attributes["metadata"]["behaviors"].contains(explorer_marker)
+        )
+
+    # Paginated outside the builder on purpose: with_pagination caps limit at 100
+    # (validate_pagination) and this endpoint has never capped. with_sorting already
+    # appends id ASC as a tiebreaker, so pagination stays stable.
+    query = (
+        QueryBuilder(db, models.TestSet)
+        .with_related(*_TEST_SET_RELATED_FIELDS)
+        .with_default_derived_field_loads()
+        .with_organization_filter(organization_id)
+        .with_custom_filter(only_explorer_test_sets)
+        .with_sorting(sort_by, sort_order)
+        .build()
+    )
+    return query.offset(skip).limit(limit).all()
+
+
+def get_test_sets_by_ids(
+    db: Session, test_set_ids: List[uuid.UUID], organization_id: str
+) -> List[models.TestSet]:
+    """Load the given test sets, scoped to the organization.
+
+    Used by the bulk-delete path to inspect each candidate's behavior before deleting;
+    ids that don't resolve simply come back missing from the result.
+
+    Parameters
+    ----------
+    db : Session
+        Database session
+    test_set_ids : list of uuid.UUID
+        Test set ids to load
+    organization_id : str
+        Organization ID for tenant isolation
+
+    Returns
+    -------
+    list of models.TestSet
+        The test sets that resolved, in no guaranteed order.
+    """
+    if not test_set_ids:
+        return []
+
+    return (
+        QueryBuilder(db, models.TestSet)
+        .with_organization_filter(organization_id)
+        .with_custom_filter(lambda q: q.filter(models.TestSet.id.in_(test_set_ids)))
+        .all()
+    )
+
+
+def get_test_ids_in_test_sets(
+    db: Session, test_set_ids: List[uuid.UUID], organization_id: str
+) -> List[uuid.UUID]:
+    """Distinct ids of the tests associated with any of the given test sets.
+
+    Parameters
+    ----------
+    db : Session
+        Database session
+    test_set_ids : list of uuid.UUID
+        Test set ids to collect tests from
+    organization_id : str
+        Organization ID for tenant isolation
+
+    Returns
+    -------
+    list of uuid.UUID
+        Distinct test ids across all the given test sets.
+    """
+    if not test_set_ids:
+        return []
+
+    rows = db.execute(
+        select(test_test_set_association.c.test_id)
+        .where(
+            test_test_set_association.c.test_set_id.in_(test_set_ids),
+            test_test_set_association.c.organization_id == organization_id,
+        )
+        .distinct()
+    ).fetchall()
+    return [row.test_id for row in rows]
+
+
+def find_unused_test_set_name(db: Session, organization_id: str, base_name: str) -> str:
+    """Pick a test set name that does not collide within the organization.
+
+    Returns ``base_name`` when it is free, otherwise the first free
+    ``"{base_name} ({n})"`` counting up from 1. Collects the taken names in one query
+    rather than probing per candidate, which is what the caller used to do.
+
+    Parameters
+    ----------
+    db : Session
+        Database session
+    organization_id : str
+        Organization ID for tenant isolation
+    base_name : str
+        Preferred name
+
+    Returns
+    -------
+    str
+        A name not currently used by any test set in the organization.
+    """
+    # LIKE wildcards in base_name would widen the match, so escape them.
+    escaped = base_name.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+    rows = (
+        db.query(models.TestSet.name)
+        .filter(
+            models.TestSet.organization_id == organization_id,
+            (models.TestSet.name == base_name)
+            | (models.TestSet.name.like(f"{escaped} (%)", escape="\\")),
+        )
+        .all()
+    )
+    taken = {row.name for row in rows}
+
+    if base_name not in taken:
+        return base_name
+
+    counter = 1
+    while f"{base_name} ({counter})" in taken:
+        counter += 1
+    return f"{base_name} ({counter})"
+
+
+# --- Tests within a test set -------------------------------------------------------
+
+
+def get_test_in_test_set(
+    db: Session, test_set_id: uuid.UUID, test_id: uuid.UUID, organization_id: str
+) -> Optional[models.Test]:
+    """Load a test, but only if it belongs to the given test set.
+
+    The membership join is the point: it doubles as the authorization check for the
+    per-test Explorer endpoints. The prompt is eager-loaded because callers either
+    rewrite or serialize it.
+
+    Parameters
+    ----------
+    db : Session
+        Database session
+    test_set_id : uuid.UUID
+        Test set the test must belong to
+    test_id : uuid.UUID
+        Test to load
+    organization_id : str
+        Organization ID for tenant isolation
+
+    Returns
+    -------
+    models.Test or None
+        The test, or None when it does not exist in that test set.
+    """
+    return (
+        db.query(models.Test)
+        .options(joinedload(models.Test.prompt))
+        .join(
+            test_test_set_association,
+            models.Test.id == test_test_set_association.c.test_id,
+        )
+        .filter(
+            models.Test.id == test_id,
+            test_test_set_association.c.test_set_id == test_set_id,
+            models.Test.organization_id == organization_id,
+        )
+        .first()
+    )
+
+
+def get_tests_under_topic(
+    db: Session, test_set_id: uuid.UUID, organization_id: str, topic_path: str
+) -> List[models.Test]:
+    """Load every test in a test set whose topic is ``topic_path`` or a descendant.
+
+    Descendants are matched on the topic name prefix (``topic_path + "/"``), since
+    Explorer stores the full path in ``Topic.name``. The topic is eager-loaded via
+    ``contains_eager`` on the join the filter already needs, so callers can read
+    ``test.topic.name`` without another round trip.
+
+    Parameters
+    ----------
+    db : Session
+        Database session
+    test_set_id : uuid.UUID
+        Test set to search within
+    organization_id : str
+        Organization ID for tenant isolation
+    topic_path : str
+        Full topic path, e.g. ``"Safety/Violence"``
+
+    Returns
+    -------
+    list of models.Test
+        Tests under the topic and all of its subtopics, topic markers included.
+    """
+    return (
+        db.query(models.Test)
+        .join(
+            test_test_set_association,
+            models.Test.id == test_test_set_association.c.test_id,
+        )
+        .join(models.Topic, models.Test.topic_id == models.Topic.id)
+        .options(contains_eager(models.Test.topic))
+        .filter(
+            test_test_set_association.c.test_set_id == test_set_id,
+            models.Test.organization_id == organization_id,
+        )
+        .filter((models.Topic.name == topic_path) | (models.Topic.name.like(topic_path + "/%")))
+        .all()
+    )
 
 
 def set_explorer_test_outputs(db: Session, outputs: Dict[str, str]) -> List[str]:
@@ -48,3 +319,113 @@ def set_explorer_test_outputs(db: Session, outputs: Dict[str, str]) -> List[str]
 
     db.flush()
     return written
+
+
+# --- Metrics ------------------------------------------------------------------------
+
+
+def get_test_set_metrics(db: Session, test_set_id: uuid.UUID) -> List[models.Metric]:
+    """Metrics attached to a test set.
+
+    Queried by id rather than via ``test_set.metrics`` because the callers
+    (``routers/explorer.py`` by way of the settings service) don't guarantee that
+    many-to-many relationship is eager-loaded on the test set they pass in.
+
+    Parameters
+    ----------
+    db : Session
+        Database session
+    test_set_id : uuid.UUID
+        Test set whose metrics to load
+
+    Returns
+    -------
+    list of models.Metric
+        The attached metrics.
+    """
+    return db.query(models.Metric).filter(models.Metric.test_sets.any(id=test_set_id)).all()
+
+
+# --- Embeddings ---------------------------------------------------------------------
+
+
+def get_test_for_embedding(
+    db: Session, test_id: str, organization_id: str
+) -> Optional[models.Test]:
+    """Load a test with the relationships ``Test.to_searchable_text()`` reads.
+
+    Parameters
+    ----------
+    db : Session
+        Database session
+    test_id : str
+        Test to load
+    organization_id : str
+        Organization ID for tenant isolation
+
+    Returns
+    -------
+    models.Test or None
+        The test with prompt, topic, behavior, category and test type loaded.
+    """
+    return (
+        QueryBuilder(db, models.Test)
+        .with_custom_filter(
+            lambda q: q.filter(
+                models.Test.id == test_id, models.Test.organization_id == organization_id
+            )
+        )
+        .with_related(
+            include(models.Test.prompt),
+            include(models.Test.topic),
+            include(models.Test.behavior),
+            include(models.Test.category),
+            include(models.Test.test_type),
+        )
+        .first()
+    )
+
+
+def get_default_embedding_model(db: Session, organization_id: str) -> Optional[models.Model]:
+    """Fallback row for ``embedding.model_id`` when user settings omit an embedding model.
+
+    Tries the organization's model named "Rhesis Default Embedding" first, then any
+    protected embedding model from the ``rhesis`` provider.
+
+    Parameters
+    ----------
+    db : Session
+        Database session
+    organization_id : str
+        Organization ID for tenant isolation
+
+    Returns
+    -------
+    models.Model or None
+        The default embedding model, or None when the organization has neither.
+    """
+    org_uuid = uuid.UUID(organization_id)
+
+    by_name = (
+        db.query(models.Model)
+        .filter(
+            models.Model.organization_id == org_uuid,
+            models.Model.name == "Rhesis Default Embedding",
+            models.Model.model_type == ModelType.EMBEDDING.value,
+        )
+        .first()
+    )
+    if by_name:
+        return by_name
+
+    return (
+        db.query(models.Model)
+        .join(models.TypeLookup, models.Model.provider_type_id == models.TypeLookup.id)
+        .filter(
+            models.Model.organization_id == org_uuid,
+            models.TypeLookup.type_value == "rhesis",
+            models.Model.is_protected.is_(True),
+            models.Model.model_type == ModelType.EMBEDDING.value,
+        )
+        .first()
+    )

--- a/apps/backend/src/rhesis/backend/app/services/explorer/embeddings.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/embeddings.py
@@ -13,14 +13,17 @@ import numpy as np
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
+from rhesis.backend.app.crud.explorer import (
+    get_default_embedding_model,
+    get_test_for_embedding,
+)
 from rhesis.backend.app.models.embedding import EmbeddingConfig
-from rhesis.backend.app.models.enums import EmbeddingStatus, ModelType
+from rhesis.backend.app.models.enums import EmbeddingStatus
 from rhesis.backend.app.models.test import Test
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.services.explorer.diversity_strategies import (
     DEFAULT_EMBEDDING_DIVERSITY_STRATEGY,
 )
-from rhesis.backend.app.utils.query_utils import QueryBuilder, include
 from rhesis.backend.app.utils.user_model_utils import get_user_embedding_model
 from rhesis.sdk.models.factory import get_model
 
@@ -119,7 +122,7 @@ def resolve_embedder(db: Session, user_id: str):
     result to :func:`generate_embedding_vector`, :func:`a_generate_embedding_vector`,
     or :func:`a_generate_embedding_vectors_batch` to avoid repeated DB lookups.
     """
-    user = db.query(User).filter(User.id == user_id).first()
+    user = crud.get_user_by_id(db, user_id)
     if not user:
         raise ValueError(f"User not found: {user_id}")
 
@@ -259,50 +262,12 @@ async def a_generate_embedding_vectors_batch(
 
 
 def load_test_for_embedding(db: Session, test_id: str, organization_id: str) -> Optional[Test]:
-    """Load a Test with relationships required for ``to_searchable_text()``."""
-    return (
-        QueryBuilder(db, Test)
-        .with_custom_filter(
-            lambda q: q.filter(Test.id == test_id, Test.organization_id == organization_id)
-        )
-        .with_related(
-            include(Test.prompt),
-            include(Test.topic),
-            include(Test.behavior),
-            include(Test.category),
-            include(Test.test_type),
-        )
-        .first()
-    )
+    """Load a Test with relationships required for ``to_searchable_text()``.
 
-
-def _organization_default_embedding_model(
-    db: Session, organization_id: str
-) -> Optional[models.Model]:
-    """Fallback row for embedding.model_id when user settings omit embedding model_id."""
-    org_uuid = UUIDType(organization_id)
-    by_name = (
-        db.query(models.Model)
-        .filter(
-            models.Model.organization_id == org_uuid,
-            models.Model.name == "Rhesis Default Embedding",
-            models.Model.model_type == ModelType.EMBEDDING.value,
-        )
-        .first()
-    )
-    if by_name:
-        return by_name
-    return (
-        db.query(models.Model)
-        .join(models.TypeLookup, models.Model.provider_type_id == models.TypeLookup.id)
-        .filter(
-            models.Model.organization_id == org_uuid,
-            models.TypeLookup.type_value == "rhesis",
-            models.Model.is_protected.is_(True),
-            models.Model.model_type == ModelType.EMBEDDING.value,
-        )
-        .first()
-    )
+    Kept as a service-level name because ``routers/explorer.py`` and this package's
+    ``__init__`` both export it.
+    """
+    return get_test_for_embedding(db, test_id, organization_id)
 
 
 def create_test_embedding(
@@ -329,7 +294,7 @@ def create_test_embedding(
     if model_id_setting:
         model_id = str(model_id_setting)
     else:
-        fallback = _organization_default_embedding_model(db, organization_id)
+        fallback = get_default_embedding_model(db, organization_id)
         if not fallback:
             logger.info(
                 "Skipping explorer test embedding persistence: no embedding model_id in user "

--- a/apps/backend/src/rhesis/backend/app/services/explorer/settings.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/settings.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
+from rhesis.backend.app.crud.explorer import get_test_set_metrics
 from rhesis.backend.app.schemas.explorer import (
     ExplorerSettingsEndpoint,
     ExplorerSettingsMetric,
@@ -52,10 +53,7 @@ def resolve_metric_names(
     if request_metric_names:
         return request_metric_names
 
-    # Queried by ID rather than via test_set.metrics -- callers of this
-    # resolver (routers/explorer.py) don't guarantee that many-to-many
-    # relationship is eager-loaded on the passed-in test_set.
-    metrics = db.query(models.Metric).filter(models.Metric.test_sets.any(id=test_set.id)).all()
+    metrics = get_test_set_metrics(db, test_set.id)
     metric_names = [metric.name for metric in metrics if metric.name]
     if not metric_names:
         raise ValueError("No metrics specified and no metrics configured in settings")
@@ -84,8 +82,7 @@ def get_explorer_settings(
         if endpoint is not None:
             endpoint_ref = ExplorerSettingsEndpoint(id=endpoint.id, name=endpoint.name)
 
-    # Queried by ID rather than via test_set.metrics -- see resolve_metric_names.
-    db_metrics = db.query(models.Metric).filter(models.Metric.test_sets.any(id=test_set.id)).all()
+    db_metrics = get_test_set_metrics(db, test_set.id)
     metrics = [ExplorerSettingsMetric(id=metric.id, name=metric.name) for metric in db_metrics]
 
     return ExplorerSettingsResponse(default_endpoint=endpoint_ref, metrics=metrics)
@@ -121,13 +118,7 @@ def update_explorer_settings(
 
     if metric_ids is not None:
         # Replace metrics atomically by removing existing and adding requested.
-        # Queried by ID rather than via test_set.metrics -- see resolve_metric_names.
-        existing_metric_ids = [
-            metric.id
-            for metric in db.query(models.Metric)
-            .filter(models.Metric.test_sets.any(id=test_set.id))
-            .all()
-        ]
+        existing_metric_ids = [metric.id for metric in get_test_set_metrics(db, test_set.id)]
         desired_metric_ids = list(dict.fromkeys(metric_ids))
 
         for metric_id in existing_metric_ids:

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -2,10 +2,14 @@ import logging
 from typing import List, Optional
 from uuid import UUID
 
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.constants import ADAPTIVE_TESTING_BEHAVIOR
+
+# Imported as a module rather than by name: this file's own public
+# get_explorer_test_sets() wraps the crud function of the same name.
+from rhesis.backend.app.crud import explorer as crud_explorer
 from rhesis.backend.app.models.test import test_test_set_association
 from rhesis.backend.app.schemas.explorer import TestTreeNode, TopicNode
 from rhesis.backend.app.services.explorer.topics import create_topic_node
@@ -17,7 +21,6 @@ from rhesis.backend.app.utils.crud_utils import (
     get_or_create_topic,
     get_or_create_type_lookup,
 )
-from rhesis.backend.app.utils.query_utils import QueryBuilder
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +108,7 @@ def get_explorer_test_sets(
     List[models.TestSet]
         Test sets configured for Explorer (Adaptive Testing behavior)
     """
-    test_sets = crud.get_explorer_test_sets(
+    test_sets = crud_explorer.get_explorer_test_sets(
         db=db,
         organization_id=organization_id,
         skip=skip,
@@ -201,7 +204,7 @@ def _delete_session_tests(
     them, so no other test set references them. Leaving them behind strands them
     in the global /tests list with no session to reach them from.
     """
-    test_ids = crud.get_test_ids_in_test_sets(db, test_set_ids, organization_id)
+    test_ids = crud_explorer.get_test_ids_in_test_sets(db, test_set_ids, organization_id)
     if not test_ids:
         return
     crud.bulk_delete_tests(
@@ -262,12 +265,7 @@ def bulk_delete_explorer_test_sets(
     if not test_set_ids:
         return {"deleted_ids": [], "not_found_ids": []}
 
-    candidates = (
-        QueryBuilder(db, models.TestSet)
-        .with_organization_filter(organization_id)
-        .with_custom_filter(lambda q: q.filter(models.TestSet.id.in_(test_set_ids)))
-        .all()
-    )
+    candidates = crud_explorer.get_test_sets_by_ids(db, test_set_ids, organization_id)
     valid_ids = [ts.id for ts in candidates if _is_explorer_test_set(ts)]
 
     _delete_session_tests(db, valid_ids, organization_id, user_id)
@@ -283,25 +281,6 @@ def bulk_delete_explorer_test_sets(
     skipped_ids = [str(i) for i in test_set_ids if str(i) not in valid_id_strs]
     result["not_found_ids"] = result["not_found_ids"] + skipped_ids
     return result
-
-
-def _unique_explorer_import_name(db: Session, organization_id: str, base_name: str) -> str:
-    """Pick a test set name that does not collide within the organization."""
-    candidate = base_name
-    counter = 0
-    while True:
-        existing = (
-            db.query(models.TestSet)
-            .filter(
-                models.TestSet.organization_id == organization_id,
-                models.TestSet.name == candidate,
-            )
-            .first()
-        )
-        if existing is None:
-            return candidate
-        counter += 1
-        candidate = f"{base_name} ({counter})"
 
 
 def import_explorer_test_set_from_source(
@@ -345,7 +324,7 @@ def import_explorer_test_set_from_source(
         raise ValueError("Source test set is already configured for Explorer")
 
     base_name = f"{db_source.name} (Adaptive)"
-    new_name = _unique_explorer_import_name(db, organization_id, base_name)
+    new_name = crud_explorer.find_unused_test_set_name(db, organization_id, base_name)
 
     new_set = create_explorer_test_set(
         db=db,
@@ -486,7 +465,7 @@ def export_regular_test_set_from_explorer(
         )
 
     base_name = f"{db_source.name} (Exported)"
-    new_name = _unique_explorer_import_name(db, organization_id, base_name)
+    new_name = crud_explorer.find_unused_test_set_name(db, organization_id, base_name)
 
     test_set_type_lookup = get_or_create_type_lookup(
         db=db,
@@ -771,21 +750,7 @@ def update_test_node(
         The updated test node, or None if test not found in the
         given test set.
     """
-    # Look up the test and verify it belongs to the test set
-    db_test = (
-        db.query(models.Test)
-        .options(joinedload(models.Test.prompt))
-        .join(
-            test_test_set_association,
-            models.Test.id == test_test_set_association.c.test_id,
-        )
-        .filter(
-            models.Test.id == test_id,
-            test_test_set_association.c.test_set_id == test_set_id,
-            models.Test.organization_id == organization_id,
-        )
-        .first()
-    )
+    db_test = crud_explorer.get_test_in_test_set(db, test_set_id, test_id, organization_id)
 
     if db_test is None:
         return None
@@ -866,20 +831,7 @@ def delete_test_node(
     bool
         True if the test was found and deleted, False otherwise.
     """
-    # Look up the test and verify it belongs to the test set
-    db_test = (
-        db.query(models.Test)
-        .join(
-            test_test_set_association,
-            models.Test.id == test_test_set_association.c.test_id,
-        )
-        .filter(
-            models.Test.id == test_id,
-            test_test_set_association.c.test_set_id == test_set_id,
-            models.Test.organization_id == organization_id,
-        )
-        .first()
-    )
+    db_test = crud_explorer.get_test_in_test_set(db, test_set_id, test_id, organization_id)
 
     if db_test is None:
         return False

--- a/apps/backend/src/rhesis/backend/app/services/explorer/topics.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/topics.py
@@ -2,9 +2,10 @@ import logging
 from typing import Optional
 from uuid import UUID
 
-from sqlalchemy.orm import Session, contains_eager
+from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
+from rhesis.backend.app.crud.explorer import get_tests_under_topic
 from rhesis.backend.app.models.test import test_test_set_association
 from rhesis.backend.app.schemas.explorer import TopicNode
 from rhesis.backend.app.services.explorer.utils import build_test_tree
@@ -169,23 +170,7 @@ def update_topic_node(
         return TopicNode(path=topic_path)
 
     # Find all tests in this test set and update their topic FKs.
-    # We need tests whose topic.name == old_path or starts with
-    # old_path + "/" (descendants).
-    db_tests = (
-        db.query(models.Test)
-        .join(
-            test_test_set_association,
-            models.Test.id == test_test_set_association.c.test_id,
-        )
-        .join(models.Topic, models.Test.topic_id == models.Topic.id)
-        .options(contains_eager(models.Test.topic))
-        .filter(
-            test_test_set_association.c.test_set_id == test_set_id,
-            models.Test.organization_id == organization_id,
-        )
-        .filter((models.Topic.name == topic_path) | (models.Topic.name.like(topic_path + "/%")))
-        .all()
-    )
+    db_tests = get_tests_under_topic(db, test_set_id, organization_id, topic_path)
 
     for db_test in db_tests:
         old_name = db_test.topic.name
@@ -253,21 +238,7 @@ def remove_topic_node(
     parent_path = existing.parent_path or ""
 
     # All tests in this test set under this topic or any subtopic
-    db_tests = (
-        db.query(models.Test)
-        .join(
-            test_test_set_association,
-            models.Test.id == test_test_set_association.c.test_id,
-        )
-        .join(models.Topic, models.Test.topic_id == models.Topic.id)
-        .options(contains_eager(models.Test.topic))
-        .filter(
-            test_test_set_association.c.test_set_id == test_set_id,
-            models.Test.organization_id == organization_id,
-        )
-        .filter((models.Topic.name == topic_path) | (models.Topic.name.like(topic_path + "/%")))
-        .all()
-    )
+    db_tests = get_tests_under_topic(db, test_set_id, organization_id, topic_path)
 
     parent_topic = None
     if parent_path:

--- a/tests/backend/crud/test_explorer_crud.py
+++ b/tests/backend/crud/test_explorer_crud.py
@@ -1,0 +1,324 @@
+"""
+🧭 Explorer CRUD Operations Testing
+
+Covers the query behaviour that the Explorer services used to hand-roll and that
+``crud/explorer.py`` now owns. The consolidations and the one-query name search are
+the parts worth pinning: the services no longer see the SQL, so a regression here
+would surface as odd tree or import behaviour rather than as a query error.
+
+Functions tested:
+- find_unused_test_set_name: collision-free naming without a query per candidate
+- get_test_in_test_set: membership-scoped single-test lookup
+- get_tests_under_topic: topic subtree matching
+
+Run with: python -m pytest tests/backend/crud/test_explorer_crud.py -v
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.crud.explorer import (
+    find_unused_test_set_name,
+    get_test_in_test_set,
+    get_tests_under_topic,
+)
+from rhesis.backend.app.models.test import test_test_set_association
+
+
+def _create_test_set(db: Session, name: str, organization_id: str, user_id: str) -> models.TestSet:
+    test_set = models.TestSet(name=name, organization_id=organization_id, user_id=user_id)
+    db.add(test_set)
+    db.flush()
+    return test_set
+
+
+def _create_topic(db: Session, name: str, organization_id: str, user_id: str) -> models.Topic:
+    topic = models.Topic(name=name, organization_id=organization_id, user_id=user_id)
+    db.add(topic)
+    db.flush()
+    return topic
+
+
+def _create_test(
+    db: Session,
+    test_set: models.TestSet,
+    organization_id: str,
+    user_id: str,
+    topic: models.Topic | None = None,
+    prompt_content: str | None = None,
+    metadata: dict | None = None,
+) -> models.Test:
+    prompt = None
+    if prompt_content is not None:
+        prompt = models.Prompt(
+            content=prompt_content, organization_id=organization_id, user_id=user_id
+        )
+        db.add(prompt)
+        db.flush()
+
+    test = models.Test(
+        topic_id=topic.id if topic else None,
+        prompt_id=prompt.id if prompt else None,
+        test_metadata=metadata,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    db.add(test)
+    db.flush()
+
+    db.execute(
+        test_test_set_association.insert().values(
+            test_id=test.id,
+            test_set_id=test_set.id,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+    )
+    db.flush()
+    return test
+
+
+@pytest.mark.unit
+@pytest.mark.crud
+class TestFindUnusedTestSetName:
+    """🏷️ Explorer import naming"""
+
+    def test_returns_base_name_when_free(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        base = f"Naming Free {uuid.uuid4().hex[:8]}"
+
+        assert find_unused_test_set_name(test_db, test_org_id, base) == base
+
+    def test_counts_up_through_consecutive_collisions(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        """The suffix sequence is base, base (1), base (2), ... with no gaps."""
+        base = f"Naming Seq {uuid.uuid4().hex[:8]}"
+
+        _create_test_set(test_db, base, test_org_id, authenticated_user_id)
+        assert find_unused_test_set_name(test_db, test_org_id, base) == f"{base} (1)"
+
+        _create_test_set(test_db, f"{base} (1)", test_org_id, authenticated_user_id)
+        assert find_unused_test_set_name(test_db, test_org_id, base) == f"{base} (2)"
+
+        _create_test_set(test_db, f"{base} (2)", test_org_id, authenticated_user_id)
+        assert find_unused_test_set_name(test_db, test_org_id, base) == f"{base} (3)"
+
+    def test_fills_a_gap_in_the_sequence(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        """(2) taken but (1) free still yields (1) -- matches the old probe loop."""
+        base = f"Naming Gap {uuid.uuid4().hex[:8]}"
+        _create_test_set(test_db, base, test_org_id, authenticated_user_id)
+        _create_test_set(test_db, f"{base} (2)", test_org_id, authenticated_user_id)
+
+        assert find_unused_test_set_name(test_db, test_org_id, base) == f"{base} (1)"
+
+    def test_like_wildcards_in_the_base_name_do_not_widen_the_match(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        """A '%' or '_' in the name is data, not a pattern."""
+        marker = uuid.uuid4().hex[:8]
+        base = f"100% Coverage {marker}"
+        _create_test_set(test_db, f"1009 Coverage {marker} (1)", test_org_id, authenticated_user_id)
+
+        # The decoy would only collide if '%' were treated as a wildcard.
+        assert find_unused_test_set_name(test_db, test_org_id, base) == base
+
+        _create_test_set(test_db, base, test_org_id, authenticated_user_id)
+        assert find_unused_test_set_name(test_db, test_org_id, base) == f"{base} (1)"
+
+    def test_a_name_taken_in_another_organization_does_not_collide(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        """Names are unique per organization, so another tenant's row must not shadow it."""
+        base = f"Naming Tenant {uuid.uuid4().hex[:8]}"
+        _create_test_set(test_db, base, test_org_id, authenticated_user_id)
+
+        assert find_unused_test_set_name(test_db, str(uuid.uuid4()), base) == base
+
+
+@pytest.mark.unit
+@pytest.mark.crud
+class TestGetTestInTestSet:
+    """🔎 Membership-scoped test lookup"""
+
+    def test_returns_the_test_with_its_prompt_loaded(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        test_set = _create_test_set(
+            test_db, f"Lookup {uuid.uuid4().hex[:8]}", test_org_id, authenticated_user_id
+        )
+        test = _create_test(
+            test_db,
+            test_set,
+            test_org_id,
+            authenticated_user_id,
+            prompt_content="How do I do the thing?",
+        )
+
+        found = get_test_in_test_set(test_db, test_set.id, test.id, test_org_id)
+
+        assert found is not None
+        assert found.id == test.id
+        assert found.prompt.content == "How do I do the thing?"
+
+    def test_returns_none_for_a_test_in_a_different_set(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        """The membership join is the authorization check -- it must not be optional."""
+        marker = uuid.uuid4().hex[:8]
+        owning_set = _create_test_set(
+            test_db, f"Owner {marker}", test_org_id, authenticated_user_id
+        )
+        other_set = _create_test_set(test_db, f"Other {marker}", test_org_id, authenticated_user_id)
+        test = _create_test(
+            test_db, owning_set, test_org_id, authenticated_user_id, prompt_content="Owned"
+        )
+
+        assert get_test_in_test_set(test_db, other_set.id, test.id, test_org_id) is None
+
+    def test_returns_none_for_another_organization(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        test_set = _create_test_set(
+            test_db, f"Tenant {uuid.uuid4().hex[:8]}", test_org_id, authenticated_user_id
+        )
+        test = _create_test(
+            test_db, test_set, test_org_id, authenticated_user_id, prompt_content="Mine"
+        )
+
+        assert get_test_in_test_set(test_db, test_set.id, test.id, str(uuid.uuid4())) is None
+
+    def test_returns_a_test_without_a_prompt(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        """Topic markers carry no prompt; the eager load must tolerate that."""
+        test_set = _create_test_set(
+            test_db, f"Marker {uuid.uuid4().hex[:8]}", test_org_id, authenticated_user_id
+        )
+        marker = _create_test(
+            test_db,
+            test_set,
+            test_org_id,
+            authenticated_user_id,
+            metadata={"label": "topic_marker"},
+        )
+
+        found = get_test_in_test_set(test_db, test_set.id, marker.id, test_org_id)
+
+        assert found is not None
+        assert found.prompt is None
+
+
+@pytest.mark.unit
+@pytest.mark.crud
+class TestGetTestsUnderTopic:
+    """🌳 Topic subtree matching"""
+
+    @pytest.fixture
+    def topic_tree(self, test_db: Session, test_org_id: str, authenticated_user_id: str):
+        """A set with Safety, Safety/Violence, Safety/Violence/Weapons and Safetyville."""
+        marker = uuid.uuid4().hex[:8]
+        test_set = _create_test_set(test_db, f"Tree {marker}", test_org_id, authenticated_user_id)
+
+        tests = {}
+        for path in (
+            f"Safety {marker}",
+            f"Safety {marker}/Violence",
+            f"Safety {marker}/Violence/Weapons",
+            f"Safety {marker}ville",
+        ):
+            topic = _create_topic(test_db, path, test_org_id, authenticated_user_id)
+            tests[path] = _create_test(
+                test_db,
+                test_set,
+                test_org_id,
+                authenticated_user_id,
+                topic=topic,
+                prompt_content=f"Prompt for {path}",
+            )
+
+        return test_set, tests, marker
+
+    def test_includes_the_topic_and_all_descendants(
+        self, test_db: Session, test_org_id, topic_tree
+    ):
+        test_set, tests, marker = topic_tree
+
+        found = get_tests_under_topic(test_db, test_set.id, test_org_id, f"Safety {marker}")
+
+        assert {t.id for t in found} == {
+            tests[f"Safety {marker}"].id,
+            tests[f"Safety {marker}/Violence"].id,
+            tests[f"Safety {marker}/Violence/Weapons"].id,
+        }
+
+    def test_a_sibling_sharing_the_name_prefix_is_excluded(
+        self, test_db: Session, test_org_id, topic_tree
+    ):
+        """'Safetyville' is not under 'Safety' -- the separator matters."""
+        test_set, tests, marker = topic_tree
+
+        found = get_tests_under_topic(test_db, test_set.id, test_org_id, f"Safety {marker}")
+
+        assert tests[f"Safety {marker}ville"].id not in {t.id for t in found}
+
+    def test_a_subtopic_returns_only_its_own_branch(
+        self, test_db: Session, test_org_id, topic_tree
+    ):
+        test_set, tests, marker = topic_tree
+
+        found = get_tests_under_topic(
+            test_db, test_set.id, test_org_id, f"Safety {marker}/Violence"
+        )
+
+        assert {t.id for t in found} == {
+            tests[f"Safety {marker}/Violence"].id,
+            tests[f"Safety {marker}/Violence/Weapons"].id,
+        }
+
+    def test_the_topic_is_eager_loaded(self, test_db: Session, test_org_id, topic_tree):
+        """Callers read test.topic.name to rewrite paths, so it must come back loaded."""
+        test_set, _, marker = topic_tree
+
+        found = get_tests_under_topic(test_db, test_set.id, test_org_id, f"Safety {marker}")
+
+        assert all(t.topic is not None for t in found)
+        assert {t.topic.name for t in found} == {
+            f"Safety {marker}",
+            f"Safety {marker}/Violence",
+            f"Safety {marker}/Violence/Weapons",
+        }
+
+    def test_tests_in_another_set_are_excluded(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str, topic_tree
+    ):
+        test_set, tests, marker = topic_tree
+        other_set = _create_test_set(
+            test_db, f"Other tree {marker}", test_org_id, authenticated_user_id
+        )
+        topic = _create_topic(
+            test_db, f"Safety {marker}/Elsewhere", test_org_id, authenticated_user_id
+        )
+        stranger = _create_test(
+            test_db,
+            other_set,
+            test_org_id,
+            authenticated_user_id,
+            topic=topic,
+            prompt_content="Not in the tree under test",
+        )
+
+        found = get_tests_under_topic(test_db, test_set.id, test_org_id, f"Safety {marker}")
+
+        assert stranger.id not in {t.id for t in found}
+
+    def test_unknown_topic_returns_empty(self, test_db: Session, test_org_id, topic_tree):
+        test_set, _, marker = topic_tree
+
+        assert get_tests_under_topic(test_db, test_set.id, test_org_id, f"Nope {marker}") == []

--- a/tests/backend/services/explorer/test_tests.py
+++ b/tests/backend/services/explorer/test_tests.py
@@ -5,6 +5,7 @@ from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
+from rhesis.backend.app.crud.explorer import get_test_ids_in_test_sets
 from rhesis.backend.app.database import without_soft_delete_filter
 from rhesis.backend.app.schemas.explorer import TestTreeNode, TopicNode
 from rhesis.backend.app.services.explorer import (
@@ -495,7 +496,7 @@ class TestDeleteExplorerTestSet:
             topic="Safety",
             input="Is this harmful?",
         )
-        test_ids = crud.get_test_ids_in_test_sets(test_db, [created.id], test_org_id)
+        test_ids = get_test_ids_in_test_sets(test_db, [created.id], test_org_id)
         # The test plus the "Safety" topic marker.
         assert len(test_ids) == 2
 
@@ -604,7 +605,7 @@ class TestBulkDeleteExplorerTestSets:
             sessions.append(created)
 
         session_ids = [s.id for s in sessions]
-        test_ids = crud.get_test_ids_in_test_sets(test_db, session_ids, test_org_id)
+        test_ids = get_test_ids_in_test_sets(test_db, session_ids, test_org_id)
         assert len(test_ids) == 4  # 2 tests + 2 topic markers
 
         bulk_delete_explorer_test_sets(
@@ -625,7 +626,7 @@ class TestBulkDeleteExplorerTestSets:
     ):
         """A non-explorer id is skipped without touching its tests."""
         regular = regular_test_set_for_import
-        test_ids = crud.get_test_ids_in_test_sets(test_db, [regular.id], test_org_id)
+        test_ids = get_test_ids_in_test_sets(test_db, [regular.id], test_org_id)
         assert test_ids
 
         result = bulk_delete_explorer_test_sets(


### PR DESCRIPTION
## Purpose

First half of item 2.2 of the Explorer roadmap. The Explorer services called `crud` for some
things (`crud.resolve_test_set`, `crud.get_test_set_tests`, `crud.delete_test`) and hand-rolled
queries for the rest. This PR moves all 13 read sites into `crud/explorer.py`, so the services
only orchestrate.

This is what makes Phase 3 tractable: once the SQL lives in one module, the separate-tables
migration is a rewrite of `crud/explorer.py` plus a data migration, instead of touching all nine
service modules.

The writes half (~34 sites) follows in a second PR stacked on this branch, per the "split, don't
grow" rule in `apps/backend/AGENTS.md`.

## What Changed

- **Moved out of the monolith** into `crud/explorer.py`: `get_explorer_test_sets` and
  `get_test_ids_in_test_sets`. `crud/__init__.py` shrinks by 53 lines.
- **`_TEST_SET_RELATED_FIELDS` stays in `crud/__init__.py`** and is imported from there.
  Three other functions in the monolith (`get_test_sets`, `get_test_set_by_nano_id_or_slug`,
  `get_test_sets_for_test`) use the same tuple, so relocating it would mean deciding a new home
  for a TestSet-wide constant while this module only owns the Explorer slice. There is no cycle:
  `crud/__init__.py` never imports this module, and the parent package always initializes first.
- **Three consolidations.** The two byte-identical topic-subtree queries in `topics.py`
  (`update_topic_node` and `remove_topic_node`) become `get_tests_under_topic`. The same metric
  query written three times in `settings.py`, each with the same explanatory comment, becomes
  `get_test_set_metrics`. The two near-identical membership lookups in `tests.py`
  (`update_test_node`, `delete_test_node`) become `get_test_in_test_set`.
- **Also moved**: `get_test_sets_by_ids` (the bulk-delete candidate load),
  `get_test_for_embedding`, `get_default_embedding_model`.

Two fixes taken while passing through, both inside code this PR already edits:

- **`_unique_explorer_import_name` was an N+1.** It probed for a name collision with one query per
  iteration inside a `while True`. The replacement, `find_unused_test_set_name`, collects the taken
  names in one query and picks the first free suffix in Python. It also escapes LIKE wildcards in
  the base name, which the old per-candidate equality check never had to worry about.
- **`resolve_embedder` queried the `User` table directly** where `crud.get_user_by_id` already
  existed and `suggestions.py:60` already used it for the identical purpose.

## Additional Context

**`get_test_in_test_set` always eager-loads the prompt.** `update_test_node` needs it,
`delete_test_node` does not. One extra many-to-one join on a single-row lookup is cheaper than a
`with_prompt` flag, and it is one fewer branch to cover. The membership join is the point of the
function — it doubles as the authorization check for the per-test endpoints, which is why there is
a test asserting a test from another set does not resolve.

**The router is untouched.** `load_test_for_embedding` stays a service-level name delegating to
`crud.explorer.get_test_for_embedding`, mirroring the existing wrapper pattern at `tests.py:78`,
because `routers/explorer.py:577` and `services/explorer/__init__.py` both export it.
`get_explorer_test_sets` keeps its service wrapper for the same reason.

**`tests.py` imports the crud module rather than the functions by name.** Everywhere else uses
direct imports per `AGENTS.md`, but that file defines its own public `get_explorer_test_sets()`
wrapping the crud function of the same name, so `crud_explorer.get_explorer_test_sets(...)` reads
better than an alias.

Deliberately left alone: `resolve_metric_names` still takes and discards `organization_id` and
still puts `db` second. It is on the roadmap's "deliberately not in scope" list and folding it in
would change a signature in a PR that otherwise moves no behaviour. The two remaining
`db.execute` calls in the services are association deletes — writes, owned by the follow-up PR.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/explorer/ \
              ../../tests/backend/routes/test_explorer.py \
              ../../tests/backend/crud/
```

344 passed, plus 65 across `routes/test_test_set_update.py`, `routes/test_test_test_sets.py`,
`routes/test_test_bulk_delete.py`, `services/adaptive_testing/`, `services/test_test_set.py` and
the embedding service suites — the callers of the monolith functions this PR moved.

Every existing test in `tests/backend/services/explorer/` passes **unchanged** except for three
lines in `test_tests.py` that called `crud.get_test_ids_in_test_sets` directly as a helper.

New `tests/backend/crud/test_explorer_crud.py` (15 tests) pins the parts that used to be implicit
in the services: the naming sequence including the gap case (`(2)` taken but `(1)` free still
yields `(1)`) and the wildcard case, the membership and tenant scoping on `get_test_in_test_set`,
and the topic-subtree predicate — including that `Safety` does not match `Safetyville`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)