### PR TITLE
Fix: Stg Grafana Datasource Rw Url

### DIFF
--- a/kubernetes/clusters/stg/grafana-resources/postgres-stg-datasource.yaml
+++ b/kubernetes/clusters/stg/grafana-resources/postgres-stg-datasource.yaml
@@ -1,8 +1,9 @@
 # Read-only Postgres datasource for staging dashboards. "grafana-viewer" (see
 # cnpg-cluster.yaml managed.roles) only has SELECT granted on public schema tables.
-# Note: stg runs a single CNPG instance (no replica), so rhesis-stg-ro resolves to the
-# same primary pod as rhesis-stg-rw — the SELECT-only grant is what enforces read-only
-# here, not replica routing (unlike prd, which has a physical hot-standby).
+# Uses rhesis-stg-rw, not rhesis-stg-ro: stg runs a single CNPG instance (no replica),
+# and CNPG's -ro service only routes to pods labeled "replica" — with none, it has zero
+# endpoints and refuses every connection. The SELECT-only grant is what enforces
+# read-only here, not replica routing (unlike prd, which has a physical hot-standby).
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 metadata:
@@ -15,10 +16,10 @@ spec:
     matchLabels:
       dashboards: grafana
   datasource:
-    name: "Rhesis STG Postgres (RO)"
+    name: "Rhesis STG Postgres (RW)"
     type: postgres
     access: proxy
-    url: rhesis-stg-ro.rhesis.svc:5432
+    url: rhesis-stg-rw.rhesis.svc:5432
     database: rhesis-stg-db
     user: grafana-viewer
     jsonData:


### PR DESCRIPTION
This PR introduces changes from the `fix/stg-grafana-datasource-rw-url` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->


## 📁 Files Changed (       1 files)

```
kubernetes/clusters/stg/grafana-resources/postgres-stg-datasource.yaml
```

## 📋 Commit Details

```
8f5394310 - fix(infra): point stg grafana datasource at rw, not ro, service (Md Asaduzzaman Miah, 2026-08-05 15:02)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->