### PR TITLE
Prevent Architect tool-call failures on the first attempt

### DIFF
--- a/apps/backend/src/rhesis/backend/app/mcp_server/local_tools.py
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/local_tools.py
@@ -9,9 +9,10 @@ Auth is handled via a delegation token passed as a Bearer header,
 so tenant isolation is preserved without requiring a static API key.
 """
 
+import asyncio
 import json
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import httpx
 
@@ -27,6 +28,11 @@ from .tools import (
 )
 
 logger = logging.getLogger(__name__)
+
+# One retry is enough for the blips this is aimed at. More would stall the
+# turn behind a genuinely broken dependency.
+_TRANSIENT_RETRIES = 1
+_RETRY_DELAY_SECONDS = 0.5
 
 
 class LocalToolProvider(MCPTool):
@@ -133,53 +139,63 @@ class LocalToolProvider(MCPTool):
         if body is None and op.get("has_body"):
             body = {}
 
-        try:
-            # ASGITransport runs the route on the caller's loop — for the
-            # architect that is the SDK background loop. Keep LLM-touching
-            # handlers sync `def` so FastAPI offloads them to its threadpool;
-            # an `async def` one reaching a run_sync bridge would deadlock it.
-            transport = httpx.ASGITransport(app=self._app)
-            async with httpx.AsyncClient(transport=transport, base_url="http://internal") as client:
-                response = await client.request(
-                    method=op["method"],
-                    url=path,
-                    headers=headers,
-                    params=query,
-                    json=body,
-                )
+        # A blip (broker hiccup, pool exhaustion, dropped connection) would
+        # otherwise surface to the agent as a permanent failure and cost it a
+        # whole ReAct iteration to re-plan around. Only retried for server-side
+        # and transport faults — a 4xx is the agent's own mistake and repeating
+        # it verbatim just fails again.
+        last_error: Optional[str] = None
+        for attempt in range(_TRANSIENT_RETRIES + 1):
+            if attempt:
+                await asyncio.sleep(_RETRY_DELAY_SECONDS)
+                logger.info("Retrying tool %s after transient failure", tool_name)
 
-            if response.status_code >= 400:
-                try:
-                    detail = response.json()
-                except Exception:
-                    detail = response.text
-                return ToolResult(
-                    tool_name=tool_name,
-                    success=False,
-                    error=json.dumps(
+            try:
+                # ASGITransport runs the route on the caller's loop — for the
+                # architect that is the SDK background loop. Keep LLM-touching
+                # handlers sync `def` so FastAPI offloads them to its threadpool;
+                # an `async def` one reaching a run_sync bridge would deadlock it.
+                transport = httpx.ASGITransport(app=self._app)
+                async with httpx.AsyncClient(
+                    transport=transport, base_url="http://internal"
+                ) as client:
+                    response = await client.request(
+                        method=op["method"],
+                        url=path,
+                        headers=headers,
+                        params=query,
+                        json=body,
+                    )
+
+                if response.status_code >= 400:
+                    try:
+                        detail = response.json()
+                    except Exception:
+                        detail = response.text
+                    last_error = json.dumps(
                         {
                             "status_code": response.status_code,
                             "detail": detail,
                         },
                         default=str,
-                    ),
+                    )
+                    if response.status_code >= 500:
+                        continue
+                    return ToolResult(tool_name=tool_name, success=False, error=last_error)
+
+                try:
+                    data = response.json()
+                except Exception:
+                    data = response.text
+                formatted = format_list_response(data, page_size, current_skip)
+                return ToolResult(
+                    tool_name=tool_name,
+                    success=True,
+                    content=json.dumps(formatted, default=str),
                 )
 
-            try:
-                data = response.json()
-            except Exception:
-                data = response.text
-            formatted = format_list_response(data, page_size, current_skip)
-            return ToolResult(
-                tool_name=tool_name,
-                success=True,
-                content=json.dumps(formatted, default=str),
-            )
+            except Exception as e:
+                logger.error("Local tool execution failed: %s", e, exc_info=True)
+                last_error = str(e)
 
-        except Exception as e:
-            logger.error("Local tool execution failed: %s", e, exc_info=True)
-            return ToolResult(
-                tool_name=tool_name,
-                success=False,
-                error=str(e),
-            )
+        return ToolResult(tool_name=tool_name, success=False, error=last_error)

--- a/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
+++ b/apps/backend/src/rhesis/backend/app/mcp_server/mcp_tools.yaml
@@ -31,6 +31,21 @@ tools:
     description: >
       Create a new project to organize test suites. A project groups
       related test sets, test configurations, and test runs.
+    parameters:
+      name:
+        description: "REQUIRED. Project name (string)."
+      description:
+        description: "What this project covers (string)."
+      project_id:
+        description: >
+          Omit. The project scope is taken from the request, not from
+          this field.
+      is_active:
+        description: "Omit. New projects are active by default."
+      icon:
+        description: "Omit unless the user asked for a specific icon."
+      attributes:
+        description: "Omit. Free-form storage, not used by test generation."
 
   # ── Test Sets ─────────────────────────────────────────────
   - name: list_test_sets
@@ -103,6 +118,10 @@ tools:
     parameters:
       name:
         description: "Test set name (required, string)"
+      project_id:
+        description: >
+          Omit. The project scope is taken from the request, not from
+          this field.
       description:
         description: "Detailed description of the test set's purpose (string)"
       short_description:
@@ -119,27 +138,25 @@ tools:
           a string like "High" or "Low". Omit if unsure.
       tests:
         description: >
-          REQUIRED array of test objects (must not be empty). The object
-          format depends on the test type.
+          REQUIRED array of test objects (must not be empty). The item
+          fields are listed below; two things the schema cannot express:
 
-          Single-Turn test: {"prompt": {"content": "the test prompt
-          text", "language_code": "en", "expected_response": "optional
-          expected answer"}, "behavior": "behavior name", "category":
-          "category name", "topic": "topic name"}.
+          1. A Single-Turn test carries "prompt". A Multi-Turn test sets
+          test_type to "Multi-Turn" and carries "test_configuration"
+          INSTEAD of prompt — never send both on the same test. The
+          test_configuration object takes: goal (required — what the
+          target SHOULD do), instructions (how to conduct the test),
+          restrictions (what the target MUST NOT do), scenario (context
+          and persona) and max_turns (integer, e.g. 10).
 
-          Multi-Turn test: {"test_type": "Multi-Turn",
-          "test_configuration": {"goal": "what the target SHOULD do
-          (required)", "instructions": "how to conduct the test
-          (optional)", "restrictions": "what the target MUST NOT do
-          (optional)", "scenario": "context and persona (optional)",
-          "max_turns": 10}, "behavior": "behavior name", "category":
-          "category name", "topic": "topic name"}. Multi-Turn tests
-          use test_configuration instead of prompt — do NOT send both.
-
-          behavior/category/topic are plain-text names (not UUIDs) —
-          the server resolves or creates them automatically. Use
-          list_behaviors, list_categories, and list_topics to discover
-          existing values first.
+          2. behavior, category and topic are plain-text names, not
+          UUIDs — the server resolves or creates them automatically. Use
+          list_behaviors, list_categories and list_topics to reuse
+          existing values rather than inventing near-duplicates.
+      metadata:
+        description: >
+          Omit. Free-form storage the synthesizers use to record how a
+          test set was produced.
 
   - name: generate_test_set
     label: Generating test set
@@ -168,23 +185,26 @@ tools:
     parameters:
       config:
         description: >
-          REQUIRED. Object with generation parameters:
-          - generation_prompt (string): Describe WHAT to test and HOW
-            (e.g. "Generate tests that verify the travel agent provides
-            accurate destination info, handles ambiguous queries, and
-            refuses off-topic requests"). Be specific — the synthesizer
-            uses this to craft test prompts.
-          - behaviors (list of strings): REQUIRED. Behavior names the
-            tests should target (e.g. ["Provides Accurate Information",
-            "Refuses Off-Topic Requests"]). At least one is required.
-          - categories (list of strings): Optional category names
-            (e.g. ["Functional", "Safety"]).
-          - topics (list of strings): Optional topic names
-            (e.g. ["Travel advisory", "Booking"]).
+          REQUIRED. Generation parameters. Be specific in
+          generation_prompt (e.g. "Generate tests that verify the travel
+          agent provides accurate destination info, handles ambiguous
+          queries, and refuses off-topic requests") — the synthesizer
+          uses it to craft the test prompts. behaviors takes behavior
+          names, e.g. ["Provides Accurate Information", "Refuses
+          Off-Topic Requests"]; categories and topics take names too,
+          e.g. ["Functional", "Safety"] and ["Travel advisory",
+          "Booking"].
       num_tests:
         description: >
           Number of tests to generate (integer, default 5). Typical
           range: 3–20 per test set.
+      batch_size:
+        description: >
+          Omit unless you have a reason to change it. Defaults to 20.
+      project_id:
+        description: >
+          Omit. The project scope is taken from the request, not from
+          this field.
       test_type:
         description: >
           "Single-Turn" or "Multi-Turn". MUST match the plan's
@@ -442,11 +462,20 @@ tools:
       (with its description) instead of auto-creating a description-less
       one. Do NOT send server-managed fields (id, user_id, organization_id,
       created_at, updated_at).
+      Behavior names are unique per organization. Creating one that
+      already exists fails with "Behavior with this name already exists".
+      Call list_behaviors first and reuse the existing id — do NOT retry
+      with a suffixed name like "Refuses Harmful Requests 2", which
+      creates a near-duplicate nobody wants.
     parameters:
       name:
         description: "REQUIRED. Behavior name (string, e.g. 'Refuses harmful requests')."
       description:
         description: "REQUIRED. Explain what this behavior means and how it should be evaluated."
+      project_id:
+        description: >
+          Omit. The project scope is taken from the request, not from
+          this field.
 
   # ── Categories & Topics ───────────────────────────────────
   - name: list_categories
@@ -536,9 +565,27 @@ tools:
       Sending only name + evaluation_prompt + score_type produces a
       threadbare metric and is a bug, not a shortcut. Fill every field you
       have grounds to fill.
+
+      FIELDS REQUIRED BY score_type — the schema cannot express this, so
+      read it here. When score_type is "numeric" you MUST also send
+      min_score, max_score AND threshold; omitting any one is rejected.
+      When score_type is "categorical" you MUST also send categories (at
+      least two labels) AND passing_categories (at least one, each of
+      which must also appear in categories). Send the numeric fields only
+      for numeric metrics and the category fields only for categorical
+      ones.
+
+      Metric names are unique per organization. Creating one that already
+      exists fails with "Metric with this name already exists". Call
+      list_metrics first and reuse the existing id, or use improve_metric
+      to change it — do NOT retry with a suffixed name.
     parameters:
       name:
         description: "Metric name, unique within the organization (required, string)"
+      project_id:
+        description: >
+          Omit. The project scope is taken from the request, not from
+          this field.
       description:
         description: >
           REQUIRED IN PRACTICE. One or two sentences on what this metric
@@ -574,8 +621,10 @@ tools:
           this field.
       score_type:
         description: >
-          REQUIRED. Must be exactly "numeric" or "categorical" (string
-          enum). No other values are accepted.
+          REQUIRED. Use "numeric" or "categorical". The third value the
+          schema still lists, "binary", is legacy and was migrated to
+          "categorical" — do not use it. Decides which other fields are
+          required; see the conditional rules in this tool's description.
       evaluation_prompt:
         description: >
           REQUIRED. The prompt template used to evaluate endpoint
@@ -583,20 +632,42 @@ tools:
           {{expected_response}} placeholders (string).
       metric_scope:
         description: >
-          REQUIRED, and rejected if missing or empty. Non-empty list of
-          strings, each exactly "Single-Turn" or "Multi-Turn". This decides
+          REQUIRED, and rejected if missing or empty. Non-empty list, each
+          entry exactly "Single-Turn" or "Multi-Turn". This decides
           which tests the metric is evaluated against: a Single-Turn metric
           is skipped on Multi-Turn tests and vice versa, so a wrong value
           means the metric silently never runs. Use ["Multi-Turn"] for
           conversation-level metrics, ["Single-Turn"] for single
           request-response metrics, and both only when the metric genuinely
           works either way.
+      reference_score:
+        description: "Deprecated. Omit — use categories instead."
+      class_name:
+        description: "Omit. Only used by built-in provider-backed metrics."
+      ground_truth_required:
+        description: >
+          Set true only when the metric cannot be scored without the
+          test's expected_response. Defaults to false.
+      context_required:
+        description: >
+          Set true only when the metric needs retrieved context to score
+          the response. Defaults to false.
+      evaluation_examples:
+        description: >
+          Optional worked examples showing how to score borderline cases.
+          Free text; helps the judge stay consistent.
       min_score:
-        description: "Minimum score value, number (numeric metrics only)"
+        description: >
+          Minimum score value, number. REQUIRED when score_type is
+          "numeric"; omit for categorical metrics.
       max_score:
-        description: "Maximum score value, number (numeric metrics only)"
+        description: >
+          Maximum score value, number. REQUIRED when score_type is
+          "numeric"; omit for categorical metrics.
       threshold:
-        description: "Pass/fail threshold, number (numeric metrics only)"
+        description: >
+          Pass/fail threshold, number. REQUIRED when score_type is
+          "numeric"; omit for categorical metrics.
       threshold_operator:
         description: >
           Comparison operator for the threshold. Must be exactly one of:
@@ -604,13 +675,15 @@ tools:
           Only used for numeric metrics.
       categories:
         description: >
-          List of category label strings (categorical metrics only).
-          Must be a non-empty list when score_type is "categorical".
+          List of category label strings. REQUIRED when score_type is
+          "categorical" and must contain at least two labels; omit for
+          numeric metrics.
       passing_categories:
         description: >
-          Subset of categories that indicate a pass (categorical metrics
-          only). Must be a non-empty list of strings that also appear in
-          "categories".
+          Subset of categories that indicate a pass. REQUIRED when
+          score_type is "categorical" and must contain at least one
+          string, each of which also appears in "categories"; omit for
+          numeric metrics.
 
   - name: generate_metric
     label: Generating metric
@@ -630,6 +703,10 @@ tools:
           REQUIRED. Natural-language description of what the metric
           should evaluate (e.g. "measure whether responses are factually
           accurate, on a 1-5 numeric scale").
+      project_id:
+        description: >
+          Omit. The project scope is taken from the request, not from
+          this field.
 
   - name: improve_metric
     label: Improving metric
@@ -649,6 +726,10 @@ tools:
           REQUIRED. Natural-language instructions describing what to change
           (e.g. "lower the threshold to 2", "switch to categorical with
           pass/fail categories").
+      project_id:
+        description: >
+          Omit. The project scope is taken from the request, not from
+          this field.
 
   - name: update_metric
     label: Updating metric
@@ -1123,6 +1204,10 @@ tools:
         description: "REQUIRED. Source title (string)."
       description:
         description: "Optional description of the source (string)."
+      project_id:
+        description: >
+          Omit. The project scope is taken from the request, not from
+          this field.
       content:
         description: >
           Raw text content for Manual-type sources. Use when the user
@@ -1136,6 +1221,8 @@ tools:
         description: >
           REQUIRED. UUID of the source type. Copy from list_sources on an
           existing source of the same type (check source_type_id field).
+      source_metadata:
+        description: "Omit. Free-form storage, not used by test generation."
 
   # ── Tags ────────────────────────────────────────────────
   - name: list_tags

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -277,9 +277,7 @@ async def generate_tests_endpoint(
         GenerateTestsResponse: The generated test cases
     """
     try:
