### PR TITLE
fix(dev): move postgres datasource database into jsonData

### DIFF
--- a/kubernetes/clusters/prd/grafana-resources/postgres-prd-datasource.yaml
+++ b/kubernetes/clusters/prd/grafana-resources/postgres-prd-datasource.yaml
@@ -17,9 +17,10 @@ spec:
     type: postgres
     access: proxy
     url: rhesis-prd-ro.rhesis.svc:5432
-    database: rhesis-prd-db
     user: grafana-viewer
+    isDefault: true
     jsonData:
+      database: rhesis-prd-db
       sslmode: disable
       postgresVersion: 1700
     editable: false

--- a/kubernetes/clusters/prd/grafana-resources/postgres-prd-datasource.yaml
+++ b/kubernetes/clusters/prd/grafana-resources/postgres-prd-datasource.yaml
@@ -18,7 +18,6 @@ spec:
     access: proxy
     url: rhesis-prd-ro.rhesis.svc:5432
     user: grafana-viewer
-    isDefault: true
     jsonData:
       database: rhesis-prd-db
       sslmode: disable

--- a/kubernetes/clusters/stg/grafana-resources/postgres-stg-datasource.yaml
+++ b/kubernetes/clusters/stg/grafana-resources/postgres-stg-datasource.yaml
@@ -20,9 +20,10 @@ spec:
     type: postgres
     access: proxy
     url: rhesis-stg-rw.rhesis.svc:5432
-    database: rhesis-stg-db
     user: grafana-viewer
+    isDefault: true
     jsonData:
+      database: rhesis-stg-db
       sslmode: disable
       postgresVersion: 1700
     editable: false

--- a/kubernetes/clusters/stg/grafana-resources/postgres-stg-datasource.yaml
+++ b/kubernetes/clusters/stg/grafana-resources/postgres-stg-datasource.yaml
@@ -21,7 +21,6 @@ spec:
     access: proxy
     url: rhesis-stg-rw.rhesis.svc:5432
     user: grafana-viewer
-    isDefault: true
     jsonData:
       database: rhesis-stg-db
       sslmode: disable


### PR DESCRIPTION
## Purpose

Grafana's SQL datasource frontend (`SqlDatasource.ts`) reads the connect-time database name from `jsonData.database`, not the legacy top-level `database` field. Both the prd and stg `GrafanaDatasource` provisioning files set `database` at the top level, so every panel query throws "You do not currently have a default database configured for this data source" before it ever reaches the backend. This happens for every viewer regardless of Grafana org role — it only looked role-dependent because Admins were seeing stale cached panel results from earlier successful loads, and manually re-saving the datasource via the UI temporarily patches the in-memory config until the next grafana-operator reconcile overwrites it back to the broken YAML.

## What Changed

- Moved `database: rhesis-prd-db` / `database: rhesis-stg-db` from the top level of `spec.datasource` into `jsonData.database` in both `postgres-prd-datasource.yaml` and `postgres-stg-datasource.yaml`
- Added `isDefault: true` to both datasources so they're picked up automatically for new panels/Explore without manual selection

## Additional Context

- Related to the RLS bypass fix in #acc17fc9a (`fix(dev): let grafana-viewer bypass RLS for cross-org dashboards`, already merged) — that fix addressed cross-org query scoping for the same `grafana-viewer` role, this fixes the connection-level database config for the same datasources

## Testing

After ArgoCD syncs this to each cluster, open the Rhesis Dashboard in Grafana as a non-admin (Editor) user and confirm the "User List" panel loads data on a fresh page load without needing a manual "Save & Test" on the datasource settings page. Repeat for stg.