### PR TITLE
Settle Explorer vocabulary on "explorer"

### DIFF
--- a/apps/backend/src/rhesis/backend/app/constants.py
+++ b/apps/backend/src/rhesis/backend/app/constants.py
@@ -108,8 +108,11 @@ class MetricType:
     CUSTOM_PROMPT = "custom-prompt"
 
 
-# Display name stored in test_set.attributes["metadata"]["behaviors"] for explorer test sets
-ADAPTIVE_TESTING_BEHAVIOR = "Adaptive Testing"
+# Marker behavior name stored in test_set.attributes["metadata"]["behaviors"] for Explorer
+# test sets. "Explorer" is the settled vocabulary (see explorer-roadmap.md 2.1) -- the value
+# itself is legacy ("Adaptive Testing", the module's old name) and must not change: it is
+# already persisted in existing test_set rows and matched via JSONB containment.
+EXPLORER_BEHAVIOR_NAME = "Adaptive Testing"
 
 
 # Error messages

--- a/apps/backend/src/rhesis/backend/app/crud/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/crud/__init__.py
@@ -15,7 +15,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Session, joinedload
 
 from rhesis.backend.app import models, schemas
-from rhesis.backend.app.constants import ADAPTIVE_TESTING_BEHAVIOR, TestExecutionContext
+from rhesis.backend.app.constants import EXPLORER_BEHAVIOR_NAME, TestExecutionContext
 from rhesis.backend.app.database import reset_session_context
 from rhesis.backend.app.models.test import test_test_set_association
 from rhesis.backend.app.schemas.tag import EntityType
