### PR TITLE
Accrue Garak-generated tests toward TEST_GENERATION

### DIFF
--- a/apps/backend/src/rhesis/backend/tasks/garak.py
+++ b/apps/backend/src/rhesis/backend/tasks/garak.py
@@ -13,6 +13,8 @@ import logging
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional
 
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.app.services.usage import dispatch_accrual
 from rhesis.backend.celery.core import app
 from rhesis.backend.notifications.email.template_service import EmailTemplate
 from rhesis.backend.tasks.base import EmailEnabledTask, email_notification
@@ -75,7 +77,16 @@ def import_garak_probes_task(
         )
         for test_set in result["test_sets"]:
             test_set["test_set_id"] = str(test_set["test_set_id"])
-        return result
+
+    # Imported probes are generated tests same as the LLM generation path
+    # (both ultimately create rows via bulk_create_test_set/bulk_create_tests),
+    # so they count toward the same TEST_GENERATION quota -- see
+    # tasks/test_set.py's own dispatch_accrual call for the pattern this
+    # mirrors. No session needed here: the accrual is queued and the worker
+    # task opens its own.
+    dispatch_accrual(org_id, QuotaResource.TEST_GENERATION, result["total_tests"])
+
+    return result
 
 
 @email_notification(
@@ -114,4 +125,11 @@ def sync_garak_test_set_task(
     with self.get_db_session() as db:
         sync_service = GarakSyncService(db)
         result = sync_service.sync_test_set(test_set_id, org_id, user_id)
-        return asdict(result)
+
+    # Only `added` counts as generated tests -- `removed`/`unchanged` are not
+    # new rows, so accruing the whole result would overcount. See
+    # import_garak_probes_task's dispatch_accrual for why this counts the
+    # same way as the LLM generation path.
+    dispatch_accrual(org_id, QuotaResource.TEST_GENERATION, result.added)
+
+    return asdict(result)

--- a/tests/backend/tasks/test_garak.py
+++ b/tests/backend/tasks/test_garak.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.tasks.garak import import_garak_probes_task, sync_garak_test_set_task
 
 
@@ -39,6 +40,7 @@ class TestImportGarakProbesTask:
                 "rhesis.backend.app.services.garak.importer.GarakImporter",
                 return_value=mock_importer,
             ) as mock_importer_cls,
+            patch("rhesis.backend.tasks.garak.dispatch_accrual"),
         ):
             result = import_garak_probes_task(
                 probes=[{"module_name": "dan", "class_name": "Dan_11_0", "custom_name": None}],
@@ -93,6 +95,7 @@ class TestImportGarakProbesTask:
                 "rhesis.backend.app.services.garak.importer.GarakImporter",
                 return_value=mock_importer,
             ),
+            patch("rhesis.backend.tasks.garak.dispatch_accrual"),
         ):
             result = import_garak_probes_task(
                 probes=[{"module_name": "dan", "class_name": "Dan_11_0", "custom_name": None}],
@@ -102,6 +105,42 @@ class TestImportGarakProbesTask:
 
         assert result["test_sets"][0]["test_set_id"] == str(raw_uuid)
         assert isinstance(result["test_sets"][0]["test_set_id"], str)
+
+    def test_dispatches_test_generation_accrual(self):
+        """Imported probes create test rows the same way LLM generation
+        does, so they must accrue against the same TEST_GENERATION quota --
+        see tasks/test_set.py's own dispatch_accrual call."""
+        mock_db = MagicMock()
+        mock_importer = MagicMock()
+        mock_importer.import_probes.return_value = {
+            "test_sets": [],
+            "total_test_sets": 2,
+            "total_tests": 42,
+            "garak_version": "0.14.0",
+        }
+
+        with (
+            patch.object(
+                import_garak_probes_task,
+                "get_tenant_context",
+                return_value=("org-1", "user", None),
+            ),
+            patch.object(
+                import_garak_probes_task, "get_db_session", return_value=_fake_db_session(mock_db)
+            ),
+            patch(
+                "rhesis.backend.app.services.garak.importer.GarakImporter",
+                return_value=mock_importer,
+            ),
+            patch("rhesis.backend.tasks.garak.dispatch_accrual") as mock_dispatch_accrual,
+        ):
+            import_garak_probes_task(
+                probes=[{"module_name": "dan", "class_name": "Dan_11_0", "custom_name": None}],
+                name_prefix="Garak",
+                description_template=None,
+            )
+
+        mock_dispatch_accrual.assert_called_once_with("org-1", QuotaResource.TEST_GENERATION, 42)
 
 
 @pytest.mark.unit
@@ -133,6 +172,7 @@ class TestSyncGarakTestSetTask:
                 "rhesis.backend.app.services.garak.sync.GarakSyncService",
                 return_value=mock_sync_service,
             ) as mock_sync_cls,
