### PR TITLE
Switch backend tests to Testcontainers

### DIFF
--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -60,18 +60,12 @@ jobs:
         working-directory: apps/backend
 
       - name: Run tests
-        # Use make docker-up then run pytest directly so we can pass --extra ee
+        # Run pytest directly (not via `make test`) so we can pass --extra ee
         # alongside --extra cpu.  `make test` uses `uv run --extra cpu` which
         # would re-sync the venv *without* the EE extra, dropping rhesis-backend-ee
         # before the EE tests under tests/backend/ee/ run.
         run: |
-          make docker-up
           uv run --extra cpu --extra ee pytest ../../tests/backend --ignore=../../tests/backend/integration -n 4 --timeout=120 --timeout-method=thread --reruns=1
-        working-directory: apps/backend
-
-      - name: Stop Docker services
-        if: always()
-        run: make docker-down
         working-directory: apps/backend
 
   # Verifies that the MIT-only build stays clean: no core module may import

--- a/apps/backend/AGENTS.md
+++ b/apps/backend/AGENTS.md
@@ -59,7 +59,9 @@ uv run pytest ../../tests/backend/ -v
 uv run pytest ../../tests/backend/services/explorer/test_tests.py::TestCreateExplorerTestSet -v
 ```
 
-Backend tests need Docker running (they use a real database). If tests fail with connection or
+Backend tests need Docker running — `tests/backend/conftest.py` starts an ephemeral Postgres and
+Redis container per pytest-xdist worker via Testcontainers (see
+`tests/backend/testcontainers_setup.py`), no manual setup needed. If tests fail with connection or
 container errors, stop and ask the user to start Docker instead of trying to work around it or
 debug the test code.
 

--- a/apps/backend/Makefile
+++ b/apps/backend/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all format lint lint_diff format_diff type-check test test-lf docs docker-up docker-down docker-clean
+.PHONY: all format lint lint_diff format_diff type-check test test-lf docs
 
 all: format_diff lint_diff type-check test docs
 
@@ -36,20 +36,10 @@ type-check:
 	PYTHONPATH=src mypy --install-types --non-interactive
 	PYTHONPATH=src mypy --package rhesis.backend
 
-# Tests (starts docker automatically)
-test: docker-up
+# Tests (Postgres/Redis start automatically via Testcontainers)
+test:
 	uv run --extra cpu pytest ../../tests/backend --ignore=../../tests/backend/integration -n 4 --timeout=120 --timeout-method=thread --reruns=1
 
-# Re-run only failed tests (starts docker automatically)
-test-lf: docker-up
+# Re-run only failed tests
+test-lf:
 	uv run --extra cpu pytest ../../tests/backend --lf --ignore=../../tests/backend/integration --timeout=120 --timeout-method=thread
-
-# Docker management for integration tests
-docker-up:
-	docker compose -f ../../tests/docker-compose.test.yml --profile backend up -d --wait
-
-docker-down:
-	docker compose -f ../../tests/docker-compose.test.yml --profile backend down
-
-docker-clean:
-	docker compose -f ../../tests/docker-compose.test.yml --profile backend down -v

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -115,6 +115,7 @@ dev = [
     "factory-boy>=3.3.0",
     "pytest-timeout>=2.3.1",
     "pytest-rerunfailures>=12.0",
+    "testcontainers[postgres,redis]>=4.13.3",
 ]
 
 # PyTorch index configuration for CPU and GPU variants

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -39,7 +39,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "2026-07-23T09:26:18.696825Z"
+exclude-newer = "2026-07-24T13:37:13.645837Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -1558,6 +1558,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docker"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32' or (extra == 'extra-14-rhesis-backend-cpu' and extra == 'extra-14-rhesis-backend-gpu')" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/731ff914b0255d3d065f45fd4e626d4b8c95dbcbaada049f337a6ac16410/docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac", size = 118731, upload-time = "2026-07-09T14:53:46.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f", size = 148775, upload-time = "2026-07-09T14:53:45.224Z" },
 ]
 
 [[package]]
@@ -6910,6 +6924,7 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "testcontainers", extra = ["redis"] },
 ]
 
 [package.metadata]
@@ -7003,6 +7018,7 @@ dev = [
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "ruff", specifier = ">=0.11.6" },
+    { name = "testcontainers", extras = ["postgres", "redis"], specifier = ">=4.13.3" },
 ]
 
 [[package]]
@@ -7851,6 +7867,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/b3/c272537f3ea2f312555efeb86398cc382cd07b740d5f3c730918c36e64e1/testcontainers-4.13.3.tar.gz", hash = "sha256:9d82a7052c9a53c58b69e1dc31da8e7a715e8b3ec1c4df5027561b47e2efe646", size = 79064, upload-time = "2025-11-14T05:08:47.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/27/c2f24b19dafa197c514abe70eda69bc031c5152c6b1f1e5b20099e2ceedd/testcontainers-4.13.3-py3-none-any.whl", hash = "sha256:063278c4805ffa6dd85e56648a9da3036939e6c0ac1001e851c9276b19b05970", size = 124784, upload-time = "2025-11-14T05:08:46.053Z" },
+]
+
+[package.optional-dependencies]
+redis = [
+    { name = "redis" },
 ]
 
 [[package]]

--- a/docs/content/contribute/backend/development-workflow.mdx
+++ b/docs/content/contribute/backend/development-workflow.mdx
@@ -24,20 +24,17 @@ Type hints are encouraged for readability and IDE support; enforcement is not st
 
 ## Tests
 
-Tests live in `tests/backend/`, wired through the backend `pyproject.toml`. Run them from `apps/backend`.
+Tests live in `tests/backend/`, wired through the backend `pyproject.toml`. Run them from `apps/backend`. Postgres and Redis are started automatically via [Testcontainers](https://testcontainers.com/) — Docker must be running, but there's no container setup step.
 
-**Full suite** — `make test` starts the test Docker profile (PostgreSQL and Redis on host ports 12001 and 12002), then runs `pytest` on `../../tests/backend` (see the `Makefile` for flags).
+**Full suite** — `make test` runs `pytest` on `../../tests/backend` (see the `Makefile` for flags).
 
-**Single test or file** — start the same stack, then run pytest yourself:
+**Single test or file**:
 
 <CodeBlock filename="run-specific-test.sh" language="bash">
-{`make docker-up
-uv run --extra cpu pytest ../../tests/backend/models/test_foo.py::TestClass::test_name -v`}
+{`uv run --extra cpu pytest ../../tests/backend/models/test_foo.py::TestClass::test_name -v`}
 </CodeBlock>
 
-Your usual dev database containers (different ports) are not used; tests expect the `backend` profile in `tests/docker-compose.test.yml`.
-
-**Teardown** — `make docker-down` (or `make docker-clean` to remove volumes).
+Your usual dev database containers are not used; each test run gets its own ephemeral Postgres and Redis instance.
 
 ## Database changes
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -803,10 +803,9 @@ Consistent, isolated test environments are crucial for reliable testing.
 
 ### 🐳 Containerized Testing
 
-All test infrastructure lives in a single unified Compose file (`tests/docker-compose.test.yml`) that uses **profiles** to select the right services per test suite:
+**Backend tests** start their own Postgres and Redis via [Testcontainers](https://testcontainers.com/) — one pair per pytest-xdist worker, on random host ports resolved at runtime (see `tests/backend/testcontainers_setup.py`). No compose file, no Make target, no manual setup — just run `pytest` from `apps/backend` with Docker running.
 
-- `--profile sdk` — PostgreSQL (10001), Redis (10002), Backend (10003)
-- `--profile backend` — PostgreSQL (12001), Redis (12002)
+**SDK tests** still use `tests/docker-compose.test.yml`'s `--profile sdk` (PostgreSQL 10001, Redis 10002, Backend 10003):
 
 ```yaml
 # tests/docker-compose.test.yml (simplified)
