### PR TITLE
Clean up CI workflows and run linting as a matrix

### DIFF
--- a/.github/actions/setup-python-build/action.yml
+++ b/.github/actions/setup-python-build/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.10'
     

--- a/.github/actions/tf-setup/action.yml
+++ b/.github/actions/tf-setup/action.yml
@@ -70,7 +70,7 @@ runs:
                      exit 1 ;;
         esac
 
-    - uses: google-github-actions/auth@v2
+    - uses: google-github-actions/auth@v3
       with:
         workload_identity_provider: ${{ inputs.wif_provider }}
         service_account: ${{ steps.ctx.outputs.service_account }}

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -43,7 +43,7 @@ jobs:
           echo "release_config.json found"
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/frontend-e2e-test.yml
+++ b/.github/workflows/frontend-e2e-test.yml
@@ -73,7 +73,7 @@ jobs:
         working-directory: apps/frontend
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-chromium-${{ steps.playwright-version.outputs.version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   changes:
-    name: Detect changed areas
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.resolve.outputs.targets }}
@@ -18,8 +17,6 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Check for file changes
-        # Skipped on workflow_dispatch: no base ref to diff against, and a
-        # manual run lints everything anyway.
         if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         id: filter
@@ -41,32 +38,29 @@ jobs:
       - name: Resolve lint targets
         id: resolve
         env:
-          # paths-filter's `changes` output is a JSON array of matched filters.
           CHANGED: ${{ github.event_name == 'workflow_dispatch' && '["backend","sdk","penelope","frontend","docs"]' || steps.filter.outputs.changes }}
         run: |
           set -euo pipefail
           echo "Changed areas: $CHANGED"
           echo "targets=$CHANGED" >> "$GITHUB_OUTPUT"
 
