### PR TITLE
Fix HPA scaling for dev worker and prd backend

### DIFF
--- a/charts/rhesis/templates/backend/hpa.yaml
+++ b/charts/rhesis/templates/backend/hpa.yaml
@@ -22,10 +22,12 @@ spec:
         target:
           type: Utilization
           averageUtilization: {{ .Values.backend.hpa.targetCPUUtilizationPercentage }}
+    {{- if .Values.backend.hpa.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: {{ .Values.backend.hpa.targetMemoryUtilizationPercentage }}
+    {{- end }}
 {{- end }}

--- a/charts/rhesis/values-dev.yaml
+++ b/charts/rhesis/values-dev.yaml
@@ -185,7 +185,10 @@ workers:
       requests:
         # Live: ~900Mi+ per worker; 250m CPU request improves spread across nodes.
         cpu: "250m"
-        memory: "1Gi"
+        # Raised from 1Gi: real usage sits at ~1.0-1.3Gi per pod, already above the
+        # old request, which pinned the memory metric near/over target regardless
+        # of actual queue load.
+        memory: "1.5Gi"
       limits:
         # Same as backend: heavy ML imports (litellm, garak) OOMKill at 1Gi
         memory: "2Gi"
@@ -193,7 +196,10 @@ workers:
     hpa:
       enabled: true
       minReplicas: 1
-      maxReplicas: 2
+      # Raised from 2: HPA was hitting TooManyReplicas under real test-run load
+      # (CPU/memory both above target) with nowhere to scale to. Dev nodes have
+      # headroom (30-50% used) to support more pods.
+      maxReplicas: 4
       targetCPUUtilizationPercentage: 60
       targetMemoryUtilizationPercentage: 75
     # Dev: Celery worker loads heavy ML imports (LiteLLM, Garak) on startup.

--- a/charts/rhesis/values-dev.yaml
+++ b/charts/rhesis/values-dev.yaml
@@ -58,7 +58,10 @@ backend:
     minReplicas: 1
     maxReplicas: 2
     targetCPUUtilizationPercentage: 60
-    targetMemoryUtilizationPercentage: 75
+    # Explicitly unset (base default is 80): with only 1-2 replicas, idle memory baseline
+    # (~800Mi of the 1Gi request) rounds up to desiredReplicas=2 via ceil(), pinning at
+    # max regardless of traffic. CPU alone reflects load here.
+    targetMemoryUtilizationPercentage: null
   resources:
     requests:
       # Live: ~750m CPU under test runs; under-requesting causes noisy-neighbor scheduling.

--- a/charts/rhesis/values-prd.yaml
+++ b/charts/rhesis/values-prd.yaml
@@ -80,7 +80,10 @@ backend:
     # 100% of combined requests during fast ramp-up, before new replicas came
     # online. Scaling earlier gives HPA more lead time to react.
     targetCPUUtilizationPercentage: 60
-    targetMemoryUtilizationPercentage: 80
+    # Explicitly unset (base default is 80): real baseline usage sits at ~2.3-2.8Gi of
+    # the 3Gi request (~78-93%), permanently above target regardless of traffic, so
+    # memory pins backend at maxReplicas even at 3% CPU. CPU alone reflects load here.
+    targetMemoryUtilizationPercentage: null
   ingress:
     enabled: true
     host: "api.rhesis.ai"


### PR DESCRIPTION
## Purpose

Continuing the HPA investigation from #2406 (which fixed dev's backend). Two more HPA issues were found by comparing HPA status against real `kubectl top` usage across dev and prd: dev's `worker-default` was capped below real demand, and prd's `backend` had the same memory-baseline pinning bug already fixed in dev.

## What Changed

- **prd backend**: dropped the memory metric from the HPA (`targetMemoryUtilizationPercentage: null`). Real baseline memory usage sits at ~2.3-2.8Gi of the 3Gi request (78-93%), permanently above the 80% target regardless of traffic, which kept backend pinned at `maxReplicas: 6` even at 3% CPU. CPU alone reflects load here.
- **dev worker-default**: raised `maxReplicas` from 2 to 4 and the memory request from 1Gi to 1.5Gi. Unlike the backend cases, this one is a genuine capacity issue, not a false metric — the HPA condition reported `TooManyReplicas`, meaning it wanted more than 2 pods under real CPU/memory load and had nowhere to scale. Memory usage also sat above the old 1Gi request (~1.0-1.3Gi observed), which further inflated the utilization percentage. Dev nodes have headroom (30-50% used) to support more pods.

## Additional Context

Continuation of the investigation in #2406. `chatbot` and `polyphemus` in prd were checked and are healthy (sitting near their floor, not pinned) — no changes needed there. prd's `worker-default` was at 3/6 replicas but settling normally from a recent real scale-up event, not the same bug — left as-is.

## Testing

Verified via `helm template` that both HPA manifests render as expected: prd backend's HPA has only the CPU metric, and dev worker-default's HPA shows `maxReplicas: 4` with the deployment requesting `memory: 1.5Gi`. The equivalent fix for dev backend (#2406) was already validated live — `kubectl describe hpa backend -n rhesis` showed a `SuccessfulRescale` event dropping it from 2 to 1 replica once the memory metric was removed. The two new changes here haven't been validated live yet; once synced, confirm with:
- `kubectl --context=context get hpa worker-default -n rhesis` — should be able to scale above 2 without hitting `TooManyReplicas`.
- `kubectl get hpa backend -n rhesis` (prd context) — should show only the `cpu` metric and scale down from 6 as CPU stays low.