### PR TITLE
fix(infra): grant secretmanager.viewer on signing key secrets too

### DIFF
--- a/terraform/infrastructure/modules/connect-gateway/gcp/main.tf
+++ b/terraform/infrastructure/modules/connect-gateway/gcp/main.tf
@@ -109,6 +109,14 @@ resource "google_project_iam_member" "ci_gkehub_viewer" {
 # manually), so they're referenced here by their literal, predictable
 # secret_id rather than a resource reference; that's fine, IAM bindings
 # don't require the target to be Terraform-managed.
+#
+# Both secretAccessor AND viewer are needed, confirmed via a live run:
+# secretAccessor only includes secretmanager.versions.access (reads the
+# actual value, license-issue.yml's "Fetch signing key" step) -- it does
+# NOT include secretmanager.secrets.get, which "Verify Secret Manager
+# entries exist" needs for `gcloud secrets describe`. viewer covers
+# secrets.get/list but not versions.access, so neither role alone is
+# sufficient.
 resource "google_secret_manager_secret_iam_member" "ci_read_private_key" {
   project   = var.project_id
   secret_id = "${var.environment}-rhesis-rhesis-license-private-key"
@@ -116,10 +124,24 @@ resource "google_secret_manager_secret_iam_member" "ci_read_private_key" {
   member    = "serviceAccount:${google_service_account.license_ci.email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "ci_view_private_key" {
+  project   = var.project_id
+  secret_id = "${var.environment}-rhesis-rhesis-license-private-key"
+  role      = "roles/secretmanager.viewer"
+  member    = "serviceAccount:${google_service_account.license_ci.email}"
+}
+
 resource "google_secret_manager_secret_iam_member" "ci_read_kid" {
   project   = var.project_id
   secret_id = "${var.environment}-rhesis-rhesis-license-kid"
   role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.license_ci.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "ci_view_kid" {
+  project   = var.project_id
+  secret_id = "${var.environment}-rhesis-rhesis-license-kid"
+  role      = "roles/secretmanager.viewer"
   member    = "serviceAccount:${google_service_account.license_ci.email}"
 }
 


### PR DESCRIPTION
## Purpose

Second issue found testing #2290 end-to-end against dev: `license-issue.yml`
got past Connect Gateway auth (fixed in #2337) but failed at "Verify Secret
Manager entries exist":

```
❌ dev-rhesis-rhesis-license-private-key not found (or no access) in project ...
❌ dev-rhesis-rhesis-license-kid not found (or no access) in project ...
```

## Root Cause

`roles/secretmanager.secretAccessor` only includes `secretmanager.versions.access`
(reads the actual secret value -- used by license-issue.yml's "Fetch signing
key" step, and license-mint-selfhosted.yml similarly). It does **not**
include `secretmanager.secrets.get`, which `gcloud secrets describe` (this
verification step) needs. `roles/secretmanager.viewer` covers
`secrets.get`/`list` but not `versions.access`. Neither role alone covers
both "does this exist" and "read the value" -- confirmed both permission
sets directly via `gcloud iam roles describe`.

(The mint destination secret, granted `secretmanager.admin` in #2290, is
unaffected -- `admin` already includes both permissions.)

## What Changed

Added a `secretmanager.viewer` grant alongside the existing `secretAccessor`
grant on each of the two signing-key secrets, per environment.

## Testing

Plan will show two new `google_secret_manager_secret_iam_member` resources
per environment (`ci_view_private_key`, `ci_view_kid`). Once applied to dev,
will re-dispatch `license-issue.yml` to confirm this clears the verification
step.