@@ -816,25 +815,14 @@ services:
     profiles: ["sdk"]
     ports:
       - "10001:5432"
-
-  backend-test-postgres:
-    image: mirror.gcr.io/pgvector/pgvector:pg16
-    profiles: ["backend"]
-    ports:
-      - "12001:5432"
 ```
 
 ### ⚙️ Environment Configuration
 
-Use the provided **Make targets** to manage test Docker services rather than calling `docker compose` directly:
-
 ```bash
-# Backend tests — start services, run tests, tear down
+# Backend tests — Postgres/Redis start automatically
 cd apps/backend
-make docker-up       # starts PostgreSQL + Redis for backend profile
-make test            # runs docker-up automatically, then pytest
-make docker-down     # stops services
-make docker-clean    # stops services and removes volumes
+make test            # runs pytest directly
 
 # SDK tests — start services, run tests, tear down
 cd sdk

--- a/tests/backend/conftest.py
+++ b/tests/backend/conftest.py
@@ -12,10 +12,9 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 # Single source of truth for test environment variables.
 # The CI workflow (backend-test.yml) only sets PYTHONPATH; everything else
 # is configured here so there is no duplication to keep in sync.
+from tests.backend.testcontainers_setup import ensure_test_containers
 
-# Port constants (must match tests/docker-compose.test.yml --profile backend)
-DATABASE_PORT = 12001
-REDIS_PORT = 12002
+_containers = ensure_test_containers()
 
 # EE bootstrap installs SignedTokenLicenseProvider unconditionally (see
 # ee/backend/.../ee/__init__.py:bootstrap()), which enforces a real signed
