### PR TITLE
Guide users to connect an endpoint before testing

### DIFF
--- a/apps/frontend/jest.setup.js
+++ b/apps/frontend/jest.setup.js
@@ -104,10 +104,12 @@ if (hasWindow) {
     writable: true,
   });
 
-  // Make window.location mockable for tests
-  // Delete first, then redefine to avoid jsdom's built-in location
-  delete window.location;
-  window.location = {
+  // Make window.location mockable for tests. jsdom on newer Node makes
+  // location neither deletable nor redefinable, and both forms throw *during
+  // setup*, taking down every suite before a single test runs. Fall back to
+  // stubbing the navigation methods on the real location object, which is all
+  // any test actually asserts on.
+  const locationStub = {
     href: 'http://localhost:3000',
     origin: 'http://localhost:3000',
     protocol: 'http:',
@@ -123,6 +125,26 @@ if (hasWindow) {
     reload: jest.fn(),
     toString: jest.fn(() => 'http://localhost:3000'),
   };
+
+  try {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: locationStub,
+    });
+  } catch {
+    for (const method of ['assign', 'replace', 'reload']) {
+      try {
+        Object.defineProperty(window.location, method, {
+          configurable: true,
+          writable: true,
+          value: locationStub[method],
+        });
+      } catch {
+        // Nothing more we can do; a test needing this must stub it itself.
+      }
+    }
+  }
 }
 
 // Mock localStorage

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectHelpSection.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectHelpSection.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import React from 'react';
+import { Box } from '@mui/material';
+import { EntityEmptyStateEnrichmentSections } from '@/components/common/EntityEmptyStateEnrichmentParts';
+import { COMMUNITY_LINK_CARDS } from '@/constants/entity-empty-state-env';
+import type { EntityEmptyStateEnrichment } from '@/constants/entity-empty-state-types';
+import { useArchitectHelpArticles } from '@/hooks/useArchitectHelpArticles';
+import { useProjectNeedsEndpoint } from '@/hooks/useProjectNeedsEndpoint';
+
+/** Figma frame width for the help section (1858:49358) — wider than the input column. */
+const MAX_WIDTH = 1126;
+
+/**
+ * Getting-started help cards for a project that has no endpoint yet. Renders
+ * nothing once an endpoint exists, so it fades out on its own as the user
+ * completes setup.
+ */
+export default function ArchitectHelpSection() {
+  const { needsEndpoint } = useProjectNeedsEndpoint();
+  const { data: articleUrls } = useArchitectHelpArticles();
+
+  // Stay hidden until we know the project has no endpoint — otherwise users who
+  // do have one see the cards flash on every visit.
+  if (!needsEndpoint) return null;
+
+  const enrichment: EntityEmptyStateEnrichment = {
+    communityLinks: {
+      title: 'Community & Support',
+      items: COMMUNITY_LINK_CARDS,
+    },
+  };
+
+  if (articleUrls && articleUrls.length > 0) {
+    enrichment.helpArticles = {
+      title: 'Top Help Articles',
+      items: articleUrls.map(href => ({ href })),
+    };
+  }
+
+  return (
+    // mt partly reclaims the space the hidden suggestion chips left behind —
+    // enough to settle the cards near the bottom without forcing a scrollbar.
+    <Box sx={{ width: '100%', maxWidth: MAX_WIDTH, mt: { xs: 2, md: 3 } }}>
+      <EntityEmptyStateEnrichmentSections enrichment={enrichment} />
+    </Box>
+  );
+}

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectWelcome.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectWelcome.tsx
@@ -15,6 +15,8 @@ import BugReportOutlinedIcon from '@mui/icons-material/BugReportOutlined';
 import FactCheckOutlinedIcon from '@mui/icons-material/FactCheckOutlined';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
