### PR TITLE
Hide Explorer tests from the tests list and counts

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/crud/__init__.py
@@ -665,12 +665,7 @@ def get_test_sets(
         query_builder = query_builder.with_custom_filter(has_runs_filter)
 
     # Exclude explorer test sets (they use the dedicated /explorer API)
-    def exclude_explorer_test_sets(query):
-        return query.filter(models.TestSet.explorer_row.is_(False))
-
-    query_builder = query_builder.with_custom_filter(exclude_explorer_test_sets)
-
-    return query_builder.all()
+    return query_builder.with_explorer_rows_excluded().all()
 
 
 def create_test_set(
@@ -2149,6 +2144,7 @@ def get_tests(
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.Test]:
+    """Get tests, minus the Explorer-owned ones (those belong to the /explorer API)."""
     # NOTE: No secondary_sort_by: Test.content sorting is a slow correlated subquery
     return get_items_detail(
         db,
@@ -2160,6 +2156,7 @@ def get_tests(
         filter,
         organization_id=organization_id,
         user_id=user_id,
+        exclude_explorer_rows=True,
     )
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/test.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test.py
@@ -199,7 +199,7 @@ def generate_test_stats(
 
 
 @router.get("/", response_model=List[schemas.TestDetail])
-@with_count_header(model=models.Test)
+@with_count_header(model=models.Test, exclude_explorer_rows=True)
 def read_tests(
     response: Response,
     skip: int = 0,
@@ -216,7 +216,11 @@ def read_tests(
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
 ):
-    """Get all tests with their related objects"""
+    """Get all tests with their related objects.
+
+    Explorer tests (flagged via explorer_row) are omitted; they are reachable
+    through the /explorer API only.
+    """
     organization_id, user_id = tenant_context
     tests = crud.get_tests(
         db,

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -313,7 +313,7 @@ def create_test_set(
 
 
 @router.get("/", response_model=list[schemas.TestSetDetail])
-@with_count_header(model=models.TestSet)
+@with_count_header(model=models.TestSet, exclude_explorer_rows=True)
 def read_test_sets(
     response: Response,
     skip: int = 0,

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -487,6 +487,7 @@ def get_items_detail(
     user_id: str = None,
     secondary_sort_by: str | None = None,
     secondary_sort_order: str = "asc",
+    exclude_explorer_rows: bool = False,
 ) -> List[T]:
     """
     Get multiple items with relationships eagerly loaded, pagination, sorting, and filtering.
@@ -500,6 +501,8 @@ def get_items_detail(
                             Format: {"relationship_name": ["nested_rel1", "nested_rel2"]}
         selectin_chains: Extra relationship-name chains to load with nested selectinload,
                         beyond the defaults above. Format: [["rel", "nested_rel"], ...]
+        exclude_explorer_rows: Drop Explorer-owned rows. Only for models with an
+                        ``explorer_row`` column (Test, TestSet).
 
     Runs as two queries rather than one: a joinless query picks the page's IDs
     (filter + sort + LIMIT/OFFSET), then a second query eager-loads
@@ -509,12 +512,16 @@ def get_items_detail(
     against a dozen tables, that cost scales with total matching rows, not
     with the page size actually returned.
     """
-    ordered_ids = (
+    ids_builder = (
         QueryBuilder(db, model)
         .with_organization_filter(organization_id)
         .with_visibility_filter(user_id)
         .with_odata_filter(filter)
-        .with_sorting(
+    )
+    if exclude_explorer_rows:
+        ids_builder = ids_builder.with_explorer_rows_excluded()
+    ordered_ids = (
+        ids_builder.with_sorting(
             sort_by,
             sort_order,
             secondary_sort_by=secondary_sort_by,
@@ -908,15 +915,22 @@ def count_items(
     filter: str = None,
     organization_id: str = None,
     user_id: str = None,
+    exclude_explorer_rows: bool = False,
 ) -> int:
-    """Get the total count of items matching filters (without pagination)."""
-    return (
+    """Get the total count of items matching filters (without pagination).
+
+    ``exclude_explorer_rows`` must match the list endpoint's own filtering, otherwise
+    the count and the returned page disagree.
+    """
+    builder = (
         QueryBuilder(db, model)
         .with_organization_filter(organization_id)
         .with_visibility_filter(user_id)
         .with_odata_filter(filter)
-        .count()
     )
+    if exclude_explorer_rows:
+        builder = builder.with_explorer_rows_excluded()
+    return builder.count()
 
 
 # ============================================================================

--- a/apps/backend/src/rhesis/backend/app/utils/decorators.py
+++ b/apps/backend/src/rhesis/backend/app/utils/decorators.py
@@ -13,7 +13,13 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-def with_count_header(model: Type):
+def with_count_header(model: Type, exclude_explorer_rows: bool = False):
+    """Set X-Total-Count for a list endpoint.
+
+    Pass ``exclude_explorer_rows=True`` when the endpoint itself hides Explorer-owned
+    rows, so the header matches what the page returns.
+    """
+
     def decorator(func: Callable) -> Callable:
         is_async = inspect.iscoroutinefunction(func)
 
@@ -29,7 +35,14 @@ def with_count_header(model: Type):
             if db and tenant_context:
                 # Standard pattern: db + tenant_context
                 organization_id, user_id = tenant_context
-                count = count_items(db, model, filter_expr, organization_id, user_id)
+                count = count_items(
+                    db,
+                    model,
+                    filter_expr,
+                    organization_id,
+                    user_id,
+                    exclude_explorer_rows=exclude_explorer_rows,
+                )
                 response.headers["X-Total-Count"] = str(count)
             else:
                 # Missing required dependencies - cannot count items without organization filtering

--- a/apps/backend/src/rhesis/backend/app/utils/query_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/query_utils.py
@@ -430,6 +430,11 @@ class QueryBuilder:
         self.query = filter_func(self.query)
         return self
 
+    def with_explorer_rows_excluded(self) -> "QueryBuilder":
+        """Drop Explorer-owned rows -- they are listed through the /explorer API only."""
+        self.query = self.query.filter(self.model.explorer_row.is_(False))
+        return self
+
     def with_field_inclusion(self, include_fields: str) -> "QueryBuilder":
         """Apply field inclusion using SQLAlchemy undefer for deferred fields"""
         if not include_fields:

--- a/tests/backend/crud/test_test_crud.py
+++ b/tests/backend/crud/test_test_crud.py
@@ -22,6 +22,7 @@ from rhesis.backend.app import crud, models
 from rhesis.backend.app.constants import EXPLORER_BEHAVIOR_NAME
 from rhesis.backend.app.models.test import test_test_set_association
 from rhesis.backend.app.services import test_set as test_set_service
+from rhesis.backend.app.utils.crud_utils import count_items
 
 
 @pytest.mark.unit
@@ -398,3 +399,61 @@ class TestBulkDeleteTests:
         still_there = test_db.query(models.Test).filter(models.Test.id == foreign_test.id).first()
         assert still_there is not None
         assert still_there.deleted_at is None
+
+
+@pytest.mark.unit
+@pytest.mark.crud
+class TestGetTestsExcludesExplorer:
+    """crud.get_tests must omit explorer tests (general test list API)."""
+
+    def test_get_tests_excludes_explorer_rows(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        regular = models.Test(
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+        explorer = models.Test(
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+            explorer_row=True,
+        )
+        test_db.add_all([regular, explorer])
+        test_db.commit()
+
+        results = crud.get_tests(
+            test_db,
+            organization_id=str(test_org_id),
+            user_id=str(authenticated_user_id),
+            limit=100,
+        )
+        ids = {test.id for test in results}
+        assert regular.id in ids
+        assert explorer.id not in ids
+
+    def test_count_items_excludes_explorer_rows(
+        self, test_db: Session, test_org_id: str, authenticated_user_id: str
+    ):
+        """X-Total-Count must match the filtered list -- see with_count_header."""
+        explorer = models.Test(
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+            explorer_row=True,
+        )
+        test_db.add(explorer)
+        test_db.commit()
+
+        counted = count_items(
+            test_db,
+            models.Test,
+            organization_id=str(test_org_id),
+            user_id=str(authenticated_user_id),
+            exclude_explorer_rows=True,
+        )
+        total = count_items(
+            test_db,
+            models.Test,
+            organization_id=str(test_org_id),
+            user_id=str(authenticated_user_id),
+        )
+        assert counted == total - 1


### PR DESCRIPTION
## Purpose

Explorer tests were showing up in the Tests tab. Explorer owns its own tests and test sets, flagged with the `explorer_row` column, and `GET /test_sets/` already filtered them out — but `GET /tests/` never did. So every Explorer test appeared in the general test list, including the prompt-less "topic marker" rows that only exist to hold the topic tree.

## What Changed

- `crud.get_tests` now excludes rows with `explorer_row = true`, matching what `crud.get_test_sets` already did.
- `X-Total-Count` on both `GET /tests/` and `GET /test_sets/` excludes them too. This fixes a second, quieter bug: the test set list already hid Explorer sets from the page but still counted them, so the grid total was higher than the rows it showed.
- The filter itself moved into one place, `QueryBuilder.with_explorer_rows_excluded()`. `get_items_detail`, `count_items`, and `with_count_header` take an `exclude_explorer_rows` flag that routes through it, so a list endpoint and its count can't drift apart.

Tests copied out of Explorer into a regular test set are unaffected — `create_explorer_test` leaves `explorer_row` false for those, so they still appear in the Tests tab as they should.

## Additional Context

- Follows up on #2364, which replaced the old Explorer marker with the `explorer_row` column and added the exclusion for test sets only.
- Based on `release/v0.12.0` (#2387), not `main`.
- No migration or API-shape change; `explorer_row` is already backfilled and is not client-settable.

## Testing

`TestGetTestsExcludesExplorer` in `tests/backend/crud/test_test_crud.py` covers both the list and the count.

```bash
cd apps/backend
uv run pytest ../../tests/backend/crud/test_test_crud.py -v
```

Also ran green: the explorer route/service/crud suites (`routes/test_explorer.py`, `routes/test_test_bulk_delete.py`, `routes/test_test_test_sets.py`, `services/test_test_set.py`, `crud/test_explorer_crud.py`, `services/explorer/`) and `tests/backend/utils/`, since `crud_utils`/`query_utils` are shared by every list endpoint.

Manually: open the Tests tab with Explorer test sets in the org. Explorer prompts and topic markers should be gone, and the row count in the header should match the rows listed.
