### PR TITLE
Extract File CRUD out of the crud/__init__.py monolith

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/crud/__init__.py
@@ -7,7 +7,7 @@ import uuid
 from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
-from sqlalchemy import and_, func, select, text
+from sqlalchemy import and_, select, text
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models, schemas
@@ -1709,127 +1709,6 @@ def delete_tool(
 ) -> Optional[models.Tool]:
     """Delete a tool (soft delete)"""
     return delete_item(db, models.Tool, tool_id, organization_id=organization_id, user_id=user_id)
-
-
-# ============================================================================
-# File CRUD operations
-# ============================================================================
-
-
-def create_file(
-    db: Session,
-    file_data: Union[schemas.FileCreate, dict],
-    organization_id: str = None,
-    user_id: str = None,
-) -> models.File:
-    """Create a file record."""
-    if isinstance(file_data, dict):
-        file_data = schemas.FileCreate(**file_data)
-
-    if hasattr(file_data, "entity_type") and hasattr(file_data.entity_type, "value"):
-        file_data.entity_type = file_data.entity_type.value
-
-    return create_item(db, models.File, file_data, organization_id, user_id)
-
-
-def get_file(
-    db: Session,
-    file_id: uuid.UUID,
-    organization_id: str = None,
-    user_id: str = None,
-) -> Optional[models.File]:
-    """Get file metadata (content is deferred, not loaded)."""
-    return get_item(db, models.File, file_id, organization_id, user_id)
-
-
-def link_file_to_entity(
-    db: Session,
-    file_id: uuid.UUID,
-    entity_id: uuid.UUID,
-    entity_type: str,
-) -> Optional[models.File]:
-    """Update a File row to link it to a new entity (e.g. a Trace after span storage).
-
-    Pure metadata update — no bytes, no storage writes.
-    Returns the updated File, or None if not found.
-    """
-    db_file = db.query(models.File).filter(models.File.id == file_id).first()
-    if not db_file:
-        return None
-    db_file.entity_id = entity_id
-    db_file.entity_type = entity_type
-    db.commit()
-    db.refresh(db_file)
-    return db_file
-
-
-def get_files_for_entity(
-    db: Session,
-    entity_id: uuid.UUID,
-    entity_type: str,
-    organization_id: str = None,
-    user_id: str = None,
-    skip: int = 0,
-    limit: int = 100,
-) -> List[models.File]:
-    """Get all files for a specific entity (content deferred)."""
-    return (
-        QueryBuilder(db, models.File)
-        .with_organization_filter(organization_id)
-        .with_custom_filter(
-            lambda q: q.filter(
-                models.File.entity_id == entity_id,
-                models.File.entity_type == entity_type,
-            )
-        )
-        .with_pagination(skip, limit)
-        .with_sorting("position", "asc")
-        .all()
-    )
-
-
-def get_entity_files_total_size(
-    db: Session,
-    entity_id: uuid.UUID,
-    entity_type: str,
-    organization_id: str = None,
-) -> int:
-    """Get total size in bytes of all files for an entity."""
-    query = db.query(func.coalesce(func.sum(models.File.size_bytes), 0)).filter(
-        models.File.entity_id == entity_id,
-        models.File.entity_type == entity_type,
-        models.File.deleted_at.is_(None),
-    )
-    if organization_id:
-        query = query.filter(models.File.organization_id == organization_id)
-    return query.scalar()
-
-
-def get_entity_files_max_position(
-    db: Session,
-    entity_id: uuid.UUID,
-    entity_type: str,
-    organization_id: str = None,
-) -> int:
-    """Get the maximum position of files for an entity, or -1 if none exist."""
-    query = db.query(func.coalesce(func.max(models.File.position), -1)).filter(
-        models.File.entity_id == entity_id,
-        models.File.entity_type == entity_type,
-        models.File.deleted_at.is_(None),
-    )
-    if organization_id:
-        query = query.filter(models.File.organization_id == organization_id)
-    return query.scalar()
-
-
-def delete_file(
-    db: Session,
-    file_id: uuid.UUID,
-    organization_id: str = None,
-    user_id: str = None,
-) -> Optional[models.File]:
-    """Soft-delete a file."""
-    return delete_item(db, models.File, file_id, organization_id, user_id)
 
 
 # ── Architect Session CRUD ──────────────────────────────────────────────

