### PR TITLE
Merge Explorer import/export test-copy loops

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -1,5 +1,6 @@
 import logging
-from typing import List, Optional
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Tuple
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -282,6 +283,113 @@ def bulk_delete_explorer_test_sets(
     return result
 
 
+@dataclass(frozen=True)
+class _TestCopy:
+    """One source test, parsed into the fields both copy directions write.
+
+    ``topic_name`` and ``topic_id`` are both carried because the two writers
+    address the topic differently: import needs the slash path so it can build
+    the topic markers, export needs the FK.
+    """
+
+    content: str
+    topic_name: str
+    topic_id: Optional[UUID]
+    output: str
+    label: str
+    labeler: str
+    model_score: float
+
+
+def _parse_test_for_copy(db_test: models.Test, default_labeler: str) -> Optional[_TestCopy]:
+    """Parse a source test into a ``_TestCopy``, or None if it can't be copied.
+
+    Returns None for topic-marker rows and for tests with no prompt content
+    (e.g. multi-turn-only); both are counted as skipped by the caller.
+    """
+    meta = db_test.test_metadata or {}
+    if meta.get("label") == "topic_marker":
+        return None
+
+    prompt = db_test.prompt
+    content = (prompt.content or "").strip() if prompt else ""
+    if not content:
+        return None
+
+    topic_name = ""
+    if db_test.topic is not None and getattr(db_test.topic, "name", None):
+        topic_name = str(db_test.topic.name) or ""
+
+    label_raw = meta.get("label", "") or ""
+
+    try:
+        model_score = float(meta.get("model_score", 0.0) or 0.0)
+    except (TypeError, ValueError):
+        model_score = 0.0
+
+    return _TestCopy(
+        content=content,
+        topic_name=topic_name,
+        topic_id=db_test.topic_id,
+        output=str(meta.get("output", "") or ""),
+        label=label_raw if label_raw in ("", "pass", "fail") else "",
+        labeler=str(meta.get("labeler", default_labeler) or default_labeler),
+        model_score=model_score,
+    )
+
+
+def _copy_test_set_tests(
+    db: Session,
+    source_test_set_id: UUID,
+    default_labeler: str,
+    write: Callable[[_TestCopy], None],
+) -> Tuple[int, int, List[str]]:
+    """Walk a test set's tests and hand each copyable one to ``write``.
+
+    Shared by import and export -- the two differ only in what ``write`` does
+    with each parsed test.
+
+    Returns
+    -------
+    tuple
+        ``(copied, skipped, skipped_test_ids)``
+    """
+    copied = 0
+    skipped = 0
+    skipped_test_ids: List[str] = []
+    # Must stay within crud.get_test_set_tests pagination max (100).
+    batch_size = 100
+    skip = 0
+
+    while True:
+        items, total = crud.get_test_set_tests(
+            db=db,
+            test_set_id=source_test_set_id,
+            skip=skip,
+            limit=batch_size,
+            sort_by="created_at",
+            sort_order="asc",
+        )
+        if not items:
+            break
+
+        for db_test in items:
+            test_copy = _parse_test_for_copy(db_test, default_labeler)
+            if test_copy is None:
+                skipped += 1
+                skipped_test_ids.append(str(db_test.id))
+                continue
+
+            write(test_copy)
+            copied += 1
+
+        skip += len(items)
+        if skip >= total:
+            break
+
+    return copied, skipped, skipped_test_ids
+
+
 def import_explorer_test_set_from_source(
     db: Session,
     source_test_set_identifier: str,
@@ -339,70 +447,28 @@ def import_explorer_test_set_from_source(
     if explorer_settings_src and isinstance(explorer_settings_src, dict):
         crud_explorer.replace_test_set_adaptive_settings(db, new_set, explorer_settings_src)
 
-    imported = 0
-    skipped = 0
-    skipped_test_ids: List[str] = []
-    # Must stay within crud.get_test_set_tests pagination max (100).
-    batch_size = 100
-    skip = 0
-
-    while True:
-        items, total = crud.get_test_set_tests(
+    def write(test_copy: _TestCopy) -> None:
+        # create_test_node() takes the topic path, not the FK: it builds the
+        # topic markers the tree is read from before resolving the topic row.
+        create_test_node(
             db=db,
-            test_set_id=db_source.id,
-            skip=skip,
-            limit=batch_size,
-            sort_by="created_at",
-            sort_order="asc",
+            test_set_id=new_set.id,
+            organization_id=organization_id,
+            user_id=user_id,
+            topic=test_copy.topic_name,
+            input=test_copy.content,
+            output=test_copy.output,
+            labeler=test_copy.labeler,
+            label=test_copy.label,
+            model_score=test_copy.model_score,
         )
-        if not items:
-            break
 
-        for db_test in items:
-            meta = db_test.test_metadata or {}
-            if meta.get("label") == "topic_marker":
-                skipped += 1
-                skipped_test_ids.append(str(db_test.id))
-                continue
-
-            prompt = db_test.prompt
-            content = (prompt.content or "").strip() if prompt else ""
-            if not content:
-                skipped += 1
-                skipped_test_ids.append(str(db_test.id))
-                continue
-
-            topic_name = ""
-            if db_test.topic is not None and getattr(db_test.topic, "name", None):
-                topic_name = str(db_test.topic.name) or ""
-
-            label_raw = meta.get("label", "") or ""
-            label = label_raw if label_raw in ("", "pass", "fail") else ""
-
-            output_val = meta.get("output", "") or ""
-            labeler_val = meta.get("labeler", "imported") or "imported"
-            try:
-                model_score_val = float(meta.get("model_score", 0.0) or 0.0)
-            except (TypeError, ValueError):
-                model_score_val = 0.0
-
-            create_test_node(
-                db=db,
-                test_set_id=new_set.id,
-                organization_id=organization_id,
-                user_id=user_id,
-                topic=topic_name,
-                input=content,
-                output=str(output_val),
-                labeler=str(labeler_val),
-                label=label,
-                model_score=model_score_val,
-            )
-            imported += 1
-
-        skip += len(items)
-        if skip >= total:
-            break
+    imported, skipped, skipped_test_ids = _copy_test_set_tests(
+        db,
+        source_test_set_id=db_source.id,
+        default_labeler="imported",
+        write=write,
+    )
 
     crud_explorer.refresh_test_set(db, new_set)
     return {
@@ -480,88 +546,47 @@ def export_regular_test_set_from_explorer(
         user_id=user_id,
     )
 
-    exported = 0
-    skipped = 0
-    skipped_test_ids: List[str] = []
-    batch_size = 100
-    skip = 0
-
-    while True:
-        items, total = crud.get_test_set_tests(
-            db=db,
-            test_set_id=db_source.id,
-            skip=skip,
-            limit=batch_size,
-            sort_by="created_at",
-            sort_order="asc",
-        )
-        if not items:
-            break
-
-        for db_test in items:
-            meta = db_test.test_metadata or {}
-            if meta.get("label") == "topic_marker":
-                skipped += 1
-                skipped_test_ids.append(str(db_test.id))
-                continue
-
-            prompt = db_test.prompt
-            content = (prompt.content or "").strip() if prompt else ""
-            if not content:
-                skipped += 1
-                skipped_test_ids.append(str(db_test.id))
-                continue
-
-            topic_id = db_test.topic_id
-            if topic_id is None:
-                topic_name = ""
-                if db_test.topic is not None and getattr(db_test.topic, "name", None):
-                    topic_name = str(db_test.topic.name) or ""
-                if topic_name:
-                    db_topic = get_or_create_topic(
-                        db=db,
-                        name=topic_name,
-                        organization_id=organization_id,
-                        user_id=user_id,
-                    )
-                    topic_id = db_topic.id
-
-            label_raw = meta.get("label", "") or ""
-            label = label_raw if label_raw in ("", "pass", "fail") else ""
-
-            output_val = meta.get("output", "") or ""
-            labeler_val = meta.get("labeler", "exported") or "exported"
-            try:
-                model_score_val = float(meta.get("model_score", 0.0) or 0.0)
-            except (TypeError, ValueError):
-                model_score_val = 0.0
-
-            new_test = crud_explorer.create_explorer_test(
-                db,
-                organization_id=organization_id,
-                user_id=user_id,
-                topic_id=topic_id,
-                content=content,
-                metadata={
-                    "output": str(output_val),
-                    "label": label,
-                    "labeler": str(labeler_val),
-                    "model_score": model_score_val,
-                },
-            )
-
-            create_test_set_associations(
+    def write(test_copy: _TestCopy) -> None:
+        # The exported set gets no topic markers, so the topic is carried by FK
+        # alone -- resolved from the path only when the source row had none.
+        topic_id = test_copy.topic_id
+        if topic_id is None and test_copy.topic_name:
+            db_topic = get_or_create_topic(
                 db=db,
-                test_set_id=str(new_set.id),
-                test_ids=[str(new_test.id)],
+                name=test_copy.topic_name,
                 organization_id=organization_id,
                 user_id=user_id,
             )
-            exported += 1
+            topic_id = db_topic.id
 
-        skip += len(items)
-        if skip >= total:
-            break
+        new_test = crud_explorer.create_explorer_test(
+            db,
+            organization_id=organization_id,
+            user_id=user_id,
+            topic_id=topic_id,
+            content=test_copy.content,
+            metadata={
+                "output": test_copy.output,
+                "label": test_copy.label,
+                "labeler": test_copy.labeler,
+                "model_score": test_copy.model_score,
+            },
+        )
+
+        create_test_set_associations(
+            db=db,
+            test_set_id=str(new_set.id),
+            test_ids=[str(new_test.id)],
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+
+    exported, skipped, skipped_test_ids = _copy_test_set_tests(
+        db,
+        source_test_set_id=db_source.id,
+        default_labeler="exported",
+        write=write,
+    )
 
     crud_explorer.refresh_test_set(db, new_set)
     return {

--- a/tests/backend/services/explorer/test_tests.py
+++ b/tests/backend/services/explorer/test_tests.py
@@ -22,6 +22,7 @@ from rhesis.backend.app.services.explorer import (
     import_explorer_test_set_from_source,
     update_test_node,
 )
+from rhesis.backend.app.services.explorer.tests import _parse_test_for_copy
 
 # ============================================================================
 # Helpers and Fixtures for get_explorer_test_sets
@@ -1214,3 +1215,93 @@ class TestExportRegularTestSetFromExplorer:
                 organization_id=test_org_id,
                 user_id=authenticated_user_id,
             )
+
+
+# ============================================================================
+# Tests for _parse_test_for_copy (shared by import and export)
+# ============================================================================
+
+
+def _copyable_test(metadata=None, content="Prompt", topic=None, topic_id=None):
+    """A detached models.Test standing in for a source row.
+
+    Not added to a session: _parse_test_for_copy only reads attributes.
+    """
+    return models.Test(
+        test_metadata=metadata,
+        prompt=models.Prompt(content=content) if content is not None else None,
+        topic=topic,
+        topic_id=topic_id,
+    )
+
+
+@pytest.mark.unit
+class TestParseTestForCopy:
+    """Test _parse_test_for_copy."""
+
+    def test_skips_topic_markers(self):
+        db_test = _copyable_test(metadata={"label": "topic_marker"})
+
+        assert _parse_test_for_copy(db_test, "imported") is None
+
+    def test_skips_missing_prompt(self):
+        assert _parse_test_for_copy(_copyable_test(content=None), "imported") is None
+
+    def test_skips_blank_prompt(self):
+        assert _parse_test_for_copy(_copyable_test(content="   "), "imported") is None
+
+    def test_strips_prompt_content(self):
+        parsed = _parse_test_for_copy(_copyable_test(content="  padded  "), "imported")
+
+        assert parsed.content == "padded"
+
+    def test_carries_both_topic_forms(self):
+        topic_id = uuid.uuid4()
+        db_test = _copyable_test(topic=models.Topic(name="Alpha/Beta"), topic_id=topic_id)
+
+        parsed = _parse_test_for_copy(db_test, "imported")
+
+        assert parsed.topic_name == "Alpha/Beta"
+        assert parsed.topic_id == topic_id
+
+    def test_defaults_when_metadata_absent(self):
+        parsed = _parse_test_for_copy(_copyable_test(metadata=None), "exported")
+
+        assert parsed.topic_name == ""
+        assert parsed.topic_id is None
+        assert parsed.output == ""
+        assert parsed.label == ""
+        assert parsed.labeler == "exported"
+        assert parsed.model_score == 0.0
+
+    @pytest.mark.parametrize("label,expected", [("pass", "pass"), ("fail", "fail"), ("", "")])
+    def test_keeps_verdict_labels(self, label, expected):
+        parsed = _parse_test_for_copy(_copyable_test(metadata={"label": label}), "imported")
+
+        assert parsed.label == expected
+
+    def test_drops_unrecognized_label(self):
+        parsed = _parse_test_for_copy(_copyable_test(metadata={"label": "error"}), "imported")
+
+        assert parsed.label == ""
+
+    def test_falls_back_to_default_labeler_when_blank(self):
+        parsed = _parse_test_for_copy(_copyable_test(metadata={"labeler": ""}), "imported")
+
+        assert parsed.labeler == "imported"
+
+    @pytest.mark.parametrize("raw", ["not a number", None, {}])
+    def test_coerces_unparseable_model_score_to_zero(self, raw):
+        parsed = _parse_test_for_copy(_copyable_test(metadata={"model_score": raw}), "imported")
+
+        assert parsed.model_score == 0.0
+
+    def test_coerces_numeric_string_model_score(self):
+        parsed = _parse_test_for_copy(_copyable_test(metadata={"model_score": "0.5"}), "imported")
+
+        assert parsed.model_score == 0.5
+
+    def test_stringifies_non_string_output(self):
+        parsed = _parse_test_for_copy(_copyable_test(metadata={"output": 42}), "imported")
+
+        assert parsed.output == "42"


### PR DESCRIPTION
## Purpose

Last open bullet of roadmap item 2.6 (deduplicate). `import_explorer_test_set_from_source` and
`export_regular_test_set_from_explorer` were two near-identical ~100-line paginate/parse/coerce
loops over a source test set's tests; only the write differed.

The roadmap deferred this to post-Phase-3 on the grounds that "Phase 3 changes both writes." That
reasoning inverts once merged — the writes are exactly the part that stays per-direction, so the
shared loop is the piece Phase 3 doesn't touch.

## What Changed

- `_copy_test_set_tests(db, source_test_set_id, default_labeler, write)` owns the pagination and
  the copied/skipped counting. Each direction passes a write closure.
- `_parse_test_for_copy()` returns a frozen `_TestCopy`, or `None` for rows that can't be copied
  (topic markers, empty prompts) — `None` is the "skip" signal. The coercions that were written
  twice each (label narrowed to `""`/`pass`/`fail`, `float()` with a `TypeError`/`ValueError`
  fallback, `str()` on output and labeler) now exist once.
- `_TestCopy` carries both `topic_name` and `topic_id`, which is the one real asymmetry between the
  directions: import hands the slash path to `create_test_node` because it builds the topic markers
  the tree is read from; export writes the FK directly, falling back to `get_or_create_topic` on the
  path only when the source row had no FK. Both writers now carry a comment saying so — previously
  the difference was visible only by diffing the two loops.
- 16 new unit tests (`TestParseTestForCopy`) against detached `models.Test` instances.

Pure refactor: both public functions keep their signature, their guard, and their return dict.
`imported` vs `exported` stay distinct deliberately — the router and the frontend read those key
names. Nothing above the service layer changed.

## Additional Context

- Follows #2304 (2.6 bullets 1 and 3) and #2315 / #2316 (2.2). This closes out 2.6.
- Checked that `crud.get_test_set_tests` eager-loads `Test.topic`, so the parser reading
  `db_test.topic` unconditionally — export previously read it only when `topic_id` was NULL — adds
  no queries.
- The `label`-as-discriminator special-case in `tests.py` went from two sites to one, which Phase 3
  will remove along with the rest.

## Testing

The coercion branches had no coverage in either direction before this — both loops were reachable
only through the two end-to-end happy-path tests. All pre-existing tests pass unchanged.

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/explorer/ -q   # 187 passed
uv run pytest ../../tests/backend/routes/test_explorer.py -q   # 88 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)