### PR TITLE
Add usage dashboard tab to organization settings

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/e90c29496562_add_usage_read_capability.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/e90c29496562_add_usage_read_capability.py
@@ -17,7 +17,7 @@ roles FK against, per the contract in
 ``tests/backend/security/test_capability_catalog.py``.
 
 Revision ID: e90c29496562
-Revises: 9550c62e80a5
+Revises: 7dd69fe35db5
 Create Date: 2026-08-04
 """
 
@@ -27,7 +27,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "e90c29496562"
-down_revision: Union[str, None] = "9550c62e80a5"
+down_revision: Union[str, None] = "7dd69fe35db5"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/apps/backend/src/rhesis/backend/alembic/versions/e90c29496562_add_usage_read_capability.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/e90c29496562_add_usage_read_capability.py
@@ -1,0 +1,62 @@
+"""Add the usage:read capability to the permission catalog
+
+``GET /usage`` and ``GET /usage/history`` were authz-exempt (authenticated,
+but no permission check), so any org member could read the org's metered
+consumption and plan limits over the API. They now require ``usage:read``.
+
+A dedicated capability rather than reusing ``organization:read``: that one is
+part of the read-only Viewer baseline (see ``_VIEWER_EXCLUDED_READS`` in
+``ee.rbac.models``) for basic org context, so gating on it would not have
+restricted anyone. ``usage:read`` is excluded from that baseline instead,
+which lands it on Owner/Admin in EE, and on the org owner in community (via
+``_OWNER_ONLY_CAPABILITIES`` in ``app.auth.rbac``).
+
+Built-in roles need no ``role_permission`` rows -- the EE provider computes
+their sets from code -- so this only inserts the catalog row that custom
+roles FK against, per the contract in
+``tests/backend/security/test_capability_catalog.py``.
+
+Revision ID: e90c29496562
+Revises: 9550c62e80a5
+Create Date: 2026-08-04
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e90c29496562"
+down_revision: Union[str, None] = "9550c62e80a5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_CAPABILITY = "usage:read"
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "INSERT INTO permission "
+            "(id, name, display_name, resource_type, action, scope, "
+            "is_retired, created_at, updated_at) "
+            "VALUES (gen_random_uuid(), :name, 'Read usage', 'usage', 'read', "
+            "'organization', false, now(), now()) "
+            "ON CONFLICT (name) DO NOTHING"
+        ).bindparams(name=_CAPABILITY)
+    )
+
+
+def downgrade() -> None:
+    """Retire rather than delete, matching the catalog's append-only contract.
+
+    ``permission`` rows are never hard-deleted: custom roles may hold
+    ``role_permission`` rows pointing at this one, and those must stay
+    auditable.
+    """
+    op.execute(
+        sa.text("UPDATE permission SET is_retired = true WHERE name = :name").bindparams(
+            name=_CAPABILITY
+        )
+    )

--- a/apps/backend/src/rhesis/backend/app/auth/capabilities.py
+++ b/apps/backend/src/rhesis/backend/app/auth/capabilities.py
@@ -283,6 +283,17 @@ class Permission:
         READ = "organization:read"
         UPDATE = "organization:update"
 
+    class Usage(_PermissionEnum):
+        """Metered-consumption reporting for the org (``GET /usage``).
+
+        Deliberately *not* covered by ``organization:read``: that one is part
+        of the read-only Viewer baseline (basic org context), whereas usage
+        totals and plan limits are billing data. Restricted to org admins --
+        Owner/Admin in EE, the org owner in community.
+        """
+
+        READ = "usage:read"
+
     class Member(_PermissionEnum):
         READ = "member:read"
         #: Add a member to the org (route-derived companion of MANAGE).
