### PR TITLE
Fix Vertex embedding 404, retry storm, and multi-turn test routing

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/40a5b6b88a52_require_metric_scope.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/40a5b6b88a52_require_metric_scope.py
@@ -1,0 +1,66 @@
+"""require a non-empty metric_scope
+
+A metric whose metric_scope is unset is filtered out by every execution path, so
+it never evaluates and reports no error. Backfill the rows that never got one,
+then constrain the column so it cannot happen again.
+
+The CHECK does the work rather than a plain NOT NULL: the offending rows in
+practice hold JSONB ``'null'`` (a JSON null value), which NOT NULL does not
+reject. It also rejects an empty array and any non-array value.
+
+Revision ID: 40a5b6b88a52
+Revises: a1927b321511
+Create Date: 2026-08-10
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "40a5b6b88a52"
+down_revision: Union[str, None] = "a1927b321511"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# SQL NULL, JSONB 'null', a non-array value, or an empty array.
+_UNSCOPED = """
+    metric_scope IS NULL
+    OR jsonb_typeof(metric_scope) <> 'array'
+    OR jsonb_array_length(metric_scope) = 0
+"""
+
+_CONSTRAINT = "ck_metric_metric_scope_non_empty"
+
+
+def upgrade() -> None:
+    # Backfill by class_name. The existing distribution is unambiguous:
+    # ConversationalJudge is Multi-Turn (670 of 681 rows), while NumericJudge and
+    # CategoricalJudge are Single-Turn (293 of 331 and 146 of 153).
+    op.execute(f"""
+        UPDATE metric
+        SET metric_scope = '["Multi-Turn"]'::jsonb
+        WHERE ({_UNSCOPED}) AND class_name = 'ConversationalJudge'
+    """)
+
+    # Everything else, including rows with no class_name, follows the Single-Turn
+    # default that migration 5806494f1668 used for the original backfill.
+    op.execute(f"""
+        UPDATE metric
+        SET metric_scope = '["Single-Turn"]'::jsonb
+        WHERE {_UNSCOPED}
+    """)
+
+    op.create_check_constraint(
+        _CONSTRAINT,
+        "metric",
+        "jsonb_typeof(metric_scope) = 'array' AND jsonb_array_length(metric_scope) > 0",
+    )
+    op.alter_column("metric", "metric_scope", nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("metric", "metric_scope", nullable=True)
+    op.drop_constraint(_CONSTRAINT, "metric", type_="check")

--- a/apps/backend/src/rhesis/backend/alembic/versions/40a5b6b88a52_require_metric_scope.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/40a5b6b88a52_require_metric_scope.py
@@ -26,10 +26,14 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 # SQL NULL, JSONB 'null', a non-array value, or an empty array.
+#
+# jsonb_array_length() raises (not NULL) on a non-array argument, so the third
+# branch guards it with its own jsonb_typeof check rather than relying on the
+# OR's left-to-right evaluation order, which SQL does not guarantee.
 _UNSCOPED = """
     metric_scope IS NULL
     OR jsonb_typeof(metric_scope) <> 'array'
-    OR jsonb_array_length(metric_scope) = 0
+    OR (jsonb_typeof(metric_scope) = 'array' AND jsonb_array_length(metric_scope) = 0)
 """
 
 _CONSTRAINT = "ck_metric_metric_scope_non_empty"

--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -561,8 +561,14 @@ tools:
           {{expected_response}} placeholders (string).
       metric_scope:
         description: >
-          List of strings. Each value must be exactly "Single-Turn" or
-          "Multi-Turn". Always include this field.
+          REQUIRED, and rejected if missing or empty. Non-empty list of
+          strings, each exactly "Single-Turn" or "Multi-Turn". This decides
+          which tests the metric is evaluated against: a Single-Turn metric
+          is skipped on multi-turn tests and vice versa, so a wrong value
+          means the metric silently never runs. Use ["Multi-Turn"] for
+          conversation-level metrics, ["Single-Turn"] for single
+          request-response metrics, and both only when the metric genuinely
+          works either way.
       min_score:
         description: "Minimum score value, number (numeric metrics only)"
       max_score:

--- a/apps/backend/src/rhesis/backend/app/models/metric.py
+++ b/apps/backend/src/rhesis/backend/app/models/metric.py
@@ -1,4 +1,13 @@
-from sqlalchemy import Boolean, Column, Float, ForeignKey, String, Table, Text
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    Float,
+    ForeignKey,
+    String,
+    Table,
+    Text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 
@@ -40,6 +49,12 @@ class Metric(
     CountsMixin,
 ):
     __tablename__ = "metric"
+    __table_args__ = (
+        CheckConstraint(
+            "jsonb_typeof(metric_scope) = 'array' AND jsonb_array_length(metric_scope) > 0",
+            name="ck_metric_metric_scope_non_empty",
+        ),
+    )
 
     name = Column(String, nullable=False)
     description = Column(Text)
@@ -59,9 +74,12 @@ class Metric(
     context_required = Column(Boolean, default=False)
     class_name = Column(String)  # useful if type is custom code or framework
     evaluation_examples = Column(String)
-    metric_scope = Column(
-        JSONB
-    )  # Array of test types this metric applies to (Single-Turn, Multi-Turn)
+    # Array of test types this metric applies to (Single-Turn, Multi-Turn).
+    # Constrained to a non-empty array: execution filters metrics by scope, so an
+    # absent or empty value means the metric is never evaluated by any path and
+    # fails silently. The CHECK also rejects JSONB ``'null'`` and non-array values,
+    # which a plain NOT NULL would let through.
+    metric_scope = Column(JSONB, nullable=False)
 
     # Foreign keys
     metric_type_id = Column(GUID(), ForeignKey("type_lookup.id"))

--- a/apps/backend/src/rhesis/backend/app/routers/metric.py
+++ b/apps/backend/src/rhesis/backend/app/routers/metric.py
@@ -81,6 +81,7 @@ def generate_metric(
         MetricBackendType,
         MetricType,
     )
+    from rhesis.backend.app.schemas.metric import MetricScope
     from rhesis.sdk.metrics.synthesizer import MetricSynthesizer
 
     organization_id, user_id = tenant_context
@@ -88,6 +89,16 @@ def generate_metric(
     try:
         synthesizer = MetricSynthesizer(model=get_model_settings().generation_model)
         generated = synthesizer.generate(request.prompt)
+
+        # metric_scope is required by MetricCreate but only requested of the LLM, so
+        # fall back rather than failing the whole generation. Single-Turn matches the
+        # historical default; the user can change it before saving.
+        if not generated.get("metric_scope"):
+            logger.warning(
+                "Generated metric %r omitted metric_scope; defaulting to Single-Turn",
+                generated.get("name"),
+            )
+            generated["metric_scope"] = [MetricScope.SINGLE_TURN.value]
 
         metric_data = schemas.MetricCreate(**generated)
         metric_data.metric_type = MetricType.CUSTOM_PROMPT

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -225,6 +225,8 @@ def generate_embedding_endpoint(
         db: The database session
         current_user: The current authenticated user
     """
+    from rhesis.backend.app.utils.model_errors import ModelConfigurationError
+
     try:
         from rhesis.backend.app.utils.user_model_utils import get_user_embedding_model
         from rhesis.sdk.models.factory import get_model