--- a/apps/backend/src/rhesis/backend/app/crud/file.py
+++ b/apps/backend/src/rhesis/backend/app/crud/file.py
@@ -1,0 +1,151 @@
+"""CRUD operations for file attachments.
+
+Part of the incremental split of the ``crud`` monolith: ``crud/__init__.py`` still holds
+the bulk of the functions, and per-entity modules like this one take over as the code
+around them is touched.
+
+A ``File`` is always an attachment to something else — it carries a generic
+``(entity_id, entity_type)`` pair rather than a real foreign key, so every read here
+filters on both. ``entity_type`` is stored as a plain string; ``create_file`` unwraps a
+passed ``EntityType`` enum member to its ``.value`` first, because callers hand it either
+form and a bare enum would be written as ``EntityType.TEST`` instead of ``"Test"``.
+
+``link_file_to_entity`` is the one function that bypasses ``QueryBuilder`` and the shared
+crud helpers. Span storage creates a ``File`` before the ``Trace`` it belongs to exists,
+then re-points it once the trace is written, so this is a targeted metadata update that
+commits on its own — it moves no bytes and touches no storage.
+
+``get_entity_files_total_size`` and ``get_entity_files_max_position`` are raw aggregates
+(quota check and next-position lookup for the upload endpoint), so they filter
+``deleted_at`` and ``organization_id`` by hand instead of going through ``QueryBuilder``.
+"""
+
+import uuid
+from typing import List, Optional, Union
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models, schemas
+from rhesis.backend.app.utils.crud_utils import (
+    create_item,
+    delete_item,
+    get_item,
+)
+from rhesis.backend.app.utils.query_utils import QueryBuilder
+
+
+def create_file(
+    db: Session,
+    file_data: Union[schemas.FileCreate, dict],
+    organization_id: str = None,
+    user_id: str = None,
+) -> models.File:
+    """Create a file record."""
+    if isinstance(file_data, dict):
+        file_data = schemas.FileCreate(**file_data)
+
+    if hasattr(file_data, "entity_type") and hasattr(file_data.entity_type, "value"):
+        file_data.entity_type = file_data.entity_type.value
+
+    return create_item(db, models.File, file_data, organization_id, user_id)
+
+
+def get_file(
+    db: Session,
+    file_id: uuid.UUID,
+    organization_id: str = None,
+    user_id: str = None,
+) -> Optional[models.File]:
+    """Get file metadata (content is deferred, not loaded)."""
+    return get_item(db, models.File, file_id, organization_id, user_id)
+
+
+def link_file_to_entity(
+    db: Session,
+    file_id: uuid.UUID,
+    entity_id: uuid.UUID,
+    entity_type: str,
+) -> Optional[models.File]:
+    """Update a File row to link it to a new entity (e.g. a Trace after span storage).
+
+    Pure metadata update — no bytes, no storage writes.
+    Returns the updated File, or None if not found.
+    """
+    db_file = db.query(models.File).filter(models.File.id == file_id).first()
+    if not db_file:
+        return None
+    db_file.entity_id = entity_id
+    db_file.entity_type = entity_type
+    db.commit()
+    db.refresh(db_file)
+    return db_file
+
+
+def get_files_for_entity(
+    db: Session,
+    entity_id: uuid.UUID,
+    entity_type: str,
+    organization_id: str = None,
+    user_id: str = None,
+    skip: int = 0,
+    limit: int = 100,
+) -> List[models.File]:
+    """Get all files for a specific entity (content deferred)."""
+    return (
+        QueryBuilder(db, models.File)
+        .with_organization_filter(organization_id)
+        .with_custom_filter(
+            lambda q: q.filter(
+                models.File.entity_id == entity_id,
+                models.File.entity_type == entity_type,
+            )
+        )
+        .with_pagination(skip, limit)
+        .with_sorting("position", "asc")
+        .all()
+    )
+
+
+def get_entity_files_total_size(
+    db: Session,
+    entity_id: uuid.UUID,
+    entity_type: str,
+    organization_id: str = None,
+) -> int:
+    """Get total size in bytes of all files for an entity."""
+    query = db.query(func.coalesce(func.sum(models.File.size_bytes), 0)).filter(
+        models.File.entity_id == entity_id,
+        models.File.entity_type == entity_type,
+        models.File.deleted_at.is_(None),
+    )
+    if organization_id:
+        query = query.filter(models.File.organization_id == organization_id)
+    return query.scalar()
+
+
+def get_entity_files_max_position(
+    db: Session,
+    entity_id: uuid.UUID,
+    entity_type: str,
+    organization_id: str = None,
+) -> int:
+    """Get the maximum position of files for an entity, or -1 if none exist."""
+    query = db.query(func.coalesce(func.max(models.File.position), -1)).filter(
+        models.File.entity_id == entity_id,
+        models.File.entity_type == entity_type,
+        models.File.deleted_at.is_(None),
+    )
+    if organization_id:
+        query = query.filter(models.File.organization_id == organization_id)
+    return query.scalar()
+
+
+def delete_file(
+    db: Session,
+    file_id: uuid.UUID,
+    organization_id: str = None,
+    user_id: str = None,
+) -> Optional[models.File]:
+    """Soft-delete a file."""
+    return delete_item(db, models.File, file_id, organization_id, user_id)

