### PR TITLE
Add rule: don't hard-wrap PR body paragraphs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,11 @@ git checkout -b feature/short-description`.
 - Branch from latest `main`: `git fetch origin && git checkout main && git pull origin main &&
 git checkout -b feature/your-feature-name`.
 - Title: action verb first (Add/Fix/Update/Remove), under 72 characters.
+- Write each paragraph as one continuous line — don't hard-wrap at a column width. `gh pr create
+  --body`/`--body-file` sends newlines through verbatim, and GitHub renders each one as a line
+  break, so a paragraph wrapped at ~100 characters shows up as choppy fragments instead of flowing
+  text. Only break lines for real markdown structure: blank lines between sections, list items,
+  headers, code blocks.
 - Description must include these sections:
 
   ```markdown


### PR DESCRIPTION
## Purpose

While opening PR #2326, its description was written with each paragraph manually wrapped at ~100 characters (a habit carried over from code). `gh pr create --body`/`--body-file` sends newlines through verbatim, and GitHub renders each one as a line break rather than collapsing it into a space, so the description rendered as choppy sentence fragments instead of flowing paragraphs.

## What Changed

- Added a bullet to `AGENTS.md`'s "Pull Requests" section: write each paragraph in a PR body as one continuous line, and only break lines for real markdown structure (blank lines between sections, list items, headers, code blocks).

## Additional Context

- Follow-up from PR #2326, where this exact issue was found and fixed.

## Testing

Docs-only change; no code to test. Verified by re-reading the rendered rule in this PR's own description, which follows it.