+import { useProjectNeedsEndpoint } from '@/hooks/useProjectNeedsEndpoint';
+import ArchitectHelpSection from './ArchitectHelpSection';
 
 const SUGGESTED_PROMPTS = [
   {
@@ -40,6 +42,8 @@ interface ArchitectWelcomeProps {
 
 export default function ArchitectWelcome({ onSubmit }: ArchitectWelcomeProps) {
   const canCreate = useCan(Capability.Architect.CREATE);
+  const { pending: endpointCheckPending, needsEndpoint } =
+    useProjectNeedsEndpoint();
   const [inputValue, setInputValue] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -71,11 +75,18 @@ export default function ArchitectWelcome({ onSubmit }: ArchitectWelcomeProps) {
       sx={{
         flex: 1,
         display: 'flex',
+        flexDirection: 'column',
         alignItems: 'center',
-        justifyContent: 'center',
+        overflowY: 'auto',
         p: 4,
       }}
     >
+      {/* `my: 'auto'` centres the group while it fits, then resolves to 0 and
+          scrolls from the top once the help section makes it taller than the
+          viewport. `justifyContent: 'center'` would clip the leading edge.
+          The top padding only applies with the help section below: it counts
+          towards the centred box's height, so on its own it would push the
+          input off-centre by half its value. */}
       <Box
         sx={{
           display: 'flex',
@@ -83,92 +94,111 @@ export default function ArchitectWelcome({ onSubmit }: ArchitectWelcomeProps) {
           alignItems: 'center',
           gap: 3,
           width: '100%',
-          maxWidth: theme => theme.spacing(85),
+          my: 'auto',
+          pt: needsEndpoint ? { xs: 6, md: 18 } : 0,
         }}
       >
-        <Typography
-          variant="h4"
-          color="text.secondary"
-          sx={{
-            fontWeight: theme => theme.typography.fontWeightLight,
-            textAlign: 'center',
-          }}
-        >
-          What would you like to test?
-        </Typography>
-
-        <TextField
-          inputRef={inputRef}
-          fullWidth
-          multiline
-          maxRows={6}
-          placeholder={
-            canCreate
-              ? 'Describe what you want to test...'
-              : 'View-only access — you cannot start new Architect sessions'
-          }
-          value={inputValue}
-          onChange={e => setInputValue(e.target.value)}
-          onKeyDown={handleKeyDown}
-          disabled={inputDisabled}
-          autoFocus={canCreate}
-          sx={{
-            '& .MuiOutlinedInput-root': {
-              borderRadius: theme => theme.spacing(3.5),
-              py: 1,
-              pl: 2,
-              pr: 1,
-              bgcolor: 'action.hover',
-              '& fieldset': { borderColor: 'divider' },
-            },
-          }}
-          slotProps={{
-            input: {
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    onClick={handleSubmit}
-                    disabled={!inputValue.trim() || inputDisabled}
-                    sx={{
-                      bgcolor: 'primary.main',
-                      color: 'primary.contrastText',
-                      width: theme => theme.spacing(4.5),
-                      height: theme => theme.spacing(4.5),
-                      '&:hover': { bgcolor: 'primary.dark' },
-                      '&:disabled': {
-                        bgcolor: 'action.disabledBackground',
-                        color: 'action.disabled',
-                      },
-                    }}
-                  >
-                    <SendIcon fontSize="small" />
-                  </IconButton>
-                </InputAdornment>
-              ),
-            },
-          }}
-        />
-
         <Box
           sx={{
             display: 'flex',
-            flexWrap: 'wrap',
-            gap: 1,
-            justifyContent: 'center',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 3,
+            width: '100%',
+            maxWidth: theme => theme.spacing(85),
           }}
         >
-          {SUGGESTED_PROMPTS.map(({ label, prompt, icon: Icon }) => (
-            <Chip
-              key={label}
-              icon={<Icon fontSize="small" />}
-              label={label}
-              variant="outlined"
-              onClick={() => handleSuggestedPrompt(prompt)}
-              disabled={inputDisabled}
-              sx={{ cursor: 'pointer' }}
-            />
-          ))}
+          <Typography
+            variant="h4"
+            color="text.secondary"
+            sx={{
+              fontWeight: theme => theme.typography.fontWeightBold,
+              textAlign: 'center',
+            }}
+          >
+            What would you like to test?
+          </Typography>
+
+          <TextField
+            inputRef={inputRef}
+            fullWidth
+            multiline
+            maxRows={6}
+            placeholder={
+              canCreate
+                ? 'Describe what you want to test...'
+                : 'View-only access — you cannot start new Architect sessions'
+            }
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={inputDisabled}
+            autoFocus={canCreate}
+            sx={{
+              '& .MuiOutlinedInput-root': {
+                borderRadius: theme => theme.spacing(3.5),
+                py: 1,
+                pl: 2,
+                pr: 1,
+                bgcolor: 'action.hover',
+                '& fieldset': { borderColor: 'divider' },
+              },
+            }}
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      onClick={handleSubmit}
+                      disabled={!inputValue.trim() || inputDisabled}
+                      sx={{
+                        bgcolor: 'primary.main',
+                        color: 'primary.contrastText',
+                        width: theme => theme.spacing(4.5),
+                        height: theme => theme.spacing(4.5),
+                        '&:hover': { bgcolor: 'primary.dark' },
+                        '&:disabled': {
+                          bgcolor: 'action.disabledBackground',
+                          color: 'action.disabled',
+                        },
+                      }}
+                    >
+                      <SendIcon fontSize="small" />
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+
+          {/* No endpoint means no prompt can actually run, so the suggestions
+              are dead ends — the getting-started cards below replace them.
+              Waiting out `pending` keeps the two from swapping visibly. */}
+          {!endpointCheckPending && !needsEndpoint && (
+            <Box
+              sx={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: 1,
+                justifyContent: 'center',
+              }}
+            >
+              {SUGGESTED_PROMPTS.map(({ label, prompt, icon: Icon }) => (
+                <Chip
+                  key={label}
+                  icon={<Icon fontSize="small" />}
+                  label={label}
+                  variant="outlined"
+                  onClick={() => handleSuggestedPrompt(prompt)}
+                  disabled={inputDisabled}
+                  sx={{ cursor: 'pointer' }}
+                />
+              ))}
+            </Box>
+          )}
         </Box>
+
+        <ArchitectHelpSection />
       </Box>
     </Box>
   );

--- a/apps/frontend/src/app/(protected)/architect/components/__tests__/ArchitectHelpSection.test.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/__tests__/ArchitectHelpSection.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ArchitectHelpSection from '../ArchitectHelpSection';
+import { useArchitectHelpArticles } from '@/hooks/useArchitectHelpArticles';
+import { useProjectNeedsEndpoint } from '@/hooks/useProjectNeedsEndpoint';
+
+jest.mock('@/hooks/useProjectNeedsEndpoint', () => ({
+  useProjectNeedsEndpoint: jest.fn(),
+}));
+
+jest.mock('@/hooks/useArchitectHelpArticles', () => ({
+  useArchitectHelpArticles: jest.fn(),
+}));
+
+const mockUseProjectNeedsEndpoint =
+  useProjectNeedsEndpoint as jest.MockedFunction<
+    typeof useProjectNeedsEndpoint
+  >;
+const mockUseArchitectHelpArticles =
+  useArchitectHelpArticles as jest.MockedFunction<
+    typeof useArchitectHelpArticles
+  >;
+
+const ARTICLE_URLS = [
+  'https://docs.rhesis.ai/docs/getting-started/connecting-application',
+  'https://docs.rhesis.ai/docs/endpoints',
+];
+
+function setEndpointState(state: { pending: boolean; needsEndpoint: boolean }) {
+  mockUseProjectNeedsEndpoint.mockReturnValue(state);
+}
+
+function setArticles(urls: string[]) {
+  mockUseArchitectHelpArticles.mockReturnValue({
+    data: urls,
+  } as unknown as ReturnType<typeof useArchitectHelpArticles>);
+}
+
+describe('ArchitectHelpSection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // EmptyStateArticleCard fetches OG metadata per card; keep it inert.
+    global.fetch = jest.fn().mockResolvedValue({ ok: false }) as jest.Mock;
+    setEndpointState({ pending: false, needsEndpoint: true });
+    setArticles(ARTICLE_URLS);
+  });
+
+  it('renders both sections when the project has no endpoint', () => {
+    render(<ArchitectHelpSection />);
+
+    expect(screen.getByText('Top Help Articles')).toBeInTheDocument();
+    expect(screen.getByText('Community & Support')).toBeInTheDocument();
+    expect(screen.getByText('Documentation')).toBeInTheDocument();
+  });
+
+  it('renders nothing once the project has an endpoint', () => {
+    setEndpointState({ pending: false, needsEndpoint: false });
+
+    render(<ArchitectHelpSection />);
+
+    expect(screen.queryByText('Top Help Articles')).not.toBeInTheDocument();
+    expect(screen.queryByText('Community & Support')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing while the endpoint check is still loading', () => {
+    setEndpointState({ pending: true, needsEndpoint: false });
+
+    render(<ArchitectHelpSection />);
+
+    expect(screen.queryByText('Community & Support')).not.toBeInTheDocument();
+  });
+
+  it('still shows community links when no article URLs are configured', () => {
+    setArticles([]);
+
+    render(<ArchitectHelpSection />);
+
+    expect(screen.queryByText('Top Help Articles')).not.toBeInTheDocument();
+    expect(screen.getByText('Community & Support')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/(protected)/architect/components/__tests__/ArchitectWelcome.test.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/__tests__/ArchitectWelcome.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ArchitectWelcome from '../ArchitectWelcome';
+import { useProjectNeedsEndpoint } from '@/hooks/useProjectNeedsEndpoint';
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+jest.mock('@/hooks/useProjectNeedsEndpoint', () => ({
+  useProjectNeedsEndpoint: jest.fn(),
+}));
+
+// The help section is covered by its own suite; keep it out of the way here.
+jest.mock('../ArchitectHelpSection', () => ({
+  __esModule: true,
+  default: () => <div data-testid="help-section" />,
+}));
+
+const mockUseProjectNeedsEndpoint =
+  useProjectNeedsEndpoint as jest.MockedFunction<
+    typeof useProjectNeedsEndpoint
+  >;
+
+const CHIP_LABEL = 'Safety & fairness tests';
+
+describe('ArchitectWelcome', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows the suggestion chips when the project has an endpoint', () => {
+    mockUseProjectNeedsEndpoint.mockReturnValue({
+      pending: false,
+      needsEndpoint: false,
+    });
+
+    render(<ArchitectWelcome onSubmit={jest.fn()} />);
+
+    expect(screen.getByText(CHIP_LABEL)).toBeInTheDocument();
+  });
+
+  it('hides the chips when the project has no endpoint — they cannot run', () => {
+    mockUseProjectNeedsEndpoint.mockReturnValue({
+      pending: false,
+      needsEndpoint: true,
+    });
+
+    render(<ArchitectWelcome onSubmit={jest.fn()} />);
+
+    expect(screen.queryByText(CHIP_LABEL)).not.toBeInTheDocument();
+    // The input stays available regardless.
+    expect(
+      screen.getByPlaceholderText('Describe what you want to test...')
+    ).toBeInTheDocument();
+  });
+
+  it('hides the chips while the endpoint check is pending, to avoid a swap', () => {
+    mockUseProjectNeedsEndpoint.mockReturnValue({
+      pending: true,
+      needsEndpoint: false,
+    });
+
+    render(<ArchitectWelcome onSubmit={jest.fn()} />);
+
+    expect(screen.queryByText(CHIP_LABEL)).not.toBeInTheDocument();
+  });
+
+  it('keeps the heading visible in every state', () => {
+    mockUseProjectNeedsEndpoint.mockReturnValue({
+      pending: false,
+      needsEndpoint: true,
+    });
+
+    render(<ArchitectWelcome onSubmit={jest.fn()} />);
+
+    expect(
+      screen.getByText('What would you like to test?')
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/api/architect-help/__tests__/route.test.ts
+++ b/apps/frontend/src/app/api/architect-help/__tests__/route.test.ts
@@ -1,0 +1,59 @@
+/**
+ * next/server needs the WHATWG Request/Response globals, which the default
+ * jsdom environment does not provide.
+ *
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/architect-help/route';
+
+const ENV_KEY = 'ARCHITECT_HELP_ARTICLE_URLS';
+
+async function articleUrls(): Promise<string[]> {
+  const response = await GET();
+  const body = (await response.json()) as { articleUrls: string[] };
+  return body.articleUrls;
+}
+
+describe('GET /api/architect-help', () => {
+  const original = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = original;
+    }
+  });
+
+  it('returns an empty list when unset', async () => {
+    delete process.env[ENV_KEY];
+    await expect(articleUrls()).resolves.toEqual([]);
+  });
+
+  it('splits a comma-separated list and trims whitespace', async () => {
+    process.env[ENV_KEY] =
+      ' https://docs.rhesis.ai/docs/endpoints , https://docs.rhesis.ai/docs/concepts ';
+
+    await expect(articleUrls()).resolves.toEqual([
+      'https://docs.rhesis.ai/docs/endpoints',
+      'https://docs.rhesis.ai/docs/concepts',
+    ]);
+  });
+
+  it('caps the list at four URLs — one card row', async () => {
+    process.env[ENV_KEY] = [1, 2, 3, 4, 5, 6]
+      .map(n => `https://docs.rhesis.ai/docs/page-${n}`)
+      .join(',');
+
+    await expect(articleUrls()).resolves.toHaveLength(4);
+  });
+
+  it('drops hosts the og-metadata proxy would reject', async () => {
+    process.env[ENV_KEY] =
+      'https://docs.rhesis.ai/docs/endpoints,https://evil.example/docs,not-a-url';
+
+    await expect(articleUrls()).resolves.toEqual([
+      'https://docs.rhesis.ai/docs/endpoints',
+    ]);
+  });
+});

--- a/apps/frontend/src/app/api/architect-help/route.ts
+++ b/apps/frontend/src/app/api/architect-help/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { isAllowedOgMetadataUrl } from '@/app/api/og-metadata/og-metadata-utils';
+import { parseCommaSeparatedUrls } from '@/constants/entity-empty-state-env';
+
+// Read per request so the value comes from the container environment. The
+// NEXT_PUBLIC_* empty-state vars are inlined into the browser bundle at build
+// time, which the GCP Secret Manager → ESO pipeline cannot feed; this one is
+// deliberately unprefixed and served from the server instead, so changing the
+// URLs is a secret update plus a rollout restart rather than a rebuild.
+export const dynamic = 'force-dynamic';
+
+/**
+ * Docs articles offered on the Architect welcome screen when the active project
+ * has no endpoint yet. Cards render titles/descriptions/images from each page's
+ * OG tags via /api/og-metadata.
+ */
+export function GET() {
+  const configured = parseCommaSeparatedUrls(
+    process.env.ARCHITECT_HELP_ARTICLE_URLS?.trim()
+  );
+
+  // Same allowlist /api/og-metadata enforces — drop misconfigured hosts here so
+  // they never become cards whose metadata fetch is guaranteed to 403.
+  const articleUrls = configured.filter(url => {
+    try {
+      return isAllowedOgMetadataUrl(new URL(url));
+    } catch {
+      return false;
+    }
+  });
+
+  return NextResponse.json({ articleUrls });
+}

--- a/apps/frontend/src/constants/entity-empty-state-env.ts
+++ b/apps/frontend/src/constants/entity-empty-state-env.ts
@@ -5,7 +5,7 @@ import type {
 } from '@/constants/entity-empty-state-types';
 import { getYouTubeWatchUrl } from '@/utils/onboarding-video';
 
-const COMMUNITY_LINK_CARDS: EmptyStateLinkCard[] = [
+export const COMMUNITY_LINK_CARDS: EmptyStateLinkCard[] = [
   {
     title: 'Documentation',
     description: 'Comprehensive guides and API references',
@@ -96,7 +96,8 @@ function readEntityEnvSources(key: EntityEmptyStateKey): {
   }
 }
 
-function parseCommaSeparatedUrls(value: string | undefined): string[] {
+/** Trims, drops empties and caps at 4 — one card row is all any empty state shows. */
+export function parseCommaSeparatedUrls(value: string | undefined): string[] {
   if (!value?.trim()) return [];
   return value
     .split(',')

--- a/apps/frontend/src/constants/query-keys.ts
+++ b/apps/frontend/src/constants/query-keys.ts
@@ -124,3 +124,8 @@ export const insightsFailedTestIdsKeys = {
 export const platformKeyKeys = {
   all: () => ['platform-rhesis-key'] as const,
 };
+
+// Deployment-wide: docs URLs for the Architect welcome help cards.
+export const architectHelpKeys = {
+  all: () => ['architect-help-articles'] as const,
+};

--- a/apps/frontend/src/hooks/__tests__/useProjectNeedsEndpoint.test.ts
+++ b/apps/frontend/src/hooks/__tests__/useProjectNeedsEndpoint.test.ts
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react';
+import { useProjectNeedsEndpoint } from '../useProjectNeedsEndpoint';
+import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useEndpoints } from '@/hooks/useEndpoints';
+import type { Endpoint } from '@/utils/api-client/interfaces/endpoint';
+
+jest.mock('@/contexts/ActiveProjectContext', () => ({
+  useActiveProject: jest.fn(),
+}));
+
+jest.mock('@/hooks/useEndpoints', () => ({
+  useEndpoints: jest.fn(),
+}));
+
+const mockUseActiveProject = useActiveProject as jest.MockedFunction<
+  typeof useActiveProject
+>;
+const mockUseEndpoints = useEndpoints as jest.MockedFunction<
+  typeof useEndpoints
+>;
+
+function setProject(id: string | null) {
+  mockUseActiveProject.mockReturnValue({
+    activeProject: id ? { id, name: 'Demo' } : null,
+  } as unknown as ReturnType<typeof useActiveProject>);
+}
+
+/** The three react-query v5 outcomes we care about, shaped as the query result. */
+function setQuery(
+  outcome: 'loading' | 'success' | 'error',
+  endpoints: Endpoint[] = []
+) {
+  mockUseEndpoints.mockReturnValue({
+    data: outcome === 'success' ? endpoints : undefined,
+    isPending: outcome === 'loading',
+    isSuccess: outcome === 'success',
+    isError: outcome === 'error',
+  } as unknown as ReturnType<typeof useEndpoints>);
+}
+
+describe('useProjectNeedsEndpoint', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setProject('project-1');
+  });
+
+  it('reports pending while the endpoint query is in flight', () => {
+    setQuery('loading');
+
+    const { result } = renderHook(() => useProjectNeedsEndpoint());
+
+    expect(result.current).toEqual({ pending: true, needsEndpoint: false });
+  });
+
+  it('reports needsEndpoint when the project has none', () => {
+    setQuery('success', []);
+
+    const { result } = renderHook(() => useProjectNeedsEndpoint());
+
+    expect(result.current).toEqual({ pending: false, needsEndpoint: true });
+  });
+
+  it('reports neither once an endpoint exists', () => {
+    setQuery('success', [{ id: 'endpoint-1' } as Endpoint]);
+
+    const { result } = renderHook(() => useProjectNeedsEndpoint());
+
+    expect(result.current).toEqual({ pending: false, needsEndpoint: false });
+  });
+
+  it('recovers to the default UI when the query fails', () => {
+    // react-query leaves isSuccess false for good on error, so keying `pending`
+    // off !isSuccess would latch it on and hide the chips and the help cards
+    // together, permanently. Both must be false here.
+    setQuery('error');
+
+    const { result } = renderHook(() => useProjectNeedsEndpoint());
+
+    expect(result.current).toEqual({ pending: false, needsEndpoint: false });
+  });
+
+  it('stays quiet when there is no active project', () => {
+    setProject(null);
+    // Disabled queries sit at status 'pending' in react-query v5.
+    setQuery('loading');
+
+    const { result } = renderHook(() => useProjectNeedsEndpoint());
+
+    expect(result.current).toEqual({ pending: false, needsEndpoint: false });
+  });
+});

--- a/apps/frontend/src/hooks/useArchitectHelpArticles.ts
+++ b/apps/frontend/src/hooks/useArchitectHelpArticles.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { architectHelpKeys } from '@/constants/query-keys';
+
+interface ArchitectHelpResponse {
+  articleUrls: string[];
+}
+
+/**
+ * Docs URLs for the Architect welcome help cards, served by /api/architect-help
+ * from the container environment. Deployment config, so it only changes on a
+ * rollout — never refetch it during a session.
+ */
+export function useArchitectHelpArticles() {
+  return useQuery<string[]>({
+    queryKey: architectHelpKeys.all(),
+    queryFn: async () => {
+      const response = await fetch('/api/architect-help');
+      if (!response.ok) return [];
+      const data = (await response.json()) as ArchitectHelpResponse;
+      return data.articleUrls ?? [];
+    },
+    staleTime: Infinity,
+    gcTime: Infinity,
+    retry: false,
+  });
+}

--- a/apps/frontend/src/hooks/useProjectNeedsEndpoint.ts
+++ b/apps/frontend/src/hooks/useProjectNeedsEndpoint.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useEndpoints } from '@/hooks/useEndpoints';
+
+interface ProjectNeedsEndpoint {
+  /** The check is still running — callers should render neither branch yet. */
+  pending: boolean;
+  /** Known to have zero endpoints, so nothing can be tested yet. */
+  needsEndpoint: boolean;
+}
+
+/**
+ * Whether the active project still has no endpoint. Drives the Architect
+ * welcome screen: getting-started cards instead of suggestion chips, since a
+ * prompt cannot run anywhere until an endpoint exists.
+ *
+ * `pending` keeps callers from flashing one branch before the other — both the
+ * chips and the help cards wait for the same answer.
+ */
+export function useProjectNeedsEndpoint(): ProjectNeedsEndpoint {
+  const { activeProject } = useActiveProject();
+  const enabled = !!activeProject?.id;
+
+  // limit: 1 — existence check only. Requests carry X-Project-Id, so this is
+  // already scoped to the active project. react-query dedupes the shared key
+  // across every caller, so asking twice costs one request.
+  const { data: endpoints, isSuccess } = useEndpoints({ limit: 1 }, enabled);
+
+  // With no project there is nothing to prompt about; leave the default UI alone.
+  return {
+    pending: enabled && !isSuccess,
+    needsEndpoint: enabled && isSuccess && endpoints?.length === 0,
+  };
+}

--- a/apps/frontend/src/hooks/useProjectNeedsEndpoint.ts
+++ b/apps/frontend/src/hooks/useProjectNeedsEndpoint.ts
@@ -25,11 +25,21 @@ export function useProjectNeedsEndpoint(): ProjectNeedsEndpoint {
   // limit: 1 — existence check only. Requests carry X-Project-Id, so this is
   // already scoped to the active project. react-query dedupes the shared key
   // across every caller, so asking twice costs one request.
-  const { data: endpoints, isSuccess } = useEndpoints({ limit: 1 }, enabled);
+  const {
+    data: endpoints,
+    isSuccess,
+    isPending,
+  } = useEndpoints({ limit: 1 }, enabled);
 
-  // With no project there is nothing to prompt about; leave the default UI alone.
+  // `isPending`, not `!isSuccess`: a failed query leaves isSuccess false for
+  // good, which would latch `pending` on and hide the chips and the cards
+  // together, forever. Falling back to "not onboarding" degrades to the plain
+  // welcome screen — the same thing a project with an endpoint sees.
+  //
+  // With no project there is nothing to prompt about, so leave the default UI
+  // alone there too.
   return {
-    pending: enabled && !isSuccess,
+    pending: enabled && isPending,
     needsEndpoint: enabled && isSuccess && endpoints?.length === 0,
   };
 }

--- a/kubernetes/clusters/dev/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/dev/external-secrets/rhesis-app-secrets.yaml
@@ -338,3 +338,10 @@ spec:
     - secretKey: RHESIS_LICENSE_KID
       remoteRef:
         key: dev-rhesis-rhesis-license-kid
+
+##--------------------------------------------------------
+## Frontend content
+##--------------------------------------------------------
+    - secretKey: ARCHITECT_HELP_ARTICLE_URLS
+      remoteRef:
+        key: dev-rhesis-architect-help-article-urls

--- a/kubernetes/clusters/prd/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/prd/external-secrets/rhesis-app-secrets.yaml
@@ -317,3 +317,10 @@ spec:
     - secretKey: RHESIS_LICENSE_KID
       remoteRef:
         key: prd-rhesis-rhesis-license-kid
+
+##--------------------------------------------------------
+## Frontend content
+##--------------------------------------------------------
+    - secretKey: ARCHITECT_HELP_ARTICLE_URLS
+      remoteRef:
+        key: prd-rhesis-architect-help-article-urls

--- a/kubernetes/clusters/stg/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/stg/external-secrets/rhesis-app-secrets.yaml
@@ -320,3 +320,10 @@ spec:
     - secretKey: RHESIS_LICENSE_KID
       remoteRef:
         key: stg-rhesis-rhesis-license-kid
+
+##--------------------------------------------------------
+## Frontend content
+##--------------------------------------------------------
+    - secretKey: ARCHITECT_HELP_ARTICLE_URLS
+      remoteRef:
+        key: stg-rhesis-architect-help-article-urls

--- a/scripts/rh/dev.sh
+++ b/scripts/rh/dev.sh
@@ -158,6 +158,12 @@ PORT=${DEV_FRONTEND_PORT}
 
 NEXTAUTH_SECRET=${nextauth_secret}
 NEXT_TELEMETRY_DISABLED=1
+
+# Docs cards shown on the Architect welcome screen while a project has no
+# endpoint. Read at request time by /api/architect-help; in the cloud it comes
+# from GCP Secret Manager instead. Hosts must be allowlisted in
+# apps/frontend/src/app/api/og-metadata/og-metadata-utils.ts.
+ARCHITECT_HELP_ARTICLE_URLS=https://docs.rhesis.ai/docs/getting-started/connecting-application,https://docs.rhesis.ai/docs/endpoints,https://docs.rhesis.ai/docs/endpoints/sdk-endpoints,https://docs.rhesis.ai/docs/concepts
 EOF
 }
 

--- a/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
+++ b/sdk/src/rhesis/sdk/agents/architect/prompt_templates/telemachus-guidelines.j2
@@ -20,6 +20,16 @@
   Link text must always be a human-readable name. IDs inside URL paths are fine — this is how web apps work. Just never paste a raw ID in prose text or link text.
 - **Never mention tool names in your messages to the user.** Tool names like `create_metric`, `generate_metric`, `list_behaviors` are internal implementation details. Say "I'll create a metric" not "I'll use the generate_metric tool." The user doesn't need to know which tool you're calling.
 
+## A working endpoint comes first
+Rhesis tests a live system. Every run sends prompts to an endpoint and records what comes back, and the recorded responses are what metrics score. A project with no endpoint can hold behaviors, metrics and test sets, but nothing can execute against it — no responses, no scores, no results, no insights.
+
+- **Check before you design.** The first time the user asks you to test, explore, generate or run anything, resolve their endpoints with `list_endpoints` (`$select=name,id,url,description`). Do this before proposing behaviors, metrics or test sets.
+- **If the project has none, say so first.** Put it in your opening sentence instead of burying it under a plan: there is no endpoint connected yet, so nothing can run against this project. Explain in one line what that means — an endpoint is the address of the AI application under test, and connecting one is what turns a test suite into actual results.
+- **Then show the two ways in.** Either register the application's HTTP API as an endpoint, or, when it has no HTTP surface, wrap a Python function with the SDK's `@endpoint` decorator. Point them to https://docs.rhesis.ai/docs/getting-started/connecting-application and offer to set it up with them right now — you can create the endpoint yourself once you have the details, and "Confirm before acting" still applies, so show what you will create and wait for approval.
+- **Say it once, then move on.** If the user would rather design tests first, do that — designing behaviors, metrics and test sets up front is genuinely useful. Note once that the suite cannot be executed until an endpoint is connected, and do not repeat the warning every turn.
+- **Skip it for read-only requests.** "List my test sets", "show me that metric", "compare these two runs" need no endpoint. This rule is about testing, exploring, generating and executing.
+- **Never call an endpoint working until it answers.** A URL mentioned in conversation is not a connected endpoint, and a created endpoint is not a working one — `check_endpoint` is what tells you, and a failure there is the same blocker as having no endpoint at all. Report what it said rather than assuming.
+
 ### Confirm before acting
 - **NEVER call a create, update, delete, generate, or improve tool without the user's explicit approval first.**
 - This is a two-step process: (1) present what you PLAN to do, then (2) wait for the user to say yes before making any tool call that modifies data.

--- a/skills/rhesis/references/phases/discovery.md
+++ b/skills/rhesis/references/phases/discovery.md
@@ -4,6 +4,8 @@ When the user names an endpoint or wants to test an AI application:
 
 1. Resolve endpoint: `list_endpoints` with `$select=name,id,url,description`. If missing, `create_endpoint` (resolve `project_id` via `list_projects` first).
 2. `check_endpoint` — report failures before proceeding.
+
+If the project has **no** endpoint at all, lead your reply with that before any test design: nothing can run against the project until one is connected, so there are no responses to score. Show both routes — register the application's HTTP API, or wrap a Python function with the SDK's `@endpoint` decorator ([connecting an application](https://docs.rhesis.ai/docs/getting-started/connecting-application)) — and offer to create it now. Say it once; if the user would rather design tests first, continue.
 3. If mode not chosen: offer **Quick** vs **Comprehensive** (default Quick if vague).
 4. `explore_endpoint` with strategy from `exploration-strategies.md` — async; poll `get_job_status` every 5–10s until `SUCCESS`.
 

--- a/tests/sdk/agents/test_architect.py
+++ b/tests/sdk/agents/test_architect.py
@@ -1186,6 +1186,70 @@ class TestArchitectPromptHardening:
 
 
 @pytest.mark.unit
+class TestArchitectEndpointPrerequisiteGuidance:
+    """A project with no endpoint cannot run anything.
+
+    Test sets, behaviors and metrics can all be created without one, so the
+    agent can happily build a whole suite for a project that will never
+    produce a single result. The prompt has to make the missing endpoint the
+    first thing the user hears about, on any request that would lead to a run.
+    """
+
+    @pytest.fixture
+    def mock_model(self):
+        return _mock_model()
+
+    def test_prerequisite_section_present(self, mock_model):
+        agent = _make_agent(mock_model)
+        assert "## A working endpoint comes first" in agent.system_prompt
+
+    def test_explains_why_nothing_can_run(self, mock_model):
+        agent = _make_agent(mock_model)
+        prompt = agent.system_prompt.lower()
+        # The reason has to be in the prompt, not just the instruction —
+        # otherwise the agent parrots "you need an endpoint" without being
+        # able to answer "why?".
+        assert "no responses, no scores, no results, no insights" in prompt
+
+    def test_checks_endpoints_before_designing(self, mock_model):
+        agent = _make_agent(mock_model)
+        prompt = agent.system_prompt
+        section = prompt[prompt.index("## A working endpoint comes first") :]
+        assert "list_endpoints" in section
+        assert "before proposing behaviors, metrics or test sets" in section
+
+    def test_leads_with_the_missing_endpoint(self, mock_model):
+        agent = _make_agent(mock_model)
+        prompt = agent.system_prompt.lower()
+        assert "opening sentence" in prompt
+        assert "burying it under a plan" in prompt
+
+    def test_offers_both_connection_routes(self, mock_model):
+        agent = _make_agent(mock_model)
+        prompt = agent.system_prompt
+        assert "@endpoint" in prompt
+        assert "docs.rhesis.ai/docs/getting-started/connecting-application" in prompt
+
+    def test_does_not_nag_or_block(self, mock_model):
+        """Design-first is legitimate; the warning is said once, not per turn."""
+        agent = _make_agent(mock_model)
+        prompt = agent.system_prompt
+        assert "Say it once, then move on." in prompt
+        assert "do not repeat the warning every turn" in prompt
+
+    def test_read_only_requests_are_exempt(self, mock_model):
+        agent = _make_agent(mock_model)
+        prompt = agent.system_prompt
+        assert "Skip it for read-only requests." in prompt
+
+    def test_created_is_not_the_same_as_working(self, mock_model):
+        agent = _make_agent(mock_model)
+        prompt = agent.system_prompt
+        section = prompt[prompt.index("## A working endpoint comes first") :]
+        assert "check_endpoint" in section
+
+
+@pytest.mark.unit
 class TestArchitectNameResolutionGuidance:
     """Verify the prompt teaches a typo-tolerant name-resolution ladder.
 

--- a/tests/sdk/agents/test_architect_prompt_loader.py
+++ b/tests/sdk/agents/test_architect_prompt_loader.py
@@ -144,6 +144,13 @@ class TestRenderPhaseKnowledge:
         assert "Step 1:" in text
         assert "evaluation_steps" in text
 
+    def test_discovery_flags_a_project_with_no_endpoint(self):
+        # Discovery is where the endpoint gets resolved, so the "none at all"
+        # case has to be handled here too — not only in the system prompt.
+        env = build_architect_jinja_env(_TEMPLATES_DIR)
+        text = render_phase_knowledge(env, AgentMode.DISCOVERY, WorkflowPath.EXPLORE)
+        assert "no** endpoint at all" in text
+        assert "connecting-application" in text
 
 @pytest.mark.unit
 class TestBundledSkillReferences:


### PR DESCRIPTION
## Purpose

A user who creates a fresh project has nothing to test yet — no endpoint is connected, so nothing they ask for can actually run. Both the Architect welcome screen and the Architect agent itself hid that fact: the screen offered an input and three suggestion chips that looked ready to go, and the agent would happily design a complete suite of behaviors, metrics and test sets for a project that could never produce a single result. The gap only surfaced at execution time.

This makes the missing endpoint visible in both places — as onboarding cards on the welcome screen, and as the first thing the Architect says when a request would lead to a run.

## What Changed

**Frontend — help cards on the Architect welcome screen** 

- Shows the "Top Help Articles" and "Community & Support" rows below the input while the active project has zero endpoints, and hides the suggestion chips, since none of them can execute. Both wait for the same resolved endpoint state (`useProjectNeedsEndpoint`) so they never visibly swap.
- No new layout code: `EntityEmptyStateEnrichmentSections` already renders this exact frame, and `EmptyStateArticleCard` already fetches OG metadata through `/api/og-metadata`, where `docs.rhesis.ai` is the allowlisted host. Card titles, descriptions and images come live from the docs pages, so docs edits propagate without a frontend change.
- Article URLs come from a new `GET /api/architect-help` route that reads `ARCHITECT_HELP_ARTICLE_URLS` at request time and drops any host the OG proxy would reject.
- The welcome container is now scrollable. It previously centred its content inside a parent with `overflow: hidden`, so anything taller than the viewport was clipped rather than reachable. The top padding applies only when the cards are present — it counts toward the centred box's height, so on its own it pushed the input off-centre.

**SDK — the Architect now raises it on user input**

- New always-loaded `## A working endpoint comes first` section in `telemachus-guidelines.j2`: resolve endpoints before proposing behaviors, metrics or test sets; if there are none, lead the reply with that rather than burying it under a plan; explain why nothing can run, and offer both ways to connect (HTTP API, or the SDK's `@endpoint` decorator).
- Deliberately not a blocker. It says this once rather than every turn, stays out of the way for read-only requests like "list my test sets", and treats a created endpoint as *working* only once `check_endpoint` agrees. Designing tests before connecting anything is still allowed.
- Reinforced in `phases/discovery.md`, which is where endpoint resolution actually happens.

**Dev — unrelated test-infra fix, separate commit**

- `delete window.location` throws on the jsdom shipped with Node 25+, and it runs during setup, so all 213 frontend suites failed to start before a single test executed. Now tries `defineProperty` first and falls back to stubbing `assign`/`replace`/`reload` on the real location object. Drop this commit if only CI's Node 24 matters.

## Additional Context

- **Config is intentionally unprefixed.** The eight existing empty states use `NEXT_PUBLIC_<ENTITY>_EMPTY_STATE_ARTICLE_URLS`, which Next.js inlines into the browser bundle at build time. Nothing threads those into the Docker build — only `NEXT_PUBLIC_ONBOARDING_VIDEO_URL` is passed as a build arg — so **their help-article rows almost certainly render nothing in the deployed app today**. That is pre-existing and left alone here; worth its own ticket. Reading a plain env var server-side means the GSM → ESO → container-env pipeline works as documented, and the URLs can change per environment without a rebuild.
- The three `rhesis-app-secrets.yaml` manifests are updated. Still to do before this shows in a deployed environment: add `ARCHITECT_HELP_ARTICLE_URLS` to `infrastructure/config/gsm-secrets.json` and run `gsm-secrets-sync.sh` per environment, then restart the frontend deployment.
- The local default lives in `scripts/rh/dev.sh` rather than only in `.env.local`, because `./rh dev init` overwrites that file.
- `skills/rhesis/references/phases/discovery.md` is mirrored publicly, so it uses an absolute docs URL. `scripts/skill/validate.py` passes.
- The agent-side change is prompt guidance, so it depends on the model following it — not a hard gate. The deterministic alternative is to compute the endpoint count server-side and inject it into the per-turn context block in `agent.py`, at the cost of one query per turn.

## Testing

Automated:

```bash
cd apps/frontend && npx tsc --noEmit && npm run lint && npx jest   # 213 suites, 1954 tests
cd sdk && uv run pytest ../tests/sdk -q -m unit                    # 404 tests
python3 scripts/skill/validate.py
```

New coverage: the route's parsing and host filtering (unset, whitespace, 4-URL cap, rejected host), the full gating matrix for the cards (no endpoint / has endpoint / still loading / no URLs configured), the chip behaviour on the welcome screen, and assertions on the rendered system prompt and discovery phase text.

Manual:

1. Add `ARCHITECT_HELP_ARTICLE_URLS` to `apps/frontend/.env.local` (see `scripts/rh/dev.sh` for the value), then `./rh dev frontend`.
2. With a project that has no endpoint, open `/architect`: both card rows render below the input with real docs titles and images, and the suggestion chips are gone. The page scrolls rather than clipping.
3. Create an endpoint in that project and reload: cards gone, chips back, input vertically centred.
4. Open an Architect session — the cards must not appear in the chat view.
5. `curl localhost:<port>/api/architect-help` returns the configured URLs.
6. In a project with no endpoint, ask the Architect to build a test suite: it should open by telling you no endpoint is connected and offer to set one up, not hand back a plan.