+            patch("rhesis.backend.tasks.garak.dispatch_accrual"),
         ):
             result = sync_garak_test_set_task(test_set_id="test-set-id")
 
@@ -149,3 +189,39 @@ class TestSyncGarakTestSetTask:
             "new_garak_version": "0.14.0",
             "old_garak_version": "0.13.0",
         }
+
+    def test_dispatches_test_generation_accrual_for_added_only(self):
+        """Only newly-created rows count as generated tests -- `removed`/
+        `unchanged` don't create new `test` rows, so accruing the full
+        result would overcount."""
+        mock_db = MagicMock()
+        mock_sync_service = MagicMock()
+
+        from rhesis.backend.app.services.garak.sync import SyncResult
+
+        mock_sync_service.sync_test_set.return_value = SyncResult(
+            added=7,
+            removed=3,
+            unchanged=100,
+            new_garak_version="0.14.0",
+            old_garak_version="0.13.0",
+        )
+
+        with (
+            patch.object(
+                sync_garak_test_set_task,
+                "get_tenant_context",
+                return_value=("org-1", "user", None),
+            ),
+            patch.object(
+                sync_garak_test_set_task, "get_db_session", return_value=_fake_db_session(mock_db)
+            ),
+            patch(
+                "rhesis.backend.app.services.garak.sync.GarakSyncService",
+                return_value=mock_sync_service,
+            ),
+            patch("rhesis.backend.tasks.garak.dispatch_accrual") as mock_dispatch_accrual,
+        ):
+            sync_garak_test_set_task(test_set_id="test-set-id")
+
+        mock_dispatch_accrual.assert_called_once_with("org-1", QuotaResource.TEST_GENERATION, 7)


### PR DESCRIPTION
## Purpose

`QuotaResource.TEST_GENERATION` is meant to track every test created through generation, but only one of Garak's three test-creation paths actually accrued anything. Tests created via Garak's static probe import or its test-set re-sync were invisible to the usage dashboard and to any future quota enforcement built on top of it.

## What Changed

Garak has three ways to create tests. `POST /garak/generate` (dynamic probes) already shares the same Celery task as the standard LLM generation path (`generate_and_save_test_set` in `tasks/test_set.py`), which already calls `dispatch_accrual(org_id, QuotaResource.TEST_GENERATION, ...)` — that path needed no change.

The other two run as separate tasks with their own services and had no accrual call at all:

- `import_garak_probes_task` (static probe import, `POST /garak/import`) now accrues `result["total_tests"]` — the actual count `GarakImporter.import_probes()` created, not the separate preview-only estimate the dry-run endpoint uses.
- `sync_garak_test_set_task` (re-sync, `POST /garak/sync/{id}`) now accrues `result.added` only. A sync's `SyncResult` also has `removed` and `unchanged` fields; only `added` corresponds to newly created `test` rows, so accruing the full result would overcount.

Both paths ultimately create rows through the same `bulk_create_test_set` / `bulk_create_tests` machinery as the LLM generation path, so "one test row created" means the same thing across all three and it's safe to count them the same way.

## Additional Context

Related to the usage-accounting feature (#2354) and its dashboard (#2355). No enforcement is affected yet — this only makes the TEST_GENERATION counter complete across all test-creation paths.

## Testing

```bash
cd apps/backend && uv run pytest ../../tests/backend/tasks/test_garak.py
```

Added two tests asserting the exact `dispatch_accrual` call: one confirming the import path accrues the importer's real total, one confirming the sync path accrues only `added` and not the full result. Existing tests updated to mock `dispatch_accrual` so they don't attempt a real (harmlessly swallowed) broker call. All 5 tests in the file pass, plus a broader sweep of `tasks/`, `services/test_usage.py`, `routes/test_usage.py`, and `app/test_usage_tracking.py` (428 passed) to confirm nothing else regressed. `ruff check`/`ruff format` clean.
