### PR TITLE
Add insights ids endpoint and flatten query API

### DIFF
--- a/apps/backend/src/rhesis/backend/app/routers/insights.py
+++ b/apps/backend/src/rhesis/backend/app/routers/insights.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Dict, List, Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -9,21 +9,17 @@ from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import get_tenant_db_session
 from rhesis.backend.app.models.user import User
-from rhesis.backend.app.services.insights import InsightsValidationError, run_batch, run_query
+from rhesis.backend.app.services.insights import (
+    InsightsValidationError,
+    run_ids,
+    run_queries,
+    run_query,
+)
 
 router = APIRouter(prefix="/insights", tags=["insights"])
 
 
-@router.get("/", response_model=schemas.InsightsResponse, **capability(Permission.Insights.READ))
-def get_insights(
-    entity: str = Query(..., description="Registry entity: test_result, metric, test_run, or test"),
-    group_by: List[str] = Query(default=[], description="Dimensions to group by"),
-    measures: List[str] = Query(default=["count"], description="Measures to compute"),
-    months: int = Query(6, description="Months of historical data to include (default: 6)"),
-    start_date: Optional[str] = Query(
-        None, description="Start date (ISO format, overrides months)"
-    ),
-    end_date: Optional[str] = Query(None, description="End date (ISO format, overrides months)"),
+def insights_filters(
     test_run_ids: Optional[List[UUID]] = Query(None, description="Filter by test run IDs"),
     behavior_ids: Optional[List[UUID]] = Query(None, description="Filter by behavior IDs"),
     category_ids: Optional[List[UUID]] = Query(None, description="Filter by category IDs"),
@@ -39,16 +35,8 @@ def get_insights(
     tags: Optional[List[str]] = Query(None, description="Filter by tags"),
     metric_names: Optional[List[str]] = Query(None, description="Filter by metric names"),
     endpoint_ids: Optional[List[UUID]] = Query(None, description="Filter by endpoint IDs"),
-    db: Session = Depends(get_tenant_db_session),
-    current_user: User = Depends(require_current_user_or_token),
-):
-    """Generic aggregation endpoint, validated against services/insights/registry.py.
-
-    Every param is checked against the registry entry for `entity` before it
-    reaches SQL -- an unknown group_by/measure/filter returns 400, not a query.
-
-    Example: `GET /insights/?entity=test_result&group_by=behavior&measures=count&measures=pass_rate`
-    """
+) -> dict:
+    """Shared registry filter query params for GET /insights and GET /insights/ids."""
     filters = {
         "test_run_ids": test_run_ids,
         "behavior_ids": behavior_ids,
@@ -66,8 +54,37 @@ def get_insights(
         "metric_names": metric_names,
         "endpoint_ids": endpoint_ids,
     }
-    filters = {key: value for key, value in filters.items() if value}
+    return {key: value for key, value in filters.items() if value}
 
+
+def insights_date_range(
+    months: int = Query(6, description="Months of historical data to include (default: 6)"),
+    start_date: Optional[str] = Query(
+        None, description="Start date (ISO format, overrides months)"
+    ),
+    end_date: Optional[str] = Query(None, description="End date (ISO format, overrides months)"),
+) -> dict:
+    """Shared date-range query params for GET /insights and GET /insights/ids."""
+    return {"months": months, "start_date": start_date, "end_date": end_date}
+
+
+@router.get("/", response_model=schemas.InsightsResponse, **capability(Permission.Insights.READ))
+def get_insights(
+    entity: str = Query(..., description="Registry entity: test_result, metric, test_run, or test"),
+    group_by: List[str] = Query(default=[], description="Dimensions to group by"),
+    measures: List[str] = Query(default=["count"], description="Measures to compute"),
+    filters: dict = Depends(insights_filters),
+    dates: dict = Depends(insights_date_range),
+    db: Session = Depends(get_tenant_db_session),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Generic aggregation endpoint, validated against services/insights/registry.py.
+
+    Every param is checked against the registry entry for `entity` before it
+    reaches SQL -- an unknown group_by/measure/filter returns 400, not a query.
+
+    Example: `GET /insights/?entity=test_result&group_by=behavior&measures=count&measures=pass_rate`
+    """
     try:
         return run_query(
             db,
@@ -75,44 +92,77 @@ def get_insights(
             group_by=group_by,
             measures=measures,
             filters=filters,
-            months=months,
-            start_date=start_date,
-            end_date=end_date,
             organization_id=current_user.organization_id,
+            **dates,
+        )
+    except InsightsValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+@router.get(
+    "/ids",
+    response_model=schemas.InsightsIdsResponse,
+    **capability(Permission.Insights.READ),
+)
+def get_insights_ids(
+    entity: str = Query(..., description="Registry entity: test_result, metric, test_run, or test"),
+    outcome: str = Query(
+        "all",
+        description="Match pass/fail/all. Only for entities that declare apply_outcome "
+        "in the registry (test_result, metric).",
+    ),
+    filters: dict = Depends(insights_filters),
+    dates: dict = Depends(insights_date_range),
+    db: Session = Depends(get_tenant_db_session),
+    current_user: User = Depends(require_current_user_or_token),
+):
+    """Resolve distinct entity IDs under the same filter universe as GET /insights.
+
+    Returns a flat ID list (not the aggregation envelope). Use this for drill-down
+    from a chart slice to a test list -- e.g. failed tests for a behavior/metric/topic.
+
+    Example: `GET /insights/ids?entity=test_result&outcome=fail&test_run_ids=...&behavior_ids=...`
+    """
+    try:
+        return run_ids(
+            db,
+            entity=entity,
+            filters=filters,
+            outcome=outcome,
+            organization_id=current_user.organization_id,
+            **dates,
         )
     except InsightsValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 @router.post(
-    "/batch",
-    response_model=schemas.InsightsBatchResponse,
+    "/query",
+    response_model=Dict[str, schemas.InsightsResponse],
     **capability(Permission.Insights.READ),
 )
-def get_insights_batch(
-    request: schemas.InsightsBatchRequest,
+def query_insights(
+    queries: Dict[str, schemas.InsightsQuery],
     db: Session = Depends(get_tenant_db_session),
     current_user: User = Depends(require_current_user_or_token),
 ):
     """Run several named registry queries in one call.
 
-    Each entry in `queries` is validated and executed independently against
+    The body is the map of label -> query directly (no wrapping `queries` key).
+    Each entry is validated and executed independently against
     services/insights/registry.py, same as GET /insights. This only batches
     the round trips -- results from different entities are never merged into
-    one row set (see services/insights/query_builder.py:run_batch), so the
+    one row set (see services/insights/query_builder.py:run_queries), so the
     caller still assembles per-entity results into whatever shape it needs.
 
     Example:
-        POST /insights/batch
-        {"queries": {
-            "topics": {"entity": "test_result", "group_by": ["behavior", "topic"],
-                       "measures": ["count", "pass_rate"]},
-            "metrics": {"entity": "metric", "group_by": ["behavior_id", "metric_name"],
-                        "measures": ["count", "passed", "pass_rate"]}
-        }}
+        POST /insights/query
+        {"topics": {"entity": "test_result", "group_by": ["behavior", "topic"],
+                    "measures": ["count", "pass_rate"]},
+         "metrics": {"entity": "metric", "group_by": ["behavior_id", "metric_name"],
+                     "measures": ["count", "passed", "pass_rate"]}}
     """
     try:
-        results = run_batch(db, request.queries, organization_id=current_user.organization_id)
+        return run_queries(db, queries, organization_id=current_user.organization_id)
     except InsightsValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return schemas.InsightsBatchResponse(results=results)

--- a/apps/backend/src/rhesis/backend/app/routers/insights.py
+++ b/apps/backend/src/rhesis/backend/app/routers/insights.py
@@ -58,13 +58,11 @@ def insights_filters(
 
 
 def insights_date_range(
-    months: int = Query(6, description="Months of historical data to include (default: 6)"),
-    start_date: Optional[str] = Query(
-        None, description="Start date (ISO format, overrides months)"
-    ),
-    end_date: Optional[str] = Query(None, description="End date (ISO format, overrides months)"),
+    months: Optional[int] = Query(None, description="Last N months (not with start/end)"),
+    start_date: Optional[str] = Query(None, description="From this ISO date onwards"),
+    end_date: Optional[str] = Query(None, description="Up to this ISO date"),
 ) -> dict:
-    """Shared date-range query params for GET /insights and GET /insights/ids."""
+    """Optional date window. Omit all for all time; start/end are independent bounds."""
     return {"months": months, "start_date": start_date, "end_date": end_date}
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/test_result.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_result.py
@@ -161,7 +161,7 @@ def generate_test_result_stats(
         None, description="Max items per dimension (e.g., top 10 behaviors)"
     ),
     months: Optional[int] = Query(
-        6, description="Months of historical data to include (default: 6)"
+        None, description="Last N months (omit for all time; not with start/end)"
     ),
     test_run_id: UUID | None = Query(
         None, description="Filter by specific test run UUID (legacy, use test_run_ids for multiple)"

--- a/apps/backend/src/rhesis/backend/app/routers/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_run.py
@@ -159,7 +159,7 @@ def generate_test_run_stats(
         None, description="Max items per dimension (e.g., top 10 executors)"
     ),
     months: Optional[int] = Query(
-        6, description="Months of historical data to include (default: 6)"
+        None, description="Last N months (omit for all time; not with start/end)"
     ),
     # Test run filters
     test_run_ids: Optional[List[UUID]] = Query(None, description="Filter by specific test run IDs"),

--- a/apps/backend/src/rhesis/backend/app/schemas/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/__init__.py
@@ -31,7 +31,7 @@ from .endpoint import (
     EndpointUpdate,
 )
 from .file import FileCreate, FileEntityType, FileResponse, FileUpdate
-from .insights import InsightsBatchRequest, InsightsBatchResponse, InsightsQuery, InsightsResponse
+from .insights import InsightsIdsResponse, InsightsQuery, InsightsResponse
 from .metric import (
     GenerateMetricRequest,
     ImproveMetricRequest,

--- a/apps/backend/src/rhesis/backend/app/schemas/insights.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/insights.py
@@ -20,7 +20,7 @@ class InsightsQuery(BaseModel):
     group_by: List[str] = Field(default_factory=list)
     measures: List[str] = Field(default_factory=lambda: ["count"])
     filters: Dict[str, List[str]] = Field(default_factory=dict)
-    months: int = 6
+    months: Optional[int] = None
     start_date: Optional[str] = None
     end_date: Optional[str] = None
 

--- a/apps/backend/src/rhesis/backend/app/schemas/insights.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/insights.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, Field
 
 
 class InsightsResponse(BaseModel):
-    """Uniform envelope returned by GET /insights, regardless of entity."""
+    """Uniform envelope returned by GET /insights and each entry of POST /insights/query."""
 
     entity: str
     dimensions: List[str]
@@ -14,7 +14,7 @@ class InsightsResponse(BaseModel):
 
 class InsightsQuery(BaseModel):
     """One entity/group_by/measures request -- the body shape of a single
-    GET /insights call, reused as one entry in an InsightsBatchRequest."""
+    GET /insights call, reused as one entry in POST /insights/query."""
 
     entity: str
     group_by: List[str] = Field(default_factory=list)
@@ -25,14 +25,12 @@ class InsightsQuery(BaseModel):
     end_date: Optional[str] = None
 
 
-class InsightsBatchRequest(BaseModel):
-    """Named sub-queries to run in one call. Each one still runs as its own
-    single-entity, single-grain query -- see services/insights/query_builder.py."""
+class InsightsIdsResponse(BaseModel):
+    """Distinct entity IDs matching Insights filters + optional outcome.
 
-    queries: Dict[str, InsightsQuery]
+    Same filter universe as GET /insights; different verb (resolve IDs, not
+    aggregate). Used for drill-down (e.g. failed-tests list under a chart slice).
+    """
 
-
-class InsightsBatchResponse(BaseModel):
-    """One InsightsResponse per label from the request."""
-
-    results: Dict[str, InsightsResponse]
+    entity: str
+    ids: List[str]

--- a/apps/backend/src/rhesis/backend/app/services/insights/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/services/insights/__init__.py
@@ -1,4 +1,10 @@
-from .query_builder import InsightsValidationError, run_batch, run_query
+from .query_builder import InsightsValidationError, run_ids, run_queries, run_query
 from .registry import REGISTRY
 
-__all__ = ["InsightsValidationError", "run_query", "run_batch", "REGISTRY"]
+__all__ = [
+    "InsightsValidationError",
+    "run_query",
+    "run_queries",
+    "run_ids",
+    "REGISTRY",
+]

--- a/apps/backend/src/rhesis/backend/app/services/insights/query_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/insights/query_builder.py
@@ -6,7 +6,7 @@ unknown entity, group_by, measure, or filter raises InsightsValidationError
 """
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from sqlalchemy.orm import Session
 
@@ -28,15 +28,6 @@ def _entry(entity: str) -> dict:
     if entry is None:
         raise InsightsValidationError(f"Unknown entity '{entity}'. Available: {sorted(REGISTRY)}")
     return entry
-
-
-def _parse_dates(
-    start_date: Optional[str], end_date: Optional[str], months: int
-) -> Tuple[Optional[datetime], Optional[datetime]]:
-    try:
-        return parse_date_range(start_date, end_date, months)
-    except ValueError as exc:
-        raise InsightsValidationError(f"Invalid start_date/end_date: {exc}") from exc
 
 
 def _apply_filters(q, db: Session, entity: str, entry: dict, filters: Optional[Dict[str, list]]):
@@ -133,13 +124,16 @@ def run_query(
     group_by: List[str],
     measures: List[str],
     filters: Optional[Dict[str, list]] = None,
-    months: int = 6,
+    months: Optional[int] = None,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     organization_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Execute the query and shape results into the uniform insights envelope."""
-    start_date_obj, end_date_obj = _parse_dates(start_date, end_date, months)
+    try:
+        start_date_obj, end_date_obj = parse_date_range(start_date, end_date, months)
+    except ValueError as exc:
+        raise InsightsValidationError(str(exc)) from exc
     q = build_query(
         db, entity, group_by, measures, filters, start_date_obj, end_date_obj, organization_id
     )
@@ -194,7 +188,7 @@ def run_ids(
     entity: str,
     filters: Optional[Dict[str, list]] = None,
     outcome: str = "all",
-    months: int = 6,
+    months: Optional[int] = None,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     organization_id: Optional[str] = None,
@@ -210,7 +204,10 @@ def run_ids(
             f"Invalid outcome '{outcome}'. Available: {sorted(VALID_OUTCOMES)}"
         )
 
-    start_date_obj, end_date_obj = _parse_dates(start_date, end_date, months)
+    try:
+        start_date_obj, end_date_obj = parse_date_range(start_date, end_date, months)
+    except ValueError as exc:
+        raise InsightsValidationError(str(exc)) from exc
     entry, view, q = _base_query(db, entity, filters, start_date_obj, end_date_obj, organization_id)
 
     id_column = entry.get("id_column")

--- a/apps/backend/src/rhesis/backend/app/services/insights/query_builder.py
+++ b/apps/backend/src/rhesis/backend/app/services/insights/query_builder.py
@@ -6,7 +6,7 @@ unknown entity, group_by, measure, or filter raises InsightsValidationError
 """
 
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from sqlalchemy.orm import Session
 
@@ -15,6 +15,7 @@ from rhesis.backend.app.services.stats.common import parse_date_range
 from .registry import REGISTRY
 
 MAX_BATCH_QUERIES = 10
+VALID_OUTCOMES = frozenset({"pass", "fail", "all"})
 
 
 class InsightsValidationError(ValueError):
@@ -29,6 +30,66 @@ def _entry(entity: str) -> dict:
     return entry
 
 
+def _parse_dates(
+    start_date: Optional[str], end_date: Optional[str], months: int
+) -> Tuple[Optional[datetime], Optional[datetime]]:
+    try:
+        return parse_date_range(start_date, end_date, months)
+    except ValueError as exc:
+        raise InsightsValidationError(f"Invalid start_date/end_date: {exc}") from exc
+
+
+def _apply_filters(q, db: Session, entity: str, entry: dict, filters: Optional[Dict[str, list]]):
+    """Apply registry-declared filters (and subquery filters) to a base query."""
+    for key, values in (filters or {}).items():
+        if not values:
+            continue
+        if key in entry["subquery_filters"]:
+            id_column, build_subquery = entry["subquery_filters"][key]
+            q = q.filter(id_column.in_(build_subquery(db, values)))
+        elif key in entry["filters"]:
+            q = q.filter(entry["filters"][key].in_(values))
+        else:
+            raise InsightsValidationError(
+                f"Unknown filter '{key}' for entity '{entity}'. "
+                f"Available: {sorted(set(entry['filters']) | set(entry['subquery_filters']))}"
+            )
+    return q
+
+
+def _apply_date_range(q, entry: dict, start_date: Optional[datetime], end_date: Optional[datetime]):
+    date_column = entry.get("date_column")
+    if start_date is not None and date_column is not None:
+        q = q.filter(date_column >= start_date)
+    if end_date is not None and date_column is not None:
+        q = q.filter(date_column <= end_date)
+    return q
+
+
+def _base_query(
+    db: Session,
+    entity: str,
+    filters: Optional[Dict[str, list]] = None,
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+    organization_id: Optional[str] = None,
+):
+    """Filtered view query shared by aggregation and ID resolution.
+
+    Returns (entry, view, query) — callers add GROUP BY / DISTINCT on top.
+    """
+    entry = _entry(entity)
+    view = entry["view"]
+    q = db.query(view)
+
+    if organization_id is not None:
+        q = q.filter(view.organization_id == organization_id)
+
+    q = _apply_filters(q, db, entity, entry, filters)
+    q = _apply_date_range(q, entry, start_date, end_date)
+    return entry, view, q
+
+
 def build_query(
     db: Session,
     entity: str,
@@ -40,7 +101,7 @@ def build_query(
     organization_id: Optional[str] = None,
 ):
     """Return a validated, filtered, grouped SQLAlchemy query to be executed."""
-    entry = _entry(entity)
+    entry, _view, q = _base_query(db, entity, filters, start_date, end_date, organization_id)
 
     unknown_dims = set(group_by) - set(entry["dimensions"])
     if unknown_dims:
@@ -56,32 +117,6 @@ def build_query(
             f"Unknown measures {sorted(unknown_measures)} for entity '{entity}'. "
             f"Available: {sorted(entry['measures'])}"
         )
-
-    view = entry["view"]
-    q = db.query(view)
-
-    if organization_id is not None:
-        q = q.filter(view.organization_id == organization_id)
-
-    for key, values in (filters or {}).items():
-        if not values:
-            continue
-        if key in entry["subquery_filters"]:
-            id_column, build_subquery = entry["subquery_filters"][key]
-            q = q.filter(id_column.in_(build_subquery(db, values)))
-        elif key in entry["filters"]:
-            q = q.filter(entry["filters"][key].in_(values))
-        else:
-            raise InsightsValidationError(
-                f"Unknown filter '{key}' for entity '{entity}'. "
-                f"Available: {sorted(set(entry['filters']) | set(entry['subquery_filters']))}"
-            )
-
-    date_column = entry.get("date_column")
-    if start_date is not None and date_column is not None:
-        q = q.filter(date_column >= start_date)
-    if end_date is not None and date_column is not None:
-        q = q.filter(date_column <= end_date)
 
     group_cols = [entry["dimensions"][g].label(g) for g in group_by]
     measure_cols = [entry["measures"][m]().label(m) for m in measures]
@@ -104,10 +139,7 @@ def run_query(
     organization_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Execute the query and shape results into the uniform insights envelope."""
-    try:
-        start_date_obj, end_date_obj = parse_date_range(start_date, end_date, months)
-    except ValueError as exc:
-        raise InsightsValidationError(f"Invalid start_date/end_date: {exc}") from exc
+    start_date_obj, end_date_obj = _parse_dates(start_date, end_date, months)
     q = build_query(
         db, entity, group_by, measures, filters, start_date_obj, end_date_obj, organization_id
     )
@@ -126,7 +158,7 @@ def run_query(
     }
 
 
-def run_batch(
+def run_queries(
     db: Session, queries: Dict[str, Any], organization_id: Optional[str] = None
 ) -> Dict[str, Dict[str, Any]]:
     """Run several named sub-queries in one call and return one envelope per label.
@@ -154,4 +186,48 @@ def run_batch(
             organization_id=organization_id,
         )
         for label, q in queries.items()
+    }
+
+
+def run_ids(
+    db: Session,
+    entity: str,
+    filters: Optional[Dict[str, list]] = None,
+    outcome: str = "all",
+    months: int = 6,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    organization_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Return distinct IDs matching the same filter universe as GET /insights.
+
+    outcome ('pass'/'fail'/'all') uses the entity's registry apply_outcome when set.
+    Dimension filters (behavior_ids, topic_ids, metric_names, …) go through the
+    normal registry filters — no name-based special cases.
+    """
+    if outcome not in VALID_OUTCOMES:
+        raise InsightsValidationError(
+            f"Invalid outcome '{outcome}'. Available: {sorted(VALID_OUTCOMES)}"
+        )
+
+    start_date_obj, end_date_obj = _parse_dates(start_date, end_date, months)
+    entry, view, q = _base_query(db, entity, filters, start_date_obj, end_date_obj, organization_id)
+
+    id_column = entry.get("id_column")
+    if id_column is None:
+        raise InsightsValidationError(f"Entity '{entity}' does not support /insights/ids")
+
+    if outcome != "all":
+        apply_outcome = entry.get("apply_outcome")
+        if apply_outcome is None:
+            raise InsightsValidationError(
+                f"outcome filter is not supported for entity '{entity}'. "
+                "Use entity=test_result or entity=metric."
+            )
+        q = q.filter(apply_outcome(view, outcome))
+
+    rows = q.with_entities(id_column).distinct().all()
+    return {
+        "entity": entity,
+        "ids": [str(row[0]) for row in rows if row[0] is not None],
     }

--- a/apps/backend/src/rhesis/backend/app/services/insights/registry.py
+++ b/apps/backend/src/rhesis/backend/app/services/insights/registry.py
@@ -1,10 +1,13 @@
-"""Declarative registry of what GET /insights can query.
+"""Declarative registry of what Insights endpoints can query.
 
 Each entity names the view backing it, the columns valid as group_by
 dimensions, the measures computable over it, and the filters accepted.
 query_builder.py validates every incoming param against this before
-touching the database and turns a validated request into one GROUP BY
-query.
+touching the database.
+
+Optional keys used only by GET /insights/ids:
+  id_column     — column to SELECT DISTINCT
+  apply_outcome — (view, 'pass'|'fail') -> SQL expression
 """
 
 from sqlalchemy import Float, case, cast, func
@@ -64,10 +67,25 @@ def _tags_subquery(db, tags):
     )
 
 
+def _overall_result_outcome(view, outcome: str):
+    """Filter by overall test result ('pass' / 'fail')."""
+    target = OverallTestResult.PASSED if outcome == "pass" else OverallTestResult.FAILED
+    return view.result == target
+
+
+def _metric_success_outcome(view, outcome: str):
+    """Filter by metric effective_success ('pass' / 'fail')."""
+    return view.effective_success.is_(outcome == "pass")
+
+
 REGISTRY = {
     "test_result": {
         "view": TR,
         "date_column": TR.created_at,
+        # GET /insights/ids — which column to SELECT DISTINCT, plus optional
+        # outcome / topic_name predicates that only that endpoint uses.
+        "id_column": TR.test_id,
+        "apply_outcome": _overall_result_outcome,
         "dimensions": {
             "behavior": TR.behavior_name,
             "behavior_id": TR.behavior_id,
@@ -112,6 +130,8 @@ REGISTRY = {
     "metric": {
         "view": ME,
         "date_column": ME.created_at,
+        "id_column": ME.test_id,
+        "apply_outcome": _metric_success_outcome,
         "dimensions": {
             "metric_name": ME.metric_name,
             "behavior_id": ME.behavior_id,
@@ -140,6 +160,7 @@ REGISTRY = {
     "test_run": {
         "view": RN,
         "date_column": RN.created_at,
+        "id_column": RN.test_run_id,
         "dimensions": {
             "status": RN.status_name,
             "test_set": RN.test_set_name,
@@ -169,6 +190,7 @@ REGISTRY = {
         # are structurally invisible to a test until it has a result.
         "view": TS,
         "date_column": TS.created_at,
+        "id_column": TS.test_id,
         "dimensions": {
             "behavior": TS.behavior_name,
             "behavior_id": TS.behavior_id,

--- a/apps/backend/src/rhesis/backend/app/services/stats/common.py
+++ b/apps/backend/src/rhesis/backend/app/services/stats/common.py
@@ -7,20 +7,27 @@ from rhesis.backend.app.constants import OverallTestResult
 
 
 def parse_date_range(
-    start_date: str | None, end_date: str | None, months: int
-) -> tuple[datetime, datetime]:
-    """Parse and validate date range parameters.
+    start_date: str | None,
+    end_date: str | None,
+    months: int | None = None,
+) -> tuple[datetime | None, datetime | None]:
+    """Optional date bounds. None means open-ended / all time.
 
-    Returns (start_date_obj, end_date_obj). If explicit dates are provided they
-    take precedence; otherwise the range spans the last *months* months.
+    - months → last N months (cannot combine with start/end)
+    - start_date → from then onwards
+    - end_date → up to then
+    - both → closed range
+    - none → (None, None)
     """
-    if start_date and end_date:
-        start_date_obj = datetime.fromisoformat(start_date.replace("Z", "+00:00"))
-        end_date_obj = datetime.fromisoformat(end_date.replace("Z", "+00:00"))
-    else:
-        end_date_obj = datetime.now(timezone.utc)
-        start_date_obj = end_date_obj - timedelta(days=30 * months)
-    return start_date_obj, end_date_obj
+    if months is not None:
+        if start_date is not None or end_date is not None:
+            raise ValueError("Use either months or start_date/end_date, not both")
+        end = datetime.now(timezone.utc)
+        return end - timedelta(days=30 * months), end
+
+    start = datetime.fromisoformat(start_date.replace("Z", "+00:00")) if start_date else None
+    end = datetime.fromisoformat(end_date.replace("Z", "+00:00")) if end_date else None
+    return start, end
 
 
 def build_pass_rate_stats(stats_dict: Dict[str, Dict[str, int]]) -> Dict[str, Dict[str, Any]]:
@@ -106,20 +113,26 @@ def build_response_data(
 
 def build_metadata(
     organization_id: str | None,
-    start_date_obj: datetime,
-    end_date_obj: datetime,
-    months: int,
+    start_date_obj: datetime | None,
+    end_date_obj: datetime | None,
+    months: int | None,
     mode: str,
     total_items: int,
     **additional_metadata,
 ) -> Dict[str, Any]:
     """Build the standard metadata dict attached to every stats response."""
+    if months is not None:
+        period = f"Last {months} months"
+    elif start_date_obj or end_date_obj:
+        period = "custom"
+    else:
+        period = "all time"
     metadata = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "organization_id": organization_id,
-        "period": f"Last {months} months",
-        "start_date": start_date_obj.isoformat(),
-        "end_date": end_date_obj.isoformat(),
+        "period": period,
+        "start_date": start_date_obj.isoformat() if start_date_obj else None,
+        "end_date": end_date_obj.isoformat() if end_date_obj else None,
         "total_items": total_items,
         "mode": mode,
     }
@@ -130,9 +143,9 @@ def build_metadata(
 def build_empty_stats_response(
     mode: str,
     mode_definitions: Dict[str, List[str]],
-    start_date_obj: datetime,
-    end_date_obj: datetime,
-    months: int,
+    start_date_obj: datetime | None,
+    end_date_obj: datetime | None,
+    months: int | None,
     organization_id: str | None,
     **additional_metadata,
 ) -> Dict[str, Any]:

--- a/apps/backend/src/rhesis/backend/app/services/stats/test.py
+++ b/apps/backend/src/rhesis/backend/app/services/stats/test.py
@@ -78,11 +78,7 @@ def get_individual_test_stats(
         - metadata: Test ID, generation timestamp, organization_id, date range
     """
     # Parse date range if provided
-    start_date_obj = None
-    end_date_obj = None
-    if start_date or end_date or months:
-        months_val = months if months else 999  # Default to all time if not specified
-        start_date_obj, end_date_obj = parse_date_range(start_date, end_date, months_val)
+    start_date_obj, end_date_obj = parse_date_range(start_date, end_date, months)
 
     # Base query for test results with eager loading
     builder = (

--- a/apps/backend/src/rhesis/backend/app/services/stats/test_result.py
+++ b/apps/backend/src/rhesis/backend/app/services/stats/test_result.py
@@ -381,7 +381,7 @@ def _test_ids_overall(base_q, outcome: str) -> List[str]:
 def get_test_result_stats(
     db: Session,
     organization_id: str | None = None,
-    months: int = 6,
+    months: int | None = None,
     test_run_id: str | None = None,
     mode: str = "all",
     test_set_ids: List[str] | None = None,
@@ -477,7 +477,7 @@ def get_test_result_stats(
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "organization_id": organization_id,
         "test_run_id": test_run_id,
-        "period": f"Last {months} months",
+        "period": f"Last {months} months" if months is not None else "all time",
         "start_date": start_date_obj.isoformat() if start_date_obj else None,
         "end_date": end_date_obj.isoformat() if end_date_obj else None,
         "total_test_runs": len(test_run_summary) if test_run_summary else 0,

--- a/apps/backend/src/rhesis/backend/app/services/stats/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/services/stats/test_run.py
@@ -166,7 +166,7 @@ def _get_stats(db: Session, filters: dict, mode: str, top: Optional[int]) -> Dic
 def get_test_run_stats(
     db: Session,
     organization_id: str | None = None,
-    months: int = 6,
+    months: int | None = None,
     mode: str = "all",
     top: int | None = None,
     test_run_ids: List[str] | None = None,

--- a/apps/frontend/src/app/(protected)/insights/components/BehaviorDimensionLists.tsx
+++ b/apps/frontend/src/app/(protected)/insights/components/BehaviorDimensionLists.tsx
@@ -87,7 +87,7 @@ function DimensionRows({
       outcome: 'all',
       ...(dimension === 'metric'
         ? { metricName: item.name }
-        : { topicName: item.name }),
+        : { topicId: item.id, topicName: item.name }),
     };
     const url = buildInsightsFailedTestsUrl(insightsFilters, scope);
     window.open(url, '_blank', 'noopener,noreferrer');

--- a/apps/frontend/src/app/(protected)/insights/hooks/__tests__/useBehaviorInsightsData.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/hooks/__tests__/useBehaviorInsightsData.test.ts
@@ -17,37 +17,35 @@ jest.mock('../../utils/behavior-insights-utils', () => ({
   buildBehaviorColumns: jest.fn(() => []),
 }));
 
-function mockInsightsBatchResponse(summaryRow: {
+function mockInsightsQueryResponse(summaryRow: {
   passed: number;
   failed: number;
   pass_rate: number;
 }) {
   return {
-    results: {
-      summary: {
-        entity: 'test_result',
-        dimensions: [],
-        measures: ['count', 'passed', 'failed', 'pass_rate'],
-        rows: [summaryRow],
-      },
-      behaviors: {
-        entity: 'test_result',
-        dimensions: ['behavior_id', 'behavior'],
-        measures: ['count', 'passed', 'failed', 'pass_rate'],
-        rows: [],
-      },
-      topics: {
-        entity: 'test_result',
-        dimensions: ['behavior_id', 'topic'],
-        measures: ['count', 'passed', 'failed', 'pass_rate'],
-        rows: [],
-      },
-      metrics: {
-        entity: 'metric',
-        dimensions: ['behavior_id', 'metric_name'],
-        measures: ['count', 'passed', 'failed', 'pass_rate'],
-        rows: [],
-      },
+    summary: {
+      entity: 'test_result',
+      dimensions: [],
+      measures: ['count', 'passed', 'failed', 'pass_rate'],
+      rows: [summaryRow],
+    },
+    behaviors: {
+      entity: 'test_result',
+      dimensions: ['behavior_id', 'behavior'],
+      measures: ['count', 'passed', 'failed', 'pass_rate'],
+      rows: [],
+    },
+    topics: {
+      entity: 'test_result',
+      dimensions: ['behavior_id', 'topic_id', 'topic'],
+      measures: ['count', 'passed', 'failed', 'pass_rate'],
+      rows: [],
+    },
+    metrics: {
+      entity: 'metric',
+      dimensions: ['behavior_id', 'metric_name'],
+      measures: ['count', 'passed', 'failed', 'pass_rate'],
+      rows: [],
     },
   };
 }
@@ -55,8 +53,8 @@ function mockInsightsBatchResponse(summaryRow: {
 jest.mock('@/utils/api-client/client-factory', () => ({
   ApiClientFactory: jest.fn().mockImplementation(() => ({
     getInsightsClient: () => ({
-      getInsightsBatch: jest.fn().mockResolvedValue(
-        mockInsightsBatchResponse({
+      getInsightsQuery: jest.fn().mockResolvedValue(
+        mockInsightsQueryResponse({
           passed: 10,
           failed: 10,
           pass_rate: 50,
@@ -93,7 +91,7 @@ describe('useBehaviorInsightsData', () => {
     jest.useRealTimers();
   });
 
-  it('resolves summary from the batch response', async () => {
+  it('resolves summary from the query response', async () => {
     mockResolveTestRunIds.mockResolvedValue(['run-1', 'run-2']);
 
     const filters = {

--- a/apps/frontend/src/app/(protected)/insights/hooks/useBehaviorInsightsData.ts
+++ b/apps/frontend/src/app/(protected)/insights/hooks/useBehaviorInsightsData.ts
@@ -110,47 +110,45 @@ export function useBehaviorInsightsData(
             ...timeParams,
           };
 
-          const batch = await insightsClient.getInsightsBatch({
-            queries: {
-              summary: {
-                entity: 'test_result',
-                group_by: [],
-                measures,
-                ...baseQuery,
-              },
-              behaviors: {
-                entity: 'test_result',
-                group_by: ['behavior_id', 'behavior'],
-                measures,
-                ...baseQuery,
-              },
-              topics: {
-                entity: 'test_result',
-                group_by: ['behavior_id', 'topic'],
-                measures,
-                ...baseQuery,
-              },
-              metrics: {
-                entity: 'metric',
-                group_by: ['behavior_id', 'metric_name'],
-                measures,
-                ...baseQuery,
-              },
+          const results = await insightsClient.getInsightsQuery({
+            summary: {
+              entity: 'test_result',
+              group_by: [],
+              measures,
+              ...baseQuery,
+            },
+            behaviors: {
+              entity: 'test_result',
+              group_by: ['behavior_id', 'behavior'],
+              measures,
+              ...baseQuery,
+            },
+            topics: {
+              entity: 'test_result',
+              group_by: ['behavior_id', 'topic_id', 'topic'],
+              measures,
+              ...baseQuery,
+            },
+            metrics: {
+              entity: 'metric',
+              group_by: ['behavior_id', 'metric_name'],
+              measures,
+              ...baseQuery,
             },
           });
 
           if (!isCurrentRequest(requestId)) return;
 
-          const summaryRow = batch.results.summary.rows[0];
+          const summaryRow = results.summary.rows[0];
           const overallSummary = summaryRow
             ? rowToPassFailStats(summaryRow)
             : EMPTY_SUMMARY;
           setSummary(overallSummary);
           setColumns(
             buildBehaviorColumns(
-              batch.results.behaviors.rows,
-              batch.results.topics.rows,
-              batch.results.metrics.rows
+              results.behaviors.rows,
+              results.topics.rows,
+              results.metrics.rows
             )
           );
 

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/behavior-insights-utils.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/behavior-insights-utils.test.ts
@@ -117,6 +117,7 @@ describe('behavior-insights-utils', () => {
     const topicRows: InsightsRow[] = [
       {
         behavior_id: 'b-1',
+        topic_id: 't-1',
         topic: 'Safety',
         count: 6,
         passed: 4,
@@ -154,7 +155,14 @@ describe('behavior-insights-utils', () => {
         pass_rate: 80,
       });
       expect(robustness.topics).toEqual([
-        { name: 'Safety', total: 6, passed: 4, failed: 2, pass_rate: 66.67 },
+        {
+          id: 't-1',
+          name: 'Safety',
+          total: 6,
+          passed: 4,
+          failed: 2,
+          pass_rate: 66.67,
+        },
       ]);
       expect(robustness.metrics).toEqual([
         { name: 'Fluency', total: 10, passed: 8, failed: 2, pass_rate: 80 },

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/fetch-failed-test-ids-resolution.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/fetch-failed-test-ids-resolution.test.ts
@@ -7,12 +7,15 @@ jest.mock('../behavior-insights-utils', () => ({
   resolveInsightsQueryTestRunIds: jest.fn(),
 }));
 
+const mockGetInsightsIds = jest.fn().mockResolvedValue({
+  entity: 'test_result',
+  ids: ['test-1'],
+});
+
 jest.mock('@/utils/api-client/client-factory', () => ({
   ApiClientFactory: jest.fn().mockImplementation(() => ({
-    getTestResultsClient: () => ({
-      getComprehensiveTestResultsStats: jest.fn().mockResolvedValue({
-        test_ids: ['test-1'],
-      }),
+    getInsightsClient: () => ({
+      getInsightsIds: mockGetInsightsIds,
     }),
   })),
 }));
@@ -25,6 +28,11 @@ const mockResolve = resolveInsightsQueryTestRunIds as jest.Mock;
 describe('fetchFailedTestIdsForInsights resolution', () => {
   beforeEach(() => {
     mockResolve.mockReset();
+    mockGetInsightsIds.mockClear();
+    mockGetInsightsIds.mockResolvedValue({
+      entity: 'test_result',
+      ids: ['test-1'],
+    });
   });
 
   it('resolves empty testRunIds via resolveInsightsQueryTestRunIds', async () => {
@@ -43,6 +51,11 @@ describe('fetchFailedTestIdsForInsights resolution', () => {
       timeRange: '1m',
       testRunIds: [],
     });
+    expect(mockGetInsightsIds).toHaveBeenCalledWith({
+      entity: 'test_result',
+      test_run_ids: ['run-a', 'run-b'],
+      outcome: 'fail',
+    });
     expect(ids).toEqual(['test-1']);
   });
 
@@ -55,6 +68,32 @@ describe('fetchFailedTestIdsForInsights resolution', () => {
     });
 
     expect(mockResolve).not.toHaveBeenCalled();
+    expect(mockGetInsightsIds).toHaveBeenCalledWith({
+      entity: 'test_result',
+      test_run_ids: ['run-1'],
+      outcome: 'fail',
+    });
+    expect(ids).toEqual(['test-1']);
+  });
+
+  it('uses metric entity when metricName is set', async () => {
+    const ids = await fetchFailedTestIdsForInsights({
+      endpointId: 'ep-1',
+      runFilterMode: 'testRuns',
+      timeRange: '1m',
+      testRunIds: ['run-1'],
+      metricName: 'Accuracy',
+      behaviorId: 'beh-1',
+      outcome: 'all',
+    });
+
+    expect(mockGetInsightsIds).toHaveBeenCalledWith({
+      entity: 'metric',
+      test_run_ids: ['run-1'],
+      outcome: 'all',
+      behavior_ids: ['beh-1'],
+      metric_names: ['Accuracy'],
+    });
     expect(ids).toEqual(['test-1']);
   });
 });

--- a/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-failed-tests.test.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/__tests__/insights-failed-tests.test.ts
@@ -92,18 +92,19 @@ describe('insights-failed-tests', () => {
         {
           behaviorId: 'beh-1',
           behaviorName: 'Safety',
+          topicId: 'topic-1',
           topicName: 'Claims',
           outcome: 'all',
         }
       )
     ).toBe(
-      '/tests?failedFromInsights=1&endpointId=ep-1&runFilterMode=timeRange&timeRange=1m&behaviorId=beh-1&behaviorName=Safety&topic=Claims&outcome=all'
+      '/tests?failedFromInsights=1&endpointId=ep-1&runFilterMode=timeRange&timeRange=1m&behaviorId=beh-1&behaviorName=Safety&topicId=topic-1&topic=Claims&outcome=all'
     );
   });
 
   it('parses insights failed tests search params', () => {
     const params = new URLSearchParams(
-      'failedFromInsights=1&endpointId=ep-1&runFilterMode=testRuns&testRunIds=run-1,run-2&behaviorId=b1&metric=m1&topic=t1&behaviorName=Beh'
+      'failedFromInsights=1&endpointId=ep-1&runFilterMode=testRuns&testRunIds=run-1,run-2&behaviorId=b1&metric=m1&topicId=tid1&topic=t1&behaviorName=Beh'
     );
     expect(parseInsightsFailedTestsSearchParams(params)).toEqual({
       endpointId: 'ep-1',
@@ -113,6 +114,7 @@ describe('insights-failed-tests', () => {
       behaviorId: 'b1',
       behaviorName: 'Beh',
       metricName: 'm1',
+      topicId: 'tid1',
       topicName: 't1',
       outcome: 'failed',
     });

--- a/apps/frontend/src/app/(protected)/insights/utils/behavior-insights-utils.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/behavior-insights-utils.ts
@@ -24,6 +24,8 @@ function endpointMatchesProject(
 
 export interface DimensionItem {
   name: string;
+  /** Present for dimensions that group by id (e.g. topics via topic_id). */
+  id?: string;
   total: number;
   passed: number;
   failed: number;
@@ -60,7 +62,7 @@ export function sortBehaviorColumns(
 }
 
 /**
- * One `/insights/batch` row -> the `PassFailStats` shape used across the Insights UI.
+ * One `/insights/query` row -> the `PassFailStats` shape used across the Insights UI.
  * `total` is `passed + failed`, not the row's raw `count` -- `count` also includes
  * pending/errored results that never got evaluated, which would make "X/Y passed"
  * text count them in the denominator without them showing up as either passed or failed.
@@ -188,7 +190,7 @@ export async function fetchTestRunIdsForEndpoint(
 }
 
 /**
- * Soft cap for `test_run_ids` query params on `/test_results/stats`.
+ * Soft cap for `test_run_ids` query params on Insights endpoints.
  * Beyond this, GET URLs risk proxy/browser length limits.
  */
 export const MAX_INSIGHTS_TEST_RUN_IDS = 100;
@@ -227,25 +229,31 @@ export async function resolveInsightsQueryTestRunIds(
   return testRunIds;
 }
 
-/** Group rows sharing a `behavior_id` into `DimensionItem[]`, keyed by `nameKey` (e.g. `topic`). */
+/** Group rows sharing a `behavior_id` into `DimensionItem[]`, keyed by `nameKey`. */
 function groupRowsByBehaviorId(
   rows: InsightsRow[],
-  nameKey: string
+  nameKey: string,
+  idKey?: string
 ): Map<string, DimensionItem[]> {
   const grouped = new Map<string, DimensionItem[]>();
   for (const row of rows) {
     const behaviorId = row.behavior_id;
     const name = row[nameKey];
     if (typeof behaviorId !== 'string' || typeof name !== 'string') continue;
+    const id = idKey != null ? row[idKey] : undefined;
     const items = grouped.get(behaviorId) ?? [];
-    items.push({ name, ...rowToPassFailStats(row) });
+    items.push({
+      name,
+      ...(typeof id === 'string' ? { id } : {}),
+      ...rowToPassFailStats(row),
+    });
     grouped.set(behaviorId, items);
   }
   return grouped;
 }
 
 /**
- * Build behavior columns straight from `/insights/batch` rows: `behaviorRows`
+ * Build behavior columns straight from `/insights/query` rows: `behaviorRows`
  * (group_by=[behavior_id,behavior]) already are "behaviors with data" -- no
  * separate behavior list fetch needed. `topicRows`/`metricRows` are grouped
  * by behavior_id to fill each column's breakdown lists.
@@ -255,7 +263,11 @@ export function buildBehaviorColumns(
   topicRows: InsightsRow[],
   metricRows: InsightsRow[]
 ): BehaviorInsightColumn[] {
-  const topicsByBehavior = groupRowsByBehaviorId(topicRows, 'topic');
+  const topicsByBehavior = groupRowsByBehaviorId(
+    topicRows,
+    'topic',
+    'topic_id'
+  );
   const metricsByBehavior = groupRowsByBehaviorId(metricRows, 'metric_name');
 
   const columns: BehaviorInsightColumn[] = behaviorRows

--- a/apps/frontend/src/app/(protected)/insights/utils/insights-failed-tests.ts
+++ b/apps/frontend/src/app/(protected)/insights/utils/insights-failed-tests.ts
@@ -22,6 +22,7 @@ export interface InsightsFailedTestsScope {
   behaviorId?: string;
   behaviorName?: string;
   metricName?: string;
+  topicId?: string;
   topicName?: string;
   outcome?: InsightsTestOutcome;
 }
@@ -34,6 +35,7 @@ export interface InsightsFailedTestsFilter {
   behaviorId?: string;
   behaviorName?: string;
   metricName?: string;
+  topicId?: string;
   topicName?: string;
   outcome?: InsightsTestOutcome;
 }
@@ -71,6 +73,9 @@ export function buildInsightsFailedTestsUrl(
   }
   if (scope?.metricName) {
     params.set('metric', scope.metricName);
+  }
+  if (scope?.topicId) {
+    params.set('topicId', scope.topicId);
   }
   if (scope?.topicName) {
     params.set('topic', scope.topicName);
@@ -168,6 +173,7 @@ export function parseInsightsFailedTestsSearchParams(
     behaviorId: searchParams.get('behaviorId') || undefined,
     behaviorName: searchParams.get('behaviorName') || undefined,
     metricName: searchParams.get('metric') || undefined,
+    topicId: searchParams.get('topicId') || undefined,
     topicName: searchParams.get('topic') || undefined,
     outcome:
       searchParams.get('outcome') === INSIGHTS_OUTCOME_ALL ? 'all' : 'failed',
@@ -178,8 +184,8 @@ export function parseInsightsFailedTestsSearchParams(
  * Resolve test case IDs that failed for the selected Insights scope,
  * optionally scoped to a behavior, metric, or topic row.
  *
- * Delegates to GET /test_results/stats?mode=ids, which resolves matching
- * test_ids server-side (a Postgres query over the stats view) instead of
+ * Delegates to GET /insights/ids, which resolves matching test_ids
+ * server-side (a Postgres query over the stats view) instead of
  * paginating full TestResultDetail rows and filtering them here.
  */
 export async function fetchFailedTestIdsForInsights(
@@ -200,17 +206,17 @@ export async function fetchFailedTestIdsForInsights(
     return [];
   }
 
-  const client = new ApiClientFactory().getTestResultsClient();
-  const result = await client.getComprehensiveTestResultsStats({
-    mode: 'ids',
+  const client = new ApiClientFactory().getInsightsClient();
+  const result = await client.getInsightsIds({
+    entity: filters.metricName ? 'metric' : 'test_result',
     test_run_ids: testRunIds,
     outcome: filters.outcome === 'all' ? 'all' : 'fail',
     ...(filters.behaviorId ? { behavior_ids: [filters.behaviorId] } : {}),
-    ...(filters.metricName ? { metric_name: filters.metricName } : {}),
-    ...(filters.topicName ? { topic_name: filters.topicName } : {}),
+    ...(filters.metricName ? { metric_names: [filters.metricName] } : {}),
+    ...(filters.topicId ? { topic_ids: [filters.topicId] } : {}),
   });
 
-  return result.test_ids ?? [];
+  return result.ids ?? [];
 }
 
 export function formatInsightsSummaryDetail(

--- a/apps/frontend/src/utils/api-client/insights-client.ts
+++ b/apps/frontend/src/utils/api-client/insights-client.ts
@@ -1,21 +1,73 @@
 import { BaseApiClient } from './base-client';
 import { API_ENDPOINTS } from './config';
-import {
-  InsightsBatchRequest,
-  InsightsBatchResponse,
+import type {
+  InsightsIdsParams,
+  InsightsIdsResponse,
+  InsightsQueryRequest,
+  InsightsQueryResponse,
 } from './interfaces/insights';
 
+function appendListParam(
+  searchParams: URLSearchParams,
+  key: string,
+  values: string[] | undefined
+): void {
+  if (!values) return;
+  for (const value of values) {
+    searchParams.append(key, value);
+  }
+}
+
 export class InsightsClient extends BaseApiClient {
-  async getInsightsBatch(
-    request: InsightsBatchRequest
-  ): Promise<InsightsBatchResponse> {
-    return this.fetch<InsightsBatchResponse>(
-      `${API_ENDPOINTS.insights}/batch`,
+  async getInsightsQuery(
+    request: InsightsQueryRequest
+  ): Promise<InsightsQueryResponse> {
+    return this.fetch<InsightsQueryResponse>(
+      `${API_ENDPOINTS.insights}/query`,
       {
         method: 'POST',
         body: JSON.stringify(request),
         cache: 'no-store',
       }
+    );
+  }
+
+  async getInsightsIds(
+    params: InsightsIdsParams
+  ): Promise<InsightsIdsResponse> {
+    const searchParams = new URLSearchParams();
+    searchParams.set('entity', params.entity);
+    if (params.outcome) {
+      searchParams.set('outcome', params.outcome);
+    }
+    if (params.months != null) {
+      searchParams.set('months', String(params.months));
+    }
+    if (params.start_date) {
+      searchParams.set('start_date', params.start_date);
+    }
+    if (params.end_date) {
+      searchParams.set('end_date', params.end_date);
+    }
+    appendListParam(searchParams, 'test_run_ids', params.test_run_ids);
+    appendListParam(searchParams, 'behavior_ids', params.behavior_ids);
+    appendListParam(searchParams, 'category_ids', params.category_ids);
+    appendListParam(searchParams, 'topic_ids', params.topic_ids);
+    appendListParam(searchParams, 'status_ids', params.status_ids);
+    appendListParam(searchParams, 'test_ids', params.test_ids);
+    appendListParam(searchParams, 'test_type_ids', params.test_type_ids);
+    appendListParam(searchParams, 'user_ids', params.user_ids);
+    appendListParam(searchParams, 'assignee_ids', params.assignee_ids);
+    appendListParam(searchParams, 'owner_ids', params.owner_ids);
+    appendListParam(searchParams, 'prompt_ids', params.prompt_ids);
+    appendListParam(searchParams, 'test_set_ids', params.test_set_ids);
+    appendListParam(searchParams, 'tags', params.tags);
+    appendListParam(searchParams, 'metric_names', params.metric_names);
+    appendListParam(searchParams, 'endpoint_ids', params.endpoint_ids);
+
+    return this.fetch<InsightsIdsResponse>(
+      `${API_ENDPOINTS.insights}/ids?${searchParams.toString()}`,
+      { cache: 'no-store' }
     );
   }
 }

--- a/apps/frontend/src/utils/api-client/interfaces/insights.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/insights.ts
@@ -1,7 +1,7 @@
-/** Registry entities exposed by `POST /insights/batch` — see backend `services/insights/registry.py`. */
+/** Registry entities exposed by Insights endpoints — see backend `services/insights/registry.py`. */
 export type InsightsEntity = 'test_result' | 'metric' | 'test_run' | 'test';
 
-/** One named sub-query in an insights batch request. */
+/** One named sub-query in a POST /insights/query request. */
 export interface InsightsQuery {
   entity: InsightsEntity;
   group_by?: string[];
@@ -12,9 +12,8 @@ export interface InsightsQuery {
   end_date?: string;
 }
 
-export interface InsightsBatchRequest {
-  queries: Record<string, InsightsQuery>;
-}
+/** Body of POST /insights/query: label -> query (no wrapping `queries` key). */
+export type InsightsQueryRequest = Record<string, InsightsQuery>;
 
 /** One aggregated row: the requested `group_by` dimension values plus the requested measures. */
 export type InsightsRow = Record<string, string | number>;
@@ -26,6 +25,35 @@ export interface InsightsResponse {
   rows: InsightsRow[];
 }
 
-export interface InsightsBatchResponse {
-  results: Record<string, InsightsResponse>;
+/** Response of POST /insights/query: label -> envelope (no wrapping `results` key). */
+export type InsightsQueryResponse = Record<string, InsightsResponse>;
+
+export type InsightsOutcome = 'pass' | 'fail' | 'all';
+
+export interface InsightsIdsParams {
+  entity: InsightsEntity;
+  outcome?: InsightsOutcome;
+  months?: number;
+  start_date?: string;
+  end_date?: string;
+  test_run_ids?: string[];
+  behavior_ids?: string[];
+  category_ids?: string[];
+  topic_ids?: string[];
+  status_ids?: string[];
+  test_ids?: string[];
+  test_type_ids?: string[];
+  user_ids?: string[];
+  assignee_ids?: string[];
+  owner_ids?: string[];
+  prompt_ids?: string[];
+  test_set_ids?: string[];
+  tags?: string[];
+  metric_names?: string[];
+  endpoint_ids?: string[];
+}
+
+export interface InsightsIdsResponse {
+  entity: string;
+  ids: string[];
 }

--- a/tests/backend/routes/test_insights.py
+++ b/tests/backend/routes/test_insights.py
@@ -1,4 +1,4 @@
-"""Route tests for the generic GET /insights aggregation endpoint."""
+"""Route tests for the generic Insights aggregation endpoints."""
 
 import pytest
 from fastapi import status
@@ -7,8 +7,9 @@ from rhesis.backend.app import models
 
 
 @pytest.fixture
-def two_test_results(test_db, test_organization, db_user, db_test_configuration, db_test_run,
-                      db_status):
+def two_test_results(
+    test_db, test_organization, db_user, db_test_configuration, db_test_run, db_status
+):
     """Two TestResult rows belonging to db_test_run."""
     results = []
     for _ in range(2):
@@ -42,11 +43,15 @@ def one_run_and_one_unrun_test(
 ):
     """One test with a result, one test with none -- exercises v_test_stats."""
     run_test = models.Test(
-        priority=1, user_id=db_user.id, organization_id=test_organization.id,
+        priority=1,
+        user_id=db_user.id,
+        organization_id=test_organization.id,
         status_id=db_status.id,
     )
     unrun_test = models.Test(
-        priority=1, user_id=db_user.id, organization_id=test_organization.id,
+        priority=1,
+        user_id=db_user.id,
+        organization_id=test_organization.id,
         status_id=db_status.id,
     )
     test_db.add_all([run_test, unrun_test])
@@ -88,9 +93,7 @@ class TestInsightsRoute:
         assert body["dimensions"] == []
         assert body["rows"][0]["count"] == 2
 
-    def test_test_entity_counts_unrun_tests(
-        self, authenticated_client, one_run_and_one_unrun_test
-    ):
+    def test_test_entity_counts_unrun_tests(self, authenticated_client, one_run_and_one_unrun_test):
         run_test, unrun_test = one_run_and_one_unrun_test
 
         response = authenticated_client.get(
@@ -122,6 +125,60 @@ class TestInsightsRoute:
                 "group_by": ["not_a_real_dimension"],
                 "measures": ["count"],
             },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_query_runs_named_subqueries(self, authenticated_client, two_test_results):
+        db_test_run, _ = two_test_results
+        run_id = str(db_test_run.id)
+
+        response = authenticated_client.post(
+            "/insights/query",
+            json={
+                "summary": {
+                    "entity": "test_result",
+                    "group_by": [],
+                    "measures": ["count"],
+                    "filters": {"test_run_ids": [run_id]},
+                },
+                "by_run": {
+                    "entity": "test_result",
+                    "group_by": ["test_run"],
+                    "measures": ["count"],
+                    "filters": {"test_run_ids": [run_id]},
+                },
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert "queries" not in body
+        assert "results" not in body
+        assert body["summary"]["rows"][0]["count"] == 2
+        assert body["by_run"]["entity"] == "test_result"
+
+    def test_ids_returns_distinct_test_ids(self, authenticated_client, two_test_results):
+        db_test_run, results = two_test_results
+        expected = {str(r.test_id) for r in results}
+
+        response = authenticated_client.get(
+            "/insights/ids",
+            params={
+                "entity": "test_result",
+                "test_run_ids": [str(db_test_run.id)],
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body["entity"] == "test_result"
+        assert set(body["ids"]) == expected
+
+    def test_ids_rejects_unknown_outcome(self, authenticated_client):
+        response = authenticated_client.get(
+            "/insights/ids",
+            params={"entity": "test_result", "outcome": "maybe"},
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## Purpose
Give Insights a proper ID-resolution endpoint and align the multi-query API shape, so the Insights page can leave `/test_results/stats?mode=ids` and use one consistent filter vocabulary.
## What Changed
- Add `GET /insights/ids` (distinct IDs + optional outcome; same registry filters as aggregation)
- Rename `POST /insights/batch` → `POST /insights/query` and flatten the body/response (no `queries` / `results` wrappers)
- Share filter/date query params via FastAPI `Depends`; extract `_base_query` and registry `id_column` / `apply_outcome`
- Point Insights failed-tests drill-down at `/insights/ids` using `topic_ids` (chart now groups by `topic_id` + `topic`)
- Update backend and frontend tests
## Additional Context
- Breaking for any caller of `/insights/batch` or the old `{ queries: … }` / `{ results: … }` shape
- No DB migration; `topic_id` already exists on the stats views
## Testing
- `cd ackend && uv run pytest ../../tests/backend/routes/test_insights.py -v`
- `cd apps/frontend && npm test -- --testPathPatterns='behavior-insights-utils|insights-failed-tests|useBehaviorInsightsData|fetch-failed-test-ids' --no-coverage`
- Manually: Insights page loads; clicking a topic/metric row still opens the failed-tests list