### PR TITLE
Extract project CRUD out of the crud/__init__.py monolith

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/crud/__init__.py
@@ -1975,129 +1975,20 @@ def delete_organization(db: Session, organization_id: uuid.UUID) -> Optional[mod
     return delete_item(db, models.Organization, organization_id)
 
 
-# Project CRUD
-def get_project(
-    db: Session, project_id: uuid.UUID, organization_id: str = None, user_id: str = None
-) -> Optional[models.Project]:
-    """Get project with relationships eagerly loaded.
-
-    When *user_id* is supplied the caller must be an explicit member of the project
-    (a row in ``project_membership``).  Non-members receive ``None`` — the same
-    result as "not found" — so the router's 404 reveals no information about
-    whether the project exists.  This closes the by-ID IDOR gap where
-    ``get_item_detail`` filters only by ``organization_id``.
-
-    Pass *user_id=None* only for internal service-layer calls that already
-    carry their own access-control context (e.g. background tasks).
-    """
-    from rhesis.backend.app.models.project_membership import ProjectMembership
-    from rhesis.backend.app.scope import bypass_tenant_filter
-
-    project = get_item_detail(db, models.Project, project_id, organization_id, user_id)
-    if project is None or user_id is None:
-        return project
-
-    # Enforce membership: the caller must have a project_membership row.
-    # bypass_tenant_filter is required because project_membership carries only
-    # tenant_isolation (org RLS), not project_isolation — this is by design so
-    # the join table remains reachable before a project context is established.
-    with bypass_tenant_filter():
-        membership = (
-            db.query(ProjectMembership).filter_by(project_id=project.id, user_id=user_id).first()
-        )
-
-    return project if membership is not None else None
-
-
-def get_projects(
-    db: Session,
-    skip: int = 0,
-    limit: int = 10,
-    sort_by: str = "created_at",
-    sort_order: str = "desc",
-    filter: str | None = None,
-    organization_id: str = None,
-    user_id: str = None,
-) -> List[models.Project]:
-    from rhesis.backend.app.models.project_membership import ProjectMembership
-    from rhesis.backend.app.scope import bypass_tenant_filter
-    from rhesis.backend.app.utils.query_utils import QueryBuilder
-
-    # Project listing must respect membership — only return projects the requesting
-    # user is a member of. An EXISTS subquery is used so that the QueryBuilder's
-    # existing pagination/sorting/filtering chain is preserved.
-    with bypass_tenant_filter():
-        builder = (
-            QueryBuilder(db, models.Project)
-            .with_related(include(models.Project.owner))
-            .with_default_derived_field_loads()
-            .with_organization_filter(organization_id)
-            .with_visibility_filter(user_id)
-            .with_odata_filter(filter)
-        )
-
-        if user_id:
-            exists_subquery = (
-                db.query(ProjectMembership)
-                .filter(
-                    ProjectMembership.project_id == models.Project.id,
-                    ProjectMembership.user_id == user_id,
-                    ProjectMembership.organization_id == organization_id,
-                )
-                .exists()
-            )
-            builder.query = builder.query.filter(exists_subquery)
-
-        return builder.with_pagination(skip, limit).with_sorting(sort_by, sort_order).all()
-
-
-def count_projects(
-    db: Session,
-    filter: str | None = None,
-    organization_id: str = None,
-    user_id: str = None,
-) -> int:
-    """Count projects the given user is a member of (mirrors get_projects membership filter)."""
-    from rhesis.backend.app.models.project_membership import ProjectMembership
-    from rhesis.backend.app.scope import bypass_tenant_filter
-    from rhesis.backend.app.utils.query_utils import QueryBuilder
-
-    with bypass_tenant_filter():
-        builder = (
-            QueryBuilder(db, models.Project)
-            .with_organization_filter(organization_id)
-            .with_visibility_filter(user_id)
-            .with_odata_filter(filter)
-        )
-        if user_id:
-            exists_subquery = (
-                db.query(ProjectMembership)
-                .filter(
-                    ProjectMembership.project_id == models.Project.id,
-                    ProjectMembership.user_id == user_id,
-                    ProjectMembership.organization_id == organization_id,
-                )
-                .exists()
-            )
-            builder.query = builder.query.filter(exists_subquery)
-        return builder.count()
-
-
-def create_project(
-    db: Session, project: schemas.ProjectCreate, organization_id: str = None, user_id: str = None
-) -> models.Project:
-    """Create project."""
-    return create_item(db, models.Project, project, organization_id, user_id)
-
-
-def update_project(
-    db: Session,
-    project_id: uuid.UUID,
-    project: schemas.ProjectUpdate,
-    organization_id: str,
-    user_id: str,
-) -> Optional[models.Project]:
-    return update_item(db, models.Project, project_id, project, organization_id, user_id)
+# Transitional re-export: removed in the next commit, once callers import
+# from rhesis.backend.app.crud.project directly.
+from rhesis.backend.app.crud.project import (  # noqa: E402, F401
+    add_project_member,
+    count_projects,
+    create_project,
+    delete_project,
+    get_my_projects,
+    get_project,
+    get_project_members,
+    get_projects,
+    remove_project_member,
+    update_project,
+)
 
 
 def get_test(
@@ -2720,125 +2611,6 @@ def delete_test_result(
     return delete_item(
         db, models.TestResult, test_result_id, organization_id=organization_id, user_id=user_id
     )
-
-
-def delete_project(
-    db: Session, project_id: uuid.UUID, organization_id: str, user_id: str
-) -> Optional[models.Project]:
-    # Project soft-delete does not cascade to project_membership, so drop the
-    # memberships and repair affected users' default_project first. Staged in the
-    # same transaction; delete_item's commit persists both.
-    from rhesis.backend.app.services.organization import unenroll_all_project_members
-
-    unenroll_all_project_members(db, project_id, organization_id)
-    return delete_item(
-        db, models.Project, project_id, organization_id=organization_id, user_id=user_id
-    )
-
-
-# ProjectMembership CRUD
-
-
-def get_project_members(
-    db: Session, project_id: uuid.UUID, organization_id: str
-) -> List[models.ProjectMembership]:
-    """List all members of a project, with user info eagerly loaded."""
-    from rhesis.backend.app.models.project_membership import ProjectMembership
-    from rhesis.backend.app.models.user import User
-    from rhesis.backend.app.scope import bypass_tenant_filter
-
-    # Explicitly scoped by (project_id, organization_id); bypass the ambient project
-    # filter so listing works regardless of which project is currently active.
-    with bypass_tenant_filter():
-        return (
-            db.query(ProjectMembership)
-            .join(User, ProjectMembership.user_id == User.id)
-            .filter(
-                ProjectMembership.project_id == project_id,
-                ProjectMembership.organization_id == organization_id,
-            )
-            .options(joinedload(ProjectMembership.user))
-            .all()
-        )
-
-
-def get_my_projects(db: Session, user_id: uuid.UUID, organization_id: str) -> List[models.Project]:
-    """Return all ACTIVE, non-deleted projects the given user is a member of."""
-    from rhesis.backend.app.models.project_membership import ProjectMembership
-
-    return (
-        db.query(models.Project)
-        .options(include(models.Project.owner))
-        .join(ProjectMembership, ProjectMembership.project_id == models.Project.id)
-        .filter(
-            ProjectMembership.user_id == user_id,
-            ProjectMembership.organization_id == organization_id,
-            models.Project.deleted_at.is_(None),
-            models.Project.is_active.is_(True),
-        )
-        .all()
-    )
-
-
-def add_project_member(
-    db: Session,
-    project_id: uuid.UUID,
-    user_id: uuid.UUID,
-    organization_id: str,
-    *,
-    role_id: Optional[uuid.UUID] = None,
-) -> models.ProjectMembership:
-    """Add a user as a project member. No-op (returns existing) if already a member.
-
-    Routes through the centralized enroll_user_in_project routine so that membership
-    creation and default-project assignment stay consistent with onboarding.
-
-    ``role_id`` is an optional FK placeholder for the EE role table (SP8).  Passes
-    through to ``enroll_user_in_project``; community callers leave it ``None``.
-    """
-    from rhesis.backend.app.models.project_membership import ProjectMembership
-    from rhesis.backend.app.scope import bypass_tenant_filter
-    from rhesis.backend.app.services.organization import enroll_user_in_project
-
-    with bypass_tenant_filter():
-        existing = (
-            db.query(ProjectMembership).filter_by(project_id=project_id, user_id=user_id).first()
-        )
-    if existing:
-        return existing
-
-    enroll_user_in_project(db, user_id, project_id, organization_id, role_id=role_id)
-    db.commit()
-
-    with bypass_tenant_filter():
-        return db.query(ProjectMembership).filter_by(project_id=project_id, user_id=user_id).first()
-
-
-def remove_project_member(
-    db: Session,
-    project_id: uuid.UUID,
-    user_id: uuid.UUID,
-    organization_id: str,
-    *,
-    requester_user_id: Optional[uuid.UUID] = None,
-) -> bool:
-    """Remove a user from a project. Returns True if removed, False if not found.
-
-    Routes through the centralized unenroll_user_from_project routine so that the
-    user's default_project is repaired if it pointed at the removed project.
-
-    Raises:
-        ProjectSelfRemovalError: if requester_user_id == user_id.
-        ProjectOwnerRemovalError: if user_id is the project owner.
-    """
-    from rhesis.backend.app.services.organization import unenroll_user_from_project
-
-    removed = unenroll_user_from_project(
-        db, user_id, project_id, organization_id, requester_user_id=requester_user_id
-    )
-    if removed:
-        db.commit()
-    return removed
 
 
 # TypeLookup CRUD

--- a/apps/backend/src/rhesis/backend/app/crud/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/crud/__init__.py
@@ -1975,22 +1975,6 @@ def delete_organization(db: Session, organization_id: uuid.UUID) -> Optional[mod
     return delete_item(db, models.Organization, organization_id)
 
 
-# Transitional re-export: removed in the next commit, once callers import
-# from rhesis.backend.app.crud.project directly.
-from rhesis.backend.app.crud.project import (  # noqa: E402, F401
-    add_project_member,
-    count_projects,
-    create_project,
-    delete_project,
-    get_my_projects,
-    get_project,
-    get_project_members,
-    get_projects,
-    remove_project_member,
-    update_project,
-)
-
-
 def get_test(
     db: Session, test_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.Test]:

--- a/apps/backend/src/rhesis/backend/app/crud/project.py
+++ b/apps/backend/src/rhesis/backend/app/crud/project.py
@@ -1,0 +1,268 @@
+"""CRUD operations for projects and project membership.
+
+Part of the incremental split of the ``crud`` monolith: ``crud/__init__.py`` still holds
+the bulk of the functions, and per-entity modules like this one take over as the code
+around them is touched.
+
+Project reads enforce membership, not just organization scope -- ``get_project`` and
+``get_projects`` return only projects the caller has a ``project_membership`` row for.
+Writes to membership route through ``services.organization`` so that a user's
+``default_project`` is repaired alongside.
+"""
+
+import uuid
+from typing import List, Optional
+
+from sqlalchemy.orm import Session, joinedload
+
+from rhesis.backend.app import models, schemas
+from rhesis.backend.app.utils.crud_utils import (
+    create_item,
+    delete_item,
+    get_item_detail,
+    update_item,
+)
+from rhesis.backend.app.utils.query_utils import include
+
+
+def get_project(
+    db: Session, project_id: uuid.UUID, organization_id: str = None, user_id: str = None
+) -> Optional[models.Project]:
+    """Get project with relationships eagerly loaded.
+
+    When *user_id* is supplied the caller must be an explicit member of the project
+    (a row in ``project_membership``).  Non-members receive ``None`` — the same
+    result as "not found" — so the router's 404 reveals no information about
+    whether the project exists.  This closes the by-ID IDOR gap where
+    ``get_item_detail`` filters only by ``organization_id``.
+
+    Pass *user_id=None* only for internal service-layer calls that already
+    carry their own access-control context (e.g. background tasks).
+    """
+    from rhesis.backend.app.models.project_membership import ProjectMembership
+    from rhesis.backend.app.scope import bypass_tenant_filter
+
+    project = get_item_detail(db, models.Project, project_id, organization_id, user_id)
+    if project is None or user_id is None:
+        return project
+
+    # Enforce membership: the caller must have a project_membership row.
+    # bypass_tenant_filter is required because project_membership carries only
+    # tenant_isolation (org RLS), not project_isolation — this is by design so
+    # the join table remains reachable before a project context is established.
+    with bypass_tenant_filter():
+        membership = (
+            db.query(ProjectMembership).filter_by(project_id=project.id, user_id=user_id).first()
+        )
+
+    return project if membership is not None else None
+
+
+def get_projects(
+    db: Session,
+    skip: int = 0,
+    limit: int = 10,
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
+    filter: str | None = None,
+    organization_id: str = None,
+    user_id: str = None,
+) -> List[models.Project]:
+    from rhesis.backend.app.models.project_membership import ProjectMembership
+    from rhesis.backend.app.scope import bypass_tenant_filter
+    from rhesis.backend.app.utils.query_utils import QueryBuilder
+
+    # Project listing must respect membership — only return projects the requesting
+    # user is a member of. An EXISTS subquery is used so that the QueryBuilder's
+    # existing pagination/sorting/filtering chain is preserved.
+    with bypass_tenant_filter():
+        builder = (
+            QueryBuilder(db, models.Project)
+            .with_related(include(models.Project.owner))
+            .with_default_derived_field_loads()
+            .with_organization_filter(organization_id)
+            .with_visibility_filter(user_id)
+            .with_odata_filter(filter)
+        )
+
+        if user_id:
+            exists_subquery = (
+                db.query(ProjectMembership)
+                .filter(
+                    ProjectMembership.project_id == models.Project.id,
+                    ProjectMembership.user_id == user_id,
+                    ProjectMembership.organization_id == organization_id,
+                )
+                .exists()
+            )
+            builder.query = builder.query.filter(exists_subquery)
+
+        return builder.with_pagination(skip, limit).with_sorting(sort_by, sort_order).all()
+
+
+def count_projects(
+    db: Session,
+    filter: str | None = None,
+    organization_id: str = None,
+    user_id: str = None,
+) -> int:
+    """Count projects the given user is a member of (mirrors get_projects membership filter)."""
+    from rhesis.backend.app.models.project_membership import ProjectMembership
+    from rhesis.backend.app.scope import bypass_tenant_filter
+    from rhesis.backend.app.utils.query_utils import QueryBuilder
+
+    with bypass_tenant_filter():
+        builder = (
+            QueryBuilder(db, models.Project)
+            .with_organization_filter(organization_id)
+            .with_visibility_filter(user_id)
+            .with_odata_filter(filter)
+        )
+        if user_id:
+            exists_subquery = (
+                db.query(ProjectMembership)
+                .filter(
+                    ProjectMembership.project_id == models.Project.id,
+                    ProjectMembership.user_id == user_id,
+                    ProjectMembership.organization_id == organization_id,
+                )
+                .exists()
+            )
+            builder.query = builder.query.filter(exists_subquery)
+        return builder.count()
+
+
+def create_project(
+    db: Session, project: schemas.ProjectCreate, organization_id: str = None, user_id: str = None
+) -> models.Project:
+    """Create project."""
+    return create_item(db, models.Project, project, organization_id, user_id)
+
+
+def update_project(
+    db: Session,
+    project_id: uuid.UUID,
+    project: schemas.ProjectUpdate,
+    organization_id: str,
+    user_id: str,
+) -> Optional[models.Project]:
+    return update_item(db, models.Project, project_id, project, organization_id, user_id)
+
+
+def delete_project(
+    db: Session, project_id: uuid.UUID, organization_id: str, user_id: str
+) -> Optional[models.Project]:
+    # Project soft-delete does not cascade to project_membership, so drop the
+    # memberships and repair affected users' default_project first. Staged in the
+    # same transaction; delete_item's commit persists both.
+    from rhesis.backend.app.services.organization import unenroll_all_project_members
+
+    unenroll_all_project_members(db, project_id, organization_id)
+    return delete_item(
+        db, models.Project, project_id, organization_id=organization_id, user_id=user_id
+    )
+
+
+# ProjectMembership CRUD
+
+
+def get_project_members(
+    db: Session, project_id: uuid.UUID, organization_id: str
+) -> List[models.ProjectMembership]:
+    """List all members of a project, with user info eagerly loaded."""
+    from rhesis.backend.app.models.project_membership import ProjectMembership
+    from rhesis.backend.app.models.user import User
+    from rhesis.backend.app.scope import bypass_tenant_filter
+
+    # Explicitly scoped by (project_id, organization_id); bypass the ambient project
+    # filter so listing works regardless of which project is currently active.
+    with bypass_tenant_filter():
+        return (
+            db.query(ProjectMembership)
+            .join(User, ProjectMembership.user_id == User.id)
+            .filter(
+                ProjectMembership.project_id == project_id,
+                ProjectMembership.organization_id == organization_id,
+            )
+            .options(joinedload(ProjectMembership.user))
+            .all()
+        )
+
+
+def get_my_projects(db: Session, user_id: uuid.UUID, organization_id: str) -> List[models.Project]:
+    """Return all ACTIVE, non-deleted projects the given user is a member of."""
+    from rhesis.backend.app.models.project_membership import ProjectMembership
+
+    return (
+        db.query(models.Project)
+        .options(include(models.Project.owner))
+        .join(ProjectMembership, ProjectMembership.project_id == models.Project.id)
+        .filter(
+            ProjectMembership.user_id == user_id,
+            ProjectMembership.organization_id == organization_id,
+            models.Project.deleted_at.is_(None),
+            models.Project.is_active.is_(True),
+        )
+        .all()
+    )
+
+
+def add_project_member(
+    db: Session,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    organization_id: str,
+    *,
+    role_id: Optional[uuid.UUID] = None,
+) -> models.ProjectMembership:
+    """Add a user as a project member. No-op (returns existing) if already a member.
+
+    Routes through the centralized enroll_user_in_project routine so that membership
+    creation and default-project assignment stay consistent with onboarding.
+
+    ``role_id`` is an optional FK placeholder for the EE role table (SP8).  Passes
+    through to ``enroll_user_in_project``; community callers leave it ``None``.
+    """
+    from rhesis.backend.app.models.project_membership import ProjectMembership
+    from rhesis.backend.app.scope import bypass_tenant_filter
+    from rhesis.backend.app.services.organization import enroll_user_in_project
+
+    with bypass_tenant_filter():
+        existing = (
+            db.query(ProjectMembership).filter_by(project_id=project_id, user_id=user_id).first()
+        )
+    if existing:
+        return existing
+
+    enroll_user_in_project(db, user_id, project_id, organization_id, role_id=role_id)
+    db.commit()
+
+    with bypass_tenant_filter():
+        return db.query(ProjectMembership).filter_by(project_id=project_id, user_id=user_id).first()
+
+
+def remove_project_member(
+    db: Session,
+    project_id: uuid.UUID,
+    user_id: uuid.UUID,
+    organization_id: str,
+    *,
+    requester_user_id: Optional[uuid.UUID] = None,
+) -> bool:
+    """Remove a user from a project. Returns True if removed, False if not found.
+
+    Routes through the centralized unenroll_user_from_project routine so that the
+    user's default_project is repaired if it pointed at the removed project.
+
+    Raises:
+        ProjectSelfRemovalError: if requester_user_id == user_id.
+        ProjectOwnerRemovalError: if user_id is the project owner.
+    """
+    from rhesis.backend.app.services.organization import unenroll_user_from_project
+
+    removed = unenroll_user_from_project(
+        db, user_id, project_id, organization_id, requester_user_id=requester_user_id
+    )
+    if removed:
+        db.commit()
+    return removed

--- a/apps/backend/src/rhesis/backend/app/routers/experiments.py
+++ b/apps/backend/src/rhesis/backend/app/routers/experiments.py
@@ -24,6 +24,7 @@ from rhesis.backend.app.auth.capabilities import Permission
 from rhesis.backend.app.auth.principal import resolve_principal_from_request
 from rhesis.backend.app.auth.rbac import authorize_object, project_id_from_scope
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+from rhesis.backend.app.crud.project import get_project
 from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
@@ -166,7 +167,7 @@ def update_experiment(
         and db_experiment.visibility == "shared"
         and new_visibility == "private"
     ):
-        project = crud.get_project(
+        project = get_project(
             db,
             project_id=db_experiment.project_id,
             organization_id=organization_id,
@@ -215,7 +216,7 @@ def delete_experiment(
     ):
         raise HTTPException(status_code=403, detail="Not authorized to delete this experiment")
 
-    project = crud.get_project(
+    project = get_project(
         db,
         project_id=db_experiment.project_id,
         organization_id=organization_id,
@@ -274,7 +275,7 @@ def create_experiment_version(
         user_id=user_id,
     )
 
-    project = crud.get_project(
+    project = get_project(
         db,
         project_id=db_experiment.project_id,
         organization_id=organization_id,

--- a/apps/backend/src/rhesis/backend/app/routers/parameters.py
+++ b/apps/backend/src/rhesis/backend/app/routers/parameters.py
@@ -28,8 +28,8 @@ from typing import Annotated
 from fastapi import Depends, HTTPException, Path, Query, Request, status
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app import crud
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+from rhesis.backend.app.crud.project import get_project
 from rhesis.backend.app.database import bind_scope_to_session
 from rhesis.backend.app.dependencies import (
     get_tenant_context,
@@ -89,7 +89,7 @@ def _load_project(
     organization_id: str,
     user_id: str,
 ):
-    db_project = crud.get_project(
+    db_project = get_project(
         db,
         project_id=project_id,
         organization_id=organization_id,

--- a/apps/backend/src/rhesis/backend/app/routers/project.py
+++ b/apps/backend/src/rhesis/backend/app/routers/project.py
@@ -5,9 +5,14 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app import crud, schemas
+from rhesis.backend.app import schemas
 from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+
+# Imported as a module, not by name: the route handlers below are called
+# create_project, update_project, add_project_member, ... too, and a bare
+# function import would shadow them.
+from rhesis.backend.app.crud import project as project_crud
 from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
@@ -47,7 +52,7 @@ def create_project(
     if not project.owner_id:
         project.owner_id = current_user.id
 
-    new_project = crud.create_project(
+    new_project = project_crud.create_project(
         db=db, project=project, organization_id=organization_id, user_id=user_id
     )
 
@@ -72,7 +77,7 @@ def read_my_projects(
 ):
     """Return all projects the current user is a member of."""
     organization_id, _user_id = tenant_context
-    return crud.get_my_projects(
+    return project_crud.get_my_projects(
         db=db,
         user_id=current_user.id,
         organization_id=organization_id,
@@ -98,7 +103,7 @@ def read_projects(
 ):
     """Get all projects the current user is a member of."""
     organization_id, user_id = tenant_context
-    results = crud.get_projects(
+    results = project_crud.get_projects(
         db=db,
         skip=skip,
         limit=limit,
@@ -109,7 +114,7 @@ def read_projects(
         user_id=user_id,
     )
     # Count uses the same membership filter so X-Total-Count matches pagination.
-    total = crud.count_projects(
+    total = project_crud.count_projects(
         db=db, filter=filter, organization_id=organization_id, user_id=user_id
     )
     response.headers["X-Total-Count"] = str(total)
@@ -134,10 +139,14 @@ def read_project_members(
 ):
     """List all members of a project."""
     organization_id, _user_id = tenant_context
-    db_project = crud.get_project(db, project_id=project_id, organization_id=organization_id)
+    db_project = project_crud.get_project(
+        db, project_id=project_id, organization_id=organization_id
+    )
     if db_project is None:
         raise HTTPException(status_code=404, detail="Project not found")
-    return crud.get_project_members(db=db, project_id=project_id, organization_id=organization_id)
+    return project_crud.get_project_members(
+        db=db, project_id=project_id, organization_id=organization_id
+    )
 
 
 @router.post(
@@ -155,7 +164,9 @@ def add_project_member(
 ):
     """Add a user as a member of a project."""
     organization_id, _user_id = tenant_context
-    db_project = crud.get_project(db, project_id=project_id, organization_id=organization_id)
+    db_project = project_crud.get_project(
+        db, project_id=project_id, organization_id=organization_id
+    )
     if db_project is None:
         raise HTTPException(status_code=404, detail="Project not found")
 
@@ -186,7 +197,7 @@ def add_project_member(
             db=db, actor=current_user, role_id=body.role_id, project_id=project_id
         )
 
-    return crud.add_project_member(
+    return project_crud.add_project_member(
         db=db,
         project_id=project_id,
         user_id=body.user_id,
@@ -218,12 +229,14 @@ def remove_project_member(
     )
 
     organization_id, _tenant_user_id = tenant_context
-    db_project = crud.get_project(db, project_id=project_id, organization_id=organization_id)
+    db_project = project_crud.get_project(
+        db, project_id=project_id, organization_id=organization_id
+    )
     if db_project is None:
         raise HTTPException(status_code=404, detail="Project not found")
 
     try:
-        removed = crud.remove_project_member(
+        removed = project_crud.remove_project_member(
             db=db,
             project_id=project_id,
             user_id=user_id,
@@ -248,7 +261,7 @@ def read_project(
 ):
     """Get a project by ID."""
     organization_id, user_id = tenant_context
-    db_project = crud.get_project(
+    db_project = project_crud.get_project(
         db, project_id=project_id, organization_id=organization_id, user_id=user_id
     )
     if db_project is None:
@@ -266,13 +279,13 @@ def update_project(
 ):
     """Update a project by ID."""
     organization_id, user_id = tenant_context
-    db_project = crud.get_project(
+    db_project = project_crud.get_project(
         db, project_id=project_id, organization_id=organization_id, user_id=user_id
     )
     if db_project is None:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    return crud.update_project(
+    return project_crud.update_project(
         db, project_id=project_id, project=project, organization_id=organization_id, user_id=user_id
     )
 
@@ -286,12 +299,12 @@ def delete_project(
 ):
     """Delete a project by ID."""
     organization_id, user_id = tenant_context
-    db_project = crud.get_project(
+    db_project = project_crud.get_project(
         db, project_id=project_id, organization_id=organization_id, user_id=user_id
     )
     if db_project is None:
         raise HTTPException(status_code=404, detail="Project not found")
 
-    return crud.delete_project(
+    return project_crud.delete_project(
         db, project_id=project_id, organization_id=organization_id, user_id=user_id
     )

--- a/apps/backend/src/rhesis/backend/app/services/experiment.py
+++ b/apps/backend/src/rhesis/backend/app/services/experiment.py
@@ -32,6 +32,7 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import DetachedInstanceError
 
 from rhesis.backend.app import crud, models
+from rhesis.backend.app.crud.project import get_project
 from rhesis.backend.app.models.experiment import Experiment
 from rhesis.backend.app.models.project import Project
 from rhesis.backend.app.schemas.parameters import (
@@ -704,7 +705,7 @@ def apply_parameter_snapshot_to_run_attributes(
     if endpoint is None or endpoint.project_id is None:
         raise ValueError("Cannot resolve parameters: endpoint or project missing")
 
-    project = crud.get_project(
+    project = get_project(
         db,
         project_id=endpoint.project_id,
         organization_id=organization_id,

--- a/apps/backend/src/rhesis/backend/app/services/test_config_generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_config_generator.py
@@ -13,6 +13,7 @@ import jinja2
 
 from rhesis.backend.app import crud
 from rhesis.backend.app.config.settings import get_model_settings
+from rhesis.backend.app.crud.project import get_project
 from rhesis.backend.app.schemas.services import TestConfigResponse
 from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 from rhesis.backend.app.utils.user_model_utils import (
@@ -160,7 +161,7 @@ class TestConfigGeneratorService:
         project_name = None
         project_description = None
         if project_id:
-            project = crud.get_project(
+            project = get_project(
                 db=self.db, project_id=project_id, organization_id=organization_id
             )
             if not project:

--- a/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_generation_pipeline.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import crud
 from rhesis.backend.app.config.settings import get_model_settings
 from rhesis.backend.app.constants import TestSetType
+from rhesis.backend.app.crud.project import get_project
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.schemas.services import (
     SourceData,
@@ -98,7 +99,7 @@ def _fetch_db_context(
     project_name = None
     project_description = None
     if project_id:
-        project = crud.get_project(db=db, project_id=project_id, organization_id=organization_id)
+        project = get_project(db=db, project_id=project_id, organization_id=organization_id)
         if not project:
             raise ValueError(f"Project with id {project_id} not found or not accessible")
         project_name = project.name

--- a/tests/backend/routes/fixtures/entities/projects.py
+++ b/tests/backend/routes/fixtures/entities/projects.py
@@ -29,7 +29,7 @@ def db_project(
     This fixture creates an actual Project record in the database that can be
     used for foreign key relationships in tests.  It also enrolls the session
     user (``authenticated_user_id``) as a project member so that
-    ``crud.get_project`` — which enforces project_membership presence — returns
+    ``crud.project.get_project`` — which enforces project_membership presence — returns
     the row rather than None when the authenticated client accesses it.
 
     Args:
@@ -56,7 +56,7 @@ def db_project(
     test_db.add(project)
     test_db.flush()
 
-    # Enroll the session user so crud.get_project sees a membership row.
+    # Enroll the session user so crud.project.get_project sees a membership row.
     membership = ProjectMembership(
         project_id=project.id,
         user_id=authenticated_user_id,

--- a/tests/backend/routes/test_project_membership.py
+++ b/tests/backend/routes/test_project_membership.py
@@ -414,7 +414,7 @@ class TestProjectMembersAPI:
 class TestProjectByIdMembershipEnforcement:
     """GET / PUT / DELETE /projects/{id} must require project membership.
 
-    Before SP0 the by-ID handlers called crud.get_project() which filtered
+    Before SP0 the by-ID handlers called crud.project.get_project() which filtered
     by organisation only, not by membership.  Any org member who knew a project
     UUID could read, update, or delete it (IDOR).  This class verifies that
     the gap is closed — non-members receive 404 on all three verbs, while

--- a/tests/backend/routes/test_telemetry_query.py
+++ b/tests/backend/routes/test_telemetry_query.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
+from rhesis.backend.app.crud.project import create_project
 from rhesis.backend.app.crud.telemetry import (
     create_trace_spans,
     get_trace_by_id,
@@ -1288,7 +1289,7 @@ class TestCrossOrganizationSecurity:
         crud.create_token(db=test_db, token=token_b_data)
 
         # Create a project for org A
-        project_a = crud.create_project(
+        project_a = create_project(
             test_db,
             {"name": f"Project A {uuid.uuid4()}", "description": "Test project"},
             organization_id=str(org_a.id),
@@ -1376,13 +1377,13 @@ class TestCrossOrganizationSecurity:
         )
 
         # Create projects for both orgs
-        project_a = crud.create_project(
+        project_a = create_project(
             test_db,
             {"name": f"Project A {uuid.uuid4()}", "description": "Test project A"},
             organization_id=str(org_a.id),
             user_id=str(user_a.id),
         )
-        project_b = crud.create_project(
+        project_b = create_project(
             test_db,
             {"name": f"Project B {uuid.uuid4()}", "description": "Test project B"},
             organization_id=str(org_b.id),
@@ -1485,13 +1486,13 @@ class TestCrossOrganizationSecurity:
         )
 
         # Create projects
-        project_a = crud.create_project(
+        project_a = create_project(
             test_db,
             {"name": f"Project A Metrics {uuid.uuid4()}", "description": "Test"},
             organization_id=str(org_a.id),
             user_id=str(user_a.id),
         )
-        project_b = crud.create_project(
+        project_b = create_project(
             test_db,
             {"name": f"Project B Metrics {uuid.uuid4()}", "description": "Test"},
             organization_id=str(org_b.id),

--- a/tests/backend/services/test_experiment_service.py
+++ b/tests/backend/services/test_experiment_service.py
@@ -112,7 +112,7 @@ class TestParameterSnapshotWithRef:
 
         with (
             patch(
-                "rhesis.backend.app.services.experiment.crud.get_project",
+                "rhesis.backend.app.services.experiment.get_project",
                 return_value=mock_project,
             ),
             patch(

--- a/tests/backend/services/test_test_generation_pipeline.py
+++ b/tests/backend/services/test_test_generation_pipeline.py
@@ -124,9 +124,14 @@ class TestFetchDbContext:
         project_id = str(uuid.uuid4())
         project = _make_project("MyProject", "A chatbot")
 
-        with patch("rhesis.backend.app.services.test_generation_pipeline.crud") as crud:
+        with (
+            patch("rhesis.backend.app.services.test_generation_pipeline.crud") as crud,
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline.get_project",
+                return_value=project,
+            ),
+        ):
             crud.get_behaviors.return_value = []
-            crud.get_project.return_value = project
             ctx = _fetch_db_context(
                 db=mock_db,
                 organization_id=org_id,
@@ -141,9 +146,14 @@ class TestFetchDbContext:
         mock_db = MagicMock()
         org_id = str(uuid.uuid4())
 
-        with patch("rhesis.backend.app.services.test_generation_pipeline.crud") as crud:
+        with (
+            patch("rhesis.backend.app.services.test_generation_pipeline.crud") as crud,
+            patch(
+                "rhesis.backend.app.services.test_generation_pipeline.get_project",
+                return_value=None,
+            ),
+        ):
             crud.get_behaviors.return_value = []
-            crud.get_project.return_value = None
             with pytest.raises(ValueError, match="not found"):
                 _fetch_db_context(
                     db=mock_db,

--- a/tests/backend/test_secret_equality.py
+++ b/tests/backend/test_secret_equality.py
@@ -67,8 +67,8 @@ SENSITIVE_MARKERS = (
 ALLOWED_SITES: frozenset[tuple[str, int]] = frozenset(
     {
         # content_hash is a SHA-based fingerprint for version dedup, not a secret
-        ("apps/backend/src/rhesis/backend/app/services/experiment.py", 148),
-        ("apps/backend/src/rhesis/backend/app/services/experiment.py", 204),
+        ("apps/backend/src/rhesis/backend/app/services/experiment.py", 149),
+        ("apps/backend/src/rhesis/backend/app/services/experiment.py", 205),
         # auth_token_project_id is a UUID project reference, not a secret token;
         # comparing it to another project UUID is safe (no timing oracle risk)
         ("apps/backend/src/rhesis/backend/app/services/connector/manager.py", 1005),


### PR DESCRIPTION
## Purpose

`crud/__init__.py` is the backend's largest file and the module everything imports. `apps/backend/AGENTS.md` says it "only shrinks from here" and that per-entity modules take over as the code around them is touched. This continues #2410 (traces) and #2411 (metrics), taking the project block out.

Project was picked over the other remaining candidates for three reasons.

**It is real code, not boilerplate.** Only 2 of its 10 functions are thin wrappers over `crud_utils` — the best ratio left in the file. That matters because most of what remains is not: after #2410 and #2411 land, 136 of the 195 remaining functions are 5-line passthroughs. Extracting those one entity at a time buys churn and nothing else, so the per-entity split should spend itself on the ~1,800 lines of real code first.

**It frees zero module-level imports,** so the import header of `crud/__init__.py` stays byte-identical to `main`. That is the same test #2411 used, and for the same reason: with other extractions in flight against this file, the import header is where they collide.

**The block is not actually a block.** Five project functions sit at line 1999; the other five sit at line 2745, with `delete_project` marooned in the middle of the test-result section for no reason. Extracting them puts them back together rather than just relocating a clean run of lines.

## What Changed

- New `crud/project.py` (268 lines): `get_project`, `get_projects`, `count_projects`, `create_project`, `update_project`, `delete_project`, `get_project_members`, `get_my_projects`, `add_project_member`, `remove_project_member`.
- `crud/__init__.py` drops from 5,203 to 4,959 lines and no longer references projects.
- All 11 caller files import from `crud.project` directly, per the AGENTS.md rule against reaching through the package root.

Read it commit by commit. The first commit is a pure move — every function body is byte-identical to the original, verified by parsing both files with `ast` and comparing each moved object's source. It adds a transitional re-export so callers keep working, which keeps that commit reviewable in isolation. The second migrates the callers and deletes the shim.

The re-export sits at the extraction site rather than in the import block, with a `# noqa: E402`, so the import header stays untouched in both commits. It exists for exactly one commit.

## Additional Context

`routers/project.py` imports the submodule as `project_crud` instead of importing the functions by name. Its route handlers are also called `create_project`, `update_project`, `add_project_member` and so on, so a bare import would shadow them — the same collision #2411 hit in `routers/metric.py`. Everywhere else imports the function directly.

**A test-patching trap, same family as the one #2410 documented.** `test_test_generation_pipeline.py` patched the whole `crud` module object — `patch("rhesis.backend.app.services.test_generation_pipeline.crud")` — and then set `crud.get_project.return_value`. No grep for `crud.<function>` finds that. Because `get_project` is now a direct import in the service, the module-object patch would have quietly stopped intercepting it, and the two tests that depend on it would have started calling the real function against a `MagicMock` session. Those tests now patch `get_project` explicitly and keep the `crud` patch for `get_behaviors`, which stays in the monolith.

**On the overlap with #2410 and #2411.** Verified by trial merge. #2411 merges clean. #2410 produces exactly one conflict, in the import header of `tests/backend/routes/test_telemetry_query.py`, where both branches add an import at the same position; the resolution is keeping both lines. `crud/__init__.py` itself auto-merges with both — the import-header discipline held.

**One test-file edit that is not a caller migration.** `tests/backend/test_secret_equality.py` keeps an allowlist of approved `==` comparisons on secret-shaped variables, keyed by file path and *absolute line number*. Adding the `get_project` import to `services/experiment.py` pushed two pre-approved `content_hash ==` comparisons from lines 148/204 to 149/205, so the allowlist stopped matching them and the scanner reported them as new violations. The entries are bumped to the new line numbers; nothing about those comparisons changed. Worth flagging for the rest of this split: every extraction adds an import line to its callers, so any allowlist entry below one will shift. `services/experiment.py` is the only file with entries today.

`ruff format` wanted to rewrite several unrelated blocks in `test_telemetry_query.py` and `test_experiment_service.py`. Both files are already not format-clean on `main` (confirmed against a clean checkout), so that reformatting was reverted and the diff in those files is limited to the import and call-site changes. This also keeps the conflict surface with #2410 down to the one line above.

Six pre-existing lint errors remain in `test_telemetry_query.py` — two `E501` on long `@pytest.mark.skip` reasons, an unused `datetime` import, an unsorted in-function import block, and two more. All confirmed present on `main` and left alone.

No behaviour change, no schema change, no API change.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/routes/test_project.py \
  ../../tests/backend/routes/test_project_membership.py \
  ../../tests/backend/routes/test_experiments.py \
  ../../tests/backend/routes/test_parameters.py \
  ../../tests/backend/routes/test_telemetry_query.py \
  ../../tests/backend/services/test_experiment_service.py \
  ../../tests/backend/services/test_test_generation_pipeline.py -q
```

230 passed, 5 skipped, 1 xfailed. The skips are pre-existing `TODO: requires multi-org fixtures` and `project does not have assignee_id field` markers.

Beyond the tests, the decoupling was checked directly: no `crud.<project fn>` call sites remain anywhere in `apps/`, `ee/`, `sdk/`, or `tests/`; nothing imports those names from the `crud` package root; and at runtime all 10 names are absent from `crud` and present on `crud.project`.
