### PR TITLE
Fix metrics grid sorting and filter options

### DIFF
--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -19,6 +19,7 @@ import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
 import PageLoadingState from '@/components/common/PageLoadingState';
 import { usePaginatedList } from '@/hooks/usePaginatedList';
+import { useTypeLookups, useRequirements } from '@/hooks/useLookups';
 
 import MetricsDirectoryTab, { type FilterState } from './MetricsDirectoryTab';
 
@@ -69,58 +70,6 @@ interface MetricsClientProps {
   initialTotalCount?: number;
 }
 
-interface MetricsOptionMaps {
-  requirements: Map<string, ApiRequirement>;
-  backendTypes: Map<string, { type_value: string }>;
-  metricTypes: Map<string, { type_value: string; description: string }>;
-}
-
-/**
- * Extracts the requirement/backend/type dropdown options a page of metrics
- * contributes and merges them into the running accumulator maps. Mutating
- * maps that persist across fetches -- rather than deriving from just the
- * current page -- matters because pages are server-filtered: filtering by
- * one backend type would otherwise make that fetch's response (and thus the
- * dropdown) contain only that value, making every other option vanish from
- * the filter UI the moment it's applied.
- */
-function deriveMetricsPageOptions(
-  data: MetricDetail[],
-  maps: MetricsOptionMaps
-) {
-  data.forEach(metric => {
-    metric.requirements?.forEach(requirement => {
-      if (requirement && typeof requirement !== 'string' && requirement.id) {
-        maps.requirements.set(requirement.id, {
-          id: requirement.id,
-          name: requirement.name || 'Unnamed Requirement',
-          description: requirement.description ?? undefined,
-        } as ApiRequirement);
-      }
-    });
-    if (metric.backend_type) {
-      const val = metric.backend_type.type_value;
-      maps.backendTypes.set(val, {
-        type_value: val.charAt(0).toUpperCase() + val.slice(1),
-      });
-    }
-    if (metric.metric_type) {
-      maps.metricTypes.set(metric.metric_type.type_value, {
-        type_value: metric.metric_type.type_value,
-        description: metric.metric_type.description || '',
-      });
-    }
-  });
-
-  const requirementsData = Array.from(maps.requirements.values());
-  return {
-    requirementsData,
-    requirementOptions: requirementsData.map(b => ({ id: b.id, name: b.name })),
-    backendTypeOptions: Array.from(maps.backendTypes.values()),
-    metricTypeOptions: Array.from(maps.metricTypes.values()),
-  };
-}
-
 export default function MetricsClientComponent({
   organizationId,
   initialData,
@@ -134,41 +83,47 @@ export default function MetricsClientComponent({
 
   const assignMode = searchParams.get('assignMode') === 'true';
 
-  // Accumulate dropdown options across page/filter navigations (see
-  // deriveMetricsPageOptions) so filtering to one value doesn't erase the
-  // other options from the dropdowns.
-  const optionMapsRef = React.useRef<MetricsOptionMaps>({
-    requirements: new Map(),
-    backendTypes: new Map(),
-    metricTypes: new Map(),
-  });
-
-  const [requirements, setRequirements] = React.useState<ApiRequirement[]>(
-    () =>
-      initialData
-        ? deriveMetricsPageOptions(initialData, optionMapsRef.current)
-            .requirementsData
-        : []
+  const lookupEnabled = !permsLoading && canRead;
+  const { data: backendTypes = [] } = useTypeLookups(
+    "type_name eq 'BackendType'",
+    lookupEnabled
   );
+  const { data: metricTypes = [] } = useTypeLookups(
+    "type_name eq 'MetricType'",
+    lookupEnabled
+  );
+  const { data: allRequirements = [] } = useRequirements(lookupEnabled);
+
+  const requirements = React.useMemo<ApiRequirement[]>(
+    () => allRequirements as ApiRequirement[],
+    [allRequirements]
+  );
+
   const [_requirementsWithMetrics, setRequirementsWithMetrics] = React.useState<
     RequirementWithMetrics[]
   >([]);
 
   // Filter state
   const [filters, setFilters] = React.useState<FilterState>(initialFilterState);
-  const [filterOptions, setFilterOptions] = React.useState<FilterOptions>(
-    () => {
-      if (!initialData) return initialFilterOptions;
-      const { requirementOptions, backendTypeOptions, metricTypeOptions } =
-        deriveMetricsPageOptions(initialData, optionMapsRef.current);
-      return {
-        ...initialFilterOptions,
-        backend: backendTypeOptions,
-        type: metricTypeOptions,
-        requirement: requirementOptions,
-      };
-    }
+
+  const filterOptions = React.useMemo<FilterOptions>(
+    () => ({
+      ...initialFilterOptions,
+      backend: backendTypes.map(t => ({
+        type_value:
+          t.type_value.charAt(0).toUpperCase() + t.type_value.slice(1),
+      })),
+      type: metricTypes.map(t => ({
+        type_value: t.type_value,
+        description: t.description || '',
+      })),
+      requirement: allRequirements
+        .filter(b => b.name?.trim())
+        .map(b => ({ id: b.id, name: b.name })),
+    }),
+    [backendTypes, metricTypes, allRequirements]
   );
+
   const [_requirementMetrics, setRequirementMetrics] =
     React.useState<RequirementMetrics>({});
 
@@ -203,8 +158,8 @@ export default function MetricsClientComponent({
       return metricsClient.getMetrics({
         skip,
         limit,
-        sort_by: 'created_at',
-        sort_order: 'desc',
+        sort_by: 'name',
+        sort_order: 'asc',
         $filter: odataFilter,
         $select: METRICS_SELECT,
         ...(filters.metricScope.length > 0 && {
@@ -216,22 +171,6 @@ export default function MetricsClientComponent({
     initialData,
     initialTotalCount,
     enabled: !permsLoading && canRead,
-    onData: data => {
-      const {
-        requirementsData,
-        requirementOptions,
-        backendTypeOptions,
-        metricTypeOptions,
-      } = deriveMetricsPageOptions(data, optionMapsRef.current);
-      setRequirements(requirementsData);
-
-      setFilterOptions(prev => ({
-        ...prev,
-        backend: backendTypeOptions,
-        type: metricTypeOptions,
-        requirement: requirementOptions,
-      }));
-    },
     onError: () => {
       notifications.show('Failed to load metrics data', {
         severity: 'error',

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -60,14 +60,6 @@ function uniqueByTypeValue(types: TypeLookup[]): TypeLookup[] {
   return Array.from(new Map(types.map(t => [t.type_value, t])).values());
 }
 
-interface RequirementMetrics {
-  [requirementId: string]: {
-    metrics: MetricDetail[];
-    isLoading: boolean;
-    error: string | null;
-  };
-}
-
 interface MetricsClientProps {
   organizationId: UUID;
   /** Server-fetched first page — when present, skips the initial client fetch. */
@@ -103,10 +95,6 @@ export default function MetricsClientComponent({
   const { data: allRequirements = NO_REQUIREMENTS } =
     useRequirements(lookupEnabled);
 
-  const [_requirementsWithMetrics, setRequirementsWithMetrics] = React.useState<
-    RequirementWithMetrics[]
-  >([]);
-
   // Filter state
   const [filters, setFilters] = React.useState<FilterState>(initialFilterState);
 
@@ -127,9 +115,6 @@ export default function MetricsClientComponent({
     }),
     [backendTypes, metricTypes, allRequirements]
   );
-
-  const [_requirementMetrics, setRequirementMetrics] =
-    React.useState<RequirementMetrics>({});
 
   const filterFingerprint = React.useMemo(
     () =>
@@ -203,8 +188,6 @@ export default function MetricsClientComponent({
         error={error}
         setFilters={setFilters}
         setMetrics={setMetrics}
-        setRequirementMetrics={setRequirementMetrics}
-        setRequirementsWithMetrics={setRequirementsWithMetrics}
         assignMode={assignMode}
       />
     </ErrorBoundary>

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -6,7 +6,7 @@ import { useNotifications } from '@/components/common/NotificationContext';
 import ErrorBoundary from '@/components/common/ErrorBoundary';
 import { MetricsClient } from '@/utils/api-client/metrics-client';
 import { MetricDetail } from '@/utils/api-client/interfaces/metric';
-import type { RequirementWithMetrics } from '@/utils/api-client/interfaces/requirement';
+import type { RequirementOption } from '@/utils/api-client/interfaces/requirement';
 import type { TypeLookup } from '@/utils/api-client/interfaces/type-lookup';
 import type { UUID } from 'crypto';
 import { TEST_TYPES } from '@/constants/test-types';
@@ -53,7 +53,7 @@ const STATIC_FILTER_OPTIONS = {
 // Stable identities: an inline `data = []` default would mint a fresh array
 // each render while a query is pending, so the memo below would never hold.
 const NO_TYPE_LOOKUPS: TypeLookup[] = [];
-const NO_REQUIREMENTS: RequirementWithMetrics[] = [];
+const NO_REQUIREMENTS: RequirementOption[] = [];
 
 /** Drops duplicate `type_value` rows so repeated options can't collide as React keys. */
 function uniqueByTypeValue(types: TypeLookup[]): TypeLookup[] {

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsClient.tsx
@@ -6,14 +6,16 @@ import { useNotifications } from '@/components/common/NotificationContext';
 import ErrorBoundary from '@/components/common/ErrorBoundary';
 import { MetricsClient } from '@/utils/api-client/metrics-client';
 import { MetricDetail } from '@/utils/api-client/interfaces/metric';
-import type {
-  Requirement as ApiRequirement,
-  RequirementWithMetrics,
-} from '@/utils/api-client/interfaces/requirement';
+import type { RequirementWithMetrics } from '@/utils/api-client/interfaces/requirement';
+import type { TypeLookup } from '@/utils/api-client/interfaces/type-lookup';
 import type { UUID } from 'crypto';
 import { TEST_TYPES } from '@/constants/test-types';
 import { buildMetricODataFilter } from '@/utils/odata-filter';
-import { METRICS_SELECT } from './metrics-constants';
+import {
+  METRICS_SELECT,
+  METRICS_SORT_BY,
+  METRICS_SORT_ORDER,
+} from './metrics-constants';
 import { useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import AccessDenied from '@/components/common/AccessDenied';
@@ -21,7 +23,10 @@ import PageLoadingState from '@/components/common/PageLoadingState';
 import { usePaginatedList } from '@/hooks/usePaginatedList';
 import { useTypeLookups, useRequirements } from '@/hooks/useLookups';
 
-import MetricsDirectoryTab, { type FilterState } from './MetricsDirectoryTab';
+import MetricsDirectoryTab, {
+  type FilterState,
+  type FilterOptions,
+} from './MetricsDirectoryTab';
 
 const initialFilterState: FilterState = {
   search: '',
@@ -32,17 +37,8 @@ const initialFilterState: FilterState = {
   requirement: '',
 };
 
-interface FilterOptions {
-  backend: { type_value: string }[];
-  type: { type_value: string; description: string }[];
-  scoreType: { value: string; label: string }[];
-  metricScope: { value: string; label: string }[];
-  requirement: { id: string; name: string }[];
-}
-
-const initialFilterOptions: FilterOptions = {
-  backend: [],
-  type: [],
+/** Filter options that are fixed rather than resolved from the backend. */
+const STATIC_FILTER_OPTIONS = {
   scoreType: [
     { value: 'numeric', label: 'Numeric' },
     { value: 'categorical', label: 'Categorical' },
@@ -52,8 +48,17 @@ const initialFilterOptions: FilterOptions = {
     { value: TEST_TYPES.MULTI_TURN, label: TEST_TYPES.MULTI_TURN },
     { value: 'Trace', label: 'Trace' },
   ],
-  requirement: [],
-};
+} satisfies Pick<FilterOptions, 'scoreType' | 'metricScope'>;
+
+// Stable identities: an inline `data = []` default would mint a fresh array
+// each render while a query is pending, so the memo below would never hold.
+const NO_TYPE_LOOKUPS: TypeLookup[] = [];
+const NO_REQUIREMENTS: RequirementWithMetrics[] = [];
+
+/** Drops duplicate `type_value` rows so repeated options can't collide as React keys. */
+function uniqueByTypeValue(types: TypeLookup[]): TypeLookup[] {
+  return Array.from(new Map(types.map(t => [t.type_value, t])).values());
+}
 
 interface RequirementMetrics {
   [requirementId: string]: {
@@ -83,21 +88,20 @@ export default function MetricsClientComponent({
 
   const assignMode = searchParams.get('assignMode') === 'true';
 
+  // Options come from the reference tables, not the metrics on screen: that
+  // list is server-paginated and server-filtered, so deriving from it hides
+  // values on later pages and drops the rest as soon as a filter is applied.
   const lookupEnabled = !permsLoading && canRead;
-  const { data: backendTypes = [] } = useTypeLookups(
+  const { data: backendTypes = NO_TYPE_LOOKUPS } = useTypeLookups(
     "type_name eq 'BackendType'",
     lookupEnabled
   );
-  const { data: metricTypes = [] } = useTypeLookups(
+  const { data: metricTypes = NO_TYPE_LOOKUPS } = useTypeLookups(
     "type_name eq 'MetricType'",
     lookupEnabled
   );
-  const { data: allRequirements = [] } = useRequirements(lookupEnabled);
-
-  const requirements = React.useMemo<ApiRequirement[]>(
-    () => allRequirements as ApiRequirement[],
-    [allRequirements]
-  );
+  const { data: allRequirements = NO_REQUIREMENTS } =
+    useRequirements(lookupEnabled);
 
   const [_requirementsWithMetrics, setRequirementsWithMetrics] = React.useState<
     RequirementWithMetrics[]
@@ -108,12 +112,12 @@ export default function MetricsClientComponent({
 
   const filterOptions = React.useMemo<FilterOptions>(
     () => ({
-      ...initialFilterOptions,
-      backend: backendTypes.map(t => ({
+      ...STATIC_FILTER_OPTIONS,
+      backend: uniqueByTypeValue(backendTypes).map(t => ({
         type_value:
           t.type_value.charAt(0).toUpperCase() + t.type_value.slice(1),
       })),
-      type: metricTypes.map(t => ({
+      type: uniqueByTypeValue(metricTypes).map(t => ({
         type_value: t.type_value,
         description: t.description || '',
       })),
@@ -158,8 +162,8 @@ export default function MetricsClientComponent({
       return metricsClient.getMetrics({
         skip,
         limit,
-        sort_by: 'name',
-        sort_order: 'asc',
+        sort_by: METRICS_SORT_BY,
+        sort_order: METRICS_SORT_ORDER,
         $filter: odataFilter,
         $select: METRICS_SELECT,
         ...(filters.metricScope.length > 0 && {
@@ -186,7 +190,6 @@ export default function MetricsClientComponent({
     <ErrorBoundary>
       <MetricsDirectoryTab
         organizationId={organizationId}
-        requirements={requirements}
         metrics={metrics}
         totalCount={totalCount}
         page={page}

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
@@ -199,10 +199,7 @@ export default function MetricsDirectoryTab({
     }
   };
 
-  const handleAssignMetric = (
-    requirementId: UUID,
-    requirementName: string
-  ) => {
+  const handleAssignMetric = (requirementId: UUID, requirementName: string) => {
     if (selectedMetric) {
       handleAssignMetricToRequirement(
         requirementId as string,

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
@@ -26,10 +26,7 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { MetricsClient } from '@/utils/api-client/metrics-client';
 import { MetricDetail } from '@/utils/api-client/interfaces/metric';
-import type {
-  Requirement as ApiRequirement,
-  RequirementWithMetrics,
-} from '@/utils/api-client/interfaces/requirement';
+import type { RequirementWithMetrics } from '@/utils/api-client/interfaces/requirement';
 import type { UUID } from 'crypto';
 import { Can, useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
@@ -47,7 +44,7 @@ export interface FilterState {
   requirement: string;
 }
 
-interface FilterOptions {
+export interface FilterOptions {
   backend: { type_value: string }[];
   type: { type_value: string; description: string }[];
   scoreType: { value: string; label: string }[];
@@ -67,7 +64,6 @@ interface RequirementMetrics {
 
 interface MetricsDirectoryTabProps {
   organizationId: UUID;
-  requirements: ApiRequirement[];
   metrics: MetricDetail[];
   totalCount: number;
   page: number;
@@ -102,9 +98,21 @@ function isValidMetricType(
   );
 }
 
+// Read off the metric rather than a separately-fetched requirements list: while
+// such a fetch is in flight every metric looks unassigned, which blanks the
+// badges and offers delete on metrics that are in use. The string branch
+// covers the interface's legacy UUID form.
+function getAssignedRequirementNames(metric: MetricDetail): string[] {
+  if (!Array.isArray(metric.requirements)) return [];
+  return metric.requirements
+    .map(requirement =>
+      typeof requirement === 'string' ? '' : (requirement.name ?? '')
+    )
+    .filter(name => name.trim() !== '');
+}
+
 export default function MetricsDirectoryTab({
   organizationId: _organizationId,
-  requirements,
   metrics,
   totalCount,
   page,
@@ -388,10 +396,6 @@ export default function MetricsDirectoryTab({
     setMetricToDeleteCompletely(null);
   };
 
-  const activeRequirements = requirements.filter(
-    b => b.name && b.name.trim() !== ''
-  );
-
   // First load — no data at all yet, show a full-page spinner
   const isInitialLoad = isLoading && metrics.length === 0 && totalCount === 0;
 
@@ -571,17 +575,10 @@ export default function MetricsDirectoryTab({
             })}
           >
             {metrics.map(metric => {
-              const assignedRequirements = activeRequirements.filter(b => {
-                if (!Array.isArray(metric.requirements)) return false;
-                // Check if requirements is an array of strings (UUIDs) or RequirementReference objects
-                const requirementIds = metric.requirements.map(requirement =>
-                  typeof requirement === 'string' ? requirement : requirement.id
-                );
-                return requirementIds.includes(b.id as string);
-              });
-              const requirementNames = assignedRequirements.map(
-                b => b.name || 'Unnamed Requirement'
-              );
+              const requirementNames = getAssignedRequirementNames(metric);
+              const hasAssignedRequirements =
+                Array.isArray(metric.requirements) &&
+                metric.requirements.length > 0;
 
               const isCustomMetric =
                 metric.backend_type?.type_value?.toLowerCase() === 'custom';
@@ -614,7 +611,7 @@ export default function MetricsDirectoryTab({
                   }
                   onDelete={
                     canDelete &&
-                    assignedRequirements.length === 0 &&
+                    !hasAssignedRequirements &&
                     metric.backend_type?.type_value?.toLowerCase() === 'custom'
                       ? () => handleDeleteMetric(metric.id, metric.name)
                       : undefined

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
@@ -26,7 +26,6 @@ import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { MetricsClient } from '@/utils/api-client/metrics-client';
 import { MetricDetail } from '@/utils/api-client/interfaces/metric';
-import type { RequirementWithMetrics } from '@/utils/api-client/interfaces/requirement';
 import type { UUID } from 'crypto';
 import { Can, useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
@@ -52,16 +51,6 @@ export interface FilterOptions {
   requirement: { id: string; name: string }[];
 }
 
-interface RequirementMetrics {
-  [requirementId: string]: {
-    metrics: MetricDetail[];
-    isLoading: boolean;
-    error: string | null;
-  };
-}
-
-// Using SelectRequirementsDialog component instead of inline dialog
-
 interface MetricsDirectoryTabProps {
   organizationId: UUID;
   metrics: MetricDetail[];
@@ -77,12 +66,6 @@ interface MetricsDirectoryTabProps {
   error: string | null;
   setFilters: React.Dispatch<React.SetStateAction<FilterState>>;
   setMetrics: React.Dispatch<React.SetStateAction<MetricDetail[]>>;
-  setRequirementMetrics: React.Dispatch<
-    React.SetStateAction<RequirementMetrics>
-  >;
-  setRequirementsWithMetrics: React.Dispatch<
-    React.SetStateAction<RequirementWithMetrics[]>
-  >;
   assignMode?: boolean;
 }
 
@@ -126,8 +109,6 @@ export default function MetricsDirectoryTab({
   error,
   setFilters,
   setMetrics,
-  setRequirementMetrics,
-  setRequirementsWithMetrics,
   assignMode = false,
 }: MetricsDirectoryTabProps) {
   const router = useRouter();
@@ -227,114 +208,12 @@ export default function MetricsDirectoryTab({
         })
       );
 
-      // Find the metric to add to requirement's metrics
-      const targetMetric = metrics.find(m => m.id === metricId);
-      if (targetMetric) {
-        // Update requirementMetrics state
-        setRequirementMetrics(prev => ({
-          ...prev,
-          [requirementId]: {
-            ...prev[requirementId],
-            metrics: [...(prev[requirementId]?.metrics || []), targetMetric],
-            isLoading: false,
-            error: null,
-          },
-        }));
-
-        // Update requirementsWithMetrics state
-        setRequirementsWithMetrics(prevRequirements =>
-          prevRequirements.map(requirement =>
-            requirement.id === requirementId
-              ? {
-                  ...requirement,
-                  metrics: [
-                    ...(requirement.metrics || []),
-                    targetMetric as MetricDetail,
-                  ],
-                }
-              : requirement
-          )
-        );
-      }
-
       notifications.show('Successfully assigned metric to requirement', {
         severity: 'success',
         autoHideDuration: 4000,
       });
     } catch (_err) {
       notifications.show('Failed to assign metric to requirement', {
-        severity: 'error',
-        autoHideDuration: 4000,
-      });
-    }
-  };
-
-  // Function to remove a metric from a requirement
-  const _handleRemoveMetricFromRequirement = async (
-    requirementId: string,
-    metricId: string
-  ) => {
-    try {
-      const metricClient = new MetricsClient();
-
-      // Remove metric from requirement
-      await metricClient.removeRequirementFromMetric(
-        metricId as UUID,
-        requirementId as UUID
-      );
-
-      // Update local state optimistically - remove requirement from metric's requirements list
-      setMetrics(prevMetrics =>
-        prevMetrics.map(metric => {
-          if (metric.id === metricId) {
-            const currentRequirements = Array.isArray(metric.requirements)
-              ? metric.requirements
-              : [];
-            return {
-              ...metric,
-              requirements: currentRequirements.filter(b => {
-                const requirementId_str = typeof b === 'string' ? b : b.id;
-                return requirementId_str !== requirementId;
-              }) as MetricDetail['requirements'],
-            };
-          }
-          return metric;
-        })
-      );
-
-      // Update requirementMetrics state - remove the metric
-      setRequirementMetrics(prev => ({
-        ...prev,
-        [requirementId]: {
-          ...prev[requirementId],
-          metrics: (prev[requirementId]?.metrics || []).filter(
-            m => m.id !== metricId
-          ),
-          isLoading: false,
-          error: null,
-        },
-      }));
-
-      // Update requirementsWithMetrics state - remove the metric
-      setRequirementsWithMetrics(prevRequirements =>
-        prevRequirements.map(requirement =>
-          requirement.id === requirementId
-            ? {
-                ...requirement,
-                metrics: (requirement.metrics || []).filter(
-                  m => m.id !== metricId
-                ),
-              }
-            : requirement
-        )
-      );
-
-      notifications.show('Successfully removed metric from requirement', {
-        severity: 'success',
-        autoHideDuration: 4000,
-      });
-    } catch (_err) {
-      notifications.show('Failed to remove metric from requirement', {
         severity: 'error',
         autoHideDuration: 4000,
       });

--- a/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/components/MetricsDirectoryTab.tsx
@@ -83,14 +83,10 @@ function isValidMetricType(
 
 // Read off the metric rather than a separately-fetched requirements list: while
 // such a fetch is in flight every metric looks unassigned, which blanks the
-// badges and offers delete on metrics that are in use. The string branch
-// covers the interface's legacy UUID form.
+// badges and offers delete on metrics that are in use.
 function getAssignedRequirementNames(metric: MetricDetail): string[] {
-  if (!Array.isArray(metric.requirements)) return [];
-  return metric.requirements
-    .map(requirement =>
-      typeof requirement === 'string' ? '' : (requirement.name ?? '')
-    )
+  return (metric.requirements ?? [])
+    .map(requirement => requirement.name ?? '')
     .filter(name => name.trim() !== '');
 }
 
@@ -162,49 +158,32 @@ export default function MetricsDirectoryTab({
     filters.backend.length === 0 &&
     activeAdvancedFilterCount === 0;
 
-  // Function to assign a metric to a requirement
   const handleAssignMetricToRequirement = async (
     requirementId: string,
-    metricId: string
+    metricId: string,
+    requirementName: string
   ) => {
     try {
       const metricClient = new MetricsClient();
 
-      // Assign metric to requirement
       await metricClient.addRequirementToMetric(
         metricId as UUID,
         requirementId as UUID
       );
 
-      // Update local state optimistically - add requirement to metric's requirements list
       setMetrics(prevMetrics =>
         prevMetrics.map(metric => {
-          if (metric.id === metricId) {
-            const currentRequirements = Array.isArray(metric.requirements)
-              ? metric.requirements
-              : [];
-            // Add requirement ID if not already present
-            const requirementIds = currentRequirements.map(b =>
-              typeof b === 'string' ? b : b.id
-            );
-            if (!requirementIds.includes(requirementId)) {
-              // Maintain consistent type - if current requirements are strings, add string; if objects, add object
-              const isStringArray =
-                currentRequirements.length === 0 ||
-                typeof currentRequirements[0] === 'string';
-              const newRequirement = isStringArray
-                ? requirementId
-                : { id: requirementId as UUID, name: '', description: '' };
-              return {
-                ...metric,
-                requirements: [
-                  ...currentRequirements,
-                  newRequirement,
-                ] as MetricDetail['requirements'],
-              };
-            }
-          }
-          return metric;
+          if (metric.id !== metricId) return metric;
+          const currentRequirements = metric.requirements ?? [];
+          if (currentRequirements.some(r => r.id === requirementId))
+            return metric;
+          return {
+            ...metric,
+            requirements: [
+              ...currentRequirements,
+              { id: requirementId as UUID, name: requirementName },
+            ],
+          };
         })
       );
 
@@ -220,11 +199,15 @@ export default function MetricsDirectoryTab({
     }
   };
 
-  const handleAssignMetric = (requirementId: UUID) => {
+  const handleAssignMetric = (
+    requirementId: UUID,
+    requirementName: string
+  ) => {
     if (selectedMetric) {
       handleAssignMetricToRequirement(
         requirementId as string,
-        selectedMetric.id
+        selectedMetric.id,
+        requirementName
       );
     }
     setAssignDialogOpen(false);
@@ -530,11 +513,9 @@ export default function MetricsDirectoryTab({
               setSelectedMetric(null);
             }}
             onSelect={handleAssignMetric}
-            excludeRequirementIds={(selectedMetric?.requirements || [])
-              .filter(b => typeof b !== 'string' && b.id)
-              .map(b =>
-                typeof b !== 'string' ? b.id : (b as unknown as UUID)
-              )}
+            excludeRequirementIds={(selectedMetric?.requirements ?? []).map(
+              r => r.id
+            )}
           />
         </>
       )}

--- a/apps/frontend/src/app/(protected)/metrics/components/metrics-constants.ts
+++ b/apps/frontend/src/app/(protected)/metrics/components/metrics-constants.ts
@@ -9,3 +9,8 @@ export const METRICS_SELECT =
 
 /** Default page size for the metrics directory grid. */
 export const DEFAULT_METRICS_PAGE_SIZE = 25;
+
+// Shared with the server prefetch: if the two drift, the first page visibly
+// reshuffles once the client refetch lands.
+export const METRICS_SORT_BY = 'name';
+export const METRICS_SORT_ORDER = 'asc' as const;

--- a/apps/frontend/src/app/(protected)/metrics/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/page.tsx
@@ -7,6 +7,8 @@ import type { UUID } from 'crypto';
 import {
   METRICS_SELECT,
   DEFAULT_METRICS_PAGE_SIZE,
+  METRICS_SORT_BY,
+  METRICS_SORT_ORDER,
 } from './components/metrics-constants';
 
 /**
@@ -30,8 +32,8 @@ export default async function MetricsPage() {
       client.getMetrics({
         skip: 0,
         limit: DEFAULT_METRICS_PAGE_SIZE,
-        sort_by: 'name',
-        sort_order: 'asc',
+        sort_by: METRICS_SORT_BY,
+        sort_order: METRICS_SORT_ORDER,
         $select: METRICS_SELECT,
       })
   );

--- a/apps/frontend/src/app/(protected)/metrics/page.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/page.tsx
@@ -30,8 +30,8 @@ export default async function MetricsPage() {
       client.getMetrics({
         skip: 0,
         limit: DEFAULT_METRICS_PAGE_SIZE,
-        sort_by: 'created_at',
-        sort_order: 'desc',
+        sort_by: 'name',
+        sort_order: 'asc',
         $select: METRICS_SELECT,
       })
   );

--- a/apps/frontend/src/components/common/SelectRequirementsDialog.tsx
+++ b/apps/frontend/src/components/common/SelectRequirementsDialog.tsx
@@ -25,7 +25,7 @@ import type { UUID } from 'crypto';
 interface SelectRequirementsDialogProps {
   open: boolean;
   onClose: () => void;
-  onSelect: (requirementId: UUID) => void;
+  onSelect: (requirementId: UUID, requirementName: string) => void;
   excludeRequirementIds?: UUID[];
 }
 
@@ -100,7 +100,8 @@ export default function SelectRequirementsDialog({
   }, [searchQuery, requirements]);
 
   const handleSelect = (requirementId: UUID) => {
-    onSelect(requirementId);
+    const selected = requirements.find(r => r.id === requirementId);
+    onSelect(requirementId, selected?.name ?? '');
     onClose();
   };
 

--- a/apps/frontend/src/components/common/__tests__/SelectRequirementsDialog.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/SelectRequirementsDialog.test.tsx
@@ -193,7 +193,7 @@ describe('SelectRequirementsDialog', () => {
 
     await user.click(screen.getByText('Relevance'));
 
-    expect(onSelect).toHaveBeenCalledWith('requirement-xyz');
+    expect(onSelect).toHaveBeenCalledWith('requirement-xyz', 'Relevance');
     expect(onClose).toHaveBeenCalled();
   });
 

--- a/apps/frontend/src/hooks/useLookups.ts
+++ b/apps/frontend/src/hooks/useLookups.ts
@@ -24,6 +24,10 @@ import { useIsAuthenticated } from '@/hooks/useIsAuthenticated';
 
 const STALE_TIME = 5 * 60_000;
 
+// Without an explicit limit `/type_lookups` defaults to 10 and silently
+// truncates. 100 is the server's ceiling (`validate_pagination` 400s above it).
+const TYPE_LOOKUP_LIMIT = 100;
+
 /**
  * Shared read-only lookup hooks for filter drawers and forms.
  *
@@ -142,6 +146,7 @@ export function useTypeLookups(filter: string, enabled = true) {
         .getTypeLookupClient()
         .getTypeLookups({
           $filter: filter,
+          limit: TYPE_LOOKUP_LIMIT,
           sort_by: 'type_value',
           sort_order: 'asc',
         });

--- a/apps/frontend/src/hooks/useLookups.ts
+++ b/apps/frontend/src/hooks/useLookups.ts
@@ -12,7 +12,7 @@ import {
 } from '@/constants/query-keys';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { Status } from '@/utils/api-client/interfaces/status';
-import { RequirementWithMetrics } from '@/utils/api-client/interfaces/requirement';
+import { RequirementOption } from '@/utils/api-client/interfaces/requirement';
 import { Category } from '@/utils/api-client/interfaces/category';
 import { Topic } from '@/utils/api-client/interfaces/topic';
 import { Tag } from '@/utils/api-client/interfaces/tag';
@@ -60,12 +60,16 @@ export function useStatuses(entityType: string, enabled = true) {
 
 export function useRequirements(enabled = true) {
   const isAuthenticated = useIsAuthenticated();
-  return useQuery<RequirementWithMetrics[]>({
-    queryKey: requirementKeys.list('', 0, 100, 'name', 'asc'),
+  return useQuery<RequirementOption[]>({
+    queryKey: requirementKeys.list('name', 0, 100, 'name', 'asc'),
     queryFn: async () => {
       const requirements = await new ApiClientFactory()
         .getRequirementClient()
-        .getAllRequirements({ sort_by: 'name', sort_order: 'asc' });
+        .getAllRequirements<RequirementOption>({
+          $select: 'name',
+          sort_by: 'name',
+          sort_order: 'asc',
+        });
       return requirements;
     },
     enabled: enabled && isAuthenticated,

--- a/apps/frontend/src/hooks/useLookups.ts
+++ b/apps/frontend/src/hooks/useLookups.ts
@@ -61,7 +61,7 @@ export function useStatuses(entityType: string, enabled = true) {
 export function useRequirements(enabled = true) {
   const isAuthenticated = useIsAuthenticated();
   return useQuery<RequirementOption[]>({
-    queryKey: requirementKeys.list('name', 0, 100, 'name', 'asc'),
+    queryKey: requirementKeys.list('', 0, 100, 'name', 'asc'),
     queryFn: async () => {
       const requirements = await new ApiClientFactory()
         .getRequirementClient()

--- a/apps/frontend/src/utils/api-client/interfaces/metric.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/metric.ts
@@ -104,8 +104,8 @@ export interface RequirementReference {
 }
 
 export interface MetricDetail extends Metric {
-  requirements?: RequirementReference[] | string[]; // Allow both reference objects and UUID strings
-  model?: Model; // Include the full model object when available
+  requirements?: RequirementReference[];
+  model?: Model;
 }
 
 export interface MetricQueryParams extends PaginationParams {

--- a/apps/frontend/src/utils/api-client/interfaces/requirement.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/requirement.ts
@@ -53,11 +53,19 @@ export interface MetricWithRelationships {
   status?: Status | null;
 }
 
+/** id + name only -- what filter dropdowns and pickers need. */
+export interface RequirementOption {
+  id: UUID;
+  name: string;
+}
+
 export interface RequirementsQueryParams {
   skip?: number;
   limit?: number;
   sort_by?: string;
   sort_order?: 'asc' | 'desc';
   $filter?: string;
+  /** Comma-separated fields to return; `id` is always included. */
+  $select?: string;
   include?: string;
 }

--- a/apps/frontend/src/utils/api-client/requirement-client.ts
+++ b/apps/frontend/src/utils/api-client/requirement-client.ts
@@ -41,19 +41,19 @@ export class RequirementClient extends BaseApiClient {
     );
   }
 
-  async getRequirements(
+  async getRequirements<T = RequirementWithMetrics>(
     params: RequirementsQueryParams = {}
-  ): Promise<RequirementWithMetrics[]> {
+  ): Promise<T[]> {
     const {
       skip = 0,
       limit = 100,
       sort_by = 'created_at',
       sort_order = 'desc',
       $filter,
+      $select,
       include: _include,
     } = params;
 
-    // Build query string
     const queryParams = new URLSearchParams();
     queryParams.append('skip', skip.toString());
     queryParams.append('limit', limit.toString());
@@ -62,26 +62,31 @@ export class RequirementClient extends BaseApiClient {
     if ($filter) {
       queryParams.append('$filter', $filter);
     }
-    // Note: The backend now always returns requirements with metrics and their relationships
-    // No need for conditional include parameter since get_items_detail always loads relationships
+    if ($select) {
+      queryParams.append('$select', $select);
+    }
 
     const url = `${API_ENDPOINTS.requirements}/?${queryParams.toString()}`;
 
-    return this.fetch<RequirementWithMetrics[]>(url, {
+    return this.fetch<T[]>(url, {
       cache: 'no-store',
     });
   }
 
-  /** Paginate through all requirements (page size 100) for lookups / filter drawers. */
-  async getAllRequirements(
+  /**
+   * Paginate through all requirements (page size 100) for lookups / filter drawers.
+   * Pass `$select` to trim the response: the default shape inlines every
+   * requirement's full metric list, which callers rendering a name list don't need.
+   */
+  async getAllRequirements<T = RequirementWithMetrics>(
     params: Omit<RequirementsQueryParams, 'skip' | 'limit'> = {}
-  ): Promise<RequirementWithMetrics[]> {
+  ): Promise<T[]> {
     const pageSize = 100;
-    const allData: RequirementWithMetrics[] = [];
+    const allData: T[] = [];
     let skip = 0;
 
     while (true) {
-      const page = await this.getRequirements({
+      const page = await this.getRequirements<T>({
         ...params,
         skip,
         limit: pageSize,


### PR DESCRIPTION
## Purpose

The metrics directory page had two bugs: metrics were sorted by creation date instead of alphabetically, and the filter buttons only offered options drawn from the metrics on the current page rather than the full set of available values.

## What Changed

- Sort the directory by `name` ascending instead of `created_at` descending. The sort constants live in `metrics-constants.ts` and are shared by the server prefetch and the client refetch, so the two cannot drift and reshuffle the first page.
- Replaced the `deriveMetricsPageOptions` accumulator, which scraped filter options out of each page of metric data as it arrived, with `useTypeLookups` and `useBehaviors`. Options now come from the reference tables that define these values, so they no longer depend on which pages have been visited or which filters are active.
- Fixed `useTypeLookups` to send an explicit `limit`. `/type_lookups` defaults to `limit=10`, so every caller was silently receiving a truncated list. This affected the five existing callers as well.
- Read each metric's assigned behavior names off `metric.behaviors` rather than a separately fetched behaviors list. The list endpoint already returns them as reference objects carrying `name`; deriving them from an async fetch meant that while it was in flight every metric looked unassigned, which blanked the "used in" badges and offered delete on custom metrics that are in use.
- Deduplicated lookups by `type_value` (they are used as React keys) and kept the filter-option memo stable while the queries are pending.

## Additional Context

- `useTypeLookups` and `useBehaviors` in `src/hooks/useLookups.ts` already existed and are used by the metrics creation page, test set drawers, and others.
- The `limit` fix addresses a review comment from peqy.

## Testing

1. Open the Metrics directory page.
2. Verify metrics are listed alphabetically (A-Z).
3. Verify the backend type pill filters all appear regardless of which page you are on.
4. Open the advanced filter drawer and confirm Type, Behavior, Score Type, and Metric Scope show their complete options.
5. Apply a filter and confirm the filter options do not disappear or shrink once the filtered results load.
6. On a metric assigned to at least one behavior, confirm the "used in" badges render on first paint and that no delete action is offered for it.