### PR TITLE
Thin explorer router's test-create embedding step

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/routers/explorer.py
@@ -553,41 +553,9 @@ def create_explorer_test(
         labeler=body.labeler,
         label=body.label or "",
         model_score=body.model_score,
+        generate_embedding=body.generate_embedding,
+        current_user=current_user,
     )
-
-    if body.generate_embedding:
-        try:
-            from rhesis.backend.app.services.explorer.embeddings import (
-                create_test_embedding,
-                generate_embedding_vector,
-                load_test_for_embedding,
-            )
-
-            db_test = load_test_for_embedding(db, node.id, str(organization_id))
-            if not db_test:
-                logger.warning(
-                    "Explorer test embedding skipped: Test row not found after create "
-                    "(test_id=%s, organization_id=%s)",
-                    node.id,
-                    organization_id,
-                )
-            else:
-                text = db_test.to_searchable_text()
-                vector = generate_embedding_vector(text, db, str(user_id))
-                stored = create_test_embedding(db, db_test, vector, current_user)
-                if stored is None:
-                    logger.warning(
-                        "Explorer test embedding not persisted (test_id=%s); "
-                        "see earlier create_test_embedding logs for the reason",
-                        node.id,
-                    )
-        except Exception as e:
-            logger.warning(
-                "Explorer test embedding skipped after create (test_id=%s): %s",
-                node.id,
-                e,
-                exc_info=True,
-            )
 
     return node
 

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -11,11 +11,17 @@ from rhesis.backend.app.constants import EXPLORER_BEHAVIOR_NAME
 # Imported as a module rather than by name: this file's own public
 # get_explorer_test_sets() wraps the crud function of the same name.
 from rhesis.backend.app.crud import explorer as crud_explorer
+from rhesis.backend.app.models.user import User
 from rhesis.backend.app.schemas.explorer import (
     ExportExplorerTestSetResponse,
     ImportExplorerTestSetResponse,
     TestTreeNode,
     TopicNode,
+)
+from rhesis.backend.app.services.explorer.embeddings import (
+    create_test_embedding,
+    generate_embedding_vector,
+    load_test_for_embedding,
 )
 from rhesis.backend.app.services.explorer.topics import create_topic_node
 from rhesis.backend.app.services.explorer.utils import _db_test_to_node, build_test_tree
@@ -600,6 +606,47 @@ def export_regular_test_set_from_explorer(
     )
 
 
+def _generate_test_embedding(
+    db: Session,
+    test_id: UUID,
+    organization_id: str,
+    user_id: str,
+    current_user: User,
+) -> None:
+    """Best-effort embed + persist for a newly created explorer test.
+
+    Never raises: a test create must succeed even if embedding generation or
+    persistence fails, so failures are logged and swallowed here.
+    """
+    try:
+        db_test = load_test_for_embedding(db, test_id, organization_id)
+        if not db_test:
+            logger.warning(
+                "Explorer test embedding skipped: Test row not found after create "
+                "(test_id=%s, organization_id=%s)",
+                test_id,
+                organization_id,
+            )
+            return
+
+        text = db_test.to_searchable_text()
+        vector = generate_embedding_vector(text, db, user_id)
+        stored = create_test_embedding(db, db_test, vector, current_user)
+        if stored is None:
+            logger.warning(
+                "Explorer test embedding not persisted (test_id=%s); "
+                "see earlier create_test_embedding logs for the reason",
+                test_id,
+            )
+    except Exception as e:
+        logger.warning(
+            "Explorer test embedding skipped after create (test_id=%s): %s",
+            test_id,
+            e,
+            exc_info=True,
+        )
+
+
 def create_test_node(
     db: Session,
     test_set_id: UUID,
@@ -611,6 +658,8 @@ def create_test_node(
     labeler: str = "user",
     label: str = "",
     model_score: float = 0.0,
+    generate_embedding: bool = False,
+    current_user: Optional[User] = None,
 ) -> TestTreeNode:
     """Create a test node in the explorer test tree.
 
@@ -642,6 +691,12 @@ def create_test_node(
         Label: 'pass', 'fail', or '' (default ``""``)
     model_score : float
         Model score for the test (default ``0.0``)
+    generate_embedding : bool
+        If true, embed the test input and persist it to the embedding table
+        on a best-effort basis (default ``False``)
+    current_user : User, optional
+        Required when ``generate_embedding`` is true; the ORM user object
+        embedding persistence reads settings from
 
     Returns
     -------
@@ -701,6 +756,11 @@ def create_test_node(
     node = _db_test_to_node(db_test)
 
     logger.info(f"Created test node in test_set={test_set_id} topic='{topic}'")
+
+    if generate_embedding:
+        if current_user is None:
+            raise ValueError("current_user is required when generate_embedding=True")
+        _generate_test_embedding(db, node.id, organization_id, user_id, current_user)
 
     return node
 

--- a/tests/backend/routes/test_explorer.py
+++ b/tests/backend/routes/test_explorer.py
@@ -1308,7 +1308,7 @@ class TestCreateExplorerTestEndpoint:
         ]
 
     @patch(
-        "rhesis.backend.app.services.explorer.embeddings.generate_embedding_vector",
+        "rhesis.backend.app.services.explorer.tests.generate_embedding_vector",
         return_value=[0.01] * 384,
     )
     def test_create_test_with_generate_embedding_persists_embedding_row(

--- a/tests/backend/services/explorer/conftest.py
+++ b/tests/backend/services/explorer/conftest.py
@@ -83,6 +83,32 @@ def _associate_tests_with_test_set(db, test_set, tests, organization_id, user_id
 
 
 @pytest.fixture
+def explorer_embedding_model(test_db: Session, test_org_id, authenticated_user_id):
+    """Create a minimal 'Rhesis Default Embedding' model so create_test_embedding can persist rows.
+
+    The model uses dimension=384 so it matches the [0.01]*384 mock vector tests use to avoid a
+    real embedding API call.
+    """
+    from rhesis.backend.app.models.enums import ModelType
+
+    model = models.Model(
+        name="Rhesis Default Embedding",
+        model_name="rhesis/rhesis-embedding",
+        model_type=ModelType.EMBEDDING.value,
+        key="test-key-not-used",
+        dimension=384,
+        is_protected=True,
+        organization_id=test_org_id,
+        user_id=authenticated_user_id,
+        owner_id=authenticated_user_id,
+    )
+    test_db.add(model)
+    test_db.flush()
+    test_db.refresh(model)
+    return model
+
+
+@pytest.fixture
 def explorer_test_set(test_db: Session, test_org_id, authenticated_user_id):
     """Create a test set with adaptive testing data.
 

--- a/tests/backend/services/explorer/test_tests.py
+++ b/tests/backend/services/explorer/test_tests.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import inspect as sa_inspect
@@ -767,6 +768,59 @@ class TestCreateTestNode:
         )
         # One new test node (topic already exists)
         assert len(nodes_after) == len(nodes_before) + 1
