### PR TITLE
Fix review UX bugs in test result drawer

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestResultDrawer.tsx
@@ -176,7 +176,8 @@ export default function TestResultDrawer({
   const handleReviewTurn = (turnNumber: number, turnSuccess: boolean) => {
     setReviewInitialComment(`@[Turn ${turnNumber}](turn:${turnNumber}) `);
     setReviewInitialStatus(turnSuccess ? 'failed' : 'passed');
-    setActiveTab(TAB.reviews);
+    // Opens the review drawer as an overlay via TestDetailReviewsTab's own
+    // effect — the Conversation tab stays active so context isn't lost.
   };
 
   const mentionableMetrics: MentionOption[] = useMemo(() => {

--- a/apps/frontend/src/components/common/MentionTextInput.tsx
+++ b/apps/frontend/src/components/common/MentionTextInput.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { MentionsInput, Mention, SuggestionDataItem } from 'react-mentions';
 import { Box, Typography, useTheme, FormHelperText } from '@mui/material';
 import { alpha } from '@mui/material/styles';
@@ -188,6 +194,11 @@ export default function MentionTextInput({
   );
 
   const containerRef = useRef<HTMLDivElement>(null);
+  const [portalHost, setPortalHost] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    setPortalHost(document.body);
+  }, []);
 
   const mentionTypeMap = useMemo(() => {
     const map = new Map<string, 'user' | 'metric' | 'turn'>();
@@ -242,6 +253,9 @@ export default function MentionTextInput({
 
   const verticalPadding = theme.spacing(1.5);
   const minHeight = `calc(${minRows} * ${theme.typography.body2.lineHeight}em + ${verticalPadding} * 2)`;
+  // Fixed border width (color-only change on focus) avoids the 1px layout
+  // shift that previously caused a visible jump when the field gained focus.
+  const borderWidth = theme.spacing(0.25);
 
   return (
     <Box ref={containerRef}>
@@ -259,6 +273,7 @@ export default function MentionTextInput({
         onChange={handleChange}
         placeholder={placeholder}
         disabled={disabled}
+        suggestionsPortalHost={portalHost ?? undefined}
         style={{
           control: {
             fontSize: theme.typography.body1.fontSize,
@@ -267,7 +282,7 @@ export default function MentionTextInput({
           },
           input: {
             padding: `${theme.spacing(1.5)} ${theme.spacing(1.75)}`,
-            border: `1px solid ${borderColor}`,
+            border: `${borderWidth} solid ${borderColor}`,
             borderRadius: `${theme.shape.borderRadius}px`,
             outline: 'none',
             fontSize: theme.typography.body2.fontSize,
@@ -280,7 +295,7 @@ export default function MentionTextInput({
           },
           highlighter: {
             padding: `${theme.spacing(1.5)} ${theme.spacing(1.75)}`,
-            border: '1px solid transparent',
+            border: `${borderWidth} solid transparent`,
             borderRadius: `${theme.shape.borderRadius}px`,
             fontSize: theme.typography.body2.fontSize,
             fontFamily: theme.typography.fontFamily,
@@ -340,18 +355,16 @@ export default function MentionTextInput({
           </Box>
         )}
         a11ySuggestionsListLabel="Mention suggestions"
-        onFocus={e => {
+        onFocus={(e: React.FocusEvent<HTMLElement>) => {
           const target = e.target as HTMLElement;
           if (target.style) {
             target.style.borderColor = focusBorderColor;
-            target.style.borderWidth = '2px';
           }
         }}
-        onBlur={e => {
+        onBlur={(e: React.FocusEvent<HTMLElement>) => {
           const target = e.target as HTMLElement;
           if (target.style) {
             target.style.borderColor = borderColor;
-            target.style.borderWidth = '1px';
           }
         }}
       >
@@ -436,7 +449,7 @@ export function renderMentionText(
       <Box
         component="span"
         key={`mention-${match.index}`}
-        sx={theme => ({
+        sx={{
           color: typeColors[type] || 'inherit',
           backgroundColor: typeBackgrounds[type] || 'transparent',
           borderRadius: BORDER_RADIUS.pill,
@@ -446,7 +459,7 @@ export function renderMentionText(
           fontSize: 'inherit',
           whiteSpace: 'nowrap',
           lineHeight: 1.4,
-        })}
+        }}
       >
         @{display}
       </Box>


### PR DESCRIPTION
## Purpose

Reviewing test results surfaced three UX bugs: the @ mention autocomplete list was invisible in the test result drawer, the mention text box showed a jarring shadow/jump on focus, and reviewing a conversation turn silently switched away from the Conversation tab, losing the reviewer's place.

## What Changed

- `MentionTextInput`: portal the mention suggestions dropdown to `document.body` via `suggestionsPortalHost`, so it escapes the drawer's `overflow: auto` scroll container that was clipping it.
- `MentionTextInput`: keep the input/highlighter border at a constant width (derived from `theme.spacing(0.25)`) and only change its color on focus/blur, instead of switching between 1px and 2px. The width change was causing a 1px layout shift that read as a shadow/jump.
- `TestResultDrawer`: stop switching to the Reviews tab when reviewing a conversation turn. `TestDetailReviewsTab` already opens the review drawer as an overlay in response to the same state change, so the Conversation tab now stays active and context isn't lost.

## Additional Context

`TestDetailPanel` (the side-by-side layout) already avoided the tab-switch bug by using its own `ReviewJudgementDrawer` instance; this brings `TestResultDrawer` in line with that behavior without duplicating the drawer.

## Testing

- `npx tsc --noEmit` — no errors
- `npx eslint` on both changed files — no errors or warnings
- `npx prettier --check` on both changed files — passes
- Manual repro steps:
  1. Open a test result drawer for a multi-turn test, open the Reviews tab, and start typing `@` in the comment box — the mention list should now appear instead of being clipped.
  2. Click into the comment box — the border should no longer visibly shift/shadow on focus.
  3. From the Conversation tab, click the review icon on a turn — the Conversation tab should remain active while the review drawer opens on top.