### PR TITLE
Align transactional emails with the new brand

### DIFF
--- a/apps/backend/scripts/preview_emails.py
+++ b/apps/backend/scripts/preview_emails.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Render every email template with sample data so they can be eyeballed.
+
+Writes one HTML file per template plus an index that shows each at 600px and
+375px side by side. Nothing is sent — this only exercises the Jinja layer.
+
+Run from apps/backend:
+
+    uv run python scripts/preview_emails.py
+    open /tmp/rhesis-email-preview/index.html
+
+Pass --out to write somewhere else. Note this renders with whatever
+EMAIL_ASSET_BASE_URL resolves to, so the logo, header wash, and web fonts only
+appear if that host is reachable and already has the assets deployed.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# The fixtures live with the tests so the previews and the brand assertions in
+# tests/notifications/test_email_brand.py can never drift apart.
+REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from rhesis.backend.notifications.email.template_service import (  # noqa: E402
+    EmailTemplate,
+    TemplateService,
+)
+from tests.notifications.email_fixtures import FIXTURES, VARIANTS  # noqa: E402
+
+INDEX_HEAD = """<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Rhesis email preview</title>
+<style>
+  body { margin: 0; padding: 32px; background: #1c1c1e; color: #f2f2f7;
+         font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  h1 { font-size: 20px; margin: 0 0 4px; }
+  .meta { color: #8e8e93; margin-bottom: 32px; }
+  section { margin-bottom: 48px; }
+  h2 { font-size: 15px; font-weight: 600; margin: 0 0 12px; }
+  h2 a { color: #64d2ff; text-decoration: none; font-weight: 400; font-size: 13px;
+         margin-left: 8px; }
+  .frames { display: flex; gap: 20px; align-items: flex-start; flex-wrap: wrap; }
+  iframe { border: 0; background: #fff; border-radius: 8px; }
+</style>
+<h1>Rhesis transactional emails</h1>
+<div class="meta">Desktop 600px and mobile 375px. Fonts and images resolve only if
+the asset host is live.</div>
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", default="/tmp/rhesis-email-preview", type=Path)
+    args = parser.parse_args()
+
+    out_dir: Path = args.out
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    service = TemplateService()
+    cases: list[tuple[str, EmailTemplate, dict]] = [
+        (template.value.removesuffix(".html.jinja2"), template, variables)
+        for template, variables in FIXTURES.items()
+    ]
+    cases.extend(VARIANTS)
+    cases.sort(key=lambda case: case[0])
+
+    index = [INDEX_HEAD]
+    for name, template, variables in cases:
+        html = service.render_template(template, variables)
+        (out_dir / f"{name}.html").write_text(html, encoding="utf-8")
+        index.append(
+            f'<section><h2>{name}<a href="{name}.html" target="_blank">open</a></h2>'
+            f'<div class="frames">'
+            f'<iframe src="{name}.html" width="620" height="900"></iframe>'
+            f'<iframe src="{name}.html" width="375" height="900"></iframe>'
+            f"</div></section>"
+        )
+        print(f"  {name}  ({len(html):,} bytes)")
+
+    (out_dir / "index.html").write_text("\n".join(index), encoding="utf-8")
+    print(f"\n{len(cases)} previews -> {out_dir / 'index.html'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/backend/src/rhesis/backend/app/config/settings.py
+++ b/apps/backend/src/rhesis/backend/app/config/settings.py
@@ -266,6 +266,9 @@ class SMTPSettings(BaseSettings):
     user: str | None = Field(default=None, alias="SMTP_USER")
     password: str | None = Field(default=None, alias="SMTP_PASSWORD")
     from_email: str = Field(default="engineering@rhesis.ai", alias="FROM_EMAIL")
+    # Where email templates load their logo, header wash, and web fonts from.
+    # Must be publicly reachable — mail clients fetch these directly.
+    asset_base_url: str = Field(default="https://rhesis.ai", alias="EMAIL_ASSET_BASE_URL")
 
 
 class ModelSettings(BaseSettings):

--- a/apps/backend/src/rhesis/backend/notifications/email/brand.py
+++ b/apps/backend/src/rhesis/backend/notifications/email/brand.py
@@ -25,6 +25,8 @@ Email constrains what can be expressed:
 
 from dataclasses import dataclass
 
+from markupsafe import Markup
+
 from rhesis.backend.app.config.settings import get_smtp_settings
 
 
@@ -82,12 +84,19 @@ class Colors:
 
 @dataclass(frozen=True)
 class Fonts:
-    """Font stacks. The first family only resolves where @font-face survives."""
+    """Font stacks. The first family only resolves where @font-face survives.
 
