### PR TITLE
Add docs lint check blocking oversized and non-WebP images

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,7 @@ jobs:
             docs:
               - 'docs/src/**'
               - 'docs/content/**'
+              - 'docs/scripts/**'
             sdk:
               - 'sdk/**'
             backend:

--- a/docs/scripts/check-image-formats.js
+++ b/docs/scripts/check-image-formats.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Keeps docs image weight out of git history.
+ *
+ * Screenshots are re-shot in batches every few months, so each PNG batch lands
+ * permanently in history at ~3.35x the WebP cost. Two rules:
+ *
+ *   A. Screenshots must be WebP.
+ *   B. No raster asset over MAX_KB, whatever its format.
+ *
+ * BASELINE lists the assets that predate these rules. It may only shrink — a
+ * stale entry is an error, so converting a file forces its removal here.
+ */
+
+const PUBLIC_DIR = path.resolve(__dirname, '..', 'src', 'public');
+const SCREENSHOT_PREFIX = 'screenshots/';
+const MAX_KB = 400;
+
+// Raster formats subject to the size budget. SVG and .ico are exempt: SVG is
+// text and compresses, .ico is required by browsers at a fixed path.
+const RASTER = /\.(png|jpe?g|gif|webp|avif)$/i;
+
+// Known debt, recorded 2026-08-10. Delete each line as the file is converted.
+const BASELINE = new Set([
+  'changelog/v0.4.1/Release 0.4.1.gif', // animated; needs animated-WebP conversion
+  'screenshots/rhesis-ai-auto-login-page.png',
+  'screenshots/rhesis-ai-create-metrics.png',
+  'screenshots/rhesis-ai-dashboard-dark.png',
+  'screenshots/rhesis-ai-dashboard-docker-spinup.png',
+  'screenshots/rhesis-ai-dashboard.png',
+  'screenshots/rhesis-ai-endpoint-create-connection-test.png',
+  'screenshots/rhesis-ai-endpoint-create-mapping-request.png',
+  'screenshots/rhesis-ai-endpoint-create-mapping-response.png',
+  'screenshots/rhesis-ai-endpoint-request-settings.png',
+  'screenshots/rhesis-ai-endpoint-test-connection.png',
+  'screenshots/rhesis-ai-endpoints-auto-configure.png',
+  'screenshots/rhesis-ai-endpoints-create.png',
+  'screenshots/rhesis-ai-generation-select-test-type.png',
+  'screenshots/rhesis-ai-generation-test-configuration.png',
+  'screenshots/rhesis-ai-generation-test-samples.png',
+  'screenshots/rhesis-ai-knowledge.png',
+  'screenshots/rhesis-ai-mcp.png',
+  'screenshots/rhesis-ai-metrics-assign.png',
+  'screenshots/rhesis-ai-models.png',
+  'screenshots/rhesis-ai-multimodal-playground.png',
+  'screenshots/rhesis-ai-multimodal-test-attach.png',
+  'screenshots/rhesis-ai-multimodal-trace.png',
+  'screenshots/rhesis-ai-playground.png',
+  'screenshots/rhesis-ai-polyphemus-access.png',
+  'screenshots/rhesis-ai-project-parameters.png',
+  'screenshots/rhesis-ai-projects-detail-view.png',
+  'screenshots/rhesis-ai-projects-overview.png',
+  'screenshots/rhesis-ai-results-overview.png',
+  'screenshots/rhesis-ai-team.png',
+  'screenshots/rhesis-ai-test-generation.png',
+  'screenshots/rhesis-ai-test-set-execution.png',
+  'screenshots/rhesis-ai-testsets-import-file.png',
+  'screenshots/rhesis-ai-testsets-import-garak.png',
+  'screenshots/rhesis-ai-testsets-inspect-data.png',
+  'screenshots/rhesis-ai-tokens.png',
+  'screenshots/rhesis-test-explorer.png',
+]);
+
+function walk(dir, rootDir, out = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, rootDir, out);
+    } else if (entry.isFile()) {
+      out.push(path.relative(rootDir, full).split(path.sep).join('/'));
+    }
+  }
+  return out;
+}
+
+function main() {
+  if (!fs.existsSync(PUBLIC_DIR)) {
+    console.error(`Public directory not found: ${PUBLIC_DIR}`);
+    process.exit(1);
+  }
+
+  const files = walk(PUBLIC_DIR, PUBLIC_DIR).filter((f) => RASTER.test(f));
+  const violations = [];
+  const seen = new Set();
+
+  for (const rel of files) {
+    const kb = Math.round(fs.statSync(path.join(PUBLIC_DIR, rel)).size / 1024);
+
+    if (BASELINE.has(rel)) {
+      seen.add(rel);
+      continue;
+    }
+
+    if (rel.startsWith(SCREENSHOT_PREFIX) && !rel.endsWith('.webp')) {
+      violations.push({
+        rel,
+        rule: 'format',
+        detail: `${path.extname(rel)} in screenshots/ (${kb} KB)`,
+        fix: `cwebp -lossless "public/${rel}" -o "public/${rel.replace(/\.[^.]+$/, '.webp')}"`,
+      });
+      continue;
+    }
+
+    if (kb > MAX_KB) {
+      violations.push({
+        rel,
+        rule: 'size',
+        detail: `${kb} KB exceeds the ${MAX_KB} KB budget`,
+        fix: 'Re-encode smaller, or crop/resize before committing.',
+      });
+    }
+  }
+
+  // A baseline entry whose file is gone means the debt was paid — the line must go too.
+  const stale = [...BASELINE].filter((rel) => !seen.has(rel));
+
+  if (violations.length === 0 && stale.length === 0) {
+    const debt = BASELINE.size;
+    console.log(`✅ Image checks passed (${files.length} raster assets).`);
+    if (debt > 0) {
+      console.log(`   ${debt} baseline exemption${debt === 1 ? '' : 's'} remaining — see BASELINE in docs/scripts/check-image-formats.js`);
+    }
+    return;
+  }
+
+  if (violations.length > 0) {
+    console.error(`❌ ${violations.length} image violation${violations.length === 1 ? '' : 's'}:\n`);
+    for (const v of violations) {
+      console.error(`  public/${v.rel}`);
+      console.error(`    ${v.rule === 'format' ? 'Screenshots must be WebP' : 'Over size budget'}: ${v.detail}`);
+      console.error(`    Fix: ${v.fix}\n`);
+    }
+    console.error('WebP costs ~3.35x less per screenshot and every version committed stays');
+    console.error('in git history permanently.\n');
+  }
+
+  if (stale.length > 0) {
+    console.error(`❌ ${stale.length} stale baseline entr${stale.length === 1 ? 'y' : 'ies'} — file gone, so remove the line from BASELINE in docs/scripts/check-image-formats.js:\n`);
+    for (const rel of stale) {
+      console.error(`  ${rel}`);
+    }
+    console.error('');
+  }
+
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/docs/src/Makefile
+++ b/docs/src/Makefile
@@ -1,33 +1,36 @@
 # Documentation Makefile
 # Provides convenient commands for linting and formatting documentation
 
-.PHONY: help lint lint-fast format format-check eslint install
+.PHONY: help lint lint-fast format format-check eslint images install
 
 # Default target
 help:
 	@echo "Available targets:"
-	@echo "  lint         - Run all linting checks (format, eslint)"
+	@echo "  lint         - Run all linting checks (format, eslint, images)"
 	@echo "  lint-fast    - Same as lint (no build needed for docs)"
 	@echo "  format       - Auto-fix code formatting"
 	@echo "  format-check - Check code formatting (errors only)"
 	@echo "  eslint       - Run ESLint (errors only)"
+	@echo "  images       - Check image formats and sizes in public/"
 	@echo "  install      - Install dependencies"
 
 # Main lint target - runs all validation steps
-lint: format-check eslint
+lint: format-check eslint images
 	@echo ""
 	@echo "✅ All lint checks passed!"
 	@echo "  ✓ Code formatting"
 	@echo "  ✓ ESLint"
+	@echo "  ✓ Image formats and sizes"
 	@echo ""
 	@echo "💡 Note: Docs has no build step - use 'make lint-fast' for same checks"
 
 # Fast lint (same as regular lint for docs since no build/type-check step)
-lint-fast: format-check eslint
+lint-fast: format-check eslint images
 	@echo ""
 	@echo "✅ Fast lint checks passed!"
 	@echo "  ✓ Code formatting"
 	@echo "  ✓ ESLint"
+	@echo "  ✓ Image formats and sizes"
 	@echo ""
 	@echo "💡 Note: Docs linting is already fast (no type-check or build step needed)"
 
@@ -46,6 +49,11 @@ format-check:
 eslint:
 	@echo "🔍 Running ESLint..."
 	@npm run lint:errors || (echo "❌ ESLint failed" && exit 1)
+
+# Image formats and sizes - keeps screenshot weight out of git history
+images:
+	@echo "🔍 Checking image formats and sizes..."
+	@npm run lint:images || (echo "❌ Image check failed" && exit 1)
 
 # Install dependencies
 install:

--- a/docs/src/package.json
+++ b/docs/src/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:errors": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
+    "lint:images": "node ../scripts/check-image-formats.js",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "node --test --test-reporter=spec lib/__tests__"


### PR DESCRIPTION
## Purpose

Docs screenshots are re-shot in batches every few months, and every version committed stays in git history permanently. Measured over the repo's first 14 months, images added 40.1 MB to history — about 26 MB/year — and screenshots are 77% of that. The PNG-to-WebP migration already underway (#2404) cuts the per-file cost 3.35x, from a 580 KB average to 173 KB, which drops the growth rate to roughly 8 MB/year. This adds a check so that gain doesn't quietly erode the next time someone re-shoots the UI, without anyone having to remember the rule.

Nothing here is urgent — the repo is ~110 MB and nowhere near a GitHub limit. It's cheap insurance on a slope, not a fix for a problem we have today.

## What Changed

- **New `docs/scripts/check-image-formats.js`** with two rules: screenshots under `public/screenshots/` must be WebP, and no raster asset anywhere under `public/` may exceed 400 KB. The size budget matters independently of format — a format-only rule would wave through a 2 MB WebP. The 400 KB figure is calibrated from the existing set: the largest WebP screenshot is 264 KB, the largest PNG is 1164 KB.
- **A `BASELINE` of 37 assets that predate the rule** — the 36 remaining PNG screenshots and one 656 KB animated changelog GIF. Without it CI would fail immediately. Stale entries are treated as an error, so converting a file forces removal of its line and the list can only shrink. The passing output reports how many exemptions remain, keeping the remaining work visible.
- **Wired into the existing docs lint job.** Adds a `lint:images` npm script and an `images` Make target, folded into `lint` and `lint-fast`. The `docs` job in `lint.yml` already runs `make lint`, so no new CI job is needed and developers get the same check locally.
- **Added `docs/scripts/**` to the `docs` paths filter** in `lint.yml`. The script lives outside `docs/src/**` and `docs/content/**`, so without this an edit to the baseline would not re-trigger the job that validates it.

## Additional Context

Follows #2404, which converted the first 40 screenshots to theme-aware WebP and observed the same ratio ("roughly a quarter the size of the PNGs they replace").

This deliberately does not convert the remaining 36 PNGs — that is a separate, larger diff and belongs in its own PR so this one stays reviewable. Converting them is what empties the baseline.

Two pre-existing issues were noticed while working here and left alone, both apparently leftovers from the docs reorganization: the `docs-format` hook in `.pre-commit-config.yaml` is scoped to `^apps/documentation/`, a path that no longer exists, so pre-commit does not cover `docs/` at all; and `docs-k8s.yml` deploys on `docs/src/**` and `docs/content/**` but not `docs/scripts/**`, even though `generate-glossary-pages.js` runs during `prebuild` and is copied by the Dockerfile.

## Testing

Run the check directly:

```bash
cd docs/src && make images
```

It should pass and report 37 baseline exemptions.

All three failure modes were verified against the working tree and then reverted:

| Scenario | Expected |
| --- | --- |
| Copy a PNG into `public/screenshots/` | Fails, exit 1, prints the `cwebp` command to fix it |
| Place a >400 KB image outside `screenshots/` | Fails, exit 1, cites the 400 KB budget |
| Delete or convert a baselined file | Fails, exit 1, names the `BASELINE` line to remove |
| Unmodified tree | Passes, exit 0 |

To confirm the CI path, this PR touches `.github/workflows/lint.yml` and `docs/src/**`, so the `docs` job should run and its `make lint` step should include the new image check.