@@ -362,6 +373,7 @@ SCOPE_PROJECT = "project"
 _ORG_SCOPED_RESOURCES: frozenset[str] = frozenset(
     {
         "organization",
+        "usage",
         "member",
         "role",
         "token",

--- a/apps/backend/src/rhesis/backend/app/auth/public_routes.py
+++ b/apps/backend/src/rhesis/backend/app/auth/public_routes.py
@@ -86,13 +86,6 @@ AUTHZ_EXEMPT_ROUTES: frozenset[tuple[str, str]] = frozenset(
         # Feature catalog: the frontend needs this before any RBAC context is set.
         # Authentication is still enforced; the response is org-filtered in the handler.
         ("GET", "/features"),
-        # Usage dashboard: read-only report of the authenticated org's own metered
-        # consumption, no different in shape or sensitivity from /features above.
-        # Authentication is still enforced; the response is org-scoped in the handler.
-        ("GET", "/usage"),
-        # Same rationale as /usage above -- the trailing-months history
-        # behind the dashboard's line charts, still org-scoped in the handler.
-        ("GET", "/usage/history"),
         # Demo / test endpoint — carries no meaningful permission boundary.
         ("GET", "/home/protected"),
         # Profile update during onboarding: the user may not have an org yet when

--- a/apps/backend/src/rhesis/backend/app/auth/public_routes.py
+++ b/apps/backend/src/rhesis/backend/app/auth/public_routes.py
@@ -90,6 +90,9 @@ AUTHZ_EXEMPT_ROUTES: frozenset[tuple[str, str]] = frozenset(
         # consumption, no different in shape or sensitivity from /features above.
         # Authentication is still enforced; the response is org-scoped in the handler.
         ("GET", "/usage"),
+        # Same rationale as /usage above -- the trailing-months history
+        # behind the dashboard's line charts, still org-scoped in the handler.
+        ("GET", "/usage/history"),
         # Demo / test endpoint — carries no meaningful permission boundary.
         ("GET", "/home/protected"),
         # Profile update during onboarding: the user may not have an org yet when

--- a/apps/backend/src/rhesis/backend/app/auth/rbac.py
+++ b/apps/backend/src/rhesis/backend/app/auth/rbac.py
@@ -170,6 +170,9 @@ def rbac_active_for(organization_id: Optional[UUID], db: Session) -> bool:
 _OWNER_ONLY_CAPABILITIES: frozenset[str] = frozenset(
     {
         str(Permission.Organization.UPDATE),
+        # Billing data: org totals against plan limits. Community has no
+        # Admin role, so the owner is the only "admin" to scope this to.
+        str(Permission.Usage.READ),
         str(Permission.Member.MANAGE),
         str(Permission.ProjectMember.MANAGE),
         str(Permission.Role.MANAGE),

--- a/apps/backend/src/rhesis/backend/app/routers/usage.py
+++ b/apps/backend/src/rhesis/backend/app/routers/usage.py
@@ -7,15 +7,15 @@ dependency planned for a later sub-plan).
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, List
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.dependencies import get_current_organization, get_tenant_db_session
 from rhesis.backend.app.models.organization import Organization
-from rhesis.backend.app.services.usage import get_usage_summary
+from rhesis.backend.app.services.usage import get_usage_history, get_usage_summary
 
 router = APIRouter(prefix="/usage", tags=["usage"])
 
@@ -33,6 +33,15 @@ class UsageResponse(BaseModel):
     edition: str
 
 
+class UsageHistoryPoint(BaseModel):
+    period_start: str
+    used: int
+
+
+class UsageHistoryResponse(BaseModel):
+    resources: Dict[str, List[UsageHistoryPoint]] = Field(default_factory=dict)
+
+
 @router.get("", response_model=UsageResponse)
 def get_usage(
     org: Organization = Depends(get_current_organization),
@@ -43,4 +52,25 @@ def get_usage(
     return UsageResponse(
         resources={k: UsageResourceItem(**v) for k, v in summary["resources"].items()},
         edition=summary["edition"],
+    )
+
+
+@router.get("/history", response_model=UsageHistoryResponse)
+def get_usage_history_endpoint(
+    months: int = Query(6, ge=1, le=24, description="Trailing calendar months to include"),
+    org: Organization = Depends(get_current_organization),
+    db: Session = Depends(get_tenant_db_session),
+) -> UsageHistoryResponse:
+    """Return monthly usage history for flow resources over the trailing period.
+
+    Stock resources (seats, projects, endpoints) have no history to
+    report -- they're live counts, not accrued -- so they're absent from
+    the response rather than repeating the same live count at every point.
+    """
+    history = get_usage_history(db, str(org.id), months)
+    return UsageHistoryResponse(
+        resources={
+            k: [UsageHistoryPoint(**p) for p in points]
+            for k, points in history["resources"].items()
+        }
     )

--- a/apps/backend/src/rhesis/backend/app/routers/usage.py
+++ b/apps/backend/src/rhesis/backend/app/routers/usage.py
@@ -7,9 +7,10 @@ dependency planned for a later sub-plan).
 
 from __future__ import annotations
 
+from datetime import date
 from typing import Dict, List
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -44,11 +45,23 @@ class UsageHistoryResponse(BaseModel):
 
 @router.get("", response_model=UsageResponse)
 def get_usage(
+    period: date | None = Query(
+        None,
+        description=(
+            "First day of the month to report; defaults to the current month. "
+            "Only affects flow resources -- stock resources (seats, projects, "
+            "endpoints) always report today's live count, since they have no "
+            "history to look up for a past month."
+        ),
+    ),
     org: Organization = Depends(get_current_organization),
     db: Session = Depends(get_tenant_db_session),
 ) -> UsageResponse:
-    """Return per-resource usage, limits, and the current billing period."""
-    summary = get_usage_summary(db, str(org.id), org)
+    """Return per-resource usage, limits, and the billing period."""
+    try:
+        summary = get_usage_summary(db, str(org.id), org, period_start=period)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     return UsageResponse(
         resources={k: UsageResourceItem(**v) for k, v in summary["resources"].items()},
         edition=summary["edition"],

--- a/apps/backend/src/rhesis/backend/app/routers/usage.py
+++ b/apps/backend/src/rhesis/backend/app/routers/usage.py
@@ -14,9 +14,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.dependencies import get_current_organization, get_tenant_db_session
 from rhesis.backend.app.models.organization import Organization
-from rhesis.backend.app.services.usage import get_usage_history, get_usage_summary
+from rhesis.backend.app.services.usage import (
+    InvalidPeriodError,
+    get_usage_history,
+    get_usage_summary,
+)
 
 router = APIRouter(prefix="/usage", tags=["usage"])
 
@@ -43,7 +48,7 @@ class UsageHistoryResponse(BaseModel):
     resources: Dict[str, List[UsageHistoryPoint]] = Field(default_factory=dict)
 
 
-@router.get("", response_model=UsageResponse)
+@router.get("", response_model=UsageResponse, **capability(Permission.Usage.READ))
 def get_usage(
     period: date | None = Query(
         None,
@@ -60,7 +65,7 @@ def get_usage(
     """Return per-resource usage, limits, and the billing period."""
     try:
         summary = get_usage_summary(db, str(org.id), org, period_start=period)
-    except ValueError as exc:
+    except InvalidPeriodError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     return UsageResponse(
         resources={k: UsageResourceItem(**v) for k, v in summary["resources"].items()},
@@ -68,7 +73,11 @@ def get_usage(
     )
 
 
-@router.get("/history", response_model=UsageHistoryResponse)
+@router.get(
+    "/history",
+    response_model=UsageHistoryResponse,
+    **capability(Permission.Usage.READ),
+)
 def get_usage_history_endpoint(
     months: int = Query(6, ge=1, le=24, description="Trailing calendar months to include"),
     org: Organization = Depends(get_current_organization),

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/service.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/service.py
@@ -8,8 +8,10 @@ from typing import TYPE_CHECKING, Any, List, Set
 
 from sqlalchemy.orm import Session
 
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.services.async_service import AsyncService
 from rhesis.backend.app.services.telemetry.enrichment.processor import TraceEnricher
+from rhesis.backend.app.services.usage import dispatch_accrual
 
 if TYPE_CHECKING:
     from rhesis.backend.app import models
@@ -171,6 +173,20 @@ class EnrichmentService(AsyncService[dict | None]):
         if not stored_spans:
             logger.warning("No spans were stored")
             return [], 0, 0
+
+        # Accrued here as well as in ``post_ingest_link``: these are the two
+        # paths that create Trace rows, and metering only the ingestion
+        # router would miss every span Rhesis itself produces while invoking
+        # an endpoint during a test run -- the primary product flow. The two
+        # paths are disjoint (this one is the invoker, that one is inbound
+        # OTLP), so no span is counted twice.
+        #
+        # Placed right after the rows are persisted rather than at the end
+        # of the function: unlike ``post_ingest_link`` there is no retrying
+        # task wrapper here, so there is no double-count to guard against,
+        # and storing the spans is what makes them billable -- a failure to
+        # dispatch enrichment below should not silently drop the count.
+        dispatch_accrual(organization_id, QuotaResource.TRACING_SPANS, len(stored_spans))
 
         async_count = 0
         sync_count = 0

--- a/apps/backend/src/rhesis/backend/app/services/test_config_generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_config_generator.py
@@ -16,8 +16,8 @@ from rhesis.backend.app.config.settings import get_model_settings
 from rhesis.backend.app.schemas.services import TestConfigResponse
 from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 from rhesis.backend.app.utils.user_model_utils import (
-    _resolve_default_hosted_model,
     get_user_generation_model,
+    resolve_default_hosted_model,
 )
 from rhesis.sdk.models.factory import get_model
 
@@ -70,7 +70,7 @@ class TestConfigGeneratorService:
                 "User generation model is Polyphemus; using fast system default for test config"
             )
             try:
-                resolved = _resolve_default_hosted_model(
+                resolved = resolve_default_hosted_model(
                     get_model_settings().generation_model, str(self.user.organization_id)
                 )
                 if isinstance(resolved, str):

--- a/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
@@ -29,8 +29,8 @@ from rhesis.backend.app.services.generation import (
 from rhesis.backend.app.services.streaming_utils import IncrementalConfigParser, ndjson
 from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 from rhesis.backend.app.utils.user_model_utils import (
-    _resolve_default_hosted_model,
     get_user_generation_model,
+    resolve_default_hosted_model,
 )
 from rhesis.sdk.models.factory import get_model
 from rhesis.sdk.synthesizers.config_synthesizer import (
@@ -60,7 +60,7 @@ def _resolve_config_llm(db: Session, user: User):
     if use_fast_default:
         logger.info("User generation model is Polyphemus; using fast default for pipeline config")
         try:
-            resolved = _resolve_default_hosted_model(
+            resolved = resolve_default_hosted_model(
                 get_model_settings().generation_model, str(user.organization_id)
             )
             if isinstance(resolved, str):

--- a/apps/backend/src/rhesis/backend/app/services/usage.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage.py
@@ -209,17 +209,43 @@ _STOCK_COUNTERS = {
 }
 
 
-def get_usage_summary(db: Session, org_id: str, org: Optional[Organization]) -> dict:
+def get_usage_summary(
+    db: Session,
+    org_id: str,
+    org: Optional[Organization],
+    period_start: Optional[date] = None,
+) -> dict:
     """Return ``{resources: {<resource>: {used, limit, period_start, period_end, kind}}, edition}``.
 
     Flow resources report cumulative usage from the ``usage`` table for the
-    current billing period. Stock resources report a live entity count.
-    Every :class:`QuotaResource` member is present in the response, even
-    when its usage is zero. ``kind`` (``"flow"`` or ``"stock"``) lets the
-    frontend group resources without duplicating the flow/stock split as a
-    second, hand-maintained list.
+    requested billing period (the current one by default). ``kind``
+    (``"flow"`` or ``"stock"``) lets the frontend group resources without
+    duplicating the flow/stock split as a second, hand-maintained list.
+
+    Pass *period_start* (first day of a month) to report a past month
+    instead of the current one -- this only affects flow resources. Stock
+    resources (seats, projects, endpoints) are live entity counts with no
+    historical row behind them, so they always report *today's* count
+    against the *current* period regardless of which month was requested:
+    there is no "seats in July" to look up, only "seats right now." Every
+    :class:`QuotaResource` member is present in the response regardless of
+    *period_start*, even when its usage is zero.
+
+    Raises ``ValueError`` if *period_start* is not the first of a month, or
+    is later than the current period -- both are caller errors, not
+    "no data yet."
     """
-    period_start, period_end = _current_period()
+    current_start, current_end = _current_period()
+    if period_start is None:
+        period_start, period_end = current_start, current_end
+    else:
+        if period_start.day != 1:
+            raise ValueError("period_start must be the first day of a month")
+        if period_start > current_start:
+            raise ValueError("period_start cannot be later than the current period")
+        last_day = monthrange(period_start.year, period_start.month)[1]
+        period_end = period_start.replace(day=last_day)
+
     limits = QuotaRegistry.get_limits(org)
 
     with bypass_tenant_filter():
@@ -234,12 +260,17 @@ def get_usage_summary(db: Session, org_id: str, org: Optional[Organization]) -> 
     resources: dict[str, dict] = {}
     for resource in QuotaResource:
         counter = _STOCK_COUNTERS.get(resource)
-        used = counter(db, org_id) if counter is not None else flow_used.get(resource.value, 0)
+        if counter is not None:
+            used = counter(db, org_id)
+            item_start, item_end = current_start, current_end
+        else:
+            used = flow_used.get(resource.value, 0)
+            item_start, item_end = period_start, period_end
         resources[resource.value] = {
             "used": used,
             "limit": limits.get(resource),
-            "period_start": period_start.isoformat(),
-            "period_end": period_end.isoformat(),
+            "period_start": item_start.isoformat(),
+            "period_end": item_end.isoformat(),
             "kind": STOCK_KIND if counter is not None else FLOW_KIND,
         }
 

--- a/apps/backend/src/rhesis/backend/app/services/usage.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage.py
@@ -45,6 +45,16 @@ FLOW_KIND = "flow"
 STOCK_KIND = "stock"
 
 
+class InvalidPeriodError(ValueError):
+    """A requested reporting period is not one this service can report on.
+
+    Distinct from a bare ``ValueError`` so callers can map *this* to a 4xx
+    without also swallowing unrelated ``ValueError``s raised deeper in the
+    call (tier-config parsing, for one), which are server faults and must
+    not be reported to the client as bad input.
+    """
+
+
 def _current_period(today: Optional[date] = None) -> tuple[date, date]:
     """Return ``(period_start, period_end)`` for the calendar month containing *today*.
 
@@ -231,18 +241,18 @@ def get_usage_summary(
     :class:`QuotaResource` member is present in the response regardless of
     *period_start*, even when its usage is zero.
 
-    Raises ``ValueError`` if *period_start* is not the first of a month, or
-    is later than the current period -- both are caller errors, not
-    "no data yet."
+    Raises :class:`InvalidPeriodError` if *period_start* is not the first of
+    a month, or is later than the current period -- both are caller errors,
+    not "no data yet."
     """
     current_start, current_end = _current_period()
     if period_start is None:
         period_start, period_end = current_start, current_end
     else:
         if period_start.day != 1:
-            raise ValueError("period_start must be the first day of a month")
+            raise InvalidPeriodError("period_start must be the first day of a month")
         if period_start > current_start:
-            raise ValueError("period_start cannot be later than the current period")
+            raise InvalidPeriodError("period_start cannot be later than the current period")
         last_day = monthrange(period_start.year, period_start.month)[1]
         period_end = period_start.replace(day=last_day)
 
@@ -308,7 +318,15 @@ def get_usage_history(db: Session, org_id: str, months: int = 6) -> dict:
     timezone risk that a raw-SQL migration comparing against a
     ``timestamptz`` column would -- see 91607f0dd412's fix for that
     specific class of bug, which does not apply to this comparison.
+
+    Raises :class:`InvalidPeriodError` if *months* is not positive. Checked
+    here rather than relying on the router's ``Query(ge=1)`` alone, so a
+    non-HTTP caller gets that instead of an ``IndexError`` off the empty
+    ``period_starts`` list below.
     """
+    if months < 1:
+        raise InvalidPeriodError("months must be at least 1")
+
     period_starts = _recent_period_starts(months)
 
     with bypass_tenant_filter():

--- a/apps/backend/src/rhesis/backend/app/services/usage.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage.py
@@ -245,3 +245,58 @@ def get_usage_summary(db: Session, org_id: str, org: Optional[Organization]) -> 
 
     edition = str(FeatureRegistry.license_info(org=org).get("edition", "community"))
     return {"resources": resources, "edition": edition}
+
+
+def _recent_period_starts(months: int, today: Optional[date] = None) -> list[date]:
+    """Return the first-of-month date for each of the last *months* calendar
+    months, oldest first, ending with the month containing *today*."""
+    today = today or datetime.now(timezone.utc).date()
+    year, month = today.year, today.month
+    starts = []
+    for _ in range(months):
+        starts.append(date(year, month, 1))
+        month -= 1
+        if month == 0:
+            month, year = 12, year - 1
+    return list(reversed(starts))
+
+
+def get_usage_history(db: Session, org_id: str, months: int = 6) -> dict:
+    """Return ``{resources: {<flow resource>: [{period_start, used}, ...]}}``.
+
+    One point per calendar month for each flow resource, oldest first,
+    covering the trailing *months* months including the current one.
+    Stock resources are excluded: they are live counts with no historical
+    row to chart (see ``get_usage_summary``'s docstring for the flow/stock
+    split). Months with no accrual get an explicit ``used: 0`` point rather
+    than being omitted, so the frontend can plot a continuous line without
+    its own gap-filling logic.
+
+    Comparing ``Usage.period_start`` (a plain ``Date`` column) against
+    plain ``date`` objects here carries none of the timestamptz/session-
+    timezone risk that a raw-SQL migration comparing against a
+    ``timestamptz`` column would -- see 91607f0dd412's fix for that
+    specific class of bug, which does not apply to this comparison.
+    """
+    period_starts = _recent_period_starts(months)
+
+    with bypass_tenant_filter():
+        rows = db.query(Usage).filter(
+            Usage.organization_id == org_id,
+            Usage.period_start >= period_starts[0],
+        )
+        used_by_key = {(row.resource, row.period_start): row.used for row in rows}
+
+    history: dict[str, list[dict]] = {}
+    for resource in QuotaResource:
+        if resource in _STOCK_COUNTERS:
+            continue
+        history[resource.value] = [
+            {
+                "period_start": period_start.isoformat(),
+                "used": used_by_key.get((resource.value, period_start), 0),
+            }
+            for period_start in period_starts
+        ]
+
+    return {"resources": history}

--- a/apps/backend/src/rhesis/backend/app/utils/usage_tracking.py
+++ b/apps/backend/src/rhesis/backend/app/utils/usage_tracking.py
@@ -15,11 +15,20 @@ instance -- everything downstream keeps working unchanged -- and every
 provider method that parses a usage dict already has a natural place to
 invoke it.
 
-Only applied to models resolved as *hosted* (Rhesis or Polyphemus without a
-user-supplied API key) -- see ``_is_hosted_model`` in
-``rhesis.backend.app.utils.user_model_utils``. Third-party models called
-with the org's own API key (OpenAI, Gemini, etc.) never get a callback:
-that usage is billed directly to the org by the provider, not by Rhesis.
+Wired in two places, for two different reasons:
+
+- ``_is_hosted_model`` in ``rhesis.backend.app.utils.user_model_utils``,
+  for an explicitly-selected Model row: only ``rhesis``/``polyphemus``
+  with no org-supplied key, meaning the call goes out on
+  ``RHESIS_API_KEY``. Any other provider an org picks (their own
+  ``vertex_ai``, ``ollama``, ``openai``, ...) is their own infrastructure,
+  never wired here regardless of whether they configured a key.
+- ``_resolve_default_hosted_model``, unconditionally, for the *system
+  default* an org gets when it configures no model at all -- whatever a
+  deployment names as its ``DEFAULT_*_MODEL`` (e.g.
+  ``vertex_ai/gemini-2.5-flash`` in dev, calling the server's own
+  ``GOOGLE_APPLICATION_CREDENTIALS``) is Rhesis's own infra cost for that
+  deployment, by definition of being the default.
 """
 
 from __future__ import annotations

--- a/apps/backend/src/rhesis/backend/app/utils/usage_tracking.py
+++ b/apps/backend/src/rhesis/backend/app/utils/usage_tracking.py
@@ -23,7 +23,7 @@ Wired in two places, for two different reasons:
   ``RHESIS_API_KEY``. Any other provider an org picks (their own
   ``vertex_ai``, ``ollama``, ``openai``, ...) is their own infrastructure,
   never wired here regardless of whether they configured a key.
-- ``_resolve_default_hosted_model``, unconditionally, for the *system
+- ``resolve_default_hosted_model``, unconditionally, for the *system
   default* an org gets when it configures no model at all -- whatever a
   deployment names as its ``DEFAULT_*_MODEL`` (e.g.
   ``vertex_ai/gemini-2.5-flash`` in dev, calling the server's own

--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -428,7 +428,7 @@ def _is_hosted_model(provider: str, api_key: Optional[str]) -> bool:
     Models UI, so those alone accrue when the row carries no org key.
     Note the *system default* -- what an org gets when it configures no
     `model_id` at all -- is a different path entirely
-    (`_resolve_default_hosted_model`), reached before this function and
+    (`resolve_default_hosted_model`), reached before this function and
     unrestricted by provider: whatever a deployment names as its
     `DEFAULT_*_MODEL` (`vertex_ai/gemini-2.5-flash`, in this dev
     environment) *is* Rhesis's own infra cost for that deployment, by
@@ -446,17 +446,23 @@ def _is_hosted_model(provider: str, api_key: Optional[str]) -> bool:
     return provider in ("rhesis", "polyphemus") and not api_key
 
 
-def _resolve_default_hosted_model(default_model: str, organization_id: str) -> Union[str, BaseLLM]:
+def resolve_default_hosted_model(default_model: str, organization_id: str) -> Union[str, BaseLLM]:
     """
     Instantiate the system default model with usage accrual when it names a hosted provider.
 
     Several callers fall back to the bare `default_model` string (e.g.
     "rhesis/rhesis-default") without ever calling `_fetch_and_configure_model`
     -- most notably `_get_user_model` when the user has no model_id configured
-    for a purpose (execution model on a freshly onboarded org, for example).
+    for a purpose (execution model on a freshly onboarded org, for example),
+    and the execution/evaluation model resolution in the batch and sequential
+    test-execution paths when a test config carries no resolvable user.
     Those calls would otherwise never accrue token usage, since the SDK only
     resolves the string into an actual model instance much later (inside
-    synthesizers/agents, with no organization context available).
+    synthesizers/agents/metrics, with no organization context available).
+
+    Public rather than underscore-prefixed because those out-of-module
+    fallbacks are the point of it: anything that would otherwise hand a bare
+    `DEFAULT_*_MODEL` string downstream should route through here instead.
 
     Construction here is cheap (no network call -- provider `__init__`s only
     set up client config) so doing it eagerly costs nothing. On any
@@ -465,7 +471,9 @@ def _resolve_default_hosted_model(default_model: str, organization_id: str) -> U
 
     Args:
         default_model: A "provider/model_name" string, e.g. "rhesis/rhesis-default"
-        organization_id: Org to attribute accrued tokens to
+        organization_id: Org to attribute accrued tokens to. Falsy (the task
+            paths derive it from a nullable column and can pass "") skips
+            accrual rather than booking the tokens against no org.
 
     Returns:
         An instance with `on_usage` wired for accrual when construction
@@ -480,10 +488,18 @@ def _resolve_default_hosted_model(default_model: str, organization_id: str) -> U
     # ``rhesis/...``. Restricting this to rhesis/polyphemus meant every such
     # deployment reported zero MODEL_TOKENS forever.
     try:
+        extra_params = {}
+        if organization_id:
+            extra_params["on_usage"] = make_usage_accrual_callback(organization_id)
+        else:
+            logger.warning(
+                "No organization_id resolving default model %s; token usage will not accrue",
+                default_model,
+            )
         return get_model(
             default_model,
             model_type="language",
-            on_usage=make_usage_accrual_callback(organization_id),
+            **extra_params,
         )
     except Exception:
         # Broad on purpose, not just ValueError: dropping the provider
@@ -566,7 +582,7 @@ def _fetch_and_configure_model(
 
     if not model or not model.provider_type:
         logger.warning("Model with id=%s not found or has no provider_type", model_id)
-        return _resolve_default_hosted_model(default_model, organization_id)
+        return resolve_default_hosted_model(default_model, organization_id)
 
     # Get provider configuration
     provider = model.provider_type.type_value
@@ -575,7 +591,7 @@ def _fetch_and_configure_model(
 
     # Special handling for Rhesis system models
     if _is_rhesis_system_model(provider, api_key):
-        return _resolve_default_hosted_model(default_model, organization_id)
+        return resolve_default_hosted_model(default_model, organization_id)
 
     # Special handling for Polyphemus models without a stored API key.
     #
@@ -675,7 +691,7 @@ def _get_user_model(
     model_id = model_settings.model_id
 
     if not model_id:
-        return _resolve_default_hosted_model(default_model, str(user.organization_id))
+        return resolve_default_hosted_model(default_model, str(user.organization_id))
 
     return _fetch_and_configure_model(
         db=db,

--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -410,13 +410,29 @@ def _is_rhesis_system_model(provider: str, api_key: str) -> bool:
 
 def _is_hosted_model(provider: str, api_key: Optional[str]) -> bool:
     """
-    Check if a model runs on Rhesis-operated infrastructure.
+    Check if an explicitly-selected Model row runs on Rhesis-operated infrastructure.
 
-    Broader than `_is_rhesis_system_model`: also covers Polyphemus without a
-    user-supplied key (SaaS delegation, or self-hosted deployments using the
-    server's own RHESIS_API_KEY). Third-party providers called with the
-    org's own API key are never "hosted" -- that usage is billed directly
-    by the provider, not by Rhesis, so it is not tracked as MODEL_TOKENS.
+    Only ever reached for a Model row an org explicitly picked via
+    `model_id` -- `_fetch_and_configure_model`'s two callers are
+    `get_generation_model_with_override` (explicit override) and
+    `_get_user_model` (the org configured a `model_id` for this purpose).
+    Whichever *other* provider the org names there -- their own
+    `vertex_ai`, `ollama`, `openai`, self-hosted `vllm`, whatever -- is
+    their own infrastructure choice: never Rhesis's, regardless of whether
+    they happened to leave the key blank (self-hosted servers commonly need
+    none). Broadening this to a bare `not api_key` (tried and reverted) both
+    overcounted those and was solving a case that doesn't occur.
+
+    `rhesis`/`polyphemus` are the two provider values that mean "use
+    Rhesis's own hosted infrastructure" as a selectable option in the
+    Models UI, so those alone accrue when the row carries no org key.
+    Note the *system default* -- what an org gets when it configures no
+    `model_id` at all -- is a different path entirely
+    (`_resolve_default_hosted_model`), reached before this function and
+    unrestricted by provider: whatever a deployment names as its
+    `DEFAULT_*_MODEL` (`vertex_ai/gemini-2.5-flash`, in this dev
+    environment) *is* Rhesis's own infra cost for that deployment, by
+    definition of being the default.
 
     Args:
         provider: The provider type value (e.g., "rhesis", "polyphemus", "openai")
@@ -452,21 +468,33 @@ def _resolve_default_hosted_model(default_model: str, organization_id: str) -> U
         organization_id: Org to attribute accrued tokens to
 
     Returns:
-        A hosted-provider instance with `on_usage` wired for accrual when
-        `default_model` names a hosted provider and construction succeeds;
-        the original string otherwise.
+        An instance with `on_usage` wired for accrual when construction
+        succeeds; the original string otherwise.
     """
-    provider = default_model.split("/", 1)[0] if "/" in default_model else ""
-    if provider not in ("rhesis", "polyphemus"):
-        return default_model
-
+    # No provider restriction: the *system default* is by definition the
+    # model this deployment runs on its own credentials, whatever provider
+    # it names. A deployment configured with
+    # ``DEFAULT_GENERATION_MODEL=vertex_ai/gemini-2.5-flash`` calls Vertex
+    # from the backend using the server's GOOGLE_APPLICATION_CREDENTIALS,
+    # so Rhesis pays for those tokens exactly as it does for
+    # ``rhesis/...``. Restricting this to rhesis/polyphemus meant every such
+    # deployment reported zero MODEL_TOKENS forever.
     try:
         return get_model(
             default_model,
             model_type="language",
             on_usage=make_usage_accrual_callback(organization_id),
         )
-    except ValueError:
+    except Exception:
+        # Broad on purpose, not just ValueError: dropping the provider
+        # restriction above means this now runs `get_model` for *any*
+        # `DEFAULT_*_MODEL`, including providers whose modules raise other
+        # error types at import/construction time (e.g. huggingface.py
+        # raises ImportError when torch/transformers aren't installed).
+        # Falling back here doesn't hide the failure -- it only defers to
+        # the lazy resolution path this eager call is layered on top of,
+        # which will raise the same error when it actually tries to use
+        # the model.
         return default_model
 
 

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
@@ -138,6 +138,7 @@ def prefetch_execution_context(
         from rhesis.backend.app.utils.user_model_utils import (
             get_evaluation_model_with_override,
             get_execution_model_with_override,
+            resolve_default_hosted_model,
         )
 
         model_settings = get_model_settings()
@@ -154,21 +155,38 @@ def prefetch_execution_context(
                     session, user, model_id=override_evaluation_model_id
                 )
             else:
+                # Resolve rather than passing the bare default string on: the
+                # string is only turned into a model much later, inside
+                # Penelope / the metric judge, where no org context is left to
+                # attribute its tokens to. See resolve_default_hosted_model.
                 logger.warning(f"User {user_id} not found, using default models")
-                execution_model = model_settings.execution_model
-                evaluation_model = model_settings.evaluation_model
+                execution_model = resolve_default_hosted_model(
+                    model_settings.execution_model, organization_id
+                )
+                evaluation_model = resolve_default_hosted_model(
+                    model_settings.evaluation_model, organization_id
+                )
         else:
-            execution_model = model_settings.execution_model
-            evaluation_model = model_settings.evaluation_model
+            execution_model = resolve_default_hosted_model(
+                model_settings.execution_model, organization_id
+            )
+            evaluation_model = resolve_default_hosted_model(
+                model_settings.evaluation_model, organization_id
+            )
     except Exception as e:
         from rhesis.backend.app.config.settings import get_model_settings
+        from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
 
         logger.warning(f"Failed to resolve execution/evaluation models: {e}")
         model_settings = get_model_settings()
         if execution_model is None:
-            execution_model = model_settings.execution_model
+            execution_model = resolve_default_hosted_model(
+                model_settings.execution_model, organization_id
+            )
         if evaluation_model is None:
-            evaluation_model = model_settings.evaluation_model
+            evaluation_model = resolve_default_hosted_model(
+                model_settings.evaluation_model, organization_id
+            )
 
     # Warm the session identity map with prompt/behavior/behavior.metrics eager-loaded
     # for every test in the batch, in one query. get_test_and_prompt/get_test_metrics

--- a/apps/backend/src/rhesis/backend/tasks/execution/sequential.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/sequential.py
@@ -50,6 +50,9 @@ def execute_tests_sequentially(
 
     # Resolve execution and evaluation models from test_config.attributes
     # overrides or user defaults (same logic as batch prefetch_execution_context).
+    # Read outside the try so the fallback paths below can attribute token usage
+    # even when model resolution itself is what failed.
+    seq_organization_id = str(test_config.organization_id) if test_config.organization_id else ""
     execution_model = None
     evaluation_model = None
     try:
@@ -58,6 +61,7 @@ def execute_tests_sequentially(
         from rhesis.backend.app.utils.user_model_utils import (
             get_evaluation_model_with_override,
             get_execution_model_with_override,
+            resolve_default_hosted_model,
         )
 
         model_settings = get_model_settings()
@@ -76,21 +80,38 @@ def execute_tests_sequentially(
                     session, user, model_id=override_evaluation_model_id
                 )
             else:
+                # Resolve rather than passing the bare default string on: the
+                # string is only turned into a model much later, inside
+                # Penelope / the metric judge, where no org context is left to
+                # attribute its tokens to. See resolve_default_hosted_model.
                 logger.warning(f"User {seq_user_id} not found, using default models")
-                execution_model = model_settings.execution_model
-                evaluation_model = model_settings.evaluation_model
+                execution_model = resolve_default_hosted_model(
+                    model_settings.execution_model, seq_organization_id
+                )
+                evaluation_model = resolve_default_hosted_model(
+                    model_settings.evaluation_model, seq_organization_id
+                )
         else:
-            execution_model = model_settings.execution_model
-            evaluation_model = model_settings.evaluation_model
+            execution_model = resolve_default_hosted_model(
+                model_settings.execution_model, seq_organization_id
+            )
+            evaluation_model = resolve_default_hosted_model(
+                model_settings.evaluation_model, seq_organization_id
+            )
     except Exception as e:
         from rhesis.backend.app.config.settings import get_model_settings
+        from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
 
         logger.warning(f"Failed to resolve execution/evaluation models: {e}")
         model_settings = get_model_settings()
         if execution_model is None:
-            execution_model = model_settings.execution_model
+            execution_model = resolve_default_hosted_model(
+                model_settings.execution_model, seq_organization_id
+            )
         if evaluation_model is None:
-            evaluation_model = model_settings.evaluation_model
+            evaluation_model = resolve_default_hosted_model(
+                model_settings.evaluation_model, seq_organization_id
+            )
 
     # Execute tests one by one
     for i, test in enumerate(tests, 1):

--- a/apps/backend/src/rhesis/backend/tasks/test_set.py
+++ b/apps/backend/src/rhesis/backend/tasks/test_set.py
@@ -221,14 +221,25 @@ def _build_task_result(
     batch_size: int,
     org_id: str,
     user_id: str,
+    tests_generated: int,
 ) -> dict:
-    """Build the comprehensive task result dictionary."""
+    """Build the comprehensive task result dictionary.
+
+    *tests_generated* is passed in rather than read off
+    ``db_test_set.tests``. Both save helpers return the ORM row *after*
+    their ``with self.get_db_session()`` block has closed, so the instance
+    is detached and the relationship is not loaded: touching it here raised
+    ``DetachedInstanceError`` and failed the whole task after the tests had
+    already been written, leaving generation marked failed with a full set
+    of tests behind it. The caller already holds the SDK test set, whose
+    ``tests`` is a plain list, so the count needs no session at all.
+    """
     return {
         "test_set_id": str(db_test_set.id),
         "test_set_name": db_test_set.name,
         "description": db_test_set.description,
         "short_description": db_test_set.short_description,
-        "num_tests_generated": len(db_test_set.tests),
+        "num_tests_generated": tests_generated,
         "num_tests_requested": num_tests,
         "synthesizer_class": synthesizer.__class__.__name__,
         "synthesizer_params": log_kwargs,  # Safe parameters for logging
@@ -567,6 +578,7 @@ def generate_and_save_test_set(
             batch_size,
             org_id,
             user_id,
+            tests_generated=len(test_set.tests),
         )
 
         # No session needed here any more -- the accrual is queued and the

--- a/apps/frontend/jest.config.js
+++ b/apps/frontend/jest.config.js
@@ -59,8 +59,13 @@ const customJestConfig = {
     '<rootDir>/node_modules/',
     '<rootDir>/out/',
   ],
+  // Jest ignores a file if ANY pattern here matches, and next/jest prepends
+  // its own `/node_modules/(?!<transpilePackages>)` pattern to this list. So
+  // un-ignoring an ESM-only dependency takes both: the package in
+  // next.config.mjs's transpilePackages (for next/jest's pattern) and in the
+  // allowlist below (for this one). Either alone leaves it ignored.
   transformIgnorePatterns: [
-    'node_modules/(?!(.*\\.mjs$|@mui|@toolpad|next-auth|@auth|msw|@mswjs))',
+    'node_modules/(?!(.*\\.mjs$|@mui|@toolpad|next-auth|@auth|msw|@mswjs|flatqueue))',
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   testMatch: [

--- a/apps/frontend/jest.polyfills.js
+++ b/apps/frontend/jest.polyfills.js
@@ -4,9 +4,20 @@
  * This file runs via jest.config.js `setupFiles` before the test framework
  * and test environment are initialized.
  *
- * Currently a placeholder — add polyfills here if tests that use MSW node
- * server (msw/node) require fetch API globals not provided by the jsdom
- * environment. For example, install `whatwg-fetch` and add:
+ * Add polyfills here if tests that use MSW node server (msw/node) require
+ * fetch API globals not provided by the jsdom environment. For example,
+ * install `whatwg-fetch` and add:
  *
  *   require('whatwg-fetch');
  */
+
+// jsdom does not expose structuredClone, which Node has had since 17.
+// @mui/x-internal-gestures calls it while constructing its gesture manager,
+// so every test that renders an @mui/x-charts chart throws without this.
+// v8's serialize/deserialize gives the same structured-clone semantics for
+// the plain config objects involved here.
+if (typeof globalThis.structuredClone !== 'function') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- setupFiles runs as CJS before the module system is set up, so import is unavailable here
+  const { deserialize, serialize } = require('node:v8');
+  globalThis.structuredClone = value => deserialize(serialize(value));
+}

--- a/apps/frontend/next.config.mjs
+++ b/apps/frontend/next.config.mjs
@@ -119,9 +119,18 @@ const nextConfig = {
   // `import`/`export` syntax unparsed for any test that imports it without
   // mocking it out. next/jest derives its transform-ignore allowlist from
   // this array (see next/dist/build/jest/jest.js), so it must be listed
-  // here, not in jest.config.js's transformIgnorePatterns — that option can
-  // only add more exclusions, never un-ignore what this array controls.
-  transpilePackages: ['@rhesis/ee-frontend', 'next-auth', '@auth/core'],
+  // here as well as there: next/jest turns this array into one pattern and
+  // jest.config.js's own pattern is a second, and a file is ignored if either
+  // matches, so an ESM-only dep must be allowed by both to get transformed.
+  // flatqueue is the same situation, reached transitively from @mui/x-charts
+  // (used by the usage history charts): ESM-only, so any test rendering a
+  // chart fails to parse it unless it is listed in both places.
+  transpilePackages: [
+    '@rhesis/ee-frontend',
+    'next-auth',
+    '@auth/core',
+    'flatqueue',
+  ],
 
   // embedding-atlas pulls in Mosaic/DuckDB WASM; keep it off the server bundle.
   // Do not also list these in transpilePackages — Turbopack rejects that conflict.

--- a/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
+++ b/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
@@ -7,6 +7,8 @@ import AuthErrorBoundary from './error-boundary';
 import VerificationBanner from '@/components/auth/VerificationBanner';
 import { FeaturesProvider } from '@/contexts/FeaturesContext';
 import type { FeaturesResponse } from '@/utils/api-client/features-client';
+import { UsageProvider } from '@/contexts/UsageContext';
+import type { UsageResponse } from '@/utils/api-client/usage-client';
 import { PermissionsProvider } from '@/contexts/PermissionsContext';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { AppShell } from '@/components/layout/AppShell';
@@ -72,6 +74,7 @@ export function ProtectedLayoutClient({
   initialFeatures,
   initialPermissions,
   initialTermsStatus,
+  initialUsage,
 }: {
   children: React.ReactNode;
   /** Server-fetched `GET /features` result, seeds FeaturesProvider so nav-gating capabilities are known on first paint (no client-side loading window). Null on fetch failure — client falls back to its own fetch. */
@@ -80,6 +83,8 @@ export function ProtectedLayoutClient({
   initialPermissions: string[] | null;
   /** Server-fetched `GET /auth/terms-status` result, passed to `TermsAcceptanceGate` so it can decide without its own client-side fetch. Null on fetch failure — the gate falls back to fetching on mount. */
   initialTermsStatus: TermsStatus | null;
+  /** Server-fetched `GET /usage` result, seeds UsageProvider for the same reason. Null on fetch failure — client falls back to its own fetch. */
+  initialUsage: UsageResponse | null;
 }) {
   const { data: session } = useSession();
   const pathname = usePathname();
@@ -102,15 +107,17 @@ export function ProtectedLayoutClient({
   return (
     <AuthErrorBoundary>
       <FeaturesProvider initialFeatures={initialFeatures}>
-        <PermissionsProvider initialPermissions={initialPermissions}>
-          <WebSocketProvider>
-            {!isOnboarding && (
-              <TermsAcceptanceGate initialTermsStatus={initialTermsStatus} />
-            )}
-            {!isOnboarding && !chromeless && <VerificationBanner />}
-            {content}
-          </WebSocketProvider>
-        </PermissionsProvider>
+        <UsageProvider initialUsage={initialUsage}>
+          <PermissionsProvider initialPermissions={initialPermissions}>
+            <WebSocketProvider>
+              {!isOnboarding && (
+                <TermsAcceptanceGate initialTermsStatus={initialTermsStatus} />
+              )}
+              {!isOnboarding && !chromeless && <VerificationBanner />}
+              {content}
+            </WebSocketProvider>
+          </PermissionsProvider>
+        </UsageProvider>
       </FeaturesProvider>
     </AuthErrorBoundary>
   );

--- a/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
+++ b/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
@@ -7,8 +7,6 @@ import AuthErrorBoundary from './error-boundary';
 import VerificationBanner from '@/components/auth/VerificationBanner';
 import { FeaturesProvider } from '@/contexts/FeaturesContext';
 import type { FeaturesResponse } from '@/utils/api-client/features-client';
-import { UsageProvider } from '@/contexts/UsageContext';
-import type { UsageResponse } from '@/utils/api-client/usage-client';
 import { PermissionsProvider } from '@/contexts/PermissionsContext';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { AppShell } from '@/components/layout/AppShell';
@@ -74,7 +72,6 @@ export function ProtectedLayoutClient({
   initialFeatures,
   initialPermissions,
   initialTermsStatus,
-  initialUsage,
 }: {
   children: React.ReactNode;
   /** Server-fetched `GET /features` result, seeds FeaturesProvider so nav-gating capabilities are known on first paint (no client-side loading window). Null on fetch failure — client falls back to its own fetch. */
@@ -83,8 +80,6 @@ export function ProtectedLayoutClient({
   initialPermissions: string[] | null;
   /** Server-fetched `GET /auth/terms-status` result, passed to `TermsAcceptanceGate` so it can decide without its own client-side fetch. Null on fetch failure — the gate falls back to fetching on mount. */
   initialTermsStatus: TermsStatus | null;
-  /** Server-fetched `GET /usage` result, seeds UsageProvider for the same reason. Null on fetch failure — client falls back to its own fetch. */
-  initialUsage: UsageResponse | null;
 }) {
   const { data: session } = useSession();
   const pathname = usePathname();
@@ -107,17 +102,15 @@ export function ProtectedLayoutClient({
   return (
     <AuthErrorBoundary>
       <FeaturesProvider initialFeatures={initialFeatures}>
-        <UsageProvider initialUsage={initialUsage}>
-          <PermissionsProvider initialPermissions={initialPermissions}>
-            <WebSocketProvider>
-              {!isOnboarding && (
-                <TermsAcceptanceGate initialTermsStatus={initialTermsStatus} />
-              )}
-              {!isOnboarding && !chromeless && <VerificationBanner />}
-              {content}
-            </WebSocketProvider>
-          </PermissionsProvider>
-        </UsageProvider>
+        <PermissionsProvider initialPermissions={initialPermissions}>
+          <WebSocketProvider>
+            {!isOnboarding && (
+              <TermsAcceptanceGate initialTermsStatus={initialTermsStatus} />
+            )}
+            {!isOnboarding && !chromeless && <VerificationBanner />}
+            {content}
+          </WebSocketProvider>
+        </PermissionsProvider>
       </FeaturesProvider>
     </AuthErrorBoundary>
   );

--- a/apps/frontend/src/app/(protected)/layout.tsx
+++ b/apps/frontend/src/app/(protected)/layout.tsx
@@ -2,26 +2,26 @@ import { auth, getFreshAccessToken } from '@/auth';
 import { headers } from 'next/headers';
 import { FeatureName } from '@/constants/features';
 import type { FeaturesResponse } from '@/utils/api-client/features-client';
-import type { UsageResponse } from '@/utils/api-client/usage-client';
 import { fetchTermsStatusServer } from '@/utils/api-client/auth-client.server';
 import type { TermsStatus } from '@/utils/api-client/auth-client';
 import {
   getServerFeatures,
   getServerPermissions,
-  getServerUsage,
 } from '@/utils/server-permissions';
 import { ProtectedLayoutClient } from './ProtectedLayoutClient';
 
 /**
- * Server-side layout that seeds `FeaturesProvider`, `UsageProvider`,
- * `PermissionsProvider`, and `TermsAcceptanceGate` with data so they don't
- * need a client-side fetch on mount. Failures are swallowed -- client
- * providers fall back to fetching.
+ * Server-side layout that seeds `FeaturesProvider`, `PermissionsProvider`,
+ * and `TermsAcceptanceGate` with data so they don't need a client-side fetch
+ * on mount. Failures are swallowed -- client providers fall back to fetching.
  *
- * Uses `getServerFeatures`/`getServerPermissions`/`getServerUsage`
- * (React.cache-wrapped) so nested server components (page.tsx via
- * prefetchList/hasServerCapability) share the same responses without
- * issuing duplicate requests.
+ * Uses `getServerFeatures`/`getServerPermissions` (React.cache-wrapped) so
+ * nested server components (page.tsx via prefetchList/hasServerCapability)
+ * share the same responses without issuing duplicate requests.
+ *
+ * `GET /usage` is deliberately absent: only the Usage page reads it, so it
+ * mounts its own `UsageProvider` rather than making every protected
+ * navigation pay for a license lookup plus four counting queries.
  */
 export default async function ProtectedLayout({
   children,
@@ -33,22 +33,16 @@ export default async function ProtectedLayout({
   let initialFeatures: FeaturesResponse | null = null;
   let initialPermissions: string[] | null = null;
   let initialTermsStatus: TermsStatus | null = null;
-  let initialUsage: UsageResponse | null = null;
 
   if (session && !session.error) {
     const { accessToken } = await getFreshAccessToken({
       headers: await headers(),
     });
 
-    const [featuresResult, termsResult, usageResult] = await Promise.allSettled(
-      [
-        getServerFeatures(),
-        accessToken
-          ? fetchTermsStatusServer(accessToken)
-          : Promise.resolve(null),
-        getServerUsage(),
-      ]
-    );
+    const [featuresResult, termsResult] = await Promise.allSettled([
+      getServerFeatures(),
+      accessToken ? fetchTermsStatusServer(accessToken) : Promise.resolve(null),
+    ]);
 
     if (featuresResult.status === 'fulfilled') {
       initialFeatures = featuresResult.value;
@@ -65,10 +59,6 @@ export default async function ProtectedLayout({
     if (termsResult.status === 'fulfilled') {
       initialTermsStatus = termsResult.value;
     }
-
-    if (usageResult.status === 'fulfilled') {
-      initialUsage = usageResult.value;
-    }
   }
 
   return (
@@ -76,7 +66,6 @@ export default async function ProtectedLayout({
       initialFeatures={initialFeatures}
       initialPermissions={initialPermissions}
       initialTermsStatus={initialTermsStatus}
-      initialUsage={initialUsage}
     >
       {children}
     </ProtectedLayoutClient>

--- a/apps/frontend/src/app/(protected)/layout.tsx
+++ b/apps/frontend/src/app/(protected)/layout.tsx
@@ -2,22 +2,26 @@ import { auth, getFreshAccessToken } from '@/auth';
 import { headers } from 'next/headers';
 import { FeatureName } from '@/constants/features';
 import type { FeaturesResponse } from '@/utils/api-client/features-client';
+import type { UsageResponse } from '@/utils/api-client/usage-client';
 import { fetchTermsStatusServer } from '@/utils/api-client/auth-client.server';
 import type { TermsStatus } from '@/utils/api-client/auth-client';
 import {
   getServerFeatures,
   getServerPermissions,
+  getServerUsage,
 } from '@/utils/server-permissions';
 import { ProtectedLayoutClient } from './ProtectedLayoutClient';
 
 /**
- * Server-side layout that seeds `FeaturesProvider`, `PermissionsProvider`, and
- * `TermsAcceptanceGate` with data so they don't need a client-side fetch on
- * mount. Failures are swallowed -- client providers fall back to fetching.
+ * Server-side layout that seeds `FeaturesProvider`, `UsageProvider`,
+ * `PermissionsProvider`, and `TermsAcceptanceGate` with data so they don't
+ * need a client-side fetch on mount. Failures are swallowed -- client
+ * providers fall back to fetching.
  *
- * Uses `getServerFeatures`/`getServerPermissions` (React.cache-wrapped) so
- * nested server components (page.tsx via prefetchList/hasServerCapability)
- * share the same responses without issuing duplicate requests.
+ * Uses `getServerFeatures`/`getServerPermissions`/`getServerUsage`
+ * (React.cache-wrapped) so nested server components (page.tsx via
+ * prefetchList/hasServerCapability) share the same responses without
+ * issuing duplicate requests.
  */
 export default async function ProtectedLayout({
   children,
@@ -29,16 +33,22 @@ export default async function ProtectedLayout({
   let initialFeatures: FeaturesResponse | null = null;
   let initialPermissions: string[] | null = null;
   let initialTermsStatus: TermsStatus | null = null;
+  let initialUsage: UsageResponse | null = null;
 
   if (session && !session.error) {
     const { accessToken } = await getFreshAccessToken({
       headers: await headers(),
     });
 
-    const [featuresResult, termsResult] = await Promise.allSettled([
-      getServerFeatures(),
-      accessToken ? fetchTermsStatusServer(accessToken) : Promise.resolve(null),
-    ]);
+    const [featuresResult, termsResult, usageResult] = await Promise.allSettled(
+      [
+        getServerFeatures(),
+        accessToken
+          ? fetchTermsStatusServer(accessToken)
+          : Promise.resolve(null),
+        getServerUsage(),
+      ]
+    );
 
     if (featuresResult.status === 'fulfilled') {
       initialFeatures = featuresResult.value;
@@ -55,6 +65,10 @@ export default async function ProtectedLayout({
     if (termsResult.status === 'fulfilled') {
       initialTermsStatus = termsResult.value;
     }
+
+    if (usageResult.status === 'fulfilled') {
+      initialUsage = usageResult.value;
+    }
   }
 
   return (
@@ -62,6 +76,7 @@ export default async function ProtectedLayout({
       initialFeatures={initialFeatures}
       initialPermissions={initialPermissions}
       initialTermsStatus={initialTermsStatus}
+      initialUsage={initialUsage}
     >
       {children}
     </ProtectedLayoutClient>

--- a/apps/frontend/src/app/(protected)/organizations/settings/components/UsageTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/components/UsageTab.tsx
@@ -9,13 +9,19 @@ import {
   Typography,
 } from '@mui/material';
 import { SectionCard } from '@/components/common/SectionCard';
+import { BaseChartsGrid, BaseLineChart } from '@/components/common/BaseCharts';
+import { filterChipSx } from '@/components/common/FilterDrawer';
 import { useUsage } from '@/contexts/UsageContext';
+import { useUsageHistory } from '@/hooks/useUsageHistory';
 import {
   QUOTA_RESOURCE_LABELS,
   QUOTA_RESOURCE_ORDER,
   type QuotaResource,
 } from '@/constants/quota';
-import type { UsageResourceItem } from '@/utils/api-client/usage-client';
+import type {
+  UsageHistoryPoint,
+  UsageResourceItem,
+} from '@/utils/api-client/usage-client';
 
 function formatPeriodDate(isoDate: string): string {
   // period_start/period_end are date-only strings (YYYY-MM-DD), computed
@@ -29,6 +35,35 @@ function formatPeriodDate(isoDate: string): string {
     day: 'numeric',
     timeZone: 'UTC',
   });
+}
+
+// Same UTC-pinning as formatPeriodDate, and for the same reason: these are
+// date-only strings, so formatting must not drift onto the previous day
+// for viewers west of UTC. Includes the year (not just "MMM") since the
+// 12-month option can span a calendar boundary, where two points would
+// otherwise both read "Jan".
+function formatMonthLabel(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString('en-US', {
+    month: 'short',
+    year: '2-digit',
+    timeZone: 'UTC',
+  });
+}
+
+const HISTORY_RANGE_OPTIONS: { months: number; label: string }[] = [
+  { months: 3, label: '3M' },
+  { months: 6, label: '6M' },
+  { months: 12, label: '12M' },
+];
+const DEFAULT_HISTORY_MONTHS = 6;
+
+function toChartData(
+  points: UsageHistoryPoint[]
+): { name: string; used: number }[] {
+  return points.map(point => ({
+    name: formatMonthLabel(point.period_start),
+    used: point.used,
+  }));
 }
 
 function progressColor(ratio: number): 'success' | 'warning' | 'error' {
@@ -113,6 +148,67 @@ function ResourceGroup({
   );
 }
 
+function UsageHistorySection() {
+  const [months, setMonths] = React.useState(DEFAULT_HISTORY_MONTHS);
+  const { resources: history, loading, error } = useUsageHistory(months);
+
+  const flowResources = QUOTA_RESOURCE_ORDER.filter(
+    resource => resource in history
+  );
+
+  return (
+    <SectionCard title="Usage Over Time">
+      <Box sx={{ display: 'flex', gap: 1, mb: 3 }}>
+        {HISTORY_RANGE_OPTIONS.map(option => (
+          <Box
+            key={option.months}
+            component="button"
+            type="button"
+            onClick={() => setMonths(option.months)}
+            sx={filterChipSx(months === option.months)}
+          >
+            {option.label}
+          </Box>
+        ))}
+      </Box>
+
+      {loading && (
+        <Stack direction="row" spacing={2}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton
+              // eslint-disable-next-line react/no-array-index-key -- fixed-count skeleton placeholders, never reordered
+              key={i}
+              variant="rectangular"
+              height={180}
+              sx={{ flex: 1 }}
+            />
+          ))}
+        </Stack>
+      )}
+
+      {!loading && error && (
+        <Typography color="error.main">
+          Could not load usage history. Please try again later.
+        </Typography>
+      )}
+
+      {!loading && !error && (
+        <BaseChartsGrid>
+          {flowResources.map(resource => (
+            <BaseLineChart
+              key={resource}
+              title={QUOTA_RESOURCE_LABELS[resource as QuotaResource]}
+              data={toChartData(history[resource])}
+              series={[{ dataKey: 'used', name: 'Used' }]}
+              height={180}
+            />
+          ))}
+        </BaseChartsGrid>
+      )}
+    </SectionCard>
+  );
+}
+
 export default function UsageTab() {
   const { resources, edition, loading, error } = useUsage();
 
@@ -145,16 +241,23 @@ export default function UsageTab() {
     : null;
 
   return (
-    <SectionCard
-      title="Usage"
-      subtitle={
-        periodLabel
-          ? `Current billing period: ${periodLabel}${edition ? ` · ${edition} plan` : ''}`
-          : undefined
-      }
-    >
-      <ResourceGroup title="Metered Resources" kind="flow" usage={resources} />
-      <ResourceGroup title="Resource Counts" kind="stock" usage={resources} />
-    </SectionCard>
+    <Stack spacing={3}>
+      <SectionCard
+        title="Usage"
+        subtitle={
+          periodLabel
+            ? `Current billing period: ${periodLabel}${edition ? ` · ${edition} plan` : ''}`
+            : undefined
+        }
+      >
+        <ResourceGroup
+          title="Metered Resources"
+          kind="flow"
+          usage={resources}
+        />
+        <ResourceGroup title="Resource Counts" kind="stock" usage={resources} />
+      </SectionCard>
+      <UsageHistorySection />
+    </Stack>
   );
 }

--- a/apps/frontend/src/app/(protected)/organizations/settings/components/UsageTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/components/UsageTab.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import * as React from 'react';
+import {
+  Box,
+  LinearProgress,
+  Skeleton,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { SectionCard } from '@/components/common/SectionCard';
+import { useUsage } from '@/contexts/UsageContext';
+import {
+  QUOTA_RESOURCE_LABELS,
+  QUOTA_RESOURCE_ORDER,
+  type QuotaResource,
+} from '@/constants/quota';
+import type { UsageResourceItem } from '@/utils/api-client/usage-client';
+
+function formatPeriodDate(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function progressColor(ratio: number): 'success' | 'warning' | 'error' {
+  if (ratio >= 1) return 'error';
+  if (ratio >= 0.8) return 'warning';
+  return 'success';
+}
+
+function ResourceMeter({
+  label,
+  item,
+}: {
+  label: string;
+  item: UsageResourceItem;
+}) {
+  const { limit } = item;
+  const ratio = limit === null ? 0 : limit === 0 ? 1 : item.used / limit;
+
+  return (
+    <Box sx={{ mb: 3, '&:last-child': { mb: 0 } }}>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="baseline"
+        sx={{ mb: 0.5 }}
+      >
+        <Typography variant="body2" sx={{ fontWeight: 600 }}>
+          {label}
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          {item.used.toLocaleString()}
+          {limit === null ? ' (Unlimited)' : ` / ${limit.toLocaleString()}`}
+        </Typography>
+      </Stack>
+      <LinearProgress
+        variant="determinate"
+        value={limit === null ? 0 : Math.min(ratio, 1) * 100}
+        color={limit === null ? 'primary' : progressColor(ratio)}
+        sx={{
+          height: 6,
+          borderRadius: 2,
+          bgcolor: theme => theme.palette.action.hover,
+          '& .MuiLinearProgress-bar': {
+            borderRadius: 2,
+          },
+        }}
+      />
+    </Box>
+  );
+}
+
+function ResourceGroup({
+  title,
+  kind,
+  usage,
+}: {
+  title: string;
+  kind: UsageResourceItem['kind'];
+  usage: Readonly<Record<string, UsageResourceItem>>;
+}) {
+  const entries = QUOTA_RESOURCE_ORDER.filter(
+    resource => usage[resource]?.kind === kind
+  );
+  if (entries.length === 0) return null;
+
+  return (
+    <Box sx={{ mb: 4, '&:last-child': { mb: 0 } }}>
+      <Typography
+        variant="subtitle2"
+        sx={{ mb: 2, color: 'text.secondary', textTransform: 'uppercase' }}
+      >
+        {title}
+      </Typography>
+      {entries.map(resource => (
+        <ResourceMeter
+          key={resource}
+          label={QUOTA_RESOURCE_LABELS[resource as QuotaResource]}
+          item={usage[resource]}
+        />
+      ))}
+    </Box>
+  );
+}
+
+export default function UsageTab() {
+  const { resources, edition, loading, error } = useUsage();
+
+  if (loading) {
+    return (
+      <SectionCard title="Usage">
+        <Stack spacing={2}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            // eslint-disable-next-line react/no-array-index-key -- fixed-count skeleton placeholders, never reordered
+            <Skeleton key={i} variant="rectangular" height={48} />
+          ))}
+        </Stack>
+      </SectionCard>
+    );
+  }
+
+  if (error) {
+    return (
+      <SectionCard title="Usage">
+        <Typography color="error.main">
+          Could not load usage data. Please try again later.
+        </Typography>
+      </SectionCard>
+    );
+  }
+
+  const anyResource = Object.values(resources)[0];
+  const periodLabel = anyResource
+    ? `${formatPeriodDate(anyResource.period_start)} – ${formatPeriodDate(anyResource.period_end)}`
+    : null;
+
+  return (
+    <SectionCard
+      title="Usage"
+      subtitle={
+        periodLabel
+          ? `Current billing period: ${periodLabel}${edition ? ` · ${edition} plan` : ''}`
+          : undefined
+      }
+    >
+      <ResourceGroup title="Metered Resources" kind="flow" usage={resources} />
+      <ResourceGroup title="Resource Counts" kind="stock" usage={resources} />
+    </SectionCard>
+  );
+}

--- a/apps/frontend/src/app/(protected)/organizations/settings/components/UsageTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/components/UsageTab.tsx
@@ -18,10 +18,16 @@ import {
 import type { UsageResourceItem } from '@/utils/api-client/usage-client';
 
 function formatPeriodDate(isoDate: string): string {
+  // period_start/period_end are date-only strings (YYYY-MM-DD), computed
+  // in UTC by the backend. `new Date(isoDate)` parses that as UTC
+  // midnight, so formatting must stay in UTC too -- otherwise
+  // toLocaleDateString() converts to the viewer's local time and users
+  // west of UTC see the previous day.
   return new Date(isoDate).toLocaleDateString('en-US', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
+    timeZone: 'UTC',
   });
 }
 

--- a/apps/frontend/src/app/(protected)/organizations/settings/components/__tests__/UsageTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/components/__tests__/UsageTab.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@/test-utils';
+import '@testing-library/jest-dom';
+
+import UsageTab from '../UsageTab';
+import { useUsage } from '@/contexts/UsageContext';
+import { useUsageHistory } from '@/hooks/useUsageHistory';
+
+jest.mock('@/contexts/UsageContext', () => ({
+  useUsage: jest.fn(),
+}));
+
+jest.mock('@/hooks/useUsageHistory', () => ({
+  useUsageHistory: jest.fn(),
+}));
+
+const mockUseUsage = useUsage as jest.Mock;
+const mockUseUsageHistory = useUsageHistory as jest.Mock;
+
+const USAGE_RESOURCES = {
+  test_executions: {
+    used: 5,
+    limit: 1000,
+    period_start: '2026-08-01',
+    period_end: '2026-08-31',
+    kind: 'flow' as const,
+  },
+  seats: {
+    used: 3,
+    limit: 10,
+    period_start: '2026-08-01',
+    period_end: '2026-08-31',
+    kind: 'stock' as const,
+  },
+};
+
+function historyState(
+  overrides: Partial<ReturnType<typeof useUsageHistory>> = {}
+) {
+  return {
+    // Deliberately a resource absent from USAGE_RESOURCES above (which only
+    // has test_executions/seats): the chart title and a meter label
+    // rendering the same text would make getByText ambiguous.
+    resources: {
+      tracing_spans: [
+        { period_start: '2026-06-01', used: 1 },
+        { period_start: '2026-07-01', used: 2 },
+        { period_start: '2026-08-01', used: 5 },
+      ],
+    },
+    loading: false,
+    error: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockUseUsage.mockReset();
+  mockUseUsageHistory.mockReset();
+  mockUseUsage.mockReturnValue({
+    resources: USAGE_RESOURCES,
+    edition: 'community',
+    loading: false,
+    error: null,
+  });
+  mockUseUsageHistory.mockReturnValue(historyState());
+});
+
+describe('UsageTab history section', () => {
+  it('renders a chart title per flow resource returned by the history hook', () => {
+    render(<UsageTab />);
+
+    expect(screen.getByText('Usage Over Time')).toBeInTheDocument();
+    // Chart title -- one per key in useUsageHistory's resources map.
+    expect(screen.getByText('Tracing Spans')).toBeInTheDocument();
+  });
+
+  it('defaults to the 6-month filter and requests history for it', () => {
+    render(<UsageTab />);
+
+    expect(mockUseUsageHistory).toHaveBeenCalledWith(6);
+  });
+
+  it('switches the requested range when a different pill is clicked', () => {
+    render(<UsageTab />);
+
+    fireEvent.click(screen.getByText('12M'));
+
+    expect(mockUseUsageHistory).toHaveBeenLastCalledWith(12);
+  });
+
+  it('shows a loading state instead of charts while history is loading', () => {
+    mockUseUsageHistory.mockReturnValue(
+      historyState({ loading: true, resources: {} })
+    );
+
+    render(<UsageTab />);
+
+    expect(screen.queryByText('Tracing Spans')).not.toBeInTheDocument();
+  });
+
+  it('shows an error message when history fails to load', () => {
+    mockUseUsageHistory.mockReturnValue(
+      historyState({ error: new Error('boom'), resources: {} })
+    );
+
+    render(<UsageTab />);
+
+    expect(
+      screen.getByText('Could not load usage history. Please try again later.')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageDetailTabs.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import React, { useCallback } from 'react';
+import { Box } from '@mui/material';
+import { useRouter, useSearchParams } from 'next/navigation';
+import DetailTabNav from '@/components/common/DetailTabNav';
+import DetailTabPanel from '@/components/common/DetailTabPanel';
+import UsageOverviewTab from './UsageOverviewTab';
+import UsageOverTimeTab from './UsageOverTimeTab';
+
+const TAB_KEYS = ['overview', 'history'] as const;
+type UsageTabKey = (typeof TAB_KEYS)[number];
+
+const TAB_LABELS: Record<UsageTabKey, string> = {
+  overview: 'Overview',
+  history: 'Usage over Time',
+};
+
+function normalizeTabParam(param: string | null): UsageTabKey {
+  if (param && TAB_KEYS.includes(param as UsageTabKey)) {
+    return param as UsageTabKey;
+  }
+  return 'overview';
+}
+
+export default function UsageDetailTabs() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const activeTab = (() => {
+    const key = normalizeTabParam(searchParams.get('tab'));
+    return TAB_KEYS.indexOf(key);
+  })();
+
+  const handleTabChange = useCallback(
+    (newIndex: number) => {
+      const key = TAB_KEYS[newIndex];
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('tab', key);
+      router.push(`?${params.toString()}`, { scroll: false });
+    },
+    [router, searchParams]
+  );
+
+  const navTabs = TAB_KEYS.map((key, index) => ({
+    key,
+    label: TAB_LABELS[key],
+    id: `usage-detail-tab-${index}`,
+    'aria-controls': `usage-detail-tabpanel-${index}`,
+  }));
+
+  return (
+    <Box>
+      <DetailTabNav
+        tabs={navTabs}
+        activeIndex={activeTab}
+        onChange={handleTabChange}
+        aria-label="Usage detail tabs"
+      />
+
+      <DetailTabPanel value={activeTab} index={0} prefix="usage-detail">
+        <UsageOverviewTab />
+      </DetailTabPanel>
+      <DetailTabPanel value={activeTab} index={1} prefix="usage-detail">
+        <UsageOverTimeTab />
+      </DetailTabPanel>
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageDetailTabs.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageDetailTabs.tsx
@@ -8,19 +8,19 @@ import DetailTabPanel from '@/components/common/DetailTabPanel';
 import UsageOverviewTab from './UsageOverviewTab';
 import UsageOverTimeTab from './UsageOverTimeTab';
 
-const TAB_KEYS = ['overview', 'history'] as const;
+const TAB_KEYS = ['resources', 'timeline'] as const;
 type UsageTabKey = (typeof TAB_KEYS)[number];
 
 const TAB_LABELS: Record<UsageTabKey, string> = {
-  overview: 'Overview',
-  history: 'Usage over Time',
+  resources: 'Resources',
+  timeline: 'Timeline',
 };
 
 function normalizeTabParam(param: string | null): UsageTabKey {
   if (param && TAB_KEYS.includes(param as UsageTabKey)) {
     return param as UsageTabKey;
   }
-  return 'overview';
+  return 'resources';
 }
 
 export default function UsageDetailTabs() {

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverTimeFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverTimeFilterDrawer.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import * as React from 'react';
+import { Box } from '@mui/material';
+import {
+  FilterDrawerShell,
+  FilterSection,
+  filterChipSx,
+} from '@/components/common/FilterDrawer';
+
+export const HISTORY_RANGE_OPTIONS: { months: number; label: string }[] = [
+  { months: 3, label: '3M' },
+  { months: 6, label: '6M' },
+  { months: 12, label: '12M' },
+];
+
+interface UsageOverTimeFilterDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  months: number;
+  onChange: (months: number) => void;
+}
+
+// No Apply/Reset footer: picking a timespan has immediate effect on the
+// charts underneath, same as before this moved into a drawer.
+export default function UsageOverTimeFilterDrawer({
+  open,
+  onClose,
+  months,
+  onChange,
+}: UsageOverTimeFilterDrawerProps) {
+  return (
+    <FilterDrawerShell open={open} onClose={onClose}>
+      <FilterSection title="Timespan">
+        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+          {HISTORY_RANGE_OPTIONS.map(option => (
+            <Box
+              key={option.months}
+              component="button"
+              type="button"
+              onClick={() => onChange(option.months)}
+              sx={filterChipSx(months === option.months)}
+            >
+              {option.label}
+            </Box>
+          ))}
+        </Box>
+      </FilterSection>
+    </FilterDrawerShell>
+  );
+}

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverTimeTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverTimeTab.tsx
@@ -1,9 +1,16 @@
 'use client';
 
 import * as React from 'react';
-import { Box, Skeleton, Stack, Typography } from '@mui/material';
+import {
+  Box,
+  Grid,
+  Skeleton,
+  Stack,
+  Typography,
+  useTheme,
+} from '@mui/material';
+import { LineChart } from '@mui/x-charts/LineChart';
 import { SectionCard } from '@/components/common/SectionCard';
-import { BaseChartsGrid, BaseLineChart } from '@/components/common/BaseCharts';
 import { FilterButton } from '@/components/common/FilterButton';
 import { BORDER_RADIUS } from '@/styles/theme';
 import UsageOverTimeFilterDrawer from './UsageOverTimeFilterDrawer';
@@ -31,20 +38,24 @@ function formatMonthLabel(isoDate: string): string {
 const DEFAULT_HISTORY_MONTHS = 6;
 
 /**
- * Shared by the loading skeletons, the chart cells, and the no-history
- * cards. The three chart-cell uses must agree: see the wrapper `Box` in
- * the grid below for why the cell needs an explicit pixel height.
+ * Outer height of one grid cell, shared by the loading skeletons, the
+ * chart cards, and the no-history cards so every cell in a row lines up.
  */
 const CHART_HEIGHT = 180;
 
-function toChartData(
-  points: UsageHistoryPoint[]
-): { name: string; used: number }[] {
-  return points.map(point => ({
-    name: formatMonthLabel(point.period_start),
-    used: point.used,
-  }));
-}
+/**
+ * Height handed to the plot itself. The title sits above it inside the
+ * same fixed-height cell, so the plot gets what's left rather than the
+ * full cell height.
+ */
+const CHART_TITLE_ALLOWANCE = 34;
+const PLOT_HEIGHT = CHART_HEIGHT - CHART_TITLE_ALLOWANCE;
+
+/**
+ * Trimmed from the default: with no legend and a single series, the
+ * stock margins leave a fixed-height plot almost no room for the line.
+ */
+const PLOT_MARGIN = { top: 8, right: 12, bottom: 24, left: 48 };
 
 // The backend zero-fills every month in range, so a resource with no
 // accrual at all still returns N points -- just every one at used: 0. A
@@ -74,6 +85,54 @@ function NoHistoryCard({ title, height }: { title: string; height: number }) {
       <Typography variant="body2" color="text.secondary" textAlign="center">
         No history for this period
       </Typography>
+    </Box>
+  );
+}
+
+function UsageHistoryChart({
+  title,
+  points,
+}: {
+  title: string;
+  points: UsageHistoryPoint[];
+}) {
+  const theme = useTheme();
+
+  return (
+    <Box
+      sx={{
+        height: CHART_HEIGHT,
+        border: theme => `1px solid ${theme.palette.divider}`,
+        borderRadius: BORDER_RADIUS.sm,
+        px: 1.5,
+        pt: 1,
+      }}
+    >
+      <Typography variant="subtitle2" noWrap>
+        {title}
+      </Typography>
+      <LineChart
+        height={PLOT_HEIGHT}
+        margin={PLOT_MARGIN}
+        hideLegend
+        xAxis={[
+          {
+            scaleType: 'point',
+            data: points.map(point => formatMonthLabel(point.period_start)),
+          },
+        ]}
+        series={[
+          {
+            data: points.map(point => point.used),
+            label: 'Used',
+            color: theme.chartPalettes.line[0],
+            // Thousands separators in the tooltip: these run to millions
+            // for model tokens, where a bare digit run is unreadable.
+            valueFormatter: value =>
+              value === null ? '' : value.toLocaleString(),
+          },
+        ]}
+      />
     </Box>
   );
 }
@@ -127,33 +186,24 @@ export default function UsageOverTimeTab() {
       )}
 
       {!loading && !error && (
-        <BaseChartsGrid columns={{ xs: 12, md: 6 }}>
+        <Grid container spacing={2}>
           {flowResources.map(resource => {
             const label = QUOTA_RESOURCE_LABELS[resource as QuotaResource];
             const points = history[resource];
             return (
-              // BaseLineChart's Card relies on `height: 100%`, which only
-              // resolves against a flex row's cross-size if some sibling
-              // in that row has an explicit pixel height to stretch
-              // against. Two charts sharing a row (no NoHistoryCard
-              // sibling to anchor it) would otherwise both collapse to
-              // their title's intrinsic height -- so every cell gets an
-              // explicit height here instead of relying on a neighbor.
-              <Box key={resource} sx={{ height: CHART_HEIGHT }}>
+              // Two per row. Every cell is a fixed CHART_HEIGHT rather than
+              // stretching, so a chart and a no-history card sharing a row
+              // still line up.
+              <Grid key={resource} size={{ xs: 12, md: 6 }}>
                 {hasAnyUsage(points) ? (
-                  <BaseLineChart
-                    title={label}
-                    data={toChartData(points)}
-                    series={[{ dataKey: 'used', name: 'Used' }]}
-                    height={CHART_HEIGHT}
-                  />
+                  <UsageHistoryChart title={label} points={points} />
                 ) : (
                   <NoHistoryCard title={label} height={CHART_HEIGHT} />
                 )}
-              </Box>
+              </Grid>
             );
           })}
-        </BaseChartsGrid>
+        </Grid>
       )}
     </SectionCard>
   );

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverTimeTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverTimeTab.tsx
@@ -146,6 +146,12 @@ export default function UsageOverTimeTab() {
     resource => resource in history
   );
 
+  // The timespan is the only filter here, so an active one is a count of 1.
+  // FilterButton needs the number as well as the boolean: given only the
+  // boolean it draws the badge with nothing inside, which reads as an empty
+  // circle rather than "1 filter applied".
+  const activeFilterCount = months !== DEFAULT_HISTORY_MONTHS ? 1 : 0;
+
   return (
     <SectionCard
       title="Usage Over Time"
@@ -154,7 +160,8 @@ export default function UsageOverTimeTab() {
         <>
           <FilterButton
             onClick={() => setDrawerOpen(true)}
-            hasActiveFilters={months !== DEFAULT_HISTORY_MONTHS}
+            hasActiveFilters={activeFilterCount > 0}
+            activeFilterCount={activeFilterCount}
           />
           <UsageOverTimeFilterDrawer
             open={drawerOpen}

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverTimeTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverTimeTab.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import * as React from 'react';
+import { Box, Skeleton, Stack, Typography } from '@mui/material';
+import { SectionCard } from '@/components/common/SectionCard';
+import { BaseChartsGrid, BaseLineChart } from '@/components/common/BaseCharts';
+import { filterChipSx } from '@/components/common/FilterDrawer';
+import { useUsageHistory } from '@/hooks/useUsageHistory';
+import {
+  QUOTA_RESOURCE_LABELS,
+  QUOTA_RESOURCE_ORDER,
+  type QuotaResource,
+} from '@/constants/quota';
+import type { UsageHistoryPoint } from '@/utils/api-client/usage-client';
+
+// Same UTC-pinning as UsageOverviewTab's formatPeriodDate, and for the same
+// reason: these are date-only strings, so formatting must not drift onto
+// the previous day for viewers west of UTC. Includes the year (not just
+// "MMM") since the 12-month option can span a calendar boundary, where two
+// points would otherwise both read "Jan".
+function formatMonthLabel(isoDate: string): string {
+  return new Date(isoDate).toLocaleDateString('en-US', {
+    month: 'short',
+    year: '2-digit',
+    timeZone: 'UTC',
+  });
+}
+
+const HISTORY_RANGE_OPTIONS: { months: number; label: string }[] = [
+  { months: 3, label: '3M' },
+  { months: 6, label: '6M' },
+  { months: 12, label: '12M' },
+];
+const DEFAULT_HISTORY_MONTHS = 6;
+
+function toChartData(
+  points: UsageHistoryPoint[]
+): { name: string; used: number }[] {
+  return points.map(point => ({
+    name: formatMonthLabel(point.period_start),
+    used: point.used,
+  }));
+}
+
+// The backend zero-fills every month in range, so a resource with no
+// accrual at all still returns N points -- just every one at used: 0. A
+// flat line at zero reads as "broken chart," not "nothing happened here
+// yet," so this is checked explicitly rather than just handing an
+// all-zero series to BaseLineChart.
+function hasAnyUsage(points: UsageHistoryPoint[]): boolean {
+  return points.some(point => point.used > 0);
+}
+
+function NoHistoryCard({ title, height }: { title: string; height: number }) {
+  return (
+    <Box
+      sx={{
+        height,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 0.5,
+        border: theme => `1px solid ${theme.palette.divider}`,
+        borderRadius: 1,
+        p: 2,
+      }}
+    >
+      <Typography variant="subtitle2">{title}</Typography>
+      <Typography variant="body2" color="text.secondary" textAlign="center">
+        No history for this period
+      </Typography>
+    </Box>
+  );
+}
+
+export default function UsageOverTimeTab() {
+  const [months, setMonths] = React.useState(DEFAULT_HISTORY_MONTHS);
+  const { resources: history, loading, error } = useUsageHistory(months);
+
+  const flowResources = QUOTA_RESOURCE_ORDER.filter(
+    resource => resource in history
+  );
+
+  return (
+    <SectionCard title="Usage Over Time">
+      <Box sx={{ display: 'flex', gap: 1, mb: 3 }}>
+        {HISTORY_RANGE_OPTIONS.map(option => (
+          <Box
+            key={option.months}
+            component="button"
+            type="button"
+            onClick={() => setMonths(option.months)}
+            sx={filterChipSx(months === option.months)}
+          >
+            {option.label}
+          </Box>
+        ))}
+      </Box>
+
+      {loading && (
+        <Stack direction="row" spacing={2}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton
+              // eslint-disable-next-line react/no-array-index-key -- fixed-count skeleton placeholders, never reordered
+              key={i}
+              variant="rectangular"
+              height={180}
+              sx={{ flex: 1 }}
+            />
+          ))}
+        </Stack>
+      )}
+
+      {!loading && error && (
+        <Typography color="error.main">
+          Could not load usage history. Please try again later.
+        </Typography>
+      )}
+
+      {!loading && !error && (
+        <BaseChartsGrid>
+          {flowResources.map(resource => {
+            const label = QUOTA_RESOURCE_LABELS[resource as QuotaResource];
+            const points = history[resource];
+            return hasAnyUsage(points) ? (
+              <BaseLineChart
+                key={resource}
+                title={label}
+                data={toChartData(points)}
+                series={[{ dataKey: 'used', name: 'Used' }]}
+                height={180}
+              />
+            ) : (
+              <NoHistoryCard key={resource} title={label} height={180} />
+            );
+          })}
+        </BaseChartsGrid>
+      )}
+    </SectionCard>
+  );
+}

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverTimeTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverTimeTab.tsx
@@ -4,7 +4,8 @@ import * as React from 'react';
 import { Box, Skeleton, Stack, Typography } from '@mui/material';
 import { SectionCard } from '@/components/common/SectionCard';
 import { BaseChartsGrid, BaseLineChart } from '@/components/common/BaseCharts';
-import { filterChipSx } from '@/components/common/FilterDrawer';
+import { FilterButton } from '@/components/common/FilterButton';
+import UsageOverTimeFilterDrawer from './UsageOverTimeFilterDrawer';
 import { useUsageHistory } from '@/hooks/useUsageHistory';
 import {
   QUOTA_RESOURCE_LABELS,
@@ -26,11 +27,6 @@ function formatMonthLabel(isoDate: string): string {
   });
 }
 
-const HISTORY_RANGE_OPTIONS: { months: number; label: string }[] = [
-  { months: 3, label: '3M' },
-  { months: 6, label: '6M' },
-  { months: 12, label: '12M' },
-];
 const DEFAULT_HISTORY_MONTHS = 6;
 
 function toChartData(
@@ -76,6 +72,7 @@ function NoHistoryCard({ title, height }: { title: string; height: number }) {
 
 export default function UsageOverTimeTab() {
   const [months, setMonths] = React.useState(DEFAULT_HISTORY_MONTHS);
+  const [drawerOpen, setDrawerOpen] = React.useState(false);
   const { resources: history, loading, error } = useUsageHistory(months);
 
   const flowResources = QUOTA_RESOURCE_ORDER.filter(
@@ -83,21 +80,24 @@ export default function UsageOverTimeTab() {
   );
 
   return (
-    <SectionCard title="Usage Over Time">
-      <Box sx={{ display: 'flex', gap: 1, mb: 3 }}>
-        {HISTORY_RANGE_OPTIONS.map(option => (
-          <Box
-            key={option.months}
-            component="button"
-            type="button"
-            onClick={() => setMonths(option.months)}
-            sx={filterChipSx(months === option.months)}
-          >
-            {option.label}
-          </Box>
-        ))}
-      </Box>
-
+    <SectionCard
+      title="Usage Over Time"
+      subtitle={`Showing the last ${months} months`}
+      actions={
+        <>
+          <FilterButton
+            onClick={() => setDrawerOpen(true)}
+            hasActiveFilters={months !== DEFAULT_HISTORY_MONTHS}
+          />
+          <UsageOverTimeFilterDrawer
+            open={drawerOpen}
+            onClose={() => setDrawerOpen(false)}
+            months={months}
+            onChange={setMonths}
+          />
+        </>
+      }
+    >
       {loading && (
         <Stack direction="row" spacing={2}>
           {Array.from({ length: 4 }).map((_, i) => (
@@ -119,20 +119,30 @@ export default function UsageOverTimeTab() {
       )}
 
       {!loading && !error && (
-        <BaseChartsGrid>
+        <BaseChartsGrid columns={{ xs: 12, md: 6 }}>
           {flowResources.map(resource => {
             const label = QUOTA_RESOURCE_LABELS[resource as QuotaResource];
             const points = history[resource];
-            return hasAnyUsage(points) ? (
-              <BaseLineChart
-                key={resource}
-                title={label}
-                data={toChartData(points)}
-                series={[{ dataKey: 'used', name: 'Used' }]}
-                height={180}
-              />
-            ) : (
-              <NoHistoryCard key={resource} title={label} height={180} />
+            return (
+              // BaseLineChart's Card relies on `height: 100%`, which only
+              // resolves against a flex row's cross-size if some sibling
+              // in that row has an explicit pixel height to stretch
+              // against. Two charts sharing a row (no NoHistoryCard
+              // sibling to anchor it) would otherwise both collapse to
+              // their title's intrinsic height -- so every cell gets an
+              // explicit height here instead of relying on a neighbor.
+              <Box key={resource} sx={{ height: 180 }}>
+                {hasAnyUsage(points) ? (
+                  <BaseLineChart
+                    title={label}
+                    data={toChartData(points)}
+                    series={[{ dataKey: 'used', name: 'Used' }]}
+                    height={180}
+                  />
+                ) : (
+                  <NoHistoryCard title={label} height={180} />
+                )}
+              </Box>
             );
           })}
         </BaseChartsGrid>

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverTimeTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverTimeTab.tsx
@@ -5,6 +5,7 @@ import { Box, Skeleton, Stack, Typography } from '@mui/material';
 import { SectionCard } from '@/components/common/SectionCard';
 import { BaseChartsGrid, BaseLineChart } from '@/components/common/BaseCharts';
 import { FilterButton } from '@/components/common/FilterButton';
+import { BORDER_RADIUS } from '@/styles/theme';
 import UsageOverTimeFilterDrawer from './UsageOverTimeFilterDrawer';
 import { useUsageHistory } from '@/hooks/useUsageHistory';
 import {
@@ -28,6 +29,13 @@ function formatMonthLabel(isoDate: string): string {
 }
 
 const DEFAULT_HISTORY_MONTHS = 6;
+
+/**
+ * Shared by the loading skeletons, the chart cells, and the no-history
+ * cards. The three chart-cell uses must agree: see the wrapper `Box` in
+ * the grid below for why the cell needs an explicit pixel height.
+ */
+const CHART_HEIGHT = 180;
 
 function toChartData(
   points: UsageHistoryPoint[]
@@ -58,7 +66,7 @@ function NoHistoryCard({ title, height }: { title: string; height: number }) {
         justifyContent: 'center',
         gap: 0.5,
         border: theme => `1px solid ${theme.palette.divider}`,
-        borderRadius: 1,
+        borderRadius: BORDER_RADIUS.sm,
         p: 2,
       }}
     >
@@ -105,7 +113,7 @@ export default function UsageOverTimeTab() {
               // eslint-disable-next-line react/no-array-index-key -- fixed-count skeleton placeholders, never reordered
               key={i}
               variant="rectangular"
-              height={180}
+              height={CHART_HEIGHT}
               sx={{ flex: 1 }}
             />
           ))}
@@ -131,16 +139,16 @@ export default function UsageOverTimeTab() {
               // sibling to anchor it) would otherwise both collapse to
               // their title's intrinsic height -- so every cell gets an
               // explicit height here instead of relying on a neighbor.
-              <Box key={resource} sx={{ height: 180 }}>
+              <Box key={resource} sx={{ height: CHART_HEIGHT }}>
                 {hasAnyUsage(points) ? (
                   <BaseLineChart
                     title={label}
                     data={toChartData(points)}
                     series={[{ dataKey: 'used', name: 'Used' }]}
-                    height={180}
+                    height={CHART_HEIGHT}
                   />
                 ) : (
-                  <NoHistoryCard title={label} height={180} />
+                  <NoHistoryCard title={label} height={CHART_HEIGHT} />
                 )}
               </Box>
             );

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewFilterDrawer.tsx
@@ -40,7 +40,7 @@ export default function UsageOverviewFilterDrawer({
       onReset={handleReset}
       onApply={handleApply}
     >
-      <FilterSection title="Billing Period">
+      <FilterSection title="Usage Period">
         <FormControl fullWidth size="small">
           <InputLabel id="usage-overview-period-label">Period</InputLabel>
           <Select

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewFilterDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewFilterDrawer.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import * as React from 'react';
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
+import {
+  FilterDrawerShell,
+  FilterSection,
+  filterDrawerSelectSx,
+  useFilterDrawerDraft,
+} from '@/components/common/FilterDrawer';
+import { getUsagePeriodOptions } from '@/utils/usagePeriods';
+
+// MUI's Select needs a defined `value` for every option -- `null` (our
+// "current period" sentinel) can't be one, so it's swapped for this string
+// at the component boundary and back on change.
+const CURRENT_PERIOD_OPTION_VALUE = '__current__';
+
+interface UsageOverviewFilterDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  periodStart: string | null;
+  onApply: (periodStart: string | null) => void;
+}
+
+export default function UsageOverviewFilterDrawer({
+  open,
+  onClose,
+  periodStart,
+  onApply,
+}: UsageOverviewFilterDrawerProps) {
+  const options = React.useMemo(() => getUsagePeriodOptions(), []);
+  const { draft, setDraft, handleReset, handleApply } = useFilterDrawerDraft<
+    string | null
+  >(open, periodStart, null, onApply, onClose);
+
+  return (
+    <FilterDrawerShell
+      open={open}
+      onClose={onClose}
+      onReset={handleReset}
+      onApply={handleApply}
+    >
+      <FilterSection title="Billing Period">
+        <FormControl fullWidth size="small">
+          <InputLabel id="usage-overview-period-label">Period</InputLabel>
+          <Select
+            labelId="usage-overview-period-label"
+            value={draft ?? CURRENT_PERIOD_OPTION_VALUE}
+            label="Period"
+            onChange={e =>
+              setDraft(
+                e.target.value === CURRENT_PERIOD_OPTION_VALUE
+                  ? null
+                  : e.target.value
+              )
+            }
+            sx={filterDrawerSelectSx}
+          >
+            {options.map(option => (
+              <MenuItem
+                key={option.value ?? CURRENT_PERIOD_OPTION_VALUE}
+                value={option.value ?? CURRENT_PERIOD_OPTION_VALUE}
+              >
+                {option.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </FilterSection>
+    </FilterDrawerShell>
+  );
+}

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
@@ -9,19 +9,13 @@ import {
   Typography,
 } from '@mui/material';
 import { SectionCard } from '@/components/common/SectionCard';
-import { BaseChartsGrid, BaseLineChart } from '@/components/common/BaseCharts';
-import { filterChipSx } from '@/components/common/FilterDrawer';
 import { useUsage } from '@/contexts/UsageContext';
-import { useUsageHistory } from '@/hooks/useUsageHistory';
 import {
   QUOTA_RESOURCE_LABELS,
   QUOTA_RESOURCE_ORDER,
   type QuotaResource,
 } from '@/constants/quota';
-import type {
-  UsageHistoryPoint,
-  UsageResourceItem,
-} from '@/utils/api-client/usage-client';
+import type { UsageResourceItem } from '@/utils/api-client/usage-client';
 
 function formatPeriodDate(isoDate: string): string {
   // period_start/period_end are date-only strings (YYYY-MM-DD), computed
@@ -35,35 +29,6 @@ function formatPeriodDate(isoDate: string): string {
     day: 'numeric',
     timeZone: 'UTC',
   });
-}
-
-// Same UTC-pinning as formatPeriodDate, and for the same reason: these are
-// date-only strings, so formatting must not drift onto the previous day
-// for viewers west of UTC. Includes the year (not just "MMM") since the
-// 12-month option can span a calendar boundary, where two points would
-// otherwise both read "Jan".
-function formatMonthLabel(isoDate: string): string {
-  return new Date(isoDate).toLocaleDateString('en-US', {
-    month: 'short',
-    year: '2-digit',
-    timeZone: 'UTC',
-  });
-}
-
-const HISTORY_RANGE_OPTIONS: { months: number; label: string }[] = [
-  { months: 3, label: '3M' },
-  { months: 6, label: '6M' },
-  { months: 12, label: '12M' },
-];
-const DEFAULT_HISTORY_MONTHS = 6;
-
-function toChartData(
-  points: UsageHistoryPoint[]
-): { name: string; used: number }[] {
-  return points.map(point => ({
-    name: formatMonthLabel(point.period_start),
-    used: point.used,
-  }));
 }
 
 function progressColor(ratio: number): 'success' | 'warning' | 'error' {
@@ -148,68 +113,7 @@ function ResourceGroup({
   );
 }
 
-function UsageHistorySection() {
-  const [months, setMonths] = React.useState(DEFAULT_HISTORY_MONTHS);
-  const { resources: history, loading, error } = useUsageHistory(months);
-
-  const flowResources = QUOTA_RESOURCE_ORDER.filter(
-    resource => resource in history
-  );
-
-  return (
-    <SectionCard title="Usage Over Time">
-      <Box sx={{ display: 'flex', gap: 1, mb: 3 }}>
-        {HISTORY_RANGE_OPTIONS.map(option => (
-          <Box
-            key={option.months}
-            component="button"
-            type="button"
-            onClick={() => setMonths(option.months)}
-            sx={filterChipSx(months === option.months)}
-          >
-            {option.label}
-          </Box>
-        ))}
-      </Box>
-
-      {loading && (
-        <Stack direction="row" spacing={2}>
-          {Array.from({ length: 4 }).map((_, i) => (
-            <Skeleton
-              // eslint-disable-next-line react/no-array-index-key -- fixed-count skeleton placeholders, never reordered
-              key={i}
-              variant="rectangular"
-              height={180}
-              sx={{ flex: 1 }}
-            />
-          ))}
-        </Stack>
-      )}
-
-      {!loading && error && (
-        <Typography color="error.main">
-          Could not load usage history. Please try again later.
-        </Typography>
-      )}
-
-      {!loading && !error && (
-        <BaseChartsGrid>
-          {flowResources.map(resource => (
-            <BaseLineChart
-              key={resource}
-              title={QUOTA_RESOURCE_LABELS[resource as QuotaResource]}
-              data={toChartData(history[resource])}
-              series={[{ dataKey: 'used', name: 'Used' }]}
-              height={180}
-            />
-          ))}
-        </BaseChartsGrid>
-      )}
-    </SectionCard>
-  );
-}
-
-export default function UsageTab() {
+export default function UsageOverviewTab() {
   const { resources, edition, loading, error } = useUsage();
 
   if (loading) {
@@ -241,23 +145,16 @@ export default function UsageTab() {
     : null;
 
   return (
-    <Stack spacing={3}>
-      <SectionCard
-        title="Usage"
-        subtitle={
-          periodLabel
-            ? `Current billing period: ${periodLabel}${edition ? ` · ${edition} plan` : ''}`
-            : undefined
-        }
-      >
-        <ResourceGroup
-          title="Metered Resources"
-          kind="flow"
-          usage={resources}
-        />
-        <ResourceGroup title="Resource Counts" kind="stock" usage={resources} />
-      </SectionCard>
-      <UsageHistorySection />
-    </Stack>
+    <SectionCard
+      title="Usage"
+      subtitle={
+        periodLabel
+          ? `Current billing period: ${periodLabel}${edition ? ` · ${edition} plan` : ''}`
+          : undefined
+      }
+    >
+      <ResourceGroup title="Metered Resources" kind="flow" usage={resources} />
+      <ResourceGroup title="Resource Counts" kind="stock" usage={resources} />
+    </SectionCard>
   );
 }

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
@@ -3,19 +3,59 @@
 import * as React from 'react';
 import {
   Box,
+  Button,
+  Chip,
   LinearProgress,
   Skeleton,
   Stack,
   Typography,
 } from '@mui/material';
 import { SectionCard } from '@/components/common/SectionCard';
-import { useUsage } from '@/contexts/UsageContext';
+import { FilterButton } from '@/components/common/FilterButton';
+import { useUsageForPeriod } from '@/hooks/useUsageForPeriod';
+import UsageOverviewFilterDrawer from './UsageOverviewFilterDrawer';
+import { BORDER_RADIUS } from '@/styles/theme';
 import {
   QUOTA_RESOURCE_LABELS,
   QUOTA_RESOURCE_ORDER,
   type QuotaResource,
 } from '@/constants/quota';
 import type { UsageResourceItem } from '@/utils/api-client/usage-client';
+
+const COMMUNITY_EDITION = 'community';
+const UPGRADE_URL = 'https://rhesis.ai/editions';
+
+function isCommunityEdition(edition: string): boolean {
+  return edition.toLowerCase() === COMMUNITY_EDITION;
+}
+
+function PlanChip({ edition }: { edition: string }) {
+  const label = `${edition.charAt(0).toUpperCase()}${edition.slice(1)} plan`;
+  return (
+    <Chip
+      label={label}
+      size="small"
+      color={isCommunityEdition(edition) ? 'default' : 'primary'}
+      sx={{ borderRadius: BORDER_RADIUS.pill, fontWeight: 600 }}
+    />
+  );
+}
+
+function UpgradeLink() {
+  return (
+    <Button
+      component="a"
+      href={UPGRADE_URL}
+      target="_blank"
+      rel="noopener noreferrer"
+      variant="outlined"
+      size="small"
+      sx={{ borderRadius: BORDER_RADIUS.sm, fontWeight: 600 }}
+    >
+      Upgrade
+    </Button>
+  );
+}
 
 function formatPeriodDate(isoDate: string): string {
   // period_start/period_end are date-only strings (YYYY-MM-DD), computed
@@ -80,28 +120,15 @@ function ResourceMeter({
   );
 }
 
-function ResourceGroup({
-  title,
-  kind,
+function ResourceList({
   usage,
 }: {
-  title: string;
-  kind: UsageResourceItem['kind'];
   usage: Readonly<Record<string, UsageResourceItem>>;
 }) {
-  const entries = QUOTA_RESOURCE_ORDER.filter(
-    resource => usage[resource]?.kind === kind
-  );
-  if (entries.length === 0) return null;
+  const entries = QUOTA_RESOURCE_ORDER.filter(resource => usage[resource]);
 
   return (
-    <Box sx={{ mb: 4, '&:last-child': { mb: 0 } }}>
-      <Typography
-        variant="subtitle2"
-        sx={{ mb: 2, color: 'text.secondary', textTransform: 'uppercase' }}
-      >
-        {title}
-      </Typography>
+    <Box>
       {entries.map(resource => (
         <ResourceMeter
           key={resource}
@@ -114,11 +141,30 @@ function ResourceGroup({
 }
 
 export default function UsageOverviewTab() {
-  const { resources, edition, loading, error } = useUsage();
+  const [periodStart, setPeriodStart] = React.useState<string | null>(null);
+  const [drawerOpen, setDrawerOpen] = React.useState(false);
+  const { resources, edition, loading, error } = useUsageForPeriod(periodStart);
+
+  const headerActions = (
+    <Stack direction="row" spacing={1.5} alignItems="center">
+      {edition && <PlanChip edition={edition} />}
+      {edition && isCommunityEdition(edition) && <UpgradeLink />}
+      <FilterButton
+        onClick={() => setDrawerOpen(true)}
+        hasActiveFilters={periodStart !== null}
+      />
+      <UsageOverviewFilterDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        periodStart={periodStart}
+        onApply={setPeriodStart}
+      />
+    </Stack>
+  );
 
   if (loading) {
     return (
-      <SectionCard title="Usage">
+      <SectionCard title="Usage" actions={headerActions}>
         <Stack spacing={2}>
           {Array.from({ length: 4 }).map((_, i) => (
             // eslint-disable-next-line react/no-array-index-key -- fixed-count skeleton placeholders, never reordered
@@ -131,7 +177,7 @@ export default function UsageOverviewTab() {
 
   if (error) {
     return (
-      <SectionCard title="Usage">
+      <SectionCard title="Usage" actions={headerActions}>
         <Typography color="error.main">
           Could not load usage data. Please try again later.
         </Typography>
@@ -143,18 +189,16 @@ export default function UsageOverviewTab() {
   const periodLabel = anyResource
     ? `${formatPeriodDate(anyResource.period_start)} – ${formatPeriodDate(anyResource.period_end)}`
     : null;
+  const periodPrefix =
+    periodStart === null ? 'Current billing period' : 'Billing period';
 
   return (
     <SectionCard
       title="Usage"
-      subtitle={
-        periodLabel
-          ? `Current billing period: ${periodLabel}${edition ? ` · ${edition} plan` : ''}`
-          : undefined
-      }
+      subtitle={periodLabel ? `${periodPrefix}: ${periodLabel}` : undefined}
+      actions={headerActions}
     >
-      <ResourceGroup title="Metered Resources" kind="flow" usage={resources} />
-      <ResourceGroup title="Resource Counts" kind="stock" usage={resources} />
+      <ResourceList usage={resources} />
     </SectionCard>
   );
 }

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
@@ -165,13 +165,19 @@ export default function UsageOverviewTab() {
   const [drawerOpen, setDrawerOpen] = React.useState(false);
   const { resources, edition, loading, error } = useUsageForPeriod(periodStart);
 
+  // The period is the only filter here, so an active one is a count of 1.
+  // Passing the number matters: given only the boolean, FilterButton draws
+  // the badge with nothing inside it.
+  const activeFilterCount = periodStart !== null ? 1 : 0;
+
   const headerActions = (
     <Stack direction="row" spacing={1.5} alignItems="center">
       {edition && <PlanChip edition={edition} />}
       {edition && isCommunityEdition(edition) && <UpgradeLink />}
       <FilterButton
         onClick={() => setDrawerOpen(true)}
-        hasActiveFilters={periodStart !== null}
+        hasActiveFilters={activeFilterCount > 0}
+        activeFilterCount={activeFilterCount}
       />
       <UsageOverviewFilterDrawer
         open={drawerOpen}

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
@@ -216,9 +216,7 @@ export default function UsageOverviewTab() {
     ? `${formatPeriodDate(periodSource.period_start)} – ${formatPeriodDate(periodSource.period_end)}`
     : null;
   const isPastPeriod = periodStart !== null;
-  const periodPrefix = isPastPeriod
-    ? 'Billing period'
-    : 'Current billing period';
+  const periodPrefix = isPastPeriod ? 'Usage period' : 'Current usage period';
 
   return (
     <SectionCard

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/UsageOverviewTab.tsx
@@ -80,9 +80,15 @@ function progressColor(ratio: number): 'success' | 'warning' | 'error' {
 function ResourceMeter({
   label,
   item,
+  showLiveCountHint = false,
 }: {
   label: string;
   item: UsageResourceItem;
+  /**
+   * Marks this row as a live count that does *not* belong to the period in
+   * the card's heading -- see `ResourceList`.
+   */
+  showLiveCountHint?: boolean;
 }) {
   const { limit } = item;
   const ratio = limit === null ? 0 : limit === 0 ? 1 : item.used / limit;
@@ -95,9 +101,16 @@ function ResourceMeter({
         alignItems="baseline"
         sx={{ mb: 0.5 }}
       >
-        <Typography variant="body2" sx={{ fontWeight: 600 }}>
-          {label}
-        </Typography>
+        <Stack direction="row" spacing={0.75} alignItems="baseline">
+          <Typography variant="body2" sx={{ fontWeight: 600 }}>
+            {label}
+          </Typography>
+          {showLiveCountHint && (
+            <Typography variant="caption" color="text.secondary">
+              as of today
+            </Typography>
+          )}
+        </Stack>
         <Typography variant="body2" color="text.secondary">
           {item.used.toLocaleString()}
           {limit === null ? ' (Unlimited)' : ` / ${limit.toLocaleString()}`}
@@ -109,10 +122,10 @@ function ResourceMeter({
         color={limit === null ? 'primary' : progressColor(ratio)}
         sx={{
           height: 6,
-          borderRadius: 2,
+          borderRadius: BORDER_RADIUS.xs,
           bgcolor: theme => theme.palette.action.hover,
           '& .MuiLinearProgress-bar': {
-            borderRadius: 2,
+            borderRadius: BORDER_RADIUS.xs,
           },
         }}
       />
@@ -122,8 +135,10 @@ function ResourceMeter({
 
 function ResourceList({
   usage,
+  isPastPeriod,
 }: {
   usage: Readonly<Record<string, UsageResourceItem>>;
+  isPastPeriod: boolean;
 }) {
   const entries = QUOTA_RESOURCE_ORDER.filter(resource => usage[resource]);
 
@@ -134,6 +149,11 @@ function ResourceList({
           key={resource}
           label={QUOTA_RESOURCE_LABELS[resource as QuotaResource]}
           item={usage[resource]}
+          // Stock resources have no historical row -- the backend always
+          // answers with today's live count, whichever period was asked
+          // for. Unlabelled under a past month's heading, "Seats 11 / 3"
+          // reads as that month's seat count, so say otherwise.
+          showLiveCountHint={isPastPeriod && usage[resource].kind === 'stock'}
         />
       ))}
     </Box>
@@ -185,12 +205,20 @@ export default function UsageOverviewTab() {
     );
   }
 
-  const anyResource = Object.values(resources)[0];
-  const periodLabel = anyResource
-    ? `${formatPeriodDate(anyResource.period_start)} – ${formatPeriodDate(anyResource.period_end)}`
+  // Specifically a *flow* resource: only those carry the requested
+  // period. Stock items always report the current one, so picking whatever
+  // resource happens to come first would silently start labelling the card
+  // with today's dates if the backend's QuotaResource order ever changed.
+  const periodSource = Object.values(resources).find(
+    item => item.kind === 'flow'
+  );
+  const periodLabel = periodSource
+    ? `${formatPeriodDate(periodSource.period_start)} – ${formatPeriodDate(periodSource.period_end)}`
     : null;
-  const periodPrefix =
-    periodStart === null ? 'Current billing period' : 'Billing period';
+  const isPastPeriod = periodStart !== null;
+  const periodPrefix = isPastPeriod
+    ? 'Billing period'
+    : 'Current billing period';
 
   return (
     <SectionCard
@@ -198,7 +226,7 @@ export default function UsageOverviewTab() {
       subtitle={periodLabel ? `${periodPrefix}: ${periodLabel}` : undefined}
       actions={headerActions}
     >
-      <ResourceList usage={resources} />
+      <ResourceList usage={resources} isPastPeriod={isPastPeriod} />
     </SectionCard>
   );
 }

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageDetailTabs.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageDetailTabs.test.tsx
@@ -28,21 +28,21 @@ beforeEach(() => {
 });
 
 describe('UsageDetailTabs', () => {
-  it('defaults to the Overview tab when no ?tab= param is present', () => {
+  it('defaults to the Resources tab when no ?tab= param is present', () => {
     render(<UsageDetailTabs />);
 
     expect(screen.getByTestId('overview-tab')).toBeVisible();
   });
 
-  it('shows the Usage over Time tab when ?tab=history', () => {
-    mockSearchParams = new URLSearchParams('tab=history');
+  it('shows the Timeline tab when ?tab=timeline', () => {
+    mockSearchParams = new URLSearchParams('tab=timeline');
 
     render(<UsageDetailTabs />);
 
     expect(screen.getByTestId('history-tab')).toBeVisible();
   });
 
-  it('falls back to Overview for an unrecognized ?tab= value', () => {
+  it('falls back to Resources for an unrecognized ?tab= value', () => {
     mockSearchParams = new URLSearchParams('tab=nonsense');
 
     render(<UsageDetailTabs />);
@@ -50,18 +50,18 @@ describe('UsageDetailTabs', () => {
     expect(screen.getByTestId('overview-tab')).toBeVisible();
   });
 
-  it('pushes the history tab key when clicking "Usage over Time"', () => {
+  it('pushes the timeline tab key when clicking "Timeline"', () => {
     render(<UsageDetailTabs />);
 
-    fireEvent.click(screen.getByText('Usage over Time'));
+    fireEvent.click(screen.getByText('Timeline'));
 
-    expect(mockPush).toHaveBeenCalledWith('?tab=history', { scroll: false });
+    expect(mockPush).toHaveBeenCalledWith('?tab=timeline', { scroll: false });
   });
 
   it('renders both tab labels', () => {
     render(<UsageDetailTabs />);
 
-    expect(screen.getByText('Overview')).toBeInTheDocument();
-    expect(screen.getByText('Usage over Time')).toBeInTheDocument();
+    expect(screen.getByText('Resources')).toBeInTheDocument();
+    expect(screen.getByText('Timeline')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageDetailTabs.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageDetailTabs.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@/test-utils';
+import '@testing-library/jest-dom';
+
+import UsageDetailTabs from '../UsageDetailTabs';
+
+const mockPush = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+jest.mock('../UsageOverviewTab', () => ({
+  __esModule: true,
+  default: () => <div data-testid="overview-tab">overview content</div>,
+}));
+
+jest.mock('../UsageOverTimeTab', () => ({
+  __esModule: true,
+  default: () => <div data-testid="history-tab">history content</div>,
+}));
+
+beforeEach(() => {
+  mockPush.mockReset();
+  mockSearchParams = new URLSearchParams();
+});
+
+describe('UsageDetailTabs', () => {
+  it('defaults to the Overview tab when no ?tab= param is present', () => {
+    render(<UsageDetailTabs />);
+
+    expect(screen.getByTestId('overview-tab')).toBeVisible();
+  });
+
+  it('shows the Usage over Time tab when ?tab=history', () => {
+    mockSearchParams = new URLSearchParams('tab=history');
+
+    render(<UsageDetailTabs />);
+
+    expect(screen.getByTestId('history-tab')).toBeVisible();
+  });
+
+  it('falls back to Overview for an unrecognized ?tab= value', () => {
+    mockSearchParams = new URLSearchParams('tab=nonsense');
+
+    render(<UsageDetailTabs />);
+
+    expect(screen.getByTestId('overview-tab')).toBeVisible();
+  });
+
+  it('pushes the history tab key when clicking "Usage over Time"', () => {
+    render(<UsageDetailTabs />);
+
+    fireEvent.click(screen.getByText('Usage over Time'));
+
+    expect(mockPush).toHaveBeenCalledWith('?tab=history', { scroll: false });
+  });
+
+  it('renders both tab labels', () => {
+    render(<UsageDetailTabs />);
+
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    expect(screen.getByText('Usage over Time')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverTimeFilterDrawer.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverTimeFilterDrawer.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@/test-utils';
+import '@testing-library/jest-dom';
+
+import UsageOverTimeFilterDrawer from '../UsageOverTimeFilterDrawer';
+
+describe('UsageOverTimeFilterDrawer', () => {
+  it('renders a chip for each timespan option', () => {
+    render(
+      <UsageOverTimeFilterDrawer
+        open
+        onClose={jest.fn()}
+        months={6}
+        onChange={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('3M')).toBeInTheDocument();
+    expect(screen.getByText('6M')).toBeInTheDocument();
+    expect(screen.getByText('12M')).toBeInTheDocument();
+  });
+
+  it('calls onChange immediately when a chip is clicked, without an Apply step', () => {
+    const onChange = jest.fn();
+    render(
+      <UsageOverTimeFilterDrawer
+        open
+        onClose={jest.fn()}
+        months={6}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText('12M'));
+
+    expect(onChange).toHaveBeenCalledWith(12);
+    expect(
+      screen.queryByRole('button', { name: 'Apply' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverTimeTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverTimeTab.test.tsx
@@ -48,6 +48,22 @@ describe('UsageOverTimeTab', () => {
     expect(screen.getByText('Showing the last 6 months')).toBeInTheDocument();
   });
 
+  it('shows no filter badge while the default timespan is selected', () => {
+    render(<UsageOverTimeTab />);
+
+    expect(screen.queryByLabelText(/active filters/i)).not.toBeInTheDocument();
+  });
+
+  it('counts the timespan filter on the badge once it differs from the default', () => {
+    render(<UsageOverTimeTab />);
+
+    fireEvent.click(screen.getByText('12M'));
+
+    // The count, not just a bare dot: FilterButton renders an empty circle
+    // when handed only hasActiveFilters.
+    expect(screen.getByLabelText('1 active filters')).toHaveTextContent('1');
+  });
+
   it('switches the requested range when a different pill is clicked', () => {
     render(<UsageOverTimeTab />);
 

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverTimeTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverTimeTab.test.tsx
@@ -97,7 +97,7 @@ describe('UsageOverTimeTab', () => {
     expect(screen.getByText('Tracing Spans')).toBeInTheDocument();
     expect(screen.getByText('No history for this period')).toBeInTheDocument();
     expect(
-      document.querySelector('.recharts-responsive-container')
+      document.querySelector('.MuiChartsSurface-root')
     ).not.toBeInTheDocument();
   });
 
@@ -120,7 +120,7 @@ describe('UsageOverTimeTab', () => {
       screen.queryByText('No history for this period')
     ).not.toBeInTheDocument();
     expect(
-      document.querySelector('.recharts-responsive-container')
+      document.querySelector('.MuiChartsSurface-root')
     ).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverTimeTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverTimeTab.test.tsx
@@ -2,45 +2,19 @@ import React from 'react';
 import { render, screen, fireEvent } from '@/test-utils';
 import '@testing-library/jest-dom';
 
-import UsageTab from '../UsageTab';
-import { useUsage } from '@/contexts/UsageContext';
+import UsageOverTimeTab from '../UsageOverTimeTab';
 import { useUsageHistory } from '@/hooks/useUsageHistory';
-
-jest.mock('@/contexts/UsageContext', () => ({
-  useUsage: jest.fn(),
-}));
 
 jest.mock('@/hooks/useUsageHistory', () => ({
   useUsageHistory: jest.fn(),
 }));
 
-const mockUseUsage = useUsage as jest.Mock;
 const mockUseUsageHistory = useUsageHistory as jest.Mock;
-
-const USAGE_RESOURCES = {
-  test_executions: {
-    used: 5,
-    limit: 1000,
-    period_start: '2026-08-01',
-    period_end: '2026-08-31',
-    kind: 'flow' as const,
-  },
-  seats: {
-    used: 3,
-    limit: 10,
-    period_start: '2026-08-01',
-    period_end: '2026-08-31',
-    kind: 'stock' as const,
-  },
-};
 
 function historyState(
   overrides: Partial<ReturnType<typeof useUsageHistory>> = {}
 ) {
   return {
-    // Deliberately a resource absent from USAGE_RESOURCES above (which only
-    // has test_executions/seats): the chart title and a meter label
-    // rendering the same text would make getByText ambiguous.
     resources: {
       tracing_spans: [
         { period_start: '2026-06-01', used: 1 },
@@ -55,34 +29,26 @@ function historyState(
 }
 
 beforeEach(() => {
-  mockUseUsage.mockReset();
   mockUseUsageHistory.mockReset();
-  mockUseUsage.mockReturnValue({
-    resources: USAGE_RESOURCES,
-    edition: 'community',
-    loading: false,
-    error: null,
-  });
   mockUseUsageHistory.mockReturnValue(historyState());
 });
 
-describe('UsageTab history section', () => {
+describe('UsageOverTimeTab', () => {
   it('renders a chart title per flow resource returned by the history hook', () => {
-    render(<UsageTab />);
+    render(<UsageOverTimeTab />);
 
     expect(screen.getByText('Usage Over Time')).toBeInTheDocument();
-    // Chart title -- one per key in useUsageHistory's resources map.
     expect(screen.getByText('Tracing Spans')).toBeInTheDocument();
   });
 
   it('defaults to the 6-month filter and requests history for it', () => {
-    render(<UsageTab />);
+    render(<UsageOverTimeTab />);
 
     expect(mockUseUsageHistory).toHaveBeenCalledWith(6);
   });
 
   it('switches the requested range when a different pill is clicked', () => {
-    render(<UsageTab />);
+    render(<UsageOverTimeTab />);
 
     fireEvent.click(screen.getByText('12M'));
 
@@ -94,7 +60,7 @@ describe('UsageTab history section', () => {
       historyState({ loading: true, resources: {} })
     );
 
-    render(<UsageTab />);
+    render(<UsageOverTimeTab />);
 
     expect(screen.queryByText('Tracing Spans')).not.toBeInTheDocument();
   });
@@ -104,10 +70,55 @@ describe('UsageTab history section', () => {
       historyState({ error: new Error('boom'), resources: {} })
     );
 
-    render(<UsageTab />);
+    render(<UsageOverTimeTab />);
 
     expect(
       screen.getByText('Could not load usage history. Please try again later.')
+    ).toBeInTheDocument();
+  });
+
+  it('shows a no-history message instead of a flat zero-line chart', () => {
+    mockUseUsageHistory.mockReturnValue(
+      historyState({
+        resources: {
+          tracing_spans: [
+            { period_start: '2026-06-01', used: 0 },
+            { period_start: '2026-07-01', used: 0 },
+            { period_start: '2026-08-01', used: 0 },
+          ],
+        },
+      })
+    );
+
+    render(<UsageOverTimeTab />);
+
+    expect(screen.getByText('Tracing Spans')).toBeInTheDocument();
+    expect(screen.getByText('No history for this period')).toBeInTheDocument();
+    expect(
+      document.querySelector('.recharts-responsive-container')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the chart (not the no-history message) when at least one point is non-zero', () => {
+    mockUseUsageHistory.mockReturnValue(
+      historyState({
+        resources: {
+          tracing_spans: [
+            { period_start: '2026-06-01', used: 0 },
+            { period_start: '2026-07-01', used: 0 },
+            { period_start: '2026-08-01', used: 1 },
+          ],
+        },
+      })
+    );
+
+    render(<UsageOverTimeTab />);
+
+    expect(
+      screen.queryByText('No history for this period')
+    ).not.toBeInTheDocument();
+    expect(
+      document.querySelector('.recharts-responsive-container')
     ).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverTimeTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverTimeTab.test.tsx
@@ -45,6 +45,7 @@ describe('UsageOverTimeTab', () => {
     render(<UsageOverTimeTab />);
 
     expect(mockUseUsageHistory).toHaveBeenCalledWith(6);
+    expect(screen.getByText('Showing the last 6 months')).toBeInTheDocument();
   });
 
   it('switches the requested range when a different pill is clicked', () => {
@@ -53,6 +54,7 @@ describe('UsageOverTimeTab', () => {
     fireEvent.click(screen.getByText('12M'));
 
     expect(mockUseUsageHistory).toHaveBeenLastCalledWith(12);
+    expect(screen.getByText('Showing the last 12 months')).toBeInTheDocument();
   });
 
   it('shows a loading state instead of charts while history is loading', () => {

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewFilterDrawer.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewFilterDrawer.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@/test-utils';
+import '@testing-library/jest-dom';
+
+import UsageOverviewFilterDrawer from '../UsageOverviewFilterDrawer';
+
+describe('UsageOverviewFilterDrawer', () => {
+  it('defaults the select to "Current period" when no period is applied', () => {
+    render(
+      <UsageOverviewFilterDrawer
+        open
+        onClose={jest.fn()}
+        periodStart={null}
+        onApply={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText('Current period')).toBeInTheDocument();
+  });
+
+  it('applies the selected past month and closes', () => {
+    const onApply = jest.fn();
+    const onClose = jest.fn();
+    render(
+      <UsageOverviewFilterDrawer
+        open
+        onClose={onClose}
+        periodStart={null}
+        onApply={onApply}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByLabelText('Period'));
+    const options = screen.getAllByRole('option');
+    // options[0] is "Current period"; the next one is the most recent past month.
+    fireEvent.click(options[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(onApply).toHaveBeenCalledWith(
+      expect.stringMatching(/^\d{4}-\d{2}-01$/)
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('resets the draft back to the current period without applying', () => {
+    const onApply = jest.fn();
+    render(
+      <UsageOverviewFilterDrawer
+        open
+        onClose={jest.fn()}
+        periodStart="2026-07-01"
+        onApply={onApply}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }));
+
+    expect(screen.getByText('Current period')).toBeInTheDocument();
+    expect(onApply).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
@@ -124,6 +124,21 @@ describe('UsageOverviewTab', () => {
     expect(screen.getByText('as of today')).toBeInTheDocument();
   });
 
+  it('counts the period filter on the badge once a past period is selected', () => {
+    render(<UsageOverviewTab />);
+
+    expect(screen.queryByLabelText(/active filters/i)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    fireEvent.mouseDown(screen.getByLabelText('Period'));
+    fireEvent.click(screen.getAllByRole('option')[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    // The count, not just a bare dot: FilterButton renders an empty circle
+    // when handed only hasActiveFilters.
+    expect(screen.getByLabelText('1 active filters')).toHaveTextContent('1');
+  });
+
   it('labels the period from a flow resource, not whichever comes first', () => {
     // Stock items carry the *current* period while flow items carry the
     // requested one, so a stock-first response must not retitle the card.

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@/test-utils';
+import { render, screen, fireEvent } from '@/test-utils';
 import '@testing-library/jest-dom';
 
 import UsageOverviewTab from '../UsageOverviewTab';
@@ -103,6 +103,55 @@ describe('UsageOverviewTab', () => {
     expect(upgradeLink).toHaveAttribute('href', 'https://rhesis.ai/editions');
     expect(upgradeLink).toHaveAttribute('target', '_blank');
     expect(upgradeLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('does not mark stock resources as live counts for the current period', () => {
+    render(<UsageOverviewTab />);
+
+    expect(screen.queryByText('as of today')).not.toBeInTheDocument();
+  });
+
+  it('marks stock resources as live counts once a past period is selected', () => {
+    render(<UsageOverviewTab />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }));
+    fireEvent.mouseDown(screen.getByLabelText('Period'));
+    fireEvent.click(screen.getAllByRole('option')[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    // One hint, on Seats (the only stock resource in the fixture) -- not on
+    // the flow resources, which do reflect the selected period.
+    expect(screen.getByText('as of today')).toBeInTheDocument();
+  });
+
+  it('labels the period from a flow resource, not whichever comes first', () => {
+    // Stock items carry the *current* period while flow items carry the
+    // requested one, so a stock-first response must not retitle the card.
+    mockUseUsage.mockReturnValue({
+      resources: {
+        seats: {
+          used: 3,
+          limit: 10,
+          period_start: '2026-08-01',
+          period_end: '2026-08-31',
+          kind: 'stock' as const,
+        },
+        test_executions: {
+          used: 5,
+          limit: 1000,
+          period_start: '2026-01-01',
+          period_end: '2026-01-31',
+          kind: 'flow' as const,
+        },
+      },
+      edition: 'community',
+      loading: false,
+      error: null,
+    });
+
+    render(<UsageOverviewTab />);
+
+    expect(screen.getByText(/Jan 1, 2026 – Jan 31, 2026/)).toBeInTheDocument();
   });
 
   it('hides the upgrade link for a paid edition', () => {

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
@@ -56,7 +56,7 @@ describe('UsageOverviewTab', () => {
 
     render(<UsageOverviewTab />);
 
-    expect(screen.queryByText('Test Executions')).not.toBeInTheDocument();
+    expect(screen.queryByText('Test Runs')).not.toBeInTheDocument();
   });
 
   it('shows an error message when usage fails to load', () => {
@@ -77,16 +77,16 @@ describe('UsageOverviewTab', () => {
   it('renders every resource as a flat list, with no category headers', () => {
     render(<UsageOverviewTab />);
 
-    expect(screen.getByText('Test Executions')).toBeInTheDocument();
+    expect(screen.getByText('Test Runs')).toBeInTheDocument();
     expect(screen.getByText('Seats')).toBeInTheDocument();
     expect(screen.queryByText('Metered Resources')).not.toBeInTheDocument();
     expect(screen.queryByText('Resource Counts')).not.toBeInTheDocument();
   });
 
-  it('shows the billing period in the subtitle', () => {
+  it('shows the usage period in the subtitle', () => {
     render(<UsageOverviewTab />);
 
-    expect(screen.getByText(/Current billing period:/)).toBeInTheDocument();
+    expect(screen.getByText(/Current usage period:/)).toBeInTheDocument();
   });
 
   it('renders "Unlimited" for a resource with no limit', () => {

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
@@ -3,13 +3,13 @@ import { render, screen } from '@/test-utils';
 import '@testing-library/jest-dom';
 
 import UsageOverviewTab from '../UsageOverviewTab';
-import { useUsage } from '@/contexts/UsageContext';
+import { useUsageForPeriod } from '@/hooks/useUsageForPeriod';
 
-jest.mock('@/contexts/UsageContext', () => ({
-  useUsage: jest.fn(),
+jest.mock('@/hooks/useUsageForPeriod', () => ({
+  useUsageForPeriod: jest.fn(),
 }));
 
-const mockUseUsage = useUsage as jest.Mock;
+const mockUseUsage = useUsageForPeriod as jest.Mock;
 
 const USAGE_RESOURCES = {
   test_executions: {
@@ -56,7 +56,7 @@ describe('UsageOverviewTab', () => {
 
     render(<UsageOverviewTab />);
 
-    expect(screen.queryByText('Metered Resources')).not.toBeInTheDocument();
+    expect(screen.queryByText('Test Executions')).not.toBeInTheDocument();
   });
 
   it('shows an error message when usage fails to load', () => {
@@ -74,26 +74,50 @@ describe('UsageOverviewTab', () => {
     ).toBeInTheDocument();
   });
 
-  it('groups resources into Metered Resources (flow) and Resource Counts (stock)', () => {
+  it('renders every resource as a flat list, with no category headers', () => {
     render(<UsageOverviewTab />);
 
-    expect(screen.getByText('Metered Resources')).toBeInTheDocument();
-    expect(screen.getByText('Resource Counts')).toBeInTheDocument();
     expect(screen.getByText('Test Executions')).toBeInTheDocument();
     expect(screen.getByText('Seats')).toBeInTheDocument();
+    expect(screen.queryByText('Metered Resources')).not.toBeInTheDocument();
+    expect(screen.queryByText('Resource Counts')).not.toBeInTheDocument();
   });
 
-  it('shows the billing period and edition in the subtitle', () => {
+  it('shows the billing period in the subtitle', () => {
     render(<UsageOverviewTab />);
 
-    expect(
-      screen.getByText(/Current billing period:.*community plan/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Current billing period:/)).toBeInTheDocument();
   });
 
   it('renders "Unlimited" for a resource with no limit', () => {
     render(<UsageOverviewTab />);
 
     expect(screen.getByText(/999.*\(Unlimited\)/)).toBeInTheDocument();
+  });
+
+  it('shows a plan chip and an upgrade link for the community edition', () => {
+    render(<UsageOverviewTab />);
+
+    expect(screen.getByText('Community plan')).toBeInTheDocument();
+    const upgradeLink = screen.getByRole('link', { name: 'Upgrade' });
+    expect(upgradeLink).toHaveAttribute('href', 'https://rhesis.ai/editions');
+    expect(upgradeLink).toHaveAttribute('target', '_blank');
+    expect(upgradeLink).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('hides the upgrade link for a paid edition', () => {
+    mockUseUsage.mockReturnValue({
+      resources: USAGE_RESOURCES,
+      edition: 'enterprise',
+      loading: false,
+      error: null,
+    });
+
+    render(<UsageOverviewTab />);
+
+    expect(screen.getByText('Enterprise plan')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Upgrade' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/components/__tests__/UsageOverviewTab.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen } from '@/test-utils';
+import '@testing-library/jest-dom';
+
+import UsageOverviewTab from '../UsageOverviewTab';
+import { useUsage } from '@/contexts/UsageContext';
+
+jest.mock('@/contexts/UsageContext', () => ({
+  useUsage: jest.fn(),
+}));
+
+const mockUseUsage = useUsage as jest.Mock;
+
+const USAGE_RESOURCES = {
+  test_executions: {
+    used: 5,
+    limit: 1000,
+    period_start: '2026-08-01',
+    period_end: '2026-08-31',
+    kind: 'flow' as const,
+  },
+  model_tokens: {
+    used: 999,
+    limit: null,
+    period_start: '2026-08-01',
+    period_end: '2026-08-31',
+    kind: 'flow' as const,
+  },
+  seats: {
+    used: 3,
+    limit: 10,
+    period_start: '2026-08-01',
+    period_end: '2026-08-31',
+    kind: 'stock' as const,
+  },
+};
+
+beforeEach(() => {
+  mockUseUsage.mockReset();
+  mockUseUsage.mockReturnValue({
+    resources: USAGE_RESOURCES,
+    edition: 'community',
+    loading: false,
+    error: null,
+  });
+});
+
+describe('UsageOverviewTab', () => {
+  it('shows a loading skeleton while usage is loading', () => {
+    mockUseUsage.mockReturnValue({
+      resources: {},
+      edition: null,
+      loading: true,
+      error: null,
+    });
+
+    render(<UsageOverviewTab />);
+
+    expect(screen.queryByText('Metered Resources')).not.toBeInTheDocument();
+  });
+
+  it('shows an error message when usage fails to load', () => {
+    mockUseUsage.mockReturnValue({
+      resources: {},
+      edition: null,
+      loading: false,
+      error: new Error('boom'),
+    });
+
+    render(<UsageOverviewTab />);
+
+    expect(
+      screen.getByText('Could not load usage data. Please try again later.')
+    ).toBeInTheDocument();
+  });
+
+  it('groups resources into Metered Resources (flow) and Resource Counts (stock)', () => {
+    render(<UsageOverviewTab />);
+
+    expect(screen.getByText('Metered Resources')).toBeInTheDocument();
+    expect(screen.getByText('Resource Counts')).toBeInTheDocument();
+    expect(screen.getByText('Test Executions')).toBeInTheDocument();
+    expect(screen.getByText('Seats')).toBeInTheDocument();
+  });
+
+  it('shows the billing period and edition in the subtitle', () => {
+    render(<UsageOverviewTab />);
+
+    expect(
+      screen.getByText(/Current billing period:.*community plan/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders "Unlimited" for a resource with no limit', () => {
+    render(<UsageOverviewTab />);
+
+    expect(screen.getByText(/999.*\(Unlimited\)/)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/organizations/usage/page.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/page.tsx
@@ -2,6 +2,7 @@
 
 import { PageLayout } from '@/components/layout/PageLayout';
 import { useOrganization } from '@/contexts/OrganizationContext';
+import { UsageProvider } from '@/contexts/UsageContext';
 import UsageDetailTabs from './components/UsageDetailTabs';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
@@ -35,7 +36,16 @@ export default function OrganizationUsagePage() {
 
   return (
     <PageLayout {...pageHeader}>
-      <UsageDetailTabs />
+      {/*
+        Mounted here rather than in the protected layout: this is the only
+        page that reads usage, and `GET /usage` costs a license lookup plus
+        a counting query per stock resource -- not worth paying on every
+        protected navigation. Inside the `canRead` guard, so a user without
+        the capability never fires a request that would only 403.
+      */}
+      <UsageProvider>
+        <UsageDetailTabs />
+      </UsageProvider>
     </PageLayout>
   );
 }

--- a/apps/frontend/src/app/(protected)/organizations/usage/page.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/page.tsx
@@ -10,10 +10,12 @@ import { useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 
 export default function OrganizationUsagePage() {
-  // Same gate as Org Settings -- usage/quota data is org-scoped in exactly
-  // the same way, and there's no separate usage/billing capability yet.
+  // Not Organization.READ: every Viewer holds that one for basic org
+  // context, so it would not gate anything. Usage is billing data, so it
+  // has its own admin-only capability, matching what the backend now
+  // requires on GET /usage.
   const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
-    Capability.Organization.READ
+    Capability.Usage.READ
   );
   const { organization } = useOrganization();
 

--- a/apps/frontend/src/app/(protected)/organizations/usage/page.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/usage/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { PageLayout } from '@/components/layout/PageLayout';
+import { useOrganization } from '@/contexts/OrganizationContext';
+import UsageDetailTabs from './components/UsageDetailTabs';
+import AccessDenied from '@/components/common/AccessDenied';
+import PageLoadingState from '@/components/common/PageLoadingState';
+import { useCanWithStatus } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
+
+export default function OrganizationUsagePage() {
+  // Same gate as Org Settings -- usage/quota data is org-scoped in exactly
+  // the same way, and there's no separate usage/billing capability yet.
+  const { allowed: canRead, loading: permsLoading } = useCanWithStatus(
+    Capability.Organization.READ
+  );
+  const { organization } = useOrganization();
+
+  const organizationName = organization?.name || 'Organization';
+
+  const breadcrumbs = [
+    { label: organizationName, href: '/organizations' },
+    { label: 'Usage', href: '/organizations/usage' },
+  ];
+
+  const pageHeader = {
+    title: 'Usage',
+    description:
+      "Track your organization's metered resource consumption against its plan limits.",
+    breadcrumbs,
+  };
+
+  if (permsLoading) return <PageLoadingState />;
+  if (!canRead) return <AccessDenied resource="usage" />;
+
+  return (
+    <PageLayout {...pageHeader}>
+      <UsageDetailTabs />
+    </PageLayout>
+  );
+}

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -22,6 +22,8 @@ import Divider from '@mui/material/Divider';
 import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 import { useSidebarCollapse } from '@/components/layout/AppShell';
 import { UserAvatar } from '@/components/common/UserAvatar';
+import { Can } from '@/components/common/Can';
+import { Capability } from '@/constants/capabilities';
 import { ColorModeContext } from '@/components/providers/ThemeProvider';
 import { handleSignOut } from '@/actions/auth';
 import {
@@ -422,37 +424,42 @@ export function Sidebar() {
               Projects
             </Typography>
           </MenuItem>
-          <MenuItem
-            onClick={() => {
-              router.push('/organizations/usage');
-              setOrgMenuAnchor(null);
-            }}
-            sx={{
-              gap: '10px',
-              px: '14px',
-              py: '8px',
-              '&:hover': {
-                bgcolor: theme => theme.palette.greyscale.border,
-              },
-            }}
-          >
-            <DataUsageOutlinedIcon
-              sx={{
-                fontSize: 24,
-                color: theme => theme.palette.greyscale.body,
+          {/* Billing data -- hidden rather than shown-then-denied for
+              members without usage:read (the same capability GET /usage
+              requires). */}
+          <Can capability={Capability.Usage.READ}>
+            <MenuItem
+              onClick={() => {
+                router.push('/organizations/usage');
+                setOrgMenuAnchor(null);
               }}
-            />
-            <Typography
               sx={{
-                fontSize: 14,
-                fontWeight: 700,
-                lineHeight: '22px',
-                color: theme => theme.palette.greyscale.body,
+                gap: '10px',
+                px: '14px',
+                py: '8px',
+                '&:hover': {
+                  bgcolor: theme => theme.palette.greyscale.border,
+                },
               }}
             >
-              Usage
-            </Typography>
-          </MenuItem>
+              <DataUsageOutlinedIcon
+                sx={{
+                  fontSize: 24,
+                  color: theme => theme.palette.greyscale.body,
+                }}
+              />
+              <Typography
+                sx={{
+                  fontSize: 14,
+                  fontWeight: 700,
+                  lineHeight: '22px',
+                  color: theme => theme.palette.greyscale.body,
+                }}
+              >
+                Usage
+              </Typography>
+            </MenuItem>
+          </Can>
           <Divider
             sx={{
               my: '6px',

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -16,6 +16,7 @@ import DarkModeOutlinedIcon from '@mui/icons-material/DarkModeOutlined';
 import ExitToAppOutlinedIcon from '@mui/icons-material/ExitToAppOutlined';
 import SettingsOutlinedIcon from '@mui/icons-material/SettingsOutlined';
 import AppsOutlinedIcon from '@mui/icons-material/AppsOutlined';
+import DataUsageOutlinedIcon from '@mui/icons-material/DataUsageOutlined';
 import SwapHorizOutlinedIcon from '@mui/icons-material/SwapHorizOutlined';
 import Divider from '@mui/material/Divider';
 import { useNavigationItems } from '@/contexts/NavigationItemsContext';
@@ -419,6 +420,37 @@ export function Sidebar() {
               }}
             >
               Projects
+            </Typography>
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              router.push('/organizations/usage');
+              setOrgMenuAnchor(null);
+            }}
+            sx={{
+              gap: '10px',
+              px: '14px',
+              py: '8px',
+              '&:hover': {
+                bgcolor: theme => theme.palette.greyscale.border,
+              },
+            }}
+          >
+            <DataUsageOutlinedIcon
+              sx={{
+                fontSize: 24,
+                color: theme => theme.palette.greyscale.body,
+              }}
+            />
+            <Typography
+              sx={{
+                fontSize: 14,
+                fontWeight: 700,
+                lineHeight: '22px',
+                color: theme => theme.palette.greyscale.body,
+              }}
+            >
+              Usage
             </Typography>
           </MenuItem>
           <Divider

--- a/apps/frontend/src/constants/capabilities.ts
+++ b/apps/frontend/src/constants/capabilities.ts
@@ -186,6 +186,14 @@ export const Capability = {
     READ: 'organization:read',
     UPDATE: 'organization:update',
   },
+  /**
+   * Metered consumption against plan limits. Separate from
+   * `Organization.READ`, which every Viewer holds for basic org context --
+   * usage is billing data and is restricted to org admins.
+   */
+  Usage: {
+    READ: 'usage:read',
+  },
   Member: {
     READ: 'member:read',
     CREATE: 'member:create',

--- a/apps/frontend/src/constants/query-keys.ts
+++ b/apps/frontend/src/constants/query-keys.ts
@@ -73,6 +73,10 @@ export const featureKeys = {
   all: (userScope: string) => ['features', userScope] as const,
 };
 
+export const usageKeys = {
+  all: (userScope: string) => ['usage', userScope] as const,
+};
+
 export const permissionKeys = {
   all: (userScope: string, projectId: string) =>
     ['permissions', userScope, projectId] as const,

--- a/apps/frontend/src/constants/query-keys.ts
+++ b/apps/frontend/src/constants/query-keys.ts
@@ -77,6 +77,8 @@ export const usageKeys = {
   all: (userScope: string) => ['usage', userScope] as const,
   history: (userScope: string, months: number) =>
     ['usage', userScope, 'history', months] as const,
+  forPeriod: (userScope: string, periodStart: string) =>
+    ['usage', userScope, 'period', periodStart] as const,
 };
 
 export const permissionKeys = {

--- a/apps/frontend/src/constants/query-keys.ts
+++ b/apps/frontend/src/constants/query-keys.ts
@@ -75,6 +75,8 @@ export const featureKeys = {
 
 export const usageKeys = {
   all: (userScope: string) => ['usage', userScope] as const,
+  history: (userScope: string, months: number) =>
+    ['usage', userScope, 'history', months] as const,
 };
 
 export const permissionKeys = {

--- a/apps/frontend/src/constants/quota.ts
+++ b/apps/frontend/src/constants/quota.ts
@@ -1,0 +1,49 @@
+/**
+ * Canonical metered-resource identifiers. Mirrors the backend
+ * `QuotaResource` enum in
+ * `apps/backend/src/rhesis/backend/app/quota/__init__.py`. Keep in sync
+ * when adding new metered resources.
+ *
+ * Uses a `const` object plus derived union type (idiomatic modern TS) so
+ * values survive to runtime and typos in call sites surface as compile
+ * errors, same pattern as `FeatureName`.
+ */
+export const QuotaResource = {
+  TEST_EXECUTIONS: 'test_executions',
+  TRACING_SPANS: 'tracing_spans',
+  TEST_GENERATION: 'test_generation',
+  MODEL_TOKENS: 'model_tokens',
+  SEATS: 'seats',
+  PROJECTS: 'projects',
+  ENDPOINTS: 'endpoints',
+} as const;
+
+export type QuotaResource = (typeof QuotaResource)[keyof typeof QuotaResource];
+
+/** Human-readable labels for the usage dashboard. */
+export const QUOTA_RESOURCE_LABELS: Record<QuotaResource, string> = {
+  [QuotaResource.TEST_EXECUTIONS]: 'Test Executions',
+  [QuotaResource.TRACING_SPANS]: 'Tracing Spans',
+  [QuotaResource.TEST_GENERATION]: 'Test Generation',
+  [QuotaResource.MODEL_TOKENS]: 'Model Tokens',
+  [QuotaResource.SEATS]: 'Seats',
+  [QuotaResource.PROJECTS]: 'Projects',
+  [QuotaResource.ENDPOINTS]: 'Endpoints',
+};
+
+/**
+ * Canonical display order for the usage dashboard. Which group (flow vs.
+ * stock) each resource belongs to comes from `UsageResourceItem.kind` on
+ * the API response, not a second hardcoded list here -- that list existed
+ * once and had already drifted from the backend's own split by the time it
+ * was caught in review.
+ */
+export const QUOTA_RESOURCE_ORDER: readonly QuotaResource[] = [
+  QuotaResource.TEST_EXECUTIONS,
+  QuotaResource.TRACING_SPANS,
+  QuotaResource.TEST_GENERATION,
+  QuotaResource.MODEL_TOKENS,
+  QuotaResource.SEATS,
+  QuotaResource.PROJECTS,
+  QuotaResource.ENDPOINTS,
+];

--- a/apps/frontend/src/constants/quota.ts
+++ b/apps/frontend/src/constants/quota.ts
@@ -20,9 +20,15 @@ export const QuotaResource = {
 
 export type QuotaResource = (typeof QuotaResource)[keyof typeof QuotaResource];
 
-/** Human-readable labels for the usage dashboard. */
+/**
+ * Human-readable labels for the usage dashboard.
+ *
+ * TEST_EXECUTIONS displays as "Test Runs" -- the platform's own term for
+ * the thing being metered -- even though the resource key itself doesn't
+ * change (it's the wire value, not UI copy).
+ */
 export const QUOTA_RESOURCE_LABELS: Record<QuotaResource, string> = {
-  [QuotaResource.TEST_EXECUTIONS]: 'Test Executions',
+  [QuotaResource.TEST_EXECUTIONS]: 'Test Runs',
   [QuotaResource.TRACING_SPANS]: 'Tracing Spans',
   [QuotaResource.TEST_GENERATION]: 'Test Generation',
   [QuotaResource.MODEL_TOKENS]: 'Model Tokens',

--- a/apps/frontend/src/contexts/UsageContext.tsx
+++ b/apps/frontend/src/contexts/UsageContext.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+/**
+ * Read-only usage accounting: per-resource counters, limits, and the
+ * current billing period, for the org usage dashboard tab.
+ *
+ * Mirrors `FeaturesContext`'s caching and SSR-seeding pattern: `useQuery`
+ * scoped by `userScope`, `staleTime` matching the other ambient providers,
+ * and an `initialUsage` prop so the very first client render already has
+ * data instead of flashing a loading state for one round trip.
+ *
+ * Fail-closed, same as `FeaturesContext`/`PermissionsContext`: `resources`
+ * is empty during the initial fetch and on error, never a stale/default
+ * numeric guess.
+ */
+
+import { usageKeys } from '@/constants/query-keys';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type {
+  UsageResponse,
+  UsageResourceItem,
+} from '@/utils/api-client/usage-client';
+import { useQuery } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
+
+interface UsageState {
+  resources: Readonly<Record<string, UsageResourceItem>>;
+  edition: string | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+const DEFAULT_STATE: UsageState = {
+  resources: {},
+  edition: null,
+  loading: true,
+  error: null,
+};
+
+const UsageContext = createContext<UsageState>(DEFAULT_STATE);
+
+export function UsageProvider({
+  children,
+  initialUsage = null,
+}: {
+  children: ReactNode;
+  /**
+   * Server-fetched `GET /usage` result (see `(protected)/layout.tsx`),
+   * seeded as this query's `initialData` so `loading` is already `false`
+   * on the very first client render. `null` (no session server-side, or
+   * the fetch failed) falls back to the normal client-side fetch.
+   */
+  initialUsage?: UsageResponse | null;
+}) {
+  const { status } = useSession();
+  const userScope = useUserScope();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: usageKeys.all(userScope),
+    queryFn: () => new ApiClientFactory().getUsageClient().getUsage(),
+    // `!!userScope` closes the gap where `status` flips to 'authenticated'
+    // before `userScope` reflects the real user id — without it the query
+    // could run (and cache) under the `''` scope key.
+    enabled: isAuthenticated(status) && !!userScope,
+    staleTime: 5 * 60_000,
+    ...(initialUsage ? { initialData: initialUsage } : {}),
+  });
+
+  const value = useMemo<UsageState>(() => {
+    if (!isAuthenticated(status) || isLoading) return DEFAULT_STATE;
+    if (error)
+      return {
+        resources: {},
+        edition: null,
+        loading: false,
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+    if (!data) return DEFAULT_STATE;
+    return {
+      resources: data.resources,
+      edition: data.edition,
+      loading: false,
+      error: null,
+    };
+  }, [data, isLoading, error, status]);
+
+  return (
+    <UsageContext.Provider value={value}>{children}</UsageContext.Provider>
+  );
+}
+
+/**
+ * Full state accessor: resources, edition, loading, error.
+ */
+export function useUsage(): UsageState {
+  return useContext(UsageContext);
+}
+
+/**
+ * Usage for a single resource (e.g. `QuotaResource.TEST_EXECUTIONS` value),
+ * or `null` while loading, on error, or if the resource is absent from the
+ * response.
+ */
+export function useResourceUsage(resource: string): UsageResourceItem | null {
+  const { resources, loading } = useContext(UsageContext);
+  if (loading) return null;
+  return resources[resource] ?? null;
+}

--- a/apps/frontend/src/contexts/UsageContext.tsx
+++ b/apps/frontend/src/contexts/UsageContext.tsx
@@ -4,10 +4,14 @@
  * Read-only usage accounting: per-resource counters, limits, and the
  * current billing period, for the org usage dashboard tab.
  *
- * Mirrors `FeaturesContext`'s caching and SSR-seeding pattern: `useQuery`
- * scoped by `userScope`, `staleTime` matching the other ambient providers,
- * and an `initialUsage` prop so the very first client render already has
- * data instead of flashing a loading state for one round trip.
+ * Mirrors `FeaturesContext`'s caching pattern: `useQuery` scoped by
+ * `userScope`, with `staleTime` matching the other ambient providers.
+ *
+ * Unlike `FeaturesProvider`, this is mounted by the Usage page itself rather
+ * than the protected layout -- nothing else reads usage, and `GET /usage`
+ * is too costly to issue on every protected navigation. That also means
+ * there is no SSR-seeded `initialData`: the page shows its loading
+ * skeleton for one round trip instead.
  *
  * Fail-closed, same as `FeaturesContext`/`PermissionsContext`: `resources`
  * is empty during the initial fetch and on error, never a stale/default
@@ -16,10 +20,7 @@
 
 import { usageKeys } from '@/constants/query-keys';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
-import type {
-  UsageResponse,
-  UsageResourceItem,
-} from '@/utils/api-client/usage-client';
+import type { UsageResourceItem } from '@/utils/api-client/usage-client';
 import { useQuery } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
@@ -41,19 +42,7 @@ const DEFAULT_STATE: UsageState = {
 
 const UsageContext = createContext<UsageState>(DEFAULT_STATE);
 
-export function UsageProvider({
-  children,
-  initialUsage = null,
-}: {
-  children: ReactNode;
-  /**
-   * Server-fetched `GET /usage` result (see `(protected)/layout.tsx`),
-   * seeded as this query's `initialData` so `loading` is already `false`
-   * on the very first client render. `null` (no session server-side, or
-   * the fetch failed) falls back to the normal client-side fetch.
-   */
-  initialUsage?: UsageResponse | null;
-}) {
+export function UsageProvider({ children }: { children: ReactNode }) {
   const { status } = useSession();
   const userScope = useUserScope();
 
@@ -65,7 +54,6 @@ export function UsageProvider({
     // could run (and cache) under the `''` scope key.
     enabled: isAuthenticated(status) && !!userScope,
     staleTime: 5 * 60_000,
-    ...(initialUsage ? { initialData: initialUsage } : {}),
   });
 
   const value = useMemo<UsageState>(() => {

--- a/apps/frontend/src/contexts/UsageContext.tsx
+++ b/apps/frontend/src/contexts/UsageContext.tsx
@@ -25,7 +25,7 @@ import { useSession } from 'next-auth/react';
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
 
-interface UsageState {
+export interface UsageState {
   resources: Readonly<Record<string, UsageResourceItem>>;
   edition: string | null;
   loading: boolean;

--- a/apps/frontend/src/hooks/__tests__/useUsageForPeriod.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useUsageForPeriod.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { render, screen, waitFor } from '@/test-utils';
+import '@testing-library/jest-dom';
+
+import { useUsageForPeriod } from '../useUsageForPeriod';
+import { useUsage } from '@/contexts/UsageContext';
+
+const mockGetUsage = jest.fn();
+
+const AUTHENTICATED_SESSION = {
+  data: { user: { id: 'user-1' } },
+  status: 'authenticated',
+};
+
+let mockSession: { data: unknown; status: string } = AUTHENTICATED_SESSION;
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => mockSession,
+}));
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getUsageClient: () => ({
+      getUsage: mockGetUsage,
+    }),
+  })),
+}));
+
+jest.mock('@/contexts/UsageContext', () => ({
+  useUsage: jest.fn(),
+}));
+
+const mockUseUsage = useUsage as jest.Mock;
+
+const CURRENT_STATE = {
+  resources: { test_executions: { used: 1, limit: 100 } },
+  edition: 'community',
+  loading: false,
+  error: null,
+};
+
+beforeEach(() => {
+  mockGetUsage.mockReset();
+  mockSession = AUTHENTICATED_SESSION;
+  mockUseUsage.mockReset();
+  mockUseUsage.mockReturnValue(CURRENT_STATE);
+});
+
+function Probe({ periodStart }: { periodStart: string | null }) {
+  const { resources, loading, error } = useUsageForPeriod(periodStart);
+  return (
+    <div>
+      <div data-testid="loading">{String(loading)}</div>
+      <div data-testid="error">{error?.message ?? 'none'}</div>
+      <div data-testid="resources">{JSON.stringify(resources)}</div>
+    </div>
+  );
+}
+
+describe('useUsageForPeriod', () => {
+  it('delegates to UsageContext when periodStart is null', () => {
+    render(<Probe periodStart={null} />);
+
+    expect(screen.getByTestId('resources')).toHaveTextContent(
+      'test_executions'
+    );
+    expect(mockGetUsage).not.toHaveBeenCalled();
+  });
+
+  it('fetches a specific period when periodStart is given', async () => {
+    mockGetUsage.mockResolvedValue({
+      resources: { test_executions: { used: 42, limit: 100 } },
+      edition: 'community',
+    });
+
+    render(<Probe periodStart="2026-07-01" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('loading')).toHaveTextContent('false')
+    );
+    expect(mockGetUsage).toHaveBeenCalledWith('2026-07-01');
+    expect(screen.getByTestId('resources')).toHaveTextContent('42');
+  });
+
+  it('fails closed on fetch error for a past period', async () => {
+    mockGetUsage.mockRejectedValue(new Error('boom'));
+
+    render(<Probe periodStart="2026-07-01" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('error')).toHaveTextContent('boom')
+    );
+    expect(screen.getByTestId('resources')).toHaveTextContent('{}');
+  });
+
+  it('re-fetches when periodStart changes', async () => {
+    mockGetUsage.mockResolvedValue({ resources: {}, edition: 'community' });
+
+    const { rerender } = render(<Probe periodStart="2026-07-01" />);
+    await waitFor(() =>
+      expect(screen.getByTestId('loading')).toHaveTextContent('false')
+    );
+
+    rerender(<Probe periodStart="2026-06-01" />);
+
+    await waitFor(() =>
+      expect(mockGetUsage).toHaveBeenCalledWith('2026-06-01')
+    );
+    expect(mockGetUsage).toHaveBeenCalledWith('2026-07-01');
+  });
+});

--- a/apps/frontend/src/hooks/__tests__/useUsageHistory.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useUsageHistory.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, waitFor } from '@/test-utils';
+import '@testing-library/jest-dom';
+
+import { useUsageHistory } from '../useUsageHistory';
+
+const mockGetUsageHistory = jest.fn();
+
+const AUTHENTICATED_SESSION = {
+  data: { user: { id: 'user-1' } },
+  status: 'authenticated',
+};
+
+// Mutable so individual tests can simulate an unauthenticated/loading session.
+let mockSession: { data: unknown; status: string } = AUTHENTICATED_SESSION;
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => mockSession,
+}));
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getUsageClient: () => ({
+      getUsageHistory: mockGetUsageHistory,
+    }),
+  })),
+}));
+
+beforeEach(() => {
+  mockGetUsageHistory.mockReset();
+  mockSession = AUTHENTICATED_SESSION;
+});
+
+function Probe({ months }: { months: number }) {
+  const { resources, loading, error } = useUsageHistory(months);
+  return (
+    <div>
+      <div data-testid="loading">{String(loading)}</div>
+      <div data-testid="error">{error?.message ?? 'none'}</div>
+      <div data-testid="resources">{JSON.stringify(resources)}</div>
+    </div>
+  );
+}
+
+describe('useUsageHistory', () => {
+  it('fetches history for the given months and exposes the resources', async () => {
+    mockGetUsageHistory.mockResolvedValue({
+      resources: {
+        test_executions: [{ period_start: '2026-06-01', used: 3 }],
+      },
+    });
+
+    render(<Probe months={6} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('loading')).toHaveTextContent('false')
+    );
+    expect(mockGetUsageHistory).toHaveBeenCalledWith(6);
+    expect(screen.getByTestId('resources')).toHaveTextContent(
+      'test_executions'
+    );
+  });
+
+  it('reports loading while the session is still resolving', () => {
+    mockSession = { data: null, status: 'loading' };
+    mockGetUsageHistory.mockResolvedValue({ resources: {} });
+
+    render(<Probe months={6} />);
+
+    expect(screen.getByTestId('loading')).toHaveTextContent('true');
+    expect(mockGetUsageHistory).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on fetch error (empty resources, error surfaced)', async () => {
+    mockGetUsageHistory.mockRejectedValue(new Error('boom'));
+
+    render(<Probe months={6} />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId('error')).toHaveTextContent('boom')
+    );
+    expect(screen.getByTestId('loading')).toHaveTextContent('false');
+    expect(screen.getByTestId('resources')).toHaveTextContent('{}');
+  });
+
+  it('re-fetches when months changes', async () => {
+    mockGetUsageHistory.mockResolvedValue({ resources: {} });
+
+    const { rerender } = render(<Probe months={6} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('loading')).toHaveTextContent('false')
+    );
+
+    rerender(<Probe months={12} />);
+
+    await waitFor(() => expect(mockGetUsageHistory).toHaveBeenCalledWith(12));
+    expect(mockGetUsageHistory).toHaveBeenCalledWith(6);
+  });
+});

--- a/apps/frontend/src/hooks/useUsageForPeriod.ts
+++ b/apps/frontend/src/hooks/useUsageForPeriod.ts
@@ -1,0 +1,59 @@
+'use client';
+
+/**
+ * Usage for a specific past billing period, or the current one when
+ * `periodStart` is `null`. The `null` case delegates to `UsageContext`
+ * rather than issuing a second fetch for data the SSR-seeded context
+ * query already has.
+ */
+
+import { usageKeys } from '@/constants/query-keys';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { useUsage, type UsageState } from '@/contexts/UsageContext';
+import { useQuery } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
+import { useMemo } from 'react';
+import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
+
+const LOADING_STATE: UsageState = {
+  resources: {},
+  edition: null,
+  loading: true,
+  error: null,
+};
+
+export function useUsageForPeriod(periodStart: string | null): UsageState {
+  const current = useUsage();
+  const { status } = useSession();
+  const userScope = useUserScope();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: usageKeys.forPeriod(userScope, periodStart ?? ''),
+    queryFn: () =>
+      new ApiClientFactory()
+        .getUsageClient()
+        .getUsage(periodStart ?? undefined),
+    enabled: periodStart !== null && isAuthenticated(status) && !!userScope,
+    staleTime: 5 * 60_000,
+  });
+
+  return useMemo<UsageState>(() => {
+    if (periodStart === null) return current;
+    if (!isAuthenticated(status) || isLoading) return LOADING_STATE;
+    if (error) {
+      return {
+        resources: {},
+        edition: null,
+        loading: false,
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+    }
+    if (!data) return LOADING_STATE;
+    return {
+      resources: data.resources,
+      edition: data.edition,
+      loading: false,
+      error: null,
+    };
+  }, [periodStart, current, data, isLoading, error, status]);
+}

--- a/apps/frontend/src/hooks/useUsageHistory.ts
+++ b/apps/frontend/src/hooks/useUsageHistory.ts
@@ -53,6 +53,12 @@ export function useUsageHistory(months: number): UsageHistoryState {
         error: error instanceof Error ? error : new Error(String(error)),
       };
     }
-    return { resources: data?.resources ?? {}, loading: false, error: null };
+    // Same guard as UsageContext/useUsageForPeriod: a *disabled* query
+    // reports `isLoading: false` with `data: undefined`, so without this
+    // the `userScope === ''` gap above would surface as
+    // `{resources: {}, loading: false}` -- which the charts render as an
+    // empty card rather than a loading state.
+    if (!data) return DEFAULT_STATE;
+    return { resources: data.resources, loading: false, error: null };
   }, [data, isLoading, error, status]);
 }

--- a/apps/frontend/src/hooks/useUsageHistory.ts
+++ b/apps/frontend/src/hooks/useUsageHistory.ts
@@ -1,0 +1,58 @@
+'use client';
+
+/**
+ * Monthly usage history for flow resources over the trailing `months`
+ * months, for the Usage tab's timespan filter + line charts.
+ *
+ * Not part of `UsageContext`/`UsageProvider`: `months` is a runtime-
+ * selectable filter value, not something the protected layout can seed
+ * once at SSR time the way the current-period snapshot is.
+ */
+
+import { usageKeys } from '@/constants/query-keys';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import type { UsageHistoryPoint } from '@/utils/api-client/usage-client';
+import { useQuery } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
+import { useMemo } from 'react';
+import { isAuthenticated, useUserScope } from '@/hooks/useIsAuthenticated';
+
+export interface UsageHistoryState {
+  resources: Readonly<Record<string, UsageHistoryPoint[]>>;
+  loading: boolean;
+  error: Error | null;
+}
+
+const DEFAULT_STATE: UsageHistoryState = {
+  resources: {},
+  loading: true,
+  error: null,
+};
+
+export function useUsageHistory(months: number): UsageHistoryState {
+  const { status } = useSession();
+  const userScope = useUserScope();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: usageKeys.history(userScope, months),
+    queryFn: () =>
+      new ApiClientFactory().getUsageClient().getUsageHistory(months),
+    // Same `!!userScope` guard as UsageContext: closes the gap where
+    // `status` flips to 'authenticated' before `userScope` reflects the
+    // real user id.
+    enabled: isAuthenticated(status) && !!userScope,
+    staleTime: 5 * 60_000,
+  });
+
+  return useMemo<UsageHistoryState>(() => {
+    if (!isAuthenticated(status) || isLoading) return DEFAULT_STATE;
+    if (error) {
+      return {
+        resources: {},
+        loading: false,
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
+    }
+    return { resources: data?.resources ?? {}, loading: false, error: null };
+  }, [data, isLoading, error, status]);
+}

--- a/apps/frontend/src/lib/org-settings-tabs-bootstrap.ts
+++ b/apps/frontend/src/lib/org-settings-tabs-bootstrap.ts
@@ -9,10 +9,20 @@
 
 import { registerOrgSettingsTab } from '@/lib/extension-registries';
 import TeamTab from '@/app/(protected)/organizations/settings/components/TeamTab';
+import UsageTab from '@/app/(protected)/organizations/settings/components/UsageTab';
 
 registerOrgSettingsTab({
   id: 'team',
   title: 'Team',
   order: 10,
   component: TeamTab,
+});
+
+registerOrgSettingsTab({
+  id: 'usage',
+  title: 'Usage',
+  // 25 sits between EE's Roles (20) and SSO (30) -- see ee/frontend/src/rbac/register.tsx
+  // and ee/frontend/src/sso/register.tsx.
+  order: 25,
+  component: UsageTab,
 });

--- a/apps/frontend/src/lib/org-settings-tabs-bootstrap.ts
+++ b/apps/frontend/src/lib/org-settings-tabs-bootstrap.ts
@@ -9,20 +9,10 @@
 
 import { registerOrgSettingsTab } from '@/lib/extension-registries';
 import TeamTab from '@/app/(protected)/organizations/settings/components/TeamTab';
-import UsageTab from '@/app/(protected)/organizations/settings/components/UsageTab';
 
 registerOrgSettingsTab({
   id: 'team',
   title: 'Team',
   order: 10,
   component: TeamTab,
-});
-
-registerOrgSettingsTab({
-  id: 'usage',
-  title: 'Usage',
-  // 25 sits between EE's Roles (20) and SSO (30) -- see ee/frontend/src/rbac/register.tsx
-  // and ee/frontend/src/sso/register.tsx.
-  order: 25,
-  component: UsageTab,
 });

--- a/apps/frontend/src/utils/__tests__/usagePeriods.test.ts
+++ b/apps/frontend/src/utils/__tests__/usagePeriods.test.ts
@@ -1,0 +1,32 @@
+import { getUsagePeriodOptions } from '../usagePeriods';
+
+describe('getUsagePeriodOptions', () => {
+  it('leads with a null-valued "Current period" option', () => {
+    const options = getUsagePeriodOptions(new Date('2026-08-15T00:00:00Z'));
+
+    expect(options[0]).toEqual({ value: null, label: 'Current period' });
+  });
+
+  it('lists the trailing 12 completed months, newest first', () => {
+    const options = getUsagePeriodOptions(new Date('2026-08-15T00:00:00Z'));
+
+    const months = options.slice(1);
+    expect(months).toHaveLength(12);
+    expect(months[0]).toEqual({ value: '2026-07-01', label: 'July 2026' });
+    expect(months[months.length - 1]).toEqual({
+      value: '2025-08-01',
+      label: 'August 2025',
+    });
+  });
+
+  it('crosses a year boundary correctly', () => {
+    const options = getUsagePeriodOptions(new Date('2026-02-10T00:00:00Z'));
+
+    const months = options.slice(1);
+    expect(months[0]).toEqual({ value: '2026-01-01', label: 'January 2026' });
+    expect(months[1]).toEqual({
+      value: '2025-12-01',
+      label: 'December 2025',
+    });
+  });
+});

--- a/apps/frontend/src/utils/api-client/client-factory.ts
+++ b/apps/frontend/src/utils/api-client/client-factory.ts
@@ -31,6 +31,7 @@ import { GarakClient } from './garak-client';
 import { ImportClient } from './import-client';
 import { FilesClient } from './files-client';
 import { FeaturesClient } from './features-client';
+import { UsageClient } from './usage-client';
 import { PermissionsClient } from './permissions-client';
 import { ParametersClient } from './parameters-client';
 import { PreflightClient } from './preflight-client';
@@ -55,6 +56,7 @@ export class ApiClientFactory {
   private importClient: ImportClient | null = null;
   private filesClient: FilesClient | null = null;
   private featuresClient: FeaturesClient | null = null;
+  private usageClient: UsageClient | null = null;
   private permissionsClient: PermissionsClient | null = null;
   private architectClient: ArchitectClient | null = null;
   private parametersClient: ParametersClient | null = null;
@@ -321,6 +323,17 @@ export class ApiClientFactory {
       );
     }
     return this.featuresClient;
+  }
+
+  getUsageClient(): UsageClient {
+    if (!this.usageClient) {
+      this.usageClient = new UsageClient(
+        this.sessionToken,
+        undefined,
+        this.projectId
+      );
+    }
+    return this.usageClient;
   }
 
   getPermissionsClient(): PermissionsClient {

--- a/apps/frontend/src/utils/api-client/usage-client.ts
+++ b/apps/frontend/src/utils/api-client/usage-client.ts
@@ -18,13 +18,33 @@ export interface UsageResponse {
   edition: string;
 }
 
+export interface UsageHistoryPoint {
+  period_start: string;
+  used: number;
+}
+
+export interface UsageHistoryResponse {
+  /**
+   * Flow resources only -- stock resources (seats/projects/endpoints) are
+   * live counts with no historical row to report, so they're absent here
+   * rather than repeating today's count at every point.
+   */
+  resources: Record<string, UsageHistoryPoint[]>;
+}
+
 /**
- * Client for the `/usage` endpoint. Returns per-resource usage counters,
+ * Client for the `/usage` endpoints. Returns per-resource usage counters,
  * limits, and the current billing period for the current user's organization.
  */
 export class UsageClient extends BaseApiClient {
   async getUsage(): Promise<UsageResponse> {
     return this.fetch<UsageResponse>('/usage', {
+      cache: 'no-store',
+    });
+  }
+
+  async getUsageHistory(months: number): Promise<UsageHistoryResponse> {
+    return this.fetch<UsageHistoryResponse>(`/usage/history?months=${months}`, {
       cache: 'no-store',
     });
   }

--- a/apps/frontend/src/utils/api-client/usage-client.ts
+++ b/apps/frontend/src/utils/api-client/usage-client.ts
@@ -37,8 +37,13 @@ export interface UsageHistoryResponse {
  * limits, and the current billing period for the current user's organization.
  */
 export class UsageClient extends BaseApiClient {
-  async getUsage(): Promise<UsageResponse> {
-    return this.fetch<UsageResponse>('/usage', {
+  /**
+   * @param periodStart First day of the month to report (`YYYY-MM-DD`).
+   * Omit for the current billing period.
+   */
+  async getUsage(periodStart?: string): Promise<UsageResponse> {
+    const query = periodStart ? `?period=${periodStart}` : '';
+    return this.fetch<UsageResponse>(`/usage${query}`, {
       cache: 'no-store',
     });
   }

--- a/apps/frontend/src/utils/api-client/usage-client.ts
+++ b/apps/frontend/src/utils/api-client/usage-client.ts
@@ -1,0 +1,31 @@
+import { BaseApiClient } from './base-client';
+
+export interface UsageResourceItem {
+  used: number;
+  limit: number | null;
+  period_start: string;
+  period_end: string;
+  /**
+   * "flow" (cumulative counter, resets each billing period) or "stock"
+   * (live entity count). Comes from the API rather than a hardcoded
+   * frontend list so the two can never drift apart.
+   */
+  kind: 'flow' | 'stock';
+}
+
+export interface UsageResponse {
+  resources: Record<string, UsageResourceItem>;
+  edition: string;
+}
+
+/**
+ * Client for the `/usage` endpoint. Returns per-resource usage counters,
+ * limits, and the current billing period for the current user's organization.
+ */
+export class UsageClient extends BaseApiClient {
+  async getUsage(): Promise<UsageResponse> {
+    return this.fetch<UsageResponse>('/usage', {
+      cache: 'no-store',
+    });
+  }
+}

--- a/apps/frontend/src/utils/server-permissions.ts
+++ b/apps/frontend/src/utils/server-permissions.ts
@@ -3,13 +3,15 @@ import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { getServerActiveProjectId } from '@/utils/server-active-project';
 import { FeatureName } from '@/constants/features';
 import type { FeaturesResponse } from '@/utils/api-client/features-client';
+import type { UsageResponse } from '@/utils/api-client/usage-client';
 import { can } from '@/utils/affordances';
 
 /**
- * Cached server-side fetchers for features and permissions. `React.cache()`
- * deduplicates within a single RSC render pass, so `layout.tsx` and
- * `page.tsx` (via `prefetchList` / `hasServerCapability`) share one
- * `GET /features` and one `GET /me/permissions` call instead of two each.
+ * Cached server-side fetchers for features, permissions, and usage.
+ * `React.cache()` deduplicates within a single RSC render pass, so
+ * `layout.tsx` and `page.tsx` (via `prefetchList` / `hasServerCapability`)
+ * share one `GET /features` and one `GET /me/permissions` call instead of
+ * two each.
  */
 export const getServerFeatures = cache(async (): Promise<FeaturesResponse> => {
   const factory = await createServerApiFactory();
@@ -20,6 +22,11 @@ export const getServerPermissions = cache(async (): Promise<string[]> => {
   const factory = await createServerApiFactory();
   const projectId = await getServerActiveProjectId();
   return factory.getPermissionsClient().getMyPermissions(projectId);
+});
+
+export const getServerUsage = cache(async (): Promise<UsageResponse> => {
+  const factory = await createServerApiFactory();
+  return factory.getUsageClient().getUsage();
 });
 
 /**

--- a/apps/frontend/src/utils/server-permissions.ts
+++ b/apps/frontend/src/utils/server-permissions.ts
@@ -3,11 +3,10 @@ import { createServerApiFactory } from '@/utils/api-client/server-factory';
 import { getServerActiveProjectId } from '@/utils/server-active-project';
 import { FeatureName } from '@/constants/features';
 import type { FeaturesResponse } from '@/utils/api-client/features-client';
-import type { UsageResponse } from '@/utils/api-client/usage-client';
 import { can } from '@/utils/affordances';
 
 /**
- * Cached server-side fetchers for features, permissions, and usage.
+ * Cached server-side fetchers for features and permissions.
  * `React.cache()` deduplicates within a single RSC render pass, so
  * `layout.tsx` and `page.tsx` (via `prefetchList` / `hasServerCapability`)
  * share one `GET /features` and one `GET /me/permissions` call instead of
@@ -22,11 +21,6 @@ export const getServerPermissions = cache(async (): Promise<string[]> => {
   const factory = await createServerApiFactory();
   const projectId = await getServerActiveProjectId();
   return factory.getPermissionsClient().getMyPermissions(projectId);
-});
-
-export const getServerUsage = cache(async (): Promise<UsageResponse> => {
-  const factory = await createServerApiFactory();
-  return factory.getUsageClient().getUsage();
 });
 
 /**

--- a/apps/frontend/src/utils/usagePeriods.ts
+++ b/apps/frontend/src/utils/usagePeriods.ts
@@ -1,0 +1,41 @@
+export interface UsagePeriodOption {
+  /** First-of-month `YYYY-MM-DD`, or `null` for the current billing period. */
+  value: string | null;
+  label: string;
+}
+
+const TRAILING_MONTHS = 12;
+
+/**
+ * Selectable billing periods for the Usage overview filter: the current
+ * period plus the trailing 12 completed months, newest first. Matches the
+ * backend backfill's own trailing-12-month range (see
+ * `9550c62e80a5_extend_usage_backfill_to_trailing_12_.py`), so every
+ * option here can actually have data behind it.
+ */
+export function getUsagePeriodOptions(
+  today: Date = new Date()
+): UsagePeriodOption[] {
+  const options: UsagePeriodOption[] = [
+    { value: null, label: 'Current period' },
+  ];
+
+  let year = today.getUTCFullYear();
+  let month = today.getUTCMonth() + 1;
+
+  for (let i = 0; i < TRAILING_MONTHS; i++) {
+    month -= 1;
+    if (month === 0) {
+      month = 12;
+      year -= 1;
+    }
+    const value = `${year}-${String(month).padStart(2, '0')}-01`;
+    const label = new Date(Date.UTC(year, month - 1, 1)).toLocaleDateString(
+      'en-US',
+      { month: 'long', year: 'numeric', timeZone: 'UTC' }
+    );
+    options.push({ value, label });
+  }
+
+  return options;
+}

--- a/ee/backend/src/rhesis/backend/ee/rbac/models.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/models.py
@@ -90,9 +90,7 @@ BUILT_IN_ROLE_DESCRIPTIONS: dict[str, str] = {
     "Member": (
         "Create, edit, and run evaluations across their projects. Manage their own API tokens."
     ),
-    "Viewer": (
-        "Read-only access to project resources. Can browse but cannot make changes."
-    ),
+    "Viewer": ("Read-only access to project resources. Can browse but cannot make changes."),
     "None": "No access. Explicitly revoke a member while keeping them in the organization.",
 }
 
@@ -125,10 +123,15 @@ def _primary_action(cap: str) -> str:
 # Org-level reads excluded from the read-only **Viewer** baseline.
 # ``role:read`` exposes the org's custom role catalog; only Owner and Admin
 # need it (Admin needs it to assign roles via member:manage).  ``token:read``
-# exposes API token metadata.  Everything else ending in ``:read`` — including
-# ``organization:read`` and ``member:read`` for basic org context — is fine
-# for a Viewer.
-_VIEWER_EXCLUDED_READS: frozenset[str] = frozenset({"role:read", "token:read"})
+# exposes API token metadata.  ``usage:read`` exposes metered consumption
+# against plan limits — billing data, not org context.  Everything else
+# ending in ``:read`` — including ``organization:read`` and ``member:read``
+# for basic org context — is fine for a Viewer.
+#
+# Excluding a read here also keeps it away from **Member**: that set is
+# ``project_actions | viewer_permissions``, and all three of these are
+# org-scoped, so they never enter ``project_actions``.
+_VIEWER_EXCLUDED_READS: frozenset[str] = frozenset({"role:read", "token:read", "usage:read"})
 
 
 def _viewer_permissions(cap_set: set[str]) -> set[str]:

--- a/sdk/src/rhesis/sdk/models/factory.py
+++ b/sdk/src/rhesis/sdk/models/factory.py
@@ -445,13 +445,30 @@ def get_model(
             f"'{resolved_type.value}'. Supported types: {supported_types}"
         )
 
+    # Applied after construction rather than forwarded as a constructor
+    # kwarg: only a couple of providers take ``**kwargs`` through to
+    # ``BaseLLM.__init__``, and the rest declare fixed signatures, so
+    # passing it down would raise TypeError for most of the registry (and
+    # threading it through all ~20 constructors just to reach an attribute
+    # BaseLLM already owns buys nothing). ``on_usage`` is plain instance
+    # state that ``BaseLLM._emit_usage`` reads at call time, so setting it
+    # here behaves identically and works for every provider.
+    on_usage = kwargs.pop("on_usage", None)
+
     # Dispatch: _ProviderSpec uses generic creator, callables are invoked directly
     if isinstance(factory, _ProviderSpec):
-        return _create_from_spec(factory, resolved_type, model_name, api_key, dimensions, **kwargs)
+        model = _create_from_spec(factory, resolved_type, model_name, api_key, dimensions, **kwargs)
     elif resolved_type == ModelType.EMBEDDING:
-        return factory(model_name, api_key, dimensions, **kwargs)
+        model = factory(model_name, api_key, dimensions, **kwargs)
     else:
-        return factory(model_name, api_key, **kwargs)
+        model = factory(model_name, api_key, **kwargs)
+
+    if on_usage is not None:
+        # Embedders have no usage to emit, so this only ever matters for
+        # language models; setting it unconditionally keeps the branch out.
+        model.on_usage = on_usage
+
+    return model
 
 
 # =============================================================================

--- a/sdk/src/rhesis/sdk/models/providers/litellm.py
+++ b/sdk/src/rhesis/sdk/models/providers/litellm.py
@@ -138,6 +138,15 @@ class LiteLLM(BaseLLM):
             **kwargs,
         )
 
+        # Emitted for every LiteLLM-backed provider (vertex_ai, gemini,
+        # openai, anthropic, ...), not just the Rhesis-native ones: whether
+        # those tokens are billable is the caller's decision, expressed by
+        # whether it passed an ``on_usage`` callback at all. A deployment
+        # whose default model is, say, ``vertex_ai/gemini-2.5-flash`` runs on
+        # the server's own credentials, so its tokens do need reporting.
+        # ``_emit_usage`` no-ops when no callback is wired.
+        self._emit_usage(getattr(response, "usage", None))
+
         response_content = response.choices[0].message.content  # type: ignore
         if schema:
             response_content = json.loads(response_content)
@@ -248,6 +257,12 @@ class LiteLLM(BaseLLM):
             *args,
             **kwargs,
         )
+
+        # One aggregate emission for the whole batch rather than one per
+        # prompt -- see ``BaseLLM._emit_usage_batch`` for why (the callback
+        # queues a durable write). Bulk test generation runs through here,
+        # so it is the single largest token consumer to account for.
+        self._emit_usage_batch(getattr(r, "usage", None) for r in responses)
 
         # Extract content from responses (each response has n choices)
         results: List[Union[str, dict]] = []

--- a/sdk/src/rhesis/sdk/models/providers/litellm.py
+++ b/sdk/src/rhesis/sdk/models/providers/litellm.py
@@ -188,11 +188,16 @@ class LiteLLM(BaseLLM):
         # RuntimeError: Event loop is closed on teardown.
         extra_headers = {"Connection": "close", **(kwargs.pop("extra_headers", None) or {})}
         timeout = kwargs.pop("timeout", self.timeout)
+        # Without this, a streamed response never carries usage at all --
+        # OpenAI-compatible streaming only includes it when explicitly
+        # requested. A caller-supplied stream_options still wins.
+        stream_options = kwargs.pop("stream_options", None) or {"include_usage": True}
         response = await acompletion(
             model=self.model_name,
             messages=messages,
             response_format=schema,
             stream=True,
+            stream_options=stream_options,
             api_key=self.api_key,
             api_base=self.api_base,
             api_version=self.api_version,
@@ -202,6 +207,13 @@ class LiteLLM(BaseLLM):
             **kwargs,
         )
         async for chunk in response:  # type: ignore[union-attr]
+            # The chunk carrying usage (when stream_options requested it) is
+            # a final, content-free one -- choices is empty on it, per
+            # OpenAI streaming semantics. Emitted before the choices check
+            # below so it isn't skipped along with "nothing to yield".
+            self._emit_usage(getattr(chunk, "usage", None))
+            if not chunk.choices:
+                continue
             content = chunk.choices[0].delta.content
             if content:
                 yield content

--- a/tests/backend/app/test_usage_tracking.py
+++ b/tests/backend/app/test_usage_tracking.py
@@ -102,7 +102,7 @@ class TestIsHostedModel:
     conflated this function's job -- classifying an org's explicit
     choice -- with the system *default*'s job of running on whatever
     the deployment names as ``DEFAULT_*_MODEL``, which
-    ``_resolve_default_hosted_model`` already handles unconditionally,
+    ``resolve_default_hosted_model`` already handles unconditionally,
     with no provider check at all.)
     """
 
@@ -152,9 +152,9 @@ class TestResolveDefaultHostedModel:
 
         monkeypatch.setattr("rhesis.backend.app.utils.user_model_utils.get_model", fake_get_model)
 
-        from rhesis.backend.app.utils.user_model_utils import _resolve_default_hosted_model
+        from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
 
-        _resolve_default_hosted_model("vertex_ai/gemini-2.5-flash", "org-1")
+        resolve_default_hosted_model("vertex_ai/gemini-2.5-flash", "org-1")
 
         assert captured["name"] == "vertex_ai/gemini-2.5-flash"
         assert callable(captured["on_usage"])
@@ -173,9 +173,9 @@ class TestResolveDefaultHostedModel:
 
         monkeypatch.setattr("rhesis.backend.app.utils.user_model_utils.get_model", boom)
 
-        from rhesis.backend.app.utils.user_model_utils import _resolve_default_hosted_model
+        from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
 
-        result = _resolve_default_hosted_model("vertex_ai/gemini-2.5-flash", "org-1")
+        result = resolve_default_hosted_model("vertex_ai/gemini-2.5-flash", "org-1")
 
         assert result == "vertex_ai/gemini-2.5-flash"
 
@@ -186,9 +186,30 @@ class TestResolveDefaultHostedModel:
             lambda name, **kwargs: captured.setdefault("on_usage", kwargs.get("on_usage")),
         )
 
-        from rhesis.backend.app.utils.user_model_utils import _resolve_default_hosted_model
+        from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
 
-        _resolve_default_hosted_model("vertex_ai/gemini-2.5-flash", "org-42")
+        resolve_default_hosted_model("vertex_ai/gemini-2.5-flash", "org-42")
         captured["on_usage"](_usage(30))
 
         assert fake_delay == [("org-42", QuotaResource.MODEL_TOKENS.value, 30)]
+
+    @pytest.mark.parametrize("organization_id", ["", None])
+    def test_no_org_still_builds_the_model_but_wires_no_accrual(self, organization_id, monkeypatch):
+        """The test-execution paths derive organization_id from a nullable
+        column and can pass "". Booking those tokens against no org at all is
+        worse than not counting them, so the model is still built (execution
+        must not break) with no callback attached."""
+        captured = {}
+
+        def fake_get_model(name, **kwargs):
+            captured["kwargs"] = kwargs
+            return object()
+
+        monkeypatch.setattr("rhesis.backend.app.utils.user_model_utils.get_model", fake_get_model)
+
+        from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
+
+        result = resolve_default_hosted_model("vertex_ai/gemini-2.5-flash", organization_id)
+
+        assert result is not None
+        assert "on_usage" not in captured["kwargs"]

--- a/tests/backend/app/test_usage_tracking.py
+++ b/tests/backend/app/test_usage_tracking.py
@@ -86,3 +86,109 @@ class TestMakeUsageAccrualCallback:
         make_usage_accrual_callback("org-1")(_usage(10))
 
         assert called == []
+
+
+class TestIsHostedModel:
+    """Which explicitly-selected Model rows accrue MODEL_TOKENS.
+
+    Only ``rhesis``/``polyphemus`` represent "use Rhesis's own hosted
+    infrastructure" as a selectable option in the Models UI. Any other
+    provider an org picks for a Model row -- their own ``vertex_ai``,
+    ``openai``, self-hosted ``ollama``/``vllm``, whatever -- is their own
+    infrastructure choice and must never accrue, regardless of whether
+    they happened to leave the key blank.
+
+    (A broader, per-provider classification was tried and reverted: it
+    conflated this function's job -- classifying an org's explicit
+    choice -- with the system *default*'s job of running on whatever
+    the deployment names as ``DEFAULT_*_MODEL``, which
+    ``_resolve_default_hosted_model`` already handles unconditionally,
+    with no provider check at all.)
+    """
+
+    @pytest.mark.parametrize("provider", ["rhesis", "polyphemus"])
+    def test_rhesis_hosted_providers_accrue_without_an_org_key(self, provider):
+        from rhesis.backend.app.utils.user_model_utils import _is_hosted_model
+
+        assert _is_hosted_model(provider, None) is True
+        assert _is_hosted_model(provider, "") is True
+
+    @pytest.mark.parametrize("provider", ["rhesis", "polyphemus"])
+    def test_rhesis_hosted_providers_do_not_accrue_with_an_org_key(self, provider):
+        """An org-supplied key on one of these means a self-hosted or
+        custom-endpoint setup using the same protocol, not Rhesis's own
+        infrastructure."""
+        from rhesis.backend.app.utils.user_model_utils import _is_hosted_model
+
+        assert _is_hosted_model(provider, "sk-org-owned") is False
+
+    @pytest.mark.parametrize(
+        "provider",
+        ["openai", "gemini", "anthropic", "vertex_ai", "ollama", "vllm", "huggingface"],
+    )
+    def test_any_org_selected_provider_never_accrues(self, provider):
+        """Regardless of whether a key is configured: an explicitly-selected
+        Model row for any provider other than rhesis/polyphemus is always
+        the org's own infrastructure choice."""
+        from rhesis.backend.app.utils.user_model_utils import _is_hosted_model
+
+        assert _is_hosted_model(provider, None) is False
+        assert _is_hosted_model(provider, "") is False
+        assert _is_hosted_model(provider, "sk-org-owned") is False
+
+
+class TestResolveDefaultHostedModel:
+    """The system default always runs on the server's own credentials."""
+
+    def test_wires_accrual_for_a_non_rhesis_default(self, monkeypatch):
+        """Regression: a ``vertex_ai/...`` default used to be handed back as
+        a bare string with no callback, so its tokens were never counted."""
+        captured = {}
+
+        def fake_get_model(name, **kwargs):
+            captured["name"] = name
+            captured["on_usage"] = kwargs.get("on_usage")
+            return object()
+
+        monkeypatch.setattr("rhesis.backend.app.utils.user_model_utils.get_model", fake_get_model)
+
+        from rhesis.backend.app.utils.user_model_utils import _resolve_default_hosted_model
+
+        _resolve_default_hosted_model("vertex_ai/gemini-2.5-flash", "org-1")
+
+        assert captured["name"] == "vertex_ai/gemini-2.5-flash"
+        assert callable(captured["on_usage"])
+
+    @pytest.mark.parametrize(
+        "error", [ValueError("no credentials"), ImportError("torch not installed")]
+    )
+    def test_falls_back_to_the_bare_string_when_construction_fails(self, error, monkeypatch):
+        """Broad on purpose: dropping the provider restriction means this now
+        calls get_model for *any* DEFAULT_*_MODEL, including providers whose
+        modules raise other error types at import/construction time (e.g.
+        huggingface.py raises ImportError without torch/transformers)."""
+
+        def boom(*args, **kwargs):
+            raise error
+
+        monkeypatch.setattr("rhesis.backend.app.utils.user_model_utils.get_model", boom)
+
+        from rhesis.backend.app.utils.user_model_utils import _resolve_default_hosted_model
+
+        result = _resolve_default_hosted_model("vertex_ai/gemini-2.5-flash", "org-1")
+
+        assert result == "vertex_ai/gemini-2.5-flash"
+
+    def test_accrues_against_the_given_org(self, monkeypatch, fake_delay):
+        captured = {}
+        monkeypatch.setattr(
+            "rhesis.backend.app.utils.user_model_utils.get_model",
+            lambda name, **kwargs: captured.setdefault("on_usage", kwargs.get("on_usage")),
+        )
+
+        from rhesis.backend.app.utils.user_model_utils import _resolve_default_hosted_model
+
+        _resolve_default_hosted_model("vertex_ai/gemini-2.5-flash", "org-42")
+        captured["on_usage"](_usage(30))
+
+        assert fake_delay == [("org-42", QuotaResource.MODEL_TOKENS.value, 30)]

--- a/tests/backend/routes/test_usage.py
+++ b/tests/backend/routes/test_usage.py
@@ -77,6 +77,39 @@ class TestUsageEndpoint:
         assert body["resources"][QuotaResource.SEATS.value]["used"] >= 1
 
 
+class TestUsagePeriodFilter:
+    def test_defaults_to_current_period_when_omitted(self, authenticated_client: TestClient):
+        default_response = authenticated_client.get("/usage")
+        explicit_response = authenticated_client.get(
+            f"/usage?period={default_response.json()['resources'][QuotaResource.SEATS.value]['period_start']}"
+        )
+
+        assert explicit_response.status_code == status.HTTP_200_OK
+        assert (
+            explicit_response.json()["resources"].keys()
+            == default_response.json()["resources"].keys()
+        )
+
+    def test_still_includes_stock_resources_for_a_past_period(
+        self, authenticated_client: TestClient
+    ):
+        response = authenticated_client.get("/usage?period=2026-01-01")
+        body = response.json()
+
+        assert response.status_code == status.HTTP_200_OK
+        assert body["resources"][QuotaResource.SEATS.value]["used"] >= 1
+
+    def test_rejects_a_period_that_is_not_the_first_of_the_month(
+        self, authenticated_client: TestClient
+    ):
+        response = authenticated_client.get("/usage?period=2026-01-15")
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_rejects_a_period_in_the_future(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage?period=2099-01-01")
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
 class TestUsageHistoryEndpoint:
     def test_requires_authentication(self, client: TestClient):
         response = client.get("/usage/history")

--- a/tests/backend/routes/test_usage.py
+++ b/tests/backend/routes/test_usage.py
@@ -75,3 +75,70 @@ class TestUsageEndpoint:
         body = response.json()
 
         assert body["resources"][QuotaResource.SEATS.value]["used"] >= 1
+
+
+class TestUsageHistoryEndpoint:
+    def test_requires_authentication(self, client: TestClient):
+        response = client.get("/usage/history")
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_returns_200_for_authenticated_user(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage/history")
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_response_shape_is_stable(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage/history")
+        body = response.json()
+
+        assert set(body.keys()) == {"resources"}
+        assert isinstance(body["resources"], dict)
+
+    def test_excludes_stock_resources(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage/history")
+        body = response.json()
+
+        stock_resources = {
+            QuotaResource.SEATS.value,
+            QuotaResource.PROJECTS.value,
+            QuotaResource.ENDPOINTS.value,
+        }
+        assert stock_resources.isdisjoint(body["resources"].keys())
+
+    def test_defaults_to_six_months(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage/history")
+        body = response.json()
+
+        assert len(body["resources"][QuotaResource.TRACING_SPANS.value]) == 6
+
+    def test_months_param_controls_point_count(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage/history?months=3")
+        body = response.json()
+
+        assert len(body["resources"][QuotaResource.TRACING_SPANS.value]) == 3
+
+    def test_rejects_months_outside_the_allowed_range(self, authenticated_client: TestClient):
+        too_low = authenticated_client.get("/usage/history?months=0")
+        too_high = authenticated_client.get("/usage/history?months=25")
+
+        assert too_low.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        assert too_high.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    def test_each_point_shape(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/usage/history?months=2")
+        body = response.json()
+
+        for points in body["resources"].values():
+            for point in points:
+                assert set(point.keys()) == {"period_start", "used"}
+                assert isinstance(point["used"], int)
+
+    def test_reflects_accrued_usage_at_the_latest_point(
+        self, authenticated_client: TestClient, test_db, test_org_id
+    ):
+        increment_usage(test_db, test_org_id, QuotaResource.MODEL_TOKENS, 999)
+
+        response = authenticated_client.get("/usage/history?months=2")
+        body = response.json()
+
+        points = body["resources"][QuotaResource.MODEL_TOKENS.value]
+        assert points[-1]["used"] == 999

--- a/tests/backend/security/test_authz_http_enforcement.py
+++ b/tests/backend/security/test_authz_http_enforcement.py
@@ -24,6 +24,7 @@ The EE per-role matrix is exhaustively covered at the provider level in
 Routes used (resolved from the live capability map):
 - ``PUT /organizations/{id}`` → ``organization:update`` (owner-only, core/non-EE).
 - ``GET /behaviors/`` → ``behavior:read`` (ordinary, not owner-only).
+- ``GET /usage`` → ``usage:read`` (owner-only in community, Owner/Admin in EE).
 
 Run with:
     cd apps/backend
@@ -43,6 +44,8 @@ from tests.backend.fixtures.test_setup import create_test_organization_and_user
 # Route + capability under test (kept in sync with the live capability map).
 OWNER_ONLY_ROUTE_CAP = "organization:update"
 ORDINARY_READ_ROUTE = "/behaviors/"
+USAGE_ROUTE = "/usage"
+USAGE_ROUTE_CAP = "usage:read"
 
 
 def _make_context(test_db, *, owner: bool):
@@ -146,6 +149,35 @@ class TestHttpAuthzEnforcement:
         )
         assert resp.status_code == 200, resp.text
 
+    def test_owner_allowed_on_usage_route(self, client, test_db):
+        """Usage is billing data, but the org owner may read it."""
+        _org, _user, token = _make_context(test_db, owner=True)
+        resp = client.get(USAGE_ROUTE, headers=_auth(token))
+        assert resp.status_code == 200, (
+            f"Org owner wrongly denied usage:read: {resp.status_code} {resp.text}"
+        )
+
+    def test_non_owner_denied_on_usage_route(self, client, test_db):
+        """A plain member may not read the org's usage totals or plan limits.
+
+        Regression guard: ``GET /usage`` used to sit in
+        ``AUTHZ_EXEMPT_ROUTES``, so any authenticated member could read it.
+        """
+        _org, _user, token = _make_context(test_db, owner=False)
+        resp = client.get(USAGE_ROUTE, headers=_auth(token))
+        assert resp.status_code == 403, (
+            f"Expected 403 for non-owner usage:read, got {resp.status_code}: {resp.text}"
+        )
+        assert resp.headers.get("X-Accepted-Permissions") == USAGE_ROUTE_CAP
+
+    def test_usage_history_is_gated_too(self, client, test_db):
+        """The history endpoint behind the charts carries the same data."""
+        _org, _user, token = _make_context(test_db, owner=False)
+        resp = client.get(f"{USAGE_ROUTE}/history", headers=_auth(token))
+        assert resp.status_code == 403, (
+            f"Expected 403 for non-owner usage history, got {resp.status_code}: {resp.text}"
+        )
+
 
 def _assign_role(test_db, organization_id, user_id, role_name: str) -> None:
     """Assign an arbitrary built-in org role (EE only; no-op in community)."""
@@ -239,6 +271,22 @@ class TestHttpAuthzEnforcementByRole:
         with _ee_active():
             resp = client.get(f"/organizations/{org.id}", headers=_auth(token))
         assert resp.status_code == 200, resp.text
+
+    def test_admin_allowed_on_usage_read(self, client, test_db):
+        """EE Admin is an org admin, so billing data is in scope."""
+        _org, _user, token = self._context(test_db, "Admin")
+        with _ee_active():
+            resp = client.get(USAGE_ROUTE, headers=_auth(token))
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.parametrize("role_name", ["Member", "Viewer"])
+    def test_non_admin_roles_denied_on_usage_read(self, role_name, client, test_db):
+        """usage:read is excluded from the Viewer baseline, and Member's set is
+        built from it, so neither role holds it."""
+        _org, _user, token = self._context(test_db, role_name)
+        with _ee_active():
+            resp = client.get(USAGE_ROUTE, headers=_auth(token))
+        assert resp.status_code == 403, resp.text
 
     def test_viewer_denied_on_organization_update(self, client, test_db):
         org, _user, token = self._context(test_db, "Viewer")

--- a/tests/backend/services/telemetry/test_enrichment_service.py
+++ b/tests/backend/services/telemetry/test_enrichment_service.py
@@ -389,6 +389,91 @@ class TestCreateAndEnrichSpansPerRootSpan:
         mock_build.assert_not_called()
 
 
+@pytest.mark.unit
+class TestCreateAndEnrichSpansUsageAccrual:
+    """Spans created by the invoker path must be metered.
+
+    ``post_ingest_link`` accrues for inbound OTLP, but this path -- the one
+    Rhesis itself uses while invoking an endpoint during a test run -- went
+    unmetered, so the primary product flow never touched TRACING_SPANS.
+    """
+
+    MODULE = "rhesis.backend.app.services.telemetry.enrichment.service"
+
+    @pytest.fixture
+    def service(self):
+        return EnrichmentService(Mock(spec=Session))
+
+    def _stored(self, count):
+        spans = []
+        for i in range(count):
+            s = Mock()
+            s.trace_id = f"T{i}"
+            s.id = f"span-{i}"
+            s.parent_span_id = None
+            spans.append(s)
+        return spans
+
+    def test_accrues_the_number_of_stored_spans(self, service):
+        stored = self._stored(3)
+        with (
+            patch(f"{self.MODULE}.build_enrichment_chain", return_value=Mock()),
+            patch("rhesis.backend.app.crud.create_trace_spans", return_value=stored),
+            patch(f"{self.MODULE}.dispatch_accrual") as mock_accrual,
+        ):
+            service.create_and_enrich_spans([], "org-1", "proj-1")
+
+        mock_accrual.assert_called_once()
+        org_id, resource, amount = mock_accrual.call_args.args
+        assert org_id == "org-1"
+        assert str(resource) == "tracing_spans"
+        assert amount == 3
+
+    def test_counts_stored_spans_not_requested_ones(self, service):
+        """Two of the three requested spans persisted; only those are billable."""
+        with (
+            patch(f"{self.MODULE}.build_enrichment_chain", return_value=Mock()),
+            patch(
+                "rhesis.backend.app.crud.create_trace_spans",
+                return_value=self._stored(2),
+            ),
+            patch(f"{self.MODULE}.dispatch_accrual") as mock_accrual,
+        ):
+            service.create_and_enrich_spans([Mock(), Mock(), Mock()], "org-1", "proj-1")
+
+        assert mock_accrual.call_args.args[2] == 2
+
+    def test_no_accrual_when_nothing_was_stored(self, service):
+        with (
+            patch("rhesis.backend.app.crud.create_trace_spans", return_value=[]),
+            patch(f"{self.MODULE}.dispatch_accrual") as mock_accrual,
+        ):
+            service.create_and_enrich_spans([], "org-1", "proj-1")
+
+        mock_accrual.assert_not_called()
+
+    def test_accrues_even_if_enrichment_dispatch_fails(self, service):
+        """The spans are persisted and billable regardless of enrichment."""
+        with (
+            patch(
+                f"{self.MODULE}.build_enrichment_chain",
+                side_effect=RuntimeError("broker down"),
+            ),
+            patch(
+                "rhesis.backend.app.crud.create_trace_spans",
+                return_value=self._stored(2),
+            ),
+            patch(f"{self.MODULE}.dispatch_accrual") as mock_accrual,
+        ):
+            try:
+                service.create_and_enrich_spans([], "org-1", "proj-1")
+            except RuntimeError:
+                pass
+
+        mock_accrual.assert_called_once()
+        assert mock_accrual.call_args.args[2] == 2
+
+
 @pytest.mark.integration
 class TestEnrichmentServiceIntegration:
     """Integration tests for EnrichmentService"""

--- a/tests/backend/services/test_usage.py
+++ b/tests/backend/services/test_usage.py
@@ -18,6 +18,7 @@ from rhesis.backend.app.models.project import Project
 from rhesis.backend.app.models.usage import Usage
 from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.services.usage import (
+    InvalidPeriodError,
     _current_period,
     _recent_period_starts,
     count_org_endpoints,
@@ -300,7 +301,7 @@ class TestGetUsageSummaryForPastPeriod:
     def test_rejects_a_period_start_that_is_not_the_first_of_the_month(self, test_db, test_org_id):
         org = test_db.get(Organization, test_org_id)
 
-        with pytest.raises(ValueError, match="first day of a month"):
+        with pytest.raises(InvalidPeriodError, match="first day of a month"):
             get_usage_summary(test_db, test_org_id, org, period_start=date(2026, 1, 15))
 
     def test_rejects_a_period_start_in_the_future(self, test_db, test_org_id):
@@ -312,7 +313,7 @@ class TestGetUsageSummaryForPastPeriod:
             1,
         )
 
-        with pytest.raises(ValueError, match="later than the current period"):
+        with pytest.raises(InvalidPeriodError, match="later than the current period"):
             get_usage_summary(test_db, test_org_id, org, period_start=next_month)
 
 
@@ -369,7 +370,10 @@ class TestGetUsageHistory:
         assert all(p["used"] == 0 for p in points[:-1])
 
     def test_includes_a_past_month_row_at_its_own_point(self, test_db, test_org_id):
-        past_period_start, past_period_end = _current_period(date(2026, 1, 15))
+        # Derived from today rather than hardcoded: a fixed date eventually
+        # falls outside the trailing 12-month window this queries, and the
+        # test would then fail for reasons unrelated to the code.
+        past_period_start, past_period_end = _current_period(_recent_period_starts(3)[0])
 
         db_row = Usage(
             organization_id=test_org_id,
@@ -386,12 +390,19 @@ class TestGetUsageHistory:
             test_org_id,
             months=12,
         )
-        history_at_jan = next(
+        point_at_past_month = next(
             p
             for p in history["resources"][QuotaResource.TEST_GENERATION.value]
             if p["period_start"] == past_period_start.isoformat()
         )
-        assert history_at_jan["used"] == 7
+        assert point_at_past_month["used"] == 7
+
+    @pytest.mark.parametrize("months", [0, -1])
+    def test_rejects_a_non_positive_month_count(self, months, test_db, test_org_id):
+        """Guarded in the service, not just by the router's ``Query(ge=1)``:
+        an empty period list would otherwise raise ``IndexError``."""
+        with pytest.raises(InvalidPeriodError, match="at least 1"):
+            get_usage_history(test_db, test_org_id, months=months)
 
     def test_points_are_ordered_oldest_first(self, test_db, test_org_id):
         history = get_usage_history(test_db, test_org_id, months=6)

--- a/tests/backend/services/test_usage.py
+++ b/tests/backend/services/test_usage.py
@@ -19,10 +19,12 @@ from rhesis.backend.app.models.usage import Usage
 from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.services.usage import (
     _current_period,
+    _recent_period_starts,
     count_org_endpoints,
     count_org_projects,
     count_org_seats,
     dispatch_accrual,
+    get_usage_history,
     get_usage_summary,
     increment_usage,
 )
@@ -234,3 +236,88 @@ class TestGetUsageSummary:
         for resource_value, item in summary["resources"].items():
             expected_kind = "stock" if resource_value in stock_resources else "flow"
             assert item["kind"] == expected_kind
+
+
+class TestRecentPeriodStarts:
+    def test_returns_months_oldest_first_ending_at_today(self):
+        starts = _recent_period_starts(3, today=date(2026, 3, 15))
+
+        assert starts == [date(2026, 1, 1), date(2026, 2, 1), date(2026, 3, 1)]
+
+    def test_crosses_a_year_boundary(self):
+        starts = _recent_period_starts(3, today=date(2026, 2, 10))
+
+        assert starts == [date(2025, 12, 1), date(2026, 1, 1), date(2026, 2, 1)]
+
+    def test_single_month_is_just_the_current_one(self):
+        starts = _recent_period_starts(1, today=date(2026, 6, 20))
+
+        assert starts == [date(2026, 6, 1)]
+
+
+class TestGetUsageHistory:
+    def test_excludes_stock_resources(self, test_db, test_org_id):
+        history = get_usage_history(test_db, test_org_id, months=3)
+
+        stock_resources = {
+            QuotaResource.SEATS.value,
+            QuotaResource.PROJECTS.value,
+            QuotaResource.ENDPOINTS.value,
+        }
+        assert stock_resources.isdisjoint(history["resources"].keys())
+        flow_resources = {
+            QuotaResource.TEST_EXECUTIONS.value,
+            QuotaResource.TRACING_SPANS.value,
+            QuotaResource.TEST_GENERATION.value,
+            QuotaResource.MODEL_TOKENS.value,
+        }
+        assert set(history["resources"].keys()) == flow_resources
+
+    def test_zero_fills_months_with_no_accrual(self, test_db, test_org_id):
+        history = get_usage_history(test_db, test_org_id, months=3)
+
+        points = history["resources"][QuotaResource.TEST_EXECUTIONS.value]
+        assert len(points) == 3
+        assert all(p["used"] == 0 for p in points)
+
+    def test_reflects_current_month_accrual_at_the_last_point(self, test_db, test_org_id):
+        increment_usage(test_db, test_org_id, QuotaResource.TRACING_SPANS, 15)
+
+        history = get_usage_history(test_db, test_org_id, months=3)
+
+        points = history["resources"][QuotaResource.TRACING_SPANS.value]
+        assert points[-1]["used"] == 15
+        assert points[-1]["period_start"] == _current_period()[0].isoformat()
+        assert all(p["used"] == 0 for p in points[:-1])
+
+    def test_includes_a_past_month_row_at_its_own_point(self, test_db, test_org_id):
+        past_period_start, past_period_end = _current_period(date(2026, 1, 15))
+
+        db_row = Usage(
+            organization_id=test_org_id,
+            resource=QuotaResource.TEST_GENERATION.value,
+            period_start=past_period_start,
+            period_end=past_period_end,
+            used=7,
+        )
+        test_db.add(db_row)
+        test_db.commit()
+
+        history = get_usage_history(
+            test_db,
+            test_org_id,
+            months=12,
+        )
+        history_at_jan = next(
+            p
+            for p in history["resources"][QuotaResource.TEST_GENERATION.value]
+            if p["period_start"] == past_period_start.isoformat()
+        )
+        assert history_at_jan["used"] == 7
+
+    def test_points_are_ordered_oldest_first(self, test_db, test_org_id):
+        history = get_usage_history(test_db, test_org_id, months=6)
+
+        points = history["resources"][QuotaResource.MODEL_TOKENS.value]
+        period_starts = [p["period_start"] for p in points]
+        assert period_starts == sorted(period_starts)

--- a/tests/backend/services/test_usage.py
+++ b/tests/backend/services/test_usage.py
@@ -238,6 +238,84 @@ class TestGetUsageSummary:
             assert item["kind"] == expected_kind
 
 
+class TestGetUsageSummaryForPastPeriod:
+    def test_reports_a_past_month_s_flow_usage(self, test_db, test_org_id):
+        org = test_db.get(Organization, test_org_id)
+        past_start, past_end = _current_period(date(2026, 1, 15))
+        test_db.add(
+            Usage(
+                organization_id=test_org_id,
+                resource=QuotaResource.TEST_EXECUTIONS.value,
+                period_start=past_start,
+                period_end=past_end,
+                used=99,
+            )
+        )
+        test_db.commit()
+
+        summary = get_usage_summary(test_db, test_org_id, org, period_start=past_start)
+
+        item = summary["resources"][QuotaResource.TEST_EXECUTIONS.value]
+        assert item["used"] == 99
+        assert item["period_start"] == past_start.isoformat()
+        assert item["period_end"] == past_end.isoformat()
+
+    def test_includes_stock_resources_for_a_past_period(self, test_db, test_org_id):
+        org = test_db.get(Organization, test_org_id)
+        past_start, _ = _current_period(date(2026, 1, 15))
+
+        summary = get_usage_summary(test_db, test_org_id, org, period_start=past_start)
+
+        assert summary["resources"][QuotaResource.SEATS.value]["used"] >= 1
+
+    def test_stock_resources_report_the_current_period_not_the_requested_one(
+        self, test_db, test_org_id
+    ):
+        org = test_db.get(Organization, test_org_id)
+        past_start, _ = _current_period(date(2026, 1, 15))
+        current_start, current_end = _current_period()
+
+        summary = get_usage_summary(test_db, test_org_id, org, period_start=past_start)
+
+        seats = summary["resources"][QuotaResource.SEATS.value]
+        assert seats["period_start"] == current_start.isoformat()
+        assert seats["period_end"] == current_end.isoformat()
+
+    def test_zero_fills_a_past_month_with_no_accrual(self, test_db, test_org_id):
+        org = test_db.get(Organization, test_org_id)
+        past_start, _ = _current_period(date(2026, 1, 15))
+
+        summary = get_usage_summary(test_db, test_org_id, org, period_start=past_start)
+
+        assert summary["resources"][QuotaResource.TRACING_SPANS.value]["used"] == 0
+
+    def test_current_period_start_is_treated_as_current(self, test_db, test_org_id):
+        org = test_db.get(Organization, test_org_id)
+        current_start, _ = _current_period()
+
+        summary = get_usage_summary(test_db, test_org_id, org, period_start=current_start)
+
+        assert set(summary["resources"].keys()) == {r.value for r in QuotaResource}
+
+    def test_rejects_a_period_start_that_is_not_the_first_of_the_month(self, test_db, test_org_id):
+        org = test_db.get(Organization, test_org_id)
+
+        with pytest.raises(ValueError, match="first day of a month"):
+            get_usage_summary(test_db, test_org_id, org, period_start=date(2026, 1, 15))
+
+    def test_rejects_a_period_start_in_the_future(self, test_db, test_org_id):
+        org = test_db.get(Organization, test_org_id)
+        current_start, _ = _current_period()
+        next_month = date(
+            current_start.year + (1 if current_start.month == 12 else 0),
+            1 if current_start.month == 12 else current_start.month + 1,
+            1,
+        )
+
+        with pytest.raises(ValueError, match="later than the current period"):
+            get_usage_summary(test_db, test_org_id, org, period_start=next_month)
+
+
 class TestRecentPeriodStarts:
     def test_returns_months_oldest_first_ending_at_today(self):
         starts = _recent_period_starts(3, today=date(2026, 3, 15))

--- a/tests/backend/tasks/test_test_set_task_result.py
+++ b/tests/backend/tasks/test_test_set_task_result.py
@@ -1,0 +1,74 @@
+"""Unit tests for ``_build_task_result`` in the test-set generation task.
+
+Narrow by design: they only pin down that building the task result never
+touches a lazy-loaded relationship on the ORM row, which is what broke
+generation in practice.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.orm.exc import DetachedInstanceError
+
+from rhesis.backend.tasks.test_set import _build_task_result
+
+
+def _detached_test_set():
+    """An ORM row whose relationship access raises, as a detached one does.
+
+    Both save helpers return the row after their ``with
+    self.get_db_session()`` block has closed, so ``.tests`` is unloaded on a
+    session-less instance. Column attributes stay readable
+    (``expire_on_commit=False``), which is why only the relationship blew up.
+    """
+    row = MagicMock()
+    row.id = "ts-1"
+    row.name = "Generated Set"
+    row.description = "Auto-generated"
+    row.short_description = "Short"
+    row.attributes = {"metadata": {"generation": {"status": "completed"}}}
+    type(row).tests = property(
+        lambda _self: (_ for _ in ()).throw(
+            DetachedInstanceError("Parent instance <TestSet> is not bound to a Session")
+        )
+    )
+    return row
+
+
+@pytest.mark.unit
+class TestBuildTaskResult:
+    def _build(self, db_test_set, tests_generated=7):
+        return _build_task_result(
+            MagicMock(),
+            db_test_set,
+            num_tests=10,
+            synthesizer=MagicMock(),
+            log_kwargs={},
+            batch_size=5,
+            org_id="org-1",
+            user_id="user-1",
+            tests_generated=tests_generated,
+        )
+
+    def test_does_not_touch_the_orm_relationship(self):
+        """Regression: this raised DetachedInstanceError and failed the task
+        *after* the tests had been written, leaving the test set marked
+        ``generation.status = failed`` with a full set of tests behind it."""
+        result = self._build(_detached_test_set())
+
+        assert result["num_tests_generated"] == 7
+
+    def test_reports_the_count_it_was_given(self):
+        """The caller passes the SDK test set's own length, which is a plain
+        list and needs no session."""
+        result = self._build(_detached_test_set(), tests_generated=200)
+
+        assert result["num_tests_generated"] == 200
+        assert result["num_tests_requested"] == 10
+
+    def test_still_reports_the_row_s_scalar_fields(self):
+        result = self._build(_detached_test_set())
+
+        assert result["test_set_id"] == "ts-1"
+        assert result["test_set_name"] == "Generated Set"
+        assert result["save_successful"] is True

--- a/tests/sdk/models/providers/test_litellm.py
+++ b/tests/sdk/models/providers/test_litellm.py
@@ -535,6 +535,80 @@ class TestLiteLLM:
 
     @pytest.mark.asyncio
     @patch("rhesis.sdk.models.providers.litellm.acompletion", new_callable=AsyncMock)
+    async def test_a_generate_stream_requests_usage_by_default(self, mock_acompletion):
+        async def _fake_stream(*args, **kwargs):
+            yield Mock(choices=[Mock(delta=Mock(content="tok"))], usage=None)
+
+        mock_acompletion.return_value = _fake_stream()
+
+        llm = LiteLLM("provider/model")
+        async for _ in await llm.a_generate(prompt="hello", stream=True):
+            pass
+
+        _, kwargs = mock_acompletion.call_args
+        assert kwargs.get("stream_options") == {"include_usage": True}
+
+    @pytest.mark.asyncio
+    @patch("rhesis.sdk.models.providers.litellm.acompletion", new_callable=AsyncMock)
+    async def test_a_generate_stream_caller_stream_options_not_overwritten(self, mock_acompletion):
+        async def _fake_stream(*args, **kwargs):
+            yield Mock(choices=[Mock(delta=Mock(content="tok"))], usage=None)
+
+        mock_acompletion.return_value = _fake_stream()
+
+        llm = LiteLLM("provider/model")
+        async for _ in await llm.a_generate(
+            prompt="hello", stream=True, stream_options={"include_usage": False}
+        ):
+            pass
+
+        _, kwargs = mock_acompletion.call_args
+        assert kwargs.get("stream_options") == {"include_usage": False}
+
+    @pytest.mark.asyncio
+    @patch("rhesis.sdk.models.providers.litellm.acompletion", new_callable=AsyncMock)
+    async def test_a_generate_stream_emits_usage_from_the_final_chunk(self, mock_acompletion):
+        """Regression: streaming never called _emit_usage at all, so a fully
+        wired hosted model still reported zero MODEL_TOKENS when the caller
+        streamed (test-config generation, explorer suggestions)."""
+        emitted = []
+        usage_chunk = Mock(choices=[])
+        usage_chunk.usage = {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12}
+
+        async def _fake_stream(*args, **kwargs):
+            yield Mock(choices=[Mock(delta=Mock(content="tok"))], usage=None)
+            yield usage_chunk
+
+        mock_acompletion.return_value = _fake_stream()
+
+        llm = LiteLLM("provider/model")
+        llm.on_usage = emitted.append
+        chunks = [c async for c in await llm.a_generate(prompt="hello", stream=True)]
+
+        assert chunks == ["tok"]
+        assert emitted == [{"input_tokens": 5, "output_tokens": 7, "total_tokens": 12}]
+
+    @pytest.mark.asyncio
+    @patch("rhesis.sdk.models.providers.litellm.acompletion", new_callable=AsyncMock)
+    async def test_a_generate_stream_skips_the_choiceless_usage_chunk(self, mock_acompletion):
+        """The final usage-carrying chunk has no choices and must not raise
+        IndexError, and must not yield an empty/garbage token."""
+        usage_chunk = Mock(choices=[])
+        usage_chunk.usage = {"total_tokens": 1}
+
+        async def _fake_stream(*args, **kwargs):
+            yield Mock(choices=[Mock(delta=Mock(content="tok"))], usage=None)
+            yield usage_chunk
+
+        mock_acompletion.return_value = _fake_stream()
+
+        llm = LiteLLM("provider/model")
+        chunks = [c async for c in await llm.a_generate(prompt="hello", stream=True)]
+
+        assert chunks == ["tok"]
+
+    @pytest.mark.asyncio
+    @patch("rhesis.sdk.models.providers.litellm.acompletion", new_callable=AsyncMock)
     async def test_a_generate_caller_connection_header_not_overwritten(self, mock_acompletion):
         """A caller-supplied Connection header value is kept unchanged (setdefault semantics)."""
         mock_response = Mock()

--- a/tests/sdk/models/providers/test_litellm.py
+++ b/tests/sdk/models/providers/test_litellm.py
@@ -656,3 +656,79 @@ class TestLiteLLMEmbedderTimeout:
         mock_aembedding.return_value = {"data": [{"embedding": [0.1, 0.2]}]}
         await LiteLLMEmbedder("provider/embed", timeout=4).a_generate("hi")
         assert mock_aembedding.call_args.kwargs["timeout"] == 4
+
+
+class TestLiteLLMUsageEmission:
+    """Token usage must reach ``on_usage`` for every LiteLLM-backed provider.
+
+    Only the Rhesis-native and Polyphemus providers emitted before, so a
+    deployment whose default model is e.g. ``vertex_ai/gemini-2.5-flash``
+    (VertexAILLM subclasses LiteLLM) never reported any token usage.
+    """
+
+    @patch("rhesis.sdk.models.providers.litellm.acompletion")
+    def test_generate_emits_normalized_usage(self, mock_completion):
+        emitted = []
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "hi"
+        mock_response.usage = {
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "total_tokens": 30,
+        }
+        mock_completion.return_value = mock_response
+
+        llm = LiteLLM("vertex_ai/gemini-2.5-flash")
+        llm.on_usage = emitted.append  # what get_model() does after construction
+        llm.generate("hello")
+
+        assert emitted == [{"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}]
+
+    @patch("rhesis.sdk.models.providers.litellm.acompletion")
+    def test_generate_without_callback_is_a_noop(self, mock_completion):
+        mock_response = Mock()
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "hi"
+        mock_response.usage = {"total_tokens": 30}
+        mock_completion.return_value = mock_response
+
+        assert LiteLLM("provider/model").generate("hello") == "hi"
+
+    @patch("rhesis.sdk.models.providers.litellm.acompletion")
+    def test_generate_tolerates_a_response_without_usage(self, mock_completion):
+        emitted = []
+        mock_response = Mock(spec=["choices"])
+        mock_response.choices = [Mock()]
+        mock_response.choices[0].message.content = "hi"
+        mock_completion.return_value = mock_response
+
+        llm = LiteLLM("provider/model")
+        llm.on_usage = emitted.append
+        llm.generate("hello")
+
+        assert emitted == []
+
+    @patch("rhesis.sdk.models.providers.litellm.batch_completion")
+    def test_generate_batch_emits_one_summed_callback(self, mock_batch_completion):
+        """One accrual per batch, not per prompt: the callback queues a
+        durable write. Bulk test generation runs through this path."""
+        emitted = []
+
+        def _resp(content, total):
+            r = Mock()
+            choice = Mock()
+            choice.message.content = content
+            r.choices = [choice]
+            r.usage = {"prompt_tokens": 1, "completion_tokens": total - 1}
+            return r
+
+        mock_batch_completion.return_value = [_resp("a", 30), _resp("b", 70)]
+
+        llm = LiteLLM("vertex_ai/gemini-2.5-flash")
+        llm.on_usage = emitted.append
+        results = llm.generate_batch(["p1", "p2"])
+
+        assert results == ["a", "b"]
+        assert len(emitted) == 1
+        assert emitted[0]["total_tokens"] == 100

--- a/tests/sdk/models/test_model_factory.py
+++ b/tests/sdk/models/test_model_factory.py
@@ -1,3 +1,5 @@
+import base64
+import json
 from unittest.mock import Mock, patch
 
 import pytest
@@ -534,6 +536,22 @@ class TestGetModelUsageCallback:
     registry, so a backend wiring accrual for e.g. ``vertex_ai`` could not
     get a callback attached at all.
     """
+
+    @pytest.fixture(autouse=True)
+    def fake_vertex_credentials(self, monkeypatch):
+        """VertexAILLM resolves credentials in ``__init__``, so these tests
+        pass only on a machine that happens to have real Google credentials
+        configured, and fail in CI otherwise.
+
+        The loader just base64-decodes and JSON-parses the value with no
+        network call and no auth, so a synthetic service-account blob is
+        enough to get past construction and reach what is actually under
+        test: whether ``get_model`` attaches ``on_usage`` to a provider
+        whose constructor takes fixed arguments rather than ``**kwargs``.
+        """
+        blob = base64.b64encode(json.dumps({"project_id": "test-project"}).encode()).decode()
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", blob)
+        monkeypatch.setenv("VERTEX_AI_LOCATION", "us-central1")
 
     @pytest.mark.parametrize(
         ("model_id", "api_key"),

--- a/tests/sdk/models/test_model_factory.py
+++ b/tests/sdk/models/test_model_factory.py
@@ -524,3 +524,38 @@ class TestAvailableModels:
             from rhesis.sdk.models.factory import get_available_embedding_models
 
             get_available_embedding_models("anthropic")
+
+
+class TestGetModelUsageCallback:
+    """``on_usage`` must reach any provider, not only the few whose
+    constructors happen to accept ``**kwargs``.
+
+    Passing it down as a constructor kwarg raised TypeError for most of the
+    registry, so a backend wiring accrual for e.g. ``vertex_ai`` could not
+    get a callback attached at all.
+    """
+
+    @pytest.mark.parametrize(
+        ("model_id", "api_key"),
+        [
+            ("vertex_ai/gemini-2.5-flash", None),
+            ("gemini/gemini-2.0-flash", None),
+            ("openai/gpt-4o", "sk-test"),
+        ],
+    )
+    def test_callback_is_attached_for_providers_with_fixed_signatures(self, model_id, api_key):
+        from rhesis.sdk.models.factory import get_model
+
+        def callback(usage):
+            return None
+
+        model = get_model(model_id, api_key=api_key, model_type="language", on_usage=callback)
+
+        assert model.on_usage is callback
+
+    def test_absent_callback_leaves_the_default(self):
+        from rhesis.sdk.models.factory import get_model
+
+        model = get_model("vertex_ai/gemini-2.5-flash", model_type="language")
+
+        assert model.on_usage is None


### PR DESCRIPTION
## Purpose

Surfaces the usage data added in #2354 to users. Read-only: an organization can see what it has consumed against its plan limits for the current billing period. Nothing here blocks or warns, and no limit is enforced.

Stacked on `feat/usage-accounting-backend` (#2354), which adds the `GET /usage` endpoint this consumes. Review that one first. The base needs retargeting to `main` once it merges.

## What Changed

A **Usage** tab in organization settings, registered at order 20 so it sits after Team and before SSO. For each resource it shows the amount used against its limit, a progress bar, and the billing period. Resources with no limit render as unlimited rather than as a bar at zero.

`UsageContext` follows the existing `FeaturesContext` and `PermissionsContext` pattern rather than inventing a third shape: SSR-seeded from the protected layout so the tab does not flash empty on first paint, cached per user scope, and fail-closed while loading or on error.

Flow and stock resources are grouped using the `kind` field the API returns. The backend already knows which resources are cumulative counters and which are live counts, so the frontend reads that rather than keeping a second hand-maintained list that could drift.

## Additional Context

Follows the repo's frontend conventions: no hardcoded styles (theme tokens only), and resource keys come from a typed `QuotaResource` const mirroring the backend enum rather than string literals scattered through the component.

One thing reviewers may want to weigh in on: because accrual is queued on a worker, the numbers here are eventually consistent and can lag a live action by seconds. The tab does not currently signal that. If it matters for perceived correctness, a "last updated" timestamp would be the smallest fix, but it seemed like speculative polish for a first read-only view.

## Testing

```bash
cd apps/frontend
npx tsc --noEmit     # clean
npm run lint         # 0 errors
npm run format:check
```

Manual, with #2354's backend running:

1. Open organization settings and select the Usage tab.
2. Confirm every resource appears, that metered and count resources are grouped separately, and that unlimited resources are labelled rather than shown as an empty bar.
3. Run a test execution, wait for the worker to drain, reload, and confirm the test-executions count moved.
4. Check the loading and error states by throttling or blocking `/usage`.
