### PR TITLE
Add SSO sign-in link to team invitation emails

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -53,6 +53,33 @@ def _settings_patch_forbids_embedding_update(settings_dict: dict) -> bool:
     return isinstance(models, dict) and "embedding" in models
 
 
+def _org_sso_enabled(organization) -> bool:
+    """True when *organization* signs its users in through an identity provider.
+
+    Drives the invitation email's sign-in instructions: an SSO org's users have
+    no Rhesis password, so telling them to sign in with an email address sends
+    them down a path that cannot work.
+
+    Both halves matter. ``sso_config.enabled`` is the org's own switch, and the
+    SSO feature must also be licensed — an unlicensed org keeps its stored
+    config but the SSO routes 404, so the link would be a dead end.
+
+    Reads the ``sso_config`` column and the core feature registry rather than
+    EE's ``_get_sso_config``: this module is core and must not import EE (the
+    ``community-boundary`` CI job).
+    """
+    if organization is None:
+        return False
+
+    config = organization.sso_config
+    if not isinstance(config, dict) or not config.get("enabled"):
+        return False
+
+    from rhesis.backend.app.features import FeatureName, FeatureRegistry
+
+    return FeatureRegistry.is_available(FeatureName.SSO, organization)
+
+
 def _user_settings_permitted_actions(
     request: Request,
     current_user: User,
@@ -184,6 +211,8 @@ def create_user(
                 organization_website=organization_website,
                 inviter_name=inviter_name,
                 inviter_email=current_user.email,
+                organization_slug=organization.slug if organization else None,
+                sso_enabled=_org_sso_enabled(organization),
             )
 
             if success:

--- a/apps/backend/src/rhesis/backend/notifications/email/service.py
+++ b/apps/backend/src/rhesis/backend/notifications/email/service.py
@@ -7,6 +7,7 @@ import os
 import re
 from email.mime.text import MIMEText
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote
 
 from rhesis.backend.app.config.settings import get_frontend_settings
 
@@ -134,6 +135,8 @@ class EmailService:
         inviter_name: str,
         inviter_email: str,
         frontend_url: Optional[str] = None,
+        organization_slug: Optional[str] = None,
+        sso_enabled: bool = False,
     ) -> bool:
         """
         Send a team invitation email to a new user.
@@ -146,6 +149,11 @@ class EmailService:
             inviter_name: Name of the person sending the invitation
             inviter_email: Email of the person sending the invitation
             frontend_url: URL to the frontend application
+            organization_slug: Org slug, used to build the SSO sign-in link
+            sso_enabled: True when the org has SSO configured and licensed. The
+                sign-in instructions differ: an SSO org's users authenticate
+                through their identity provider, not with an email address, so
+                pointing them at the generic sign-in page is misleading.
 
         Returns:
             bool: True if email was sent successfully, False otherwise
@@ -162,6 +170,13 @@ class EmailService:
 
         subject = f"You're invited to join {organization_name} on Rhesis AI!"
 
+        # Deep-link to the org's sign-in page so it offers that org's identity
+        # provider. The `org` param is what AuthForm reads to fetch the org's
+        # auth config; without it the page cannot know which IdP to show.
+        sso_login_url = ""
+        if sso_enabled and organization_slug:
+            sso_login_url = f"{frontend_url.rstrip('/')}/auth/signin?org={quote(organization_slug)}"
+
         template_variables = {
             "recipient_email": recipient_email,
             "recipient_name": recipient_name or "",
@@ -170,6 +185,12 @@ class EmailService:
             "inviter_name": inviter_name,
             "inviter_email": inviter_email,
             "frontend_url": frontend_url,
+            # Deliberately NOT declared in TemplateService.template_variables:
+            # missing required vars are filled with the string "N/A", which is
+            # truthy and would switch the SSO copy on for every org. Left
+            # undefined instead, which Jinja treats as falsy.
+            "sso_enabled": bool(sso_login_url),
+            "sso_login_url": sso_login_url,
         }
 
         return self.send_email(

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/team_invitation.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/team_invitation.html.jinja2
@@ -53,19 +53,35 @@
             Your account has been created and you can start using Rhesis AI right away:
         </p>
         <ol style="margin: 0; padding-left: 20px;">
+            {% if sso_enabled -%}
+            <li style="margin-bottom: 8px;">Click the "Sign in with single sign-on" button below</li>
+            <li style="margin-bottom: 8px;">Sign in with your {{ organization_name }} account (single sign-on)</li>
+            {%- else -%}
             <li style="margin-bottom: 8px;">Click the "Get Started" button below</li>
             <li style="margin-bottom: 8px;">Sign in with your email address ({{ recipient_email }})</li>
+            {%- endif %}
             <li style="margin-bottom: 8px;">Complete your profile setup</li>
             <li>Start collaborating with your team!</li>
         </ol>
     </div>
 
-    {% if frontend_url -%}
+    {% if sso_enabled -%}
+    <div style="background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
+        <h3 style="color: #1D2939; margin-top: 0;">Single sign-on is enabled</h3>
+        <p style="margin: 0;">
+            {{ organization_name }} uses single sign-on, so you do not need a separate
+            Rhesis AI password. The button below takes you to your organization's
+            sign-in page. Use your usual work account.
+        </p>
+    </div>
+    {%- endif %}
+
+    {% if sso_enabled or frontend_url -%}
     <div style="text-align: center; margin: 30px 0;">
-        <a href="{{ frontend_url }}" 
-           style="display: inline-block; background-color: #F38755; color: white; padding: 12px 30px; 
+        <a href="{{ sso_login_url if sso_enabled else frontend_url }}"
+           style="display: inline-block; background-color: #F38755; color: white; padding: 12px 30px;
                   text-decoration: none; border-radius: 5px; font-weight: bold; font-size: 16px;">
-            Get Started
+            {{ 'Sign in with single sign-on' if sso_enabled else 'Get Started' }}
         </a>
     </div>
     {%- endif %}

--- a/tests/notifications/test_team_invitation_sso.py
+++ b/tests/notifications/test_team_invitation_sso.py
@@ -1,0 +1,162 @@
+"""Tests for SSO-aware team invitation emails.
+
+An invited user in an SSO org has no Rhesis password, so the generic
+"sign in with your email address" instructions send them somewhere that
+cannot work. The invitation must instead point at the org's sign-in page
+with `?org=<slug>`, which is what AuthForm reads to resolve the org's
+identity provider.
+"""
+
+from unittest.mock import MagicMock, create_autospec, patch
+
+import pytest
+
+from rhesis.backend.notifications.email.sendgrid_client import SendGridClient
+from rhesis.backend.notifications.email.service import EmailService
+from rhesis.backend.notifications.email.template_service import (
+    EmailTemplate,
+    TemplateService,
+)
+
+BASE_KWARGS = {
+    "recipient_email": "new.hire@netgo.example",
+    "recipient_name": "New Hire",
+    "organization_name": "netgo",
+    "organization_website": None,
+    "inviter_name": "Admin",
+    "inviter_email": "admin@netgo.example",
+    "frontend_url": "https://app.rhesis.ai",
+}
+
+
+def _service():
+    """EmailService with transports patched out, capturing send_email calls."""
+    mock_sg = create_autospec(SendGridClient, instance=True)
+    mock_sg.is_configured = True
+
+    with (
+        patch(
+            "rhesis.backend.notifications.email.service.SendGridClient",
+            return_value=mock_sg,
+        ),
+        patch("rhesis.backend.notifications.email.service.SMTPService"),
+        patch("rhesis.backend.notifications.email.service.TemplateService"),
+    ):
+        service = EmailService()
+
+    service.send_email = MagicMock(return_value=True)
+    return service
+
+
+def _sent_vars(service):
+    """The template_variables passed to send_email."""
+    return service.send_email.call_args.kwargs["template_variables"]
+
+
+@pytest.mark.unit
+class TestInvitationSSOLink:
+    def test_sso_org_gets_org_scoped_signin_link(self):
+        service = _service()
+
+        service.send_team_invitation_email(
+            **BASE_KWARGS, organization_slug="netgo", sso_enabled=True
+        )
+
+        sent = _sent_vars(service)
+        assert sent["sso_enabled"] is True
+        assert sent["sso_login_url"] == "https://app.rhesis.ai/auth/signin?org=netgo"
+
+    def test_non_sso_org_gets_no_sso_messaging(self):
+        service = _service()
+
+        service.send_team_invitation_email(
+            **BASE_KWARGS, organization_slug="netgo", sso_enabled=False
+        )
+
+        sent = _sent_vars(service)
+        assert sent["sso_enabled"] is False
+        assert sent["sso_login_url"] == ""
+
+    def test_defaults_to_non_sso_when_caller_omits_the_flags(self):
+        service = _service()
+
+        service.send_team_invitation_email(**BASE_KWARGS)
+
+        sent = _sent_vars(service)
+        assert sent["sso_enabled"] is False
+
+    # Without a slug the ?org= param cannot be built, and a bare /auth/signin
+    # link would not surface the org's provider. Fall back rather than emit a
+    # link that silently drops the caller on the generic page.
+    def test_sso_without_a_slug_falls_back(self):
+        service = _service()
+
+        service.send_team_invitation_email(**BASE_KWARGS, organization_slug=None, sso_enabled=True)
+
+        sent = _sent_vars(service)
+        assert sent["sso_enabled"] is False
+        assert sent["sso_login_url"] == ""
+
+    def test_slug_is_url_encoded(self):
+        service = _service()
+
+        service.send_team_invitation_email(
+            **{**BASE_KWARGS, "frontend_url": "https://app.rhesis.ai/"},
+            organization_slug="acme corp&co",
+            sso_enabled=True,
+        )
+
+        sent = _sent_vars(service)
+        # Single slash after the host, and the slug escaped.
+        assert sent["sso_login_url"] == "https://app.rhesis.ai/auth/signin?org=acme%20corp%26co"
+
+
+@pytest.mark.unit
+class TestInvitationTemplateRendering:
+    """The real Jinja template, so the copy and href actually change."""
+
+    def _render(self, **overrides):
+        variables = {
+            "recipient_email": "new.hire@netgo.example",
+            "recipient_name": "New Hire",
+            "organization_name": "netgo",
+            "organization_website": "",
+            "inviter_name": "Admin",
+            "inviter_email": "admin@netgo.example",
+            "frontend_url": "https://app.rhesis.ai",
+        }
+        variables.update(overrides)
+        return TemplateService().render_template(EmailTemplate.TEAM_INVITATION, variables)
+
+    def test_sso_variant_links_to_the_org_signin_page(self):
+        html = self._render(
+            sso_enabled=True,
+            sso_login_url="https://app.rhesis.ai/auth/signin?org=netgo",
+        )
+
+        assert "auth/signin?org=netgo" in html
+        assert "single sign-on" in html.lower()
+        # The email-address instruction is what misleads SSO users.
+        assert "Sign in with your email address" not in html
+
+    def test_default_variant_is_unchanged(self):
+        html = self._render()
+
+        assert "Sign in with your email address" in html
+        assert "single sign-on" not in html.lower()
+        assert "auth/signin?org=" not in html
+
+    # Missing required vars are filled with the string "N/A", which is truthy.
+    # sso_enabled must therefore never be a declared required var, or every org
+    # would get the SSO copy.
+    def test_sso_enabled_is_not_a_declared_required_variable(self):
+        required = TemplateService().get_template_variables(EmailTemplate.TEAM_INVITATION)
+
+        assert "sso_enabled" not in required
+        assert "sso_login_url" not in required
+
+    def test_undefined_sso_flag_renders_the_default_variant(self):
+        # sso_enabled absent entirely, mimicking any other caller of this template.
+        html = self._render()
+
+        assert "Sign in with your email address" in html


### PR DESCRIPTION
## Purpose

The invitation email told every recipient to "Sign in with your email address" and linked to the bare frontend URL. Users in an SSO org have no Rhesis password, so those instructions point them somewhere that cannot work. The generic sign-in page also has no way to know which identity provider to offer without the `org` param.

For SSO-orgs this is the difference between an invited user landing on a page that works and one that does not.

## What Changed

When the org has SSO configured and licensed, the invitation now:

- links to `{frontend}/auth/signin?org=<slug>` instead of the bare frontend URL. That `org` param is what `AuthForm.tsx:106-113` reads to fetch the org's auth config and render its provider.
- adds a short "Single sign-on is enabled" section explaining there is no separate Rhesis password.
- swaps the sign-in step and the CTA label to match ("Sign in with single sign-on" rather than "Get Started").

Non-SSO orgs render exactly as before.

Two conditions are both required, via `_org_sso_enabled` in `routers/user.py`:

- `sso_config.enabled`, the org's own switch
- `FeatureRegistry.is_available(FeatureName.SSO, org)`, because an unlicensed org keeps its stored config while the SSO routes 404, so the link would be a dead end

If SSO is on but the org has no slug, it falls back to the standard email rather than emitting a link that drops the user on the generic page.

## Additional Context

- Follows #2313 (SSO login fix) and #2325 (hiding create-project from users without permission).
- **EE boundary**: `_org_sso_enabled` deliberately does not use EE's `_get_sso_config`. It reads the `sso_config` JSON column on the core `Organization` model and the core feature registry, so no EE import enters core. Confirmed by running the CI boundary job locally, which AST-scans every `.py` under `apps/backend/src/rhesis/backend`, including both files changed here.
- One subtlety worth flagging for review: `TemplateService._prepare_context` fills missing *required* variables with the string `"N/A"`, which is truthy. `sso_enabled` is therefore intentionally left out of `template_variables`, so an omitted flag stays a falsy Jinja `Undefined` instead of switching the SSO copy on for every org. There is a test pinning this.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/notifications ../../tests/backend/routes/test_user_settings.py ../../tests/backend/ee/sso -q
pytest ../../tests/backend/test_ee_boundary.py --noconftest -q   # community boundary
```

- 9 new tests; 27 in `tests/notifications` and 201 across the user/SSO suites pass.
- Both template variants rendered and read end to end to check the copy and the button label agree.
- Ruff clean.