### PR TITLE
Fix single-turn Conversation tab showing Failed when metrics passed

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailConversationTab.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestDetailConversationTab.tsx
@@ -21,6 +21,7 @@ import {
   resolveConversationSummary,
 } from '@/utils/conversation-from-spans';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { getEffectiveTestResultStatus } from '@/utils/test-result-status';
 
 interface TestDetailConversationTabProps {
   test: TestResultDetail;
@@ -180,7 +181,9 @@ export default function TestDetailConversationTab({
         penelope_reasoning: '',
         penelope_message: test.test?.prompt?.content ?? '',
         target_response: test.test_output?.output ?? '',
-        success: test.test_output?.goal_evaluation?.all_criteria_met ?? false,
+        // Single-turn results have no goal_evaluation, so the turn status comes
+        // from the result status (review > backend status > metrics).
+        success: getEffectiveTestResultStatus(test) === 'Pass',
       },
     ];
 

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/__tests__/TestDetailConversationTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/__tests__/TestDetailConversationTab.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TestDetailConversationTab from '../TestDetailConversationTab';
+import type {
+  ConversationTurn,
+  TestResultDetail,
+} from '@/utils/api-client/interfaces/test-results';
+import type { UUID } from 'crypto';
+
+// ---- Stub children: only the summary handed to ConversationHistory matters ----
+
+let lastSummary: ConversationTurn[] = [];
+
+jest.mock('@/components/common/ConversationHistory', () => ({
+  __esModule: true,
+  default: ({
+    conversationSummary,
+  }: {
+    conversationSummary: ConversationTurn[];
+  }) => {
+    lastSummary = conversationSummary;
+    return null;
+  },
+}));
+
+jest.mock('@/app/(protected)/traces/components/TraceDrawer', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ data: null, status: 'unauthenticated' }),
+}));
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getTelemetryClient: () => ({
+      listTraces: jest.fn().mockResolvedValue({ traces: [] }),
+    }),
+    getFilesClient: () => ({ getSpanFiles: jest.fn().mockResolvedValue([]) }),
+  })),
+}));
+
+// ---- Fixtures ----
+
+const u = (n: number): UUID =>
+  `00000000-0000-0000-0000-${String(n).padStart(12, '0')}` as UUID;
+
+// Single-turn result: passing metric, and no goal_evaluation (multi-turn only).
+const makeSingleTurnResult = (
+  overrides: Partial<TestResultDetail> = {}
+): TestResultDetail =>
+  ({
+    id: u(1),
+    test_metrics: {
+      execution_time: 100,
+      metrics: {
+        'Non-English Deferral Compliance': {
+          score: 'Compliant Deferral',
+          reason: 'Refused in English and did not answer the request.',
+          backend: 'custom',
+          description: '',
+          is_successful: true,
+        },
+      },
+    },
+    test_output: { output: 'I am only able to provide assistance in English.' },
+    test: { prompt: { content: 'Pouvez-vous me donner des conseils ?' } },
+    status: { id: u(10), name: 'Pass' },
+    ...overrides,
+  }) as unknown as TestResultDetail;
+
+// ---- Tests ----
+
+describe('TestDetailConversationTab — single-turn turn status', () => {
+  beforeEach(() => {
+    lastSummary = [];
+  });
+
+  it('marks the turn passed when the result passed', () => {
+    render(<TestDetailConversationTab test={makeSingleTurnResult()} />);
+
+    expect(lastSummary).toHaveLength(1);
+    expect(lastSummary[0].success).toBe(true);
+  });
+
+  it('marks the turn failed when a metric failed', () => {
+    const test = makeSingleTurnResult({
+      test_metrics: {
+        execution_time: 100,
+        metrics: {
+          'Non-English Deferral Compliance': {
+            score: 'Answered Anyway',
+            reason: 'Answered the request in French.',
+            backend: 'custom',
+            description: '',
+            is_successful: false,
+          },
+        },
+      },
+      status: { id: u(11), name: 'Fail' },
+    } as unknown as Partial<TestResultDetail>);
+
+    render(<TestDetailConversationTab test={test} />);
+
+    expect(lastSummary[0].success).toBe(false);
+  });
+
+  it('follows a human review that overrides a failed result', () => {
+    const test = makeSingleTurnResult({
+      test_metrics: {
+        execution_time: 100,
+        metrics: {
+          'Non-English Deferral Compliance': {
+            score: 'Answered Anyway',
+            reason: 'Answered the request in French.',
+            backend: 'custom',
+            description: '',
+            is_successful: false,
+          },
+        },
+      },
+      status: { id: u(11), name: 'Fail' },
+      last_review: { status: { id: u(10), name: 'Pass' } },
+    } as unknown as Partial<TestResultDetail>);
+
+    render(<TestDetailConversationTab test={test} />);
+
+    expect(lastSummary[0].success).toBe(true);
+  });
+});


### PR DESCRIPTION
## Purpose

On a single-turn test result, the Conversation tab always showed a red **Failed** chip on Turn 1 — even when the Metrics tab reported 100% pass. Seen on test run `breezy-harrier` (`14mnJXITB6ut`), where the only metric, Non-English Deferral Compliance, passed but the turn header read Failed.

The single-turn branch derived the turn status from `test_output.goal_evaluation.all_criteria_met`. `goal_evaluation` is the multi-turn (Penelope) construct — a single-turn result never has one, so the `?? false` fallback hit every time. `ConversationHistory` then falls through human override → criteria → `turn.success`, and with no criteria either it rendered the hardcoded false as Failed.

Every other place that reads `all_criteria_met` guards it first (e.g. `getTestResultDisplayStatus` checks `isMultiTurn && test_output?.goal_evaluation` and otherwise computes from metrics). The Conversation tab was the one spot missing that guard.

## What Changed

- `TestDetailConversationTab` now derives the single-turn `success` flag from `getEffectiveTestResultStatus(test) === 'Pass'`, the same source the rest of the test-run UI uses. That honours, in order: a test-result-level human review, the backend status (which already accounts for metric and turn overrides), then the metric-based fallback.
- Added `__tests__/TestDetailConversationTab.test.tsx` covering the single-turn summary handed to `ConversationHistory`: passing metric → passed, failing metric → failed, and a human review that overrides a failed result → passed.

Multi-turn behaviour is untouched — that branch builds its summary from `resolveConversationSummary` and still uses per-turn criteria.

## Additional Context

- No backend change needed: the stored result was already correct (`is_successful: true`, status `Pass`). This was purely a display bug in the turn chip.
- The first new test fails on `main` and passes with the fix.

## Testing

- `npx jest TestDetailConversationTab` — 3 passing.
- `npx tsc --noEmit`, `npx eslint`, `npx prettier --check` on the touched files — all clean.
- Manually: open a single-turn test result in a test run where all metrics pass, go to the Conversation tab, and confirm Turn 1 now shows a green Passed chip matching the Metrics tab.

Note: the jest suite as a whole does not run on Node 26 locally — `jest.setup.js:109` (`delete window.location`) throws on every suite. That is pre-existing and unrelated to this change; CI on the supported Node version is unaffected.
