### PR TITLE
fix(dev): let stg grafana-viewer bypass RLS for cross-org dashboards

### DIFF
--- a/kubernetes/clusters/stg/cnpg-cluster/cnpg-cluster.yaml
+++ b/kubernetes/clusters/stg/cnpg-cluster/cnpg-cluster.yaml
@@ -65,7 +65,11 @@ spec:
       - name: grafana-viewer
         ensure: present
         login: true
-        bypassrls: false
+        # bypassrls: this role backs an org-wide usage dashboard in Grafana, so it
+        # needs to read across every tenant rather than being scoped to one
+        # organization via app.current_organization/app.current_project. Still
+        # SELECT-only (see postInitApplicationSQL/GRANTs below) — read access, no writes.
+        bypassrls: true
         passwordSecret:
           name: grafana-viewer-credentials
   bootstrap:


### PR DESCRIPTION
## Purpose

The stg Grafana Postgres datasource throws `ERROR: unrecognized configuration parameter "app.current_organization" (SQLSTATE 42704)` on every panel query. The `grafana-viewer` role has `bypassrls: false`, so RLS policies apply to its queries, and those policies check `current_setting('app.current_organization')` — a session variable Grafana never sets, since it just runs raw SQL through a shared proxy connection. This is the same bug already fixed for prd in #2417 (`acc17fc9a`, "let grafana-viewer bypass RLS for cross-org dashboards"), just never mirrored to stg.

## What Changed

- Set `bypassrls: true` for the `grafana-viewer` managed role in `kubernetes/clusters/stg/cnpg-cluster/cnpg-cluster.yaml`, matching the prd config
- Role stays SELECT-only (see the existing `postInitApplicationSQL` GRANTs) — this only lifts row filtering, not write access

## Additional Context

- Follow-up to #2436 (moved the stg/prd Grafana datasource `database` config into `jsonData`), which fixed the "no default database configured" error but left this RLS error underneath it for stg

## Testing

After CNPG reconciles the role change and ArgoCD syncs, open the stg Grafana dashboard and confirm the "User List" panel (or any panel using the stg Postgres datasource) loads data without the `app.current_organization` error, for both Admin and Editor roles.