### PR TITLE
Remove dead code and duplication from release tooling

### DIFF
--- a/.github/release
+++ b/.github/release
@@ -15,8 +15,8 @@ from pathlib import Path
 github_dir = Path(__file__).parent
 sys.path.insert(0, str(github_dir))
 
-# Import and run the CLI
-from release_tools.cli import main
+# Import must follow the sys.path tweak above
+from release_tools.cli import main  # noqa: E402
 
 if __name__ == "__main__":
     main()

--- a/.github/release_tools/changelog.py
+++ b/.github/release_tools/changelog.py
@@ -203,7 +203,10 @@ This release includes the following component versions:
             elif commits:
                 # Fallback to first few commit messages
                 commit_msgs = [commit["message"].splitlines()[0] for commit in commits[:3]]
-                platform_entry += f"Key changes include: {', '.join(commit_msgs[:2])}{'...' if len(commits) > 2 else ''}.\n\n"
+                ellipsis = "..." if len(commits) > 2 else ""
+                platform_entry += (
+                    f"Key changes include: {', '.join(commit_msgs[:2])}{ellipsis}.\n\n"
+                )
             else:
                 platform_entry += "Initial release or no significant changes.\n\n"
 

--- a/.github/release_tools/changelog.py
+++ b/.github/release_tools/changelog.py
@@ -16,6 +16,9 @@ from .utils import call_gemini_api, info, success, warn
 # catches the 400 from an out-of-range value.
 GEMINI_MAX_OUTPUT_TOKENS = 8192
 