@@ -666,7 +666,7 @@ def get_test_sets(
         query_builder = query_builder.with_custom_filter(has_runs_filter)
 
     # Exclude explorer test sets (they use the dedicated /explorer API)
-    explorer_marker = cast([ADAPTIVE_TESTING_BEHAVIOR], JSONB)
+    explorer_marker = cast([EXPLORER_BEHAVIOR_NAME], JSONB)
     behaviors_json = models.TestSet.attributes["metadata"]["behaviors"]
 
     def exclude_explorer_test_sets(query):

--- a/apps/backend/src/rhesis/backend/app/crud/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/crud/explorer.py
@@ -18,7 +18,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, contains_eager, joinedload
 
 from rhesis.backend.app import models, schemas
-from rhesis.backend.app.constants import ADAPTIVE_TESTING_BEHAVIOR
+from rhesis.backend.app.constants import EXPLORER_BEHAVIOR_NAME
 
 # _TEST_SET_RELATED_FIELDS is imported rather than relocated: three other functions in
 # the monolith use the same tuple, and moving it would mean deciding a new home for a
@@ -70,9 +70,9 @@ def get_explorer_test_sets(
     Returns
     -------
     list of models.TestSet
-        Test sets carrying the Adaptive Testing behavior.
+        Test sets carrying the Explorer marker behavior.
     """
-    explorer_marker = cast([ADAPTIVE_TESTING_BEHAVIOR], JSONB)
+    explorer_marker = cast([EXPLORER_BEHAVIOR_NAME], JSONB)
 
     def only_explorer_test_sets(query):
         return query.filter(
@@ -160,10 +160,14 @@ def get_test_ids_in_test_sets(
     return [row.test_id for row in rows]
 
 
-def replace_test_set_adaptive_settings(
+def replace_test_set_explorer_settings(
     db: Session, test_set: models.TestSet, settings: Dict[str, Any]
 ) -> models.TestSet:
     """Overwrite a test set's ``attributes["adaptive_settings"]`` wholesale.
+
+    The JSONB key itself stays ``adaptive_settings`` -- it's already persisted on existing
+    test sets, and renaming it would silently drop settings written under the old key
+    without a data migration (tracked with the rest of the blob in Phase 3).
 
     Used by import, which copies the source set's settings across as a unit. Contrast
     :func:`set_test_set_default_endpoint`, which patches a single key.

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
-from rhesis.backend.app.constants import ADAPTIVE_TESTING_BEHAVIOR
+from rhesis.backend.app.constants import EXPLORER_BEHAVIOR_NAME
 
 # Imported as a module rather than by name: this file's own public
 # get_explorer_test_sets() wraps the crud function of the same name.
@@ -159,13 +159,13 @@ def create_explorer_test_set(
     """
     behavior = get_or_create_behavior(
         db=db,
-        name=ADAPTIVE_TESTING_BEHAVIOR,
+        name=EXPLORER_BEHAVIOR_NAME,
         organization_id=organization_id,
         user_id=user_id,
     )
     attributes = {
         "behaviors": [str(behavior.id)],
-        "metadata": {"behaviors": [ADAPTIVE_TESTING_BEHAVIOR]},
+        "metadata": {"behaviors": [EXPLORER_BEHAVIOR_NAME]},
     }
     test_set_type_lookup = get_or_create_type_lookup(
         db=db,
@@ -189,11 +189,11 @@ def create_explorer_test_set(
 
 
 def _is_explorer_test_set(test_set: models.TestSet) -> bool:
-    """True if the test set has Adaptive Testing in metadata.behaviors."""
+    """True if the test set has the Explorer marker behavior in metadata.behaviors."""
     attrs = test_set.attributes or {}
     metadata = attrs.get("metadata") or {}
     behaviors = metadata.get("behaviors") or []
-    return ADAPTIVE_TESTING_BEHAVIOR in behaviors
+    return EXPLORER_BEHAVIOR_NAME in behaviors
 
 
 def _delete_session_tests(
@@ -434,7 +434,7 @@ def import_explorer_test_set_from_source(
     if _is_explorer_test_set(db_source):
         raise ValueError("Source test set is already configured for Explorer")
 
-    base_name = f"{db_source.name} (Adaptive)"
+    base_name = f"{db_source.name} (Explorer)"
     new_name = crud_explorer.find_unused_test_set_name(db, organization_id, base_name)
 
     new_set = create_explorer_test_set(
@@ -449,7 +449,7 @@ def import_explorer_test_set_from_source(
     src_attrs = db_source.attributes or {}
     explorer_settings_src = src_attrs.get("adaptive_settings")
     if explorer_settings_src and isinstance(explorer_settings_src, dict):
-        crud_explorer.replace_test_set_adaptive_settings(db, new_set, explorer_settings_src)
+        crud_explorer.replace_test_set_explorer_settings(db, new_set, explorer_settings_src)
 
     def write(test_copy: _TestCopy) -> None:
         # create_test_node() takes the topic path, not the FK: it builds the

--- a/tests/backend/crud/test_explorer_crud.py
+++ b/tests/backend/crud/test_explorer_crud.py
@@ -14,7 +14,7 @@ Functions tested:
 - update_explorer_test: selective field application, and the topic reload it depends on
 - reassign_tests_topic: per-test topic moves, including orphaning
 - remove_tests_from_test_set: batched association detach
-- replace_test_set_adaptive_settings / set_test_set_default_endpoint: replace vs patch
+- replace_test_set_explorer_settings / set_test_set_default_endpoint: replace vs patch
 - set_explorer_test_metadata: batched metadata writes
 
 Run with: python -m pytest tests/backend/crud/test_explorer_crud.py -v
@@ -33,7 +33,7 @@ from rhesis.backend.app.crud.explorer import (
     get_tests_under_topic,
     reassign_tests_topic,
     remove_tests_from_test_set,
-    replace_test_set_adaptive_settings,
+    replace_test_set_explorer_settings,
     set_explorer_test_metadata,
     set_test_set_default_endpoint,
     update_explorer_test,
@@ -624,7 +624,7 @@ class TestAdaptiveSettingsWrites:
         }
         test_db.flush()
 
-        replace_test_set_adaptive_settings(test_db, test_set, {"default_endpoint_id": "fresh"})
+        replace_test_set_explorer_settings(test_db, test_set, {"default_endpoint_id": "fresh"})
 
         assert test_set.attributes["adaptive_settings"] == {"default_endpoint_id": "fresh"}
         # Everything outside adaptive_settings survives.

--- a/tests/backend/crud/test_test_crud.py
+++ b/tests/backend/crud/test_test_crud.py
@@ -19,7 +19,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
-from rhesis.backend.app.constants import ADAPTIVE_TESTING_BEHAVIOR
+from rhesis.backend.app.constants import EXPLORER_BEHAVIOR_NAME
 from rhesis.backend.app.models.test import test_test_set_association
 from rhesis.backend.app.services import test_set as test_set_service
 
@@ -185,7 +185,7 @@ class TestTestOperations:
             name="Explorer Test Set",
             organization_id=test_org_id,
             user_id=authenticated_user_id,
-            attributes={"metadata": {"behaviors": [ADAPTIVE_TESTING_BEHAVIOR]}},
+            attributes={"metadata": {"behaviors": [EXPLORER_BEHAVIOR_NAME]}},
         )
         test_db.add_all([db_test, explorer_test_set])
         test_db.flush()
@@ -216,7 +216,7 @@ class TestTestOperations:
         )
         assert reloaded_explorer_test_set is not None
         assert reloaded_explorer_test_set.attributes["metadata"]["behaviors"] == [
-            ADAPTIVE_TESTING_BEHAVIOR
+            EXPLORER_BEHAVIOR_NAME
         ]
 
 

--- a/tests/backend/routes/test_explorer.py
+++ b/tests/backend/routes/test_explorer.py
@@ -579,7 +579,7 @@ class TestImportExplorerTestSetEndpoint:
 
         new_id = data["test_set"]["id"]
         assert new_id != str(src.id)
-        assert "(Adaptive)" in data["test_set"]["name"]
+        assert "(Explorer)" in data["test_set"]["name"]
 
         tests_resp = authenticated_client.get(f"/explorer/{new_id}/tests")
         assert tests_resp.status_code == status.HTTP_200_OK

--- a/tests/backend/services/test_test_set.py
+++ b/tests/backend/services/test_test_set.py
@@ -13,7 +13,7 @@ from faker import Faker
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
-from rhesis.backend.app.constants import ADAPTIVE_TESTING_BEHAVIOR
+from rhesis.backend.app.constants import EXPLORER_BEHAVIOR_NAME
 from rhesis.backend.app.services import test_set as test_set_service
 
 # Use existing data factories from the established pattern
@@ -663,7 +663,7 @@ class TestGetTestSetsExcludesExplorer:
             organization_id=test_org_id,
             user_id=authenticated_user_id,
             visibility="organization",
-            attributes={"metadata": {"behaviors": [ADAPTIVE_TESTING_BEHAVIOR]}},
+            attributes={"metadata": {"behaviors": [EXPLORER_BEHAVIOR_NAME]}},
         )
         test_db.add_all([regular, explorer])
         test_db.commit()


### PR DESCRIPTION
## Purpose

Explorer's code used three names for one concept: the module/API is *explorer*, the behavior
constant was `"Adaptive Testing"`, and settings lived under `attributes.adaptive_settings`. This is
roadmap item 2.1 from the Explorer refactor plan -- settling on `explorer` since it's already the
router, the frontend surface, and the docs term.

## What Changed

- `constants.ADAPTIVE_TESTING_BEHAVIOR` renamed to `EXPLORER_BEHAVIOR_NAME` (value unchanged),
  updated at all call sites (`crud/__init__.py`, `crud/explorer.py`, `services/explorer/tests.py`)
  and the tests that import it directly.
- `crud.explorer.replace_test_set_adaptive_settings` renamed to `replace_test_set_explorer_settings`.
- The generated import name suffix `f"{name} (Adaptive)"` renamed to `f"{name} (Explorer)"` --
  only affects test sets created going forward.
- Left unchanged, deliberately: the literal `"Adaptive Testing"` behavior string and the
  `adaptive_settings` JSONB key. Both are already persisted in existing test sets' `attributes`
  (matched via JSONB containment / read directly), so renaming either without a data migration
  would silently stop matching or reading old sessions. Phase 3 of the Explorer roadmap already
  plans to retire both for good when the JSONB blob moves into real tables.

## Additional Context

Part of the Explorer backend refactor roadmap (internal `playground/explorer-roadmap.md`,
gitignored, not part of this diff).

## Testing

- `tests/backend/crud/test_explorer_crud.py`, `test_test_crud.py`,
  `tests/backend/services/test_test_set.py`, `tests/backend/routes/test_explorer.py`: 144 passed.
- Full `tests/backend/services/explorer/` suite: 187 passed.
- `ruff check` clean on all touched files.