### PR TITLE
Preselect the only endpoint in the playground

### DIFF
--- a/apps/frontend/src/app/(protected)/playground/components/PlaygroundClient.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/PlaygroundClient.tsx
@@ -156,18 +156,19 @@ export default function PlaygroundClient() {
     [endpointOptions, selectedEndpointId]
   );
 
-  // Apply initial endpoint from URL params after endpoints are loaded
+  // Apply initial endpoint after endpoints are loaded: URL param if it matches,
+  // otherwise the only endpoint when there is exactly one to choose from.
   useEffect(() => {
     if (!initialEndpointApplied && endpointOptions.length > 0) {
       const endpointIdParam = searchParams.get('endpointId');
-      if (endpointIdParam) {
-        const matchingOption = endpointOptions.find(
-          opt => opt.endpointId === endpointIdParam
-        );
-        if (matchingOption) {
-          setSelectedEndpointId(endpointIdParam);
-          setSelectedProjectId(matchingOption.projectId);
-        }
+      const initialOption = endpointIdParam
+        ? endpointOptions.find(opt => opt.endpointId === endpointIdParam)
+        : endpointOptions.length === 1
+          ? endpointOptions[0]
+          : undefined;
+      if (initialOption) {
+        setSelectedEndpointId(initialOption.endpointId);
+        setSelectedProjectId(initialOption.projectId);
       }
       setInitialEndpointApplied(true);
     }

--- a/apps/frontend/src/app/(protected)/playground/components/__tests__/PlaygroundClient.test.tsx
+++ b/apps/frontend/src/app/(protected)/playground/components/__tests__/PlaygroundClient.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ThemeProvider } from '@mui/material/styles';
+import lightTheme from '@/styles/theme';
+import PlaygroundClient from '../PlaygroundClient';
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+jest.mock('next/navigation', () => ({
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock('@/hooks/useEndpoints', () => ({
+  useEndpointOptions: jest.fn(),
+}));
+
+jest.mock('../PlaygroundChat', () => ({
+  __esModule: true,
+  default: ({ endpointId }: { endpointId: string }) => (
+    <div data-testid="playground-chat">{endpointId}</div>
+  ),
+}));
+
+jest.mock('../PlaygroundEndpointDrawer', () => ({
+  __esModule: true,
+  default: () => <div data-testid="endpoint-drawer" />,
+}));
+
+import { useSearchParams } from 'next/navigation';
+import { useEndpointOptions, type EndpointOption } from '@/hooks/useEndpoints';
+
+function makeOption(id: string): EndpointOption {
+  return {
+    endpointId: id,
+    endpointName: `Endpoint ${id}`,
+    projectId: `project-${id}`,
+    projectName: `Project ${id}`,
+    environment: 'development',
+  };
+}
+
+function mockEndpoints(options: EndpointOption[]) {
+  (useEndpointOptions as jest.Mock).mockReturnValue({
+    options,
+    isLoading: false,
+    error: null,
+  });
+}
+
+function mockSearchParams(params: Record<string, string> = {}) {
+  (useSearchParams as jest.Mock).mockReturnValue(new URLSearchParams(params));
+}
+
+function renderClient() {
+  return render(
+    <ThemeProvider theme={lightTheme}>
+      <PlaygroundClient />
+    </ThemeProvider>
+  );
+}
+
+describe('PlaygroundClient endpoint defaulting', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('selects the only endpoint automatically', () => {
+    mockSearchParams();
+    mockEndpoints([makeOption('a')]);
+
+    renderClient();
+
+    expect(screen.getByTestId('playground-chat')).toHaveTextContent('a');
+  });
+
+  it('shows the placeholder when several endpoints are available', () => {
+    mockSearchParams();
+    mockEndpoints([makeOption('a'), makeOption('b')]);
+
+    renderClient();
+
+    expect(screen.queryByTestId('playground-chat')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Select an endpoint to start chatting')
+    ).toBeInTheDocument();
+  });
+
+  it('prefers the endpointId URL param over the single-endpoint default', () => {
+    mockSearchParams({ endpointId: 'b' });
+    mockEndpoints([makeOption('a'), makeOption('b')]);
+
+    renderClient();
+
+    expect(screen.getByTestId('playground-chat')).toHaveTextContent('b');
+  });
+
+  it('leaves nothing selected when the URL param does not match an endpoint', () => {
+    mockSearchParams({ endpointId: 'missing' });
+    mockEndpoints([makeOption('a')]);
+
+    renderClient();
+
+    expect(screen.queryByTestId('playground-chat')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Purpose

A user whose organization has only one endpoint still had to open the endpoint drawer, pick the single option, and confirm before they could type a message. That step carries no decision — there is nothing to choose between — so the playground now starts with that endpoint selected and the chat ready.

## What Changed

- `PlaygroundClient` selects the only endpoint automatically when the loaded list has exactly one entry, instead of rendering the "Select an endpoint to start chatting" placeholder.
- An `endpointId` URL param still takes precedence. With two or more endpoints, nothing is auto-selected — behavior is unchanged there.
- If an `endpointId` param names an endpoint that does not exist, nothing is selected. The param is an explicit request, so it does not fall through to the single-endpoint default.
- Added `PlaygroundClient.test.tsx` covering all four cases above.

## Additional Context

- "Reset playground" still clears the selection, so a single-endpoint user has to reopen the drawer after a reset. Restoring the default there needs a remount key (the chat clears today by unmounting), so it was left out of this PR.
- Unrelated, noticed while verifying: the frontend jest suite fails to run on Node 26 at `apps/frontend/jest.setup.js:109` — `delete window.location` throws `TypeError: Cannot delete property 'location' of #<Window>` because jsdom's `location` is non-configurable on that version. This reproduces on `main` for every suite, including the existing `PlaygroundChat.test.tsx`, and is worth a separate fix.

## Testing

- `npx jest playground/components/__tests__/PlaygroundClient` — 4 passed. Because of the Node 26 setup issue above, this was run locally against a patched copy of `jest.setup.js` (the repo file is untouched); CI on a supported Node version needs no workaround.
- `npx tsc --noEmit`, `npx eslint` on both files, and `npx prettier --check` all clean.
- Manual: as a user with a single endpoint, open the playground — the chat pane appears with the endpoint name in the header and the message box usable, no drawer step. With two or more endpoints, the placeholder still appears. Visiting `/playground?endpointId=<id>` still opens that endpoint.
