### PR TITLE
Fix various frontend bugs

### DIFF
--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectChat.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectChat.tsx
@@ -96,7 +96,9 @@ function planDataToMarkdown(data: Record<string, unknown>): string {
     lines.push('');
   }
   const mappings = data.behavior_metric_mappings as
-    PlanSpec[] | Record<string, string[]> | undefined;
+    | PlanSpec[]
+    | Record<string, string[]>
+    | undefined;
   if (mappings) {
     lines.push('## Behavior-Metric Mappings', '');
     if (Array.isArray(mappings)) {

--- a/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/EndpointForm.tsx
@@ -287,7 +287,9 @@ const EndpointForm = forwardRef<EndpointFormHandle, EndpointFormProps>(
           input_data: inputData,
           endpoint_path: formData.endpoint_path || undefined,
           response_format: (formData.response_format || 'json') as
-            'json' | 'xml' | 'text',
+            | 'json'
+            | 'xml'
+            | 'text',
         });
 
         const r = result as Record<string, unknown>;

--- a/apps/frontend/src/app/(protected)/endpoints/components/JsonPreview.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/components/JsonPreview.tsx
@@ -226,13 +226,21 @@ export function JsonPreview({
                   fontWeight: isAlreadyMapped ? 600 : 400,
                   ...(onKeyClick && {
                     cursor: 'pointer',
-                    borderRadius: '2px',
-                    px: '2px',
-                    ml: '-2px',
+                    borderRadius: '4px',
+                    px: '4px',
+                    ml: '-4px',
+                    bgcolor: (t: Theme) =>
+                      alpha(
+                        t.palette.primary.main,
+                        isAlreadyMapped ? 0.14 : 0.08
+                      ),
+                    border: '1px dashed',
+                    borderColor: 'primary.main',
                     '&:hover': {
-                      bgcolor: (t: Theme) => alpha(t.palette.primary.main, 0.1),
-                      outline: '1px dashed',
-                      outlineColor: 'primary.main',
+                      bgcolor: (t: Theme) =>
+                        alpha(t.palette.primary.main, 0.22),
+                      border: '1px solid',
+                      borderColor: 'primary.main',
                     },
                   }),
                 }}

--- a/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentVersionsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/experiments/[identifier]/components/ExperimentVersionsGrid.tsx
@@ -185,7 +185,8 @@ export default function ExperimentVersionsGrid({
           row.values[field.name] ?? null,
         renderCell: (params: GridRenderCellParams<ExperimentVersion>) => {
           const val = params.row.values[field.name] as
-            ParameterValue | undefined;
+            | ParameterValue
+            | undefined;
           return (
             <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
               {val !== undefined ? (

--- a/apps/frontend/src/app/(protected)/knowledge/[identifier]/components/SourcePreviewClientWrapper.tsx
+++ b/apps/frontend/src/app/(protected)/knowledge/[identifier]/components/SourcePreviewClientWrapper.tsx
@@ -392,8 +392,11 @@ export default function SourcePreviewClientWrapper({
       // Update local source state
       setLocalSource(prev => ({
         ...prev,
-        title: fieldValues.title || prev.title,
-        description: fieldValues.description || prev.description,
+        title: fieldValues.title !== undefined ? fieldValues.title : prev.title,
+        description:
+          fieldValues.description !== undefined
+            ? fieldValues.description
+            : prev.description,
       }));
       setIsEditing(null);
 

--- a/apps/frontend/src/app/(protected)/organizations/settings/components/OrganizationSettingsTabs.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/settings/components/OrganizationSettingsTabs.tsx
@@ -68,13 +68,15 @@ export default function OrganizationSettingsTabs({
   const allTabs: MergedTab[] = useMemo(() => {
     const merged: MergedTab[] = [
       ...BUILT_IN_TABS,
-      ...dynamicTabs.map((t): DynamicTab => ({
-        id: t.id,
-        label: t.title,
-        order: t.order,
-        dynamic: true,
-        component: t.component,
-      })),
+      ...dynamicTabs.map(
+        (t): DynamicTab => ({
+          id: t.id,
+          label: t.title,
+          order: t.order,
+          dynamic: true,
+          component: t.component,
+        })
+      ),
     ];
     return merged.sort((a, b) => a.order - b.order);
   }, [dynamicTabs]);

--- a/apps/frontend/src/app/(protected)/tasks/components/TaskDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TaskDrawer.tsx
@@ -150,7 +150,8 @@ export default function TaskDrawer({
 
   const entityType = initialEntity?.entityType;
   const commentId = initialEntity?.task_metadata?.comment_id as
-    string | undefined;
+    | string
+    | undefined;
 
   return (
     <BaseDrawer

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -443,7 +443,8 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
             (params.row.attributes?.parameter_experiment_name as string) ||
             undefined;
           const version = params.row.attributes?.parameter_version as
-            string | undefined;
+            | string
+            | undefined;
 
           if (!name && !version) return null;
 

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/ChipGroup.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/ChipGroup.tsx
@@ -35,7 +35,11 @@ export default function ChipGroup({
     };
 
     return colorMap[chip.colorVariant || 'blue'] as
-      'primary' | 'secondary' | 'warning' | 'success' | undefined;
+      | 'primary'
+      | 'secondary'
+      | 'warning'
+      | 'success'
+      | undefined;
   };
 
   const getChipSx = (chip: ChipConfig) => {

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/SelectionModal.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/SelectionModal.tsx
@@ -26,7 +26,12 @@ export interface SelectionCardConfig {
   buttonLabel: string;
   buttonVariant: 'contained' | 'outlined';
   buttonColor?:
-    'primary' | 'secondary' | 'warning' | 'error' | 'info' | 'success';
+    | 'primary'
+    | 'secondary'
+    | 'warning'
+    | 'error'
+    | 'info'
+    | 'success';
   onClick: () => void;
   preview?: ReactNode;
 }

--- a/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/types.ts
+++ b/apps/frontend/src/app/(protected)/test-sets/new-generated/components/shared/types.ts
@@ -178,4 +178,8 @@ export interface FlowState {
  * Document processing status
  */
 export type DocumentStatus =
-  'uploading' | 'extracting' | 'generating' | 'completed' | 'error';
+  | 'uploading'
+  | 'extracting'
+  | 'generating'
+  | 'completed'
+  | 'error';

--- a/apps/frontend/src/app/(protected)/tests/components/TestDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/tests/components/TestDrawer.tsx
@@ -29,7 +29,8 @@ export default function TestDrawer({
   const { data: session } = useSession();
   const getCurrentUserId = () =>
     session?.user?.id as
-      `${string}-${string}-${string}-${string}-${string}` | undefined;
+      | `${string}-${string}-${string}-${string}-${string}`
+      | undefined;
 
   const handleSave = async () => {
     try {

--- a/apps/frontend/src/app/(protected)/traces/components/ConversationTraceView.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/ConversationTraceView.tsx
@@ -47,7 +47,8 @@ function getPerTurnOverrides(
   rootSpans: SpanNode[]
 ): Record<number, TurnOverrideEntry> {
   const traceMetrics = rootSpans.find(s => s.trace_metrics)?.trace_metrics as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   if (!traceMetrics) return {};
 
   const turnOverrides = traceMetrics.turn_overrides as

--- a/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceDrawer.tsx
@@ -249,14 +249,17 @@ export default function TraceDrawer({
 
   const mentionableMetrics: MentionOption[] = useMemo(() => {
     const traceMetrics = selectedSpan?.trace_metrics as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     if (!traceMetrics) return [];
     const names: string[] = [];
     for (const section of ['turn_metrics', 'conversation_metrics']) {
       const sectionData = traceMetrics[section] as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       const metrics = sectionData?.metrics as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       if (metrics) {
         names.push(...Object.keys(metrics));
       }
@@ -304,15 +307,18 @@ export default function TraceDrawer({
   const handleReviewMetric = useCallback(
     (metricName: string) => {
       const traceMetrics = selectedSpan?.trace_metrics as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       if (!traceMetrics) return;
 
       let isSuccessful = false;
       for (const section of ['turn_metrics', 'conversation_metrics']) {
         const sectionData = traceMetrics[section] as
-          Record<string, unknown> | undefined;
+          | Record<string, unknown>
+          | undefined;
         const metrics = sectionData?.metrics as
-          Record<string, { is_successful?: boolean }> | undefined;
+          | Record<string, { is_successful?: boolean }>
+          | undefined;
         if (metrics?.[metricName]) {
           isSuccessful = !!metrics[metricName].is_successful;
           break;
@@ -366,7 +372,8 @@ export default function TraceDrawer({
         const testRun = await testRunsClient.getTestRun(trace.test_run.id);
         if (testRun?.experiment_id) {
           const attrs = testRun.attributes as
-            Record<string, unknown> | undefined;
+            | Record<string, unknown>
+            | undefined;
           setExperimentInfo({
             id: testRun.experiment_id,
             name: (attrs?.parameter_experiment_name as string) || 'Unknown',

--- a/apps/frontend/src/app/(protected)/traces/components/TraceMetricsTab.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceMetricsTab.tsx
@@ -287,7 +287,8 @@ export default function TraceMetricsTab({
   const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
 
   const traceMetrics = selectedSpan?.trace_metrics as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
 
   const turnMetrics = useMemo(() => {
     if (!traceMetrics?.turn_metrics) return null;

--- a/apps/frontend/src/app/(protected)/traces/components/TraceReviewDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceReviewDrawer.tsx
@@ -59,7 +59,8 @@ function getAllTraceMetrics(
   const result: Record<string, MetricEntry> = {};
   for (const section of ['turn_metrics', 'conversation_metrics']) {
     const sectionData = traceMetrics[section] as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     const metrics = (sectionData?.metrics ?? {}) as Record<string, MetricEntry>;
     Object.assign(result, metrics);
   }
@@ -128,13 +129,16 @@ export default function TraceReviewDrawer({
 
   const getTurnMetricsAutomatedStatus = useCallback((): 'passed' | 'failed' => {
     const traceMetrics = selectedSpan?.trace_metrics as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     const turnSection = traceMetrics?.turn_metrics as
-      Record<string, unknown> | undefined;
+      | Record<string, unknown>
+      | undefined;
     if (!turnSection) return 'failed';
 
     const metrics = turnSection.metrics as
-      Record<string, { is_successful?: boolean }> | undefined;
+      | Record<string, { is_successful?: boolean }>
+      | undefined;
     if (metrics && Object.keys(metrics).length > 0) {
       return Object.values(metrics).every(m => m?.is_successful)
         ? 'passed'

--- a/apps/frontend/src/app/(protected)/traces/components/TraceReviewsTab.tsx
+++ b/apps/frontend/src/app/(protected)/traces/components/TraceReviewsTab.tsx
@@ -39,6 +39,7 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { Status } from '@/utils/api-client/interfaces/status';
 import { alpha } from '@mui/material/styles';
 import { DeleteModal } from '@/components/common/DeleteModal';
+import { useNotifications } from '@/components/common/NotificationContext';
 import StatusChip from '@/components/common/StatusChip';
 import { Capability } from '@/constants/capabilities';
 import { can, Can } from '@/components/common/Can';
@@ -77,6 +78,7 @@ export default function TraceReviewsTab({
 }: TraceReviewsTabProps) {
   const theme = useTheme();
   const queryClient = useQueryClient();
+  const notifications = useNotifications();
 
   const invalidateAnnotations = () => {
     void queryClient.invalidateQueries({ queryKey: annotationKeys.all() });
@@ -236,8 +238,9 @@ export default function TraceReviewsTab({
 
       setDeleteDialogOpen(false);
       setReviewToDelete(null);
-    } catch (_err) {
-      // Error handling
+    } catch (err) {
+      console.error('Failed to delete review:', err);
+      notifications.show('Failed to delete review', { severity: 'error' });
     } finally {
       setDeleting(false);
     }
@@ -260,7 +263,8 @@ export default function TraceReviewsTab({
 
     for (const section of ['turn_metrics', 'conversation_metrics']) {
       const sectionData = traceMetrics[section] as
-        Record<string, unknown> | undefined;
+        | Record<string, unknown>
+        | undefined;
       const metrics = (sectionData?.metrics ?? {}) as Record<
         string,
         { is_successful?: boolean }

--- a/apps/frontend/src/components/common/EditableSection.tsx
+++ b/apps/frontend/src/components/common/EditableSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { SectionCard } from '@/components/common/SectionCard';
 import {
   SectionEditButton,
@@ -45,20 +45,39 @@ export function EditableSection<T>({
   const [draft, setDraft] = useState<T>(initialValue);
   const [isSaving, setIsSaving] = useState(false);
 
+  // After a successful save, `initialValue` still reflects the pre-save prop
+  // until the caller's data refetch resolves. Without this, the effect below
+  // would snap the field back to the old value for a moment, which reads as
+  // "the save didn't stick" even though it did.
+  const pendingSaveRef = useRef<{ staleValue: T; savedValue: T } | null>(null);
+
+  const resolveValue = useCallback((value: T) => {
+    const pending = pendingSaveRef.current;
+    if (
+      pending &&
+      JSON.stringify(value) === JSON.stringify(pending.staleValue)
+    ) {
+      return pending.savedValue;
+    }
+    pendingSaveRef.current = null;
+    return value;
+  }, []);
+
   useEffect(() => {
     if (!isEditing) {
-      setDraft(initialValue);
+      setDraft(resolveValue(initialValue));
     }
-  }, [initialValue, isEditing]);
+  }, [initialValue, isEditing, resolveValue]);
 
   const dirty = isDirty(draft, initialValue);
 
   const handleEdit = useCallback(() => {
-    setDraft(initialValue);
+    setDraft(resolveValue(initialValue));
     setIsEditing(true);
-  }, [initialValue]);
+  }, [initialValue, resolveValue]);
 
   const handleCancel = useCallback(() => {
+    pendingSaveRef.current = null;
     setDraft(initialValue);
     setIsEditing(false);
   }, [initialValue]);
@@ -69,12 +88,16 @@ export function EditableSection<T>({
     try {
       const ok = await onSave(draft);
       if (ok !== false) {
+        pendingSaveRef.current = {
+          staleValue: initialValue,
+          savedValue: draft,
+        };
         setIsEditing(false);
       }
     } finally {
       setIsSaving(false);
     }
-  }, [dirty, isSaving, onSave, draft]);
+  }, [dirty, isSaving, onSave, draft, initialValue]);
 
   const actionButtons = isEditing ? (
     <SectionSaveCancelActions

--- a/apps/frontend/src/components/common/NotificationContext.tsx
+++ b/apps/frontend/src/components/common/NotificationContext.tsx
@@ -2,7 +2,11 @@ import * as React from 'react';
 import { Snackbar, Alert, useTheme } from '@mui/material';
 
 export type NotificationSeverity =
-  'success' | 'info' | 'warning' | 'error' | 'neutral';
+  | 'success'
+  | 'info'
+  | 'warning'
+  | 'error'
+  | 'neutral';
 
 interface NotificationOptions {
   severity?: NotificationSeverity;

--- a/apps/frontend/src/components/common/TestRunStatus.tsx
+++ b/apps/frontend/src/components/common/TestRunStatus.tsx
@@ -11,7 +11,11 @@ import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
 import BlockIcon from '@mui/icons-material/Block';
 
 export type TestRunStatusColor =
-  'success' | 'error' | 'warning' | 'info' | 'default';
+  | 'success'
+  | 'error'
+  | 'warning'
+  | 'info'
+  | 'default';
 
 /**
  * Get the color for a test run status

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -118,10 +118,12 @@ export function Sidebar() {
   const groups = groupNavItems(navigation);
 
   const mainGroups = groups.filter(g => g.type !== 'footer-links') as (
-    StandaloneGroup | SectionGroup
+    | StandaloneGroup
+    | SectionGroup
   )[];
   const footerGroup = groups.find(g => g.type === 'footer-links') as
-    FooterLinksGroup | undefined;
+    | FooterLinksGroup
+    | undefined;
 
   const sidebarWidth = collapsed ? SIDEBAR_COLLAPSED_WIDTH : SIDEBAR_WIDTH;
 

--- a/apps/frontend/src/components/tasks/TasksSection.tsx
+++ b/apps/frontend/src/components/tasks/TasksSection.tsx
@@ -178,7 +178,11 @@ export function TasksSection({
             label={params.row.status?.name || 'Unknown'}
             color={
               getStatusColor(params.row.status?.name) as
-                'warning' | 'primary' | 'success' | 'error' | 'default'
+                | 'warning'
+                | 'primary'
+                | 'success'
+                | 'error'
+                | 'default'
             }
             size="small"
           />

--- a/apps/frontend/src/config/onboarding-tours.ts
+++ b/apps/frontend/src/config/onboarding-tours.ts
@@ -166,7 +166,9 @@ export const driverConfig = {
   prevBtnText: 'Back',
   doneBtnText: 'Got it!',
   showButtons: ['next', 'previous', 'close'] as (
-    'next' | 'previous' | 'close'
+    | 'next'
+    | 'previous'
+    | 'close'
   )[],
   allowClose: true,
   overlayClickNext: false,

--- a/apps/frontend/src/hooks/useArchitectChat.ts
+++ b/apps/frontend/src/hooks/useArchitectChat.ts
@@ -658,7 +658,8 @@ export function useArchitectChat(
     unsubs.push(
       subscribe(EventType.SUBSCRIPTION_ERROR, (msg: WebSocketMessage) => {
         const payload = msg.payload as
-          { channel?: string; error?: string } | undefined;
+          | { channel?: string; error?: string }
+          | undefined;
         const deniedChannel = payload?.channel ?? msg.channel;
         if (deniedChannel !== `architect:${sessionId}`) return;
 

--- a/apps/frontend/src/hooks/useWebSocket.ts
+++ b/apps/frontend/src/hooks/useWebSocket.ts
@@ -15,7 +15,8 @@ import { EventType, WebSocketMessage, EventHandler } from '@/utils/websocket';
  * `preflight:{id}`) can use the plain string form.
  */
 export type ChannelSubscription =
-  string | { channel: string; projectId?: string | null };
+  | string
+  | { channel: string; projectId?: string | null };
 
 /**
  * Options for the useWebSocket hook.

--- a/apps/frontend/src/utils/api-client/interfaces/embedding.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/embedding.ts
@@ -18,4 +18,5 @@ export interface Scatter2DGraph {
 }
 
 export type EmbeddingGraphGetResponse =
-  { status: 'pending' } | { status: 'ready'; graph: Scatter2DGraph };
+  | { status: 'pending' }
+  | { status: 'ready'; graph: Scatter2DGraph };

--- a/apps/frontend/src/utils/conversation-from-spans.ts
+++ b/apps/frontend/src/utils/conversation-from-spans.ts
@@ -7,15 +7,18 @@ import type {
 
 function getAutomatedTurnSuccess(rootSpans: SpanNode[]): boolean | undefined {
   const traceMetrics = rootSpans.find(s => s.trace_metrics)?.trace_metrics as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   if (!traceMetrics) return undefined;
 
   const turnSection = traceMetrics.turn_metrics as
-    Record<string, unknown> | undefined;
+    | Record<string, unknown>
+    | undefined;
   if (!turnSection) return undefined;
 
   const metrics = turnSection.metrics as
-    Record<string, { is_successful?: boolean }> | undefined;
+    | Record<string, { is_successful?: boolean }>
+    | undefined;
   if (metrics && Object.keys(metrics).length > 0) {
     return Object.values(metrics).every(m => m?.is_successful);
   }

--- a/apps/frontend/src/utils/websocket/client.ts
+++ b/apps/frontend/src/utils/websocket/client.ts
@@ -323,7 +323,8 @@ export class WebSocketClient {
     // Handle connection confirmation
     if (message.type === EventType.CONNECTED) {
       const payload = message.payload as unknown as
-        ConnectedPayload | undefined;
+        | ConnectedPayload
+        | undefined;
       this.state.connectionId = payload?.connection_id;
     }
 


### PR DESCRIPTION
## Purpose

Editing a Test's Behavior/Topic/Category/Priority fields appeared to fail — the save showed a success toast but the fields snapped back to their old values. Investigation traced this to a shared component bug affecting every entity that uses inline editing (Tests, Behaviors, Metrics, Test Sets, Tasks, Endpoints, Organizations, Projects), plus two related but independent UI bugs found during a broader audit of CRUD save/delete flows across the frontend.

## What Changed

- `EditableSection.tsx`: after a successful save, the component reset its fields back to the pre-save prop value before the page's refetch/`router.refresh()` had resolved, making a successful save look like it silently failed. It now keeps showing the just-saved value until the refreshed data actually lands.
- `SourcePreviewClientWrapper.tsx`: clearing a Source's title or description to blank saved correctly to the backend, but the UI fell back to the old value because `value || prev` treats an intentionally-cleared empty string the same as "no change".
- `TraceReviewsTab.tsx`: deleting a trace review that failed gave no error feedback at all (empty `catch` block) — now shows an error toast.
- `JsonPreview.tsx`: styling tweak to the mapped-key highlight (dashed border instead of outline, larger padding).
- Repo-wide prettier reformat (whitespace only, no logic changes) — the pre-commit format hook runs across the whole frontend on every commit (`pass_filenames: false`), so pre-existing baseline drift surfaced while committing the fixes above.

## Additional Context

Backend persistence itself was verified correct before making any frontend changes — a passing DB-level test (`tests/backend/crud/test_test_crud.py`) confirms `crud.update_test` writes and re-reads correctly. All three UI bugs are display/feedback issues, not data-loss issues.

## Testing

- `npx tsc --noEmit` and `npx eslint` pass clean on all changed files.
- Manually reproduce each bug on `release/v0.12.0` before this branch, then confirm on this branch: edit a Test's Behavior/Topic/Category and Save (no more revert flash); clear a Source's title/description and Save (blank now displays correctly); trigger a failed trace review delete (now shows an error toast).