### PR TITLE
Fix Enterprise upsell links and empty-state styling

### DIFF
--- a/ee/frontend/src/api-clients/components/ApiClientsEmptyState.tsx
+++ b/ee/frontend/src/api-clients/components/ApiClientsEmptyState.tsx
@@ -13,7 +13,7 @@ export default function ApiClientsEmptyState() {
       actionLabel="Learn about Enterprise"
       onAction={() =>
         window.open(
-          'https://rhesis.ai/pricing',
+          'https://rhesis.ai/editions',
           '_blank',
           'noopener,noreferrer'
         )

--- a/ee/frontend/src/api-clients/components/ApiClientsEmptyState.tsx
+++ b/ee/frontend/src/api-clients/components/ApiClientsEmptyState.tsx
@@ -7,6 +7,8 @@ import ApiIcon from '@mui/icons-material/Api';
 export default function ApiClientsEmptyState() {
   return (
     <EntityEmptyState
+      card
+      showAddIcon={false}
       icon={ApiIcon}
       title="API Clients are an Enterprise feature"
       description="Issue scoped OAuth client credentials for machine-to-machine access to your organization's data."

--- a/ee/frontend/src/rbac/components/RolesEmptyState.tsx
+++ b/ee/frontend/src/rbac/components/RolesEmptyState.tsx
@@ -11,7 +11,13 @@ export default function RolesEmptyState() {
       title="Roles are an Enterprise feature"
       description="Fine-grained role-based access control lets you define custom roles, assign them to team members, and control who can do what across your organization."
       actionLabel="Learn about Enterprise"
-      onAction={() => window.open('https://rhesis.ai/pricing', '_blank')}
+      onAction={() =>
+        window.open(
+          'https://rhesis.ai/editions',
+          '_blank',
+          'noopener,noreferrer'
+        )
+      }
     />
   );
 }

--- a/ee/frontend/src/rbac/components/RolesEmptyState.tsx
+++ b/ee/frontend/src/rbac/components/RolesEmptyState.tsx
@@ -7,6 +7,8 @@ import SecurityIcon from '@mui/icons-material/Security';
 export default function RolesEmptyState() {
   return (
     <EntityEmptyState
+      card
+      showAddIcon={false}
       icon={SecurityIcon}
       title="Roles are an Enterprise feature"
       description="Fine-grained role-based access control lets you define custom roles, assign them to team members, and control who can do what across your organization."

--- a/ee/frontend/src/sso/components/SSOEmptyState.tsx
+++ b/ee/frontend/src/sso/components/SSOEmptyState.tsx
@@ -7,6 +7,8 @@ import VerifiedUserIcon from '@mui/icons-material/VerifiedUser';
 export default function SSOEmptyState() {
   return (
     <EntityEmptyState
+      card
+      showAddIcon={false}
       icon={VerifiedUserIcon}
       title="Single Sign-On is an Enterprise feature"
       description="Let your team sign in with your identity provider (SAML, OIDC) instead of managing separate passwords."

--- a/ee/frontend/src/sso/components/SSOEmptyState.tsx
+++ b/ee/frontend/src/sso/components/SSOEmptyState.tsx
@@ -13,7 +13,7 @@ export default function SSOEmptyState() {
       actionLabel="Learn about Enterprise"
       onAction={() =>
         window.open(
-          'https://rhesis.ai/pricing',
+          'https://rhesis.ai/editions',
           '_blank',
           'noopener,noreferrer'
         )


### PR DESCRIPTION
## Purpose

The three Enterprise upsell empty states (SSO, Roles, API Clients) sent people to `rhesis.ai/pricing`, but editions are described at `rhesis.ai/editions`. While fixing that, the states also turned out to render a different empty-state variant than every other page-level empty state in the app, so they looked out of place in the org settings tabs.

## What Changed

- Point the "Learn about Enterprise" buttons at `https://rhesis.ai/editions` in `SSOEmptyState`, `RolesEmptyState`, and `ApiClientsEmptyState`. No `rhesis.ai/pricing` references remain in the repo; the usage tab already used `/editions`.
- Add the missing `noopener,noreferrer` argument to `RolesEmptyState`'s `window.open`, which the other two already had.
- Switch all three to `EntityEmptyState`'s `card` variant — bordered Paper card, 32px icon, outlined button — matching the tokens page, tools page, and project members. They previously used the standalone variant (64px icon, contained pill button, no card shell).
- Pass `showAddIcon={false}`, since `card` enables a leading `+` icon by default and that doesn't belong on a "Learn about Enterprise" button.

## Additional Context

- Targets `release/v0.12.0` rather than `main`: the `ee/` tree only exists on that branch.
- Purely presentational — no behaviour, gating, or API changes. All three components are `FeatureGate` fallbacks, so they only render on editions without the feature.

## Testing

Ran the frontend and backend locally from a worktree on this branch and opened the org settings tabs at `/organizations/settings?tab=sso`, `?tab=roles`, and `?tab=api-clients`.

- `npm run type-check` (covers both `apps/frontend` and `ee/frontend`) passes.
- `npm run format:check` in `ee/frontend` passes; `npm run lint` reports only the 6 pre-existing warnings in other files.
- Jest could not be run locally: every suite, including untouched ones, fails in `jest.setup.js` at `delete window.location` with `TypeError: Cannot delete property 'location' of #<Window>`. That is a local jsdom/Node issue rather than anything from this change, so CI should be the judge. None of the three changed components have tests of their own.