--- a/apps/backend/src/rhesis/backend/app/routers/file.py
+++ b/apps/backend/src/rhesis/backend/app/routers/file.py
@@ -12,7 +12,7 @@ Threading note
 ``SessionLocal`` in this codebase is a plain ``sessionmaker`` — Session
 instances it produces are *not* thread-safe.  The async endpoints below
 therefore do **not** share a request-scoped ``db`` across threadpool
-workers via ``asyncio.to_thread(crud.x, db, ...)``.  All DB work flows
+workers via ``asyncio.to_thread(file_crud.x, db, ...)``.  All DB work flows
 through :func:`_in_fresh_session`, which opens a short-lived tenant-scoped
 session inside the worker thread, runs the callable, and closes it before
 returning the result.
@@ -27,8 +27,9 @@ from fastapi import Depends, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import RedirectResponse, StreamingResponse
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app import crud, schemas
+from rhesis.backend.app import schemas
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+from rhesis.backend.app.crud import file as file_crud
 from rhesis.backend.app.database import get_db_with_tenant_variables
 from rhesis.backend.app.dependencies import get_tenant_context
 from rhesis.backend.app.models.user import User
@@ -161,8 +162,12 @@ async def upload_files(
         organization_id,
         str(user_id),
         lambda db: (
-            crud.get_entity_files_total_size(db, entity_id, entity_type.value, organization_id),
-            crud.get_entity_files_max_position(db, entity_id, entity_type.value, organization_id),
+            file_crud.get_entity_files_total_size(
+                db, entity_id, entity_type.value, organization_id
+            ),
+            file_crud.get_entity_files_max_position(
+                db, entity_id, entity_type.value, organization_id
+            ),
         ),
     )
     next_position = max_position + 1
@@ -236,7 +241,7 @@ async def upload_files(
             organization_id,
             str(user_id),
             lambda db, fd=file_data: schemas.FileResponse.model_validate(
-                crud.create_file(db, fd, organization_id=organization_id, user_id=user_id)
+                file_crud.create_file(db, fd, organization_id=organization_id, user_id=user_id)
             ),
         )
         created_files.append(created)
