### PR TITLE
Add venv setup step to the backend-testing skill

### DIFF
--- a/.agents/skills/backend-testing/SKILL.md
+++ b/.agents/skills/backend-testing/SKILL.md
@@ -13,8 +13,13 @@ Backend tests must run from `apps/backend` — its `pyproject.toml` sets
 `testpaths = ["../../tests/backend"]` and `pythonpath = ["src"]`, so paths/imports only resolve
 from that directory. Never run `uv run pytest tests/backend/...` from the repo root.
 
+A fresh worktree has no `apps/backend/.venv`, and a plain `uv sync` is not enough — `rhesis-sdk`
+sits behind the `all` extra and `rhesis.backend.ee` behind `ee`, so the tests fail with
+`ModuleNotFoundError` on those imports. Sync both extras once per worktree.
+
 ```bash
 cd apps/backend
+uv sync --extra all --extra ee  # once per worktree
 uv run pytest ../../tests/backend/ -v
 # single test class:
 uv run pytest ../../tests/backend/services/explorer/test_tests.py::TestCreateExplorerTestSet -v


### PR DESCRIPTION
## Purpose

Three agents working in fresh worktrees each hit the same wall independently today: `uv run pytest` from `apps/backend` fails with `ModuleNotFoundError: No module named 'rhesis.sdk'`, and once that's fixed, `No module named 'rhesis.backend.ee'`. Both packages sit behind optional extras, so a plain `uv sync` doesn't install them. The `backend-testing` skill covered the working directory and the Docker requirement but said nothing about the venv, so each agent rediscovered the fix by trial and error.

## What Changed

- Added two sentences plus a `uv sync --extra all --extra ee` line to `.agents/skills/backend-testing/SKILL.md`, placed right before the pytest invocations where the failure happens. The wording names which extra carries which package, since that's the non-obvious part.

## Additional Context

- `rhesis-sdk` is in the `all` extra and `rhesis-backend-ee` is in the `ee` extra in `apps/backend/pyproject.toml`.
- CI (`.github/workflows/backend-test.yml`) runs `uv sync --dev --extra all --extra cpu --extra ee`. The documented command drops two of those flags deliberately: `--dev` is uv's default (the `dev` dependency group carries pytest and installs without the flag), and `--extra cpu` only selects the CPU torch wheel index — torch arrives transitively via `all` regardless, so it isn't needed to make the tests run. Keeping the command minimal keeps the skill short.
- `.claude/skills/backend-testing` and `.cursor/skills/backend-testing` are symlinks to the `.agents/` path, so they pick this up with no change.

## Testing

Verified end to end in a fresh worktree, which starts in exactly the broken state:

1. With no `apps/backend/.venv`, `uv run pytest ../../tests/backend/services/explorer/test_tests.py` failed with `ModuleNotFoundError: No module named 'rhesis.sdk'` — the reported failure, reproduced.
2. After `uv sync --extra all --extra ee`, the same command passed: 69 passed in 6.84s.
3. Confirmed the `ee` extra is load-bearing and not cargo cult: re-syncing with `--extra all` alone uninstalls `rhesis-backend-ee`, and `pytest ../../tests/backend/ee/licensing` then fails with `ModuleNotFoundError: No module named 'rhesis.backend.ee'`. Re-adding `--extra ee` fixes it.

Docker was running, so the Testcontainers Postgres and Redis came up normally.
