### PR TITLE
Replace Explorer marker with explorer_row column

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/7dd69fe35db5_add_explorer_row_to_test_set_and_test.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/7dd69fe35db5_add_explorer_row_to_test_set_and_test.py
@@ -2,32 +2,27 @@
 
 Replaces the JSONB marker (attributes.metadata.behaviors contains "Adaptive
 Testing") with a real boolean column, backfilled from that marker and from the
-test_test_set association. The marker itself is left in attributes, not
-stripped: an org that happens to have a real Behavior literally named
-"Adaptive Testing" tagged on an unrelated test set would otherwise have that
-tag destructively deleted on top of the (already-possible) misflagging. Every
-Explorer test set created going forward never writes the marker in the first
-place (services/explorer/tests.py sets explorer_row directly), so this is a
-one-time, existing-rows-only wart -- new sessions are clean, and the leftover
-marker on old ones is inert once explorer_row is the source of truth.
+test_test_set association. The marker is left in attributes, not stripped: an
+org with a real Behavior literally named "Adaptive Testing" on an unrelated
+test set would otherwise have that tag destructively deleted. New Explorer
+test sets never write the marker (services/explorer/tests.py sets
+explorer_row directly), so this is a one-time wart on pre-migration rows only.
 
-downgrade() restores the marker before dropping the column, using explorer_row
-itself to know which rows need it back -- not a byte-for-byte inverse (the
-original attributes.behaviors UUID reference isn't restored), but it makes a
-rolled-back backend recognize Explorer sets again, including ones created after
-this migration shipped (which never had the marker at all). For rows that still
-carry the marker from before upgrade() stopped stripping it, this is a no-op.
+downgrade() only drops the column and its index -- it does not write the
+marker back into attributes. A backend rolled back to a pre-explorer_row
+version will not recognize as Explorer any test set created after this
+migration shipped (those never had the marker); this migration does not
+attempt to fix that up, to avoid mutating attributes/behaviors data at all
+on the way down.
 
-test/test_set/test_test_set have FORCE ROW LEVEL SECURITY, so a plain UPDATE
-under a non-BYPASSRLS role would silently match zero rows. Both directions
-disable RLS around their writes and fail loud if a verification query finds
-rows the write should have touched but didn't, before RLS goes back on --
-except when the connection's role already has BYPASSRLS (prod's rhesis-admin),
-in which case the disable/enable dance is skipped entirely. That dance is
-ALTER TABLE ... ROW LEVEL SECURITY, which takes an ACCESS EXCLUSIVE lock; on
-these three hot tables that's a real production risk (a9b8c7d6e5f4 hit this
-exact problem and stayed off hot tables entirely for that reason), so it's
-worth skipping whenever the role doesn't actually need it.
+test_set/test have FORCE ROW LEVEL SECURITY, so a plain UPDATE under a
+non-BYPASSRLS role would silently match zero rows. upgrade()'s backfill
+disables RLS around its writes and fails loud if a verification query finds
+unmatched rows, before RLS goes back on -- except when the role already has
+BYPASSRLS (prod's rhesis-admin), which skips the disable/enable dance since
+its ALTER TABLE ... ROW LEVEL SECURITY takes an ACCESS EXCLUSIVE lock on
+these hot tables for no benefit to a role that ignores RLS anyway. downgrade()
+does no DML, so it never needs that dance.
 
 Revision ID: 7dd69fe35db5
 Revises: 91607f0dd412
@@ -49,7 +44,6 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
-# Tables whose RLS we toggle for the backfill.
 _RLS_TABLES = ("test_set", "test", "test_test_set")
 
 # Mirrors EXPLORER_BEHAVIOR_NAME (app/constants.py) -- migrations can't import app code.
@@ -66,12 +60,7 @@ def _neutralize_rls_trigger_and_lock_timeout(conn) -> None:
 
 
 def _has_bypassrls(conn) -> bool:
-    """True if the connection's role already bypasses RLS (prod's rhesis-admin).
-
-    When true, _disable_rls()/_restore_rls() below are skipped: their ALTER
-    TABLE ... ROW LEVEL SECURITY calls take an ACCESS EXCLUSIVE lock, which is
-    unnecessary risk on hot tables for a role that ignores RLS anyway.
-    """
+    """True if the connection's role already bypasses RLS (prod's rhesis-admin)."""
     return bool(
         conn.execute(
             sa.text("SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user")
@@ -104,7 +93,6 @@ def upgrade() -> None:
     _neutralize_rls_trigger_and_lock_timeout(conn)
     bypasses_rls = _has_bypassrls(conn)
 
-    # 1. Idempotent column adds.
     if not column_exists(conn, "test_set", "explorer_row"):
         op.add_column(
             "test_set",
@@ -116,11 +104,9 @@ def upgrade() -> None:
             sa.Column("explorer_row", sa.Boolean(), nullable=False, server_default=sa.false()),
         )
 
-    # 2. Disable RLS, capturing prior state to restore afterward. Skipped when
-    # the role already bypasses RLS -- see _has_bypassrls().
     prior_rls = {} if bypasses_rls else _disable_rls(conn)
 
-    # 3. Backfill. No deleted_at filter -- flag soft-deleted rows too.
+    # No deleted_at filter -- flag soft-deleted rows too.
     conn.execute(
         sa.text(
             f"""
@@ -142,7 +128,6 @@ def upgrade() -> None:
         )
     )
 
-    # 4. Fail loud if RLS silently filtered the backfill to zero rows.
     unflagged_test_sets = conn.execute(
         sa.text(
             f"SELECT count(*) FROM test_set WHERE explorer_row = false "
@@ -173,72 +158,19 @@ def upgrade() -> None:
             "RLS likely filtered the UPDATE silently. Aborting before re-enabling RLS."
         )
 
-    # 5. Index explorer_row -- it's the WHERE filter on every /test_sets
-    # (exclude) and /explorer (include) listing, and had no index before this.
+    # explorer_row is the WHERE filter on every /test_sets (exclude) and
+    # /explorer (include) listing, and had no index before this.
     if not index_exists(conn, "ix_test_set_explorer_row"):
         op.create_index("ix_test_set_explorer_row", "test_set", ["explorer_row"])
     if not index_exists(conn, "ix_test_explorer_row"):
         op.create_index("ix_test_explorer_row", "test", ["explorer_row"])
 
-    # 6. Restore RLS to its prior per-table state (no-op if it was never disabled).
-    # The marker itself is left in attributes on purpose -- see module docstring.
     _restore_rls(conn, prior_rls)
 
 
 def downgrade() -> None:
     conn = op.get_bind()
-    behavior_marker = f'["{_EXPLORER_BEHAVIOR_NAME}"]'
     _neutralize_rls_trigger_and_lock_timeout(conn)
-    bypasses_rls = _has_bypassrls(conn)
-    prior_rls = {} if bypasses_rls else _disable_rls(conn)
-
-    # Restore the marker on every row explorer_row still flags -- read it now,
-    # before dropping the column erases that information for good. The CASE
-    # guards fall back to {}/[] when a value isn't the expected shape, since
-    # jsonb_set() errors ("cannot set path in scalar") on a non-object target.
-    conn.execute(
-        sa.text(
-            """
-            UPDATE test_set
-            SET attributes = jsonb_set(
-                CASE WHEN jsonb_typeof(attributes) = 'object'
-                     THEN attributes ELSE '{}'::jsonb END,
-                '{metadata}',
-                jsonb_set(
-                    CASE WHEN jsonb_typeof(attributes -> 'metadata') = 'object'
-                         THEN attributes -> 'metadata' ELSE '{}'::jsonb END,
-                    '{behaviors}',
-                    (CASE WHEN jsonb_typeof(attributes #> '{metadata,behaviors}') = 'array'
-                          THEN attributes #> '{metadata,behaviors}' ELSE '[]'::jsonb END)
-                        || CAST(:behavior_marker AS jsonb)
-                )
-            )
-            WHERE explorer_row = true
-              AND NOT COALESCE(attributes #> '{metadata,behaviors}', '[]'::jsonb)
-                  @> CAST(:behavior_marker AS jsonb)
-            """
-        ),
-        {"behavior_marker": behavior_marker},
-    )
-
-    unrestored = conn.execute(
-        sa.text(
-            """
-            SELECT count(*) FROM test_set
-            WHERE explorer_row = true
-              AND NOT COALESCE(attributes #> '{metadata,behaviors}', '[]'::jsonb)
-                  @> CAST(:behavior_marker AS jsonb)
-            """
-        ),
-        {"behavior_marker": behavior_marker},
-    ).scalar()
-    if unrestored:
-        raise RuntimeError(
-            f"downgrade left {unrestored} test_set row(s) without the marker restored -- "
-            "RLS likely filtered the UPDATE silently. Aborting before dropping the columns."
-        )
-
-    _restore_rls(conn, prior_rls)
 
     if index_exists(conn, "ix_test_explorer_row"):
         op.drop_index("ix_test_explorer_row", table_name="test")

--- a/apps/backend/src/rhesis/backend/alembic/versions/7dd69fe35db5_add_explorer_row_to_test_set_and_test.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/7dd69fe35db5_add_explorer_row_to_test_set_and_test.py
@@ -2,18 +2,32 @@
 
 Replaces the JSONB marker (attributes.metadata.behaviors contains "Adaptive
 Testing") with a real boolean column, backfilled from that marker and from the
-test_test_set association, then strips the marker out of attributes.
+test_test_set association. The marker itself is left in attributes, not
+stripped: an org that happens to have a real Behavior literally named
+"Adaptive Testing" tagged on an unrelated test set would otherwise have that
+tag destructively deleted on top of the (already-possible) misflagging. Every
+Explorer test set created going forward never writes the marker in the first
+place (services/explorer/tests.py sets explorer_row directly), so this is a
+one-time, existing-rows-only wart -- new sessions are clean, and the leftover
+marker on old ones is inert once explorer_row is the source of truth.
 
 downgrade() restores the marker before dropping the column, using explorer_row
 itself to know which rows need it back -- not a byte-for-byte inverse (the
 original attributes.behaviors UUID reference isn't restored), but it makes a
 rolled-back backend recognize Explorer sets again, including ones created after
-this migration shipped (which never had the marker at all).
+this migration shipped (which never had the marker at all). For rows that still
+carry the marker from before upgrade() stopped stripping it, this is a no-op.
 
 test/test_set/test_test_set have FORCE ROW LEVEL SECURITY, so a plain UPDATE
 under a non-BYPASSRLS role would silently match zero rows. Both directions
 disable RLS around their writes and fail loud if a verification query finds
-rows the write should have touched but didn't, before RLS goes back on.
+rows the write should have touched but didn't, before RLS goes back on --
+except when the connection's role already has BYPASSRLS (prod's rhesis-admin),
+in which case the disable/enable dance is skipped entirely. That dance is
+ALTER TABLE ... ROW LEVEL SECURITY, which takes an ACCESS EXCLUSIVE lock; on
+these three hot tables that's a real production risk (a9b8c7d6e5f4 hit this
+exact problem and stayed off hot tables entirely for that reason), so it's
+worth skipping whenever the role doesn't actually need it.
 
 Revision ID: 7dd69fe35db5
 Revises: 91607f0dd412
@@ -26,7 +40,7 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-from rhesis.backend.alembic.utils.idempotency import column_exists
+from rhesis.backend.alembic.utils.idempotency import column_exists, index_exists
 
 # revision identifiers, used by Alembic.
 revision: str = "7dd69fe35db5"
@@ -51,6 +65,20 @@ def _neutralize_rls_trigger_and_lock_timeout(conn) -> None:
     conn.execute(sa.text("SET LOCAL auto_rls.active = 'true'"))
 
 
+def _has_bypassrls(conn) -> bool:
+    """True if the connection's role already bypasses RLS (prod's rhesis-admin).
+
+    When true, _disable_rls()/_restore_rls() below are skipped: their ALTER
+    TABLE ... ROW LEVEL SECURITY calls take an ACCESS EXCLUSIVE lock, which is
+    unnecessary risk on hot tables for a role that ignores RLS anyway.
+    """
+    return bool(
+        conn.execute(
+            sa.text("SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user")
+        ).scalar()
+    )
+
+
 def _disable_rls(conn) -> dict:
     prior_rls: dict[str, bool] = {}
     for tbl in _RLS_TABLES:
@@ -65,7 +93,7 @@ def _disable_rls(conn) -> dict:
 
 def _restore_rls(conn, prior_rls: dict) -> None:
     for tbl in _RLS_TABLES:
-        if prior_rls[tbl]:
+        if prior_rls.get(tbl):
             conn.execute(sa.text(f"ALTER TABLE {tbl} ENABLE ROW LEVEL SECURITY"))
     conn.execute(sa.text("SET LOCAL auto_rls.active = 'false'"))
 
@@ -74,6 +102,7 @@ def upgrade() -> None:
     conn = op.get_bind()
     behavior_marker = f'["{_EXPLORER_BEHAVIOR_NAME}"]'
     _neutralize_rls_trigger_and_lock_timeout(conn)
+    bypasses_rls = _has_bypassrls(conn)
 
     # 1. Idempotent column adds.
     if not column_exists(conn, "test_set", "explorer_row"):
@@ -87,8 +116,9 @@ def upgrade() -> None:
             sa.Column("explorer_row", sa.Boolean(), nullable=False, server_default=sa.false()),
         )
 
-    # 2. Disable RLS, capturing prior state to restore afterward.
-    prior_rls = _disable_rls(conn)
+    # 2. Disable RLS, capturing prior state to restore afterward. Skipped when
+    # the role already bypasses RLS -- see _has_bypassrls().
+    prior_rls = {} if bypasses_rls else _disable_rls(conn)
 
     # 3. Backfill. No deleted_at filter -- flag soft-deleted rows too.
     conn.execute(
@@ -143,32 +173,15 @@ def upgrade() -> None:
             "RLS likely filtered the UPDATE silently. Aborting before re-enabling RLS."
         )
 
-    # 5. Strip the marker, then drop behaviors if that left it empty.
-    conn.execute(
-        sa.text(
-            f"""
-            UPDATE test_set
-            SET attributes = jsonb_set(
-                attributes,
-                '{{metadata,behaviors}}',
-                (attributes #> '{{metadata,behaviors}}') - :behavior_name
-            )
-            WHERE {_TEST_SET_MATCH_PREDICATE}
-            """
-        ),
-        {"behavior_marker": behavior_marker, "behavior_name": _EXPLORER_BEHAVIOR_NAME},
-    )
-    conn.execute(
-        sa.text(
-            """
-            UPDATE test_set
-            SET attributes = attributes #- '{metadata,behaviors}'
-            WHERE attributes #> '{metadata,behaviors}' = '[]'::jsonb
-            """
-        )
-    )
+    # 5. Index explorer_row -- it's the WHERE filter on every /test_sets
+    # (exclude) and /explorer (include) listing, and had no index before this.
+    if not index_exists(conn, "ix_test_set_explorer_row"):
+        op.create_index("ix_test_set_explorer_row", "test_set", ["explorer_row"])
+    if not index_exists(conn, "ix_test_explorer_row"):
+        op.create_index("ix_test_explorer_row", "test", ["explorer_row"])
 
-    # 6. Restore RLS to its prior per-table state.
+    # 6. Restore RLS to its prior per-table state (no-op if it was never disabled).
+    # The marker itself is left in attributes on purpose -- see module docstring.
     _restore_rls(conn, prior_rls)
 
 
@@ -176,17 +189,13 @@ def downgrade() -> None:
     conn = op.get_bind()
     behavior_marker = f'["{_EXPLORER_BEHAVIOR_NAME}"]'
     _neutralize_rls_trigger_and_lock_timeout(conn)
-    prior_rls = _disable_rls(conn)
+    bypasses_rls = _has_bypassrls(conn)
+    prior_rls = {} if bypasses_rls else _disable_rls(conn)
 
     # Restore the marker on every row explorer_row still flags -- read it now,
-    # before dropping the column erases that information for good.
-    #
-    # jsonb_set() raises "cannot set path in scalar" if the value already at
-    # its target path exists but isn't an object/array (e.g. attributes.metadata
-    # is a string). The two CASE guards below fall back to an empty object/array
-    # in that situation instead of passing the scalar straight through -- same
-    # "not a byte-for-byte inverse, just good enough to re-recognize the row"
-    # philosophy as the null/malformed handling on the upgrade() side.
+    # before dropping the column erases that information for good. The CASE
+    # guards fall back to {}/[] when a value isn't the expected shape, since
+    # jsonb_set() errors ("cannot set path in scalar") on a non-object target.
     conn.execute(
         sa.text(
             """
@@ -230,6 +239,11 @@ def downgrade() -> None:
         )
 
     _restore_rls(conn, prior_rls)
+
+    if index_exists(conn, "ix_test_explorer_row"):
+        op.drop_index("ix_test_explorer_row", table_name="test")
+    if index_exists(conn, "ix_test_set_explorer_row"):
+        op.drop_index("ix_test_set_explorer_row", table_name="test_set")
 
     op.drop_column("test", "explorer_row")
     op.drop_column("test_set", "explorer_row")

--- a/apps/backend/src/rhesis/backend/alembic/versions/7dd69fe35db5_add_explorer_row_to_test_set_and_test.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/7dd69fe35db5_add_explorer_row_to_test_set_and_test.py
@@ -1,0 +1,225 @@
+"""Add explorer_row to test_set and test
+
+Replaces the JSONB marker (attributes.metadata.behaviors contains "Adaptive
+Testing") with a real boolean column, backfilled from that marker and from the
+test_test_set association, then strips the marker out of attributes.
+
+downgrade() restores the marker before dropping the column, using explorer_row
+itself to know which rows need it back -- not a byte-for-byte inverse (the
+original attributes.behaviors UUID reference isn't restored), but it makes a
+rolled-back backend recognize Explorer sets again, including ones created after
+this migration shipped (which never had the marker at all).
+
+test/test_set/test_test_set have FORCE ROW LEVEL SECURITY, so a plain UPDATE
+under a non-BYPASSRLS role would silently match zero rows. Both directions
+disable RLS around their writes and fail loud if a verification query finds
+rows the write should have touched but didn't, before RLS goes back on.
+
+Revision ID: 7dd69fe35db5
+Revises: 91607f0dd412
+Create Date: 2026-08-04
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+from rhesis.backend.alembic.utils.idempotency import column_exists
+
+# revision identifiers, used by Alembic.
+revision: str = "7dd69fe35db5"
+down_revision: Union[str, None] = "91607f0dd412"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Tables whose RLS we toggle for the backfill.
+_RLS_TABLES = ("test_set", "test", "test_test_set")
+
+# Mirrors EXPLORER_BEHAVIOR_NAME (app/constants.py) -- migrations can't import app code.
+_EXPLORER_BEHAVIOR_NAME = "Adaptive Testing"
+
+_TEST_SET_MATCH_PREDICATE = """
+    attributes -> 'metadata' -> 'behaviors' @> :behavior_marker
+"""
+
+
+def _neutralize_rls_trigger_and_lock_timeout(conn) -> None:
+    conn.execute(sa.text("SET LOCAL lock_timeout = '120s'"))
+    conn.execute(sa.text("SET LOCAL auto_rls.active = 'true'"))
+
+
+def _disable_rls(conn) -> dict:
+    prior_rls: dict[str, bool] = {}
+    for tbl in _RLS_TABLES:
+        enabled = conn.execute(
+            sa.text("SELECT relrowsecurity FROM pg_class WHERE relname = :t"),
+            {"t": tbl},
+        ).scalar()
+        prior_rls[tbl] = bool(enabled)
+        conn.execute(sa.text(f"ALTER TABLE {tbl} DISABLE ROW LEVEL SECURITY"))
+    return prior_rls
+
+
+def _restore_rls(conn, prior_rls: dict) -> None:
+    for tbl in _RLS_TABLES:
+        if prior_rls[tbl]:
+            conn.execute(sa.text(f"ALTER TABLE {tbl} ENABLE ROW LEVEL SECURITY"))
+    conn.execute(sa.text("SET LOCAL auto_rls.active = 'false'"))
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    behavior_marker = f'["{_EXPLORER_BEHAVIOR_NAME}"]'
+    _neutralize_rls_trigger_and_lock_timeout(conn)
+
+    # 1. Idempotent column adds.
+    if not column_exists(conn, "test_set", "explorer_row"):
+        op.add_column(
+            "test_set",
+            sa.Column("explorer_row", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+    if not column_exists(conn, "test", "explorer_row"):
+        op.add_column(
+            "test",
+            sa.Column("explorer_row", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+
+    # 2. Disable RLS, capturing prior state to restore afterward.
+    prior_rls = _disable_rls(conn)
+
+    # 3. Backfill. No deleted_at filter -- flag soft-deleted rows too.
+    conn.execute(
+        sa.text(
+            f"""
+            UPDATE test_set SET explorer_row = true
+            WHERE explorer_row = false
+              AND {_TEST_SET_MATCH_PREDICATE}
+            """
+        ),
+        {"behavior_marker": behavior_marker},
+    )
+
+    conn.execute(
+        sa.text(
+            """
+            UPDATE test t SET explorer_row = true
+            FROM test_test_set tts JOIN test_set ts ON ts.id = tts.test_set_id
+            WHERE tts.test_id = t.id AND ts.explorer_row = true AND t.explorer_row = false
+            """
+        )
+    )
+
+    # 4. Fail loud if RLS silently filtered the backfill to zero rows.
+    unflagged_test_sets = conn.execute(
+        sa.text(
+            f"SELECT count(*) FROM test_set WHERE explorer_row = false "
+            f"AND {_TEST_SET_MATCH_PREDICATE}"
+        ),
+        {"behavior_marker": behavior_marker},
+    ).scalar()
+    if unflagged_test_sets:
+        raise RuntimeError(
+            f"explorer_row backfill left {unflagged_test_sets} test_set row(s) unflagged -- "
+            "RLS likely filtered the UPDATE silently. Aborting before re-enabling RLS."
+        )
+
+    unflagged_tests = conn.execute(
+        sa.text(
+            """
+            SELECT count(*)
+            FROM test t
+            JOIN test_test_set tts ON tts.test_id = t.id
+            JOIN test_set ts ON ts.id = tts.test_set_id
+            WHERE ts.explorer_row = true AND t.explorer_row = false
+            """
+        )
+    ).scalar()
+    if unflagged_tests:
+        raise RuntimeError(
+            f"explorer_row backfill left {unflagged_tests} test row(s) unflagged -- "
+            "RLS likely filtered the UPDATE silently. Aborting before re-enabling RLS."
+        )
+
+    # 5. Strip the marker, then drop behaviors if that left it empty.
+    conn.execute(
+        sa.text(
+            f"""
+            UPDATE test_set
+            SET attributes = jsonb_set(
+                attributes,
+                '{{metadata,behaviors}}',
+                (attributes #> '{{metadata,behaviors}}') - :behavior_name
+            )
+            WHERE {_TEST_SET_MATCH_PREDICATE}
+            """
+        ),
+        {"behavior_marker": behavior_marker, "behavior_name": _EXPLORER_BEHAVIOR_NAME},
+    )
+    conn.execute(
+        sa.text(
+            """
+            UPDATE test_set
+            SET attributes = attributes #- '{metadata,behaviors}'
+            WHERE attributes #> '{metadata,behaviors}' = '[]'::jsonb
+            """
+        )
+    )
+
+    # 6. Restore RLS to its prior per-table state.
+    _restore_rls(conn, prior_rls)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    behavior_marker = f'["{_EXPLORER_BEHAVIOR_NAME}"]'
+    _neutralize_rls_trigger_and_lock_timeout(conn)
+    prior_rls = _disable_rls(conn)
+
+    # Restore the marker on every row explorer_row still flags -- read it now,
+    # before dropping the column erases that information for good.
+    conn.execute(
+        sa.text(
+            """
+            UPDATE test_set
+            SET attributes = jsonb_set(
+                COALESCE(attributes, '{}'::jsonb),
+                '{metadata}',
+                jsonb_set(
+                    COALESCE(attributes -> 'metadata', '{}'::jsonb),
+                    '{behaviors}',
+                    COALESCE(attributes #> '{metadata,behaviors}', '[]'::jsonb)
+                        || CAST(:behavior_marker AS jsonb)
+                )
+            )
+            WHERE explorer_row = true
+              AND NOT COALESCE(attributes #> '{metadata,behaviors}', '[]'::jsonb)
+                  @> CAST(:behavior_marker AS jsonb)
+            """
+        ),
+        {"behavior_marker": behavior_marker},
+    )
+
+    unrestored = conn.execute(
+        sa.text(
+            """
+            SELECT count(*) FROM test_set
+            WHERE explorer_row = true
+              AND NOT COALESCE(attributes #> '{metadata,behaviors}', '[]'::jsonb)
+                  @> CAST(:behavior_marker AS jsonb)
+            """
+        ),
+        {"behavior_marker": behavior_marker},
+    ).scalar()
+    if unrestored:
+        raise RuntimeError(
+            f"downgrade left {unrestored} test_set row(s) without the marker restored -- "
+            "RLS likely filtered the UPDATE silently. Aborting before dropping the columns."
+        )
+
+    _restore_rls(conn, prior_rls)
+
+    op.drop_column("test", "explorer_row")
+    op.drop_column("test_set", "explorer_row")

--- a/apps/backend/src/rhesis/backend/alembic/versions/7dd69fe35db5_add_explorer_row_to_test_set_and_test.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/7dd69fe35db5_add_explorer_row_to_test_set_and_test.py
@@ -39,7 +39,7 @@ from rhesis.backend.alembic.utils.idempotency import column_exists, index_exists
 
 # revision identifiers, used by Alembic.
 revision: str = "7dd69fe35db5"
-down_revision: Union[str, None] = "91607f0dd412"
+down_revision: Union[str, None] = "9550c62e80a5"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/apps/backend/src/rhesis/backend/alembic/versions/7dd69fe35db5_add_explorer_row_to_test_set_and_test.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/7dd69fe35db5_add_explorer_row_to_test_set_and_test.py
@@ -180,17 +180,27 @@ def downgrade() -> None:
 
     # Restore the marker on every row explorer_row still flags -- read it now,
     # before dropping the column erases that information for good.
+    #
+    # jsonb_set() raises "cannot set path in scalar" if the value already at
+    # its target path exists but isn't an object/array (e.g. attributes.metadata
+    # is a string). The two CASE guards below fall back to an empty object/array
+    # in that situation instead of passing the scalar straight through -- same
+    # "not a byte-for-byte inverse, just good enough to re-recognize the row"
+    # philosophy as the null/malformed handling on the upgrade() side.
     conn.execute(
         sa.text(
             """
             UPDATE test_set
             SET attributes = jsonb_set(
-                COALESCE(attributes, '{}'::jsonb),
+                CASE WHEN jsonb_typeof(attributes) = 'object'
+                     THEN attributes ELSE '{}'::jsonb END,
                 '{metadata}',
                 jsonb_set(
-                    COALESCE(attributes -> 'metadata', '{}'::jsonb),
+                    CASE WHEN jsonb_typeof(attributes -> 'metadata') = 'object'
+                         THEN attributes -> 'metadata' ELSE '{}'::jsonb END,
                     '{behaviors}',
-                    COALESCE(attributes #> '{metadata,behaviors}', '[]'::jsonb)
+                    (CASE WHEN jsonb_typeof(attributes #> '{metadata,behaviors}') = 'array'
+                          THEN attributes #> '{metadata,behaviors}' ELSE '[]'::jsonb END)
                         || CAST(:behavior_marker AS jsonb)
                 )
             )

--- a/apps/backend/src/rhesis/backend/app/crud/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/crud/__init__.py
@@ -10,12 +10,11 @@ from enum import Enum
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 from uuid import UUID
 
-from sqlalchemy import and_, cast, desc, func, or_, select, text
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import and_, desc, func, or_, select, text
 from sqlalchemy.orm import Session, joinedload
 
 from rhesis.backend.app import models, schemas
-from rhesis.backend.app.constants import EXPLORER_BEHAVIOR_NAME, TestExecutionContext
+from rhesis.backend.app.constants import TestExecutionContext
 from rhesis.backend.app.database import reset_session_context
 from rhesis.backend.app.models.test import test_test_set_association
 from rhesis.backend.app.schemas.tag import EntityType
@@ -666,17 +665,8 @@ def get_test_sets(
         query_builder = query_builder.with_custom_filter(has_runs_filter)
 
     # Exclude explorer test sets (they use the dedicated /explorer API)
-    explorer_marker = cast([EXPLORER_BEHAVIOR_NAME], JSONB)
-    behaviors_json = models.TestSet.attributes["metadata"]["behaviors"]
-
     def exclude_explorer_test_sets(query):
-        return query.filter(
-            or_(
-                models.TestSet.attributes.is_(None),
-                behaviors_json.is_(None),
-                ~behaviors_json.contains(explorer_marker),
-            )
-        )
+        return query.filter(models.TestSet.explorer_row.is_(False))
 
     query_builder = query_builder.with_custom_filter(exclude_explorer_test_sets)
 

--- a/apps/backend/src/rhesis/backend/app/crud/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/crud/explorer.py
@@ -12,13 +12,11 @@ import logging
 import uuid
 from typing import Dict, List, Optional, Sequence, Tuple
 
-from sqlalchemy import cast, select
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, contains_eager, joinedload
 
 from rhesis.backend.app import models, schemas
-from rhesis.backend.app.constants import EXPLORER_BEHAVIOR_NAME
 
 # _TEST_SET_RELATED_FIELDS is imported rather than relocated: three other functions in
 # the monolith use the same tuple, and moving it would mean deciding a new home for a
@@ -76,14 +74,11 @@ def get_explorer_test_sets(
     Returns
     -------
     list of models.TestSet
-        Test sets carrying the Explorer marker behavior.
+        Test sets flagged as Explorer-owned.
     """
-    explorer_marker = cast([EXPLORER_BEHAVIOR_NAME], JSONB)
 
     def only_explorer_test_sets(query):
-        return query.filter(
-            models.TestSet.attributes["metadata"]["behaviors"].contains(explorer_marker)
-        )
+        return query.filter(models.TestSet.explorer_row.is_(True))
 
     # Paginated outside the builder on purpose: with_pagination caps limit at 100
     # (validate_pagination) and this endpoint has never capped. with_sorting already
@@ -98,6 +93,29 @@ def get_explorer_test_sets(
         .build()
     )
     return query.offset(skip).limit(limit).all()
+
+
+def mark_test_set_as_explorer(db: Session, test_set: models.TestSet) -> models.TestSet:
+    """Flag a test set as Explorer-owned via the ``explorer_row`` column.
+
+    Not client-settable -- called only from ``create_explorer_test_set``.
+
+    Parameters
+    ----------
+    db : Session
+        Database session
+    test_set : models.TestSet
+        Test set to flag
+
+    Returns
+    -------
+    models.TestSet
+        The same instance, flushed.
+    """
+    test_set.explorer_row = True
+    db.add(test_set)
+    db.flush()
+    return test_set
 
 
 def get_test_sets_by_ids(
@@ -395,6 +413,7 @@ def create_explorer_test(
     topic_id: Optional[uuid.UUID] = None,
     content: Optional[str] = None,
     metadata: Optional[ExplorerTestMetadata] = None,
+    explorer_row: bool = False,
 ) -> models.Test:
     """Insert an Explorer test, plus the prompt holding its input when it has one.
 
@@ -417,6 +436,9 @@ def create_explorer_test(
         Prompt text; when None no prompt row is created
     metadata : ExplorerTestMetadata, optional
         Value for ``test_metadata``
+    explorer_row : bool, default False
+        Whether this test is Explorer-owned. Defaults false so a caller that
+        forgets can't mislabel a test copied out to a regular test set.
 
     Returns
     -------
@@ -442,6 +464,7 @@ def create_explorer_test(
         ),
         organization_id=organization_id,
         user_id=user_id,
+        explorer_row=explorer_row,
     )
     db.add(db_test)
     db.flush()

--- a/apps/backend/src/rhesis/backend/app/models/test.py
+++ b/apps/backend/src/rhesis/backend/app/models/test.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, ForeignKey, Integer, Table, and_, case, inspect, select
+from sqlalchemy import Boolean, Column, ForeignKey, Integer, Table, and_, case, inspect, select
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import object_session, relationship
@@ -59,6 +59,8 @@ class Test(
     # Test source info (origin, inputs, context)
     # Named 'test_metadata' to avoid SQLAlchemy's reserved 'metadata' attribute
     test_metadata = Column(JSONB)
+    # Set only by services/explorer/{tests,topics}.py — not client-settable.
+    explorer_row = Column(Boolean, nullable=False, server_default="false", default=False)
 
     # Relationships
     prompt = relationship("Prompt", back_populates="tests")

--- a/apps/backend/src/rhesis/backend/app/models/test.py
+++ b/apps/backend/src/rhesis/backend/app/models/test.py
@@ -60,7 +60,9 @@ class Test(
     # Named 'test_metadata' to avoid SQLAlchemy's reserved 'metadata' attribute
     test_metadata = Column(JSONB)
     # Set only by services/explorer/{tests,topics}.py — not client-settable.
-    explorer_row = Column(Boolean, nullable=False, server_default="false", default=False)
+    explorer_row = Column(
+        Boolean, nullable=False, server_default="false", default=False, index=True
+    )
 
     # Relationships
     prompt = relationship("Prompt", back_populates="tests")

--- a/apps/backend/src/rhesis/backend/app/models/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/models/test_set.py
@@ -71,7 +71,9 @@ class TestSet(
     attributes = Column(JSONB)
     is_published = Column(Boolean, default=False)
     # Set only by services/explorer/tests.py::create_explorer_test_set — not client-settable.
-    explorer_row = Column(Boolean, nullable=False, server_default="false", default=False)
+    explorer_row = Column(
+        Boolean, nullable=False, server_default="false", default=False, index=True
+    )
     visibility = Column(Text, default="organization")
     owner_id = Column(GUID(), ForeignKey("user.id"))
     assignee_id = Column(GUID(), ForeignKey("user.id"))

--- a/apps/backend/src/rhesis/backend/app/models/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/models/test_set.py
@@ -70,6 +70,8 @@ class TestSet(
     organization_id = Column(GUID(), ForeignKey("organization.id"), index=True)
     attributes = Column(JSONB)
     is_published = Column(Boolean, default=False)
+    # Set only by services/explorer/tests.py::create_explorer_test_set — not client-settable.
+    explorer_row = Column(Boolean, nullable=False, server_default="false", default=False)
     visibility = Column(Text, default="organization")
     owner_id = Column(GUID(), ForeignKey("user.id"))
     assignee_id = Column(GUID(), ForeignKey("user.id"))

--- a/apps/backend/src/rhesis/backend/app/routers/explorer.py
+++ b/apps/backend/src/rhesis/backend/app/routers/explorer.py
@@ -1,7 +1,7 @@
 """Router for Explorer test-tree HTTP endpoints.
 
 Provides views over test set data as explorer trees:
-- List explorer test sets (metadata includes Adaptive Testing behavior)
+- List explorer test sets (flagged via the explorer_row column)
 - Full tree (all nodes including topic markers)
 - Tests only (excludes topic markers)
 - Topics only (hierarchical topic structure)
@@ -165,7 +165,7 @@ def export_regular_test_set_from_explorer_endpoint(
     """Create a new regular test set by exporting from an explorer test set.
 
     Copies tests with prompts; skips topic markers and empty prompts. The new
-    set has no Adaptive Testing behavior or adaptive_settings.
+    set is not flagged as Explorer-owned and has no adaptive_settings.
     """
     organization_id, user_id = tenant_context
     try:
@@ -199,7 +199,7 @@ def list_explorer_test_sets(
 ):
     """List explorer test sets.
 
-    Returns test sets whose behavior includes Adaptive Testing.
+    Returns test sets flagged as Explorer-owned.
     """
     organization_id, _user_id = tenant_context
     return get_explorer_test_sets(
@@ -221,8 +221,8 @@ def bulk_delete_explorer_test_sets_endpoint(
 ):
     """Delete multiple Explorer test sets at once.
 
-    Ids that don't resolve to a test set with the Adaptive Testing behavior
-    are reported in `not_found_ids` rather than deleted.
+    Ids that don't resolve to a test set flagged as Explorer-owned are
+    reported in `not_found_ids` rather than deleted.
 
     Registered before /{test_set_identifier} below -- FastAPI matches routes
     in registration order, so a literal /bulk path must come first or the
@@ -249,8 +249,8 @@ def delete_explorer_test_set_endpoint(
 ):
     """Delete a test set configured for Explorer.
 
-    Only test sets that include the Adaptive Testing behavior can be removed
-    through this endpoint.
+    Only test sets flagged as Explorer-owned can be removed through this
+    endpoint.
     """
     organization_id, user_id = tenant_context
     try:

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -336,8 +336,8 @@ def read_test_sets(
     """
     Get test sets with flexible filtering.
 
-    Explorer test sets (metadata.behaviors includes
-    "Adaptive Testing") are omitted; list those via GET /explorer/.
+    Explorer test sets (flagged via explorer_row) are omitted; list those
+    via GET /explorer/.
 
     Args:
         skip: Number of items to skip

--- a/apps/backend/src/rhesis/backend/app/schemas/explorer_metadata.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/explorer_metadata.py
@@ -1,36 +1,21 @@
-"""Pydantic validation for the two JSONB dicts Explorer reads and writes directly:
+"""Pydantic validation for the JSONB dicts Explorer reads and writes directly:
 ``Test.test_metadata`` and ``TestSet.attributes["adaptive_settings"]``.
 
-Both columns are shared with non-explorer writers (garak sync/import, general test-set
-attribute generation), so the models here use ``extra="allow"`` -- an unrecognized shape
-must round-trip losslessly, not raise and not silently drop keys.
+Both columns are shared with non-explorer writers (garak, general test-set attribute
+generation), so models here use ``extra="allow"`` to round-trip unrecognized keys
+losslessly instead of raising or dropping them.
 
-Pure schema module, no ORM imports, so it's importable from ``crud/``, ``services/explorer/``,
-and ``services/test_set.py`` without layering violations.
-
-Contract:
-
-- Every ``parse_*`` function is **total** -- it never raises. ``None``, ``{}``, a non-mapping,
-  or a garbage-shaped mapping all come back as an empty (all-defaults) model. The lenient
-  ``mode="before"`` validators on each model make a ``ValidationError`` unreachable in
-  practice; the ``try/except`` in each ``parse_*`` is the backstop that guarantees a
-  foreign-shaped row (e.g. garak) can never crash an explorer endpoint.
-- Dumping back to a JSONB-safe dict is always ``model.model_dump(mode="json", exclude_none=True)``,
-  done at the call site rather than through a wrapper. ``mode="json"`` turns non-JSON-native types
-  (e.g. ``UUID``) into strings. ``exclude_none=True`` makes "field is ``None``" round-trip as "key
-  absent", reproducing the ``del meta["evaluation"]`` / ``meta.pop("metrics", None)`` idioms the
-  call sites used before this module existed. This also means a foreign key explicitly set to
-  ``null`` today would come back absent after a round trip through here -- no known caller does
-  that, but it's worth knowing.
+Contract: every ``parse_*`` is total (never raises -- garbage input becomes an
+all-defaults model). Dumping is always ``model_dump(mode="json", exclude_none=True)``
+at the call site, so a ``None`` field comes back as an absent key, not ``null``.
 """
 
 import logging
 from typing import Any, Dict, Final, List, Literal, Mapping, Optional, get_args
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
 
-from rhesis.backend.app.constants import EXPLORER_BEHAVIOR_NAME
 from rhesis.backend.app.utils.uuid_utils import sanitize_uuid_field
 
 logger = logging.getLogger(__name__)
@@ -96,10 +81,8 @@ class ExplorerEvaluationEntry(BaseModel):
 class ExplorerTestMetadata(BaseModel):
     """``Test.test_metadata`` for explorer-owned rows.
 
-    ``output``/``labeler`` are ``Optional[str]`` rather than ``str`` so that "key absent"
-    (``None``) stays distinguishable from "key present but empty" (``""``) -- callers that
-    need a default only for the missing case (e.g. ``NO_OUTPUT``, ``"imported"``) rely on
-    that distinction.
+    ``output``/``labeler`` are ``Optional[str]`` so "key absent" (``None``) stays
+    distinguishable from "key present but empty" (``""``).
     """
 
     model_config = ConfigDict(extra="allow", validate_assignment=True)
@@ -174,33 +157,15 @@ class ExplorerAdaptiveSettings(BaseModel):
         return sanitize_uuid_field(v)
 
 
-class ExplorerTestSetAttributeMetadata(BaseModel):
-    """``TestSet.attributes["metadata"]`` -- the general behaviors/metadata blob."""
-
-    model_config = ConfigDict(extra="allow")
-
-    behaviors: List[str] = Field(default_factory=list)
-
-    @field_validator("behaviors", mode="before")
-    @classmethod
-    def _validate_behaviors(cls, v: Any) -> List[str]:
-        if not isinstance(v, list):
-            return []
-        return [item for item in v if isinstance(item, str)]
-
-
 class ExplorerTestSetAttributes(BaseModel):
-    """Read-only view of ``TestSet.attributes`` -- never dumped/round-tripped as a whole."""
+    """Read-only view of ``TestSet.attributes``, for reading ``adaptive_settings``.
+
+    Explorer ownership itself lives on ``models.TestSet.explorer_row``, not here.
+    """
 
     model_config = ConfigDict(extra="allow")
 
-    metadata: Optional[ExplorerTestSetAttributeMetadata] = None
     adaptive_settings: Optional[ExplorerAdaptiveSettings] = None
-
-    @property
-    def is_explorer(self) -> bool:
-        behaviors = self.metadata.behaviors if self.metadata else []
-        return EXPLORER_BEHAVIOR_NAME in behaviors
 
     @property
     def default_endpoint_id(self) -> Optional[UUID]:

--- a/apps/backend/src/rhesis/backend/app/schemas/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_set.py
@@ -57,6 +57,9 @@ class TestSet(TestSetBase):
     id: UUID4
     created_at: Union[datetime, str]
     updated_at: Union[datetime, str]
+    # Response-only (not on TestSetBase) -- a client-settable flag would let anyone
+    # forge an Explorer set.
+    explorer_row: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/apps/backend/src/rhesis/backend/app/services/explorer/settings.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/settings.py
@@ -58,7 +58,7 @@ def get_explorer_settings(
     user_id: str,
 ) -> ExplorerSettingsResponse:
     if not is_explorer_test_set(test_set):
-        raise ValueError("Test set is not configured for Explorer (Adaptive Testing behavior)")
+        raise ValueError("Test set is not configured for Explorer")
 
     endpoint_ref = None
     endpoint_id = parse_explorer_test_set_attributes(test_set.attributes).default_endpoint_id
@@ -87,7 +87,7 @@ def update_explorer_settings(
     metric_ids: Optional[list[UUID]] = None,
 ) -> ExplorerSettingsResponse:
     if not is_explorer_test_set(test_set):
-        raise ValueError("Test set is not configured for Explorer (Adaptive Testing behavior)")
+        raise ValueError("Test set is not configured for Explorer")
 
     if default_endpoint_id is not None:
         endpoint = crud.get_endpoint(

--- a/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/tests.py
@@ -7,7 +7,6 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
-from rhesis.backend.app.constants import EXPLORER_BEHAVIOR_NAME
 
 # Imported as a module rather than by name: this file's own public
 # get_explorer_test_sets() wraps the crud function of the same name.
@@ -34,7 +33,6 @@ from rhesis.backend.app.services.explorer.utils import _db_test_to_node, build_t
 from rhesis.backend.app.services.test import create_test_set_associations
 from rhesis.backend.app.utils.crud_utils import (
     bulk_delete_by_ids,
-    get_or_create_behavior,
     get_or_create_topic,
     get_or_create_type_lookup,
 )
@@ -100,10 +98,9 @@ def get_explorer_test_sets(
     sort_by: str = "created_at",
     sort_order: str = "desc",
 ) -> List[models.TestSet]:
-    """Get all test sets that have the Adaptive Testing behavior.
+    """Get all test sets flagged as Explorer-owned.
 
-    Queries test sets whose ``attributes -> 'metadata' -> 'behaviors'``
-    JSONB array contains the ``"Adaptive Testing"`` string.
+    Queries test sets whose ``explorer_row`` column is ``true``.
 
     Parameters
     ----------
@@ -123,7 +120,7 @@ def get_explorer_test_sets(
     Returns
     -------
     List[models.TestSet]
-        Test sets configured for Explorer (Adaptive Testing behavior)
+        Test sets flagged as Explorer-owned
     """
     test_sets = crud_explorer.get_explorer_test_sets(
         db=db,
@@ -148,8 +145,7 @@ def create_explorer_test_set(
 ) -> models.TestSet:
     """Create a new test set for Explorer.
 
-    The created test set has attributes.metadata.behaviors containing
-    "Adaptive Testing" so it appears in get_explorer_test_sets.
+    Flagged via ``mark_test_set_as_explorer`` (``explorer_row``).
 
     Parameters
     ----------
@@ -169,16 +165,6 @@ def create_explorer_test_set(
     models.TestSet
         The created test set
     """
-    behavior = get_or_create_behavior(
-        db=db,
-        name=EXPLORER_BEHAVIOR_NAME,
-        organization_id=organization_id,
-        user_id=user_id,
-    )
-    attributes = {
-        "behaviors": [str(behavior.id)],
-        "metadata": {"behaviors": [EXPLORER_BEHAVIOR_NAME]},
-    }
     test_set_type_lookup = get_or_create_type_lookup(
         db=db,
         type_name="TestType",
@@ -189,23 +175,20 @@ def create_explorer_test_set(
     test_set_data = schemas.TestSetCreate(
         name=name,
         description=description,
-        attributes=attributes,
         test_set_type_id=test_set_type_lookup.id,
     )
-    return crud.create_test_set(
+    new_set = crud.create_test_set(
         db=db,
         test_set=test_set_data,
         organization_id=organization_id,
         user_id=user_id,
     )
+    return crud_explorer.mark_test_set_as_explorer(db, new_set)
 
 
 def is_explorer_test_set(test_set: models.TestSet) -> bool:
-    """True if the test set has the Explorer marker behavior in metadata.behaviors."""
-    attrs = test_set.attributes or {}
-    metadata = attrs.get("metadata") or {}
-    behaviors = metadata.get("behaviors") or []
-    return EXPLORER_BEHAVIOR_NAME in behaviors
+    """True if the test set is Explorer-owned."""
+    return bool(test_set.explorer_row)
 
 
 def _delete_session_tests(
@@ -241,13 +224,13 @@ def delete_explorer_test_set(
     """Delete a test set that is configured for Explorer, along with its tests.
 
     Resolves the test set by UUID, nano_id, or slug. Raises ValueError if the
-    set is missing or does not include the Adaptive Testing behavior.
+    set is missing or is not flagged as Explorer-owned.
     """
     db_test_set = crud.resolve_test_set(test_set_identifier, db, organization_id)
     if db_test_set is None:
         raise ValueError("Test set not found with provided identifier")
     if not is_explorer_test_set(db_test_set):
-        raise ValueError("Test set is not configured for Explorer (Adaptive Testing behavior)")
+        raise ValueError("Test set is not configured for Explorer")
 
     # Build the response payload before deleting to avoid response serialization
     # touching an expired/deleted SQLAlchemy instance after commit.
@@ -274,9 +257,9 @@ def bulk_delete_explorer_test_sets(
 ) -> dict:
     """Delete multiple Explorer test sets at once, along with their tests.
 
-    Any id that doesn't resolve to a test set with the Adaptive Testing
-    behavior is reported back in "not_found_ids" rather than deleted -- same
-    guard delete_explorer_test_set() enforces per-item, applied to the batch
+    Any id that doesn't resolve to a test set flagged as Explorer-owned is
+    reported back in "not_found_ids" rather than deleted -- same guard
+    delete_explorer_test_set() enforces per-item, applied to the batch
     up front so bulk_delete_by_ids() only ever touches valid ids.
     """
     if not test_set_ids:
@@ -537,9 +520,7 @@ def export_regular_test_set_from_explorer(
         raise ValueError("Test set not found with provided identifier")
 
     if not is_explorer_test_set(db_source):
-        raise ValueError(
-            "Source test set is not configured for Explorer (Adaptive Testing behavior)"
-        )
+        raise ValueError("Source test set is not configured for Explorer")
 
     base_name = f"{db_source.name} (Exported)"
     new_name = crud_explorer.find_unused_test_set_name(db, organization_id, base_name)
@@ -577,6 +558,8 @@ def export_regular_test_set_from_explorer(
             )
             topic_id = db_topic.id
 
+        # explorer_row left at its False default -- this copies the test OUT to a
+        # regular test set, so marking it Explorer-owned would mislabel it.
         new_test = crud_explorer.create_explorer_test(
             db,
             organization_id=organization_id,
@@ -747,6 +730,7 @@ def create_test_node(
             labeler=labeler,
             model_score=model_score,
         ),
+        explorer_row=True,
     )
 
     # Associate the test with the test set

--- a/apps/backend/src/rhesis/backend/app/services/explorer/topics.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/topics.py
@@ -88,6 +88,7 @@ def create_topic_node(
             user_id=user_id,
             topic_id=db_topic.id,
             metadata=ExplorerTestMetadata.topic_marker(labeler="user"),
+            explorer_row=True,
         )
 
         # 3. Associate the test with the test set

--- a/apps/backend/src/rhesis/backend/app/services/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_set.py
@@ -20,7 +20,6 @@ from rhesis.backend.app.constants import (
 )
 from rhesis.backend.app.models import Prompt, TestSet
 from rhesis.backend.app.models.test import test_test_set_association
-from rhesis.backend.app.schemas.explorer_metadata import parse_explorer_test_set_attributes
 from rhesis.backend.app.services.stats import StatsCalculator
 from rhesis.backend.app.services.test import bulk_create_test_set_associations, bulk_create_tests
 from rhesis.backend.app.utils.crud_utils import get_or_create_status, get_or_create_type_lookup
@@ -621,7 +620,7 @@ def update_test_set_attributes(
         return
 
     # Explorer test sets manage their own attributes; skip regeneration.
-    if parse_explorer_test_set_attributes(test_set.attributes).is_explorer:
+    if test_set.explorer_row:
         return
 
     # Get defaults and license type - use test_set's organization context

--- a/apps/frontend/src/app/(protected)/explorer/components/ImportExplorerTestSetDialog.tsx
+++ b/apps/frontend/src/app/(protected)/explorer/components/ImportExplorerTestSetDialog.tsx
@@ -19,8 +19,7 @@ import { useNotifications } from '@/components/common/NotificationContext';
 import type { ImportExplorerTestSetResponse } from '@/utils/api-client/interfaces/explorer';
 
 function isExplorerTestSet(testSet: TestSet): boolean {
-  const behaviors = testSet.attributes?.metadata?.behaviors;
-  return Array.isArray(behaviors) && behaviors.includes('Adaptive Testing');
+  return testSet.explorer_row === true;
 }
 
 interface ImportExplorerTestSetDialogProps {

--- a/apps/frontend/src/utils/api-client/explorer-client.ts
+++ b/apps/frontend/src/utils/api-client/explorer-client.ts
@@ -98,7 +98,7 @@ export class ExplorerClient extends BaseApiClient {
   // ===========================================================================
 
   /**
-   * List explorer test sets (Adaptive Testing behavior in metadata).
+   * List explorer test sets (flagged via explorer_row).
    * @param skip Pagination offset
    * @param limit Maximum number of records
    * @param sortBy Field to sort by

--- a/apps/frontend/src/utils/api-client/interfaces/test-set.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/test-set.ts
@@ -60,6 +60,8 @@ export interface TestSet {
   priority?: number;
   organization_id?: UUID;
   is_published: boolean;
+  /** Explorer ownership flag. Response-only — not client-settable. */
+  explorer_row?: boolean;
   counts?: {
     comments: number;
     tasks: number;

--- a/tests/backend/alembic/test_explorer_row_migration.py
+++ b/tests/backend/alembic/test_explorer_row_migration.py
@@ -470,6 +470,34 @@ class TestDowngradeRestoresMarker:
         attrs = _test_set_attributes(conn, ts_id)
         assert attrs["metadata"]["behaviors"] == ["Safety"]
 
+    @pytest.mark.parametrize(
+        "attributes",
+        [
+            {"metadata": "not-an-object"},
+            "not-an-object",
+            {"metadata": {"behaviors": "not-an-array"}},
+        ],
+    )
+    def test_restores_the_marker_without_raising_when_attributes_shape_is_malformed(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id, attributes
+    ):
+        """jsonb_set() errors on a scalar target ("cannot set path in scalar") --
+        the restore UPDATE must fall back to an empty object/array instead of
+        raising when metadata (or attributes itself) isn't the expected shape."""
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn, org_id=test_org_id, user_id=authenticated_user_id, attributes=attributes
+        )
+        conn.execute(
+            sa.text("UPDATE test_set SET explorer_row = true WHERE id = CAST(:id AS uuid)"),
+            {"id": ts_id},
+        )
+
+        _migration.downgrade()  # must not raise
+
+        attrs = _test_set_attributes(conn, ts_id)
+        assert attrs["metadata"]["behaviors"] == [_EXPLORER_BEHAVIOR_NAME]
+
     def test_column_is_dropped(self, test_db, migration_ops):
         conn = test_db.connection()
 

--- a/tests/backend/alembic/test_explorer_row_migration.py
+++ b/tests/backend/alembic/test_explorer_row_migration.py
@@ -436,89 +436,23 @@ class TestMarkerIsNotStripped:
 
 
 @pytest.mark.integration
-class TestDowngradeRestoresMarker:
-    """downgrade() writes the marker back onto every row explorer_row still
-    flags, reading that column before dropping it."""
-
-    def test_restores_the_marker_alongside_other_behaviors(
-        self, test_db, migration_ops, test_org_id, authenticated_user_id
-    ):
-        conn = test_db.connection()
-        ts_id = _insert_test_set(
-            conn,
-            org_id=test_org_id,
-            user_id=authenticated_user_id,
-            attributes={"metadata": {"behaviors": ["Safety"]}},
-        )
-        conn.execute(
-            sa.text("UPDATE test_set SET explorer_row = true WHERE id = CAST(:id AS uuid)"),
-            {"id": ts_id},
-        )
-
-        _migration.downgrade()
-
-        attrs = _test_set_attributes(conn, ts_id)
-        assert attrs["metadata"]["behaviors"] == ["Safety", _EXPLORER_BEHAVIOR_NAME]
-
-    def test_is_a_noop_when_upgrade_left_the_marker_in_place(
-        self, test_db, migration_ops, test_org_id, authenticated_user_id
-    ):
-        conn = test_db.connection()
-        ts_id = _insert_test_set(
-            conn,
-            org_id=test_org_id,
-            user_id=authenticated_user_id,
-            attributes={"metadata": {"behaviors": [_EXPLORER_BEHAVIOR_NAME]}},
-        )
-
-        _migration.upgrade()  # flags explorer_row; marker stays (see module docstring)
-        _migration.downgrade()  # marker's already there; must not duplicate it
-
-        attrs = _test_set_attributes(conn, ts_id)
-        assert attrs["metadata"]["behaviors"] == [_EXPLORER_BEHAVIOR_NAME]
-
-    def test_restores_the_marker_from_scratch_when_attributes_is_null(
-        self, test_db, migration_ops, test_org_id, authenticated_user_id
-    ):
-        conn = test_db.connection()
-        ts_id = _insert_test_set(
-            conn, org_id=test_org_id, user_id=authenticated_user_id, attributes=None
-        )
-        conn.execute(
-            sa.text("UPDATE test_set SET explorer_row = true WHERE id = CAST(:id AS uuid)"),
-            {"id": ts_id},
-        )
-
-        _migration.downgrade()
-
-        attrs = _test_set_attributes(conn, ts_id)
-        assert attrs["metadata"]["behaviors"] == [_EXPLORER_BEHAVIOR_NAME]
-
-    def test_leaves_non_explorer_rows_untouched(
-        self, test_db, migration_ops, test_org_id, authenticated_user_id
-    ):
-        conn = test_db.connection()
-        ts_id = _insert_test_set(
-            conn,
-            org_id=test_org_id,
-            user_id=authenticated_user_id,
-            attributes={"metadata": {"behaviors": ["Safety"]}},
-        )
-
-        _migration.downgrade()
-
-        attrs = _test_set_attributes(conn, ts_id)
-        assert attrs["metadata"]["behaviors"] == ["Safety"]
+class TestDowngradeDoesNotTouchAttributes:
+    """downgrade() only drops the column and its index -- it never writes to
+    attributes. A backend rolled back after this migration won't recognize as
+    Explorer any test set created since (see module docstring); this is a
+    deliberate tradeoff to keep downgrade() free of attributes/behaviors
+    mutation."""
 
     @pytest.mark.parametrize(
         "attributes",
         [
+            {"metadata": {"behaviors": ["Safety"]}},
+            {"metadata": {"behaviors": [_EXPLORER_BEHAVIOR_NAME]}},
+            None,
             {"metadata": "not-an-object"},
-            "not-an-object",
-            {"metadata": {"behaviors": "not-an-array"}},
         ],
     )
-    def test_restores_the_marker_without_raising_when_attributes_shape_is_malformed(
+    def test_attributes_are_unchanged_regardless_of_explorer_row(
         self, test_db, migration_ops, test_org_id, authenticated_user_id, attributes
     ):
         conn = test_db.connection()
@@ -529,11 +463,11 @@ class TestDowngradeRestoresMarker:
             sa.text("UPDATE test_set SET explorer_row = true WHERE id = CAST(:id AS uuid)"),
             {"id": ts_id},
         )
+        before = _test_set_attributes(conn, ts_id)
 
-        _migration.downgrade()  # must not raise
+        _migration.downgrade()  # must not raise, must not touch attributes
 
-        attrs = _test_set_attributes(conn, ts_id)
-        assert attrs["metadata"]["behaviors"] == [_EXPLORER_BEHAVIOR_NAME]
+        assert _test_set_attributes(conn, ts_id) == before
 
     def test_column_is_dropped(self, test_db, migration_ops):
         conn = test_db.connection()
@@ -592,10 +526,11 @@ class TestDowngradeUpgradeRoundTrip:
 
 @pytest.mark.integration
 class TestBypassRLSSkipsDisableEnable:
-    """_has_bypassrls() lets upgrade()/downgrade() skip the ALTER TABLE ...
-    ROW LEVEL SECURITY dance for a role that already ignores RLS (prod's
-    rhesis-admin) -- that dance takes an ACCESS EXCLUSIVE lock these hot tables
-    shouldn't need to pay for when the role never needed the bypass anyway."""
+    """_has_bypassrls() lets upgrade() skip the ALTER TABLE ... ROW LEVEL
+    SECURITY dance for a role that already ignores RLS (prod's rhesis-admin)
+    -- that dance takes an ACCESS EXCLUSIVE lock these hot tables shouldn't
+    need to pay for when the role never needed the bypass anyway. downgrade()
+    does no DML, so it never calls _has_bypassrls() at all."""
 
     def test_has_bypassrls_reflects_the_role_attribute(self, test_db, migration_ops):
         conn = test_db.connection()
@@ -625,7 +560,5 @@ class TestBypassRLSSkipsDisableEnable:
             assert _explorer_row(conn, "test_set", ts_id) is True
 
             _migration.downgrade()  # must not raise either
-            attrs = _test_set_attributes(conn, ts_id)
-            assert attrs["metadata"]["behaviors"] == [_EXPLORER_BEHAVIOR_NAME]
         finally:
             conn.execute(sa.text("ALTER ROLE CURRENT_USER NOBYPASSRLS"))

--- a/tests/backend/alembic/test_explorer_row_migration.py
+++ b/tests/backend/alembic/test_explorer_row_migration.py
@@ -161,6 +161,24 @@ class TestColumnShape:
         assert is_nullable == "NO"
         assert column_default is not None and "false" in column_default.lower()
 
+    @pytest.mark.parametrize(
+        "table,index_name",
+        [("test_set", "ix_test_set_explorer_row"), ("test", "ix_test_explorer_row")],
+    )
+    def test_explorer_row_is_indexed(self, test_db, table, index_name):
+        row = (
+            test_db.connection()
+            .execute(
+                sa.text(
+                    "SELECT 1 FROM pg_indexes "
+                    "WHERE schemaname = 'public' AND tablename = :t AND indexname = :n"
+                ),
+                {"t": table, "n": index_name},
+            )
+            .fetchone()
+        )
+        assert row is not None, f"{index_name} missing on {table}"
+
 
 @pytest.mark.integration
 class TestBackfillLogic:
@@ -342,11 +360,14 @@ class TestBackfillLogic:
 
 
 @pytest.mark.integration
-class TestMarkerStripping:
-    """upgrade() removes the "Adaptive Testing" marker from attributes once
-    explorer_row is verified."""
+class TestMarkerIsNotStripped:
+    """upgrade() leaves the "Adaptive Testing" marker in attributes untouched --
+    only explorer_row is written. Stripping it would delete a real Behavior tag
+    from any unrelated test set that happens to be named "Adaptive Testing";
+    leaving it is a one-time wart on pre-migration rows, not new ones (see
+    module docstring)."""
 
-    def test_marker_only_drops_the_whole_behaviors_key(
+    def test_marker_only_set_stays_in_attributes(
         self, test_db, migration_ops, test_org_id, authenticated_user_id
     ):
         conn = test_db.connection()
@@ -361,9 +382,9 @@ class TestMarkerStripping:
 
         assert _explorer_row(conn, "test_set", ts_id) is True
         attrs = _test_set_attributes(conn, ts_id)
-        assert "behaviors" not in attrs.get("metadata", {})
+        assert attrs["metadata"]["behaviors"] == [_EXPLORER_BEHAVIOR_NAME]
 
-    def test_marker_among_other_behaviors_only_removes_the_marker(
+    def test_marker_among_other_behaviors_stays_in_attributes(
         self, test_db, migration_ops, test_org_id, authenticated_user_id
     ):
         conn = test_db.connection()
@@ -377,7 +398,7 @@ class TestMarkerStripping:
         _migration.upgrade()
 
         attrs = _test_set_attributes(conn, ts_id)
-        assert attrs["metadata"]["behaviors"] == ["Safety"]
+        assert attrs["metadata"]["behaviors"] == ["Safety", _EXPLORER_BEHAVIOR_NAME]
 
     def test_regular_test_set_attributes_are_untouched(
         self, test_db, migration_ops, test_org_id, authenticated_user_id
@@ -395,7 +416,7 @@ class TestMarkerStripping:
         attrs = _test_set_attributes(conn, ts_id)
         assert attrs["metadata"]["behaviors"] == ["Safety"]
 
-    def test_idempotent_rerun_does_not_error_once_marker_is_gone(
+    def test_idempotent_rerun_does_not_error(
         self, test_db, migration_ops, test_org_id, authenticated_user_id
     ):
         conn = test_db.connection()
@@ -407,9 +428,11 @@ class TestMarkerStripping:
         )
 
         _migration.upgrade()
-        _migration.upgrade()  # marker is already gone; must not raise
+        _migration.upgrade()  # already flagged; must not raise or change anything
 
         assert _explorer_row(conn, "test_set", ts_id) is True
+        attrs = _test_set_attributes(conn, ts_id)
+        assert attrs["metadata"]["behaviors"] == [_EXPLORER_BEHAVIOR_NAME]
 
 
 @pytest.mark.integration
@@ -436,6 +459,23 @@ class TestDowngradeRestoresMarker:
 
         attrs = _test_set_attributes(conn, ts_id)
         assert attrs["metadata"]["behaviors"] == ["Safety", _EXPLORER_BEHAVIOR_NAME]
+
+    def test_is_a_noop_when_upgrade_left_the_marker_in_place(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": [_EXPLORER_BEHAVIOR_NAME]}},
+        )
+
+        _migration.upgrade()  # flags explorer_row; marker stays (see module docstring)
+        _migration.downgrade()  # marker's already there; must not duplicate it
+
+        attrs = _test_set_attributes(conn, ts_id)
+        assert attrs["metadata"]["behaviors"] == [_EXPLORER_BEHAVIOR_NAME]
 
     def test_restores_the_marker_from_scratch_when_attributes_is_null(
         self, test_db, migration_ops, test_org_id, authenticated_user_id
@@ -481,9 +521,6 @@ class TestDowngradeRestoresMarker:
     def test_restores_the_marker_without_raising_when_attributes_shape_is_malformed(
         self, test_db, migration_ops, test_org_id, authenticated_user_id, attributes
     ):
-        """jsonb_set() errors on a scalar target ("cannot set path in scalar") --
-        the restore UPDATE must fall back to an empty object/array instead of
-        raising when metadata (or attributes itself) isn't the expected shape."""
         conn = test_db.connection()
         ts_id = _insert_test_set(
             conn, org_id=test_org_id, user_id=authenticated_user_id, attributes=attributes
@@ -508,6 +545,17 @@ class TestDowngradeRestoresMarker:
                 "SELECT 1 FROM information_schema.columns "
                 "WHERE table_name = 'test_set' AND column_name = 'explorer_row'"
             )
+        ).fetchone()
+        assert exists is None
+
+    @pytest.mark.parametrize("index_name", ["ix_test_set_explorer_row", "ix_test_explorer_row"])
+    def test_index_is_dropped(self, test_db, migration_ops, index_name):
+        conn = test_db.connection()
+
+        _migration.downgrade()
+
+        exists = conn.execute(
+            sa.text("SELECT 1 FROM pg_indexes WHERE indexname = :n"), {"n": index_name}
         ).fetchone()
         assert exists is None
 
@@ -540,3 +588,44 @@ class TestDowngradeUpgradeRoundTrip:
 
         assert _explorer_row(conn, "test_set", ts_id) is True
         assert _explorer_row(conn, "test", t_id) is True
+
+
+@pytest.mark.integration
+class TestBypassRLSSkipsDisableEnable:
+    """_has_bypassrls() lets upgrade()/downgrade() skip the ALTER TABLE ...
+    ROW LEVEL SECURITY dance for a role that already ignores RLS (prod's
+    rhesis-admin) -- that dance takes an ACCESS EXCLUSIVE lock these hot tables
+    shouldn't need to pay for when the role never needed the bypass anyway."""
+
+    def test_has_bypassrls_reflects_the_role_attribute(self, test_db, migration_ops):
+        conn = test_db.connection()
+        # Testcontainers' superuser role has BYPASSRLS by default (see module docstring).
+        assert _migration._has_bypassrls(conn) is True
+
+        conn.execute(sa.text("ALTER ROLE CURRENT_USER NOBYPASSRLS"))
+        try:
+            assert _migration._has_bypassrls(conn) is False
+        finally:
+            conn.execute(sa.text("ALTER ROLE CURRENT_USER BYPASSRLS"))
+
+    def test_upgrade_and_downgrade_still_work_when_role_bypasses_rls(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        conn.execute(sa.text("ALTER ROLE CURRENT_USER BYPASSRLS"))
+        try:
+            ts_id = _insert_test_set(
+                conn,
+                org_id=test_org_id,
+                user_id=authenticated_user_id,
+                attributes={"metadata": {"behaviors": [_EXPLORER_BEHAVIOR_NAME]}},
+            )
+
+            _migration.upgrade()  # must not raise, must not touch RLS to succeed
+            assert _explorer_row(conn, "test_set", ts_id) is True
+
+            _migration.downgrade()  # must not raise either
+            attrs = _test_set_attributes(conn, ts_id)
+            assert attrs["metadata"]["behaviors"] == [_EXPLORER_BEHAVIOR_NAME]
+        finally:
+            conn.execute(sa.text("ALTER ROLE CURRENT_USER NOBYPASSRLS"))

--- a/tests/backend/alembic/test_explorer_row_migration.py
+++ b/tests/backend/alembic/test_explorer_row_migration.py
@@ -1,0 +1,514 @@
+"""Pre-merge confidence tests for the ``explorer_row`` backfill migration.
+
+TEMPORARY: delete once that migration has shipped everywhere.
+
+Drives the migration's ``upgrade()``/``downgrade()`` directly against the
+``test_db`` connection inside an ``Operations.context``, so the DDL rolls back
+at teardown. Skips the ``client`` fixture: ``upgrade()`` holds ACCESS EXCLUSIVE
+locks that a second connection would block on.
+
+Testcontainers runs as superuser, so it can't catch a broken RLS disable/enable
+dance -- that's on the migration's own fail-loud verification, not this file.
+"""
+
+import importlib.util
+import json
+import os
+import uuid
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.operations import Operations
+from alembic.runtime.migration import MigrationContext
+
+RHESIS_SKIP_MIGRATIONS = os.environ.get("RHESIS_SKIP_MIGRATIONS", "").lower() in (
+    "1",
+    "true",
+    "yes",
+)
+
+pytestmark = pytest.mark.skipif(
+    RHESIS_SKIP_MIGRATIONS,
+    reason="Depends on the head schema; skipped when RHESIS_SKIP_MIGRATIONS is set.",
+)
+
+_MIGRATION_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "apps"
+    / "backend"
+    / "src"
+    / "rhesis"
+    / "backend"
+    / "alembic"
+    / "versions"
+    / "7dd69fe35db5_add_explorer_row_to_test_set_and_test.py"
+)
+
+_EXPLORER_BEHAVIOR_NAME = "Adaptive Testing"
+
+
+def _load_migration_module():
+    spec = importlib.util.spec_from_file_location(
+        "explorer_row_migration_under_test", _MIGRATION_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_migration = _load_migration_module()
+
+
+@pytest.fixture
+def migration_ops(test_db):
+    """Activates an Operations context so the migration's bare ``op.xxx`` calls resolve."""
+    ctx = MigrationContext.configure(test_db.connection())
+    with Operations.context(ctx):
+        yield
+
+
+def _insert_test_set(conn, *, org_id, user_id, attributes) -> uuid.UUID:
+    attrs_json = None if attributes is None else json.dumps(attributes)
+    row = conn.execute(
+        sa.text(
+            """
+            INSERT INTO test_set (name, organization_id, user_id, visibility, attributes)
+            VALUES (
+                :name, CAST(:org_id AS uuid), CAST(:user_id AS uuid), 'organization',
+                CAST(:attrs AS jsonb)
+            )
+            RETURNING id
+            """
+        ),
+        {
+            "name": f"explorer_row migration test {uuid.uuid4().hex[:8]}",
+            "org_id": org_id,
+            "user_id": user_id,
+            "attrs": attrs_json,
+        },
+    ).fetchone()
+    return row[0]
+
+
+def _insert_test(conn, *, org_id, user_id) -> uuid.UUID:
+    row = conn.execute(
+        sa.text(
+            """
+            INSERT INTO test (organization_id, user_id)
+            VALUES (CAST(:org_id AS uuid), CAST(:user_id AS uuid))
+            RETURNING id
+            """
+        ),
+        {"org_id": org_id, "user_id": user_id},
+    ).fetchone()
+    return row[0]
+
+
+def _associate(conn, *, test_id, test_set_id, org_id, user_id) -> None:
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO test_test_set (test_id, test_set_id, organization_id, user_id)
+            VALUES (
+                CAST(:test_id AS uuid), CAST(:test_set_id AS uuid),
+                CAST(:org_id AS uuid), CAST(:user_id AS uuid)
+            )
+            """
+        ),
+        {"test_id": test_id, "test_set_id": test_set_id, "org_id": org_id, "user_id": user_id},
+    )
+
+
+def _explorer_row(conn, table: str, row_id: uuid.UUID) -> bool:
+    return conn.execute(
+        sa.text(f"SELECT explorer_row FROM {table} WHERE id = CAST(:id AS uuid)"),  # noqa: S608
+        {"id": row_id},
+    ).scalar()
+
+
+def _test_set_attributes(conn, test_set_id: uuid.UUID):
+    raw = conn.execute(
+        sa.text("SELECT attributes FROM test_set WHERE id = CAST(:id AS uuid)"),
+        {"id": test_set_id},
+    ).scalar()
+    return json.loads(raw) if isinstance(raw, str) else raw
+
+
+@pytest.mark.integration
+class TestColumnShape:
+    """The column exists on both tables as boolean/not-null/default-false."""
+
+    @pytest.mark.parametrize("table", ["test_set", "test"])
+    def test_column_is_boolean_not_null_default_false(self, test_db, table):
+        row = (
+            test_db.connection()
+            .execute(
+                sa.text(
+                    "SELECT data_type, is_nullable, column_default "
+                    "FROM information_schema.columns "
+                    "WHERE table_schema = 'public' AND table_name = :t "
+                    "AND column_name = 'explorer_row'"
+                ),
+                {"t": table},
+            )
+            .fetchone()
+        )
+
+        assert row is not None, f"explorer_row column missing on {table}"
+        data_type, is_nullable, column_default = row
+        assert data_type == "boolean"
+        assert is_nullable == "NO"
+        assert column_default is not None and "false" in column_default.lower()
+
+
+@pytest.mark.integration
+class TestBackfillLogic:
+    """Re-running upgrade() against freshly seeded rows exercises the real backfill SQL."""
+
+    def test_marker_only_test_set_becomes_true(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": [_EXPLORER_BEHAVIOR_NAME]}},
+        )
+
+        _migration.upgrade()
+
+        assert _explorer_row(conn, "test_set", ts_id) is True
+
+    def test_marker_among_other_behaviors_becomes_true(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": ["Safety", _EXPLORER_BEHAVIOR_NAME]}},
+        )
+
+        _migration.upgrade()
+
+        assert _explorer_row(conn, "test_set", ts_id) is True
+
+    def test_regular_test_set_stays_false(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": ["Safety"]}},
+        )
+
+        _migration.upgrade()
+
+        assert _explorer_row(conn, "test_set", ts_id) is False
+
+    @pytest.mark.parametrize(
+        "attributes",
+        [
+            None,
+            {},
+            {"metadata": "not-an-object"},
+            {"unexpected": True},
+        ],
+    )
+    def test_null_or_malformed_attributes_stay_false_without_error(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id, attributes
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn, org_id=test_org_id, user_id=authenticated_user_id, attributes=attributes
+        )
+
+        _migration.upgrade()  # must not raise
+
+        assert _explorer_row(conn, "test_set", ts_id) is False
+
+    def test_test_associated_with_an_explorer_set_becomes_true(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": [_EXPLORER_BEHAVIOR_NAME]}},
+        )
+        t_id = _insert_test(conn, org_id=test_org_id, user_id=authenticated_user_id)
+        _associate(
+            conn,
+            test_id=t_id,
+            test_set_id=ts_id,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        _migration.upgrade()
+
+        assert _explorer_row(conn, "test_set", ts_id) is True
+        assert _explorer_row(conn, "test", t_id) is True
+
+    def test_test_only_in_regular_sets_stays_false(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": ["Safety"]}},
+        )
+        t_id = _insert_test(conn, org_id=test_org_id, user_id=authenticated_user_id)
+        _associate(
+            conn,
+            test_id=t_id,
+            test_set_id=ts_id,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        _migration.upgrade()
+
+        assert _explorer_row(conn, "test", t_id) is False
+
+    def test_test_shared_between_an_explorer_and_a_regular_set_becomes_true(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        explorer_ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": [_EXPLORER_BEHAVIOR_NAME]}},
+        )
+        regular_ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": ["Safety"]}},
+        )
+        t_id = _insert_test(conn, org_id=test_org_id, user_id=authenticated_user_id)
+        _associate(
+            conn,
+            test_id=t_id,
+            test_set_id=explorer_ts_id,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        _associate(
+            conn,
+            test_id=t_id,
+            test_set_id=regular_ts_id,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        _migration.upgrade()
+
+        assert _explorer_row(conn, "test", t_id) is True
+
+    def test_idempotent_rerun_changes_nothing(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": [_EXPLORER_BEHAVIOR_NAME]}},
+        )
+        t_id = _insert_test(conn, org_id=test_org_id, user_id=authenticated_user_id)
+        _associate(
+            conn,
+            test_id=t_id,
+            test_set_id=ts_id,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        _migration.upgrade()
+        _migration.upgrade()  # must not raise, must not change the outcome
+
+        assert _explorer_row(conn, "test_set", ts_id) is True
+        assert _explorer_row(conn, "test", t_id) is True
+
+
+@pytest.mark.integration
+class TestMarkerStripping:
+    """upgrade() removes the "Adaptive Testing" marker from attributes once
+    explorer_row is verified."""
+
+    def test_marker_only_drops_the_whole_behaviors_key(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": [_EXPLORER_BEHAVIOR_NAME]}},
+        )
+
+        _migration.upgrade()
+
+        assert _explorer_row(conn, "test_set", ts_id) is True
+        attrs = _test_set_attributes(conn, ts_id)
+        assert "behaviors" not in attrs.get("metadata", {})
+
+    def test_marker_among_other_behaviors_only_removes_the_marker(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": ["Safety", _EXPLORER_BEHAVIOR_NAME]}},
+        )
+
+        _migration.upgrade()
+
+        attrs = _test_set_attributes(conn, ts_id)
+        assert attrs["metadata"]["behaviors"] == ["Safety"]
+
+    def test_regular_test_set_attributes_are_untouched(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": ["Safety"]}},
+        )
+
+        _migration.upgrade()
+
+        attrs = _test_set_attributes(conn, ts_id)
+        assert attrs["metadata"]["behaviors"] == ["Safety"]
+
+    def test_idempotent_rerun_does_not_error_once_marker_is_gone(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": [_EXPLORER_BEHAVIOR_NAME]}},
+        )
+
+        _migration.upgrade()
+        _migration.upgrade()  # marker is already gone; must not raise
+
+        assert _explorer_row(conn, "test_set", ts_id) is True
+
+
+@pytest.mark.integration
+class TestDowngradeRestoresMarker:
+    """downgrade() writes the marker back onto every row explorer_row still
+    flags, reading that column before dropping it."""
+
+    def test_restores_the_marker_alongside_other_behaviors(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": ["Safety"]}},
+        )
+        conn.execute(
+            sa.text("UPDATE test_set SET explorer_row = true WHERE id = CAST(:id AS uuid)"),
+            {"id": ts_id},
+        )
+
+        _migration.downgrade()
+
+        attrs = _test_set_attributes(conn, ts_id)
+        assert attrs["metadata"]["behaviors"] == ["Safety", _EXPLORER_BEHAVIOR_NAME]
+
+    def test_restores_the_marker_from_scratch_when_attributes_is_null(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn, org_id=test_org_id, user_id=authenticated_user_id, attributes=None
+        )
+        conn.execute(
+            sa.text("UPDATE test_set SET explorer_row = true WHERE id = CAST(:id AS uuid)"),
+            {"id": ts_id},
+        )
+
+        _migration.downgrade()
+
+        attrs = _test_set_attributes(conn, ts_id)
+        assert attrs["metadata"]["behaviors"] == [_EXPLORER_BEHAVIOR_NAME]
+
+    def test_leaves_non_explorer_rows_untouched(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": ["Safety"]}},
+        )
+
+        _migration.downgrade()
+
+        attrs = _test_set_attributes(conn, ts_id)
+        assert attrs["metadata"]["behaviors"] == ["Safety"]
+
+    def test_column_is_dropped(self, test_db, migration_ops):
+        conn = test_db.connection()
+
+        _migration.downgrade()
+
+        exists = conn.execute(
+            sa.text(
+                "SELECT 1 FROM information_schema.columns "
+                "WHERE table_name = 'test_set' AND column_name = 'explorer_row'"
+            )
+        ).fetchone()
+        assert exists is None
+
+
+@pytest.mark.integration
+class TestDowngradeUpgradeRoundTrip:
+    def test_round_trip_rederives_correct_values_from_scratch(
+        self, test_db, migration_ops, test_org_id, authenticated_user_id
+    ):
+        conn = test_db.connection()
+
+        _migration.downgrade()  # drop both columns
+
+        ts_id = _insert_test_set(
+            conn,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+            attributes={"metadata": {"behaviors": [_EXPLORER_BEHAVIOR_NAME]}},
+        )
+        t_id = _insert_test(conn, org_id=test_org_id, user_id=authenticated_user_id)
+        _associate(
+            conn,
+            test_id=t_id,
+            test_set_id=ts_id,
+            org_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+        _migration.upgrade()  # re-add columns and re-derive from scratch
+
+        assert _explorer_row(conn, "test_set", ts_id) is True
+        assert _explorer_row(conn, "test", t_id) is True

--- a/tests/backend/crud/test_test_crud.py
+++ b/tests/backend/crud/test_test_crud.py
@@ -186,6 +186,7 @@ class TestTestOperations:
             organization_id=test_org_id,
             user_id=authenticated_user_id,
             attributes={"metadata": {"behaviors": [EXPLORER_BEHAVIOR_NAME]}},
+            explorer_row=True,
         )
         test_db.add_all([db_test, explorer_test_set])
         test_db.flush()

--- a/tests/backend/routes/test_explorer.py
+++ b/tests/backend/routes/test_explorer.py
@@ -289,7 +289,7 @@ def regular_source_test_set_for_import(test_db: Session, test_org_id, authentica
     return test_set
 
 
-def _make_test_set_with_attrs(db, name, attributes, organization_id, user_id):
+def _make_test_set_with_attrs(db, name, attributes, organization_id, user_id, explorer_row=False):
     """Create a test set with given attributes."""
     ts = models.TestSet(
         name=name,
@@ -297,6 +297,7 @@ def _make_test_set_with_attrs(db, name, attributes, organization_id, user_id):
         organization_id=organization_id,
         user_id=user_id,
         attributes=attributes,
+        explorer_row=explorer_row,
     )
     db.add(ts)
     db.flush()
@@ -308,7 +309,7 @@ def explorer_and_regular_test_sets(test_db: Session, test_org_id, authenticated_
     """Create a mix of explorer and non-explorer test sets for route tests.
 
     Creates:
-    - 2 test sets WITH ``Adaptive Testing`` behavior in metadata
+    - 2 test sets with ``explorer_row=True``
     - 1 test set with a different behavior
     - 1 test set with no attributes
     """
@@ -318,6 +319,7 @@ def explorer_and_regular_test_sets(test_db: Session, test_org_id, authenticated_
         {"metadata": {"behaviors": ["Adaptive Testing"]}},
         test_org_id,
         authenticated_user_id,
+        explorer_row=True,
     )
     ts_adaptive_2 = _make_test_set_with_attrs(
         test_db,
@@ -327,6 +329,7 @@ def explorer_and_regular_test_sets(test_db: Session, test_org_id, authenticated_
         },
         test_org_id,
         authenticated_user_id,
+        explorer_row=True,
     )
     ts_regular = _make_test_set_with_attrs(
         test_db,
@@ -365,7 +368,7 @@ class TestListExplorerTestSetsEndpoint:
         authenticated_client: TestClient,
         explorer_and_regular_test_sets,
     ):
-        """Should return only test sets with Adaptive Testing behavior."""
+        """Should return only test sets flagged as Explorer-owned."""
         response = authenticated_client.get("/explorer")
 
         assert response.status_code == status.HTTP_200_OK
@@ -509,10 +512,7 @@ class TestCreateExplorerTestSetEndpoint:
         assert "id" in data
         assert data["name"] == "My Adaptive Set"
         assert data["description"] == "Optional"
-        assert "attributes" in data
-        assert "metadata" in data["attributes"]
-        assert "behaviors" in data["attributes"]["metadata"]
-        assert "Adaptive Testing" in data["attributes"]["metadata"]["behaviors"]
+        assert data["explorer_row"] is True
         assert "created_at" in data
         assert "updated_at" in data
 
@@ -699,9 +699,8 @@ class TestExportRegularTestSetFromExplorerEndpoint:
         assert new_id != adaptive_id
         assert "(Exported)" in data["test_set"]["name"]
 
+        assert data["test_set"]["explorer_row"] is False
         attrs = data["test_set"].get("attributes") or {}
-        meta = attrs.get("metadata") or {}
-        assert "Adaptive Testing" not in (meta.get("behaviors") or [])
         assert attrs.get("adaptive_settings") is None
 
         tests_resp = authenticated_client.get(f"/test_sets/{new_id}/tests?limit=100")

--- a/tests/backend/schemas/test_explorer_metadata.py
+++ b/tests/backend/schemas/test_explorer_metadata.py
@@ -210,21 +210,8 @@ class TestExplorerAdaptiveSettings:
 
 @pytest.mark.unit
 class TestExplorerTestSetAttributes:
-    def test_is_explorer_true_when_behavior_present(self):
-        attrs = parse_explorer_test_set_attributes(
-            {"metadata": {"behaviors": ["Adaptive Testing", "Safety"]}}
-        )
-
-        assert attrs.is_explorer is True
-
-    def test_is_explorer_false_without_marker_behavior(self):
-        attrs = parse_explorer_test_set_attributes({"metadata": {"behaviors": ["Safety"]}})
-
-        assert attrs.is_explorer is False
-
-    def test_is_explorer_false_when_metadata_absent(self):
-        assert parse_explorer_test_set_attributes({}).is_explorer is False
-        assert parse_explorer_test_set_attributes(None).is_explorer is False
+    """Explorer ownership is read from models.TestSet.explorer_row, not this blob --
+    this model only exists to read adaptive_settings off the shared attributes column."""
 
     def test_default_endpoint_id_reads_through_adaptive_settings(self):
         endpoint_id = uuid.uuid4()
@@ -243,7 +230,6 @@ class TestExplorerTestSetAttributes:
             {"source": "garak", "garak_module": "dan", "garak_probe_class": "Dan_11_0"}
         )
 
-        assert attrs.is_explorer is False
         assert attrs.default_endpoint_id is None
 
     def test_garbage_input_does_not_raise(self):

--- a/tests/backend/services/explorer/test_tests.py
+++ b/tests/backend/services/explorer/test_tests.py
@@ -31,7 +31,7 @@ from rhesis.backend.app.services.explorer.tests import _parse_test_for_copy
 # ============================================================================
 
 
-def _make_test_set(db, name, attributes, organization_id, user_id):
+def _make_test_set(db, name, attributes, organization_id, user_id, explorer_row=False):
     """Helper to create a test set with given attributes."""
     ts = models.TestSet(
         name=name,
@@ -39,6 +39,7 @@ def _make_test_set(db, name, attributes, organization_id, user_id):
         organization_id=organization_id,
         user_id=user_id,
         attributes=attributes,
+        explorer_row=explorer_row,
     )
     db.add(ts)
     db.flush()
@@ -50,7 +51,7 @@ def explorer_and_regular_test_sets(test_db: Session, test_org_id, authenticated_
     """Create a mix of adaptive and non-adaptive test sets.
 
     Creates:
-    - 2 test sets WITH ``Adaptive Testing`` in metadata.behaviors
+    - 2 test sets with ``explorer_row=True``
     - 1 test set with different behavior
     - 1 test set with no attributes at all
     """
@@ -60,6 +61,7 @@ def explorer_and_regular_test_sets(test_db: Session, test_org_id, authenticated_
         {"metadata": {"behaviors": ["Adaptive Testing"]}},
         test_org_id,
         authenticated_user_id,
+        explorer_row=True,
     )
     ts_adaptive_2 = _make_test_set(
         test_db,
@@ -70,6 +72,7 @@ def explorer_and_regular_test_sets(test_db: Session, test_org_id, authenticated_
         },
         test_org_id,
         authenticated_user_id,
+        explorer_row=True,
     )
     ts_regular = _make_test_set(
         test_db,
@@ -265,7 +268,7 @@ class TestExplorerTreeTopics:
 @pytest.mark.integration
 @pytest.mark.service
 class TestGetExplorerTestSets:
-    """Test get_explorer_test_sets - returns test sets with Adaptive Testing."""
+    """Test get_explorer_test_sets - returns test sets flagged as Explorer-owned."""
 
     def test_returns_only_adaptive_test_sets(
         self,
@@ -273,7 +276,7 @@ class TestGetExplorerTestSets:
         explorer_and_regular_test_sets,
         test_org_id,
     ):
-        """Should return only the 2 test sets with Adaptive Testing behavior."""
+        """Should return only the 2 test sets flagged as Explorer-owned."""
         result = get_explorer_test_sets(
             db=test_db,
             organization_id=test_org_id,
@@ -414,20 +417,15 @@ class TestCreateExplorerTestSet:
         assert result.name == "My Adaptive Set"
         assert result.description == "Optional description"
 
-    def test_attributes_contain_adaptive_testing_behavior(
-        self, test_db, test_org_id, authenticated_user_id
-    ):
-        """Created test set has attributes.metadata.behaviors containing Adaptive Testing."""
+    def test_is_flagged_as_explorer_owned(self, test_db, test_org_id, authenticated_user_id):
+        """Created test set is flagged via explorer_row."""
         result = create_explorer_test_set(
             db=test_db,
             organization_id=test_org_id,
             user_id=authenticated_user_id,
             name=f"Adaptive Set {uuid.uuid4().hex[:6]}",
         )
-        assert result.attributes is not None
-        assert "metadata" in result.attributes
-        assert "behaviors" in result.attributes["metadata"]
-        assert "Adaptive Testing" in result.attributes["metadata"]["behaviors"]
+        assert result.explorer_row is True
 
     def test_has_correct_organization_and_user(self, test_db, test_org_id, authenticated_user_id):
         """Created test set has correct organization_id and user_id."""
@@ -530,7 +528,7 @@ class TestDeleteExplorerTestSet:
     def test_delete_non_adaptive_set(
         self, test_db, explorer_and_regular_test_sets, test_org_id, authenticated_user_id
     ):
-        """Regular test set without Adaptive Testing behavior raises ValueError."""
+        """Regular test set not flagged as Explorer-owned raises ValueError."""
         regular = explorer_and_regular_test_sets["regular"]
         with pytest.raises(ValueError, match="not configured for Explorer"):
             delete_explorer_test_set(
@@ -1109,9 +1107,7 @@ class TestImportExplorerTestSetFromSource:
         assert result.imported == 2
         assert result.skipped == 1
         new_set = result.test_set
-        assert "Adaptive Testing" in ((new_set.attributes or {}).get("metadata") or {}).get(
-            "behaviors", []
-        )
+        assert new_set.explorer_row is True
 
         tests = get_tree_tests(
             db=test_db,
@@ -1292,8 +1288,7 @@ class TestExportRegularTestSetFromExplorer:
         assert result.skipped == 2
         new_set = result.test_set
         assert "(Exported)" in new_set.name
-        meta_behaviors = ((new_set.attributes or {}).get("metadata") or {}).get("behaviors") or []
-        assert "Adaptive Testing" not in meta_behaviors
+        assert new_set.explorer_row is False
         assert (new_set.attributes or {}).get("adaptive_settings") is None
 
         items, total = crud.get_test_set_tests(

--- a/tests/backend/services/test_test_set.py
+++ b/tests/backend/services/test_test_set.py
@@ -664,6 +664,7 @@ class TestGetTestSetsExcludesExplorer:
             user_id=authenticated_user_id,
             visibility="organization",
             attributes={"metadata": {"behaviors": [EXPLORER_BEHAVIOR_NAME]}},
+            explorer_row=True,
         )
         test_db.add_all([regular, explorer])
         test_db.commit()


### PR DESCRIPTION
## Purpose

Explorer test sets and their tests were identified by a fragile JSONB marker: attributes.metadata.behaviors containing the literal string "Adaptive Testing". This meant every query that needed to include or exclude Explorer content had to reach into JSONB to check for that string, and any regular test set that happened to carry a real Behavior tag with that exact name would be misidentified as an Explorer set. This PR replaces that marker with a real boolean column, explorer_row, on test_set and test, backfilled by a migration.

## What Changed

- Added a migration (7dd69fe35db5) that adds explorer_row (boolean, default false) to test_set and test, backfills it from the existing marker and from the test_test_set association, and indexes both columns since explorer_row is now the WHERE filter on every /test_sets (exclude) and /explorer (include) listing.
- The migration does not strip the old marker from attributes during backfill. Stripping it would destructively delete a real Behavior tag from any unrelated test set that happens to be named "Adaptive Testing" — leaving it is a one-time wart on pre-migration rows only; every Explorer session created going forward never writes the marker in the first place.
- The migration skips the ALTER TABLE ... ROW LEVEL SECURITY disable/enable dance entirely when the connecting role already has BYPASSRLS (prod's rhesis-admin). That dance takes an ACCESS EXCLUSIVE lock on test/test_set/test_test_set — the app's hottest tables — which is unnecessary risk for a role that ignores RLS anyway. Roles without BYPASSRLS (dev/CI fallback) keep the original disable/enable behavior.
- downgrade() restores the marker before dropping the column, guarded against non-object attributes/metadata shapes so a malformed value falls back to an empty object/array instead of crashing jsonb_set().
- Updated crud/explorer.py, crud/__init__.py, routers/explorer.py, routers/test_set.py, and the relevant services to filter/set explorer_row directly instead of inspecting attributes.metadata.behaviors.
- Dropped the now-unused marker validation from schemas/explorer_metadata.py, and exposed explorer_row on the TestSet API response (schemas/test_set.py) so the frontend checks it directly.
- Updated the frontend Explorer import dialog and API client types to match.

## Additional Context

Reviewed with /code-review, which surfaced the RLS-lock, missing-index, and destructive-marker-strip issues fixed here, plus the downgrade() jsonb_set crash risk. All were addressed in follow-up commits on this branch.

## Testing

- tests/backend/alembic/test_explorer_row_migration.py: 32 tests covering upgrade()/downgrade() backfill logic, idempotency, index presence, malformed-attributes handling, and the BYPASSRLS skip path — all passing.
- Manually validated end to end against the local dev Postgres instance (not just testcontainers): reset the dev database, migrated to the revision before this one, seeded realistic pre-migration data (marker-only, mixed-behaviors, regular, and a simulated name-collision test set), ran alembic upgrade head, and confirmed explorer_row was backfilled correctly, the collision-case test set's marker was preserved (not stripped), both indexes exist, and RLS stayed continuously enabled/forced on test/test_set/test_test_set throughout (confirming the BYPASSRLS skip engaged). Also validated the downgrade/upgrade round trip, including a simulated post-migration Explorer session getting its marker correctly restored on downgrade without duplicating markers on rows that already had one.