### PR TITLE
Fix annotations list hiding every pre-project-scoping review

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/annotations.py
+++ b/apps/backend/src/rhesis/backend/app/services/annotations.py
@@ -78,6 +78,14 @@ def list_annotations(
     Explicit org/project predicates are required because this uses ``text()``
     SQL (ORM auto-filter does not apply).
 
+    Test-result project scoping matches the ORM auto-filter and the
+    ``project_isolation`` RLS policy: rows in the active project *plus*
+    org-level rows whose ``project_id`` is NULL. Strict equality would hide
+    reviews that the test run page and ``get_test_result`` both show, because
+    a run whose test configuration carries no project produces results with a
+    NULL project_id. ``trace.project_id`` is NOT NULL, so the trace branch
+    needs no such allowance.
+
     ``test_run_id`` and ``test_result_id`` narrow *both* branches: ``trace``
     carries its own ``test_run_id``/``test_result_id``, so scoping to a run
     returns reviews on that run's test results and on the traces it produced.
@@ -141,6 +149,7 @@ def list_annotations(
               AND (
                     CAST(:project_id AS uuid) IS NULL
                     OR tr.project_id = CAST(:project_id AS uuid)
+                    OR tr.project_id IS NULL
                   )
               AND (
                     CAST(:test_run_id AS uuid) IS NULL

--- a/sdk/src/rhesis/sdk/agents/architect/agent.py
+++ b/sdk/src/rhesis/sdk/agents/architect/agent.py
@@ -85,6 +85,24 @@ def _unwrap_list_envelope(data: Any) -> Tuple[Optional[List[Any]], Dict[str, Any
     return None, {}
 
 
+def _trim_for_summary(value: Any, max_chars: int) -> Any:
+    """Drop empty values and clip long strings, recursively.
+
+    Keeps an unnamed record readable in a prompt without dumping the
+    whole payload.
+    """
+    if isinstance(value, str):
+        return value[:max_chars].rstrip() + "…" if len(value) > max_chars else value
+    if isinstance(value, dict):
+        trimmed = {
+            k: _trim_for_summary(v, max_chars) for k, v in value.items() if v not in (None, "", [])
+        }
+        return trimmed
+    if isinstance(value, list):
+        return [_trim_for_summary(v, max_chars) for v in value]
+    return value
+
+
 class ArchitectAgent(BaseAgent):
     """Conversational agent for designing and creating test suites.
 
@@ -1214,7 +1232,20 @@ class ArchitectAgent(BaseAgent):
 
         shown = data[:max_items]
         for item in shown:
-            name = item.get("name") or item.get("title") or "?"
+            name = item.get("name") or item.get("title")
+            if not name:
+                # Annotations, test results and anything else without a label
+                # would render as a bare "- ?", hiding every field from the
+                # LLM — which then invents the content. Keep the record.
+                # ensure_ascii=False so non-ASCII review text stays readable
+                # rather than arriving at the LLM as \uXXXX escapes.
+                compact_item = json.dumps(
+                    _trim_for_summary(item, desc_chars),
+                    default=str,
+                    ensure_ascii=False,
+                )
+                lines.append(f"  - {compact_item}")
+                continue
             eid = item.get("id", "")
             desc = item.get("description") or item.get("summary") or ""
             if isinstance(desc, str) and len(desc) > desc_chars:
@@ -1606,7 +1637,13 @@ class ArchitectAgent(BaseAgent):
             compact = self._compact_list_result_for_history(tr.content)
             if compact is not None:
                 return f"{prefix}:\n{compact}"
-            return f"{prefix}: {tr.content[:preview]}"
+            if len(tr.content) > preview:
+                # Say so — an unmarked cut reads as a complete record and the
+                # LLM fills in the missing half itself.
+                return (
+                    f"{prefix}: {tr.content[:preview]}… [truncated, {len(tr.content)} chars total]"
+                )
+            return f"{prefix}: {tr.content}"
         if tr.error:
             return f"{prefix} Error: {tr.error}"
         return None

--- a/tests/backend/routes/test_annotations.py
+++ b/tests/backend/routes/test_annotations.py
@@ -35,7 +35,7 @@ def _project_scope(test_db, organization_id, user_id, project_id):
     test_db.info["_scope"] = RequestScope(
         organization_id=str(organization_id),
         user_id=str(user_id),
-        project_id=str(project_id),
+        project_id=str(project_id) if project_id else None,
     )
     try:
         yield
@@ -491,6 +491,71 @@ class TestAnnotationScoping:
         trace_item = by_id[trace_review["review_id"]]
         assert trace_item["test_run_id"] == str(test_run.id)
         assert trace_item["test_result_id"] == str(test_result.id)
+
+    def test_org_level_rows_without_a_project_are_visible(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_organization,
+        test_type_lookup,
+        db_user,
+        authenticated_user,
+        db_project,
+        db_endpoint,
+    ):
+        """Reviews on test results with a NULL project_id must still be listed.
+
+        A run whose test configuration carries no project produces test
+        results stamped with a NULL project_id. Those rows are org-level: the
+        ORM auto-filter and the ``project_isolation`` RLS policy both admit
+        them under any active project, and the test run page shows their
+        reviews. Strict ``project_id = :project_id`` here hid them, so the
+        architect reported "no annotations" on runs that visibly had them.
+
+        Traces need no equivalent case — ``trace.project_id`` is NOT NULL.
+        """
+        pass_status, _ = _ensure_pass_fail_statuses(
+            test_db, test_organization, test_type_lookup, db_user
+        )
+        review = _review_payload(pass_status.id, authenticated_user.id)
+        review["comments"] = "null-project-result"
+
+        # No ambient project → auto-stamp leaves project_id NULL.
+        with _project_scope(test_db, test_organization.id, authenticated_user.id, None):
+            test_config = TestConfiguration(
+                endpoint_id=db_endpoint.id,
+                organization_id=test_organization.id,
+                user_id=authenticated_user.id,
+            )
+            test_db.add(test_config)
+            test_db.flush()
+            test_run = TestRun(
+                test_configuration_id=test_config.id,
+                organization_id=test_organization.id,
+                user_id=authenticated_user.id,
+            )
+            test_db.add(test_run)
+            test_db.flush()
+            test_result = TestResult(
+                organization_id=test_organization.id,
+                user_id=authenticated_user.id,
+                test_configuration_id=test_config.id,
+                test_run_id=test_run.id,
+                test_reviews={"metadata": {"total_reviews": 1}, "reviews": [review]},
+            )
+            test_db.add(test_result)
+            test_db.commit()
+            test_db.refresh(test_result)
+
+        assert test_result.project_id is None
+
+        with _project_scope(test_db, test_organization.id, authenticated_user.id, db_project.id):
+            response = authenticated_client.get(f"/annotations/?test_run_id={test_run.id}")
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert {i["review_id"] for i in data} == {review["review_id"]}
+        assert data[0]["comments"] == "null-project-result"
 
     def test_operation_trace_annotation_has_null_run_and_result(
         self,

--- a/tests/backend/routes/test_annotations.py
+++ b/tests/backend/routes/test_annotations.py
@@ -492,7 +492,7 @@ class TestAnnotationScoping:
         assert trace_item["test_run_id"] == str(test_run.id)
         assert trace_item["test_result_id"] == str(test_result.id)
 
-    def test_org_level_rows_without_a_project_are_visible(
+    def test_pre_project_scoping_rows_are_visible(
         self,
         authenticated_client: TestClient,
         test_db,
@@ -505,12 +505,13 @@ class TestAnnotationScoping:
     ):
         """Reviews on test results with a NULL project_id must still be listed.
 
-        A run whose test configuration carries no project produces test
-        results stamped with a NULL project_id. Those rows are org-level: the
-        ORM auto-filter and the ``project_isolation`` RLS policy both admit
-        them under any active project, and the test run page shows their
-        reviews. Strict ``project_id = :project_id`` here hid them, so the
-        architect reported "no annotations" on runs that visibly had them.
+        Migration a1b2c3d4e5f0 added ``project_id`` as a nullable column with
+        no backfill, so every test result predating project scoping carries a
+        NULL project_id — permanently. Those rows are org-level: the ORM
+        auto-filter and the ``project_isolation`` RLS policy both admit them
+        under any active project, which is why the test run page counts their
+        reviews. Strict ``project_id = :project_id`` here hid them, emptying
+        the annotations list for every historical run.
 
         Traces need no equivalent case — ``trace.project_id`` is NOT NULL.
         """

--- a/tests/sdk/agents/test_architect.py
+++ b/tests/sdk/agents/test_architect.py
@@ -2211,6 +2211,137 @@ class TestArchitectCompactListRendering:
         assert "List response" not in formatted
 
 
+@pytest.mark.unit
+class TestCompactUnnamedListResults:
+    """Items with no name/title must keep their content.
+
+    ``list_annotations`` returns reviews keyed on ``review_id`` with the
+    human's words in ``comments`` — no name, no title, and ``id`` is
+    always null. Rendering those as a bare "- ?" told the LLM that N
+    reviews existed while showing it none of them, and it filled the
+    gap by inventing reviewers, comments and turn numbers.
+    """
+
+    @staticmethod
+    def _annotation(idx: int) -> dict:
+        return {
+            "id": None,
+            "nano_id": None,
+            "review_id": f"r-{idx}",
+            "source": "test_result",
+            "comments": f"Turn {idx} contradicted the itinerary",
+            "status": {"name": "Fail"},
+            "user": {"name": "Nicolai Bohn"},
+            "target": {"type": "turn", "reference": f"Turn {idx}"},
+            "resolved": False,
+            "test_run_id": "run-1",
+            "behavior_name": "Goal Achievement",
+        }
+
+    def test_annotation_content_survives_compaction(self):
+        payload = {
+            "results": [self._annotation(1), self._annotation(2)],
+            "_pagination": {"returned": 2, "has_more": False},
+        }
+        out = ArchitectAgent._compact_list_result_for_history(json.dumps(payload))
+        assert out is not None
+        assert "List response: 2 item(s)" in out
+        # The regression: every line collapsed to "  - ?"
+        assert "  - ?" not in out
+        for idx in (1, 2):
+            assert f"Turn {idx} contradicted the itinerary" in out
+        assert "Nicolai Bohn" in out
+        assert "Fail" in out
+        assert "Goal Achievement" in out
+
+    def test_null_fields_are_dropped(self):
+        """``id``/``nano_id`` are null on every annotation — noise."""
+        out = ArchitectAgent._compact_list_result_for_history(
+            json.dumps([self._annotation(1)])
+        )
+        assert out is not None
+        assert "nano_id" not in out
+
+    def test_long_comment_is_clipped(self):
+        item = self._annotation(1)
+        item["comments"] = "z" * 500
+        out = ArchitectAgent._compact_list_result_for_history(
+            json.dumps([item]), desc_chars=100
+        )
+        assert out is not None
+        assert "z" * 500 not in out
+        assert "…" in out
+
+    def test_named_items_keep_the_compact_form(self):
+        """Entities with names are unaffected — no raw JSON for them."""
+        out = ArchitectAgent._compact_list_result_for_history(
+            json.dumps([{"id": "u-1", "name": "Alpha", "description": "first"}])
+        )
+        assert out is not None
+        assert "  - Alpha (id: u-1) — first" in out
+        assert "{" not in out
+
+    def test_format_history_surfaces_annotation_comments(self):
+        """End-to-end through the prompt builder."""
+        agent = _make_agent(_mock_model())
+        agent._execution_history.append(
+            ExecutionStep(
+                iteration=1,
+                reasoning="check human feedback on the run",
+                action="call_tool",
+                tool_calls=[],
+                tool_results=[
+                    ToolResult(
+                        tool_name="list_annotations",
+                        success=True,
+                        content=json.dumps(
+                            {
+                                "results": [self._annotation(1)],
+                                "_pagination": {"returned": 1, "has_more": False},
+                            }
+                        ),
+                    )
+                ],
+            )
+        )
+        formatted = agent._format_history()
+        assert "Turn 1 contradicted the itinerary" in formatted
+        assert "Nicolai Bohn" in formatted
+
+
+@pytest.mark.unit
+class TestToolResultTruncationMarker:
+    """A cut-off record must announce itself.
+
+    Without a marker the LLM reads truncated JSON as a complete record
+    and completes the missing half from imagination.
+    """
+
+    def test_marker_added_when_content_exceeds_preview(self):
+        agent = _make_agent(_mock_model())
+        content = json.dumps({"test_output": {"output": "x" * 6000}})
+        rendered = agent._render_tool_result(
+            ToolResult(tool_name="get_test_result", success=True, content=content),
+            prefix="[get_test_result]",
+            preview=4000,
+        )
+        assert rendered is not None
+        assert "[truncated" in rendered
+        assert str(len(content)) in rendered
+
+    def test_no_marker_when_content_fits(self):
+        agent = _make_agent(_mock_model())
+        content = json.dumps({"id": "u-1", "status": "Passed"})
+        rendered = agent._render_tool_result(
+            ToolResult(tool_name="get_test_result", success=True, content=content),
+            prefix="[get_test_result]",
+            preview=4000,
+        )
+        assert rendered is not None
+        assert "truncated" not in rendered
+        assert "Passed" in rendered
+
+
 # ── Mapping completion tests ─────────────────────────────────────
 
 


### PR DESCRIPTION
## Purpose

The Annotations page shows `0–0 of 0` while the Test Runs grid shows review counts on nearly every run, and the Architect reports "no annotations" on runs that visibly have them — then invents reviewer names, comment text and turn numbers when it does have annotation data. Two independent bugs, one per symptom.

**Nothing is listed.** `list_annotations` scoped test results with strict `project_id = :project_id`. Migration `a1b2c3d4e5f0` added `project_id` as a nullable column **with no backfill**, so every test result predating project scoping carries a NULL `project_id` permanently — and nothing has assigned one since. Everywhere else in the app those rows are visible: the ORM auto-filter (`models/scope_events.py`) and the `project_isolation` RLS policy both apply `project_id = :pid OR project_id IS NULL`, which is why the test run page counts their reviews via `reviewed_tests`. Only this query disagreed, so the annotations list came back empty for the entire historical dataset. This is not an edge case — for an org whose reviewed runs all predate the migration, the feature has never returned anything. `trace.project_id` is `NOT NULL`, so the trace branch needs no equivalent allowance.

**The content is invented.** Every list-shaped tool result passes through `_compact_list_result_for_history` before reaching the prompt. That renderer builds each line from `name`/`title`, `id` and `description`. An annotation has none of them — the human's words live in `comments`, the key is `review_id`, and the inherited `id` is always null. A real production payload:

```json
{"id": null, "nano_id": null, "review_id": "e87b6bc0-…", "comments": "Test review",
 "status": {"name": "Pass"}, "user": {"name": "Nicolai Bohn"}, "behavior_name": "Off-Domain Request Redirect"}
```

rendered to the LLM as `List response: 1 item(s)` followed by a single line reading `  - ?`. Told that reviews exist but shown none of their content, the model fills the gap from imagination. This is data starvation, not creativity: restore the payload and there is nothing left to guess at.

Both were confirmed against production. Worker logs for the reported session show `list_annotations` called five times, all succeeding, none erroring — ruling out a 400 (missing project scope), a 422 (URL passed instead of a UUID) and any permission problem. The model then fell back to `list_test_results` → `get_test_result`, which returns `test_reviews` inline; that is where the real review text it quoted came from. A freshly created review on a project-stamped test result comes back from the endpoint correctly, isolating NULL `project_id` as the discriminator.

## What Changed

- `services/annotations.py`: the test-result branch now admits `tr.project_id IS NULL`, matching the ORM auto-filter and the RLS policy. Org isolation is untouched, and the trace branch is deliberately left strict.
- `architect/agent.py`: items without a `name`/`title` render as their own trimmed JSON — empty values dropped, long strings clipped, non-ASCII left readable — instead of collapsing to `- ?`. Named entities keep the existing compact one-line form, so `list_metrics` and friends are unaffected. This also fixes `list_test_results`, which has no `name` either and was collapsing to `- ? (id: …)`.
- `architect/agent.py`: tool results cut at the 4000-char preview now say so. An unmarked cut reads as a complete record, and a large `get_test_result` easily exceeds it.

## Additional Context

- The test run Reviews tab never used this endpoint — it counts reviews straight off `test_result.test_reviews` (`test-run-summary-utils.ts`), and the runs grid uses `counts.reviewed_tests` from `result_processor.py`. Both go through the ORM, which is why the UI and the API disagreed with no error anywhere.
- Every existing test in `tests/backend/routes/test_annotations.py` created test results with an explicit `project_id`, which is exactly why the NULL case slipped through.
- **Not addressed here:** whether historical test results should be backfilled with a project (derivable via `test_run → test_configuration → endpoint.project_id`). The `OR IS NULL` predicate is correct on its own merits — it is what the ORM and RLS already do — but a backfill would additionally stop those rows appearing in every project's view. That is a separate change with its own migration and risk.
- `BaseAgent._format_history` in the SDK has the same unmarked 4000-char truncation. Left alone to keep this focused on the architect path; worth a follow-up for the agents using the base implementation.
- No migration, no API-contract change. The annotations list can now return rows it previously hid — that is the fix, not a regression.

## Testing

```bash
cd apps/backend && uv run pytest ../../tests/backend/routes/test_annotations.py   # 19 passed
cd sdk && uv run pytest ../tests/sdk/agents/test_architect.py                      # 157 passed
```

`test_pre_project_scoping_rows_are_visible` seeds a run with no ambient project scope, so auto-stamp leaves `project_id` NULL exactly as pre-migration rows are, then asserts the review comes back under an active project. Reverting the one-line SQL change makes it fail with `assert set() == {'e8c33efb-…'}` — the endpoint returning nothing, reproducing the production symptom exactly.

`TestCompactUnnamedListResults` asserts that annotation comments, reviewer, verdict and behavior all survive the renderer and that no line collapses to `- ?`, with an end-to-end case through `_format_history()`. `TestToolResultTruncationMarker` covers the truncation notice.

To verify by hand: open the Annotations page on an org whose reviewed runs predate project scoping. It should list reviews the Test Runs grid already counts. Then ask the Architect about one of those runs and confirm it both finds the reviews and quotes them accurately.
