### PR TITLE
Hide invite-drawer role pickers in the community edition

### DIFF
--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteForm.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamInviteForm.tsx
@@ -35,6 +35,8 @@ import { useState, useEffect } from 'react';
 import { useSession } from 'next-auth/react';
 import { useNotifications } from '@/components/common/NotificationContext';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useFeature } from '@/contexts/FeaturesContext';
+import { FeatureName } from '@/constants/features';
 import { getMemberRoleExtensions } from '@/lib/extension-registries';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { safeRandomUUID } from '@/utils/uuid';
@@ -79,8 +81,20 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
     const { data: session, status } = useSession();
     const notifications = useNotifications();
     const { projects: availableProjects } = useActiveProject();
-    const { AddMemberRoleField, InviteOrgRoleField, assignOrgMemberRole } =
-      getMemberRoleExtensions();
+    const {
+      AddMemberRoleField,
+      InviteOrgRoleField,
+      assignOrgMemberRole: assignOrgRole,
+    } = getMemberRoleExtensions();
+    // The EE bundle registers the role extensions unconditionally, so their
+    // presence only means "EE code is loaded", not "this org licenses RBAC".
+    // Community has no graded roles — invitees always get the default member
+    // role — so hide the pickers (and skip the org-role assignment) when the
+    // RBAC feature is off, instead of rendering selects with an empty catalog.
+    const rbacEnabled = useFeature(FeatureName.RBAC);
+    const OrgRoleField = rbacEnabled ? InviteOrgRoleField : undefined;
+    const ProjectRoleField = rbacEnabled ? AddMemberRoleField : undefined;
+    const assignOrgMemberRole = rbacEnabled ? assignOrgRole : undefined;
 
     const [formData, setFormData] = useState<FormData>({
       invites: [createInvite()],
@@ -502,13 +516,13 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
                   variant="outlined"
                   sx={{
                     ...drawerOutlinedFieldSx,
-                    flex: InviteOrgRoleField ? 1.4 : 1,
+                    flex: OrgRoleField ? 1.4 : 1,
                   }}
                   data-tour={index === 0 ? 'invite-email-input' : undefined}
                 />
-                {InviteOrgRoleField && isAuthenticated(status) && (
+                {OrgRoleField && isAuthenticated(status) && (
                   <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <InviteOrgRoleField
+                    <OrgRoleField
                       value={invite.orgRoleId}
                       onChange={roleId => handleOrgRoleChange(invite, roleId)}
                       active={drawerOpen}
@@ -621,10 +635,10 @@ const TeamInviteForm = React.forwardRef<HTMLFormElement, TeamInviteFormProps>(
                             )}
                           </Box>
                           {isSelected &&
-                            AddMemberRoleField &&
+                            ProjectRoleField &&
                             isAuthenticated(status) && (
                               <Box sx={{ flexShrink: 0 }}>
-                                <AddMemberRoleField
+                                <ProjectRoleField
                                   value={projectRoles[projectId] ?? null}
                                   onChange={roleId =>
                                     setProjectRoles(prev => ({


### PR DESCRIPTION
## Purpose

In the community edition the invite drawer showed two "Assign role" dropdowns — one beside each email address, one on each selected project — and both were empty. Community has no graded roles, so there is nothing to pick: invitees always get the default member role. The empty selects were dead UI that suggested a choice the edition doesn't offer.

The cause is that the EE bundle calls `registerMemberRoleExtensions` unconditionally in `ee/frontend/src/rbac/register.tsx`. `InviteOrgRoleField` and `AddMemberRoleField` are therefore always defined once EE code is loaded, and the invite form only checked whether the extension was registered. That check answers "is EE code loaded?", not "does this org license RBAC?". The fields rendered, fetched `GET /rbac/roles`, took a feature-gated 404 (`{"detail": "Not available"}`), swallowed the error, and drew a select with an empty catalog.

## What Changed

- `TeamInviteForm` now gates both role pickers on `useFeature(FeatureName.RBAC)` in addition to the registry check. When RBAC is off, neither field renders and the email input goes back to full width (the `flex: 1.4` split is tied to the same condition, so no empty gap is left behind).
- `assignOrgMemberRole` is also nulled out when RBAC is off, so nothing can call the EE assign endpoint from this form.
- Invitees fall back to the default member role: the org role is never set, and project enrollment already posts `role: 'member'` with no `role_id`.

## Additional Context

- Branched from and targeting `release/v0.12.0`.
- Feature state is seeded server-side by the protected layout (`FeaturesProvider` `initialFeatures`), so EE users don't see the dropdowns flash in on first render.
- Not addressed here, same root cause: `ProjectAddMemberDrawer` renders `AddMemberRoleField` on the registry check alone, and `TeamMembersGrid` prewarms `/rbac/roles` and `/rbac/organization-members` on the team page in community, where both 404 and are silently discarded. Harmless, but worth a follow-up.
- A tidier structural fix would be to make `RoleSelectField` return `null` when RBAC is off. That was rejected because the host needs to know the field is absent to fix its own layout — a self-nulling component would leave an empty `flex: 1` gap next to the email input.

## Testing

Verified against a local community-edition stack: the `ee` package installed, no `RHESIS_LICENSE` env var, and no `license` value on the org. `SignedTokenLicenseProvider` then resolves no entitlements, so `GET /features` returns `enabled: []` with `edition: community, licensed: false`, and `/rbac/*` 404s.

1. Open the team page and click **Invite team members**.
2. Confirm no "Assign role" dropdown appears beside the email field, and that the email input spans the full drawer width.
3. Select a project under **Project access** and confirm no role picker appears on the row.
4. Send an invite and confirm the user is created and enrolled with the default member role.

With RBAC licensed, both pickers should still appear and behave exactly as before.

`npx tsc --noEmit` and `npm run lint` are clean (the 6 remaining lint warnings are pre-existing, in unrelated EE files).
