### PR TITLE
Add agent skills config for engineering skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,19 @@ automatically when you read files there via a sibling `CLAUDE.md`:
 - `apps/frontend/AGENTS.md` — affordances, TypeScript/ESLint conventions, codebase layout
 - `sdk/AGENTS.md` — codebase layout, test invocation
 - `docs/AGENTS.md` — Nextra/MDX rules
+
+## Agent skills
+
+### Issue tracker
+
+Issues live as GitHub issues in `rhesis-ai/rhesis`, managed with the `gh` CLI. See
+`docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage roles, each label string equal to its name. See
+`docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context, kept untracked under `playground/`. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`playground/CONTEXT.md`** — the domain glossary for this repo.
+- **`playground/adr/`** — read ADRs that touch the area you're about to work in.
+
+These live under `playground/`, which is gitignored — they are local, untracked working notes, not committed repo documentation. A fresh clone won't have them.
+
+If they don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo, with the domain docs kept out of version control:
+
+```
+playground/                            ← gitignored
+├── CONTEXT.md
+└── adr/
+    ├── 0001-event-sourced-orders.md
+    └── 0002-postgres-for-write-model.md
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `playground/CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Purpose

The Matt Pocock engineering skills (`/triage`, `/to-tickets`, `/to-spec`, `/code-review`, `/domain-modeling`, and others) expect a small amount of per-repo configuration: where issues live, what our triage label strings actually are, and where domain docs sit. Without it each skill has to guess, and `/triage` in particular would invent its own label vocabulary rather than using ours. This adds that config so the skills read our conventions instead of their defaults.

## What Changed

- Added `docs/agents/issue-tracker.md` — declares GitHub Issues as the tracker for this repo, with the `gh` commands each skill should use. Treating external PRs as a request surface is left off.
- Added `docs/agents/triage-labels.md` — maps the five canonical triage roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) to our label strings. We kept the default names, so the mapping is one-to-one.
- Added `docs/agents/domain.md` — tells the skills to read `playground/CONTEXT.md` and `playground/adr/` before exploring the codebase, and to proceed silently when those files don't exist. `playground/` is gitignored, so these stay local working notes rather than committed docs.
- Added an `## Agent skills` section to `CLAUDE.md` pointing at the three files above.

Generated by the `/setup-matt-pocock-skills` skill, then edited: the seed template puts domain docs at `CONTEXT.md` and `docs/adr/` in the repo root, and we repointed those at `playground/`.

## Additional Context

- The four missing triage labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`) have already been created in this repo via `gh label create`, so they exist independently of this PR. `wontfix` was already there and is unchanged.
- The config files have to live at `docs/agents/` — other skills reference that literal path (for example `code-review/SKILL.md`). Nextra only publishes `docs/content/`, so nothing here lands on the docs site.
- Because `playground/` is gitignored, the glossary and ADRs are per-machine. A fresh clone won't have them, and agents running on a clean checkout won't see them. That's intended: they're personal working notes, not shared team decisions.
- No application code, CI, or dependencies are touched.

## Testing

Documentation and agent config only — nothing to run.

- `docs/agents/*.md` are new files; `CLAUDE.md` is append-only, so existing rules are unchanged (`git diff main -- CLAUDE.md`).
- To sanity-check the label mapping, run `gh label list` and confirm the five names in `docs/agents/triage-labels.md` all exist.
- To check the config is actually picked up, run `/triage` and confirm it queries GitHub Issues and proposes our label strings rather than inventing new ones.
