### PR TITLE
Fix SSO invitation link dropping the org parameter

### DIFF
--- a/apps/backend/src/rhesis/backend/notifications/email/service.py
+++ b/apps/backend/src/rhesis/backend/notifications/email/service.py
@@ -170,12 +170,18 @@ class EmailService:
 
         subject = f"You're invited to join {organization_name} on Rhesis AI!"
 
-        # Deep-link to the org's sign-in page so it offers that org's identity
-        # provider. The `org` param is what AuthForm reads to fetch the org's
-        # auth config; without it the page cannot know which IdP to show.
+        # Deep-link to the login page so it offers that org's identity provider.
+        # The `org` param is what AuthForm reads to fetch the org's auth config;
+        # without it the page cannot know which IdP to show.
+        #
+        # Target the site root, NOT /auth/signin. Despite the name, /auth/signin
+        # is the auth-code callback, not the login form: with no `code` param it
+        # redirects to `/` and forwards only `return_to`, so `org` is dropped and
+        # the provider is never resolved. AuthForm is mounted via LoginSection at
+        # `/` (app/page.tsx) and `/auth/register`.
         sso_login_url = ""
         if sso_enabled and organization_slug:
-            sso_login_url = f"{frontend_url.rstrip('/')}/auth/signin?org={quote(organization_slug)}"
+            sso_login_url = f"{frontend_url.rstrip('/')}/?org={quote(organization_slug)}"
 
         template_variables = {
             "recipient_email": recipient_email,

--- a/tests/notifications/test_team_invitation_sso.py
+++ b/tests/notifications/test_team_invitation_sso.py
@@ -64,7 +64,20 @@ class TestInvitationSSOLink:
 
         sent = _sent_vars(service)
         assert sent["sso_enabled"] is True
-        assert sent["sso_login_url"] == "https://app.rhesis.ai/auth/signin?org=netgo"
+        assert sent["sso_login_url"] == "https://app.rhesis.ai/?org=netgo"
+
+    # Regression: /auth/signin looks like the login form but is the auth-code
+    # callback. With no `code` it redirects to `/` forwarding only `return_to`,
+    # so `org` is dropped and the org's provider is never resolved. AuthForm is
+    # mounted at `/` via LoginSection.
+    def test_link_does_not_target_the_auth_code_callback(self):
+        service = _service()
+
+        service.send_team_invitation_email(
+            **BASE_KWARGS, organization_slug="netgo", sso_enabled=True
+        )
+
+        assert "/auth/signin" not in _sent_vars(service)["sso_login_url"]
 
     def test_non_sso_org_gets_no_sso_messaging(self):
         service = _service()
@@ -108,7 +121,7 @@ class TestInvitationSSOLink:
 
         sent = _sent_vars(service)
         # Single slash after the host, and the slug escaped.
-        assert sent["sso_login_url"] == "https://app.rhesis.ai/auth/signin?org=acme%20corp%26co"
+        assert sent["sso_login_url"] == "https://app.rhesis.ai/?org=acme%20corp%26co"
 
 
 @pytest.mark.unit
@@ -131,10 +144,10 @@ class TestInvitationTemplateRendering:
     def test_sso_variant_links_to_the_org_signin_page(self):
         html = self._render(
             sso_enabled=True,
-            sso_login_url="https://app.rhesis.ai/auth/signin?org=netgo",
+            sso_login_url="https://app.rhesis.ai/?org=netgo",
         )
 
-        assert "auth/signin?org=netgo" in html
+        assert "https://app.rhesis.ai/?org=netgo" in html
         assert "single sign-on" in html.lower()
         # The email-address instruction is what misleads SSO users.
         assert "Sign in with your email address" not in html
@@ -144,7 +157,7 @@ class TestInvitationTemplateRendering:
 
         assert "Sign in with your email address" in html
         assert "single sign-on" not in html.lower()
-        assert "auth/signin?org=" not in html
+        assert "?org=" not in html
 
     # Missing required vars are filled with the string "N/A", which is truthy.
     # sso_enabled must therefore never be a declared required var, or every org


### PR DESCRIPTION
## Purpose

The SSO invitation link added in #2328 does not work. Clicking "Sign in with single sign-on" on `https://<app-host>/auth/signin?org=<slug>` bounces straight to `https://<app-host>/` with the `org` parameter gone, so the org's identity provider is never offered.

Despite its name, `/auth/signin` is not the login form. It is the auth-code callback. With no `code` parameter it falls through to:

```ts
const homeUrl = new URL('/', window.location.origin);
if (returnTo) homeUrl.searchParams.set('return_to', returnTo);
window.location.replace(homeUrl.toString());
```

Only `return_to` is forwarded, so `org` is dropped.

`AuthForm`, which is the component that reads `?org=` to fetch the org's auth config (`AuthForm.tsx:106-113`), is mounted via `LoginSection` at `/` (`app/page.tsx:184`) and `/auth/register`. The site root is therefore the correct target, and it strips only `session_expired` and `force_logout`, leaving `org` intact.

## What Changed

- The invitation link now targets `{frontend}/?org=<slug>` instead of `{frontend}/auth/signin?org=<slug>`.
- Added a regression test asserting the link never targets `/auth/signin`, with the reason, plus a comment in the builder so the next person does not "fix" it back.

Generated link, for an org with slug `acme`:

```
https://app.example.com/?org=acme
```

## Additional Context

- Follows #2328, which was merged before this correction landed, so `main` currently carries the broken link.
- Root cause of the original mistake: `AuthForm` was confirmed to read the `org` param, but the route named `/auth/signin` was assumed to be where it is mounted, without tracing where the component actually renders.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/notifications -q
```

28 tests pass. Ruff clean.