### PR TITLE
Fix editable project field on endpoint details

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointOverviewTab.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/EndpointOverviewTab.tsx
@@ -6,12 +6,9 @@ import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import {
   Box,
-  CircularProgress,
   FormControlLabel,
   FormHelperText,
   Grid,
-  ListItemIcon,
-  ListItemText,
   MenuItem,
   Select,
   Switch,
@@ -20,7 +17,6 @@ import {
   InputLabel,
 } from '@mui/material';
 import GridBadge from '@/components/common/GridBadge';
-import { getProjectIcon } from '@/components/common/ProjectIcons';
 import EditableSection from '@/components/common/EditableSection';
 import ViewField from '@/components/common/ViewField';
 import { Endpoint } from '@/utils/api-client/interfaces/endpoint';
@@ -35,7 +31,6 @@ import {
 interface EndpointDetailsDraft {
   name: string;
   description: string;
-  project_id: string;
   environment: string;
   disable_tracing: boolean;
 }
@@ -43,24 +38,20 @@ interface EndpointDetailsDraft {
 function detailsFromEndpoint(endpoint: {
   name: string;
   description?: string;
-  project_id?: string;
   environment: string;
   disable_tracing?: boolean;
 }): EndpointDetailsDraft {
   return {
     name: endpoint.name,
     description: endpoint.description || '',
-    project_id: endpoint.project_id || '',
     environment: endpoint.environment,
     disable_tracing: endpoint.disable_tracing ?? false,
   };
 }
 
 export default function EndpointOverviewTab() {
-  const { endpoint, projects, loadingProjects, saveFields } =
-    useEndpointDetailContext();
+  const { endpoint, projects, saveFields } = useEndpointDetailContext();
   const canEditEndpoint = useCan(Capability.Endpoint.UPDATE);
-  const projectList = useMemo(() => Object.values(projects), [projects]);
 
   const detailsInitial = useMemo(
     () => detailsFromEndpoint(endpoint),
@@ -83,7 +74,6 @@ export default function EndpointOverviewTab() {
           await saveFields({
             name: draft.name,
             description: draft.description,
-            project_id: draft.project_id || undefined,
             environment: draft.environment as Endpoint['environment'],
             disable_tracing: draft.disable_tracing,
           });
@@ -95,67 +85,21 @@ export default function EndpointOverviewTab() {
             columnSpacing={detailGridSpacing.columnSpacing(isEditing)}
             rowSpacing={detailGridSpacing.rowSpacing(isEditing)}
           >
+            {/* Project is fixed once the endpoint exists — an endpoint cannot be
+                moved between projects, so this stays read-only even while editing. */}
             <Grid size={{ xs: 12, md: 6 }}>
-              {isEditing ? (
-                <FormControl fullWidth required>
-                  <InputLabel>Project</InputLabel>
-                  <Select
-                    value={draft.project_id}
-                    label="Project"
-                    disabled={loadingProjects}
-                    onChange={e =>
-                      setDraft(prev => ({
-                        ...prev,
-                        project_id: e.target.value,
-                      }))
-                    }
-                    renderValue={selected => {
-                      const p = projects[selected];
-                      return (
-                        <Box
-                          sx={{ display: 'flex', alignItems: 'center', gap: 1 }}
-                        >
-                          {p && getProjectIcon(p)}
-                          {p?.name || 'Select project'}
-                        </Box>
-                      );
-                    }}
+              <ViewField label="Project">
+                {endpoint.project_id ? (
+                  <Link
+                    href={`/projects/${endpoint.project_id}`}
+                    style={{ color: 'inherit', fontWeight: 500 }}
                   >
-                    {loadingProjects ? (
-                      <MenuItem disabled value={draft.project_id || ''}>
-                        <CircularProgress size={20} sx={{ mr: 1 }} />
-                        Loading projects...
-                      </MenuItem>
-                    ) : (
-                      projectList.map(p => (
-                        <MenuItem key={p.id} value={p.id}>
-                          <ListItemIcon>{getProjectIcon(p)}</ListItemIcon>
-                          <ListItemText
-                            primary={p.name}
-                            secondary={p.description}
-                          />
-                        </MenuItem>
-                      ))
-                    )}
-                  </Select>
-                  {!draft.project_id && (
-                    <FormHelperText>Required</FormHelperText>
-                  )}
-                </FormControl>
-              ) : (
-                <ViewField label="Project">
-                  {endpoint.project_id ? (
-                    <Link
-                      href={`/projects/${endpoint.project_id}`}
-                      style={{ color: 'inherit', fontWeight: 500 }}
-                    >
-                      {projectName}
-                    </Link>
-                  ) : (
-                    'No project assigned'
-                  )}
-                </ViewField>
-              )}
+                    {projectName}
+                  </Link>
+                ) : (
+                  'No project assigned'
+                )}
+              </ViewField>
             </Grid>
             <Grid size={{ xs: 12, md: 6 }}>
               {isEditing ? (

--- a/apps/frontend/src/app/(protected)/endpoints/components/__tests__/EndpointDetail.test.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/__tests__/EndpointDetail.test.tsx
@@ -340,6 +340,37 @@ describe('EndpointDetail', () => {
       );
     });
 
+    it('keeps the project read-only while the details card is edited', async () => {
+      mockUpdateEndpoint.mockResolvedValue({ success: true });
+      renderEndpointDetail({
+        ...baseEndpoint,
+        project: { id: 'proj-1', name: 'Proj One' },
+      });
+
+      const editButtons = screen.getAllByRole('button', { name: /^edit$/i });
+      await userEvent.click(editButtons[0]);
+
+      // No project picker: an endpoint cannot be moved between projects.
+      expect(
+        screen.queryByRole('combobox', { name: /project/i })
+      ).not.toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Proj One' })).toHaveAttribute(
+        'href',
+        '/projects/proj-1'
+      );
+
+      // Saving an unrelated change must not carry a project_id along.
+      await userEvent.type(screen.getByLabelText('Name'), ' v2');
+      await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateEndpoint).toHaveBeenCalledTimes(1);
+      });
+      const payload = mockUpdateEndpoint.mock.calls[0][1];
+      expect(payload.name).toBe('My Endpoint v2');
+      expect(payload).not.toHaveProperty('project_id');
+    });
+
     it('exits edit mode and restores Edit button', async () => {
       renderEndpointDetail(baseEndpoint);
 


### PR DESCRIPTION
## Purpose

The endpoint details card let you pick a different project while editing, but an endpoint cannot actually be moved between projects — the save appeared to succeed and the project stayed where it was. The field should not pretend to be editable.

## What Changed

- The Project field on the endpoint Overview tab now stays read-only in edit mode: it always renders as the linked view field, like Connection type, Status, and Config source already do.
- `project_id` is no longer part of the details edit draft, so saving a name, description, environment, or tracing change never sends a project move along with it.
- Added a regression test: in edit mode there is no project combobox, the project link is still shown, and a name change saves without `project_id` in the payload.

## Additional Context

- Creating an endpoint still lets you choose the project (`EndpointForm` in the create drawer) — that path works and is untouched.
- The backend still accepts `project_id` on `PUT /endpoints/{id}`, so the API can still be asked to move an endpoint. Rejecting it server-side is a separate follow-up.

## Testing

`cd apps/frontend && npx jest --testPathPatterns endpoints` — 10 suites, 80 tests pass. `npx tsc --noEmit`, eslint, and prettier are clean.

Manually: open an endpoint, click Edit on the "Endpoint details" card. The Project row shows the project name as a link instead of a dropdown, and saving other fields keeps the project unchanged.
