### PR TITLE
Fix CORS rejection that breaks login in every dev worktree

### DIFF
--- a/scripts/rh/dev.sh
+++ b/scripts/rh/dev.sh
@@ -102,6 +102,12 @@ QUICK_START=true
 # Server (start.sh reads PORT from here)
 PORT=${DEV_BACKEND_PORT}
 
+# The backend's CORS allowlist is derived from this single value
+# (config/settings.py::cors_origins). Unset, it defaults to localhost:3000,
+# which only matches a worktree running on the base port block -- every other
+# worktree gets its browser requests rejected as a disallowed origin.
+FRONTEND_URL=http://localhost:${DEV_FRONTEND_PORT}
+
 # Database
 DB_HOST=localhost
 DB_NAME=rhesis-db


### PR DESCRIPTION
## Purpose

The backend derives its entire CORS allowlist from a single value, `FRONTEND_URL` (`apps/backend/src/rhesis/backend/app/config/settings.py::cors_origins`). `./rh dev init` never wrote that key into `apps/backend/.env`, so the backend fell back to its default of `http://localhost:3000`.

That default is correct in the main checkout and wrong in every worktree. A worktree on port offset 30 serves the frontend from `:3030`, so the browser's cross-origin request to the backend on `:8110` is rejected with `400 Disallowed CORS origin`. The landing page's auto-login effect catches that as `TypeError: Failed to fetch` and retries, so the app presents as an endless loading loop.

It is an unpleasant one to diagnose because neither log looks broken: the backend happily answers server-side proxy calls with 200s, and the frontend only reports a generic fetch failure. Nothing points at the port block being the cause.

## What Changed

- `create_backend_env` in `scripts/rh/dev.sh` now writes `FRONTEND_URL=http://localhost:${DEV_FRONTEND_PORT}` into the generated backend env file, with a comment explaining what depends on it.

It is taken from `DEV_FRONTEND_PORT` — the same variable `create_frontend_env` already uses for its own `FRONTEND_URL` — so the backend and frontend env files agree on the port by construction rather than by coincidence.

## Additional Context

- No behaviour change in the main checkout: offset 0 resolves to `http://localhost:3000`, which is exactly the default being replaced.
- Only affects newly generated env files. Existing worktrees need the line added by hand, or `./rh dev init` re-run — see Testing.
- Found while running `./rh dev tmux` in a worktree at offset 30, where the frontend on `:3030` could not log in at all.

## Testing

In an existing worktree with a non-zero offset, confirm the bug first — `curl -s -o /dev/null -w '%{http_code}\n' -X OPTIONS http://localhost:<backend-port>/auth/local-login -H 'Origin: http://localhost:<frontend-port>' -H 'Access-Control-Request-Method: POST'` returns `400`, with a body of `Disallowed CORS origin`.

Add `FRONTEND_URL=http://localhost:<frontend-port>` to `apps/backend/.env`, restart the backend, and the same request returns `200` with an `access-control-allow-origin` header naming that origin. The landing page then completes auto-login instead of looping.

For the change itself: run `./rh dev init` in a fresh worktree and check that the generated `apps/backend/.env` carries a `FRONTEND_URL` matching the port in `apps/frontend/.env.local`.
