### PR TITLE
Fix permanent Architect deadlock in the sync/async bridge

### DIFF
--- a/apps/backend/src/rhesis/backend/app/mcp_server/local_tools.py
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/local_tools.py
@@ -134,6 +134,10 @@ class LocalToolProvider(MCPTool):
             body = {}
 
         try:
+            # ASGITransport runs the route on the caller's loop — for the
+            # architect that is the SDK background loop. Keep LLM-touching
+            # handlers sync `def` so FastAPI offloads them to its threadpool;
+            # an `async def` one reaching a run_sync bridge would deadlock it.
             transport = httpx.ASGITransport(app=self._app)
             async with httpx.AsyncClient(transport=transport, base_url="http://internal") as client:
                 response = await client.request(

--- a/apps/backend/src/rhesis/backend/tasks/architect/chat.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/chat.py
@@ -94,7 +94,8 @@ def architect_chat_task(
                     project_id=project_id,
                 )
 
-        result: ArchitectChatResult = run_sync(_run())
+        # soft_time_limit is inert under --pool threads; enforce here
+        result: ArchitectChatResult = run_sync(_run(), timeout=280)
 
         if result.content:
             try:

--- a/sdk/src/rhesis/sdk/async_utils.py
+++ b/sdk/src/rhesis/sdk/async_utils.py
@@ -7,6 +7,8 @@ using a persistent background thread/loop to avoid event loop lifecycle issues.
 import asyncio
 import atexit
 import logging
+import threading
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from threading import Thread
 
 logger = logging.getLogger(__name__)
@@ -80,20 +82,61 @@ def close_background_loop():
         _background_thread = None
 
 
-def run_sync(coro):
+def run_sync(coro, timeout: float | None = None):
     """Run an async coroutine from synchronous code.
 
-    Always dispatches to a persistent background thread via
-    run_coroutine_threadsafe, regardless of whether a loop is already running.
-    This avoids nested loop errors in Jupyter/FastAPI and prevents
-    RuntimeError('Event loop is closed') from fire-and-forget cleanup tasks
-    (e.g. litellm's AsyncHTTPHandler) that outlive asyncio.run().
+    Dispatches to a persistent background thread via
+    run_coroutine_threadsafe.  This avoids nested loop errors in
+    Jupyter/FastAPI and prevents RuntimeError('Event loop is closed')
+    from fire-and-forget cleanup tasks (e.g. litellm's AsyncHTTPHandler)
+    that outlive asyncio.run().
 
     Args:
         coro: An awaitable coroutine to execute.
+        timeout: Optional seconds to wait for the result.  ``None``
+            (default) waits indefinitely.  Pass an explicit value at
+            call sites where an unbounded wait would mask a hang; on
+            expiry the coroutine is cancelled rather than left running.
 
     Returns:
         The result of the coroutine.
+
+    Raises:
+        RuntimeError: If called from the background event loop thread
+            (would deadlock -- the loop cannot run the coroutine it is
+            blocked on).
+        concurrent.futures.TimeoutError: If *timeout* elapses first.
     """
+    # Self-call on the background thread is an unbreakable deadlock: the
+    # loop would block in future.result() inside its own callback and so
+    # could never run the coroutine it is waiting for. Fail loudly.
+    if threading.current_thread() is _background_thread:
+        coro.close()  # avoid "coroutine was never awaited"
+        raise RuntimeError(
+            "run_sync() called from the background event loop thread. "
+            "This would deadlock: the loop cannot run the coroutine it "
+            "is blocked on. Await the coroutine directly instead."
+        )
+
+    # Not a deadlock, but it stalls the caller's loop for the whole call.
+    # Warn so these surface before someone moves the code onto our loop.
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        logger.warning(
+            "run_sync() called from a thread with a running event loop; "
+            "this blocks that loop until the coroutine completes. "
+            "Await the coroutine directly instead.",
+            stacklevel=2,
+        )
+
     future = asyncio.run_coroutine_threadsafe(coro, _get_background_loop())
-    return future.result()
+    try:
+        return future.result(timeout)
+    except FuturesTimeoutError:
+        # Reclaim the slot -- otherwise the abandoned coroutine keeps
+        # running on the shared loop and burning its resources.
+        future.cancel()
+        raise

--- a/sdk/src/rhesis/sdk/async_utils.py
+++ b/sdk/src/rhesis/sdk/async_utils.py
@@ -135,8 +135,11 @@ def run_sync(coro, timeout: float | None = None):
     future = asyncio.run_coroutine_threadsafe(coro, _get_background_loop())
     try:
         return future.result(timeout)
-    except FuturesTimeoutError:
+    except FuturesTimeoutError as exc:
         # Reclaim the slot -- otherwise the abandoned coroutine keeps
         # running on the shared loop and burning its resources.
         future.cancel()
-        raise
+        # future.result() raises a bare TimeoutError whose str() is empty,
+        # which downstream error formatters read as "no detail" and replace
+        # with a generic message. Re-raise with the reason spelled out.
+        raise FuturesTimeoutError(f"Operation timed out after {timeout}s") from exc

--- a/sdk/src/rhesis/sdk/async_utils.py
+++ b/sdk/src/rhesis/sdk/async_utils.py
@@ -92,7 +92,9 @@ def run_sync(coro, timeout: float | None = None):
     that outlive asyncio.run().
 
     Args:
-        coro: An awaitable coroutine to execute.
+        coro: A coroutine object to execute.  Must be a coroutine, not an
+            arbitrary awaitable -- ``run_coroutine_threadsafe`` rejects
+            Tasks and Futures with ``TypeError``.
         timeout: Optional seconds to wait for the result.  ``None``
             (default) waits indefinitely.  Pass an explicit value at
             call sites where an unbounded wait would mask a hang; on

--- a/sdk/src/rhesis/sdk/models/base.py
+++ b/sdk/src/rhesis/sdk/models/base.py
@@ -248,8 +248,10 @@ class BaseLLM(BaseModel):
     def generate(self, *args, **kwargs) -> Union[str, Dict[str, Any]]:
         """Runs the model to output LLM response.
 
-        Bridges to a_generate() via run_sync(), which auto-detects
-        whether a running event loop exists.
+        Bridges to a_generate() via run_sync(), which dispatches to a
+        shared background event loop. Never call this from async code --
+        ``await a_generate()`` directly. From a coroutine already running
+        on that background loop this raises rather than deadlocking.
 
         Returns:
             A string or dict (if schema provided).
@@ -285,11 +287,11 @@ class BaseLLM(BaseModel):
     ) -> AsyncIterator[str]:
         """Stream LLM response token-by-token.
 
-        Yields delta content strings. Default implementation falls back
-        to ``generate()`` and yields the full result as a single chunk.
+        Yields delta content strings. Default implementation awaits
+        ``a_generate()`` and yields the full result as a single chunk.
         Providers should override this for true streaming.
         """
-        result = self.generate(prompt=prompt, system_prompt=system_prompt, **kwargs)
+        result = await self.a_generate(prompt=prompt, system_prompt=system_prompt, **kwargs)
         if isinstance(result, dict):
             import json
 

--- a/tests/sdk/models/test_streaming_contract.py
+++ b/tests/sdk/models/test_streaming_contract.py
@@ -1,0 +1,88 @@
+"""Contract tests for the BaseLLM streaming fallback.
+
+Guards the invariant behind a 38-hour architect worker deadlock: the
+default ``generate_stream`` must reach a provider without crossing the
+sync bridge (``run_sync``).  Crossing it from the background event loop
+self-deadlocks -- the loop blocks on a coroutine only it can run.
+
+A provider satisfies the contract by overriding ``generate_stream`` (true
+streaming) or by implementing ``a_generate`` (the awaited fallback).
+"""
+
+import importlib
+
+import pytest
+
+from rhesis.sdk.models.base import BaseLLM
+from rhesis.sdk.models.factory import (
+    UNIFIED_MODEL_REGISTRY,
+    ModelType,
+    _ProviderSpec,
+)
+
+
+def _language_provider_specs():
+    """Every registered language provider, as pytest params keyed by name."""
+    params = []
+    for provider, by_type in sorted(UNIFIED_MODEL_REGISTRY.items()):
+        spec = by_type.get(ModelType.LANGUAGE)
+        # Callable entries are special-case wrappers, not plain class specs.
+        if isinstance(spec, _ProviderSpec):
+            params.append(pytest.param(spec, id=provider))
+    return params
+
+
+@pytest.mark.parametrize("spec", _language_provider_specs())
+def test_provider_streams_without_sync_bridge(spec):
+    """Each provider either streams natively or supports the async fallback."""
+    try:
+        module = importlib.import_module(spec.module)
+    except ImportError as exc:  # optional heavy deps (e.g. torch)
+        pytest.skip(f"provider dependencies unavailable: {exc}")
+
+    cls = getattr(module, spec.class_name)
+    assert issubclass(cls, BaseLLM)
+
+    overrides_stream = cls.generate_stream is not BaseLLM.generate_stream
+    implements_a_generate = cls.a_generate is not BaseLLM.a_generate
+
+    assert overrides_stream or implements_a_generate, (
+        f"{cls.__name__} inherits the BaseLLM.generate_stream fallback but "
+        "does not implement a_generate(), so streaming would raise "
+        "NotImplementedError. Override generate_stream() for true streaming "
+        "or implement a_generate()."
+    )
+
+
+def test_base_fallback_yields_from_a_generate():
+    """The inherited fallback awaits a_generate rather than calling generate.
+
+    Calling the sync ``generate()`` here is what deadlocked the worker:
+    it bridges through ``run_sync`` while already on the event loop.
+    """
+    calls = []
+
+    class StubLLM(BaseLLM):
+        def load_model(self, *args, **kwargs):
+            return None
+
+        def generate(self, *args, **kwargs):
+            calls.append("generate")
+            return "sync"
+
+        async def a_generate(self, *args, **kwargs):
+            calls.append("a_generate")
+            return "async"
+
+        def generate_batch(self, *args, **kwargs):
+            return []
+
+    llm = StubLLM(model_name="stub")
+
+    async def collect():
+        return [chunk async for chunk in llm.generate_stream(prompt="hi")]
+
+    import asyncio
+
+    assert asyncio.run(collect()) == ["async"]
+    assert calls == ["a_generate"], f"fallback took the sync path: {calls}"

--- a/tests/sdk/test_async_utils.py
+++ b/tests/sdk/test_async_utils.py
@@ -161,6 +161,27 @@ def test_run_sync_timeout_raises():
     close_background_loop()
 
 
+def test_run_sync_timeout_message_is_not_empty():
+    """The timeout carries a reason.
+
+    ``future.result()`` raises a bare TimeoutError with an empty str(),
+    which error formatters read as "no detail" and swap for a generic
+    message -- telling the user to check model settings on a timeout.
+    """
+    close_background_loop()
+
+    async def slow():
+        await asyncio.sleep(60)
+
+    with pytest.raises(FuturesTimeoutError) as excinfo:
+        run_sync(slow(), timeout=0.1)
+
+    message = str(excinfo.value)
+    assert message.strip(), "timeout must carry a message, not an empty string"
+    assert "timed out" in message.lower()
+    close_background_loop()
+
+
 def test_run_sync_timeout_cancels_coroutine():
     """A timed-out coroutine is cancelled, not left running on the loop."""
     close_background_loop()

--- a/tests/sdk/test_async_utils.py
+++ b/tests/sdk/test_async_utils.py
@@ -1,10 +1,13 @@
 """Tests for rhesis.sdk.async_utils."""
 
 import asyncio
+import threading
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 
 import pytest
 
 from rhesis.sdk.async_utils import (
+    _get_background_loop,
     close_background_loop,
     reset_litellm_vertex_async_locks,
     run_sync,
@@ -79,4 +82,144 @@ def test_run_sync_reuses_background_loop_across_calls():
     run_sync(record_loop())
     assert len(loop_ids) == 2
     assert loop_ids[0] == loop_ids[1]
+    close_background_loop()
+
+
+# ---------------------------------------------------------------------------
+# run_sync self-call guard (Fix 2)
+# ---------------------------------------------------------------------------
+
+
+def test_run_sync_raises_on_self_call():
+    """Calling run_sync from the background loop thread raises RuntimeError."""
+    close_background_loop()
+
+    error_holder = []
+
+    async def call_run_sync_from_loop():
+        async def inner():
+            return 42
+
+        try:
+            run_sync(inner())
+        except RuntimeError as exc:
+            error_holder.append(exc)
+
+    loop = _get_background_loop()
+    future = asyncio.run_coroutine_threadsafe(call_run_sync_from_loop(), loop)
+    future.result(timeout=5)
+
+    assert len(error_holder) == 1
+    assert "deadlock" in str(error_holder[0]).lower()
+    close_background_loop()
+
+
+def test_run_sync_closes_coroutine_on_self_call():
+    """The coroutine is closed (no 'never awaited' warning) on self-call."""
+    close_background_loop()
+    import warnings
+
+    async def inner():
+        return 42
+
+    async def trigger():
+        coro = inner()
+        try:
+            run_sync(coro)
+        except RuntimeError:
+            pass
+        # After the RuntimeError, coro should be closed -- calling
+        # close() again is a no-op and should not raise.
+        coro.close()
+
+    loop = _get_background_loop()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        future = asyncio.run_coroutine_threadsafe(trigger(), loop)
+        future.result(timeout=5)
+
+    never_awaited = [x for x in w if "never awaited" in str(x.message)]
+    assert never_awaited == []
+    close_background_loop()
+
+
+# ---------------------------------------------------------------------------
+# run_sync timeout (Fix 2)
+# ---------------------------------------------------------------------------
+
+
+def test_run_sync_timeout_raises():
+    """A slow coroutine with timeout raises TimeoutError."""
+    close_background_loop()
+
+    async def slow():
+        await asyncio.sleep(60)
+
+    with pytest.raises(FuturesTimeoutError):
+        run_sync(slow(), timeout=0.1)
+
+    close_background_loop()
+
+
+def test_run_sync_timeout_cancels_coroutine():
+    """A timed-out coroutine is cancelled, not left running on the loop."""
+    close_background_loop()
+
+    cancelled = threading.Event()
+
+    async def slow():
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    with pytest.raises(FuturesTimeoutError):
+        run_sync(slow(), timeout=0.1)
+
+    assert cancelled.wait(timeout=5), "coroutine was not cancelled after timeout"
+    close_background_loop()
+
+
+# ---------------------------------------------------------------------------
+# generate_stream deadlock regression (Fix 1)
+# ---------------------------------------------------------------------------
+
+
+def test_generate_stream_does_not_deadlock():
+    """BaseLLM.generate_stream must not call run_sync on the background loop.
+
+    Before Fix 1, a BaseLLM subclass that only implemented a_generate
+    would deadlock when generate_stream was called from an async context
+    on the background loop thread (the architect's execution path).
+    """
+    close_background_loop()
+
+    from rhesis.sdk.models.base import BaseLLM
+
+    class StubLLM(BaseLLM):
+        def load_model(self, *args, **kwargs):
+            pass
+
+        async def a_generate(self, *args, **kwargs):
+            return "hello from a_generate"
+
+        def generate_batch(self, *args, **kwargs):
+            return []
+
+    llm = StubLLM(model_name="stub")
+
+    async def collect_stream():
+        chunks = []
+        async for chunk in llm.generate_stream(prompt="test"):
+            chunks.append(chunk)
+        return chunks
+
+    # Run on the background loop thread -- this is the exact path
+    # the architect worker takes.
+    loop = _get_background_loop()
+    future = asyncio.run_coroutine_threadsafe(collect_stream(), loop)
+    result = future.result(timeout=5)
+
+    assert result == ["hello from a_generate"]
     close_background_loop()


### PR DESCRIPTION
## Purpose

The Architect deadlocked permanently. Messages showed "thinking" forever, and a worker pod on the netgo deployment sat wedged for ~38 hours with 23 queued messages and 4 unacked in-flight. Restarting the pod appeared to fix it, which is why this looked like a worker availability problem at first. It isn't. It is a deterministic self-deadlock, and a fresh process re-wedges within a couple of turns.

`BaseLLM.generate_stream` is an `async def` whose default body called the **synchronous** `generate()`. That bridges through `run_sync()`, which dispatches to a shared background event loop and blocks on `future.result()`. Called from a coroutine already running on that loop, the loop blocks inside its own callback and can never run the coroutine it is waiting for. The future never resolves.

`RhesisLLM` is the default model (`rhesis/rhesis-default`) and inherits that fallback, so the Architect hit this on every turn that streamed a final response. The background loop is a process-wide singleton, so one occurrence killed every `run_sync` in the process, not just the Architect's.

Nothing recovered it. `soft_time_limit`/`time_limit` are implemented only in Celery's prefork pool and this worker runs `--pool threads`, so both were inert (the wedged tasks ran ~36 hours past a 360s limit). asyncio and httpx timeouts are loop callbacks, and the loop was the thing blocked. `try/except` around the stream cannot catch a deadlock. The liveness probe runs in a separate PID and reported healthy the whole time.

## What Changed

Two independent bugs, both fixed. Fixing only the trigger would leave the landmine for the next caller; fixing only the guard would leave the feature broken.

- **`sdk/models/base.py`** — `generate_stream` awaits `a_generate()` instead of calling sync `generate()`. This removes the trigger. Verified all 18 registered providers are compatible: `LiteLLM` and its family override `generate_stream` already, and the three classes overriding both methods (`HuggingFaceLLM`, `LiteLLMProxy`, `PolyphemusLLM`) implement `a_generate` as `asyncio.to_thread(self.generate, ...)`, so behaviour is unchanged.
- **`sdk/async_utils.py`** — `run_sync` now refuses to run on the background loop thread and raises instead of hanging. This is the structural part: no present or future caller can wedge the loop this way again. It also takes an optional `timeout` that cancels the coroutine on expiry rather than leaving it running on the shared loop, and warns when called from any thread with a running loop, which does not deadlock but stalls that loop for the whole call.
- **`tasks/architect/chat.py`** — passes an explicit `timeout=280`, just under the intended 300s budget, since `soft_time_limit` cannot enforce it under the threads pool. A stuck turn now fails and reports to the user instead of holding a worker thread.
- **`mcp_server/local_tools.py`** — comment only. `ASGITransport` runs each route on the caller's loop, which for the Architect is the background loop. That is safe only because every LLM-touching handler is a sync `def` that FastAPI offloads to its threadpool. Recorded so converting one to `async def` does not silently create a new deadlock path.

Also fixes, as a side effect, four FastAPI SSE endpoints (`test_generation_pipeline.py`, `explorer/suggestions.py`, and two synthesizer paths behind `generation.py`) that reached the same fallback on the main API loop. Those never deadlocked, they just blocked the entire API event loop for the duration of an LLM call.

## Additional Context

An audit of every `run_sync` call site and every sync-bridge-reachable-from-async path found exactly one dangerous path, the one fixed here. Specifically cleared as safe:

- **Metric evaluation.** The DeepEval and Ragas sync model shims look like the same shape but are never reached from their async paths. AST-scanned the installed `deepeval` and `ragas` packages to confirm. The one async metric driver uses `await a_evaluate` throughout.
- **Endpoint invocation and Penelope exploration.** The agent wraps sync target calls in `asyncio.to_thread`, so the nested `run_sync` lands on a threadpool thread with the loop free.
- **Embedders and `generate_batch`.** All callers are in sync contexts.

Deliberately **not** done here, and worth separate discussion:

- **No watchdog or forced process restart.** A wedged loop cannot be repaired in place, so the only recovery is process-level, and `close_background_loop()` cannot work against a wedged loop (it reports success while leaving it wedged). That is a real gap, but it treats the symptom. The point of this PR is that the wedge should now be unreachable.
- **Not switching to the prefork pool.** `start.sh` documents the deliberate choice: no `fork()`, so no fork-safety issues with native gRPC (the venv ships `grpcio` plus three `google-cloud-*` packages). It would also not fix this, since the soft limit would raise in the task while leaving the child's background loop wedged for every subsequent task.
- **Broker reliability** (`visibility_timeout` is unset, so kombu's 3600s default drove hourly redelivery and amplified 4 tasks into ~144 submissions) and the liveness probe not reflecting worker liveness.

The currently wedged netgo pod still needs a restart after this deploys; this PR does not unwedge a running process. The 23 queued messages are still there and are real user turns, so they are worth dumping (`LRANGE architect 0 -1`) rather than discarding silently.

## Testing

The regression guards were verified to actually guard: temporarily restoring the buggy line makes `test_generate_stream_does_not_deadlock` and `test_base_fallback_yields_from_a_generate` **fail in 0.17s rather than hang**, which is the `run_sync` guard converting the deadlock into an immediate error.

```bash
# SDK: guard, timeout, cancellation, deadlock regression, provider contract
cd sdk && uv run pytest ../tests/sdk/test_async_utils.py ../tests/sdk/models/ ../tests/sdk/synthesizers -q
# 419 passed, 8 skipped

# SDK: nothing regressed in the metric and agent paths that use the bridge
cd sdk && uv run pytest ../tests/sdk/metrics ../tests/sdk/agents -q
# 904 passed, 7 skipped

# Backend
cd apps/backend && uv run pytest ../../tests/backend/services/websocket/ ../../tests/backend/tasks/architect/ ../../tests/backend/services/architect/ -q
# 226 passed
```

`tests/sdk/models/test_streaming_contract.py` is parametrized over `UNIFIED_MODEL_REGISTRY`, so a newly added provider that neither overrides `generate_stream` nor implements `a_generate` fails CI instead of shipping a latent deadlock.

End to end, the check that matters is an Architect turn against `rhesis/rhesis-default` (the model that deadlocked) completing a streamed final response, and `LLEN architect` returning to ~0 under load.
