### PR TITLE
Make explorer's cross-module private helpers public

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/explorer/evaluation.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/evaluation.py
@@ -26,7 +26,7 @@ from rhesis.sdk.metrics import MetricConfig, MetricFactory
 
 logger = logging.getLogger(__name__)
 
-_EVAL_MAX_CONCURRENCY = 20
+EVAL_MAX_CONCURRENCY = 20
 
 
 def _serialize_details_for_api(details: Dict[str, Any]) -> Dict[str, Any]:
@@ -113,7 +113,7 @@ def aggregate_metric_verdict(
     )
 
 
-def _resolve_sdk_metrics(
+def resolve_sdk_metrics(
     db: Session,
     organization_id: str,
     user_id: str,
@@ -167,7 +167,7 @@ def _resolve_sdk_metrics(
     return sdk_metrics
 
 
-async def _run_metrics_on_text(
+async def run_metrics_on_text(
     sdk_metrics: List[Tuple[Any, MetricConfig]],
     input_text: str,
     output_text: str,
@@ -263,7 +263,7 @@ async def evaluate_tests_for_explorer_set(
     """Evaluate explorer test-set tests with the specified metrics.
 
     Uses SDK metric instances directly via ``a_evaluate`` with up to
-    ``_EVAL_MAX_CONCURRENCY`` items evaluated concurrently.
+    ``EVAL_MAX_CONCURRENCY`` items evaluated concurrently.
 
     Parameters
     ----------
@@ -296,7 +296,7 @@ async def evaluate_tests_for_explorer_set(
     ValueError
         If any metric name does not exist or the test set is not found.
     """
-    sdk_metrics = _resolve_sdk_metrics(db, organization_id, user_id, metric_names)
+    sdk_metrics = resolve_sdk_metrics(db, organization_id, user_id, metric_names)
 
     db_test_set = crud.resolve_test_set(test_set_identifier, db, organization_id=organization_id)
     if db_test_set is None:
@@ -332,7 +332,7 @@ async def evaluate_tests_for_explorer_set(
             return {"status": "failed", "test_id": test_id_str, "error": "no output"}, None
 
         try:
-            metric_results = await _run_metrics_on_text(sdk_metrics, input_text, output_text)
+            metric_results = await run_metrics_on_text(sdk_metrics, input_text, output_text)
 
             verdict = aggregate_metric_verdict(metric_results, metric_names)
             if verdict is None:
@@ -377,7 +377,7 @@ async def evaluate_tests_for_explorer_set(
                 "error": str(e),
             }, meta
 
-    semaphore = asyncio.Semaphore(_EVAL_MAX_CONCURRENCY)
+    semaphore = asyncio.Semaphore(EVAL_MAX_CONCURRENCY)
 
     async def _bounded(test):
         async with semaphore:

--- a/apps/backend/src/rhesis/backend/app/services/explorer/settings.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/settings.py
@@ -15,7 +15,7 @@ from rhesis.backend.app.schemas.explorer import (
     ExplorerSettingsMetric,
     ExplorerSettingsResponse,
 )
-from rhesis.backend.app.services.explorer.tests import _is_explorer_test_set
+from rhesis.backend.app.services.explorer.tests import is_explorer_test_set
 
 
 def _get_default_endpoint_id_from_attributes(
@@ -70,7 +70,7 @@ def get_explorer_settings(
     organization_id: str,
     user_id: str,
 ) -> ExplorerSettingsResponse:
-    if not _is_explorer_test_set(test_set):
+    if not is_explorer_test_set(test_set):
         raise ValueError("Test set is not configured for Explorer (Adaptive Testing behavior)")
 
     endpoint_ref = None
@@ -99,7 +99,7 @@ def update_explorer_settings(
     default_endpoint_id: Optional[UUID] = None,
     metric_ids: Optional[list[UUID]] = None,
 ) -> ExplorerSettingsResponse:
-    if not _is_explorer_test_set(test_set):
+    if not is_explorer_test_set(test_set):
         raise ValueError("Test set is not configured for Explorer (Adaptive Testing behavior)")
 
     if default_endpoint_id is not None:

--- a/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
@@ -12,11 +12,11 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import crud
 from rhesis.backend.app.schemas.explorer import GenerateSuggestionsResponse, SuggestedTest
 from rhesis.backend.app.services.explorer.evaluation import (
-    _EVAL_MAX_CONCURRENCY,
+    EVAL_MAX_CONCURRENCY,
     MetricVerdict,
-    _resolve_sdk_metrics,
-    _run_metrics_on_text,
     aggregate_metric_verdict,
+    resolve_sdk_metrics,
+    run_metrics_on_text,
 )
 from rhesis.backend.app.services.explorer.invocation import NO_OUTPUT, EndpointInvoker
 from rhesis.backend.app.services.explorer.utils import (
@@ -421,7 +421,7 @@ async def suggestion_pipeline_stream(
         user_id=user_id,
         max_concurrency=10,
     )
-    sdk_metrics = _resolve_sdk_metrics(db, organization_id, user_id, metric_names)
+    sdk_metrics = resolve_sdk_metrics(db, organization_id, user_id, metric_names)
 
     embedder = None
     if generate_embeddings:
@@ -437,7 +437,7 @@ async def suggestion_pipeline_stream(
     num_examples_used = 0
 
     embed_results: Dict[int, Optional[List[float]]] = {}
-    eval_semaphore = asyncio.Semaphore(_EVAL_MAX_CONCURRENCY)
+    eval_semaphore = asyncio.Semaphore(EVAL_MAX_CONCURRENCY)
     fanout = EventFanout()
 
     outputs_generated = 0
@@ -462,7 +462,7 @@ async def suggestion_pipeline_stream(
         logger.info("[%s] idx=%02d evaluation_start", _ts(), index)
         async with eval_semaphore:
             try:
-                metric_results = await _run_metrics_on_text(
+                metric_results = await run_metrics_on_text(
                     sdk_metrics,
                     input_text,
                     output_text,
@@ -707,8 +707,8 @@ async def evaluate_suggestions_stream(
          "model_score": float, "metrics": dict|null, "error": str|null}
       - {"type": "summary", "evaluated": int, "total": int}
     """
-    sdk_metrics = _resolve_sdk_metrics(db, organization_id, user_id, metric_names)
-    semaphore = asyncio.Semaphore(_EVAL_MAX_CONCURRENCY)
+    sdk_metrics = resolve_sdk_metrics(db, organization_id, user_id, metric_names)
+    semaphore = asyncio.Semaphore(EVAL_MAX_CONCURRENCY)
     fanout = EventFanout()
     evaluated = 0
     total = len(suggestions)
@@ -727,9 +727,7 @@ async def evaluate_suggestions_stream(
                 }
             else:
                 try:
-                    metric_results = await _run_metrics_on_text(
-                        sdk_metrics, input_text, output_text
-                    )
+                    metric_results = await run_metrics_on_text(sdk_metrics, input_text, output_text)
                     verdict = aggregate_metric_verdict(metric_results, metric_names)
                     if verdict is None:
                         result = {

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -194,7 +194,7 @@ def create_explorer_test_set(
     )
 
 
-def _is_explorer_test_set(test_set: models.TestSet) -> bool:
+def is_explorer_test_set(test_set: models.TestSet) -> bool:
     """True if the test set has the Explorer marker behavior in metadata.behaviors."""
     attrs = test_set.attributes or {}
     metadata = attrs.get("metadata") or {}
@@ -240,7 +240,7 @@ def delete_explorer_test_set(
     db_test_set = crud.resolve_test_set(test_set_identifier, db, organization_id)
     if db_test_set is None:
         raise ValueError("Test set not found with provided identifier")
-    if not _is_explorer_test_set(db_test_set):
+    if not is_explorer_test_set(db_test_set):
         raise ValueError("Test set is not configured for Explorer (Adaptive Testing behavior)")
 
     # Build the response payload before deleting to avoid response serialization
@@ -277,7 +277,7 @@ def bulk_delete_explorer_test_sets(
         return {"deleted_ids": [], "not_found_ids": []}
 
     candidates = crud_explorer.get_test_sets_by_ids(db, test_set_ids, organization_id)
-    valid_ids = [ts.id for ts in candidates if _is_explorer_test_set(ts)]
+    valid_ids = [ts.id for ts in candidates if is_explorer_test_set(ts)]
 
     _delete_session_tests(db, valid_ids, organization_id, user_id)
 
@@ -437,7 +437,7 @@ def import_explorer_test_set_from_source(
     if db_source is None:
         raise ValueError("Test set not found with provided identifier")
 
-    if _is_explorer_test_set(db_source):
+    if is_explorer_test_set(db_source):
         raise ValueError("Source test set is already configured for Explorer")
 
     base_name = f"{db_source.name} (Explorer)"
@@ -527,7 +527,7 @@ def export_regular_test_set_from_explorer(
     if db_source is None:
         raise ValueError("Test set not found with provided identifier")
 
-    if not _is_explorer_test_set(db_source):
+    if not is_explorer_test_set(db_source):
         raise ValueError(
             "Source test set is not configured for Explorer (Adaptive Testing behavior)"
         )

--- a/tests/backend/services/explorer/test_evaluation.py
+++ b/tests/backend/services/explorer/test_evaluation.py
@@ -16,7 +16,7 @@ from rhesis.backend.app.services.explorer.evaluation import (
 )
 
 _FACTORY_PATCH = "rhesis.sdk.metrics.factory.MetricFactory.create"
-_RUN_METRICS_PATCH = "rhesis.backend.app.services.explorer.evaluation._run_metrics_on_text"
+_RUN_METRICS_PATCH = "rhesis.backend.app.services.explorer.evaluation.run_metrics_on_text"
 
 
 def _create_metric(db, name, organization_id, user_id):

--- a/tests/backend/services/explorer/test_suggestions.py
+++ b/tests/backend/services/explorer/test_suggestions.py
@@ -17,8 +17,8 @@ _DB_CTX_PATCH = "rhesis.backend.app.database.get_db_with_tenant_variables"
 _SVC_PATCH = "rhesis.backend.app.dependencies.get_endpoint_service"
 
 # Imported by name into suggestions.py, so patched there rather than at their source module.
-_RESOLVE_METRICS_PATCH = "rhesis.backend.app.services.explorer.suggestions._resolve_sdk_metrics"
-_RUN_METRICS_PATCH = "rhesis.backend.app.services.explorer.suggestions._run_metrics_on_text"
+_RESOLVE_METRICS_PATCH = "rhesis.backend.app.services.explorer.suggestions.resolve_sdk_metrics"
+_RUN_METRICS_PATCH = "rhesis.backend.app.services.explorer.suggestions.run_metrics_on_text"
 _GENERATE_SUGGESTIONS_PATCH = (
     "rhesis.backend.app.services.explorer.suggestions.generate_suggestions"
 )


### PR DESCRIPTION
## Purpose

`playground/explorer-architecture-review.md` finding #4 (bullet 3) — never had a roadmap item, flagged in the review's own "Not included in the roadmap" section as a real gap. Four helpers in `services/explorer/` are imported and called from a sibling module, making them de-facto public API, while their leading underscore signals "don't touch this from outside this file."

## What Changed

Pure rename, no logic moved:

- `_is_explorer_test_set` (`services/explorer/tests.py`) → `is_explorer_test_set`, imported by `services/explorer/settings.py`
- `_EVAL_MAX_CONCURRENCY`, `_resolve_sdk_metrics`, `_run_metrics_on_text` (`services/explorer/evaluation.py`) → `EVAL_MAX_CONCURRENCY`, `resolve_sdk_metrics`, `run_metrics_on_text`, all imported by `services/explorer/suggestions.py`

Test files that patch two of these by dotted path (`test_evaluation.py`, `test_suggestions.py`) had their patch-string values updated; the test-local constant names patching them keep their own leading underscore, since those really are private to the test files.

## Additional Context

- Tracked in `playground/explorer-roadmap.md` (gitignored, not part of this PR) as new item 2.9, added retroactively to Phase 2 since it came from the review's own untracked-gap section rather than the original roadmap numbering.
- Follows on from #2341 (2.5) and #2342 (2.8).

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/explorer/ ../../tests/backend/routes/test_explorer.py -v
```

196 + 88 tests pass. Also ran `ruff check`/`ruff format` on all touched files.