-    sans: str = (
+    Wrapped in `Markup` because the environment autoescapes unconditionally,
+    which would turn the quotes around multi-word family names into `&#39;`.
+    These are developer-controlled constants, never user input, so marking them
+    safe is sound — nothing else on `brand` needs it, since hex values, URLs and
+    shadow values contain no escapable characters.
+    """
+
+    sans: str = Markup(
         "'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
     )
-    mono: str = "'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+    mono: str = Markup("'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace")
 
 
 @dataclass(frozen=True)

--- a/apps/backend/src/rhesis/backend/notifications/email/brand.py
+++ b/apps/backend/src/rhesis/backend/notifications/email/brand.py
@@ -1,0 +1,174 @@
+"""Brand tokens for transactional email templates.
+
+Single source of truth for the values the email templates render. Kept in
+Python rather than a Jinja include so the same tokens are importable from
+tests and from any future email code.
+
+The values mirror the marketing site (`website/src/components/home/*.tsx`) —
+**not** the `@theme` block in `website/src/styles/tailwind.css`, which still
+holds the previous brand (`#50B9E0`, `#2AA1CE`) that the redesigned sections
+no longer use. Semantic colors come from the product UI
+(`apps/frontend/src/styles/theme.ts`), since these emails link into it.
+
+Email constrains what can be expressed:
+
+- Web fonts reach maybe half of recipients. `@font-face` works in Apple Mail,
+  Outlook for Mac, and Thunderbird; Gmail (every client), Outlook Windows,
+  Outlook.com, and Yahoo strip it. Hence every token that names a font names a
+  full stack, and Sora never appears — its only job on the site is the
+  wordmark, which is baked into `logo-lockup-v1.png` instead.
+- `border-radius` is dropped by Outlook Windows, so cards carry a 1px border
+  to stay defined there and buttons degrade to solid rectangles.
+- `box-shadow` renders inconsistently and muddily in mail, so the site's card
+  and button shadows are omitted rather than approximated.
+"""
+
+from dataclasses import dataclass
+
+from rhesis.backend.app.config.settings import get_smtp_settings
+
+
+@dataclass(frozen=True)
+class Colors:
+    """Palette. Lowercase hex throughout so the regression test can match it."""
+
+    # Surfaces
+    canvas: str = "#f9fafa"  # page background (site: Home.tsx)
+    surface: str = "#ffffff"  # cards
+    # Recessed panels: fallback-link boxes, info callouts, secondary cards.
+    # Neutral on purpose — a blue tint here clashes with the header wash's cyan
+    # and reads as a different brand. The site keeps these greys and reserves
+    # blue for type and CTAs.
+    surface_subtle: str = "#f0f2f6"
+
+    # Text — three levels, and that is the whole set. Anything that wants a
+    # fourth is really asking for a different size or weight.
+    heading: str = "#101011"  # headlines, subheads, table values
+    body: str = "#2c2c2c"  # prose
+    muted: str = "#6b7280"  # small print, table labels, the imprint
+
+    # Lines
+    border: str = "#e5e7eb"  # rules and table dividers
+    # Card edges are far lighter than rules. On the site a card is defined by
+    # its shadow and carries no border at all; this is only here so the card
+    # does not dissolve into the canvas in Outlook, which drops box-shadow.
+    card_edge: str = "#eceff3"
+
+    # Brand
+    blue: str = "#0080af"  # primary; also the product UI primary
+    blue_dark: str = "#006d96"
+    blue_light: str = "#009bd3"
+    yellow: str = "#fdd803"
+    orange: str = "#f97316"
+
+    # Semantic, from apps/frontend/src/styles/theme.ts
+    success: str = "#38ad87"
+    success_tint: str = "#eef8f4"
+    success_border: str = "#c3e6da"
+    warning: str = "#f57c00"
+    warning_tint: str = "#fff7ed"
+    warning_border: str = "#fed7aa"
+    error: str = "#de3355"
+    error_tint: str = "#fdeff2"
+    error_border: str = "#f6c9d3"
+
+    # CTAs. The site's navbar CTA is a near-black pill
+    # (linear-gradient(179.48deg, #101011, #424246)); flattened to its top stop
+    # here because Outlook ignores gradients. Blue stays the accent colour for
+    # headline tails and links rather than doubling as the button fill.
+    button: str = "#101011"
+    inverse: str = "#ffffff"  # text on a solid dark fill
+
+
+@dataclass(frozen=True)
+class Fonts:
+    """Font stacks. The first family only resolves where @font-face survives."""
+
+    sans: str = (
+        "'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif"
+    )
+    mono: str = "'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace"
+
+
+@dataclass(frozen=True)
+class Type:
+    """The whole type ramp. Five steps — no template should introduce a sixth.
+
+    18 does double duty: regular weight is a lede, bold is a section head. The
+    distinction is weight, not size, which is what keeps the ramp short.
+    """
+
+    headline: int = 32  # one per email
+    lede: int = 18  # intro line (400) and section heads (700)
+    body: int = 16  # prose, buttons, table values
+    small: int = 13  # small print, table labels, the imprint
+    label: int = 11  # mono eyebrows and chips
+
+
+@dataclass(frozen=True)
+class Layout:
+    """Geometry. Widths in px because email measures in px."""
+
+    width: int = 600  # the canonical email content width
+    radius_card: int = 24  # the site's card range is 20-30px
+    radius_chip: int = 999
+    radius_button: int = 999  # pill, matching the site's rounded-full CTAs
+    gutter: int = 32
+
+    # The site's card shadow. Honoured by Apple Mail, iOS, and Gmail; Outlook
+    # drops it, which is what card_edge covers for.
+    shadow_card: str = "0 4px 30px 0 rgba(45, 30, 133, 0.1)"
+
+    # Display sizes of the raster assets. Both are rendered at 2x by
+    # website/scripts/build-email-assets.mjs, which prints these numbers —
+    # keep them in step with that script's output.
+    logo_width: int = 232
+    logo_height: int = 60
+    wash_height: int = 297
+    # How far down the content table the wash starts, so its centre (half of
+    # wash_height) lands on the CTA. Measured button centres in the auth emails:
+    # 334-427px at 600px wide, 378-523px at 375px, because the copy reflows to
+    # more lines on a phone. Hence two offsets — the mobile one is applied by a
+    # media query in _base.html.jinja2. Longer emails (a stat tile ahead of the
+    # button) push their button below the wash; one offset serves every
+    # template, so it tracks the high-volume transactional ones.
+    wash_offset: int = 200
+    wash_offset_mobile: int = 240
+
+
+@dataclass(frozen=True)
+class Brand:
+    """Everything a template needs, exposed to Jinja as `brand`."""
+
+    color: Colors
+    font: Fonts
+    type: Type
+    layout: Layout
+    asset_base_url: str
+
+    @property
+    def logo_url(self) -> str:
+        return f"{self.asset_base_url}/email/logo-lockup-v1.png"
+
+    @property
+    def wash_url(self) -> str:
+        return f"{self.asset_base_url}/email/header-gradient-v1.jpg"
+
+    @property
+    def font_sans_url(self) -> str:
+        return f"{self.asset_base_url}/fonts/Geist-VariableFont_wght.woff2"
+
+    @property
+    def font_mono_url(self) -> str:
+        return f"{self.asset_base_url}/fonts/GeistMono-VariableFont_wght.woff2"
+
+
+def get_brand() -> Brand:
+    """Build the brand tokens, resolving the asset host from settings."""
+    return Brand(
+        color=Colors(),
+        font=Fonts(),
+        type=Type(),
+        layout=Layout(),
+        asset_base_url=get_smtp_settings().asset_base_url.rstrip("/"),
+    )

--- a/apps/backend/src/rhesis/backend/notifications/email/template_service.py
+++ b/apps/backend/src/rhesis/backend/notifications/email/template_service.py
@@ -10,6 +10,8 @@ from typing import Any, Dict
 
 import jinja2
 
+from rhesis.backend.notifications.email.brand import get_brand
+
 logger = logging.getLogger(__name__)
 
 
@@ -47,6 +49,10 @@ class TemplateService:
         # Add custom filters
         self.jinja_env.filters["datetime_format"] = self._datetime_format
         self.jinja_env.filters["format_number"] = lambda value: f"{int(value):,}"
+
+        # Brand tokens are a global so every template and macro reads the same
+        # palette, font stacks, and asset URLs. See brand.py.
+        self.jinja_env.globals["brand"] = get_brand()
 
         # Define required variables for each template
         self.template_variables = {

--- a/apps/backend/src/rhesis/backend/notifications/email/template_service.py
+++ b/apps/backend/src/rhesis/backend/notifications/email/template_service.py
@@ -38,10 +38,18 @@ class TemplateService:
         # Get template directory path
         self.template_dir = Path(__file__).parent / "templates"
 
-        # Initialize Jinja2 environment
+        # Initialize Jinja2 environment.
+        #
+        # autoescape is unconditional, not select_autoescape(["html", "xml"]).
+        # select_autoescape matches on the filename's suffix, and every template
+        # here ends in `.jinja2` rather than `.html`, so it returned False for
+        # all of them and escaping never engaged. Recipient-controlled fields
+        # (feedback, justification, task_description, organization_name, entity
+        # names) rendered as live HTML, which lets someone inject a link into a
+        # Rhesis-branded email.
         self.jinja_env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(str(self.template_dir)),
-            autoescape=jinja2.select_autoescape(["html", "xml"]),
+            autoescape=True,
             trim_blocks=True,
             lstrip_blocks=True,
         )

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/_base.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/_base.html.jinja2
@@ -1,0 +1,169 @@
+{#-
+  Shared shell for every transactional email.
+
+  Children do:  {% extends '_base.html.jinja2' %}
+                {% block title %}...{% endblock %}
+                {% block preheader %}...{% endblock %}
+                {% block content %}<tr><td>...</td></tr>{% endblock %}
+
+  The content block sits inside a 600px <table>, so it must emit <tr> rows.
+  Use the macros in _components.html.jinja2 rather than hand-rolling styles.
+
+  Why it looks like 2005 HTML: Outlook Windows renders through Word, which
+  ignores <body> widths, most of the box model, and border-radius. Tables with
+  presentation roles and inline styles are the only reliably portable layout.
+  Light mode is locked (see the color-scheme meta) — there is no dark variant.
+-#}
+<!DOCTYPE html>
+<html lang="en" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    {#- Locked to light: clients that honour this skip their auto-invert pass,
+        which otherwise mangles the flattened header assets. -#}
+    <meta name="color-scheme" content="light">
+    <meta name="supported-color-schemes" content="light">
+    <title>{% block title %}Rhesis AI{% endblock %}</title>
+    <!--[if mso]>
+    <xml><o:OfficeDocumentSettings><o:PixelsPerInch>96</o:PixelsPerInch></o:OfficeDocumentSettings></xml>
+    <![endif]-->
+    <style>
+        /* Gmail, Outlook Windows, Outlook.com, and Yahoo strip @font-face, so
+           Geist is an enhancement. Every element also carries an inline
+           font-family stack that falls back to Helvetica/Arial. */
+        @font-face {
+            font-family: 'Geist';
+            font-style: normal;
+            font-weight: 100 900;
+            font-display: swap;
+            src: url('{{ brand.font_sans_url }}') format('woff2');
+        }
+        @font-face {
+            font-family: 'Geist Mono';
+            font-style: normal;
+            font-weight: 100 900;
+            font-display: swap;
+            src: url('{{ brand.font_mono_url }}') format('woff2');
+        }
+
+        :root { color-scheme: light; supported-color-schemes: light; }
+
+        body, table, td, a {
+            -webkit-text-size-adjust: 100%;
+            -ms-text-size-adjust: 100%;
+        }
+        table, td {
+            border-collapse: collapse;
+            mso-table-lspace: 0pt;
+            mso-table-rspace: 0pt;
+        }
+        img {
+            border: 0;
+            height: auto;
+            line-height: 100%;
+            outline: none;
+            text-decoration: none;
+            -ms-interpolation-mode: bicubic;
+        }
+        /* Stop iOS and Gmail auto-linking dates, addresses, and phone numbers
+           into blue underlined text that ignores our palette. */
+        a[x-apple-data-detectors], .unstyled-auto-detected a {
+            color: inherit !important;
+            text-decoration: none !important;
+            font-size: inherit !important;
+            font-weight: inherit !important;
+        }
+
+        @media only screen and (max-width: 620px) {
+            /* The copy reflows to more lines on a phone, pushing the CTA down,
+               so the wash needs its own offset to stay behind it. !important
+               because it has to beat the inline style on the table. */
+            .wash { background-position: center {{ brand.layout.wash_offset_mobile }}px !important; }
+            .sm-full { width: 100% !important; max-width: 100% !important; }
+            .sm-px { padding-left: 20px !important; padding-right: 20px !important; }
+            .sm-h1 { font-size: 26px !important; }
+            .sm-stat { font-size: 36px !important; }
+            .sm-stack {
+                display: block !important;
+                width: 100% !important;
+                padding-left: 0 !important;
+                padding-right: 0 !important;
+            }
+        }
+    </style>
+</head>
+<body style="margin: 0; padding: 0; width: 100%; background-color: {{ brand.color.canvas }};">
+
+    {#- Inbox preview line. Hidden in the body but read by most clients. -#}
+    <div style="display: none; font-size: 1px; color: {{ brand.color.canvas }}; line-height: 1px; max-height: 0; max-width: 0; opacity: 0; overflow: hidden;">
+        {% block preheader %}{% endblock %}
+    </div>
+
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" bgcolor="{{ brand.color.canvas }}" style="background-color: {{ brand.color.canvas }};">
+        <tr>
+            <td align="center" style="padding: 32px 12px;">
+                <!--[if mso]><table role="presentation" width="{{ brand.layout.width }}" cellpadding="0" cellspacing="0" border="0"><tr><td><![endif]-->
+                {#- The wash rides the whole content table rather than any one
+                    cell. That lets it start below the logo and trail down past
+                    the headline into the first card, with no height floor
+                    anywhere to pad the layout out. Cards are opaque, so they
+                    sit over it the way they do on the site.
+
+                    Outlook Windows ignores background-image and shows the flat
+                    canvas instead. That is the intended degradation — the wash
+                    is decorative, and the VML alternative needs a hardcoded
+                    pixel height, which breaks as soon as content reflows. -#}
+                {#- background-size is fixed rather than `100% auto`: scaling it
+                    to the viewport shrank the wash to ~122px on a phone, which
+                    both shortened the bloom and lifted its centre well above
+                    the button. At 375px the 600px image is centre-cropped
+                    instead, which is fine — the bloom is centred and already
+                    bleeds off both sides. -#}
+                <table role="presentation" width="{{ brand.layout.width }}" cellpadding="0" cellspacing="0" border="0" class="sm-full wash"
+                       background="{{ brand.wash_url }}"
+                       style="width: {{ brand.layout.width }}px; max-width: {{ brand.layout.width }}px; background-image: url('{{ brand.wash_url }}'); background-position: center {{ brand.layout.wash_offset }}px; background-repeat: no-repeat; background-size: {{ brand.layout.width }}px {{ brand.layout.wash_height }}px;">
+
+                    {#- The lockup is a raster because on the site the wordmark
+                        is live Sora text, and Sora has no usable fallback in
+                        mail. The wash is not a row of its own — it is the
+                        background of the header cell that row_header() emits,
+                        so the bloom sits behind the headline. -#}
+                    <tr>
+                        <td align="center" style="padding: 0 0 6px 0;">
+                            <a href="https://rhesis.ai" style="text-decoration: none;">
+                                <img src="{{ brand.logo_url }}" alt="Rhesis AI"
+                                     width="{{ brand.layout.logo_width }}" height="{{ brand.layout.logo_height }}"
+                                     style="display: block; width: {{ brand.layout.logo_width }}px; height: auto; border: 0;">
+                            </a>
+                        </td>
+                    </tr>
+
+                    {% block content %}{% endblock %}
+
+                    {#- Sign-off. Templates that need their own (the founder
+                        letter) override the block. Its bottom padding is what
+                        separates the imprint's rule from the text above —
+                        without it the rule sits flush against the sign-off. -#}
+                    {% block signoff %}
+                    <tr>
+                        <td class="sm-px" style="padding: 8px 0 36px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; line-height: 1.6; color: {{ brand.color.body }};">
+                            Best regards,<br>The Rhesis AI team
+                        </td>
+                    </tr>
+                    {% endblock %}
+
+                    <tr>
+                        <td style="padding: 0;">
+                            {% include '_imprint.html.jinja2' %}
+                        </td>
+                    </tr>
+
+                </table>
+                <!--[if mso]></td></tr></table><![endif]-->
+            </td>
+        </tr>
+    </table>
+
+</body>
+</html>

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/_components.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/_components.html.jinja2
@@ -1,0 +1,309 @@
+{#-
+  Email building blocks. Every macro emits inline styles built from `brand`,
+  because classes can't be relied on: Gmail strips some <style> rules and
+  Outlook Windows ignores most of the box model.
+
+  Macros whose name starts with `row_` emit a full <tr> and belong directly in
+  a template's {% block content %}. The rest emit fragments for use inside one.
+
+  ## Layout model — read this before adding a box
+
+  It follows the site, which has exactly two surfaces:
+
+  1. The canvas. Headlines, body copy, lists, sign-offs, and small print all
+     sit directly on it with no container. This is the default. On the site,
+     prose is never boxed.
+  2. One card. White, 24px radius, defined by the site's soft shadow with the
+     lightest possible border behind it for Outlook. Reserved for discrete
+     tiles — a details table, a stat, a code block. Never for a paragraph.
+
+  There is no third surface: no grey recessed panels, no bordered rectangles,
+  no blue-ruled quote blocks. Semantic tints (success / warning / error) are
+  the one exception, because they carry meaning rather than decoration, and
+  the app colour-codes status the same way.
+
+  Buttons are pills, matching the site's rounded-full CTAs. They are table
+  cells with border-radius, not VML roundrects: Outlook Windows squares the
+  corners, which still reads as an intentional solid button, whereas VML needs
+  a hardcoded pixel width per button that breaks whenever a label changes.
+-#}
+
+{#- ─────────────────────────── canvas-level type ─────────────────────────── -#}
+
+{#- Small uppercase mono label. Mirrors the site's hero badges and footer
+    column headers. -#}
+{% macro eyebrow(text) -%}
+<div style="font-family: {{ brand.font.mono }}; font-size: {{ brand.type.label }}px; font-weight: 400; line-height: 1.4; letter-spacing: 0.6px; text-transform: uppercase; color: {{ brand.color.muted }}; padding-bottom: 10px;">{{ text }}</div>
+{%- endmacro %}
+
+{#- Page headline. `accent` renders as the site's light-weight blue tail on an
+    otherwise bold black headline. -#}
+{% macro headline(text, accent=None) -%}
+<h1 class="sm-h1" style="margin: 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.headline }}px; font-weight: 700; line-height: 1.15; letter-spacing: -0.01em; color: {{ brand.color.heading }};">{{ text }}{% if accent %} <span style="font-weight: 300; color: {{ brand.color.blue }};">{{ accent }}</span>{% endif %}</h1>
+{%- endmacro %}
+
+{% macro subhead(text) -%}
+<h2 style="margin: 0 0 10px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.lede }}px; font-weight: 700; line-height: 1.3; color: {{ brand.color.heading }};">{{ text }}</h2>
+{%- endmacro %}
+
+{% macro card_title(text) -%}
+<h3 style="margin: 0 0 14px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; font-weight: 700; line-height: 1.3; color: {{ brand.color.heading }};">{{ text }}</h3>
+{%- endmacro %}
+
+{% macro p(text, size=None, color=None, top=0, bottom=16) -%}
+{%- set size = size or brand.type.body -%}
+<p style="margin: {{ top }}px 0 {{ bottom }}px 0; font-family: {{ brand.font.sans }}; font-size: {{ size }}px; font-weight: 400; line-height: 1.6; color: {{ color or brand.color.body }};">{{ text }}</p>
+{%- endmacro %}
+
+{#- Bulleted or numbered list. Email needs the margins stated explicitly. -#}
+{% macro bullets(items, ordered=False) -%}
+{%- set tag = 'ol' if ordered else 'ul' -%}
+<{{ tag }} style="margin: 0 0 16px 0; padding-left: 22px; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; font-weight: 400; line-height: 1.6; color: {{ brand.color.body }};">
+    {% for item in items %}
+    <li style="margin-bottom: 8px;">{{ item }}</li>
+    {% endfor %}
+</{{ tag }}>
+{%- endmacro %}
+
+{#- Inline link, so templates don't restate the colour. -#}
+{% macro link(url, label) -%}
+<a href="{{ url }}" style="color: {{ brand.color.blue }}; text-decoration: none; font-weight: 500;">{{ label }}</a>
+{%- endmacro %}
+
+{#- Inline monospace value: IDs, tokens, anything meant to be copied. -#}
+{% macro mono(text) -%}
+<span style="font-family: {{ brand.font.mono }}; font-size: {{ brand.type.small }}px; color: {{ brand.color.body }}; word-break: break-all;">{{ text }}</span>
+{%- endmacro %}
+
+{#- User-supplied prose that has to keep its own line breaks. -#}
+{% macro quoted(text) -%}
+<div style="font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; font-weight: 400; line-height: 1.65; color: {{ brand.color.body }}; white-space: pre-wrap;">{{ text }}</div>
+{%- endmacro %}
+
+{#- ───────────────────────────── canvas rows ─────────────────────────────── -#}
+
+{#- Header block: eyebrow + headline + optional lede. The brand wash sits
+    behind this on the content table (see _base.html.jinja2), so nothing here
+    carries a background. -#}
+{% macro row_header(title, lede=None, accent=None, label=None) -%}
+<tr>
+    <td class="sm-px" style="padding: 18px 0 22px 0;">
+        {% if label %}{{ eyebrow(label) }}{% endif %}
+        {{ headline(title, accent) }}
+        {% if lede %}
+        <p style="margin: 14px 0 0 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.lede }}px; font-weight: 400; line-height: 1.45; color: {{ brand.color.body }};">{{ lede }}</p>
+        {% endif %}
+    </td>
+</tr>
+{%- endmacro %}
+
+{#- Prose on the canvas. This is the default container for body copy — use it
+    instead of wrapping paragraphs in a card. -#}
+{% macro row_prose(bottom=22) %}
+<tr>
+    <td class="sm-px" style="padding: 0 0 {{ bottom }}px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; line-height: 1.6; color: {{ brand.color.body }};">
+        {{ caller() }}
+    </td>
+</tr>
+{% endmacro %}
+
+{#- Small print: security notes, "ignore this if you didn't ask" lines. -#}
+{% macro row_note(text) -%}
+<tr>
+    <td class="sm-px" style="padding: 0 0 22px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.small }}px; font-weight: 400; line-height: 1.6; color: {{ brand.color.muted }};">{{ text }}</td>
+</tr>
+{%- endmacro %}
+
+{#- Copy-pasteable URL for when the button doesn't survive the client. Plain
+    small print on the canvas — it used to be a grey panel, which made a
+    fallback affordance louder than the button it backs up. -#}
+{% macro row_fallback_link(url, note='If the button does not work, copy and paste this link into your browser:') -%}
+<tr>
+    <td class="sm-px" style="padding: 0 0 22px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.small }}px; font-weight: 400; line-height: 1.6; color: {{ brand.color.muted }};">
+        {{ note }}<br>
+        <a href="{{ url }}" style="color: {{ brand.color.blue }}; text-decoration: none; word-break: break-all;">{{ url }}</a>
+    </td>
+</tr>
+{%- endmacro %}
+
+{% macro row_spacer(height=8) -%}
+<tr><td style="height: {{ height }}px; font-size: 0; line-height: 0;">&nbsp;</td></tr>
+{%- endmacro %}
+
+{#- Hairline rule, for separating canvas sections without boxing them. -#}
+{% macro row_rule(bottom=22) -%}
+<tr>
+    <td style="padding: 0 0 {{ bottom }}px 0;">
+        <div style="height: 1px; background-color: {{ brand.color.border }}; font-size: 0; line-height: 0;">&nbsp;</div>
+    </td>
+</tr>
+{%- endmacro %}
+
+{#- ──────────────────────────────── the card ─────────────────────────────── -#}
+
+{#- The one card. White, 24px, shadow-defined like the site's.
+    Use as {% call card() %}...{% endcall %} — and only for a tile, never for a
+    paragraph. -#}
+{% macro card(align='left') %}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; background-color: {{ brand.color.surface }}; border: 1px solid {{ brand.color.card_edge }}; border-radius: {{ brand.layout.radius_card }}px; box-shadow: {{ brand.layout.shadow_card }};">
+    <tr>
+        <td class="sm-px" align="{{ align }}" style="padding: 26px {{ brand.layout.gutter - 4 }}px; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; line-height: 1.6; color: {{ brand.color.body }};">
+            {{ caller() }}
+        </td>
+    </tr>
+</table>
+{% endmacro %}
+
+{#- The card as a top-level row, with the vertical rhythm applied.
+    `caller()` has to be captured before the inner {% call %}, which rebinds
+    `caller` to its own (empty) block. -#}
+{% macro row_card(align='left') %}
+{%- set body = caller() -%}
+<tr>
+    <td style="padding: 0 0 22px 0;">
+        {% call card(align=align) %}{{ body }}{% endcall %}
+    </td>
+</tr>
+{% endmacro %}
+
+{#- ──────────────────────────────── content ──────────────────────────────── -#}
+
+{#- Label/value table. Belongs inside a card. Each row is a dict:
+      label  (str, required)
+      value  (str, required)
+      url    (str, optional)  renders the value as a link
+      color  (str, optional)  overrides the value colour
+      bold   (bool, optional)
+      mono   (bool, optional) monospace, for IDs and other copied values -#}
+{% macro kv_table(rows) -%}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%;">
+    {% for row in rows %}
+    <tr>
+        <td width="42%" valign="top" style="width: 42%; padding: 9px 12px 9px 0; {% if not loop.last %}border-bottom: 1px solid {{ brand.color.card_edge }};{% endif %} font-family: {{ brand.font.sans }}; font-size: {{ brand.type.small }}px; font-weight: 500; line-height: 1.5; color: {{ brand.color.muted }};">{{ row.label }}</td>
+        <td valign="top" style="padding: 9px 0; {% if not loop.last %}border-bottom: 1px solid {{ brand.color.card_edge }};{% endif %} font-family: {{ brand.font.mono if row.mono else brand.font.sans }}; font-size: {{ brand.type.small if row.mono else brand.type.body }}px; font-weight: {{ 700 if row.bold else 400 }}; line-height: 1.5; color: {{ row.color or brand.color.heading }}; word-break: break-word;">
+            {%- if row.url -%}
+            <a href="{{ row.url }}" style="color: {{ brand.color.blue }}; text-decoration: none; font-weight: {{ 700 if row.bold else 500 }};">{{ row.value }}</a>
+            {%- else -%}
+            {{ row.value }}
+            {%- endif -%}
+        </td>
+    </tr>
+    {% endfor %}
+</table>
+{%- endmacro %}
+
+{#- Preformatted block that keeps its line breaks. `tone`: dark (for commands)
+    or error (for stack traces and failure output). -#}
+{% macro code_block(text, tone='dark') -%}
+{%- if tone == 'error' -%}
+{%- set bg, fg = brand.color.error_tint, brand.color.error -%}
+{%- else -%}
+{%- set bg, fg = brand.color.heading, '#ffffff' -%}
+{%- endif -%}
+<div style="margin: 0 0 12px 0; padding: 14px 16px; background-color: {{ bg }}; border-radius: 10px; font-family: {{ brand.font.mono }}; font-size: {{ brand.type.small }}px; font-weight: 400; line-height: 1.5; color: {{ fg }}; white-space: pre-wrap; word-break: break-word;">{{ text }}</div>
+{%- endmacro %}
+
+{#- Call-to-action button. `variant`: primary (solid blue) or secondary
+    (outlined). -#}
+{% macro button(url, label, variant='primary', align='center') -%}
+{%- if variant == 'secondary' -%}
+{%- set bg = brand.color.canvas -%}
+{%- set fg = brand.color.button -%}
+{%- set border = '2px solid ' ~ brand.color.button -%}
+{%- set pad = '13px 28px' -%}
+{%- else -%}
+{%- set bg = brand.color.button -%}
+{%- set fg = brand.color.inverse -%}
+{%- set border = '0' -%}
+{%- set pad = '15px 30px' -%}
+{%- endif -%}
+<table role="presentation" cellpadding="0" cellspacing="0" border="0" align="{{ align }}" style="{% if align == 'center' %}margin: 0 auto;{% endif %}">
+    <tr>
+        <td bgcolor="{{ bg }}" style="background-color: {{ bg }}; border: {{ border }}; border-radius: {{ brand.layout.radius_button }}px;">
+            <a href="{{ url }}" style="display: inline-block; padding: {{ pad }}; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; font-weight: 700; line-height: 1; color: {{ fg }}; text-decoration: none; white-space: nowrap;">{{ label }}</a>
+        </td>
+    </tr>
+</table>
+{%- endmacro %}
+
+{% macro row_button(url, label, variant='primary') -%}
+<tr>
+    <td align="center" style="padding: 2px 0 26px 0;">
+        {{ button(url, label, variant) }}
+    </td>
+</tr>
+{%- endmacro %}
+
+{#- ─────────────────── semantic tints (meaning, not decor) ────────────────── -#}
+
+{#- fill / edge / accent per tone. A module-level set is visible to the macros
+    below, and `brand` resolves because it is an environment global. -#}
+{% set TONES = {
+    'success': (brand.color.success_tint, brand.color.success_border, brand.color.success),
+    'warning': (brand.color.warning_tint, brand.color.warning_border, brand.color.warning),
+    'error': (brand.color.error_tint, brand.color.error_border, brand.color.error),
+    'neutral': (brand.color.surface, brand.color.card_edge, brand.color.blue),
+} %}
+
+{#- Headline number, in the site's light-weight stat style. `tone`:
+    success | error | warning | neutral. -#}
+{% macro row_stat(value, label=None, tone='neutral') -%}
+{%- set fill, edge, accent = TONES.get(tone, TONES['neutral']) -%}
+<tr>
+    <td style="padding: 0 0 22px 0;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; background-color: {{ fill }}; border: 1px solid {{ edge }}; border-radius: {{ brand.layout.radius_card }}px; box-shadow: {{ brand.layout.shadow_card }};">
+            <tr>
+                <td align="center" class="sm-px" style="padding: 30px {{ brand.layout.gutter }}px;">
+                    <div class="sm-stat" style="font-family: {{ brand.font.sans }}; font-size: {{ brand.type.headline * 3 // 2 }}px; font-weight: 300; line-height: 1.05; color: {{ accent }};">{{ value }}</div>
+                    {% if label %}
+                    <div style="padding-top: 10px; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; font-weight: 500; line-height: 1.4; color: {{ brand.color.body }};">{{ label }}</div>
+                    {% endif %}
+                </td>
+            </tr>
+        </table>
+    </td>
+</tr>
+{%- endmacro %}
+
+{#- Tinted note. `kind`: success | warning | error. A neutral note is just
+    prose — use row_prose instead of asking for one here. -#}
+{% macro row_callout(text, kind='warning', title=None) -%}
+{%- set fill, edge, accent = TONES.get(kind, TONES['warning']) -%}
+<tr>
+    <td style="padding: 0 0 22px 0;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; background-color: {{ fill }}; border: 1px solid {{ edge }}; border-radius: {{ brand.layout.radius_card }}px;">
+            <tr>
+                <td class="sm-px" style="padding: 20px {{ brand.layout.gutter - 4 }}px;">
+                    {% if title %}
+                    <div style="padding-bottom: 6px; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; font-weight: 700; line-height: 1.4; color: {{ accent }};">{{ title }}</div>
+                    {% endif %}
+                    <div style="font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; font-weight: 400; line-height: 1.6; color: {{ brand.color.body }};">{{ text }}</div>
+                </td>
+            </tr>
+        </table>
+    </td>
+</tr>
+{%- endmacro %}
+
+{#- Inline pill, for status and priority values. `tone`: neutral | success |
+    warning | error — keeps the priority colour-coding the old templates had. -#}
+{% macro chip(text, tone='neutral') -%}
+{%- if tone == 'success' -%}
+{%- set bg, fg = brand.color.success_tint, brand.color.success -%}
+{%- elif tone == 'warning' -%}
+{%- set bg, fg = brand.color.warning_tint, brand.color.warning -%}
+{%- elif tone == 'error' -%}
+{%- set bg, fg = brand.color.error_tint, brand.color.error -%}
+{%- else -%}
+{%- set bg, fg = brand.color.surface_subtle, brand.color.blue -%}
+{%- endif -%}
+<span style="display: inline-block; padding: 4px 12px; background-color: {{ bg }}; border-radius: {{ brand.layout.radius_chip }}px; font-family: {{ brand.font.mono }}; font-size: {{ brand.type.label }}px; font-weight: 400; line-height: 1.5; letter-spacing: 0.6px; text-transform: uppercase; color: {{ fg }}; white-space: nowrap;">{{ text }}</span>
+{%- endmacro %}
+
+{#- Maps a priority name onto a chip tone. -#}
+{% macro priority_tone(name) -%}
+{%- if name and name.lower() == 'high' -%}error
+{%- elif name and name.lower() == 'medium' -%}warning
+{%- else -%}success
+{%- endif -%}
+{%- endmacro %}

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/_imprint.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/_imprint.html.jinja2
@@ -1,12 +1,19 @@
-{#- Reusable imprint footer for all email templates -#}
-<div style="margin-top: 20px; padding-top: 15px; border-top: 1px solid #e9ecef; font-size: 0.8em; color: #868e96;">
-    <p style="margin: 0; line-height: 1.4;">
-        <strong>Rhesis AI GmbH</strong><br>
-        August-Bebel-Str. 89<br>
-        14482 Potsdam, Germany<br>
-        Managing Director: Dr. Nicolai Bohn<br>
-        Registered at: HRB 39358 Potsdam<br>
-        VAT No.: DE368312944<br>
-        E-Mail: <a href="mailto:hello@rhesis.ai" style="color: #6c757d;">hello@rhesis.ai</a>
-    </p>
-</div>
+{#- Legal imprint. Included by _base.html.jinja2, so templates get it for free.
+    The rule above it is separated from the sign-off by the signoff block's own
+    bottom padding — spacing above a border has to come from the preceding
+    cell, not from this one. -#}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%;">
+    <tr>
+        <td class="sm-px" style="padding: 26px 0 0 0; border-top: 1px solid {{ brand.color.border }};">
+            <p class="unstyled-auto-detected" style="margin: 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.small }}px; font-weight: 400; line-height: 1.7; color: {{ brand.color.muted }};">
+                <span style="font-weight: 700; color: {{ brand.color.heading }};">Rhesis AI GmbH</span><br>
+                August-Bebel-Str. 89<br>
+                14482 Potsdam, Germany<br>
+                Managing Director: Dr. Nicolai Bohn<br>
+                Registered at: HRB 39358 Potsdam<br>
+                VAT No.: DE368312944<br>
+                E-Mail: <a href="mailto:hello@rhesis.ai" style="color: {{ brand.color.muted }}; text-decoration: none;">hello@rhesis.ai</a>
+            </p>
+        </td>
+    </tr>
+</table>

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/email_verification.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/email_verification.html.jinja2
@@ -1,68 +1,19 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Verify your email - Rhesis AI</title>
-</head>
-<body style="font-family: 'Be Vietnam Pro', Arial, sans-serif; line-height: 1.6; color: #3D3D3D; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #FFFFFF;">
+{% extends '_base.html.jinja2' %}
+{% import '_components.html.jinja2' as c %}
 
-    <!-- Logo -->
-    <div style="text-align: center; margin-bottom: 30px;">
-        <img src="https://raw.githubusercontent.com/rhesis-ai/rhesis/main/apps/frontend/public/logos/rhesis-logo-website.png" alt="Rhesis AI" style="max-width: 200px; height: auto;">
-    </div>
+{% block title %}Verify your email - Rhesis AI{% endblock %}
+{% block preheader %}One quick step to get started. This link expires in 24 hours.{% endblock %}
 
-    <!-- Hero Section -->
-    <div style="background: linear-gradient(135deg, #F2F9FD 0%, #E4F2FA 100%); border-radius: 12px; padding: 30px 20px; margin-bottom: 25px; text-align: center;">
-        <h1 style="color: #2AA1CE; margin: 0 0 15px 0; font-size: 28px; font-weight: 600;">
-            Verify your email
-        </h1>
-        <p style="margin: 0; font-size: 16px; color: #3D3D3D;">
-            One quick step to get started.
-        </p>
-    </div>
+{% block content %}
+{{ c.row_header('Verify your', accent='email', lede='One quick step to get started.') }}
 
-    <!-- Message -->
-    <div style="background: white; border-left: 4px solid #50B9E0; padding: 20px; margin-bottom: 25px; border-radius: 4px;">
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            Hi{{ ' ' + recipient_name if recipient_name else '' }},
-        </p>
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            Thanks for signing up for Rhesis AI! Please verify your email address by clicking the button below.
-        </p>
-        <p style="margin: 0; font-size: 14px; line-height: 1.8; color: #6c757d;">
-            This link will expire in 24 hours.
-        </p>
-    </div>
+{% call c.row_prose() %}
+    {{ c.p("Hi" ~ (' ' ~ recipient_name if recipient_name else '') ~ ",") }}
+    {{ c.p('Thanks for signing up for Rhesis AI! Please verify your email address by clicking the button below.') }}
+    {{ c.p('This link will expire in 24 hours.', size=brand.type.small, color=brand.color.muted, bottom=0) }}
+{% endcall %}
 
-    <!-- CTA Button -->
-    <div style="text-align: center; margin-bottom: 25px;">
-        <a href="{{ verification_url }}"
-           style="display: inline-block; background-color: #2AA1CE; color: white; padding: 14px 32px;
-                  text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 16px;">
-            Verify Email Address
-        </a>
-    </div>
-
-    <!-- Fallback link -->
-    <div style="background: #F2F9FD; border-radius: 8px; padding: 15px; margin-bottom: 25px;">
-        <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #6c757d;">
-            If the button doesn't work, copy and paste this link into your browser:<br>
-            <a href="{{ verification_url }}" style="color: #2AA1CE; text-decoration: none; word-break: break-all;">{{ verification_url }}</a>
-        </p>
-    </div>
-
-    <!-- Security note -->
-    <div style="margin-bottom: 25px;">
-        <p style="margin: 0; font-size: 13px; color: #6c757d;">
-            If you didn't create an account with Rhesis AI, you can safely ignore this email.
-        </p>
-    </div>
-
-    <!-- Legal Imprint -->
-    <div style="text-align: left;">
-        {% include '_imprint.html.jinja2' %}
-    </div>
-
-</body>
-</html>
+{{ c.row_button(verification_url, 'Verify email address') }}
+{{ c.row_fallback_link(verification_url) }}
+{{ c.row_note("If you didn't create an account with Rhesis AI, you can safely ignore this email.") }}
+{% endblock %}

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/feedback.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/feedback.html.jinja2
@@ -1,45 +1,25 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Rhesis AI Feedback</title>
-</head>
-<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-    <div style="background: #e8f4fd; border-left: 4px solid #0ea5e9; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h2 style="color: #0369a1; margin-top: 0;">
-            User Feedback
-        </h2>
-        <p style="margin: 0; color: #0369a1;">
-            A user has submitted feedback for Rhesis AI.
-        </p>
-    </div>
+{% extends '_base.html.jinja2' %}
+{% import '_components.html.jinja2' as c %}
 
-    <div style="background: white; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h3 style="color: #1D2939; margin-top: 0;">User Information</h3>
-        <table style="width: 100%; border-collapse: collapse;">
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold; width: 40%;">Name:</td>
-                <td style="padding: 8px 0;">{{ user_name }}</td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Email:</td>
-                <td style="padding: 8px 0;">{{ user_email }}</td>
-            </tr>
-            {% if rating and rating != "N/A" %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Rating:</td>
-                <td style="padding: 8px 0;">{{ rating }}/5 stars</td>
-            </tr>
-            {% endif %}
-        </table>
-    </div>
+{% block title %}Rhesis AI Feedback{% endblock %}
+{% block preheader %}{{ user_name }} submitted feedback{% if rating and rating != 'N/A' %} ({{ rating }}/5){% endif %}.{% endblock %}
 
-    <div style="background: white; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h3 style="color: #1D2939; margin-top: 0;">Feedback</h3>
-        <p style="white-space: pre-wrap; margin: 0;">{{ feedback }}</p>
-    </div>
+{% block content %}
+{{ c.row_header('User', accent='feedback', lede='A user has submitted feedback for Rhesis AI.', label='Internal') }}
 
-    {% include '_imprint.html.jinja2' %}
-</body>
-</html>
+{% call c.row_card() %}
+    {%- set rows = [
+        {'label': 'Name', 'value': user_name, 'bold': True},
+        {'label': 'Email', 'value': user_email, 'url': 'mailto:' ~ user_email},
+    ] -%}
+    {%- if rating and rating != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Rating', 'value': rating ~ '/5 stars'}] -%}
+    {%- endif -%}
+    {{ c.kv_table(rows) }}
+{% endcall %}
+
+{% call c.row_prose() %}
+    {{ c.subhead('Feedback') }}
+    {{ c.quoted(feedback) }}
+{% endcall %}
+{% endblock %}

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/magic_link.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/magic_link.html.jinja2
@@ -1,82 +1,37 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% if is_new_user %}Welcome to Rhesis AI{% else %}Sign in to Rhesis AI{% endif %}</title>
-</head>
-<body style="font-family: 'Be Vietnam Pro', Arial, sans-serif; line-height: 1.6; color: #3D3D3D; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #FFFFFF;">
+{% extends '_base.html.jinja2' %}
+{% import '_components.html.jinja2' as c %}
 
-    <!-- Logo -->
-    <div style="text-align: center; margin-bottom: 30px;">
-        <img src="https://raw.githubusercontent.com/rhesis-ai/rhesis/main/apps/frontend/public/logos/rhesis-logo-website.png" alt="Rhesis AI" style="max-width: 200px; height: auto;">
-    </div>
+{% block title %}{% if is_new_user %}Welcome to Rhesis AI{% else %}Sign in to Rhesis AI{% endif %}{% endblock %}
+{% block preheader %}
+{%- if is_new_user -%}
+Your account has been created. Your sign-in link expires in 15 minutes.
+{%- else -%}
+Your sign-in link — no password needed. Expires in 15 minutes.
+{%- endif -%}
+{% endblock %}
 
-    <!-- Hero Section -->
-    <div style="background: linear-gradient(135deg, #F2F9FD 0%, #E4F2FA 100%); border-radius: 12px; padding: 30px 20px; margin-bottom: 25px; text-align: center;">
-        <h1 style="color: #2AA1CE; margin: 0 0 15px 0; font-size: 28px; font-weight: 600;">
-            {% if is_new_user %}Welcome to Rhesis AI{% else %}Your sign-in link{% endif %}
-        </h1>
-        <p style="margin: 0; font-size: 16px; color: #3D3D3D;">
-            {% if is_new_user %}
-                Your account has been created. Click the link below to get started.
-            {% else %}
-                Click the link below to sign in &mdash; no password needed.
-            {% endif %}
-        </p>
-    </div>
+{% block content %}
+{% if is_new_user %}
+{{ c.row_header('Welcome to', accent='Rhesis AI', lede='Your account has been created. Use the link below to get started.') }}
+{% else %}
+{{ c.row_header('Your', accent='sign-in link', lede='Click the link below to sign in — no password needed.') }}
+{% endif %}
 
-    <!-- Message -->
-    <div style="background: white; border-left: 4px solid #50B9E0; padding: 20px; margin-bottom: 25px; border-radius: 4px;">
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            Hi{{ ' ' + recipient_name if recipient_name else '' }},
-        </p>
-        {% if is_new_user %}
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            We've created your Rhesis AI account. Click the button below to sign in and complete your setup.
-        </p>
-        {% else %}
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            We received a request to sign you in to Rhesis AI. Use the button below to log in instantly.
-        </p>
-        {% endif %}
-        <p style="margin: 0; font-size: 14px; line-height: 1.8; color: #6c757d;">
-            This link will expire in 15 minutes.
-        </p>
-    </div>
+{% call c.row_prose() %}
+    {{ c.p("Hi" ~ (' ' ~ recipient_name if recipient_name else '') ~ ",") }}
+    {% if is_new_user %}
+    {{ c.p("We've created your Rhesis AI account. Click the button below to sign in and complete your setup.") }}
+    {% else %}
+    {{ c.p('We received a request to sign you in to Rhesis AI. Use the button below to log in instantly.') }}
+    {% endif %}
+    {{ c.p('This link will expire in 15 minutes.', size=brand.type.small, color=brand.color.muted, bottom=0) }}
+{% endcall %}
 
-    <!-- CTA Button -->
-    <div style="text-align: center; margin-bottom: 25px;">
-        <a href="{{ magic_link_url }}"
-           style="display: inline-block; background-color: #2AA1CE; color: white; padding: 14px 32px;
-                  text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 16px;">
-            {% if is_new_user %}Get Started{% else %}Sign In to Rhesis AI{% endif %}
-        </a>
-    </div>
-
-    <!-- Fallback link -->
-    <div style="background: #F2F9FD; border-radius: 8px; padding: 15px; margin-bottom: 25px;">
-        <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #6c757d;">
-            If the button doesn't work, copy and paste this link into your browser:<br>
-            <a href="{{ magic_link_url }}" style="color: #2AA1CE; text-decoration: none; word-break: break-all;">{{ magic_link_url }}</a>
-        </p>
-    </div>
-
-    <!-- Security note -->
-    <div style="margin-bottom: 25px;">
-        <p style="margin: 0; font-size: 13px; color: #6c757d;">
-            {% if is_new_user %}
-                If you didn't sign up for Rhesis AI, you can safely ignore this email.
-            {% else %}
-                If you didn't request this link, you can safely ignore this email. No action will be taken on your account.
-            {% endif %}
-        </p>
-    </div>
-
-    <!-- Legal Imprint -->
-    <div style="text-align: left;">
-        {% include '_imprint.html.jinja2' %}
-    </div>
-
-</body>
-</html>
+{{ c.row_button(magic_link_url, 'Get started' if is_new_user else 'Sign in to Rhesis AI') }}
+{{ c.row_fallback_link(magic_link_url) }}
+{% if is_new_user %}
+{{ c.row_note("If you didn't sign up for Rhesis AI, you can safely ignore this email.") }}
+{% else %}
+{{ c.row_note("If you didn't request this link, you can safely ignore this email. No action will be taken on your account.") }}
+{% endif %}
+{% endblock %}

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/migration_password_setup.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/migration_password_setup.html.jinja2
@@ -1,71 +1,20 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Set up your new password - Rhesis AI</title>
-</head>
-<body style="font-family: 'Be Vietnam Pro', Arial, sans-serif; line-height: 1.6; color: #3D3D3D; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #FFFFFF;">
+{% extends '_base.html.jinja2' %}
+{% import '_components.html.jinja2' as c %}
 
-    <!-- Logo -->
-    <div style="text-align: center; margin-bottom: 30px;">
-        <img src="https://raw.githubusercontent.com/rhesis-ai/rhesis/main/apps/frontend/public/logos/rhesis-logo-website.png" alt="Rhesis AI" style="max-width: 200px; height: auto;">
-    </div>
+{% block title %}Set up your new password - Rhesis AI{% endblock %}
+{% block preheader %}A security upgrade means you need to set a new password. This link expires in 1 hour.{% endblock %}
 
-    <!-- Hero Section -->
-    <div style="background: linear-gradient(135deg, #F2F9FD 0%, #E4F2FA 100%); border-radius: 12px; padding: 30px 20px; margin-bottom: 25px; text-align: center;">
-        <h1 style="color: #2AA1CE; margin: 0 0 15px 0; font-size: 28px; font-weight: 600;">
-            Set up your new password
-        </h1>
-        <p style="margin: 0; font-size: 16px; color: #3D3D3D;">
-            We've upgraded our authentication system.
-        </p>
-    </div>
+{% block content %}
+{{ c.row_header('Set up your new', accent='password', lede="We've upgraded our authentication system.") }}
 
-    <!-- Message -->
-    <div style="background: white; border-left: 4px solid #50B9E0; padding: 20px; margin-bottom: 25px; border-radius: 4px;">
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            Hi{{ ' ' + recipient_name if recipient_name else '' }},
-        </p>
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            As part of a security upgrade, we've moved to a new authentication system. Your account and data are safe &mdash; you just need to set a new password to continue using Rhesis AI.
-        </p>
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            Click the button below to choose a password for your account.
-        </p>
-        <p style="margin: 0; font-size: 14px; line-height: 1.8; color: #6c757d;">
-            This link will expire in 1 hour.
-        </p>
-    </div>
+{% call c.row_prose() %}
+    {{ c.p("Hi" ~ (' ' ~ recipient_name if recipient_name else '') ~ ",") }}
+    {{ c.p("As part of a security upgrade, we've moved to a new authentication system. Your account and data are safe — you just need to set a new password to continue using Rhesis AI.") }}
+    {{ c.p('Click the button below to choose a password for your account.') }}
+    {{ c.p('This link will expire in 1 hour.', size=brand.type.small, color=brand.color.muted, bottom=0) }}
+{% endcall %}
 
-    <!-- CTA Button -->
-    <div style="text-align: center; margin-bottom: 25px;">
-        <a href="{{ reset_url }}"
-           style="display: inline-block; background-color: #2AA1CE; color: white; padding: 14px 32px;
-                  text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 16px;">
-            Set Password
-        </a>
-    </div>
-
-    <!-- Fallback link -->
-    <div style="background: #F2F9FD; border-radius: 8px; padding: 15px; margin-bottom: 25px;">
-        <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #6c757d;">
-            If the button doesn't work, copy and paste this link into your browser:<br>
-            <a href="{{ reset_url }}" style="color: #2AA1CE; text-decoration: none; word-break: break-all;">{{ reset_url }}</a>
-        </p>
-    </div>
-
-    <!-- Note -->
-    <div style="margin-bottom: 25px;">
-        <p style="margin: 0; font-size: 13px; color: #6c757d;">
-            If you no longer use this account, you can safely ignore this email.
-        </p>
-    </div>
-
-    <!-- Legal Imprint -->
-    <div style="text-align: left;">
-        {% include '_imprint.html.jinja2' %}
-    </div>
-
-</body>
-</html>
+{{ c.row_button(reset_url, 'Set password') }}
+{{ c.row_fallback_link(reset_url) }}
+{{ c.row_note('If you no longer use this account, you can safely ignore this email.') }}
+{% endblock %}

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/password_reset.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/password_reset.html.jinja2
@@ -1,68 +1,19 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Reset your password - Rhesis AI</title>
-</head>
-<body style="font-family: 'Be Vietnam Pro', Arial, sans-serif; line-height: 1.6; color: #3D3D3D; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #FFFFFF;">
+{% extends '_base.html.jinja2' %}
+{% import '_components.html.jinja2' as c %}
 
-    <!-- Logo -->
-    <div style="text-align: center; margin-bottom: 30px;">
-        <img src="https://raw.githubusercontent.com/rhesis-ai/rhesis/main/apps/frontend/public/logos/rhesis-logo-website.png" alt="Rhesis AI" style="max-width: 200px; height: auto;">
-    </div>
+{% block title %}Reset your password - Rhesis AI{% endblock %}
+{% block preheader %}Choose a new password for your Rhesis AI account. This link expires in 1 hour.{% endblock %}
 
-    <!-- Hero Section -->
-    <div style="background: linear-gradient(135deg, #F2F9FD 0%, #E4F2FA 100%); border-radius: 12px; padding: 30px 20px; margin-bottom: 25px; text-align: center;">
-        <h1 style="color: #2AA1CE; margin: 0 0 15px 0; font-size: 28px; font-weight: 600;">
-            Reset your password
-        </h1>
-        <p style="margin: 0; font-size: 16px; color: #3D3D3D;">
-            We received a request to reset your password.
-        </p>
-    </div>
+{% block content %}
+{{ c.row_header('Reset your', accent='password', lede='We received a request to reset your password.') }}
 
-    <!-- Message -->
-    <div style="background: white; border-left: 4px solid #50B9E0; padding: 20px; margin-bottom: 25px; border-radius: 4px;">
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            Hi{{ ' ' + recipient_name if recipient_name else '' }},
-        </p>
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            Click the button below to choose a new password for your Rhesis AI account.
-        </p>
-        <p style="margin: 0; font-size: 14px; line-height: 1.8; color: #6c757d;">
-            This link will expire in 1 hour.
-        </p>
-    </div>
+{% call c.row_prose() %}
+    {{ c.p("Hi" ~ (' ' ~ recipient_name if recipient_name else '') ~ ",") }}
+    {{ c.p('Click the button below to choose a new password for your Rhesis AI account.') }}
+    {{ c.p('This link will expire in 1 hour.', size=brand.type.small, color=brand.color.muted, bottom=0) }}
+{% endcall %}
 
-    <!-- CTA Button -->
-    <div style="text-align: center; margin-bottom: 25px;">
-        <a href="{{ reset_url }}"
-           style="display: inline-block; background-color: #2AA1CE; color: white; padding: 14px 32px;
-                  text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 16px;">
-            Reset Password
-        </a>
-    </div>
-
-    <!-- Fallback link -->
-    <div style="background: #F2F9FD; border-radius: 8px; padding: 15px; margin-bottom: 25px;">
-        <p style="margin: 0; font-size: 13px; line-height: 1.6; color: #6c757d;">
-            If the button doesn't work, copy and paste this link into your browser:<br>
-            <a href="{{ reset_url }}" style="color: #2AA1CE; text-decoration: none; word-break: break-all;">{{ reset_url }}</a>
-        </p>
-    </div>
-
-    <!-- Security note -->
-    <div style="margin-bottom: 25px;">
-        <p style="margin: 0; font-size: 13px; color: #6c757d;">
-            If you didn't request a password reset, you can safely ignore this email. Your password will not be changed.
-        </p>
-    </div>
-
-    <!-- Legal Imprint -->
-    <div style="text-align: left;">
-        {% include '_imprint.html.jinja2' %}
-    </div>
-
-</body>
-</html>
+{{ c.row_button(reset_url, 'Reset password') }}
+{{ c.row_fallback_link(reset_url) }}
+{{ c.row_note("If you didn't request a password reset, you can safely ignore this email. Your password will not be changed.") }}
+{% endblock %}

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/polyphemus_access_request.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/polyphemus_access_request.html.jinja2
@@ -1,130 +1,76 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Polyphemus Access Request - Rhesis AI</title>
-</head>
-<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-    <div style="background: #fff3cd; border-left: 4px solid #ffc107; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h2 style="color: #856404; margin-top: 0;">
-            ⚠️ Polyphemus Access Request
-        </h2>
-        <p style="margin: 0; color: #856404;">
-            A user has requested access to the Polyphemus adversarial model. 
-            Please review the details below and approve or deny the request.
-        </p>
-    </div>
-    
-    <div style="background: white; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h3 style="color: #1D2939; margin-top: 0;">User Information</h3>
-        <table style="width: 100%; border-collapse: collapse;">
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold; width: 40%;">Name:</td>
-                <td style="padding: 8px 0;">{{ user_name }}</td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Email:</td>
-                <td style="padding: 8px 0;">{{ user_email }}</td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">User ID:</td>
-                <td style="padding: 8px 0;"><code style="background: #f8f9fa; padding: 2px 6px; border-radius: 3px; font-size: 12px;">{{ user_id }}</code></td>
-            </tr>
-        </table>
-    </div>
+{% extends '_base.html.jinja2' %}
+{% import '_components.html.jinja2' as c %}
 
-    {% if organization_name -%}
-    <div style="background: white; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h3 style="color: #1D2939; margin-top: 0;">Organization Information</h3>
-        <table style="width: 100%; border-collapse: collapse;">
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold; width: 40%;">Name:</td>
-                <td style="padding: 8px 0;">{{ organization_name }}</td>
-            </tr>
-            {% if organization_display_name -%}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Display Name:</td>
-                <td style="padding: 8px 0;">{{ organization_display_name }}</td>
-            </tr>
-            {%- endif %}
-            {% if organization_email -%}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Email:</td>
-                <td style="padding: 8px 0;">{{ organization_email }}</td>
-            </tr>
-            {%- endif %}
-            {% if organization_website -%}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Website:</td>
-                <td style="padding: 8px 0;">
-                    <a href="{{ organization_website }}" style="color: #F38755; text-decoration: none;">
-                        {{ organization_website }}
-                    </a>
-                </td>
-            </tr>
-            {%- endif %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Active:</td>
-                <td style="padding: 8px 0;">{{ 'Yes' if organization_is_active else 'No' }}</td>
-            </tr>
-        </table>
-    </div>
-    {%- else %}
-    <div style="background: #f8d7da; border-left: 4px solid #dc3545; border-radius: 8px; padding: 15px; margin-bottom: 20px;">
-        <p style="margin: 0; color: #721c24;">
-            <strong>Warning:</strong> User does not belong to an organization.
-        </p>
-    </div>
-    {%- endif %}
+{% block title %}Polyphemus Access Request - Rhesis AI{% endblock %}
+{% block preheader %}{{ user_name }} requested access to the Polyphemus adversarial model.{% endblock %}
 
-    <div style="background: white; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h3 style="color: #1D2939; margin-top: 0;">Request Details</h3>
-        <table style="width: 100%; border-collapse: collapse;">
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold; width: 40%;">Expected Monthly Requests:</td>
-                <td style="padding: 8px 0;">{{ expected_monthly_requests | int | format_number }}</td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Request Time:</td>
-                <td style="padding: 8px 0;">{{ request_timestamp }}</td>
-            </tr>
-        </table>
-    </div>
+{% block content %}
+{{ c.row_header('Polyphemus access', accent='request', label='Internal · action needed') }}
 
-    <div style="background: white; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h3 style="color: #1D2939; margin-top: 0;">Justification</h3>
-        <div style="background: #f8f9fa; border-radius: 4px; padding: 15px; white-space: pre-wrap; font-family: Arial, sans-serif;">{{ justification }}</div>
-    </div>
+{% call c.row_prose() %}
+    {{ c.p('A user has requested access to the Polyphemus adversarial model. Review the details below and approve or deny the request.', bottom=0) }}
+{% endcall %}
 
-    <div style="background: #d4edda; border-left: 4px solid #28a745; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h3 style="color: #155724; margin-top: 0;">Admin Actions</h3>
-        <p style="color: #155724; margin-top: 0;">
-            To <strong>grant</strong> access, run the following SQL command:
-        </p>
-        <pre style="background: #1D2939; color: #ffffff; padding: 12px; border-radius: 4px; overflow-x: auto; font-size: 13px;"><code>SELECT grant_polyphemus_access('{{ user_id }}');</code></pre>
-        
-        <p style="color: #155724; margin-top: 20px;">
-            To <strong>revoke</strong> access (if previously granted), run:
-        </p>
-        <pre style="background: #1D2939; color: #ffffff; padding: 12px; border-radius: 4px; overflow-x: auto; font-size: 13px;"><code>SELECT revoke_polyphemus_access('{{ user_id }}');</code></pre>
-    </div>
+{#- One card for the whole request. Splitting user, organization, and request
+    details into three boxes made an admin notice look like a dashboard. -#}
+{% call c.row_card() %}
+    {{ c.card_title('Request') }}
+    {%- set rows = [
+        {'label': 'Name', 'value': user_name, 'bold': True},
+        {'label': 'Email', 'value': user_email, 'url': 'mailto:' ~ user_email},
+        {'label': 'User ID', 'value': user_id, 'mono': True},
+    ] -%}
+    {%- if organization_name and organization_name != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Organization', 'value': organization_name}] -%}
+    {%- if organization_display_name is defined and organization_display_name and organization_display_name != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Display name', 'value': organization_display_name}] -%}
+    {%- endif -%}
+    {%- if organization_email is defined and organization_email and organization_email != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Organization email', 'value': organization_email}] -%}
+    {%- endif -%}
+    {%- if organization_website is defined and organization_website and organization_website != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Website', 'value': organization_website, 'url': organization_website}] -%}
+    {%- endif -%}
+    {%- set rows = rows + [{'label': 'Organization active', 'value': 'Yes' if organization_is_active is defined and organization_is_active else 'No'}] -%}
+    {%- endif -%}
+    {%- set rows = rows + [
+        {'label': 'Expected monthly requests', 'value': (expected_monthly_requests | default(0) | int | format_number)},
+        {'label': 'Requested at', 'value': request_timestamp | default('N/A')},
+    ] -%}
+    {{ c.kv_table(rows) }}
+{% endcall %}
 
-    <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #dee2e6; text-align: center;">
-        <p style="margin: 0; font-size: 12px; color: #6c757d;">
-            This request was submitted by {{ user_name }} ({{ user_email }}){{ ' from ' + organization_name if organization_name else '' }}.
-            <br>
-            Please review carefully before granting access to the Polyphemus adversarial model.
-        </p>
-        <p style="margin: 10px 0 0 0; font-size: 12px; color: #6c757d;">
-            Best regards,<br>
-            <strong>Rhesis AI Automated System</strong>
-        </p>
-        
-        <div style="text-align: left;">
-            {% include '_imprint.html.jinja2' %}
-        </div>
-    </div>
-</body>
-</html>
+{% if not organization_name or organization_name == 'N/A' %}
+{{ c.row_callout('This user does not belong to an organization.', kind='error', title='Warning') }}
+{% endif %}
 
+{% call c.row_prose() %}
+    {{ c.subhead('Justification') }}
+    {{ c.quoted(justification | default('N/A')) }}
+{% endcall %}
+
+{{ c.row_rule() }}
+
+{% call c.row_prose() %}
+    {{ c.subhead('Admin actions') }}
+    {{ c.p('To grant access, run:', size=brand.type.small) }}
+    {{ c.code_block("SELECT grant_polyphemus_access('" ~ user_id ~ "');") }}
+    {{ c.p('To revoke access (if previously granted), run:', size=brand.type.small, top=8) }}
+    {{ c.code_block("SELECT revoke_polyphemus_access('" ~ user_id ~ "');") }}
+{% endcall %}
+
+{{ c.row_note(
+    'This request was submitted by ' ~ user_name ~ ' (' ~ user_email ~ ')'
+    ~ (' from ' ~ organization_name if organization_name and organization_name != 'N/A' else '')
+    ~ '. Review carefully before granting access to the Polyphemus adversarial model.'
+) }}
+{% endblock %}
+
+{% block signoff %}
+<tr>
+    <td class="sm-px" style="padding: 8px 0 36px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; line-height: 1.6; color: {{ brand.color.body }};">
+        Best regards,<br>
+        <span style="font-weight: 700; color: {{ brand.color.heading }};">Rhesis AI Automated System</span>
+    </td>
+</tr>
+{% endblock %}

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/task_assignment.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/task_assignment.html.jinja2
@@ -1,117 +1,61 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Task Assignment Notification</title>
-</head>
-<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-    <div style="background: #e3f2fd; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h2 style="color: #1976d2; margin-top: 0;">
-            📋 New Task Assignment
-        </h2>
-        <p>
-            {%- if assignee_name -%}
-            Hello {{ assignee_name }},
-            {%- else -%}
-            Hello,
-            {%- endif %}
-        </p>
-        <p>You have been assigned a new task by 
-            {%- if assigner_name -%}
-            <strong> {{ assigner_name }}</strong>
-            {%- else -%}
-            <strong> a team member</strong>
-            {%- endif %}
-        </p>
-    </div>
-    
-    <div style="background: white; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px;">
-        <h3 style="color: #495057; margin-top: 0;">Task Details</h3>
-        <table style="width: 100%; border-collapse: collapse;">
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Task Title:</td>
-                <td style="padding: 8px 0;">{{ task_title }}</td>
-            </tr>
-            {%- if task_description %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Description:</td>
-                <td style="padding: 8px 0;">{{ task_description }}</td>
-            </tr>
-            {%- endif %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Task ID:</td>
-                <td style="padding: 8px 0; font-family: monospace; font-size: 1.1em; font-weight: bold;">{{ task_id }}</td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Status:</td>
-                <td style="padding: 8px 0; color: #007bff; font-weight: bold;">
-                    {{ status_name }}
-                </td>
-            </tr>
-            {%- if priority_name %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Priority:</td>
-                <td style="padding: 8px 0;">
-                    <span style="
-                        padding: 4px 8px; 
-                        border-radius: 4px; 
-                        font-size: 0.8em; 
-                        font-weight: bold;
-                        {%- if priority_name.lower() == 'high' -%}
-                        background: #ffebee; color: #c62828;
-                        {%- elif priority_name.lower() == 'medium' -%}
-                        background: #fff3e0; color: #ef6c00;
-                        {%- else -%}
-                        background: #e8f5e8; color: #2e7d32;
-                        {%- endif %}
-                    ">
-                        {{ priority_name }}
-                    </span>
-                </td>
-            </tr>
-            {%- endif %}
-            {%- if entity_type and entity_id %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Related to:</td>
-                <td style="padding: 8px 0;">
-                    {{ entity_type }}
-                    {%- if entity_name and entity_name != 'N/A' and entity_name != 'None' %} - {{ entity_name }}{%- endif %}
-                    <br>
-                    <span style="color: #6c757d; font-family: monospace; font-size: 1.1em; font-weight: bold;">{{ entity_id }}</span>
-                </td>
-            </tr>
-            {%- endif %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Created:</td>
-                <td style="padding: 8px 0;">{{ created_at }}</td>
-            </tr>
-        </table>
-    </div>
+{% extends '_base.html.jinja2' %}
+{% import '_components.html.jinja2' as c %}
 
-    {%- if task_metadata and task_metadata.comment_id %}
-    <div style="background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px; margin-top: 20px;">
-        <h3 style="color: #495057; margin-top: 0;">Related Comment</h3>
-        <p style="margin: 0; color: #6c757d; font-size: 0.9em;">
-            This task was created from a comment. 
-            <small style="font-family: monospace;">Comment ID: {{ task_metadata.comment_id }}</small>
-        </p>
-    </div>
-    {%- endif %}
+{% block title %}Task Assignment Notification - Rhesis AI{% endblock %}
+{% block preheader %}{{ assigner_name }} assigned you: {{ task_title }}{% endblock %}
 
-    {%- if frontend_url %}
-    <div style="text-align: center; margin: 30px 0;">
-        <a href="{{ frontend_url }}/tasks/{{ task_id }}" 
-           style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
-            View Task
-        </a>
-    </div>
-    {%- endif %}
-    
-    <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #dee2e6; color: #6c757d; font-size: 0.9em;">
-        <p>Best regards,<br>Rhesis AI Team</p>
-        
-        {% include '_imprint.html.jinja2' %}
-    </div>
-</body>
-</html>
+{% block content %}
+{{ c.row_header('New task', accent='assignment', label='Assigned to you') }}
+
+{% call c.row_prose() %}
+    {{ c.p('Hello' ~ (' ' ~ assignee_name if assignee_name and assignee_name != 'N/A' else '') ~ ',') }}
+    <p style="margin: 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; line-height: 1.6; color: {{ brand.color.body }};">
+        You have been assigned a new task by
+        <span style="font-weight: 700;">{{ assigner_name if assigner_name and assigner_name != 'N/A' else 'a team member' }}</span>.
+    </p>
+{% endcall %}
+
+{% call c.row_card() %}
+    {{ c.card_title('Task details') }}
+    {%- set rows = [{'label': 'Task title', 'value': task_title, 'bold': True}] -%}
+    {%- if task_description and task_description != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Description', 'value': task_description}] -%}
+    {%- endif -%}
+    {%- set rows = rows + [{'label': 'Task ID', 'value': task_id, 'mono': True}] -%}
+    {{ c.kv_table(rows) }}
+
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width: 100%; margin-top: 16px;">
+        <tr>
+            <td width="42%" valign="top" style="width: 42%; padding: 9px 12px 9px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.small }}px; font-weight: 500; color: {{ brand.color.muted }};">Status</td>
+            <td valign="top" style="padding: 9px 0;">{{ c.chip(status_name) }}</td>
+        </tr>
+        {% if priority_name and priority_name != 'N/A' %}
+        <tr>
+            <td width="42%" valign="top" style="width: 42%; padding: 9px 12px 9px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.small }}px; font-weight: 500; color: {{ brand.color.muted }};">Priority</td>
+            <td valign="top" style="padding: 9px 0;">{{ c.chip(priority_name, tone=c.priority_tone(priority_name) | trim) }}</td>
+        </tr>
+        {% endif %}
+        {% if entity_type and entity_type != 'N/A' and entity_id and entity_id != 'N/A' %}
+        <tr>
+            <td width="42%" valign="top" style="width: 42%; padding: 9px 12px 9px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.small }}px; font-weight: 500; color: {{ brand.color.muted }};">Related to</td>
+            <td valign="top" style="padding: 9px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; line-height: 1.5; color: {{ brand.color.heading }};">
+                {{ entity_type }}{% if entity_name and entity_name not in ('N/A', 'None') %} — {{ entity_name }}{% endif %}<br>
+                {{ c.mono(entity_id) }}
+            </td>
+        </tr>
+        {% endif %}
+        <tr>
+            <td width="42%" valign="top" style="width: 42%; padding: 9px 12px 9px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.small }}px; font-weight: 500; color: {{ brand.color.muted }};">Created</td>
+            <td valign="top" style="padding: 9px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; color: {{ brand.color.heading }};">{{ created_at | datetime_format }}</td>
+        </tr>
+    </table>
+{% endcall %}
+
+{% if task_metadata and task_metadata != 'N/A' and task_metadata.comment_id is defined and task_metadata.comment_id %}
+{{ c.row_note('This task was created from a comment. Comment ID: ' ~ task_metadata.comment_id) }}
+{% endif %}
+
+{% if frontend_url and frontend_url != 'N/A' %}
+{{ c.row_button(frontend_url ~ '/tasks/' ~ task_id, 'View task') }}
+{% endif %}
+{% endblock %}

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/task_completion.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/task_completion.html.jinja2
@@ -1,116 +1,64 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Task Completion Notification</title>
-</head>
-<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-    <div style="background: #f8f9fa; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h2 style="color: #2c3e50; margin-top: 0;">
-            {% if status.lower() == 'success' -%}
-            ✅ Task Completed
-            {%- else -%}
-            ❌ Task Completed
-            {%- endif %}
-        </h2>
-        <p>
-            {%- if recipient_name -%}
-            Hello {{ recipient_name }},
-            {%- else -%}
-            Hello,
-            {%- endif %}
-        </p>
-        <p>Your task has completed with status: 
-            <strong style="color: {% if status.lower() == 'success' %}#28a745{% else %}#dc3545{% endif %};">
-                {{ status.upper() }}
-            </strong>
-        </p>
-    </div>
-    
-    <div style="background: white; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px;">
-        <h3 style="color: #495057; margin-top: 0;">Task Details</h3>
-        <table style="width: 100%; border-collapse: collapse;">
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Task Name:</td>
-                <td style="padding: 8px 0;">{{ task_name }}</td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Task ID:</td>
-                <td style="padding: 8px 0; font-family: monospace; font-size: 0.9em;">{{ task_id }}</td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Status:</td>
-                <td style="padding: 8px 0; color: {% if status.lower() == 'success' %}#28a745{% else %}#dc3545{% endif %}; font-weight: bold;">
-                    {{ status.title() }}
-                </td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Completed at:</td>
-                <td style="padding: 8px 0;">{{ completed_at }} UTC</td>
-            </tr>
-            {%- if execution_time %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Execution Time:</td>
-                <td style="padding: 8px 0;">{{ execution_time }}</td>
-            </tr>
-            {%- endif %}
-            {%- if test_run_id and test_run_id != "N/A" %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Test Run ID:</td>
-                <td style="padding: 8px 0; font-family: monospace; font-size: 0.9em;">{{ test_run_id }}</td>
-            </tr>
-            {%- endif %}
-            {%- if test_set_id and test_set_id != "N/A" %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Test Set ID:</td>
-                <td style="padding: 8px 0; font-family: monospace; font-size: 0.9em;">{{ test_set_id }}</td>
-            </tr>
-            {%- endif %}
-            {%- if test_set_name %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Test Set Name:</td>
-                <td style="padding: 8px 0;">{{ test_set_name }}</td>
-            </tr>
-            {%- endif %}
-            {%- if num_tests_generated %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Tests Generated:</td>
-                <td style="padding: 8px 0;">{{ num_tests_generated }}</td>
-            </tr>
-            {%- endif %}
-        </table>
-    </div>
+{% extends '_base.html.jinja2' %}
+{% import '_components.html.jinja2' as c %}
 
-    {%- if status.lower() == 'failed' and error_message %}
-    <div style="background: #f8d7da; border: 1px solid #f5c6cb; border-radius: 8px; padding: 20px; margin-top: 20px;">
-        <h3 style="color: #721c24; margin-top: 0;">Error Details</h3>
-        <pre style="color: #721c24; white-space: pre-wrap; font-family: monospace; font-size: 0.9em;">{{ error_message }}</pre>
-    </div>
-    {%- endif %}
+{% block title %}Task Completion Notification - Rhesis AI{% endblock %}
+{% block preheader %}{{ task_name }} finished with status {{ status | upper }}.{% endblock %}
 
-    {%- if frontend_url %}
-        {%- if test_run_id and test_run_id != "N/A" %}
-        <div style="text-align: center; margin: 30px 0;">
-            <a href="{{ frontend_url }}/test-runs/{{ test_run_id }}" 
-               style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
-                View Test Run
-            </a>
-        </div>
-        {%- elif test_set_id and test_set_id != "N/A" %}
-        <div style="text-align: center; margin: 30px 0;">
-            <a href="{{ frontend_url }}/test-sets/{{ test_set_id }}" 
-               style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
-                View Test Set
-            </a>
-        </div>
-        {%- endif %}
-    {%- endif %}
-    
-    <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #dee2e6; color: #6c757d; font-size: 0.9em;">
-        <p>Best regards,<br>Rhesis AI Team</p>
-        
-        {% include '_imprint.html.jinja2' %}
-    </div>
-</body>
-</html> 
+{% block content %}
+{%- set ok = status.lower() == 'success' %}
+
+{{ c.row_header('Task', accent='completed' if ok else 'failed', label='Background task') }}
+
+{% call c.row_prose() %}
+    {{ c.p('Hello' ~ (' ' ~ recipient_name if recipient_name and recipient_name != 'N/A' else '') ~ ',') }}
+    <p style="margin: 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; line-height: 1.6; color: {{ brand.color.body }};">
+        Your task has completed with status
+        <span style="font-weight: 700; color: {{ brand.color.success if ok else brand.color.error }};">{{ status.upper() }}</span>.
+    </p>
+{% endcall %}
+
+{% call c.row_card() %}
+    {{ c.card_title('Task details') }}
+    {%- set rows = [
+        {'label': 'Task name', 'value': task_name, 'bold': True},
+        {'label': 'Task ID', 'value': task_id, 'mono': True},
+        {'label': 'Status', 'value': status.title(), 'color': brand.color.success if ok else brand.color.error, 'bold': True},
+        {'label': 'Completed at', 'value': (completed_at | datetime_format) ~ ' UTC'},
+    ] -%}
+    {%- if execution_time and execution_time != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Execution time', 'value': execution_time}] -%}
+    {%- endif -%}
+    {%- if test_run_id is defined and test_run_id and test_run_id != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Test run ID', 'value': test_run_id, 'mono': True}] -%}
+    {%- endif -%}
+    {%- if test_set_id is defined and test_set_id and test_set_id != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Test set ID', 'value': test_set_id, 'mono': True}] -%}
+    {%- endif -%}
+    {%- if test_set_name is defined and test_set_name and test_set_name != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Test set name', 'value': test_set_name}] -%}
+    {%- endif -%}
+    {%- if num_tests_generated is defined and num_tests_generated -%}
+    {%- set rows = rows + [{'label': 'Tests generated', 'value': num_tests_generated}] -%}
+    {%- endif -%}
+    {{ c.kv_table(rows) }}
+{% endcall %}
+
+{% if status.lower() in ('failed', 'failure') and error_message and error_message != 'N/A' %}
+<tr>
+    <td style="padding: 0 0 20px 0;">
+        {% call c.card() %}
+            {{ c.card_title('Error details') }}
+            {{ c.code_block(error_message, tone='error') }}
+        {% endcall %}
+    </td>
+</tr>
+{% endif %}
+
+{% if frontend_url and frontend_url != 'N/A' %}
+    {% if test_run_id is defined and test_run_id and test_run_id != 'N/A' %}
+    {{ c.row_button(frontend_url ~ '/test-runs/' ~ test_run_id, 'View test run') }}
+    {% elif test_set_id is defined and test_set_id and test_set_id != 'N/A' %}
+    {{ c.row_button(frontend_url ~ '/test-sets/' ~ test_set_id, 'View test set') }}
+    {% endif %}
+{% endif %}
+{% endblock %}

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/team_invitation.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/team_invitation.html.jinja2
@@ -1,114 +1,67 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Team Invitation - Rhesis AI</title>
-</head>
-<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-    <div style="background: #f8f9fa; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h2 style="color: #1D2939; margin-top: 0;">
-            🎉 You're Invited to Join {{ organization_name }}!
-        </h2>
-        <p>
-            Hello{{ ' ' + recipient_name if recipient_name else '' }},
-        </p>
-        <p>
-            <strong>{{ inviter_name }}</strong> has invited you to join their team on <strong>Rhesis AI</strong>, 
-            the comprehensive test management platform for Gen AI applications.
-        </p>
-    </div>
-    
-    <div style="background: white; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h3 style="color: #1D2939; margin-top: 0;">Organization Details</h3>
-        <table style="width: 100%; border-collapse: collapse;">
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Organization:</td>
-                <td style="padding: 8px 0;">{{ organization_name }}</td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Invited by:</td>
-                <td style="padding: 8px 0;">{{ inviter_name }} ({{ inviter_email }})</td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Your Email:</td>
-                <td style="padding: 8px 0;">{{ recipient_email }}</td>
-            </tr>
-            {% if organization_website -%}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Website:</td>
-                <td style="padding: 8px 0;">
-                    <a href="{{ organization_website }}" style="color: #F38755; text-decoration: none;">
-                        {{ organization_website }}
-                    </a>
-                </td>
-            </tr>
-            {%- endif %}
-        </table>
-    </div>
+{% extends '_base.html.jinja2' %}
+{% import '_components.html.jinja2' as c %}
 
-    <div style="background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h3 style="color: #1D2939; margin-top: 0;">What's Next?</h3>
-        <p style="margin-bottom: 15px;">
-            Your account has been created and you can start using Rhesis AI right away:
-        </p>
-        <ol style="margin: 0; padding-left: 20px;">
-            {% if sso_enabled -%}
-            <li style="margin-bottom: 8px;">Click the "Sign in with single sign-on" button below</li>
-            <li style="margin-bottom: 8px;">Sign in with your {{ organization_name }} account (single sign-on)</li>
-            {%- else -%}
-            <li style="margin-bottom: 8px;">Click the "Get Started" button below</li>
-            <li style="margin-bottom: 8px;">Sign in with your email address ({{ recipient_email }})</li>
-            {%- endif %}
-            <li style="margin-bottom: 8px;">Complete your profile setup</li>
-            <li>Start collaborating with your team!</li>
-        </ol>
-    </div>
+{% block title %}Team Invitation - Rhesis AI{% endblock %}
+{% block preheader %}{{ inviter_name }} invited you to join {{ organization_name }} on Rhesis AI.{% endblock %}
 
-    {% if sso_enabled -%}
-    <div style="background: #f8f9fa; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h3 style="color: #1D2939; margin-top: 0;">Single sign-on is enabled</h3>
-        <p style="margin: 0;">
-            {{ organization_name }} uses single sign-on, so you do not need a separate
-            Rhesis AI password. The button below takes you to your organization's
-            sign-in page. Use your usual work account.
-        </p>
-    </div>
-    {%- endif %}
+{% block content %}
+{{ c.row_header("You're invited to join", accent=organization_name, label='Team invitation') }}
 
-    {% if sso_enabled or frontend_url -%}
-    <div style="text-align: center; margin: 30px 0;">
-        <a href="{{ sso_login_url if sso_enabled else frontend_url }}"
-           style="display: inline-block; background-color: #F38755; color: white; padding: 12px 30px;
-                  text-decoration: none; border-radius: 5px; font-weight: bold; font-size: 16px;">
-            {{ 'Sign in with single sign-on' if sso_enabled else 'Get Started' }}
-        </a>
-    </div>
-    {%- endif %}
+{% call c.row_prose() %}
+    {{ c.p("Hello" ~ (' ' ~ recipient_name if recipient_name and recipient_name != 'N/A' else '') ~ ",") }}
+    <p style="margin: 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; line-height: 1.6; color: {{ brand.color.body }};">
+        <span style="font-weight: 700;">{{ inviter_name }}</span> has invited you to join their team on <span style="font-weight: 700;">Rhesis AI</span>, the comprehensive test management platform for Gen AI applications.
+    </p>
+{% endcall %}
 
-    <div style="background: #f8f9fa; border-radius: 8px; padding: 15px; margin-top: 20px;">
-        <h4 style="color: #1D2939; margin-top: 0; margin-bottom: 10px;">About Rhesis AI</h4>
-        <p style="margin: 0; font-size: 14px; color: #6c757d;">
-            Rhesis AI is a comprehensive test management platform specifically designed for Gen AI applications. 
-            Evaluate, manage, and improve your AI systems with advanced testing frameworks, collaborative 
-            workflows, and detailed performance insights.
-        </p>
-    </div>
+{#- A card, because it is a details table — a tile, not prose. -#}
+{% call c.row_card() %}
+    {{ c.card_title('Organization details') }}
+    {%- set rows = [
+        {'label': 'Organization', 'value': organization_name, 'bold': True},
+        {'label': 'Invited by', 'value': inviter_name ~ ' (' ~ inviter_email ~ ')'},
+        {'label': 'Your email', 'value': recipient_email},
+    ] -%}
+    {%- if organization_website and organization_website != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Website', 'value': organization_website, 'url': organization_website}] -%}
+    {%- endif -%}
+    {{ c.kv_table(rows) }}
+{% endcall %}
 
-    <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #dee2e6; text-align: center;">
-        <p style="margin: 0; font-size: 12px; color: #6c757d;">
-            This invitation was sent by {{ inviter_name }} from {{ organization_name }}.
-            <br>
-            If you have any questions, please contact them directly or reach out to our support team.
-        </p>
-        <p style="margin: 10px 0 0 0; font-size: 12px; color: #6c757d;">
-            Best regards,<br>
-            <strong>The Rhesis AI Team</strong>
-        </p>
-        
-        <div style="text-align: left;">
-            {% include '_imprint.html.jinja2' %}
-        </div>
-    </div>
-</body>
-</html> 
+{% call c.row_prose() %}
+    {{ c.subhead("What's next?") }}
+    {{ c.p('Your account has been created and you can start using Rhesis AI right away:') }}
+    {% if sso_enabled %}
+    {{ c.bullets([
+        'Click the "Sign in with single sign-on" button below',
+        'Sign in with your ' ~ organization_name ~ ' account (single sign-on)',
+        'Complete your profile setup',
+        'Start collaborating with your team',
+    ], ordered=True) }}
+    {{ c.p(organization_name ~ " uses single sign-on, so you do not need a separate Rhesis AI password. The button below takes you to your organization's sign-in page — use your usual work account.", size=brand.type.small, color=brand.color.muted, bottom=0) }}
+    {% else %}
+    {{ c.bullets([
+        'Click the "Get started" button below',
+        'Sign in with your email address (' ~ recipient_email ~ ')',
+        'Complete your profile setup',
+        'Start collaborating with your team',
+    ], ordered=True) }}
+    {% endif %}
+{% endcall %}
+
+{% if sso_enabled or (frontend_url and frontend_url != 'N/A') %}
+{{ c.row_button(
+    sso_login_url if sso_enabled else frontend_url,
+    'Sign in with single sign-on' if sso_enabled else 'Get started',
+) }}
+{% endif %}
+
+{{ c.row_rule() }}
+
+{% call c.row_prose() %}
+    {{ c.subhead('About Rhesis AI') }}
+    {{ c.p('Rhesis AI is a comprehensive test management platform specifically designed for Gen AI applications. Evaluate, manage, and improve your AI systems with advanced testing frameworks, collaborative workflows, and detailed performance insights.', size=brand.type.small, bottom=0) }}
+{% endcall %}
+
+{{ c.row_note('This invitation was sent by ' ~ inviter_name ~ ' from ' ~ organization_name ~ '. If you have any questions, please contact them directly or reach out to our support team.') }}
+{% endblock %}

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/test_execution_summary.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/test_execution_summary.html.jinja2
@@ -1,131 +1,72 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Test Execution Summary</title>
-</head>
-<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
-    <div style="background: #f8f9fa; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h2 style="color: #2c3e50; margin-top: 0;">
-            {% if execution_status == "Complete" -%}
-            ✅ Test Execution Complete
-            {%- elif execution_status == "Partial" -%}
-            ⚠️ Test Execution Partial
-            {%- else -%}
-            ❌ Test Execution Failed
-            {%- endif %}
-        </h2>
-        <p>
-            {%- if recipient_name -%}
-            Hello {{ recipient_name }},
-            {%- else -%}
-            Hello,
-            {%- endif %}
-        </p>
-        <p>Your test configuration execution has finished.</p>
-    </div>
+{% extends '_base.html.jinja2' %}
+{% import '_components.html.jinja2' as c %}
 
-    {%- set execution_errors = execution_errors | default(0) %}
-    {%- set tests_failed = tests_failed | default(0) %}
-    {%- set tests_passed = tests_passed | default(0) %}
-    {%- set total_tests = total_tests | default(0) %}
-    <div style="background: {% if tests_failed == 0 and execution_errors == 0 %}#d4edda{% else %}#f8d7da{% endif %}; border: 2px solid {% if tests_failed == 0 and execution_errors == 0 %}#28a745{% else %}#dc3545{% endif %}; border-radius: 8px; padding: 20px; margin-bottom: 20px; text-align: center;">
-        <h3 style="color: {% if tests_failed == 0 and execution_errors == 0 %}#155724{% else %}#721c24{% endif %}; margin-top: 0; margin-bottom: 10px;">Test Results</h3>
-        <div style="font-size: 36px; font-weight: bold; margin: 10px 0;">
-            {%- if tests_failed == 0 and execution_errors == 0 -%}
-            <span style="color: #28a745;">✓ {{ tests_passed }}/{{ total_tests }} Passed</span>
-            {%- else -%}
-            <span style="color: #dc3545;">✗ {{ tests_failed }}/{{ total_tests }} Failed</span>
-            {%- endif -%}
-        </div>
-        {%- if execution_errors > 0 %}
-        <div style="font-size: 18px; color: #856404; margin-top: 10px;">
-            ⚠ {{ execution_errors }} test{{ 's' if execution_errors != 1 else '' }} had execution errors
-        </div>
-        {%- endif %}
-    </div>
+{% block title %}Test Execution Summary - Rhesis AI{% endblock %}
+{% block preheader %}{{ tests_passed | default(0) }} of {{ total_tests | default(0) }} tests passed on {{ task_name }}.{% endblock %}
 
-    <div style="background: white; border: 1px solid #dee2e6; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h3 style="color: #495057; margin-top: 0;">Execution Details</h3>
-        <table style="width: 100%; border-collapse: collapse;">
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Test Configuration:</td>
-                <td style="padding: 8px 0;">{{ task_name }}</td>
-            </tr>
-            {%- if project_name %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Project:</td>
-                <td style="padding: 8px 0;">{{ project_name }}</td>
-            </tr>
-            {%- endif %}
-            {%- if test_set_name %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Test Set:</td>
-                <td style="padding: 8px 0;">{{ test_set_name }}</td>
-            </tr>
-            {%- endif %}
-            {%- if endpoint_name %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Endpoint:</td>
-                <td style="padding: 8px 0;">
-                    {%- if endpoint_url -%}
-                    <a href="{{ endpoint_url }}" style="color: #007bff; text-decoration: none;">{{ endpoint_name }}</a>
-                    {%- else -%}
-                    {{ endpoint_name }}
-                    {%- endif -%}
-                </td>
-            </tr>
-            {%- endif %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Total Tests:</td>
-                <td style="padding: 8px 0;">{{ total_tests }}</td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Tests Passed:</td>
-                <td style="padding: 8px 0; color: #28a745; font-weight: bold;">{{ tests_passed }}</td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Tests Failed:</td>
-                <td style="padding: 8px 0; color: #dc3545; font-weight: bold;">{{ tests_failed }}</td>
-            </tr>
-            {%- if execution_errors is defined and execution_errors > 0 %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Execution Errors:</td>
-                <td style="padding: 8px 0; color: #ff8c00; font-weight: bold;">{{ execution_errors }}</td>
-            </tr>
-            {%- endif %}
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Execution Time:</td>
-                <td style="padding: 8px 0;">{{ execution_time or "N/A" }}</td>
-            </tr>
-            <tr>
-                <td style="padding: 8px 0; font-weight: bold;">Completed at:</td>
-                <td style="padding: 8px 0;">{{ completed_at }} UTC</td>
-            </tr>
-        </table>
-    </div>
+{% block content %}
+{%- set execution_errors = execution_errors | default(0) | int %}
+{%- set tests_failed = tests_failed | default(0) | int %}
+{%- set tests_passed = tests_passed | default(0) | int %}
+{%- set total_tests = total_tests | default(0) | int %}
+{%- set clean = tests_failed == 0 and execution_errors == 0 %}
 
-    {%- if status_details %}
-    <div style="background: {% if status.lower() == 'success' %}#d4edda{% elif status.lower() == 'partial' %}#fff3cd{% else %}#f8d7da{% endif %}; border: 1px solid {% if status.lower() == 'success' %}#c3e6cb{% elif status.lower() == 'partial' %}#ffeaa7{% else %}#f5c6cb{% endif %}; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
-        <h3 style="color: {% if status.lower() == 'success' %}#155724{% elif status.lower() == 'partial' %}#856404{% else %}#721c24{% endif %}; margin-top: 0;">Result Details</h3>
-        <p style="color: {% if status.lower() == 'success' %}#155724{% elif status.lower() == 'partial' %}#856404{% else %}#721c24{% endif %}; margin: 0;">{{ status_details }}</p>
-    </div>
-    {%- endif %}
+{% if execution_status == 'Complete' %}
+{{ c.row_header('Test execution', accent='complete', lede='Your test configuration execution has finished.', label='Test run') }}
+{% elif execution_status == 'Partial' %}
+{{ c.row_header('Test execution', accent='partial', lede='Your test configuration execution has finished.', label='Test run') }}
+{% else %}
+{{ c.row_header('Test execution', accent='failed', lede='Your test configuration execution has finished.', label='Test run') }}
+{% endif %}
 
-    {%- if frontend_url and test_run_id %}
-    <div style="text-align: center; margin: 30px 0;">
-        <a href="{{ frontend_url }}/test-runs/{{ test_run_id }}"
-           style="background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block; font-weight: bold;">
-            View Test Run
-        </a>
-    </div>
-    {%- endif %}
+{#- The headline number, in the site's light-weight stat treatment. -#}
+{% if clean %}
+{{ c.row_stat(tests_passed ~ '/' ~ total_tests ~ ' passed', label='Every test passed.', tone='success') }}
+{% else %}
+{{ c.row_stat(
+    tests_failed ~ '/' ~ total_tests ~ ' failed',
+    label=(execution_errors ~ ' test' ~ ('s' if execution_errors != 1 else '') ~ ' also had execution errors.') if execution_errors > 0 else None,
+    tone='error',
+) }}
+{% endif %}
 
-    <div style="margin-top: 30px; padding-top: 20px; border-top: 1px solid #dee2e6; color: #6c757d; font-size: 0.9em;">
-        <p>Best regards,<br>Rhesis AI Team</p>
+{% call c.row_card() %}
+    {{ c.card_title('Execution details') }}
+    {%- set rows = [{'label': 'Test configuration', 'value': task_name, 'bold': True}] -%}
+    {%- if project_name and project_name != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Project', 'value': project_name}] -%}
+    {%- endif -%}
+    {%- if test_set_name and test_set_name != 'N/A' -%}
+    {%- set rows = rows + [{'label': 'Test set', 'value': test_set_name}] -%}
+    {%- endif -%}
+    {%- if endpoint_name and endpoint_name != 'N/A' -%}
+    {%- set rows = rows + [{
+        'label': 'Endpoint',
+        'value': endpoint_name,
+        'url': endpoint_url if endpoint_url and endpoint_url != 'N/A' else None,
+    }] -%}
+    {%- endif -%}
+    {%- set rows = rows + [
+        {'label': 'Total tests', 'value': total_tests},
+        {'label': 'Tests passed', 'value': tests_passed, 'color': brand.color.success, 'bold': True},
+        {'label': 'Tests failed', 'value': tests_failed, 'color': brand.color.error, 'bold': True},
+    ] -%}
+    {%- if execution_errors > 0 -%}
+    {%- set rows = rows + [{'label': 'Execution errors', 'value': execution_errors, 'color': brand.color.warning, 'bold': True}] -%}
+    {%- endif -%}
+    {%- set rows = rows + [
+        {'label': 'Execution time', 'value': execution_time if execution_time and execution_time != 'N/A' else 'N/A'},
+        {'label': 'Completed at', 'value': (completed_at | datetime_format) ~ ' UTC'},
+    ] -%}
+    {{ c.kv_table(rows) }}
+{% endcall %}
 
-        {% include '_imprint.html.jinja2' %}
-    </div>
-</body>
-</html>
+{% if status_details and status_details != 'N/A' %}
+{%- set tone = 'success' if status.lower() == 'success' else ('warning' if status.lower() == 'partial' else 'error') %}
+{{ c.row_callout(status_details, kind=tone, title='Result details') }}
+{% endif %}
+
+{% if frontend_url and frontend_url != 'N/A' and test_run_id and test_run_id != 'N/A' %}
+{{ c.row_button(frontend_url ~ '/test-runs/' ~ test_run_id, 'View test run') }}
+{% endif %}
+{% endblock %}

--- a/apps/backend/src/rhesis/backend/notifications/email/templates/welcome.html.jinja2
+++ b/apps/backend/src/rhesis/backend/notifications/email/templates/welcome.html.jinja2
@@ -1,111 +1,62 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Welcome to Rhesis AI</title>
-</head>
-<body style="font-family: 'Be Vietnam Pro', Arial, sans-serif; line-height: 1.6; color: #3D3D3D; max-width: 600px; margin: 0 auto; padding: 20px; background-color: #FFFFFF;">
+{% extends '_base.html.jinja2' %}
+{% import '_components.html.jinja2' as c %}
 
-    <!-- Logo -->
-    <div style="text-align: center; margin-bottom: 30px;">
-        <img src="https://raw.githubusercontent.com/rhesis-ai/rhesis/main/apps/frontend/public/logos/rhesis-logo-website.png" alt="Rhesis AI" style="max-width: 200px; height: auto;">
-    </div>
+{% block title %}Welcome to Rhesis AI{% endblock %}
+{% block preheader %}A note from Nicolai, plus how to get your first test set running.{% endblock %}
 
-    <!-- Hero Welcome Section -->
-    <div style="background: linear-gradient(135deg, #F2F9FD 0%, #E4F2FA 100%); border-radius: 12px; padding: 30px 20px; margin-bottom: 25px; text-align: center;">
-        <h1 style="color: #2AA1CE; margin: 0 0 15px 0; font-size: 28px; font-weight: 600;">
-            Welcome to Rhesis AI!
-        </h1>
-        <p style="margin: 0; font-size: 16px; color: #3D3D3D;">
-            We're excited to have you on board!
-        </p>
-    </div>
+{#- Deliberately card-free. This is a letter from the founder, and the site
+    never boxes prose — headline, letter, list, and sign-off all sit on the
+    canvas, separated by hairlines rather than containers. -#}
+{% block content %}
+{{ c.row_header('Welcome to', accent='Rhesis AI', lede="We're excited to have you on board!") }}
 
-    <!-- Personal Message Section -->
-    <div style="background: white; border-left: 4px solid #50B9E0; padding: 20px; margin-bottom: 25px; border-radius: 4px;">
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            Thank you for signing up for Rhesis! I'm Nicolai, Co-Founder & CEO, and I personally wanted to reach out to welcome you to our platform.
-        </p>
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            Rhesis is an open-source testing platform & SDK for LLM and agentic applications. Define what your app should and shouldn't do in plain language, and Rhesis generates hundreds of test scenarios, runs them, and shows you where it breaks before production.
-        </p>
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            Built for cross-functional teams to collaborate, we're here to help you test and improve your LLM applications and agentic systems with confidence.
-        </p>
-        <p style="margin: 0; font-size: 15px; line-height: 1.8; color: #2AA1CE; font-weight: 500;">
-            📧 Over the next few days, you'll receive 3 emails from me with tips and resources to help you get started with Rhesis.
-        </p>
-    </div>
+{% call c.row_prose() %}
+    {{ c.p("Thank you for signing up for Rhesis! I'm Nicolai, Co-Founder & CEO, and I personally wanted to reach out to welcome you to our platform.") }}
+    {{ c.p('Rhesis is an open-source testing platform & SDK for LLM and agentic applications. Define what your app should and should not do in plain language, and Rhesis generates hundreds of test scenarios, runs them, and shows you where it breaks before production.') }}
+    {{ c.p('Built for cross-functional teams to collaborate, we are here to help you test and improve your LLM applications and agentic systems with confidence.') }}
+    {{ c.p("Over the next few days, you'll receive 3 emails from me with tips and resources to help you get started with Rhesis.", size=brand.type.small, color=brand.color.blue, bottom=0) }}
+{% endcall %}
 
-    <!-- Getting Started Section -->
-    <div style="background: #F2F9FD; border-radius: 8px; padding: 20px; margin-bottom: 25px;">
-        <h3 style="color: #2AA1CE; margin-top: 0; margin-bottom: 15px; font-size: 18px;">
-            Ready to Get Started?
-        </h3>
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            You can start exploring Rhesis AI right away:
-        </p>
-        <ul style="margin: 0 0 15px 0; padding-left: 25px; font-size: 15px; line-height: 1.8;">
-            <li style="margin-bottom: 8px;">Create your first project and test sets</li>
-            <li style="margin-bottom: 8px;">Run automated tests on your AI endpoints</li>
-            <li style="margin-bottom: 8px;">Invite your team members to collaborate</li>
-            <li>Explore our comprehensive documentation and guides</li>
-        </ul>
-        {% if frontend_url -%}
-        <div style="text-align: center; margin-top: 20px;">
-            <a href="{{ frontend_url }}"
-               style="display: inline-block; background-color: #2AA1CE; color: white; padding: 14px 32px;
-                      text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 16px;">
-                Open Rhesis AI
-            </a>
-        </div>
-        {%- endif %}
-    </div>
+{{ c.row_rule() }}
 
-    <!-- Personal Invitation Section -->
-    <div style="background: white; border: 2px solid #E4F2FA; border-radius: 8px; padding: 20px; margin-bottom: 25px;">
-        <h3 style="color: #3D3D3D; margin-top: 0; margin-bottom: 15px; font-size: 18px;">
-            Have Questions? Let's Talk!
-        </h3>
-        <p style="margin: 0 0 15px 0; font-size: 15px; line-height: 1.8;">
-            I'd love to hear about your use case and help you get the most out of Rhesis AI. Feel free to book a call with me directly – no sales pitch, just a friendly chat about how we can support your AI testing needs.
-        </p>
-        {% if calendar_link -%}
-        <div style="text-align: center; margin-top: 20px;">
-            <a href="{{ calendar_link }}"
-               style="display: inline-block; background-color: #FD6E12; color: white; padding: 14px 32px;
-                      text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 16px;">
-                Book a call with me
-            </a>
-        </div>
-        {%- endif %}
-    </div>
+{% call c.row_prose(bottom=16) %}
+    {{ c.subhead('Ready to get started?') }}
+    {{ c.p('You can start exploring Rhesis AI right away:') }}
+    {{ c.bullets([
+        'Create your first project and test sets',
+        'Run automated tests on your AI endpoints',
+        'Invite your team members to collaborate',
+        'Explore our comprehensive documentation and guides',
+    ]) }}
+{% endcall %}
+{% if frontend_url and frontend_url != 'N/A' %}
+{{ c.row_button(frontend_url, 'Open Rhesis AI') }}
+{% endif %}
 
-    <!-- Support Section -->
-    <div style="background: #F2F9FD; border-radius: 8px; padding: 20px; margin-bottom: 25px;">
-        <h4 style="color: #3D3D3D; margin-top: 0; margin-bottom: 12px; font-size: 16px;">
-            Need Help Getting Started?
-        </h4>
-        <p style="margin: 0; font-size: 14px; line-height: 1.6; color: #3D3D3D;">
-            Check out our <a href="https://docs.rhesis.ai" style="color: #2AA1CE; text-decoration: none; font-weight: 600;">documentation</a> or reach out to our support team at <a href="mailto:hello@rhesis.ai" style="color: #2AA1CE; text-decoration: none;">hello@rhesis.ai</a>. We're here to help!
-        </p>
-    </div>
+{{ c.row_rule() }}
 
-    <!-- Founder Signature -->
-    <div style="margin-top: 30px; padding-top: 20px; border-top: 2px solid #E4F2FA;">
-        <p style="margin: 0 0 5px 0; font-size: 15px; line-height: 1.6;">
-            Best,
-        </p>
-        <p style="margin: 0 0 15px 0; font-size: 16px; font-weight: 600; color: #2AA1CE;">
-            Nicolai
-        </p>
-    </div>
+{% call c.row_prose(bottom=16) %}
+    {{ c.subhead("Have questions? Let's talk") }}
+    {{ c.p("I'd love to hear about your use case and help you get the most out of Rhesis AI. Feel free to book a call with me directly — no sales pitch, just a friendly chat about how we can support your AI testing needs.", bottom=0) }}
+{% endcall %}
+{% if calendar_link and calendar_link != 'N/A' %}
+{{ c.row_button(calendar_link, 'Book a call with me', variant='secondary') }}
+{% endif %}
 
-    <!-- Legal Imprint -->
-    <div style="text-align: left;">
-        {% include '_imprint.html.jinja2' %}
-    </div>
+{{ c.row_rule() }}
 
-</body>
-</html>
+{% call c.row_prose() %}
+    <p style="margin: 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.small }}px; line-height: 1.6; color: {{ brand.color.muted }};">
+        Need help getting started? Check out our {{ c.link('https://docs.rhesis.ai', 'documentation') }} or reach out to our support team at {{ c.link('mailto:hello@rhesis.ai', 'hello@rhesis.ai') }}. We're here to help.
+    </p>
+{% endcall %}
+{% endblock %}
+
+{% block signoff %}
+<tr>
+    <td class="sm-px" style="padding: 8px 0 36px 0; font-family: {{ brand.font.sans }}; font-size: {{ brand.type.body }}px; line-height: 1.6; color: {{ brand.color.body }};">
+        Best,<br>
+        <span style="font-weight: 700; color: {{ brand.color.heading }};">Nicolai</span>
+    </td>
+</tr>
+{% endblock %}

--- a/tests/notifications/email_fixtures.py
+++ b/tests/notifications/email_fixtures.py
@@ -1,0 +1,180 @@
+"""Sample payloads for every email template.
+
+Shared by tests/notifications/test_email_brand.py and
+apps/backend/scripts/preview_emails.py so the previews and the brand assertions
+always exercise the same data. Values are deliberately long in places (names,
+task titles, URLs) to shake out wrapping problems at 375px.
+"""
+
+from datetime import datetime, timezone
+
+from rhesis.backend.notifications.email.template_service import EmailTemplate
+
+FRONTEND = "https://app.rhesis.ai"
+NOW = datetime(2026, 8, 3, 14, 30, tzinfo=timezone.utc)
+
+# One fixture per template. Values are deliberately long in places (names,
+# task titles, URLs) to shake out wrapping problems at 375px.
+FIXTURES: dict[EmailTemplate, dict] = {
+    EmailTemplate.WELCOME: {
+        "recipient_name": "Alex Nguyen",
+        "recipient_email": "alex@example.com",
+        "frontend_url": FRONTEND,
+        "calendar_link": "https://cal.com/rhesis/intro",
+    },
+    EmailTemplate.EMAIL_VERIFICATION: {
+        "recipient_name": "Alex",
+        "verification_url": (
+            f"{FRONTEND}/auth/verify-email"
+            "?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.longish-token-value"
+        ),
+    },
+    EmailTemplate.PASSWORD_RESET: {
+        "recipient_name": "Alex",
+        "reset_url": (
+            f"{FRONTEND}/auth/reset-password"
+            "?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.longish-token-value"
+        ),
+    },
+    EmailTemplate.MAGIC_LINK: {
+        "recipient_name": "Alex",
+        "magic_link_url": (
+            f"{FRONTEND}/auth/magic?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.longish"
+        ),
+        "is_new_user": False,
+    },
+    EmailTemplate.MIGRATION_PASSWORD_SETUP: {
+        "recipient_name": "Alex",
+        "reset_url": f"{FRONTEND}/auth/reset-password?token=migration-token-value",
+    },
+    EmailTemplate.TEAM_INVITATION: {
+        "recipient_name": "Alex Nguyen",
+        "recipient_email": "alex@example.com",
+        "organization_name": "Northwind Health Analytics",
+        "organization_website": "https://northwind.example.com",
+        "inviter_name": "Priya Raman",
+        "inviter_email": "priya@northwind.example.com",
+        "frontend_url": FRONTEND,
+    },
+    EmailTemplate.TASK_ASSIGNMENT: {
+        "assignee_name": "Alex Nguyen",
+        "assigner_name": "Priya Raman",
+        "task_title": "Review the refusal-rate regression on the triage assistant",
+        "task_description": (
+            "The nightly run shows refusals up 12 points on the German prompts. "
+            "Check whether the system prompt change from Tuesday is responsible."
+        ),
+        "task_id": "8f2c1e94-7b3a-4d21-9c8e-1a2b3c4d5e6f",
+        "status_name": "In Progress",
+        "priority_name": "High",
+        "entity_type": "TestRun",
+        "entity_id": "3a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9",
+        "entity_name": "Triage assistant · nightly",
+        "created_at": NOW,
+        "task_metadata": None,
+        "frontend_url": FRONTEND,
+    },
+    EmailTemplate.TASK_COMPLETION: {
+        "recipient_name": "Alex",
+        "task_name": "Generate adversarial test set",
+        "task_id": "8f2c1e94-7b3a-4d21-9c8e-1a2b3c4d5e6f",
+        "status": "SUCCESS",
+        "completed_at": NOW,
+        "execution_time": "4m 12s",
+        "error_message": None,
+        "frontend_url": FRONTEND,
+        "test_set_id": "11112222-3333-4444-5555-666677778888",
+    },
+    EmailTemplate.TEST_EXECUTION_SUMMARY: {
+        "recipient_name": "Alex",
+        "task_name": "Triage assistant · nightly regression",
+        "task_id": "8f2c1e94-7b3a-4d21-9c8e-1a2b3c4d5e6f",
+        "status": "partial",
+        "execution_status": "Partial",
+        "completed_at": NOW,
+        "total_tests": 248,
+        "tests_passed": 231,
+        "tests_failed": 14,
+        "execution_errors": 3,
+        "execution_time": "11m 48s",
+        "test_run_id": "3a1b2c3d-4e5f-6071-8293-a4b5c6d7e8f9",
+        "status_details": (
+            "14 tests failed on the German prompt set and 3 could not reach the endpoint."
+        ),
+        "frontend_url": FRONTEND,
+        "test_set_name": "Adversarial · healthcare triage",
+        "endpoint_name": "triage-assistant-staging",
+        "endpoint_url": "https://staging.northwind.example.com/v1/triage",
+        "project_name": "Northwind Triage",
+    },
+    EmailTemplate.FEEDBACK: {
+        "user_name": "Alex Nguyen",
+        "user_email": "alex@example.com",
+        "feedback": (
+            "The explorer view is great, but I'd love to filter by metric score.\n\n"
+            "Also: the export button is easy to miss."
+        ),
+        "rating": 4,
+    },
+    EmailTemplate.POLYPHEMUS_ACCESS_REQUEST: {
+        "user_name": "Alex Nguyen",
+        "user_email": "alex@example.com",
+        "user_id": "99998888-7777-6666-5555-444433332222",
+        "organization_name": "Northwind Health Analytics",
+        "organization_display_name": "Northwind Health",
+        "organization_email": "ops@northwind.example.com",
+        "organization_website": "https://northwind.example.com",
+        "organization_is_active": True,
+        "expected_monthly_requests": 25000,
+        "request_timestamp": "2026-08-03 14:30:00 UTC",
+        "justification": (
+            "We're red-teaming a clinical triage assistant ahead of a September rollout "
+            "and need adversarial coverage on the German prompt set."
+        ),
+    },
+}
+
+# Extra passes worth looking at because they take a different branch.
+VARIANTS: list[tuple[str, EmailTemplate, dict]] = [
+    (
+        "magic_link__new_user",
+        EmailTemplate.MAGIC_LINK,
+        {**FIXTURES[EmailTemplate.MAGIC_LINK], "is_new_user": True},
+    ),
+    (
+        "test_execution_summary__all_passed",
+        EmailTemplate.TEST_EXECUTION_SUMMARY,
+        {
+            **FIXTURES[EmailTemplate.TEST_EXECUTION_SUMMARY],
+            "status": "success",
+            "execution_status": "Complete",
+            "total_tests": 248,
+            "tests_passed": 248,
+            "tests_failed": 0,
+            "execution_errors": 0,
+            "status_details": "All tests passed.",
+        },
+    ),
+    (
+        "test_execution_summary__failed",
+        EmailTemplate.TEST_EXECUTION_SUMMARY,
+        {
+            **FIXTURES[EmailTemplate.TEST_EXECUTION_SUMMARY],
+            "status": "failure",
+            "execution_status": "Failed",
+            "tests_passed": 0,
+            "tests_failed": 248,
+            "execution_errors": 0,
+            "status_details": "The endpoint returned 502 for every request.",
+        },
+    ),
+    (
+        "task_completion__failed",
+        EmailTemplate.TASK_COMPLETION,
+        {
+            **FIXTURES[EmailTemplate.TASK_COMPLETION],
+            "status": "FAILURE",
+            "error_message": "TimeoutError: the generation model did not respond within 300s",
+        },
+    ),
+]

--- a/tests/notifications/test_email_brand.py
+++ b/tests/notifications/test_email_brand.py
@@ -147,3 +147,62 @@ def test_no_literal_none_or_undefined_leaks(rendered: dict[str, str], name: str)
     html = rendered[name]
     assert ">None<" not in html, f"{name} rendered a bare None"
     assert "Undefined" not in html
+
+
+# Fields a user or another tenant can set, per template. Each renders into the
+# body, so each is a place someone could inject markup.
+INJECTABLE = [
+    (EmailTemplate.FEEDBACK, "feedback"),
+    (EmailTemplate.FEEDBACK, "user_name"),
+    (EmailTemplate.POLYPHEMUS_ACCESS_REQUEST, "justification"),
+    (EmailTemplate.POLYPHEMUS_ACCESS_REQUEST, "organization_name"),
+    (EmailTemplate.TASK_ASSIGNMENT, "task_description"),
+    (EmailTemplate.TASK_ASSIGNMENT, "task_title"),
+    (EmailTemplate.TASK_ASSIGNMENT, "entity_name"),
+    (EmailTemplate.TEAM_INVITATION, "organization_name"),
+    (EmailTemplate.TEAM_INVITATION, "inviter_name"),
+    (EmailTemplate.TEST_EXECUTION_SUMMARY, "status_details"),
+    (EmailTemplate.TEST_EXECUTION_SUMMARY, "endpoint_name"),
+    (EmailTemplate.TASK_COMPLETION, "task_name"),
+    # WELCOME is absent on purpose: it is a founder letter that interpolates no
+    # user-supplied field into its body, so there is nothing to inject into.
+]
+
+PAYLOAD = '<a href="https://evil.example/reset">Reset your password</a>'
+
+
+@pytest.mark.parametrize(
+    ("template", "field"), INJECTABLE, ids=[f"{t.name}.{f}" for t, f in INJECTABLE]
+)
+def test_user_fields_are_escaped(template: EmailTemplate, field: str):
+    """No user-supplied field may render as live HTML.
+
+    The environment escapes unconditionally. It used to use
+    select_autoescape(["html", "xml"]), which matches on the filename suffix —
+    and these templates end in `.jinja2`, not `.html`, so escaping never
+    engaged and every field below rendered as markup. A link injected into,
+    say, a feedback message arrives inside a Rhesis-branded email.
+    """
+    variables = dict(FIXTURES[template])
+    variables[field] = PAYLOAD
+    html = TemplateService().render_template(template, variables)
+
+    assert PAYLOAD not in html, f"{template.name}.{field} rendered raw HTML"
+    assert "&lt;a href=" in html, f"{template.name}.{field} did not render the escaped payload"
+
+
+def test_font_stacks_survive_escaping():
+    """The quotes in multi-word family names must not become entities.
+
+    brand.Fonts wraps its stacks in Markup for exactly this reason; without it
+    `'Geist'` renders as `&#39;Geist&#39;`.
+    """
+    html = TemplateService().render_template(
+        EmailTemplate.MAGIC_LINK, dict(FIXTURES[EmailTemplate.MAGIC_LINK])
+    )
+    assert "font-family: 'Geist'" in html
+    assert "font-family: 'Geist Mono'" in html
+    # Scoped to the family names. A bare `&#39;` check would fail on copy that
+    # legitimately contains an apostrophe ("you didn't request this link"),
+    # where escaping is doing its job.
+    assert "&#39;Geist" not in html

--- a/tests/notifications/test_email_brand.py
+++ b/tests/notifications/test_email_brand.py
@@ -1,0 +1,149 @@
+"""Guards that the email templates stay on the current brand.
+
+The templates went through three visual generations before this — old-brand
+(Be Vietnam Pro, #2AA1CE), generic Bootstrap (Arial, #007bff, alert greens and
+reds), and the current one. Nothing structural stops a fourth from creeping
+back in one template at a time, so these tests render every template and fail
+on the specific markers of the old ones.
+
+Pure unit tests: Jinja only, nothing is sent.
+"""
+
+import re
+
+import pytest
+
+from rhesis.backend.notifications.email.brand import get_brand
+from rhesis.backend.notifications.email.template_service import EmailTemplate, TemplateService
+from tests.notifications.email_fixtures import FIXTURES, VARIANTS
+
+# Hex values and font names from the superseded generations. Matched
+# case-insensitively — the old templates mixed #2AA1CE and #2aa1ce.
+RETIRED_COLORS = [
+    "#2AA1CE",  # old brand primary
+    "#50B9E0",  # old brand light blue
+    "#F2F9FD",  # old brand tint
+    "#E4F2FA",  # old brand tint
+    "#3D3D3D",  # old brand body text
+    "#F38755",  # old brand link
+    "#e5f2ff",  # blue panel tint — clashed with the header wash, now neutral
+    "#007bff",  # Bootstrap primary
+    "#1976d2",  # Material blue
+    "#0ea5e9",
+    "#f8f9fa",  # Bootstrap panel
+    "#dee2e6",  # Bootstrap border
+    "#e9ecef",
+    "#868e96",
+    "#6c757d",
+    "#d4edda",  # Bootstrap alert success
+    "#28a745",
+    "#155724",
+    "#f8d7da",  # Bootstrap alert danger
+    "#dc3545",
+    "#721c24",
+    "#fff3cd",  # Bootstrap alert warning
+    "#856404",
+    "#2c3e50",
+    "#1D2939",
+    "#495057",
+]
+
+RETIRED_FONTS = ["Be Vietnam Pro", "Plus Jakarta", "DM Sans", "JetBrains Mono"]
+
+
+def _cases():
+    cases = [
+        (template.value.removesuffix(".html.jinja2"), template, variables)
+        for template, variables in FIXTURES.items()
+    ]
+    cases.extend(VARIANTS)
+    return cases
+
+
+CASES = _cases()
+CASE_IDS = [name for name, _, _ in CASES]
+
+
+@pytest.fixture(scope="module")
+def rendered() -> dict[str, str]:
+    """Every template rendered once, keyed by case name."""
+    service = TemplateService()
+    return {name: service.render_template(template, dict(v)) for name, template, v in CASES}
+
+
+def test_every_template_has_a_case():
+    """A new template without a fixture would silently skip every check here."""
+    covered = {template for _, template, _ in CASES}
+    missing = sorted(t.value for t in set(EmailTemplate) - covered)
+    assert covered == set(EmailTemplate), f"templates with no preview fixture: {missing}"
+
+
+@pytest.mark.parametrize("name", CASE_IDS)
+def test_no_retired_colors(rendered: dict[str, str], name: str):
+    html = rendered[name]
+    found = [color for color in RETIRED_COLORS if color.lower() in html.lower()]
+    assert not found, f"{name} uses retired colours: {found}"
+
+
+@pytest.mark.parametrize("name", CASE_IDS)
+def test_no_retired_fonts(rendered: dict[str, str], name: str):
+    html = rendered[name]
+    found = [font for font in RETIRED_FONTS if font in html]
+    assert not found, f"{name} uses retired fonts: {found}"
+
+
+@pytest.mark.parametrize("name", CASE_IDS)
+def test_font_stacks_lead_with_geist(rendered: dict[str, str], name: str):
+    """Arial is the fallback, never the first choice."""
+    # Capture up to the `;` or the closing `"` of an inline style. Single quotes
+    # have to stay inside the class, or the family names in the @font-face rules
+    # (font-family: 'Geist';) capture as an empty string.
+    stacks = re.findall(r"font-family:\s*([^;\"]+)", rendered[name])
+    assert stacks, f"{name} declares no font-family at all"
+    for stack in stacks:
+        first = stack.split(",")[0].strip().strip("'\"")
+        assert first in ("Geist", "Geist Mono"), f"{name} has a stack starting with {first!r}"
+
+
+@pytest.mark.parametrize("name", CASE_IDS)
+def test_assets_come_from_the_configured_host(rendered: dict[str, str], name: str):
+    """raw.githubusercontent.com is branch-coupled and rate-limited, and Gmail's
+    image proxy caches by URL — a change to main would mutate already-sent mail."""
+    html = rendered[name]
+    assert "raw.githubusercontent.com" not in html
+    assert get_brand().logo_url in html
+
+
+@pytest.mark.parametrize("name", CASE_IDS)
+def test_client_compatibility_scaffold(rendered: dict[str, str], name: str):
+    """The pieces that make these render outside Apple Mail."""
+    html = rendered[name]
+    # Outlook Windows ignores a width on <body>; the 600px table is what works.
+    assert 'width="600"' in html, f"{name} is missing the 600px table"
+    # Light is locked, so clients skip their auto-invert pass.
+    assert '<meta name="color-scheme" content="light">' in html
+    assert '<meta name="supported-color-schemes" content="light">' in html
+    # Gmail strips @font-face, so inline stacks are what carry the typeface.
+    assert "@font-face" in html
+
+
+@pytest.mark.parametrize("name", CASE_IDS)
+def test_imprint_is_present(rendered: dict[str, str], name: str):
+    """Legally required on every outbound mail."""
+    assert "Rhesis AI GmbH" in rendered[name]
+    assert "HRB 39358 Potsdam" in rendered[name]
+
+
+@pytest.mark.parametrize("name", CASE_IDS)
+def test_no_unrendered_jinja(rendered: dict[str, str], name: str):
+    html = rendered[name]
+    for marker in ("{{", "}}", "{%"):
+        assert marker not in html, f"{name} leaked an unrendered {marker} into the output"
+
+
+@pytest.mark.parametrize("name", CASE_IDS)
+def test_no_literal_none_or_undefined_leaks(rendered: dict[str, str], name: str):
+    """A missing optional variable should drop its row, not print 'None'."""
+    html = rendered[name]
+    assert ">None<" not in html, f"{name} rendered a bare None"
+    assert "Undefined" not in html


### PR DESCRIPTION
## Purpose

Our emails looked nothing like the website. The 11 templates had drifted into three visual generations, none of them the current brand:

- **Old brand (5)** — `welcome`, `magic_link`, `email_verification`, `password_reset`, `migration_password_setup`: Be Vietnam Pro, `#2AA1CE` headings, `#50B9E0` left rules, a `linear-gradient(135deg, #F2F9FD, #E4F2FA)` hero card, 6px-radius buttons.
- **Generic Bootstrap (6)** — `test_execution_summary`, `task_completion`, `task_assignment`, `team_invitation`, `feedback`, `polyphemus_access_request`: Arial, `#333` on `#f8f9fa`, `#007bff` buttons, `#d4edda`/`#dc3545` alert colours, **no logo at all**.

Each was a standalone HTML document repeating its own inline styles, so there was no single place to change a colour and nothing to stop a fourth generation appearing.

## Screenshots

`magic_link`, before (main) and after — I can't attach images through `gh`, so these are on disk and need dragging into this description:

- `<scratchpad>/shots/email-before-after.png` — side by side, labelled
- `<scratchpad>/shots/compare-before.png` and `compare-after.png` — individually

## What Changed

- **`brand.py`** — one source of truth for palette, type ramp, layout, and asset URLs, exposed to Jinja as a `brand` global. Values come from what the site's components actually use, **not** from the `@theme` block in the website's `tailwind.css`, which still holds the previous brand (`#50B9E0`, `#2AA1CE`) that the redesigned sections no longer reference. Semantic colours come from the product UI's `theme.ts`, since these emails link into it.
- **`_base.html.jinja2`** — the document shell: `color-scheme` locked to light, `@font-face` for Geist, mobile media queries, the Outlook `PixelsPerInch` block, and the 600px table scaffold. Previously `max-width: 600px` sat on `<body>`, which Outlook ignores, so these rendered full-width there.
- **`_components.html.jinja2`** — macros for every block, each emitting inline styles from `brand`.
- **11 templates** rewritten as `{% extends %}` plus a content block, dropping from ~1000 lines of duplicated CSS to 20–70 lines each.
- **`scripts/preview_emails.py`** — renders all 11 plus 4 branch variants to HTML with an index at 600px and 375px. Nothing is sent.
- **`tests/notifications/test_email_brand.py`** — 149 assertions that fail if a retired hex, `Be Vietnam Pro`, an Arial-first font stack, or a `raw.githubusercontent.com` URL comes back, and that every template still carries the imprint and the Outlook scaffold.

## Design decisions worth reviewing

**Layout follows the site's two surfaces.** Prose sits directly on the canvas; the one card style — white, 24px, the site's `0 4px 30px rgba(45,30,133,0.1)` shadow — is reserved for tiles. My first pass boxed every paragraph in a bordered rectangle and added grey recessed panels, which matched neither the site nor the app. `welcome` and the four auth emails now have **zero** cards; `polyphemus_access_request` went from five to one.

**Type ramp is five steps** (32 / 18 / 16 / 13 / 11) and no template carries a literal `font-size`. It was six sizes and five text colours on a single email; text colours are down to three.

**Buttons are black** (`#101011`), matching the site's navbar CTA pill, flattened from its gradient because Outlook ignores those. Blue is now purely the accent for headline tails and links.

**Assets no longer come from `raw.githubusercontent.com`.** That URL is branch-coupled to `main` and rate-limited, and because Gmail's image proxy caches by URL, a template change would retroactively alter already-sent mail. Now `EMAIL_ASSET_BASE_URL`, default `https://rhesis.ai`.

## Deliberate degradations

Rather than approximated: `box-shadow` is dropped by Outlook, so cards carry a near-invisible `#eceff3` edge to stay defined there. Buttons are table cells with `border-radius`, not VML roundrects — Outlook squares the corners, which still reads as a solid button, whereas VML needs a hardcoded pixel width per button that breaks whenever a label or translation changes. The header wash is a cell background, so Outlook shows flat canvas instead.

## Additional Context

- **Depends on rhesis-ai/website#81**, which adds the logo and wash to `https://rhesis.ai/email/`. Merge and deploy that first or the images 404.
- **Fonts won't render anywhere until the website gets a CORS header on `/fonts/`.** WebKit blocks cross-origin font fetches, so Apple Mail falls back to Helvetica like everything else. Called out in that PR; the layout is fine either way.
- Light mode is locked — no dark variant. Clients that honour `color-scheme` skip their auto-invert pass, which otherwise mangles the flattened header assets.
- The wash offset is one value for all templates, tuned to sit behind the CTA in the short auth emails. `welcome` (button at 781px) and `test_execution_summary` (1083px) have real content between headline and button, so it sits behind mid-content there instead.
- Emails are still `MIMEText(html, "html")` with no `multipart/alternative` text part. Unchanged here, worth a follow-up for deliverability.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/notifications/ -v     # 149 passed
```

To look at them, serve the website's `public/` locally so the assets and fonts resolve, then render against it:

```bash
cd ../../  # repo root
(cd ../website/public && python3 -m http.server 8899 &)
cd apps/backend
EMAIL_ASSET_BASE_URL=http://localhost:8899 uv run python scripts/preview_emails.py
open /tmp/rhesis-email-preview/index.html
```

Checked in Chromium at 600px and 375px. Not yet verified in a real client — the matrix that matters is Gmail web/mobile, Apple Mail, Outlook 365 Windows, Outlook Mac, and Outlook.com, and the fallback path (no Geist) is what most recipients will see.
