### PR TITLE
Fix Explorer streaming timeouts and stuck loading state

### DIFF
--- a/apps/frontend/src/app/(protected)/explorer/[identifier]/components/SuggestionsDialog.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/[identifier]/components/SuggestionsDialog.tsx
@@ -473,6 +473,8 @@ export default function SuggestionsDialog({
       );
     } catch (err) {
       setTestGenStatus('idle');
+      setOutputsStatus('idle');
+      setMetricsStatus('idle');
       setError(
         err instanceof Error ? err.message : 'Failed to generate suggestions.'
       );

--- a/apps/frontend/src/utils/api-client/explorer-client.ts
+++ b/apps/frontend/src/utils/api-client/explorer-client.ts
@@ -33,8 +33,32 @@ export class ExplorerClient extends BaseApiClient {
     return `${API_ENDPOINTS.explorer}/${testSetId}`;
   }
 
+  /** Reads one chunk, erroring out if none arrives within `idleTimeoutMs`. */
+  private async readChunkWithTimeout(
+    reader: ReadableStreamDefaultReader<Uint8Array>,
+    idleTimeoutMs: number
+  ): Promise<ReadableStreamReadResult<Uint8Array>> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reader.cancel().catch(() => {});
+        reject(
+          new Error(
+            `Stream stalled: no data received for ${idleTimeoutMs / 1000}s.`
+          )
+        );
+      }, idleTimeoutMs);
+    });
+    try {
+      return await Promise.race([reader.read(), timeout]);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
   private async *readNdjsonStream(
-    response: Response
+    response: Response,
+    idleTimeoutMs = 150_000
   ): AsyncGenerator<unknown, void, void> {
     const reader = response.body?.getReader();
     if (!reader) {
@@ -45,7 +69,10 @@ export class ExplorerClient extends BaseApiClient {
     let buffer = '';
 
     while (true) {
-      const { value, done } = await reader.read();
+      const { value, done } = await this.readChunkWithTimeout(
+        reader,
+        idleTimeoutMs
+      );
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
 

--- a/apps/frontend/src/utils/backend-proxy.ts
+++ b/apps/frontend/src/utils/backend-proxy.ts
@@ -18,13 +18,24 @@ const LONG_RUNNING_PATH_PREFIXES = [
   '/garak/sync',
 ];
 
+/**
+ * Same idea, but for paths with a test-set id in the middle
+ * (`/explorer/{id}/suggestion_pipeline`), where a prefix match can't work.
+ */
+const LONG_RUNNING_PATH_SUFFIXES = [
+  '/suggestion_pipeline',
+  '/generate_outputs',
+  '/evaluate',
+];
+
 const LONG_RUNNING_TIMEOUT_MS = 300_000;
 
 /** Pick the timeout budget for a given backend-relative pathname. */
 export function resolveTimeoutMs(pathname: string): number {
-  return LONG_RUNNING_PATH_PREFIXES.some(prefix => pathname.startsWith(prefix))
-    ? LONG_RUNNING_TIMEOUT_MS
-    : DEFAULT_TIMEOUT_MS;
+  const isLongRunning =
+    LONG_RUNNING_PATH_PREFIXES.some(prefix => pathname.startsWith(prefix)) ||
+    LONG_RUNNING_PATH_SUFFIXES.some(suffix => pathname.endsWith(suffix));
+  return isLongRunning ? LONG_RUNNING_TIMEOUT_MS : DEFAULT_TIMEOUT_MS;
 }
 
 const FORWARDED_REQUEST_HEADERS = [


### PR DESCRIPTION
## Purpose

Explorer's suggestion generation was surfacing spurious `API error: 504 - Backend request timed out` errors, and in other cases would get stuck in a loading state indefinitely until the user manually refreshed the page.

## What Changed

- `backend-proxy.ts`: Explorer's streaming endpoints (`suggestion_pipeline`, `generate_outputs`, `evaluate`) were only getting the default 10s BFF-proxy timeout, sized for ordinary CRUD calls. These are slow, synchronous-until-first-byte operations (LLM generation, endpoint invocation, evaluation) that can easily exceed 10s. Added a suffix-based match (these paths are nested under a test-set id, so a prefix match can't distinguish them from fast Explorer CRUD calls) so they get the same 5-minute budget as other long-running operations.
- `explorer-client.ts`: the proxy's timeout only bounds time-to-first-byte — once the stream starts, nothing ever re-arms it. If the backend stalled partway through a stream (e.g. a slow endpoint invocation mid-pipeline), the NDJSON read loop would hang forever with no error, silently stuck until the user refreshed the page and started a new request. Added a 150s idle timeout on the read loop, reset on every chunk received, so a genuine stall now surfaces as a real error instead of hanging indefinitely.
- `SuggestionsDialog.tsx`: the error handler didn't reset `outputsStatus`/`metricsStatus`, so the progress bar could stay visually stuck on a phase even after the error alert was shown.

## Additional Context

None.

## Testing

- `npx tsc --noEmit`, `npx eslint`, and `npx prettier --check` all pass on the changed files.
- Manual verification: reasoned through both failure modes (early stall before first byte vs. mid-stream stall) against the updated timeout values to confirm both now produce a visible, immediate error instead of a silent hang.