### PR TITLE
Validate explorer test metadata with Pydantic

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/crud/explorer.py
@@ -10,7 +10,7 @@ Every function here flushes and never commits -- the request session owns the co
 
 import logging
 import uuid
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 
 from sqlalchemy import cast, select
 from sqlalchemy.dialects.postgresql import JSONB
@@ -31,6 +31,12 @@ from rhesis.backend.app.crud import (
 )
 from rhesis.backend.app.models.enums import ModelType
 from rhesis.backend.app.models.test import test_test_set_association
+from rhesis.backend.app.schemas.explorer_metadata import (
+    ExplorerAdaptiveSettings,
+    ExplorerTestMetadata,
+    parse_explorer_adaptive_settings,
+    parse_explorer_test_metadata,
+)
 from rhesis.backend.app.utils.query_utils import QueryBuilder, include
 
 logger = logging.getLogger(__name__)
@@ -161,7 +167,7 @@ def get_test_ids_in_test_sets(
 
 
 def replace_test_set_explorer_settings(
-    db: Session, test_set: models.TestSet, settings: Dict[str, Any]
+    db: Session, test_set: models.TestSet, settings: ExplorerAdaptiveSettings
 ) -> models.TestSet:
     """Overwrite a test set's ``attributes["adaptive_settings"]`` wholesale.
 
@@ -178,7 +184,7 @@ def replace_test_set_explorer_settings(
         Database session
     test_set : models.TestSet
         Test set to write to
-    settings : dict
+    settings : ExplorerAdaptiveSettings
         The new ``adaptive_settings`` value
 
     Returns
@@ -187,7 +193,7 @@ def replace_test_set_explorer_settings(
         The same instance, flushed.
     """
     attrs = dict(test_set.attributes or {})
-    attrs["adaptive_settings"] = dict(settings)
+    attrs["adaptive_settings"] = settings.model_dump(mode="json", exclude_none=True)
     test_set.attributes = attrs
     db.add(test_set)
     db.flush()
@@ -216,9 +222,9 @@ def set_test_set_default_endpoint(
         The same instance, flushed and refreshed.
     """
     attrs = dict(test_set.attributes or {})
-    explorer_settings = dict(attrs.get("adaptive_settings") or {})
-    explorer_settings["default_endpoint_id"] = str(endpoint_id)
-    attrs["adaptive_settings"] = explorer_settings
+    explorer_settings = parse_explorer_adaptive_settings(attrs.get("adaptive_settings"))
+    explorer_settings.default_endpoint_id = endpoint_id
+    attrs["adaptive_settings"] = explorer_settings.model_dump(mode="json", exclude_none=True)
     test_set.attributes = attrs
     db.add(test_set)
     db.flush()
@@ -388,7 +394,7 @@ def create_explorer_test(
     user_id: str,
     topic_id: Optional[uuid.UUID] = None,
     content: Optional[str] = None,
-    metadata: Optional[Dict[str, Any]] = None,
+    metadata: Optional[ExplorerTestMetadata] = None,
 ) -> models.Test:
     """Insert an Explorer test, plus the prompt holding its input when it has one.
 
@@ -409,7 +415,7 @@ def create_explorer_test(
         Topic to file the test under
     content : str, optional
         Prompt text; when None no prompt row is created
-    metadata : dict, optional
+    metadata : ExplorerTestMetadata, optional
         Value for ``test_metadata``
 
     Returns
@@ -431,7 +437,9 @@ def create_explorer_test(
     db_test = models.Test(
         topic_id=topic_id,
         prompt_id=prompt_id,
-        test_metadata=metadata,
+        test_metadata=(
+            metadata.model_dump(mode="json", exclude_none=True) if metadata is not None else None
+        ),
         organization_id=organization_id,
         user_id=user_id,
     )
@@ -445,7 +453,7 @@ def update_explorer_test(
     db_test: models.Test,
     *,
     prompt_content: Optional[str] = None,
-    metadata: Optional[Dict[str, Any]] = None,
+    metadata: Optional[ExplorerTestMetadata] = None,
     topic_id: Optional[uuid.UUID] = None,
 ) -> models.Test:
     """Apply the given changes to a test, then flush and refresh it.
@@ -463,7 +471,7 @@ def update_explorer_test(
         Test to update
     prompt_content : str, optional
         New prompt text; ignored when the test has no prompt
-    metadata : dict, optional
+    metadata : ExplorerTestMetadata, optional
         Replacement ``test_metadata``, written only when it differs
     topic_id : uuid.UUID, optional
         New topic
@@ -477,8 +485,10 @@ def update_explorer_test(
         db_test.prompt.content = prompt_content
         db.add(db_test.prompt)
 
-    if metadata is not None and metadata != (db_test.test_metadata or {}):
-        db_test.test_metadata = metadata
+    if metadata is not None:
+        dumped = metadata.model_dump(mode="json", exclude_none=True)
+        if dumped != (db_test.test_metadata or {}):
+            db_test.test_metadata = dumped
 
     if topic_id is not None:
         db_test.topic_id = topic_id
@@ -547,7 +557,7 @@ def remove_tests_from_test_set(
 
 
 def set_explorer_test_metadata(
-    db: Session, updates: Sequence[Tuple[models.Test, Dict[str, Any]]]
+    db: Session, updates: Sequence[Tuple[models.Test, ExplorerTestMetadata]]
 ) -> None:
     """Write new ``test_metadata`` onto already-loaded tests, flushing once.
 
@@ -559,14 +569,14 @@ def set_explorer_test_metadata(
     ----------
     db : Session
         Database session
-    updates : sequence of (models.Test, dict)
+    updates : sequence of (models.Test, ExplorerTestMetadata)
         Tests paired with their replacement metadata
     """
     if not updates:
         return
 
     for db_test, metadata in updates:
-        db_test.test_metadata = metadata
+        db_test.test_metadata = metadata.model_dump(mode="json", exclude_none=True)
 
     db.flush()
 
@@ -597,9 +607,9 @@ def set_explorer_test_outputs(db: Session, outputs: Dict[str, str]) -> List[str]
     written: List[str] = []
     for db_test in db_tests:
         test_id_str = str(db_test.id)
-        meta = dict(db_test.test_metadata or {})
-        meta["output"] = outputs[test_id_str]
-        db_test.test_metadata = meta
+        meta = parse_explorer_test_metadata(db_test.test_metadata)
+        meta.output = outputs[test_id_str]
+        db_test.test_metadata = meta.model_dump(mode="json", exclude_none=True)
         written.append(test_id_str)
 
     db.flush()

--- a/apps/backend/src/rhesis/backend/app/schemas/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/explorer.py
@@ -2,11 +2,12 @@
 
 import uuid
 from functools import cached_property
-from typing import Any, Dict, List, Literal, Optional
+from typing import Dict, List, Optional
 
 from pydantic import UUID4, BaseModel, ConfigDict, Field, computed_field
 
 from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.explorer_metadata import ExplorerLabel, ExplorerMetricEvalDetail
 from rhesis.backend.app.schemas.test_set import TestSet as TestSetSchema
 
 # ---------------------------------------------------------------------------
@@ -22,11 +23,11 @@ class TestTreeNode(BaseModel):
     input: str = ""
     output: str = ""
     # "error" is written by the evaluation path when a metric raises.
-    label: Literal["", "topic_marker", "pass", "fail", "error"] = ""
+    label: ExplorerLabel = ""
     labeler: str = ""
     to_eval: bool = True
     model_score: float = 0.0
-    metrics: Optional[Dict[str, Any]] = None
+    metrics: Optional[Dict[str, ExplorerMetricEvalDetail]] = None
 
 
 class TopicNode(BaseModel):
@@ -202,15 +203,6 @@ class EvaluateRequest(Base):
     topic: Optional[str] = None
     include_subtopics: bool = True
     overwrite: bool = False
-
-
-class ExplorerMetricEvalDetail(BaseModel):
-    """Per-metric evaluation row (keyed by metric name on the parent model)."""
-
-    score: float
-    is_successful: bool
-    reason: Optional[str] = None
-    details: Optional[Dict[str, Any]] = None
 
 
 class EvaluateResultItem(BaseModel):

--- a/apps/backend/src/rhesis/backend/app/schemas/explorer_metadata.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/explorer_metadata.py
@@ -1,0 +1,238 @@
+"""Pydantic validation for the two JSONB dicts Explorer reads and writes directly:
+``Test.test_metadata`` and ``TestSet.attributes["adaptive_settings"]``.
+
+Both columns are shared with non-explorer writers (garak sync/import, general test-set
+attribute generation), so the models here use ``extra="allow"`` -- an unrecognized shape
+must round-trip losslessly, not raise and not silently drop keys.
+
+Pure schema module, no ORM imports, so it's importable from ``crud/``, ``services/explorer/``,
+and ``services/test_set.py`` without layering violations.
+
+Contract:
+
+- Every ``parse_*`` function is **total** -- it never raises. ``None``, ``{}``, a non-mapping,
+  or a garbage-shaped mapping all come back as an empty (all-defaults) model. The lenient
+  ``mode="before"`` validators on each model make a ``ValidationError`` unreachable in
+  practice; the ``try/except`` in each ``parse_*`` is the backstop that guarantees a
+  foreign-shaped row (e.g. garak) can never crash an explorer endpoint.
+- Dumping back to a JSONB-safe dict is always ``model.model_dump(mode="json", exclude_none=True)``,
+  done at the call site rather than through a wrapper. ``mode="json"`` turns non-JSON-native types
+  (e.g. ``UUID``) into strings. ``exclude_none=True`` makes "field is ``None``" round-trip as "key
+  absent", reproducing the ``del meta["evaluation"]`` / ``meta.pop("metrics", None)`` idioms the
+  call sites used before this module existed. This also means a foreign key explicitly set to
+  ``null`` today would come back absent after a round trip through here -- no known caller does
+  that, but it's worth knowing.
+"""
+
+import logging
+from typing import Any, Dict, Final, List, Literal, Mapping, Optional, get_args
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from rhesis.backend.app.constants import EXPLORER_BEHAVIOR_NAME
+from rhesis.backend.app.utils.uuid_utils import sanitize_uuid_field
+
+logger = logging.getLogger(__name__)
+
+ExplorerLabel = Literal["", "topic_marker", "pass", "fail", "error"]
+TOPIC_MARKER_LABEL: Final[str] = "topic_marker"
+_VALID_LABELS = set(get_args(ExplorerLabel))
+
+
+def _coerce_label(value: Any) -> str:
+    return value if isinstance(value, str) and value in _VALID_LABELS else ""
+
+
+def _coerce_optional_str(value: Any) -> Optional[str]:
+    return None if value is None else str(value)
+
+
+def _coerce_model_score(value: Any) -> float:
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+class ExplorerMetricEvalDetail(BaseModel):
+    """Per-metric evaluation row (keyed by metric name on the parent model)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    score: float
+    is_successful: bool
+    reason: Optional[str] = None
+    details: Optional[Dict[str, Any]] = None
+
+
+class ExplorerEvaluationEntry(BaseModel):
+    """One row of ``test_metadata["evaluation"]`` -- a per-metric verdict breakdown."""
+
+    model_config = ConfigDict(extra="allow")
+
+    label: ExplorerLabel = ""
+    labeler: str = ""
+    model_score: float = 0.0
+
+    @field_validator("label", mode="before")
+    @classmethod
+    def _validate_label(cls, v: Any) -> str:
+        return _coerce_label(v)
+
+    @field_validator("labeler", mode="before")
+    @classmethod
+    def _validate_labeler(cls, v: Any) -> str:
+        return "" if v is None else str(v)
+
+    @field_validator("model_score", mode="before")
+    @classmethod
+    def _validate_model_score(cls, v: Any) -> float:
+        return _coerce_model_score(v)
+
+
+class ExplorerTestMetadata(BaseModel):
+    """``Test.test_metadata`` for explorer-owned rows.
+
+    ``output``/``labeler`` are ``Optional[str]`` rather than ``str`` so that "key absent"
+    (``None``) stays distinguishable from "key present but empty" (``""``) -- callers that
+    need a default only for the missing case (e.g. ``NO_OUTPUT``, ``"imported"``) rely on
+    that distinction.
+    """
+
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
+
+    output: Optional[str] = None
+    label: ExplorerLabel = ""
+    labeler: Optional[str] = None
+    model_score: float = 0.0
+    metrics: Optional[Dict[str, ExplorerMetricEvalDetail]] = None
+    evaluation: Optional[List[ExplorerEvaluationEntry]] = None
+
+    @field_validator("label", mode="before")
+    @classmethod
+    def _validate_label(cls, v: Any) -> str:
+        return _coerce_label(v)
+
+    @field_validator("output", "labeler", mode="before")
+    @classmethod
+    def _validate_optional_str(cls, v: Any) -> Optional[str]:
+        return _coerce_optional_str(v)
+
+    @field_validator("model_score", mode="before")
+    @classmethod
+    def _validate_model_score(cls, v: Any) -> float:
+        return _coerce_model_score(v)
+
+    @field_validator("metrics", mode="before")
+    @classmethod
+    def _validate_metrics(cls, v: Any) -> Optional[Dict[str, Any]]:
+        if not isinstance(v, dict):
+            return None
+        cleaned: Dict[str, Any] = {}
+        for name, entry in v.items():
+            if not isinstance(entry, dict):
+                logger.warning("Dropping non-dict explorer metric entry %r", name)
+                continue
+            try:
+                ExplorerMetricEvalDetail.model_validate(entry)
+            except ValidationError:
+                logger.warning("Dropping invalid explorer metric entry %r", name)
+                continue
+            cleaned[name] = entry
+        return cleaned or None
+
+    @field_validator("evaluation", mode="before")
+    @classmethod
+    def _validate_evaluation(cls, v: Any) -> Optional[List[Any]]:
+        if not isinstance(v, list):
+            return None
+        cleaned = [entry for entry in v if isinstance(entry, dict)]
+        return cleaned or None
+
+    @property
+    def is_topic_marker(self) -> bool:
+        return self.label == TOPIC_MARKER_LABEL
+
+    @classmethod
+    def topic_marker(cls, labeler: str = "user") -> "ExplorerTestMetadata":
+        return cls(label=TOPIC_MARKER_LABEL, labeler=labeler, output="")
+
+
+class ExplorerAdaptiveSettings(BaseModel):
+    """``TestSet.attributes["adaptive_settings"]``."""
+
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
+
+    default_endpoint_id: Optional[UUID] = None
+
+    @field_validator("default_endpoint_id", mode="before")
+    @classmethod
+    def _validate_default_endpoint_id(cls, v: Any) -> Optional[str]:
+        return sanitize_uuid_field(v)
+
+
+class ExplorerTestSetAttributeMetadata(BaseModel):
+    """``TestSet.attributes["metadata"]`` -- the general behaviors/metadata blob."""
+
+    model_config = ConfigDict(extra="allow")
+
+    behaviors: List[str] = Field(default_factory=list)
+
+    @field_validator("behaviors", mode="before")
+    @classmethod
+    def _validate_behaviors(cls, v: Any) -> List[str]:
+        if not isinstance(v, list):
+            return []
+        return [item for item in v if isinstance(item, str)]
+
+
+class ExplorerTestSetAttributes(BaseModel):
+    """Read-only view of ``TestSet.attributes`` -- never dumped/round-tripped as a whole."""
+
+    model_config = ConfigDict(extra="allow")
+
+    metadata: Optional[ExplorerTestSetAttributeMetadata] = None
+    adaptive_settings: Optional[ExplorerAdaptiveSettings] = None
+
+    @property
+    def is_explorer(self) -> bool:
+        behaviors = self.metadata.behaviors if self.metadata else []
+        return EXPLORER_BEHAVIOR_NAME in behaviors
+
+    @property
+    def default_endpoint_id(self) -> Optional[UUID]:
+        return self.adaptive_settings.default_endpoint_id if self.adaptive_settings else None
+
+
+def parse_explorer_test_metadata(raw: Optional[Mapping[str, Any]]) -> ExplorerTestMetadata:
+    """Parse ``Test.test_metadata``. Never raises -- see module docstring."""
+    try:
+        return ExplorerTestMetadata.model_validate(raw or {})
+    except ValidationError:
+        logger.warning("Failed to parse explorer test metadata %r; using defaults", raw)
+        return ExplorerTestMetadata()
+
+
+def parse_explorer_adaptive_settings(
+    raw: Optional[Mapping[str, Any]],
+) -> ExplorerAdaptiveSettings:
+    """Parse ``TestSet.attributes["adaptive_settings"]``. Never raises -- see module docstring."""
+    try:
+        return ExplorerAdaptiveSettings.model_validate(raw or {})
+    except ValidationError:
+        logger.warning("Failed to parse explorer adaptive settings %r; using defaults", raw)
+        return ExplorerAdaptiveSettings()
+
+
+def parse_explorer_test_set_attributes(
+    raw: Optional[Mapping[str, Any]],
+) -> ExplorerTestSetAttributes:
+    """Parse ``TestSet.attributes``. Never raises -- see module docstring."""
+    try:
+        return ExplorerTestSetAttributes.model_validate(raw or {})
+    except ValidationError:
+        logger.warning("Failed to parse explorer test set attributes %r; using defaults", raw)
+        return ExplorerTestSetAttributes()

--- a/apps/backend/src/rhesis/backend/app/services/explorer/evaluation.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/evaluation.py
@@ -15,6 +15,11 @@ from rhesis.backend.app.schemas.explorer import (
     EvaluateResponse,
     EvaluateResultItem,
 )
+from rhesis.backend.app.schemas.explorer_metadata import (
+    ExplorerMetricEvalDetail,
+    ExplorerTestMetadata,
+    parse_explorer_test_metadata,
+)
 from rhesis.backend.app.services.explorer.invocation import NO_OUTPUT
 from rhesis.backend.app.services.explorer.utils import (
     _build_eligible_tests,
@@ -45,16 +50,13 @@ def build_metrics_summary_for_response(
     """Build per-metric payload for HTTP responses and ``test_metadata.metrics``."""
     out: Dict[str, Dict[str, Any]] = {}
     for name, v in valid.items():
-        row: Dict[str, Any] = {
-            "score": v.get("score"),
-            "is_successful": v.get("is_successful"),
-        }
-        if v.get("reason") is not None:
-            row["reason"] = v["reason"]
-        det = v.get("details")
-        if det:
-            row["details"] = det
-        out[name] = row
+        detail = ExplorerMetricEvalDetail(
+            score=v.get("score") or 0.0,
+            is_successful=bool(v.get("is_successful")),
+            reason=v.get("reason"),
+            details=v.get("details") or None,
+        )
+        out[name] = detail.model_dump(mode="json", exclude_none=True)
     return out
 
 
@@ -314,7 +316,7 @@ async def evaluate_tests_for_explorer_set(
             continue
         eligible.append(t)
 
-    async def _evaluate_test(test) -> Tuple[Dict[str, Any], Optional[Dict[str, Any]]]:
+    async def _evaluate_test(test) -> Tuple[Dict[str, Any], Optional[ExplorerTestMetadata]]:
         """Evaluate one test, returning its outcome and the metadata to persist.
 
         Returns the metadata rather than assigning it: these run concurrently on the
@@ -323,7 +325,8 @@ async def evaluate_tests_for_explorer_set(
         """
         test_id_str = str(test.id)
         input_text = (test.prompt.content or "").strip()
-        output_text = (test.test_metadata or {}).get("output", "")
+        existing_meta = parse_explorer_test_metadata(test.test_metadata)
+        output_text = existing_meta.output or ""
 
         if not output_text or output_text == NO_OUTPUT:
             logger.warning(
@@ -343,10 +346,13 @@ async def evaluate_tests_for_explorer_set(
                     "error": "no metric results",
                 }, None
 
-            meta = dict(test.test_metadata or {})
-            meta.update(verdict.as_payload())
+            meta = existing_meta.model_copy()
+            meta.label = verdict.label
+            meta.labeler = verdict.labeler
+            meta.model_score = verdict.model_score
+            meta.metrics = verdict.metrics
             if len(sdk_metrics) > 1:
-                meta["evaluation"] = [
+                meta.evaluation = [
                     {
                         "label": "pass" if r.get("is_successful") else "fail",
                         "labeler": key,
@@ -354,8 +360,8 @@ async def evaluate_tests_for_explorer_set(
                     }
                     for key, r in verdict.per_metric.items()
                 ]
-            elif "evaluation" in meta:
-                del meta["evaluation"]
+            else:
+                meta.evaluation = None
 
             return {
                 "status": "ok",
@@ -368,9 +374,12 @@ async def evaluate_tests_for_explorer_set(
                 f"Evaluation failed for test {test_id_str}: {e}",
                 exc_info=True,
             )
-            meta = dict(test.test_metadata or {})
-            meta.update(MetricVerdict.error(metric_names).as_payload())
-            meta.pop("metrics", None)  # absent, not null — matches what readers expect
+            error_verdict = MetricVerdict.error(metric_names)
+            meta = existing_meta.model_copy()
+            meta.label = error_verdict.label
+            meta.labeler = error_verdict.labeler
+            meta.model_score = error_verdict.model_score
+            meta.metrics = None  # absent, not null — matches what readers expect
             return {
                 "status": "failed",
                 "test_id": test_id_str,

--- a/apps/backend/src/rhesis/backend/app/services/explorer/settings.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/settings.py
@@ -15,21 +15,8 @@ from rhesis.backend.app.schemas.explorer import (
     ExplorerSettingsMetric,
     ExplorerSettingsResponse,
 )
+from rhesis.backend.app.schemas.explorer_metadata import parse_explorer_test_set_attributes
 from rhesis.backend.app.services.explorer.tests import is_explorer_test_set
-
-
-def _get_default_endpoint_id_from_attributes(
-    test_set: models.TestSet,
-) -> Optional[UUID]:
-    attrs = test_set.attributes or {}
-    explorer_settings = attrs.get("adaptive_settings") or {}
-    raw_id = explorer_settings.get("default_endpoint_id")
-    if not raw_id:
-        return None
-    try:
-        return UUID(str(raw_id))
-    except (ValueError, TypeError):
-        return None
 
 
 def resolve_endpoint_id(
@@ -39,7 +26,7 @@ def resolve_endpoint_id(
     if request_endpoint_id is not None:
         return str(request_endpoint_id)
 
-    endpoint_id = _get_default_endpoint_id_from_attributes(test_set)
+    endpoint_id = parse_explorer_test_set_attributes(test_set.attributes).default_endpoint_id
     if endpoint_id is None:
         raise ValueError("No endpoint specified and no default endpoint configured in settings")
 
@@ -74,7 +61,7 @@ def get_explorer_settings(
         raise ValueError("Test set is not configured for Explorer (Adaptive Testing behavior)")
 
     endpoint_ref = None
-    endpoint_id = _get_default_endpoint_id_from_attributes(test_set)
+    endpoint_id = parse_explorer_test_set_attributes(test_set.attributes).default_endpoint_id
     if endpoint_id is not None:
         endpoint = crud.get_endpoint(
             db=db,

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -19,6 +19,11 @@ from rhesis.backend.app.schemas.explorer import (
     TestTreeNode,
     TopicNode,
 )
+from rhesis.backend.app.schemas.explorer_metadata import (
+    ExplorerTestMetadata,
+    parse_explorer_adaptive_settings,
+    parse_explorer_test_metadata,
+)
 from rhesis.backend.app.services.explorer.embeddings import (
     create_test_embedding,
     generate_embedding_vector,
@@ -319,8 +324,8 @@ def _parse_test_for_copy(db_test: models.Test, default_labeler: str) -> Optional
     Returns None for topic-marker rows and for tests with no prompt content
     (e.g. multi-turn-only); both are counted as skipped by the caller.
     """
-    meta = db_test.test_metadata or {}
-    if meta.get("label") == "topic_marker":
+    meta = parse_explorer_test_metadata(db_test.test_metadata)
+    if meta.is_topic_marker:
         return None
 
     prompt = db_test.prompt
@@ -332,21 +337,14 @@ def _parse_test_for_copy(db_test: models.Test, default_labeler: str) -> Optional
     if db_test.topic is not None and getattr(db_test.topic, "name", None):
         topic_name = str(db_test.topic.name) or ""
 
-    label_raw = meta.get("label", "") or ""
-
-    try:
-        model_score = float(meta.get("model_score", 0.0) or 0.0)
-    except (TypeError, ValueError):
-        model_score = 0.0
-
     return _TestCopy(
         content=content,
         topic_name=topic_name,
         topic_id=db_test.topic_id,
-        output=str(meta.get("output", "") or ""),
-        label=label_raw if label_raw in ("", "pass", "fail") else "",
-        labeler=str(meta.get("labeler", default_labeler) or default_labeler),
-        model_score=model_score,
+        output=meta.output if meta.output is not None else "",
+        label=meta.label if meta.label in ("", "pass", "fail") else "",
+        labeler=meta.labeler or default_labeler,
+        model_score=meta.model_score,
     )
 
 
@@ -464,7 +462,9 @@ def import_explorer_test_set_from_source(
     src_attrs = db_source.attributes or {}
     explorer_settings_src = src_attrs.get("adaptive_settings")
     if explorer_settings_src and isinstance(explorer_settings_src, dict):
-        crud_explorer.replace_test_set_explorer_settings(db, new_set, explorer_settings_src)
+        crud_explorer.replace_test_set_explorer_settings(
+            db, new_set, parse_explorer_adaptive_settings(explorer_settings_src)
+        )
 
     def write(test_copy: _TestCopy) -> None:
         # create_test_node() takes the topic path, not the FK: it builds the
@@ -583,12 +583,12 @@ def export_regular_test_set_from_explorer(
             user_id=user_id,
             topic_id=topic_id,
             content=test_copy.content,
-            metadata={
-                "output": test_copy.output,
-                "label": test_copy.label,
-                "labeler": test_copy.labeler,
-                "model_score": test_copy.model_score,
-            },
+            metadata=ExplorerTestMetadata(
+                output=test_copy.output,
+                label=test_copy.label,
+                labeler=test_copy.labeler,
+                model_score=test_copy.model_score,
+            ),
         )
 
         create_test_set_associations(
@@ -741,12 +741,12 @@ def create_test_node(
         user_id=user_id,
         topic_id=db_topic.id if db_topic else None,
         content=input,
-        metadata={
-            "output": output,
-            "label": label,
-            "labeler": labeler,
-            "model_score": model_score,
-        },
+        metadata=ExplorerTestMetadata(
+            output=output,
+            label=label,
+            labeler=labeler,
+            model_score=model_score,
+        ),
     )
 
     # Associate the test with the test set
@@ -826,13 +826,13 @@ def update_test_node(
         return None
 
     # Update metadata fields (output, label, model_score)
-    meta = dict(db_test.test_metadata or {})
+    meta = parse_explorer_test_metadata(db_test.test_metadata)
     if output is not None:
-        meta["output"] = output
+        meta.output = output
     if label is not None:
-        meta["label"] = label
+        meta.label = label
     if model_score is not None:
-        meta["model_score"] = model_score
+        meta.model_score = model_score
 
     # Update topic
     topic_id = None

--- a/apps/backend/src/rhesis/backend/app/services/explorer/topics.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/topics.py
@@ -12,6 +12,10 @@ from rhesis.backend.app.crud.explorer import (
     remove_tests_from_test_set,
 )
 from rhesis.backend.app.schemas.explorer import TopicNode
+from rhesis.backend.app.schemas.explorer_metadata import (
+    ExplorerTestMetadata,
+    parse_explorer_test_metadata,
+)
 from rhesis.backend.app.services.explorer.utils import build_test_tree
 from rhesis.backend.app.services.test import create_test_set_associations
 from rhesis.backend.app.utils.crud_utils import get_or_create_topic
@@ -83,11 +87,7 @@ def create_topic_node(
             organization_id=organization_id,
             user_id=user_id,
             topic_id=db_topic.id,
-            metadata={
-                "label": "topic_marker",
-                "labeler": "user",
-                "output": "",
-            },
+            metadata=ExplorerTestMetadata.topic_marker(labeler="user"),
         )
 
         # 3. Associate the test with the test set
@@ -255,7 +255,7 @@ def remove_topic_node(
     topic_marker_ids = []
     orphaned = []
     for db_test in db_tests:
-        is_marker = (db_test.test_metadata or {}).get("label") == "topic_marker"
+        is_marker = parse_explorer_test_metadata(db_test.test_metadata).is_topic_marker
         if is_marker:
             topic_marker_ids.append(db_test.id)
         else:

--- a/apps/backend/src/rhesis/backend/app/services/explorer/utils.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/utils.py
@@ -1,11 +1,12 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 from uuid import UUID
 
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models
 from rhesis.backend.app.schemas.explorer import TestTreeNode
+from rhesis.backend.app.schemas.explorer_metadata import parse_explorer_test_metadata
 from rhesis.backend.app.services.explorer.invocation import NO_OUTPUT
 from rhesis.backend.app.services.explorer.tree import TestTreeData
 
@@ -22,32 +23,26 @@ def _db_test_to_node(db_test: models.Test) -> TestTreeNode | None:
 
     Returns None for tests without prompts (unless they are topic markers).
     """
-    meta = db_test.test_metadata or {}
-    is_topic_marker = meta.get("label") == "topic_marker"
+    meta = parse_explorer_test_metadata(db_test.test_metadata)
 
     # Skip tests without prompts (e.g., multi-turn tests)
     # But allow topic markers which have empty prompts
-    if not is_topic_marker and (not db_test.prompt or not db_test.prompt.content):
+    if not meta.is_topic_marker and (not db_test.prompt or not db_test.prompt.content):
         return None
 
     topic_name = ""
     if db_test.topic:
         topic_name = db_test.topic.name if hasattr(db_test.topic, "name") else ""
 
-    raw_metrics = meta.get("metrics")
-    metrics: Optional[Dict[str, Any]] = None
-    if isinstance(raw_metrics, dict):
-        metrics = raw_metrics
-
     return TestTreeNode(
         id=str(db_test.id),
         topic=topic_name,
         input=db_test.prompt.content if db_test.prompt else "",
-        output=meta.get("output", NO_OUTPUT),
-        label=meta.get("label", ""),
-        labeler=meta.get("labeler", "imported"),
-        model_score=meta.get("model_score", 0.0),
-        metrics=metrics,
+        output=meta.output if meta.output is not None else NO_OUTPUT,
+        label=meta.label,
+        labeler=meta.labeler if meta.labeler is not None else "imported",
+        model_score=meta.model_score,
+        metrics=meta.metrics,
     )
 
 
@@ -140,8 +135,8 @@ def _build_eligible_tests(
     """
     eligible: List[models.Test] = []
     for t in tests:
-        meta = t.test_metadata or {}
-        if meta.get("label") == "topic_marker":
+        meta = parse_explorer_test_metadata(t.test_metadata)
+        if meta.is_topic_marker:
             continue
         if not t.prompt or not (t.prompt.content or "").strip():
             continue

--- a/apps/backend/src/rhesis/backend/app/services/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_set.py
@@ -20,6 +20,7 @@ from rhesis.backend.app.constants import (
 )
 from rhesis.backend.app.models import Prompt, TestSet
 from rhesis.backend.app.models.test import test_test_set_association
+from rhesis.backend.app.schemas.explorer_metadata import parse_explorer_test_set_attributes
 from rhesis.backend.app.services.stats import StatsCalculator
 from rhesis.backend.app.services.test import bulk_create_test_set_associations, bulk_create_tests
 from rhesis.backend.app.utils.crud_utils import get_or_create_status, get_or_create_type_lookup
@@ -620,9 +621,7 @@ def update_test_set_attributes(
         return
 
     # Explorer test sets manage their own attributes; skip regeneration.
-    existing_attrs = test_set.attributes or {}
-    existing_behaviors = existing_attrs.get("metadata", {}).get("behaviors", [])
-    if "Adaptive Testing" in existing_behaviors:
+    if parse_explorer_test_set_attributes(test_set.attributes).is_explorer:
         return
 
     # Get defaults and license type - use test_set's organization context

--- a/tests/backend/crud/test_explorer_crud.py
+++ b/tests/backend/crud/test_explorer_crud.py
@@ -39,6 +39,10 @@ from rhesis.backend.app.crud.explorer import (
     update_explorer_test,
 )
 from rhesis.backend.app.models.test import test_test_set_association
+from rhesis.backend.app.schemas.explorer_metadata import (
+    ExplorerAdaptiveSettings,
+    ExplorerTestMetadata,
+)
 
 
 def _create_test_set(db: Session, name: str, organization_id: str, user_id: str) -> models.TestSet:
@@ -355,7 +359,9 @@ class TestCreateExplorerTest:
             user_id=authenticated_user_id,
             topic_id=topic.id,
             content="What is the capital of France?",
-            metadata={"output": "Paris", "label": "pass", "labeler": "user", "model_score": 1.0},
+            metadata=ExplorerTestMetadata(
+                output="Paris", label="pass", labeler="user", model_score=1.0
+            ),
         )
 
         assert db_test.id is not None
@@ -377,7 +383,7 @@ class TestCreateExplorerTest:
             organization_id=test_org_id,
             user_id=authenticated_user_id,
             topic_id=topic.id,
-            metadata={"label": "topic_marker", "labeler": "user", "output": ""},
+            metadata=ExplorerTestMetadata.topic_marker(labeler="user"),
         )
 
         assert db_test.id is not None
@@ -430,7 +436,9 @@ class TestUpdateExplorerTest:
             test_db,
             db_test,
             prompt_content="new input",
-            metadata={"output": "new", "label": "pass", "labeler": "model", "model_score": 0.9},
+            metadata=ExplorerTestMetadata(
+                output="new", label="pass", labeler="model", model_score=0.9
+            ),
             topic_id=new_topic.id,
         )
 
@@ -455,11 +463,13 @@ class TestUpdateExplorerTest:
         _, db_test, _ = existing_test
         original_topic_id = db_test.topic_id
 
-        updated = update_explorer_test(test_db, db_test, metadata={"output": "only this"})
+        updated = update_explorer_test(
+            test_db, db_test, metadata=ExplorerTestMetadata(output="only this")
+        )
 
         assert updated.prompt.content == "original input"
         assert updated.topic_id == original_topic_id
-        assert updated.test_metadata == {"output": "only this"}
+        assert updated.test_metadata == {"output": "only this", "label": "", "model_score": 0.0}
 
     def test_a_test_without_a_prompt_ignores_prompt_content(
         self, test_db: Session, test_org_id: str, authenticated_user_id: str
@@ -623,10 +633,15 @@ class TestAdaptiveSettingsWrites:
             "adaptive_settings": {"default_endpoint_id": "stale", "other": "dropped"},
         }
         test_db.flush()
+        fresh_endpoint_id = uuid.uuid4()
 
-        replace_test_set_explorer_settings(test_db, test_set, {"default_endpoint_id": "fresh"})
+        replace_test_set_explorer_settings(
+            test_db, test_set, ExplorerAdaptiveSettings(default_endpoint_id=fresh_endpoint_id)
+        )
 
-        assert test_set.attributes["adaptive_settings"] == {"default_endpoint_id": "fresh"}
+        assert test_set.attributes["adaptive_settings"] == {
+            "default_endpoint_id": str(fresh_endpoint_id)
+        }
         # Everything outside adaptive_settings survives.
         assert test_set.attributes["metadata"] == {"behaviors": ["Adaptive Testing"]}
 
@@ -690,8 +705,8 @@ class TestSetExplorerTestMetadata:
         set_explorer_test_metadata(
             test_db,
             [
-                (t1, {"output": "a-out", "label": "pass", "model_score": 0.9}),
-                (t2, {"output": "b-out", "label": "fail", "model_score": 0.1}),
+                (t1, ExplorerTestMetadata(output="a-out", label="pass", model_score=0.9)),
+                (t2, ExplorerTestMetadata(output="b-out", label="fail", model_score=0.1)),
             ],
         )
 

--- a/tests/backend/schemas/test_explorer_metadata.py
+++ b/tests/backend/schemas/test_explorer_metadata.py
@@ -1,0 +1,250 @@
+"""Tests for the explorer JSONB metadata schemas.
+
+Covers the contract every call site in crud/explorer.py and services/explorer/* relies
+on: parse_* is total (never raises, even on garak-shaped or garbage input), dumping via
+model_dump(mode="json", exclude_none=True) drops None fields rather than writing them as
+null, and the lenient coercion matches the manual .get()/isinstance() checks these models
+replace.
+"""
+
+import uuid
+
+import pytest
+
+from rhesis.backend.app.schemas.explorer_metadata import (
+    TOPIC_MARKER_LABEL,
+    ExplorerAdaptiveSettings,
+    ExplorerTestMetadata,
+    ExplorerTestSetAttributes,
+    parse_explorer_adaptive_settings,
+    parse_explorer_test_metadata,
+    parse_explorer_test_set_attributes,
+)
+
+
+@pytest.mark.unit
+class TestParseExplorerTestMetadataIsTotal:
+    """parse_explorer_test_metadata never raises, whatever it's handed."""
+
+    @pytest.mark.parametrize("raw", [None, {}])
+    def test_none_and_empty_dict_give_defaults(self, raw):
+        meta = parse_explorer_test_metadata(raw)
+
+        assert meta == ExplorerTestMetadata()
+
+    def test_garbage_shaped_input_does_not_raise(self):
+        meta = parse_explorer_test_metadata(
+            {
+                "label": 12345,
+                "labeler": {"nested": "object"},
+                "model_score": ["not", "a", "number"],
+                "metrics": "not even a dict",
+                "evaluation": "also not a list",
+            }
+        )
+
+        assert meta.label == ""
+        assert meta.model_score == 0.0
+        assert meta.metrics is None
+        assert meta.evaluation is None
+
+    def test_garak_shaped_row_does_not_raise(self):
+        """test_metadata also carries garak sync/import data on the same column."""
+        meta = parse_explorer_test_metadata(
+            {"source": "garak", "garak_probe_id": "abc123", "garak_notes": "some notes"}
+        )
+
+        assert meta.label == ""
+        assert meta.output is None
+
+    def test_non_mapping_input_does_not_raise(self):
+        assert parse_explorer_test_metadata("not a mapping at all") == ExplorerTestMetadata()
+
+
+@pytest.mark.unit
+class TestExplorerTestMetadataRoundTrip:
+    """Foreign/unknown keys and None-vs-absent semantics survive a parse -> dump round trip."""
+
+    def test_foreign_keys_survive_round_trip(self):
+        raw = {"label": "pass", "source": "garak", "garak_probe_id": "abc123"}
+        meta = parse_explorer_test_metadata(raw)
+        dumped = meta.model_dump(mode="json", exclude_none=True)
+
+        assert dumped["source"] == "garak"
+        assert dumped["garak_probe_id"] == "abc123"
+        assert dumped["label"] == "pass"
+
+    def test_none_fields_dump_to_absent_keys_not_null(self):
+        dumped = ExplorerTestMetadata().model_dump(mode="json", exclude_none=True)
+
+        assert "output" not in dumped
+        assert "labeler" not in dumped
+        assert "metrics" not in dumped
+        assert "evaluation" not in dumped
+        # non-None defaults still serialize.
+        assert dumped["label"] == ""
+        assert dumped["model_score"] == 0.0
+
+    def test_present_empty_string_survives_as_empty_not_absent(self):
+        meta = parse_explorer_test_metadata({"output": "", "labeler": ""})
+        dumped = meta.model_dump(mode="json", exclude_none=True)
+
+        assert dumped["output"] == ""
+        assert dumped["labeler"] == ""
+
+
+@pytest.mark.unit
+class TestExplorerTestMetadataLabelCoercion:
+    @pytest.mark.parametrize("label", ["", "topic_marker", "pass", "fail", "error"])
+    def test_valid_labels_pass_through(self, label):
+        assert parse_explorer_test_metadata({"label": label}).label == label
+
+    @pytest.mark.parametrize("raw", ["unknown", 123, None, {}])
+    def test_invalid_labels_normalize_to_empty(self, raw):
+        assert parse_explorer_test_metadata({"label": raw}).label == ""
+
+
+@pytest.mark.unit
+class TestExplorerTestMetadataModelScoreCoercion:
+    @pytest.mark.parametrize("raw", ["not a number", None, {}, []])
+    def test_unparseable_scores_default_to_zero(self, raw):
+        assert parse_explorer_test_metadata({"model_score": raw}).model_score == 0.0
+
+    def test_numeric_string_coerces(self):
+        assert parse_explorer_test_metadata({"model_score": "0.5"}).model_score == 0.5
+
+
+@pytest.mark.unit
+class TestExplorerTestMetadataMetricsCoercion:
+    def test_a_malformed_entry_is_dropped_while_siblings_survive(self):
+        meta = parse_explorer_test_metadata(
+            {
+                "metrics": {
+                    "Good": {"score": 0.9, "is_successful": True},
+                    "Malformed": "not a dict",
+                    "MissingRequired": {"reason": "no score or is_successful"},
+                }
+            }
+        )
+
+        assert set(meta.metrics) == {"Good"}
+        assert meta.metrics["Good"].score == 0.9
+        assert meta.metrics["Good"].is_successful is True
+
+    def test_non_dict_metrics_value_normalizes_to_none(self):
+        assert parse_explorer_test_metadata({"metrics": "nope"}).metrics is None
+
+    def test_all_entries_dropped_normalizes_to_none(self):
+        meta = parse_explorer_test_metadata({"metrics": {"Bad": "nope"}})
+
+        assert meta.metrics is None
+
+
+@pytest.mark.unit
+class TestExplorerTestMetadataEvaluationCoercion:
+    def test_non_dict_entries_are_dropped(self):
+        meta = parse_explorer_test_metadata(
+            {
+                "evaluation": [
+                    {"label": "pass", "labeler": "MetricA", "model_score": 1.0},
+                    "not a dict",
+                    None,
+                ]
+            }
+        )
+
+        assert len(meta.evaluation) == 1
+        assert meta.evaluation[0].labeler == "MetricA"
+
+    def test_non_list_normalizes_to_none(self):
+        assert parse_explorer_test_metadata({"evaluation": "nope"}).evaluation is None
+
+
+@pytest.mark.unit
+class TestTopicMarker:
+    def test_topic_marker_shape(self):
+        meta = ExplorerTestMetadata.topic_marker(labeler="user")
+
+        assert meta.label == TOPIC_MARKER_LABEL
+        assert meta.labeler == "user"
+        assert meta.output == ""
+        assert meta.is_topic_marker is True
+
+    def test_default_labeler(self):
+        assert ExplorerTestMetadata.topic_marker().labeler == "user"
+
+    def test_is_topic_marker_false_for_other_labels(self):
+        assert parse_explorer_test_metadata({"label": "pass"}).is_topic_marker is False
+
+
+@pytest.mark.unit
+class TestExplorerAdaptiveSettings:
+    def test_valid_uuid_string_parses(self):
+        endpoint_id = uuid.uuid4()
+        settings = parse_explorer_adaptive_settings({"default_endpoint_id": str(endpoint_id)})
+
+        assert settings.default_endpoint_id == endpoint_id
+
+    @pytest.mark.parametrize("raw", ["", "not-a-uuid", None, 12345])
+    def test_blank_or_unparseable_normalizes_to_none(self, raw):
+        assert (
+            parse_explorer_adaptive_settings({"default_endpoint_id": raw}).default_endpoint_id
+            is None
+        )
+
+    def test_none_and_empty_dict_give_defaults(self):
+        assert parse_explorer_adaptive_settings(None) == ExplorerAdaptiveSettings()
+        assert parse_explorer_adaptive_settings({}) == ExplorerAdaptiveSettings()
+
+    def test_foreign_keys_survive_round_trip(self):
+        settings = parse_explorer_adaptive_settings({"kept": "yes", "default_endpoint_id": None})
+        dumped = settings.model_dump(mode="json", exclude_none=True)
+
+        assert dumped == {"kept": "yes"}
+
+    def test_garbage_input_does_not_raise(self):
+        assert (
+            parse_explorer_adaptive_settings("not a mapping at all") == ExplorerAdaptiveSettings()
+        )
+
+
+@pytest.mark.unit
+class TestExplorerTestSetAttributes:
+    def test_is_explorer_true_when_behavior_present(self):
+        attrs = parse_explorer_test_set_attributes(
+            {"metadata": {"behaviors": ["Adaptive Testing", "Safety"]}}
+        )
+
+        assert attrs.is_explorer is True
+
+    def test_is_explorer_false_without_marker_behavior(self):
+        attrs = parse_explorer_test_set_attributes({"metadata": {"behaviors": ["Safety"]}})
+
+        assert attrs.is_explorer is False
+
+    def test_is_explorer_false_when_metadata_absent(self):
+        assert parse_explorer_test_set_attributes({}).is_explorer is False
+        assert parse_explorer_test_set_attributes(None).is_explorer is False
+
+    def test_default_endpoint_id_reads_through_adaptive_settings(self):
+        endpoint_id = uuid.uuid4()
+        attrs = parse_explorer_test_set_attributes(
+            {"adaptive_settings": {"default_endpoint_id": str(endpoint_id)}}
+        )
+
+        assert attrs.default_endpoint_id == endpoint_id
+
+    def test_default_endpoint_id_none_when_adaptive_settings_absent(self):
+        assert parse_explorer_test_set_attributes({}).default_endpoint_id is None
+
+    def test_garak_shaped_attributes_do_not_raise(self):
+        """attributes also carries garak's own shape on the same column."""
+        attrs = parse_explorer_test_set_attributes(
+            {"source": "garak", "garak_module": "dan", "garak_probe_class": "Dan_11_0"}
+        )
+
+        assert attrs.is_explorer is False
+        assert attrs.default_endpoint_id is None
+
+    def test_garbage_input_does_not_raise(self):
+        assert parse_explorer_test_set_attributes("nope") == ExplorerTestSetAttributes()

--- a/tests/backend/services/explorer/test_tests.py
+++ b/tests/backend/services/explorer/test_tests.py
@@ -1124,6 +1124,37 @@ class TestImportExplorerTestSetFromSource:
         assert "Prompt one" in inputs
         assert "Prompt two" in inputs
 
+    def test_import_copies_adaptive_settings_from_source_without_crashing(
+        self,
+        test_db: Session,
+        test_org_id,
+        authenticated_user_id,
+    ):
+        """A source set whose attributes already carry an adaptive_settings block (e.g. a
+        previously exported-then-reimported set) must copy it, not crash on a raw dict."""
+        endpoint_id = uuid.uuid4()
+        src = models.TestSet(
+            name=f"Import With Settings {uuid.uuid4().hex[:8]}",
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={
+                "metadata": {"behaviors": ["Safety"]},
+                "adaptive_settings": {"default_endpoint_id": str(endpoint_id)},
+            },
+        )
+        test_db.add(src)
+        test_db.flush()
+
+        result = import_explorer_test_set_from_source(
+            db=test_db,
+            source_test_set_identifier=str(src.id),
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        new_attrs = result.test_set.attributes or {}
+        assert new_attrs.get("adaptive_settings") == {"default_endpoint_id": str(endpoint_id)}
+
     def test_skips_test_that_fails_to_write_and_keeps_the_rest(
         self,
         test_db: Session,

--- a/tests/backend/services/explorer/test_tree.py
+++ b/tests/backend/services/explorer/test_tree.py
@@ -54,7 +54,8 @@ class TestTestTreeNode:
         assert node.labeler == "user"
         assert node.to_eval is False
         assert node.model_score == 0.95
-        assert node.metrics == {"answer_relevancy": {"score": 0.95, "is_successful": True}}
+        assert node.metrics["answer_relevancy"].score == 0.95
+        assert node.metrics["answer_relevancy"].is_successful is True
 
     def test_missing_input_uses_default(self):
         """Should use empty string as default for input."""


### PR DESCRIPTION
## Purpose

Explorer stores per-test output/verdict data in `Test.test_metadata` (JSONB) and per-session settings in `TestSet.attributes.adaptive_settings` (also JSONB, nested under `attributes`). Both are shared with non-explorer writers on the same columns (garak sync/import writes its own shape into `test_metadata`, `services/test_set.py` writes the general `behaviors`/`metadata` attributes into `TestSet.attributes`), so neither column could be wrapped with the existing `PydanticColumn`/`PydanticListColumn` pattern, which assumes single-feature column ownership. Until now both were read and written as raw dicts throughout `crud/explorer.py` and `services/explorer/*.py`, via `.get()` calls, manual type coercion (`float(x or 0.0)`, bare `try/except UUID(...)`), and inline dict literals, with nothing validating the round trip.

## What Changed

- Added `app/schemas/explorer_metadata.py`: `ExplorerTestMetadata` and `ExplorerAdaptiveSettings` (plus `ExplorerTestSetAttributes`, `ExplorerMetricEvalDetail`, `ExplorerEvaluationEntry`), each with lenient `mode="before"` validators reproducing today's manual coercion, and `extra="allow"` so foreign/unknown keys (garak, general test-set attributes) round-trip losslessly instead of raising or getting silently dropped.
- `parse_explorer_test_metadata` / `parse_explorer_adaptive_settings` / `parse_explorer_test_set_attributes` are total — they never raise, even on `None`, `{}`, or a garbage/garak-shaped mapping — so a foreign-shaped row can never crash an explorer endpoint.
- Migrated every read/write call site to the new models: `crud/explorer.py` (`create_explorer_test`, `update_explorer_test`, `set_explorer_test_metadata`, `set_explorer_test_outputs`, `replace_test_set_explorer_settings`, `set_test_set_default_endpoint`), `services/explorer/{utils,settings,evaluation,tests,topics}.py`, and the Explorer-ownership guard in `services/test_set.py::update_test_set_attributes`.
- Tightened `schemas/explorer.py`'s `TestTreeNode.metrics` from `Optional[Dict[str, Any]]` to `Optional[Dict[str, ExplorerMetricEvalDetail]]` and shared the `ExplorerLabel` literal instead of a second inline copy.
- Updated existing tests to construct `ExplorerTestMetadata`/`ExplorerAdaptiveSettings` instead of raw dicts at crud call sites, and added `tests/backend/schemas/test_explorer_metadata.py` covering totality, round trips, `None`-vs-absent dumping, and coercion edge cases.

## Additional Context

- **Unknown `label` no longer 500s.** Today an out-of-vocabulary label raises inside `TestTreeNode`'s `Literal` validation, breaking the whole tree read; it now normalizes to `""`.
- **Stored bytes change slightly.** Dumping always emits non-`None` defaults (e.g. a topic marker now includes `"model_score": 0.0` where it previously had no such key). Every reader already defaults identically, so this is harmless but does change what's persisted.
- **`exclude_none=True` drops null-valued extras**, not just null-valued declared fields — covered by a round-trip test; no known caller sets a foreign key to explicit `null` today.
- Out of scope: no model or migration changes to either JSONB column, and no work on topic-marker/`parent_id` hierarchy cleanup.

## Testing

Docker must be running (Testcontainers). From `apps/backend`:

```bash
uv run pytest ../../tests/backend/schemas/test_explorer_metadata.py -v
uv run pytest ../../tests/backend/crud/test_explorer_crud.py -v
uv run pytest ../../tests/backend/services/explorer/ -v
uv run pytest ../../tests/backend/routes/test_explorer.py -v
uv run pytest ../../tests/backend/services/test_test_set.py -v
```

All 381 tests pass; `ruff check`/`ruff format --check` clean on every touched file.