### PR TITLE
Let the architect read annotations and create complete metrics

### DIFF
--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -1013,13 +1013,16 @@ tools:
       - test_result_id: one result plus traces linked to it.
       - trace_id (32-char OpenTelemetry hex id) or trace_db_id (internal
         UUID): one trace only. Use whichever id you already have; both are
-        returned on every annotation.
+        returned on every trace annotation.
       - source: restrict to "test_result" or "trace" when you want one side.
 
       Key response fields: comments (the human's actual words),
       status.name (Pass/Fail), resolved, target.type (what was reviewed —
       test_result, trace, metric, or turn), plus behavior_name and the
-      test_run_id/test_result_id/trace_id deep-link ids.
+      test_run_id/test_result_id/trace_id deep-link ids. Annotations on a
+      test-execution trace carry the run and result ids too, so you can
+      walk from a trace review back to the run — they are null only for
+      traces recorded outside a test run.
 
       CHAIN: after get_test_result_stats shows failures, call this with the
       same test_run_id to see whether a human already diagnosed them — then

--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -1024,6 +1024,10 @@ tools:
       walk from a trace review back to the run — they are null only for
       traces recorded outside a test run.
 
+      When linking to a trace in the UI, use trace_db_id (a UUID) in the
+      URL path, not trace_id (a 32-char hex string). Only trace_db_id
+      resolves to a trace page.
+
       CHAIN: after get_test_result_stats shows failures, call this with the
       same test_run_id to see whether a human already diagnosed them — then
       use get_test_result on the ids it returns to read the full exchange.

--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -505,9 +505,43 @@ tools:
       assignee_id, status_id, model_id, backend_type_id, metric_type_id).
       If you only have a natural-language description, prefer
       generate_metric instead.
+
+      ALWAYS send the descriptive fields alongside the scoring
+      configuration: description, evaluation_steps, reasoning, and
+      explanation. They are optional to the API but a metric without them
+      is a poor metric — reviewers cannot tell what it measures, and the
+      judge LLM has less to work with, so scores get less consistent.
+      Sending only name + evaluation_prompt + score_type produces a
+      threadbare metric and is a bug, not a shortcut. Fill every field you
+      have grounds to fill.
     parameters:
       name:
         description: "Metric name, unique within the organization (required, string)"
