### PR TITLE
Hide create-project actions from users without permission

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/components/TabOverview.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/TabOverview.tsx
@@ -25,6 +25,8 @@ import { SectionCard } from '@/components/common/SectionCard';
 import FormSectionDivider from '@/components/common/FormSectionDivider';
 import { getProjectIcon } from '@/components/common/ProjectIcons';
 import { Project } from '@/utils/api-client/interfaces/project';
+import { useCan } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
 import type { FormData } from './EndpointForm';
 
 const ENVIRONMENTS = ['production', 'staging', 'development', 'local'];
@@ -44,23 +46,32 @@ function ProjectSelect({
   projects,
   loadingProjects,
 }: TabOverviewProps) {
+  const canCreateProject = useCan(Capability.Project.CREATE);
+
   if (projects.length === 0 && !loadingProjects) {
     return (
       <Alert
         severity="warning"
         sx={{ mb: 2 }}
+        // Only offer the shortcut to callers who hold project:create. The
+        // built-in Member role does not, so linking them to the wizard just
+        // produces a 403 once they reach the end of it.
         action={
-          <Button
-            color="inherit"
-            size="small"
-            component="a"
-            href="/projects/create-new"
-          >
-            Create Project
-          </Button>
+          canCreateProject ? (
+            <Button
+              color="inherit"
+              size="small"
+              component="a"
+              href="/projects/create-new"
+            >
+              Create Project
+            </Button>
+          ) : undefined
         }
       >
-        No projects available. Please create a project first.
+        {canCreateProject
+          ? 'No projects available. Please create a project first.'
+          : 'No projects available. Ask an administrator to add you to a project.'}
       </Alert>
     );
   }

--- a/apps/frontend/src/app/(protected)/projects/create-new/components/CreateProjectClient.tsx
+++ b/apps/frontend/src/app/(protected)/projects/create-new/components/CreateProjectClient.tsx
@@ -20,6 +20,10 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { ProjectCreate } from '@/utils/api-client/interfaces/project';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { writeActiveProjectId } from '@/utils/active-project';
+import { useCanWithStatus } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+import AccessDenied from '@/components/common/AccessDenied';
+import PageLoadingState from '@/components/common/PageLoadingState';
 import type { UUID } from 'crypto';
 
 interface FormData {
@@ -47,6 +51,9 @@ export default function CreateProjectClient({
   const router = useRouter();
   const theme = useTheme();
   const { refresh: refreshActiveProjects } = useActiveProject();
+  const { allowed: canCreate, loading: permsLoading } = useCanWithStatus(
+    Capability.Project.CREATE
+  );
   const [activeStep, setActiveStep] = React.useState(0);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -175,6 +182,12 @@ export default function CreateProjectClient({
   const handleCloseError = () => {
     setError(null);
   };
+
+  // Final defence against direct URL access: project:create is org-scoped, and
+  // the built-in Member role does not hold it. Without this the wizard renders
+  // fine and only fails with a 403 on submit, after the form is filled in.
+  if (permsLoading) return <PageLoadingState />;
+  if (!canCreate) return <AccessDenied resource="project creation" />;
 
   return (
     <Container

--- a/apps/frontend/src/app/(protected)/projects/create-new/components/CreateProjectClient.tsx
+++ b/apps/frontend/src/app/(protected)/projects/create-new/components/CreateProjectClient.tsx
@@ -187,7 +187,7 @@ export default function CreateProjectClient({
   // the built-in Member role does not hold it. Without this the wizard renders
   // fine and only fails with a 403 on submit, after the form is filled in.
   if (permsLoading) return <PageLoadingState />;
-  if (!canCreate) return <AccessDenied resource="project creation" />;
+  if (!canCreate) return <AccessDenied resource="the project creation page" />;
 
   return (
     <Container

--- a/apps/frontend/src/components/common/NoProjectAccess.tsx
+++ b/apps/frontend/src/components/common/NoProjectAccess.tsx
@@ -8,17 +8,24 @@ import { useRouter } from 'next/navigation';
 import { BORDER_RADIUS } from '@/styles/theme';
 import ProjectSwitcherDrawer from '@/components/navigation/ProjectSwitcherDrawer';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useCan } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
 
 /**
  * Shown when the authenticated user belongs to an organization but has no
- * project memberships.  Offers two exits:
- *  1. Create a new project (which auto-enrolls them as owner).
+ * project memberships.  Offers up to two exits:
+ *  1. Create a new project (which auto-enrolls them as owner) — only when they
+ *     hold `project:create`. That capability is org-scoped and the built-in
+ *     Member role does not have it, so SSO-provisioned users land here without
+ *     it; offering the button anyway sends them into a wizard that 403s on
+ *     submit.
  *  2. Refresh the switcher in case an admin just added them.
  */
 export default function NoProjectAccess() {
   const router = useRouter();
   const { refresh } = useActiveProject();
   const [switcherOpen, setSwitcherOpen] = useState(false);
+  const canCreateProject = useCan(Capability.Project.CREATE);
 
   const handleRefresh = async () => {
     await refresh({ listOnly: false });
@@ -68,8 +75,9 @@ export default function NoProjectAccess() {
             No project access
           </Typography>
           <Typography variant="body1" color="text.secondary">
-            You are not a member of any project yet. Ask an administrator to add
-            you to a project, or create a new one.
+            {canCreateProject
+              ? 'You are not a member of any project yet. Ask an administrator to add you to a project, or create a new one.'
+              : 'You are not a member of any project yet. Ask an administrator to add you to a project.'}
           </Typography>
         </Box>
 
@@ -82,24 +90,28 @@ export default function NoProjectAccess() {
             width: '100%',
           }}
         >
-          <Button
-            variant="contained"
-            size="large"
-            startIcon={<AddIcon />}
-            onClick={() => router.push('/projects/create-new')}
-            sx={{ borderRadius: BORDER_RADIUS.sm }}
-          >
-            Create a new project
-          </Button>
+          {canCreateProject && (
+            <>
+              <Button
+                variant="contained"
+                size="large"
+                startIcon={<AddIcon />}
+                onClick={() => router.push('/projects/create-new')}
+                sx={{ borderRadius: BORDER_RADIUS.sm }}
+              >
+                Create a new project
+              </Button>
 
-          <Divider>
-            <Typography variant="caption" color="text.disabled">
-              or
-            </Typography>
-          </Divider>
+              <Divider>
+                <Typography variant="caption" color="text.disabled">
+                  or
+                </Typography>
+              </Divider>
+            </>
+          )}
 
           <Button
-            variant="outlined"
+            variant={canCreateProject ? 'outlined' : 'contained'}
             size="large"
             onClick={handleRefresh}
             sx={{ borderRadius: BORDER_RADIUS.sm }}

--- a/apps/frontend/src/components/common/__tests__/NoProjectAccess.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/NoProjectAccess.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import NoProjectAccess from '../NoProjectAccess';
+
+const mockPush = jest.fn();
+let mockCanCreate = true;
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => mockCanCreate,
+  useCanWithStatus: () => ({ allowed: mockCanCreate, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => mockCanCreate,
+}));
+
+jest.mock('@/contexts/ActiveProjectContext', () => ({
+  useActiveProject: () => ({ refresh: jest.fn() }),
+}));
+
+jest.mock('@/components/navigation/ProjectSwitcherDrawer', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe('NoProjectAccess', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockCanCreate = true;
+  });
+
+  it('offers project creation when the user holds project:create', () => {
+    render(<NoProjectAccess />);
+
+    expect(
+      screen.getByRole('button', { name: /create a new project/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/or create a new one/i)).toBeInTheDocument();
+  });
+
+  // The built-in Member role does not hold project:create (it is org-scoped),
+  // so SSO-provisioned users land here without it. Offering the button anyway
+  // sent them into the wizard, which only failed with a 403 on submit.
+  it('hides project creation when the user lacks project:create', () => {
+    mockCanCreate = false;
+
+    render(<NoProjectAccess />);
+
+    expect(
+      screen.queryByRole('button', { name: /create a new project/i })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/or create a new one/i)).not.toBeInTheDocument();
+  });
+
+  it('always offers the re-check action', () => {
+    mockCanCreate = false;
+
+    render(<NoProjectAccess />);
+
+    expect(
+      screen.getByRole('button', { name: /check again/i })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Purpose

An SSO-provisioned user hit `403 - Permission denied: project:create` after filling in the entire Create Project wizard.

`project:create` is org-scoped (`capabilities.py:376`), and `_member_permissions` (`ee/rbac/models.py:150`) only grants create/update/delete on *project*-scoped resources plus three hardcoded org-scoped extras. `project:create` is not one of them, so the built-in **Member** role does not hold it. SSO auto-provisioning assigns Member (`ee/rbac/default_role.py:84`, since the new user is not the org owner), which means every auto-provisioned user was being shown an action they cannot perform.

Confirmed against the live capability registry:

| role | level | total perms | `project:create` |
|---|---|---|---|
| Owner | 100 | 176 | yes |
| Admin | 80 | 176 | yes |
| **Member** | 60 | 159 | **no** |
| Viewer | 40 | 41 | no |

This PR stops offering the action. It does not change who can create projects.

## What Changed

Gated the three ungated entry points on `useCan(Capability.Project.CREATE)`:

- **`NoProjectAccess`**: the screen a user with no project memberships lands on, and the most likely route into the wizard. Hides the button and its divider, and drops "or create a new one" from the copy. The re-check action is promoted to `contained` so the screen still has a primary action.
- **`endpoints/TabOverview`**: the no-projects warning's "Create Project" shortcut.
- **`CreateProjectClient`**: page guard following the documented `useCanWithStatus` + `AccessDenied` pattern, so direct URL access shows Access Denied instead of an unsubmittable form.

The projects list page already gated its FAB correctly (`ProjectsClientWrapper.tsx:215`) and is unchanged.

## Additional Context

- Follows #2313 (the SSO login fix). Users can now log in, which is how they reached this next wall.
- `useCan` returns `true` when RBAC is off (`Can.tsx:36`), so community and RBAC-off deployments keep the button. The existing `TabBasics` test still passes unchanged, which confirms that path.
- **This is UI-only.** The underlying question of whether a Member *should* be able to create a project is still open. Right now an SSO-provisioned Member is in a dead end: they cannot create a project, and `_resolve_role` (`provider.py:193`) denies every project-scoped permission for an org role below Admin with no `project_membership` row. Until that is decided, an Owner or Admin has to either promote them or add them to a project.

## Testing

```bash
cd apps/frontend
npm run format && npx tsc --noEmit && npm run lint
npx jest src/components/common src/app/\(protected\)/projects src/app/\(protected\)/endpoints
```

- 291 tests across 31 suites pass.
- Type check clean; lint reports 0 errors (6 pre-existing warnings in untouched `ee/frontend` files).
- New `NoProjectAccess.test.tsx` covers both the permitted and denied cases.