@@ -56,8 +55,8 @@ _LICENSE_TEST_TOKEN = jwt.encode(
 
 _TEST_DB_USER = "rhesis-user"
 _TEST_DB_PASS = "your-secured-password"  # trufflehog:ignore
-_TEST_DB_HOST = "localhost"
-_TEST_DB_PORT = str(DATABASE_PORT)
+_TEST_DB_HOST = _containers["db_host"]
+_TEST_DB_PORT = str(_containers["db_port"])
 _TEST_DB_NAME = "rhesis-test-db"
 _TEST_DB_DRIVER = "postgresql"
 
@@ -74,8 +73,12 @@ _TEST_ENV_VARS = {
     "APP_DB_USER": _TEST_DB_USER,
     "APP_DB_PASS": _TEST_DB_PASS,
     "STORAGE_SERVICE_URI": f"file://{os.path.join(tempfile.gettempdir(), 'rhesis-test-storage')}",
-    "BROKER_URL": f"redis://:rhesis-redis-pass@localhost:{REDIS_PORT}/0",
-    "CELERY_RESULT_BACKEND": f"redis://:rhesis-redis-pass@localhost:{REDIS_PORT}/1",
+    "BROKER_URL": (
+        f"redis://:rhesis-redis-pass@{_containers['redis_host']}:{_containers['redis_port']}/0"
+    ),
+    "CELERY_RESULT_BACKEND": (
+        f"redis://:rhesis-redis-pass@{_containers['redis_host']}:{_containers['redis_port']}/1"
+    ),
     "JWT_SECRET_KEY": "test-jwt-secret-key-for-backend-tests",
     "SESSION_SECRET_KEY": "test-session-secret-key-for-backend-tests",
     "JWT_ALGORITHM": "HS256",
@@ -300,47 +303,18 @@ def _run_migrations() -> None:
 
 
 @pytest.fixture(scope="session", autouse=True)
-def run_migrations_once(tmp_path_factory, request):
+def run_migrations_once():
     """
     Run Alembic migrations once per test session.
 
     Idempotent: if the DB is already at head, this is a fast no-op.
     Set RHESIS_SKIP_MIGRATIONS=1 to skip (e.g. for unit-only runs without DB).
-
-    Under pytest-xdist, every worker is a separate process with its own
-    ``session``-scoped fixtures, so without coordination each worker would
-    race to run ``alembic upgrade`` concurrently against the same database.
-    A cross-process file lock (shared under xdist's own root temp dir, one
-    level above each worker's private tmp dir) plus a sentinel file makes
-    only the first worker to grab the lock actually run migrations; the rest
-    see the sentinel and skip.
-
-    The worker id is read from ``request.config.workerinput`` (set by xdist
-    only when it's actually active) rather than requesting the ``worker_id``
-    fixture directly, so this doesn't hard-depend on the ``pytest-xdist``
-    plugin being installed — a plain, non-xdist ``pytest`` run still works.
     """
     if os.environ.get("RHESIS_SKIP_MIGRATIONS", "").lower() in ("1", "true", "yes"):
         yield
         return
 
-    workerinput = getattr(request.config, "workerinput", None)
-    worker_id = workerinput["workerid"] if workerinput is not None else "master"
-
-    if worker_id == "master":
-        _run_migrations()
-        yield
-        return
-
-    from filelock import FileLock
-
-    root_tmp_dir = tmp_path_factory.getbasetemp().parent
-    with FileLock(str(root_tmp_dir / "migrations.lock")):
-        sentinel = root_tmp_dir / "migrations.done"
-        if not sentinel.exists():
-            _run_migrations()
-            sentinel.write_text("done")
-
+    _run_migrations()
     yield
 
 

--- a/tests/backend/testcontainers_setup.py
+++ b/tests/backend/testcontainers_setup.py
@@ -1,0 +1,47 @@
+"""Ephemeral Postgres/Redis containers for the backend test session.
+
+Must run before any backend/app module is imported — tests.backend.fixtures.database
+reads DB_HOST/DB_PORT to build its module-level engine at import time.
+
+Each pytest-xdist worker starts its own container pair rather than sharing one:
+a container handle only works in the process that created it, and a shared
+container risks a worker tearing it down mid-test for its siblings.
+"""
+
+from __future__ import annotations
+
+import atexit
+
+
+def ensure_test_containers() -> dict:
+    """Start this process's own Postgres/Redis containers.
+
+    Returns a dict with ``db_host``/``db_port``/``redis_host``/``redis_port``.
+    """
+    from testcontainers.postgres import PostgresContainer
+    from testcontainers.redis import RedisContainer
+
+    postgres = PostgresContainer(
+        image="mirror.gcr.io/pgvector/pgvector:pg16",
+        username="rhesis-user",
+        password="your-secured-password",  # trufflehog:ignore
+        dbname="rhesis-test-db",
+    )
+    postgres.with_command("postgres -c max_connections=200")
+    postgres.with_kwargs(tmpfs={"/var/lib/postgresql/data": "rw"})
+    postgres.start()
+    atexit.register(postgres.stop)
+
+    redis = RedisContainer(
+        image="mirror.gcr.io/redis:7-alpine",
+        password="rhesis-redis-pass",
+    )
+    redis.start()
+    atexit.register(redis.stop)
+
+    return {
+        "db_host": postgres.get_container_host_ip(),
+        "db_port": postgres.get_exposed_port(5432),
+        "redis_host": redis.get_container_host_ip(),
+        "redis_port": redis.get_exposed_port(6379),
+    }

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -1,12 +1,11 @@
-# Unified test infrastructure for SDK and Backend integration tests
+# Test infrastructure for SDK integration tests.
+# Backend tests use Testcontainers instead (see tests/backend/testcontainers_setup.py).
 #
 # Usage:
-#   SDK tests:     docker compose -f tests/docker-compose.test.yml --profile sdk up -d --build
-#   Backend tests: docker compose -f tests/docker-compose.test.yml --profile backend up -d --wait
+#   SDK tests: docker compose -f tests/docker-compose.test.yml --profile sdk up -d --build
 #
 # Port allocation:
-#   SDK:     PostgreSQL 10001, Redis 10002, Backend 10003
-#   Backend: PostgreSQL 12001, Redis 12002
+#   SDK: PostgreSQL 10001, Redis 10002, Backend 10003
 
 # SDK backend environment configuration
 x-sdk-database-config: &sdk-database-config
@@ -104,51 +103,6 @@ services:
       - ../apps/backend/src:/app/apps/backend/src
       - ../apps/backend/start.sh:/app/apps/backend/start.sh
 
-  # ==========================================================================
-  # Backend Integration Tests (--profile backend)
-  # PostgreSQL: 12001, Redis: 12002
-  # ==========================================================================
-
-  backend-test-postgres:
-    image: mirror.gcr.io/pgvector/pgvector:pg16
-    profiles: ["backend"]
-    command: postgres -c max_connections=200
-    environment:
-      POSTGRES_DB: rhesis-test-db
-      POSTGRES_USER: rhesis-user
-      POSTGRES_PASSWORD: your-secured-password
-    ports:
-      - "12001:5432"
-    tmpfs:
-      - /var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U rhesis-user -d rhesis-test-db"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    networks:
-      - backend-test-network
-
-  backend-test-redis:
-    image: mirror.gcr.io/redis:7-alpine
-    profiles: ["backend"]
-    command: redis-server --requirepass rhesis-redis-pass
-    ports:
-      - "12002:6379"
-    environment:
-      - REDIS_PASSWORD=rhesis-redis-pass
-    tmpfs:
-      - /data
-    healthcheck:
-      test: ["CMD", "redis-cli", "-a", "rhesis-redis-pass", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    networks:
-      - backend-test-network
-
 networks:
   sdk-test-network:
-    driver: bridge
-  backend-test-network:
     driver: bridge


### PR DESCRIPTION
## Purpose

Backend tests depended on `tests/docker-compose.test.yml`'s `backend` profile: fixed-port Postgres (12001) and Redis (12002), started via `make docker-up` (which CI also called) before pytest ran. The ports were hardcoded in three places kept in sync by hand — the compose file, `apps/backend/Makefile`, and `tests/backend/conftest.py`. Testcontainers starts Postgres/Redis directly from the test process on random ports resolved at runtime, removing that duplication and the manual container lifecycle step entirely.

## What Changed

- Added `tests/backend/testcontainers_setup.py`: starts a Postgres (`pgvector/pgvector:pg16`, `max_connections=200`, tmpfs data dir) and Redis (`redis:7-alpine`, password-protected) container. Each pytest-xdist worker gets its own pair rather than sharing one — a Testcontainers container handle only works in the process that created it, and sharing one would need coordination plus risk a worker tearing it down mid-test for its siblings.
- `tests/backend/conftest.py` calls it instead of hardcoding `DATABASE_PORT = 12001` / `REDIS_PORT = 12002`. Dropped the `FileLock`/sentinel coordination in `run_migrations_once` — no longer needed once each worker has its own isolated database to migrate.
- Added `testcontainers[postgres,redis]` to `apps/backend/pyproject.toml` dev deps.
- Removed the `docker-up`/`docker-down`/`docker-clean` Makefile targets and the corresponding CI steps in `.github/workflows/backend-test.yml`; `test`/`test-lf` now just run `pytest` directly.
- Removed the `backend` profile from `tests/docker-compose.test.yml` (the `sdk` profile is untouched — confirmed nothing outside the backend profile depends on it).
- Updated `apps/backend/AGENTS.md`, `tests/README.md`, and `docs/content/contribute/backend/development-workflow.mdx` to describe the new flow.

## Additional Context

GitHub Actions `ubuntu-latest` runners have Docker available natively, so no CI runner changes were needed beyond removing the compose steps.

## Testing

Ran real tests through the full chain (containers start → Alembic migrations → test execution → teardown), both single-process and under `-n 2`, confirming per-worker container isolation and full cleanup via `docker ps` after each run:

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/explorer/test_tests.py -v          # 66 passed
uv run pytest ../../tests/backend/services/explorer/test_tests.py ../../tests/backend/routes/test_features.py -n 2 -v   # 75 passed
```