+      description:
+        description: >
+          REQUIRED IN PRACTICE. One or two sentences on what this metric
+          measures and why it matters, written for a human scanning a list
+          of metrics. Do not restate the name.
+      evaluation_steps:
+        description: >
+          REQUIRED IN PRACTICE. Numbered step-by-step instructions the
+          judge LLM should follow to reach a score (e.g. "1. Identify each
+          factual claim. 2. Check it against the provided context.
+          3. Count unsupported claims. 4. Map the count to the scale.").
+          Concrete steps make scoring far more repeatable than criteria
+          prose alone.
+      reasoning:
+        description: >
+          REQUIRED IN PRACTICE. Instructions for how the judge should
+          explain its verdict — what evidence to cite and how to justify
+          the score it gives. Surfaced in the UI as "Reasoning
+          Instructions".
+      explanation:
+        description: >
+          REQUIRED IN PRACTICE. What a passing versus failing result
+          actually means for the system under test, so someone reading a
+          result knows what to do about it. Surfaced in the UI as "Result
+          Explanation".
       metric_type:
         description: >
           Must be "custom-prompt" for user-defined metrics. Always

--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -956,6 +956,61 @@ tools:
       end_date:
         description: "End date in ISO format (overrides months)."
 
+  # ── Annotations (human reviews) ──────────────────────────
+  - name: list_annotations
+    label: Reading annotations
+    method: GET
+    path: /annotations/
+    page_size: 20
+    description: >
+      List human annotations — reviews a person left on a test result or on
+      a trace. Each annotation carries a Pass/Fail rating in status.name, a
+      free-text comment, who wrote it, and a resolved flag. This is ground
+      truth from a human, so it outranks automated metric scores when the
+      two disagree.
+
+      Use this to answer "what did people flag?", to explain why a test is
+      considered wrong when metrics say it passed, and to find work that is
+      still open. Pass resolved=false for open items only.
+
+      Scoping:
+      - test_run_id: everything reviewed in that run — both the run's test
+        results and the traces it produced. This is the main entry point.
+      - test_result_id: one result plus traces linked to it.
+      - trace_id (32-char OpenTelemetry hex id) or trace_db_id (internal
+        UUID): one trace only. Use whichever id you already have; both are
+        returned on every annotation.
+      - source: restrict to "test_result" or "trace" when you want one side.
+
+      Key response fields: comments (the human's actual words),
+      status.name (Pass/Fail), resolved, target.type (what was reviewed —
+      test_result, trace, metric, or turn), plus behavior_name and the
+      test_run_id/test_result_id/trace_id deep-link ids.
+
+      CHAIN: after get_test_result_stats shows failures, call this with the
+      same test_run_id to see whether a human already diagnosed them — then
+      use get_test_result on the ids it returns to read the full exchange.
+      NEVER: assume no annotations exist because a run looks clean; a human
+      can fail a test the metrics passed.
+    parameters:
+      search:
+        description: >
+          Free-text search across comments, annotator name, target
+          reference, rating, and behavior name.
+      resolved:
+        description: >
+          true for resolved reviews, false for still-open ones. Omit for
+          both.
+      rating:
+        description: >
+          "Pass" or "Fail" — the human's verdict, independent of the
+          automated status on the test result.
+      target_type:
+        description: >
+          What the review is attached to: "test_result", "trace", "metric"
+          (a specific metric on a result), or "turn" (one turn of a
+          conversation).
+
   # ── Knowledge Sources ────────────────────────────────────
   - name: list_sources
     label: Listing knowledge sources

--- a/apps/backend/src/rhesis/backend/app/routers/annotations.py
+++ b/apps/backend/src/rhesis/backend/app/routers/annotations.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import List, Literal, Optional
+from uuid import UUID
 
 from fastapi import Depends, HTTPException, Query, Request, Response
 from sqlalchemy.orm import Session
@@ -49,11 +50,42 @@ def read_annotations(
     target_type: Optional[Literal["test_result", "trace", "metric", "turn"]] = Query(
         None, description="Filter by review target type"
     ),
+    test_run_id: Optional[UUID] = Query(
+        None,
+        description=(
+            "Scope to one test run (UUID). Returns reviews on that run's test "
+            "results and on the traces the run produced."
+        ),
+    ),
+    test_result_id: Optional[UUID] = Query(
+        None,
+        description=(
+            "Scope to one test result (UUID). Returns reviews on the result "
+            "itself and on traces linked to it."
+        ),
+    ),
+    trace_id: Optional[str] = Query(
+        None,
+        description=(
+            "Scope to one trace by its OpenTelemetry trace id (32-char hex "
+            "string). Returns trace reviews only."
+        ),
+    ),
+    trace_db_id: Optional[UUID] = Query(
+        None,
+        description=(
+            "Scope to one trace span by its internal database id (UUID). "
+            "Returns trace reviews only."
+        ),
+    ),
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
 ) -> List[AnnotationListItem]:
     """List human annotations (reviews) across test results and traces.
+
+    Scope with ``test_run_id``/``test_result_id`` to cover both sources at
+    once, or with ``trace_id``/``trace_db_id`` for traces alone.
 
     Dual-gated: callers need ``test_result:read`` and/or ``telemetry:read``.
     Each source branch is included only when the matching permission is present.
@@ -94,6 +126,14 @@ def read_annotations(
             detail=f"Permission denied: {TELEMETRY_READ}",
             headers={"X-Accepted-Permissions": str(TELEMETRY_READ)},
         )
+    # trace_id/trace_db_id can only ever match traces. Deny explicitly rather
+    # than letting the empty-branch guard return a misleading empty list.
+    if (trace_id is not None or trace_db_id is not None) and not can_read_traces:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Permission denied: {TELEMETRY_READ}",
+            headers={"X-Accepted-Permissions": str(TELEMETRY_READ)},
+        )
 
     include_test_results = can_read_test_results and source in (None, "test_result")
     include_traces = can_read_traces and source in (None, "trace")
@@ -109,6 +149,10 @@ def read_annotations(
         resolved=resolved,
         rating=rating,
         target_type=target_type,
+        test_run_id=str(test_run_id) if test_run_id else None,
+        test_result_id=str(test_result_id) if test_result_id else None,
+        trace_id=trace_id,
+        trace_db_id=str(trace_db_id) if trace_db_id else None,
         skip=skip,
         limit=limit,
     )

--- a/apps/backend/src/rhesis/backend/app/routers/metric.py
+++ b/apps/backend/src/rhesis/backend/app/routers/metric.py
@@ -143,6 +143,8 @@ def improve_metric(
             "description": db_metric.description,
             "evaluation_prompt": db_metric.evaluation_prompt,
             "evaluation_steps": db_metric.evaluation_steps,
+            "reasoning": db_metric.reasoning,
+            "explanation": db_metric.explanation,
             "score_type": (
                 db_metric.score_type.value
                 if hasattr(db_metric.score_type, "value")

--- a/apps/backend/src/rhesis/backend/app/services/annotations.py
+++ b/apps/backend/src/rhesis/backend/app/services/annotations.py
@@ -83,6 +83,13 @@ def list_annotations(
     returns reviews on that run's test results and on the traces it produced.
     ``trace_id``/``trace_db_id`` exist only on traces, so they narrow to the
     trace branch.
+
+    Trace rows project their real ``test_run_id``/``test_result_id`` rather
+    than NULL, so a caller can walk from a trace annotation back to the run
+    that produced it. Both stay NULL for traces outside a test execution,
+    which is the column's own meaning. This is not a disclosure the trace
+    branch did not already permit — ``TraceResponse`` exposes both ids to
+    the same ``telemetry:read`` holders.
     """
     # Narrow to the requested source by turning the other branch off.
     # Do not force the matching flag True — callers may have already
@@ -151,8 +158,8 @@ def list_annotations(
             SELECT
                 (elem->>'review_id') AS review_id,
                 'trace' AS source,
-                NULL::uuid AS test_result_id,
-                NULL::uuid AS test_run_id,
+                t.test_result_id AS test_result_id,
+                t.test_run_id AS test_run_id,
                 t.id AS trace_db_id,
                 t.trace_id AS trace_id,
                 t.project_id AS project_id,

--- a/apps/backend/src/rhesis/backend/app/services/annotations.py
+++ b/apps/backend/src/rhesis/backend/app/services/annotations.py
@@ -65,6 +65,10 @@ def list_annotations(
     resolved: Optional[bool] = None,
     rating: Optional[AnnotationRating] = None,
     target_type: Optional[AnnotationTargetType] = None,
+    test_run_id: Optional[str] = None,
+    test_result_id: Optional[str] = None,
+    trace_id: Optional[str] = None,
+    trace_db_id: Optional[str] = None,
     skip: int = 0,
     limit: int = 50,
 ) -> tuple[list[AnnotationListItem], int]:
@@ -73,6 +77,12 @@ def list_annotations(
     Each source branch is included only when the corresponding flag is True.
     Explicit org/project predicates are required because this uses ``text()``
     SQL (ORM auto-filter does not apply).
+
+    ``test_run_id`` and ``test_result_id`` narrow *both* branches: ``trace``
+    carries its own ``test_run_id``/``test_result_id``, so scoping to a run
+    returns reviews on that run's test results and on the traces it produced.
+    ``trace_id``/``trace_db_id`` exist only on traces, so they narrow to the
+    trace branch.
     """
     # Narrow to the requested source by turning the other branch off.
     # Do not force the matching flag True — callers may have already
@@ -80,6 +90,10 @@ def list_annotations(
     if source == "test_result":
         include_traces = False
     elif source == "trace":
+        include_test_results = False
+
+    # Trace-only identifiers can never match a test_result row.
+    if trace_id is not None or trace_db_id is not None:
         include_test_results = False
 
     if not include_test_results and not include_traces:
@@ -121,6 +135,14 @@ def list_annotations(
                     CAST(:project_id AS uuid) IS NULL
                     OR tr.project_id = CAST(:project_id AS uuid)
                   )
+              AND (
+                    CAST(:test_run_id AS uuid) IS NULL
+                    OR tr.test_run_id = CAST(:test_run_id AS uuid)
+                  )
+              AND (
+                    CAST(:test_result_id AS uuid) IS NULL
+                    OR tr.id = CAST(:test_result_id AS uuid)
+                  )
             """
         )
     if include_traces:
@@ -149,6 +171,22 @@ def list_annotations(
               AND (
                     CAST(:project_id AS uuid) IS NULL
                     OR t.project_id = CAST(:project_id AS uuid)
+                  )
+              AND (
+                    CAST(:test_run_id AS uuid) IS NULL
+                    OR t.test_run_id = CAST(:test_run_id AS uuid)
+                  )
+              AND (
+                    CAST(:test_result_id AS uuid) IS NULL
+                    OR t.test_result_id = CAST(:test_result_id AS uuid)
+                  )
+              AND (
+                    CAST(:trace_id AS text) IS NULL
+                    OR t.trace_id = CAST(:trace_id AS text)
+                  )
+              AND (
+                    CAST(:trace_db_id AS uuid) IS NULL
+                    OR t.id = CAST(:trace_db_id AS uuid)
                   )
             """
         )
@@ -215,9 +253,16 @@ def list_annotations(
         "resolved": resolved,
         "rating": rating,
         "target_type": target_type,
+        "test_run_id": test_run_id,
+        "test_result_id": test_result_id,
         "limit": limit,
         "skip": skip,
     }
+    # The trace-only params appear in the SQL only when the trace branch is
+    # present; text() ignores extra keys, but keep the payload honest.
+    if include_traces:
+        params["trace_id"] = trace_id
+        params["trace_db_id"] = trace_db_id
 
     result = db.execute(sql, params)
     rows = result.fetchall()

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/streaming_response.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/streaming_response.j2
@@ -56,7 +56,8 @@ When presenting a comparison between test runs, structure the output clearly:
 When you reference platform entities whose IDs you know from tool results, include markdown links using these URL patterns:
 - Test sets: `[Name](/test-sets/id)`, Tests: `[Name](/tests/id)`, Metrics: `[Name](/metrics/id)`
 - Endpoints: `[Name](/endpoints/id)`, Projects: `[Name](/projects/id)`, Test runs: `[Name](/test-runs/id)`
-Behaviors and test results do NOT have detail pages — refer to them by name only, without links. For test results, link to the parent test run instead.
+- Behaviors: `[Name](/behaviors/id)`, Traces: `[Span Name](/traces/id)`
+Test results do NOT have a detail page — refer to them by name only, without a link, and link to the parent test run instead.
 Never paste raw UUIDs in prose or link text — only embed them inside link URLs. Link text must always be a human-readable name (e.g., `[Basic Travel Agent Functionality](/test-runs/6aa1639e...)`, never `[Run 6aa1639e...](/test-runs/6aa1639e...)`).
 
 ## Boundaries (always enforce)

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/streaming_response.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/streaming_response.j2
@@ -56,7 +56,8 @@ When presenting a comparison between test runs, structure the output clearly:
 When you reference platform entities whose IDs you know from tool results, include markdown links using these URL patterns:
 - Test sets: `[Name](/test-sets/id)`, Tests: `[Name](/tests/id)`, Metrics: `[Name](/metrics/id)`
 - Endpoints: `[Name](/endpoints/id)`, Projects: `[Name](/projects/id)`, Test runs: `[Name](/test-runs/id)`
-- Behaviors: `[Name](/behaviors/id)`, Traces: `[Span Name](/traces/id)`
+- Behaviors: `[Name](/behaviors/id)`, Traces: `[Span Name](/traces/trace_db_id)`
+Trace links must use `trace_db_id` (a UUID), never `trace_id` (a 32-character hex string) — only the former resolves.
 Test results do NOT have a detail page — refer to them by name only, without a link, and link to the parent test run instead.
 Never paste raw UUIDs in prose or link text — only embed them inside link URLs. Link text must always be a human-readable name (e.g., `[Basic Travel Agent Functionality](/test-runs/6aa1639e...)`, never `[Run 6aa1639e...](/test-runs/6aa1639e...)`).
 

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
@@ -5,6 +5,7 @@
 - If you lack information, ask rather than assume — but prefer using tools over asking. Never ask for an ID when the user already gave you a name.
 - Always discover existing platform entities before proposing new ones
 - After creating metrics, always link them to behaviors — a metric without behavior links is incomplete
+- **Create metrics rich, never threadbare.** A metric is not finished when it scores — it is finished when someone else can read it and understand what it measures. Always send `description`, `evaluation_steps`, and `reasoning` along with `name`, `evaluation_prompt`, `score_type` and the scoring configuration, plus `explanation` where it applies. These fields are optional to the API but not optional to you: `evaluation_steps` (numbered steps the judge follows) makes scoring repeatable, `reasoning` tells the judge how to justify its verdict, and `description`/`explanation` are what a human reads later. Leaving them blank produces a metric nobody can maintain. Derive them from the user's intent — if the intent is too thin to write them, ask one clarifying question rather than shipping empty fields
 - **Never paste raw IDs (UUIDs, Nano IDs, etc.) in prose.** Refer to entities by name in your text. IDs are internal — use them in tool calls, not in plain text.
 - **Include entity links** when you reference a platform entity whose ID you know (from tool results). Use standard markdown links with the platform URL pattern: `[Entity Name](/entity-path/id)`. URL patterns:
   - Test sets: `[Safety Test Set](/test-sets/abc123)`

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
@@ -15,7 +15,7 @@
   - Test runs: `[Basic Travel Agent Functionality](/test-runs/abc123)` — use the test set name, never a UUID or generic label like "Run abc123"
   - Behaviors: `[Provides Accurate Information](/behaviors/abc123)`
   - Metrics: `[Escalation Accuracy](/metrics/abc123)`
-  - Traces: `[ai.llm.invoke](/traces/abc123)` — use the span name as link text
+  - Traces: `[ai.llm.invoke](/traces/abc123)` — use the span name as link text, and use the trace's **`trace_db_id`** (a UUID) in the URL, never the `trace_id` (a 32-character hex string). `list_annotations` returns both; only `trace_db_id` resolves, so a link built from `trace_id` is broken
   Test results do NOT have a detail page — refer to them by name only, without a link, and link to the test run instead.
   Link text must always be a human-readable name. IDs inside URL paths are fine — this is how web apps work. Just never paste a raw ID in prose text or link text.
 - **Never mention tool names in your messages to the user.** Tool names like `create_metric`, `generate_metric`, `list_behaviors` are internal implementation details. Say "I'll create a metric" not "I'll use the generate_metric tool." The user doesn't need to know which tool you're calling.

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
@@ -40,6 +40,7 @@
   - `id` is always returned even if not listed in `$select`
 - **For accurate counts**, use `get_test_run` (which returns total_tests, pass counts, etc.) rather than counting items from a `list_test_results` call — list responses may be truncated
 - **For run comparison**, use `get_test_result_stats` with `mode=test_runs` and `test_run_ids` — this returns pre-computed per-run pass rates in a single call, much more efficient than fetching and comparing full result lists
+- **For human feedback**, use `list_annotations` with `test_run_id` when analysing a run or explaining failures — it returns the reviews people left on that run's test results and traces in one call. Add `resolved=false` for open items only. A human's Pass/Fail verdict is ground truth: when it contradicts a metric score, say so and go with the human. Check this before concluding a run looks fine — someone may have failed a test the metrics passed
 - **Use `$filter`** to narrow results. Use `tolower()` for case-insensitive matching. Combine multiple lookups with OR: `$filter=tolower(name) eq 'x' or tolower(name) eq 'y'`
 - **Navigation properties**: To filter by a related entity's field, use slash notation: `related/field`. For example, to filter test results by status name: `$filter=status/name eq 'Failed'`. Do NOT filter by `status_id` with a string value — `status_id` is a UUID. Common navigation filters:
   - Test results by status: `$filter=test_run_id eq '<id>' and status/name eq 'Failed'`

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
@@ -13,7 +13,10 @@
   - Endpoints: `[File Chatbot](/endpoints/abc123)`
   - Projects: `[My Project](/projects/abc123)`
   - Test runs: `[Basic Travel Agent Functionality](/test-runs/abc123)` — use the test set name, never a UUID or generic label like "Run abc123"
-  Behaviors, metrics and test results do NOT have detail pages — refer to them by name only, without links. For test results, link to the test run instead.
+  - Behaviors: `[Provides Accurate Information](/behaviors/abc123)`
+  - Metrics: `[Escalation Accuracy](/metrics/abc123)`
+  - Traces: `[ai.llm.invoke](/traces/abc123)` — use the span name as link text
+  Test results do NOT have a detail page — refer to them by name only, without a link, and link to the test run instead.
   Link text must always be a human-readable name. IDs inside URL paths are fine — this is how web apps work. Just never paste a raw ID in prose text or link text.
 - **Never mention tool names in your messages to the user.** Tool names like `create_metric`, `generate_metric`, `list_behaviors` are internal implementation details. Say "I'll create a metric" not "I'll use the generate_metric tool." The user doesn't need to know which tool you're calling.
 

--- a/sdk/src/rhesis/sdk/metrics/assets/generate_metric.jinja
+++ b/sdk/src/rhesis/sdk/metrics/assets/generate_metric.jinja
@@ -1,6 +1,28 @@
 You are a metric designer for AI evaluation.
 Given a user description, produce a complete metric definition.
 
+## Completeness
+
+Every field is part of the metric. A metric that only scores is not
+finished — someone has to maintain it, and a judge LLM has to apply it
+consistently. Fill all of these, never leave one thin or generic:
+
+- **description**: one or two sentences on what the metric measures and
+  why it matters, for a human scanning a list of metrics. Do not restate
+  the name.
+- **evaluation_steps**: numbered steps the judge follows to reach a
+  score. Be concrete and ordered — this is what makes scoring
+  repeatable. Example: "1. Identify each factual claim in the response.
+  2. Check each claim against the provided context. 3. Count the
+  unsupported claims. 4. Map that count onto the score scale."
+- **reasoning**: how the judge should justify its verdict — which
+  evidence to quote and how to tie it to the score it assigns.
+- **explanation**: what a passing versus failing result means for the
+  system under test, so whoever reads a result knows what to do next.
+
+Derive all four from the user's request. Do not pad them with filler —
+make each one specific to this metric.
+
 ## Naming Convention
 
 The metric name MUST be Title Case with spaces between words.

--- a/sdk/src/rhesis/sdk/metrics/assets/improve_metric.jinja
+++ b/sdk/src/rhesis/sdk/metrics/assets/improve_metric.jinja
@@ -7,6 +7,11 @@ Apply the requested changes and return the complete updated metric.
 1. Return ALL fields, not just the ones that changed.
 2. Preserve any field the edit request does not mention.
 3. Follow the same naming, score type, and scope rules below.
+4. `description`, `evaluation_steps`, `reasoning` and `explanation` are
+   required in the result. If the existing metric shows one as empty or
+   "None", write it now from the metric's own criteria — do not carry the
+   blank forward. If the existing value is already good and the edit
+   request does not touch it, return it unchanged.
 
 ## Naming Convention
 
@@ -51,6 +56,8 @@ clearly applies to only one.
 - **description**: {{ existing_metric.description }}
 - **evaluation_prompt**: {{ existing_metric.evaluation_prompt }}
 - **evaluation_steps**: {{ existing_metric.evaluation_steps }}
+- **reasoning**: {{ existing_metric.reasoning }}
+- **explanation**: {{ existing_metric.explanation }}
 - **score_type**: {{ existing_metric.score_type }}
 - **min_score**: {{ existing_metric.min_score }}
 - **max_score**: {{ existing_metric.max_score }}

--- a/sdk/src/rhesis/sdk/metrics/synthesizer.py
+++ b/sdk/src/rhesis/sdk/metrics/synthesizer.py
@@ -35,9 +35,28 @@ class GeneratedMetric(BaseModel):
             "progression, coherence across turns)."
         )
     )
-    evaluation_steps: Optional[str] = Field(
-        default=None,
-        description="Step-by-step evaluation instructions",
+    evaluation_steps: str = Field(
+        description=(
+            "Numbered step-by-step instructions the judge LLM follows to "
+            'reach a score (e.g. "1. Identify each factual claim. '
+            "2. Check it against the provided context. 3. Count "
+            'unsupported claims. 4. Map the count to the scale."). '
+            "Concrete steps make scoring far more repeatable than "
+            "criteria prose alone."
+        )
+    )
+    reasoning: str = Field(
+        description=(
+            "Instructions for how the judge should explain its verdict — "
+            "what evidence to cite and how to justify the score it gives."
+        )
+    )
+    explanation: str = Field(
+        description=(
+            "What a passing versus failing result means for the system "
+            "under test, so whoever reads a result knows what to do "
+            "about it."
+        )
     )
     score_type: str = Field(description='Must be exactly "numeric" or "categorical"')
     min_score: Optional[float] = Field(

--- a/tests/backend/routes/test_annotations.py
+++ b/tests/backend/routes/test_annotations.py
@@ -486,6 +486,57 @@ class TestAnnotationScoping:
         assert by_id[result_review["review_id"]]["test_result_id"] == str(test_result.id)
         assert by_id[trace_review["review_id"]]["trace_id"] == trace.trace_id
 
+        # A trace annotation carries the run/result it belongs to, so the
+        # agent can walk back to the run it was filtered by.
+        trace_item = by_id[trace_review["review_id"]]
+        assert trace_item["test_run_id"] == str(test_run.id)
+        assert trace_item["test_result_id"] == str(test_result.id)
+
+    def test_operation_trace_annotation_has_null_run_and_result(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_organization,
+        test_type_lookup,
+        db_user,
+        authenticated_user,
+        db_project,
+    ):
+        """A trace outside a test run has no run/result ids to report."""
+        pass_status, _ = _ensure_pass_fail_statuses(
+            test_db, test_organization, test_type_lookup, db_user
+        )
+        review = _review_payload(pass_status.id, authenticated_user.id, target_type="trace")
+        now = datetime.now(timezone.utc)
+        with _project_scope(test_db, test_organization.id, authenticated_user.id, db_project.id):
+            trace = Trace(
+                trace_id=uuid.uuid4().hex,
+                span_id=uuid.uuid4().hex[:16],
+                project_id=db_project.id,
+                organization_id=test_organization.id,
+                environment="development",
+                span_name="ai.llm.invoke",
+                span_kind="CLIENT",
+                start_time=now,
+                end_time=now + timedelta(seconds=1),
+                duration_ms=1000.0,
+                status_code="OK",
+                attributes={},
+                events=[],
+                links=[],
+                resource={},
+                trace_reviews={"metadata": {"total_reviews": 1}, "reviews": [review]},
+            )
+            test_db.add(trace)
+            test_db.commit()
+
+            response = authenticated_client.get(f"/annotations/?trace_id={trace.trace_id}")
+
+        assert response.status_code == status.HTTP_200_OK
+        item = next(i for i in response.json() if i["review_id"] == review["review_id"])
+        assert item["test_run_id"] is None
+        assert item["test_result_id"] is None
+
     def test_scope_by_test_result_id_includes_linked_traces(
         self,
         authenticated_client: TestClient,

--- a/tests/backend/routes/test_annotations.py
+++ b/tests/backend/routes/test_annotations.py
@@ -2,18 +2,22 @@
 
 import uuid
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
+from sqlalchemy.orm.attributes import flag_modified
 
 from rhesis.backend.app.auth.capabilities import Permission
 from rhesis.backend.app.models.behavior import Behavior
 from rhesis.backend.app.models.status import Status
 from rhesis.backend.app.models.test import Test
+from rhesis.backend.app.models.test_configuration import TestConfiguration
 from rhesis.backend.app.models.test_result import TestResult
+from rhesis.backend.app.models.test_run import TestRun
+from rhesis.backend.app.models.trace import Trace
 from rhesis.backend.app.scope import RequestScope
 from tests.backend.routes.fixtures.data_factories import TraceDataFactory
 
@@ -114,6 +118,84 @@ def _review_payload(status_id, user_id, user_name="Test User", target_type="test
     }
 
 
+def _seed_annotated_run(
+    test_db,
+    *,
+    organization_id,
+    user_id,
+    project_id,
+    endpoint_id,
+    status_id,
+    marker,
+):
+    """Seed one test run with an annotated result and an annotated trace.
+
+    The trace is linked to both the run and the result via ``test_run_id`` /
+    ``test_result_id``, which is how real execution traces are stored — that
+    linkage is what lets ``?test_run_id=`` span both sources.
+
+    Returns ``(test_run, test_result, trace, result_review, trace_review)``.
+    """
+    test_config = TestConfiguration(
+        endpoint_id=endpoint_id,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    test_db.add(test_config)
+    test_db.flush()
+
+    test_run = TestRun(
+        test_configuration_id=test_config.id,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    test_db.add(test_run)
+    test_db.flush()
+
+    result_review = _review_payload(status_id, user_id)
+    result_review["comments"] = f"{marker}-result"
+    test_result = TestResult(
+        organization_id=organization_id,
+        user_id=user_id,
+        project_id=project_id,
+        test_configuration_id=test_config.id,
+        test_run_id=test_run.id,
+        test_reviews={"metadata": {"total_reviews": 1}, "reviews": [result_review]},
+    )
+    test_db.add(test_result)
+    test_db.flush()
+
+    now = datetime.now(timezone.utc)
+    trace_review = _review_payload(status_id, user_id, target_type="trace")
+    trace_review["comments"] = f"{marker}-trace"
+    trace = Trace(
+        trace_id=uuid.uuid4().hex,
+        span_id=uuid.uuid4().hex[:16],
+        project_id=project_id,
+        organization_id=organization_id,
+        environment="development",
+        span_name="ai.llm.invoke",
+        span_kind="CLIENT",
+        start_time=now,
+        end_time=now + timedelta(seconds=1),
+        duration_ms=1000.0,
+        status_code="OK",
+        attributes={},
+        events=[],
+        links=[],
+        resource={},
+        test_run_id=test_run.id,
+        test_result_id=test_result.id,
+        trace_reviews={"metadata": {"total_reviews": 1}, "reviews": [trace_review]},
+    )
+    test_db.add(trace)
+    test_db.commit()
+    test_db.refresh(test_run)
+    test_db.refresh(test_result)
+    test_db.refresh(trace)
+    return test_run, test_result, trace, result_review, trace_review
+
+
 @pytest.mark.integration
 class TestListAnnotations:
     def test_list_empty(
@@ -124,9 +206,7 @@ class TestListAnnotations:
         authenticated_user,
         db_project,
     ):
-        with _project_scope(
-            test_db, test_organization.id, authenticated_user.id, db_project.id
-        ):
+        with _project_scope(test_db, test_organization.id, authenticated_user.id, db_project.id):
             response = authenticated_client.get("/annotations/")
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == []
@@ -158,9 +238,7 @@ class TestListAnnotations:
 
         # Seed a test result with a review linked to a behavior via test
         review = _review_payload(pass_status.id, authenticated_user.id)
-        with _project_scope(
-            test_db, test_organization.id, authenticated_user.id, db_project.id
-        ):
+        with _project_scope(test_db, test_organization.id, authenticated_user.id, db_project.id):
             behavior = Behavior(
                 name="Annotation Hub Behavior",
                 organization_id=test_organization.id,
@@ -205,10 +283,6 @@ class TestListAnnotations:
             assert detail.status_code == status.HTTP_200_OK
             root = detail.json()["root_spans"][0]
             trace_db_id = root["id"]
-
-            from sqlalchemy.orm.attributes import flag_modified
-
-            from rhesis.backend.app.models.trace import Trace
 
             trace = test_db.query(Trace).filter(Trace.id == uuid.UUID(trace_db_id)).first()
             assert trace is not None
@@ -271,9 +345,7 @@ class TestListAnnotations:
         review["resolved_at"] = review["updated_at"]
         legacy_open = _review_payload(pass_status.id, authenticated_user.id)
         legacy_open["resolved"] = "false"
-        with _project_scope(
-            test_db, test_organization.id, authenticated_user.id, db_project.id
-        ):
+        with _project_scope(test_db, test_organization.id, authenticated_user.id, db_project.id):
             test_result = TestResult(
                 organization_id=test_organization.id,
                 user_id=authenticated_user.id,
@@ -315,9 +387,7 @@ class TestListAnnotations:
             "name": "Fail",
         }
 
-        with _project_scope(
-            test_db, test_organization.id, authenticated_user.id, db_project.id
-        ):
+        with _project_scope(test_db, test_organization.id, authenticated_user.id, db_project.id):
             test_result = TestResult(
                 organization_id=test_organization.id,
                 user_id=authenticated_user.id,
@@ -330,9 +400,7 @@ class TestListAnnotations:
             test_db.add(test_result)
             test_db.commit()
 
-            search = authenticated_client.get(
-                "/annotations/?search=unique-open-annotation-marker"
-            )
+            search = authenticated_client.get("/annotations/?search=unique-open-annotation-marker")
             assert search.status_code == status.HTTP_200_OK
             search_ids = {i["review_id"] for i in search.json()}
             assert open_review["review_id"] in search_ids
@@ -352,6 +420,174 @@ class TestListAnnotations:
 
 
 @pytest.mark.integration
+class TestAnnotationScoping:
+    """Scoping annotations to a test run, test result, or trace."""
+
+    @pytest.fixture
+    def two_runs(
+        self,
+        test_db,
+        test_organization,
+        test_type_lookup,
+        db_user,
+        authenticated_user,
+        db_project,
+        db_endpoint,
+    ):
+        """Two independent annotated runs, so filters can be shown to exclude."""
+        pass_status, _ = _ensure_pass_fail_statuses(
+            test_db, test_organization, test_type_lookup, db_user
+        )
+        with _project_scope(test_db, test_organization.id, authenticated_user.id, db_project.id):
+            target = _seed_annotated_run(
+                test_db,
+                organization_id=test_organization.id,
+                user_id=authenticated_user.id,
+                project_id=db_project.id,
+                endpoint_id=db_endpoint.id,
+                status_id=pass_status.id,
+                marker="scoped-run",
+            )
+            other = _seed_annotated_run(
+                test_db,
+                organization_id=test_organization.id,
+                user_id=authenticated_user.id,
+                project_id=db_project.id,
+                endpoint_id=db_endpoint.id,
+                status_id=pass_status.id,
+                marker="other-run",
+            )
+            yield target, other
+
+    def test_scope_by_test_run_id_spans_results_and_traces(
+        self,
+        authenticated_client: TestClient,
+        two_runs,
+    ):
+        target, other = two_runs
+        test_run, test_result, trace, result_review, trace_review = target
+        _, _, _, other_result_review, other_trace_review = other
+
+        response = authenticated_client.get(f"/annotations/?test_run_id={test_run.id}")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        ids = {i["review_id"] for i in data}
+        assert result_review["review_id"] in ids
+        assert trace_review["review_id"] in ids
+        assert other_result_review["review_id"] not in ids
+        assert other_trace_review["review_id"] not in ids
+
+        # Both sources come back from a single run-scoped call.
+        assert {i["source"] for i in data} == {"test_result", "trace"}
+        assert response.headers.get("X-Total-Count") == "2"
+
+        by_id = {i["review_id"]: i for i in data}
+        assert by_id[result_review["review_id"]]["test_result_id"] == str(test_result.id)
+        assert by_id[trace_review["review_id"]]["trace_id"] == trace.trace_id
+
+    def test_scope_by_test_result_id_includes_linked_traces(
+        self,
+        authenticated_client: TestClient,
+        two_runs,
+    ):
+        target, other = two_runs
+        _, test_result, _, result_review, trace_review = target
+        _, _, _, other_result_review, _ = other
+
+        response = authenticated_client.get(f"/annotations/?test_result_id={test_result.id}")
+        assert response.status_code == status.HTTP_200_OK
+        ids = {i["review_id"] for i in response.json()}
+        assert ids == {result_review["review_id"], trace_review["review_id"]}
+        assert other_result_review["review_id"] not in ids
+
+    def test_scope_by_trace_id_returns_traces_only(
+        self,
+        authenticated_client: TestClient,
+        two_runs,
+    ):
+        target, _ = two_runs
+        _, _, trace, result_review, trace_review = target
+
+        response = authenticated_client.get(f"/annotations/?trace_id={trace.trace_id}")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert [i["review_id"] for i in data] == [trace_review["review_id"]]
+        assert all(i["source"] == "trace" for i in data)
+        # The sibling test-result review is on the same run but is not a trace.
+        assert result_review["review_id"] not in {i["review_id"] for i in data}
+
+    def test_scope_by_trace_db_id_returns_traces_only(
+        self,
+        authenticated_client: TestClient,
+        two_runs,
+    ):
+        target, _ = two_runs
+        _, _, trace, _, trace_review = target
+
+        response = authenticated_client.get(f"/annotations/?trace_db_id={trace.id}")
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert [i["review_id"] for i in data] == [trace_review["review_id"]]
+        assert data[0]["trace_db_id"] == str(trace.id)
+
+    def test_scope_composes_with_source_filter(
+        self,
+        authenticated_client: TestClient,
+        two_runs,
+    ):
+        target, _ = two_runs
+        test_run, _, _, result_review, trace_review = target
+
+        response = authenticated_client.get(
+            f"/annotations/?test_run_id={test_run.id}&source=test_result"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        ids = {i["review_id"] for i in response.json()}
+        assert ids == {result_review["review_id"]}
+        assert trace_review["review_id"] not in ids
+
+    def test_scope_composes_with_resolved_filter(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        two_runs,
+    ):
+        target, _ = two_runs
+        test_run, _, trace, result_review, trace_review = target
+
+        trace.trace_reviews["reviews"][0]["resolved"] = True
+        flag_modified(trace, "trace_reviews")
+        test_db.commit()
+
+        open_items = authenticated_client.get(
+            f"/annotations/?test_run_id={test_run.id}&resolved=false"
+        )
+        assert open_items.status_code == status.HTTP_200_OK
+        assert {i["review_id"] for i in open_items.json()} == {result_review["review_id"]}
+
+        resolved_items = authenticated_client.get(
+            f"/annotations/?test_run_id={test_run.id}&resolved=true"
+        )
+        assert resolved_items.status_code == status.HTTP_200_OK
+        assert {i["review_id"] for i in resolved_items.json()} == {trace_review["review_id"]}
+
+    def test_contradictory_trace_and_source_filters_return_empty(
+        self,
+        authenticated_client: TestClient,
+        two_runs,
+    ):
+        target, _ = two_runs
+        _, _, trace, _, _ = target
+
+        response = authenticated_client.get(
+            f"/annotations/?trace_id={trace.trace_id}&source=test_result"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+
+@pytest.mark.integration
 class TestAnnotationsDualGateAuth:
     """Negative tests for the in-handler dual-gate on GET /annotations."""
 
@@ -363,9 +599,7 @@ class TestAnnotationsDualGateAuth:
         authenticated_user,
         db_project,
     ):
-        with _project_scope(
-            test_db, test_organization.id, authenticated_user.id, db_project.id
-        ):
+        with _project_scope(test_db, test_organization.id, authenticated_user.id, db_project.id):
             with patch(
                 "rhesis.backend.app.routers.annotations.authorize",
                 return_value=False,
@@ -388,9 +622,7 @@ class TestAnnotationsDualGateAuth:
         def _authorize(_principal, permission, **_kwargs):
             return str(permission) == str(Permission.TestResult.READ)
 
-        with _project_scope(
-            test_db, test_organization.id, authenticated_user.id, db_project.id
-        ):
+        with _project_scope(test_db, test_organization.id, authenticated_user.id, db_project.id):
             with patch(
                 "rhesis.backend.app.routers.annotations.authorize",
                 side_effect=_authorize,
@@ -398,6 +630,75 @@ class TestAnnotationsDualGateAuth:
                 response = authenticated_client.get("/annotations/?source=trace")
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert response.headers.get("X-Accepted-Permissions") == str(
-            Permission.Telemetry.READ
+        assert response.headers.get("X-Accepted-Permissions") == str(Permission.Telemetry.READ)
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "trace_id=0123456789abcdef0123456789abcdef",
+            "trace_db_id=11111111-1111-1111-1111-111111111111",
+        ],
+    )
+    def test_forbidden_trace_scoped_filter_without_telemetry_read(
+        self,
+        query,
+        authenticated_client: TestClient,
+        test_db,
+        test_organization,
+        authenticated_user,
+        db_project,
+    ):
+        """Trace-only filters must 403, not silently return an empty list."""
+
+        def _authorize(_principal, permission, **_kwargs):
+            return str(permission) == str(Permission.TestResult.READ)
+
+        with _project_scope(test_db, test_organization.id, authenticated_user.id, db_project.id):
+            with patch(
+                "rhesis.backend.app.routers.annotations.authorize",
+                side_effect=_authorize,
+            ):
+                response = authenticated_client.get(f"/annotations/?{query}")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.headers.get("X-Accepted-Permissions") == str(Permission.Telemetry.READ)
+
+    def test_run_scoped_filter_with_only_telemetry_read_returns_trace_side(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_organization,
+        test_type_lookup,
+        db_user,
+        authenticated_user,
+        db_project,
+        db_endpoint,
+    ):
+        """test_run_id spans both sources, so it degrades rather than 403s."""
+        pass_status, _ = _ensure_pass_fail_statuses(
+            test_db, test_organization, test_type_lookup, db_user
         )
+
+        def _authorize(_principal, permission, **_kwargs):
+            return str(permission) == str(Permission.Telemetry.READ)
+
+        with _project_scope(test_db, test_organization.id, authenticated_user.id, db_project.id):
+            test_run, _, _, result_review, trace_review = _seed_annotated_run(
+                test_db,
+                organization_id=test_organization.id,
+                user_id=authenticated_user.id,
+                project_id=db_project.id,
+                endpoint_id=db_endpoint.id,
+                status_id=pass_status.id,
+                marker="telemetry-only",
+            )
+            with patch(
+                "rhesis.backend.app.routers.annotations.authorize",
+                side_effect=_authorize,
+            ):
+                response = authenticated_client.get(f"/annotations/?test_run_id={test_run.id}")
+
+        assert response.status_code == status.HTTP_200_OK
+        ids = {i["review_id"] for i in response.json()}
+        assert ids == {trace_review["review_id"]}
+        assert result_review["review_id"] not in ids

--- a/tests/backend/services/test_mcp_tools_yaml.py
+++ b/tests/backend/services/test_mcp_tools_yaml.py
@@ -77,22 +77,24 @@ class TestInputSchemaPropertyNames:
 
 @pytest.mark.unit
 class TestNewMcpToolsPresent:
-    NEW_TOOLS = frozenset({
-        "get_test_set",
-        "list_test_set_tests",
-        "get_endpoint",
-        "get_metric",
-        "create_source",
-        "update_metric",
-        "remove_behavior_from_metric",
-        "update_test_set",
-        "get_test",
-        "update_test",
-        "get_behavior",
-        "get_test_set_last_run",
-        "get_test_set_metrics",
-        "get_project",
-    })
+    NEW_TOOLS = frozenset(
+        {
+            "get_test_set",
+            "list_test_set_tests",
+            "get_endpoint",
+            "get_metric",
+            "create_source",
+            "update_metric",
+            "remove_behavior_from_metric",
+            "update_test_set",
+            "get_test",
+            "update_test",
+            "get_behavior",
+            "get_test_set_last_run",
+            "get_test_set_metrics",
+            "get_project",
+        }
+    )
 
     def test_new_tools_in_yaml(self):
         names = {tc["name"] for tc in load_tool_configs()}
@@ -123,6 +125,78 @@ class TestTagMcpToolsPresent:
     def test_assign_tag_requires_confirmation(self):
         by_name = {tc["name"]: tc for tc in load_tool_configs()}
         assert by_name["assign_tag"].get("requires_confirmation") is True
+
+
+@pytest.mark.unit
+class TestListAnnotationsTool:
+    """The annotations tool is how the architect sees human review feedback."""
+
+    def _cfg(self):
+        return {tc["name"]: tc for tc in load_tool_configs()}["list_annotations"]
+
+    def test_list_annotations_in_yaml(self):
+        names = {tc["name"] for tc in load_tool_configs()}
+        assert "list_annotations" in names
+
+    def test_list_annotations_is_read_only_get(self):
+        cfg = self._cfg()
+        assert cfg["method"].upper() == "GET"
+        # GET gets readOnlyHint automatically, so it must not be confirmation-gated.
+        assert "requires_confirmation" not in cfg
+
+    def test_list_annotations_path_has_trailing_slash(self):
+        # Must match the OpenAPI path key exactly or the tool is silently skipped.
+        assert self._cfg()["path"] == "/annotations/"
+
+    def test_list_annotations_declares_page_size(self):
+        page_size = self._cfg().get("page_size")
+        assert page_size is not None
+        # peek-ahead sends limit=page_size+1, which must stay within the
+        # endpoint's le=100 cap.
+        assert page_size + 1 <= 100
+
+    def test_list_annotations_description_documents_scoping(self):
+        description = self._cfg()["description"]
+        for token in ("test_run_id", "test_result_id", "trace_id", "trace_db_id"):
+            assert token in description, f"description should explain {token}"
+
+    def test_list_annotations_input_schema_exposes_filters(self):
+        """Build the schema from the real app so a path/param drift fails here."""
+        from rhesis.backend.app.main import app
+        from rhesis.backend.app.mcp_server.tools import build_tools_and_operations
+
+        tools, operations = build_tools_and_operations(app)
+        by_name = {t.name: t for t in tools}
+        assert "list_annotations" in by_name, (
+            "tool absent — path likely does not match any OpenAPI route"
+        )
+
+        props = by_name["list_annotations"].inputSchema["properties"]
+        for param in (
+            "test_run_id",
+            "test_result_id",
+            "trace_id",
+            "trace_db_id",
+            "resolved",
+            "rating",
+            "source",
+            "target_type",
+            "skip",
+        ):
+            assert param in props, f"{param} missing from tool schema"
+
+        # page_size means the server owns pagination.
+        assert "limit" not in props
+        assert operations["list_annotations"]["method"] == "GET"
+
+    def test_list_annotations_is_readonly_hinted(self):
+        from rhesis.backend.app.main import app
+        from rhesis.backend.app.mcp_server.tools import build_tools_and_operations
+
+        tools, _ = build_tools_and_operations(app)
+        tool = {t.name: t for t in tools}["list_annotations"]
+        assert tool.annotations.readOnlyHint is True
+        assert tool.annotations.destructiveHint is False
 
 
 @pytest.mark.unit

--- a/tests/backend/services/test_mcp_tools_yaml.py
+++ b/tests/backend/services/test_mcp_tools_yaml.py
@@ -200,6 +200,50 @@ class TestListAnnotationsTool:
 
 
 @pytest.mark.unit
+class TestCreateMetricDocumentsDescriptiveFields:
+    """A metric the architect creates must be rich, not just scoreable.
+
+    These fields exist on MetricCreate but carry no Pydantic descriptions,
+    so the YAML overrides are the only thing telling the agent to fill
+    them. Without them the agent sends name + evaluation_prompt only.
+    """
+
+    RICH_FIELDS = ("description", "evaluation_steps", "reasoning", "explanation")
+
+    def _cfg(self):
+        return {tc["name"]: tc for tc in load_tool_configs()}["create_metric"]
+
+    def test_descriptive_fields_are_documented(self):
+        params = self._cfg().get("parameters", {})
+        missing = [f for f in self.RICH_FIELDS if f not in params]
+        assert not missing, f"create_metric does not document: {missing}"
+
+    def test_descriptive_field_docs_are_substantive(self):
+        params = self._cfg()["parameters"]
+        for field in self.RICH_FIELDS:
+            text = (params[field] or {}).get("description", "")
+            assert len(text.strip()) > 40, f"{field} needs a real description, got: {text!r}"
+
+    def test_tool_description_demands_rich_metrics(self):
+        description = self._cfg()["description"]
+        for field in self.RICH_FIELDS:
+            assert field in description, f"description should name {field}"
+
+    def test_descriptive_fields_reach_the_tool_schema(self):
+        from rhesis.backend.app.main import app
+        from rhesis.backend.app.mcp_server.tools import build_tools_and_operations
+
+        tools, _ = build_tools_and_operations(app)
+        props = {t.name: t for t in tools}["create_metric"].inputSchema["properties"]
+        for field in self.RICH_FIELDS:
+            assert field in props, f"{field} absent from create_metric schema"
+            assert props[field].get("description"), (
+                f"{field} reached the schema with no description — the agent "
+                "has no reason to fill it"
+            )
+
+
+@pytest.mark.unit
 class TestMcpToolsYamlStructure:
     """Every tool entry must declare name, method, and path."""
 

--- a/tests/sdk/agents/test_architect_prompt_loader.py
+++ b/tests/sdk/agents/test_architect_prompt_loader.py
@@ -183,3 +183,54 @@ class TestBundledSkillReferences:
         assert any(n.endswith("prompt_templates/skill_refs/entity-model.md") for n in names), (
             f"skill refs missing from wheel: {[n for n in names if 'skill_refs' in n][:5]}"
         )
+
+
+_FRONTEND_ROUTES = _REPO_ROOT / "apps" / "frontend" / "src" / "app" / "(protected)"
+
+
+def _has_detail_page(segment: str) -> bool:
+    """True when the frontend has a dynamic detail route for this segment."""
+    return (_FRONTEND_ROUTES / segment / "[identifier]").is_dir()
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(
+    not _FRONTEND_ROUTES.is_dir(),
+    reason="frontend tree not present (SDK checked out standalone)",
+)
+class TestEntityLinkGuidanceMatchesFrontend:
+    """Keep link guidance honest about which entities have detail pages.
+
+    Both templates previously told the agent that behaviors and metrics had
+    no detail pages. Both do, so the agent was suppressing links a user
+    could have followed — and the two files disagreed with each other.
+    """
+
+    TEMPLATES = ("telemachus-guidelines.j2", "streaming_response.j2")
+    # Entities the prompts tell the agent to link.
+    LINKED = ("test-sets", "tests", "endpoints", "projects", "test-runs", "behaviors", "metrics")
+
+    @pytest.mark.parametrize("segment", LINKED)
+    def test_linked_entities_really_have_detail_pages(self, segment):
+        assert _has_detail_page(segment), (
+            f"prompts link /{segment}/<id> but no [identifier] route exists"
+        )
+
+    def test_test_results_still_has_no_detail_page(self):
+        """The one negative claim the prompts make must stay true."""
+        assert not _has_detail_page("test-results")
+
+    @pytest.mark.parametrize("template", TEMPLATES)
+    def test_templates_do_not_deny_behavior_or_metric_pages(self, template):
+        text = (_TEMPLATES_DIR / template).read_text()
+        for stale in (
+            "Behaviors, metrics and test results do NOT have detail pages",
+            "Behaviors and test results do NOT have detail pages",
+        ):
+            assert stale not in text, f"{template} still carries stale claim: {stale!r}"
+
+    @pytest.mark.parametrize("template", TEMPLATES)
+    def test_templates_document_behavior_and_metric_links(self, template):
+        text = (_TEMPLATES_DIR / template).read_text()
+        assert "/behaviors/" in text, f"{template} never shows a behavior link"
+        assert "/metrics/" in text, f"{template} never shows a metric link"

--- a/tests/sdk/agents/test_architect_prompt_loader.py
+++ b/tests/sdk/agents/test_architect_prompt_loader.py
@@ -234,3 +234,20 @@ class TestEntityLinkGuidanceMatchesFrontend:
         text = (_TEMPLATES_DIR / template).read_text()
         assert "/behaviors/" in text, f"{template} never shows a behavior link"
         assert "/metrics/" in text, f"{template} never shows a metric link"
+
+    @pytest.mark.parametrize("template", TEMPLATES)
+    def test_trace_links_specify_the_resolvable_id(self, template):
+        """/traces/<id> resolves a span DB UUID, not the OTel trace_id.
+
+        The frontend route calls lookupSpan(identifier) against
+        GET /telemetry/spans/{span_db_id}/lookup, typed UUID. Since
+        list_annotations returns both ids, guidance that just says "id"
+        invites a broken link.
+        """
+        text = (_TEMPLATES_DIR / template).read_text()
+        if "/traces/" not in text:
+            pytest.skip(f"{template} does not document trace links")
+        assert "trace_db_id" in text, (
+            f"{template} documents trace links without naming trace_db_id — "
+            "the agent may use trace_id, which does not resolve"
+        )

--- a/tests/sdk/metrics/test_synthesizer.py
+++ b/tests/sdk/metrics/test_synthesizer.py
@@ -4,6 +4,7 @@ import os
 from unittest.mock import Mock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from rhesis.sdk.metrics.synthesizer import GeneratedMetric, MetricSynthesizer
 from rhesis.sdk.models.base import BaseLLM
@@ -78,6 +79,8 @@ _NUMERIC_RESPONSE = {
     "description": "Measures factual accuracy of the response.",
     "evaluation_prompt": "Evaluate {{response}} for factual accuracy.",
     "evaluation_steps": "1. Read the response.\n2. Assign a score.",
+    "reasoning": "Cite the specific claims that drove the score.",
+    "explanation": "A failing score means the endpoint states unsupported facts.",
     "score_type": "numeric",
     "min_score": 1.0,
     "max_score": 5.0,
@@ -92,7 +95,9 @@ _CATEGORICAL_RESPONSE = {
     "name": "Tone Appropriateness",
     "description": "Checks if the response tone is appropriate.",
     "evaluation_prompt": "Classify the tone of {{response}}.",
-    "evaluation_steps": None,
+    "evaluation_steps": "1. Read the response.\n2. Pick the closest category.",
+    "reasoning": "Quote the phrasing that determined the category.",
+    "explanation": "An inappropriate result means the tone breaches brand guidance.",
     "score_type": "categorical",
     "min_score": None,
     "max_score": None,
@@ -219,6 +224,56 @@ def test_generate_template_contains_single_turn_guidance():
     assert "Accuracy" in rendered
     assert "Relevance" in rendered
     assert "Safety" in rendered
+
+
+# ── Descriptive-field completeness ───────────────────────────────
+
+_RICH_FIELDS = ("description", "evaluation_steps", "reasoning", "explanation")
+
+
+def test_generated_metric_requires_descriptive_fields():
+    """These are required so a generated metric is never threadbare."""
+    for field in _RICH_FIELDS:
+        assert field in GeneratedMetric.model_fields, f"{field} missing from schema"
+        assert GeneratedMetric.model_fields[field].is_required(), (
+            f"{field} is optional — the LLM will skip it and the metric lands with an empty field"
+        )
+
+
+def test_generated_metric_descriptive_fields_guide_the_llm():
+    for field in _RICH_FIELDS:
+        text = GeneratedMetric.model_fields[field].description or ""
+        assert len(text.strip()) > 40, f"{field} needs a real description, got {text!r}"
+
+
+def test_omitting_a_descriptive_field_is_a_validation_error():
+    for field in _RICH_FIELDS:
+        payload = {k: v for k, v in _NUMERIC_RESPONSE.items() if k != field}
+        with pytest.raises(ValidationError):
+            GeneratedMetric(**payload)
+
+
+def test_generate_template_asks_for_descriptive_fields():
+    mock_model = Mock(spec=BaseLLM)
+    synth = MetricSynthesizer(model=mock_model)
+    rendered = synth.prompt_template.render(prompt="test")
+    for field in _RICH_FIELDS:
+        assert field in rendered, f"generation template never mentions {field}"
+
+
+def test_improve_template_shows_all_descriptive_fields():
+    """Rule 2 says preserve unmentioned fields — impossible if unshown."""
+    mock_model = Mock(spec=BaseLLM)
+    synth = MetricSynthesizer(model=mock_model)
+    rendered = synth.improve_template.render(
+        existing_metric=_NUMERIC_RESPONSE,
+        prompt="make the threshold stricter",
+    )
+    for field in _RICH_FIELDS:
+        assert f"**{field}**" in rendered, f"improve template hides {field}"
+    # The actual current values must be visible, not just the labels.
+    assert _NUMERIC_RESPONSE["reasoning"] in rendered
+    assert _NUMERIC_RESPONSE["explanation"] in rendered
 
 
 # ── Improve template ─────────────────────────────────────────────


### PR DESCRIPTION
## Purpose

Two gaps in what the architect agent can see and produce.

**It could not see human review feedback.** Everything the architect can do comes from one whitelist, `mcp_server/mcp_tools.yaml` — a route absent from that file is unreachable. `GET /annotations/` was absent, and there is no trace or telemetry tool at all, so trace reviews were entirely out of reach. Reviews on test results leaked through incidentally (`test_reviews` sits on `TestResultBase`, so `get_test_result` returns it) but nothing told the agent it was there and there was no way to filter for annotated results.

**Metrics it created arrived nearly empty.** Description, evaluation steps, reasoning instructions and result explanation were all blank on generated metrics — the fields exist and the API accepts them, but nothing asked for them.

## What Changed

### Annotations become readable

- `list_annotations` filters added: `test_run_id`, `test_result_id`, `trace_id`, `trace_db_id`. Pushed into the per-source branch `WHERE` clauses so they prune before the `UNION ALL` and hit existing indexes.
- `test_run_id` and `test_result_id` deliberately narrow **both** branches. `trace` carries its own `test_run_id`/`test_result_id`, so one run-scoped call returns reviews on that run's test results *and* on the traces the run produced — which is what makes this useful for failure analysis.
- `trace_id`/`trace_db_id` are trace-only, so they disable the test-result branch, reusing the narrowing the existing `source` handling already does. Following its documented rule: turn the other branch off, never force a branch on, because the flags may already encode a permission denial.
- Trace-only filters raise 403 without `telemetry:read` rather than returning a misleading empty list. `test_run_id` spans both sources so it degrades to the trace side instead of denying.
- Trace annotations now report their real `test_run_id`/`test_result_id` instead of `NULL`. The branch filtered on those columns but projected null, so a run-scoped call returned trace reviews that could not say which run they came from. `TraceResponse` already exposes both ids to the same `telemetry:read` holders, so this discloses nothing new; they stay null only for traces outside a test execution.
- Exposed as the read-only `list_annotations` MCP tool, plus a guideline telling the agent to check human feedback when analysing a run and to treat a human verdict as outranking a metric score.

The write side is deliberately **not** included — an agent closing out someone else's review is a separate decision.

### Metrics get created rich

- `create_metric` now documents `description`, `evaluation_steps`, `reasoning` and `explanation`. These were already in the tool's input schema via `MetricCreate`, but `MetricBase` carries no Pydantic field descriptions, so they reached the agent bare, with no reason to fill them. The YAML overrides are the only place that guidance can live.
- `GeneratedMetric` (behind `generate_metric`/`improve_metric`) had **no** `reasoning` or `explanation` field at all and never asked for `evaluation_steps`. All three are now required, so structured output cannot skip them, and both Jinja templates ask for them explicitly.
- The improve path had a field whitelist that never showed `reasoning`/`explanation` to the LLM. Left alone, requiring them in the schema would have blanked those fields on every improve, since the template tells the model to preserve what the edit request does not mention — it cannot preserve what it is not shown.

### Entity links stop lying about detail pages

Both prompt templates told the agent that behaviors and metrics have no detail pages, so it referred to them by name and suppressed links a user could have followed. Both have `[identifier]` routes. The two templates also disagreed with each other — `streaming_response.j2` listed metrics as linkable while `telemachus-guidelines.j2` did not. Both now carry behavior, metric and trace link patterns, and the negative claim is narrowed to test results, which genuinely have no detail page.

## Additional Context

- No migration. Every column and schema field already existed; this is about what the agent is told and what it can filter on.
- `list_annotations` inherits the endpoint's existing fail-closed behaviour: it needs an ambient project and 400s without one. Architect sessions satisfy that — `LocalToolProvider` sends `X-Project-Id` when it has a project, wired from the session in `services/architect/runner.py`.
- Making the three descriptive fields required on `GeneratedMetric` is a behaviour change for any direct `MetricSynthesizer` caller: an LLM response missing one is now a validation error rather than a silent `None`.
- `TestEntityLinkGuidanceMatchesFrontend` derives the linkable-entity set from `apps/frontend/src/app/(protected)/*/[identifier]`, so an SDK test now reads the frontend route tree. It skips when that tree is absent (SDK checked out standalone). This is deliberate — the drift it catches is exactly what caused the stale claim.
- One incidental reformat: `ruff format` rewrapped the `NEW_TOOLS` frozenset in `test_mcp_tools_yaml.py`, a block this PR does not otherwise touch.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/routes/test_annotations.py \
              ../../tests/backend/services/test_mcp_tools_yaml.py \
              ../../tests/backend/routes/test_metric.py
cd ../../sdk
uv run pytest ../tests/sdk/metrics/test_synthesizer.py \
              ../tests/sdk/agents/test_architect_prompt_loader.py
```

97 backend and 49 SDK tests pass. Docker must be running for the backend suite.

New coverage:

- Run-scoped annotations span both sources and exclude an unrelated run; result-scoped includes traces linked to it; each trace identifier returns traces only; contradictory filters return empty rather than erroring.
- Trace-only filter without `telemetry:read` → 403 (parametrised over both identifiers); run-scoped with only `telemetry:read` → trace side, no 403.
- `list_annotations` builds against the real OpenAPI, so a path or param drift fails the suite instead of silently dropping the tool — the failure mode the whitelist makes easy.
- The four descriptive fields reach the `create_metric` schema *with* descriptions; omitting any of them from `GeneratedMetric` is a validation error; the improve template renders all of them with their current values.

Worth a manual check: open the architect on a project with annotations and ask what people flagged on the last run, then have it create a metric and confirm the detail page has no blank fields.
