### PR TITLE
Fix architect creating single-turn tests in multi-turn test sets

### DIFF
--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -107,20 +107,39 @@ tools:
         description: "Detailed description of the test set's purpose (string)"
       short_description:
         description: "Brief summary, one line (string)"
+      test_set_type:
+        description: >
+          REQUIRED. "Single-Turn" or "Multi-Turn". Must match the
+          test_type of the tests in the array. A Multi-Turn test set
+          must contain Multi-Turn tests; a Single-Turn test set must
+          contain Single-Turn tests.
       priority:
         description: >
           Integer priority value (e.g. 1, 2, 3). Must be an integer, NOT
           a string like "High" or "Low". Omit if unsure.
       tests:
         description: >
-          REQUIRED array of test objects (must not be empty). Each object:
-          {"prompt": {"content": "the test prompt text",
-          "language_code": "en", "expected_response": "optional expected
-          answer"}, "behavior": "behavior name", "category": "category
-          name", "topic": "topic name"}. behavior/category/topic are
-          plain-text names (not UUIDs) — the server resolves or creates
-          them automatically. Use list_behaviors, list_categories, and
-          list_topics to discover existing values first.
+          REQUIRED array of test objects (must not be empty). The object
+          format depends on the test type.
+
+          Single-Turn test: {"prompt": {"content": "the test prompt
+          text", "language_code": "en", "expected_response": "optional
+          expected answer"}, "behavior": "behavior name", "category":
+          "category name", "topic": "topic name"}.
+
+          Multi-Turn test: {"test_type": "Multi-Turn",
+          "test_configuration": {"goal": "what the target SHOULD do
+          (required)", "instructions": "how to conduct the test
+          (optional)", "restrictions": "what the target MUST NOT do
+          (optional)", "scenario": "context and persona (optional)",
+          "max_turns": 10}, "behavior": "behavior name", "category":
+          "category name", "topic": "topic name"}. Multi-Turn tests
+          use test_configuration instead of prompt — do NOT send both.
+
+          behavior/category/topic are plain-text names (not UUIDs) —
+          the server resolves or creates them automatically. Use
+          list_behaviors, list_categories, and list_topics to discover
+          existing values first.
 
   - name: generate_test_set
     label: Generating test set
@@ -137,7 +156,7 @@ tools:
       get_test_set + list_test_set_tests to verify content → offer
       execute_test_set. For grounded tests, pass source IDs from
       list_sources or create_source in the sources parameter.
-      Supports both single-turn and multi-turn test generation via the
+      Supports both Single-Turn and Multi-Turn test generation via the
       test_type parameter.
       PRECONDITION: when a saved plan is in effect, every behavior,
       metric, and behavior→metric mapping in the plan must be marked
@@ -168,10 +187,13 @@ tools:
           range: 3–20 per test set.
       test_type:
         description: >
-          "Single-Turn" or "Multi-Turn". Single-turn tests send one
-          prompt and evaluate the response. Multi-turn tests generate
-          a goal and instructions for a multi-turn conversation.
-          Default: "Single-Turn".
+          "Single-Turn" or "Multi-Turn". MUST match the plan's
+          test_type for this test set — if the plan says Multi-Turn,
+          pass "Multi-Turn" here. Single-Turn tests generate a prompt
+          and evaluate the response. Multi-Turn tests generate a goal
+          and instructions that drive a conversation over several
+          turns. Default: "Single-Turn" — you MUST override this for
+          Multi-Turn sets.
       name:
         description: >
           Name for the generated test set (string). Use the test set
@@ -184,8 +206,8 @@ tools:
           by ID automatically and injects it into the synthesizer — do NOT
           attempt to load or pass source content yourself. Use list_sources
           to discover available sources and pass their IDs here.
-          LIMITATION: only single-turn test generation uses sources.
-          Multi-turn tests currently ignore this parameter.
+          LIMITATION: only Single-Turn test generation uses sources.
+          Multi-Turn tests currently ignore this parameter.
 
   - name: execute_test_set
     label: Running test set
@@ -564,7 +586,7 @@ tools:
           REQUIRED, and rejected if missing or empty. Non-empty list of
           strings, each exactly "Single-Turn" or "Multi-Turn". This decides
           which tests the metric is evaluated against: a Single-Turn metric
-          is skipped on multi-turn tests and vice versa, so a wrong value
+          is skipped on Multi-Turn tests and vice versa, so a wrong value
           means the metric silently never runs. Use ["Multi-Turn"] for
           conversation-level metrics, ["Single-Turn"] for single
           request-response metrics, and both only when the metric genuinely
@@ -1074,7 +1096,7 @@ tools:
       $filter=contains(tolower(title), 'keyword'). The agent should
       NEVER fetch source content — pass IDs directly to generate_test_set
       and the backend handles content injection. CHAIN: if no match,
-      create_source then pass new id to generate_test_set (single-turn only).
+      create_source then pass new id to generate_test_set (Single-Turn only).
     parameters:
       filter:
         description: >
@@ -1090,7 +1112,7 @@ tools:
       Create a knowledge source for grounding test generation. ENTITY: Source.
       PREREQUISITES: copy source_type_id from list_sources (same type) or
       from an existing source of that type. CHAIN: after create, pass
-      [{"id": "<uuid>"}] to generate_test_set sources (single-turn only).
+      [{"id": "<uuid>"}] to generate_test_set sources (Single-Turn only).
       For pasted text: title + content (Manual type). For URLs: title + url
       (Website type). NEVER fetch or pass raw content to generate_test_set —
       only the ID. File uploads require the UI (POST /sources/upload not

--- a/sdk/src/rhesis/sdk/agents/architect/plan.py
+++ b/sdk/src/rhesis/sdk/agents/architect/plan.py
@@ -51,7 +51,15 @@ class TestSetSpec(BaseModel):
     num_tests: int = Field(default=15, description="Number of tests to generate")
     test_type: Literal["Single-Turn", "Multi-Turn"] = Field(
         default="Single-Turn",
-        description='Must be exactly "Single-Turn" or "Multi-Turn"',
+        description=(
+            'Must be exactly "Single-Turn" or "Multi-Turn". Decide from '
+            "what the user asked for and what the behavior needs: "
+            "Multi-Turn when the test depends on earlier turns (context "
+            "retention, multi-step tasks, tone under pressure, guardrails "
+            "under repeated pressure); Single-Turn when a single prompt "
+            "settles it. If the user asked for Multi-Turn tests, set this "
+            "to Multi-Turn — it does not default to it."
+        ),
     )
     generation_prompt: str = Field(
         default="",

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
@@ -25,7 +25,7 @@
 - This is a two-step process: (1) present what you PLAN to do, then (2) wait for the user to say yes before making any tool call that modifies data.
 - When presenting your plan, use future tense ("I will create…", "Here's the metric I'd like to create:") — never past tense ("I've created…", "I updated…"). You have NOT done it yet.
 - Before creating a metric, show: name, score type, evaluation prompt, evaluation steps, result configuration (thresholds, categories, passing categories), scope, and explanation.
-- Before creating a test set, show: name, description, number of tests, target behaviors.
+- Before creating a test set, show: name, description, number of tests, test type (Single-Turn or Multi-Turn), target behaviors.
 - Before creating a behavior, show: name and description.
 - Before creating a project, show: name and description.
 - Before updating or improving an entity, show the proposed changes.
@@ -78,7 +78,7 @@ When `has_more: true`, choose the right resolution strategy:
 Never pass `limit` directly in your tool arguments — page size is controlled by the server and cannot be changed.
 
 ## Knowledge Sources
-Knowledge sources are platform-managed documents and reference material (product specs, FAQs, API docs, policy documents) that users have uploaded. The backend can ground single-turn test generation in this content automatically — you only need to pass the source ID.
+Knowledge sources are platform-managed documents and reference material (product specs, FAQs, API docs, policy documents) that users have uploaded. The backend can ground Single-Turn test generation in this content automatically — you only need to pass the source ID.
 
 ### When to use knowledge sources
 - The user says "based on our docs", "use the FAQ", "I have reference material", "our product spec", "ground the tests in our documentation"
@@ -88,7 +88,7 @@ Knowledge sources are platform-managed documents and reference material (product
 ### When NOT to use knowledge sources
 - The user has not mentioned documentation and the endpoint is generic (coding assistant, chit-chat bot, general-purpose API)
 - The user explicitly declined when offered
-- The user asks for multi-turn tests — multi-turn generation does not consume sources (see limitation below)
+- The user asks for Multi-Turn tests — Multi-Turn generation does not consume sources (see limitation below)
 
 ### Workflow
 1. If the user @mentioned a source, the ID is already in the "User Context" section — skip to step 5
@@ -101,4 +101,4 @@ Knowledge sources are platform-managed documents and reference material (product
 ### Hard rules
 - **Never attempt to fetch source content.** There is no content-fetching tool exposed to you and source text is large enough to overflow the context window. Pass the ID and let the backend handle the rest.
 - **Never fabricate facts from a source.** If the user asks "what does the FAQ say about X?", tell them you pass the source ID to the synthesizer but do not read the content yourself.
-- **Sources only apply to single-turn test generation.** If the user asks for multi-turn tests with source grounding, explain that multi-turn generation does not currently consume sources and offer a single-turn alternative.
+- **Sources only apply to Single-Turn test generation.** If the user asks for Multi-Turn tests with source grounding, explain that Multi-Turn generation does not currently consume sources and offer a Single-Turn alternative.

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-save-plan.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-save-plan.j2
@@ -33,7 +33,7 @@ Top-level structure (all three array fields are required, even if empty):
 - `description`: string (required)
 - `short_description`: string (optional)
 - `num_tests`: integer (optional, defaults to 15) — must be a number, NOT a string like `"15"`
-- `test_type`: string (optional, defaults to `"Single-Turn"`) — must be exactly `"Single-Turn"` or `"Multi-Turn"`. No other values, no lower-case variants.
+- `test_type`: string (optional, defaults to `"Single-Turn"`) — must be exactly `"Single-Turn"` or `"Multi-Turn"`. No other values, no lower-case variants. Set it explicitly to `"Multi-Turn"` when the user asked for Multi-Turn tests: this records the intent, and you must pass the same value to `generate_test_set` (or `create_test_set_bulk`) when you create the set. Nothing forwards it for you.
 - `generation_prompt`: string (optional)
 - `behaviors`: array of strings (optional) — behavior names this test set targets
 - `categories`: array of strings (optional)

--- a/skills/rhesis/references/entity-model.md
+++ b/skills/rhesis/references/entity-model.md
@@ -43,7 +43,7 @@ flowchart TB
 |----------|---------|-------|
 | Behavior ↔ Metric | Many-to-many; **required before test generation** | `add_behavior_to_metric`, `get_metric_behaviors`, `remove_behavior_from_metric` |
 | TestSet → Test | Tests belong to a set | `generate_test_set`, `list_test_set_tests`, `get_test_set` |
-| Source → TestSet | Sources ground **single-turn** generation only | `list_sources`, `create_source` → `generate_test_set` |
+| Source → TestSet | Sources ground **Single-Turn** generation only | `list_sources`, `create_source` → `generate_test_set` |
 | TestSet + Endpoint → TestRun | Execution is always a pair | `execute_test_set` |
 | TestRun → TestResult | Results scoped to a run | `list_test_results` with `$filter=test_run_id eq '…'` |
 | Metric → TestResult | Scores when metric is linked to the test's behavior | `get_test_result`, `get_test_result_stats` |

--- a/skills/rhesis/references/phases/creation.md
+++ b/skills/rhesis/references/phases/creation.md
@@ -11,12 +11,19 @@ Execute the approved plan exactly — no extra entities.
 5. Metrics — **(reuse)** skip; **(improve)** `improve_metric`; **(new)** `create_metric` with plan name, **`metric_scope`**, `score_type`, `evaluation_prompt`. Do NOT use `generate_metric`
 6. `add_behavior_to_metric` — all mappings before generation
 7. `assign_tag` — if planned (PRD path); `entity_type` `Behavior` or `Metric`
-8. `generate_test_set` — per set; `config.behaviors`, `generation_prompt`, `test_type`, optional `sources` (Single-Turn only). Prefer over `create_test_set_bulk` unless importing verbatim user prompts.
+8. `generate_test_set` — per set; `config.behaviors`, `generation_prompt`, `test_type`, optional `sources` (Single-Turn only). **Read `test_type` from the plan** for each test set and pass it explicitly — Multi-Turn sets MUST send `test_type: "Multi-Turn"`. Prefer over `create_test_set_bulk` unless importing verbatim user prompts.
 9. **Wait for generation** — call `await_task` with the `task_id`(s) from the responses. Do NOT poll `get_job_status` manually; the system resumes when all tasks finish.
 10. `get_test_set` + `list_test_set_tests` spot-check generated prompts
 11. Summarize by name (never IDs); offer execution: "Would you like me to run these against [endpoint name]?"
 
 **Critical:** test sets are generated LAST, only after every behavior, metric, and behavior→metric link is in place. Calling `generate_test_set` before that point is rejected with "Cannot generate test sets yet…". Wait until the "Plan progress" line shows N/N for behaviors, metrics, and mappings.
+
+## Multi-Turn test sets
+
+Multi-Turn and Single-Turn test sets produce structurally different tests. Getting this wrong creates a test set that says "Multi-Turn" but contains Single-Turn tests.
+
+- **`generate_test_set`**: pass `test_type: "Multi-Turn"`. The synthesizer generates goals and instructions instead of prompts. Omitting `test_type` or leaving the default produces Single-Turn tests regardless of the test set name.
+- **`create_test_set_bulk`**: pass `test_set_type: "Multi-Turn"`. Each test in the `tests` array must use `test_configuration` (with `goal`, optional `instructions`, `restrictions`, `scenario`, `max_turns`) instead of `prompt`, and set `test_type: "Multi-Turn"` on each test object. The server types each test from its own content, so tests carrying a `prompt` land as Single-Turn even inside a Multi-Turn set. Do NOT send `prompt` and `test_configuration` on the same test.
 
 ## Naming
 

--- a/skills/rhesis/references/phases/planning.md
+++ b/skills/rhesis/references/phases/planning.md
@@ -17,6 +17,31 @@ Before proposing a plan:
 
 Requirements plans: follow section list in `requirements-workflow.md` and shape in `use-case-bracketfeld.md`.
 
+## Choosing `test_type`
+
+Decide this per test set while planning. Do not fall through to Single-Turn by habit — it is the default, so an unset value silently produces Single-Turn tests.
+
+**Multi-Turn** when the behavior only shows up across turns:
+
+- Context retention — the target must recall something said earlier
+- Multi-step tasks — filing a claim, completing a booking, troubleshooting to resolution
+- Tone under pressure — a user who grows frustrated over several messages
+- Guardrails under persistence — a request refused once, then re-framed turn after turn
+
+**Single-Turn** when one prompt settles it:
+
+- Factual accuracy of a single answer
+- Refusing a clearly harmful request stated once
+- Format, schema, or tone of one reply
+
+Words in the user's request that point to Multi-Turn: "conversation", "back and forth", "follow-up", "remembers", "keeps context", "gets frustrated", "multi-turn". If the user asks for Multi-Turn tests, every test set you plan for that request is Multi-Turn unless they say otherwise.
+
+A suite can mix both — split them into separate test sets, never one set with both shapes.
+
+When the request is genuinely ambiguous, ask one question instead of guessing.
+
+State the type for each test set when you present the plan, and check that the mapped metrics' `metric_scope` covers it — `save_plan` rejects a Multi-Turn set whose behaviors only have Single-Turn metrics.
+
 ## Reuse
 
 Propose existing entities when they match. Say explicitly: "I'll reuse 'Refuses Harmful Requests'."

--- a/skills/rhesis/references/tool-catalog.md
+++ b/skills/rhesis/references/tool-catalog.md
@@ -315,10 +315,10 @@ Generate a test set using the Rhesis synthesizer. An LLM creates diverse test pr
   - `categories` (optional list of strings)
   - `topics` (optional list of strings)
 - `num_tests` — integer, default 5, typical range 3–20
-- `test_type` — `"Single-Turn"` (default) or `"Multi-Turn"`
+- `test_type` — `"Single-Turn"` (default) or `"Multi-Turn"`. Take this from the plan's test set and pass it explicitly. Omitting it produces Single-Turn tests no matter what the test set is called.
 - `sources` — optional list of knowledge source objects to ground tests in real content. Each object must contain only the `id` field: `[{"id": "<source-uuid>"}]`. The backend fetches and injects source content automatically — do NOT fetch or pass content yourself. Use `list_sources` to discover available sources. Only works with Single-Turn; ignored for Multi-Turn.
 
-**Common mistakes:** Omitting `config.behaviors`, using `test_type: "single-turn"` (wrong case).
+**Common mistakes:** Omitting `config.behaviors`, using `test_type: "single-turn"` (wrong case), omitting `test_type` for a Multi-Turn test set.
 
 ---
 
@@ -330,8 +330,15 @@ Use this **only** when importing specific user-provided test prompts that must b
 **Key parameters:**
 - `name` (required)
 - `description`
-- `tests` (required, non-empty array) — each item: `{"prompt": {"content": "...", "language_code": "en"}, "behavior": "name", "category": "name", "topic": "name"}`
+- `test_set_type` (required) — `"Single-Turn"` or `"Multi-Turn"`
+- `tests` (required, non-empty array) — item shape depends on the test type:
+  - Single-Turn: `{"prompt": {"content": "...", "language_code": "en"}, "behavior": "name", "category": "name", "topic": "name"}`
+  - Multi-Turn: `{"test_type": "Multi-Turn", "test_configuration": {"goal": "...", "instructions": "...", "restrictions": "...", "scenario": "...", "max_turns": 10}, "behavior": "name", "category": "name", "topic": "name"}`
 - `priority` — integer (1, 2, 3), not a string
+
+Only `goal` is required inside `test_configuration`. A test uses either `prompt` or `test_configuration`, never both.
+
+**Common mistakes:** Setting `test_set_type: "Multi-Turn"` but sending tests with `prompt` — the server types each test from its own content, so those tests land as Single-Turn inside a Multi-Turn set. Set `test_type` on every test object.
 
 ---
 
@@ -497,7 +504,7 @@ Update an existing endpoint's configuration. Send **only** the fields you want t
 ---
 
 ### `create_source`
-Create a knowledge source for grounding single-turn `generate_test_set`.
+Create a knowledge source for grounding Single-Turn `generate_test_set`.
 
 **Patterns:**
 - Pasted text: `title` + `content` (Manual type — copy `source_type_id` from `list_sources`)


### PR DESCRIPTION
## Purpose

When a user asked the architect (Telemachus) for a multi-turn test set, it created the test set but filled it with single-turn tests. Retrying and regenerating did not help, because nothing in the agent's guidance explained how the two shapes differ or that the type has to be passed explicitly at creation time.

The backend pipeline is correct: `generate_test_set` with `test_type: "Multi-Turn"` dispatches to `MultiTurnSynthesizer`, which sets `test_type` per test and `test_set_type` on the set. The failure was entirely in what the agent was told. Two specific gaps caused it. The `test_type` parameter defaults to `"Single-Turn"`, and nothing said the plan's value is not forwarded for you, so the agent saved a Multi-Turn plan and then called the tool without the argument. And `create_test_set_bulk` was documented with only the single-turn `prompt` shape, with the required `test_set_type` field missing from the catalog entirely, so the manual fallback produced single-turn tests too.

## What Changed

- `mcp_tools.yaml`: documented the multi-turn `test_configuration` shape (`goal`, `instructions`, `restrictions`, `scenario`, `max_turns`) alongside the single-turn `prompt` shape on `create_test_set_bulk`, added the missing `test_set_type` parameter, and made `generate_test_set`'s `test_type` explicit that it must be overridden for multi-turn sets.
- `plan.py`: moved the type-choice criteria into the `TestSetSpec.test_type` Pydantic `Field` description, which flows into the `save_plan` tool schema through `model_json_schema()`, so the guidance is schema-driven rather than duplicated prose.
- `planning.md`: added a "Choosing `test_type`" section. The file previously listed `test_type` in the plan structure with no guidance on how to pick it. It now gives concrete criteria (context retention, multi-step tasks, tone under pressure, guardrails under repeated pressure for Multi-Turn; one prompt settling it for Single-Turn), the signal words in a user's request, the rule that mixed suites split into separate sets, and instructions to ask when genuinely ambiguous.
- `tool-catalog.md`: added `test_set_type` and the multi-turn item shape, and documented the failure mode. The server types each test from its own content, so a test carrying a `prompt` lands as Single-Turn even inside a Multi-Turn set.
- `creation.md`, `telemachus-save-plan.j2`, `telemachus-guidelines.j2`: clarified that the plan records intent and the same value must be passed at creation, and added test type to what is shown before creating a test set.
- Normalised turn-type references to the canonical `Single-Turn` / `Multi-Turn` spelling, including pre-existing drift. Left alone the deliberate wrong-case examples that teach the model what to avoid, and descriptions of Penelope's multi-turn conversation mechanics, which are not type values.

## Additional Context

Docs, prompts, and one schema field description only. No behavior change.

Every documented field was verified against the real Pydantic schemas rather than assumed. This mattered: `build_input_schema` silently invents a phantom `{"type": "string"}` property for any YAML parameter name that does not match a real body field, so a typo would have shipped a fake parameter to the model.

On why the tool description carries a JSON example rather than relying on the schema: `build_input_schema` does produce the full `TestData` structure under `tests.items.properties`, but `_format_tools` (`sdk/src/rhesis/sdk/agents/base.py:455`) renders only top-level properties and `_schema_type` returns `array[object]` without recursing. The nested shape never reaches the model, so the description is the only channel. Two follow-ups would make this genuinely schema-driven: making `_format_tools` recurse into nested schemas, and typing `TestData.test_configuration` (currently `Dict[str, Any]`, so `MultiTurnTestConfig` is only reached by a runtime validator and never appears in the schema).

Known gap, deliberately out of scope: nothing prevents a mismatched set from being created by a non-agent API client. A validator on `TestSetBulkCreate` comparing each test's effective type against `test_set_type` would close it, but it interacts with the SDK's `_infer_test_set_type` (`sdk/src/rhesis/sdk/entities/test_set.py:1152`), which labels a set `Multi-Turn` if any test is multi-turn, so strict rejection could break imports of mixed CSV/JSONL files. Left for a separate PR.

## Testing

No automated tests, since this changes only prompt and documentation text plus one schema field description.

Verified manually:

- Both documented examples validate against the real schema: `TestSetBulkCreate.model_validate()` accepts the multi-turn payload and returns `test_type = Multi-Turn` with `prompt = None`, and accepts the single-turn payload.
- Every documented parameter name exists on the real models. `test_set_type` is confirmed present and required on `TestSetBulkCreate`; `test_type` and `test_configuration` are confirmed on `TestData`; `test_type` on `GenerateTestsRequest`.
- `build_save_plan_tool()` carries the new guidance with `enum: ['Single-Turn', 'Multi-Turn']`, and a Multi-Turn plan still round-trips through `ArchitectPlan.model_validate()`.
- `python scripts/skill/validate.py` passes, `mcp_tools.yaml` parses with all 48 tools intact, and `ruff check` and `ruff format --check` pass on `plan.py`.
