### PR TITLE
Hoist explorer's leftover deferred imports (2.8)

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/explorer/evaluation.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/evaluation.py
@@ -1,18 +1,15 @@
 import asyncio
+import dataclasses
 import json
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud
 from rhesis.backend.app.crud.explorer import set_explorer_test_metadata
-
-if TYPE_CHECKING:
-    from rhesis.sdk.metrics import MetricConfig
-
 from rhesis.backend.app.schemas.explorer import (
     EvaluateFailedItem,
     EvaluateResponse,
@@ -24,6 +21,8 @@ from rhesis.backend.app.services.explorer.utils import (
     _get_test_set_tests_from_db,
 )
 from rhesis.backend.app.utils.user_model_utils import get_evaluation_model
+from rhesis.backend.metrics.metric_config import metric_model_to_config
+from rhesis.sdk.metrics import MetricConfig, MetricFactory
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +118,7 @@ def _resolve_sdk_metrics(
     organization_id: str,
     user_id: str,
     metric_names: List[str],
-) -> List[Tuple[Any, "MetricConfig"]]:
+) -> List[Tuple[Any, MetricConfig]]:
     """Resolve metric names from the DB and instantiate SDK metric objects.
 
     Returns a list of tuples containing the ready-to-use SDK ``BaseMetric`` instances
@@ -128,11 +127,6 @@ def _resolve_sdk_metrics(
     Raises ``ValueError`` when a requested metric name does not exist
     or none of the resolved metrics could be instantiated.
     """
-    import dataclasses
-
-    from rhesis.backend.metrics.metric_config import metric_model_to_config
-    from rhesis.sdk.metrics import MetricConfig, MetricFactory
-
     name_clauses = " or ".join(f"name eq '{n}'" for n in metric_names)
     resolved = crud.get_metrics(
         db,
@@ -174,7 +168,7 @@ def _resolve_sdk_metrics(
 
 
 async def _run_metrics_on_text(
-    sdk_metrics: List[Tuple[Any, "MetricConfig"]],
+    sdk_metrics: List[Tuple[Any, MetricConfig]],
     input_text: str,
     output_text: str,
 ) -> Dict[str, Any]:

--- a/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
@@ -23,8 +23,16 @@ from rhesis.backend.app.services.explorer.utils import (
     _build_eligible_tests,
     _get_test_set_tests_from_db,
 )
+from rhesis.backend.app.services.streaming_utils import (
+    EventFanout,
+    IncrementalJsonArrayParser,
+)
+from rhesis.backend.app.services.streaming_utils import ndjson as _ndjson
 
 logger = logging.getLogger(__name__)
+
+# Keep the private alias for backward compatibility within this module
+_IncrementalJsonArrayParser = IncrementalJsonArrayParser
 
 
 class _GeneratedTestSuggestionItem(BaseModel):
@@ -76,18 +84,6 @@ def _resolve_llm_model(model_or_provider: Any):
     if isinstance(model_or_provider, str):
         return get_model(model_or_provider, model_type="language")
     return model_or_provider
-
-
-from rhesis.backend.app.services.streaming_utils import (
-    EventFanout,
-    IncrementalJsonArrayParser,
-)
-from rhesis.backend.app.services.streaming_utils import (
-    ndjson as _ndjson,
-)
-
-# Keep the private alias for backward compatibility within this module
-_IncrementalJsonArrayParser = IncrementalJsonArrayParser
 
 
 def _build_suggestion_prompt(

--- a/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
@@ -31,9 +31,6 @@ from rhesis.backend.app.services.streaming_utils import ndjson as _ndjson
 
 logger = logging.getLogger(__name__)
 
-# Keep the private alias for backward compatibility within this module
-_IncrementalJsonArrayParser = IncrementalJsonArrayParser
-
 
 class _GeneratedTestSuggestionItem(BaseModel):
     """One LLM-generated test input (shape enforced via structured output)."""
@@ -224,7 +221,7 @@ async def _generate_suggestions_stream(
         logger.error("LLM streaming generation failed: %s", e, exc_info=True)
         raise ValueError(f"LLM generation failed: {e}") from e
 
-    parser = _IncrementalJsonArrayParser()
+    parser = IncrementalJsonArrayParser()
 
     async for chunk in token_stream:
         for item in parser.feed(chunk):


### PR DESCRIPTION
## Purpose

Explorer roadmap item 2.8, the last open item in Phase 2: after 2.5 removed the deferred imports that existed purely to dodge the services→tasks circular import, two remaining deferred/misplaced import sites had no such excuse and were flagged as needing a pass to tell load-bearing from habit.

## What Changed

- `_resolve_sdk_metrics` (`app/services/explorer/evaluation.py`) deferred `dataclasses`, `metric_model_to_config`, and `MetricConfig`/`MetricFactory` inside the function body. None had a circular-import risk or a test patching the deferred call site, and `rhesis.sdk.metrics` is already lightweight at import time (heavy backends load lazily on `MetricFactory.create(...)`, not on import). All moved to top-level imports, and the `if TYPE_CHECKING` block + quoted `"MetricConfig"` forward references that existed only to avoid an unconditional top-level import are gone.
- The `suggestions.py:76-84` block wasn't a deferred import at all — it was an ordinary top-level import statement placed after two function definitions instead of with the rest of the file's imports. Moved up and merged into one `streaming_utils` import.
- Dropped the `_IncrementalJsonArrayParser` "backward-compat" alias that came along with that import — it had exactly one caller left in the file and no external ones, so it was pure clutter. That caller now uses `IncrementalJsonArrayParser` directly.

Scope held to exactly the two items named in the roadmap; `_run_metrics_on_text`'s own deferred imports (`inspect`, `ScoreEvaluator`) aren't part of this item and were left alone.

## Additional Context

- Tracked in `playground/explorer-roadmap.md` (gitignored, not part of this PR) as item 2.8, now moved to the roadmap's Fixed section. This closes out Phase 2 entirely — nothing left blocking Phase 3's schema migration.
- Follows on from #2341 (2.5 — fix the inverted tasks dependency).

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/explorer/ ../../tests/backend/routes/test_explorer.py ../../tests/backend/metrics/test_metric_model_to_config.py -v
```

196 + 96 + unit tests all pass. Also ran `ruff check`/`ruff format` on both touched files.