+
+    @patch(
+        "rhesis.backend.app.services.explorer.tests.generate_embedding_vector",
+        return_value=[0.01] * 384,
+    )
+    def test_generate_embedding_persists_embedding_row(
+        self,
+        _mock_embed,
+        test_db,
+        explorer_test_set,
+        test_org_id,
+        authenticated_user_id,
+        authenticated_user,
+        explorer_embedding_model,
+    ):
+        """generate_embedding=True should persist an embedding row for the created test."""
+        result = create_test_node(
+            db=test_db,
+            test_set_id=explorer_test_set.id,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+            topic="Safety",
+            input="Embedding persistence check prompt",
+            output="ok",
+            generate_embedding=True,
+            current_user=authenticated_user,
+        )
+
+        row = (
+            test_db.query(models.Embedding)
+            .filter(
+                models.Embedding.entity_id == uuid.UUID(result.id),
+                models.Embedding.entity_type == "Test",
+            )
+            .first()
+        )
+        assert row is not None, "expected embedding row for created explorer test"
+        assert row.embedding_config.get("source") == "explorer"
+
+    def test_generate_embedding_requires_current_user(
+        self, test_db, explorer_test_set, test_org_id, authenticated_user_id
+    ):
+        """generate_embedding=True without current_user is a caller error, not swallowed."""
+        with pytest.raises(ValueError, match="current_user is required"):
+            create_test_node(
+                db=test_db,
+                test_set_id=explorer_test_set.id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+                topic="Safety",
+                input="Should not be created without current_user",
+                generate_embedding=True,
+            )
 
 
 # ============================================================================


### PR DESCRIPTION
## Purpose

`create_explorer_test` in `routers/explorer.py` did inline embedding orchestration: a function-body import plus three service calls (`load_test_for_embedding`, `generate_embedding_vector`, `create_test_embedding`) with their own error handling, all sitting in the router. Routers should be thin — this belongs behind one service call. This is roadmap item 2.3 in `playground/explorer-roadmap.md`, sourced from `explorer-architecture-review.md` §3.

## What Changed

- Added `generate_embedding: bool = False` and `current_user: Optional[User] = None` params to `create_test_node` (`services/explorer/tests.py`).
- Moved the three-call embedding sequence into a new private helper, `_generate_test_embedding`, called from `create_test_node` when `generate_embedding=True`. Same best-effort, swallow-and-log contract as before — a test create never fails because embedding did. Raises `ValueError` if `generate_embedding=True` with no `current_user` (a caller-contract bug, not a transient failure, so it isn't swallowed).
- `create_explorer_test` (`routers/explorer.py`) is now a single call into `create_test_node`; the 45-line embedding block and its function-body import are gone.
- Updated the existing route-level embedding test's mock patch target to follow the code move (`services.explorer.embeddings.generate_embedding_vector` → `services.explorer.tests.generate_embedding_vector`).
- Added two service-level tests for `create_test_node`'s new `generate_embedding` behavior, plus an `explorer_embedding_model` fixture in `tests/backend/services/explorer/conftest.py`.

## Additional Context

- Roadmap: `playground/explorer-roadmap.md` item 2.3.
- `create_test_node`'s only other caller, `import_explorer_test_set_from_source`, never passes embedding params, so the new params (defaulting to off) don't affect it.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/routes/test_explorer.py -v
uv run pytest ../../tests/backend/services/explorer/ -v
```

All 277 tests in `tests/backend/routes/test_explorer.py` and `tests/backend/services/explorer/` pass, including the two new `generate_embedding` service tests. Ruff check/format clean on all changed files.