+# New entries go directly below this heading, newest first
+UNRELEASED_MARKER = "## [Unreleased]"
+
 
 def generate_changelog_with_llm(
     api_key: str,
@@ -99,6 +102,27 @@ def generate_fallback_changelog(version: str, commits: List[Dict[str, str]]) -> 
     return changelog
 
 
+def _insert_under_unreleased(changelog_path: Path, entry: str) -> None:
+    """Insert an entry directly below the [Unreleased] heading.
+
+    Does nothing if the heading is absent, which is how both callers have always
+    behaved -- they rewrite the file unchanged and still report success.
+    """
+    lines = changelog_path.read_text().split("\n")
+
+    new_lines = []
+    inserted = False
+
+    for line in lines:
+        new_lines.append(line)
+        if line.strip() == UNRELEASED_MARKER and not inserted:
+            new_lines.append("")
+            new_lines.extend(entry.split("\n"))
+            inserted = True
+
+    changelog_path.write_text("\n".join(new_lines))
+
+
 def update_component_changelog(
     component: str, new_version: str, changelog_content: str, repo_root: Path, dry_run: bool = False
 ) -> bool:
@@ -126,26 +150,12 @@ All notable changes to the {component} component will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+{UNRELEASED_MARKER}
 
 """
         changelog_path.write_text(header)
 
-    # Insert new changelog entry after [Unreleased] section
-    content = changelog_path.read_text()
-    lines = content.split("\n")
-
-    new_lines = []
-    inserted = False
-
-    for line in lines:
-        new_lines.append(line)
-        if line.strip() == "## [Unreleased]" and not inserted:
-            new_lines.append("")
-            new_lines.extend(changelog_content.split("\n"))
-            inserted = True
-
-    changelog_path.write_text("\n".join(new_lines))
+    _insert_under_unreleased(changelog_path, changelog_content)
     success(f"Updated changelog: {COMPONENTS[component].changelog_path}")
     return True
 
@@ -221,20 +231,6 @@ This release includes the following component versions:
 
     platform_entry += "\n"
 
-    # Insert into changelog
-    content = changelog_path.read_text()
-    lines = content.split("\n")
-
-    new_lines = []
-    inserted = False
-
-    for line in lines:
-        new_lines.append(line)
-        if line.strip() == "## [Unreleased]" and not inserted:
-            new_lines.append("")
-            new_lines.extend(platform_entry.split("\n"))
-            inserted = True
-
-    changelog_path.write_text("\n".join(new_lines))
+    _insert_under_unreleased(changelog_path, platform_entry)
     success(f"Updated platform changelog: {PLATFORM_CHANGELOG}")
     return True

--- a/.github/release_tools/cli.py
+++ b/.github/release_tools/cli.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from .processor import ReleaseProcessor
 from .publish import publish_releases
-from .utils import error
+from .utils import error, find_repository_root
 
 
 def create_argument_parser() -> argparse.ArgumentParser:
@@ -95,20 +95,6 @@ def parse_component_arguments(remaining_args: list) -> dict:
             return {}
 
     return component_bumps
-
-
-def find_repository_root() -> Path:
-    """Find the repository root directory"""
-    repo_root = Path.cwd()
-    while repo_root != repo_root.parent:
-        if (repo_root / ".git").exists():
-            break
-        repo_root = repo_root.parent
-    else:
-        error("Not in a git repository")
-        sys.exit(1)
-
-    return repo_root
 
 
 def main():

--- a/.github/release_tools/config.py
+++ b/.github/release_tools/config.py
@@ -2,6 +2,8 @@
 Configuration for the Rhesis release tool including component definitions.
 """
 
+from pathlib import PurePosixPath
+
 
 class ComponentConfig:
     """Configuration for a component"""
@@ -10,6 +12,16 @@ class ComponentConfig:
         self.config_file = config_file
         self.config_type = config_type
         self.changelog_path = changelog_path
+
+    @property
+    def path(self) -> str:
+        """Directory the component lives in, used to scope `git log` to its own commits.
+
+        Every component keeps its version file at the root of its own directory, so the
+        config file's parent is the component root. PurePosixPath because git wants
+        forward slashes regardless of platform.
+        """
+        return str(PurePosixPath(self.config_file).parent)
 
 
 # Component configurations
@@ -39,17 +51,12 @@ COMPONENTS = {
 PLATFORM_VERSION_FILE = "VERSION"
 PLATFORM_CHANGELOG = "CHANGELOG.md"
 
-# Component paths for git operations
-COMPONENT_PATHS = {
-    "backend": "apps/backend",
-    "frontend": "apps/frontend",
-    "worker": "apps/worker",
-    "chatbot": "apps/chatbot",
-    "polyphemus": "apps/polyphemus",
-    "sdk": "sdk",
-    "ee-backend": "ee/backend",
-    "platform": ".",
-}
+
+def get_component_path(component: str) -> str:
+    """Directory to scope git operations to; the platform spans the whole repository"""
+    if component in COMPONENTS:
+        return COMPONENTS[component].path
+    return "."
 
 
 def format_component_name(component: str) -> str:

--- a/.github/release_tools/git_ops.py
+++ b/.github/release_tools/git_ops.py
@@ -7,7 +7,7 @@ import re
 import subprocess
 from typing import Dict, List, Optional
 
-from .config import COMPONENT_PATHS
+from .config import get_component_path
 from .utils import error, info, success, warn
 
 
@@ -36,7 +36,7 @@ def get_commits_since_tag(component: str, last_tag: Optional[str]) -> List[Dict[
 
     Returns commits with full message (subject + body) for better changelog context.
     """
-    component_path = COMPONENT_PATHS.get(component, ".")
+    component_path = get_component_path(component)
 
     git_range = f"{last_tag}..HEAD" if last_tag else "HEAD"
 

--- a/.github/release_tools/git_ops.py
+++ b/.github/release_tools/git_ops.py
@@ -124,13 +124,8 @@ def create_release_branch(
     component_bumps: Dict[str, str],
     get_version_func,
     dry_run: bool = False,
-    no_branch: bool = False,
 ) -> bool:
     """Create appropriate release branch based on components and versions"""
-    if no_branch:
-        info("Skipping branch creation (--no-branch specified)")
-        return True
-
     # Check if we're on main branch
     try:
         current_branch = subprocess.run(

--- a/.github/release_tools/processor.py
+++ b/.github/release_tools/processor.py
@@ -50,7 +50,6 @@ class ReleaseProcessor:
             self.component_bumps,
             lambda component: get_current_version(component, self.repo_root),
             self.dry_run,
-            self.no_branch,
         )
 
     def process_releases(self) -> bool:

--- a/.github/release_tools/publish.py
+++ b/.github/release_tools/publish.py
@@ -89,13 +89,9 @@ def generate_tag_name(component: str, version: str) -> str:
         return f"{component}-v{version}"
 
 
-def create_and_push_tag(component: str, version: str, dry_run: bool = False) -> bool:
+def create_and_push_tag(component: str, version: str) -> bool:
     """Create and push a git tag for a component"""
     tag_name = generate_tag_name(component, version)
-
-    if dry_run:
-        info(f"Would create and push tag: {tag_name}")
-        return True
 
     try:
         # Create annotated tag
@@ -132,14 +128,9 @@ def get_changelog_content(changelog_path: Path) -> str:
 
 
 def create_github_release(
-    component: str, version: str, tag_name: str, dry_run: bool = False, set_as_latest: bool = False
+    component: str, version: str, tag_name: str, set_as_latest: bool = False
 ) -> bool:
     """Create a GitHub release for a component"""
-    if dry_run:
-        latest_info = " (marked as latest)" if set_as_latest else ""
-        info(f"Would create GitHub release for {tag_name}{latest_info}")
-        return True
-
     try:
         # Use gh CLI if available
         result = subprocess.run(["which", "gh"], capture_output=True)
@@ -298,7 +289,7 @@ def publish_releases(repo_root: Path, dry_run: bool = False) -> bool:
 
     created_tags = []
     for component, version, tag_name in tags_to_create:
-        if create_and_push_tag(component, version, dry_run):
+        if create_and_push_tag(component, version):
             created_tags.append((component, version, tag_name))
         else:
             error(f"Failed to create tag for {component} v{version}")
@@ -311,9 +302,7 @@ def publish_releases(repo_root: Path, dry_run: bool = False) -> bool:
     for component, version, tag_name in created_tags:
         # Determine if the component is the platform and if it should be marked as latest
         is_platform = component == "platform"
-        if not create_github_release(
-            component, version, tag_name, dry_run, set_as_latest=is_platform
-        ):
+        if not create_github_release(component, version, tag_name, set_as_latest=is_platform):
             warn(f"Failed to create GitHub release for {tag_name}")
             # Continue with other releases even if one fails
 

--- a/.github/release_tools/publish.py
+++ b/.github/release_tools/publish.py
@@ -7,7 +7,7 @@ import os
 import re
 import subprocess
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from .config import COMPONENTS, format_component_name
 from .utils import error, find_repository_root, info, log, success, warn
@@ -183,55 +183,27 @@ def create_github_release(
         return False
 
 
-def confirm_publish_action(components_to_publish: Dict[str, str], remote_tags: List[str]) -> bool:
-    """Ask user for confirmation before publishing"""
+def confirm_publish_action(tags_to_create: List[Tuple[str, str, str]]) -> bool:
+    """Show the already-planned actions and ask the user for confirmation"""
     print()
     warn("⚠️  PUBLISH MODE - This will create tags and GitHub releases!")
     print()
 
     info("The following actions will be performed:")
 
-    # Separate platform from other components for proper display ordering
-    platform_actions = []
-    other_actions = []
-
-    for component, version in components_to_publish.items():
-        tag_name = generate_tag_name(component, version)
-        if tag_name not in remote_tags:
-            action_info = [f"Create and push tag: {tag_name}"]
-            if component == "platform":
-                action_info.append(f"Create GitHub release: {tag_name} (marked as latest)")
-                platform_actions.extend([f"  • {action}" for action in action_info])
-            else:
-                action_info.append(f"Create GitHub release: {tag_name}")
-                other_actions.extend([f"  • {action}" for action in action_info])
-        else:
-            info(f"  • Skip {tag_name} (already exists)")
-
-    # Display other components first, then platform
-    for action in other_actions:
-        info(action)
-
-    if platform_actions:
-        if other_actions:
+    for index, (component, _version, tag_name) in enumerate(tags_to_create):
+        # The caller orders the platform last; mark where it starts
+        if component == "platform" and index > 0:
             info("  • --- Platform release (created last) ---")
-        for action in platform_actions:
-            info(action)
-
-    tags_to_create = (
-        len(other_actions) // 2 + len(platform_actions) // 2
-    )  # Each component has 2 actions
-    if tags_to_create == 0:
-        warn("No new tags to create. All component versions already have tags.")
-        return False
+        info(f"  • Create and push tag: {tag_name}")
+        latest_note = " (marked as latest)" if component == "platform" else ""
+        info(f"  • Create GitHub release: {tag_name}{latest_note}")
 
     print()
     if os.environ.get("GITHUB_ACTIONS") == "true":
         info("Publishing in GitHub Actions - skipping confirmation")
         return True
-    else:
-        response = input("Do you want to proceed with publishing? (y/N): ").strip().lower()
-        return response == "y"
+    return input("Do you want to proceed with publishing? (y/N): ").strip().lower() == "y"
 
 
 def publish_releases(repo_root: Path, dry_run: bool = False) -> bool:
@@ -312,7 +284,7 @@ def publish_releases(repo_root: Path, dry_run: bool = False) -> bool:
         return True
 
     # Ask for confirmation
-    if not confirm_publish_action(components_version, remote_tags):
+    if not confirm_publish_action(tags_to_create):
         info("Publish cancelled by user")
         return False
 

--- a/.github/release_tools/publish.py
+++ b/.github/release_tools/publish.py
@@ -137,7 +137,7 @@ def get_changelog_content(changelog_path: Path) -> str:
 
     # Extract the first version section (latest) using regex
     # Pattern breakdown:
-    # ^## \[([^\]]+)\] - (\d{4}-\d{2}-\d{2})\n  - matches version header like "## [0.4.0] - 2025-10-10"
+    # ^## \[([^\]]+)\] - (\d{4}-\d{2}-\d{2})\n  - version header, e.g. "## [0.4.0] - 2025-10-10"
     # (.*?)  - captures all content after the header (non-greedy)
     # (?=\n## \[|\Z)  - stops at next version header or end of file (positive lookahead)
     pattern = r"^## \[([^\]]+)\] - (\d{4}-\d{2}-\d{2})\n(.*?)(?=\n## \[|\Z)"

--- a/.github/release_tools/publish.py
+++ b/.github/release_tools/publish.py
@@ -6,27 +6,12 @@ Handles tag creation, pushing tags, and creating GitHub releases.
 import os
 import re
 import subprocess
-import sys
 from pathlib import Path
 from typing import Dict, List, Optional
 
 from .config import COMPONENTS, format_component_name
-from .utils import error, info, log, success, warn
+from .utils import error, find_repository_root, info, log, success, warn
 from .version import get_current_version
-
-
-def find_repository_root() -> Path:
-    """Find the repository root directory"""
-    repo_root = Path.cwd()
-    while repo_root != repo_root.parent:
-        if (repo_root / ".git").exists():
-            break
-        repo_root = repo_root.parent
-    else:
-        error("Not in a git repository")
-        sys.exit(1)
-
-    return repo_root
 
 
 def get_current_branch() -> Optional[str]:

--- a/.github/release_tools/utils.py
+++ b/.github/release_tools/utils.py
@@ -3,7 +3,6 @@ Utilities for the Rhesis release tool including logging, colors, and prerequisit
 """
 
 import json
-import os
 import subprocess
 import urllib.error
 import urllib.request

--- a/.github/release_tools/utils.py
+++ b/.github/release_tools/utils.py
@@ -4,6 +4,7 @@ Utilities for the Rhesis release tool including logging, colors, and prerequisit
 
 import json
 import subprocess
+import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -39,6 +40,20 @@ def success(message: str) -> None:
 
 def info(message: str) -> None:
     print(f"{Colors.CYAN}[INFO]{Colors.NC} {message}")
+
+
+def find_repository_root() -> Path:
+    """Find the repository root directory"""
+    repo_root = Path.cwd()
+    while repo_root != repo_root.parent:
+        if (repo_root / ".git").exists():
+            break
+        repo_root = repo_root.parent
+    else:
+        error("Not in a git repository")
+        sys.exit(1)
+
+    return repo_root
 
 
 def command_exists(command: str) -> bool:

--- a/.github/release_tools/version.py
+++ b/.github/release_tools/version.py
@@ -47,7 +47,9 @@ def get_current_version(component: str, repo_root: Path) -> str:
 
 def _get_pyproject_version(config_path: Path) -> str:
     """Get version from pyproject.toml"""
-    cmd = ["uv", "version", "--short", "--project", config_path]
+    # --color never: uv honours FORCE_COLOR even when its output is captured, and the ANSI
+    # escapes then end up inside the version string, where int() chokes on them.
+    cmd = ["uv", "version", "--short", "--color", "never", "--project", config_path]
 
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, check=True)
@@ -148,7 +150,18 @@ def _update_platform_version(new_version: str, repo_root: Path, dry_run: bool) -
 
 def _update_pyproject_version(config_path: Path, bump_type: str) -> bool:
     """Update version in pyproject.toml"""
-    cmd = ["uv", "version", "--bump", bump_type, "--project", config_path, "--no-sync"]
+    # --color never keeps escape codes out of the stderr we print on failure
+    cmd = [
+        "uv",
+        "version",
+        "--bump",
+        bump_type,
+        "--color",
+        "never",
+        "--project",
+        config_path,
+        "--no-sync",
+    ]
 
     try:
         subprocess.run(cmd, capture_output=True, text=True, check=True)

--- a/.github/release_tools/version.py
+++ b/.github/release_tools/version.py
@@ -36,7 +36,8 @@ def get_current_version(component: str, repo_root: Path) -> str:
             from .utils import warn
 
             warn(
-                f"Component {component} uses requirements.txt - no version file, using default 0.1.0"
+                f"Component {component} uses requirements.txt - "
+                "no version file, using default 0.1.0"
             )
             return "0.1.0"  # Default for requirements.txt based components
     except Exception as e:
@@ -168,7 +169,7 @@ def _update_pyproject_version(config_path: Path, bump_type: str) -> bool:
     cmd = ["uv", "version", "--bump", bump_type, "--project", config_path, "--no-sync"]
 
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        subprocess.run(cmd, capture_output=True, text=True, check=True)
         return True
     except subprocess.CalledProcessError as e:
         print(e.stderr)

--- a/.github/release_tools/version.py
+++ b/.github/release_tools/version.py
@@ -7,7 +7,7 @@ import subprocess
 from pathlib import Path
 
 from .config import COMPONENTS, PLATFORM_VERSION_FILE
-from .utils import error, success
+from .utils import error, info, success, warn
 
 
 def get_current_version(component: str, repo_root: Path) -> str:
@@ -33,16 +33,12 @@ def get_current_version(component: str, repo_root: Path) -> str:
         elif config.config_type == "package":
             return _get_package_version(config_path)
         elif config.config_type == "requirements":
-            from .utils import warn
-
             warn(
                 f"Component {component} uses requirements.txt - "
                 "no version file, using default 0.1.0"
             )
             return "0.1.0"  # Default for requirements.txt based components
     except Exception as e:
-        from .utils import error
-
         error(f"Failed to get version for component {component}: {e}")
         raise
 
@@ -70,24 +66,16 @@ def _get_package_version(config_path: Path) -> str:
             data = json.load(f)
         version = data.get("version")
         if not version:
-            from .utils import error
-
             error(f"No version field found in {config_path}")
             raise KeyError("version field missing")
         return version
     except FileNotFoundError:
-        from .utils import error
-
         error(f"Package.json file not found: {config_path}")
         raise
     except json.JSONDecodeError as e:
-        from .utils import error
-
         error(f"Invalid JSON in {config_path}: {e}")
         raise
     except Exception as e:
-        from .utils import error
-
         error(f"Failed to parse {config_path}: {e}")
         raise
 
@@ -131,8 +119,6 @@ def update_version_file(
     config_path = repo_root / config.config_file
 
     if dry_run:
-        from .utils import info
-
         info(f"Would update {config.config_file} version to: {new_version}")
         return True
     bump_type = component_bumps[component]
@@ -142,8 +128,6 @@ def update_version_file(
     elif config.config_type == "package":
         return _update_package_version(config_path, new_version, repo_root)
     elif config.config_type == "requirements":
-        from .utils import info
-
         info(f"Component {component} uses requirements.txt - version tracked via git tags only")
         return True
 
@@ -153,8 +137,6 @@ def update_version_file(
 def _update_platform_version(new_version: str, repo_root: Path, dry_run: bool) -> bool:
     """Update platform version file"""
     if dry_run:
-        from .utils import info
-
         info(f"Would update {PLATFORM_VERSION_FILE} to: {new_version}")
         return True
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -105,8 +105,8 @@ jobs:
           3. Check if the version changes are correct
           4. Check if the SDK and backend tests pass
           5. Give the team time for review and hotfixes. Hotfixes must be merged into the release branch.
-          6. Once the release branch is approved, it can be merged into main.
-          7. After the merge, you need to run the \"[Release] 3. Publish\" workflow.  **The workflow must be run on the release branch.** The workflow tags the release and uploads the new version of the SDK to PyPI. It does not deploy.
+          6. Once the release branch is approved, run the \"[Release] 3. Publish\" workflow. **The workflow must be run on the release branch.** It tags the release, which uploads the new version of the SDK to PyPI. It does not merge this PR and does not deploy.
+          7. Merge this pull request into main. Merge after publishing, not before: the tags are cut from the release branch, and merging can delete it.
           8. Deploy to production separately: run the \"[Build & Deploy] All for K8s\" workflow with environment \`prd\`.
 
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -43,9 +43,3 @@ jobs:
 
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-
-      - name: Close release PR and merge to main
-        run: |
-          gh pr merge --merge
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/docs/content/contribute/releasing.mdx
+++ b/docs/content/contribute/releasing.mdx
@@ -1,6 +1,6 @@
 # Releasing
 
-A Rhesis release is produced by three workflows in the repository's GitHub Actions tab, run in order, followed by a manual production deploy. Each one is triggered by hand — nothing starts a release automatically.
+A Rhesis release is produced by three workflows in the repository's GitHub Actions tab, run in order, followed by a manual merge and a manual production deploy. Each one is triggered by hand — nothing starts a release automatically.
 
 Components are versioned independently and tagged `<component>-v<version>`. The platform is the coordinated snapshot across them, tagged `v<version>` and marked as the latest GitHub release.
 
@@ -31,12 +31,18 @@ Check the generated changelogs and the version changes in the pull request, and 
 
 Switch to the release branch and run `[Release] 3. Publish` from it.
 
-The workflow creates and pushes the tags, creates a GitHub release for each component, and merges the release pull request into `main`.
+The workflow creates and pushes the tags and creates a GitHub release for each component. It does not merge the pull request.
 
 <Callout type="error">
   Run this workflow **on the release branch**. A run started from `main` is skipped by a branch
   guard and still reports success, so a release can look published when no tags were created.
 </Callout>
+
+### Merge the release pull request
+
+Merge the pull request opened in step 2, so the version bumps and changelogs land on `main`.
+
+Merge after publishing, not before: the tags are cut from the release branch, and merging can delete it.
 
 ### Deploy production
 
@@ -54,4 +60,3 @@ Publishing sets off several workflows that run independently of each other, so `
 - **GitHub releases** — created from the changelog entries, with the platform release marked as latest.
 - **PyPI** — `rhesis` and `rhesis-sdk` published. This is triggered by the `sdk-v*` tag, not by the publish workflow.
 - **GHCR images** — built from the `v*` platform tag.
-- **Release pull request** — merged into `main`.


### PR DESCRIPTION
## Purpose

Follow-up to #2417, which formatted the release tooling so this diff would be readable. This removes dead code and duplication from `.github/release_tools/`, fixes a bug that makes the tool unusable in some environments, and removes a hidden `gh pr merge` from the publish workflow that contradicted its own instructions.

Net effect: 174 lines removed, 115 added, across 12 files.

## What Changed

One commit per change, smallest first, so each can be reviewed on its own.

**Dead code**

- `ruff check` findings: unused `os` import, unused `result` assignment, `noqa: E402` on the import that must follow the `sys.path` tweak in `.github/release`.
- Nine function-local `from .utils import ...` statements in `version.py`. Five re-imported `error`, which the module already imports; `info` and `warn` were added to the module-level import. Worth noting: an import inside a function makes that name local to the whole function, so `error` was function-local and bound only inside `except` blocks — referencing it earlier would have raised `UnboundLocalError`.
- The `no_branch` parameter and early return in `create_release_branch`. `processor.run()` already guards the call with `if not self.no_branch`, so it could never see `no_branch=True`, and its "Skipping branch creation" message has never printed.
- The `dry_run` parameter and early returns in `create_and_push_tag` and `create_github_release`. `publish_releases` returns from its own `dry_run` block before reaching either, so neither could ever receive `dry_run=True`.
- The unreachable zero-tag check in `confirm_publish_action`, along with the `len(actions) // 2` arithmetic that existed only to feed it.

**Duplication**

- `find_repository_root` was a byte-identical copy in `cli.py` and `publish.py`. Now one in `utils.py`.
- `COMPONENT_PATHS` repeated every component's directory, which is already the parent of its `config_file`. Replaced with a `path` property on `ComponentConfig` plus `get_component_path()`. Trade-off worth flagging: the `git log` scope is now tied to where the config file sits. That holds for all seven components today.
- The 14-line "insert below `## [Unreleased]`" loop was duplicated verbatim in both changelog writers. Extracted as `_insert_under_unreleased()`, with an `UNRELEASED_MARKER` constant so the heading is spelled once instead of three times.
- `confirm_publish_action` rebuilt the publish plan that `publish_releases` had already computed. It now receives the ordered plan.

**Bug fix**

- `uv` honours `FORCE_COLOR` even when its output is captured, so `uv version --short` returned `\x1b[36m0.12.0\x1b[39m` and `bump_version` died with `invalid literal for int() with base 10: '\x1b[36m0'`. The tool was unusable for anyone whose environment sets `FORCE_COLOR` or `CLICOLOR_FORCE` — Claude Code sets `FORCE_COLOR=3`, as do some terminals. CI was unaffected, which is why it went unnoticed. Both `uv` calls now pass `--color never`.

**Release process**

`[Release] 3. Publish` ended with `gh pr merge --merge`, which contradicted the PR body that `[Release] 2.` generates. That body said "merge the branch, then run Publish on the release branch" — impossible once merging deletes the branch, and the trailing `gh pr merge` then fails on an already-merged PR.

- Removed the merge step, so Publish only creates tags and GitHub releases.
- `docs/content/contribute/releasing.mdx`: the Publish step no longer claims to merge; merging is now its own numbered step after it, with the reason for the ordering. Dropped the duplicated "Release pull request — merged into `main`" verify item.
- The generated PR body now reads publish-then-merge, and no longer claims the workflow uploads the SDK to PyPI — pushing the `sdk-v*` tag triggers `publish-pypi.yml`.

Consequence to be aware of: nothing merges the release branch automatically now, so a forgotten merge leaves the version bumps and changelogs off `main` while the tags exist. That is why merging is a numbered step in both the docs and the PR body rather than a footnote.

## Additional Context

**Two intentional behaviour changes**, both described above: skipped tags are listed once instead of twice in the publish confirmation, and the publish workflow no longer merges the release PR. Everything else is behaviour-preserving.

**Deliberately left alone**, happy to do as follow-ups:

- `_insert_under_unreleased` silently writes the file back unchanged when `## [Unreleased]` is missing, while both callers still print "Updated changelog" and return `True`. This is pre-existing and the refactor preserved it, but `ee/backend/CHANGELOG.md` is the only changelog in the repo without that heading, so it is a live case: bumping `ee-backend` reports a changelog update, changes nothing, and `--publish` then ships the stale `## [0.7.0]` section as the release notes for the new tag. Verified by running it. Centralising the loop means there is now one place to add a `warn()`.
- `get_changelog_content` does `match.group(3)` with no `None` check. A changelog whose newest heading lacks a ` - YYYY-MM-DD` date raises `AttributeError`, which `create_github_release` does not catch, so it escapes as "Unexpected error during publish" *after* tags have been pushed — remaining components get no release, and a re-run skips their tags as already existing.
- The `requirements` config type is dead. `apps/chatbot/requirements.txt` does not exist — chatbot has a `pyproject.toml` with version `1.0.0` — so `get_current_version` raises at the `exists()` check and chatbot is skipped.
- `get_components_version` decides what to publish by `version != "0.1.0"`. A component legitimately at 0.1.0 is silently skipped — the only reason `worker` isn't being tagged today.
- Dry runs still write `/tmp/version_changes.json`.
- Bumping `ee-backend` creates an `ee/backend/uv.lock` that is not in the repo, which `create-release.yml`'s `git add .` would commit.
- Five `E501` long lines remain in `changelog.py`. They are inside the Gemini prompt strings, and rewrapping them would change the text sent to the model.
- `git_ops.py` and `publish.py` parse `git` output the same way `version.py` parsed `uv` output. Git disables colour when not writing to a terminal, so it is safe by default, but `color.ui = always` in a user's gitconfig would cause the same class of failure.
- `.github/release_tools/` is matched by no `.pre-commit-config.yaml` hook, which is why it drifted in the first place.

## Testing

`.github/**` is not covered by `lint.yml`, and the release tool has no test suite, so every step was verified by running the tool rather than by reading the diff.

- `uvx ruff check` — clean apart from the 5 prompt-string `E501`s noted above. `uvx ruff format --check` — all 10 files clean. All files compile.
- **Version bumping**: dry runs and real runs across backend, frontend, sdk, polyphemus, worker, ee-backend and platform, checking computed versions, written `pyproject.toml`/`package.json`/`VERSION` values, and generated changelog entries.
- **Changelog generation** (the step 7 refactor rewrites file-generation logic): ran a real release before the change, saved both changelogs, reverted, applied the refactor, re-ran the identical command — component and platform changelogs came out **byte-identical**. The header path for a component with no existing changelog was driven separately via `worker`.
- **Publish flow**: a harness drives `publish_releases` end to end with a mixed scenario (2 tags to create, 2 already tagged, plus platform) and `create_and_push_tag`/`create_github_release` stubbed so nothing touched git or GitHub. Captured the operator-facing output before any changes; the final output differs only by the two duplicated skip lines, and the dry-run path is byte-identical to the original baseline. Five edge cases checked: platform-only, components-only, all-tags-already-exist, operator declining, operator accepting.
- **Branch creation** (step 6 changed that signature): verified dry-run naming, a real run creating and switching to `release/sdk-v0.12.1`, a real `--no-branch` run leaving the branch untouched, and the already-exists error. Test branch deleted afterwards.
- **Error paths** that normal runs never touch were driven directly: all four `_get_package_version` failures, `get_current_version`'s handler via a corrupt `package.json`, both `requirements` branches via a synthesised file, both dry-run `info` branches, and the unknown-component error.
- **Path derivation** (step 4): all 8 keys plus the unknown-name fallback resolve to the same values the deleted dict held, and `get_commits_since_tag` returns identical commit hashes to `git log <tag>..HEAD -- <old hardcoded path>` for every component (5, 2, 107, 102, 2, 1, 24 and 20 commits).
- **The bug fix**: reproduced the crash with `FORCE_COLOR=3` set, then confirmed a dry run reads all versions cleanly and a real run with `CLICOLOR_FORCE=1` also set writes `version = "0.13.0"` correctly.
- **Workflow changes**: both workflows still parse as valid YAML and `publish-release.yml`'s remaining steps were listed to confirm only the merge step went. Grepped `.github`, `docs/content` and `RELEASING.md` for any surviving `gh pr merge` or claim that Publish merges — none. Rendered the generated PR body through bash with a stubbed `gh` and a fake `version_changes.json` to confirm the edit did not break the shell quoting: escaped quotes and the `` `prd` `` backticks come out correct and the numbered order reads publish → merge. Checked the MDX for unescaped curly braces.

All test-run side effects were reverted.