-        # Validate config
-        if not request.config.behaviors:
-            raise HTTPException(status_code=400, detail="At least one behavior must be specified")
+        # config.behaviors is enforced by GenerationConfig, so it arrives non-empty.
 
         # Validate per-request model override exists and belongs to user's org
         model_id_str = str(request.model_id) if request.model_id else None

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -127,13 +127,9 @@ def generate_test_set(
         Task information including task ID and estimated test count
     """
     try:
-        # Validate config
-        if not request.config.behaviors:
-            raise HTTPException(status_code=400, detail="At least one behavior must be specified")
-
-        name = (request.name or "").strip()
-        if not name:
-            raise HTTPException(status_code=400, detail="A test set name is required")
+        # config.behaviors and name are enforced by TestSetGenerationRequest,
+        # so they arrive non-empty and already stripped.
+        name = request.name
 
         # Callers that already scope the request (the X-Project-Id header, or a
         # project-bound API token) need not repeat the project in the body.

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -14,6 +14,7 @@ from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.crud import metric as metric_crud
 from rhesis.backend.app.dependencies import (
+    get_project_context,
     get_tenant_context,
     get_tenant_db_session,
 )
@@ -102,10 +103,11 @@ def resolve_test_set_or_raise(identifier: str, db: Session, organization_id: str
     "/generate", response_model=TestSetGenerationResponse, **capability(Permission.TestSet.GENERATE)
 )
 def generate_test_set(
-    request: services_schemas.GenerateTestsRequest,
+    request: services_schemas.TestSetGenerationRequest,
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
+    scoped_project_id: Optional[str] = Depends(get_project_context),
     _validate_model=Depends(validate_generation_model),
 ):
     """
@@ -118,6 +120,8 @@ def generate_test_set(
         request: Unified generation request with config, num_tests, sources
         db: Database session
         current_user: Current authenticated user
+        scoped_project_id: Project resolved from the request scope, used when
+            the body omits project_id
 
     Returns:
         Task information including task ID and estimated test count
@@ -131,20 +135,25 @@ def generate_test_set(
         if not name:
             raise HTTPException(status_code=400, detail="A test set name is required")
 
-        if not request.project_id:
+        # Callers that already scope the request (the X-Project-Id header, or a
+        # project-bound API token) need not repeat the project in the body.
+        project_id = str(request.project_id) if request.project_id else scoped_project_id
+        if not project_id:
             raise HTTPException(
                 status_code=400,
-                detail="A project_id is required to generate a test set",
+                detail=(
+                    "A project_id is required to generate a test set. "
+                    "Send it in the request body or scope the request with "
+                    "the X-Project-Id header."
+                ),
             )
-
-        test_type = request.test_type
 
         # Resolve TestSetType for the pending row
         from rhesis.backend.app.constants import TestSetType as TestSetTypeEnum
 
-        resolved_type = (
-            TestSetTypeEnum.from_string(test_type) if test_type else TestSetTypeEnum.SINGLE_TURN
-        )
+        resolved_type = request.test_type or TestSetTypeEnum.SINGLE_TURN
+        # The Celery task and its downstream synthesizers expect the plain string.
+        test_type = resolved_type.value
 
         # Pre-create a placeholder task_id so we can stamp the test set before launching
         import uuid as _uuid
@@ -157,7 +166,7 @@ def generate_test_set(
             name=name,
             organization_id=str(current_user.organization_id),
             user_id=str(current_user.id),
-            project_id=str(request.project_id),
+            project_id=project_id,
             task_id=placeholder_task_id,
             requested_tests=request.num_tests,
             test_type=resolved_type,

--- a/apps/backend/src/rhesis/backend/app/schemas/services.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/services.py
@@ -1,8 +1,15 @@
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional
+from typing import Annotated, Any, Dict, List, Literal, Optional
 
-from pydantic import UUID4, BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    UUID4,
+    BaseModel,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
 
 from rhesis.backend.app.constants import TestSetType
 
@@ -108,7 +115,10 @@ class TestSetGenerationRequest(GenerateTestsRequest):
     the OpenAPI schema and, through it, MCP clients and the Architect agent.
     """
 
-    name: str = Field(..., min_length=1)
+    # Stripped before the length check, so a whitespace-only name is rejected
+    # as a 422 here rather than a 400 further in. The router then uses the
+    # value as-is.
+    name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
 class TestPrompt(BaseModel):

--- a/apps/backend/src/rhesis/backend/app/schemas/services.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/services.py
@@ -16,7 +16,10 @@ class GenerationConfig(BaseModel):
     """
 
     generation_prompt: Optional[str] = None  # Describe what you want to test
-    behaviors: Optional[List[str]] = None  # Behaviors to test
+    # Required, not optional: both generation routes already reject an empty list
+    # with a 400. Declaring it here puts the requirement in the OpenAPI schema,
+    # which is what MCP clients and the Architect agent read.
+    behaviors: List[str] = Field(..., min_length=1)  # Behaviors to test
     categories: Optional[List[str]] = None  # Test categories
     topics: Optional[List[str]] = None  # Topics to cover
     additional_context: Optional[str] = None  # Additional context (JSON string)
@@ -77,9 +80,11 @@ class GenerateTestsRequest(BaseModel):
     batch_size: int = 20
     sources: Optional[List[SourceData]] = None
     name: Optional[str] = None  # Used only for bulk generation to name the test set
-    test_type: Optional[str] = TestSetType.SINGLE_TURN.value
+    # Typed as the enum so the allowed values appear in the OpenAPI schema. The
+    # before-validator below still accepts snake_case and loose casing.
+    test_type: Optional[TestSetType] = TestSetType.SINGLE_TURN
     model_id: Optional[UUID4] = None  # Override user's default generation model for this request
-    project_id: Optional[UUID4] = None  # Required for bulk generation via /test_sets/generate
+    project_id: Optional[UUID4] = None  # Falls back to the request's project scope
 
     @field_validator("test_type", mode="before")
     @classmethod
@@ -93,6 +98,17 @@ class GenerateTestsRequest(BaseModel):
             valid = [t.value for t in TestSetType]
             raise ValueError(f"Unsupported test_type {v!r}. Valid values: {valid}")
         return resolved.value
+
+
+class TestSetGenerationRequest(GenerateTestsRequest):
+    """Bulk generation via ``POST /test_sets/generate``.
+
+    Unlike the sampling route, this one persists a test set, so it needs a name.
+    Declared here rather than checked in the router so the requirement reaches
+    the OpenAPI schema and, through it, MCP clients and the Architect agent.
+    """
+
+    name: str = Field(..., min_length=1)
 
 
 class TestPrompt(BaseModel):

--- a/apps/backend/src/rhesis/backend/app/schemas/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_set.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator
 
+from rhesis.backend.app.constants import TestSetType, TestType
 from rhesis.backend.app.schemas import Base
 from rhesis.backend.app.schemas.references import StatusReference, TypeLookupReference
 from rhesis.backend.app.schemas.tag import Tag, TagRead
@@ -87,7 +88,9 @@ class TestData(BaseModel):
     behavior: str
     category: str
     topic: str
-    test_type: Optional[str] = None
+    # Typed as the enum so the two legal values appear in the OpenAPI schema.
+    # The before-validator keeps accepting loose casing from existing clients.
+    test_type: Optional[TestType] = None
     test_configuration: Optional[Dict[str, Any]] = None
     assignee_id: Optional[UUID4] = None
     owner_id: Optional[UUID4] = None
@@ -95,7 +98,7 @@ class TestData(BaseModel):
     priority: Optional[int] = None
     metadata: Optional[Dict[str, Any]] = {}
 
-    @field_validator("test_type")
+    @field_validator("test_type", mode="before")
     @classmethod
     def validate_test_type(cls, v: Optional[str]) -> Optional[str]:
         from rhesis.backend.app.schemas.validators import format_test_type
@@ -149,7 +152,9 @@ class TestSetBulkCreate(BaseModel):
     name: str
     description: Optional[str] = None
     short_description: Optional[str] = None
-    test_set_type: str
+    # Typed as the enum so the two legal values appear in the OpenAPI schema.
+    # The before-validator keeps accepting loose casing from existing clients.
+    test_set_type: TestSetType
     owner_id: Optional[UUID4] = None
     assignee_id: Optional[UUID4] = None
     priority: Optional[int] = None
@@ -157,7 +162,7 @@ class TestSetBulkCreate(BaseModel):
     tests: List[TestData]
     metadata: Optional[Dict[str, Any]] = None
 
-    @field_validator("test_set_type")
+    @field_validator("test_set_type", mode="before")
     @classmethod
     def validate_test_set_type(cls, v: str) -> str:
         from rhesis.backend.app.schemas.validators import format_test_set_type

--- a/sdk/src/rhesis/sdk/agents/architect/agent.py
+++ b/sdk/src/rhesis/sdk/agents/architect/agent.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple, Union
 
 from pydantic import ValidationError
 
+from rhesis.sdk.agents.arg_validation import find_missing_arguments
 from rhesis.sdk.agents.base import BaseAgent, BaseTool, MCPTool
 from rhesis.sdk.agents.constants import (
     Action,
@@ -166,6 +167,10 @@ class ArchitectAgent(BaseAgent):
         self._creation_approved: bool = False
         self._confirming_tools: FrozenSet[str] = frozenset()
         self._mutating_tools: Optional[FrozenSet[str]] = None
+        # Populated by get_available_tools(); empty until the first call,
+        # which makes the pre-dispatch check a no-op rather than a false
+        # rejection.
+        self._tool_schemas: Dict[str, Any] = {}
         self._auto_approve_all: bool = False
         self._blocked_this_turn: bool = False
 
@@ -461,6 +466,10 @@ class ArchitectAgent(BaseAgent):
         tools.append(self._SAVE_PLAN_TOOL)
         tools.append(self._AWAIT_TASK_TOOL)
 
+        # Kept so execute_tool can check arguments against the same schema
+        # the LLM was shown, before paying for an HTTP round trip.
+        self._tool_schemas = {t["name"]: t.get("inputSchema") for t in tools}
+
         if self._mutating_tools is None:
             self._mutating_tools = self._classify_mutating(tools)
             logger.debug(
@@ -728,7 +737,14 @@ class ArchitectAgent(BaseAgent):
         if tool_call.tool_name == InternalTool.AWAIT_TASK:
             return await self._execute_await_task(tool_call)
 
-        error = self._check_plan_constraints(tool_call) or self._validate_tool_arguments(tool_call)
+        error = (
+            self._check_plan_constraints(tool_call)
+            or self._validate_tool_arguments(tool_call)
+            or find_missing_arguments(
+                tool_call.arguments,
+                self._tool_schemas.get(tool_call.tool_name),
+            )
+        )
         if error:
             logger.warning(
                 "[Architect] Rejected tool %s: %s",
@@ -1656,9 +1672,15 @@ class ArchitectAgent(BaseAgent):
         for step in exec_window:
             reasoning_preview = step.reasoning[: cfg.reasoning_preview_chars]
             parts.append(f"[Tool iteration {step.iteration}] Reasoning: {reasoning_preview}")
-            if step.tool_calls:
-                for tc in step.tool_calls:
-                    parts.append(f"  Called: {tc.tool_name}")
+            for i, tc in enumerate(step.tool_calls):
+                line = f"  Called: {tc.tool_name}"
+                # Echo the payload back only when the call failed. Without it
+                # the model sees the rejection but not what it sent, so it
+                # cannot tell which argument to change and retries blind.
+                if self._call_failed(step, i) and tc.arguments:
+                    preview = self._preview_args(tc.arguments, limit=cfg.failed_args_preview_chars)
+                    line += f" with arguments: {preview}"
+                parts.append(line)
             if step.tool_results:
                 for tr in step.tool_results:
                     rendered = self._render_tool_result(
@@ -1670,3 +1692,15 @@ class ArchitectAgent(BaseAgent):
                         parts.append(rendered)
 
         return "\n".join(parts) if parts else ""
+
+    @staticmethod
+    def _call_failed(step: ExecutionStep, index: int) -> bool:
+        """Whether the tool call at ``index`` produced a failed result.
+
+        ``_execute_tools`` returns results in call order, so the indices
+        line up. Steps that carry no result for a call (the confirmation
+        block path) are treated as not failed.
+        """
+        if index >= len(step.tool_results):
+            return False
+        return not step.tool_results[index].success

--- a/sdk/src/rhesis/sdk/agents/architect/config.py
+++ b/sdk/src/rhesis/sdk/agents/architect/config.py
@@ -43,6 +43,9 @@ class ArchitectConfig:
     # ── streaming / tool-result preview ───────────────────────────
     tool_result_preview_chars: int = 4_000
     reasoning_preview_chars: int = 200
+    # Only echoed back for calls that failed, so the cost is bounded by
+    # how often the agent gets a call wrong.
+    failed_args_preview_chars: int = 1_500
 
     # ── HTTP methods treated as read-only ─────────────────────────
     readonly_http_methods: frozenset = field(

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/iteration_prompt.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/iteration_prompt.j2
@@ -36,6 +36,11 @@ Conversation & Execution History:
 
 Based on the user's message, the current mode, available tools, and history above, decide what to do next.
 
+If a tool call above failed, the history shows both the error and the arguments you sent. Read them together and work out which argument caused it before calling anything. Never re-send a payload identical to one that was just rejected — it fails the same way and wastes a turn. Specifically:
+- Missing or invalid field: fix that field against the parameter list for the tool. Check required fields and, for nested objects and array items, the fields listed under "Each item:".
+- "already exists": the entity is there. Resolve it with the matching `list_*` tool and reuse its id. Do not retry with a suffixed name.
+- "Cannot generate test sets yet" or "already completed": this is the plan telling you the step is out of order or done. Move to the next incomplete plan item instead of retrying.
+
 {% else %}
 This is the start of the conversation. Analyze the user's request. If it's a direct action (e.g. update a metric, list entities, link a behavior), execute it immediately using the available tools. Otherwise, begin the discovery phase.
 

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/personality.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/personality.j2
@@ -40,7 +40,9 @@ natural, like how a friendly colleague texts.
 - **Errors**: You stay calm and matter-of-fact. You describe what happened,
   what it means, and what to do about it. No drama, no apologies. "The
   endpoint isn't responding — getting a connection timeout. Want to check if
-  it's running? I'll be here."
+  it's running? I'll be here." You never guess at a cause you cannot see. If
+  your own tool call was rejected, you fix it rather than narrating a theory
+  about why the platform misbehaved.
 
 - **Confusion**: When a user is unsure, you offer a concrete next step or a
   simple choice rather than over-explaining. "Let me explore your endpoint

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
@@ -35,6 +35,13 @@
 - Only after the user confirms (e.g., "yes", "go ahead", "looks good") should you call the tool.
 - The Accept/Change confirmation UI is owned by the platform, not by you. It appears automatically the first time you try to call a tool flagged with `requires_confirmation: true` in the platform's tool metadata — and only then. Open-ended or multiple-choice questions ("Quick or Comprehensive exploration?", "What should I name this test set?") and informational summaries are conversational turns with no pending action; just ask the question and wait for the user's typed reply. Do not try to manage the Accept/Change UI through the response schema — it ignores any flag you set.
 
+### When a tool call fails
+- **The error tells you what is wrong. Read it.** It names the field and the reason. Fix that field and call the **same** tool again. Most failures are a missing or misshapen argument, not a broken platform.
+- **Never blame the platform.** Do not tell the user about a "sync delay", "registry propagation", a "known quirk", or a "hiccup on the platform side". You have no evidence for any of that, and saying it sends them chasing a bug that does not exist. If you genuinely cannot fix the call, say what you tried and quote what the error said.
+- **Never swap in a different tool because one failed.** A tool that fails is a call to correct, not a route to work around. In particular `create_test_set_bulk` is NOT a fallback for `generate_test_set`: generation produces a full set of synthesized tests, while bulk creation only stores the handful of prompts you write out yourself. Substituting one for the other quietly hands the user a much smaller, hand-written test set when they asked for a generated one.
+- **Never present a reduced result as success.** If you set out to generate 15 multi-turn tests and ended up with one hand-written scenario, that is a failure to report, not a win to announce. Tell the user what they actually have.
+- Common fixes: `generate_test_set` needs `config.behaviors` (a non-empty list of behavior **names**, not IDs) and a `name`; `create_test_set_bulk` needs `test_set_type` plus `behavior`, `category` and `topic` on every test. "Already exists" means resolve the entity with the matching `list_*` tool and reuse it — never retry with a suffixed name.
+
 ### Efficient tool usage
 - **Use `$select`** on list_* calls to request only the fields you need. This keeps responses small and avoids truncation. **Omit large fields** like `response`, `prompt`, and `evaluation_prompt` unless you specifically need them. Examples:
   - Browsing endpoints: `$select=name,id,url,description`

--- a/sdk/src/rhesis/sdk/agents/arg_validation.py
+++ b/sdk/src/rhesis/sdk/agents/arg_validation.py
@@ -1,0 +1,94 @@
+"""Pre-dispatch checks on tool arguments.
+
+Catches the argument mistakes that the server is guaranteed to reject, so
+the agent gets an exact message instead of a raw 422 it has to decode.
+
+Deliberately narrow: only missing required fields are reported. Types and
+enum values are left alone because the API normalises a lot of what looks
+wrong here -- ``"multi_turn"`` and ``"multi-turn"`` both resolve to
+``Multi-Turn``, and numeric strings coerce to integers. Rejecting those
+locally would invent failures the server would have accepted, which is the
+opposite of the point.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+# Cap on how many array items to inspect. Bulk payloads run to hundreds of
+# tests and the first few are representative -- if item 0 is missing
+# ``category``, item 87 almost certainly is too.
+_MAX_ITEMS_CHECKED = 5
+
+
+def _unwrap_optional(schema: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the single non-null variant of an ``anyOf``/``oneOf``."""
+    for key in ("anyOf", "oneOf"):
+        if key in schema:
+            variants = [v for v in schema[key] if v.get("type") != "null"]
+            if len(variants) == 1:
+                return variants[0]
+    return schema
+
+
+def _missing_required(
+    value: Dict[str, Any],
+    schema: Dict[str, Any],
+    path: str,
+) -> List[str]:
+    """Collect required properties absent from ``value``, recursively."""
+    errors: List[str] = []
+    required = schema.get("required", [])
+    properties = schema.get("properties", {})
+
+    for name in required:
+        if value.get(name) is None:
+            errors.append(f"{path}{name}")
+
+    for name, prop_schema in properties.items():
+        child = value.get(name)
+        if child is None:
+            continue
+        inner = _unwrap_optional(prop_schema)
+
+        if isinstance(child, dict) and inner.get("properties"):
+            errors.extend(_missing_required(child, inner, f"{path}{name}."))
+        elif isinstance(child, list) and inner.get("type") == "array":
+            items = _unwrap_optional(inner.get("items", {}))
+            if not items.get("properties"):
+                continue
+            for i, item in enumerate(child[:_MAX_ITEMS_CHECKED]):
+                if isinstance(item, dict):
+                    errors.extend(_missing_required(item, items, f"{path}{name}[{i}]."))
+
+    return errors
+
+
+def find_missing_arguments(
+    arguments: Dict[str, Any],
+    input_schema: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    """Return an error message naming missing required fields, or None.
+
+    Args:
+        arguments: The arguments the agent intends to send.
+        input_schema: The tool's JSON Schema. ``None`` or a schema with no
+            ``required`` list means nothing to check.
+    """
+    if not input_schema:
+        return None
+
+    missing = _missing_required(arguments, input_schema, "")
+    if not missing:
+        return None
+
+    fields = ", ".join(missing)
+    if not arguments:
+        return (
+            f"No arguments were received, but this tool requires: {fields}. "
+            "Re-send the call with the arguments as a valid JSON object."
+        )
+    return (
+        f"Missing required argument(s): {fields}. "
+        "Add them and call the tool again; do not re-send the same payload."
+    )

--- a/sdk/src/rhesis/sdk/agents/base.py
+++ b/sdk/src/rhesis/sdk/agents/base.py
@@ -40,10 +40,16 @@ _MAX_LLM_CONTENT = 8000
 
 _LLM_TRACER = trace.get_tracer("rhesis.sdk.agents.llm")
 
+# How many levels of nested object/array-item properties to expand in the
+# tool descriptions.  Two covers ``tests[].prompt.content`` — the deepest
+# shape in the Rhesis catalog — without bloating the prompt further.
+_MAX_SCHEMA_DEPTH = 2
+
 # Fields managed by the server — agents should never send these.
 _SERVER_MANAGED_FIELDS: frozenset[str] = frozenset(
     {
         "id",
+        "nano_id",
         "user_id",
         "organization_id",
         "created_at",
@@ -427,6 +433,21 @@ class BaseAgent:
         )
 
     @staticmethod
+    def _unwrap_optional(prop: Dict[str, Any]) -> Dict[str, Any]:
+        """Return the single meaningful variant of an ``anyOf``/``oneOf``.
+
+        ``Optional[TestPrompt]`` reaches us as ``anyOf: [TestPrompt, null]``.
+        Unwrapping it is what lets the nested renderer see the object's
+        fields instead of stopping at the union.
+        """
+        for key in ("anyOf", "oneOf"):
+            if key in prop:
+                variants = [v for v in prop[key] if v.get("type") != "null"]
+                if len(variants) == 1:
+                    return variants[0]
+        return prop
+
+    @staticmethod
     def _schema_type(prop: Dict[str, Any]) -> str:
         """Derive a human-readable type string from a JSON Schema property."""
         # Enum values → show literals
@@ -452,12 +473,67 @@ class BaseAgent:
 
         return str(typ)
 
+    def _format_schema_properties(
+        self,
+        schema: Dict[str, Any],
+        indent: str,
+        depth: int,
+    ) -> List[str]:
+        """Render a JSON Schema object's properties as indented lines."""
+        properties = schema.get("properties", {})
+        required_set = set(schema.get("required", []))
+
+        lines: List[str] = []
+        for pname, pschema in properties.items():
+            # Only the request body's own top-level fields are server-managed.
+            # Nested objects use the same names for real references — the
+            # ``id`` inside a ``sources`` item is the one field that matters.
+            if depth == 0 and pname in _SERVER_MANAGED_FIELDS:
+                continue
+            type_str = self._schema_type(pschema)
+            req = " (required)" if pname in required_set else ""
+            pdesc = pschema.get("description", "")
+            line = f"{indent}{pname}: {type_str}{req}"
+            if pdesc:
+                line += f"  -- {pdesc}"
+            lines.append(line)
+            if depth < _MAX_SCHEMA_DEPTH:
+                lines.extend(self._format_nested_properties(pschema, indent + "  ", depth + 1))
+        return lines
+
+    def _format_nested_properties(
+        self,
+        prop: Dict[str, Any],
+        indent: str,
+        depth: int,
+    ) -> List[str]:
+        """Render the inner shape of an object or array-of-object property.
+
+        Without this the LLM only ever sees ``array[object]`` and has to
+        guess the item fields, which is a common source of 422s from the
+        server on its first attempt.
+        """
+        inner = self._unwrap_optional(prop)
+
+        if inner.get("type") == "array":
+            items = self._unwrap_optional(inner.get("items", {}))
+            if items.get("properties"):
+                return [f"{indent}Each item:"] + self._format_schema_properties(
+                    items, indent + "  ", depth
+                )
+            return []
+
+        if inner.get("properties"):
+            return self._format_schema_properties(inner, indent, depth)
+        return []
+
     def _format_tools(self, tools: List[Dict[str, Any]]) -> str:
         """Build a rich tool description for the LLM.
 
         Each parameter shows its type, whether it is required, and its
-        description.  Server-managed fields are excluded so the LLM
-        never tries to send them.
+        description.  Nested object and array-item shapes are expanded up
+        to ``_MAX_SCHEMA_DEPTH`` levels.  Server-managed fields are
+        excluded so the LLM never tries to send them.
         """
         if not tools:
             return "(no tools available)"
@@ -466,23 +542,10 @@ class BaseAgent:
         for tool in tools:
             desc = f"- {tool['name']}: {tool.get('description', 'No description')}"
             schema = tool.get("inputSchema") or {}
-            properties = schema.get("properties", {})
-            required_set = set(schema.get("required", []))
 
-            if properties:
-                param_lines: List[str] = []
-                for pname, pschema in properties.items():
-                    if pname in _SERVER_MANAGED_FIELDS:
-                        continue
-                    type_str = self._schema_type(pschema)
-                    req = " (required)" if pname in required_set else ""
-                    pdesc = pschema.get("description", "")
-                    line = f"    {pname}: {type_str}{req}"
-                    if pdesc:
-                        line += f"  -- {pdesc}"
-                    param_lines.append(line)
-                if param_lines:
-                    desc += "\n  Parameters:\n" + "\n".join(param_lines)
+            param_lines = self._format_schema_properties(schema, "    ", 0)
+            if param_lines:
+                desc += "\n  Parameters:\n" + "\n".join(param_lines)
 
             descriptions.append(desc)
         return "\n".join(descriptions)

--- a/sdk/src/rhesis/sdk/agents/schemas.py
+++ b/sdk/src/rhesis/sdk/agents/schemas.py
@@ -1,20 +1,43 @@
 """Shared schemas for agent structured outputs."""
 
 import json
+import logging
 from typing import Annotated, Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, BeforeValidator, Field, WithJsonSchema
 
 from rhesis.sdk.agents.constants import Action
 
+logger = logging.getLogger(__name__)
+
 
 def _parse_arguments(v: Any) -> Dict[str, Any]:
-    """Coerce JSON strings and other values to ``dict``."""
+    """Coerce JSON strings and other values to ``dict``.
+
+    Falls back to ``{}`` rather than raising, so one malformed argument
+    string cannot take down the whole ``AgentAction``. That fallback is
+    logged: dispatching a tool with no arguments produces a baffling
+    "field required" from the server, and the log is the only trace of
+    why the payload went missing.
+    """
     if isinstance(v, str):
         try:
-            return json.loads(v)
+            parsed = json.loads(v)
         except json.JSONDecodeError:
+            logger.error(
+                "Tool arguments were not valid JSON; dispatching with no "
+                "arguments. First 200 chars: %s",
+                v[:200],
+            )
             return {}
+        if not isinstance(parsed, dict):
+            logger.error(
+                "Tool arguments parsed to %s, expected an object; "
+                "dispatching with no arguments.",
+                type(parsed).__name__,
+            )
+            return {}
+        return parsed
     return v if isinstance(v, dict) else {}
 
 

--- a/sdk/src/rhesis/sdk/agents/schemas.py
+++ b/sdk/src/rhesis/sdk/agents/schemas.py
@@ -32,8 +32,7 @@ def _parse_arguments(v: Any) -> Dict[str, Any]:
             return {}
         if not isinstance(parsed, dict):
             logger.error(
-                "Tool arguments parsed to %s, expected an object; "
-                "dispatching with no arguments.",
+                "Tool arguments parsed to %s, expected an object; dispatching with no arguments.",
                 type(parsed).__name__,
             )
             return {}

--- a/skills/rhesis/references/tool-catalog.md
+++ b/skills/rhesis/references/tool-catalog.md
@@ -235,6 +235,8 @@ Call this **before** `create_test_set_bulk` so that when test objects reference 
 - `name` (required) — Title Case, e.g. `"Refuses Harmful Requests"`
 - `description` (required) — explain what the behavior means and how it should be evaluated
 
+**Common mistakes:** Behavior names are unique per organization, so creating one that already exists fails with "Behavior with this name already exists". Resolve it with `list_behaviors` and reuse its id. Never retry with a suffixed name like `"Refuses Harmful Requests 2"`.
+
 ---
 
 ### `update_behavior`
@@ -261,10 +263,19 @@ Prefer `generate_metric` when you know what to measure but don't want to fill ev
 - `score_type` (required) — must be exactly `"numeric"` or `"categorical"`
 - `evaluation_prompt` (required) — the prompt template used to score responses; may use `{{prompt}}`, `{{response}}`, `{{expected_response}}`
 - `metric_scope` (required) — list of strings, each must be `"Single-Turn"` or `"Multi-Turn"`
-- For numeric metrics: `min_score`, `max_score`, `threshold`, `threshold_operator` (one of `"="`, `"<"`, `">"`, `"<="`, `">="`, `"!="`)
-- For categorical metrics: `categories` (non-empty list), `passing_categories` (subset of `categories`)
+
+**Fields required by `score_type`.** These are enforced by the server but cannot be expressed in the JSON schema, so they are easy to miss:
+
+| `score_type` | Also required |
+|--------------|---------------|
+| `"numeric"` | `min_score`, `max_score` **and** `threshold`. Optionally `threshold_operator` (one of `"="`, `"<"`, `">"`, `"<="`, `">="`, `"!="`, default `">="`) |
+| `"categorical"` | `categories` (at least two labels) **and** `passing_categories` (at least one, each also present in `categories`) |
+
+Send the numeric fields only for numeric metrics and the category fields only for categorical ones.
 
 **Never send:** `id`, `user_id`, `organization_id`, `created_at`, `updated_at`, `owner_id`, `status_id`, `model_id`, `backend_type_id`, `metric_type_id`
+
+**Common mistakes:** Sending `score_type: "numeric"` without `min_score`/`max_score`/`threshold` — rejected. Metric names are unique per organization, so creating one that already exists fails with "Metric with this name already exists"; resolve it with `list_metrics` and reuse it, or use `improve_metric`. Never retry with a suffixed name.
 
 ---
 
@@ -318,7 +329,9 @@ Generate a test set using the Rhesis synthesizer. An LLM creates diverse test pr
 - `test_type` — `"Single-Turn"` (default) or `"Multi-Turn"`. Take this from the plan's test set and pass it explicitly. Omitting it produces Single-Turn tests no matter what the test set is called.
 - `sources` — optional list of knowledge source objects to ground tests in real content. Each object must contain only the `id` field: `[{"id": "<source-uuid>"}]`. The backend fetches and injects source content automatically — do NOT fetch or pass content yourself. Use `list_sources` to discover available sources. Only works with Single-Turn; ignored for Multi-Turn.
 
-**Common mistakes:** Omitting `config.behaviors`, using `test_type: "single-turn"` (wrong case), omitting `test_type` for a Multi-Turn test set.
+`project_id` is resolved from the request scope — omit it.
+
+**Common mistakes:** Omitting `config.behaviors` (rejected with "At least one behavior must be specified"), omitting `name`, omitting `test_type` for a Multi-Turn test set. If this call fails, fix the argument it names and call it again — do **not** fall back to `create_test_set_bulk`, which stores only the prompts you write by hand and produces a far smaller test set than the user asked for.
 
 ---
 

--- a/tests/backend/services/test_mcp_tools_yaml.py
+++ b/tests/backend/services/test_mcp_tools_yaml.py
@@ -306,6 +306,25 @@ class TestToolParameterDocumentation:
     # duplicate them.
     EXEMPT = {"skip", "limit", "sort_by", "sort_order", "filter", "select"}
 
+    # Mirrors _SERVER_MANAGED_FIELDS in rhesis.sdk.agents.base, which strips
+    # these before the agent ever sees them. Duplicated rather than imported
+    # so the backend suite does not depend on the SDK being installed, and
+    # does not reach into a private name across package boundaries.
+    SERVER_MANAGED = {
+        "id",
+        "nano_id",
+        "user_id",
+        "organization_id",
+        "created_at",
+        "updated_at",
+        "owner_id",
+        "assignee_id",
+        "status_id",
+        "model_id",
+        "backend_type_id",
+        "metric_type_id",
+    }
+
     @staticmethod
     def _build_tools():
         from rhesis.backend.app.main import app
@@ -325,14 +344,12 @@ class TestToolParameterDocumentation:
         return None
 
     def test_creation_tool_parameters_are_described(self):
-        from rhesis.sdk.agents.base import _SERVER_MANAGED_FIELDS
-
         by_name, _ = self._build_tools()
         undescribed = []
         for name in sorted(self.CREATION_TOOLS):
             schema = by_name[name].inputSchema or {}
             for param, prop in schema.get("properties", {}).items():
-                if param in _SERVER_MANAGED_FIELDS or param in self.EXEMPT:
+                if param in self.SERVER_MANAGED or param in self.EXEMPT:
                     continue
                 if not prop.get("description"):
                     undescribed.append(f"{name}.{param}")

--- a/tests/backend/services/test_mcp_tools_yaml.py
+++ b/tests/backend/services/test_mcp_tools_yaml.py
@@ -276,3 +276,108 @@ class TestMcpToolsYamlStructure:
             cfg = by_name[name]
             assert cfg["method"].upper() == method
             assert cfg["path"] == path
+
+
+@pytest.mark.unit
+class TestToolParameterDocumentation:
+    """The rendered tool schema is the agent's only source of truth.
+
+    An undescribed parameter is a field the model has to guess at, and a
+    guess that misses costs a failed call plus a wasted ReAct iteration.
+    """
+
+    # The tools the Architect drives when it builds a suite. Failures here
+    # are the ones users actually see, so these must be fully documented.
+    # The rest of the catalog (update_*, endpoint config) still has gaps —
+    # widen this set as they get cleaned up rather than relaxing the rule.
+    CREATION_TOOLS = {
+        "create_project",
+        "create_behavior",
+        "create_metric",
+        "generate_metric",
+        "improve_metric",
+        "create_source",
+        "add_behavior_to_metric",
+        "create_test_set_bulk",
+        "generate_test_set",
+    }
+
+    # Described by the OpenAPI schema itself, so a YAML override would only
+    # duplicate them.
+    EXEMPT = {"skip", "limit", "sort_by", "sort_order", "filter", "select"}
+
+    @staticmethod
+    def _build_tools():
+        from rhesis.backend.app.main import app
+        from rhesis.backend.app.mcp_server.tools import build_tools_and_operations
+
+        tools, operations = build_tools_and_operations(app)
+        return {t.name: t for t in tools}, operations
+
+    @staticmethod
+    def _enum_values(prop):
+        """Read enum values through the anyOf wrapper Optional[X] produces."""
+        if "enum" in prop:
+            return prop["enum"]
+        for variant in prop.get("anyOf", []):
+            if "enum" in variant:
+                return variant["enum"]
+        return None
+
+    def test_creation_tool_parameters_are_described(self):
+        from rhesis.sdk.agents.base import _SERVER_MANAGED_FIELDS
+
+        by_name, _ = self._build_tools()
+        undescribed = []
+        for name in sorted(self.CREATION_TOOLS):
+            schema = by_name[name].inputSchema or {}
+            for param, prop in schema.get("properties", {}).items():
+                if param in _SERVER_MANAGED_FIELDS or param in self.EXEMPT:
+                    continue
+                if not prop.get("description"):
+                    undescribed.append(f"{name}.{param}")
+
+        assert not undescribed, (
+            "Undescribed parameters on creation tools — the agent has to "
+            "guess what to send. Add a description in mcp_tools.yaml: "
+            f"{sorted(undescribed)}"
+        )
+
+    def test_required_fields_are_marked_in_schema(self):
+        """Fields the route rejects when missing must say so in the schema.
+
+        generate_test_set used to 400 on a missing name while declaring it
+        optional, so the agent omitted it and ate a failure every time.
+        """
+        by_name, _ = self._build_tools()
+
+        generate = by_name["generate_test_set"].inputSchema
+        assert "config" in generate["required"]
+        assert "name" in generate["required"]
+        assert generate["properties"]["config"]["required"] == ["behaviors"]
+
+        bulk = by_name["create_test_set_bulk"].inputSchema
+        assert "test_set_type" in bulk["required"]
+        assert "tests" in bulk["required"]
+        item_required = bulk["properties"]["tests"]["items"]["required"]
+        assert {"behavior", "category", "topic"} <= set(item_required)
+
+    def test_turn_type_fields_expose_their_allowed_values(self):
+        """Bare `string` makes the model learn the two values from prose."""
+        by_name, _ = self._build_tools()
+        expected = ["Single-Turn", "Multi-Turn"]
+
+        bulk = by_name["create_test_set_bulk"].inputSchema["properties"]
+        assert self._enum_values(bulk["test_set_type"]) == expected
+        item = bulk["tests"]["items"]["properties"]["test_type"]
+        assert self._enum_values(item) == expected
+
+        generate = by_name["generate_test_set"].inputSchema["properties"]
+        assert self._enum_values(generate["test_type"]) == expected
+
+    def test_project_id_is_not_required_for_generation(self):
+        """It resolves from the request scope, so the agent need not send it."""
+        by_name, _ = self._build_tools()
+        generate = by_name["generate_test_set"].inputSchema
+        assert "project_id" not in generate.get("required", [])
+        assert generate["properties"]["project_id"].get("description")

--- a/tests/sdk/agents/test_architect.py
+++ b/tests/sdk/agents/test_architect.py
@@ -1393,6 +1393,101 @@ class TestArchitectArgumentValidation:
         assert result.success is True
         assert result.content == "ok"
 
+    @pytest.mark.asyncio
+    async def test_missing_required_argument_rejected_before_dispatch(self, mock_model):
+        """A required field the server would 422 on never leaves the process."""
+        tool = DummyTool()
+        agent = _make_agent(mock_model, tools=[tool])
+        agent._tool_schemas = {
+            "dummy": {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+                "required": ["x"],
+            }
+        }
+        from rhesis.sdk.agents.schemas import ToolCall
+
+        result = await agent.execute_tool(ToolCall(tool_name="dummy", arguments="{}"))
+        assert result.success is False
+        assert "x" in result.error
+
+    @pytest.mark.asyncio
+    async def test_unknown_tool_schema_does_not_block(self, mock_model):
+        """No cached schema means no check — never a false rejection."""
+        tool = DummyTool()
+        agent = _make_agent(mock_model, tools=[tool])
+        from rhesis.sdk.agents.schemas import ToolCall
+
+        result = await agent.execute_tool(ToolCall(tool_name="dummy", arguments="{}"))
+        assert result.success is True
+
+
+@pytest.mark.unit
+class TestArchitectFailedCallHistory:
+    """Failed calls must show what was sent, not just what came back."""
+
+    @pytest.fixture
+    def mock_model(self):
+        return _mock_model()
+
+    @staticmethod
+    def _step(success, arguments):
+        from rhesis.sdk.agents.schemas import ToolCall
+
+        return ExecutionStep(
+            iteration=1,
+            reasoning="doing a thing",
+            action="call_tool",
+            tool_calls=[ToolCall(tool_name="create_test_set_bulk", arguments=arguments)],
+            tool_results=[
+                ToolResult(
+                    tool_name="create_test_set_bulk",
+                    success=success,
+                    content="ok" if success else "",
+                    error=None if success else "422: category is required",
+                )
+            ],
+        )
+
+    def test_failed_call_echoes_arguments(self, mock_model):
+        agent = _make_agent(mock_model)
+        agent._execution_history = [self._step(False, {"name": "Safety Tests"})]
+        history = agent._format_history()
+        assert "with arguments:" in history
+        assert "Safety Tests" in history
+        assert "422: category is required" in history
+
+    def test_successful_call_does_not_echo_arguments(self, mock_model):
+        agent = _make_agent(mock_model)
+        agent._execution_history = [self._step(True, {"name": "Safety Tests"})]
+        history = agent._format_history()
+        assert "with arguments:" not in history
+        assert "Called: create_test_set_bulk" in history
+
+    def test_argument_preview_is_truncated(self, mock_model):
+        agent = _make_agent(mock_model)
+        agent._execution_history = [self._step(False, {"name": "x" * 5000})]
+        history = agent._format_history()
+        assert "more chars]" in history
+        assert len(history) < 5000
+
+    def test_missing_result_is_not_treated_as_failure(self, mock_model):
+        """The confirmation-block path records calls without results."""
+        from rhesis.sdk.agents.schemas import ToolCall
+
+        agent = _make_agent(mock_model)
+        agent._execution_history = [
+            ExecutionStep(
+                iteration=1,
+                reasoning="blocked",
+                action="call_tool",
+                tool_calls=[ToolCall(tool_name="create_metric", arguments={"name": "n"})],
+                tool_results=[],
+            )
+        ]
+        history = agent._format_history()
+        assert "with arguments:" not in history
+
 
 # ── await_task tests ─────────────────────────────────────────────
 

--- a/tests/sdk/agents/test_arg_validation.py
+++ b/tests/sdk/agents/test_arg_validation.py
@@ -1,0 +1,113 @@
+"""Tests for pre-dispatch tool argument checks."""
+
+import pytest
+
+from rhesis.sdk.agents.arg_validation import find_missing_arguments
+
+# Mirrors the real create_test_set_bulk schema closely enough to exercise
+# the nested-item path that produced most of the server 422s.
+BULK_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "test_set_type": {"type": "string"},
+        "tests": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "behavior": {"type": "string"},
+                    "category": {"type": "string"},
+                    "topic": {"type": "string"},
+                    "prompt": {
+                        "anyOf": [
+                            {
+                                "type": "object",
+                                "properties": {"content": {"type": "string"}},
+                                "required": ["content"],
+                            },
+                            {"type": "null"},
+                        ]
+                    },
+                },
+                "required": ["behavior", "category", "topic"],
+            },
+        },
+    },
+    "required": ["name", "test_set_type", "tests"],
+}
+
+
+def _test_item(**overrides):
+    item = {"behavior": "b", "category": "c", "topic": "t"}
+    item.update(overrides)
+    return item
+
+
+@pytest.mark.unit
+class TestFindMissingArguments:
+    def test_no_schema_is_a_no_op(self):
+        assert find_missing_arguments({"anything": 1}, None) is None
+        assert find_missing_arguments({}, {}) is None
+
+    def test_valid_payload_passes(self):
+        args = {"name": "n", "test_set_type": "Multi-Turn", "tests": [_test_item()]}
+        assert find_missing_arguments(args, BULK_SCHEMA) is None
+
+    def test_missing_top_level_field(self):
+        args = {"name": "n", "tests": [_test_item()]}
+        error = find_missing_arguments(args, BULK_SCHEMA)
+        assert error is not None
+        assert "test_set_type" in error
+
+    def test_missing_item_field_is_located_by_index(self):
+        args = {
+            "name": "n",
+            "test_set_type": "Single-Turn",
+            "tests": [_test_item(), {"behavior": "b"}],
+        }
+        error = find_missing_arguments(args, BULK_SCHEMA)
+        assert error is not None
+        assert "tests[1].category" in error
+        assert "tests[1].topic" in error
+
+    def test_nested_object_required_field(self):
+        args = {
+            "name": "n",
+            "test_set_type": "Single-Turn",
+            "tests": [_test_item(prompt={"language_code": "en"})],
+        }
+        error = find_missing_arguments(args, BULK_SCHEMA)
+        assert error is not None
+        assert "tests[0].prompt.content" in error
+
+    def test_empty_arguments_get_a_distinct_message(self):
+        """The silently-dropped-payload case must not read like a normal miss."""
+        error = find_missing_arguments({}, BULK_SCHEMA)
+        assert error is not None
+        assert "No arguments were received" in error
+        assert "name" in error
+
+    def test_only_first_items_are_checked(self):
+        """Bulk payloads are sampled, not scanned end to end."""
+        args = {
+            "name": "n",
+            "test_set_type": "Single-Turn",
+            "tests": [_test_item() for _ in range(20)] + [{"behavior": "b"}],
+        }
+        assert find_missing_arguments(args, BULK_SCHEMA) is None
+
+    def test_null_counts_as_missing(self):
+        args = {"name": None, "test_set_type": "Single-Turn", "tests": [_test_item()]}
+        error = find_missing_arguments(args, BULK_SCHEMA)
+        assert error is not None
+        assert "name" in error
+
+    def test_loose_enum_values_are_not_rejected(self):
+        """The API normalises casing, so local checks must not second-guess it."""
+        args = {"name": "n", "test_set_type": "multi_turn", "tests": [_test_item()]}
+        assert find_missing_arguments(args, BULK_SCHEMA) is None
+
+    def test_empty_list_is_left_to_the_server(self):
+        args = {"name": "n", "test_set_type": "Single-Turn", "tests": []}
+        assert find_missing_arguments(args, BULK_SCHEMA) is None

--- a/tests/sdk/agents/test_base.py
+++ b/tests/sdk/agents/test_base.py
@@ -311,6 +311,168 @@ class TestToolCallSchema:
         tc = ToolCall(tool_name="test", arguments="not json")
         assert tc.arguments == {}
 
+    def test_invalid_json_is_logged(self, caplog):
+        """Silently dropping the payload makes the server's 422 unreadable."""
+        with caplog.at_level("ERROR", logger="rhesis.sdk.agents.schemas"):
+            ToolCall(tool_name="test", arguments="{broken")
+        assert "not valid JSON" in caplog.text
+
+    def test_valid_json_non_object_becomes_empty_dict(self):
+        """A bare list parses fine but would otherwise fail ToolCall validation."""
+        tc = ToolCall(tool_name="test", arguments="[1, 2]")
+        assert tc.arguments == {}
+
     def test_default_is_empty_dict(self):
         tc = ToolCall(tool_name="test")
         assert tc.arguments == {}
+
+
+@pytest.mark.unit
+class TestFormatTools:
+    """Test the tool descriptions rendered into the iteration prompt."""
+
+    @pytest.fixture
+    def agent(self):
+        model = Mock(spec=BaseLLM)
+        model.a_generate = AsyncMock(return_value={})
+        return _make_agent(model)
+
+    @staticmethod
+    def _tool(properties, required=None):
+        schema = {"type": "object", "properties": properties}
+        if required:
+            schema["required"] = required
+        return [{"name": "t", "description": "d", "inputSchema": schema}]
+
+    def test_no_tools(self, agent):
+        assert agent._format_tools([]) == "(no tools available)"
+
+    def test_top_level_params_and_required_flag(self, agent):
+        out = agent._format_tools(
+            self._tool({"name": {"type": "string", "description": "The name"}}, ["name"])
+        )
+        assert "name: string (required)  -- The name" in out
+
+    def test_server_managed_fields_excluded(self, agent):
+        out = agent._format_tools(self._tool({"id": {"type": "string"}, "x": {"type": "string"}}))
+        assert "id:" not in out
+        assert "x: string" in out
+
+    def test_nested_id_is_kept(self, agent):
+        """A nested 'id' is a reference, not a server-managed field.
+
+        generate_test_set's sources items carry only an id — hiding it
+        would contradict the tool description.
+        """
+        out = agent._format_tools(
+            self._tool(
+                {
+                    "sources": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {"id": {"type": "string"}},
+                            "required": ["id"],
+                        },
+                    }
+                }
+            )
+        )
+        assert "id: string (required)" in out
+
+    def test_array_item_properties_are_expanded(self, agent):
+        """The 'tests: array[object]' case — item fields must be visible."""
+        out = agent._format_tools(
+            self._tool(
+                {
+                    "tests": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "behavior": {"type": "string"},
+                                "category": {"type": "string"},
+                            },
+                            "required": ["behavior", "category"],
+                        },
+                    }
+                },
+                ["tests"],
+            )
+        )
+        assert "tests: array[object] (required)" in out
+        assert "Each item:" in out
+        assert "behavior: string (required)" in out
+        assert "category: string (required)" in out
+
+    def test_nested_object_properties_are_expanded(self, agent):
+        out = agent._format_tools(
+            self._tool(
+                {
+                    "config": {
+                        "type": "object",
+                        "properties": {"generation_prompt": {"type": "string"}},
+                    }
+                }
+            )
+        )
+        assert "generation_prompt: string" in out
+
+    def test_optional_wrapper_is_unwrapped(self, agent):
+        """Optional[Model] arrives as anyOf[Model, null] and must still expand."""
+        out = agent._format_tools(
+            self._tool(
+                {
+                    "prompt": {
+                        "anyOf": [
+                            {
+                                "type": "object",
+                                "properties": {"content": {"type": "string"}},
+                                "required": ["content"],
+                            },
+                            {"type": "null"},
+                        ]
+                    }
+                }
+            )
+        )
+        assert "content: string (required)" in out
+
+    def test_recursion_stops_at_max_depth(self, agent):
+        """Three levels below the top — enough for tests[].prompt.content — then stop."""
+        deep = {
+            "type": "object",
+            "properties": {
+                "l1": {
+                    "type": "object",
+                    "properties": {
+                        "l2": {
+                            "type": "object",
+                            "properties": {
+                                "l3": {
+                                    "type": "object",
+                                    "properties": {"l4": {"type": "string"}},
+                                }
+                            },
+                        }
+                    },
+                }
+            },
+        }
+        out = agent._format_tools([{"name": "t", "description": "d", "inputSchema": deep}])
+        assert "l1: object" in out
+        assert "l2: object" in out
+        assert "l3: object" in out
+        assert "l4:" not in out
+
+    def test_dict_any_object_has_nothing_to_expand(self, agent):
+        """Dict[str, Any] renders as a bare object with no invented fields."""
+        out = agent._format_tools(self._tool({"metadata": {"type": "object"}}))
+        assert "metadata: object" in out
+        assert "Each item:" not in out
+
+    def test_enum_renders_literals(self, agent):
+        out = agent._format_tools(
+            self._tool({"test_type": {"type": "string", "enum": ["Single-Turn", "Multi-Turn"]}})
+        )
+        assert 'test_type: "Single-Turn" | "Multi-Turn"' in out


### PR DESCRIPTION
## Purpose

The Architect fails a tool call, retries, fails again, and eventually succeeds. The task completes, but every failed attempt burns one of the 15 iterations allowed per turn and shows the user a red marker.

One theme is behind almost all of it: **the model writes its arguments from the rendered tool schema, and that schema was consistently vaguer than what the endpoint actually enforces.** Where the schema under-specified, the model guessed; the guess was wrong; the server rejected it.

A concrete case from a real session. The user asked for a multi-turn test set about insurance fraud. `generate_test_set` was rejected with "At least one behavior must be specified" (`routers/test_set.py:132`, which fires when `config.behaviors` is empty). The model had been shown `config: object` with the requirement buried in a prose bullet list, while the schema itself declared nothing required. The agent then told the user this was a platform bug — "the system registry takes a few moments to propagate the new behavior-metric linkages" — which is invented; that endpoint reads `config.behaviors` straight off the request body and never queries the database. It then worked around the failure by switching to `create_test_set_bulk`, which only stores prompts the model writes out by hand. The user asked for a generated multi-turn set and received a single hand-written scenario, announced as "Good news!"

Scope is prevention. How the remaining failures are displayed is deliberately out of scope.

## What Changed

**Make the schema tell the truth**

- `_format_tools` recurses into nested objects and array items, so `tests: array[object]` now shows that every item requires `behavior`, `category` and `topic`. Costs +830 chars across the whole 48-tool catalog (+1.7%), because most `object` params are `Dict[str, Any]` with nothing to expand.
- `generate_test_set` resolves `project_id` from the request's project scope via the existing `get_project_context` dependency. The Architect already sends `X-Project-Id`, so it no longer has to supply a field nothing told it about. Fewer required fields beats better docs.
- `name` is required on a `TestSetGenerationRequest` subclass used only by the bulk route, and `config.behaviors` is required with `min_length=1` — both matching what the routers already enforced.
- `test_set_type` and `test_type` are typed as their enums, so `"Single-Turn" | "Multi-Turn"` reaches the schema instead of a bare `string`. The `mode="before"` normalizers are kept, so loose casing and snake_case still pass exactly as before.
- `create_metric`'s conditional requirements are documented: numeric metrics need `min_score`, `max_score` and `threshold`; categorical ones need at least two `categories` and one `passing_categories`. Flat JSON Schema cannot express this, and it was stated nowhere, making a numeric metric a guaranteed first-attempt 422. Metrics get created before test sets in every plan.
- Behaviors and metrics gain duplicate-name guidance (resolve and reuse, never retry with a suffixed name), and the undescribed parameters on the creation tools are described.

**Let the model learn from its own failure**

- `_format_history` wrote `Called: <tool_name>` and nothing else, so on a rejection the model saw the error but not the payload. It now echoes a truncated argument preview for failed calls only.
- The iteration prompt says what to do with a failure: fix the named argument, never re-send an identical payload, treat an ordering or already-exists message as an instruction rather than something to retry.
- Three new rules stop the workaround behaviour: never attribute a failure to a sync delay or platform quirk you cannot see, never substitute a different tool because one failed (`create_test_set_bulk` called out by name), never present a reduced result as success.

**Stop losing and re-failing payloads**

- `_parse_arguments` silently returned `{}` when the model's JSON-string arguments failed to parse, so the server replied "field required" for fields the model believed it had sent. It now logs, and coerces a valid-but-non-object result to `{}` instead of letting it kill the whole `AgentAction`.
- Arguments are checked against the tool's own `inputSchema` before dispatch, naming the missing field without an HTTP round trip. Deliberately narrow — only missing required fields. Types and enum values are left alone because the API normalises much of what looks wrong here, and rejecting those locally would invent failures the server would have accepted.
- A 5xx or dropped connection is retried once instead of becoming a permanent failure that costs an iteration.

## Additional Context

- Follow-up to #2428, which covered the turn-type guidance and left enforcement out.
- Two things found and corrected mid-change: the recursion initially hid `sources[].id` because `id` is in the server-managed field list, so that filter now applies only at the top level; and a `min_length=1` on the bulk `tests` array was reverted after finding that `sdk/src/rhesis/sdk/entities/test_set.py:983` deliberately pushes empty lists, with integration coverage.
- Breaking-ish: `GenerationConfig.behaviors` and `TestSetGenerationRequest.name` now fail as 422 rather than 400. Both were already rejected; only the status code changes. The frontend sends both in every flow and surfaces either identically.
- The new `test_mcp_tools_yaml.py` coverage test is scoped to the creation path. `update_*` and endpoint config still carry ~60 undescribed parameters; widen the set as they are cleaned up rather than relaxing the rule.

## Testing

```bash
cd sdk && make test                    # 2354 passed
uvx ruff check && uvx ruff format --check   # clean on all touched files
```

**Backend tests have not been run — Docker was unavailable in this environment.** That leaves the `project_id` fallback, the enum-typed schemas and the new `test_mcp_tools_yaml.py` assertions unverified by the suite. I checked every one of those assertions against the real generated tool catalog using a stub app, and all pass, but that is not the same as running them. Please run:

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/test_mcp_tools_yaml.py -v
uv run pytest ../../tests/backend/routes/test_test_set.py ../../tests/backend/services/test_test_set.py -v
```

Manual check — the original failing prompt:

1. `./rh dev up`, open the Architect
2. "let's create a multi-turn test set about insurance fraud", pick one behavior, approve
3. `generate_test_set` should now succeed on the first call. It should never fall back to `create_test_set_bulk`, and never describe a failure as a platform sync issue.
