### PR TITLE
Fix license-issuer RBAC: split secrets rule so create verb works

### DIFF
--- a/kubernetes/clusters/dev/rhesis/license-issuer-rbac.yaml
+++ b/kubernetes/clusters/dev/rhesis/license-issuer-rbac.yaml
@@ -22,11 +22,12 @@
 # access boundary is who can dispatch license-issue.yml in the private
 # rhesis-ee repo, not this Role.
 #
-# secrets get/update/delete are scoped via resourceNames to the one Secret
-# the workflow actually manages. Kubernetes RBAC cannot apply resourceNames
-# to "create" (the object doesn't exist yet at authorization time), so this
-# Role can still create a Secret under any name -- it just can't read,
-# change, or remove anything other than "license-issue-signing" afterward.
+# secrets: split into two rules because resourceNames silently blocks
+# "create" -- K8s RBAC checks the resource name at admission time, and a
+# create request has no name to match, so the verb never fires. The
+# unrestricted create rule lets the workflow create the signing Secret
+# under any name (harmless -- the namespace is already the blast radius);
+# get/update/patch/delete are scoped to the one Secret it actually manages.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -44,8 +45,11 @@ rules:
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
     resourceNames: ["license-issue-signing"]
-    verbs: ["create", "get", "update", "delete"]
+    verbs: ["get", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/kubernetes/clusters/prd/rhesis/license-issuer-rbac.yaml
+++ b/kubernetes/clusters/prd/rhesis/license-issuer-rbac.yaml
@@ -23,11 +23,12 @@
 # rhesis-ee repo, not this Role -- for prd, that's gated by required
 # reviewer approval on the "prd" GitHub Environment (see license-issue.yml).
 #
-# secrets get/update/delete are scoped via resourceNames to the one Secret
-# the workflow actually manages. Kubernetes RBAC cannot apply resourceNames
-# to "create" (the object doesn't exist yet at authorization time), so this
-# Role can still create a Secret under any name -- it just can't read,
-# change, or remove anything other than "license-issue-signing" afterward.
+# secrets: split into two rules because resourceNames silently blocks
+# "create" -- K8s RBAC checks the resource name at admission time, and a
+# create request has no name to match, so the verb never fires. The
+# unrestricted create rule lets the workflow create the signing Secret
+# under any name (harmless -- the namespace is already the blast radius);
+# get/update/patch/delete are scoped to the one Secret it actually manages.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -45,8 +46,11 @@ rules:
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
     resourceNames: ["license-issue-signing"]
-    verbs: ["create", "get", "update", "delete"]
+    verbs: ["get", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/kubernetes/clusters/stg/rhesis/license-issuer-rbac.yaml
+++ b/kubernetes/clusters/stg/rhesis/license-issuer-rbac.yaml
@@ -22,11 +22,12 @@
 # access boundary is who can dispatch license-issue.yml in the private
 # rhesis-ee repo, not this Role.
 #
-# secrets get/update/delete are scoped via resourceNames to the one Secret
-# the workflow actually manages. Kubernetes RBAC cannot apply resourceNames
-# to "create" (the object doesn't exist yet at authorization time), so this
-# Role can still create a Secret under any name -- it just can't read,
-# change, or remove anything other than "license-issue-signing" afterward.
+# secrets: split into two rules because resourceNames silently blocks
+# "create" -- K8s RBAC checks the resource name at admission time, and a
+# create request has no name to match, so the verb never fires. The
+# unrestricted create rule lets the workflow create the signing Secret
+# under any name (harmless -- the namespace is already the blast radius);
+# get/update/patch/delete are scoped to the one Secret it actually manages.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -44,8 +45,11 @@ rules:
     verbs: ["get"]
   - apiGroups: [""]
     resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["secrets"]
     resourceNames: ["license-issue-signing"]
-    verbs: ["create", "get", "update", "delete"]
+    verbs: ["get", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/terraform/infrastructure/modules/connect-gateway/gcp/main.tf
+++ b/terraform/infrastructure/modules/connect-gateway/gcp/main.tf
@@ -77,16 +77,22 @@ resource "google_gke_hub_membership" "cluster" {
   depends_on = [google_project_service.gkehub]
 }
 
-# Reach the cluster via Connect Gateway. gatewayReader alone
-# (gkehub.gateway.generateCredentials/get + gkehub.memberships.get) is not
-# sufficient -- `gcloud container fleet memberships get-credentials` also
-# needs gkehub.memberships.list, confirmed empirically against a live
-# license-issue.yml run (PERMISSION_DENIED on 'gkehub.memberships.list').
-# gkehub.viewer covers that; it's read-only (no mutation permissions on
-# Fleet/membership resources), so this adds visibility, not write access.
-resource "google_project_iam_member" "ci_gateway_reader" {
+# Reach the cluster via Connect Gateway. gatewayEditor (not Reader) is
+# required because the workflow creates and deletes K8s resources (Secrets,
+# Jobs). gatewayReader only includes gkehub.gateway.get, which proxies
+# read-only kubectl calls; write operations (create/update/delete) need
+# gkehub.gateway.post/put/patch/delete, which only gatewayEditor and
+# gatewayAdmin carry. Confirmed: gatewayReader caused "(Forbidden): unknown"
+# on kubectl create secret through Connect Gateway even though the K8s RBAC
+# (SubjectAccessReview) returned allowed=true -- the gateway's own IAM
+# check blocked the write before it reached the cluster.
+#
+# gkehub.viewer (below) is still needed for gkehub.memberships.list, which
+# `gcloud container fleet memberships get-credentials` requires and neither
+# gatewayReader nor gatewayEditor includes.
+resource "google_project_iam_member" "ci_gateway_editor" {
   project = var.project_id
-  role    = "roles/gkehub.gatewayReader"
+  role    = "roles/gkehub.gatewayEditor"
   member  = "serviceAccount:${google_service_account.license_ci.email}"
 
   depends_on = [google_project_service.connectgateway]


### PR DESCRIPTION
## Purpose

The license-issue.yml workflow fails with "Forbidden" when trying to create the signing K8s Secret through Connect Gateway. The root cause: the license-issuer Role had `create` bundled with `resourceNames: ["license-issue-signing"]`, but Kubernetes RBAC silently blocks `create` when `resourceNames` is set because there is no existing resource name to match at admission time.

## What Changed

- Split the secrets rule in all three environments (dev/stg/prd) into two rules:
  1. Unrestricted `create` on secrets (the namespace is the blast radius, same as Jobs)
  2. `get`, `update`, `patch`, `delete` scoped to `license-issue-signing` via `resourceNames`
- Added `patch` verb (used by `kubectl apply`'s client-side apply path)
- Fixed the comment that incorrectly claimed `create` was unrestricted under `resourceNames`

## Additional Context

- Already applied to the dev cluster via `kubectl apply` for immediate testing
- stg/prd will pick this up via ArgoCD once merged (or need manual apply if ArgoCD is stuck)
- This unblocks the license-issue.yml workflow that was failing at the "Fetch signing key and stage it as a K8s Secret" step

## Testing

Re-trigger license-issue.yml against dev after the RBAC is applied (already done). The Secret creation step should now succeed through Connect Gateway.