### PR TITLE
Fix: keep good explorer copies when one test fails

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Callable, List, Optional, Tuple
 from uuid import UUID
 
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
@@ -391,8 +392,16 @@ def _copy_test_set_tests(
                 skipped_test_ids.append(str(db_test.id))
                 continue
 
-            write(test_copy)
-            copied += 1
+            try:
+                with db.begin_nested():
+                    write(test_copy)
+                copied += 1
+            except SQLAlchemyError:
+                logger.warning(
+                    "Skipping test %s during copy: write failed", db_test.id, exc_info=True
+                )
+                skipped += 1
+                skipped_test_ids.append(str(db_test.id))
 
         skip += len(items)
         if skip >= total:

--- a/tests/backend/routes/test_explorer.py
+++ b/tests/backend/routes/test_explorer.py
@@ -18,9 +18,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models
+from rhesis.backend.app.crud.explorer import create_explorer_test
 from rhesis.backend.app.models.test import test_test_set_association
 
 
@@ -591,6 +593,36 @@ class TestImportExplorerTestSetEndpoint:
         assert "Alpha" in paths
         assert "Alpha/Beta" in paths
 
+    def test_import_partial_failure_returns_201_with_skipped_test(
+        self,
+        authenticated_client: TestClient,
+        regular_source_test_set_for_import,
+    ):
+        """A write failure for one test is a 201 with it skipped, not a 500."""
+        src = regular_source_test_set_for_import
+
+        def flaky_create_explorer_test(db, **kwargs):
+            if kwargs.get("content") == "Second prompt":
+                raise IntegrityError("stmt", {}, Exception("dup key"))
+            return create_explorer_test(db, **kwargs)
+
+        with patch(
+            "rhesis.backend.app.crud.explorer.create_explorer_test",
+            side_effect=flaky_create_explorer_test,
+        ):
+            response = authenticated_client.post(f"/explorer/import/{src.id}")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["imported"] == 1
+        assert data["skipped"] == 2
+        assert len(data["skipped_test_ids"]) == 2
+
+        new_id = data["test_set"]["id"]
+        tests_resp = authenticated_client.get(f"/explorer/{new_id}/tests")
+        assert tests_resp.status_code == status.HTTP_200_OK
+        assert len(tests_resp.json()) == 1
+
     def test_import_explorer_source_returns_400(
         self,
         authenticated_client: TestClient,
@@ -680,6 +712,54 @@ class TestExportRegularTestSetFromExplorerEndpoint:
         for row in tests:
             meta_t = row.get("test_metadata") or {}
             assert meta_t.get("label") != "topic_marker"
+
+    def test_export_partial_failure_returns_201_with_skipped_test(
+        self,
+        authenticated_client: TestClient,
+    ):
+        """A write failure for one test is a 201 with it skipped, not a 500."""
+        create_resp = authenticated_client.post(
+            "/explorer",
+            json={"name": f"Export Src {uuid.uuid4().hex[:8]}", "description": None},
+        )
+        assert create_resp.status_code == status.HTTP_201_CREATED
+        adaptive_id = create_resp.json()["id"]
+
+        for content in ("First prompt", "Second prompt", "Third prompt"):
+            t_resp = authenticated_client.post(
+                f"/explorer/{adaptive_id}/tests",
+                json={
+                    "topic": "Alpha/Beta",
+                    "input": content,
+                    "output": "out",
+                    "labeler": "human",
+                    "label": "pass",
+                    "model_score": 1.0,
+                },
+            )
+            assert t_resp.status_code == status.HTTP_201_CREATED
+
+        def flaky_create_explorer_test(db, **kwargs):
+            if kwargs.get("content") == "Second prompt":
+                raise IntegrityError("stmt", {}, Exception("dup key"))
+            return create_explorer_test(db, **kwargs)
+
+        with patch(
+            "rhesis.backend.app.crud.explorer.create_explorer_test",
+            side_effect=flaky_create_explorer_test,
+        ):
+            response = authenticated_client.post(f"/explorer/export/{adaptive_id}")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["exported"] == 2
+        assert data["skipped"] == 3
+        assert len(data["skipped_test_ids"]) == 3
+
+        new_id = data["test_set"]["id"]
+        tests_resp = authenticated_client.get(f"/test_sets/{new_id}/tests?limit=100")
+        assert tests_resp.status_code == status.HTTP_200_OK
+        assert len(tests_resp.json()) == 2
 
     def test_export_regular_source_returns_400(
         self,

--- a/tests/backend/services/explorer/test_tests.py
+++ b/tests/backend/services/explorer/test_tests.py
@@ -3,10 +3,11 @@ from unittest.mock import patch
 
 import pytest
 from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
-from rhesis.backend.app.crud.explorer import get_test_ids_in_test_sets
+from rhesis.backend.app.crud.explorer import create_explorer_test, get_test_ids_in_test_sets
 from rhesis.backend.app.database import without_soft_delete_filter
 from rhesis.backend.app.schemas.explorer import TestTreeNode, TopicNode
 from rhesis.backend.app.services.explorer import (
@@ -1123,6 +1124,46 @@ class TestImportExplorerTestSetFromSource:
         assert "Prompt one" in inputs
         assert "Prompt two" in inputs
 
+    def test_skips_test_that_fails_to_write_and_keeps_the_rest(
+        self,
+        test_db: Session,
+        test_org_id,
+        authenticated_user_id,
+        regular_test_set_for_import,
+    ):
+        """A write failure for one test is recorded as skipped, not a hard failure."""
+        src = regular_test_set_for_import
+
+        def flaky_create_explorer_test(db, **kwargs):
+            if kwargs.get("content") == "Prompt two":
+                raise IntegrityError("stmt", {}, Exception("dup key"))
+            return create_explorer_test(db, **kwargs)
+
+        with patch(
+            "rhesis.backend.app.crud.explorer.create_explorer_test",
+            side_effect=flaky_create_explorer_test,
+        ):
+            result = import_explorer_test_set_from_source(
+                db=test_db,
+                source_test_set_identifier=str(src.id),
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+
+        # 1 copied ("Prompt one"), 2 skipped (the topic marker, plus the failed write).
+        assert result.imported == 1
+        assert result.skipped == 2
+        assert len(result.skipped_test_ids) == 2
+
+        tests = get_tree_tests(
+            db=test_db,
+            test_set_id=result.test_set.id,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        assert len(tests) == 1
+        assert tests[0].input == "Prompt one"
+
     def test_raises_when_source_is_adaptive(
         self,
         test_db: Session,
@@ -1239,6 +1280,70 @@ class TestExportRegularTestSetFromExplorer:
             assert t.topic.name == "Alpha/Beta"
         inputs = {(t.prompt.content or "").strip() for t in items if t.prompt}
         assert inputs == {"First prompt", "Second prompt"}
+
+    def test_skips_test_that_fails_to_write_and_keeps_the_rest(
+        self,
+        test_db: Session,
+        test_org_id,
+        authenticated_user_id,
+    ):
+        """A write failure for one test is recorded as skipped, not a hard failure."""
+        adaptive = create_explorer_test_set(
+            db=test_db,
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+            name=f"Export source {uuid.uuid4().hex[:8]}",
+            description="adaptive source",
+        )
+        test_db.flush()
+        for content in ("First prompt", "Second prompt", "Third prompt"):
+            create_test_node(
+                db=test_db,
+                test_set_id=adaptive.id,
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+                topic="Alpha/Beta",
+                input=content,
+                output="o",
+                labeler="human",
+                label="pass",
+                model_score=1.0,
+            )
+        test_db.commit()
+
+        def flaky_create_explorer_test(db, **kwargs):
+            if kwargs.get("content") == "Second prompt":
+                raise IntegrityError("stmt", {}, Exception("dup key"))
+            return create_explorer_test(db, **kwargs)
+
+        with patch(
+            "rhesis.backend.app.crud.explorer.create_explorer_test",
+            side_effect=flaky_create_explorer_test,
+        ):
+            result = export_regular_test_set_from_explorer(
+                db=test_db,
+                source_test_set_identifier=str(adaptive.id),
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+            )
+
+        # 2 copied (First, Third), 3 skipped (the "Alpha" and "Alpha/Beta" topic
+        # markers, plus the failed write for "Second prompt").
+        assert result.exported == 2
+        assert result.skipped == 3
+        assert len(result.skipped_test_ids) == 3
+
+        items, total = crud.get_test_set_tests(
+            db=test_db,
+            test_set_id=result.test_set.id,
+            skip=0,
+            limit=100,
+            sort_by="created_at",
+            sort_order="asc",
+        )
+        assert total == 2
+        inputs = {(t.prompt.content or "").strip() for t in items if t.prompt}
+        assert inputs == {"First prompt", "Third prompt"}
 
     def test_raises_when_source_is_not_adaptive(
         self,


### PR DESCRIPTION
## Purpose

A code review of the Explorer import/export flow flagged `_copy_test_set_tests` for having no transaction boundary around the multi-test copy loop. Tracing the full request path showed the database itself is already safe — the whole request runs as one transaction, and any uncaught exception rolls everything back cleanly. The real problem is user-facing: today, if a single test fails to write partway through a batch (e.g. a duplicate-key collision), the whole import or export aborts with an unhandled 500, discarding every test that copied fine. This change makes the copy loop best-effort instead, matching how the loop already treats uncopyable rows (topic markers, empty-content tests) as skipped rather than fatal.

## What Changed

- Wrapped each test's `write()` call in `_copy_test_set_tests` (`services/explorer/tests.py`) in a `db.begin_nested()` savepoint, catching `SQLAlchemyError`. This mirrors the existing recovery pattern in `crud/explorer.py`'s `upsert_test_embedding`.
- A test that fails to write is now recorded as skipped (via the existing `skipped` / `skipped_test_ids` counters) instead of aborting the whole import/export.
- Added a service-level test per direction (`test_tests.py`) and a route-level test per direction (`test_explorer.py`) that force one test's write to fail and assert the response still returns success (201) with the good tests copied and the bad one skipped.

## Additional Context

- Only `SQLAlchemyError` is caught, deliberately narrow — a non-DB bug in the write path should still fail loudly rather than being silently absorbed as a "skip."
- No schema or frontend changes: `ImportExplorerTestSetResponse` / `ExportExplorerTestSetResponse` already expose generic `skipped` / `skipped_test_ids` fields that don't distinguish *why* a test was skipped, and the frontend already renders a "skipped N" toast off that count.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/explorer/test_tests.py ../../tests/backend/routes/test_explorer.py -v
```

Verified the new tests fail against the old code (uncaught exception -> 500) by temporarily reverting the fix, then confirmed they pass with it restored. Full explorer service + route suite (158 tests) passes with no regressions.