### PR TITLE
Centralize dev ports in scripts/rh/ports.sh

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -5,8 +5,8 @@
     "node": ">=20.9.0"
   },
   "scripts": {
-    "dev": "next dev --webpack -H 0.0.0.0 -p 3000",
-    "dev:turbo": "next dev --turbo -H 0.0.0.0 -p 3000",
+    "dev": "next dev --webpack -H 0.0.0.0 -p ${PORT:-3000}",
+    "dev:turbo": "next dev --turbo -H 0.0.0.0 -p ${PORT:-3000}",
     "build": "npm run clean && next build --webpack",
     "postinstall": "patch-package",
     "start": "next start -p ${PORT}",

--- a/apps/frontend/start.sh
+++ b/apps/frontend/start.sh
@@ -54,10 +54,19 @@ ensure_dependencies() {
     fi
 }
 
+# next reads .env.local itself, but the port is a flag, needed before it starts.
+load_port() {
+    if [ -z "${PORT:-}" ] && [ -f ".env.local" ]; then
+        PORT=$(grep -m1 '^PORT=' .env.local | cut -d= -f2)
+        export PORT
+    fi
+}
+
 # Function to start the development server
 start_server() {
     log "${BLUE}📋 Server Configuration:${NC}"
     log "  Host: 0.0.0.0 (from npm run dev:turbo)"
+    log "  Port: ${PORT:-3000}"
     log "  Environment: development"
     echo ""
 
@@ -100,6 +109,8 @@ main() {
 
     # Ensure dependencies are installed
     ensure_dependencies
+
+    load_port
 
     # Start the server
     start_server

--- a/apps/frontend/start.sh
+++ b/apps/frontend/start.sh
@@ -55,11 +55,16 @@ ensure_dependencies() {
 }
 
 # next reads .env.local itself, but the port is a flag, needed before it starts.
+# Quotes, padding and CRLF are stripped; an unparseable value is left to the
+# npm script's own default.
 load_port() {
-    if [ -z "${PORT:-}" ] && [ -f ".env.local" ]; then
-        PORT=$(grep -m1 '^PORT=' .env.local | cut -d= -f2)
-        export PORT
-    fi
+    [ -n "${PORT:-}" ] && return 0
+    [ -f ".env.local" ] || return 0
+
+    local value
+    value=$(grep -m1 '^[[:space:]]*PORT[[:space:]]*=' .env.local | cut -d= -f2- | tr -d "\"' \t\r")
+    [ -n "$value" ] && export PORT="$value"
+    return 0
 }
 
 # Function to start the development server

--- a/rh
+++ b/rh
@@ -6,8 +6,8 @@
 
 RH_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scripts/rh"
 
-# common.sh first: the others use SCRIPT_DIR at load time.
-for rh_lib in common dev quickstart services help; do
+# common.sh and ports.sh first: the others read SCRIPT_DIR and the ports at load time.
+for rh_lib in common ports dev quickstart services help; do
     # shellcheck source=/dev/null
     source "$RH_LIB_DIR/$rh_lib.sh" || {
         echo "❌ Failed to load scripts/rh/$rh_lib.sh" >&2

--- a/scripts/rh/dev.sh
+++ b/scripts/rh/dev.sh
@@ -5,9 +5,7 @@
 # Configuration
 # ============================================================================
 
-# Dev ports are deliberately distinct from prod (5432/6379) and test (10001/10002).
-DEV_POSTGRES_PORT=11000
-DEV_REDIS_PORT=11001
+# Ports live in ports.sh, which ./rh sources ahead of this file.
 
 DEV_POSTGRES_CONTAINER="rhesis-dev-postgres"
 DEV_REDIS_CONTAINER="rhesis-dev-redis"
@@ -77,6 +75,9 @@ $DEV_ENV_MARKER on $timestamp
 
 QUICK_START=true
 
+# Server (start.sh reads PORT from here)
+PORT=${DEV_BACKEND_PORT}
+
 # Database
 DB_HOST=localhost
 DB_NAME=rhesis-db
@@ -117,10 +118,14 @@ create_frontend_env() {
     cat > "$env_file" << EOF
 $DEV_ENV_MARKER on $timestamp
 
-API_BASE_URL=http://localhost:8080
+API_BASE_URL=http://localhost:${DEV_BACKEND_PORT}
 FRONTEND_ENV=local
-BACKEND_URL=http://localhost:8080
-FRONTEND_URL=http://localhost:3000
+BACKEND_URL=http://localhost:${DEV_BACKEND_PORT}
+
+# FRONTEND_URL is also NextAuth's base URL (src/auth.ts), so it tracks PORT.
+FRONTEND_URL=http://localhost:${DEV_FRONTEND_PORT}
+PORT=${DEV_FRONTEND_PORT}
+
 NEXTAUTH_SECRET=${nextauth_secret}
 NEXT_TELEMETRY_DISABLED=1
 EOF
@@ -471,7 +476,8 @@ dev_tmux() {
 seed_dev_resources() {
     local script="$SCRIPT_DIR/apps/developer-tools/seed_dev_resources.sh"
     if [ -f "$script" ]; then
-        bash "$script"
+        # The script has its own 8080 default; point it at our backend.
+        API_BASE_URL="${API_BASE_URL:-http://localhost:${DEV_BACKEND_PORT}}" bash "$script"
     else
         warn "Seed script not found: $script"
         return 1

--- a/scripts/rh/ports.sh
+++ b/scripts/rh/ports.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Every port ./rh dev uses. Quick start has its own, in .env.docker.
+#
+#   RHESIS_PORT_OFFSET=100 ./rh dev up   shifts the whole stack
+#   DEV_FLOWER_PORT=5556 ./rh dev worker shifts one port
+#
+# Ports reach the env files at ./rh dev init time — re-run it after a change.
+
+RHESIS_PORT_OFFSET="${RHESIS_PORT_OFFSET:-0}"
+
+# Distinct from prod (5432/6379) and test (10001/10002).
+DEV_POSTGRES_PORT="${DEV_POSTGRES_PORT:-$((11000 + RHESIS_PORT_OFFSET))}"
+DEV_REDIS_PORT="${DEV_REDIS_PORT:-$((11001 + RHESIS_PORT_OFFSET))}"
+
+DEV_BACKEND_PORT="${DEV_BACKEND_PORT:-$((8080 + RHESIS_PORT_OFFSET))}"
+DEV_FRONTEND_PORT="${DEV_FRONTEND_PORT:-$((3000 + RHESIS_PORT_OFFSET))}"
+DEV_FLOWER_PORT="${DEV_FLOWER_PORT:-$((5555 + RHESIS_PORT_OFFSET))}"
+DEV_CHATBOT_PORT="${DEV_CHATBOT_PORT:-$((8000 + RHESIS_PORT_OFFSET))}"
+DEV_POLYPHEMUS_PORT="${DEV_POLYPHEMUS_PORT:-$((8082 + RHESIS_PORT_OFFSET))}"
+
+# The worker binds nothing in dev — only Flower listens. The mock servers set
+# their own ports in apps/developer-tools/mock_*/main.py (18080, 18090).

--- a/scripts/rh/services.sh
+++ b/scripts/rh/services.sh
@@ -3,7 +3,8 @@
 
 CELERY_WORKER_CONCURRENCY="${CELERY_WORKER_CONCURRENCY:-4}"
 CELERY_WORKER_PREFETCH_MULTIPLIER="${CELERY_WORKER_PREFETCH_MULTIPLIER:-4}"
-FLOWER_PORT="${FLOWER_PORT:-5555}"
+
+# Ports come from ports.sh, which ./rh sources ahead of this file.
 
 # Mirrors apps/backend/Dockerfile build-backend. EE is included because deployed
 # images ship it by default and gate it at runtime on the license.
@@ -44,6 +45,8 @@ start_backend() {
 
 start_frontend() {
     echo -e "${GREEN}Starting Rhesis Frontend...${NC}"
+    # The npm script passes PORT to next dev as -p.
+    export PORT="$DEV_FRONTEND_PORT"
     run_start_script apps/frontend "Frontend"
 }
 
@@ -81,9 +84,9 @@ start_chatbot() {
     cd_or_die "$SCRIPT_DIR/apps/chatbot" "Chatbot"
 
     echo -e "${GREEN}Starting Chatbot service...${NC}"
-    announce_uvicorn 8000
+    announce_uvicorn "$DEV_CHATBOT_PORT"
 
-    exec uv run uvicorn client:app --host 0.0.0.0 --port 8000 --reload
+    exec uv run uvicorn client:app --host 0.0.0.0 --port "$DEV_CHATBOT_PORT" --reload
 }
 
 # ============================================================================
@@ -117,9 +120,9 @@ start_polyphemus() {
     pip_install_editable apps/polyphemus "Polyphemus"
 
     echo -e "${GREEN}Starting Polyphemus service...${NC}"
-    announce_uvicorn 8082
+    announce_uvicorn "$DEV_POLYPHEMUS_PORT"
 
-    exec uvicorn rhesis.polyphemus.main:app --host 0.0.0.0 --port 8082 --reload
+    exec uvicorn rhesis.polyphemus.main:app --host 0.0.0.0 --port "$DEV_POLYPHEMUS_PORT" --reload
 }
 
 # ============================================================================
@@ -201,10 +204,10 @@ start_worker() {
     trap 'cleanup_worker_stack; exit 143' TERM
 
     echo -e "${GREEN}Starting Flower (Celery monitor)...${NC}"
-    uv run celery -A rhesis.backend.worker.app flower --port="$FLOWER_PORT" &
+    uv run celery -A rhesis.backend.worker.app flower --port="$DEV_FLOWER_PORT" &
     FLOWER_PID=$!
-    echo -e "${BLUE}Flower dashboard: http://127.0.0.1:${FLOWER_PORT}/${NC}"
-    echo -e "${BLUE}Override the port with: ${WHITE}FLOWER_PORT=<port> ./rh dev worker${NC}"
+    echo -e "${BLUE}Flower dashboard: http://127.0.0.1:${DEV_FLOWER_PORT}/${NC}"
+    echo -e "${BLUE}Override the port with: ${WHITE}DEV_FLOWER_PORT=<port> ./rh dev worker${NC}"
     echo ""
 
     # UUID suffix so rapid restarts cannot collide: worker@server1-a1b2c3d4


### PR DESCRIPTION
## Purpose

Dev ports were scattered: postgres and redis were variables in `dev.sh`, while the backend (8080), frontend (3000), flower (5555), chatbot (8000) and polyphemus (8082) were literals repeated two or three times each. The backend dev port was not settable from the `rh` scripts at all — `PORT` was never written into the generated `.env`, so the backend bound `start.sh`'s own default while `dev.sh` separately hardcoded 8080 into the frontend env. Changing one meant knowing about the other.

This is the first step towards running several checkouts (worktrees) side by side: one place to shift the whole stack, so a second copy of the app can bind a free set of ports.

## What Changed

- New `scripts/rh/ports.sh` holds every port `./rh dev` uses. `./rh` sources it right after `common.sh`.
- `RHESIS_PORT_OFFSET` shifts all of them at once (`RHESIS_PORT_OFFSET=100 ./rh dev up`), and each port stays individually overridable (`DEV_FLOWER_PORT=5556 ./rh dev worker`).
- `dev.sh` no longer declares ports. The generated `apps/backend/.env` gets `PORT`, and `apps/frontend/.env.local` gets `PORT` plus `API_BASE_URL` / `BACKEND_URL` / `FRONTEND_URL` built from the variables.
- `./rh dev seed` now points the seed script at the configured backend instead of letting it fall back to its own `localhost:8080` default.
- `services.sh` reads the variables for flower, chatbot and polyphemus, and exports `PORT` for the frontend. `FLOWER_PORT` is renamed `DEV_FLOWER_PORT` (the on-screen hint was updated too).
- `apps/frontend/package.json` `dev` / `dev:turbo` take `-p ${PORT:-3000}`, matching what the existing `start` script already did, and `apps/frontend/start.sh` picks `PORT` up from `.env.local` when it is not exported, so `cd apps/frontend && ./start.sh` binds the same port as `./rh dev frontend`.
- No worker port: `./rh dev worker` runs celery directly and binds nothing. The health server on 8080 lives in `apps/worker/start.sh`, the Docker entrypoint, where it answers the Kubernetes probes. A comment in `ports.sh` records this so nobody adds one back.

Quick start (`./rh start`) is untouched — it keeps asking for its ports and storing them in `.env.docker`.

## Additional Context

Defaults are byte-identical to before (11000, 11001, 8080, 3000, 5555, 8000, 8082), so this is a no-op for existing setups and existing `.env` files need no regenerating — they simply lack `PORT` and both start scripts fall back to the same values.

The `package.json` change also touches one deployment path: the frontend Dockerfile CMD has a fallback branch that runs `npm run dev` when `FRONTEND_ENV` is not production/staging/development/local. That branch already exports `PORT=${PORT:-3000}` and its healthcheck already probes `${PORT:-3000}`, so honouring `PORT` in the dev script fixes a latent mismatch there rather than creating one. Real deployments run `node apps/frontend/server.js` and are unaffected. Playwright's `npm run dev:turbo -- -p 3100` still wins as the last `-p` flag, exactly as before.

Still open for follow-ups: per-worktree container and volume names, tmux session name, and the worker `pkill` pattern (which currently matches workers from every checkout), then allocating an offset when a worktree is created.

## Testing

```bash
# defaults unchanged
./rh dev help          # still shows postgres:11000, redis:11001
./rh dev status

# whole stack shifts together
RHESIS_PORT_OFFSET=100 ./rh dev init   # env files get 8180 / 3100 / 11100 / 11101
RHESIS_PORT_OFFSET=100 ./rh dev up     # containers bind the shifted ports

# single port override
DEV_FLOWER_PORT=5556 ./rh dev worker

# both frontend entry points agree
./rh dev frontend
cd apps/frontend && ./start.sh         # same port, logged at startup
```

Verified locally: `bash -n` clean on all changed shell files, generated env files carry consistent ports at offset 0 and 100, single-port override works, and `./rh help` / `./rh dev status` render unchanged.
