### PR TITLE
Add YAML-driven tier config and quota registry

### DIFF
--- a/apps/backend/src/rhesis/backend/app/quota/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/quota/__init__.py
@@ -1,0 +1,163 @@
+"""Usage quota registry and enforcement gate.
+
+Every "has org X exhausted resource Y?" question flows through
+:meth:`QuotaRegistry.get_limit`.  This is the single extension point
+where tier-aware limit resolution plugs in (by swapping
+:class:`DefaultQuotaProvider` for a config-backed provider via
+:meth:`QuotaRegistry.set_quota_provider`).
+
+:class:`QuotaResource` is the canonical source of truth for metered
+resource identifiers.  Add new members here when adding a new metered
+resource.  Because ``QuotaResource`` inherits from ``str``, members
+serialize transparently to JSON and compare equal to their raw string
+values (``QuotaResource.TEST_EXECUTIONS == "test_executions"``).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional, Protocol, Union
+
+from rhesis.backend.app.models.organization import Organization
+
+
+class QuotaResource(str, Enum):
+    """Canonical identifiers for metered resources.
+
+    Inheriting from ``str`` means members compare equal to their value
+    and FastAPI serializes them to their raw string over the wire.
+
+    ``__str__`` is overridden so ``str(QuotaResource.TEST_EXECUTIONS)``
+    returns ``"test_executions"`` on Python 3.10-3.11 (where the default
+    Enum.__str__ returns ``"QuotaResource.TEST_EXECUTIONS"`` for
+    str+Enum subclasses).
+    """
+
+    def __str__(self) -> str:
+        return self.value
+
+    TEST_EXECUTIONS = "test_executions"
+    TRACING_SPANS = "tracing_spans"
+    TEST_GENERATION = "test_generation"
+    HOSTED_MODEL_TOKENS = "hosted_model_tokens"
+    SEATS = "seats"
+    PROJECTS = "projects"
+    ENDPOINTS = "endpoints"
+
+
+QuotaResourceLike = Union[QuotaResource, str]
+
+
+# Free-tier defaults applied when no EE quota provider is installed, and the
+# safety-net catalog EE falls back to if its tier config YAML is missing or
+# malformed. Exported (not underscore-prefixed) so both consumers -- and a
+# test asserting the YAML's "community" entry matches -- can reference the
+# same numbers instead of duplicating them.
+FREE_TIER_LIMITS: dict[QuotaResource, int | None] = {
+    QuotaResource.TEST_EXECUTIONS: 1_000,
+    QuotaResource.TRACING_SPANS: 50_000,
+    QuotaResource.TEST_GENERATION: 500,
+    QuotaResource.HOSTED_MODEL_TOKENS: 5_000_000,
+    QuotaResource.SEATS: 3,
+    QuotaResource.PROJECTS: 1,
+    QuotaResource.ENDPOINTS: 1,
+}
+
+
+def limits_to_wire(limits: dict[QuotaResource, int | None]) -> dict[str, int | None]:
+    """Convert a ``QuotaResource``-keyed limits dict to string keys for the wire.
+
+    Single conversion point for both the JWT ``lic.limits`` claim (see
+    :func:`~rhesis.backend.ee.licensing.tiers.tier_to_lic_claim`) and the
+    ``GET /features`` response -- both need the same enum-to-string shape.
+    """
+    return {str(k): v for k, v in limits.items()}
+
+
+class QuotaProvider(Protocol):
+    """Pluggable limit resolver.
+
+    Implementations decide what numeric limits apply to a given
+    organization for each metered resource.  Only one implementation is
+    active per process, installed via
+    :meth:`QuotaRegistry.set_quota_provider`.
+    """
+
+    def get_limits(self, org: Optional[Organization] = None) -> dict[QuotaResource, int | None]: ...
+
+
+class DefaultQuotaProvider:
+    """Returns hardcoded free-tier limits for every org.
+
+    Active when the EE package is not installed or no license is
+    configured.  In production,
+    :class:`~rhesis.backend.ee.licensing.quota_provider.ConfigQuotaProvider`
+    replaces this and resolves limits from the tier YAML config.
+    """
+
+    def get_limits(self, org: Optional[Organization] = None) -> dict[QuotaResource, int | None]:
+        return dict(FREE_TIER_LIMITS)
+
+
+class QuotaRegistry:
+    """Singleton registry for quota limits.
+
+    Holds the installed :class:`QuotaProvider`.  Callers query limits
+    via :meth:`get_limit` / :meth:`get_limits`; the provider decides
+    how to resolve them (hardcoded defaults vs. YAML config vs. DB).
+    """
+
+    _provider: QuotaProvider = DefaultQuotaProvider()
+
+    @classmethod
+    def set_quota_provider(cls, provider: QuotaProvider) -> None:
+        """Install the quota provider.  Call once at bootstrap."""
+        cls._provider = provider
+
+    @staticmethod
+    def _coerce(resource: QuotaResourceLike) -> QuotaResource:
+        """Coerce *resource* to a :class:`QuotaResource`.
+
+        :raises ValueError: if *resource* is not a known member. A
+            typo'd or unrecognized resource must fail loud here -- ``None``
+            already means "unlimited" downstream, so silently returning it
+            for an unknown resource would grant unmetered access instead of
+            surfacing the mistake.
+        """
+        if isinstance(resource, QuotaResource):
+            return resource
+        return QuotaResource(resource)
+
+    @classmethod
+    def get_limits(cls, org: Optional[Organization] = None) -> dict[QuotaResource, int | None]:
+        """Return all resource limits for *org*."""
+        return cls._provider.get_limits(org)
+
+    @classmethod
+    def get_limit(
+        cls,
+        org: Optional[Organization],
+        resource: QuotaResourceLike,
+    ) -> int | None:
+        """Return the limit for a single *resource*, or ``None`` if unlimited.
+
+        :raises ValueError: if *resource* is not a known :class:`QuotaResource`.
+        """
+        key = cls._coerce(resource)
+        return cls.get_limits(org).get(key)
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reinstall the default provider.  For tests only."""
+        cls._provider = DefaultQuotaProvider()
+
+
+__all__ = [
+    "DefaultQuotaProvider",
+    "FREE_TIER_LIMITS",
+    "QuotaProvider",
+    "QuotaRegistry",
+    "QuotaResource",
+    "QuotaResourceLike",
+    "limits_to_wire",
+]

--- a/apps/backend/src/rhesis/backend/app/routers/features.py
+++ b/apps/backend/src/rhesis/backend/app/routers/features.py
@@ -22,6 +22,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app.dependencies import get_tenant_context, get_tenant_db_session
 from rhesis.backend.app.features import FeatureRegistry
 from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.quota import QuotaRegistry, limits_to_wire
 
 router = APIRouter(prefix="/features", tags=["features"])
 
@@ -35,6 +36,7 @@ class FeaturesResponse(BaseModel):
     license: LicenseInfo
     enabled: List[str]
     warnings: Dict[str, str] = Field(default_factory=dict)
+    limits: Dict[str, int | None] = Field(default_factory=dict)
 
 
 @router.get("", response_model=FeaturesResponse)
