### PR TITLE
Lazy-load Ragas metrics, disable deepeval's autoloaded pytest plugin

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -220,7 +220,8 @@ pythonpath = [
     "src",
 ]
 asyncio_default_fixture_loop_scope = "function"
-addopts = "-o asyncio_default_fixture_loop_scope=function"
+# no:plugins disables deepeval's autoloaded pytest plugin (entry point name "plugins")
+addopts = "-o asyncio_default_fixture_loop_scope=function -p no:plugins"
 filterwarnings = [
     "ignore::pytest.PytestDeprecationWarning:pytest_asyncio.plugin",
 ]

--- a/apps/backend/src/rhesis/backend/metrics/__init__.py
+++ b/apps/backend/src/rhesis/backend/metrics/__init__.py
@@ -23,11 +23,6 @@ from rhesis.sdk.metrics import (
     MetricResult,
     # Native metrics (renamed)
     NumericJudge,
-    # Ragas metrics
-    RagasAnswerAccuracy,
-    RagasAspectCritic,
-    RagasContextRelevance,
-    RagasFaithfulness,
 )
 
 from .evaluator import MetricEvaluator as Evaluator
@@ -64,18 +59,26 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):
-    """Lazy load deepeval metric classes to avoid eager imports."""
-    # DeepEval metrics
-    deepeval_metrics = [
+_LAZY_SDK_NAMES = frozenset(
+    {
+        # Ragas metrics (pulls in ragas/transformers/torch/datasets on first use)
+        "RagasAnswerAccuracy",
+        "RagasAspectCritic",
+        "RagasContextRelevance",
+        "RagasFaithfulness",
+        # DeepEval metrics
         "DeepEvalAnswerRelevancy",
         "DeepEvalFaithfulness",
         "DeepEvalContextualPrecision",
         "DeepEvalContextualRecall",
         "DeepEvalContextualRelevancy",
-    ]
+    }
+)
 
-    if name in deepeval_metrics:
+
+def __getattr__(name: str):
+    """Lazy load ragas/deepeval metric classes to avoid eager imports."""
+    if name in _LAZY_SDK_NAMES:
         from rhesis.sdk.metrics import __getattr__ as sdk_getattr
 
         return sdk_getattr(name)


### PR DESCRIPTION
## Purpose

Every backend test process import pays for eagerly importing heavy ML libraries (ragas, transformers, torch, datasets, deepeval) that most tests never touch. This adds several seconds of fixed overhead to every `pytest` invocation, independent of test content.

## What Changed

- `apps/backend/src/rhesis/backend/metrics/__init__.py`: `RagasAnswerAccuracy`/`RagasAspectCritic`/`RagasContextRelevance`/`RagasFaithfulness` were imported eagerly at module top level, pulling in `ragas -> transformers, torch, datasets` on every import of `rhesis.backend.app.main` (via `routers.endpoint -> tasks -> metrics.evaluator -> this module`), regardless of whether a test or request ever touches a Ragas metric. Extends the existing DeepEval lazy-load `__getattr__` pattern already in this file to cover Ragas too, so both resolve on first actual use instead of at import time.
- `apps/backend/pyproject.toml`: added `-p no:plugins` to `addopts`, disabling deepeval's autoloaded pytest plugin (registered under the `pytest11` entry point group as name `"plugins"`, see `deepeval/plugins/plugin.py`). Pytest auto-loads this on every invocation regardless of test content. Confirmed no test in the suite uses deepeval's own pytest integration (`assert_test`/fixtures) — everything uses deepeval only as a metrics library.

## Additional Context

Profiled with `python -X importtime` to find these two eager-import sites. A third, deeper issue remains: `sdk/src/rhesis/sdk/metrics/providers/deepeval/__init__.py` unconditionally imports `metric_base.py`, which does `from deepeval.test_case.llm_test_case import LLMTestCase` at module top level — and merely importing anything under the `deepeval` namespace triggers deepeval's own `__init__.py`, which unconditionally pulls in `deepeval.evaluate -> deepeval.metrics -> deepeval.models.llms.*` (~1.5s). Fixing that requires moving those top-level imports into function-local imports in the SDK (mirroring the pattern `metrics.py`/`conversational_metrics.py` already use correctly) — left out of this PR since it touches SDK class definitions and needs more care; can follow up separately.

## Testing

Profiled with `python -X importtime -m pytest ... --collect-only` before and after each change to confirm `ragas`/`torch`/`transformers`/`datasets` and `deepeval.plugins.plugin` drop out of the eager import chain. Ran the full backend metrics suite and confirmed lazy attribute resolution still works for both Ragas and DeepEval names:

```bash
cd apps/backend
uv run pytest ../../tests/backend/metrics/ -q   # 172 passed, 4 skipped (pre-existing, missing API key)
```

Measured wall-clock overhead apples-to-apples against `main`, same warm docker-compose Postgres/Redis container throughout (only code changed between measurements, to isolate noise from container/migration state):

| | `main` | `main` + this PR |
|---|---|---|
| Average total (single test file) | 13.47s | 9.96s |
| pytest-reported test time | ~3.4s | ~3.4s |
| **Overhead** | **~10.1s** | **~6.5s** |

~3.5s saved, ~35% overhead reduction, on every backend test process invocation.