### PR TITLE
fix(infra): grant gkehub.viewer to license-ci-<env>

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -26,9 +26,12 @@ join the VPN, and per-repo self-hosted runners (`arc-runner-<env>`, see
 the repo they're registered against -- a workflow in a different repo can
 never reach them. `terraform/infrastructure/modules/connect-gateway/gcp`
 registers each cluster with GKE Hub (Fleet) and creates a dedicated
-`license-ci-<env>` service account granted `roles/gkehub.gatewayReader`, so
-CI can fetch working credentials over HTTPS with no network-level access to
-the cluster at all:
+`license-ci-<env>` service account granted `roles/gkehub.gatewayReader` +
+`roles/gkehub.viewer` (the latter read-only, needed because
+`gatewayReader` alone doesn't cover `gkehub.memberships.list`, which
+`gcloud container fleet memberships get-credentials` requires), so CI can
+fetch working credentials over HTTPS with no network-level access to the
+cluster at all:
 
 `license-ci-<env>` is a purpose-built identity, not `terraform-<env>` (the
 infra-admin identity `terraform-infrastructure.yml` authenticates as via

--- a/terraform/infrastructure/modules/connect-gateway/gcp/main.tf
+++ b/terraform/infrastructure/modules/connect-gateway/gcp/main.tf
@@ -77,10 +77,24 @@ resource "google_gke_hub_membership" "cluster" {
   depends_on = [google_project_service.gkehub]
 }
 
-# Reach the cluster via Connect Gateway.
+# Reach the cluster via Connect Gateway. gatewayReader alone
+# (gkehub.gateway.generateCredentials/get + gkehub.memberships.get) is not
+# sufficient -- `gcloud container fleet memberships get-credentials` also
+# needs gkehub.memberships.list, confirmed empirically against a live
+# license-issue.yml run (PERMISSION_DENIED on 'gkehub.memberships.list').
+# gkehub.viewer covers that; it's read-only (no mutation permissions on
+# Fleet/membership resources), so this adds visibility, not write access.
 resource "google_project_iam_member" "ci_gateway_reader" {
   project = var.project_id
   role    = "roles/gkehub.gatewayReader"
+  member  = "serviceAccount:${google_service_account.license_ci.email}"
+
+  depends_on = [google_project_service.connectgateway]
+}
+
+resource "google_project_iam_member" "ci_gkehub_viewer" {
+  project = var.project_id
+  role    = "roles/gkehub.viewer"
   member  = "serviceAccount:${google_service_account.license_ci.email}"
 
   depends_on = [google_project_service.connectgateway]


### PR DESCRIPTION
## Purpose

First real end-to-end test of `license-issue.yml` against dev (after #2290
merged and applied, and `rhesis-ee`'s `GCP_SA_KEY` was rotated to
`license-ci-dev`) failed at the Connect Gateway step:

```
ERROR: (gcloud.container.fleet.memberships.get-credentials) PERMISSION_DENIED:
Permission 'gkehub.memberships.list' denied on 'projects/.../locations/-/memberships'.
This command is authenticated as license-ci-dev@....iam.gserviceaccount.com
```

Confirms the key rotation itself worked (authenticating as the right
identity) -- the remaining gap is a missing permission.

## Root Cause

`roles/gkehub.gatewayReader` only includes:

```
gkehub.gateway.generateCredentials
gkehub.gateway.get
gkehub.memberships.get
```

`gcloud container fleet memberships get-credentials <name>` apparently
resolves the membership via a list call internally, not a direct get by
name -- `gkehub.memberships.list` isn't in `gatewayReader` at all.

## What Changed

- Added `roles/gkehub.viewer` to `license-ci-<env>` (in addition to
  `gatewayReader`, not instead of). `viewer` is read-only -- no mutation
  permissions on Fleet/membership resources -- so this doesn't change the
  blast-radius picture from #2290's fix, just adds visibility.
- Updated `kubernetes/README.md` to mention both roles.

## Testing

Plan will confirm the single new `google_project_iam_member.ci_gkehub_viewer`
resource per environment. Once applied to dev, will re-dispatch
`license-issue.yml` against dev to confirm this clears the Connect Gateway
step (the real test of whether the whole chain works end-to-end).