@@ -63,6 +65,7 @@ def list_features(
     enabled = [f.name.value for f in FeatureRegistry.licensed_features(org)]
     warnings = FeatureRegistry.feature_warnings(org)
     info = FeatureRegistry.license_info(org=org)
+    limits = limits_to_wire(QuotaRegistry.get_limits(org))
     return FeaturesResponse(
         license=LicenseInfo(
             edition=str(info.get("edition", "community")),
@@ -70,4 +73,5 @@ def list_features(
         ),
         enabled=enabled,
         warnings=warnings,
+        limits=limits,
     )

--- a/ee/backend/src/rhesis/backend/ee/__init__.py
+++ b/ee/backend/src/rhesis/backend/ee/__init__.py
@@ -109,10 +109,16 @@ def bootstrap(app: "FastAPI") -> None:
                 "the API Clients audit log relies on it for hashed_email"
             )
 
+    from rhesis.backend.app.quota import QuotaRegistry
+    from rhesis.backend.ee.licensing.quota_provider import ConfigQuotaProvider
+
     # ---- License provider -----------------------------------------------
     # Install before feature registration so any is_available() call that
     # races during bootstrap already sees the correct provider.
     FeatureRegistry.set_license_provider(SignedTokenLicenseProvider())
+
+    # ---- Quota provider -------------------------------------------------
+    QuotaRegistry.set_quota_provider(ConfigQuotaProvider())
 
     # ---- Feature registry -----------------------------------------------
     FeatureRegistry.register(

--- a/ee/backend/src/rhesis/backend/ee/licensing/entitlements.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/entitlements.py
@@ -29,19 +29,17 @@ class LicenseEdition(str, Enum):
     rather than raising, keeping verification fail-soft on cosmetic fields.
 
     Adding a sellable tier is a two-step change: add a member here, then add
-    its entitlement spec to
-    :data:`~rhesis.backend.ee.licensing.tiers.EDITION_ENTITLEMENTS`.
-    ``COMMUNITY`` and ``UNKNOWN`` are non-sellable sentinels and are
-    intentionally absent from that catalog.
+    its entitlement spec to the tier config YAML
+    (``tier_config.yaml``).  ``COMMUNITY`` and ``UNKNOWN`` are
+    non-sellable sentinels and are intentionally absent from the
+    sellable catalog.
     """
 
     COMMUNITY = "community"
     # --- Sellable tiers (see tiers.EDITION_ENTITLEMENTS) ---
-    STARTER = "starter"
-    PREMIUM = "premium"
+    TEAM = "team"
     ENTERPRISE = "enterprise"
     MASTER = "master"
-    TRIAL = "trial"
     UNKNOWN = "unknown"
 
     @classmethod
@@ -99,11 +97,9 @@ LIC_ALL_FEATURES = "all_features"
 LIC_FEATURES = "features"
 LIC_LIMITS = "limits"
 
-# Well-known keys inside the ``limits`` map. Limits are open-ended; these are
-# just the names the platform understands today.
-LIMIT_SEATS = "seats"
-
 # --- Environment variable names --------------------------------------------
+ENV_TIER_CONFIG = "RHESIS_TIER_CONFIG"
+
 ENV_LICENSE = "RHESIS_LICENSE"
 ENV_LICENSE_PUBLIC_KEY = "RHESIS_LICENSE_PUBLIC_KEY"
 # Private key for the minting/issuance side only — never set on the running
@@ -214,6 +210,7 @@ __all__ = [
     "CLAIM_LICENSE",
     "CLAIM_SUBJECT",
     "Entitlements",
+    "ENV_TIER_CONFIG",
     "EXPIRY_LEEWAY_SECONDS",
     "ENV_LICENSE",
     "ENV_LICENSE_KID",
@@ -229,6 +226,5 @@ __all__ = [
     "LIC_FEATURES",
     "LIC_LIMITS",
     "LIC_STATUS",
-    "LIMIT_SEATS",
     "REQUIRED_CLAIMS",
 ]

--- a/ee/backend/src/rhesis/backend/ee/licensing/entitlements.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/entitlements.py
@@ -29,10 +29,16 @@ class LicenseEdition(str, Enum):
     rather than raising, keeping verification fail-soft on cosmetic fields.
 
     Adding a sellable tier is a two-step change: add a member here, then add
-    its entitlement spec to the tier config YAML
-    (``tier_config.yaml``).  ``COMMUNITY`` and ``UNKNOWN`` are
-    non-sellable sentinels and are intentionally absent from the
-    sellable catalog.
+    its entitlement spec to the tier config YAML (``tier_config.yaml``).
+    Both steps are enforced -- ``tiers._assert_catalog_complete()`` refuses
+    to start if a member declared here has no config entry, and
+    ``tiers._parse_edition()`` rejects a config entry naming an edition not
+    declared here. Neither half can ship alone.
+
+    ``COMMUNITY`` and ``UNKNOWN`` are non-sellable sentinels and are
+    intentionally absent from the sellable catalog. ``COMMUNITY`` still
+    carries free-tier limits for unlicensed orgs; ``UNKNOWN`` is a
+    decode-time sentinel only and must never appear in the config.
     """
 
     COMMUNITY = "community"

--- a/ee/backend/src/rhesis/backend/ee/licensing/quota_provider.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/quota_provider.py
@@ -1,0 +1,60 @@
+"""Config-backed quota provider that resolves limits from tier_config.yaml.
+
+Installed by :func:`~rhesis.backend.ee.bootstrap` when the EE package
+is present.  Resolves the organization's edition from the license
+provider, then looks up per-resource limits in the YAML-loaded tier
+catalog.  Unlicensed orgs get the community (free-tier) entry.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.ee.licensing.entitlements import LicenseEdition
+from rhesis.backend.ee.licensing.tiers import resolve_limits
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigQuotaProvider:
+    """Resolves quota limits from the tier YAML config.
+
+    For each organization, it determines the edition from the license
+    provider's entitlements, then returns the limits defined in the
+    config for that edition.
+    """
+
+    def _resolve_edition(self, org: Optional[Organization]) -> Optional[LicenseEdition]:
+        """Determine the org's edition from the license provider."""
+        if org is None:
+            return None
+
+        from rhesis.backend.app.features import FeatureRegistry
+
+        info = FeatureRegistry.license_info(org)
+        edition_str = info.get("edition")
+        if edition_str is None:
+            return None
+
+        # LicenseEdition._missing_ coerces any unrecognized value to
+        # UNKNOWN rather than raising, so check explicitly -- a bare
+        # try/except ValueError here would never fire.
+        edition = LicenseEdition(edition_str)
+        if edition is LicenseEdition.UNKNOWN:
+            logger.warning(
+                "Unknown edition %r on license info for org %s, falling back to community limits",
+                edition_str,
+                org.id,
+            )
+            return None
+        return edition
+
+    def get_limits(self, org: Optional[Organization] = None) -> dict[QuotaResource, int | None]:
+        edition = self._resolve_edition(org)
+        return resolve_limits(edition)
+
+
+__all__ = ["ConfigQuotaProvider"]

--- a/ee/backend/src/rhesis/backend/ee/licensing/tier_config.yaml
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tier_config.yaml
@@ -1,0 +1,57 @@
+# Tier configuration -- the single source of truth for what each edition
+# is entitled to.  Keys under `limits` must match QuotaResource enum
+# values defined in rhesis.backend.app.quota.
+#
+# null = unlimited.  Unlicensed orgs resolve to the `community` entry.
+# Override at runtime via RHESIS_TIER_CONFIG env var pointing to a
+# different YAML file (e.g. mounted from a K8s ConfigMap).
+
+community:
+  all_features: false
+  features: []
+  limits:
+    test_executions: 1000
+    tracing_spans: 50000
+    test_generation: 500
+    hosted_model_tokens: 5000000
+    seats: 3
+    projects: 1
+    endpoints: 1
+  retention_days: 14
+  overage: hard
+
+team:
+  all_features: false
+  features:
+    - rbac
+  limits:
+    test_executions: 100000
+    tracing_spans: 5000000
+    test_generation: 50000
+    hosted_model_tokens: 250000000
+    seats: null
+    projects: null
+    endpoints: null
+  retention_days: 90
+  overage: soft
+
+enterprise: &unlimited_tier
+  all_features: true
+  features: []
+  limits:
+    test_executions: null
+    tracing_spans: null
+    test_generation: null
+    hosted_model_tokens: null
+    seats: null
+    projects: null
+    endpoints: null
+  retention_days: 365
+  overage: soft
+
+# Internal tier (see LicenseEdition docstring). Currently identical to
+# enterprise; the merge key keeps that fact explicit instead of two
+# copies of the same block silently drifting apart. Add sibling keys
+# below the merge to override specific fields if master ever diverges.
+master:
+  <<: *unlimited_tier

--- a/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
@@ -54,6 +54,50 @@ _BUNDLED_CONFIG = Path(__file__).parent / "tier_config.yaml"
 # minted a token for it).
 NON_SELLABLE_EDITIONS = frozenset({LicenseEdition.COMMUNITY, LicenseEdition.UNKNOWN})
 
+# Editions the config is required to define. Derived from the enum rather
+# than listed by hand so adding a member to LicenseEdition automatically
+# extends what _assert_catalog_complete() demands of the YAML.
+SELLABLE_EDITIONS = frozenset(LicenseEdition) - NON_SELLABLE_EDITIONS
+
+# Every edition the catalog is allowed to contain: the sellable tiers plus
+# COMMUNITY, which carries free-tier limits for unlicensed orgs but is never
+# minted. UNKNOWN is excluded -- it is a decode-time sentinel, not a tier,
+# and must never pick up limits from a config entry.
+CATALOG_EDITIONS = SELLABLE_EDITIONS | {LicenseEdition.COMMUNITY}
+
+
+def all_sellable() -> frozenset[LicenseEdition]:
+    """Return every edition that can be minted a license token.
+
+    Single source of truth for "what tiers exist" -- prefer this over
+    hardcoding edition lists in callers and tests, so adding a tier does
+    not require hunting down literal lists.
+    """
+    return SELLABLE_EDITIONS
+
+
+def _parse_edition(edition_key: object) -> Optional[LicenseEdition]:
+    """Strictly resolve a YAML edition key to a :class:`LicenseEdition`.
+
+    ``LicenseEdition(value)`` cannot be used directly here: its
+    :meth:`~LicenseEdition._missing_` coerces anything unrecognized to
+    ``UNKNOWN`` instead of raising, which would silently bind a typo'd or
+    not-yet-declared tier's limits onto the ``UNKNOWN`` sentinel -- and
+    every org whose license carries an unrecognized edition resolves to
+    ``UNKNOWN``. Match against real member values instead, so an unknown
+    key is reported rather than absorbed.
+
+    :returns: the matching member, or ``None`` if *edition_key* is not a
+        declared edition (or is the ``UNKNOWN`` sentinel, which the config
+        must never define).
+    """
+    if not isinstance(edition_key, str):
+        return None
+    for edition in CATALOG_EDITIONS:
+        if edition.value == edition_key:
+            return edition
+    return None
+
 
 @dataclass(frozen=True)
 class TierSpec:
@@ -165,11 +209,13 @@ def _load_tier_config() -> dict[LicenseEdition, TierSpec]:
 
     catalog: dict[LicenseEdition, TierSpec] = {}
     for edition_key, spec_raw in raw.items():
-        try:
-            edition = LicenseEdition(edition_key)
-        except ValueError:
-            logger.warning("Unknown edition %r in tier config, skipping", edition_key)
-            continue
+        edition = _parse_edition(edition_key)
+        if edition is None:
+            raise ValueError(
+                f"Unknown edition {edition_key!r} in tier config at {config_path}. "
+                f"Declare it in LicenseEdition first. "
+                f"Valid keys: {sorted(e.value for e in CATALOG_EDITIONS)}"
+            )
 
         if not isinstance(spec_raw, dict):
             logger.warning(
@@ -221,10 +267,39 @@ def _load_tier_config() -> dict[LicenseEdition, TierSpec]:
     return catalog
 
 
+def _assert_catalog_complete(catalog: dict[LicenseEdition, TierSpec]) -> None:
+    """Fail loud if the enum and the tier config disagree.
+
+    Adding a tier is a two-step change (declare it in
+    :class:`LicenseEdition`, then define it in ``tier_config.yaml``). This
+    gate makes it impossible to ship it half-done: a declared-but-undefined
+    tier would otherwise fail late and cryptically with a ``KeyError`` the
+    first time someone tried to mint it, and the reverse case is caught by
+    :func:`_parse_edition`.
+
+    Skipped when the catalog is the free-tier fallback, which is by design
+    community-only -- see :func:`_fallback_catalog`.
+
+    :raises RuntimeError: naming exactly which editions are missing.
+    """
+    if set(catalog) == {LicenseEdition.COMMUNITY}:
+        return
+
+    missing = sorted(e.value for e in SELLABLE_EDITIONS - set(catalog))
+    if missing:
+        raise RuntimeError(
+            f"Tier config is missing an entry for declared edition(s): {missing}. "
+            f"Every LicenseEdition member except "
+            f"{sorted(e.value for e in NON_SELLABLE_EDITIONS)} "
+            f"must have a corresponding entry in tier_config.yaml."
+        )
+
+
 # ---------------------------------------------------------------------------
 # THE CATALOG — loaded from tier_config.yaml at import time.
 # ---------------------------------------------------------------------------
 EDITION_ENTITLEMENTS: dict[LicenseEdition, TierSpec] = _load_tier_config()
+_assert_catalog_complete(EDITION_ENTITLEMENTS)
 
 
 def is_sellable(edition: LicenseEdition) -> bool:
@@ -284,9 +359,12 @@ def tier_to_lic_claim(
 
 
 __all__ = [
+    "CATALOG_EDITIONS",
     "EDITION_ENTITLEMENTS",
     "NON_SELLABLE_EDITIONS",
+    "SELLABLE_EDITIONS",
     "TierSpec",
+    "all_sellable",
     "is_sellable",
     "resolve_limits",
     "resolve_tier",

--- a/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
@@ -1,113 +1,238 @@
-"""License tier catalog — the single source of truth for what each
-:class:`~rhesis.backend.ee.licensing.entitlements.LicenseEdition` is entitled
-to.
+"""License tier catalog loaded from YAML config.
 
-This is the one place to edit when adding a new paid tier or changing what an
-existing tier includes. It is consumed by the license *minting* side (Unit 2)
-to stamp the correct ``lic`` claim into a signed token.
+The YAML file (``tier_config.yaml``, bundled alongside this module) is
+the single source of truth for what each
+:class:`~rhesis.backend.ee.licensing.entitlements.LicenseEdition` is
+entitled to.  It is consumed by the license *minting* side to stamp
+the correct ``lic`` claim into a signed token and by the
+:class:`~rhesis.backend.ee.licensing.quota_provider.ConfigQuotaProvider`
+to resolve usage limits at runtime.
 
-Verification stays **token-authoritative**: the running server trusts the
-signed token's explicit ``all_features`` / ``features`` rather than
-re-deriving them from this catalog. That decoupling is what keeps the model
-flexible — a tier's contents can change, or a one-off custom deal can be
-issued to a single org, without redeploying the backend. This catalog simply
-guarantees that the *standard* tiers are minted consistently.
+Override the bundled config at runtime by setting the
+``RHESIS_TIER_CONFIG`` env var to a path (e.g. a K8s ConfigMap mount).
+
+Verification stays **token-authoritative**: the running server trusts
+the signed token's explicit ``all_features`` / ``features`` rather
+than re-deriving them from this catalog.
 
 Adding or changing a tier
 -------------------------
 1. Add a member to :class:`LicenseEdition` in ``entitlements.py``.
-2. Add (or edit) one :class:`TierSpec` entry in :data:`EDITION_ENTITLEMENTS`.
-
-Nothing else needs to change: ``feature_values`` and ``tier_to_lic_claim``
-derive the wire payload, and ``FeatureName`` keeps feature identifiers in
-sync with the registry so a typo'd feature is a static error, not a silent
-runtime miss.
+2. Add (or edit) an entry in ``tier_config.yaml``.
 """
 
 from __future__ import annotations
 
+import logging
+import os
 from dataclasses import dataclass, field
-from typing import Any, Mapping
+from pathlib import Path
+from typing import Optional
+
+import yaml
 
 from rhesis.backend.app.features import FeatureName
+from rhesis.backend.app.quota import FREE_TIER_LIMITS, QuotaResource, limits_to_wire
 from rhesis.backend.ee.licensing.entitlements import (
+    ENV_TIER_CONFIG,
     LIC_ALL_FEATURES,
     LIC_EDITION,
     LIC_FEATURES,
     LIC_LIMITS,
     LIC_STATUS,
-    LIMIT_SEATS,
     LicenseEdition,
     LicenseStatus,
 )
 
+logger = logging.getLogger(__name__)
+
+_BUNDLED_CONFIG = Path(__file__).parent / "tier_config.yaml"
+
+# Editions that are never a real, mintable tier -- absent by design from
+# "is this sellable" checks even though COMMUNITY has a limits entry in the
+# catalog (unlicensed orgs still need a limits lookup; they just can't be
+# minted a token for it).
+NON_SELLABLE_EDITIONS = frozenset({LicenseEdition.COMMUNITY, LicenseEdition.UNKNOWN})
+
 
 @dataclass(frozen=True)
 class TierSpec:
-    """Declarative entitlement spec for one sellable tier.
+    """Declarative entitlement spec for one tier.
 
     :param edition: the tier this spec describes.
-    :param all_features: when ``True`` the tier unlocks every registered EE
-        feature; ``features`` is then ignored (kept empty by convention).
-    :param features: explicit set of :class:`FeatureName` members granted when
-        ``all_features`` is ``False``. Using the enum (not raw strings) means a
-        feature rename or typo is caught statically.
-    :param limits: open-ended numeric/string limits (e.g. ``{"seats": 50}``).
+    :param all_features: when ``True`` the tier unlocks every registered
+        EE feature; ``features`` is then ignored.
+    :param features: explicit set of :class:`FeatureName` members
+        granted when ``all_features`` is ``False``.
+    :param limits: metered resource limits keyed by
+        :class:`QuotaResource`.  ``None`` values mean unlimited.
+    :param retention_days: data retention in days for this tier.
+    :param overage: ``"hard"`` (block) or ``"soft"`` (warn + allow).
     """
 
     edition: LicenseEdition
     all_features: bool = False
     features: frozenset[FeatureName] = frozenset()
-    limits: Mapping[str, Any] = field(default_factory=dict)
+    limits: dict[QuotaResource, int | None] = field(default_factory=dict)
+    retention_days: int = 14
+    overage: str = "hard"
 
     def feature_values(self) -> list[str]:
         """Return granted feature identifiers as sorted wire strings."""
         return sorted(f.value for f in self.features)
 
 
+def _parse_features(raw: list[str]) -> frozenset[FeatureName]:
+    """Coerce raw YAML feature strings to ``FeatureName`` members.
+
+    Unknown names are skipped with a warning rather than raising, unlike
+    :func:`_parse_limits`. Features are additive and forward-compatible --
+    a config authored for a newer backend can reference a feature this
+    version doesn't know about yet, and skipping it is harmless. Limits are
+    safety-critical: a typo'd key would silently leave a resource unmetered,
+    so that case fails fast instead.
+    """
+    result = set()
+    for name in raw:
+        try:
+            result.add(FeatureName(name))
+        except ValueError:
+            logger.warning("Unknown feature %r in tier config, skipping", name)
+    return frozenset(result)
+
+
+def _parse_limits(raw: dict[str, int | None]) -> dict[QuotaResource, int | None]:
+    """Coerce raw YAML limit keys to ``QuotaResource`` members.
+
+    :raises ValueError: on an unrecognized key. Deliberately not caught by
+        :func:`_load_tier_config`'s fallback -- a config that parses as YAML
+        but names a resource that doesn't exist is a real bug that must
+        surface at startup, not degrade into a silently-unmetered resource.
+    """
+    result: dict[QuotaResource, int | None] = {}
+    for key, value in raw.items():
+        try:
+            resource = QuotaResource(key)
+        except ValueError:
+            raise ValueError(
+                f"Unknown limit key {key!r} in tier config. "
+                f"Valid keys: {[r.value for r in QuotaResource]}"
+            )
+        result[resource] = value
+    return result
+
+
+def _fallback_catalog() -> dict[LicenseEdition, TierSpec]:
+    """Safety-net catalog used when the tier config can't be read at all.
+
+    Only the community entry is populated, using the same numbers as
+    :data:`~rhesis.backend.app.quota.FREE_TIER_LIMITS`. This keeps free-tier
+    orgs metered (rather than silently unlimited) if the bundled YAML is
+    missing or an operator's ``RHESIS_TIER_CONFIG`` override is broken.
+    Paid editions are intentionally absent: :func:`resolve_limits` falls
+    back to this same community entry for any edition not in the catalog,
+    and :func:`is_sellable` correctly reports paid tiers as unsellable until
+    the config is fixed, rather than minting tokens against stale defaults.
+    """
+    return {
+        LicenseEdition.COMMUNITY: TierSpec(
+            edition=LicenseEdition.COMMUNITY,
+            limits=dict(FREE_TIER_LIMITS),
+        )
+    }
+
+
+def _load_tier_config() -> dict[LicenseEdition, TierSpec]:
+    """Load tier specs from YAML, falling back to the bundled file."""
+    config_path_str = os.environ.get(ENV_TIER_CONFIG)
+    config_path = Path(config_path_str) if config_path_str else _BUNDLED_CONFIG
+
+    try:
+        raw = yaml.safe_load(config_path.read_text())
+    except Exception:
+        logger.exception(
+            "Failed to load tier config from %s, falling back to free-tier defaults",
+            config_path,
+        )
+        return _fallback_catalog()
+
+    if not isinstance(raw, dict):
+        logger.error(
+            "Tier config at %s is not a YAML mapping, falling back to free-tier defaults",
+            config_path,
+        )
+        return _fallback_catalog()
+
+    catalog: dict[LicenseEdition, TierSpec] = {}
+    for edition_key, spec_raw in raw.items():
+        try:
+            edition = LicenseEdition(edition_key)
+        except ValueError:
+            logger.warning("Unknown edition %r in tier config, skipping", edition_key)
+            continue
+
+        limits = _parse_limits(spec_raw.get("limits", {}))
+        features = _parse_features(spec_raw.get("features", []))
+
+        # Only pass fields the YAML actually sets; TierSpec's own dataclass
+        # defaults apply for the rest. Hardcoding e.g. `retention_days=14`
+        # here would duplicate TierSpec's default and silently drift from
+        # it if that default ever changes.
+        overrides = {
+            key: spec_raw[key]
+            for key in ("all_features", "retention_days", "overage")
+            if key in spec_raw
+        }
+        catalog[edition] = TierSpec(
+            edition=edition,
+            features=features,
+            limits=limits,
+            **overrides,
+        )
+
+    return catalog
+
+
 # ---------------------------------------------------------------------------
-# THE CATALOG — edit here to add a tier or change what one includes.
+# THE CATALOG — loaded from tier_config.yaml at import time.
 # ---------------------------------------------------------------------------
-EDITION_ENTITLEMENTS: dict[LicenseEdition, TierSpec] = {
-    LicenseEdition.STARTER: TierSpec(
-        edition=LicenseEdition.STARTER,
-        features=frozenset({FeatureName.SSO}),
-        limits={LIMIT_SEATS: 5},
-    ),
-    LicenseEdition.PREMIUM: TierSpec(
-        edition=LicenseEdition.PREMIUM,
-        features=frozenset({FeatureName.SSO, FeatureName.API_CLIENTS}),
-        limits={LIMIT_SEATS: 50},
-    ),
-    LicenseEdition.ENTERPRISE: TierSpec(
-        edition=LicenseEdition.ENTERPRISE,
-        all_features=True,
-    ),
-    LicenseEdition.MASTER: TierSpec(
-        edition=LicenseEdition.MASTER,
-        all_features=True,
-    ),
-    LicenseEdition.TRIAL: TierSpec(
-        edition=LicenseEdition.TRIAL,
-        all_features=True,
-        limits={LIMIT_SEATS: 10},
-    ),
-}
+EDITION_ENTITLEMENTS: dict[LicenseEdition, TierSpec] = _load_tier_config()
 
 
 def is_sellable(edition: LicenseEdition) -> bool:
-    """Return ``True`` if *edition* is a real, mintable tier."""
-    return edition in EDITION_ENTITLEMENTS
+    """Return ``True`` if *edition* is a real, mintable tier.
+
+    ``COMMUNITY`` has a catalog entry (for limits lookups) but is never
+    sellable -- see :data:`NON_SELLABLE_EDITIONS`.
+    """
+    return edition in EDITION_ENTITLEMENTS and edition not in NON_SELLABLE_EDITIONS
 
 
 def resolve_tier(edition: LicenseEdition) -> TierSpec:
     """Return the :class:`TierSpec` for *edition*.
 
-    :raises KeyError: if *edition* is not a sellable tier (``community``,
-        ``dev``, ``unknown``) — the mint side must never issue a non-tier
-        license, so this fails loud rather than minting an empty entitlement.
+    :raises KeyError: if *edition* is not a sellable tier (including
+        ``community``, which has limits but must never be minted).
     """
+    if edition in NON_SELLABLE_EDITIONS:
+        raise KeyError(edition)
     return EDITION_ENTITLEMENTS[edition]
+
+
+def resolve_limits(edition: Optional[LicenseEdition]) -> dict[QuotaResource, int | None]:
+    """Return limits for *edition*, falling back to community defaults.
+
+    Used for quota lookups, not minting -- unlike :func:`resolve_tier`,
+    this intentionally accepts ``None``/``community`` and any edition
+    absent from the catalog, since every org (licensed or not) needs a
+    resolvable limits dict.
+    """
+    spec = EDITION_ENTITLEMENTS.get(edition) if edition is not None else None
+    if spec is None:
+        spec = EDITION_ENTITLEMENTS.get(LicenseEdition.COMMUNITY)
+    if spec is None:
+        return {}
+    return dict(spec.limits)
 
 
 def tier_to_lic_claim(
@@ -116,9 +241,9 @@ def tier_to_lic_claim(
 ) -> dict:
     """Build the ``lic`` claim payload for *edition* (for the minting side).
 
-    The returned dict is JSON-ready (enum values rendered as strings) and
-    matches the schema :func:`~rhesis.backend.ee.licensing.verify.verify_token`
-    expects.
+    The returned dict is JSON-ready (enum values rendered as strings)
+    and matches the schema
+    :func:`~rhesis.backend.ee.licensing.verify.verify_token` expects.
     """
     spec = resolve_tier(edition)
     return {
@@ -126,14 +251,16 @@ def tier_to_lic_claim(
         LIC_STATUS: status.value,
         LIC_ALL_FEATURES: spec.all_features,
         LIC_FEATURES: spec.feature_values(),
-        LIC_LIMITS: dict(spec.limits),
+        LIC_LIMITS: limits_to_wire(spec.limits),
     }
 
 
 __all__ = [
     "EDITION_ENTITLEMENTS",
+    "NON_SELLABLE_EDITIONS",
     "TierSpec",
     "is_sellable",
+    "resolve_limits",
     "resolve_tier",
     "tier_to_lic_claim",
 ]

--- a/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
@@ -171,8 +171,36 @@ def _load_tier_config() -> dict[LicenseEdition, TierSpec]:
             logger.warning("Unknown edition %r in tier config, skipping", edition_key)
             continue
 
-        limits = _parse_limits(spec_raw.get("limits", {}))
-        features = _parse_features(spec_raw.get("features", []))
+        if not isinstance(spec_raw, dict):
+            logger.warning(
+                "Tier config entry %r is not a mapping (got %s), skipping",
+                edition_key,
+                type(spec_raw).__name__,
+            )
+            continue
+
+        raw_limits = spec_raw.get("limits", {})
+        if not isinstance(raw_limits, dict):
+            logger.warning(
+                "Tier config entry %r has a non-mapping `limits` (got %s), skipping",
+                edition_key,
+                type(raw_limits).__name__,
+            )
+            continue
+
+        raw_features = spec_raw.get("features", [])
+        if not isinstance(raw_features, list):
+            # A string would otherwise iterate per-character in _parse_features
+            # and silently resolve to an empty feature set instead of failing.
+            logger.warning(
+                "Tier config entry %r has a non-list `features` (got %s), skipping",
+                edition_key,
+                type(raw_features).__name__,
+            )
+            continue
+
+        limits = _parse_limits(raw_limits)
+        features = _parse_features(raw_features)
 
         # Only pass fields the YAML actually sets; TierSpec's own dataclass
         # defaults apply for the rest. Hardcoding e.g. `retention_days=14`

--- a/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
@@ -146,12 +146,23 @@ def _parse_features(raw: list[str]) -> frozenset[FeatureName]:
 
 
 def _parse_limits(raw: dict[str, int | None]) -> dict[QuotaResource, int | None]:
-    """Coerce raw YAML limit keys to ``QuotaResource`` members.
+    """Coerce and validate raw YAML limits into ``QuotaResource`` members.
 
-    :raises ValueError: on an unrecognized key. Deliberately not caught by
-        :func:`_load_tier_config`'s fallback -- a config that parses as YAML
-        but names a resource that doesn't exist is a real bug that must
-        surface at startup, not degrade into a silently-unmetered resource.
+    Both the key and the value are checked. ``yaml.safe_load`` happily
+    returns strings, booleans and negative numbers, none of which are a
+    meaningful quota: a string limit raises ``TypeError`` the first time
+    enforcement compares ``used >= limit``, ``True`` silently means a limit
+    of 1 (``bool`` is an ``int`` subclass), and a negative limit blocks every
+    request. These flow straight into the JWT ``lic.limits`` claim and the
+    ``/features`` response, so they are rejected here rather than surfacing
+    far from their cause.
+
+    :raises ValueError: on an unrecognized key, or a value that is neither
+        ``None`` (unlimited) nor a non-negative ``int``. Deliberately not
+        caught by :func:`_load_tier_config`'s fallback -- a config that
+        parses as YAML but is semantically wrong is a real bug that must
+        surface at startup, not degrade into a silently-unmetered or
+        permanently-blocked resource.
     """
     result: dict[QuotaResource, int | None] = {}
     for key, value in raw.items():
@@ -162,6 +173,19 @@ def _parse_limits(raw: dict[str, int | None]) -> dict[QuotaResource, int | None]
                 f"Unknown limit key {key!r} in tier config. "
                 f"Valid keys: {[r.value for r in QuotaResource]}"
             )
+
+        # bool must be rejected explicitly: it passes isinstance(v, int).
+        if value is not None and (isinstance(value, bool) or not isinstance(value, int)):
+            raise ValueError(
+                f"Invalid limit for {key!r} in tier config: {value!r} "
+                f"({type(value).__name__}). Expected an integer, or null for unlimited."
+            )
+        if value is not None and value < 0:
+            raise ValueError(
+                f"Invalid limit for {key!r} in tier config: {value!r}. "
+                f"Limits must be non-negative (use null for unlimited)."
+            )
+
         result[resource] = value
     return result
 
@@ -277,6 +301,12 @@ def _assert_catalog_complete(catalog: dict[LicenseEdition, TierSpec]) -> None:
     first time someone tried to mint it, and the reverse case is caught by
     :func:`_parse_edition`.
 
+    Checks COMMUNITY as well as the sellable tiers. A malformed community
+    entry is dropped by the shape checks in :func:`_load_tier_config`, and
+    without it :func:`resolve_limits` returns an empty dict for every
+    unlicensed org -- which reads downstream as *unlimited*. Requiring it
+    here turns that fail-open into a startup failure.
+
     Skipped when the catalog is the free-tier fallback, which is by design
     community-only -- see :func:`_fallback_catalog`.
 
@@ -285,13 +315,14 @@ def _assert_catalog_complete(catalog: dict[LicenseEdition, TierSpec]) -> None:
     if set(catalog) == {LicenseEdition.COMMUNITY}:
         return
 
-    missing = sorted(e.value for e in SELLABLE_EDITIONS - set(catalog))
+    missing = sorted(e.value for e in CATALOG_EDITIONS - set(catalog))
     if missing:
         raise RuntimeError(
             f"Tier config is missing an entry for declared edition(s): {missing}. "
             f"Every LicenseEdition member except "
-            f"{sorted(e.value for e in NON_SELLABLE_EDITIONS)} "
-            f"must have a corresponding entry in tier_config.yaml."
+            f"{sorted(e.value for e in NON_SELLABLE_EDITIONS - {LicenseEdition.COMMUNITY})} "
+            f"must have a corresponding entry in tier_config.yaml "
+            f"(community included -- it carries the free-tier limits)."
         )
 
 

--- a/tests/backend/app/test_quota_registry.py
+++ b/tests/backend/app/test_quota_registry.py
@@ -1,0 +1,102 @@
+"""Unit tests for :mod:`rhesis.backend.app.quota`."""
+
+from __future__ import annotations
+
+import pytest
+
+from rhesis.backend.app.quota import (
+    FREE_TIER_LIMITS,
+    DefaultQuotaProvider,
+    QuotaProvider,
+    QuotaRegistry,
+    QuotaResource,
+)
+
+
+@pytest.fixture
+def clean_registry():
+    """Reset the registry before each test, restore the real state after.
+
+    Mirrors the ``clean_registry`` fixture in ``test_feature_registry.py``:
+    ``ee.bootstrap()`` installs the config-backed provider once at process
+    import time, so a bare ``QuotaRegistry.reset()`` on teardown would leave
+    the default provider installed for the rest of the suite.
+    """
+    saved_provider = QuotaRegistry._provider
+    QuotaRegistry.reset()
+    yield
+    QuotaRegistry._provider = saved_provider
+
+
+class _FixedProvider:
+    """Provider returning a fixed limits dict, regardless of org."""
+
+    def __init__(self, limits: dict[QuotaResource, int | None]):
+        self._limits = limits
+
+    def get_limits(self, org=None) -> dict[QuotaResource, int | None]:
+        return dict(self._limits)
+
+
+class TestDefaultQuotaProvider:
+    def test_returns_free_tier_limits(self, clean_registry):
+        assert QuotaRegistry.get_limits() == FREE_TIER_LIMITS
+
+    def test_ignores_org(self, clean_registry):
+        """The default provider has no org-awareness -- everyone gets the
+        same free-tier numbers until an EE provider is installed."""
+        assert QuotaRegistry.get_limits(org=object()) == FREE_TIER_LIMITS
+
+
+class TestGetLimits:
+    def test_delegates_to_installed_provider(self, clean_registry):
+        custom = {QuotaResource.SEATS: 42}
+        QuotaRegistry.set_quota_provider(_FixedProvider(custom))
+        assert QuotaRegistry.get_limits() == custom
+
+
+class TestGetLimit:
+    def test_returns_limit_for_known_resource(self, clean_registry):
+        assert QuotaRegistry.get_limit(None, QuotaResource.SEATS) == 3
+
+    def test_accepts_raw_string_equivalent(self, clean_registry):
+        """QuotaResourceLike accepts wire strings, mirroring FeatureName."""
+        assert QuotaRegistry.get_limit(None, "seats") == 3
+
+    def test_none_means_unlimited(self, clean_registry):
+        QuotaRegistry.set_quota_provider(_FixedProvider({QuotaResource.SEATS: None}))
+        assert QuotaRegistry.get_limit(None, QuotaResource.SEATS) is None
+
+    def test_resource_absent_from_provider_returns_none(self, clean_registry):
+        """Distinct from an unknown resource name: a resource the provider
+        simply didn't set a limit for is treated as unlimited, same as an
+        explicit ``None`` value."""
+        QuotaRegistry.set_quota_provider(_FixedProvider({}))
+        assert QuotaRegistry.get_limit(None, QuotaResource.SEATS) is None
+
+    def test_unknown_resource_name_raises(self, clean_registry):
+        """A typo'd resource name must fail loud, not silently return None
+        (which would read as "unlimited") -- see QuotaRegistry._coerce."""
+        with pytest.raises(ValueError):
+            QuotaRegistry.get_limit(None, "not_a_real_resource")
+
+
+class TestSetQuotaProvider:
+    def test_installed_provider_takes_effect_immediately(self, clean_registry):
+        assert QuotaRegistry.get_limits() == FREE_TIER_LIMITS
+        QuotaRegistry.set_quota_provider(_FixedProvider({QuotaResource.SEATS: 100}))
+        assert QuotaRegistry.get_limits() == {QuotaResource.SEATS: 100}
+
+
+class TestReset:
+    def test_reinstalls_default_provider(self, clean_registry):
+        QuotaRegistry.set_quota_provider(_FixedProvider({QuotaResource.SEATS: 100}))
+        QuotaRegistry.reset()
+        assert isinstance(QuotaRegistry._provider, DefaultQuotaProvider)
+        assert QuotaRegistry.get_limits() == FREE_TIER_LIMITS
+
+
+class TestQuotaProviderProtocol:
+    def test_default_provider_satisfies_protocol(self):
+        provider: QuotaProvider = DefaultQuotaProvider()
+        assert provider.get_limits() == FREE_TIER_LIMITS

--- a/tests/backend/ee/licensing/test_mint.py
+++ b/tests/backend/ee/licensing/test_mint.py
@@ -1,6 +1,6 @@
 """Tests for :mod:`rhesis.backend.ee.licensing.mint`.
 
-Round-trip tests: mint_token → verify_token → assert entitlements match the
+Round-trip tests: mint_token -> verify_token -> assert entitlements match the
 tier catalog. Also covers edge cases for private-key absence, blanket-subject
 rejection, custom overrides, and the dry-run flag.
 
@@ -14,7 +14,6 @@ keypair; here we additionally expose the *private* key as
 from __future__ import annotations
 
 import base64
-import os
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -27,14 +26,14 @@ from cryptography.hazmat.primitives.serialization import (
 )
 
 from rhesis.backend.app.features import FeatureName
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.ee.licensing.entitlements import (
     BLANKET_SUBJECT,
     ENV_LICENSE_PRIVATE_KEY,
     LicenseEdition,
     LicenseStatus,
-    LIMIT_SEATS,
 )
-from rhesis.backend.ee.licensing.tiers import EDITION_ENTITLEMENTS
+from rhesis.backend.ee.licensing.tiers import EDITION_ENTITLEMENTS, is_sellable
 from rhesis.backend.ee.licensing.verify import verify_token
 
 pytestmark = pytest.mark.skipif(
@@ -68,12 +67,12 @@ def private_key_env(ed25519_keypair, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# mint_token — round-trip tests per sellable edition
+# mint_token -- round-trip tests per sellable edition
 # ---------------------------------------------------------------------------
 
 
 class TestMintTokenRoundTrip:
-    """mint_token → verify_token produces entitlements that match the catalog."""
+    """mint_token -> verify_token produces entitlements that match the catalog."""
 
     ORG_ID = "00000000-0000-0000-0000-000000000042"
 
@@ -83,28 +82,20 @@ class TestMintTokenRoundTrip:
         token = mint_token(
             org_id=self.ORG_ID,
             edition=edition,
-            kid="test-v1",  # matches the throwaway key registered in conftest.py
+            kid="test-v1",
         )
         ent = verify_token(token)
         assert ent is not None, f"verify_token returned None for edition={edition}"
         return ent
 
-    def test_starter_round_trip(self, private_key_env):
-        ent = self._mint_and_verify(LicenseEdition.STARTER)
-        assert ent.edition is LicenseEdition.STARTER
+    def test_team_round_trip(self, private_key_env):
+        ent = self._mint_and_verify(LicenseEdition.TEAM)
+        assert ent.edition is LicenseEdition.TEAM
         assert ent.status is LicenseStatus.ACTIVE
         assert ent.all_features is False
-        assert ent.allows(FeatureName.SSO.value) is True
-        assert ent.allows(FeatureName.API_CLIENTS.value) is False
-        assert ent.limits == {LIMIT_SEATS: 5}
+        assert ent.allows(FeatureName.RBAC.value) is True
+        assert ent.allows(FeatureName.SSO.value) is False
         assert ent.sub == self.ORG_ID
-
-    def test_premium_round_trip(self, private_key_env):
-        ent = self._mint_and_verify(LicenseEdition.PREMIUM)
-        assert ent.edition is LicenseEdition.PREMIUM
-        assert ent.allows(FeatureName.SSO.value) is True
-        assert ent.allows(FeatureName.API_CLIENTS.value) is True
-        assert ent.limits == {LIMIT_SEATS: 50}
 
     def test_enterprise_round_trip(self, private_key_env):
         ent = self._mint_and_verify(LicenseEdition.ENTERPRISE)
@@ -117,22 +108,15 @@ class TestMintTokenRoundTrip:
         assert ent.edition is LicenseEdition.MASTER
         assert ent.all_features is True
 
-    def test_trial_round_trip(self, private_key_env):
-        ent = self._mint_and_verify(LicenseEdition.TRIAL)
-        assert ent.edition is LicenseEdition.TRIAL
-        assert ent.all_features is True
-        assert ent.limits == {LIMIT_SEATS: 10}
-
     def test_all_sellable_editions_covered(self, private_key_env):
-        """Ensure every edition in the catalog has been exercised above."""
+        """Ensure every sellable edition in the catalog has been exercised above."""
         covered = {
-            LicenseEdition.STARTER,
-            LicenseEdition.PREMIUM,
+            LicenseEdition.TEAM,
             LicenseEdition.ENTERPRISE,
             LicenseEdition.MASTER,
-            LicenseEdition.TRIAL,
         }
-        assert covered == set(EDITION_ENTITLEMENTS.keys())
+        sellable = {e for e in EDITION_ENTITLEMENTS if is_sellable(e)}
+        assert covered == sellable
 
 
 class TestMintTokenBlanket:
@@ -158,21 +142,15 @@ class TestMintTokenStandardClaims:
     def test_sub_is_org_id(self, private_key_env):
         from rhesis.backend.ee.licensing.mint import mint_token
 
-        ent = verify_token(
-            mint_token(self.ORG_ID, LicenseEdition.ENTERPRISE, kid="test-v1")
-        )
+        ent = verify_token(mint_token(self.ORG_ID, LicenseEdition.ENTERPRISE, kid="test-v1"))
         assert ent is not None
         assert ent.sub == self.ORG_ID
 
     def test_jti_is_set_and_unique(self, private_key_env):
         from rhesis.backend.ee.licensing.mint import mint_token
 
-        ent1 = verify_token(
-            mint_token(self.ORG_ID, LicenseEdition.ENTERPRISE, kid="test-v1")
-        )
-        ent2 = verify_token(
-            mint_token(self.ORG_ID, LicenseEdition.ENTERPRISE, kid="test-v1")
-        )
+        ent1 = verify_token(mint_token(self.ORG_ID, LicenseEdition.ENTERPRISE, kid="test-v1"))
+        ent2 = verify_token(mint_token(self.ORG_ID, LicenseEdition.ENTERPRISE, kid="test-v1"))
         assert ent1 is not None and ent2 is not None
         assert ent1.jti is not None
         assert ent2.jti is not None
@@ -182,13 +160,17 @@ class TestMintTokenStandardClaims:
         from rhesis.backend.ee.licensing.mint import mint_token
 
         ent = verify_token(
-            mint_token(self.ORG_ID, LicenseEdition.ENTERPRISE, ttl_days=30, kid="test-v1")
+            mint_token(
+                self.ORG_ID,
+                LicenseEdition.ENTERPRISE,
+                ttl_days=30,
+                kid="test-v1",
+            )
         )
         assert ent is not None
         assert ent.expires_at is not None
         now = datetime.now(tz=timezone.utc)
         delta = ent.expires_at - now
-        # Allow ±60s clock slop but confirm the order-of-magnitude is 30 days.
         assert 29 * 86400 < delta.total_seconds() < 31 * 86400
 
     def test_status_is_passed_through(self, private_key_env):
@@ -197,7 +179,7 @@ class TestMintTokenStandardClaims:
         ent = verify_token(
             mint_token(
                 self.ORG_ID,
-                LicenseEdition.PREMIUM,
+                LicenseEdition.TEAM,
                 status=LicenseStatus.PAST_DUE,
                 kid="test-v1",
             )
@@ -220,7 +202,7 @@ class TestMintTokenOverrides:
         ent = verify_token(
             mint_token(
                 self.ORG_ID,
-                LicenseEdition.STARTER,
+                LicenseEdition.TEAM,
                 kid="test-v1",
                 custom_features=["sso", "api_clients"],
             )
@@ -236,7 +218,7 @@ class TestMintTokenOverrides:
         ent = verify_token(
             mint_token(
                 self.ORG_ID,
-                LicenseEdition.PREMIUM,
+                LicenseEdition.TEAM,
                 kid="test-v1",
                 custom_limits={"seats": 200, "extra_quota": 50},
             )
@@ -251,13 +233,13 @@ class TestMintTokenOverrides:
         ent = verify_token(
             mint_token(
                 self.ORG_ID,
-                LicenseEdition.STARTER,
+                LicenseEdition.TEAM,
                 kid="test-v1",
-                custom_limits={LIMIT_SEATS: 99},
+                custom_limits={str(QuotaResource.SEATS): 99},
             )
         )
         assert ent is not None
-        assert ent.limits[LIMIT_SEATS] == 99
+        assert ent.limits[str(QuotaResource.SEATS)] == 99
 
 
 # ---------------------------------------------------------------------------
@@ -314,7 +296,7 @@ class TestMintTokenErrors:
         assert ent.edition == LicenseEdition.ENTERPRISE
 
     def test_invalid_base64_content_raises(self, monkeypatch):
-        """A non-PEM string that is valid base64 but decodes to garbage raises RuntimeError."""
+        """A non-PEM string that is valid base64 but decodes to garbage."""
         junk_b64 = base64.b64encode(b"this is not a pem").decode()
         monkeypatch.setenv(ENV_LICENSE_PRIVATE_KEY, junk_b64)
         from rhesis.backend.ee.licensing.mint import mint_token
@@ -322,21 +304,24 @@ class TestMintTokenErrors:
         with pytest.raises(RuntimeError):
             mint_token(self.ORG_ID, LicenseEdition.ENTERPRISE, kid="test-v1")
 
-    def test_non_sellable_edition_raises(self, private_key_env):
-        from rhesis.backend.ee.licensing.mint import mint_token
-
-        with pytest.raises(KeyError):
-            mint_token(self.ORG_ID, LicenseEdition.COMMUNITY, kid="test-v1")
-
     def test_unknown_edition_raises(self, private_key_env):
         from rhesis.backend.ee.licensing.mint import mint_token
 
         with pytest.raises(KeyError):
             mint_token(self.ORG_ID, LicenseEdition.UNKNOWN, kid="test-v1")
 
+    def test_community_edition_raises(self, private_key_env):
+        """COMMUNITY has a catalog entry (for limits lookups) but must
+        never be minted -- self-hosted/unlicensed orgs get free-tier
+        defaults without a signed token, not a "community" license."""
+        from rhesis.backend.ee.licensing.mint import mint_token
+
+        with pytest.raises(KeyError):
+            mint_token(self.ORG_ID, LicenseEdition.COMMUNITY, kid="test-v1")
+
 
 # ---------------------------------------------------------------------------
-# issue() — DB write path
+# issue() -- DB write path
 # ---------------------------------------------------------------------------
 
 
@@ -368,7 +353,6 @@ class TestIssue:
         ent = verify_token(token)
         assert ent is not None
         assert ent.sub == self.ORG_ID
-        # DB must not have been touched
         db.commit.assert_not_called()
         assert org.license is None
 
@@ -377,11 +361,7 @@ class TestIssue:
 
         db, org = self._make_db()
 
-        # bind_scope_to_session is imported lazily inside issue() so we patch
-        # it at its source module rather than on the mint module namespace.
-        with patch(
-            "rhesis.backend.app.database.bind_scope_to_session"
-        ) as mock_bind:
+        with patch("rhesis.backend.app.database.bind_scope_to_session") as mock_bind:
             token = issue(
                 db,
                 org_id=self.ORG_ID,
@@ -395,7 +375,7 @@ class TestIssue:
         db.commit.assert_called_once()
 
     def test_live_issue_is_idempotent(self, private_key_env):
-        """Calling issue twice overwrites the token — no uniqueness error."""
+        """Calling issue twice overwrites the token."""
         from rhesis.backend.ee.licensing.mint import issue
 
         db, org = self._make_db()
@@ -413,7 +393,6 @@ class TestIssue:
                 edition=LicenseEdition.ENTERPRISE,
                 kid="test-v1",
             )
-        # Both tokens are valid; jti differs so they are distinct
         ent1 = verify_token(token1)
         ent2 = verify_token(token2)
         assert ent1 is not None and ent2 is not None
@@ -435,12 +414,12 @@ class TestIssue:
             token = issue(
                 db,
                 org_id=self.ORG_ID,
-                edition=LicenseEdition.TRIAL,
+                edition=LicenseEdition.TEAM,
                 kid="test-v1",
             )
         ent = verify_token(token)
         assert ent is not None
-        assert ent.edition is LicenseEdition.TRIAL
+        assert ent.edition is LicenseEdition.TEAM
         assert ent.sub == self.ORG_ID
 
 

--- a/tests/backend/ee/licensing/test_tiers.py
+++ b/tests/backend/ee/licensing/test_tiers.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 import pytest
 
 from rhesis.backend.app.features import FeatureName
+from rhesis.backend.app.quota import FREE_TIER_LIMITS, QuotaResource
 from rhesis.backend.ee.licensing.entitlements import (
     LIC_ALL_FEATURES,
     LIC_EDITION,
     LIC_FEATURES,
     LIC_LIMITS,
     LIC_STATUS,
-    LIMIT_SEATS,
     LicenseEdition,
     LicenseStatus,
 )
@@ -24,6 +24,7 @@ from rhesis.backend.ee.licensing.tiers import (
     EDITION_ENTITLEMENTS,
     TierSpec,
     is_sellable,
+    resolve_limits,
     resolve_tier,
     tier_to_lic_claim,
 )
@@ -46,48 +47,60 @@ class TestCatalogShape:
             assert isinstance(spec, TierSpec)
 
     def test_non_sellable_editions_absent(self):
-        for edition in (
-            LicenseEdition.COMMUNITY,
-            LicenseEdition.UNKNOWN,
-        ):
+        """COMMUNITY and UNKNOWN are never mintable, even though COMMUNITY
+        has a catalog entry (needed for limits lookups on unlicensed orgs)."""
+        for edition in (LicenseEdition.COMMUNITY, LicenseEdition.UNKNOWN):
             assert not is_sellable(edition)
             with pytest.raises(KeyError):
                 resolve_tier(edition)
 
     def test_sellable_editions_present(self):
         for edition in (
-            LicenseEdition.STARTER,
-            LicenseEdition.PREMIUM,
+            LicenseEdition.TEAM,
             LicenseEdition.ENTERPRISE,
             LicenseEdition.MASTER,
-            LicenseEdition.TRIAL,
         ):
             assert is_sellable(edition)
 
+    def test_community_entry_exists_for_limits_lookup(self):
+        """COMMUNITY is in the catalog (for resolve_limits) despite being non-sellable."""
+        assert LicenseEdition.COMMUNITY in EDITION_ENTITLEMENTS
+
+    def test_community_limits_match_core_free_tier_defaults(self):
+        """The YAML's community entry must stay in sync with core's
+        FREE_TIER_LIMITS -- the two are duplicated by necessity (core can't
+        import EE), so drift between them would only show up here."""
+        assert resolve_limits(LicenseEdition.COMMUNITY) == FREE_TIER_LIMITS
+
+    def test_limit_keys_are_quota_resources(self):
+        """All limit keys in every tier spec are QuotaResource members."""
+        for edition, spec in EDITION_ENTITLEMENTS.items():
+            for key in spec.limits:
+                assert isinstance(key, QuotaResource), (
+                    f"Limit key {key!r} in {edition} is not a QuotaResource"
+                )
+
 
 class TestTierToLicClaim:
-    def test_starter_claim_lists_only_sso(self):
-        claim = tier_to_lic_claim(LicenseEdition.STARTER)
-        assert claim[LIC_EDITION] == "starter"
+    def test_team_claim_lists_rbac(self):
+        claim = tier_to_lic_claim(LicenseEdition.TEAM)
+        assert claim[LIC_EDITION] == "team"
         assert claim[LIC_STATUS] == "active"
         assert claim[LIC_ALL_FEATURES] is False
-        assert claim[LIC_FEATURES] == [FeatureName.SSO.value]
-        assert claim[LIC_LIMITS] == {LIMIT_SEATS: 5}
+        assert claim[LIC_FEATURES] == [FeatureName.RBAC.value]
 
-    def test_premium_claim_lists_both_features(self):
-        claim = tier_to_lic_claim(LicenseEdition.PREMIUM)
-        assert set(claim[LIC_FEATURES]) == {
-            FeatureName.SSO.value,
-            FeatureName.API_CLIENTS.value,
-        }
-        assert claim[LIC_ALL_FEATURES] is False
+    def test_team_claim_has_quota_limits(self):
+        claim = tier_to_lic_claim(LicenseEdition.TEAM)
+        limits = claim[LIC_LIMITS]
+        assert limits[str(QuotaResource.TEST_EXECUTIONS)] == 100_000
+        assert limits[str(QuotaResource.SEATS)] is None
 
     def test_enterprise_claim_is_all_features(self):
         claim = tier_to_lic_claim(LicenseEdition.ENTERPRISE)
         assert claim[LIC_ALL_FEATURES] is True
 
     def test_status_override(self):
-        claim = tier_to_lic_claim(LicenseEdition.PREMIUM, status=LicenseStatus.PAST_DUE)
+        claim = tier_to_lic_claim(LicenseEdition.TEAM, status=LicenseStatus.PAST_DUE)
         assert claim[LIC_STATUS] == "past_due"
 
 
@@ -106,27 +119,17 @@ class TestMintVerifyRoundTrip:
             limits=claim[LIC_LIMITS],
         )
 
-    def test_starter_grants_sso_only(self, mint_token):
-        token = self._mint_from_tier(mint_token, LicenseEdition.STARTER)
+    def test_team_grants_rbac(self, mint_token):
+        token = self._mint_from_tier(mint_token, LicenseEdition.TEAM)
         ent = verify_token(token)
         assert ent is not None
-        assert ent.edition is LicenseEdition.STARTER
-        assert ent.allows(FeatureName.SSO.value) is True
-        assert ent.allows(FeatureName.API_CLIENTS.value) is False
-        assert ent.limits == {LIMIT_SEATS: 5}
-
-    def test_premium_grants_both(self, mint_token):
-        token = self._mint_from_tier(mint_token, LicenseEdition.PREMIUM)
-        ent = verify_token(token)
-        assert ent is not None
-        assert ent.allows(FeatureName.SSO.value) is True
-        assert ent.allows(FeatureName.API_CLIENTS.value) is True
+        assert ent.edition is LicenseEdition.TEAM
+        assert ent.allows(FeatureName.RBAC.value) is True
+        assert ent.allows(FeatureName.SSO.value) is False
 
     def test_enterprise_grants_everything(self, mint_token):
         token = self._mint_from_tier(mint_token, LicenseEdition.ENTERPRISE)
         ent = verify_token(token)
         assert ent is not None
         assert ent.all_features is True
-        # all_features short-circuits allows() for any feature, including ones
-        # not yet registered — future-proof against new EE features.
         assert ent.allows("some_future_feature") is True

--- a/tests/backend/ee/licensing/test_tiers.py
+++ b/tests/backend/ee/licensing/test_tiers.py
@@ -22,6 +22,7 @@ from rhesis.backend.ee.licensing.entitlements import (
     LicenseStatus,
 )
 from rhesis.backend.ee.licensing.tiers import (
+    _BUNDLED_CONFIG,
     EDITION_ENTITLEMENTS,
     SELLABLE_EDITIONS,
     TierSpec,
@@ -165,6 +166,42 @@ class TestLoadTierConfig:
                 "community:\n  limits:\n    seats: 3\nunknown:\n  limits:\n    seats: 999\n",
             )
 
+    @pytest.mark.parametrize(
+        "value,description",
+        [
+            ('"100"', "string"),
+            ("-1", "negative"),
+            ("true", "bool"),
+            ("1.5", "float"),
+            ("[]", "list"),
+        ],
+    )
+    def test_invalid_limit_values_are_rejected(self, tmp_path, monkeypatch, value, description):
+        """yaml.safe_load accepts these happily, but none is a usable quota.
+
+        A string limit raises TypeError the first time enforcement compares
+        `used >= limit`, `true` silently means a limit of 1 (bool is an int
+        subclass), and a negative limit blocks every request. They also flow
+        into the JWT lic.limits claim and the /features response.
+        """
+        with pytest.raises(ValueError, match="[Ii]nvalid limit"):
+            self._load_from(
+                tmp_path,
+                monkeypatch,
+                f"community:\n  limits:\n    seats: {value}\n",
+            )
+
+    def test_zero_and_null_limits_are_valid(self, tmp_path, monkeypatch):
+        """0 is a legitimate limit (nothing allowed); null means unlimited."""
+        catalog = self._load_from(
+            tmp_path,
+            monkeypatch,
+            "community:\n  limits:\n    seats: 0\n    projects: null\n",
+        )
+        limits = catalog[LicenseEdition.COMMUNITY].limits
+        assert limits[QuotaResource.SEATS] == 0
+        assert limits[QuotaResource.PROJECTS] is None
+
 
 class TestCatalogCompleteness:
     """The enum and the tier config must agree; neither half ships alone."""
@@ -196,9 +233,42 @@ class TestCatalogCompleteness:
         fallback = {LicenseEdition.COMMUNITY: TierSpec(edition=LicenseEdition.COMMUNITY)}
         _assert_catalog_complete(fallback)
 
+    def test_missing_community_entry_raises(self):
+        """A catalog with every paid tier but no community entry must fail.
+
+        resolve_limits() falls back to the community entry for unlicensed
+        orgs; without it that returns an empty dict, which reads downstream
+        as unlimited. This is the fail-open case the gate exists to stop."""
+        paid_only = {e: TierSpec(edition=e) for e in SELLABLE_EDITIONS}
+        with pytest.raises(RuntimeError, match="community"):
+            _assert_catalog_complete(paid_only)
+
     def test_real_bundled_config_is_complete(self):
         """The shipped tier_config.yaml satisfies the gate."""
         _assert_catalog_complete(EDITION_ENTITLEMENTS)
+        assert all_sellable() <= set(EDITION_ENTITLEMENTS)
+
+
+class TestBundledConfigIsPackaged:
+    """The bundled YAML must ship as package data, not just exist in the repo.
+
+    _BUNDLED_CONFIG resolves relative to the module file, so if a future
+    build-config change stops including non-Python files in the EE wheel,
+    _load_tier_config() silently falls back to the community-only catalog
+    and every paid tier becomes unsellable. That failure is quiet, so guard
+    it here.
+    """
+
+    def test_bundled_config_file_exists(self):
+        assert _BUNDLED_CONFIG.is_file(), (
+            f"{_BUNDLED_CONFIG} is missing. If the EE build config changed, "
+            f"confirm tier_config.yaml is still included as package data."
+        )
+
+    def test_default_catalog_is_not_the_fallback(self):
+        """Loading with no override must yield the real multi-tier catalog,
+        not the community-only safety net."""
+        assert set(EDITION_ENTITLEMENTS) != {LicenseEdition.COMMUNITY}
         assert all_sellable() <= set(EDITION_ENTITLEMENTS)
 
 

--- a/tests/backend/ee/licensing/test_tiers.py
+++ b/tests/backend/ee/licensing/test_tiers.py
@@ -23,8 +23,11 @@ from rhesis.backend.ee.licensing.entitlements import (
 )
 from rhesis.backend.ee.licensing.tiers import (
     EDITION_ENTITLEMENTS,
+    SELLABLE_EDITIONS,
     TierSpec,
+    _assert_catalog_complete,
     _load_tier_config,
+    all_sellable,
     is_sellable,
     resolve_limits,
     resolve_tier,
@@ -57,11 +60,13 @@ class TestCatalogShape:
                 resolve_tier(edition)
 
     def test_sellable_editions_present(self):
-        for edition in (
-            LicenseEdition.TEAM,
-            LicenseEdition.ENTERPRISE,
-            LicenseEdition.MASTER,
-        ):
+        """Every sellable edition has a catalog entry.
+
+        Driven off all_sellable() rather than a literal list so adding a
+        tier does not require editing this test -- the startup gate in
+        _assert_catalog_complete() enforces the same invariant, and this
+        confirms it holds for the real bundled config."""
+        for edition in all_sellable():
             assert is_sellable(edition)
 
     def test_community_entry_exists_for_limits_lookup(self):
@@ -134,6 +139,67 @@ class TestLoadTierConfig:
             "enterprise:\n  all_features: true\n  limits:\n    seats: null\n",
         )
         assert set(catalog.keys()) == {LicenseEdition.COMMUNITY, LicenseEdition.ENTERPRISE}
+
+    def test_undeclared_edition_key_raises(self, tmp_path, monkeypatch):
+        """A config naming a tier that isn't in LicenseEdition must fail loud.
+
+        LicenseEdition._missing_ coerces unrecognized values to UNKNOWN
+        instead of raising, so a naive ``LicenseEdition(key)`` would bind
+        the undeclared tier's limits onto the UNKNOWN sentinel -- and every
+        org whose license carries an unrecognized edition resolves to
+        UNKNOWN, so it would silently inherit those limits.
+        """
+        with pytest.raises(ValueError, match="pro"):
+            self._load_from(
+                tmp_path,
+                monkeypatch,
+                "community:\n  limits:\n    seats: 3\npro:\n  limits:\n    seats: 25\n",
+            )
+
+    def test_unknown_sentinel_cannot_be_configured(self, tmp_path, monkeypatch):
+        """UNKNOWN is a decode-time sentinel, never a configurable tier."""
+        with pytest.raises(ValueError, match="unknown"):
+            self._load_from(
+                tmp_path,
+                monkeypatch,
+                "community:\n  limits:\n    seats: 3\nunknown:\n  limits:\n    seats: 999\n",
+            )
+
+
+class TestCatalogCompleteness:
+    """The enum and the tier config must agree; neither half ships alone."""
+
+    def test_declared_edition_without_config_entry_raises(self):
+        """A LicenseEdition member with no YAML entry fails at startup
+        rather than late, with a KeyError, the first time someone mints it."""
+        partial = {
+            LicenseEdition.COMMUNITY: TierSpec(edition=LicenseEdition.COMMUNITY),
+            LicenseEdition.TEAM: TierSpec(edition=LicenseEdition.TEAM),
+        }
+        with pytest.raises(RuntimeError, match="missing an entry"):
+            _assert_catalog_complete(partial)
+
+    def test_error_names_the_missing_editions(self):
+        partial = {
+            LicenseEdition.COMMUNITY: TierSpec(edition=LicenseEdition.COMMUNITY),
+            LicenseEdition.TEAM: TierSpec(edition=LicenseEdition.TEAM),
+        }
+        with pytest.raises(RuntimeError) as exc_info:
+            _assert_catalog_complete(partial)
+        message = str(exc_info.value)
+        for missing in SELLABLE_EDITIONS - {LicenseEdition.TEAM}:
+            assert missing.value in message
+
+    def test_community_only_fallback_is_exempt(self):
+        """_fallback_catalog() is community-only by design; the gate must
+        not turn a degraded-but-working config into a boot failure."""
+        fallback = {LicenseEdition.COMMUNITY: TierSpec(edition=LicenseEdition.COMMUNITY)}
+        _assert_catalog_complete(fallback)
+
+    def test_real_bundled_config_is_complete(self):
+        """The shipped tier_config.yaml satisfies the gate."""
+        _assert_catalog_complete(EDITION_ENTITLEMENTS)
+        assert all_sellable() <= set(EDITION_ENTITLEMENTS)
 
 
 class TestTierToLicClaim:

--- a/tests/backend/ee/licensing/test_tiers.py
+++ b/tests/backend/ee/licensing/test_tiers.py
@@ -12,6 +12,7 @@ import pytest
 from rhesis.backend.app.features import FeatureName
 from rhesis.backend.app.quota import FREE_TIER_LIMITS, QuotaResource
 from rhesis.backend.ee.licensing.entitlements import (
+    ENV_TIER_CONFIG,
     LIC_ALL_FEATURES,
     LIC_EDITION,
     LIC_FEATURES,
@@ -23,6 +24,7 @@ from rhesis.backend.ee.licensing.entitlements import (
 from rhesis.backend.ee.licensing.tiers import (
     EDITION_ENTITLEMENTS,
     TierSpec,
+    _load_tier_config,
     is_sellable,
     resolve_limits,
     resolve_tier,
@@ -79,6 +81,59 @@ class TestCatalogShape:
                 assert isinstance(key, QuotaResource), (
                     f"Limit key {key!r} in {edition} is not a QuotaResource"
                 )
+
+
+class TestLoadTierConfig:
+    """_load_tier_config() must degrade gracefully on malformed input --
+    a bad entry should skip just that tier, never crash the whole loader
+    or silently misparse into a wrong-but-valid-looking TierSpec."""
+
+    def _load_from(self, tmp_path, monkeypatch, content: str) -> dict:
+        config_file = tmp_path / "tier_config.yaml"
+        config_file.write_text(content)
+        monkeypatch.setenv(ENV_TIER_CONFIG, str(config_file))
+        return _load_tier_config()
+
+    def test_null_edition_value_is_skipped_not_crashed(self, tmp_path, monkeypatch):
+        """`team:` with no value parses to None, not a dict."""
+        catalog = self._load_from(
+            tmp_path,
+            monkeypatch,
+            "community:\n  limits:\n    seats: 3\nteam: null\n",
+        )
+        assert LicenseEdition.COMMUNITY in catalog
+        assert LicenseEdition.TEAM not in catalog
+
+    def test_non_mapping_limits_is_skipped(self, tmp_path, monkeypatch):
+        catalog = self._load_from(
+            tmp_path,
+            monkeypatch,
+            "community:\n  limits:\n    seats: 3\nenterprise:\n  limits: not_a_mapping\n",
+        )
+        assert LicenseEdition.COMMUNITY in catalog
+        assert LicenseEdition.ENTERPRISE not in catalog
+
+    def test_non_list_features_is_skipped(self, tmp_path, monkeypatch):
+        """A string `features` value would otherwise iterate per-character
+        and silently resolve to an empty feature set instead of failing."""
+        catalog = self._load_from(
+            tmp_path,
+            monkeypatch,
+            "community:\n  limits:\n    seats: 3\n"
+            "master:\n  features: not_a_list\n  limits:\n    seats: null\n",
+        )
+        assert LicenseEdition.COMMUNITY in catalog
+        assert LicenseEdition.MASTER not in catalog
+
+    def test_valid_entries_still_load_alongside_malformed_ones(self, tmp_path, monkeypatch):
+        catalog = self._load_from(
+            tmp_path,
+            monkeypatch,
+            "community:\n  limits:\n    seats: 3\n"
+            "team: null\n"
+            "enterprise:\n  all_features: true\n  limits:\n    seats: null\n",
+        )
+        assert set(catalog.keys()) == {LicenseEdition.COMMUNITY, LicenseEdition.ENTERPRISE}
 
 
 class TestTierToLicClaim:

--- a/tests/backend/routes/test_features.py
+++ b/tests/backend/routes/test_features.py
@@ -143,14 +143,25 @@ class TestFeaturesEndpoint:
     def test_response_shape_is_stable(self, client: TestClient, registered_sso, mock_current_user):
         response = client.get("/features")
         body = response.json()
-        assert set(body.keys()) == {"license", "enabled", "warnings"}
+        assert set(body.keys()) == {"license", "enabled", "warnings", "limits"}
         assert set(body["license"].keys()) == {"edition", "licensed"}
         assert isinstance(body["enabled"], list)
         assert all(isinstance(name, str) for name in body["enabled"])
         assert isinstance(body["warnings"], dict)
+        assert isinstance(body["limits"], dict)
 
     def test_license_info_reflects_org(self, client: TestClient, registered_sso, mock_current_user):
-        """license_info() must receive the org object, not None."""
+        """license_info() must always receive the org object, never None.
+
+        May fire more than once per request: QuotaRegistry's
+        ConfigQuotaProvider (installed by ee.bootstrap()) also resolves the
+        org's edition via FeatureRegistry.license_info() to look up quota
+        limits, independent of the router's own call for the ``license``
+        field. That's fine in production -- SignedTokenLicenseProvider.info()
+        bottoms out in the lru_cache'd verify_token(), so a repeat call is a
+        cache hit, not re-verification. The invariant that actually matters
+        is that every call gets the real org, never None.
+        """
         received_orgs: list = []
 
         class _CapturingProvider:
@@ -165,9 +176,9 @@ class TestFeaturesEndpoint:
         try:
             response = client.get("/features")
             assert response.status_code == status.HTTP_200_OK
-            # Provider must have been called with the org, not None
-            assert len(received_orgs) == 1
-            assert received_orgs[0] is not None
+            # Provider must always be called with the org, never None
+            assert len(received_orgs) >= 1
+            assert all(org is not None for org in received_orgs)
             assert response.json()["license"] == {"edition": "enterprise", "licensed": True}
         finally:
             FeatureRegistry.reset()


### PR DESCRIPTION
## Purpose

Rhesis needs per-organization usage limits to convert free users into paying customers. This is Sub-plan 1 of the usage-limits plan: the tier configuration infrastructure that later enforcement and observability work builds on. It replaces the hardcoded `EDITION_ENTITLEMENTS` dict with a YAML-driven catalog, so tier limits can change via config + redeploy instead of re-minting every license token, and it introduces a typed `QuotaResource` enum so no part of the quota system ever passes a raw resource-name string.

## What Changed

- Added `apps/backend/.../app/quota/__init__.py`: `QuotaResource(str, Enum)` (the canonical list of metered resources), `QuotaProvider` protocol, `DefaultQuotaProvider` (hardcoded free-tier limits), `QuotaRegistry` singleton -- mirrors the existing `FeatureRegistry`/`LicenseProvider` pattern.
- Replaced the hardcoded tier catalog in `ee/backend/.../licensing/tiers.py` with a YAML loader (`tier_config.yaml`, bundled in the ee package). Override at runtime with `RHESIS_TIER_CONFIG` (e.g. a K8s ConfigMap mount). Missing/malformed config falls back to free-tier defaults rather than failing open to unlimited usage; an unknown limit key in an otherwise-valid config fails fast at import instead of silently leaving a resource unmetered.
- Replaced the `STARTER`/`PREMIUM`/`TRIAL` license editions with `TEAM`, matching the tiers the team decided on (Free / Team / Enterprise). `COMMUNITY` keeps a catalog entry (needed so unlicensed orgs get resolvable limits) but stays explicitly non-sellable -- it can never be minted a token.
- Added `ConfigQuotaProvider` (ee) and wired it into `ee/__init__.py:bootstrap()` so licensed orgs resolve their limits from the same YAML catalog the license editions come from.
- Added a `limits` field to `GET /features`, populated from `QuotaRegistry.get_limits(org)`, so the frontend can render usage against the org's actual tier limits in a later sub-plan.

## Additional Context

- Part of the broader usage-limits initiative (design doc in Notion). This is Sub-plan 1 of 4; usage accounting, enforcement, and observability follow in separate PRs.
- `ee/backend/` is not a separate repo -- it's a directory in this same monorepo, stripped out at build time for the community/MIT distribution. Everything for this sub-plan ships in one PR.
- Existing licenses minted with the old editions (`starter`/`premium`/`trial`) will need to be re-minted with `team` once this lands.

## Testing

- `tests/backend/app/test_quota_registry.py` (new): `QuotaRegistry` default provider, custom provider installation, unknown-resource rejection (raises instead of silently returning "unlimited").
- `tests/backend/ee/licensing/test_tiers.py`, `test_mint.py`: updated for the edition rename and the new community-is-non-sellable-but-has-limits contract; includes a test asserting the YAML's `community` limits stay in sync with core's `FREE_TIER_LIMITS`.
- Manually verified end-to-end in an isolated worktree (YAML loading, edition minting/rejection, `ConfigQuotaProvider` resolution, `GET /features` response shape) since Docker wasn't available to run the full pytest suite locally -- run `cd apps/backend && uv run pytest ../../tests/backend/ee/licensing/ ../../tests/backend/app/test_quota_registry.py -v` to confirm.
- `uvx ruff check` / `uvx ruff format` pass on all changed files.