### PR TITLE
Extract fan-out helper for Explorer NDJSON streams

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
@@ -79,6 +79,7 @@ def _resolve_llm_model(model_or_provider: Any):
 
 
 from rhesis.backend.app.services.streaming_utils import (
+    EventFanout,
     IncrementalJsonArrayParser,
 )
 from rhesis.backend.app.services.streaming_utils import (
@@ -442,30 +443,26 @@ async def suggestion_pipeline_stream(
     suggestions: List[Dict[str, Any]] = []
     num_examples_used = 0
 
-    embedding_tasks: Dict[int, asyncio.Task] = {}
     embed_results: Dict[int, Optional[List[float]]] = {}
-    invoke_tasks: set = set()
-    eval_tasks: set = set()
-
     eval_semaphore = asyncio.Semaphore(_EVAL_MAX_CONCURRENCY)
-    event_queue: asyncio.Queue = asyncio.Queue()
+    fanout = EventFanout()
 
     outputs_generated = 0
     outputs_failed = 0
     evals_done = 0
     evals_failed = 0
 
-    # ── Background task helpers (all push to the shared event_queue) ──
+    # ── Background task helpers (all push to the shared fanout) ──
 
     async def _embed_one(idx: int, text: str):
         try:
             vec = await a_generate_embedding_vector(text, db, user_id, embedder=embedder)
             embed_results[idx] = vec
-            await event_queue.put({"type": "embedding", "index": idx})
+            await fanout.emit({"type": "embedding", "index": idx})
         except Exception as e:  # noqa: BLE001
             logger.warning("Embedding failed for suggestion %s: %s", idx, e)
             embed_results[idx] = None
-            await event_queue.put({"type": "embedding", "index": idx})
+            await fanout.emit({"type": "embedding", "index": idx})
 
     async def _evaluate_one(index: int, input_text: str, output_text: str):
         nonlocal evals_done, evals_failed
@@ -479,7 +476,7 @@ async def suggestion_pipeline_stream(
                 )
                 verdict = aggregate_metric_verdict(metric_results, metric_names)
                 if verdict is None:
-                    await event_queue.put(
+                    await fanout.emit(
                         {
                             "type": "evaluation",
                             "index": index,
@@ -491,7 +488,7 @@ async def suggestion_pipeline_stream(
                     evals_failed += 1
                     return
 
-                await event_queue.put(
+                await fanout.emit(
                     {
                         "type": "evaluation",
                         "index": index,
@@ -503,7 +500,7 @@ async def suggestion_pipeline_stream(
                 evals_done += 1
             except Exception as e:  # noqa: BLE001
                 logger.warning("Pipeline eval failed for index %s: %s", index, e)
-                await event_queue.put(
+                await fanout.emit(
                     {
                         "type": "evaluation",
                         "index": index,
@@ -528,7 +525,7 @@ async def suggestion_pipeline_stream(
 
         logger.info("[%s] idx=%02d output_stop", _ts(), index)
 
-        await event_queue.put(
+        await fanout.emit(
             {
                 "type": "output",
                 "index": index,
@@ -539,9 +536,7 @@ async def suggestion_pipeline_stream(
         )
 
         if not error and output and output != NO_OUTPUT:
-            task = asyncio.create_task(_evaluate_one(index, input_text, output))
-            eval_tasks.add(task)
-            task.add_done_callback(eval_tasks.discard)
+            fanout.spawn(_evaluate_one(index, input_text, output))
 
     # ── Stream suggestions, immediately spawning all background work ──
 
@@ -569,43 +564,24 @@ async def suggestion_pipeline_stream(
 
         # Spawn embedding task
         if embedder and text:
-            task = asyncio.create_task(_embed_one(idx, text))
-            embedding_tasks[idx] = task
+            fanout.spawn(_embed_one(idx, text))
 
         # Spawn endpoint invocation immediately
         if text:
-            t = asyncio.create_task(_invoke_one(idx, text))
-            invoke_tasks.add(t)
-            t.add_done_callback(invoke_tasks.discard)
+            fanout.spawn(_invoke_one(idx, text))
 
         # Drain any ready events (embedding, output, evaluation)
-        while not event_queue.empty():
-            yield _ndjson(await event_queue.get())
+        for ready_event in fanout.drain_ready():
+            yield _ndjson(ready_event)
             await anyio.sleep(0)
 
     logger.info("[%s] all generation_stop (%d suggestions)", _ts(), len(suggestions))
 
     # ── Drain all remaining background work ──
-    # Embedding tasks, invoke tasks, and eval tasks all push to event_queue.
-    all_bg_tasks = set(embedding_tasks.values()) | invoke_tasks | eval_tasks
-
-    while all_bg_tasks or not event_queue.empty():
-        while not event_queue.empty():
-            yield _ndjson(await event_queue.get())
-            await anyio.sleep(0)
-        # Recompute live set (eval_tasks grow dynamically from _invoke_one)
-        all_bg_tasks = set(embedding_tasks.values()) | invoke_tasks | eval_tasks
-        live = {t for t in all_bg_tasks if not t.done()}
-        if live:
-            await asyncio.wait(live, timeout=0.2, return_when=asyncio.FIRST_COMPLETED)
-        elif not event_queue.empty():
-            continue
-        else:
-            break
-
-    # Final flush
-    while not event_queue.empty():
-        yield _ndjson(await event_queue.get())
+    # Embedding, invoke, and eval tasks (the latter spawned dynamically from
+    # _invoke_one) all push their events through the same fanout.
+    async for event in fanout.stream():
+        yield _ndjson(event)
         await anyio.sleep(0)
 
     # ── suggestions_done with diversity order and scores ──
@@ -690,36 +666,36 @@ async def invoke_endpoint_for_suggestions_stream(
         max_concurrency=10,
     )
 
-    async def _invoke_one(index: int, input_text: str) -> tuple:
+    fanout = EventFanout()
+    generated = 0
+    total = len(suggestions)
+
+    async def _invoke_one(index: int, input_text: str) -> None:
+        nonlocal generated
         output, error = await invoker.invoke(input_text)
         if error:
             logger.warning(f"Suggestion output generation failed: {error}")
-        return (index, input_text, output, error)
-
-    total = len(suggestions)
-    tasks = [
-        asyncio.create_task(_invoke_one(i, s.input))  # type: ignore[attr-defined]
-        for i, s in enumerate(suggestions)
-    ]
-
-    generated = 0
-    for fut in asyncio.as_completed(tasks):
-        index, input_text, output, error = await fut
-        if error is None:
+        else:
             generated += 1
 
-        event = {
-            "type": "item",
-            "index": index,
-            "input": input_text,
-            "output": output,
-            "error": error,
-        }
-        yield (json.dumps(event) + "\n").encode("utf-8")
+        await fanout.emit(
+            {
+                "type": "item",
+                "index": index,
+                "input": input_text,
+                "output": output,
+                "error": error,
+            }
+        )
+
+    for i, s in enumerate(suggestions):
+        fanout.spawn(_invoke_one(i, s.input))  # type: ignore[attr-defined]
+
+    async for event in fanout.stream():
+        yield _ndjson(event)
         await anyio.sleep(0)
 
-    summary = {"type": "summary", "generated": generated, "total": total}
-    yield (json.dumps(summary) + "\n").encode("utf-8")
+    yield _ndjson({"type": "summary", "generated": generated, "total": total})
 
 
 async def evaluate_suggestions_stream(
@@ -739,84 +715,73 @@ async def evaluate_suggestions_stream(
       - {"type": "summary", "evaluated": int, "total": int}
     """
     sdk_metrics = _resolve_sdk_metrics(db, organization_id, user_id, metric_names)
+    semaphore = asyncio.Semaphore(_EVAL_MAX_CONCURRENCY)
+    fanout = EventFanout()
+    evaluated = 0
+    total = len(suggestions)
 
-    async def _evaluate_one(index: int, item: Dict[str, str]) -> tuple:
+    async def _evaluate_one(index: int, item: Dict[str, str]) -> None:
+        nonlocal evaluated
         input_text = item["input"]
         output_text = item["output"]
 
-        if not output_text or output_text == NO_OUTPUT:
-            return (
-                index,
-                {
+        async with semaphore:
+            if not output_text or output_text == NO_OUTPUT:
+                result = {
                     "input": input_text,
                     **MetricVerdict.unlabeled().as_payload(),
                     "error": "no output to evaluate",
-                },
-            )
-
-        try:
-            metric_results = await _run_metrics_on_text(sdk_metrics, input_text, output_text)
-
-            verdict = aggregate_metric_verdict(metric_results, metric_names)
-            if verdict is None:
-                return (
-                    index,
-                    {
+                }
+            else:
+                try:
+                    metric_results = await _run_metrics_on_text(
+                        sdk_metrics, input_text, output_text
+                    )
+                    verdict = aggregate_metric_verdict(metric_results, metric_names)
+                    if verdict is None:
+                        result = {
+                            "input": input_text,
+                            **MetricVerdict.unlabeled().as_payload(),
+                            "error": "no metric results",
+                        }
+                    else:
+                        result = {
+                            "input": input_text,
+                            **verdict.as_payload(),
+                            "error": None,
+                        }
+                except Exception as e:  # noqa: BLE001
+                    logger.warning(
+                        f"Suggestion evaluation failed: {e}",
+                        exc_info=True,
+                    )
+                    result = {
                         "input": input_text,
-                        **MetricVerdict.unlabeled().as_payload(),
-                        "error": "no metric results",
-                    },
-                )
+                        **MetricVerdict.error(metric_names).as_payload(),
+                        "error": str(e),
+                    }
 
-            return (
-                index,
-                {
-                    "input": input_text,
-                    **verdict.as_payload(),
-                    "error": None,
-                },
-            )
-        except Exception as e:  # noqa: BLE001
-            logger.warning(
-                f"Suggestion evaluation failed: {e}",
-                exc_info=True,
-            )
-            return (
-                index,
-                {
-                    "input": input_text,
-                    **MetricVerdict.error(metric_names).as_payload(),
-                    "error": str(e),
-                },
-            )
-
-    semaphore = asyncio.Semaphore(_EVAL_MAX_CONCURRENCY)
-
-    async def _bounded(index: int, item: Dict[str, str]) -> tuple:
-        async with semaphore:
-            return await _evaluate_one(index, item)
-
-    total = len(suggestions)
-    tasks = [asyncio.create_task(_bounded(i, s)) for i, s in enumerate(suggestions)]
-
-    evaluated = 0
-    for fut in asyncio.as_completed(tasks):
-        index, result = await fut
         if result.get("label") in ("pass", "fail"):
             evaluated += 1
 
-        event = {
-            "type": "item",
-            "index": index,
-            "input": result.get("input", ""),
-            "label": result.get("label", ""),
-            "labeler": result.get("labeler", ""),
-            "model_score": result.get("model_score", 0.0),
-            "metrics": result.get("metrics"),
-            "error": result.get("error"),
-        }
-        yield (json.dumps(event) + "\n").encode("utf-8")
+        await fanout.emit(
+            {
+                "type": "item",
+                "index": index,
+                "input": result.get("input", ""),
+                "label": result.get("label", ""),
+                "labeler": result.get("labeler", ""),
+                "model_score": result.get("model_score", 0.0),
+                "metrics": result.get("metrics"),
+                "error": result.get("error"),
+            }
+        )
+
+    for i, s in enumerate(suggestions):
+        fanout.spawn(_evaluate_one(i, s))
+
+    async for event in fanout.stream():
+        yield _ndjson(event)
         await anyio.sleep(0)
 
-    summary = {"type": "summary", "evaluated": evaluated, "total": total}
-    yield (json.dumps(summary) + "\n").encode("utf-8")
+    yield _ndjson({"type": "summary", "evaluated": evaluated, "total": total})

--- a/apps/backend/src/rhesis/backend/app/services/streaming_utils.py
+++ b/apps/backend/src/rhesis/backend/app/services/streaming_utils.py
@@ -1,21 +1,78 @@
 """Shared utilities for NDJSON streaming responses."""
 
+import asyncio
 import json
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple
 
 from rhesis.sdk.synthesizers.streaming import IncrementalJsonArrayParser
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["ndjson", "IncrementalJsonArrayParser", "IncrementalConfigParser"]
+__all__ = ["ndjson", "EventFanout", "IncrementalJsonArrayParser", "IncrementalConfigParser"]
 
 _CONFIG_ARRAY_KEYS = ("behaviors", "topics", "categories")
+
+_FANOUT_DONE = object()
 
 
 def ndjson(event: Dict[str, Any]) -> bytes:
     """Encode a single NDJSON event."""
     return (json.dumps(event) + "\n").encode("utf-8")
+
+
+class EventFanout:
+    """Fan out concurrent async work and drain result events as they complete.
+
+    Call ``spawn()`` to register a background task; the task (or any task it
+    spawns before returning) calls ``emit()`` to push a result. ``stream()``
+    yields events as they arrive and returns once every spawned task has
+    finished and the queue is empty — no polling: a task's done-callback
+    pushes a wake-up sentinel the moment the outstanding count reaches zero.
+    """
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self._outstanding = 0
+
+    def spawn(self, coro) -> "asyncio.Task":
+        """Track ``coro`` as outstanding work and run it as a task."""
+        self._outstanding += 1
+        task = asyncio.create_task(coro)
+        task.add_done_callback(self._on_done)
+        return task
+
+    def _on_done(self, task: "asyncio.Task") -> None:
+        self._outstanding -= 1
+        if not task.cancelled() and (exc := task.exception()) is not None:
+            logger.error("EventFanout task failed: %s", exc, exc_info=exc)
+        if self._outstanding == 0:
+            self._queue.put_nowait(_FANOUT_DONE)
+
+    async def emit(self, event: Dict[str, Any]) -> None:
+        """Push a result event, to be picked up by ``stream()``/``drain_ready()``."""
+        await self._queue.put(event)
+
+    def drain_ready(self) -> List[Dict[str, Any]]:
+        """Pop events already queued, without waiting.
+
+        For interleaving with a producer loop that has its own items to
+        yield between checking on background work.
+        """
+        ready = []
+        while not self._queue.empty():
+            event = self._queue.get_nowait()
+            if event is not _FANOUT_DONE:
+                ready.append(event)
+        return ready
+
+    async def stream(self) -> AsyncGenerator[Dict[str, Any], None]:
+        """Yield remaining events until every spawned task has finished."""
+        while self._outstanding > 0 or not self._queue.empty():
+            event = await self._queue.get()
+            if event is _FANOUT_DONE:
+                continue
+            yield event
 
 
 class IncrementalConfigParser:

--- a/apps/backend/src/rhesis/backend/app/services/streaming_utils.py
+++ b/apps/backend/src/rhesis/backend/app/services/streaming_utils.py
@@ -44,8 +44,12 @@ class EventFanout:
 
     def _on_done(self, task: "asyncio.Task") -> None:
         self._outstanding -= 1
-        if not task.cancelled() and (exc := task.exception()) is not None:
-            logger.error("EventFanout task failed: %s", exc, exc_info=exc)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception:  # noqa: BLE001
+            logger.exception("EventFanout task failed")
         if self._outstanding == 0:
             self._queue.put_nowait(_FANOUT_DONE)
 

--- a/tests/backend/services/explorer/test_suggestions.py
+++ b/tests/backend/services/explorer/test_suggestions.py
@@ -6,11 +6,27 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app.services.explorer import invoke_endpoint_for_suggestions_stream
+from rhesis.backend.app.services.explorer import (
+    evaluate_suggestions_stream,
+    invoke_endpoint_for_suggestions_stream,
+    suggestion_pipeline_stream,
+)
 
 # Resolved at call time inside EndpointInvoker, so the source modules are the patch targets.
 _DB_CTX_PATCH = "rhesis.backend.app.database.get_db_with_tenant_variables"
 _SVC_PATCH = "rhesis.backend.app.dependencies.get_endpoint_service"
+
+# Imported by name into suggestions.py, so patched there rather than at their source module.
+_RESOLVE_METRICS_PATCH = "rhesis.backend.app.services.explorer.suggestions._resolve_sdk_metrics"
+_RUN_METRICS_PATCH = "rhesis.backend.app.services.explorer.suggestions._run_metrics_on_text"
+_GENERATE_SUGGESTIONS_PATCH = (
+    "rhesis.backend.app.services.explorer.suggestions.generate_suggestions"
+)
+_INVOKER_PATCH = "rhesis.backend.app.services.explorer.suggestions.EndpointInvoker"
+
+# Function-body imports inside suggestion_pipeline_stream, so patched at their source module.
+_RESOLVE_EMBEDDER_PATCH = "rhesis.backend.app.services.explorer.embeddings.resolve_embedder"
+_EMBED_ONE_PATCH = "rhesis.backend.app.services.explorer.embeddings.a_generate_embedding_vector"
 
 
 def _mock_db_context(test_db):
@@ -172,3 +188,267 @@ class TestInvokeEndpointForSuggestionsStream:
         assert len(calls) == 2
         for args in calls:
             assert args == (test_org_id, authenticated_user_id, "")
+
+
+@pytest.mark.integration
+@pytest.mark.service
+@pytest.mark.asyncio
+class TestEvaluateSuggestionsStream:
+    """Test the NDJSON stream that evaluates non-persisted suggestion outputs."""
+
+    async def test_emits_one_item_per_suggestion_then_summary(
+        self, test_db: Session, test_org_id, authenticated_user_id
+    ):
+        """Every suggestion gets an item event, followed by a single summary."""
+        run_metrics = AsyncMock(return_value={"Correctness": {"score": 1.0, "is_successful": True}})
+
+        with (
+            patch(_RESOLVE_METRICS_PATCH, return_value=[]),
+            patch(_RUN_METRICS_PATCH, new=run_metrics),
+        ):
+            events = await _collect(
+                evaluate_suggestions_stream(
+                    db=test_db,
+                    organization_id=test_org_id,
+                    user_id=authenticated_user_id,
+                    metric_names=["Correctness"],
+                    suggestions=[
+                        {"input": "first", "output": "answer one"},
+                        {"input": "second", "output": "answer two"},
+                    ],
+                )
+            )
+
+        items = [e for e in events if e["type"] == "item"]
+        summary = [e for e in events if e["type"] == "summary"]
+
+        assert len(items) == 2
+        assert summary == [{"type": "summary", "evaluated": 2, "total": 2}]
+        assert events[-1]["type"] == "summary"
+        assert {i["index"] for i in items} == {0, 1}
+        assert all(i["label"] == "pass" and i["error"] is None for i in items)
+
+    async def test_missing_output_is_unlabeled_and_excluded_from_evaluated(
+        self, test_db: Session, test_org_id, authenticated_user_id
+    ):
+        """A suggestion with no output yet is reported as unlabeled, not evaluated."""
+        with (
+            patch(_RESOLVE_METRICS_PATCH, return_value=[]),
+            patch(_RUN_METRICS_PATCH, new=AsyncMock()),
+        ):
+            events = await _collect(
+                evaluate_suggestions_stream(
+                    db=test_db,
+                    organization_id=test_org_id,
+                    user_id=authenticated_user_id,
+                    metric_names=["Correctness"],
+                    suggestions=[{"input": "no output yet", "output": ""}],
+                )
+            )
+
+        item = next(e for e in events if e["type"] == "item")
+        summary = next(e for e in events if e["type"] == "summary")
+
+        assert item["label"] == ""
+        assert item["error"] == "no output to evaluate"
+        assert summary == {"type": "summary", "evaluated": 0, "total": 1}
+
+    async def test_metric_failure_reported_as_error_item(
+        self, test_db: Session, test_org_id, authenticated_user_id
+    ):
+        """A metric run that raises is reported as an error item, not a crash."""
+        with (
+            patch(_RESOLVE_METRICS_PATCH, return_value=[]),
+            patch(_RUN_METRICS_PATCH, new=AsyncMock(side_effect=RuntimeError("metric exploded"))),
+        ):
+            events = await _collect(
+                evaluate_suggestions_stream(
+                    db=test_db,
+                    organization_id=test_org_id,
+                    user_id=authenticated_user_id,
+                    metric_names=["Correctness"],
+                    suggestions=[{"input": "in", "output": "out"}],
+                )
+            )
+
+        item = next(e for e in events if e["type"] == "item")
+        summary = next(e for e in events if e["type"] == "summary")
+
+        assert item["label"] == "error"
+        assert item["error"] == "metric exploded"
+        assert summary == {"type": "summary", "evaluated": 0, "total": 1}
+
+    async def test_empty_suggestions_emits_only_summary(
+        self, test_db: Session, test_org_id, authenticated_user_id
+    ):
+        """No suggestions means no item events, and a zero summary."""
+        with (
+            patch(_RESOLVE_METRICS_PATCH, return_value=[]),
+            patch(_RUN_METRICS_PATCH, new=AsyncMock()),
+        ):
+            events = await _collect(
+                evaluate_suggestions_stream(
+                    db=test_db,
+                    organization_id=test_org_id,
+                    user_id=authenticated_user_id,
+                    metric_names=["Correctness"],
+                    suggestions=[],
+                )
+            )
+
+        assert events == [{"type": "summary", "evaluated": 0, "total": 0}]
+
+
+async def _fake_suggestion_stream(items):
+    """Stand-in for generate_suggestions(..., stream=True)'s async generator."""
+    yield {"type": "meta", "num_examples_used": len(items)}
+    for topic, text in items:
+        yield {"type": "item", "topic": topic, "input": text}
+
+
+@pytest.mark.integration
+@pytest.mark.service
+@pytest.mark.asyncio
+class TestSuggestionPipelineStream:
+    """Test the unified generate → embed → invoke → evaluate NDJSON stream."""
+
+    async def test_pipelines_generation_output_and_evaluation(
+        self, test_db: Session, test_org_id, authenticated_user_id
+    ):
+        """Each suggestion gets a matching output and evaluation, ending in the summaries."""
+        mock_invoker = MagicMock()
+        mock_invoker.invoke = AsyncMock(return_value=("an answer", None))
+        run_metrics = AsyncMock(return_value={"Correctness": {"score": 1.0, "is_successful": True}})
+
+        with (
+            patch(
+                _GENERATE_SUGGESTIONS_PATCH,
+                new=AsyncMock(
+                    return_value=_fake_suggestion_stream([("", "first"), ("", "second")])
+                ),
+            ),
+            patch(_INVOKER_PATCH, return_value=mock_invoker),
+            patch(_RESOLVE_METRICS_PATCH, return_value=[]),
+            patch(_RUN_METRICS_PATCH, new=run_metrics),
+        ):
+            events = await _collect(
+                suggestion_pipeline_stream(
+                    db=test_db,
+                    test_set_identifier="some-test-set",
+                    organization_id=test_org_id,
+                    user_id=authenticated_user_id,
+                    endpoint_id=str(uuid.uuid4()),
+                    metric_names=["Correctness"],
+                    num_suggestions=2,
+                )
+            )
+
+        by_type = {}
+        for e in events:
+            by_type.setdefault(e["type"], []).append(e)
+
+        assert {e["index"] for e in by_type["suggestion"]} == {0, 1}
+        assert {e["index"] for e in by_type["output"]} == {0, 1}
+        assert {e["index"] for e in by_type["evaluation"]} == {0, 1}
+        assert all(e["label"] == "pass" for e in by_type["evaluation"])
+        assert by_type["suggestions_done"] == [
+            {
+                "type": "suggestions_done",
+                "total": 2,
+                "num_examples_used": 2,
+                "diversity_order": None,
+                "diversity_scores": None,
+            }
+        ]
+        assert by_type["output_summary"] == [{"type": "output_summary", "generated": 2, "total": 2}]
+        assert by_type["eval_summary"] == [{"type": "eval_summary", "evaluated": 2, "total": 2}]
+        assert events[-1]["type"] == "done"
+
+    async def test_output_failure_skips_evaluation_for_that_item(
+        self, test_db: Session, test_org_id, authenticated_user_id
+    ):
+        """An endpoint failure produces an output error event and no evaluation event."""
+        mock_invoker = MagicMock()
+        mock_invoker.invoke = AsyncMock(return_value=("", "endpoint exploded"))
+
+        with (
+            patch(
+                _GENERATE_SUGGESTIONS_PATCH,
+                new=AsyncMock(return_value=_fake_suggestion_stream([("", "only")])),
+            ),
+            patch(_INVOKER_PATCH, return_value=mock_invoker),
+            patch(_RESOLVE_METRICS_PATCH, return_value=[]),
+            patch(_RUN_METRICS_PATCH, new=AsyncMock()),
+        ):
+            events = await _collect(
+                suggestion_pipeline_stream(
+                    db=test_db,
+                    test_set_identifier="some-test-set",
+                    organization_id=test_org_id,
+                    user_id=authenticated_user_id,
+                    endpoint_id=str(uuid.uuid4()),
+                    metric_names=["Correctness"],
+                    num_suggestions=1,
+                )
+            )
+
+        output_events = [e for e in events if e["type"] == "output"]
+        assert output_events == [
+            {
+                "type": "output",
+                "index": 0,
+                "input": "only",
+                "output": "",
+                "error": "endpoint exploded",
+            }
+        ]
+        assert not any(e["type"] == "evaluation" for e in events)
+        output_summary = next(e for e in events if e["type"] == "output_summary")
+        eval_summary = next(e for e in events if e["type"] == "eval_summary")
+        assert output_summary == {"type": "output_summary", "generated": 0, "total": 1}
+        assert eval_summary == {"type": "eval_summary", "evaluated": 0, "total": 0}
+
+    async def test_generate_embeddings_produces_diversity_order(
+        self, test_db: Session, test_org_id, authenticated_user_id
+    ):
+        """With generate_embeddings=True, suggestions_done carries a real diversity ordering."""
+        mock_invoker = MagicMock()
+        mock_invoker.invoke = AsyncMock(return_value=("an answer", None))
+        run_metrics = AsyncMock(return_value={"Correctness": {"score": 1.0, "is_successful": True}})
+
+        vectors = {"first": [1.0, 0.0], "second": [0.0, 1.0]}
+
+        async def _fake_embed(text, db, user_id, embedder=None):
+            return vectors[text]
+
+        with (
+            patch(
+                _GENERATE_SUGGESTIONS_PATCH,
+                new=AsyncMock(
+                    return_value=_fake_suggestion_stream([("", "first"), ("", "second")])
+                ),
+            ),
+            patch(_INVOKER_PATCH, return_value=mock_invoker),
+            patch(_RESOLVE_METRICS_PATCH, return_value=[]),
+            patch(_RUN_METRICS_PATCH, new=run_metrics),
+            patch(_RESOLVE_EMBEDDER_PATCH, return_value=MagicMock()),
+            patch(_EMBED_ONE_PATCH, new=AsyncMock(side_effect=_fake_embed)),
+        ):
+            events = await _collect(
+                suggestion_pipeline_stream(
+                    db=test_db,
+                    test_set_identifier="some-test-set",
+                    organization_id=test_org_id,
+                    user_id=authenticated_user_id,
+                    endpoint_id=str(uuid.uuid4()),
+                    metric_names=["Correctness"],
+                    num_suggestions=2,
+                    generate_embeddings=True,
+                )
+            )
+
+        done = next(e for e in events if e["type"] == "suggestions_done")
+        assert done["total"] == 2
+        assert sorted(done["diversity_order"]) == [0, 1]
+        assert len(done["diversity_scores"]) == 2
+        assert all(score is not None for score in done["diversity_scores"])

--- a/tests/backend/services/test_streaming_utils.py
+++ b/tests/backend/services/test_streaming_utils.py
@@ -1,0 +1,99 @@
+"""Unit tests for EventFanout, the fan-out/fan-in helper behind the NDJSON streams."""
+
+import asyncio
+import logging
+
+import pytest
+
+from rhesis.backend.app.services.streaming_utils import EventFanout
+
+
+async def _collect(fanout: EventFanout) -> list:
+    return [event async for event in fanout.stream()]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestEventFanout:
+    """EventFanout fans out spawned tasks and drains their emitted events."""
+
+    async def test_stream_yields_events_from_all_spawned_tasks(self):
+        fanout = EventFanout()
+
+        async def worker(n: int):
+            await asyncio.sleep(0.01 * (3 - n))
+            await fanout.emit({"n": n})
+
+        for n in range(3):
+            fanout.spawn(worker(n))
+
+        events = await asyncio.wait_for(_collect(fanout), timeout=2)
+
+        assert {e["n"] for e in events} == {0, 1, 2}
+
+    async def test_stream_terminates_with_no_spawned_tasks(self):
+        fanout = EventFanout()
+
+        events = await asyncio.wait_for(_collect(fanout), timeout=2)
+
+        assert events == []
+
+    async def test_dynamic_spawn_from_within_a_task_is_not_dropped(self):
+        """A task spawning another task before it returns must not let stream()
+        finish early — the classic case is _invoke_one spawning _evaluate_one."""
+        fanout = EventFanout()
+
+        async def child():
+            await fanout.emit({"who": "child"})
+
+        async def parent():
+            fanout.spawn(child())
+            await fanout.emit({"who": "parent"})
+
+        fanout.spawn(parent())
+
+        events = await asyncio.wait_for(_collect(fanout), timeout=2)
+
+        assert {e["who"] for e in events} == {"parent", "child"}
+
+    async def test_task_exception_is_logged_and_does_not_hang_stream(self, caplog):
+        fanout = EventFanout()
+
+        async def bad():
+            raise RuntimeError("boom")
+
+        async def good():
+            await fanout.emit({"ok": True})
+
+        fanout.spawn(bad())
+        fanout.spawn(good())
+
+        with caplog.at_level(logging.ERROR):
+            events = await asyncio.wait_for(_collect(fanout), timeout=2)
+
+        assert events == [{"ok": True}]
+        assert "boom" in caplog.text
+
+    async def test_drain_ready_returns_only_already_queued_events(self):
+        fanout = EventFanout()
+
+        await fanout.emit({"idx": 0})
+        await fanout.emit({"idx": 1})
+
+        ready = fanout.drain_ready()
+
+        assert ready == [{"idx": 0}, {"idx": 1}]
+        assert fanout.drain_ready() == []
+
+    async def test_drain_ready_does_not_yield_the_done_sentinel(self):
+        fanout = EventFanout()
+
+        async def worker():
+            await fanout.emit({"done": False})
+
+        fanout.spawn(worker())
+        await asyncio.sleep(0.05)  # let the task finish and push its wake-up sentinel
+
+        ready = fanout.drain_ready()
+
+        assert ready == [{"done": False}]


### PR DESCRIPTION
## Purpose

`suggestion_pipeline_stream` (`services/explorer/suggestions.py`) hand-managed task sets, an `asyncio.Queue`, a semaphore, done-callbacks, and a busy-wait drain loop (`asyncio.wait(..., timeout=0.2)` polling) to fan out embedding/invocation/evaluation work and stream results as NDJSON. The other two streaming functions in the same file (`invoke_endpoint_for_suggestions_stream`, `evaluate_suggestions_stream`) duplicated the fan-out pattern with `asyncio.as_completed` and hand-rolled `(json.dumps(event) + "\n").encode()` instead of the existing `ndjson()` helper. This extracts a shared, unit-testable fan-out helper so all three streams work the same way, and adds test coverage that didn't exist before for two of the three streams.

## What Changed

- Added `EventFanout` to `streaming_utils.py`: `spawn()` tracks a background task by an outstanding count, `emit()` pushes a result event, `stream()` yields events until every spawned task (including tasks spawned from within other spawned tasks) has finished — no polling, a task's done-callback wakes the consumer via a sentinel the moment the count hits zero. `drain_ready()` gives a non-blocking peek for producer loops that interleave their own yields with background events.
- Refactored `suggestion_pipeline_stream`, `invoke_endpoint_for_suggestions_stream`, and `evaluate_suggestions_stream` to use `EventFanout`, removing the manual task-set bookkeeping and the busy-wait drain loop.
- Unified NDJSON encoding: all three streams now call the shared `ndjson()`/`_ndjson` helper instead of two of them hand-rolling the same encode call.
- Event shapes on the wire are unchanged — this only touches the internal fan-out mechanism.

## Additional Context

- Part of the Explorer refactor roadmap (Phase 2, item 2.7 — "extract a streaming helper").
- No behavior change intended; existing route contracts are preserved.

## Testing

- New `tests/backend/services/test_streaming_utils.py` (6 tests): `EventFanout` in isolation — draining events from multiple spawned tasks, a task spawning another task before returning (the `_invoke_one` → `_evaluate_one` case), a task that raises being logged instead of hanging the stream, and `drain_ready()` never surfacing the internal sentinel.
- Extended `tests/backend/services/explorer/test_suggestions.py` with `TestEvaluateSuggestionsStream` (4 tests) and `TestSuggestionPipelineStream` (3 tests) — `suggestion_pipeline_stream` had no test coverage before this change.
- All 49 tests across the touched files pass: `cd apps/backend && uv run pytest ../../tests/backend/services/test_streaming_utils.py ../../tests/backend/services/explorer/test_suggestions.py ../../tests/backend/services/explorer/test_evaluation.py ../../tests/backend/services/explorer/test_invocation.py -v`
- `ruff check` / `ruff format` clean on all touched files (one pre-existing, out-of-scope `E402` in `suggestions.py` remains, tracked separately).