### PR TITLE
Add usage accounting for metered resources

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/77df3dbea77d_add_usage_table.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/77df3dbea77d_add_usage_table.py
@@ -115,6 +115,11 @@ def upgrade() -> None:
             ["organization_id"],
         )
 
+    # Not a duplicate of Base.deleted_at's `index=True`: raw op.create_table
+    # above does not honor that ORM-level flag, so nothing indexes this
+    # column until this explicit op.create_index runs. Same two-step
+    # (unindexed column in create_table, then this idempotent check) as
+    # c7f4d9b2e1a3_add_auth_client_table.py's ix_auth_client_deleted_at.
     deleted_at_index_exists = conn.execute(
         sa.text(
             "SELECT 1 FROM pg_indexes WHERE tablename='usage' AND indexname='ix_usage_deleted_at'"

--- a/apps/backend/src/rhesis/backend/alembic/versions/77df3dbea77d_add_usage_table.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/77df3dbea77d_add_usage_table.py
@@ -1,0 +1,149 @@
+"""add usage table
+
+Per-organization, per-resource, per-billing-period cumulative usage
+counter backing the read-only ``GET /usage`` endpoint. ``resource``
+stores ``QuotaResource`` string values (see
+``rhesis.backend.app.quota``); the unique constraint on
+``(organization_id, resource, period_start)`` is what
+``increment_usage`` upserts against.
+
+``organization_id`` cascades on delete so removing an org does not
+leave orphaned counters behind.
+
+RLS: ``usage`` gets the same ``tenant_isolation`` policy (ENABLE +
+FORCE) as every other tenant table, following the per-table pattern
+established after the original blanket-RLS migration (see e.g.
+``d9e0f1a2b3c4_add_rbac_catalog_tables.py``) -- new tables are not
+covered automatically. This matters more than usual here: the usage
+service intentionally runs its reads/writes under
+``bypass_tenant_filter()`` (the ORM-level auto-filter, which the raw
+``INSERT ... ON CONFLICT`` upserts bypass entirely anyway), so without
+this policy the application-level ``org_id`` predicate would be the
+*only* tenant boundary on a table that tracks billable usage.
+
+Excluded from the generic recycle-bin routes (``routers/recycle.py``):
+see the accompanying change there. A `usage` row reachable through
+generic soft-delete/restore/hard-delete would let an org member zero
+their own metered usage (hard delete bypasses the soft-delete check
+entirely) or, on restore, resurrect a row the increment path's
+raw SQL would keep updating invisibly (the ORM's soft-delete filter
+would hide it from `GET /usage`'s SELECT while the accrual still lands
+on it).
+
+Revision ID: 77df3dbea77d
+Revises: c4ca0e395084
+Create Date: 2026-08-03
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "77df3dbea77d"
+down_revision: Union[str, None] = "c4ca0e395084"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    table_exists = conn.execute(
+        sa.text("SELECT 1 FROM information_schema.tables WHERE table_name='usage'")
+    ).fetchone()
+
+    if not table_exists:
+        op.create_table(
+            "usage",
+            sa.Column(
+                "id",
+                sa.dialects.postgresql.UUID(),
+                primary_key=True,
+                server_default=sa.text("gen_random_uuid()"),
+                nullable=False,
+            ),
+            sa.Column("nano_id", sa.String(), nullable=True, unique=True),
+            sa.Column(
+                "created_at",
+                sa.TIMESTAMP(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.TIMESTAMP(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column(
+                "organization_id",
+                sa.dialects.postgresql.UUID(),
+                sa.ForeignKey("organization.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("resource", sa.String(64), nullable=False),
+            sa.Column("period_start", sa.Date(), nullable=False),
+            sa.Column("period_end", sa.Date(), nullable=False),
+            sa.Column(
+                "used",
+                sa.BigInteger(),
+                server_default=sa.text("0"),
+                nullable=False,
+            ),
+            sa.UniqueConstraint(
+                "organization_id",
+                "resource",
+                "period_start",
+                name="uq_usage_org_resource_period",
+            ),
+        )
+
+    index_exists = conn.execute(
+        sa.text(
+            "SELECT 1 FROM pg_indexes "
+            "WHERE tablename='usage' "
+            "AND indexname='ix_usage_organization_id'"
+        )
+    ).fetchone()
+    if not index_exists:
+        op.create_index(
+            "ix_usage_organization_id",
+            "usage",
+            ["organization_id"],
+        )
+
+    deleted_at_index_exists = conn.execute(
+        sa.text(
+            "SELECT 1 FROM pg_indexes WHERE tablename='usage' AND indexname='ix_usage_deleted_at'"
+        )
+    ).fetchone()
+    if not deleted_at_index_exists:
+        op.create_index(
+            "ix_usage_deleted_at",
+            "usage",
+            ["deleted_at"],
+        )
+
+    op.execute("DROP POLICY IF EXISTS tenant_isolation ON usage")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON usage
+            USING (
+                organization_id = NULLIF(
+                    current_setting('app.current_organization', true), ''
+                )::uuid
+            )
+        """
+    )
+    op.execute("ALTER TABLE usage ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE usage FORCE ROW LEVEL SECURITY")
+
+
+def downgrade() -> None:
+    op.execute("DROP POLICY IF EXISTS tenant_isolation ON usage")
+    op.drop_index("ix_usage_deleted_at", table_name="usage")
+    op.drop_index("ix_usage_organization_id", table_name="usage")
+    op.drop_table("usage")

--- a/apps/backend/src/rhesis/backend/app/auth/public_routes.py
+++ b/apps/backend/src/rhesis/backend/app/auth/public_routes.py
@@ -86,6 +86,10 @@ AUTHZ_EXEMPT_ROUTES: frozenset[tuple[str, str]] = frozenset(
         # Feature catalog: the frontend needs this before any RBAC context is set.
         # Authentication is still enforced; the response is org-filtered in the handler.
         ("GET", "/features"),
+        # Usage dashboard: read-only report of the authenticated org's own metered
+        # consumption, no different in shape or sensitivity from /features above.
+        # Authentication is still enforced; the response is org-scoped in the handler.
+        ("GET", "/usage"),
         # Demo / test endpoint — carries no meaningful permission boundary.
         ("GET", "/home/protected"),
         # Profile update during onboarding: the user may not have an org yet when

--- a/apps/backend/src/rhesis/backend/app/dependencies.py
+++ b/apps/backend/src/rhesis/backend/app/dependencies.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app.auth.principal import REQUEST_STATE_API_TOKEN_PROJECT_ID
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.database import get_db, get_db_with_tenant_variables
+from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.services.endpoint import EndpointService
 
@@ -259,6 +260,39 @@ def get_tenant_db_session(
 
     with get_db_with_tenant_variables(organization_id, user_id, project_id or "") as db:
         yield db
+
+
+def get_current_organization(
+    tenant_context: tuple = Depends(get_tenant_context),
+    db: Session = Depends(get_tenant_db_session),
+) -> Organization:
+    """
+    FastAPI dependency resolving the authenticated user's organization row.
+
+    Shared by any endpoint that needs the actual `Organization` object (not
+    just the id) -- e.g. to pass into `FeatureRegistry`/`QuotaRegistry`
+    lookups. Both dependencies resolve through the same
+    `require_current_user_or_token` call (FastAPI deduplicates it), so the
+    organization id always comes from the authenticated tenant context,
+    never user-supplied input.
+
+    Raises:
+        HTTPException: 403 if there is no organization context, or the
+            organization row cannot be found.
+    """
+    organization_id, _user_id = tenant_context
+    if not organization_id:
+        raise HTTPException(
+            status_code=403,
+            detail="Organization context required",
+        )
+    org = db.get(Organization, organization_id)
+    if org is None:
+        raise HTTPException(
+            status_code=403,
+            detail="Organization not found",
+        )
+    return org
 
 
 async def bind_affordance_context(

--- a/apps/backend/src/rhesis/backend/app/models/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/models/__init__.py
@@ -45,6 +45,7 @@ from .tool import Tool
 from .topic import Topic
 from .trace import Trace
 from .type_lookup import TypeLookup
+from .usage import Usage
 from .use_case import UseCase
 from .user import User
 
@@ -100,6 +101,7 @@ __all__ = [
     "test_set_metric_association",
     "TestRunStatsView",
     "TestResultStatsView",
+    "Usage",
 ]
 
 # Set up soft delete event listener

--- a/apps/backend/src/rhesis/backend/app/models/usage.py
+++ b/apps/backend/src/rhesis/backend/app/models/usage.py
@@ -1,0 +1,42 @@
+from sqlalchemy import BigInteger, Column, Date, ForeignKey, Index, String, UniqueConstraint, text
+
+from .base import Base
+from .guid import GUID
+
+
+class Usage(Base):
+    """Cumulative usage counter for a metered resource within a billing period.
+
+    Not org-scoped via ``OrganizationMixin``: the usage service performs
+    explicit atomic upserts (``INSERT ... ON CONFLICT DO UPDATE``), which
+    the ambient tenant auto-filter/auto-stamp listeners are not built for.
+    Protected by a ``tenant_isolation`` RLS policy at the database level
+    instead (see the ``77df3dbea77d_add_usage_table`` migration).
+
+    Excluded from the generic recycle-bin routes (see
+    ``routers/recycle.py``) -- see that module for why.
+
+    ``resource`` stores :class:`~rhesis.backend.app.quota.QuotaResource`
+    string values. Application code always writes through the enum, never
+    a raw string.
+    """
+
+    __tablename__ = "usage"
+
+    organization_id = Column(
+        GUID(), ForeignKey("organization.id", ondelete="CASCADE"), nullable=False
+    )
+    resource = Column(String(64), nullable=False)
+    period_start = Column(Date, nullable=False)
+    period_end = Column(Date, nullable=False)
+    used = Column(BigInteger, nullable=False, server_default=text("0"))
+
+    __table_args__ = (
+        UniqueConstraint(
+            "organization_id",
+            "resource",
+            "period_start",
+            name="uq_usage_org_resource_period",
+        ),
+        Index("ix_usage_organization_id", "organization_id"),
+    )

--- a/apps/backend/src/rhesis/backend/app/quota/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/quota/__init__.py
@@ -39,7 +39,7 @@ class QuotaResource(str, Enum):
     TEST_EXECUTIONS = "test_executions"
     TRACING_SPANS = "tracing_spans"
     TEST_GENERATION = "test_generation"
-    HOSTED_MODEL_TOKENS = "hosted_model_tokens"
+    MODEL_TOKENS = "model_tokens"
     SEATS = "seats"
     PROJECTS = "projects"
     ENDPOINTS = "endpoints"
@@ -57,7 +57,7 @@ FREE_TIER_LIMITS: dict[QuotaResource, int | None] = {
     QuotaResource.TEST_EXECUTIONS: 1_000,
     QuotaResource.TRACING_SPANS: 50_000,
     QuotaResource.TEST_GENERATION: 500,
-    QuotaResource.HOSTED_MODEL_TOKENS: 5_000_000,
+    QuotaResource.MODEL_TOKENS: 5_000_000,
     QuotaResource.SEATS: 3,
     QuotaResource.PROJECTS: 1,
     QuotaResource.ENDPOINTS: 1,

--- a/apps/backend/src/rhesis/backend/app/routers/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/routers/__init__.py
@@ -58,6 +58,7 @@ from .token import router as token_router
 from .tools import router as tools_router
 from .topic import router as topic_router
 from .type_lookup import router as type_lookup_router
+from .usage import router as usage_router
 from .use_case import router as use_case_router
 from .user import router as user_router
 from .websocket import router as websocket_router
@@ -106,6 +107,7 @@ __all__ = [
     "explorer",
     "architect",
     "preflight",
+    "usage",
 ]
 
 # Export all routers for use in main.py
@@ -162,6 +164,7 @@ routers = sorted(
         explorer_router,
         architect_router,
         capabilities_router,
+        usage_router,
     ],
     key=lambda x: x.tags[0].lower() if x.tags else "",
 )

--- a/apps/backend/src/rhesis/backend/app/routers/features.py
+++ b/apps/backend/src/rhesis/backend/app/routers/features.py
@@ -14,12 +14,10 @@ from __future__ import annotations
 
 from typing import Dict, List
 
-from fastapi import APIRouter, Depends, HTTPException
-from fastapi import status as http_status
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
-from sqlalchemy.orm import Session
 
-from rhesis.backend.app.dependencies import get_tenant_context, get_tenant_db_session
+from rhesis.backend.app.dependencies import get_current_organization
 from rhesis.backend.app.features import FeatureRegistry
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.quota import QuotaRegistry, limits_to_wire
@@ -41,27 +39,9 @@ class FeaturesResponse(BaseModel):
 
 @router.get("", response_model=FeaturesResponse)
 def list_features(
-    tenant_context: tuple = Depends(get_tenant_context),
-    db: Session = Depends(get_tenant_db_session),
+    org: Organization = Depends(get_current_organization),
 ) -> FeaturesResponse:
-    """Return license info and the set of features enabled for the current user's org.
-
-    Both dependencies resolve through the same ``require_current_user_or_token``
-    call (FastAPI deduplicates it). ``tenant_context`` provides the
-    authenticated organization ID so we never accept user-supplied input.
-    """
-    organization_id, _user_id = tenant_context
-    if not organization_id:
-        raise HTTPException(
-            status_code=http_status.HTTP_403_FORBIDDEN,
-            detail="Organization context required",
-        )
-    org = db.get(Organization, organization_id)
-    if org is None:
-        raise HTTPException(
-            status_code=http_status.HTTP_403_FORBIDDEN,
-            detail="Organization not found",
-        )
+    """Return license info and the set of features enabled for the current user's org."""
     enabled = [f.name.value for f in FeatureRegistry.licensed_features(org)]
     warnings = FeatureRegistry.feature_warnings(org)
     info = FeatureRegistry.license_info(org=org)

--- a/apps/backend/src/rhesis/backend/app/routers/recycle.py
+++ b/apps/backend/src/rhesis/backend/app/routers/recycle.py
@@ -32,13 +32,26 @@ logger = logging.getLogger(__name__)
 
 router = RhesisRouter(prefix="/recycle", tags=["recycle"], resource="recycle")
 
+# Tables that must never be reachable through the generic recycle-bin routes,
+# even though they inherit deleted_at from Base like every other model.
+#
+# usage: a billing counter, not user content. Reachable here it would let an
+# org member zero their own metered usage (hard delete has no "already
+# soft-deleted" precondition -- see hard_delete_item/get_item(include_deleted=True))
+# or, via restore, resurrect a row that the increment path's raw-SQL upsert
+# would keep updating invisibly (the ORM soft-delete filter hides it from
+# GET /usage's SELECT while accrual still lands on it). There is no
+# legitimate soft-delete/restore workflow for a counter row.
+RECYCLE_EXCLUDED_TABLES = frozenset({"usage"})
+
 
 def get_all_models() -> Dict[str, type]:
     """
     Automatically discover all SQLAlchemy models that inherit from Base.
 
     Returns:
-        Dictionary mapping lowercase model names to model classes
+        Dictionary mapping lowercase model names to model classes, excluding
+        RECYCLE_EXCLUDED_TABLES.
     """
     model_map = {}
 
@@ -48,6 +61,8 @@ def get_all_models() -> Dict[str, type]:
             model_class = mapper.class_
             # Use the table name as the key (already lowercase)
             table_name = model_class.__tablename__
+            if table_name in RECYCLE_EXCLUDED_TABLES:
+                continue
             model_map[table_name] = model_class
         except UnmappedClassError:
             # Skip models that haven't been fully mapped yet

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -173,17 +173,33 @@ async def generate_content_endpoint(
             model = get_model(model, model_type="language")
 
         captured_usage: dict = {}
-        if hasattr(model, "on_usage"):
-            original_on_usage = model.on_usage
+        has_on_usage = hasattr(model, "on_usage")
+        original_on_usage = model.on_usage if has_on_usage else None
 
-            def _capture_and_forward(usage: dict) -> None:
-                captured_usage.update(usage)
-                if original_on_usage:
-                    original_on_usage(usage)
+        def _capture_and_forward(usage: dict) -> None:
+            # Sum rather than `dict.update()`: if `on_usage` ever fires more
+            # than once for a single call, `update()` would replace the
+            # running totals with the latest emission instead of adding to
+            # them, undercounting what gets forwarded via the header.
+            for key, value in usage.items():
+                captured_usage[key] = captured_usage.get(key, 0) + value
+            if original_on_usage:
+                original_on_usage(usage)
 
+        if has_on_usage:
             model.on_usage = _capture_and_forward
 
-        result = await model.a_generate(request.prompt, schema=request.schema_)
+        try:
+            result = await model.a_generate(request.prompt, schema=request.schema_)
+        finally:
+            # Restore the original callback: `model` is a fresh instance
+            # resolved for this request today, but this handler must not
+            # assume that stays true. Leaving the override in place on a
+            # model that outlives the request (e.g. a future caching layer)
+            # would nest a new `_capture_and_forward` on every reuse, firing
+            # `original_on_usage` once per layer of nesting per real event.
+            if has_on_usage:
+                model.on_usage = original_on_usage
 
         if captured_usage:
             http_response.headers[USAGE_HEADER] = json.dumps(captured_usage)

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -1,6 +1,7 @@
+import json
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import Depends, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
@@ -39,6 +40,7 @@ from rhesis.backend.app.services.tool.mcp import (
 )
 from rhesis.backend.app.utils.execution_validation import validate_generation_model
 from rhesis.sdk.context import EndpointContext
+from rhesis.sdk.models.providers.native import USAGE_HEADER
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +98,7 @@ def get_github_contents(repo_url: str):
 @router.post("/generate/content")
 async def generate_content_endpoint(
     request: GenerateContentRequest,
+    http_response: Response,
     db: Session = Depends(get_tenant_db_session),
     current_user: User = Depends(require_current_user_or_token),
 ):
@@ -138,6 +141,28 @@ async def generate_content_endpoint(
 
     Note: Plain JSON schemas are not supported. The schema must include the
     "type": "json_schema" wrapper with name, schema, and strict fields.
+
+    Usage forwarding: this endpoint has two kinds of caller. A developer (or
+    any HTTP client) can call it directly with their own API key -- in that
+    case `current_user` here is the real org to bill, and the normal
+    accrual wired by `get_generation_model_with_override` covers it with no
+    extra work needed. It's also reached indirectly, via `RhesisLLM` acting
+    as a relay: a self-hosted deployment's own "Rhesis Default" model
+    delegating out to this platform instance, or (for SaaS-direct
+    customers) this same deployment calling itself in a loopback. For that
+    second case, whoever originated the call already resolved the
+    *calling* org and wants its own local usage counter to reflect this
+    request too -- accrual here (against `current_user`, the delegation
+    identity) and accrual there (against the calling org) are two separate,
+    legitimate books, not a duplicate of the same one, so both proceed:
+    this handler accrues normally *and* additionally captures the usage and
+    forwards it via the ``X-Rhesis-Usage`` response header (not the body --
+    the body's contract is bare content, str or a schema-validated dict,
+    and embedding usage there would collide with dict-shaped content or
+    require a schema-breaking envelope). ``RhesisLLM.create_completion()``
+    reads that header and emits it through its own ``on_usage`` when
+    present; a direct/curl caller has no such reader and simply never sees
+    the header, which is fine -- their accrual already happened here.
     """
     try:
         from rhesis.backend.app.utils.user_model_utils import get_generation_model_with_override
@@ -146,8 +171,24 @@ async def generate_content_endpoint(
         model = get_generation_model_with_override(db, current_user)
         if isinstance(model, str):
             model = get_model(model, model_type="language")
-        response = await model.a_generate(request.prompt, schema=request.schema_)
-        return response
+
+        captured_usage: dict = {}
+        if hasattr(model, "on_usage"):
+            original_on_usage = model.on_usage
+
+            def _capture_and_forward(usage: dict) -> None:
+                captured_usage.update(usage)
+                if original_on_usage:
+                    original_on_usage(usage)
+
+            model.on_usage = _capture_and_forward
+
+        result = await model.a_generate(request.prompt, schema=request.schema_)
+
+        if captured_usage:
+            http_response.headers[USAGE_HEADER] = json.dumps(captured_usage)
+
+        return result
     except Exception as e:
         error_msg = str(e) if str(e) else "Unknown error"
         logger.error(f"Failed to generate content: {error_msg}", exc_info=True)

--- a/apps/backend/src/rhesis/backend/app/routers/usage.py
+++ b/apps/backend/src/rhesis/backend/app/routers/usage.py
@@ -1,0 +1,46 @@
+"""Usage accounting endpoint.
+
+Exposes :func:`~rhesis.backend.app.services.usage.get_usage_summary` to
+the frontend. Read-only -- no enforcement (see the `require_quota`
+dependency planned for a later sub-plan).
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.dependencies import get_current_organization, get_tenant_db_session
+from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.services.usage import get_usage_summary
+
+router = APIRouter(prefix="/usage", tags=["usage"])
+
+
+class UsageResourceItem(BaseModel):
+    used: int
+    limit: int | None
+    period_start: str
+    period_end: str
+    kind: str
+
+
+class UsageResponse(BaseModel):
+    resources: Dict[str, UsageResourceItem] = Field(default_factory=dict)
+    edition: str
+
+
+@router.get("", response_model=UsageResponse)
+def get_usage(
+    org: Organization = Depends(get_current_organization),
+    db: Session = Depends(get_tenant_db_session),
+) -> UsageResponse:
+    """Return per-resource usage, limits, and the current billing period."""
+    summary = get_usage_summary(db, str(org.id), org)
+    return UsageResponse(
+        resources={k: UsageResourceItem(**v) for k, v in summary["resources"].items()},
+        edition=summary["edition"],
+    )

--- a/apps/backend/src/rhesis/backend/app/services/test_config_generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_config_generator.py
@@ -15,7 +15,10 @@ from rhesis.backend.app import crud
 from rhesis.backend.app.config.settings import get_model_settings
 from rhesis.backend.app.schemas.services import TestConfigResponse
 from rhesis.backend.app.utils.model_errors import ModelConfigurationError
-from rhesis.backend.app.utils.user_model_utils import get_user_generation_model
+from rhesis.backend.app.utils.user_model_utils import (
+    _resolve_default_hosted_model,
+    get_user_generation_model,
+)
 from rhesis.sdk.models.factory import get_model
 
 MAX_SAMPLE_SIZE = 6
@@ -67,7 +70,15 @@ class TestConfigGeneratorService:
                 "User generation model is Polyphemus; using fast system default for test config"
             )
             try:
-                return get_model(get_model_settings().generation_model)
+                resolved = _resolve_default_hosted_model(
+                    get_model_settings().generation_model, str(self.user.organization_id)
+                )
+                if isinstance(resolved, str):
+                    # Non-hosted default string (e.g. an ops override to a
+                    # third-party provider) -- construct it the same way the
+                    # pre-existing fallback below does.
+                    return get_model(resolved)
+                return resolved
             except ValueError as e:
                 logger.warning(
                     "Fast system default unavailable for test config (Polyphemus user); "

--- a/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
@@ -28,7 +28,10 @@ from rhesis.backend.app.services.generation import (
 )
 from rhesis.backend.app.services.streaming_utils import IncrementalConfigParser, ndjson
 from rhesis.backend.app.utils.model_errors import ModelConfigurationError
-from rhesis.backend.app.utils.user_model_utils import get_user_generation_model
+from rhesis.backend.app.utils.user_model_utils import (
+    _resolve_default_hosted_model,
+    get_user_generation_model,
+)
 from rhesis.sdk.models.factory import get_model
 from rhesis.sdk.synthesizers.config_synthesizer import (
     GenerationConfig as SDKGenerationConfig,
@@ -57,7 +60,15 @@ def _resolve_config_llm(db: Session, user: User):
     if use_fast_default:
         logger.info("User generation model is Polyphemus; using fast default for pipeline config")
         try:
-            return get_model(get_model_settings().generation_model)
+            resolved = _resolve_default_hosted_model(
+                get_model_settings().generation_model, str(user.organization_id)
+            )
+            if isinstance(resolved, str):
+                # Non-hosted default string (e.g. an ops override to a
+                # third-party provider) -- construct it the same way the
+                # pre-existing fallback below does.
+                return get_model(resolved)
+            return resolved
         except ValueError:
             pass
 

--- a/apps/backend/src/rhesis/backend/app/services/usage.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage.py
@@ -1,0 +1,247 @@
+"""Usage accounting service.
+
+Tracks actual consumption per organization per :class:`QuotaResource`.
+
+Two kinds of resource:
+
+- **Flow resources** (``TEST_EXECUTIONS``, ``TEST_GENERATION``,
+  ``TRACING_SPANS``, ``MODEL_TOKENS``): cumulative counters for the
+  current calendar-month billing period, stored in the ``usage`` table
+  and incremented atomically by :func:`increment_usage`.
+- **Stock resources** (``SEATS``, ``PROJECTS``, ``ENDPOINTS``): a live
+  count of existing entities -- there is nothing to accrue or reset
+  monthly, so these are computed on read via ``count_org_*``.
+
+:func:`get_usage_summary` merges both kinds against
+:class:`~rhesis.backend.app.quota.QuotaRegistry` limits for the
+read-only ``GET /usage`` endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+from calendar import monthrange
+from datetime import date, datetime, timezone
+from typing import Optional
+
+from sqlalchemy import func
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.features import FeatureRegistry
+from rhesis.backend.app.models.endpoint import Endpoint
+from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.models.project import Project
+from rhesis.backend.app.models.usage import Usage
+from rhesis.backend.app.models.user import User
+from rhesis.backend.app.quota import QuotaRegistry, QuotaResource
+from rhesis.backend.app.scope import bypass_tenant_filter
+
+logger = logging.getLogger(__name__)
+
+_USAGE_CONFLICT_INDEX = ["organization_id", "resource", "period_start"]
+
+FLOW_KIND = "flow"
+STOCK_KIND = "stock"
+
+
+def _current_period(today: Optional[date] = None) -> tuple[date, date]:
+    """Return ``(period_start, period_end)`` for the calendar month containing *today*.
+
+    Anchored to UTC rather than the host's local date. Billing periods must
+    not depend on which timezone a worker happens to run in: with local
+    dates, a worker in UTC+13 and one in UTC-8 disagree about which month a
+    call near midnight belongs to, and would accrue against two different
+    rows for the same instant.
+    """
+    today = today or datetime.now(timezone.utc).date()
+    period_start = today.replace(day=1)
+    last_day = monthrange(today.year, today.month)[1]
+    period_end = today.replace(day=last_day)
+    return period_start, period_end
+
+
+def dispatch_accrual(
+    organization_id: Optional[str], resource: QuotaResource, amount: int = 1
+) -> None:
+    """Queue an accrual of *amount* against *resource* for *organization_id*.
+
+    **This is the only entry point call sites should use.**
+    :func:`increment_usage` is the database primitive behind it and is
+    called solely by the worker task.
+
+    Fire-and-forget, for two reasons:
+
+    - *It must not be able to break the thing it is measuring.* Accrual is
+      bookkeeping attached to some primary operation (a test run, a span
+      batch, an LLM call). Writing inline made a failed counter write fail
+      that operation -- in ``post_ingest_link`` a raised ``increment_usage``
+      was caught by the task's blanket ``except`` and retried the entire
+      body, re-dispatching enrichment for spans that had already been
+      linked. Here, a dispatch failure is logged and swallowed; the caller
+      never sees it.
+    - *It must not add latency to interactive requests.* The callback wired
+      into hosted models (see
+      ``rhesis.backend.app.utils.usage_tracking``) fires on request paths a
+      user is waiting on -- explorer suggestions, Architect chat, metric
+      evaluation. ``.delay()`` publishes a broker message and returns; the
+      connection checkout, RLS ``SET``, and upsert all happen on a worker.
+
+    A queued task also gets Celery's retry policy, which an inline write in
+    someone else's transaction never had.
+    """
+    if amount <= 0 or not organization_id:
+        return
+
+    # Imported lazily, not at module scope: `tasks/__init__.py` eagerly
+    # imports every task module, and `tasks.usage` imports this module back
+    # for `increment_usage`. A module-scope import here would be circular,
+    # and would also drag the whole Celery app graph into any request that
+    # merely touches the usage service.
+    from rhesis.backend.tasks.usage import accrue_usage
+
+    try:
+        accrue_usage.delay(str(organization_id), resource.value, amount)
+    except Exception:
+        logger.warning(
+            "Failed to queue %s accrual (amount=%s) for org %s",
+            resource.value,
+            amount,
+            organization_id,
+            exc_info=True,
+        )
+
+
+def increment_usage(
+    db: Session, org_id: Optional[str], resource: QuotaResource, amount: int = 1
+) -> None:
+    """Atomically add *amount* to the org's counter for *resource* in the current period.
+
+    The database primitive behind :func:`dispatch_accrual`, and called only
+    by the ``accrue_usage`` worker task. Call ``dispatch_accrual`` instead
+    unless you are that task: this function commits *db*, which means
+    calling it with a session borrowed from some other unit of work commits
+    that work too, and it raises on failure, which in a Celery task body
+    means retrying whatever else that task does.
+
+    A single ``INSERT ... ON CONFLICT DO UPDATE`` (upsert): creates the
+    period row with ``used = amount`` if absent, or adds *amount* to the
+    existing row if present, all in one statement. This replaced an earlier
+    UPDATE-then-fallback-INSERT design that had a real race: two workers
+    missing the UPDATE at the same instant would both attempt to create the
+    row, and the second would hit ``uq_usage_org_resource_period`` and raise
+    instead of accruing. Concurrent Celery workers accruing the same
+    org/resource/period are the normal case, not an edge case, so this needs
+    to be genuinely atomic rather than retried.
+
+    Requires the session's ``app.current_organization`` GUC to match
+    *org_id*: ``usage`` has a FORCE'd ``tenant_isolation`` RLS policy whose
+    ``USING`` clause Postgres also applies as the ``WITH CHECK`` for
+    inserts, so an unbound or mismatched scope makes this raise rather than
+    write to the wrong tenant. The task binds scope before calling.
+
+    No-ops on ``amount <= 0`` or a falsy ``org_id`` (e.g. a task whose
+    tenant context never resolved) -- silently skipping is correct here:
+    there is no organization to attribute the usage to, and casting an
+    empty string to ``uuid`` would raise.
+    """
+    if amount <= 0 or not org_id:
+        return
+
+    period_start, period_end = _current_period()
+    stmt = (
+        pg_insert(Usage.__table__)
+        .values(
+            organization_id=org_id,
+            resource=resource.value,
+            period_start=period_start,
+            period_end=period_end,
+            used=amount,
+        )
+        .on_conflict_do_update(
+            index_elements=_USAGE_CONFLICT_INDEX,
+            set_={
+                "used": Usage.__table__.c.used + amount,
+                "updated_at": func.now(),
+            },
+        )
+    )
+    db.execute(stmt)
+    db.commit()
+
+
+def _count_org_rows(db: Session, model, org_id: str, *, exclude_deleted: bool) -> int:
+    """Live ``COUNT(*)`` of *model* rows belonging to *org_id*.
+
+    Shared by the stock-resource counters below -- they differ only in
+    which model to count and whether soft-deleted rows should be excluded.
+    """
+    with bypass_tenant_filter():
+        filters = [model.organization_id == org_id]
+        if exclude_deleted:
+            filters.append(model.deleted_at.is_(None))
+        return db.query(func.count(model.id)).filter(*filters).scalar() or 0
+
+
+def count_org_seats(db: Session, org_id: str) -> int:
+    """Count users whose ``organization_id`` points to *org_id*.
+
+    Removed users have ``organization_id`` set to ``NULL`` (they become
+    orgless, not soft-deleted), so no ``deleted_at`` filter is applied.
+    """
+    return _count_org_rows(db, User, org_id, exclude_deleted=False)
+
+
+def count_org_projects(db: Session, org_id: str) -> int:
+    """Count non-deleted projects belonging to *org_id*."""
+    return _count_org_rows(db, Project, org_id, exclude_deleted=True)
+
+
+def count_org_endpoints(db: Session, org_id: str) -> int:
+    """Count non-deleted endpoints belonging to *org_id*."""
+    return _count_org_rows(db, Endpoint, org_id, exclude_deleted=True)
+
+
+_STOCK_COUNTERS = {
+    QuotaResource.SEATS: count_org_seats,
+    QuotaResource.PROJECTS: count_org_projects,
+    QuotaResource.ENDPOINTS: count_org_endpoints,
+}
+
+
+def get_usage_summary(db: Session, org_id: str, org: Optional[Organization]) -> dict:
+    """Return ``{resources: {<resource>: {used, limit, period_start, period_end, kind}}, edition}``.
+
+    Flow resources report cumulative usage from the ``usage`` table for the
+    current billing period. Stock resources report a live entity count.
+    Every :class:`QuotaResource` member is present in the response, even
+    when its usage is zero. ``kind`` (``"flow"`` or ``"stock"``) lets the
+    frontend group resources without duplicating the flow/stock split as a
+    second, hand-maintained list.
+    """
+    period_start, period_end = _current_period()
+    limits = QuotaRegistry.get_limits(org)
+
+    with bypass_tenant_filter():
+        flow_used = {
+            row.resource: row.used
+            for row in db.query(Usage).filter(
+                Usage.organization_id == org_id,
+                Usage.period_start == period_start,
+            )
+        }
+
+    resources: dict[str, dict] = {}
+    for resource in QuotaResource:
+        counter = _STOCK_COUNTERS.get(resource)
+        used = counter(db, org_id) if counter is not None else flow_used.get(resource.value, 0)
+        resources[resource.value] = {
+            "used": used,
+            "limit": limits.get(resource),
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "kind": STOCK_KIND if counter is not None else FLOW_KIND,
+        }
+
+    edition = str(FeatureRegistry.license_info(org=org).get("edition", "community"))
+    return {"resources": resources, "edition": edition}

--- a/apps/backend/src/rhesis/backend/app/utils/usage_tracking.py
+++ b/apps/backend/src/rhesis/backend/app/utils/usage_tracking.py
@@ -1,0 +1,46 @@
+"""Token-usage accrual callback for Rhesis-hosted LLM providers.
+
+Passed into hosted model constructors as ``on_usage=...`` (see
+``rhesis.sdk.models.base.BaseLLM.on_usage``), invoked wherever a provider
+parses token usage out of its own API response -- see
+``PolyphemusLLM.generate``/``generate_batch`` and ``RhesisLLM.a_generate``.
+This is the successor to an earlier design that wrapped the resolved model
+in a proxy object overriding ``generate()``/``a_generate()``: that broke
+every ``isinstance(model, BaseLLM)`` check downstream (LLM-judge metrics,
+Architect's agent loop, preflight) since the proxy was not a ``BaseLLM``
+subclass, and covered only two of the four call shapes a model exposes
+(missed ``generate_batch``, the primary bulk test-generation path). A
+constructor-supplied callback keeps the returned object a real provider
+instance -- everything downstream keeps working unchanged -- and every
+provider method that parses a usage dict already has a natural place to
+invoke it.
+
+Only applied to models resolved as *hosted* (Rhesis or Polyphemus without a
+user-supplied API key) -- see ``_is_hosted_model`` in
+``rhesis.backend.app.utils.user_model_utils``. Third-party models called
+with the org's own API key (OpenAI, Gemini, etc.) never get a callback:
+that usage is billed directly to the org by the provider, not by Rhesis.
+"""
+
+from __future__ import annotations
+
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.app.services.usage import dispatch_accrual
+from rhesis.sdk.models.base import TokenUsage, UsageCallback
+
+
+def make_usage_accrual_callback(organization_id: str) -> UsageCallback:
+    """Build an ``on_usage`` callback that accrues MODEL_TOKENS for *organization_id*.
+
+    The callback receives an already-normalized :class:`TokenUsage` -- the
+    SDK resolves each provider's spelling of "prompt tokens" before calling
+    back (see ``BaseLLM._emit_usage``), so there is no parsing to do here.
+    :func:`dispatch_accrual` queues the write on a worker and never raises,
+    which matters most on this path: unlike the Celery call sites, this
+    callback fires during interactive requests a user is waiting on.
+    """
+
+    def _on_usage(usage: TokenUsage) -> None:
+        dispatch_accrual(organization_id, QuotaResource.MODEL_TOKENS, usage["total_tokens"])
+
+    return _on_usage

--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -7,7 +7,7 @@ for different purposes (generation, evaluation, embedding, etc.)
 
 import logging
 import os
-from typing import Union
+from typing import Optional, Union
 
 from sqlalchemy.orm import Session
 
@@ -408,7 +408,7 @@ def _is_rhesis_system_model(provider: str, api_key: str) -> bool:
     return provider == "rhesis" and not api_key
 
 
-def _is_hosted_model(provider: str, api_key: str) -> bool:
+def _is_hosted_model(provider: str, api_key: Optional[str]) -> bool:
     """
     Check if a model runs on Rhesis-operated infrastructure.
 
@@ -420,7 +420,8 @@ def _is_hosted_model(provider: str, api_key: str) -> bool:
 
     Args:
         provider: The provider type value (e.g., "rhesis", "polyphemus", "openai")
-        api_key: The API key stored for the model
+        api_key: The API key stored for the model, e.g. `model_record.key`,
+            which is nullable
 
     Returns:
         True if this model's tokens should accrue against the org's

--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -15,6 +15,7 @@ from rhesis.backend.app import crud
 from rhesis.backend.app.config.settings import get_model_settings, get_rhesis_settings
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.utils.model_errors import ModelConfigurationError
+from rhesis.backend.app.utils.usage_tracking import make_usage_accrual_callback
 from rhesis.sdk.models.base import BaseEmbedder, BaseLLM
 from rhesis.sdk.models.factory import get_model
 
@@ -407,7 +408,68 @@ def _is_rhesis_system_model(provider: str, api_key: str) -> bool:
     return provider == "rhesis" and not api_key
 
 
-def _call_polyphemus_with_delegation(user: User, model_name: str, **kwargs):
+def _is_hosted_model(provider: str, api_key: str) -> bool:
+    """
+    Check if a model runs on Rhesis-operated infrastructure.
+
+    Broader than `_is_rhesis_system_model`: also covers Polyphemus without a
+    user-supplied key (SaaS delegation, or self-hosted deployments using the
+    server's own RHESIS_API_KEY). Third-party providers called with the
+    org's own API key are never "hosted" -- that usage is billed directly
+    by the provider, not by Rhesis, so it is not tracked as MODEL_TOKENS.
+
+    Args:
+        provider: The provider type value (e.g., "rhesis", "polyphemus", "openai")
+        api_key: The API key stored for the model
+
+    Returns:
+        True if this model's tokens should accrue against the org's
+        MODEL_TOKENS quota.
+    """
+    return provider in ("rhesis", "polyphemus") and not api_key
+
+
+def _resolve_default_hosted_model(default_model: str, organization_id: str) -> Union[str, BaseLLM]:
+    """
+    Instantiate the system default model with usage accrual when it names a hosted provider.
+
+    Several callers fall back to the bare `default_model` string (e.g.
+    "rhesis/rhesis-default") without ever calling `_fetch_and_configure_model`
+    -- most notably `_get_user_model` when the user has no model_id configured
+    for a purpose (execution model on a freshly onboarded org, for example).
+    Those calls would otherwise never accrue token usage, since the SDK only
+    resolves the string into an actual model instance much later (inside
+    synthesizers/agents, with no organization context available).
+
+    Construction here is cheap (no network call -- provider `__init__`s only
+    set up client config) so doing it eagerly costs nothing. On any
+    construction error (e.g. missing RHESIS_API_KEY), falls back to the bare
+    string so callers retain today's lazy-resolution behavior.
+
+    Args:
+        default_model: A "provider/model_name" string, e.g. "rhesis/rhesis-default"
+        organization_id: Org to attribute accrued tokens to
+
+    Returns:
+        A hosted-provider instance with `on_usage` wired for accrual when
+        `default_model` names a hosted provider and construction succeeds;
+        the original string otherwise.
+    """
+    provider = default_model.split("/", 1)[0] if "/" in default_model else ""
+    if provider not in ("rhesis", "polyphemus"):
+        return default_model
+
+    try:
+        return get_model(
+            default_model,
+            model_type="language",
+            on_usage=make_usage_accrual_callback(organization_id),
+        )
+    except ValueError:
+        return default_model
+
+
+def _call_polyphemus_with_delegation(user: User, model_name: str, organization_id: str, **kwargs):
     """
     Create Polyphemus client with delegation token.
 
@@ -417,10 +479,11 @@ def _call_polyphemus_with_delegation(user: User, model_name: str, **kwargs):
     Args:
         user: User on whose behalf the request is made
         model_name: Polyphemus model name (e.g., "default")
+        organization_id: Org to attribute accrued MODEL_TOKENS usage to
         **kwargs: Additional arguments to pass to PolyphemusLLM
 
     Returns:
-        Configured PolyphemusLLM instance
+        Configured PolyphemusLLM instance, with usage accrual wired
 
     Raises:
         ValueError: If user is not active or not verified
@@ -444,6 +507,7 @@ def _call_polyphemus_with_delegation(user: User, model_name: str, **kwargs):
         model_name=model_name,
         api_key=delegation_token,
         base_url=polyphemus_url,
+        on_usage=make_usage_accrual_callback(organization_id),
         **kwargs,
     )
 
@@ -473,7 +537,7 @@ def _fetch_and_configure_model(
 
     if not model or not model.provider_type:
         logger.warning("Model with id=%s not found or has no provider_type", model_id)
-        return default_model
+        return _resolve_default_hosted_model(default_model, organization_id)
 
     # Get provider configuration
     provider = model.provider_type.type_value
@@ -482,7 +546,7 @@ def _fetch_and_configure_model(
 
     # Special handling for Rhesis system models
     if _is_rhesis_system_model(provider, api_key):
-        return default_model
+        return _resolve_default_hosted_model(default_model, organization_id)
 
     # Special handling for Polyphemus models without a stored API key.
     #
@@ -498,13 +562,15 @@ def _fetch_and_configure_model(
         if get_rhesis_settings().api_key:
             logger.debug("Using configured RHESIS_API_KEY for Polyphemus (self-hosted mode)")
         elif user:
-            return _call_polyphemus_with_delegation(user, model_name)
+            return _call_polyphemus_with_delegation(user, model_name, organization_id)
 
     # Use SDK's get_model to create configured instance with error handling
     try:
         extra_params = {}
         if model.endpoint and model.endpoint.strip():
             extra_params["api_base"] = model.endpoint.strip()
+        if _is_hosted_model(provider, api_key):
+            extra_params["on_usage"] = make_usage_accrual_callback(organization_id)
         return get_model(
             provider=provider,
             model_name=model_name,
@@ -580,7 +646,7 @@ def _get_user_model(
     model_id = model_settings.model_id
 
     if not model_id:
-        return default_model
+        return _resolve_default_hosted_model(default_model, str(user.organization_id))
 
     return _fetch_and_configure_model(
         db=db,

--- a/apps/backend/src/rhesis/backend/metrics/strategies/local.py
+++ b/apps/backend/src/rhesis/backend/metrics/strategies/local.py
@@ -662,13 +662,21 @@ def _resolve_metric_model(
         )
 
         if model_record and model_record.provider_type:
+            from rhesis.backend.app.utils.usage_tracking import make_usage_accrual_callback
+            from rhesis.backend.app.utils.user_model_utils import _is_hosted_model
+
+            provider = model_record.provider_type.type_value
+            api_key = model_record.key
+
             extra_params = {}
             if model_record.endpoint and model_record.endpoint.strip():
                 extra_params["api_base"] = model_record.endpoint.strip()
+            if organization_id and _is_hosted_model(provider, api_key):
+                extra_params["on_usage"] = make_usage_accrual_callback(organization_id)
             llm = get_model(
-                provider=model_record.provider_type.type_value,
+                provider=provider,
                 model_name=model_record.model_name,
-                api_key=model_record.key,
+                api_key=api_key,
                 **extra_params,
             )
             logger.info(

--- a/apps/backend/src/rhesis/backend/tasks/__init__.py
+++ b/apps/backend/src/rhesis/backend/tasks/__init__.py
@@ -17,6 +17,7 @@ from rhesis.backend.tasks import (
     task_notifications,  # noqa: F401
     test_configuration,  # noqa: F401
     test_set,  # noqa: F401
+    usage,  # noqa: F401
 )
 from rhesis.backend.tasks.base import (
     BaseTask,
@@ -49,6 +50,7 @@ from rhesis.backend.tasks.example_task import (
 from rhesis.backend.tasks.execution.results import collect_results
 from rhesis.backend.tasks.test_configuration import execute_test_configuration
 from rhesis.backend.tasks.test_set import count_test_sets
+from rhesis.backend.tasks.usage import accrue_usage
 from rhesis.backend.tasks.utils import increment_test_run_progress
 
 logger = logging.getLogger(__name__)
@@ -83,6 +85,7 @@ __all__ = [
     "manual_db_example",
     "email_notification_test",
     "process_data",
+    "accrue_usage",
     # Constants
     "DEFAULT_METRIC_WORKERS",
     "DEFAULT_RESULT_STATUS",

--- a/apps/backend/src/rhesis/backend/tasks/telemetry/post_ingest.py
+++ b/apps/backend/src/rhesis/backend/tasks/telemetry/post_ingest.py
@@ -14,6 +14,8 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models
 from rhesis.backend.app.database import SessionLocal, bind_scope_to_session
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.app.services.usage import dispatch_accrual
 from rhesis.backend.celery.core import app
 
 logger = logging.getLogger(__name__)
@@ -143,6 +145,19 @@ def post_ingest_link(
                     logger.warning(
                         f"Failed to enqueue enrichment for trace {trace_id}: {enrich_error}"
                     )
+
+        # Accrue on definite success, not at the top of the function: this
+        # task retries the *entire* body on exception (see the except block
+        # below), so accruing early would double- (or triple-) count a
+        # batch that fails after linking but succeeds on retry. Placed here,
+        # accrual fires exactly once per successfully processed batch.
+        # Counts stored_spans (rows actually found/persisted), not
+        # stored_span_ids (ids requested -- some may not exist).
+        #
+        # Queued rather than written on `db`: a raised counter write inside
+        # this try block would be caught below and retry the whole body,
+        # re-dispatching enrichment for spans already linked above.
+        dispatch_accrual(organization_id, QuotaResource.TRACING_SPANS, len(stored_spans))
 
         return {
             "status": "success",

--- a/apps/backend/src/rhesis/backend/tasks/test_configuration.py
+++ b/apps/backend/src/rhesis/backend/tasks/test_configuration.py
@@ -7,6 +7,8 @@ from uuid import UUID
 
 from rhesis.backend.app import crud
 from rhesis.backend.app.database import get_db_with_tenant_variables
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.app.services.usage import dispatch_accrual
 from rhesis.backend.celery.core import app
 from rhesis.backend.tasks.base import SilentTask
 from rhesis.backend.tasks.enums import RunStatus
@@ -154,6 +156,16 @@ def execute_test_configuration(self, test_configuration_id: str, test_run_id: st
                 test_run,
                 reference_test_run_id=reference_test_run_id,
             )
+
+            # Accrue TEST_EXECUTIONS for the count actually processed by this
+            # run -- result["total_tests"] is computed once at the start of
+            # execute_test_cases from the same tests list it iterates, so it
+            # reflects what was billed for, not what the test set currently
+            # contains. Re-querying the test set's live count here instead
+            # would open a window between execution and accrual: tests
+            # added or removed from the set mid-run would shift what gets
+            # billed away from what was actually executed.
+            dispatch_accrual(org_id, QuotaResource.TEST_EXECUTIONS, result.get("total_tests", 0))
 
         # Use utility to create standardized result
         # Remove test_run_id from result if present to avoid duplicate parameter

--- a/apps/backend/src/rhesis/backend/tasks/test_set.py
+++ b/apps/backend/src/rhesis/backend/tasks/test_set.py
@@ -5,6 +5,7 @@ from rhesis.backend.app import crud
 from rhesis.backend.app.constants import TestSetType
 from rhesis.backend.app.database import get_db_with_tenant_variables
 from rhesis.backend.app.models.test_set import TestSet
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.schemas.services import GenerationConfig, SourceData
 from rhesis.backend.app.services.test import bulk_create_tests
 from rhesis.backend.app.services.test_set import (
@@ -12,6 +13,7 @@ from rhesis.backend.app.services.test_set import (
     generate_test_set_attributes,
     load_defaults,
 )
+from rhesis.backend.app.services.usage import dispatch_accrual
 from rhesis.backend.app.utils.user_model_utils import (
     get_generation_model_with_override,
 )
@@ -566,6 +568,12 @@ def generate_and_save_test_set(
             org_id,
             user_id,
         )
+
+        # No session needed here any more -- the accrual is queued and the
+        # worker task opens its own. dispatch_accrual no-ops on a count of
+        # zero, so the guard that used to protect the session checkout is
+        # gone too.
+        dispatch_accrual(org_id, QuotaResource.TEST_GENERATION, len(test_set.tests))
 
         self.log_with_context(
             "info",

--- a/apps/backend/src/rhesis/backend/tasks/usage.py
+++ b/apps/backend/src/rhesis/backend/tasks/usage.py
@@ -1,0 +1,52 @@
+"""Celery task that performs usage accrual off the caller's path.
+
+One task for every :class:`QuotaResource`, not one per resource: the work
+is identical in each case (bind tenant scope, upsert a counter), only the
+resource name and amount differ. Always reached via
+``app.services.usage.dispatch_accrual`` -- see that function for why
+accrual is queued rather than written inline by its callers.
+"""
+
+import logging
+
+from rhesis.backend.app.database import SessionLocal, bind_scope_to_session
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.app.services.usage import increment_usage
+from rhesis.backend.celery.core import app
+
+logger = logging.getLogger(__name__)
+
+
+@app.task(bind=True, max_retries=3, default_retry_delay=30)
+def accrue_usage(self, organization_id: str, resource: str, amount: int) -> None:
+    """Add *amount* to *organization_id*'s counter for *resource*.
+
+    *resource* arrives as a plain string because task arguments are JSON
+    over the broker; it is converted back to :class:`QuotaResource` here so
+    an unknown value fails loudly instead of quietly creating a counter
+    nobody reads. That conversion sits outside the retry block on purpose:
+    a bad resource name is a programming error, and retrying it three times
+    will not make it a good one.
+    """
+    quota_resource = QuotaResource(resource)
+
+    db = SessionLocal()
+    try:
+        # This task owns its session for its whole lifetime, so scope is
+        # bound onto it directly rather than through a request-scoped
+        # context manager. Required, not merely tidy: the `usage` table's
+        # FORCE'd `tenant_isolation` RLS policy rejects the upsert outright
+        # when `app.current_organization` is unset.
+        bind_scope_to_session(db, organization_id)
+        increment_usage(db, organization_id, quota_resource, amount)
+    except Exception as e:
+        logger.warning(
+            "Failed to accrue %s usage (amount=%s) for org %s",
+            resource,
+            amount,
+            organization_id,
+            exc_info=True,
+        )
+        raise self.retry(exc=e)
+    finally:
+        db.close()

--- a/ee/backend/src/rhesis/backend/ee/licensing/tier_config.yaml
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tier_config.yaml
@@ -13,7 +13,7 @@ community:
     test_executions: 1000
     tracing_spans: 50000
     test_generation: 500
-    hosted_model_tokens: 5000000
+    model_tokens: 5000000
     seats: 3
     projects: 1
     endpoints: 1
@@ -28,7 +28,7 @@ team:
     test_executions: 100000
     tracing_spans: 5000000
     test_generation: 50000
-    hosted_model_tokens: 250000000
+    model_tokens: 250000000
     seats: null
     projects: null
     endpoints: null
@@ -42,7 +42,7 @@ enterprise: &unlimited_tier
     test_executions: null
     tracing_spans: null
     test_generation: null
-    hosted_model_tokens: null
+    model_tokens: null
     seats: null
     projects: null
     endpoints: null

--- a/sdk/src/rhesis/sdk/models/base.py
+++ b/sdk/src/rhesis/sdk/models/base.py
@@ -1,11 +1,80 @@
+import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, AsyncGenerator, AsyncIterator, Dict, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    TypedDict,
+    Union,
+)
 
 from rhesis.sdk.async_utils import run_sync
 from rhesis.sdk.models.utils import llm_retry
 
 if TYPE_CHECKING:
     from rhesis.sdk.entities.model import Model
+
+logger = logging.getLogger(__name__)
+
+
+class TokenUsage(TypedDict):
+    """Token counts for one LLM call, normalized across providers.
+
+    Field names follow the OpenAI Responses API ``usage`` object, which is
+    also what OpenTelemetry's GenAI semantic conventions use
+    (``gen_ai.usage.input_tokens`` / ``gen_ai.usage.output_tokens``).
+    Providers report these under a dozen different spellings
+    (``prompt_tokens``, ``prompt_token_count``, ``promptTokenCount``, ...);
+    :func:`_normalize_usage` maps all of them onto these three keys so
+    consumers never have to guess which dialect a provider speaks.
+    """
+
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+
+
+UsageCallback = Callable[[TokenUsage], None]
+
+
+def _normalize_usage(usage: Any) -> Optional[TokenUsage]:
+    """Parse a provider's raw usage payload into a :class:`TokenUsage`.
+
+    Returns ``None`` when there is nothing worth reporting (no payload, or
+    a payload that yields zero total tokens), so callers can treat the
+    result as a simple "emit or skip" decision.
+
+    Delegates the actual key-name matching to
+    :func:`~rhesis.sdk.telemetry.utils.token_extraction.extract_token_usage`,
+    which already handles every provider dialect and is used by the
+    LangChain tracing integration -- there is no reason for the accrual
+    path to grow a second, thinner copy of that logic. Imported lazily
+    because ``rhesis.sdk.telemetry`` builds the OTel tracer and exporter
+    on package init, and this module is on the import path of every SDK
+    user; the ``on_usage is None`` guard in the callers means the import
+    only ever happens for callers that actually wired up accrual.
+    """
+    if not usage:
+        return None
+
+    from rhesis.sdk.telemetry.utils.token_extraction import extract_token_usage
+
+    input_tokens, output_tokens, total_tokens = extract_token_usage(usage)
+    if not total_tokens:
+        return None
+
+    return TokenUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+    )
+
 
 # Type alias for embeddings
 Embedding = List[float]
@@ -80,10 +149,32 @@ class BaseModel(ABC):
 class BaseLLM(BaseModel):
     MODEL_TYPE = "language"
 
-    def __init__(self, model_name, *args, **kwargs):
+    def __init__(
+        self,
+        model_name,
+        *args,
+        on_usage: Optional[UsageCallback] = None,
+        **kwargs,
+    ):
+        # `on_usage` is consumed here (keyword-only, not absorbed into
+        # `**kwargs`) so it never reaches `load_model(*args, **kwargs)` --
+        # provider `load_model()` implementations take no such parameter and
+        # would raise TypeError if it leaked through.
         super().__init__(model_name, *args, **kwargs)
         self.model = self.load_model(*args, **kwargs)
         self.a_generate = llm_retry(self.a_generate)
+
+        # Optional callback invoked with a normalized :class:`TokenUsage` at
+        # the point a provider parses usage out of its API response --
+        # inline, in the same call, rather than stashed on a shared attribute
+        # for an external caller to poll afterward. That side-channel-attribute
+        # design was tried and dropped: concurrent calls against one instance
+        # (agents, batch executors) would race on it, and wrapping the
+        # instance to intercept generate()/a_generate() broke every
+        # ``isinstance(model, BaseLLM)`` check elsewhere in the stack. A
+        # constructor-supplied callback keeps the returned object a real
+        # provider instance and each call's usage local to its own stack frame.
+        self.on_usage = on_usage
 
         # # Only wrap generate with sync retry if the subclass overrides it.
         # # The base generate() delegates to a_generate() which already has
@@ -99,6 +190,60 @@ class BaseLLM(BaseModel):
             A model object
         """
         pass
+
+    def _emit_usage(self, usage: Optional[Dict[str, Any]]) -> None:
+        """Invoke ``on_usage`` with normalized token counts for one call.
+
+        Providers call this at the exact point they parse ``usage`` out of a
+        raw API response -- see ``PolyphemusLLM.generate`` and
+        ``RhesisLLM.create_completion`` for call sites. The raw payload is
+        run through :func:`_normalize_usage` first, so a provider that
+        reports only ``prompt_tokens``/``completion_tokens`` (no
+        ``total_tokens``) still accrues correctly instead of being silently
+        dropped.
+        """
+        if self.on_usage is None:
+            return
+        normalized = _normalize_usage(usage)
+        if normalized is not None:
+            self._invoke_on_usage(normalized)
+
+    def _emit_usage_batch(self, usages: Iterable[Optional[Dict[str, Any]]]) -> None:
+        """Sum usage across a batch's items and invoke ``on_usage`` once.
+
+        One aggregate emission rather than one per item: the callback
+        typically queues a durable write (see
+        ``rhesis.backend.app.services.usage.dispatch_accrual``), and a batch
+        of N prompts should cost one of those, not N. Items with no usage
+        payload contribute nothing.
+        """
+        if self.on_usage is None:
+            return
+
+        totals = TokenUsage(input_tokens=0, output_tokens=0, total_tokens=0)
+        for usage in usages:
+            normalized = _normalize_usage(usage)
+            if normalized is None:
+                continue
+            for key in totals:
+                totals[key] += normalized[key]  # type: ignore[literal-required]
+
+        if totals["total_tokens"]:
+            self._invoke_on_usage(totals)
+
+    def _invoke_on_usage(self, usage: TokenUsage) -> None:
+        """Call ``on_usage``, swallowing anything it raises.
+
+        ``on_usage`` is caller-supplied (e.g. a closure that queues a usage
+        accrual -- see
+        ``rhesis.backend.app.utils.usage_tracking.make_usage_accrual_callback``),
+        and a broken accrual callback must never break the LLM call that
+        produced the usage.
+        """
+        try:
+            self.on_usage(usage)  # type: ignore[misc]
+        except Exception:
+            logger.warning("on_usage callback raised; usage not recorded", exc_info=True)
 
     def generate(self, *args, **kwargs) -> Union[str, Dict[str, Any]]:
         """Runs the model to output LLM response.

--- a/sdk/src/rhesis/sdk/models/providers/native.py
+++ b/sdk/src/rhesis/sdk/models/providers/native.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import os
 import time
@@ -24,6 +25,16 @@ DEFAULT_LANGUAGE_MODEL_NAME = model_name_from_id(DEFAULT_MODEL)
 DEFAULT_EMBEDDING_MODEL_NAME = model_name_from_id(DEFAULT_EMBEDDING_MODELS["rhesis"])
 API_ENDPOINT = "services/generate/content"
 DEFAULT_REQUEST_TIMEOUT = DEFAULT_LLM_TIMEOUT  # 5 minutes
+
+# Response header carrying the token usage for a `services/generate/content`
+# call, as a JSON object using the field names of `BaseLLM`'s TokenUsage.
+# Usage travels out-of-band because that endpoint's body contract is bare
+# content (a str, or a schema-validated dict) with no envelope to put a
+# sibling `usage` field in, the way an OpenAI-compatible response would.
+# Defined here, next to API_ENDPOINT, because this module owns the client
+# half of that wire contract; the server half imports this same constant
+# (see `rhesis.backend.app.routers.services.generate_content_endpoint`).
+USAGE_HEADER = "X-Rhesis-Usage"
 
 
 class RhesisLLM(BaseLLM):
@@ -100,6 +111,11 @@ class RhesisLLM(BaseLLM):
             if system_prompt:
                 combined_prompt = f"{system_prompt}\n\n{prompt}"
 
+            # Usage is emitted inside create_completion() from USAGE_HEADER,
+            # not read off `result`: this endpoint returns bare content, so a
+            # dict result is the caller's own schema-validated payload. A
+            # `usage` key in there belongs to their schema and must not be
+            # mistaken for token counts.
             return await self.create_completion(
                 prompt=combined_prompt,
                 schema=schema,
@@ -213,6 +229,18 @@ class RhesisLLM(BaseLLM):
                     "[RhesisLLM] HTTP 200 in %.1fs",
                     request_elapsed,
                 )
+
+                # This deployment is acting as a relay: the platform side ran
+                # the model and reported what it cost via USAGE_HEADER, so
+                # the calling org's own counter reflects the call too.
+                # Emitted here rather than in a_generate() because this is
+                # the one place with access to the raw response headers.
+                usage_header = response.headers.get(USAGE_HEADER)
+                if usage_header:
+                    try:
+                        self._emit_usage(json.loads(usage_header))
+                    except (json.JSONDecodeError, TypeError):
+                        logger.warning("[RhesisLLM] Malformed %s header, ignoring", USAGE_HEADER)
 
                 result: Dict[str, Any] = await response.json()
                 return result

--- a/sdk/src/rhesis/sdk/models/providers/polyphemus.py
+++ b/sdk/src/rhesis/sdk/models/providers/polyphemus.py
@@ -125,6 +125,8 @@ class PolyphemusLLM(BaseLLM):
                 **kwargs,
             )
 
+            self._emit_usage(response.get("usage"))
+
             # Extract the assistant's message content from the response
             if "choices" in response and len(response["choices"]) > 0:
                 content = response["choices"][0]["message"]["content"]
@@ -235,7 +237,10 @@ class PolyphemusLLM(BaseLLM):
             )
 
         results: List[Any] = []
+        batch_usage: List[Any] = []
         for item in batch_response.get("responses", []):
+            batch_usage.append(item.get("usage"))
+
             if item.get("error"):
                 results.append(err_placeholder(str(item["error"])))
                 continue
@@ -259,6 +264,14 @@ class PolyphemusLLM(BaseLLM):
                 if not include_reasoning:
                     content = self._strip_reasoning_tokens(content)
                 results.append(content)
+
+        # One aggregate accrual for the whole batch, rather than per-item.
+        # Summing is left to _emit_usage_batch so each item's payload goes
+        # through the same provider-agnostic normalization as a single call:
+        # reading item["usage"]["total_tokens"] directly here used to drop
+        # the whole item whenever the server reported only prompt/completion
+        # counts.
+        self._emit_usage_batch(batch_usage)
 
         # Guarantee result list length matches input length.
         # Fill any missing items (server returned fewer than requested).

--- a/tests/backend/app/test_usage_tracking.py
+++ b/tests/backend/app/test_usage_tracking.py
@@ -1,0 +1,88 @@
+"""Unit tests for :mod:`rhesis.backend.app.utils.usage_tracking`.
+
+Pure unit tests -- no database, no Docker, no Celery broker. The task's
+`.delay()` is monkeypatched so these verify dispatch behavior in isolation
+from the real Celery app and the usage-accounting service.
+
+The callback is only ever handed an already-normalized ``TokenUsage`` by
+``BaseLLM._emit_usage``, which also drops empty/zero payloads before they
+get here. Provider-dialect parsing is therefore tested at that boundary
+(``tests/sdk/models/test_base_usage.py``), not in this file.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rhesis.backend.app.quota import QuotaResource
+
+
+@pytest.fixture
+def fake_delay(monkeypatch):
+    """Capture calls to accrue_usage.delay(...) without a broker."""
+    recorded = []
+    monkeypatch.setattr(
+        "rhesis.backend.tasks.usage.accrue_usage.delay",
+        lambda *args, **kwargs: recorded.append(args),
+    )
+    return recorded
+
+
+def _usage(total: int) -> dict:
+    return {"input_tokens": 1, "output_tokens": total - 1, "total_tokens": total}
+
+
+class TestMakeUsageAccrualCallback:
+    def test_dispatches_model_tokens_accrual(self, fake_delay):
+        from rhesis.backend.app.utils.usage_tracking import make_usage_accrual_callback
+
+        make_usage_accrual_callback("org-1")(_usage(123))
+
+        assert fake_delay == [("org-1", QuotaResource.MODEL_TOKENS.value, 123)]
+
+    def test_dispatch_failure_is_swallowed(self, monkeypatch):
+        """A broker outage (or any dispatch error) must never raise back
+        into the LLM call site."""
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("broker unreachable")
+
+        monkeypatch.setattr("rhesis.backend.tasks.usage.accrue_usage.delay", boom)
+
+        from rhesis.backend.app.utils.usage_tracking import make_usage_accrual_callback
+
+        # Must not raise.
+        make_usage_accrual_callback("org-1")(_usage(10))
+
+    def test_each_callback_uses_its_own_org_id(self, fake_delay):
+        """Separate callbacks (e.g. two different orgs' models in the same
+        process) never cross-contaminate -- organization_id is closed over
+        per callback, not read from shared/global state."""
+        from rhesis.backend.app.utils.usage_tracking import make_usage_accrual_callback
+
+        make_usage_accrual_callback("org-a")(_usage(2))
+        make_usage_accrual_callback("org-b")(_usage(3))
+
+        assert fake_delay == [
+            ("org-a", QuotaResource.MODEL_TOKENS.value, 2),
+            ("org-b", QuotaResource.MODEL_TOKENS.value, 3),
+        ]
+
+    def test_does_not_touch_the_database_synchronously(self, monkeypatch):
+        """The whole point of queueing instead of writing inline: no
+        SessionLocal() / DB call happens in the calling thread."""
+        called = []
+        monkeypatch.setattr(
+            "rhesis.backend.app.database.SessionLocal",
+            lambda: called.append(True),
+        )
+        monkeypatch.setattr(
+            "rhesis.backend.tasks.usage.accrue_usage.delay",
+            lambda *a, **k: None,
+        )
+
+        from rhesis.backend.app.utils.usage_tracking import make_usage_accrual_callback
+
+        make_usage_accrual_callback("org-1")(_usage(10))
+
+        assert called == []

--- a/tests/backend/routes/test_services.py
+++ b/tests/backend/routes/test_services.py
@@ -1,7 +1,8 @@
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Response
 
 from rhesis.backend.app.routers.services import generate_content_endpoint
 from rhesis.backend.app.schemas.services import GenerateContentRequest
@@ -22,6 +23,7 @@ class TestGenerateContentEndpoint:
         expected_response = {"code": "def test_function():\n    return True"}
         mock_db = MagicMock()
         mock_user = MagicMock()
+        http_response = Response()
 
         with patch(
             "rhesis.backend.app.utils.user_model_utils.get_generation_model_with_override"
@@ -31,7 +33,7 @@ class TestGenerateContentEndpoint:
             mock_get_gen.return_value = mock_model
 
             result = await generate_content_endpoint(
-                mock_request, db=mock_db, current_user=mock_user
+                mock_request, http_response, db=mock_db, current_user=mock_user
             )
 
             assert result == expected_response
@@ -51,6 +53,7 @@ class TestGenerateContentEndpoint:
         )
         mock_db = MagicMock()
         mock_user = MagicMock()
+        http_response = Response()
 
         with patch(
             "rhesis.backend.app.utils.user_model_utils.get_generation_model_with_override"
@@ -60,9 +63,101 @@ class TestGenerateContentEndpoint:
             # Act & Assert
             with pytest.raises(HTTPException) as exc_info:
                 await generate_content_endpoint(
-                    mock_request, db=mock_db, current_user=mock_user
+                    mock_request, http_response, db=mock_db, current_user=mock_user
                 )
 
             assert exc_info.value.status_code == 400
             assert "Failed to generate content:" in str(exc_info.value.detail)
             assert "Model initialization failed" in str(exc_info.value.detail)
+
+
+class TestGenerateContentEndpointUsageForwarding:
+    """`X-Rhesis-Usage` header forwarding -- see generate_content_endpoint's
+    docstring. The resolved model's on_usage (if any) must still fire
+    normally (covers a direct/curl caller authenticated as current_user),
+    *and* the same usage must be captured and forwarded via the response
+    header (covers a relaying RhesisLLM instance accruing on its own side).
+    """
+
+    @pytest.mark.asyncio
+    async def test_forwards_captured_usage_via_header_and_still_calls_original_on_usage(self):
+        mock_request = GenerateContentRequest(prompt="hello")
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+        http_response = Response()
+
+        original_on_usage_calls = []
+
+        with patch(
+            "rhesis.backend.app.utils.user_model_utils.get_generation_model_with_override"
+        ) as mock_get_gen:
+            mock_model = MagicMock()
+            mock_model.on_usage = lambda usage: original_on_usage_calls.append(usage)
+
+            async def fake_a_generate(*args, **kwargs):
+                mock_model.on_usage({"total_tokens": 42})
+                return "hi there"
+
+            mock_model.a_generate = fake_a_generate
+            mock_get_gen.return_value = mock_model
+
+            result = await generate_content_endpoint(
+                mock_request, http_response, db=mock_db, current_user=mock_user
+            )
+
+            assert result == "hi there"
+            # The platform's own accrual (current_user's org) still fires --
+            # covers a direct/curl caller with no relay to forward to.
+            assert original_on_usage_calls == [{"total_tokens": 42}]
+            # And the same usage is also forwarded for a relaying caller.
+            assert json.loads(http_response.headers["X-Rhesis-Usage"]) == {"total_tokens": 42}
+
+    @pytest.mark.asyncio
+    async def test_no_usage_emitted_means_no_header(self):
+        mock_request = GenerateContentRequest(prompt="hello")
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+        http_response = Response()
+
+        with patch(
+            "rhesis.backend.app.utils.user_model_utils.get_generation_model_with_override"
+        ) as mock_get_gen:
+            mock_model = MagicMock()
+            mock_model.on_usage = None
+            mock_model.a_generate = AsyncMock(return_value="hi there")
+            mock_get_gen.return_value = mock_model
+
+            await generate_content_endpoint(
+                mock_request, http_response, db=mock_db, current_user=mock_user
+            )
+
+            assert "X-Rhesis-Usage" not in http_response.headers
+
+    @pytest.mark.asyncio
+    async def test_string_model_from_get_model_has_no_on_usage_and_is_not_wrapped(self):
+        """A bare-string model resolution (get_model() fallback path) is
+        constructed without on_usage wiring -- hasattr guards against
+        AttributeError, and no header is ever set for that case."""
+        mock_request = GenerateContentRequest(prompt="hello")
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+        http_response = Response()
+
+        with (
+            patch(
+                "rhesis.backend.app.utils.user_model_utils.get_generation_model_with_override"
+            ) as mock_get_gen,
+            patch("rhesis.sdk.models.factory.get_model") as mock_sdk_get_model,
+        ):
+            mock_get_gen.return_value = "openai/gpt-4o"
+
+            mock_model = MagicMock(spec=["a_generate"])
+            mock_model.a_generate = AsyncMock(return_value="hi there")
+            mock_sdk_get_model.return_value = mock_model
+
+            result = await generate_content_endpoint(
+                mock_request, http_response, db=mock_db, current_user=mock_user
+            )
+
+            assert result == "hi there"
+            assert "X-Rhesis-Usage" not in http_response.headers

--- a/tests/backend/routes/test_services.py
+++ b/tests/backend/routes/test_services.py
@@ -161,3 +161,87 @@ class TestGenerateContentEndpointUsageForwarding:
 
             assert result == "hi there"
             assert "X-Rhesis-Usage" not in http_response.headers
+
+    @pytest.mark.asyncio
+    async def test_sums_usage_across_multiple_emissions_in_one_call(self):
+        """`captured_usage` must accumulate, not `dict.update()`: a model
+        that emits on_usage more than once in a single a_generate() call
+        (e.g. a future streaming provider) must not have its earlier
+        emission overwritten by a later, smaller one."""
+        mock_request = GenerateContentRequest(prompt="hello")
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+        http_response = Response()
+
+        with patch(
+            "rhesis.backend.app.utils.user_model_utils.get_generation_model_with_override"
+        ) as mock_get_gen:
+            mock_model = MagicMock()
+            mock_model.on_usage = None
+
+            async def fake_a_generate(*args, **kwargs):
+                mock_model.on_usage({"total_tokens": 10})
+                mock_model.on_usage({"total_tokens": 5})
+                return "hi there"
+
+            mock_model.a_generate = fake_a_generate
+            mock_get_gen.return_value = mock_model
+
+            await generate_content_endpoint(
+                mock_request, http_response, db=mock_db, current_user=mock_user
+            )
+
+            assert json.loads(http_response.headers["X-Rhesis-Usage"]) == {"total_tokens": 15}
+
+    @pytest.mark.asyncio
+    async def test_restores_original_on_usage_after_the_call(self):
+        """The override must not leak past this request: a model that
+        outlives the request (e.g. a future caching layer) must be left
+        with its original callback, not a closure over this request's
+        now-stale captured_usage dict."""
+        mock_request = GenerateContentRequest(prompt="hello")
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+        http_response = Response()
+
+        def original_callback(usage):
+            pass
+
+        with patch(
+            "rhesis.backend.app.utils.user_model_utils.get_generation_model_with_override"
+        ) as mock_get_gen:
+            mock_model = MagicMock()
+            mock_model.on_usage = original_callback
+            mock_model.a_generate = AsyncMock(return_value="hi there")
+            mock_get_gen.return_value = mock_model
+
+            await generate_content_endpoint(
+                mock_request, http_response, db=mock_db, current_user=mock_user
+            )
+
+            assert mock_model.on_usage is original_callback
+
+    @pytest.mark.asyncio
+    async def test_restores_original_on_usage_even_if_a_generate_raises(self):
+        mock_request = GenerateContentRequest(prompt="hello")
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+        http_response = Response()
+
+        def original_callback(usage):
+            pass
+
+        with patch(
+            "rhesis.backend.app.utils.user_model_utils.get_generation_model_with_override"
+        ) as mock_get_gen:
+            mock_model = MagicMock()
+            mock_model.on_usage = original_callback
+            mock_model.a_generate = AsyncMock(side_effect=RuntimeError("boom"))
+            mock_get_gen.return_value = mock_model
+
+            with pytest.raises(HTTPException):
+                await generate_content_endpoint(
+                    mock_request, http_response, db=mock_db, current_user=mock_user
+                )
+
+            assert mock_model.on_usage is original_callback

--- a/tests/backend/routes/test_usage.py
+++ b/tests/backend/routes/test_usage.py
@@ -1,0 +1,77 @@
+"""Integration tests for the ``GET /usage`` endpoint.
+
+Unlike ``GET /features`` (which only touches in-memory registries),
+``GET /usage`` queries the real `usage` table plus live stock-resource
+counts, so these tests use ``authenticated_client`` (a real DB-backed
+session under savepoint isolation) rather than mocked dependencies.
+"""
+
+from __future__ import annotations
+
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.app.services.usage import increment_usage
+
+
+class TestUsageEndpoint:
+    def test_requires_authentication(self, client: TestClient):
+        response = client.get("/usage")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_returns_200_for_authenticated_user(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage")
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_response_shape_is_stable(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage")
+        body = response.json()
+
+        assert set(body.keys()) == {"resources", "edition"}
+        assert isinstance(body["resources"], dict)
+        assert isinstance(body["edition"], str)
+
+    def test_includes_every_quota_resource(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage")
+        body = response.json()
+
+        assert set(body["resources"].keys()) == {r.value for r in QuotaResource}
+
+    def test_each_resource_item_shape(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage")
+        body = response.json()
+
+        for item in body["resources"].values():
+            assert set(item.keys()) == {"used", "limit", "period_start", "period_end", "kind"}
+            assert isinstance(item["used"], int)
+            assert item["kind"] in ("flow", "stock")
+
+    def test_kind_matches_stock_vs_flow_resource(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage")
+        body = response.json()
+
+        stock_resources = {
+            QuotaResource.SEATS.value,
+            QuotaResource.PROJECTS.value,
+            QuotaResource.ENDPOINTS.value,
+        }
+        for resource_value, item in body["resources"].items():
+            expected_kind = "stock" if resource_value in stock_resources else "flow"
+            assert item["kind"] == expected_kind
+
+    def test_reflects_accrued_flow_usage(
+        self, authenticated_client: TestClient, test_db, test_org_id
+    ):
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 7)
+
+        response = authenticated_client.get("/usage")
+        body = response.json()
+
+        assert body["resources"][QuotaResource.TEST_EXECUTIONS.value]["used"] == 7
+
+    def test_reflects_live_stock_count(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage")
+        body = response.json()
+
+        assert body["resources"][QuotaResource.SEATS.value]["used"] >= 1

--- a/tests/backend/services/test_usage.py
+++ b/tests/backend/services/test_usage.py
@@ -1,0 +1,236 @@
+"""Tests for rhesis.backend.app.services.usage.
+
+Flow-resource tests exercise the real `usage` table via `test_db` (a
+Postgres-backed session, isolated per test via SAVEPOINT rollback -- see
+tests/backend/fixtures/database.py). Stock-resource tests create Project/
+Endpoint rows directly against the same session.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+from rhesis.backend.app.models.endpoint import Endpoint
+from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.models.project import Project
+from rhesis.backend.app.models.usage import Usage
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.app.services.usage import (
+    _current_period,
+    count_org_endpoints,
+    count_org_projects,
+    count_org_seats,
+    dispatch_accrual,
+    get_usage_summary,
+    increment_usage,
+)
+
+
+class TestCurrentPeriod:
+    def test_returns_first_and_last_day_of_month(self):
+        start, end = _current_period(date(2026, 2, 10))
+        assert start == date(2026, 2, 1)
+        assert end == date(2026, 2, 28)
+
+    def test_handles_leap_year(self):
+        _, end = _current_period(date(2024, 2, 10))
+        assert end == date(2024, 2, 29)
+
+    def test_handles_31_day_month(self):
+        _, end = _current_period(date(2026, 1, 15))
+        assert end == date(2026, 1, 31)
+
+    def test_defaults_to_the_utc_date_not_the_local_one(self):
+        """Billing periods are UTC-anchored so workers in different
+        timezones agree on which month a call belongs to."""
+        start, end = _current_period()
+        utc_today = datetime.now(timezone.utc).date()
+
+        assert start == utc_today.replace(day=1)
+        assert end.month == utc_today.month
+
+
+class TestDispatchAccrual:
+    """`dispatch_accrual` is the only entry point call sites use. It queues
+    the write and must never raise back into the operation it measures."""
+
+    @pytest.fixture
+    def fake_delay(self, monkeypatch):
+        recorded = []
+        monkeypatch.setattr(
+            "rhesis.backend.tasks.usage.accrue_usage.delay",
+            lambda *args: recorded.append(args),
+        )
+        return recorded
+
+    def test_queues_the_task_with_the_resource_as_a_string(self, fake_delay):
+        dispatch_accrual("org-1", QuotaResource.TEST_EXECUTIONS, 12)
+
+        assert fake_delay == [("org-1", "test_executions", 12)]
+
+    def test_defaults_to_one(self, fake_delay):
+        dispatch_accrual("org-1", QuotaResource.TEST_EXECUTIONS)
+
+        assert fake_delay == [("org-1", "test_executions", 1)]
+
+    @pytest.mark.parametrize("amount", [0, -5])
+    def test_non_positive_amount_queues_nothing(self, amount, fake_delay):
+        dispatch_accrual("org-1", QuotaResource.TEST_EXECUTIONS, amount)
+
+        assert fake_delay == []
+
+    @pytest.mark.parametrize("org_id", [None, ""])
+    def test_missing_org_queues_nothing(self, org_id, fake_delay):
+        """A task whose tenant context never resolved has no org to bill."""
+        dispatch_accrual(org_id, QuotaResource.TEST_EXECUTIONS, 5)
+
+        assert fake_delay == []
+
+    def test_broker_failure_is_swallowed(self, monkeypatch):
+        """The primary operation must survive a broker outage: an unlogged
+        counter is recoverable, a failed test run is not."""
+
+        def boom(*args):
+            raise RuntimeError("broker unreachable")
+
+        monkeypatch.setattr("rhesis.backend.tasks.usage.accrue_usage.delay", boom)
+
+        dispatch_accrual("org-1", QuotaResource.TRACING_SPANS, 5)  # must not raise
+
+
+class TestIncrementUsage:
+    def test_creates_and_increments_on_first_call(self, test_db, test_org_id):
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_GENERATION, 5)
+
+        assert _usage_row(test_db, test_org_id, QuotaResource.TEST_GENERATION).used == 5
+
+    def test_accumulates_across_calls(self, test_db, test_org_id):
+        increment_usage(test_db, test_org_id, QuotaResource.MODEL_TOKENS, 100)
+        increment_usage(test_db, test_org_id, QuotaResource.MODEL_TOKENS, 250)
+
+        assert _usage_row(test_db, test_org_id, QuotaResource.MODEL_TOKENS).used == 350
+
+    def test_zero_amount_is_noop(self, test_db, test_org_id):
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 0)
+
+        assert _usage_row(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS) is None
+
+    def test_negative_amount_is_noop(self, test_db, test_org_id):
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, -5)
+
+        assert _usage_row(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS) is None
+
+    def test_default_amount_is_one(self, test_db, test_org_id):
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS)
+
+        assert _usage_row(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS).used == 1
+
+
+def _usage_row(db, org_id, resource: QuotaResource) -> Usage | None:
+    period_start, _ = _current_period()
+    return (
+        db.query(Usage)
+        .filter(
+            Usage.organization_id == org_id,
+            Usage.resource == resource.value,
+            Usage.period_start == period_start,
+        )
+        .first()
+    )
+
+
+class TestStockCounters:
+    def test_count_org_seats_includes_session_user(self, test_db, test_org_id):
+        assert count_org_seats(test_db, test_org_id) >= 1
+
+    def test_count_org_projects_excludes_soft_deleted(self, test_db, test_org_id):
+        baseline = count_org_projects(test_db, test_org_id)
+
+        active = Project(name="usage-test-active-project", organization_id=test_org_id)
+        deleted = Project(
+            name="usage-test-deleted-project",
+            organization_id=test_org_id,
+            deleted_at=datetime.now(timezone.utc),
+        )
+        test_db.add_all([active, deleted])
+        test_db.commit()
+
+        assert count_org_projects(test_db, test_org_id) == baseline + 1
+
+    def test_count_org_endpoints_excludes_soft_deleted(self, test_db, test_org_id):
+        project = Project(name="usage-test-endpoint-project", organization_id=test_org_id)
+        test_db.add(project)
+        test_db.commit()
+        test_db.refresh(project)
+
+        baseline = count_org_endpoints(test_db, test_org_id)
+
+        active = Endpoint(
+            name="usage-test-endpoint-active",
+            connection_type="rest",
+            organization_id=test_org_id,
+            project_id=project.id,
+        )
+        deleted = Endpoint(
+            name="usage-test-endpoint-deleted",
+            connection_type="rest",
+            organization_id=test_org_id,
+            project_id=project.id,
+            deleted_at=datetime.now(timezone.utc),
+        )
+        test_db.add_all([active, deleted])
+        test_db.commit()
+
+        assert count_org_endpoints(test_db, test_org_id) == baseline + 1
+
+
+class TestGetUsageSummary:
+    def test_includes_every_quota_resource(self, test_db, test_org_id):
+        org = test_db.get(Organization, test_org_id)
+
+        summary = get_usage_summary(test_db, test_org_id, org)
+
+        assert set(summary["resources"].keys()) == {r.value for r in QuotaResource}
+        assert "edition" in summary
+
+    def test_flow_resource_reflects_accrued_usage(self, test_db, test_org_id):
+        org = test_db.get(Organization, test_org_id)
+        increment_usage(test_db, test_org_id, QuotaResource.TRACING_SPANS, 42)
+
+        summary = get_usage_summary(test_db, test_org_id, org)
+
+        assert summary["resources"][QuotaResource.TRACING_SPANS.value]["used"] == 42
+
+    def test_stock_resource_reflects_live_count(self, test_db, test_org_id):
+        org = test_db.get(Organization, test_org_id)
+
+        summary = get_usage_summary(test_db, test_org_id, org)
+
+        assert summary["resources"][QuotaResource.SEATS.value]["used"] >= 1
+
+    def test_every_resource_has_limit_and_period_fields(self, test_db, test_org_id):
+        org = test_db.get(Organization, test_org_id)
+
+        summary = get_usage_summary(test_db, test_org_id, org)
+
+        for item in summary["resources"].values():
+            assert "limit" in item
+            assert "period_start" in item
+            assert "period_end" in item
+            assert item["kind"] in ("flow", "stock")
+
+    def test_kind_matches_stock_vs_flow_split(self, test_db, test_org_id):
+        org = test_db.get(Organization, test_org_id)
+
+        summary = get_usage_summary(test_db, test_org_id, org)
+
+        stock_resources = {
+            QuotaResource.SEATS.value,
+            QuotaResource.PROJECTS.value,
+            QuotaResource.ENDPOINTS.value,
+        }
+        for resource_value, item in summary["resources"].items():
+            expected_kind = "stock" if resource_value in stock_resources else "flow"
+            assert item["kind"] == expected_kind

--- a/tests/backend/tasks/test_usage_accrual_task.py
+++ b/tests/backend/tasks/test_usage_accrual_task.py
@@ -1,0 +1,104 @@
+"""Unit tests for the `accrue_usage` Celery task.
+
+Pure unit tests -- no database, no Docker, no broker. Calling a
+`bind=True` Celery task directly (not via `.delay()`) runs its body
+synchronously with `self` bound to the task instance, which is the
+standard way to unit test task logic without a broker.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.tasks.usage import accrue_usage
+
+
+class _FakeSession:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def fake_session(monkeypatch):
+    session = _FakeSession()
+    monkeypatch.setattr("rhesis.backend.tasks.usage.SessionLocal", lambda: session)
+    return session
+
+
+@pytest.fixture
+def fake_bind_scope(monkeypatch):
+    recorded = []
+    monkeypatch.setattr(
+        "rhesis.backend.tasks.usage.bind_scope_to_session",
+        lambda db, org_id: recorded.append((db, org_id)),
+    )
+    return recorded
+
+
+@pytest.fixture
+def recorded_increments(monkeypatch):
+    recorded = []
+    monkeypatch.setattr(
+        "rhesis.backend.tasks.usage.increment_usage",
+        lambda db, org_id, resource, amount: recorded.append((org_id, resource, amount)),
+    )
+    return recorded
+
+
+class TestAccrueUsage:
+    def test_binds_scope_and_increments_usage(
+        self, fake_session, fake_bind_scope, recorded_increments
+    ):
+        accrue_usage("org-1", QuotaResource.MODEL_TOKENS.value, 123)
+
+        assert fake_bind_scope == [(fake_session, "org-1")]
+        assert recorded_increments == [("org-1", QuotaResource.MODEL_TOKENS, 123)]
+
+    @pytest.mark.parametrize("resource", list(QuotaResource))
+    def test_handles_every_quota_resource(
+        self, resource, fake_session, fake_bind_scope, recorded_increments
+    ):
+        """One task serves all resources, so each member must round-trip
+        through the broker's string form back to its enum."""
+        accrue_usage("org-1", resource.value, 7)
+
+        assert recorded_increments == [("org-1", resource, 7)]
+
+    def test_unknown_resource_raises_without_retrying(self, fake_session, fake_bind_scope):
+        """A bad resource name is a programming error, not a transient
+        fault -- it must surface immediately rather than burn three
+        retries. The conversion happens before the session is even opened.
+        """
+        with pytest.raises(ValueError):
+            accrue_usage("org-1", "not_a_resource", 5)
+
+        assert fake_bind_scope == []
+
+    def test_closes_session_after_use(self, fake_session, fake_bind_scope, recorded_increments):
+        accrue_usage("org-1", QuotaResource.SEATS.value, 10)
+
+        assert fake_session.closed is True
+
+    def test_retries_on_increment_usage_failure(self, fake_session, fake_bind_scope, monkeypatch):
+        def boom(*args, **kwargs):
+            raise RuntimeError("db unreachable")
+
+        monkeypatch.setattr("rhesis.backend.tasks.usage.increment_usage", boom)
+
+        with pytest.raises(Exception):
+            accrue_usage("org-1", QuotaResource.TRACING_SPANS.value, 10)
+
+    def test_closes_session_even_when_retrying(self, fake_session, fake_bind_scope, monkeypatch):
+        monkeypatch.setattr(
+            "rhesis.backend.tasks.usage.increment_usage",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("db unreachable")),
+        )
+
+        with pytest.raises(Exception):
+            accrue_usage("org-1", QuotaResource.TRACING_SPANS.value, 10)
+
+        assert fake_session.closed is True

--- a/tests/backend/utils/test_llm_delegation.py
+++ b/tests/backend/utils/test_llm_delegation.py
@@ -36,7 +36,7 @@ class TestPolyphemusDelegation:
         from rhesis.backend.app.utils.user_model_utils import _call_polyphemus_with_delegation
 
         # Call the function
-        _call_polyphemus_with_delegation(test_user, "default")
+        _call_polyphemus_with_delegation(test_user, "default", "org-456")
 
         # Verify PolyphemusLLM was instantiated
         mock_polyphemus_class.assert_called_once()
@@ -64,7 +64,7 @@ class TestPolyphemusDelegation:
 
         test_url = "http://localhost:8000"
         with patch.dict(os.environ, {"DEFAULT_POLYPHEMUS_URL": test_url}):
-            _call_polyphemus_with_delegation(test_user, "default")
+            _call_polyphemus_with_delegation(test_user, "default", "org-456")
 
             call_kwargs = mock_polyphemus_class.call_args[1]
             assert call_kwargs["base_url"] == test_url
@@ -79,7 +79,7 @@ class TestPolyphemusDelegation:
             if "DEFAULT_POLYPHEMUS_URL" in os.environ:
                 del os.environ["DEFAULT_POLYPHEMUS_URL"]
 
-            _call_polyphemus_with_delegation(test_user, "default")
+            _call_polyphemus_with_delegation(test_user, "default", "org-456")
 
             call_kwargs = mock_polyphemus_class.call_args[1]
             assert call_kwargs["base_url"] == "https://polyphemus.rhesis.ai"
@@ -91,7 +91,7 @@ class TestPolyphemusDelegation:
 
         custom_kwargs = {"temperature": 0.7, "max_tokens": 1000}
 
-        _call_polyphemus_with_delegation(test_user, "default", **custom_kwargs)
+        _call_polyphemus_with_delegation(test_user, "default", "org-456", **custom_kwargs)
 
         call_kwargs = mock_polyphemus_class.call_args[1]
         assert call_kwargs["temperature"] == 0.7
@@ -110,7 +110,7 @@ class TestPolyphemusDelegation:
         mock_token = "mock.jwt.token"
         mock_create_token.return_value = mock_token
 
-        _call_polyphemus_with_delegation(test_user, "default")
+        _call_polyphemus_with_delegation(test_user, "default", "org-456")
 
         # Verify token creation was called correctly
         mock_create_token.assert_called_once_with(test_user, "polyphemus")
@@ -127,7 +127,7 @@ class TestPolyphemusDelegation:
         test_user.is_verified = True
 
         with pytest.raises(ValueError, match="User account is inactive"):
-            _call_polyphemus_with_delegation(test_user, "default")
+            _call_polyphemus_with_delegation(test_user, "default", "org-456")
 
     def test_delegation_unverified_user(self, test_user):
         """Test that delegation fails for unverified users."""
@@ -137,7 +137,7 @@ class TestPolyphemusDelegation:
         test_user.is_verified = False
 
         with pytest.raises(ValueError, match="User account is not verified"):
-            _call_polyphemus_with_delegation(test_user, "default")
+            _call_polyphemus_with_delegation(test_user, "default", "org-456")
 
 
 class TestPolyphemusModelConfiguration:

--- a/tests/sdk/models/providers/test_polyphemus.py
+++ b/tests/sdk/models/providers/test_polyphemus.py
@@ -805,3 +805,122 @@ class TestCreateBatchCompletion:
         result = llm.create_batch_completion([{"messages": [{"role": "user", "content": "hi"}]}])
 
         assert result == expected
+
+
+class TestPolyphemusOnUsage:
+    """`on_usage` accrual -- see rhesis.sdk.models.base.BaseLLM.on_usage.
+
+    Replaced an earlier `last_usage` side-channel attribute design (wrapped
+    by a proxy object in the backend to intercept generate()/a_generate())
+    that broke `isinstance(model, BaseLLM)` checks everywhere downstream and
+    never covered generate_batch. `on_usage` is a plain constructor kwarg
+    invoked inline wherever a provider parses usage out of its response, so
+    the returned object stays a real PolyphemusLLM/RhesisLLM instance.
+    """
+
+    @patch("rhesis.sdk.models.providers.polyphemus.requests.post")
+    def test_generate_invokes_on_usage_with_response_usage(self, mock_post):
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        received = []
+        llm = PolyphemusLLM(api_key="test_key", on_usage=received.append)
+        llm.generate("hello")
+
+        # Normalized to TokenUsage field names by BaseLLM._emit_usage.
+        assert received == [{"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}]
+
+    @patch("rhesis.sdk.models.providers.polyphemus.requests.post")
+    def test_generate_without_usage_in_response_skips_callback(self, mock_post):
+        mock_response = Mock()
+        mock_response.json.return_value = {"choices": [{"message": {"content": "hi"}}]}
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        received = []
+        llm = PolyphemusLLM(api_key="test_key", on_usage=received.append)
+        llm.generate("hello")
+
+        assert received == []
+
+    @patch("rhesis.sdk.models.providers.polyphemus.requests.post")
+    def test_generate_without_on_usage_configured_does_not_raise(self, mock_post):
+        """Third-party/BYO-key models never get on_usage wired -- must no-op, not crash."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {"total_tokens": 15},
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        llm = PolyphemusLLM(api_key="test_key")
+        result = llm.generate("hello")
+
+        assert result == "hi"
+
+    @patch("rhesis.sdk.models.providers.polyphemus.requests.post")
+    def test_generate_batch_aggregates_usage_across_items(self, mock_post):
+        """generate_batch makes one HTTP call covering all prompts (bypassing
+        generate()/a_generate() entirely), so it needs its own on_usage
+        aggregation rather than inheriting it from generate()."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "responses": [
+                {
+                    "choices": [{"message": {"content": "A"}}],
+                    "usage": {"total_tokens": 10},
+                },
+                {
+                    "choices": [{"message": {"content": "B"}}],
+                    "usage": {"total_tokens": 20},
+                },
+            ]
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        received = []
+        llm = PolyphemusLLM(api_key="test_key", on_usage=received.append)
+        llm.generate_batch(["P1", "P2"])
+
+        assert received == [{"input_tokens": 0, "output_tokens": 0, "total_tokens": 30}]
+
+    @patch("rhesis.sdk.models.providers.polyphemus.requests.post")
+    def test_generate_batch_without_any_usage_skips_callback(self, mock_post):
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "responses": [{"choices": [{"message": {"content": "A"}}]}]
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        received = []
+        llm = PolyphemusLLM(api_key="test_key", on_usage=received.append)
+        llm.generate_batch(["P1"])
+
+        assert received == []
+
+    @patch("rhesis.sdk.models.providers.polyphemus.requests.post")
+    def test_on_usage_exception_does_not_break_generate(self, mock_post):
+        """A broken accrual callback must never break the underlying LLM call."""
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "choices": [{"message": {"content": "hi"}}],
+            "usage": {"total_tokens": 15},
+        }
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+
+        def boom(usage):
+            raise RuntimeError("accrual backend down")
+
+        llm = PolyphemusLLM(api_key="test_key", on_usage=boom)
+        result = llm.generate("hello")
+
+        assert result == "hi"

--- a/tests/sdk/models/providers/test_rhesis.py
+++ b/tests/sdk/models/providers/test_rhesis.py
@@ -21,15 +21,21 @@ class Continent(BaseModel):
     capitals: list[Capital]
 
 
-def _mock_aiohttp_session(response_json=None, status=200, raise_for_status=None):
+def _mock_aiohttp_session(response_json=None, status=200, raise_for_status=None, headers=None):
     """Build a mock aiohttp.ClientSession for use with ``async with``.
 
     aiohttp's session.post() returns a context manager synchronously,
     so we use MagicMock for the call and AsyncMock for __aenter__/__aexit__.
+
+    ``headers`` defaults to an empty real dict (not a MagicMock) so
+    ``response.headers.get("X-Rhesis-Usage")`` cleanly returns ``None`` for
+    tests that don't care about usage forwarding, rather than a truthy
+    MagicMock instance that would trip the ``if usage_header:`` check.
     """
     mock_response = MagicMock()
     mock_response.status = status
     mock_response.json = AsyncMock(return_value=response_json)
+    mock_response.headers = headers if headers is not None else {}
     if raise_for_status:
         mock_response.raise_for_status.side_effect = raise_for_status
     else:
@@ -322,3 +328,98 @@ class TestRhesisLLM:
 
         for call_kwargs in post_calls:
             assert "_session" not in call_kwargs["json"]
+
+
+class TestRhesisLLMUsageHeaderForwarding:
+    """`X-Rhesis-Usage` response header -- see
+    `apps/backend/.../routers/services.py:generate_content_endpoint`'s
+    docstring. The platform relay attaches this header (not a body field)
+    when it captured usage from its own model call; `create_completion` is
+    the one place with access to the raw response to read it.
+    """
+
+    @pytest.fixture
+    def mock_env_vars(self):
+        with patch.dict(
+            os.environ,
+            {
+                "RHESIS_API_KEY": "test_api_key",
+                "RHESIS_BASE_URL": "https://test.example.com",
+            },
+        ):
+            yield
+
+    @pytest.fixture
+    def mock_client(self):
+        with patch("rhesis.sdk.models.providers.native.APIClient") as mock_client_class:
+            mock_client = Mock()
+            mock_client.api_key = "test_api_key"
+            mock_client.get_url.return_value = "https://test.example.com/services/generate/content"
+            mock_client_class.return_value = mock_client
+            yield mock_client_class
+
+    @patch("aiohttp.ClientSession")
+    def test_emits_usage_from_header(self, mock_session_class, mock_env_vars, mock_client):
+        received = []
+        service = RhesisLLM(on_usage=received.append)
+        service.load_model()
+
+        session_ctx, _, _ = _mock_aiohttp_session(
+            response_json="hi there",
+            headers={"X-Rhesis-Usage": '{"total_tokens": 42}'},
+        )
+        mock_session_class.return_value = session_ctx
+
+        result = service.generate(prompt="Test prompt")
+
+        assert result == "hi there"
+        assert received == [{"input_tokens": 0, "output_tokens": 0, "total_tokens": 42}]
+
+    @patch("aiohttp.ClientSession")
+    def test_no_header_means_no_emission(self, mock_session_class, mock_env_vars, mock_client):
+        received = []
+        service = RhesisLLM(on_usage=received.append)
+        service.load_model()
+
+        session_ctx, _, _ = _mock_aiohttp_session(response_json="hi there")
+        mock_session_class.return_value = session_ctx
+
+        service.generate(prompt="Test prompt")
+
+        assert received == []
+
+    @patch("aiohttp.ClientSession")
+    def test_malformed_header_is_ignored_not_raised(
+        self, mock_session_class, mock_env_vars, mock_client
+    ):
+        received = []
+        service = RhesisLLM(on_usage=received.append)
+        service.load_model()
+
+        session_ctx, _, _ = _mock_aiohttp_session(
+            response_json="hi there",
+            headers={"X-Rhesis-Usage": "not-valid-json"},
+        )
+        mock_session_class.return_value = session_ctx
+
+        result = service.generate(prompt="Test prompt")
+
+        assert result == "hi there"
+        assert received == []
+
+    @patch("aiohttp.ClientSession")
+    def test_without_on_usage_configured_header_is_harmlessly_ignored(
+        self, mock_session_class, mock_env_vars, mock_client
+    ):
+        service = RhesisLLM()
+        service.load_model()
+
+        session_ctx, _, _ = _mock_aiohttp_session(
+            response_json="hi there",
+            headers={"X-Rhesis-Usage": '{"total_tokens": 42}'},
+        )
+        mock_session_class.return_value = session_ctx
+
+        result = service.generate(prompt="Test prompt")
+
+        assert result == "hi there"

--- a/tests/sdk/models/test_base_usage.py
+++ b/tests/sdk/models/test_base_usage.py
@@ -1,0 +1,134 @@
+"""Tests for BaseLLM's token-usage normalization and emission.
+
+This is the boundary where a provider's raw ``usage`` payload becomes a
+:class:`TokenUsage` for accrual callbacks. Every provider dialect is
+resolved here, so consumers downstream (notably the backend's
+MODEL_TOKENS callback) never parse token counts themselves.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+import pytest
+
+from rhesis.sdk.models.base import BaseLLM, TokenUsage, _normalize_usage
+
+
+class _StubLLM(BaseLLM):
+    """Minimal concrete BaseLLM -- load_model/generate_batch are abstract."""
+
+    def load_model(self, *args, **kwargs):
+        return self
+
+    def generate_batch(self, *args, **kwargs):
+        return []
+
+
+@pytest.fixture
+def emitted() -> List[Any]:
+    return []
+
+
+@pytest.fixture
+def model(emitted):
+    return _StubLLM("stub-model", on_usage=emitted.append)
+
+
+class TestNormalizeUsage:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ({"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}, (10, 20, 30)),
+            ({"input_tokens": 12, "output_tokens": 18, "total_tokens": 30}, (12, 18, 30)),
+            ({"prompt_token_count": 15, "candidates_token_count": 25}, (15, 25, 40)),
+            ({"promptTokenCount": 3, "candidatesTokenCount": 4}, (3, 4, 7)),
+        ],
+        ids=["openai-legacy", "openai-responses", "gemini", "gemini-camel"],
+    )
+    def test_resolves_provider_dialects(self, raw, expected):
+        result = _normalize_usage(raw)
+
+        assert result == TokenUsage(
+            input_tokens=expected[0], output_tokens=expected[1], total_tokens=expected[2]
+        )
+
+    def test_derives_total_when_provider_omits_it(self):
+        """The case the old hand-rolled `usage["total_tokens"]` read dropped
+        on the floor."""
+        assert _normalize_usage({"prompt_tokens": 7, "completion_tokens": 5})["total_tokens"] == 12
+
+    def test_is_idempotent(self):
+        """Already-normalized input must survive a second pass unchanged --
+        _emit_usage_batch relies on this when re-normalizing its own sums."""
+        once = _normalize_usage({"prompt_tokens": 10, "completion_tokens": 20})
+
+        assert _normalize_usage(once) == once
+
+    @pytest.mark.parametrize("raw", [None, {}, {"total_tokens": 0}, {"unrelated": "value"}])
+    def test_returns_none_when_there_is_nothing_to_report(self, raw):
+        assert _normalize_usage(raw) is None
+
+
+class TestEmitUsage:
+    def test_emits_normalized_counts(self, model, emitted):
+        model._emit_usage({"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30})
+
+        assert emitted == [TokenUsage(input_tokens=10, output_tokens=20, total_tokens=30)]
+
+    @pytest.mark.parametrize("raw", [None, {}, {"total_tokens": 0}])
+    def test_skips_empty_payloads(self, model, emitted, raw):
+        model._emit_usage(raw)
+
+        assert emitted == []
+
+    def test_no_callback_configured_is_a_noop(self):
+        _StubLLM("stub-model")._emit_usage({"total_tokens": 5})  # must not raise
+
+    def test_callback_exception_never_escapes(self):
+        """A broken accrual callback must not break the LLM call that
+        produced the usage."""
+
+        def boom(_usage):
+            raise RuntimeError("accrual backend down")
+
+        model = _StubLLM("stub-model", on_usage=boom)
+
+        model._emit_usage({"total_tokens": 5})  # must not raise
+
+
+class TestEmitUsageBatch:
+    def test_sums_across_items_and_emits_once(self, model, emitted):
+        model._emit_usage_batch(
+            [
+                {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+                {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+            ]
+        )
+
+        assert emitted == [TokenUsage(input_tokens=11, output_tokens=22, total_tokens=33)]
+
+    def test_counts_items_that_omit_total_tokens(self, model, emitted):
+        """Per-item normalization, not a raw `total_tokens` read: an item
+        reporting only prompt/completion counts still contributes."""
+        model._emit_usage_batch(
+            [
+                {"total_tokens": 30, "prompt_tokens": 10, "completion_tokens": 20},
+                {"prompt_tokens": 4, "completion_tokens": 6},
+            ]
+        )
+
+        assert emitted[0]["total_tokens"] == 40
+
+    def test_ignores_items_with_no_usage(self, model, emitted):
+        model._emit_usage_batch([None, {"total_tokens": 5}, {}])
+
+        assert emitted == [TokenUsage(input_tokens=0, output_tokens=0, total_tokens=5)]
+
+    def test_batch_with_no_usage_at_all_emits_nothing(self, model, emitted):
+        model._emit_usage_batch([None, {}, {"total_tokens": 0}])
+
+        assert emitted == []
+
+    def test_no_callback_configured_is_a_noop(self):
+        _StubLLM("stub-model")._emit_usage_batch([{"total_tokens": 5}])  # must not raise


### PR DESCRIPTION
## Purpose

Sub-plan 2 of usage accounting. Sub-plan 1 (#2350) shipped the `QuotaResource` enum, the quota registry and YAML-driven tier limits. This adds the other half: a durable record of what each organization has actually consumed, and a read-only endpoint to report it.

No enforcement here. Nothing is blocked, no request is rejected. That is Sub-plan 3.

## What Changed

**Counter storage.** A `usage` table holding one row per organization, resource and billing period, unique on `(organization_id, resource, period_start)` so accrual can upsert against it. It deliberately does not use `OrganizationMixin`: the service writes through raw atomic upserts that the ORM auto-filter listeners are not built for, so a FORCE'd `tenant_isolation` RLS policy is the tenant boundary instead. It is also excluded from the generic recycle-bin routes, where an org member could otherwise hard-delete their own row to zero their counters.

**Two kinds of resource.** Flow resources (test executions, tracing spans, test generation, model tokens) are cumulative counters for the current UTC calendar month. Stock resources (seats, projects, endpoints) are live entity counts computed on read, since there is nothing to accrue or reset. `GET /usage` returns both with a `kind` field so consumers group them without keeping their own copy of that split.

**One accrual path.** `dispatch_accrual` is the only entry point call sites use. It queues the write on a Celery worker and never raises, so a failed counter can neither slow down nor break the operation it measures. `increment_usage` is the database primitive behind it, called only by that worker, where committing the session and raising on failure are safe because the session belongs to nothing else.

**Token usage from the SDK.** `BaseLLM` takes an optional `on_usage` callback that providers invoke at the point they parse `usage` out of their own API response. A plain constructor kwarg keeps the returned object a real provider instance, so every `isinstance(model, BaseLLM)` check downstream keeps working. Payloads are normalized to a `TokenUsage` before the callback sees them, reusing the existing `extract_token_usage` helper rather than growing a second copy of provider-dialect matching.

**Where tokens are counted.** Hosted models (Rhesis or Polyphemus with no user-supplied API key) get the callback wired in at construction, because Rhesis pays for that inference. A model using the org's own provider key gets none, since that usage is billed to them directly.

## Additional Context

Three counting bugs surfaced while wiring this up and are fixed here:

- `/services/generate/content` discarded usage entirely, so the `rhesis-default` provider never accrued anything. That endpoint has two kinds of caller and both must count. A developer calling it directly is billed against their own org. A relaying `RhesisLLM` (self-hosted delegation, or a same-deployment loopback) needs its own local counter to move too, so the endpoint composes rather than replaces: it accrues normally *and* forwards the usage via an `X-Rhesis-Usage` header. Two books for two orgs, not a double-count of one. The header carries it because that endpoint returns bare content with no envelope for a sibling `usage` field.
- Polyphemus's batch path read `item['usage']['total_tokens']` directly and dropped any item that reported only prompt/completion counts.
- `RhesisLLM` read usage off the response body, where a dict is the caller's own schema-validated payload, so a schema containing a `usage` field could be mistaken for token counts.

Two notes for reviewers:

- Billing periods are UTC-anchored rather than local. With local dates, workers in different timezones disagree about which month a call near midnight belongs to and accrue to two different rows.
- Because accrual is queued, the counter is eventually consistent and can lag by seconds. That is the right tradeoff for reporting and for the soft enforcement planned in Sub-plan 3, but worth confirming when that gate is built.

On not using OpenTelemetry for this: the repo has two OTel systems and neither can be the billing source. `apps/backend/telemetry/` is opt-in product analytics that drops spans when a user disables telemetry. `sdk/telemetry/` traces the *customer's* application, so those tokens are the customer's own spend rather than Rhesis-hosted inference. Enforcement also needs a transactional read to return a 402, which a metrics backend cannot serve. The one thing worth borrowing was the naming, so `TokenUsage` uses the field names of the OpenAI Responses API `usage` object, which is also what OTel's `gen_ai.usage.*` conventions use.

The frontend dashboard that consumes `GET /usage` is a follow-up PR stacked on this branch.

## Testing

```bash
# backend
cd apps/backend && uv run pytest ../../tests/backend/services/test_usage.py \
  ../../tests/backend/routes/test_usage.py ../../tests/backend/app/test_usage_tracking.py \
  ../../tests/backend/tasks/ ../../tests/backend/routes/test_services.py \
  ../../tests/backend/utils/test_llm_delegation.py ../../tests/backend/ee/licensing/

# sdk
cd sdk && uv run pytest ../tests/sdk/ --ignore=../tests/sdk/integration
```

707 backend and 2264 SDK tests pass locally. `ruff check` and `ruff format` clean on all touched files.

Manual check: call a hosted model, then `GET /usage`, and confirm `model_tokens` reflects the call after the worker drains.
