### PR TITLE
Fix ArgoCD root Application self-heal for targetRevision drift

### DIFF
--- a/kubernetes/clusters/dev/kustomization.yaml
+++ b/kubernetes/clusters/dev/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # The root Application manages itself so selfHeal corrects manual targetRevision drift.
+  - base.yaml
   - argocd/argocd-application.yaml
   - argocd/argocd-ingress.yaml
   - external-secrets.yaml

--- a/kubernetes/clusters/prd/kustomization.yaml
+++ b/kubernetes/clusters/prd/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # The root Application manages itself so selfHeal corrects manual targetRevision drift.
+  - base.yaml
   - argocd/argocd-application.yaml
   - argocd/argocd-ingress.yaml
   - external-secrets.yaml

--- a/kubernetes/clusters/stg/kustomization.yaml
+++ b/kubernetes/clusters/stg/kustomization.yaml
@@ -3,6 +3,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  # The root Application manages itself so selfHeal corrects manual targetRevision drift.
+  - base.yaml
   - argocd/argocd-application.yaml
   - argocd/argocd-ingress.yaml
   - external-secrets.yaml


### PR DESCRIPTION
## Purpose

The `dev-base` Application on the dev cluster has been stuck on `targetRevision: feat/deploy-kubenetes-inprd` for ~2 months. The git definition in `base.yaml` correctly says `targetRevision: main`, but ArgoCD never corrected the drift because `base.yaml` was not included in the kustomization.yaml resource list. The root Application synced everything under `kubernetes/clusters/dev/` except itself.

## What Changed

- Added `base.yaml` to the `resources` list in `kubernetes/clusters/{dev,stg,prd}/kustomization.yaml`

This makes the root Application a managed resource within its own sync tree. Since all three base Applications have `selfHeal: true`, any manual `targetRevision` patch will be auto-corrected on the next sync cycle.

## One-time remediation (dev)

After merging, the live dev-base Application still needs a one-time patch because the current targetRevision (`feat/deploy-kubenetes-inprd`) does not contain this commit. Run:

```bash
kubectl patch application dev-base -n argocd \
  --type merge \
  -p '{"spec":{"source":{"targetRevision":"main"}}}'
```

Once that lands, ArgoCD will sync the new kustomization.yaml (which includes `base.yaml`) and from that point forward the Application manages itself.

## Additional Context

- stg and prd base Applications currently have the correct `targetRevision` on the live cluster, so this is preventative for those environments
- The `k8s-deploy.yml` workflow only touches the `rhesis` Application (image tags via `argocd app set`), not the root base Applications, so there was no mechanism to catch this drift

## Testing

- Verify kustomize builds cleanly: `kubectl kustomize kubernetes/clusters/dev/`
- After merging + applying the kubectl patch, confirm `argocd app get dev-base` shows `targetRevision: main` and the Application is Synced/Healthy