@@ -234,13 +236,18 @@ def generate_embedding_endpoint(
         if isinstance(embedder, str):
             embedder = get_model(embedder, model_type="embedding")
         if isinstance(embedder, RhesisEmbedder):
-            raise ValueError(
+            raise ModelConfigurationError(
                 "Embedding model resolved to the Rhesis native provider, which would call "
                 "this endpoint recursively. Set DEFAULT_EMBEDDING_MODEL to an actual "
                 "provider (e.g. vertex_ai/text-embedding-005)."
             )
         embedding = embedder.generate(text=request.text)
         return embedding
+    except ModelConfigurationError as e:
+        # Deployment misconfiguration (DEFAULT_EMBEDDING_MODEL), not a bad
+        # request from this caller — no client-side fix makes this succeed.
+        logger.error(f"Embedding model misconfigured: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=str(e))
     except Exception as e:
         error_msg = str(e) if str(e) else "Unknown error"
         logger.error(f"Failed to generate embedding: {error_msg}", exc_info=True)

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -228,10 +228,17 @@ def generate_embedding_endpoint(
     try:
         from rhesis.backend.app.utils.user_model_utils import get_user_embedding_model
         from rhesis.sdk.models.factory import get_model
+        from rhesis.sdk.models.providers.native import RhesisEmbedder
 
         embedder = get_user_embedding_model(db, current_user)
         if isinstance(embedder, str):
             embedder = get_model(embedder, model_type="embedding")
+        if isinstance(embedder, RhesisEmbedder):
+            raise ValueError(
+                "Embedding model resolved to the Rhesis native provider, which would call "
+                "this endpoint recursively. Set DEFAULT_EMBEDDING_MODEL to an actual "
+                "provider (e.g. vertex_ai/text-embedding-005)."
+            )
         embedding = embedder.generate(text=request.text)
         return embedding
     except Exception as e:

--- a/apps/backend/src/rhesis/backend/app/schemas/metric.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/metric.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import UUID4, ConfigDict, model_validator
+from pydantic import UUID4, ConfigDict, Field, field_validator, model_validator
 
 from rhesis.backend.app.schemas import Base
 from rhesis.backend.app.schemas.metric_types import ScoreType, ThresholdOperator
@@ -53,6 +53,13 @@ class MetricBase(Base):
 
 
 class MetricCreate(MetricBase):
+    # Required on create, unlike the rest of MetricBase. A metric with no scope is
+    # filtered out by every execution path, so accepting one silently creates dead
+    # configuration that never evaluates and reports no error. Enforced here rather
+    # than only in the UI so the SDK, MCP, and the Architect agent are covered too;
+    # the metric table also carries a CHECK constraint as a backstop.
+    metric_scope: List[MetricScope] = Field(..., min_length=1)
+
     @model_validator(mode="after")
     def validate_score_type_fields(self) -> "MetricCreate":
         if self.score_type == ScoreType.NUMERIC:
@@ -75,6 +82,16 @@ class MetricUpdate(MetricBase):
     evaluation_prompt: Optional[str] = None
     score_type: Optional[ScoreType] = None
     threshold_operator: Optional[ThresholdOperator] = None
+
+    @field_validator("metric_scope")
+    @classmethod
+    def scope_cannot_be_emptied(
+        cls, v: Optional[List[MetricScope]]
+    ) -> Optional[List[MetricScope]]:
+        """None means "not being updated"; an empty list would disable the metric."""
+        if v is not None and len(v) == 0:
+            raise ValueError("metric_scope cannot be empty")
+        return v
 
 
 class Metric(MetricBase):

--- a/apps/backend/src/rhesis/backend/app/schemas/metric.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/metric.py
@@ -85,9 +85,7 @@ class MetricUpdate(MetricBase):
 
     @field_validator("metric_scope")
     @classmethod
-    def scope_cannot_be_emptied(
-        cls, v: Optional[List[MetricScope]]
-    ) -> Optional[List[MetricScope]]:
+    def scope_cannot_be_emptied(cls, v: Optional[List[MetricScope]]) -> Optional[List[MetricScope]]:
         """None means "not being updated"; an empty list would disable the metric."""
         if v is not None and len(v) == 0:
             raise ValueError("metric_scope cannot be empty")

--- a/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
@@ -12,6 +12,10 @@ from rhesis.backend.app.models.embedding import EmbeddingConfig
 from rhesis.backend.app.models.enums import EmbeddingStatus
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.utils.crud_utils import get_item
+from rhesis.backend.app.utils.model_errors import (
+    ModelConfigurationError,
+    is_permanent_model_error,
+)
 from rhesis.backend.app.utils.user_model_utils import get_user_embedding_model
 from rhesis.sdk.models.factory import get_model
 
@@ -205,6 +209,12 @@ class EmbeddingGenerator:
         try:
             embedding_vector = embedder.generate(searchable_text)
         except Exception as e:
+            # Keep permanent provider errors distinguishable so the Celery task
+            # fails once instead of autoretrying an unfixable request.
+            if is_permanent_model_error(e):
+                raise ModelConfigurationError(
+                    f"Failed to generate embedding: {e}", original_error=e
+                )
             raise ValueError(f"Failed to generate embedding: {e}")
 
         vec_dim = len(embedding_vector)

--- a/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
+++ b/apps/backend/src/rhesis/backend/app/services/embedding/generator.py
@@ -62,7 +62,7 @@ class EmbeddingGenerator:
             raise ValueError(f"User not found: {user_id}")
 
         resolved = get_user_embedding_model(self.db, user)
-        return (
+        resolved_embedder = (
             get_model(
                 resolved,
                 model_type="embedding",
@@ -71,6 +71,25 @@ class EmbeddingGenerator:
             if isinstance(resolved, str)
             else resolved
         )
+
+        # Caught here, in-process, rather than left to surface as an HTTP error
+        # from generate_embedding_endpoint's own recursion guard: this path runs
+        # inside the Celery embedding task, and a permanent misconfiguration
+        # error raised from an HTTP call is only distinguishable from a
+        # retryable one by status code, which a generic 5xx wouldn't be. Raising
+        # ModelConfigurationError directly, before any network call, sidesteps
+        # that and makes the failure genuinely instant rather than a wasted
+        # round-trip that error-classification would then have to interpret.
+        from rhesis.sdk.models.providers.native import RhesisEmbedder
+
+        if isinstance(resolved_embedder, RhesisEmbedder):
+            raise ModelConfigurationError(
+                "Embedding model resolved to the Rhesis native provider, which would call "
+                "the embedding endpoint recursively. Set DEFAULT_EMBEDDING_MODEL to an "
+                "actual provider (e.g. vertex_ai/text-embedding-005)."
+            )
+
+        return resolved_embedder
 
     def _get_status(self, name: EmbeddingStatus, organization_id: str, user_id: str):
         """Fetch or create embedding status row and fail fast when unavailable."""

--- a/apps/backend/src/rhesis/backend/app/services/explorer/embeddings.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/embeddings.py
@@ -25,6 +25,7 @@ from rhesis.backend.app.models.user import User
 from rhesis.backend.app.services.explorer.diversity_strategies import (
     DEFAULT_EMBEDDING_DIVERSITY_STRATEGY,
 )
+from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 from rhesis.backend.app.utils.user_model_utils import get_user_embedding_model
 from rhesis.sdk.models.factory import get_model
 
@@ -129,9 +130,27 @@ def resolve_embedder(db: Session, user_id: str):
 
     target_dim = EXPLORER_EMBEDDING_DIMENSION
     resolved = get_user_embedding_model(db, user)
-    if isinstance(resolved, str):
-        return get_model(resolved, model_type="embedding", dimensions=target_dim)
-    return resolved
+    embedder = (
+        get_model(resolved, model_type="embedding", dimensions=target_dim)
+        if isinstance(resolved, str)
+        else resolved
+    )
+
+    # Same latent recursion as EmbeddingGenerator._resolve_embedder: a
+    # misconfigured DEFAULT_EMBEDDING_MODEL resolves to the Rhesis native
+    # provider, whose .generate() would call this backend's own
+    # /services/generate/embedding endpoint over HTTP. Catch it here, in
+    # process, before paying for that doomed round-trip.
+    from rhesis.sdk.models.providers.native import RhesisEmbedder
+
+    if isinstance(embedder, RhesisEmbedder):
+        raise ModelConfigurationError(
+            "Embedding model resolved to the Rhesis native provider, which would call "
+            "the embedding endpoint recursively. Set DEFAULT_EMBEDDING_MODEL to an "
+            "actual provider (e.g. vertex_ai/text-embedding-005)."
+        )
+
+    return embedder
 
 
 def generate_embedding_vector(

--- a/apps/backend/src/rhesis/backend/app/utils/model_errors.py
+++ b/apps/backend/src/rhesis/backend/app/utils/model_errors.py
@@ -16,13 +16,26 @@ class ModelConfigurationError(ValueError):
 # bad request, missing/invalid credentials, no permission, unknown model.
 _PERMANENT_PROVIDER_STATUSES = frozenset({400, 401, 403, 404})
 
+# Attribute names carrying an HTTP status, in priority order. No single name
+# covers our providers: litellm and the OpenAI SDK use ``status_code``, aiohttp
+# (raised by RhesisEmbedder) uses ``status``, and google-api-core uses ``code``.
+# ``code`` is last because aiohttp also defines it as a deprecated alias, and
+# reaching it would emit a DeprecationWarning.
+_STATUS_ATTRIBUTES = ("status_code", "status", "code")
+
 
 def is_permanent_model_error(error: BaseException) -> bool:
     """Return True when a provider error cannot be resolved by retrying.
 
-    litellm and the OpenAI SDK both attach ``status_code`` to their exceptions.
     A 404 for a model that isn't served in the configured region is the case
     this exists for: retrying it only multiplies the log noise.
+
+    Only integer values in :data:`_PERMANENT_PROVIDER_STATUSES` count, so an
+    unrelated attribute of the same name cannot accidentally mark a transient
+    failure permanent.
     """
-    status_code = getattr(error, "status_code", None)
-    return isinstance(status_code, int) and status_code in _PERMANENT_PROVIDER_STATUSES
+    for attribute in _STATUS_ATTRIBUTES:
+        status = getattr(error, attribute, None)
+        if isinstance(status, int):
+            return status in _PERMANENT_PROVIDER_STATUSES
+    return False

--- a/apps/backend/src/rhesis/backend/app/utils/model_errors.py
+++ b/apps/backend/src/rhesis/backend/app/utils/model_errors.py
@@ -10,3 +10,19 @@ class ModelConfigurationError(ValueError):
         self.message = message
         self.original_error = original_error
         super().__init__(self.message)
+
+
+# Provider statuses that mean "this request is wrong", not "try again later":
+# bad request, missing/invalid credentials, no permission, unknown model.
+_PERMANENT_PROVIDER_STATUSES = frozenset({400, 401, 403, 404})
+
+
+def is_permanent_model_error(error: BaseException) -> bool:
+    """Return True when a provider error cannot be resolved by retrying.
+
+    litellm and the OpenAI SDK both attach ``status_code`` to their exceptions.
+    A 404 for a model that isn't served in the configured region is the case
+    this exists for: retrying it only multiplies the log noise.
+    """
+    status_code = getattr(error, "status_code", None)
+    return isinstance(status_code, int) and status_code in _PERMANENT_PROVIDER_STATUSES

--- a/apps/backend/src/rhesis/backend/tasks/base.py
+++ b/apps/backend/src/rhesis/backend/tasks/base.py
@@ -9,6 +9,7 @@ from rhesis.backend.app.config.settings import get_frontend_settings
 from rhesis.backend.app.database import (
     get_db_with_tenant_variables,
 )
+from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 from rhesis.backend.tasks.enums import DEFAULT_MAX_RETRIES, DEFAULT_RETRY_BACKOFF_MAX
 
 logger = logging.getLogger(__name__)
@@ -67,6 +68,11 @@ class BaseTask(Task):
     # Automatically retry on exceptions except TestExecutionError
     autoretry_for = (Exception,)
     retry_for_unexpected_only = True  # Only retry for unexpected exceptions
+
+    # Checked by Celery before autoretry_for. A bad model configuration (wrong
+    # region, unknown model, missing credentials) returns the same error on
+    # every attempt, so retrying it just multiplies the log noise.
+    dont_autoretry_for = (ModelConfigurationError,)
 
     # Maximum number of retries - use centralized constant
     max_retries = DEFAULT_MAX_RETRIES
@@ -204,12 +210,21 @@ class BaseTask(Task):
 
         retries = getattr(self.request, "retries", 0)
 
+        # Non-retryable exceptions are final on their first attempt, so don't
+        # report them as "will retry" — Celery already stopped the autoretry.
+        is_non_retryable = isinstance(exc, tuple(self.dont_autoretry_for or ()))
+
         # Only send email notification if task permanently failed (not retrying)
         # and email is enabled
-        if isinstance(exc, TestExecutionError) or retries >= self.max_retries:
+        if isinstance(exc, TestExecutionError) or is_non_retryable or retries >= self.max_retries:
+            reason = (
+                "Task failed permanently (not retryable)"
+                if is_non_retryable
+                else f"Task permanently failed after {retries} attempts"
+            )
             self.log_with_context(
                 "error",
-                f"Task permanently failed after {retries} attempts",
+                reason,
                 error=str(exc),
                 exception_type=type(exc).__name__,
                 execution_time=self._get_execution_time() or "Unknown",

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
@@ -201,6 +201,9 @@ def prefetch_execution_context(
         ).with_related(
             include(Test.prompt),
             include(Test.behavior, Behavior.metrics),
+            # test_type decides which executor each test gets. Eager-load it so it
+            # is already populated when the Test objects are expunged below.
+            include(Test.test_type),
         ).all()
 
     # Pre-fetch per-test data

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/evaluation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/evaluation.py
@@ -11,7 +11,8 @@ from rhesis.backend.app.utils.response_extractor import (
     has_http_error_in_result,
 )
 from rhesis.backend.tasks.execution.batch.context import ExecutionContext
-from rhesis.backend.tasks.execution.constants import PENELOPE_EVALUATED_METRICS
+from rhesis.backend.tasks.execution.constants import PENELOPE_EVALUATED_METRICS, MetricScope
+from rhesis.backend.tasks.execution.evaluation import filter_configs_by_scope
 
 logger = logging.getLogger(__name__)
 
@@ -79,8 +80,15 @@ async def _evaluate_multi_turn_metrics(
     test_config_data = test.test_configuration or {}
     goal = test_config_data.get("goal", "")
 
+    # The batch prefetch cannot scope-filter (one shared config list may serve a
+    # mixed-type test set), so it happens here. Without it, Single-Turn metrics
+    # ran against conversations with the context=[] passed below and failed by
+    # construction, dragging down the pass rate.
+    filtered_configs = filter_configs_by_scope(
+        metric_configs, MetricScope.MULTI_TURN, str(getattr(test, "id", "?"))
+    )
     filtered_configs = [
-        mc for mc in metric_configs if mc.class_name not in PENELOPE_EVALUATED_METRICS
+        mc for mc in filtered_configs if mc.class_name not in PENELOPE_EVALUATED_METRICS
     ]
 
     if not filtered_configs:
@@ -128,11 +136,12 @@ async def _evaluate_single_turn_metrics(
     garak_notes = (test.test_metadata or {}).get("garak_notes") if test else None
     metric_configs = _inject_probe_notes(metric_configs, garak_notes)
 
-    # Drop metrics that are scoped exclusively to Multi-Turn — they require
-    # conversation_history which is not available for single-turn tests.
-    from rhesis.backend.tasks.execution.evaluation import _is_multi_turn_only
-
-    metric_configs = [mc for mc in metric_configs if not _is_multi_turn_only(mc)]
+    # Keep only metrics scoped to Single-Turn. This previously dropped just the
+    # Multi-Turn-*only* ones, which let undeclared-scope metrics through and had
+    # no counterpart on the multi-turn side.
+    metric_configs = filter_configs_by_scope(
+        metric_configs, MetricScope.SINGLE_TURN, str(getattr(test, "id", "?"))
+    )
 
     if not metric_configs:
         return {}

--- a/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
@@ -67,27 +67,36 @@ def filter_configs_by_scope(
     single-turn metrics run against multi-turn conversations, where they get
     ``context=[]`` and fail by construction, inflating the metric count and
     depressing the pass rate.
+
+    Logging follows filter_metrics_by_scope's convention: an explicitly-wrong
+    scope is routine (most behaviors mix Single-Turn and Multi-Turn metrics) and
+    logs at debug; no declared scope at all is worth surfacing at warning, since
+    the metric table's CHECK constraint makes that structurally impossible for a
+    real DB row — seeing it means a non-DB caller handed in an unscoped config.
     """
     wanted = getattr(scope, "value", scope)
 
-    kept, dropped = [], []
+    kept, wrong_scope, no_scope = [], [], []
     for mc in metric_configs:
         name = getattr(mc, "name", None) or getattr(mc, "class_name", "?")
         scopes = _scope_values(mc)
         if wanted in scopes:
             kept.append(mc)
+        elif scopes:
+            wrong_scope.append(f"{name}({scopes})")
         else:
-            dropped.append(f"{name}({scopes or 'no scope'})")
+            no_scope.append(str(name))
 
-    if dropped:
-        # debug, not info: this fires on every mixed-scope behavior, which in
-        # practice is most of them, not on a misconfiguration worth surfacing
-        # per test. filter_metrics_by_scope (the ORM-level sibling) follows the
-        # same convention — per-metric exclusion detail at debug, aggregate
-        # counts at info.
+    if wrong_scope:
         logger.debug(
-            f"Excluded {len(dropped)} metric(s) not scoped to {wanted} "
-            f"for test {test_id}: {', '.join(dropped)}"
+            f"Excluded {len(wrong_scope)} metric(s) not scoped to {wanted} "
+            f"for test {test_id}: {', '.join(wrong_scope)}"
+        )
+    if no_scope:
+        logger.warning(
+            f"Excluded {len(no_scope)} metric(s) with no declared metric_scope "
+            f"for test {test_id}: {', '.join(no_scope)}. This metric row should "
+            f"not exist — metric_scope is required and non-empty in the database."
         )
 
     return kept

--- a/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
@@ -37,23 +37,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _is_multi_turn_only(mc: Any) -> bool:
-    """Return True when a metric config is scoped exclusively to Multi-Turn.
-
-    Handles both MetricConfig objects and raw dicts, and guards against a
-    mis-shaped metric_scope that is a bare string rather than a list.
-    """
-    from rhesis.sdk.metrics.base import MetricScope
-
-    scope = mc.get("metric_scope") if isinstance(mc, dict) else getattr(mc, "metric_scope", None)
-    if not scope or not isinstance(scope, (list, tuple, set)):
-        return False
-    return all(
-        (s if isinstance(s, MetricScope) else MetricScope(s)) == MetricScope.MULTI_TURN
-        for s in scope
-    )
-
-
 def _scope_values(mc: Any) -> List[str]:
     """Return a metric config's declared scopes as plain strings.
 
@@ -97,7 +80,12 @@ def filter_configs_by_scope(
             dropped.append(f"{name}({scopes or 'no scope'})")
 
     if dropped:
-        logger.info(
+        # debug, not info: this fires on every mixed-scope behavior, which in
+        # practice is most of them, not on a misconfiguration worth surfacing
+        # per test. filter_metrics_by_scope (the ORM-level sibling) follows the
+        # same convention — per-metric exclusion detail at debug, aggregate
+        # counts at info.
+        logger.debug(
             f"Excluded {len(dropped)} metric(s) not scoped to {wanted} "
             f"for test {test_id}: {', '.join(dropped)}"
         )
@@ -150,6 +138,7 @@ def evaluate_single_turn_metrics(
     context: List[str],
     result: Dict,
     metrics: List[Union[Dict[str, Any], MetricConfig]],
+    test_id: str = "unknown",
 ) -> Dict:
     """
     Evaluate single-turn metrics on a prompt/response pair.
@@ -164,6 +153,7 @@ def evaluate_single_turn_metrics(
         context: List of context strings
         result: The response dictionary from endpoint invocation
         metrics: List of metric configurations to use for evaluation
+        test_id: Test ID, used only for the scope-filtering debug log
 
     Returns:
         Dictionary containing the evaluation results
@@ -175,8 +165,10 @@ def evaluate_single_turn_metrics(
     metadata = result.get("metadata") if isinstance(result, dict) else None
     tool_calls = result.get("tool_calls") if isinstance(result, dict) else None
 
-    # Drop metrics scoped exclusively to Multi-Turn — they require conversation_history.
-    metrics = [mc for mc in metrics if not _is_multi_turn_only(mc)]
+    # Callers normally already scope-filtered via prepare_metric_configs(...,
+    # scope=MetricScope.SINGLE_TURN) before this runs (see executors/runners.py),
+    # so this is defense in depth for any caller that hands in metrics directly.
+    metrics = filter_configs_by_scope(metrics, MetricScope.SINGLE_TURN, test_id)
 
     if not metrics:
         return metrics_results

--- a/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/evaluation.py
@@ -54,6 +54,57 @@ def _is_multi_turn_only(mc: Any) -> bool:
     )
 
 
+def _scope_values(mc: Any) -> List[str]:
+    """Return a metric config's declared scopes as plain strings.
+
+    Accepts MetricConfig objects and raw dicts, and tolerates MetricScope enums,
+    bare strings, or a mis-shaped non-list value (treated as undeclared).
+    """
+    scope = mc.get("metric_scope") if isinstance(mc, dict) else getattr(mc, "metric_scope", None)
+    if not scope or not isinstance(scope, (list, tuple, set)):
+        return []
+    return [getattr(s, "value", s) for s in scope]
+
+
+def filter_configs_by_scope(
+    metric_configs: List[Any],
+    scope: MetricScope,
+    test_id: str,
+) -> List[Any]:
+    """Keep only the configs that declare support for ``scope``.
+
+    Config-level counterpart to
+    :func:`~rhesis.backend.tasks.execution.executors.metrics.filter_metrics_by_scope`,
+    which operates on ORM Metric rows. The batch path converts to MetricConfig
+    during prefetch, before it knows each test's turn type, so it has to filter
+    here instead.
+
+    Undeclared scope means dropped, matching the ORM-level filter: a metric that
+    never says which turn types it supports is not evaluated. Skipping this let
+    single-turn metrics run against multi-turn conversations, where they get
+    ``context=[]`` and fail by construction, inflating the metric count and
+    depressing the pass rate.
+    """
+    wanted = getattr(scope, "value", scope)
+
+    kept, dropped = [], []
+    for mc in metric_configs:
+        name = getattr(mc, "name", None) or getattr(mc, "class_name", "?")
+        scopes = _scope_values(mc)
+        if wanted in scopes:
+            kept.append(mc)
+        else:
+            dropped.append(f"{name}({scopes or 'no scope'})")
+
+    if dropped:
+        logger.info(
+            f"Excluded {len(dropped)} metric(s) not scoped to {wanted} "
+            f"for test {test_id}: {', '.join(dropped)}"
+        )
+
+    return kept
+
+
 def _build_conversation_history(
     conversation_summary: List[Dict[str, Any]],
 ) -> Optional[ConversationHistory]:

--- a/apps/backend/src/rhesis/backend/tasks/execution/executors/runners.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/executors/runners.py
@@ -264,6 +264,7 @@ class SingleTurnRunner(BaseRunner):
                 context=context,
                 result=processed_result,
                 metrics=metric_configs,
+                test_id=test_id,
             )
 
         return execution_time, processed_result, metrics_results

--- a/apps/backend/src/rhesis/backend/tasks/execution/modes.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/modes.py
@@ -198,6 +198,7 @@ def get_test_type(test: Test) -> TestType:
     """
     from sqlalchemy import inspect as sa_inspect
     from sqlalchemy.orm import object_session
+    from sqlalchemy.orm.attributes import set_committed_value
     from sqlalchemy.orm.state import InstanceState
 
     from rhesis.backend.app.models.type_lookup import TypeLookup
@@ -212,11 +213,27 @@ def get_test_type(test: Test) -> TestType:
     elif test.test_type_id and (sess := object_session(test)) is not None:
         with sess.no_autoflush:
             test_type = sess.get(TypeLookup, test.test_type_id)
+        # Cache it on the instance. The batch path expunges its Test objects and
+        # re-checks the type afterwards, and without this the lookup above leaves
+        # the relationship unloaded, so the detached re-check found no session and
+        # silently downgraded Multi-Turn tests to Single-Turn.
+        # set_committed_value populates without emitting SQL or dirtying the
+        # instance, so it stays safe inside the ORM event listeners above.
+        if test_type is not None:
+            set_committed_value(test, "test_type", test_type)
     else:
         test_type = None
 
     if not test_type:
-        logger.debug(f"Test {test.id} has no test_type set, defaulting to Single-Turn")
+        # A set test_type_id we could not resolve is a bug, not an untyped test:
+        # returning Single-Turn here runs multi-turn tests down the wrong path.
+        if getattr(test, "test_type_id", None):
+            logger.warning(
+                f"Test {test.id} has test_type_id={test.test_type_id} but it could not be "
+                "resolved (detached instance with no session?); defaulting to Single-Turn"
+            )
+        else:
+            logger.debug(f"Test {test.id} has no test_type set, defaulting to Single-Turn")
         return TestType.SINGLE_TURN
 
     # Get the type_value from the TypeLookup relationship

--- a/charts/rhesis/templates/configmap.yaml
+++ b/charts/rhesis/templates/configmap.yaml
@@ -77,6 +77,9 @@ data:
   # GCP / Vertex AI
   # -------------------------------------------------------------------------
   VERTEX_AI_LOCATION: {{ .Values.config.vertexAiLocation | quote }}
+  # Embedding models are not served from the us/eu multi-region endpoints, so
+  # they need a concrete region even when vertexAiLocation is a multi-region.
+  VERTEX_AI_EMBEDDING_LOCATION: {{ .Values.config.vertexAiEmbeddingLocation | quote }}
   VERTEX_AI_PROJECT: {{ .Values.config.vertexAiProject | quote }}
 
   # -------------------------------------------------------------------------

--- a/charts/rhesis/values-dev.yaml
+++ b/charts/rhesis/values-dev.yaml
@@ -46,6 +46,7 @@ config:
   defaultExecutionModel: "vertex_ai/gemini-3.1-flash-lite"
   defaultEmbeddingModel: "vertex_ai/text-embedding-005"
   vertexAiLocation: "eu"
+  vertexAiEmbeddingLocation: "europe-west4"
   azureOpenAiApiVersion: "2024-02-01"
 
 # ---------------------------------------------------------------------------

--- a/charts/rhesis/values-prd.yaml
+++ b/charts/rhesis/values-prd.yaml
@@ -56,6 +56,7 @@ config:
   defaultExecutionModel: "vertex_ai/gemini-3.1-flash-lite"
   defaultEmbeddingModel: "vertex_ai/text-embedding-005"
   vertexAiLocation: "eu"
+  vertexAiEmbeddingLocation: "europe-west4"
   azureOpenAiApiVersion: "2024-02-01"
 
 # ---------------------------------------------------------------------------

--- a/charts/rhesis/values-stg.yaml
+++ b/charts/rhesis/values-stg.yaml
@@ -50,6 +50,7 @@ config:
   defaultExecutionModel: "vertex_ai/gemini-3.1-flash-lite"
   defaultEmbeddingModel: "vertex_ai/text-embedding-005"
   vertexAiLocation: "eu"
+  vertexAiEmbeddingLocation: "europe-west4"
   azureOpenAiApiVersion: "2024-02-01"
 
 # ---------------------------------------------------------------------------

--- a/charts/rhesis/values.yaml
+++ b/charts/rhesis/values.yaml
@@ -99,6 +99,9 @@ config:
 
   # GCP / Vertex AI
   vertexAiLocation: "eu"
+  # Embeddings need a concrete region: text-embedding-* is not served from the
+  # "eu" multi-region endpoint that Gemini accepts.
+  vertexAiEmbeddingLocation: "europe-west4"
   vertexAiProject: ""
 
   # Chatbot

--- a/kubernetes/clusters/dev/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/dev/external-secrets/rhesis-app-secrets.yaml
@@ -168,13 +168,10 @@ spec:
       remoteRef:
         key: dev-rhesis-gcp-service-account
 
-    - secretKey: VERTEX_AI_LOCATION
-      remoteRef:
-        key: dev-rhesis-vertex-ai-location
-
-    - secretKey: VERTEX_AI_PROJECT
-      remoteRef:
-        key: dev-rhesis-vertex-ai-project
+    # VERTEX_AI_LOCATION / VERTEX_AI_PROJECT are deliberately absent: they are
+    # not secrets and are set in the Helm ConfigMap. Deployments list
+    # secretRef after configMapRef, so a key here silently overrides the chart
+    # value and makes values-*.yaml edits look like no-ops.
 
     # -----------------------------------------------------------------------
     # GitHub OAuth (if used)

--- a/kubernetes/clusters/prd/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/prd/external-secrets/rhesis-app-secrets.yaml
@@ -133,13 +133,10 @@ spec:
       remoteRef:
         key: prd-rhesis-gcp-service-account
 
-    - secretKey: VERTEX_AI_LOCATION
-      remoteRef:
-        key: prd-rhesis-vertex-ai-location
-
-    - secretKey: VERTEX_AI_PROJECT
-      remoteRef:
-        key: prd-rhesis-vertex-ai-project
+    # VERTEX_AI_LOCATION / VERTEX_AI_PROJECT are deliberately absent: they are
+    # not secrets and are set in the Helm ConfigMap. Deployments list
+    # secretRef after configMapRef, so a key here silently overrides the chart
+    # value and makes values-*.yaml edits look like no-ops.
 
     # -----------------------------------------------------------------------
     # GitHub OAuth (if used)

--- a/kubernetes/clusters/stg/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/stg/external-secrets/rhesis-app-secrets.yaml
@@ -132,13 +132,10 @@ spec:
       remoteRef:
         key: stg-rhesis-gcp-service-account
 
-    - secretKey: VERTEX_AI_LOCATION
-      remoteRef:
-        key: stg-rhesis-vertex-ai-location
-
-    - secretKey: VERTEX_AI_PROJECT
-      remoteRef:
-        key: stg-rhesis-vertex-ai-project
+    # VERTEX_AI_LOCATION / VERTEX_AI_PROJECT are deliberately absent: they are
+    # not secrets and are set in the Helm ConfigMap. Deployments list
+    # secretRef after configMapRef, so a key here silently overrides the chart
+    # value and makes values-*.yaml edits look like no-ops.
 
     # -----------------------------------------------------------------------
     # GitHub OAuth (if used)

--- a/sdk/src/rhesis/sdk/metrics/synthesizer.py
+++ b/sdk/src/rhesis/sdk/metrics/synthesizer.py
@@ -95,7 +95,7 @@ class GeneratedMetric(BaseModel):
         description=(
             'Non-empty list containing "Single-Turn" and/or "Multi-Turn". Always '
             "provide it. This decides which tests the metric is evaluated against, "
-            "so a wrong value means it silently never runs. Use [\"Multi-Turn\"] for "
+            'so a wrong value means it silently never runs. Use ["Multi-Turn"] for '
             'metrics that judge a whole conversation, ["Single-Turn"] for a single '
             "request-response exchange, and both only when it genuinely works either way."
         ),

--- a/sdk/src/rhesis/sdk/metrics/synthesizer.py
+++ b/sdk/src/rhesis/sdk/metrics/synthesizer.py
@@ -92,7 +92,13 @@ class GeneratedMetric(BaseModel):
     )
     metric_scope: Optional[List[str]] = Field(
         default=None,
-        description='List containing "Single-Turn" and/or "Multi-Turn"',
+        description=(
+            'Non-empty list containing "Single-Turn" and/or "Multi-Turn". Always '
+            "provide it. This decides which tests the metric is evaluated against, "
+            "so a wrong value means it silently never runs. Use [\"Multi-Turn\"] for "
+            'metrics that judge a whole conversation, ["Single-Turn"] for a single '
+            "request-response exchange, and both only when it genuinely works either way."
+        ),
     )
 
 

--- a/sdk/src/rhesis/sdk/models/providers/native.py
+++ b/sdk/src/rhesis/sdk/models/providers/native.py
@@ -218,10 +218,12 @@ class RhesisLLM(BaseLLM):
                 request_elapsed = time.time() - request_start
 
                 if response.status >= 400:
+                    body = await response.text()
                     logger.error(
-                        "[RhesisLLM] HTTP %s after %.1fs",
+                        "[RhesisLLM] HTTP %s after %.1fs — %s",
                         response.status,
                         request_elapsed,
+                        body,
                     )
                     response.raise_for_status()
 
@@ -301,11 +303,18 @@ class RhesisEmbedder(BaseEmbedder):
             timeout = aiohttp.ClientTimeout(total=DEFAULT_REQUEST_TIMEOUT)
             async with aiohttp.ClientSession(timeout=timeout) as session:
                 async with session.post(url, headers=self.headers, json={"text": text}) as response:
-                    response.raise_for_status()
+                    if response.status >= 400:
+                        body = await response.text()
+                        logger.error(
+                            "Embedding request failed: HTTP %s — %s",
+                            response.status,
+                            body,
+                        )
+                        response.raise_for_status()
                     result: List[float] = await response.json()
                     return result
         except aiohttp.ClientResponseError as e:
-            logger.error(f"Error generating embedding: {e}", exc_info=True)
+            logger.error("Error generating embedding: %s", e, exc_info=True)
             raise
 
     def generate_batch(self, texts: List[str], **kwargs: Any) -> List[List[float]]:

--- a/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
+++ b/sdk/src/rhesis/sdk/models/providers/vertex_ai.py
@@ -431,13 +431,14 @@ class VertexAIEmbedder(VertexAICredentialsMixin, LiteLLMEmbedder):
             - Or file path to JSON file (standard for local development)
             - If not provided, uses GOOGLE_APPLICATION_CREDENTIALS environment variable
         location: GCP region (e.g., "europe-west4")
-            - If not provided, uses VERTEX_AI_LOCATION environment variable
+            - If not provided, uses VERTEX_AI_EMBEDDING_LOCATION, then VERTEX_AI_LOCATION
         project: GCP project ID (usually auto-extracted from credentials)
             - Priority: init parameter > VERTEX_AI_PROJECT env var > credentials file
         dimensions: Optional embedding dimensions (supported by text-embedding-005).
 
     Environment Variables (used as fallback):
         GOOGLE_APPLICATION_CREDENTIALS: Service account credentials
+        VERTEX_AI_EMBEDDING_LOCATION: (Optional) GCP region for embeddings only
         VERTEX_AI_LOCATION: GCP region
         VERTEX_AI_PROJECT: (Optional) GCP project ID override
 
@@ -469,6 +470,20 @@ class VertexAIEmbedder(VertexAICredentialsMixin, LiteLLMEmbedder):
             dimensions=dimensions,
             timeout=timeout,
         )
+
+    def _get_location(self) -> str:
+        """Resolve the region, preferring an embedding-specific override.
+
+        Embedding publisher models are not served from the ``us``/``eu``
+        multi-region endpoints that Gemini accepts, so a deployment that pins
+        VERTEX_AI_LOCATION to ``eu`` for Gemini gets a 404 here unless it can
+        name a concrete region for embeddings alone.
+        """
+        if not self._init_location:
+            embedding_location = os.getenv("VERTEX_AI_EMBEDDING_LOCATION")
+            if embedding_location:
+                return embedding_location
+        return super()._get_location()
 
     def _with_vertex_credentials(self, func, *args, **kwargs):
         """Execute a function with Vertex AI credentials injected.

--- a/tests/backend/metrics/fixtures/metric_fixtures.py
+++ b/tests/backend/metrics/fixtures/metric_fixtures.py
@@ -138,6 +138,8 @@ def test_metric_numeric(test_db, test_org_id, authenticated_user_id):
         threshold_operator=">=",
         backend_type_id=backend_type.id,
         metric_type_id=metric_type.id,
+        # Required and NOT NULL: an unscoped metric is never evaluated.
+        metric_scope=["Single-Turn"],
         organization_id=test_org_id,
         user_id=authenticated_user_id,
     )
@@ -182,6 +184,8 @@ def test_metric_categorical(test_db, test_org_id, authenticated_user_id):
         reference_score="positive",
         backend_type_id=backend_type.id,
         metric_type_id=metric_type.id,
+        # Required and NOT NULL: an unscoped metric is never evaluated.
+        metric_scope=["Single-Turn"],
         organization_id=test_org_id,
         user_id=authenticated_user_id,
     )

--- a/tests/backend/metrics/test_database_integration.py
+++ b/tests/backend/metrics/test_database_integration.py
@@ -53,6 +53,7 @@ class TestDatabaseIntegration:
             threshold_operator=">=",
             backend_type_id=backend_type.id,
             metric_type_id=metric_type.id,
+            metric_scope=["Single-Turn"],
         )
 
         metric = create_metric(
@@ -121,6 +122,7 @@ class TestDatabaseIntegration:
         )
 
         metric = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Metric to Delete",
             class_name="RhesisPromptMetric",
             score_type="numeric",
@@ -166,6 +168,7 @@ class TestDatabaseIntegration:
         )
 
         metric = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Metric with Model",
             class_name="RhesisPromptMetric",
             score_type="numeric",

--- a/tests/backend/metrics/test_e2e_flow.py
+++ b/tests/backend/metrics/test_e2e_flow.py
@@ -292,6 +292,7 @@ class TestE2EFlow:
         )
 
         ragas_metric = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Ragas Answer Relevancy",
             class_name="RagasAnswerRelevancy",
             score_type="numeric",
@@ -496,6 +497,7 @@ class TestE2EFlow:
 
         # Create a real RhesisPromptMetric in the database
         metric = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Integration Test Metric",
             class_name="RhesisPromptMetric",  # Will be split to NumericJudge by adapter
             score_type="numeric",

--- a/tests/backend/metrics/test_garak_pipeline.py
+++ b/tests/backend/metrics/test_garak_pipeline.py
@@ -43,6 +43,9 @@ def _garak_metric_config(
         threshold=0.5,
         threshold_operator="<",
         parameters=parameters or {},
+        # Every Garak metric row in the DB is scoped Single-Turn, and batch
+        # evaluation drops configs that declare no scope.
+        metric_scope=["Single-Turn"],
     )
 
 
@@ -54,6 +57,7 @@ def _non_garak_metric_config() -> MetricConfig:
         description="A non-garak metric",
         score_type="numeric",
         threshold=0.5,
+        metric_scope=["Single-Turn"],
     )
 
 

--- a/tests/backend/metrics/test_task_execution.py
+++ b/tests/backend/metrics/test_task_execution.py
@@ -197,6 +197,7 @@ class TestTaskExecution:
 
         # Create an execution-time metric
         execution_metric = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Execution Metric",
             class_name="NumericJudge",
             score_type="numeric",
@@ -286,6 +287,7 @@ class TestTaskExecution:
 
         # Create a test set metric
         test_set_metric = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Test Set Metric",
             class_name="CategoricalJudge",
             score_type="categorical",
@@ -300,6 +302,7 @@ class TestTaskExecution:
 
         # Create an execution-time metric
         execution_metric = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Execution Override Metric",
             class_name="NumericJudge",
             score_type="numeric",
@@ -384,6 +387,7 @@ class TestTaskExecution:
 
         # Create a test set metric
         test_set_metric = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Test Set Override Metric",
             class_name="CategoricalJudge",
             score_type="categorical",
@@ -444,6 +448,7 @@ class TestTaskExecution:
 
         # Create Metric models
         metric1 = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Test Metric 1",
             class_name="NumericJudge",
             score_type="numeric",
@@ -453,6 +458,7 @@ class TestTaskExecution:
             user_id=authenticated_user_id,
         )
         metric2 = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Test Metric 2",
             class_name="CategoricalJudge",
             score_type="categorical",
@@ -490,6 +496,7 @@ class TestTaskExecution:
 
         # Create valid metric
         valid_metric = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Valid Metric",
             class_name="NumericJudge",
             score_type="numeric",
@@ -501,6 +508,7 @@ class TestTaskExecution:
 
         # Create invalid metric (missing class_name)
         invalid_metric = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Invalid Metric",
             class_name=None,
             score_type="numeric",
@@ -719,6 +727,7 @@ class TestTaskExecution:
         )
 
         valid_metric = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Valid Metric",
             class_name="RhesisPromptMetric",
             score_type="numeric",
@@ -733,6 +742,7 @@ class TestTaskExecution:
 
         # Create invalid metric (missing class_name)
         invalid_metric = models.Metric(
+            metric_scope=["Single-Turn"],
             name="Invalid Metric",
             class_name=None,
             score_type="numeric",

--- a/tests/backend/metrics/test_task_execution.py
+++ b/tests/backend/metrics/test_task_execution.py
@@ -561,6 +561,7 @@ class TestTaskExecution:
                     "class_name": "RhesisPromptMetric",
                     "backend": "rhesis",
                     "threshold": 7,
+                    "metric_scope": ["Single-Turn"],
                     "parameters": {
                         "evaluation_prompt": "Test",
                         "evaluation_steps": "Step 1",
@@ -656,6 +657,7 @@ class TestTaskExecution:
                 "class_name": "RhesisPromptMetric",
                 "backend": "rhesis",
                 "threshold": 7,
+                "metric_scope": ["Single-Turn"],
                 "parameters": {
                     "evaluation_prompt": "Test 1",
                     "evaluation_steps": "Step 1",
@@ -670,6 +672,7 @@ class TestTaskExecution:
                 "class_name": "RhesisPromptMetric",
                 "backend": "rhesis",
                 "reference_score": "positive",
+                "metric_scope": ["Single-Turn"],
                 "parameters": {
                     "evaluation_prompt": "Test 2",
                     "evaluation_steps": "Step 1",

--- a/tests/backend/routes/fixtures/data_factories.py
+++ b/tests/backend/routes/fixtures/data_factories.py
@@ -307,8 +307,8 @@ class MetricDataFactory(BaseDataFactory):
     """Factory for generating metric test data"""
 
     @classmethod
-    def _add_score_type_fields(cls, data: Dict[str, Any]) -> Dict[str, Any]:
-        """Add required fields based on score_type."""
+    def _add_required_fields(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Fill in the fields MetricCreate requires but callers rarely care about."""
         if data.get("score_type") == "categorical":
             data.setdefault("categories", ["pass", "fail", "partial"])
             data.setdefault("passing_categories", ["pass"])
@@ -316,7 +316,13 @@ class MetricDataFactory(BaseDataFactory):
             data.setdefault("min_score", 0)
             data.setdefault("max_score", 10)
             data.setdefault("threshold", 5)
+        # Required on create and NOT NULL in the table: a metric with no scope is
+        # never evaluated by any execution path.
+        data.setdefault("metric_scope", ["Single-Turn"])
         return data
+
+    # Kept as an alias: the old name described only part of what it now does.
+    _add_score_type_fields = _add_required_fields
 
     @classmethod
     def minimal_data(cls) -> Dict[str, Any]:
@@ -363,14 +369,14 @@ class MetricDataFactory(BaseDataFactory):
     def edge_case_data(cls, case_type: str) -> Dict[str, Any]:
         """Generate metric edge case data"""
         if case_type == "long_name":
-            return {
+            data = {
                 "name": fake.text(max_nb_chars=800).replace("\n", " "),
                 "evaluation_prompt": fake.sentence(nb_words=8),
                 "score_type": "numeric",
                 "description": fake.text(max_nb_chars=100),
             }
         elif case_type == "special_chars":
-            return {
+            data = {
                 "name": f"{fake.word()} 📊 émoji & metrics! @#$%^&*()",
                 "evaluation_prompt": "How well does this handle special chars? 🤔",
                 "score_type": "categorical",
@@ -379,7 +385,7 @@ class MetricDataFactory(BaseDataFactory):
                 "description": fake.text(max_nb_chars=100),
             }
         elif case_type == "unicode":
-            return {
+            data = {
                 "name": f"Test 测试 тест テスト {fake.word()} Metric",
                 "evaluation_prompt": "Unicode evaluation: 测试 тест テスト",
                 "score_type": "categorical",
@@ -388,14 +394,16 @@ class MetricDataFactory(BaseDataFactory):
                 "description": "Unicode description: 测试 тест テスト",
             }
         elif case_type == "sql_injection":
-            return {
+            data = {
                 "name": "'; DROP TABLE metrics; --",
                 "evaluation_prompt": "1' OR '1'='1",
                 "score_type": "numeric",
                 "description": "SQL injection attempt",
             }
+        else:
+            return super().edge_case_data(case_type)
 
-        return super().edge_case_data(case_type)
+        return cls._add_required_fields(data)
 
 
 @dataclass

--- a/tests/backend/routes/test_metric.py
+++ b/tests/backend/routes/test_metric.py
@@ -193,6 +193,7 @@ class TestMetricValidation(MetricTestMixin, BaseEntityTests):
                 "name": fake.word().title() + f" {score_type.title()} Metric",
                 "evaluation_prompt": fake.sentence(nb_words=8),
                 "score_type": score_type,
+                "metric_scope": ["Single-Turn"],
             }
 
             # Add required fields per score type

--- a/tests/backend/routes/test_services.py
+++ b/tests/backend/routes/test_services.py
@@ -4,8 +4,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException, Response
 
-from rhesis.backend.app.routers.services import generate_content_endpoint
-from rhesis.backend.app.schemas.services import GenerateContentRequest
+from rhesis.backend.app.routers.services import (
+    generate_content_endpoint,
+    generate_embedding_endpoint,
+)
+from rhesis.backend.app.schemas.services import GenerateContentRequest, GenerateEmbeddingRequest
 
 
 class TestGenerateContentEndpoint:
@@ -69,6 +72,59 @@ class TestGenerateContentEndpoint:
             assert exc_info.value.status_code == 400
             assert "Failed to generate content:" in str(exc_info.value.detail)
             assert "Model initialization failed" in str(exc_info.value.detail)
+
+
+class TestGenerateEmbeddingEndpoint:
+    """Test cases for generate_embedding_endpoint's error status codes.
+
+    A bad request from the caller (invalid text, provider rejects the
+    content) and a deployment misconfiguration (DEFAULT_EMBEDDING_MODEL
+    pointing back at this same endpoint) are different failure classes and
+    must not both surface as a generic HTTP 400 — no client-side retry or
+    input change fixes the second one.
+    """
+
+    def test_plain_provider_error_returns_400(self):
+        """A provider-side failure is still a 400 — the request itself is bad."""
+        mock_request = GenerateEmbeddingRequest(text="some text")
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+
+        with patch(
+            "rhesis.backend.app.utils.user_model_utils.get_user_embedding_model"
+        ) as mock_get_embedding_model:
+            mock_get_embedding_model.side_effect = Exception("Provider rejected the request")
+
+            with pytest.raises(HTTPException) as exc_info:
+                generate_embedding_endpoint(mock_request, db=mock_db, current_user=mock_user)
+
+            assert exc_info.value.status_code == 400
+            assert "Failed to generate embedding:" in str(exc_info.value.detail)
+
+    def test_recursive_native_provider_returns_500_not_400(self):
+        """DEFAULT_EMBEDDING_MODEL resolving back to RhesisEmbedder is a server
+        misconfiguration, not a bad request — must return 500."""
+        from rhesis.sdk.models.providers.native import RhesisEmbedder
+
+        mock_request = GenerateEmbeddingRequest(text="some text")
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+
+        # isinstance() against a Mock(spec=...) succeeds, so this stands in for
+        # a real RhesisEmbedder without needing RHESIS_API_KEY configured.
+        fake_native_embedder = MagicMock(spec=RhesisEmbedder)
+
+        with patch(
+            "rhesis.backend.app.utils.user_model_utils.get_user_embedding_model",
+            return_value=fake_native_embedder,
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                generate_embedding_endpoint(mock_request, db=mock_db, current_user=mock_user)
+
+            assert exc_info.value.status_code == 500
+            assert "recursively" in str(exc_info.value.detail)
+
+        fake_native_embedder.generate.assert_not_called()
 
 
 class TestGenerateContentEndpointUsageForwarding:

--- a/tests/backend/schemas/test_metric_scope_required.py
+++ b/tests/backend/schemas/test_metric_scope_required.py
@@ -1,0 +1,90 @@
+"""A metric cannot be created without a scope.
+
+Execution filters metrics by scope, so an absent or empty `metric_scope` means the
+metric is never evaluated by any path and reports no error. Enforcing it in
+`MetricCreate` covers every writer that goes through the API: the UI, the SDK, the
+MCP `create_metric` tool, and the Architect agent (which calls the same endpoint).
+The `metric` table carries a matching CHECK constraint as the backstop for anything
+that bypasses the API.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from rhesis.backend.app.schemas.metric import (
+    MetricCreate,
+    MetricScope,
+    MetricUpdate,
+)
+
+
+def _valid_payload(**overrides):
+    """A numeric metric that satisfies every other MetricCreate rule."""
+    payload = dict(
+        name="Faithfulness",
+        evaluation_prompt="Judge whether the response is faithful to the context.",
+        score_type="numeric",
+        min_score=0.0,
+        max_score=1.0,
+        threshold=0.5,
+        metric_scope=[MetricScope.SINGLE_TURN],
+    )
+    payload.update(overrides)
+    return payload
+
+
+@pytest.mark.unit
+class TestMetricCreateRequiresScope:
+    def test_valid_scope_is_accepted(self):
+        metric = MetricCreate(**_valid_payload())
+        assert metric.metric_scope == [MetricScope.SINGLE_TURN]
+
+    def test_omitted_scope_is_rejected(self):
+        payload = _valid_payload()
+        del payload["metric_scope"]
+
+        with pytest.raises(ValidationError) as exc_info:
+            MetricCreate(**payload)
+
+        assert "metric_scope" in str(exc_info.value)
+
+    def test_empty_scope_is_rejected(self):
+        with pytest.raises(ValidationError):
+            MetricCreate(**_valid_payload(metric_scope=[]))
+
+    def test_null_scope_is_rejected(self):
+        with pytest.raises(ValidationError):
+            MetricCreate(**_valid_payload(metric_scope=None))
+
+    def test_invalid_scope_value_is_rejected(self):
+        with pytest.raises(ValidationError):
+            MetricCreate(**_valid_payload(metric_scope=["Sometimes"]))
+
+    @pytest.mark.parametrize(
+        "scope",
+        [
+            [MetricScope.MULTI_TURN],
+            [MetricScope.SINGLE_TURN, MetricScope.MULTI_TURN],
+            ["Multi-Turn"],
+        ],
+    )
+    def test_accepted_scope_shapes(self, scope):
+        assert MetricCreate(**_valid_payload(metric_scope=scope)).metric_scope
+
+
+@pytest.mark.unit
+class TestMetricUpdateScope:
+    def test_omitting_scope_is_allowed(self):
+        """None means "not being updated" on a partial update."""
+        assert MetricUpdate(name="Renamed").metric_scope is None
+
+    def test_scope_cannot_be_emptied(self):
+        """Clearing the scope would silently disable the metric."""
+        with pytest.raises(ValidationError) as exc_info:
+            MetricUpdate(metric_scope=[])
+
+        assert "metric_scope cannot be empty" in str(exc_info.value)
+
+    def test_scope_can_be_changed(self):
+        updated = MetricUpdate(metric_scope=[MetricScope.MULTI_TURN])
+        assert updated.metric_scope == [MetricScope.MULTI_TURN]

--- a/tests/backend/security/test_organization_filtering.py
+++ b/tests/backend/security/test_organization_filtering.py
@@ -465,6 +465,7 @@ class TestCrudOrganizationFiltering:
             ground_truth_required=False,
             context_required=False,
             class_name="TestMetric",
+            metric_scope=["Single-Turn"],
         )
 
         metric = create_metric(

--- a/tests/backend/services/explorer/test_embeddings.py
+++ b/tests/backend/services/explorer/test_embeddings.py
@@ -1,0 +1,68 @@
+"""Tests for explorer embedding resolution."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.services.explorer.embeddings import resolve_embedder
+from rhesis.backend.app.utils.model_errors import ModelConfigurationError
+
+
+@pytest.mark.unit
+class TestResolveEmbedder:
+    def test_user_not_found_raises(self, test_db: Session):
+        with pytest.raises(ValueError, match="User not found"):
+            resolve_embedder(test_db, "00000000-0000-0000-0000-000000000000")
+
+    @patch("rhesis.backend.app.services.explorer.embeddings.get_user_embedding_model")
+    def test_recursive_native_provider_fails_before_any_network_call(
+        self,
+        mock_get_user_embedding_model,
+        test_db: Session,
+        test_org_id: str,
+        authenticated_user_id: str,
+    ):
+        """DEFAULT_EMBEDDING_MODEL misconfigured back to the Rhesis native
+        provider must fail in-process, not via a doomed HTTP round-trip to
+        this backend's own /services/generate/embedding endpoint.
+
+        Same latent recursion as EmbeddingGenerator._resolve_embedder
+        (apps/backend/.../services/embedding/generator.py), just reached from
+        the explorer suggestions/test-embedding paths instead of the Celery
+        embedding task.
+        """
+        from rhesis.sdk.models.providers.native import RhesisEmbedder
+
+        # isinstance() against a Mock(spec=...) succeeds, so this stands in for
+        # a real RhesisEmbedder without needing RHESIS_API_KEY configured.
+        fake_native_embedder = Mock(spec=RhesisEmbedder)
+        mock_get_user_embedding_model.return_value = fake_native_embedder
+
+        with pytest.raises(ModelConfigurationError, match="recursively"):
+            resolve_embedder(test_db, authenticated_user_id)
+
+        fake_native_embedder.generate.assert_not_called()
+
+    @patch("rhesis.backend.app.services.explorer.embeddings.get_model")
+    @patch("rhesis.backend.app.services.explorer.embeddings.get_user_embedding_model")
+    def test_ordinary_provider_string_is_resolved_normally(
+        self,
+        mock_get_user_embedding_model,
+        mock_get_model,
+        test_db: Session,
+        test_org_id: str,
+        authenticated_user_id: str,
+    ):
+        """A correctly configured provider still resolves — the recursion
+        guard must not fire on an unrelated embedder type."""
+        mock_get_user_embedding_model.return_value = "vertex_ai/text-embedding-005"
+        mock_embedder = Mock()
+        mock_get_model.return_value = mock_embedder
+
+        result = resolve_embedder(test_db, authenticated_user_id)
+
+        assert result is mock_embedder
+        mock_get_model.assert_called_once_with(
+            "vertex_ai/text-embedding-005", model_type="embedding", dimensions=768
+        )

--- a/tests/backend/services/explorer/test_evaluation.py
+++ b/tests/backend/services/explorer/test_evaluation.py
@@ -22,6 +22,7 @@ _RUN_METRICS_PATCH = "rhesis.backend.app.services.explorer.evaluation.run_metric
 def _create_metric(db, name, organization_id, user_id):
     """Create a Metric row so it can be resolved by name."""
     metric = models.Metric(
+        metric_scope=["Single-Turn"],
         name=name,
         class_name="StubMetric",
         evaluation_prompt="stub prompt",

--- a/tests/backend/services/explorer/test_settings.py
+++ b/tests/backend/services/explorer/test_settings.py
@@ -53,6 +53,7 @@ def _create_endpoint(
 
 def _create_metric(db: Session, organization_id: str, user_id: str, name: str) -> models.Metric:
     metric = models.Metric(
+        metric_scope=["Single-Turn"],
         name=name,
         class_name="StubMetric",
         evaluation_prompt="stub prompt",

--- a/tests/backend/services/test_embedding_generator.py
+++ b/tests/backend/services/test_embedding_generator.py
@@ -453,6 +453,41 @@ class TestEmbeddingGenerator:
                 model_id=str(embedding_model.id),
             )
 
+    @patch("rhesis.backend.app.services.embedding.generator.get_user_embedding_model")
+    def test_recursive_native_provider_fails_before_any_network_call(
+        self,
+        mock_get_user_embedding_model,
+        test_db,
+        test_entity,
+        embedding_model,
+        test_org_id,
+        authenticated_user_id,
+    ):
+        """DEFAULT_EMBEDDING_MODEL misconfigured back to the Rhesis native
+        provider must fail in-process, not via a doomed HTTP round-trip to
+        generate_embedding_endpoint whose eventual error only a status code
+        would distinguish as permanent-vs-transient.
+        """
+        from rhesis.sdk.models.providers.native import RhesisEmbedder
+
+        # isinstance() against a Mock(spec=...) succeeds, so this stands in for
+        # a real RhesisEmbedder without needing RHESIS_API_KEY configured.
+        fake_native_embedder = Mock(spec=RhesisEmbedder)
+        mock_get_user_embedding_model.return_value = fake_native_embedder
+
+        generator = EmbeddingGenerator(test_db)
+
+        with pytest.raises(ModelConfigurationError, match="recursively"):
+            generator.generate(
+                entity_id=str(test_entity.id),
+                entity_type="Test",
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+                model_id=str(embedding_model.id),
+            )
+
+        fake_native_embedder.generate.assert_not_called()
+
     @patch("rhesis.backend.app.services.embedding.generator.get_model")
     def test_transient_provider_error_stays_retryable(
         self,

--- a/tests/backend/services/test_embedding_generator.py
+++ b/tests/backend/services/test_embedding_generator.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session, joinedload
 from rhesis.backend.app import models
 from rhesis.backend.app.models.enums import EmbeddingStatus, ModelType
 from rhesis.backend.app.services.embedding.generator import EmbeddingGenerator
+from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 
 
 @pytest.fixture
@@ -416,6 +417,69 @@ class TestEmbeddingGenerator:
                 user_id=authenticated_user_id,
                 model_id="00000000-0000-0000-0000-000000000000",
             )
+
+    @patch("rhesis.backend.app.services.embedding.generator.get_model")
+    def test_permanent_provider_error_raises_model_configuration_error(
+        self,
+        mock_get_model,
+        test_db,
+        test_entity,
+        embedding_model,
+        test_org_id,
+        authenticated_user_id,
+    ):
+        """A provider 404 must stay identifiable so Celery does not autoretry it.
+
+        Reproduces the region mismatch that produced the Vertex
+        ``text-embedding-005`` not-found storm: the model is absent from the
+        configured location, so every retry returns the same 404.
+        """
+
+        class NotFoundError(Exception):
+            status_code = 404
+
+        generator = EmbeddingGenerator(test_db)
+
+        mock_embedder = Mock()
+        mock_embedder.generate.side_effect = NotFoundError("Publisher model was not found")
+        mock_get_model.return_value = mock_embedder
+
+        with pytest.raises(ModelConfigurationError, match="Failed to generate embedding"):
+            generator.generate(
+                entity_id=str(test_entity.id),
+                entity_type="Test",
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+                model_id=str(embedding_model.id),
+            )
+
+    @patch("rhesis.backend.app.services.embedding.generator.get_model")
+    def test_transient_provider_error_stays_retryable(
+        self,
+        mock_get_model,
+        test_db,
+        test_entity,
+        embedding_model,
+        test_org_id,
+        authenticated_user_id,
+    ):
+        """A timeout carries no permanent status, so it must remain retryable."""
+        generator = EmbeddingGenerator(test_db)
+
+        mock_embedder = Mock()
+        mock_embedder.generate.side_effect = TimeoutError("upstream timed out")
+        mock_get_model.return_value = mock_embedder
+
+        with pytest.raises(ValueError, match="Failed to generate embedding") as exc_info:
+            generator.generate(
+                entity_id=str(test_entity.id),
+                entity_type="Test",
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+                model_id=str(embedding_model.id),
+            )
+
+        assert not isinstance(exc_info.value, ModelConfigurationError)
 
     @pytest.mark.parametrize("empty_text", ["", "   ", "\n\t"])
     @patch("rhesis.backend.app.services.embedding.generator.get_model")

--- a/tests/backend/tasks/test_batch_per_test_metrics.py
+++ b/tests/backend/tasks/test_batch_per_test_metrics.py
@@ -24,10 +24,19 @@ from rhesis.backend.tasks.execution.batch.context import ExecutionContext
 # ============================================================================
 
 
-def _make_metric_config(name: str, class_name: str) -> MagicMock:
+def _make_metric_config(
+    name: str,
+    class_name: str,
+    metric_scope: list | None = None,
+) -> MagicMock:
     mc = MagicMock()
     mc.name = name
     mc.class_name = class_name
+    # Batch evaluation drops configs that declare no scope, so default to both
+    # turn types: these tests are about which configs are selected, not scope.
+    mc.metric_scope = (
+        metric_scope if metric_scope is not None else ["Single-Turn", "Multi-Turn"]
+    )
     return mc
 
 
@@ -516,10 +525,6 @@ class TestBatchEvaluationPerTestMetrics:
             patch(
                 "rhesis.backend.app.utils.response_extractor.normalize_context_to_list",
                 return_value=[],
-            ),
-            patch(
-                "rhesis.backend.tasks.execution.evaluation._is_multi_turn_only",
-                return_value=False,
             ),
         ):
             from rhesis.backend.tasks.execution.batch.evaluation import (

--- a/tests/backend/tasks/test_filter_configs_by_scope.py
+++ b/tests/backend/tasks/test_filter_configs_by_scope.py
@@ -1,0 +1,188 @@
+"""Scope filtering for metric configs in the batch execution path.
+
+The batch path converts metrics to MetricConfig during prefetch, before it knows
+each test's turn type, so `prepare_metric_configs` is called without a scope and
+filtering has to happen at evaluation time instead.
+
+Regression: nothing filtered on the multi-turn side, so `["Single-Turn"]` metrics
+such as RagasFaithfulness ran against conversations. The multi-turn evaluator
+passes `context=[]`, so they failed by construction, inflating the metric count
+and depressing the reported pass rate.
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from rhesis.backend.app.schemas.metric import MetricScope
+from rhesis.backend.tasks.execution.evaluation import filter_configs_by_scope
+
+
+class _Config:
+    """Stands in for MetricConfig, which is what the batch path holds."""
+
+    def __init__(self, name, metric_scope, class_name="SomeJudge"):
+        self.name = name
+        self.class_name = class_name
+        self.metric_scope = metric_scope
+
+
+@pytest.mark.unit
+class TestFilterConfigsByScope:
+    def test_single_turn_metric_excluded_from_multi_turn(self):
+        """The reported bug: Faithfulness ran in a multi-turn test."""
+        configs = [
+            _Config("Faithfulness", ["Single-Turn"], "RagasFaithfulness"),
+            _Config("Booking Momentum", ["Multi-Turn"], "ConversationalJudge"),
+        ]
+
+        kept = filter_configs_by_scope(configs, MetricScope.MULTI_TURN, "t1")
+
+        assert [c.name for c in kept] == ["Booking Momentum"]
+
+    def test_multi_turn_metric_excluded_from_single_turn(self):
+        """The mirror case, which the old _is_multi_turn_only check did cover."""
+        configs = [
+            _Config("Faithfulness", ["Single-Turn"], "RagasFaithfulness"),
+            _Config("Booking Momentum", ["Multi-Turn"], "ConversationalJudge"),
+        ]
+
+        kept = filter_configs_by_scope(configs, MetricScope.SINGLE_TURN, "t1")
+
+        assert [c.name for c in kept] == ["Faithfulness"]
+
+    @pytest.mark.parametrize(
+        "scope", [MetricScope.SINGLE_TURN, MetricScope.MULTI_TURN]
+    )
+    def test_dual_scoped_metric_kept_for_both(self, scope):
+        configs = [_Config("Response Conciseness", ["Single-Turn", "Multi-Turn"])]
+
+        assert len(filter_configs_by_scope(configs, scope, "t1")) == 1
+
+    @pytest.mark.parametrize("undeclared", [None, [], "Multi-Turn", 42])
+    def test_undeclared_scope_is_dropped(self, undeclared):
+        """Parity with the ORM-level filter: no declared scope means no evaluation.
+
+        A bare string is deliberately included: it is mis-shaped data, not a
+        one-element list, and must not be treated as a declared scope.
+        """
+        configs = [_Config("Unscoped", undeclared)]
+
+        assert filter_configs_by_scope(configs, MetricScope.MULTI_TURN, "t1") == []
+        assert filter_configs_by_scope(configs, MetricScope.SINGLE_TURN, "t1") == []
+
+    def test_accepts_metric_scope_enums_not_just_strings(self):
+        configs = [_Config("Enum scoped", [MetricScope.MULTI_TURN])]
+
+        assert len(filter_configs_by_scope(configs, MetricScope.MULTI_TURN, "t1")) == 1
+        assert filter_configs_by_scope(configs, MetricScope.SINGLE_TURN, "t1") == []
+
+    def test_accepts_dict_configs(self):
+        configs = [
+            {"name": "Faithfulness", "metric_scope": ["Single-Turn"]},
+            {"name": "State Consistency", "metric_scope": ["Multi-Turn"]},
+        ]
+
+        kept = filter_configs_by_scope(configs, MetricScope.MULTI_TURN, "t1")
+
+        assert [c["name"] for c in kept] == ["State Consistency"]
+
+    def test_empty_input_returns_empty(self):
+        assert filter_configs_by_scope([], MetricScope.MULTI_TURN, "t1") == []
+
+    def test_reproduces_the_reported_behavior_metric_set_helper(self):
+        """The exact 10 metrics on the 'Booking Flow Completion' behavior.
+
+        Multi-turn evaluation must keep 8 and drop the 2 single-turn-only ones,
+        so the run scores out of 9 (8 plus Goal Achievement) rather than 11.
+        """
+        configs = [
+            _Config("Answer Accuracy", ["Single-Turn"], "RagasAnswerAccuracy"),
+            _Config("Faithfulness", ["Single-Turn"], "RagasFaithfulness"),
+            _Config("Booking Momentum", ["Multi-Turn"]),
+            _Config("Conversation Completeness", ["Multi-Turn"]),
+            _Config("Progressive Clarification", ["Multi-Turn"]),
+            _Config("Recovery Effectiveness", ["Multi-Turn"]),
+            _Config("State Consistency", ["Multi-Turn"]),
+            _Config("Capability Boundary Honesty", ["Single-Turn", "Multi-Turn"]),
+            _Config("Failure Transparency", ["Single-Turn", "Multi-Turn"]),
+            _Config("Response Conciseness", ["Single-Turn", "Multi-Turn"]),
+        ]
+
+        kept = {c.name for c in filter_configs_by_scope(configs, MetricScope.MULTI_TURN, "t1")}
+
+        assert "Faithfulness" not in kept
+        assert "Answer Accuracy" not in kept
+        assert len(kept) == 8
+
+
+@pytest.mark.unit
+class TestMultiTurnEvaluatorAppliesScopeFilter:
+    """Covers the wiring, not just the helper.
+
+    Deleting the `filter_configs_by_scope` call in `_evaluate_multi_turn_metrics`
+    passes every helper-level test above, so this asserts on what the evaluator
+    actually receives.
+    """
+
+    @staticmethod
+    def _conversation_output():
+        return {
+            "conversation_summary": [
+                {
+                    "penelope_message": "I need to check in for my flight",
+                    "target_response": "I can only help with insurance questions.",
+                }
+            ]
+        }
+
+    @pytest.mark.asyncio
+    async def test_single_turn_metric_never_reaches_the_evaluator(self):
+        from rhesis.backend.tasks.execution.batch.evaluation import (
+            _evaluate_multi_turn_metrics,
+        )
+
+        configs = [
+            _Config("Faithfulness", ["Single-Turn"], "RagasFaithfulness"),
+            _Config("State Consistency", ["Multi-Turn"], "ConversationalJudge"),
+        ]
+
+        evaluator = MagicMock()
+        future = asyncio.Future()
+        future.set_result({"State Consistency": {"is_successful": True}})
+        evaluator.a_evaluate = MagicMock(return_value=future)
+
+        test = MagicMock()
+        test.id = "test-1"
+        test.test_configuration = {"goal": "check in for a flight"}
+
+        await _evaluate_multi_turn_metrics(
+            MagicMock(), evaluator, test, self._conversation_output(), configs
+        )
+
+        passed = evaluator.a_evaluate.call_args.kwargs["metrics"]
+        assert [c.name for c in passed] == ["State Consistency"]
+
+    @pytest.mark.asyncio
+    async def test_no_evaluation_when_nothing_is_in_scope(self):
+        """All-single-turn metrics must short-circuit, not call the evaluator."""
+        from rhesis.backend.tasks.execution.batch.evaluation import (
+            _evaluate_multi_turn_metrics,
+        )
+
+        configs = [_Config("Faithfulness", ["Single-Turn"], "RagasFaithfulness")]
+
+        evaluator = MagicMock()
+        evaluator.a_evaluate = MagicMock()
+
+        test = MagicMock()
+        test.id = "test-1"
+        test.test_configuration = {"goal": "check in for a flight"}
+
+        result = await _evaluate_multi_turn_metrics(
+            MagicMock(), evaluator, test, self._conversation_output(), configs
+        )
+
+        assert result == {}
+        evaluator.a_evaluate.assert_not_called()

--- a/tests/backend/tasks/test_filter_configs_by_scope.py
+++ b/tests/backend/tasks/test_filter_configs_by_scope.py
@@ -72,6 +72,34 @@ class TestFilterConfigsByScope:
         assert filter_configs_by_scope(configs, MetricScope.MULTI_TURN, "t1") == []
         assert filter_configs_by_scope(configs, MetricScope.SINGLE_TURN, "t1") == []
 
+    def test_wrong_scope_logs_at_debug_not_info(self, caplog):
+        """Explicitly-out-of-scope is routine — most behaviors mix scopes."""
+        import logging
+
+        configs = [_Config("Faithfulness", ["Single-Turn"], "RagasFaithfulness")]
+
+        with caplog.at_level(logging.DEBUG, logger="rhesis.backend.tasks.execution.evaluation"):
+            filter_configs_by_scope(configs, MetricScope.MULTI_TURN, "t1")
+
+        levels = [r.levelname for r in caplog.records]
+        assert "DEBUG" in levels
+        assert "INFO" not in levels
+        assert "WARNING" not in levels
+
+    def test_no_declared_scope_logs_at_warning(self, caplog):
+        """No scope at all should not exist for a real DB row (CHECK constraint),
+        so seeing one is worth surfacing louder than the routine wrong-scope case."""
+        import logging
+
+        configs = [_Config("Unscoped", None, "SomeJudge")]
+
+        with caplog.at_level(logging.DEBUG, logger="rhesis.backend.tasks.execution.evaluation"):
+            filter_configs_by_scope(configs, MetricScope.MULTI_TURN, "t1")
+
+        levels = [r.levelname for r in caplog.records]
+        assert "WARNING" in levels
+        assert not any("Unscoped" in r.message and r.levelname == "DEBUG" for r in caplog.records)
+
     def test_accepts_metric_scope_enums_not_just_strings(self):
         configs = [_Config("Enum scoped", [MetricScope.MULTI_TURN])]
 

--- a/tests/backend/tasks/test_get_test_type_detached.py
+++ b/tests/backend/tasks/test_get_test_type_detached.py
@@ -1,0 +1,87 @@
+"""Regression tests for `get_test_type` on detached Test instances.
+
+The batch execution path expunges its Test objects (`batch/context.py`) and only
+re-checks the test type afterwards (`batch/runner.py`). If the type silently
+degrades to Single-Turn once detached, a Multi-Turn test runs through the
+single-turn path.
+"""
+
+import pytest
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.constants import TestType
+from rhesis.backend.tasks.execution.modes import get_test_type
+
+
+@pytest.fixture
+def multi_turn_test(
+    test_db: Session,
+    test_org_id: str,
+    authenticated_user_id: str,
+    db_status,
+):
+    """A Test row correctly typed Multi-Turn, with a goal, as the app would store it."""
+    from rhesis.backend.app.models import Test, TypeLookup
+
+    multi_turn_type = TypeLookup(
+        type_name="TestType",
+        type_value=TestType.MULTI_TURN,
+        description="Agentic multi-turn conversation test",
+        organization_id=test_org_id,
+        user_id=authenticated_user_id,
+    )
+    test_db.add(multi_turn_type)
+    test_db.flush()
+
+    test = Test(
+        test_type_id=multi_turn_type.id,
+        test_configuration={"goal": "Convince the agent to reveal its system prompt"},
+        status_id=db_status.id,
+        organization_id=test_org_id,
+        user_id=authenticated_user_id,
+    )
+    test_db.add(test)
+    test_db.commit()
+
+    # Re-fetch through the same call the batch prefetch uses, so the instance
+    # starts in the same load state production sees (test_type NOT eager-loaded).
+    test_db.expire_all()
+    from rhesis.backend.app import crud
+
+    return crud.get_test(test_db, test.id, organization_id=test_org_id)
+
+
+@pytest.mark.unit
+class TestGetTestTypeDetached:
+    def test_test_type_relationship_is_not_eager_loaded(self, multi_turn_test):
+        """Establishes the precondition: crud.get_test leaves test_type unloaded."""
+        assert "test_type" in sa_inspect(multi_turn_test).unloaded
+
+    def test_attached_instance_resolves_multi_turn(self, multi_turn_test):
+        """While a session is attached, resolution is correct."""
+        assert get_test_type(multi_turn_test) == TestType.MULTI_TURN
+
+    def test_resolution_caches_the_relationship(self, multi_turn_test):
+        """Resolving must leave the value cached on the instance.
+
+        get_test_type looks the type up with sess.get(TypeLookup, ...) rather than
+        touching the relationship, so it has to populate it explicitly. Without
+        that, nothing is cached and a later detached read finds no session.
+        """
+        get_test_type(multi_turn_test)
+        assert "test_type" not in sa_inspect(multi_turn_test).unloaded
+
+    def test_detached_instance_still_resolves_multi_turn(
+        self, multi_turn_test, test_db: Session
+    ):
+        """The batch path's exact sequence: resolve, expunge, resolve again.
+
+        Regression: this returned Single-Turn, routing Multi-Turn tests through
+        SingleTurnTestExecutor with an empty prompt.
+        """
+        assert get_test_type(multi_turn_test) == TestType.MULTI_TURN
+
+        test_db.expunge(multi_turn_test)
+
+        assert get_test_type(multi_turn_test) == TestType.MULTI_TURN

--- a/tests/backend/tasks/test_metrics_evaluation.py
+++ b/tests/backend/tasks/test_metrics_evaluation.py
@@ -42,7 +42,7 @@ class TestEvaluateSingleTurnMetrics:
             expected_response="4",
             context=["math"],
             result={"output": "4"},
-            metrics=[{"name": "accuracy"}],
+            metrics=[{"name": "accuracy", "metric_scope": ["Single-Turn"]}],
         )
 
         assert result == {"accuracy": {"score": 0.9, "is_successful": True}}
@@ -63,7 +63,7 @@ class TestEvaluateSingleTurnMetrics:
                 expected_response="expected",
                 context=[],
                 result={"output": "raw"},
-                metrics=[{"name": "m1"}],
+                metrics=[{"name": "m1", "metric_scope": ["Single-Turn"]}],
             )
 
         mock_extract.assert_called_once_with({"output": "raw"})
@@ -81,7 +81,7 @@ class TestEvaluateSingleTurnMetrics:
             expected_response="e",
             context=[],
             result={"output": "o"},
-            metrics=[{"name": "m"}],
+            metrics=[{"name": "m", "metric_scope": ["Single-Turn"]}],
         )
 
         assert result == {}
@@ -183,11 +183,14 @@ class TestEvaluateSingleTurnMetrics:
         mock_evaluator.evaluate.assert_not_called()
         assert result == {}
 
-    def test_bare_string_metric_scope_is_not_excluded(self):
-        """A mis-shaped bare-string metric_scope does not crash and is treated as non-filtering.
+    def test_bare_string_metric_scope_is_excluded(self):
+        """A mis-shaped bare-string metric_scope does not crash, and is dropped.
 
-        MetricConfig validates and rejects bare strings, so this scenario can only
-        arrive via a loosely-typed object (e.g. a dict-converted mock).
+        filter_configs_by_scope treats anything that isn't a list/tuple/set as
+        undeclared scope — same as no scope at all — rather than as "matches
+        every scope". MetricConfig validates and rejects bare strings, so this
+        scenario can only arrive via a loosely-typed object (e.g. a
+        dict-converted mock), but it must not crash and must not silently pass.
         """
         mock_evaluator = MagicMock()
         mock_evaluator.evaluate.return_value = {}
@@ -195,7 +198,7 @@ class TestEvaluateSingleTurnMetrics:
         bad_scope_metric = MagicMock()
         bad_scope_metric.metric_scope = "Multi-Turn"  # bare string, not a list
 
-        evaluate_single_turn_metrics(
+        result = evaluate_single_turn_metrics(
             metrics_evaluator=mock_evaluator,
             prompt_content="test",
             expected_response="",
@@ -204,7 +207,8 @@ class TestEvaluateSingleTurnMetrics:
             metrics=[bad_scope_metric],
         )
 
-        mock_evaluator.evaluate.assert_called_once()
+        mock_evaluator.evaluate.assert_not_called()
+        assert result == {}
 
 
 # ============================================================================
@@ -230,7 +234,7 @@ class TestEvaluatePromptResponseAlias:
             expected_response="e",
             context=[],
             result={"output": "o"},
-            metrics=[{"name": "m1"}],
+            metrics=[{"name": "m1", "metric_scope": ["Single-Turn"]}],
         )
 
         assert result == {"m1": {"score": 0.5}}
@@ -666,64 +670,3 @@ class TestEvaluateMultiTurnMetrics:
 
         tc_list = conv.get_assistant_tool_calls()
         assert tc_list[0] == [{"name": "search", "arguments": {"q": "policy"}}]
-
-
-# ============================================================================
-# _is_multi_turn_only helper tests
-# ============================================================================
-
-
-class TestIsMultiTurnOnly:
-    """Unit tests for the _is_multi_turn_only helper used by both evaluation paths."""
-
-    def setup_method(self):
-        from rhesis.backend.tasks.execution.evaluation import _is_multi_turn_only
-        from rhesis.sdk.metrics.base import MetricScope
-
-        self._fn = _is_multi_turn_only
-        self._MT = MetricScope.MULTI_TURN
-        self._ST = MetricScope.SINGLE_TURN
-
-    def test_object_multi_turn_only_returns_true(self):
-        from rhesis.sdk.metrics import MetricConfig
-
-        mc = MetricConfig(name="m", class_name="C", metric_scope=[self._MT])
-        assert self._fn(mc) is True
-
-    def test_object_single_turn_only_returns_false(self):
-        from rhesis.sdk.metrics import MetricConfig
-
-        mc = MetricConfig(name="m", class_name="C", metric_scope=[self._ST])
-        assert self._fn(mc) is False
-
-    def test_object_mixed_scope_returns_false(self):
-        from rhesis.sdk.metrics import MetricConfig
-
-        mc = MetricConfig(name="m", class_name="C", metric_scope=[self._ST, self._MT])
-        assert self._fn(mc) is False
-
-    def test_object_none_scope_returns_false(self):
-        from rhesis.sdk.metrics import MetricConfig
-
-        mc = MetricConfig(name="m", class_name="C", metric_scope=None)
-        assert self._fn(mc) is False
-
-    def test_dict_multi_turn_only_returns_true(self):
-        mc = {"name": "m", "class_name": "C", "metric_scope": [self._MT]}
-        assert self._fn(mc) is True
-
-    def test_dict_single_turn_only_returns_false(self):
-        mc = {"name": "m", "class_name": "C", "metric_scope": [self._ST]}
-        assert self._fn(mc) is False
-
-    def test_dict_no_metric_scope_key_returns_false(self):
-        mc = {"name": "m", "class_name": "C"}
-        assert self._fn(mc) is False
-
-    def test_bare_string_scope_returns_false_and_does_not_crash(self):
-        """A mis-shaped bare string must not raise — treated as non-filtering."""
-        from unittest.mock import MagicMock
-
-        mc = MagicMock()
-        mc.metric_scope = "Multi-Turn"
-        assert self._fn(mc) is False

--- a/tests/backend/tasks/test_permanent_error_no_retry.py
+++ b/tests/backend/tasks/test_permanent_error_no_retry.py
@@ -1,0 +1,110 @@
+"""Guards that permanent model errors are not autoretried.
+
+`BaseTask` sets `autoretry_for = (Exception,)`, so every failure retries by
+default. `ModelConfigurationError` is listed in `dont_autoretry_for` to opt out.
+Celery wires both at task-registration time, so this is behaviour of the
+generated wrapper rather than of any code in this repo, and only a real task
+exercises it.
+"""
+
+import pytest
+
+from rhesis.backend.app.utils.model_errors import (
+    ModelConfigurationError,
+    is_permanent_model_error,
+)
+from rhesis.backend.celery.core import app
+from rhesis.backend.tasks.base import BaseTask
+
+
+@app.task(base=BaseTask, bind=True, name="tests.permanent_error_task")
+def _permanent_error_task(self):
+    raise ModelConfigurationError("embedding model is not served in this region")
+
+
+@app.task(base=BaseTask, bind=True, name="tests.transient_error_task")
+def _transient_error_task(self):
+    raise TimeoutError("upstream timed out")
+
+
+class _RetryAttempted(Exception):
+    """Sentinel standing in for Celery's real retry, which would re-execute."""
+
+
+@pytest.fixture
+def record_retries(monkeypatch):
+    """Replace Task.retry so we can tell "retried" from "propagated"."""
+    attempts = []
+
+    def fake_retry(self, *args, **kwargs):
+        attempts.append(kwargs)
+        raise _RetryAttempted()
+
+    monkeypatch.setattr(BaseTask, "retry", fake_retry, raising=False)
+    return attempts
+
+
+@pytest.mark.unit
+class TestPermanentErrorNoRetry:
+    def test_permanent_error_propagates_without_retrying(self, record_retries):
+        """dont_autoretry_for must win over autoretry_for=(Exception,)."""
+        result = _permanent_error_task.apply()
+
+        assert isinstance(result.result, ModelConfigurationError)
+        assert record_retries == [], "permanent error was retried"
+
+    def test_transient_error_still_retries(self, record_retries):
+        """The opt-out must be narrow: ordinary failures keep retrying."""
+        result = _transient_error_task.apply()
+
+        assert record_retries, "transient error was not retried"
+        assert isinstance(result.result, _RetryAttempted)
+
+    def test_dont_autoretry_for_is_declared_on_the_task(self):
+        """Catches the wiring being dropped from BaseTask or the decorator."""
+        assert ModelConfigurationError in _permanent_error_task.dont_autoretry_for
+
+
+@pytest.mark.unit
+class TestIsPermanentModelError:
+    """Provider exceptions do not agree on which attribute holds the status."""
+
+    @pytest.mark.parametrize(
+        "attribute, status, expected",
+        [
+            # litellm / OpenAI SDK
+            ("status_code", 404, True),
+            ("status_code", 400, True),
+            ("status_code", 401, True),
+            ("status_code", 403, True),
+            ("status_code", 429, False),
+            ("status_code", 500, False),
+            # aiohttp, raised by RhesisEmbedder against the Rhesis API
+            ("status", 400, True),
+            ("status", 404, True),
+            ("status", 503, False),
+            # google-api-core
+            ("code", 404, True),
+            ("code", 500, False),
+        ],
+    )
+    def test_status_attribute_variants(self, attribute, status, expected):
+        error = type("ProviderError", (Exception,), {attribute: status})()
+        assert is_permanent_model_error(error) is expected
+
+    def test_error_without_any_status_is_transient(self):
+        assert is_permanent_model_error(TimeoutError("timed out")) is False
+
+    def test_non_integer_status_is_ignored(self):
+        """A string status must not be treated as a permanent HTTP code."""
+        error = type("ProviderError", (Exception,), {"status_code": "404"})()
+        assert is_permanent_model_error(error) is False
+
+    def test_real_aiohttp_error_is_detected(self):
+        """The concrete type RhesisEmbedder.a_generate raises."""
+        import aiohttp
+
+        error = aiohttp.ClientResponseError(
+            request_info=None, history=(), status=400, message="Bad Request"
+        )
+        assert is_permanent_model_error(error) is True

--- a/tests/sdk/models/providers/test_rhesis.py
+++ b/tests/sdk/models/providers/test_rhesis.py
@@ -35,6 +35,7 @@ def _mock_aiohttp_session(response_json=None, status=200, raise_for_status=None,
     mock_response = MagicMock()
     mock_response.status = status
     mock_response.json = AsyncMock(return_value=response_json)
+    mock_response.text = AsyncMock(return_value="mock error body")
     mock_response.headers = headers if headers is not None else {}
     if raise_for_status:
         mock_response.raise_for_status.side_effect = raise_for_status

--- a/tests/sdk/models/providers/test_vertex_ai.py
+++ b/tests/sdk/models/providers/test_vertex_ai.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from rhesis.sdk.models.providers.vertex_ai import (
     DEFAULT_MODEL_NAME,
+    VertexAIEmbedder,
     VertexAILLM,
 )
 
@@ -525,6 +526,75 @@ class TestVertexAIRegionalLocations:
         ):
             llm = VertexAILLM()
             assert llm.model["location"] == location
+
+
+class TestVertexAIEmbedderLocation:
+    """`VERTEX_AI_EMBEDDING_LOCATION` overrides the region for embeddings only.
+
+    Embedding publisher models are not served from the ``us``/``eu``
+    multi-region endpoints Gemini accepts, so a deployment pinned to ``eu``
+    needs to name a concrete region for the embedder without moving Gemini.
+    """
+
+    @staticmethod
+    def _encoded_creds() -> str:
+        mock_creds = {
+            "type": "service_account",
+            "project_id": "test-project",
+            "client_email": "test@test.iam.gserviceaccount.com",
+        }
+        return base64.b64encode(json.dumps(mock_creds).encode()).decode()
+
+    def test_embedding_location_overrides_shared_location(self):
+        with patch.dict(
+            os.environ,
+            {
+                "GOOGLE_APPLICATION_CREDENTIALS": self._encoded_creds(),
+                "VERTEX_AI_LOCATION": "eu",
+                "VERTEX_AI_EMBEDDING_LOCATION": "europe-west4",
+            },
+            clear=True,
+        ):
+            embedder = VertexAIEmbedder()
+            assert embedder._vertex_config["location"] == "europe-west4"
+
+    def test_falls_back_to_shared_location_when_unset(self):
+        with patch.dict(
+            os.environ,
+            {
+                "GOOGLE_APPLICATION_CREDENTIALS": self._encoded_creds(),
+                "VERTEX_AI_LOCATION": "europe-west1",
+            },
+            clear=True,
+        ):
+            embedder = VertexAIEmbedder()
+            assert embedder._vertex_config["location"] == "europe-west1"
+
+    def test_explicit_location_argument_still_wins(self):
+        with patch.dict(
+            os.environ,
+            {
+                "GOOGLE_APPLICATION_CREDENTIALS": self._encoded_creds(),
+                "VERTEX_AI_LOCATION": "eu",
+                "VERTEX_AI_EMBEDDING_LOCATION": "europe-west4",
+            },
+            clear=True,
+        ):
+            embedder = VertexAIEmbedder(location="us-central1")
+            assert embedder._vertex_config["location"] == "us-central1"
+
+    def test_llm_ignores_the_embedding_override(self):
+        with patch.dict(
+            os.environ,
+            {
+                "GOOGLE_APPLICATION_CREDENTIALS": self._encoded_creds(),
+                "VERTEX_AI_LOCATION": "eu",
+                "VERTEX_AI_EMBEDDING_LOCATION": "europe-west4",
+            },
+            clear=True,
+        ):
+            llm = VertexAILLM()
+            assert llm.model["location"] == "eu"
 
 
 class TestVertexAICredentialSecurity:


### PR DESCRIPTION
## Purpose

Embedding generation was failing in production with a wall of retried Celery errors. The cause is a region mismatch: `VERTEX_AI_LOCATION` is set to the `eu` multi-region, which Gemini serves on that host but `text-embedding-005` does not, so every embedding call returned 404.

```
Publisher model `projects/playground-437609/locations/eu/publishers/google/models/text-embedding-005`
was not found or your project does not have access to it.
```

Two things made this worse than a one-line config error. The failure was invisible: the SDK discarded the response body, so the only symptom reaching the caller was an opaque `HTTP 400` from `/services/generate/embedding`. And it was loud: a 404 is permanent, but `BaseTask` autoretries every exception, so one bad config produced four failures per entity.

A second, unrelated bug surfaced while investigating: multi-turn tests were being executed as single-turn. `get_test_type` resolves the type with `sess.get(TypeLookup, test.test_type_id)`, which returns the row without populating `test.test_type`. The batch path expunges its Test objects (`batch/context.py:358`) and re-checks the type afterwards (`batch/runner.py:272`), so the detached read found an unloaded relationship and no session, fell through to `None`, and silently returned Single-Turn.

The data was correct in every case: tests typed Multi-Turn, metrics correctly scoped, test set typed Multi-Turn. Only the runtime resolution was losing it. The consequences compounded: the test ran through `SingleTurnTestExecutor` with the empty prompt the multi-turn prefetch had returned, so judges scored it as "the input provided was empty", and every `["Multi-Turn"]` scoped metric was dropped by the single-turn scope filter. Where a behavior had only multi-turn metrics, nothing survived, leaving `{}`, which `results.py:247` stamps as `Error` with an empty Evaluation column.

## What Changed

- **`VERTEX_AI_EMBEDDING_LOCATION`** gives the embedder its own region. `vertexAiLocation` stays `eu` for Gemini; embeddings use `europe-west4`, which keeps them in the EU and matches the region already used throughout `infrastructure/config/service-secrets-config.sh.example`. Falls back to `VERTEX_AI_LOCATION` when unset, and an explicit `location=` argument still wins, so this is inert for anyone who does not set it.
- **Permanent provider errors no longer autoretry.** `is_permanent_model_error()` treats 400/401/403/404 as permanent. The embedding generator was flattening every provider error into a bare `ValueError`, which erased the distinction, so it now raises `ModelConfigurationError` and `BaseTask` lists that in `dont_autoretry_for`. Rate limits and timeouts stay retryable. `on_failure` also stops logging these as "will retry, attempt 0/3".
- **Model API errors log the server's explanation** instead of just a status code. This is what would have identified the 404 immediately.
- **Removed `VERTEX_AI_LOCATION` and `VERTEX_AI_PROJECT` from the cluster ExternalSecrets.** Deployments list `secretRef` after `configMapRef`, and later `envFrom` sources win, so a key in both places let the Secret silently override the chart. Without this, the `vertexAiEmbeddingLocation` change above would have been a no-op.
- **The embedding endpoint refuses to recurse** when `DEFAULT_EMBEDDING_MODEL` resolves to the Rhesis native provider, which would make the endpoint call itself over HTTP instead of reaching a real provider.
- **Test type survives detachment.** `get_test_type` now caches the resolved `TypeLookup` with `set_committed_value`, which populates the relationship without emitting SQL or dirtying the instance, so it stays safe inside the ORM event listeners that also call this function. `batch/context.py` additionally eager-loads `Test.test_type` alongside prompt and behavior, which both prevents the situation and removes an N+1. An unresolvable `test_type_id` now logs a warning rather than being indistinguishable from a genuinely untyped test.

## Verified against the live API

litellm derives the host from the location string, in `llms/vertex_ai/common_utils.py:275-293`. A value with no hyphen is treated as a multi-region geography and routed to a REP host, which is what turns `eu` into a different endpoint rather than just a different path:

| location | host litellm builds |
| --- | --- |
| `eu` (no hyphen) | `aiplatform.eu.rep.googleapis.com` |
| `europe-west4` (hyphen) | `europe-west4-aiplatform.googleapis.com` |

Probing `playground-437609` directly confirms the split:

| host | model | result |
| --- | --- | --- |
| `aiplatform.eu.rep.googleapis.com` | `text-embedding-005` | **404** `NOT_FOUND`, reproducing the production log verbatim |
| `aiplatform.eu.rep.googleapis.com` | `gemini-3.1-flash-lite` | **200** |
| `europe-west4-aiplatform.googleapis.com` | `text-embedding-005` | **200**, 768 dimensions |

The Gemini row is the control: same host, same project, same credentials, so the failure is specific to the embedding model on the multi-region REP host and not a credentials or project-access problem. The 768 dimensions match `EmbeddingConfig.SUPPORTED_DIMENSIONS`, so the persistence path is unaffected.

One nuance worth recording: `locations/eu` on the plain global host (`aiplatform.googleapis.com`) does return 200 for this model. It is the REP host specifically that does not serve it. litellm never uses the global host for `eu`, so this does not change the fix.

## Additional Context

Removing the two ExternalSecret keys is behaviour-preserving, not a guess: the ConfigMap already declares `playground-437609` and `eu`, which is exactly what production reported in the 404 path. Whatever the Secret held, the effective value is unchanged.

Four other keys remain duplicated between the ConfigMap and the ExternalSecret (`OTEL_PROCESSOR_ENDPOINT` in all envs, `ANALYTICS_DB_*` in stg/prd, `APP_DB_USER`/`DB_HOST`/`DB_NAME` in dev). Those point at live databases, so removing them needs each Secret Manager value checked against the chart value first. Tracked separately rather than batched in here.

The two bugs here are independent of each other. Embeddings are dispatched from an `after_commit` hook after the result row is already written, and no embedder is used anywhere in metric evaluation, so the 404 never affected metrics. They shared only a symptom: noisy failures in the same worker.

Still not addressed, and worth a follow-up: `results.py:247` maps empty metrics to a bare `Error` with nothing displayed, collapsing three different situations (no metrics configured, all metrics dropped by scope, evaluation raised) into one opaque status. That is what made the routing bug take so long to identify. Test runs recorded before this fix also stay wrong and need re-running rather than repair, since their stored `test_output` is single-turn-shaped.

## Testing

```bash
# SDK, includes 4 new tests for the region override, fallback, and precedence
cd sdk && uv run pytest ../tests/sdk/models/ -q          # 356 passed, 8 skipped

# Backend, includes 2 new tests for the permanent vs transient split
cd apps/backend
uv run pytest ../../tests/backend/services/test_embedding_generator.py \
              ../../tests/backend/services/test_embedding_service.py -q   # 31 passed
uv run pytest ../../tests/backend/tasks/ -q              # 399 passed, 3 skipped
```

`tests/backend/tasks/test_get_test_type_detached.py` covers the routing bug specifically. It reproduces the batch sequence (resolve, expunge, resolve again) and asserts the type survives, plus the precondition that `crud.get_test` leaves `test_type` unloaded and that resolution now caches it. Reverting either change in `modes.py` fails it.

Chart rendering, which should show `eu` for Gemini and `europe-west4` for embeddings in all three envs:

```bash
for env in dev stg prd; do helm template rhesis charts/rhesis -f charts/rhesis/values-$env.yaml | grep -E "VERTEX_AI_(EMBEDDING_)?LOCATION" | sort -u; done
```

No key should appear in both the rendered ConfigMap and the ExternalSecret for the Vertex pair:

```bash
env=prd
helm template rhesis charts/rhesis -f charts/rhesis/values-$env.yaml | awk '/kind: ConfigMap/,/^---/' | grep -oE '^  [A-Z][A-Z0-9_]+:' | tr -d ' :' | sort -u > /tmp/cm.txt
grep -oE 'secretKey: [A-Z][A-Z0-9_]+' kubernetes/clusters/$env/external-secrets/rhesis-app-secrets.yaml | awk '{print $2}' | sort -u > /tmp/sec.txt
comm -12 /tmp/cm.txt /tmp/sec.txt   # VERTEX_AI_* absent
```

`europe-west4` was confirmed against the live API in `playground-437609` before merging, returning 200 with a 768-dimension vector. See the table above.