@@ -286,7 +291,7 @@ def _load_file_or_404_factory(
     """
 
     def _load(db: Session) -> Optional[schemas.FileResponse]:
-        row = crud.get_file(db, file_id, organization_id, user_id)
+        row = file_crud.get_file(db, file_id, organization_id, user_id)
         if not row:
             return None
         return schemas.FileResponse.model_validate(row)
@@ -332,7 +337,7 @@ def _load_file_for_download_factory(
     """Build a session-local callable that materialises the download view."""
 
     def _load(db: Session) -> Optional[_FileForDownload]:
-        row = crud.get_file(db, file_id, organization_id, user_id)
+        row = file_crud.get_file(db, file_id, organization_id, user_id)
         if not row:
             return None
         return _FileForDownload(row)
@@ -570,7 +575,7 @@ async def delete_file(
     organization_id, user_id = tenant_context
 
     def _delete(db: Session) -> Optional[schemas.FileResponse]:
-        row = crud.delete_file(db, file_id, organization_id, user_id)
+        row = file_crud.delete_file(db, file_id, organization_id, user_id)
         if not row:
             return None
         return schemas.FileResponse.model_validate(row)

--- a/apps/backend/src/rhesis/backend/app/routers/telemetry.py
+++ b/apps/backend/src/rhesis/backend/app/routers/telemetry.py
@@ -9,13 +9,14 @@ from fastapi import Depends, HTTPException, Query, Request, status
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
-from rhesis.backend.app import crud, schemas
+from rhesis.backend.app import schemas
 from rhesis.backend.app.auth.affordances import populate_review_permitted_actions
 from rhesis.backend.app.auth.capabilities import Permission
 from rhesis.backend.app.auth.principal import resolve_principal_from_request
 from rhesis.backend.app.auth.rbac import project_id_from_scope
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.constants import EnrichedDataKeys, EntityType, TestResultStatus
+from rhesis.backend.app.crud import file as file_crud
 from rhesis.backend.app.crud.telemetry import (
     create_trace_spans,
     get_trace_by_db_id,
@@ -720,7 +721,7 @@ def list_span_files(
 ):
     """List files attached to a trace span."""
     organization_id, user_id = tenant_context
-    return crud.get_files_for_entity(
+    return file_crud.get_files_for_entity(
         db, span_db_id, EntityType.TRACE.value, organization_id, user_id
     )
 

--- a/apps/backend/src/rhesis/backend/app/routers/test.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+from rhesis.backend.app.crud import file as file_crud
 from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
@@ -459,4 +460,4 @@ def list_test_files(
 ):
     """List input files attached to a test."""
     organization_id, user_id = tenant_context
-    return crud.get_files_for_entity(db, test_id, "Test", organization_id, user_id)
+    return file_crud.get_files_for_entity(db, test_id, "Test", organization_id, user_id)

--- a/apps/backend/src/rhesis/backend/app/routers/test_result.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_result.py
@@ -14,6 +14,7 @@ from rhesis.backend.app.auth.capabilities import Permission
 from rhesis.backend.app.auth.principal import resolve_principal_from_request
 from rhesis.backend.app.auth.rbac import authorize_object, project_id_from_scope
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+from rhesis.backend.app.crud import file as file_crud
 from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
@@ -593,4 +594,6 @@ def list_test_result_files(
 ):
     """List output files attached to a test result."""
     organization_id, user_id = tenant_context
-    return crud.get_files_for_entity(db, test_result_id, "TestResult", organization_id, user_id)
+    return file_crud.get_files_for_entity(
+        db, test_result_id, "TestResult", organization_id, user_id
+    )

--- a/apps/backend/src/rhesis/backend/app/services/invokers/tracing.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/tracing.py
@@ -323,8 +323,8 @@ def _store_trace_files(
     For legacy inline-base64 dicts (playground path): uploads to storage and
     creates the File row (backward compat).
     """
-    from rhesis.backend.app import crud as _crud
     from rhesis.backend.app import schemas
+    from rhesis.backend.app.crud import file as file_crud
 
     for idx, file_data in enumerate(files):
         if not isinstance(file_data, dict):
@@ -336,7 +336,7 @@ def _store_trace_files(
             try:
                 import uuid as _uuid
 
-                _crud.link_file_to_entity(
+                file_crud.link_file_to_entity(
                     db,
                     file_id=_uuid.UUID(file_id),
                     entity_id=trace_id,
@@ -365,6 +365,6 @@ def _store_trace_files(
             entity_type="Trace",
             position=idx,
         )
-        _crud.create_file(db, file_create, organization_id=organization_id)
+        file_crud.create_file(db, file_create, organization_id=organization_id)
 
     logger.debug(f"Processed {len(files)} input file(s) for trace_id={trace_id}")

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/conversation_linking.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/conversation_linking.py
@@ -629,9 +629,9 @@ def apply_pending_files(
                 try:
                     import uuid
 
-                    from rhesis.backend.app import crud as _crud
+                    from rhesis.backend.app.crud import file as file_crud
 
-                    _crud.link_file_to_entity(
+                    file_crud.link_file_to_entity(
                         db,
                         file_id=uuid.UUID(file_id),
                         entity_id=span.id,
@@ -667,9 +667,9 @@ def apply_pending_files(
                 entity_type="Trace",
                 position=idx,
             )
-            from rhesis.backend.app import crud as _crud
+            from rhesis.backend.app.crud import file as file_crud
 
-            _crud.create_file(db, file_create, organization_id=organization_id)
+            file_crud.create_file(db, file_create, organization_id=organization_id)
             total += 1
 
         logger.info(

--- a/apps/backend/src/rhesis/backend/tasks/execution/executors/results.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/executors/results.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, schemas
 from rhesis.backend.app.constants import TestResultStatus
+from rhesis.backend.app.crud import file as file_crud
 from rhesis.backend.app.models.test import Test
 from rhesis.backend.app.utils.crud_utils import get_or_create_status
 from rhesis.backend.app.utils.response_extractor import has_http_error_in_result
@@ -495,7 +496,7 @@ def _store_output_files(
                 content_hash=file_data.get("content_hash"),
                 extraction_status="pending",
             )
-            crud.create_file(db, file_create, organization_id=organization_id, user_id=user_id)
+            file_crud.create_file(db, file_create, organization_id=organization_id, user_id=user_id)
             continue
 
         # Path B: base64-encoded bytes — decode and write to storage.
@@ -540,7 +541,7 @@ def _store_output_files(
             content_hash=content_hash,
             extraction_status="pending",
         )
-        crud.create_file(db, file_create, organization_id=organization_id, user_id=user_id)
+        file_crud.create_file(db, file_create, organization_id=organization_id, user_id=user_id)
 
     logger.info(
         f"[TEST_RESULT] Stored {len(output_files_data)} output files "

--- a/tests/backend/services/test_file_execution.py
+++ b/tests/backend/services/test_file_execution.py
@@ -155,8 +155,8 @@ class TestOutputFileCapture:
 
         with (
             patch(
-                "rhesis.backend.tasks.execution.executors.results.crud"
-            ) as mock_crud,
+                "rhesis.backend.tasks.execution.executors.results.file_crud"
+            ) as mock_file_crud,
             patch(
                 "rhesis.backend.app.services.storage_service.StorageService",
                 return_value=mock_storage,
@@ -165,8 +165,8 @@ class TestOutputFileCapture:
             _store_output_files(db, result_id, output_files, org_id, user_id)
 
             mock_storage.put_object_bytes.assert_called_once()
-            mock_crud.create_file.assert_called_once()
-            call_args = mock_crud.create_file.call_args
+            mock_file_crud.create_file.assert_called_once()
+            call_args = mock_file_crud.create_file.call_args
             file_create = call_args[0][1]
             assert file_create.filename == "output.txt"
             assert file_create.entity_id == result_id
@@ -182,10 +182,10 @@ class TestOutputFileCapture:
         """When processed_result has no 'output_files', no File records created."""
         db = MagicMock()
 
-        with patch("rhesis.backend.tasks.execution.executors.results.crud") as mock_crud:
+        with patch("rhesis.backend.tasks.execution.executors.results.file_crud") as mock_file_crud:
             # Empty list
             _store_output_files(db, uuid4(), [], str(uuid4()), str(uuid4()))
-            mock_crud.create_file.assert_not_called()
+            mock_file_crud.create_file.assert_not_called()
 
     def test_output_files_invalid_base64_skipped(self):
         """Invalid base64 in output_files is skipped gracefully."""
@@ -198,18 +198,18 @@ class TestOutputFileCapture:
             }
         ]
 
-        with patch("rhesis.backend.tasks.execution.executors.results.crud") as mock_crud:
+        with patch("rhesis.backend.tasks.execution.executors.results.file_crud") as mock_file_crud:
             # Should not raise
             _store_output_files(db, uuid4(), output_files, str(uuid4()), str(uuid4()))
-            mock_crud.create_file.assert_not_called()
+            mock_file_crud.create_file.assert_not_called()
 
     def test_output_files_not_list_skipped(self):
         """Non-list output_files value is skipped."""
         db = MagicMock()
 
-        with patch("rhesis.backend.tasks.execution.executors.results.crud") as mock_crud:
+        with patch("rhesis.backend.tasks.execution.executors.results.file_crud") as mock_file_crud:
             _store_output_files(db, uuid4(), "not a list", str(uuid4()), str(uuid4()))
-            mock_crud.create_file.assert_not_called()
+            mock_file_crud.create_file.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -309,8 +309,8 @@ class TestStoreOutputFilesPathA:
         user_id = str(uuid4())
 
         with patch(
-            "rhesis.backend.tasks.execution.executors.results.crud"
-        ) as mock_crud:
+            "rhesis.backend.tasks.execution.executors.results.file_crud"
+        ) as mock_file_crud:
             _store_output_files(
                 db,
                 result_id,
@@ -319,8 +319,8 @@ class TestStoreOutputFilesPathA:
                 user_id,
             )
 
-            mock_crud.create_file.assert_called_once()
-            file_create = mock_crud.create_file.call_args[0][1]
+            mock_file_crud.create_file.assert_called_once()
+            file_create = mock_file_crud.create_file.call_args[0][1]
             assert file_create.storage_path == self._good_payload(
                 org_id, result_id
             )["storage_path"]
@@ -337,10 +337,10 @@ class TestStoreOutputFilesPathA:
 
         payload = self._good_payload(other_org, result_id)
         with patch(
-            "rhesis.backend.tasks.execution.executors.results.crud"
-        ) as mock_crud:
+            "rhesis.backend.tasks.execution.executors.results.file_crud"
+        ) as mock_file_crud:
             _store_output_files(db, result_id, [payload], org_id, user_id)
-            mock_crud.create_file.assert_not_called()
+            mock_file_crud.create_file.assert_not_called()
 
     def test_rejects_traversal_storage_path(self):
         db = MagicMock()
@@ -353,10 +353,10 @@ class TestStoreOutputFilesPathA:
             f"attachments/{org_id}/TestResult/{result_id}/../../other-org/private.bin"
         )
         with patch(
-            "rhesis.backend.tasks.execution.executors.results.crud"
-        ) as mock_crud:
+            "rhesis.backend.tasks.execution.executors.results.file_crud"
+        ) as mock_file_crud:
             _store_output_files(db, result_id, [payload], org_id, user_id)
-            mock_crud.create_file.assert_not_called()
+            mock_file_crud.create_file.assert_not_called()
 
     def test_rejects_absolute_storage_path(self):
         db = MagicMock()
@@ -367,10 +367,10 @@ class TestStoreOutputFilesPathA:
         payload = self._good_payload(org_id, result_id)
         payload["storage_path"] = "/etc/passwd"
         with patch(
-            "rhesis.backend.tasks.execution.executors.results.crud"
-        ) as mock_crud:
+            "rhesis.backend.tasks.execution.executors.results.file_crud"
+        ) as mock_file_crud:
             _store_output_files(db, result_id, [payload], org_id, user_id)
-            mock_crud.create_file.assert_not_called()
+            mock_file_crud.create_file.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/backend/services/test_file_integration.py
+++ b/tests/backend/services/test_file_integration.py
@@ -99,7 +99,7 @@ class TestFileExecutionIntegration:
         ]
 
         with (
-            patch("rhesis.backend.tasks.execution.executors.results.crud") as mock_crud,
+            patch("rhesis.backend.tasks.execution.executors.results.file_crud") as mock_file_crud,
             patch(
                 "rhesis.backend.app.services.storage_service.StorageService.put_object_bytes",
                 return_value=("attachments/org/TestResult/rid/fid/original.png", "deadbeef"),
@@ -112,8 +112,8 @@ class TestFileExecutionIntegration:
             assert put_kwargs["content"] == generated_content
             assert put_kwargs["content_type"] == "image/png"
 
-            mock_crud.create_file.assert_called_once()
-            file_create = mock_crud.create_file.call_args[0][1]
+            mock_file_crud.create_file.assert_called_once()
+            file_create = mock_file_crud.create_file.call_args[0][1]
             assert file_create.filename == "generated.png"
             assert file_create.content_type == "image/png"
             assert file_create.entity_type == "TestResult"


### PR DESCRIPTION
## Purpose

`crud/__init__.py` is a 1946-line monolith that the codebase is splitting one entity at a time, following #2411, #2412, #2438, #2439, #2441, #2442, #2449, #2450 and #2451. This takes the File block out. Per `apps/backend/AGENTS.md` the package only shrinks from here — nothing new goes back into `__init__.py`.

## What Changed

- Moved `create_file`, `get_file`, `link_file_to_entity`, `get_files_for_entity`, `get_entity_files_total_size`, `get_entity_files_max_position` and `delete_file` into a new `crud/file.py` (151 lines), unchanged. The `# File CRUD operations` banner in `__init__.py` goes with them.
- `crud/__init__.py` drops 121 lines.
- Nothing is re-exported, matching the earlier splits. All 27 call sites across 9 files now use `from rhesis.backend.app.crud import file as file_crud`.
- Nothing dropped — all seven functions have callers.
- `routers/telemetry.py` and `routers/file.py` no longer need `from rhesis.backend.app import crud` at all. `services/invokers/tracing.py` and `services/telemetry/conversation_linking.py` had function-local `from rhesis.backend.app import crud as _crud` imports, now direct submodule imports.
- Removing the block left `func` with no module-scope use in `__init__.py`, which turned the pre-existing function-local `from sqlalchemy import func` inside `get_user_by_email` into a ruff `F811`. `func` is therefore dropped from the top-level `from sqlalchemy import and_, func, select, text`. `and_`, `select` and `text` are still used.

## Additional Context

- One of four parallel extractions: Behavior (#2455), File, Model (#2457) and User (#2458). The four blocks were chosen so they do not touch each other in `crud/__init__.py`, and `git merge-tree` confirms `__init__.py` merges clean across all six pairings — including the `func` import change above.
- This branch is conflict-free against all three siblings.
- Suggested landing order across the four: this one and Behavior first (conflict-free), then Model, then User.
- Deliberately avoids `get_test_sets` and `get_tests`, which #2446 modifies.

## Testing

Pure move — behaviour is unchanged, so the existing suite is the check.

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/test_file_execution.py ../../tests/backend/services/test_file_integration.py ../../tests/backend/routes/test_file.py
# 35 passed

uv run pytest ../../tests/backend/crud ../../tests/backend/routes/test_telemetry.py ../../tests/backend/routes/test_trace_linking_timing.py ../../tests/backend/tasks
# 546 passed, 3 skipped

uv run pytest ../../tests/backend/services
# 1862 passed, 1 skipped, 1 xfailed

uv run pytest ../../tests/backend/routes ../../tests/backend/security
# 2514 passed, 39 skipped
```

Skips are pre-existing `@pytest.mark.skip`s. A repo-wide grep across `apps/`, `tests/`, `sdk/`, `ee/`, `packages/` and `penelope/` for the seven old `crud.*` names returns nothing, and there is no `getattr(crud, ...)`/`hasattr(crud, ...)` reflection anywhere that could reach them dynamically.

Two pre-existing ruff findings remain in `routers/test_result.py` (`I001`, and unused `typing.Optional`). Both were confirmed against a stashed baseline and left alone rather than mixed into this refactor.

Worth a reviewer's eye: the two file test modules patch by module attribute, so `"...results.crud"` became `"...results.file_crud"` and `mock_crud` became `mock_file_crud`. Left unchanged these would have failed loudly on `assert_called_once()` rather than silently passing.