-          # The Python areas all lint the same way (uv + `make lint`), so they
-          # share one matrix. Frontend and docs have their own jobs.
           PYTHON=$(jq -nc --argjson changed "$CHANGED" '
-            [ {id: "backend",  name: "Backend",  dir: "apps/backend"},
-              {id: "sdk",      name: "SDK",      dir: "sdk"},
-              {id: "penelope", name: "Penelope", dir: "penelope"} ]
-            | map(select(.id as $id | $changed | index($id)))')
+            [ {id: "backend",  dir: "apps/backend"},
+              {id: "sdk",      dir: "sdk"},
+              {id: "penelope", dir: "penelope"} ]
+            | map(select(.id as $id | $changed | index($id)))
+            | map(.dir)')
           echo "python=$PYTHON" >> "$GITHUB_OUTPUT"
           echo "Python matrix: $PYTHON"
 
   python:
-    name: Lint ${{ matrix.target.name }}
     needs: changes
     if: needs.changes.outputs.python != '[]'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        target: ${{ fromJSON(needs.changes.outputs.python) }}
+        dir: ${{ fromJSON(needs.changes.outputs.python) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -77,12 +71,11 @@ jobs:
           version: latest
           enable-cache: true
 
-      - name: Run ${{ matrix.target.name }} linting
+      - name: Run lint
         run: make lint
-        working-directory: ${{ matrix.target.dir }}
+        working-directory: ${{ matrix.dir }}
 
   frontend:
-    name: Lint Frontend
     needs: changes
     if: contains(fromJSON(needs.changes.outputs.targets), 'frontend')
     runs-on: ubuntu-latest
@@ -113,7 +106,6 @@ jobs:
         run: npm run type-check
 
   docs:
-    name: Lint Docs
     needs: changes
     if: contains(fromJSON(needs.changes.outputs.targets), 'docs')
     runs-on: ubuntu-latest
@@ -151,7 +143,6 @@ jobs:
                         "frontend=${{ needs.frontend.result }}" \
                         "docs=${{ needs.docs.result }}"; do
             echo "$RESULT"
-            # skipped = area not touched by this PR, which is a pass.
             case "${RESULT#*=}" in
               success|skipped) ;;
               *) FAILED=1 ;;

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -138,9 +138,6 @@ jobs:
         run: make lint
 
   lint:
-    # Single stable check for branch protection: the matrix job names vary with
-    # which areas changed, so they cannot be required directly.
-    name: Lint
     needs: [changes, python, frontend, docs]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,159 +7,161 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
+  changes:
+    name: Detect changed areas
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.resolve.outputs.targets }}
+      python: ${{ steps.resolve.outputs.python }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Check for file changes
+        # Skipped on workflow_dispatch: no base ref to diff against, and a
+        # manual run lints everything anyway.
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'apps/frontend/**'
+              - 'ee/frontend/**'
+            docs:
+              - 'docs/src/**'
+              - 'docs/content/**'
+            sdk:
+              - 'sdk/**'
+            backend:
+              - 'apps/backend/**'
+            penelope:
+              - 'penelope/**'
+
+      - name: Resolve lint targets
+        id: resolve
+        env:
+          # paths-filter's `changes` output is a JSON array of matched filters.
+          CHANGED: ${{ github.event_name == 'workflow_dispatch' && '["backend","sdk","penelope","frontend","docs"]' || steps.filter.outputs.changes }}
+        run: |
+          set -euo pipefail
+          echo "Changed areas: $CHANGED"
+          echo "targets=$CHANGED" >> "$GITHUB_OUTPUT"
+
+          # The Python areas all lint the same way (uv + `make lint`), so they
+          # share one matrix. Frontend and docs have their own jobs.
+          PYTHON=$(jq -nc --argjson changed "$CHANGED" '
+            [ {id: "backend",  name: "Backend",  dir: "apps/backend"},
+              {id: "sdk",      name: "SDK",      dir: "sdk"},
+              {id: "penelope", name: "Penelope", dir: "penelope"} ]
+            | map(select(.id as $id | $changed | index($id)))')
+          echo "python=$PYTHON" >> "$GITHUB_OUTPUT"
+          echo "Python matrix: $PYTHON"
+
+  python:
+    name: Lint ${{ matrix.target.name }}
+    needs: changes
+    if: needs.changes.outputs.python != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(needs.changes.outputs.python) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: latest
+          enable-cache: true
+
+      - name: Run ${{ matrix.target.name }} linting
+        run: make lint
+        working-directory: ${{ matrix.target.dir }}
+
+  frontend:
+    name: Lint Frontend
+    needs: changes
+    if: contains(fromJSON(needs.changes.outputs.targets), 'frontend')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/frontend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: apps/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run format check
+        run: npm run format:check
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run type check
+        run: npm run type-check
+
+  docs:
+    name: Lint Docs
+    needs: changes
+    if: contains(fromJSON(needs.changes.outputs.targets), 'docs')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs/src
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: docs/src/package-lock.json
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Run lint
+        run: make lint
+
   lint:
+    # Single stable check for branch protection: the matrix job names vary with
+    # which areas changed, so they cannot be required directly.
+    name: Lint
+    needs: [changes, python, frontend, docs]
+    if: always()
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0  # Needed for paths-filter
-
-    - name: Check for file changes
-      uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          frontend:
-            - 'apps/frontend/**'
-            - 'ee/frontend/**'
-          docs:
-            - 'docs/src/**'
-            - 'docs/content/**'
-          sdk:
-            - 'sdk/**'
-          backend:
-            - 'apps/backend/**'
-          penelope:
-            - 'penelope/**'
-
-
-    - name: Install uv
-      if: steps.filter.outputs.sdk == 'true' || steps.filter.outputs.backend == 'true' || steps.filter.outputs.penelope == 'true' || github.event_name == 'workflow_dispatch'
-      uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-      with:
-        version: latest
-        enable-cache: true
-
-    # - name: Check SDK uv.lock file
-    #   if: steps.filter.outputs.sdk == 'true' ||  github.event_name == 'workflow_dispatch'
-    #   run: |
-    #     cd sdk
-    #     uv lock --check
-
-    - name: Run SDK linting
-      if: steps.filter.outputs.sdk == 'true' || github.event_name == 'workflow_dispatch'
-      run: |
-        cd sdk
-        make lint
-      continue-on-error: false
-
-    # - name: Check Backend uv.lock file
-    #   if: steps.filter.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
-    #   run: |
-    #     cd apps/backend
-    #     uv lock --check
-
-    - name: Run Backend linting
-      if: steps.filter.outputs.backend == 'true' || github.event_name == 'workflow_dispatch'
-      run: |
-        cd apps/backend
-        make lint
-      continue-on-error: false
-
-    - name: Run Penelope linting
-      if: steps.filter.outputs.penelope == 'true' || github.event_name == 'workflow_dispatch'
-      run: |
-        cd penelope
-        make lint
-      continue-on-error: false
-
-    # Frontend & Docs Linting (both use Node.js)
-    - name: Set up Node.js for Frontend/Docs
-      if: steps.filter.outputs.frontend == 'true' || steps.filter.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
-      uses: actions/setup-node@v6
-      with:
-          node-version: '24'
-
-    - name: Install frontend dependencies
-      if: steps.filter.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
-      run: |
-        cd apps/frontend
-        npm ci --legacy-peer-deps
-
-    - name: Run frontend format check
-      if: steps.filter.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
-      run: |
-        cd apps/frontend
-        npm run format:check
-      continue-on-error: false
-
-    - name: Run frontend lint
-      if: steps.filter.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
-      run: |
-        cd apps/frontend
-        npm run lint
-      continue-on-error: false
-
-    - name: Run frontend type check
-      if: steps.filter.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
-      run: |
-        cd apps/frontend
-        npm run type-check
-      continue-on-error: false
-
-    # Documentation Linting
-    - name: Install docs dependencies
-      if: steps.filter.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
-      run: |
-        cd docs/src
-        make install
-
-    - name: Run docs linting
-      if: steps.filter.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
-      run: |
-        cd docs/src
-        make lint
-      continue-on-error: false
-
-    # Summary
-    - name: Lint Summary
-      if: always()
-      run: |
-        {
-          echo "## Lint Check Results ✅"
-          echo ""
-          echo "- **Branch**: ${{ github.ref_name }}"
-          echo ""
-          echo "### What was checked:"
-        } >> "$GITHUB_STEP_SUMMARY"
-
-        if [ "${{ steps.filter.outputs.sdk }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-          echo "- **SDK**: Code formatting and linting with ruff ✅" >> "$GITHUB_STEP_SUMMARY"
-        else
-          echo "- **SDK**: Skipped (no changes detected)" >> "$GITHUB_STEP_SUMMARY"
-        fi
-
-        # if [ "${{ steps.filter.outputs.backend }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-        #   echo "- **Backend**: Code formatting and linting with ruff ✅" >> "$GITHUB_STEP_SUMMARY"
-        # else
-        #   echo "- **Backend**: Skipped (no changes detected)" >> "$GITHUB_STEP_SUMMARY"
-        # fi
-
-        if [ "${{ steps.filter.outputs.penelope }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-          echo "- **Penelope**: Code formatting and linting with ruff ✅" >> "$GITHUB_STEP_SUMMARY"
-        else
-          echo "- **Penelope**: Skipped (no changes detected)" >> "$GITHUB_STEP_SUMMARY"
-        fi
-
-        if [ "${{ steps.filter.outputs.frontend }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-          echo "- **Frontend**: ESLint, Prettier formatting, TypeScript type checking, and build validation ✅" >> "$GITHUB_STEP_SUMMARY"
-        else
-          echo "- **Frontend**: Skipped (no changes detected)" >> "$GITHUB_STEP_SUMMARY"
-        fi
-
-        if [ "${{ steps.filter.outputs.docs }}" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-          echo "- **Docs**: ESLint and Prettier formatting ✅" >> "$GITHUB_STEP_SUMMARY"
-        else
-          echo "- **Docs**: Skipped (no changes detected)" >> "$GITHUB_STEP_SUMMARY"
-        fi
+      - name: Check lint results
+        run: |
+          set -euo pipefail
+          FAILED=0
+          for RESULT in "changes=${{ needs.changes.result }}" \
+                        "python=${{ needs.python.result }}" \
+                        "frontend=${{ needs.frontend.result }}" \
+                        "docs=${{ needs.docs.result }}"; do
+            echo "$RESULT"
+            # skipped = area not touched by this PR, which is a pass.
+            case "${RESULT#*=}" in
+              success|skipped) ;;
+              *) FAILED=1 ;;
+            esac
+          done
+          if [ "$FAILED" -ne 0 ]; then
+            echo "One or more lint jobs failed." >&2
+            exit 1
+          fi
+          echo "All lint checks passed."

--- a/.github/workflows/penelope-test.yml
+++ b/.github/workflows/penelope-test.yml
@@ -37,9 +37,17 @@ jobs:
     #     uv run pyright
     #   continue-on-error: false
       
-    - name: Test Penelope
+    - name: Test Penelope (fast)
       run: |
         cd penelope
+        uv run pytest
+      continue-on-error: false
+
+    - name: Test Penelope (full)
+      if: github.event_name == 'push'
+      run: |
+        cd penelope
+        uv sync --extra all
         uv run pytest
       continue-on-error: false
 

--- a/.github/workflows/penelope-test.yml
+++ b/.github/workflows/penelope-test.yml
@@ -37,17 +37,9 @@ jobs:
     #     uv run pyright
     #   continue-on-error: false
       
-    - name: Test Penelope (fast)
+    - name: Test Penelope
       run: |
         cd penelope
-        uv run pytest
-      continue-on-error: false
-
-    - name: Test Penelope (full)
-      if: github.event_name == 'push'
-      run: |
-        cd penelope
-        uv sync --extra all
         uv run pytest
       continue-on-error: false
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,7 +28,7 @@ jobs:
             git config user.email "237771051+rheo-app[bot]@users.noreply.github.com"
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -9,13 +9,7 @@ on:
 
 permissions:
   contents: read
-  security-events: write
-  actions: read
-  checks: write
-  pull-requests: write
-  issues: write
-  discussions: write
-  packages: read
+
 jobs:
   secret-scanning:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform-infrastructure.yml
+++ b/.github/workflows/terraform-infrastructure.yml
@@ -85,7 +85,7 @@ jobs:
       target_env: ${{ steps.tf_setup.outputs.target_env }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/tf-setup
         id: tf_setup
@@ -170,7 +170,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' && inputs.action == 'apply'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/tf-setup
         id: tf_setup

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,12 @@ race condition), and framework/infra terms (GUC, RLS policy, `ContextVar`, Celer
 abstract engineering-speak that carries no information — "leverage the abstraction", "surface area",
 "idiomatic", "orthogonal concerns", "non-trivial", "first-class citizen".
 
+## Code Comments
+
+Keep comments concise — usually one line, and only where the code can't say it itself: a non-obvious
+"why", or a real trap. Multi-line is fine when the thing is genuinely complex or hard to follow, but
+not for ordinary code. Never restate what the next line does.
+
 ## Technology Stack
 
 Backend and Python SDK: Python 3.10+, `uv` with `pyproject.toml`, Pydantic 2.x, pytest.


### PR DESCRIPTION
## Purpose

Follow-up to a review of the workflows in `.github/workflows/`. This picks off four independent cleanups that don't depend on each other: version drift across actions, a test suite that ran twice, over-broad permissions on secret scanning, and linting that ran every area in series.

## What Changed

One commit per item, so any of them can be dropped independently.

- **Action versions pinned to one major each.** Four actions were in use at two versions simultaneously: `actions/setup-python` (v4 + v6), `actions/checkout` (v4 + v6), `actions/cache` (v4 + v5), and `google-github-actions/auth` (v2 + v3). Each now sits at the highest version already used in the repo. All are drop-in for the inputs used here, and `auth@v3` was already proven in `polyphemus-vertex-ai.yml`. Actions used at a single version are untouched — no drift, and bumping them blind is a separate change.
- **Penelope's duplicate test run removed.** The `Test Penelope (full)` step re-synced dependencies and then ran the same `uv run pytest` as the `(fast)` step, so every push to main ran the identical suite twice. Compare `sdk-test.yml`, where `full` actually calls `make test-integration`.
- **Secret scanning permissions trimmed to `contents: read`.** TruffleHog only reads the repo and fails the job on a finding. There's no SARIF upload or PR comment step, so `security-events`, `checks`, `pull-requests`, `issues`, `discussions`, `actions` and `packages` were all unused.
- **Lint runs as a matrix.** `lint.yml` was a single sequential job, so a PR touching backend and frontend waited for both in series. It's now a `changes` job that turns paths-filter output into a matrix, then parallel jobs per area. Backend, SDK and Penelope lint identically (`uv` + `make lint`), so three copy-pasted step pairs collapse into one matrix with `fail-fast: false`. Frontend and docs keep their own jobs, since their install and lint commands have nothing in common and a matrix there would just be `if`s in disguise.

## Additional Context

- **No branch protection change needed.** The matrix job names vary with which areas a PR touches (`Lint Backend`, `Lint SDK`, …), so they can't be required status checks. The aggregate job is deliberately named `lint`, which keeps the existing `Lint Check / lint` check name working. It treats `skipped` as a pass, since skipped means the area wasn't touched.
- **It fails safe.** If paths-filter can't determine changes it errors, which fails the `changes` job, which fails the `lint` gate. It can't degrade into "no areas changed, everything green."
- **Three things dropped from `lint.yml`** while restructuring: the step summary (the job list now shows what ran, and its backend section was commented out, so backend linting was invisible in it either way), the commented-out `uv lock --check` steps, and `fetch-depth: 0` on checkout. On the last one — paths-filter uses the GitHub REST API on `pull_request` and needs no git history, so the `# Needed for paths-filter` comment was wrong. If `lint.yml` ever gains a `push:` trigger, paths-filter switches to git-based detection and that line becomes load-bearing again. Easy to restore if you'd rather keep it.
- Linting behavior is otherwise unchanged: same commands, same working directories, just parallel. Frontend and docs also pick up the npm cache, which the old job didn't use.

## Testing

- YAML of every changed file parses.
- The jq matrix builder and the aggregate pass/fail logic were exercised locally:

  | changed areas | python matrix | result |
  |---|---|---|
  | `["backend","sdk"]` | Backend, SDK | both run in parallel |
  | `["docs","penelope"]` | Penelope | docs runs as its own job |
  | `["frontend"]` | `[]` | python job skipped by its `if` guard |
  | `[]` | `[]` | all skipped, `lint` gate passes |

- Worth being straight about what this PR does *not* prove: it only touches `.github/**`, so no paths-filter area matches. The expected result here is `changes` succeeding with `python`, `frontend` and `docs` all skipped and the `lint` gate green — which exercises the empty-matrix path but not the fan-out. The first PR touching two areas will confirm that.
- To exercise it deliberately before merge: run `Lint Check` via `workflow_dispatch`, which skips the filter and lints all five areas.
