### PR TITLE
Route Claude Code worktrees through ./rh worktree

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,5 +5,27 @@
   },
   "enabledPlugins": {
     "ralph-loop@claude-plugins-official": true
+  },
+  "hooks": {
+    "WorktreeCreate": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/scripts/rh/worktree-hook.sh\" create"
+          }
+        ]
+      }
+    ],
+    "WorktreeRemove": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/scripts/rh/worktree-hook.sh\" remove"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -334,11 +334,11 @@ deepeval_telemetry.jsonl.gz.part
 # Cursor IDE
 .cursor/plans/
 
-# Playground
-playground/*
+# Playground — no trailing slash, so the symlink `./rh worktree` creates is ignored too
+/playground
 
-# Simulations
-simulations/
+# Simulations — as above, matches both the directory and a worktree's symlink
+/simulations
 
 # K8s files
 infrastructure/k8s/manifests/secrets/*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,28 @@ Backend and Python SDK: Python 3.10+, `uv` with `pyproject.toml`, Pydantic 2.x, 
   at the worktree root, and `./rh dev *` reads it from there. So don't assume 8080/3000 — run
   `./rh dev status` to see this checkout's ports, containers and offset.
 
+## Worktrees
+
+Every worktree must come from `./rh worktree`, never from a bare `git worktree add`. Only
+`./rh worktree` symlinks `playground/` and `simulations/` back to the main checkout, so notes
+written there survive the worktree being removed — they're gitignored, so nothing else preserves
+them. It also gives the worktree its own dev ports and container names; a worktree without
+`.rhesis-ports` shares the main checkout's stack, and `./rh dev clean` in one would delete main's
+dev database.
+
+The `WorktreeCreate` hook in `.claude/settings.json` handles this for you. It replaces Claude Code's
+git logic everywhere worktrees are created — `--worktree`, `isolation: worktree` subagents,
+background sessions, and the `EnterWorktree` tool — so **call `EnterWorktree` with a `name`
+normally** and it routes through `./rh worktree`. Don't pass `EnterWorktree` a path to work around
+it: paths under `~/worktrees/rhesis/` are only accepted from the main checkout, not from a session
+that's already in a worktree.
+
+Port blocks run out after 20 concurrent worktrees, so remove yours when done:
+
+```bash
+./rh worktree <name> --remove
+```
+
 ## Testing
 
 Tests live in `tests/backend/` and `tests/sdk/`, not next to source. See `apps/backend/AGENTS.md`

--- a/scripts/rh/worktree-hook.sh
+++ b/scripts/rh/worktree-hook.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# WorktreeCreate / WorktreeRemove hooks: route Claude Code's automatic worktrees
+# through `./rh worktree` so they get the shared playground/ and simulations/
+# symlinks, the .env symlinks, and their own block of dev ports.
+#
+# Without this, Claude creates bare worktrees under .claude/worktrees/ with an
+# empty playground/. Anything written there (domain docs, scratch notes) is lost
+# when the worktree is removed, because playground/ is gitignored.
+#
+# Contract (verified against the 2.1.227 binary, and see
+# https://code.claude.com/docs/en/hooks#worktreecreate):
+#
+#   create  — stdin carries `.name`. Print ONLY the worktree path on stdout.
+#             Any non-zero exit fails worktree creation, which kills the session
+#             outright, so every failure path here still yields a worktree.
+#   remove  — stdin carries `.worktree_path`, NOT `.name`. Once a WorktreeRemove
+#             hook is configured Claude Code skips its own `git worktree remove`,
+#             so if this doesn't remove the worktree, nothing does and the
+#             directory, branch, containers and port block all leak.
+
+set -uo pipefail
+
+action="${1:-}"
+payload="$(cat)"
+
+# Everything except the final path must go to stderr — stdout is the return value.
+log() { echo "$*" >&2; }
+
+# jq is not guaranteed on every machine, and exiting non-zero here would fail
+# session creation, so fall back to sed. Every field read is a flat string; the
+# leading quote in the pattern keeps `"name"` from matching `hook_event_name`.
+if command -v jq >/dev/null 2>&1; then
+    field() { printf '%s' "$payload" | jq -r ".$1 // empty" 2>/dev/null; }
+else
+    field() {
+        printf '%s' "$payload" |
+            sed -n 's/.*"'"$1"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1
+    }
+fi
+
+abs() { (cd "$1" 2>/dev/null && pwd); }
+
+# The hook's cwd may itself be a worktree (a worktree session spawning a subagent).
+# --git-common-dir always resolves to the main checkout's .git, so worktrees never
+# nest inside each other.
+main_checkout_from() {
+    local from common
+    from="$1"
+    [ -n "$from" ] && [ -d "$from" ] || return 1
+    common="$(git -C "$from" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 1
+    [ -n "$common" ] || return 1
+    dirname "$common"
+}
+
+main_checkout="$(main_checkout_from "$(field cwd)")" ||
+    main_checkout="$(main_checkout_from "$PWD")" || {
+    log "rh worktree hook: cannot locate the main checkout"
+    exit 1
+}
+
+# `./rh worktree` derives this from the repo root; mirror it rather than
+# re-deriving WORKTREES_BASE.
+worktrees_base="$main_checkout/../../worktrees/rhesis"
+
+branch_exists() { git -C "$main_checkout" show-ref --verify --quiet "refs/heads/$1"; }
+
+is_registered_worktree() {
+    git -C "$main_checkout" worktree list --porcelain 2>/dev/null |
+        grep -qxF "worktree $1"
+}
+
+# A worktree with no .rhesis-ports inherits RHESIS_PORT_OFFSET=0 and an empty
+# RHESIS_WORKTREE_NAME, which makes RHESIS_DEV_PREFIX `rhesis-dev` — the main
+# checkout's own stack. `./rh dev clean` there would delete main's dev database.
+# Naming the worktree is what prevents that; the offset is a separate problem.
+write_fallback_ports() {
+    local dir="$1" name="$2" wt_name
+    [ -f "$dir/.rhesis-ports" ] && return 0
+    wt_name="$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]' |
+        sed -E -e 's/[^a-z0-9]+/-/g' -e 's/^-+//' -e 's/-+$//')"
+    [ -n "$wt_name" ] || wt_name="hook"
+    printf 'RHESIS_PORT_OFFSET=0\nRHESIS_WORKTREE_NAME=%s\n' "$wt_name" >"$dir/.rhesis-ports"
+    log "rh worktree hook: no free port block — containers are namespaced as"
+    log "  rhesis-wt-${wt_name} but the ports collide with the main checkout."
+    log "  Don't run ./rh dev here; free a block with ./rh worktree <name> --remove."
+}
+
+link_shared_dirs() {
+    local dir="$1"
+    for shared in playground simulations; do
+        [ -d "$main_checkout/$shared" ] || continue
+        [ -e "$dir/$shared" ] && continue
+        ln -s "$main_checkout/$shared" "$dir/$shared" 2>/dev/null ||
+            log "rh worktree hook: could not symlink $shared/"
+    done
+}
+
+case "$action" in
+create)
+    name="$(field name)"
+    if [ -z "$name" ]; then
+        log "rh worktree hook: no .name in the WorktreeCreate payload"
+        exit 1
+    fi
+    # `./rh worktree --list` and friends print help and exit 0 without creating
+    # anything, which would leave us returning an empty path.
+    case "$name" in
+    -* | help | list)
+        log "rh worktree hook: '$name' is a ./rh worktree flag, not a usable name"
+        exit 1
+        ;;
+    esac
+
+    resolved="$(abs "$worktrees_base/$name")"
+
+    # Reusing an existing name is what Claude Code does natively, but only adopt
+    # the directory if git actually knows it as a worktree — a stale directory
+    # would otherwise be handed back as an isolated checkout it isn't.
+    if [ -n "$resolved" ]; then
+        is_registered_worktree "$resolved" ||
+            git -C "$main_checkout" worktree prune >/dev/null 2>&1
+        if is_registered_worktree "$resolved"; then
+            log "rh worktree hook: reusing existing worktree $name"
+            write_fallback_ports "$resolved" "$name"
+            link_shared_dirs "$resolved"
+            printf '%s\n' "$resolved"
+            exit 0
+        fi
+        # Claude Code would reject an unregistered directory anyway, so fail here
+        # with a message that says what to do instead of one that doesn't.
+        if rmdir "$resolved" 2>/dev/null; then
+            resolved=""
+        else
+            log "rh worktree hook: $resolved exists but is not a registered worktree."
+            log "  Remove it or pick another name."
+            exit 1
+        fi
+    fi
+
+    (cd "$main_checkout" && ./rh worktree "$name" >&2) ||
+        log "rh worktree hook: ./rh worktree failed, salvaging what it left behind"
+    resolved="$(abs "$worktrees_base/$name")"
+
+    # `./rh worktree` runs `git worktree add` before it allocates ports, so a
+    # port-exhaustion failure still leaves a usable worktree behind. Adopt it
+    # rather than trying to create it again.
+    if [ -z "$resolved" ]; then
+        mkdir -p "$(dirname "$worktrees_base/$name")" || exit 1
+        if branch_exists "$name"; then
+            git -C "$main_checkout" worktree add "$worktrees_base/$name" "$name" >&2 || exit 1
+        else
+            git -C "$main_checkout" worktree add -b "$name" "$worktrees_base/$name" >&2 || exit 1
+        fi
+        resolved="$(abs "$worktrees_base/$name")"
+    fi
+
+    if [ -z "$resolved" ]; then
+        log "rh worktree hook: no worktree directory to return for $name"
+        exit 1
+    fi
+
+    write_fallback_ports "$resolved" "$name"
+    link_shared_dirs "$resolved"
+    printf '%s\n' "$resolved"
+    ;;
+
+remove)
+    worktree_path="$(field worktree_path)"
+    if [ -z "$worktree_path" ]; then
+        log "rh worktree hook: no .worktree_path in the WorktreeRemove payload"
+        exit 1
+    fi
+
+    if [ ! -d "$worktree_path" ]; then
+        log "rh worktree hook: $worktree_path already gone"
+        git -C "$main_checkout" worktree prune >&2 2>/dev/null
+        exit 0
+    fi
+
+    resolved="$(abs "$worktree_path")"
+    base_resolved="$(abs "$worktrees_base")"
+
+    # Only `./rh worktree --remove` also tears down the dev containers, volumes
+    # and tmux session, but it addresses worktrees by name relative to its base.
+    # Strip the base rather than using basename, so nested slugs like `feat/foo`
+    # survive.
+    name=""
+    if [ -n "$base_resolved" ] && [ "${resolved#"$base_resolved"/}" != "$resolved" ]; then
+        name="${resolved#"$base_resolved"/}"
+    fi
+
+    if [ -n "$name" ]; then
+        (cd "$main_checkout" && ./rh worktree "$name" --remove >&2) ||
+            log "rh worktree hook: ./rh worktree --remove failed for $name"
+    else
+        log "rh worktree hook: $resolved is outside $base_resolved, removing with git"
+        git -C "$main_checkout" worktree remove --force "$resolved" >&2 ||
+            log "rh worktree hook: git worktree remove failed for $resolved"
+    fi
+
+    # Claude Code treats a zero exit as "removed" and reports it to the user, so
+    # only claim success if the directory is actually gone.
+    if [ -d "$resolved" ]; then
+        log "rh worktree hook: $resolved is still present"
+        exit 1
+    fi
+    ;;
+
+*)
+    log "rh worktree hook: expected 'create' or 'remove', got '${action:-<empty>}'"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Purpose

Claude Code creates worktrees on its own — for `--worktree`, for `isolation: worktree` subagents, for background sessions, and for the `EnterWorktree` tool. Those worktrees are bare `git worktree add` checkouts under `.claude/worktrees/`, so `playground/` starts empty and local instead of pointing at the main checkout. Because `playground/` is gitignored, anything an agent writes there is destroyed when the worktree is removed and nothing preserves it.

This is not hypothetical. A `/grill-with-docs` session wrote a full release-vocabulary glossary to `playground/CONTEXT.md` inside an agent worktree, and it was lost with the worktree — the content had to be recovered from the session transcript. The same applies to `simulations/`, and to dev ports: a worktree without `.rhesis-ports` inherits offset 0 and an empty worktree name, which resolves `RHESIS_DEV_PREFIX` to `rhesis-dev` — the main checkout's own stack. Running `./rh dev clean` in such a worktree deletes main's dev database.

`./rh worktree` already solves all of this. The problem was only that Claude Code never called it.

## What Changed

- **`scripts/rh/worktree-hook.sh`** (new): a `WorktreeCreate` / `WorktreeRemove` hook that replaces Claude Code's git logic with `./rh worktree`, so every automatically created worktree gets the shared `playground/` and `simulations/` symlinks, the `.env` symlinks, and its own block of dev ports.
- **`.claude/settings.json`**: registers both hooks via `$CLAUDE_PROJECT_DIR`.
- **`.gitignore`**: `playground/*` → `/playground` and `simulations/` → `/simulations`. A trailing slash matches directories only, and git treats a symlink as a file, so neither old pattern could ever ignore the symlink `./rh worktree` creates — every worktree showed `?? playground` in `git status`. The leading slash anchors to the repo root so the tracked `apps/frontend/src/app/(protected)/playground/` tree is unaffected.
- **`AGENTS.md`**: a Worktrees section recording that `./rh worktree` is the only supported way to create one, and why.

The hook resolves the main checkout with `git rev-parse --git-common-dir` rather than trusting its cwd, so a worktree session that spawns a subagent does not nest worktrees inside worktrees. Several failure paths needed care, because a non-zero exit from `WorktreeCreate` fails session creation outright:

- `WorktreeRemove` receives `worktree_path`, not `name`, and once a `WorktreeRemove` hook is configured Claude Code skips its own `git worktree remove` fallback. If the hook does not remove the worktree, nothing does — the directory, branch, containers and port block all leak, and the 20-block port ceiling eventually breaks worktree creation for everything.
- `worktree_create` in `scripts/rh/worktree.sh` runs `git worktree add` before it allocates ports, so port exhaustion leaves a usable worktree behind. The hook adopts it instead of trying to create it again.
- A salvaged worktree gets a `.rhesis-ports` naming it, so its containers are namespaced `rhesis-wt-<name>` and `./rh dev clean` cannot reach main's volumes. Ports still collide in that state, and the hook says so loudly on stderr.
- `jq` is not a hard dependency; the hook falls back to `sed` rather than failing session creation on a machine without it.

## Additional Context

- The [worktrees documentation](https://code.claude.com/docs/en/worktrees#customize-worktree-creation) lists `WorktreeCreate` as firing for `--worktree`, `isolation: worktree` and background sessions, and does not mention `EnterWorktree`. That is incomplete: in the 2.1.227 binary all three call sites of the hook executor are guarded by `hasWorktreeCreateHook()`, and one of them is the `EnterWorktree` tool. So `EnterWorktree` with a `name` routes through this hook too, which is why `AGENTS.md` tells agents to keep using it normally rather than passing a path — paths outside `.claude/worktrees/` are rejected from a session that is already in a worktree.
- Hooks are read at session start, so this takes effect in new sessions, and Claude Code may ask you to trust the hook the first time.
- Port blocks cap at 20 concurrent worktrees (`RHESIS_OFFSET_MAX=200`, step 10). Past that the hook still hands back a working worktree with the playground symlink, just without its own ports.

## Testing

The hook was exercised directly with real payloads, from the main checkout:

```bash
# create, including a nested slug
printf '{"hook_event_name":"WorktreeCreate","name":"nest/deep-probe","cwd":"'"$PWD"'"}' \
  | ./scripts/rh/worktree-hook.sh create
# -> prints only /Users/<you>/worktrees/rhesis/nest/deep-probe on stdout

# remove, using the real payload shape
printf '{"hook_event_name":"WorktreeRemove","worktree_path":"<path from above>","cwd":"'"$PWD"'"}' \
  | ./scripts/rh/worktree-hook.sh remove
```

Confirmed in the created worktree: `playground -> <main>/playground`, stdout is exactly one path line with all `rh` output on stderr, and re-running `create` on an existing name reuses it. Confirmed on remove: worktree and branch gone, exit 0, idempotent on a second call, nested slugs resolved via base-prefix stripping rather than `basename`, and all files in the real `playground/` intact afterwards — the symlink is not followed.

For the salvage path, a bare `git worktree add` (no `.rhesis-ports`, simulating post-port-exhaustion state) was handed to `create`: it warned, wrote `.rhesis-ports` naming the worktree, and `./rh dev status` there then reported `Worktree: probe2 (offset 0)` instead of main's stack.

For the `.gitignore` change: `?? playground` no longer appears in a worktree's `git status`, `git check-ignore -v playground` reports `/playground`, and `apps/frontend/src/app/(protected)/playground/NewFile.tsx` is still not ignored. A scratch repo confirmed `/playground` continues to ignore `playground/CONTEXT.md` while leaving a nested `apps/playground/Real.tsx` alone.

End-to-end firing by Claude Code itself was not tested, since hooks load at session start.
