### PR TITLE
Add in-app notifications for long-running jobs

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/449d5364b4ff_create_notification_table.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/449d5364b4ff_create_notification_table.py
@@ -81,10 +81,14 @@ def upgrade() -> None:
             rhesis.backend.app.models.guid.GUID(),
             nullable=True,
         ),
+        # NOT NULL, unlike the nullable user_id the mixin declares for most
+        # tables: here it's the recipient, not "created by". A NULL would be
+        # unreachable anyway -- every read filters user_id == the caller -- so
+        # the row would be invisible dead data rather than a shared notification.
         sa.Column(
             "user_id",
             rhesis.backend.app.models.guid.GUID(),
-            nullable=True,
+            nullable=False,
         ),
         # Constraints. A notification is meaningless without its recipient, org,
         # or project, so all three cascade on delete (unlike Chunk.user_id,

--- a/apps/backend/src/rhesis/backend/alembic/versions/449d5364b4ff_create_notification_table.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/449d5364b4ff_create_notification_table.py
@@ -1,0 +1,161 @@
+"""create notification table
+
+Revision ID: 449d5364b4ff
+Revises: 82881df987af
+Create Date: 2026-08-09
+
+RLS policies are added explicitly below rather than relying solely on the
+``auto_apply_rls_policies`` event trigger (see
+``b8c9d0e1f2a3_fail_closed_project_isolation_rls``): the trigger does not
+reliably fire for a brand-new ``CREATE TABLE`` in every environment
+(``tests/backend/security/test_rls_coverage.py`` caught this table missing
+its policies under a fresh migration replay), so the exact policy bodies
+are duplicated here. Each ``CREATE POLICY`` is preceded by
+``DROP POLICY IF EXISTS`` -- the same guard ``b8c9d0e1f2a3`` uses -- so this
+stays idempotent on an environment where the trigger *did* already create
+the same policy.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+import rhesis.backend.app.models.guid
+
+# revision identifiers, used by Alembic.
+revision: str = "449d5364b4ff"
+down_revision: Union[str, None] = "82881df987af"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create notification table with indexes."""
+    op.create_table(
+        "notification",
+        sa.Column(
+            "id",
+            rhesis.backend.app.models.guid.GUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("nano_id", sa.String(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("deleted_at", sa.DateTime(), nullable=True),
+        # Notification content
+        sa.Column("event_type", sa.String(), nullable=False),
+        sa.Column("section", sa.String(), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("is_failure", sa.Boolean(), server_default=sa.text("false"), nullable=False),
+        sa.Column("entity_type", sa.String(), nullable=True),
+        sa.Column("entity_id", rhesis.backend.app.models.guid.GUID(), nullable=True),
+        sa.Column(
+            "payload",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=True),
+        # Multi-tenancy. project_id is nullable: NULL means org-wide, visible
+        # regardless of the recipient's active project.
+        sa.Column(
+            "organization_id",
+            rhesis.backend.app.models.guid.GUID(),
+            nullable=True,
+        ),
+        sa.Column(
+            "project_id",
+            rhesis.backend.app.models.guid.GUID(),
+            nullable=True,
+        ),
+        sa.Column(
+            "user_id",
+            rhesis.backend.app.models.guid.GUID(),
+            nullable=True,
+        ),
+        # Constraints. A notification is meaningless without its recipient, org,
+        # or project, so all three cascade on delete (unlike Chunk.user_id,
+        # which is "created by" and survives the user's deletion). Declared here
+        # rather than on the mixins -- see the Notification model docstring.
+        sa.ForeignKeyConstraint(
+            ["organization_id"],
+            ["organization.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["project_id"],
+            ["project.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Indexes
+    op.create_index("ix_notification_id", "notification", ["id"], unique=True)
+    op.create_index("ix_notification_nano_id", "notification", ["nano_id"], unique=True)
+    op.create_index("ix_notification_event_type", "notification", ["event_type"])
+    op.create_index("ix_notification_section", "notification", ["section"])
+    op.create_index("ix_notification_entity_id", "notification", ["entity_id"])
+    op.create_index("ix_notification_read_at", "notification", ["read_at"])
+    op.create_index("ix_notification_organization_id", "notification", ["organization_id"])
+    op.create_index("ix_notification_project_id", "notification", ["project_id"])
+    op.create_index("ix_notification_user_id", "notification", ["user_id"])
+
+    # RLS: tenant_isolation (PERMISSIVE, organization_id) + project_isolation
+    # (RESTRICTIVE, fail-closed on project_id) -- exact bodies duplicated from
+    # d4e5f6a7b8c3 and b8c9d0e1f2a3 respectively. DROP ... IF EXISTS first:
+    # see the module docstring for why.
+    op.execute("ALTER TABLE notification ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE notification FORCE ROW LEVEL SECURITY")
+    op.execute("DROP POLICY IF EXISTS tenant_isolation ON notification")
+    op.execute(
+        """
+        CREATE POLICY tenant_isolation ON notification
+            USING (organization_id = current_setting('app.current_organization')::uuid)
+        """
+    )
+    op.execute("DROP POLICY IF EXISTS project_isolation ON notification")
+    op.execute(
+        """
+        CREATE POLICY project_isolation ON notification
+            AS RESTRICTIVE
+            FOR ALL
+            USING (
+                project_id = NULLIF(current_setting('app.current_project', true), '')::uuid
+                OR project_id IS NULL
+                OR current_setting('app.current_organization', true) = ''
+            )
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop notification table and indexes."""
+    op.drop_index("ix_notification_user_id", table_name="notification")
+    op.drop_index("ix_notification_project_id", table_name="notification")
+    op.drop_index("ix_notification_organization_id", table_name="notification")
+    op.drop_index("ix_notification_read_at", table_name="notification")
+    op.drop_index("ix_notification_entity_id", table_name="notification")
+    op.drop_index("ix_notification_section", table_name="notification")
+    op.drop_index("ix_notification_event_type", table_name="notification")
+    op.drop_index("ix_notification_nano_id", table_name="notification")
+    op.drop_index("ix_notification_id", table_name="notification")
+    op.drop_table("notification")

--- a/apps/backend/src/rhesis/backend/alembic/versions/81fbf5ad9a1f_add_notification_capabilities.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/81fbf5ad9a1f_add_notification_capabilities.py
@@ -1,0 +1,74 @@
+"""Add the notification:read capability
+
+Gates all three notification routes: GET /notifications/summary,
+GET /notifications, and POST /notifications/read. Granted to built-in Viewer,
+Member, Admin, and Owner via ``permissions_for_built_in_role()`` (generic
+":read" rule) -- no role-specific carve-out needed.
+
+Mark-as-read rides on this one capability rather than a separate
+``notification:update``: see ``Permission.Notification`` for why (a separate
+:update would be denied to Viewer, who would then never be able to clear
+their own badge).
+
+Revision ID: 81fbf5ad9a1f
+Revises: 449d5364b4ff
+Create Date: 2026-08-09
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "81fbf5ad9a1f"
+down_revision: Union[str, None] = "449d5364b4ff"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_NEW_PERMISSIONS: list[tuple[str, str, str, str, str]] = [
+    (
+        "notification:read",
+        "Read notifications",
+        "notification",
+        "read",
+        "project",
+    ),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO permission (
+                id, name, display_name, resource_type, action, scope,
+                is_retired, created_at, updated_at
+            )
+            VALUES (
+                gen_random_uuid(), :name, :display_name, :resource_type,
+                :action, :scope, false, now(), now()
+            )
+            ON CONFLICT (name) DO NOTHING
+            """
+        ),
+        [
+            {
+                "name": name,
+                "display_name": display_name,
+                "resource_type": resource_type,
+                "action": action,
+                "scope": scope,
+            }
+            for name, display_name, resource_type, action, scope in _NEW_PERMISSIONS
+        ],
+    )
+
+
+def downgrade() -> None:
+    """Retire rather than delete, matching the catalog's append-only contract."""
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("UPDATE permission SET is_retired = true WHERE name = :name"),
+        [{"name": name} for name, *_ in _NEW_PERMISSIONS],
+    )

--- a/apps/backend/src/rhesis/backend/app/auth/capabilities.py
+++ b/apps/backend/src/rhesis/backend/app/auth/capabilities.py
@@ -73,7 +73,8 @@ class Permission:
       :class:`TestResult`, :class:`TestConfiguration`, :class:`Experiment`
     - Endpoints & connectors (project-scoped): :class:`Endpoint`
     - Metrics & models (project-scoped): :class:`Metric`, :class:`Model`
-    - Collaboration (project-scoped): :class:`Comment`, :class:`Task`
+    - Collaboration (project-scoped): :class:`Comment`, :class:`Task`,
+      :class:`Notification`
     - Files (project/org): :class:`File`
     - Project administration (project-scoped): :class:`Project`,
       :class:`ProjectMember`
@@ -185,6 +186,21 @@ class Permission:
         UPDATE_ASSIGNED = "task:update:assigned"
         #: Delete a task the caller created (object-level :own qualifier).
         DELETE_OWN = "task:delete:own"
+
+    class Notification(_PermissionEnum):
+        """The recipient's own in-app notifications (badge counts, mark-as-read).
+
+        Deliberately a single capability, and marking-read rides on it rather
+        than a separate ``:update``. Notifications are per-user state that only
+        the system creates (via ``services.notification.notify``, never a
+        router), and every query is filtered to the caller's own rows. There is
+        no coherent state where a user may see their own badge but not clear
+        it -- a separate ``:update`` would be denied to the built-in Viewer
+        role (``_viewer_permissions`` grants only ``:read``), leaving Viewers
+        with a badge that reappears on every reload, permanently.
+        """
+
+        READ = "notification:read"
 
     # --- Knowledge base (project-scoped) ------------------------------------
 

--- a/apps/backend/src/rhesis/backend/app/constants.py
+++ b/apps/backend/src/rhesis/backend/app/constants.py
@@ -20,6 +20,7 @@ class EntityType(Enum):
     SOURCE = "Source"
     CHUNK = "Chunk"
     TRACE = "Trace"
+    ARCHITECT_SESSION = "ArchitectSession"
 
     @classmethod
     def get_value(cls, entity_type):
@@ -27,6 +28,14 @@ class EntityType(Enum):
         if isinstance(entity_type, cls):
             return entity_type.value
         return entity_type
+
+
+#: Prefix on the synthetic user message the architect monitor sends when it
+#: auto-resumes a session after the background tasks it was awaiting finish.
+#: Shared because three places key off it: the monitor builds the message, the
+#: runner routes it to the auto-resume handler, and the notification catalog
+#: uses it to tell a plan-concluding turn from an ordinary interactive one.
+ARCHITECT_RESUME_PREFIX = "[TASK_COMPLETED]"
 
 
 # TestType Enum - DB-level test classification aligned with initial_data.json type_lookup

--- a/apps/backend/src/rhesis/backend/app/crud/notification.py
+++ b/apps/backend/src/rhesis/backend/app/crud/notification.py
@@ -116,17 +116,20 @@ def mark_notifications_read(
     db: Session,
     user_id: str,
     section: Optional[str] = None,
-    ids: Optional[List[UUID]] = None,
+    notification_ids: Optional[List[UUID]] = None,
 ) -> int:
     """Stamp ``read_at`` on the caller's unread notifications matching the filters.
 
-    ``section`` and ``ids`` narrow together (AND), so passing both means "these
-    ids, within this section" and can never mark more than either filter alone
-    would. Returns 0 when neither is given rather than marking everything read
-    -- the router rejects that case with a 400, this is the belt-and-braces
-    half of the same guard.
+    ``section`` and ``notification_ids`` narrow together (AND), so passing both
+    means "these notifications, within this section" and can never mark more
+    than either filter alone would. Returns 0 when neither is given rather than
+    marking everything read -- the router rejects that case with a 400, this is
+    the belt-and-braces half of the same guard.
+
+    ``notification_ids`` are ``Notification.id`` values, not the ``entity_id``
+    of whatever the notification is about -- hence the explicit name.
     """
-    if not section and not ids:
+    if not section and not notification_ids:
         return 0
 
     query = db.query(Notification).filter(
@@ -134,8 +137,8 @@ def mark_notifications_read(
     )
     if section:
         query = query.filter(Notification.section == section)
-    if ids:
-        query = query.filter(Notification.id.in_(ids))
+    if notification_ids:
+        query = query.filter(Notification.id.in_(notification_ids))
 
     count = query.update({Notification.read_at: func.now()}, synchronize_session=False)
     db.commit()

--- a/apps/backend/src/rhesis/backend/app/crud/notification.py
+++ b/apps/backend/src/rhesis/backend/app/crud/notification.py
@@ -1,0 +1,142 @@
+"""CRUD operations for in-app notifications.
+
+Every query here adds an explicit ``Notification.user_id == user_id`` filter.
+The ambient auto-filter (see "Ambient Request Scope" in apps/backend/AGENTS.md)
+scopes by organization and project automatically, but not by user -- without
+this filter, one user's `GET /notifications/summary` would return every
+recipient's rows in the same org/project.
+"""
+
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.models.notification import Notification
+
+
+def create_notification(
+    db: Session,
+    *,
+    event_type: str,
+    section: str,
+    title: str,
+    user_id: str,
+    body: Optional[str] = None,
+    is_failure: bool = False,
+    entity_type: Optional[str] = None,
+    entity_id: Optional[UUID] = None,
+    payload: Optional[Dict[str, Any]] = None,
+    organization_id: Optional[str] = None,
+    project_id: Optional[str] = None,
+) -> Notification:
+    """Create and commit a notification for its recipient."""
+    notification = Notification(
+        event_type=event_type,
+        section=section,
+        title=title,
+        body=body,
+        is_failure=is_failure,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        payload=payload,
+        user_id=user_id,
+        organization_id=organization_id,
+        project_id=project_id,
+    )
+    db.add(notification)
+    db.commit()
+    db.refresh(notification)
+    return notification
+
+
+#: Cap on unread rows scanned for highlight ids per /summary call. Counts are
+#: aggregated in SQL and stay exact regardless; only the highlight list is
+#: bounded. A grid page shows at most ~50 rows, so this is far more than the UI
+#: can use, and it keeps the endpoint's cost flat for a user who lets
+#: notifications pile up instead of growing with every completed job.
+_SUMMARY_HIGHLIGHT_SCAN_LIMIT = 200
+
+
+def get_notification_summary(db: Session, user_id: str) -> Dict[str, Dict[str, Any]]:
+    """Unread count and highlightable entity ids, grouped by section.
+
+    Sections with zero unread notifications are omitted -- the frontend
+    treats an absent key the same as ``{"unread": 0, "entity_ids": []}``.
+    """
+    counts = (
+        db.query(Notification.section, func.count(Notification.id))
+        .filter(Notification.user_id == user_id, Notification.read_at.is_(None))
+        .group_by(Notification.section)
+        .all()
+    )
+    summary: Dict[str, Dict[str, Any]] = {
+        section: {"unread": count, "entity_ids": []} for section, count in counts
+    }
+    if not summary:
+        return summary
+
+    recent = (
+        db.query(Notification)
+        .filter(Notification.user_id == user_id, Notification.read_at.is_(None))
+        .order_by(Notification.created_at.desc())
+        .limit(_SUMMARY_HIGHLIGHT_SCAN_LIMIT)
+        .all()
+    )
+    for row in recent:
+        bucket = summary.get(row.section)
+        if bucket is None:
+            continue
+        if row.entity_id is not None:
+            bucket["entity_ids"].append(row.entity_id)
+        extra_ids = (row.payload or {}).get("entity_ids")
+        if extra_ids:
+            bucket["entity_ids"].extend(extra_ids)
+    return summary
+
+
+def get_notifications(
+    db: Session,
+    user_id: str,
+    section: Optional[str] = None,
+    unread_only: bool = False,
+    skip: int = 0,
+    limit: int = 100,
+) -> List[Notification]:
+    query = db.query(Notification).filter(Notification.user_id == user_id)
+    if section:
+        query = query.filter(Notification.section == section)
+    if unread_only:
+        query = query.filter(Notification.read_at.is_(None))
+    return query.order_by(Notification.created_at.desc()).offset(skip).limit(limit).all()
+
+
+def mark_notifications_read(
+    db: Session,
+    user_id: str,
+    section: Optional[str] = None,
+    ids: Optional[List[UUID]] = None,
+) -> int:
+    """Stamp ``read_at`` on the caller's unread notifications matching the filters.
+
+    ``section`` and ``ids`` narrow together (AND), so passing both means "these
+    ids, within this section" and can never mark more than either filter alone
+    would. Returns 0 when neither is given rather than marking everything read
+    -- the router rejects that case with a 400, this is the belt-and-braces
+    half of the same guard.
+    """
+    if not section and not ids:
+        return 0
+
+    query = db.query(Notification).filter(
+        Notification.user_id == user_id, Notification.read_at.is_(None)
+    )
+    if section:
+        query = query.filter(Notification.section == section)
+    if ids:
+        query = query.filter(Notification.id.in_(ids))
+
+    count = query.update({Notification.read_at: func.now()}, synchronize_session=False)
+    db.commit()
+    return count

--- a/apps/backend/src/rhesis/backend/app/models/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/models/__init__.py
@@ -14,6 +14,7 @@ from .guid import GUID
 from .metric import Metric, behavior_metric_association
 from .mixins import ProjectMixin, TagsMixin
 from .model import Model
+from .notification import Notification
 from .organization import Organization
 
 # Import models with dependencies
@@ -62,6 +63,7 @@ __all__ = [
     "GUID",
     "Metric",
     "Model",
+    "Notification",
     "PromptTemplate",
     "Prompt",
     "TestConfiguration",

--- a/apps/backend/src/rhesis/backend/app/models/enums.py
+++ b/apps/backend/src/rhesis/backend/app/models/enums.py
@@ -71,6 +71,7 @@ class NotificationSection(str, Enum):
     TEST_SETS = "test-sets"
     TEST_RUNS = "test-runs"
     TASKS = "tasks"
+    ARCHITECT = "architect"
 
 
 class NotificationEventType:
@@ -92,6 +93,12 @@ class NotificationEventType:
 
     class Task(str, Enum):
         ASSIGNED = "task.assigned"
+
+    class Architect(str, Enum):
+        #: One architect turn concluded a background wait with nothing left
+        #: pending -- i.e. the plan is done. Mid-plan turns don't notify; see
+        #: the renderer in services/notification/catalog.py.
+        PLAN_COMPLETED = "architect.plan_completed"
 
 
 # Notification.entity_type reuses rhesis.backend.app.constants.EntityType

--- a/apps/backend/src/rhesis/backend/app/models/enums.py
+++ b/apps/backend/src/rhesis/backend/app/models/enums.py
@@ -58,3 +58,38 @@ class EmbeddingOrigin(str, Enum):
     USER = "user"
     GENERATED = "generated"
     IMPORTED = "imported"
+
+
+class NotificationSection(str, Enum):
+    """Sidebar section a notification's badge count belongs to.
+
+    Values must equal the frontend NavigationPageItem.segment for that page
+    (mirrored in src/constants/notifications.ts, kept in sync manually like
+    FeatureName/Capability).
+    """
+
+    TEST_SETS = "test-sets"
+    TEST_RUNS = "test-runs"
+
+
+class NotificationEventType:
+    """Namespace of notification event-kind identifiers, grouped by resource.
+
+    Mirrors ``Permission``'s nested-enum grouping in ``auth/capabilities.py``
+    (``Permission.TestSet.READ``) rather than one flat enum, so a resource
+    with several event kinds reads as ``NotificationEventType.TestSet.X``
+    instead of a repeated ``TEST_SET_`` prefix on every member.
+    """
+
+    class TestSet(str, Enum):
+        GENERATION_COMPLETED = "test_set.generation_completed"
+        GARAK_IMPORT_COMPLETED = "test_set.garak_import_completed"
+        GARAK_SYNC_COMPLETED = "test_set.garak_sync_completed"
+
+    class TestRun(str, Enum):
+        EXECUTION_COMPLETED = "test_run.execution_completed"
+
+
+# Notification.entity_type reuses rhesis.backend.app.constants.EntityType
+# (the same enum Comment.entity_type is typed with) rather than a new enum —
+# it already carries TEST_SET / TEST_RUN.

--- a/apps/backend/src/rhesis/backend/app/models/enums.py
+++ b/apps/backend/src/rhesis/backend/app/models/enums.py
@@ -70,6 +70,7 @@ class NotificationSection(str, Enum):
 
     TEST_SETS = "test-sets"
     TEST_RUNS = "test-runs"
+    TASKS = "tasks"
 
 
 class NotificationEventType:
@@ -88,6 +89,9 @@ class NotificationEventType:
 
     class TestRun(str, Enum):
         EXECUTION_COMPLETED = "test_run.execution_completed"
+
+    class Task(str, Enum):
+        ASSIGNED = "task.assigned"
 
 
 # Notification.entity_type reuses rhesis.backend.app.constants.EntityType

--- a/apps/backend/src/rhesis/backend/app/models/notification.py
+++ b/apps/backend/src/rhesis/backend/app/models/notification.py
@@ -1,0 +1,42 @@
+from sqlalchemy import Boolean, Column, DateTime, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB
+
+from .base import Base
+from .guid import GUID
+from .mixins import OrganizationAndUserMixin, ProjectMixin
+
+
+class Notification(Base, ProjectMixin, OrganizationAndUserMixin):
+    """In-app notification for a completed background job (test set generation,
+    test run execution, ...).
+
+    ``event_type`` and ``section`` store the ``.value`` of the matching enum in
+    ``models/enums.py``; ``entity_type`` stores the ``.value`` of
+    :class:`rhesis.backend.app.constants.EntityType` (the same enum
+    ``Comment.entity_type`` uses). Application code always writes through the
+    enum, never a raw string.
+
+    ``user_id`` is the recipient, set explicitly at creation time (not relied on
+    for auto-stamp) since it is not necessarily "whoever is running the current
+    request". ``project_id`` is nullable: NULL means org-wide, visible regardless
+    of the caller's active project (same convention as every other ProjectMixin
+    table).
+
+    The org/user/project FKs come from the mixins, which declare no
+    ``ondelete``; the ``ON DELETE CASCADE`` that makes a notification die with
+    its recipient, org, or project is defined in the create-table migration
+    only. Same split as ``Chunk`` -- so a schema built by
+    ``Base.metadata.create_all`` instead of Alembic has no cascade.
+    """
+
+    __tablename__ = "notification"
+
+    event_type = Column(String, nullable=False, index=True)
+    section = Column(String, nullable=False, index=True)
+    title = Column(String, nullable=False)
+    body = Column(Text, nullable=True)
+    is_failure = Column(Boolean, nullable=False, server_default=text("false"))
+    entity_type = Column(String, nullable=True)
+    entity_id = Column(GUID(), nullable=True, index=True)
+    payload = Column(JSONB, nullable=True)
+    read_at = Column(DateTime(timezone=True), nullable=True, index=True)

--- a/apps/backend/src/rhesis/backend/app/models/notification.py
+++ b/apps/backend/src/rhesis/backend/app/models/notification.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, DateTime, String, Text, text
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String, Text, text
 from sqlalchemy.dialects.postgresql import JSONB
 
 from .base import Base
@@ -18,9 +18,11 @@ class Notification(Base, ProjectMixin, OrganizationAndUserMixin):
 
     ``user_id`` is the recipient, set explicitly at creation time (not relied on
     for auto-stamp) since it is not necessarily "whoever is running the current
-    request". ``project_id`` is nullable: NULL means org-wide, visible regardless
-    of the caller's active project (same convention as every other ProjectMixin
-    table).
+    request". It overrides the mixin's nullable column to be NOT NULL: a
+    notification with no recipient can never be read back, because every query
+    filters ``user_id`` to the caller. ``project_id`` is nullable: NULL means
+    org-wide, visible regardless of the caller's active project (same convention
+    as every other ProjectMixin table).
 
     The org/user/project FKs come from the mixins, which declare no
     ``ondelete``; the ``ON DELETE CASCADE`` that makes a notification die with
@@ -30,6 +32,9 @@ class Notification(Base, ProjectMixin, OrganizationAndUserMixin):
     """
 
     __tablename__ = "notification"
+
+    # Overrides OrganizationAndUserMixin's nullable user_id -- see the docstring.
+    user_id = Column(GUID(), ForeignKey("user.id"), nullable=False)
 
     event_type = Column(String, nullable=False, index=True)
     section = Column(String, nullable=False, index=True)

--- a/apps/backend/src/rhesis/backend/app/routers/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/routers/__init__.py
@@ -23,6 +23,7 @@ from .insights import router as insights_router
 from .job import router as task_router
 from .metric import router as metric_router
 from .model import router as model_router
+from .notification import router as notification_router
 from .organization import router as organization_router
 from .parameters import (
     project_experiments_router as project_experiments_router,
@@ -140,6 +141,7 @@ routers = sorted(
         type_lookup_router,
         metric_router,
         model_router,
+        notification_router,
         task_router,
         task_management_router,
         tools_router,

--- a/apps/backend/src/rhesis/backend/app/routers/notification.py
+++ b/apps/backend/src/rhesis/backend/app/routers/notification.py
@@ -1,0 +1,93 @@
+"""In-app notification endpoints: badge summary, list, mark-as-read.
+
+Notifications are created only by the system (via
+``services.notification.notify``, called from Celery task hooks and, in a
+follow-up plan, websocket handlers) -- this router is read/update only, no
+create/delete.
+"""
+
+from typing import List, Optional
+
+from fastapi import Depends, HTTPException, Query
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import schemas
+from rhesis.backend.app.auth.capabilities import Permission, capability
+from rhesis.backend.app.auth.user_utils import require_current_user_or_token
+from rhesis.backend.app.crud.notification import (
+    get_notification_summary,
+    get_notifications,
+    mark_notifications_read,
+)
+from rhesis.backend.app.dependencies import get_tenant_context, get_tenant_db_session
+from rhesis.backend.app.routers.base import RhesisRouter
+
+router = RhesisRouter(
+    prefix="/notifications",
+    tags=["notification"],
+    dependencies=[Depends(require_current_user_or_token)],
+    resource="notification",
+)
+
+
+@router.get(
+    "/summary",
+    response_model=schemas.NotificationSummaryResponse,
+    **capability(Permission.Notification.READ),
+)
+def read_notification_summary(
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+) -> schemas.NotificationSummaryResponse:
+    """Unread count and highlightable entity ids per sidebar section.
+
+    Called on mount and on every active-project switch -- the ambient
+    auto-filter already scopes this to the caller's org and active project.
+    """
+    _organization_id, user_id = tenant_context
+    summary = get_notification_summary(db, user_id=user_id)
+    return schemas.NotificationSummaryResponse(sections=summary)
+
+
+@router.get(
+    "/",
+    response_model=List[schemas.NotificationRead],
+    **capability(Permission.Notification.READ),
+)
+def read_notifications(
+    section: Optional[str] = None,
+    unread_only: bool = False,
+    skip: int = 0,
+    limit: int = Query(100, le=200),
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+) -> List[schemas.NotificationRead]:
+    """Paginated notification history. Not consumed by the sidebar badge --
+    that's /summary -- this is for a future notification drawer."""
+    _organization_id, user_id = tenant_context
+    return get_notifications(
+        db,
+        user_id=user_id,
+        section=section,
+        unread_only=unread_only,
+        skip=skip,
+        limit=limit,
+    )
+
+
+@router.post(
+    "/read",
+    # Gated on READ, not a separate :update -- see Permission.Notification.
+    **capability(Permission.Notification.READ),
+)
+def mark_read(
+    body: schemas.NotificationMarkReadRequest,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+) -> dict:
+    """Mark notifications read. At least one of ``section``/``ids`` required."""
+    if not body.section and not body.ids:
+        raise HTTPException(status_code=400, detail="section or ids is required")
+    _organization_id, user_id = tenant_context
+    updated = mark_notifications_read(db, user_id=user_id, section=body.section, ids=body.ids)
+    return {"updated": updated}

--- a/apps/backend/src/rhesis/backend/app/routers/notification.py
+++ b/apps/backend/src/rhesis/backend/app/routers/notification.py
@@ -85,9 +85,14 @@ def mark_read(
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
 ) -> dict:
-    """Mark notifications read. At least one of ``section``/``ids`` required."""
-    if not body.section and not body.ids:
-        raise HTTPException(status_code=400, detail="section or ids is required")
+    """Mark notifications read. At least one of ``section``/``notification_ids`` required."""
+    if not body.section and not body.notification_ids:
+        raise HTTPException(status_code=400, detail="section or notification_ids is required")
     _organization_id, user_id = tenant_context
-    updated = mark_notifications_read(db, user_id=user_id, section=body.section, ids=body.ids)
+    updated = mark_notifications_read(
+        db,
+        user_id=user_id,
+        section=body.section,
+        notification_ids=body.notification_ids,
+    )
     return {"updated": updated}

--- a/apps/backend/src/rhesis/backend/app/routers/task_management.py
+++ b/apps/backend/src/rhesis/backend/app/routers/task_management.py
@@ -17,7 +17,10 @@ from rhesis.backend.app.dependencies import (
 )
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.services.task_management import validate_task_organization_constraints
-from rhesis.backend.app.services.task_notification import send_task_assignment_notification
+from rhesis.backend.app.services.task_notification import (
+    send_task_assignment_in_app_notification,
+    send_task_assignment_notification,
+)
 from rhesis.backend.app.utils.decorators import with_count_header
 from rhesis.backend.telemetry import (
     set_telemetry_enabled,
@@ -66,6 +69,7 @@ def create_task(
         if created_task.assignee_id:
             frontend_url = get_frontend_settings().url
             send_task_assignment_notification(db=db, task=created_task, frontend_url=frontend_url)
+            send_task_assignment_in_app_notification(db=db, task=created_task)
 
         # Track feature usage
         track_feature_usage(
@@ -243,6 +247,7 @@ def update_task(
         if assignee_changed and updated_task.assignee_id:
             frontend_url = get_frontend_settings().url
             send_task_assignment_notification(db=db, task=updated_task, frontend_url=frontend_url)
+            send_task_assignment_in_app_notification(db=db, task=updated_task)
 
         # Track feature usage
         track_feature_usage(

--- a/apps/backend/src/rhesis/backend/app/schemas/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/__init__.py
@@ -43,6 +43,12 @@ from .metric import (
     ScoreType,
 )
 from .model import Model, ModelBase, ModelCreate, ModelDetail, ModelRead, ModelUpdate
+from .notification import (
+    NotificationMarkReadRequest,
+    NotificationRead,
+    NotificationSectionSummary,
+    NotificationSummaryResponse,
+)
 from .organization import Organization, OrganizationBase, OrganizationCreate, OrganizationUpdate
 from .parameters import (
     ENVIRONMENT_NAME_MAX_LENGTH,
@@ -203,6 +209,10 @@ __all__ = [
     "ModelDetail",
     "ModelRead",
     "ModelUpdate",
+    "NotificationMarkReadRequest",
+    "NotificationRead",
+    "NotificationSectionSummary",
+    "NotificationSummaryResponse",
     "PromptTemplate",
     "PromptTemplateBase",
     "PromptTemplateCreate",

--- a/apps/backend/src/rhesis/backend/app/schemas/notification.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/notification.py
@@ -1,0 +1,51 @@
+import datetime
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .base import Base
+
+
+class NotificationRead(Base):
+    """A single notification, as returned by the API and carried in the
+    websocket ``NOTIFICATION`` event payload."""
+
+    event_type: str
+    section: str
+    title: str
+    body: Optional[str] = None
+    is_failure: bool
+    entity_type: Optional[str] = None
+    entity_id: Optional[UUID] = None
+    payload: Optional[Dict[str, Any]] = None
+    read_at: Optional[datetime.datetime] = None
+    created_at: datetime.datetime
+
+    model_config = ConfigDict(from_attributes=True, use_enum_values=True)
+
+
+class NotificationSectionSummary(BaseModel):
+    """Unread count and highlightable entity ids for one sidebar section."""
+
+    unread: int = 0
+    entity_ids: list[UUID] = Field(default_factory=list)
+
+
+class NotificationSummaryResponse(BaseModel):
+    """``GET /notifications/summary`` response, keyed by NotificationSection value."""
+
+    sections: Dict[str, NotificationSectionSummary] = Field(default_factory=dict)
+
+
+class NotificationMarkReadRequest(BaseModel):
+    """``POST /notifications/read`` body.
+
+    ``section`` marks every unread notification in that section read; ``ids``
+    marks specific notifications read. At least one must be set (400 otherwise).
+    The two narrow together, so passing both means "these ids, within this
+    section".
+    """
+
+    section: Optional[str] = None
+    ids: Optional[list[UUID]] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/notification.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/notification.py
@@ -41,11 +41,16 @@ class NotificationSummaryResponse(BaseModel):
 class NotificationMarkReadRequest(BaseModel):
     """``POST /notifications/read`` body.
 
-    ``section`` marks every unread notification in that section read; ``ids``
-    marks specific notifications read. At least one must be set (400 otherwise).
-    The two narrow together, so passing both means "these ids, within this
-    section".
+    ``section`` marks every unread notification in that section read;
+    ``notification_ids`` marks specific notifications read. At least one must be
+    set (400 otherwise). The two narrow together, so passing both means "these
+    notifications, within this section".
+
+    Named ``notification_ids`` rather than ``ids`` because notifications carry
+    an ``entity_id`` and a ``payload["entity_ids"]`` too, and the whole
+    highlight feature is built on entity ids -- passing those here would match
+    nothing and silently report ``updated: 0``.
     """
 
     section: Optional[str] = None
-    ids: Optional[list[UUID]] = None
+    notification_ids: Optional[list[UUID]] = None

--- a/apps/backend/src/rhesis/backend/app/services/architect/runner.py
+++ b/apps/backend/src/rhesis/backend/app/services/architect/runner.py
@@ -13,6 +13,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
+from rhesis.backend.app.constants import ARCHITECT_RESUME_PREFIX
 from rhesis.backend.app.database import get_db_with_tenant_variables
 from rhesis.backend.app.schemas.websocket import EventType
 from rhesis.backend.app.services.architect.attachments import process_attachments
@@ -192,9 +193,9 @@ async def _handle_auto_resume(
 ) -> None:
     """Persist auto-resume system messages and notify streaming start.
 
-    No-ops on ordinary turns; only fires for ``[TASK_COMPLETED]`` messages.
+    No-ops on ordinary turns; only fires for auto-resume messages.
     """
-    if not user_message.startswith("[TASK_COMPLETED]"):
+    if not user_message.startswith(ARCHITECT_RESUME_PREFIX):
         return
 
     from rhesis.backend.app import crud, schemas

--- a/apps/backend/src/rhesis/backend/app/services/notification/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/services/notification/__init__.py
@@ -1,0 +1,13 @@
+from rhesis.backend.app.services.notification.catalog import (
+    NOTIFICATION_CATALOG,
+    NotificationKind,
+    RenderedNotification,
+)
+from rhesis.backend.app.services.notification.service import notify
+
+__all__ = [
+    "NOTIFICATION_CATALOG",
+    "NotificationKind",
+    "RenderedNotification",
+    "notify",
+]

--- a/apps/backend/src/rhesis/backend/app/services/notification/catalog.py
+++ b/apps/backend/src/rhesis/backend/app/services/notification/catalog.py
@@ -8,7 +8,7 @@ for how a catalog entry turns into a row + websocket event.
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Optional
 
-from rhesis.backend.app.constants import EntityType
+from rhesis.backend.app.constants import ARCHITECT_RESUME_PREFIX, EntityType
 from rhesis.backend.app.models.enums import NotificationEventType, NotificationSection
 
 
@@ -29,7 +29,11 @@ class RenderedNotification:
 # message (None on success). The caller normalizes a failed or non-dict return
 # to ``{}`` (see BaseTask._send_task_completion_notification), so renderers can
 # read keys off it without guarding -- but must not assume any key is present.
-RenderFn = Callable[[Any, Dict[str, Any], Optional[str]], RenderedNotification]
+#
+# Returning None means "this completion isn't worth notifying about" and no row
+# is written -- for a task that runs many times per user request, where only
+# some runs are a finished job (see _render_architect_plan_completed).
+RenderFn = Callable[[Any, Dict[str, Any], Optional[str]], Optional[RenderedNotification]]
 
 
 @dataclass(frozen=True)
@@ -110,6 +114,40 @@ def _render_execution_completed(task, retval, error) -> RenderedNotification:
     )
 
 
+def _render_architect_plan_completed(task, retval, error) -> Optional[RenderedNotification]:
+    """Notify only for the architect turn that concludes a background wait.
+
+    ``architect_chat_task`` runs once per turn, and one user request spans
+    several: the first turn hands off to long-running tasks, the monitor
+    auto-resumes a new turn once they finish, and that turn may hand off
+    again. Only the turn that both *is* an auto-resume and leaves nothing
+    pending means "the work you walked away from is done" -- an ordinary
+    interactive turn is the user chatting live, and a turn that starts a
+    wait would notify at the wrong end of it. The awaited tasks
+    (generation, execution) notify for their own artifacts separately, so
+    this is strictly about the plan being ready for the user again.
+    """
+    session_id = retval.get("session_id") or _task_kwargs(task).get("session_id")
+    user_message = _task_kwargs(task).get("user_message") or ""
+
+    if not user_message.startswith(ARCHITECT_RESUME_PREFIX):
+        return None
+    # Absent on the failure path (retval is normalized to {}), which is the
+    # right default: a crashed resume turn leaves nothing pending either.
+    if retval.get("awaiting_task"):
+        return None
+
+    if error:
+        return RenderedNotification(
+            title="Architect run failed", is_failure=True, entity_id=session_id
+        )
+    return RenderedNotification(
+        title="Architect finished your plan",
+        body="The background work it was waiting on is complete",
+        entity_id=session_id,
+    )
+
+
 NOTIFICATION_CATALOG: Dict[str, NotificationKind] = {
     NotificationEventType.TestSet.GENERATION_COMPLETED: NotificationKind(
         event_type=NotificationEventType.TestSet.GENERATION_COMPLETED,
@@ -140,5 +178,11 @@ NOTIFICATION_CATALOG: Dict[str, NotificationKind] = {
         section=NotificationSection.TASKS,
         entity_type=EntityType.TASK.value,
         # Emitted directly from task_notification.py, not a Celery hook.
+    ),
+    NotificationEventType.Architect.PLAN_COMPLETED: NotificationKind(
+        event_type=NotificationEventType.Architect.PLAN_COMPLETED,
+        section=NotificationSection.ARCHITECT,
+        entity_type=EntityType.ARCHITECT_SESSION.value,
+        render=_render_architect_plan_completed,
     ),
 }

--- a/apps/backend/src/rhesis/backend/app/services/notification/catalog.py
+++ b/apps/backend/src/rhesis/backend/app/services/notification/catalog.py
@@ -40,7 +40,9 @@ class NotificationKind:
     event_type: str
     section: NotificationSection
     entity_type: Optional[str]
-    render: RenderFn
+    #: None for a kind emitted by a direct notify() caller (e.g. a router) --
+    #: only the Celery-hook caller (tasks/base.py) ever invokes this.
+    render: Optional[RenderFn] = None
 
 
 def _task_kwargs(task) -> Dict[str, Any]:
@@ -132,5 +134,11 @@ NOTIFICATION_CATALOG: Dict[str, NotificationKind] = {
         section=NotificationSection.TEST_RUNS,
         entity_type=EntityType.TEST_RUN.value,
         render=_render_execution_completed,
+    ),
+    NotificationEventType.Task.ASSIGNED: NotificationKind(
+        event_type=NotificationEventType.Task.ASSIGNED,
+        section=NotificationSection.TASKS,
+        entity_type=EntityType.TASK.value,
+        # Emitted directly from task_notification.py, not a Celery hook.
     ),
 }

--- a/apps/backend/src/rhesis/backend/app/services/notification/catalog.py
+++ b/apps/backend/src/rhesis/backend/app/services/notification/catalog.py
@@ -1,0 +1,136 @@
+"""Declarative registry of in-app notification kinds.
+
+Adding a notification for a new completed job means adding one entry here --
+nothing in ``tasks/base.py`` or the router changes. See ``service.notify()``
+for how a catalog entry turns into a row + websocket event.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from rhesis.backend.app.constants import EntityType
+from rhesis.backend.app.models.enums import NotificationEventType, NotificationSection
+
+
+@dataclass(frozen=True)
+class RenderedNotification:
+    title: str
+    is_failure: bool = False
+    body: Optional[str] = None
+    entity_id: Optional[str] = None
+    #: Extra ids beyond entity_id (e.g. a Garak import's several test sets),
+    #: stored in Notification.payload["entity_ids"] for the frontend to
+    #: highlight every affected row, not just one.
+    entity_ids: Optional[list] = None
+
+
+# A render function receives the Celery task instance (for self.request.kwargs /
+# .headers / .get_tenant_context()), the task's return value, and the exception
+# message (None on success). The caller normalizes a failed or non-dict return
+# to ``{}`` (see BaseTask._send_task_completion_notification), so renderers can
+# read keys off it without guarding -- but must not assume any key is present.
+RenderFn = Callable[[Any, Dict[str, Any], Optional[str]], RenderedNotification]
+
+
+@dataclass(frozen=True)
+class NotificationKind:
+    #: A NotificationEventType.<Resource> member. Typed as ``str`` since
+    #: NotificationEventType is a namespace, not itself an enum -- see its
+    #: docstring in models/enums.py.
+    event_type: str
+    section: NotificationSection
+    entity_type: Optional[str]
+    render: RenderFn
+
+
+def _task_kwargs(task) -> Dict[str, Any]:
+    return getattr(task.request, "kwargs", None) or {}
+
+
+def _task_headers(task) -> Dict[str, Any]:
+    return getattr(task.request, "headers", None) or {}
+
+
+def _render_generation_completed(task, retval, error) -> RenderedNotification:
+    test_set_id = retval.get("test_set_id") or _task_kwargs(task).get("test_set_id")
+    if error:
+        return RenderedNotification(
+            title="Test set generation failed", is_failure=True, entity_id=test_set_id
+        )
+    name = retval.get("test_set_name") or "Test set"
+    count = retval.get("num_tests_generated", 0)
+    return RenderedNotification(
+        title=f'"{name}" is ready',
+        body=f"{count} tests generated",
+        entity_id=test_set_id,
+    )
+
+
+def _render_garak_import_completed(task, retval, error) -> RenderedNotification:
+    if error:
+        return RenderedNotification(title="Garak import failed", is_failure=True)
+    test_sets = retval.get("test_sets", [])
+    return RenderedNotification(
+        title=f"Imported {retval.get('total_test_sets', len(test_sets))} Garak test set(s)",
+        body=f"{retval.get('total_tests', 0)} tests total",
+        # One notification covers the whole batch, so every created id goes in
+        # entity_ids and all of their rows highlight.
+        entity_ids=[
+            ts["test_set_id"] for ts in test_sets if isinstance(ts, dict) and ts.get("test_set_id")
+        ],
+    )
+
+
+def _render_garak_sync_completed(task, retval, error) -> RenderedNotification:
+    test_set_id = _task_kwargs(task).get("test_set_id")
+    if error:
+        return RenderedNotification(
+            title="Garak sync failed", is_failure=True, entity_id=test_set_id
+        )
+    return RenderedNotification(
+        title="Garak sync complete",
+        body=f"{retval.get('added', 0)} added, {retval.get('removed', 0)} removed",
+        entity_id=test_set_id,
+    )
+
+
+def _render_execution_completed(task, retval, error) -> RenderedNotification:
+    test_run_id = retval.get("test_run_id") or _task_headers(task).get("test_run_id")
+    if error:
+        return RenderedNotification(title="Test run failed", is_failure=True, entity_id=test_run_id)
+    passed = retval.get("tests_passed", 0)
+    failed = retval.get("tests_failed", 0)
+    name = retval.get("test_set_name") or "Test run"
+    return RenderedNotification(
+        title=f'"{name}" finished',
+        body=f"{passed} passed, {failed} failed",
+        entity_id=test_run_id,
+    )
+
+
+NOTIFICATION_CATALOG: Dict[str, NotificationKind] = {
+    NotificationEventType.TestSet.GENERATION_COMPLETED: NotificationKind(
+        event_type=NotificationEventType.TestSet.GENERATION_COMPLETED,
+        section=NotificationSection.TEST_SETS,
+        entity_type=EntityType.TEST_SET.value,
+        render=_render_generation_completed,
+    ),
+    NotificationEventType.TestSet.GARAK_IMPORT_COMPLETED: NotificationKind(
+        event_type=NotificationEventType.TestSet.GARAK_IMPORT_COMPLETED,
+        section=NotificationSection.TEST_SETS,
+        entity_type=EntityType.TEST_SET.value,
+        render=_render_garak_import_completed,
+    ),
+    NotificationEventType.TestSet.GARAK_SYNC_COMPLETED: NotificationKind(
+        event_type=NotificationEventType.TestSet.GARAK_SYNC_COMPLETED,
+        section=NotificationSection.TEST_SETS,
+        entity_type=EntityType.TEST_SET.value,
+        render=_render_garak_sync_completed,
+    ),
+    NotificationEventType.TestRun.EXECUTION_COMPLETED: NotificationKind(
+        event_type=NotificationEventType.TestRun.EXECUTION_COMPLETED,
+        section=NotificationSection.TEST_RUNS,
+        entity_type=EntityType.TEST_RUN.value,
+        render=_render_execution_completed,
+    ),
+}

--- a/apps/backend/src/rhesis/backend/app/services/notification/service.py
+++ b/apps/backend/src/rhesis/backend/app/services/notification/service.py
@@ -39,13 +39,18 @@ def notify(
     matching how ``BaseTask._send_task_completion_email`` never breaks task
     completion on email failure.
     """
-    kind = NOTIFICATION_CATALOG[event_type]
-    payload = {"entity_ids": rendered.entity_ids} if rendered.entity_ids else None
-
-    # .value if event_type is an enum member (the normal case), else already
-    # a plain string -- NotificationEventType members don't override
-    # __str__, so str(event_type) would return "TestSet.X" on Python <=3.11.
+    # Normalize before the lookup, not after. Both an enum member and a plain
+    # value string resolve the same catalog entry either way -- the nested
+    # NotificationEventType enums mix in `str`, which precedes `Enum` in the
+    # MRO, so a member hashes as its own value -- but relying on that would
+    # make the declared `event_type: str` signature quietly untrue, and it
+    # would break the moment one of those enums dropped the `str` mixin.
+    # `.value` for a member, unchanged for a string; note str(event_type)
+    # would give "TestSet.X" on Python <= 3.11, so it can't be used here.
     event_type_value = getattr(event_type, "value", event_type)
+
+    kind = NOTIFICATION_CATALOG[event_type_value]
+    payload = {"entity_ids": rendered.entity_ids} if rendered.entity_ids else None
 
     notification = create_notification(
         db,

--- a/apps/backend/src/rhesis/backend/app/services/notification/service.py
+++ b/apps/backend/src/rhesis/backend/app/services/notification/service.py
@@ -1,0 +1,75 @@
+"""The single primitive for creating an in-app notification.
+
+Callable from anywhere a completed job needs to tell its recipient: a Celery
+task's on_success/on_failure (see tasks/base.py's in_app_notification hook),
+a live websocket handler, or a router. Takes project_id explicitly rather
+than reading it from ambient scope, since not every caller has a request-
+scoped session to read it from.
+"""
+
+import logging
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.crud.notification import create_notification
+from rhesis.backend.app.schemas.notification import NotificationRead
+from rhesis.backend.app.schemas.websocket import EventType, UserTarget, WebSocketMessage
+from rhesis.backend.app.services.notification.catalog import (
+    NOTIFICATION_CATALOG,
+    RenderedNotification,
+)
+from rhesis.backend.app.services.websocket.publisher import publish_event
+
+logger = logging.getLogger(__name__)
+
+
+def notify(
+    db: Session,
+    *,
+    event_type: str,
+    rendered: RenderedNotification,
+    user_id: str,
+    organization_id: Optional[str] = None,
+    project_id: Optional[str] = None,
+) -> None:
+    """Persist *rendered* for its recipient and push it over their websocket.
+
+    Publishing never raises -- a Redis failure must not fail the caller,
+    matching how ``BaseTask._send_task_completion_email`` never breaks task
+    completion on email failure.
+    """
+    kind = NOTIFICATION_CATALOG[event_type]
+    payload = {"entity_ids": rendered.entity_ids} if rendered.entity_ids else None
+
+    # .value if event_type is an enum member (the normal case), else already
+    # a plain string -- NotificationEventType members don't override
+    # __str__, so str(event_type) would return "TestSet.X" on Python <=3.11.
+    event_type_value = getattr(event_type, "value", event_type)
+
+    notification = create_notification(
+        db,
+        event_type=event_type_value,
+        section=kind.section.value,
+        title=rendered.title,
+        body=rendered.body,
+        is_failure=rendered.is_failure,
+        entity_type=kind.entity_type,
+        entity_id=rendered.entity_id,
+        payload=payload,
+        user_id=user_id,
+        organization_id=organization_id,
+        project_id=project_id,
+    )
+
+    try:
+        notification_read = NotificationRead.model_validate(notification)
+        publish_event(
+            WebSocketMessage(
+                type=EventType.NOTIFICATION,
+                payload=notification_read.model_dump(mode="json"),
+            ),
+            UserTarget(user_id=str(user_id)),
+        )
+    except Exception:
+        logger.exception("Failed to publish notification event for user %s", user_id)

--- a/apps/backend/src/rhesis/backend/app/services/task_notification.py
+++ b/apps/backend/src/rhesis/backend/app/services/task_notification.py
@@ -1,5 +1,5 @@
 """
-Service for sending task assignment email notifications.
+Service for sending task assignment notifications (email and in-app).
 """
 
 import logging
@@ -10,6 +10,8 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import models
 from rhesis.backend.app.crud import get_status, get_type_lookup
 from rhesis.backend.app.crud import user as user_crud
+from rhesis.backend.app.models.enums import NotificationEventType
+from rhesis.backend.app.services.notification import RenderedNotification, notify
 from rhesis.backend.notifications import EmailTemplate, email_service
 
 logger = logging.getLogger(__name__)
@@ -104,6 +106,34 @@ def send_task_assignment_notification(
     except Exception as e:
         logger.error(f"Error sending task assignment email for task {task.id}: {str(e)}")
         return False
+
+
+def send_task_assignment_in_app_notification(db: Session, task: models.Task) -> None:
+    """In-app counterpart to send_task_assignment_notification.
+
+    Badges the assignee's Tasks nav item and highlights the row -- no email
+    involved, and no self-assignment special-case (the email path above
+    doesn't skip self-assignment either, so this stays consistent with it).
+    """
+    if not task.assignee_id:
+        return
+
+    creator = user_crud.get_user(db, task.user_id) if task.user_id else None
+    creator_name = (creator.name or creator.given_name) if creator else None
+
+    rendered = RenderedNotification(
+        title=f'"{task.title}" was assigned to you',
+        body=f"Assigned by {creator_name}" if creator_name else None,
+        entity_id=str(task.id),
+    )
+    notify(
+        db,
+        event_type=NotificationEventType.Task.ASSIGNED,
+        rendered=rendered,
+        user_id=str(task.assignee_id),
+        organization_id=str(task.organization_id) if task.organization_id else None,
+        project_id=str(task.project_id) if task.project_id else None,
+    )
 
 
 def _get_entity_name(

--- a/apps/backend/src/rhesis/backend/tasks/architect/chat.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/chat.py
@@ -7,6 +7,7 @@ via Redis pub/sub, and persists the final response + updated state.
 import logging
 from typing import Any, Dict, Optional
 
+from rhesis.backend.app.models.enums import NotificationEventType
 from rhesis.backend.app.schemas.websocket import (
     ChannelTarget,
     EventType,
@@ -17,13 +18,16 @@ from rhesis.backend.tasks.architect.telemetry import (
     _conversation_telemetry_context,
     _load_session_trace_id,
 )
-from rhesis.backend.tasks.base import SilentTask
+from rhesis.backend.tasks.base import SilentTask, in_app_notification
 from rhesis.backend.worker import app
 from rhesis.sdk.agents.errors import format_user_facing_error
 
 logger = logging.getLogger(__name__)
 
 
+# Fires on at most one turn per user request -- the renderer declines the
+# interactive and mid-plan turns. See _render_architect_plan_completed.
+@in_app_notification(NotificationEventType.Architect.PLAN_COMPLETED)
 @app.task(
     base=SilentTask,
     name="rhesis.backend.tasks.architect.architect_chat_task",
@@ -158,6 +162,9 @@ def architect_chat_task(
             "session_id": session_id,
             "response_length": len(result.content),
             "mode": result.mode,
+            # Read by the in-app notification renderer to tell a turn that
+            # finished the plan from one that just started another wait.
+            "awaiting_task": result.awaiting_task,
         }
 
     except Exception as e:

--- a/apps/backend/src/rhesis/backend/tasks/architect/monitor.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/monitor.py
@@ -26,6 +26,7 @@ import redis as _redis_lib
 from celery.signals import task_postrun
 
 from rhesis.backend.app.config.settings import get_redis_settings
+from rhesis.backend.app.constants import ARCHITECT_RESUME_PREFIX
 
 logger = logging.getLogger(__name__)
 
@@ -243,7 +244,7 @@ def _resume_architect(
     r.delete(f"arch:count:{session_id}")
 
     message = (
-        "[TASK_COMPLETED] The background tasks you were waiting "
+        f"{ARCHITECT_RESUME_PREFIX} The background tasks you were waiting "
         "for have finished. Here are the results:\n"
         + "\n".join(f"- {s}" for s in summaries)
         + "\nPlease continue with the next steps in the plan."

--- a/apps/backend/src/rhesis/backend/tasks/base.py
+++ b/apps/backend/src/rhesis/backend/tasks/base.py
@@ -554,6 +554,10 @@ class BaseTask(Task):
             return
 
         kind = NOTIFICATION_CATALOG[event_type]
+        if kind.render is None:
+            raise ValueError(
+                f"NotificationKind for {event_type!r} has no render fn for a Celery hook"
+            )
         # Normalized to a dict here so every render function can read keys off it
         # directly. A task that returns None or a non-dict on success would
         # otherwise raise inside the renderer, and on_success swallows that --

--- a/apps/backend/src/rhesis/backend/tasks/base.py
+++ b/apps/backend/src/rhesis/backend/tasks/base.py
@@ -226,20 +226,28 @@ class BaseTask(Task):
                     exception_type=type(e).__name__,
                 )
 
-        # Send in-app notification for successful completion if enabled
-        if getattr(self, "_notification_kind", None) is not None:
-            try:
-                self._send_task_completion_notification(retval, None)
-            except Exception as e:
-                # Never let notification failures break task completion
-                self.log_with_context(
-                    "error",
-                    "In-app notification failed in on_success",
-                    error=str(e),
-                    exception_type=type(e).__name__,
-                )
+        self._notify_task_success(retval)
 
         return super().on_success(retval, task_id, args, kwargs)
+
+    def _notify_task_success(self, retval) -> None:
+        """Send the in-app notification for a successful run, if one is configured.
+
+        Split out of ``on_success`` so ``SilentTask`` can call it without
+        inheriting the rest of that method -- see SilentTask.on_success.
+        """
+        if getattr(self, "_notification_kind", None) is None:
+            return
+        try:
+            self._send_task_completion_notification(retval, None)
+        except Exception as e:
+            # Never let notification failures break task completion
+            self.log_with_context(
+                "error",
+                "In-app notification failed in on_success",
+                error=str(e),
+                exception_type=type(e).__name__,
+            )
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         """Log failed task with context information."""
@@ -564,6 +572,10 @@ class BaseTask(Task):
         # losing the notification with only a log line.
         result = retval if isinstance(retval, dict) else {}
         rendered = kind.render(self, result, error)
+        if rendered is None:
+            # The renderer declined: this run completed but isn't a finished
+            # job worth telling the user about (see RenderFn's docstring).
+            return
 
         with self.get_db_session() as db:
             notify(
@@ -588,5 +600,14 @@ class SilentTask(BaseTask):
     send_email_notification_flag = False
 
     def on_success(self, retval, task_id, args, kwargs):
-        """Skip generic completion logging; callers log task-specific outcomes."""
+        """Skip generic completion logging; callers log task-specific outcomes.
+
+        In-app notifications still fire. "Silent" here means no email and no
+        generic log line, not no notification -- they're opt-in per task via
+        ``@in_app_notification``, so a task only gets one by asking. Without
+        this call, skipping ``BaseTask.on_success`` would drop them on
+        success while ``on_failure`` (not overridden) kept sending them,
+        leaving a decorated SilentTask notifying on failure only.
+        """
+        self._notify_task_success(retval)
         return super(BaseTask, self).on_success(retval, task_id, args, kwargs)

--- a/apps/backend/src/rhesis/backend/tasks/base.py
+++ b/apps/backend/src/rhesis/backend/tasks/base.py
@@ -45,6 +45,31 @@ def email_notification(template=None, subject_template=None):
     return decorator
 
 
+def in_app_notification(event_type):
+    """Decorator to enable an in-app notification for task completion.
+
+    Args:
+        event_type: NotificationEventType enum value identifying the
+            NOTIFICATION_CATALOG entry to render and publish.
+
+    Usage:
+        @in_app_notification(NotificationEventType.TestSet.GENERATION_COMPLETED)
+        @app.task(base=BaseTask, bind=True)
+        def my_task(self, ...):
+            ...
+
+    Unlike ``email_notification``, no matching base class is needed:
+    ``BaseTask.on_success``/``on_failure`` check for this attribute
+    unconditionally, so the decorator alone is enough to enable it.
+    """
+
+    def decorator(task_func):
+        task_func._notification_kind = event_type
+        return task_func
+
+    return decorator
+
+
 class BaseTask(Task):
     """Base task class with tenant context, logging, retry logic, and email notifications."""
 
@@ -201,6 +226,19 @@ class BaseTask(Task):
                     exception_type=type(e).__name__,
                 )
 
+        # Send in-app notification for successful completion if enabled
+        if getattr(self, "_notification_kind", None) is not None:
+            try:
+                self._send_task_completion_notification(retval, None)
+            except Exception as e:
+                # Never let notification failures break task completion
+                self.log_with_context(
+                    "error",
+                    "In-app notification failed in on_success",
+                    error=str(e),
+                    exception_type=type(e).__name__,
+                )
+
         return super().on_success(retval, task_id, args, kwargs)
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
@@ -243,6 +281,19 @@ class BaseTask(Task):
                     )
             else:
                 self.log_with_context("debug", "Email notification disabled for this task type")
+
+            # Send in-app notification for permanent failure if enabled
+            if getattr(self, "_notification_kind", None) is not None:
+                try:
+                    self._send_task_completion_notification(None, str(exc))
+                except Exception as notification_error:
+                    # Never let notification failures break task error handling
+                    self.log_with_context(
+                        "error",
+                        "In-app notification failed in on_failure",
+                        error=str(notification_error),
+                        exception_type=type(notification_error).__name__,
+                    )
         else:
             self.log_with_context(
                 "warning",
@@ -482,6 +533,43 @@ class BaseTask(Task):
         except Exception as e:
             logger.error(f"Failed to send email notification: {str(e)}")
             return False
+
+    def _send_task_completion_notification(
+        self, retval: Optional[dict], error: Optional[str]
+    ) -> None:
+        """Render and send the in-app notification configured via ``in_app_notification``.
+
+        Args:
+            retval: The task's return value on success, or None on failure.
+            error: The exception message on failure, or None on success.
+        """
+        from rhesis.backend.app.services.notification import NOTIFICATION_CATALOG, notify
+
+        event_type = self._notification_kind
+        organization_id, user_id, project_id = self.get_tenant_context()
+        if not user_id:
+            self.log_with_context(
+                "warning", "No user_id in tenant context, skipping in-app notification"
+            )
+            return
+
+        kind = NOTIFICATION_CATALOG[event_type]
+        # Normalized to a dict here so every render function can read keys off it
+        # directly. A task that returns None or a non-dict on success would
+        # otherwise raise inside the renderer, and on_success swallows that --
+        # losing the notification with only a log line.
+        result = retval if isinstance(retval, dict) else {}
+        rendered = kind.render(self, result, error)
+
+        with self.get_db_session() as db:
+            notify(
+                db,
+                event_type=event_type,
+                rendered=rendered,
+                user_id=user_id,
+                organization_id=organization_id,
+                project_id=project_id,
+            )
 
 
 class EmailEnabledTask(BaseTask):

--- a/apps/backend/src/rhesis/backend/tasks/execution/results.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/results.py
@@ -8,12 +8,14 @@ from uuid import UUID
 
 from rhesis.backend.app.crud.test_run import get_test_run
 from rhesis.backend.app.database import get_db_with_tenant_variables
+from rhesis.backend.app.models.enums import NotificationEventType
 from rhesis.backend.celery.core import app
 from rhesis.backend.notifications.email.template_service import EmailTemplate
-from rhesis.backend.tasks.base import EmailEnabledTask, email_notification
+from rhesis.backend.tasks.base import EmailEnabledTask, email_notification, in_app_notification
 from rhesis.backend.tasks.execution.result_processor import TestRunProcessor
 
 
+@in_app_notification(NotificationEventType.TestRun.EXECUTION_COMPLETED)
 @email_notification(
     template=EmailTemplate.TEST_EXECUTION_SUMMARY,
     subject_template='Test Execution "{task_name}" {execution_status}',

--- a/apps/backend/src/rhesis/backend/tasks/garak.py
+++ b/apps/backend/src/rhesis/backend/tasks/garak.py
@@ -13,15 +13,17 @@ import logging
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional
 
+from rhesis.backend.app.models.enums import NotificationEventType
 from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.services.usage import dispatch_accrual
 from rhesis.backend.celery.core import app
 from rhesis.backend.notifications.email.template_service import EmailTemplate
-from rhesis.backend.tasks.base import EmailEnabledTask, email_notification
+from rhesis.backend.tasks.base import EmailEnabledTask, email_notification, in_app_notification
 
 logger = logging.getLogger(__name__)
 
 
+@in_app_notification(NotificationEventType.TestSet.GARAK_IMPORT_COMPLETED)
 @email_notification(
     template=EmailTemplate.TASK_COMPLETION,
     subject_template="Garak Import Complete: {task_name} - {status}",
@@ -89,6 +91,7 @@ def import_garak_probes_task(
     return result
 
 
+@in_app_notification(NotificationEventType.TestSet.GARAK_SYNC_COMPLETED)
 @email_notification(
     template=EmailTemplate.TASK_COMPLETION,
     subject_template="Garak Sync Complete: {task_name} - {status}",

--- a/apps/backend/src/rhesis/backend/tasks/test_set.py
+++ b/apps/backend/src/rhesis/backend/tasks/test_set.py
@@ -5,6 +5,7 @@ from rhesis.backend.app import crud
 from rhesis.backend.app.constants import TestSetType
 from rhesis.backend.app.crud import user as user_crud
 from rhesis.backend.app.database import get_db_with_tenant_variables
+from rhesis.backend.app.models.enums import NotificationEventType
 from rhesis.backend.app.models.test_set import TestSet
 from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.schemas.services import GenerationConfig, SourceData
@@ -20,7 +21,12 @@ from rhesis.backend.app.utils.user_model_utils import (
 )
 from rhesis.backend.celery.core import app
 from rhesis.backend.notifications.email.template_service import EmailTemplate
-from rhesis.backend.tasks.base import BaseTask, EmailEnabledTask, email_notification
+from rhesis.backend.tasks.base import (
+    BaseTask,
+    EmailEnabledTask,
+    email_notification,
+    in_app_notification,
+)
 
 # SDK components (BaseLLM, ConfigSynthesizer, MultiTurnSynthesizer) are
 # imported lazily inside task functions to avoid pulling litellm → gRPC
@@ -401,6 +407,7 @@ def _mark_test_set_generation_failed(
         )
 
 
+@in_app_notification(NotificationEventType.TestSet.GENERATION_COMPLETED)
 @email_notification(
     template=EmailTemplate.TASK_COMPLETION,
     subject_template="Test Set Generation Complete: {task_name} - {status}",

--- a/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
+++ b/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
@@ -12,6 +12,7 @@ import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { AppShell } from '@/components/layout/AppShell';
 import { Sidebar } from '@/components/navigation/Sidebar';
 import { WebSocketProvider } from '@/contexts/WebSocketContext';
+import { NotificationsProvider } from '@/contexts/NotificationsContext';
 import NoProjectAccess from '@/components/common/NoProjectAccess';
 import TermsAcceptanceGate from '@/components/auth/TermsAcceptanceGate';
 import type { TermsStatus } from '@/utils/api-client/auth-client';
@@ -104,11 +105,13 @@ export function ProtectedLayoutClient({
       <FeaturesProvider initialFeatures={initialFeatures}>
         <PermissionsProvider initialPermissions={initialPermissions}>
           <WebSocketProvider>
-            {!isOnboarding && (
-              <TermsAcceptanceGate initialTermsStatus={initialTermsStatus} />
-            )}
-            {!isOnboarding && !chromeless && <VerificationBanner />}
-            {content}
+            <NotificationsProvider>
+              {!isOnboarding && (
+                <TermsAcceptanceGate initialTermsStatus={initialTermsStatus} />
+              )}
+              {!isOnboarding && !chromeless && <VerificationBanner />}
+              {content}
+            </NotificationsProvider>
           </WebSocketProvider>
         </PermissionsProvider>
       </FeaturesProvider>

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectClient.tsx
@@ -14,6 +14,8 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { ArchitectSession } from '@/utils/api-client/architect-client';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
+import { useViewingEntity } from '@/contexts/NotificationsContext';
+import { NotificationSection } from '@/constants/notifications';
 import { useCanWithStatus } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { architectSessionKeys } from '@/constants/query-keys';
@@ -48,6 +50,10 @@ export default function ArchitectClient() {
   const [pendingMessage, setPendingMessage] = useState<string | null>(null);
   const [isCreatingSession, setIsCreatingSession] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(true);
+
+  // No badge for the session that's open on screen -- this page streams that
+  // session's own progress live. Another session completing still badges.
+  useViewingEntity(NotificationSection.ARCHITECT, activeSessionId);
 
   const projectKey = activeProject?.id ?? '';
   // Memoize so `updateSessions` (and the ?session= effect that depends on it)

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -220,6 +220,10 @@ export default function TasksGrid({
       });
     },
     enabled: isAuthenticated(status),
+    // Always refetch when the list is opened -- a task assigned to you while
+    // you were elsewhere must show up on arrival. See the same note in
+    // TestSetsGrid.
+    staleTime: 0,
   });
   const tasks: Task[] = tasksData?.data ?? [];
   const totalCount = tasksData?.totalCount ?? 0;

--- a/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
+++ b/apps/frontend/src/app/(protected)/tasks/components/TasksGrid.tsx
@@ -34,6 +34,13 @@ import {
 } from '@/components/common/createRowActionsColumn';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import { useNotifications } from '@/components/common/NotificationContext';
+// Renamed on import: distinct from the toast system's useNotifications above --
+// this is the persistent, backend-tracked "assigned to you" badge/highlight.
+import { useNotifications as useJobNotifications } from '@/contexts/NotificationsContext';
+import {
+  HIGHLIGHTED_ROW_CLASS,
+  NotificationSection,
+} from '@/constants/notifications';
 import { useQueryClient } from '@tanstack/react-query';
 import { taskKeys } from '@/constants/query-keys';
 import { useGridState } from '@/hooks/useGridState';
@@ -118,6 +125,7 @@ export default function TasksGrid({
 }: TasksGridProps) {
   const router = useRouter();
   const notifications = useNotifications();
+  const { highlightedIds, clearHighlight } = useJobNotifications();
   const queryClient = useQueryClient();
   const { status } = useSession();
 
@@ -218,9 +226,10 @@ export default function TasksGrid({
 
   const handleRowClick = useCallback(
     (params: GridRowParams) => {
+      clearHighlight(NotificationSection.TASKS, String(params.id));
       router.push(`/tasks/${params.id}`);
     },
-    [router]
+    [router, clearHighlight]
   );
 
   const handleRowDeleteAction = useCallback((id: string) => {
@@ -392,6 +401,13 @@ export default function TasksGrid({
               onFilterModelChange={handleFilterModelChange}
               disableRowSelectionOnClick
               onRowClick={handleRowClick}
+              getRowClassName={params =>
+                highlightedIds(NotificationSection.TASKS).includes(
+                  String(params.id)
+                )
+                  ? HIGHLIGHTED_ROW_CLASS
+                  : ''
+              }
               serverSidePagination={true}
               totalRows={totalCount}
               pageSizeOptions={[10, 25, 50, 100]}

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -293,6 +293,10 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
       });
     },
     enabled: isAuthenticated(status),
+    // Always refetch when the list is opened -- a run appears here as soon as
+    // it's started, so cached-but-not-yet-stale data hides it. See the same
+    // note in TestSetsGrid.
+    staleTime: 0,
   });
 
   const testRuns = testRunsData?.data ?? [];

--- a/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/components/TestRunsGrid.tsx
@@ -42,6 +42,13 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import PersonIcon from '@mui/icons-material/Person';
 import RateReviewOutlinedIcon from '@mui/icons-material/RateReviewOutlined';
 import { useNotifications } from '@/components/common/NotificationContext';
+// Renamed on import: distinct from the toast system's useNotifications above --
+// this one tracks the persistent "a background job finished" badge/highlight.
+import { useNotifications as useJobNotifications } from '@/contexts/NotificationsContext';
+import {
+  HIGHLIGHTED_ROW_CLASS,
+  NotificationSection,
+} from '@/constants/notifications';
 import { TestRun, TestRunDetail } from '@/utils/api-client/interfaces/test-run';
 import { can } from '@/utils/affordances';
 import { Capability } from '@/constants/capabilities';
@@ -159,6 +166,8 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
   const queryClient = useQueryClient();
   const router = useRouter();
   const notifications = useNotifications();
+  const { highlightedIds, clearHighlight } = useJobNotifications();
+  const testRunHighlights = highlightedIds(NotificationSection.TEST_RUNS);
 
   // ── Search + status filter ─────────────────────────────────────────────────
   const [searchQuery, setSearchQuery] = useState('');
@@ -641,9 +650,10 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
 
   const handleRowClick = useCallback(
     (params: { id: string | number }) => {
+      clearHighlight(NotificationSection.TEST_RUNS, String(params.id));
       router.push(`/test-runs/${params.id}`);
     },
-    [router]
+    [router, clearHighlight]
   );
 
   // ── Delete handlers ───────────────────────────────────────────────────────
@@ -799,6 +809,11 @@ function TestRunsGrid({ canCreate, onCreateClick }: TestRunsGridProps) {
             onSortModelChange={handleSortModelChange}
             serverSideFiltering={true}
             onRowClick={handleRowClick}
+            getRowClassName={params =>
+              testRunHighlights.includes(String(params.id))
+                ? HIGHLIGHTED_ROW_CLASS
+                : ''
+            }
             getRowUrl={row => `/test-runs/${row.id}`}
             serverSidePagination={true}
             totalRows={totalCount}

--- a/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetLinkedTestsSection.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/[identifier]/components/TestSetLinkedTestsSection.tsx
@@ -59,6 +59,13 @@ export default function TestSetLinkedTestsSection({
     setTotalCount(initialTestCount);
   }, [initialTestCount]);
 
+  // Mirrors the totalCount sync above -- isGenerating is only ever flipped
+  // to false via this effect, from the refreshed prop, never directly from
+  // the poll below. See the comment inside checkStatus for why.
+  useEffect(() => {
+    setIsGenerating(initialIsGenerating);
+  }, [initialIsGenerating]);
+
   useEffect(() => {
     if (!isGenerating) return;
 
@@ -77,11 +84,21 @@ export default function TestSetLinkedTestsSection({
         const generationStatus =
           testSet.attributes?.metadata?.generation?.status;
         if (generationStatus !== 'in_progress') {
-          setIsGenerating(false);
           if (pollRef.current) {
             clearInterval(pollRef.current);
             pollRef.current = null;
           }
+          // Deliberately not setIsGenerating(false) here. testCount and
+          // isGenerating are both derived from the same server read (see
+          // page.tsx) and land together in router.refresh()'s refreshed
+          // props. Flipping isGenerating locally first would render one
+          // frame with isGenerating=false but totalCount still stale at
+          // its old (often 0) value -- bouncing through the "No tests
+          // yet" empty state before the real grid mounts, which is what
+          // caused the flicker on the grid's pills as it mounted. Staying
+          // on the "Generating tests..." placeholder a moment longer, and
+          // switching both values in the same render once the refresh
+          // lands, avoids that extra state.
           router.refresh();
         }
       } catch {

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -290,6 +290,13 @@ export default function TestSetsGrid({
       });
     },
     enabled: isAuthenticated(status),
+    // Always refetch when the list is opened. A test set row exists from the
+    // moment generation is *submitted* (the flow then redirects to its detail
+    // page), so under the app-wide 5-minute staleTime, coming back to this
+    // list served cache that predated the new row -- it only showed up after a
+    // hard reload. keepPreviousData in useGridQuery means the current rows stay
+    // put while the refetch runs, so this costs no loading flash.
+    staleTime: 0,
   });
   const testSets = testSetsData?.data ?? [];
   const totalCount = testSetsData?.pagination.totalCount ?? 0;

--- a/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
+++ b/apps/frontend/src/app/(protected)/test-sets/components/TestSetsGrid.tsx
@@ -44,6 +44,13 @@ import { useSession } from 'next-auth/react';
 import RunDrawer from '@/components/common/RunDrawer';
 import { DeleteModal } from '@/components/common/DeleteModal';
 import { useNotifications } from '@/components/common/NotificationContext';
+// Renamed on import: distinct from the toast system's useNotifications above --
+// this one tracks the persistent "a background job finished" badge/highlight.
+import { useNotifications as useJobNotifications } from '@/contexts/NotificationsContext';
+import {
+  HIGHLIGHTED_ROW_CLASS,
+  NotificationSection,
+} from '@/constants/notifications';
 import { formatDate } from '@/utils/date';
 import TestSetFilterDrawer, {
   type TestSetFilters,
@@ -172,6 +179,8 @@ export default function TestSetsGrid({
   const router = useRouter();
   const { status } = useSession();
   const notifications = useNotifications();
+  const { highlightedIds, clearHighlight } = useJobNotifications();
+  const testSetHighlights = highlightedIds(NotificationSection.TEST_SETS);
   const canEditTestSet = useCan(Capability.TestSet.UPDATE);
   const canDeleteTestSet = useCan(Capability.TestSet.DELETE);
   const queryClient = useQueryClient();
@@ -289,9 +298,10 @@ export default function TestSetsGrid({
 
   const handleRowClick = useCallback(
     (params: GridRowParams) => {
+      clearHighlight(NotificationSection.TEST_SETS, String(params.id));
       router.push(`/test-sets/${params.id}`);
     },
-    [router]
+    [router, clearHighlight]
   );
 
   const handleSelectionChange = useCallback(
@@ -687,6 +697,11 @@ export default function TestSetsGrid({
             getRowId={row => row.id}
             showToolbar={true}
             onRowClick={handleRowClick}
+            getRowClassName={params =>
+              testSetHighlights.includes(String(params.id))
+                ? HIGHLIGHTED_ROW_CLASS
+                : ''
+            }
             getRowUrl={row => `/test-sets/${row.id}`}
             paginationModel={paginationModel}
             onPaginationModelChange={handlePaginationModelChange}

--- a/apps/frontend/src/components/common/BaseDataGrid.tsx
+++ b/apps/frontend/src/components/common/BaseDataGrid.tsx
@@ -27,6 +27,7 @@ import {
   TextField,
   InputAdornment,
   Menu,
+  alpha,
 } from '@mui/material';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SearchIcon from '@mui/icons-material/Search';
@@ -68,6 +69,7 @@ import {
   useRowActionsGridRootProps,
 } from '@/components/common/createRowActionsColumn';
 import { BORDER_RADIUS, ELEVATION } from '@/styles/theme';
+import { HIGHLIGHTED_ROW_CLASS } from '@/constants/notifications';
 
 /**
  * Shared "grid card" look — the bordered, rounded, shadowed Paper every grid
@@ -105,6 +107,8 @@ interface BaseDataGridProps {
   getRowId?: (row: GridRowModel) => string | number;
   showToolbar?: boolean;
   onRowClick?: (params: GridRowParams) => void;
+  /** Per-row extra CSS class, e.g. to gently highlight a row with an unseen notification. */
+  getRowClassName?: (params: GridRowParams) => string;
   density?: GridDensity;
   sx?: SxProps<Theme>;
   disableMultipleRowSelection?: boolean;
@@ -610,6 +614,7 @@ export default function BaseDataGrid({
   getRowId,
   showToolbar: _showToolbar = false,
   onRowClick,
+  getRowClassName,
   density,
   sx: _sx,
   disableMultipleRowSelection,
@@ -653,7 +658,7 @@ export default function BaseDataGrid({
   hideFooter = false,
   hideRowsPerPageBelow = 10,
 }: BaseDataGridProps) {
-  const _theme = useTheme();
+  const theme = useTheme();
   const router = useRouter();
   const apiRef = useGridApiRef();
 
@@ -1176,6 +1181,15 @@ export default function BaseDataGrid({
         display: 'none',
       },
     },
+    {
+      [`& .${HIGHLIGHTED_ROW_CLASS}`]: {
+        backgroundColor: alpha(theme.palette.primary.main, 0.08),
+        transition: 'background-color 0.3s ease',
+      },
+      [`& .${HIGHLIGHTED_ROW_CLASS}:hover`]: {
+        backgroundColor: alpha(theme.palette.primary.main, 0.14),
+      },
+    },
     ...(Array.isArray(_sx) ? _sx : _sx ? [_sx] : []),
   ].filter(Boolean) as SxProps<Theme>;
 
@@ -1427,6 +1441,7 @@ export default function BaseDataGrid({
                       rowSelectionModel,
                     })}
                     {...(isRowSelectable && { isRowSelectable })}
+                    {...(getRowClassName && { getRowClassName })}
                     {...(disableRowSelectionOnClick && {
                       disableRowSelectionOnClick,
                     })}
@@ -1500,6 +1515,7 @@ export default function BaseDataGrid({
                         rowSelectionModel,
                       })}
                       {...(isRowSelectable && { isRowSelectable })}
+                      {...(getRowClassName && { getRowClassName })}
                       {...(disableRowSelectionOnClick && {
                         disableRowSelectionOnClick,
                       })}

--- a/apps/frontend/src/components/navigation/NavItem.tsx
+++ b/apps/frontend/src/components/navigation/NavItem.tsx
@@ -6,11 +6,17 @@ import { usePathname } from 'next/navigation';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Tooltip from '@mui/material/Tooltip';
+import Badge from '@mui/material/Badge';
 import { BORDER_RADIUS } from '@/styles/theme';
 import { type NavigationPageItem } from '@/types/navigation';
 import { useCan } from '@/components/common/Can';
 import { useAmbientPermissions } from '@/contexts/PermissionsContext';
+import { useNotifications } from '@/contexts/NotificationsContext';
+import { NotificationSection } from '@/constants/notifications';
 import { isActive, collapsedNavItemSx } from './sidebar-utils';
+
+const NOTIFICATION_SECTION_VALUES: string[] =
+  Object.values(NotificationSection);
 
 interface NavItemProps {
   item: NavigationPageItem;
@@ -26,6 +32,10 @@ export function NavItem({ item, collapsed, parentPath = '' }: NavItemProps) {
   const active = isActive(pathname, fullPath);
   const ambient = useAmbientPermissions();
   const singlePermitted = useCan(item.requiredPermission ?? '');
+  const { unreadBySection } = useNotifications();
+  const unread = NOTIFICATION_SECTION_VALUES.includes(item.segment)
+    ? (unreadBySection[item.segment as NotificationSection] ?? 0)
+    : 0;
 
   const requiredAnyOf = item.requiredAnyOf;
   const isGated = Boolean(requiredAnyOf?.length || item.requiredPermission);
@@ -86,7 +96,13 @@ export function NavItem({ item, collapsed, parentPath = '' }: NavItemProps) {
             '& svg': { width: 24, height: 24 },
           }}
         >
-          {item.icon}
+          {collapsed && unread > 0 ? (
+            <Badge badgeContent={unread} color="primary" max={99}>
+              {item.icon}
+            </Badge>
+          ) : (
+            item.icon
+          )}
         </Box>
       )}
       {!collapsed && (
@@ -108,6 +124,25 @@ export function NavItem({ item, collapsed, parentPath = '' }: NavItemProps) {
           >
             {item.title}
           </Typography>
+          {unread > 0 && (
+            <Box
+              sx={{
+                flexShrink: 0,
+                minWidth: 20,
+                height: 20,
+                px: '6px',
+                borderRadius: BORDER_RADIUS.sm,
+                bgcolor: active ? 'primary.contrastText' : 'primary.main',
+                color: active ? 'primary.main' : 'primary.contrastText',
+                fontSize: 12,
+                fontWeight: 600,
+                lineHeight: '20px',
+                textAlign: 'center',
+              }}
+            >
+              {unread > 99 ? '99+' : unread}
+            </Box>
+          )}
           {item.action && <Box sx={{ flexShrink: 0 }}>{item.action}</Box>}
         </>
       )}

--- a/apps/frontend/src/components/navigation/__tests__/NavItem.test.tsx
+++ b/apps/frontend/src/components/navigation/__tests__/NavItem.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { NavItem } from '../NavItem';
+import { type NavigationPageItem } from '@/types/navigation';
+import { NotificationSection } from '@/constants/notifications';
+
+jest.mock('@/contexts/PermissionsContext', () => ({
+  useAmbientPermissions: () => ({
+    permitted_actions: [],
+    loading: false,
+    error: null,
+    enabled: false, // RBAC off -- every item permitted, matching NavSection.test.tsx's pattern
+  }),
+}));
+
+const mockUnreadBySection: Record<string, number> = {};
+
+jest.mock('@/contexts/NotificationsContext', () => ({
+  useNotifications: () => ({
+    unreadBySection: mockUnreadBySection,
+    highlightedIds: () => [],
+    markSectionRead: jest.fn(),
+    clearHighlight: jest.fn(),
+  }),
+}));
+
+function testSetsItem(): NavigationPageItem {
+  return {
+    kind: 'page',
+    segment: NotificationSection.TEST_SETS,
+    title: 'Test Sets',
+    icon: <svg data-testid="icon" />,
+  };
+}
+
+describe('NavItem notification badge', () => {
+  beforeEach(() => {
+    Object.keys(mockUnreadBySection).forEach(
+      key => delete mockUnreadBySection[key]
+    );
+  });
+
+  it('shows no badge when there are no unread notifications', () => {
+    render(<NavItem item={testSetsItem()} collapsed={false} />);
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
+  });
+
+  it('shows the unread count next to the title when expanded', () => {
+    mockUnreadBySection[NotificationSection.TEST_SETS] = 3;
+    render(<NavItem item={testSetsItem()} collapsed={false} />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Test Sets')).toBeInTheDocument();
+  });
+
+  it('caps the displayed count at 99+', () => {
+    mockUnreadBySection[NotificationSection.TEST_SETS] = 150;
+    render(<NavItem item={testSetsItem()} collapsed={false} />);
+    expect(screen.getByText('99+')).toBeInTheDocument();
+  });
+
+  it('does not badge a segment with no matching NotificationSection', () => {
+    mockUnreadBySection[NotificationSection.TEST_SETS] = 5;
+    const item: NavigationPageItem = {
+      kind: 'page',
+      segment: 'playground',
+      title: 'Playground',
+    };
+    render(<NavItem item={item} collapsed={false} />);
+    expect(screen.queryByText('5')).not.toBeInTheDocument();
+  });
+
+  it('renders a Badge around the icon when collapsed with unread notifications', () => {
+    mockUnreadBySection[NotificationSection.TEST_SETS] = 2;
+    render(<NavItem item={testSetsItem()} collapsed={true} />);
+    // MUI Badge renders the count in a span with class MuiBadge-badge.
+    expect(document.querySelector('.MuiBadge-badge')).toHaveTextContent('2');
+  });
+});

--- a/apps/frontend/src/constants/notifications.ts
+++ b/apps/frontend/src/constants/notifications.ts
@@ -9,6 +9,9 @@ export const NotificationSection = {
   TEST_SETS: 'test-sets',
   TEST_RUNS: 'test-runs',
   TASKS: 'tasks',
+  // Badge only -- the architect page is a chat/session UI, not a grid, so
+  // there are no rows for HIGHLIGHTED_ROW_CLASS to apply to.
+  ARCHITECT: 'architect',
 } as const;
 
 export type NotificationSection =

--- a/apps/frontend/src/constants/notifications.ts
+++ b/apps/frontend/src/constants/notifications.ts
@@ -8,6 +8,7 @@
 export const NotificationSection = {
   TEST_SETS: 'test-sets',
   TEST_RUNS: 'test-runs',
+  TASKS: 'tasks',
 } as const;
 
 export type NotificationSection =

--- a/apps/frontend/src/constants/notifications.ts
+++ b/apps/frontend/src/constants/notifications.ts
@@ -1,0 +1,17 @@
+/**
+ * Notification sidebar sections. Mirrors the backend `NotificationSection`
+ * enum in `apps/backend/src/rhesis/backend/app/models/enums.py`. Values must
+ * equal the `NavigationPageItem.segment` of the page they badge (see
+ * `src/app/layout.tsx`) -- keep in sync when adding a new section, same as
+ * `FeatureName`/`Capability`.
+ */
+export const NotificationSection = {
+  TEST_SETS: 'test-sets',
+  TEST_RUNS: 'test-runs',
+} as const;
+
+export type NotificationSection =
+  (typeof NotificationSection)[keyof typeof NotificationSection];
+
+/** CSS class applied to a grid row whose entity has an unseen notification. */
+export const HIGHLIGHTED_ROW_CLASS = 'rhesis-row-notified';

--- a/apps/frontend/src/contexts/NotificationsContext.tsx
+++ b/apps/frontend/src/contexts/NotificationsContext.tsx
@@ -122,10 +122,10 @@ export function NotificationsProvider({
     []
   );
 
-  const markIdsRead = useCallback((ids: string[]) => {
+  const markIdsRead = useCallback((notificationIds: string[]) => {
     new ApiClientFactory()
       .getNotificationsClient()
-      .markRead({ ids })
+      .markRead({ notification_ids: notificationIds })
       .catch(error => {
         console.warn('Failed to mark notifications read:', error);
       });

--- a/apps/frontend/src/contexts/NotificationsContext.tsx
+++ b/apps/frontend/src/contexts/NotificationsContext.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 import { usePathname } from 'next/navigation';
@@ -20,6 +21,7 @@ type SectionCounts = Partial<Record<NotificationSection, number>>;
 type SectionHighlights = Partial<Record<NotificationSection, string[]>>;
 
 interface NotificationEventPayload {
+  id?: string;
   section?: string;
   entity_id?: string | null;
   project_id?: string | null;
@@ -35,6 +37,15 @@ interface NotificationsContextValue {
   markSectionRead: (section: NotificationSection) => void;
   /** Drop one id from a section's highlight list (e.g. on row click). */
   clearHighlight: (section: NotificationSection, id: string) => void;
+  /**
+   * Declare that this entity is on screen right now, so its own notifications
+   * are pointless. Returns an unregister function. Prefer the
+   * `useViewingEntity` hook over calling this directly.
+   */
+  registerViewing: (
+    section: NotificationSection,
+    entityId: string
+  ) => () => void;
 }
 
 // Default (no provider in the tree) is "no notifications", not a thrown
@@ -47,6 +58,7 @@ const defaultNotificationsContext: NotificationsContextValue = {
   highlightedIds: () => [],
   markSectionRead: () => {},
   clearHighlight: () => {},
+  registerViewing: () => () => {},
 };
 
 const NotificationsContext = createContext<NotificationsContextValue>(
@@ -94,6 +106,30 @@ export function NotificationsProvider({
 
   const [unreadBySection, setUnreadBySection] = useState<SectionCounts>({});
   const [highlighted, setHighlighted] = useState<SectionHighlights>({});
+  // "section:entityId" for every entity currently on screen. A ref, not
+  // state: the websocket handler reads it, and re-running that effect on
+  // every navigation would churn the subscription for no benefit.
+  const viewingRef = useRef<Set<string>>(new Set());
+
+  const registerViewing = useCallback(
+    (section: NotificationSection, entityId: string) => {
+      const key = `${section}:${entityId}`;
+      viewingRef.current.add(key);
+      return () => {
+        viewingRef.current.delete(key);
+      };
+    },
+    []
+  );
+
+  const markIdsRead = useCallback((ids: string[]) => {
+    new ApiClientFactory()
+      .getNotificationsClient()
+      .markRead({ ids })
+      .catch(error => {
+        console.warn('Failed to mark notifications read:', error);
+      });
+  }, []);
 
   const fetchSummary = useCallback(async () => {
     try {
@@ -134,6 +170,20 @@ export function NotificationsProvider({
       }
 
       const section = payload.section;
+
+      // The user is looking at this exact entity, so telling them about it is
+      // pointless -- the page showing it live is responsible for its own
+      // updates (the architect page streams its session over a channel, for
+      // instance). Mark the row read straight away so it doesn't resurface on
+      // the next load, and skip the badge, the highlight and the list
+      // invalidation. Note this is per-entity: a notification for a *different*
+      // architect session still badges normally.
+      const entityId = payload.entity_id ? String(payload.entity_id) : null;
+      if (entityId && viewingRef.current.has(`${section}:${entityId}`)) {
+        if (payload.id) markIdsRead([String(payload.id)]);
+        return;
+      }
+
       setUnreadBySection(prev => ({
         ...prev,
         [section]: (prev[section] ?? 0) + 1,
@@ -168,7 +218,7 @@ export function NotificationsProvider({
     // and `subscribe` silently returns a no-op unsubscribe. `subscribe` itself
     // has a stable identity, so without re-running when the socket comes up
     // the handler would never be registered at all.
-  }, [subscribe, isConnected, activeProject?.id, queryClient]);
+  }, [subscribe, isConnected, activeProject?.id, queryClient, markIdsRead]);
 
   const markSectionRead = useCallback((section: NotificationSection) => {
     setUnreadBySection(prev => {
@@ -225,6 +275,7 @@ export function NotificationsProvider({
     highlightedIds,
     markSectionRead,
     clearHighlight,
+    registerViewing,
   };
 
   return (
@@ -236,4 +287,23 @@ export function NotificationsProvider({
 
 export function useNotifications(): NotificationsContextValue {
   return useContext(NotificationsContext);
+}
+
+/**
+ * Suppress notifications for the entity this component is currently showing.
+ *
+ * For a page that already streams its own live updates, a badge for the thing
+ * on screen is noise. While mounted with a non-null `entityId`, a matching
+ * notification is marked read on arrival instead of badged. Pass null when
+ * nothing is open (e.g. no architect session selected) to suppress nothing.
+ */
+export function useViewingEntity(
+  section: NotificationSection,
+  entityId: string | null | undefined
+): void {
+  const { registerViewing } = useNotifications();
+  useEffect(() => {
+    if (!entityId) return;
+    return registerViewing(section, entityId);
+  }, [registerViewing, section, entityId]);
 }

--- a/apps/frontend/src/contexts/NotificationsContext.tsx
+++ b/apps/frontend/src/contexts/NotificationsContext.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import { usePathname } from 'next/navigation';
 import { useSession } from 'next-auth/react';
+import { useQueryClient } from '@tanstack/react-query';
 import { EventType } from '@/utils/websocket';
 import { useWebSocketContext } from './WebSocketContext';
 import { useActiveProject } from './ActiveProjectContext';
@@ -82,6 +83,7 @@ export function NotificationsProvider({
   const { activeProject } = useActiveProject();
   const pathname = usePathname();
   const { data: session } = useSession();
+  const queryClient = useQueryClient();
   // The endpoints resolve tenant context from the caller's org and 403 without
   // one, so a user still in onboarding has nothing to fetch -- skip rather than
   // fire a request on every onboarding page load that can only fail.
@@ -137,6 +139,17 @@ export function NotificationsProvider({
         [section]: (prev[section] ?? 0) + 1,
       }));
 
+      // Invalidate only the section's *list* queries (e.g. testSetKeys.list()
+      // === ['test-sets', 'list', ...], see constants/query-keys.ts), not
+      // the whole ['test-sets'] prefix -- that would also match a test
+      // set's own detail-page query (testSetKeys.detail(id), whose key is
+      // ['test-sets', 'detail', id, ...]) and force it to refetch too,
+      // flickering an unrelated test set's page every time any test set's
+      // list changes. Refetches a currently-mounted grid immediately and
+      // marks it stale for its next mount, so a newly created row shows up
+      // without a manual page reload.
+      queryClient.invalidateQueries({ queryKey: [section, 'list'] });
+
       const newIds = [
         ...(payload.entity_id ? [payload.entity_id] : []),
         ...(payload.payload?.entity_ids ?? []),
@@ -155,7 +168,7 @@ export function NotificationsProvider({
     // and `subscribe` silently returns a no-op unsubscribe. `subscribe` itself
     // has a stable identity, so without re-running when the socket comes up
     // the handler would never be registered at all.
-  }, [subscribe, isConnected, activeProject?.id]);
+  }, [subscribe, isConnected, activeProject?.id, queryClient]);
 
   const markSectionRead = useCallback((section: NotificationSection) => {
     setUnreadBySection(prev => {
@@ -170,12 +183,22 @@ export function NotificationsProvider({
       });
   }, []);
 
-  // Visiting a section clears its badge. Fires again on a later render if a
-  // new notification for the current section arrives while already here --
-  // unreadBySection[section] going back above 0 re-triggers the effect.
+  // Visiting a section's own list page clears its badge. Fires again on a
+  // later render if a new notification for the current section arrives
+  // while already here -- unreadBySection[section] going back above 0
+  // re-triggers the effect.
+  //
+  // Must be the exact list route, not just a matching first path segment --
+  // e.g. generating a test set redirects straight to that new test set's
+  // *detail* page (/test-sets/[id]), which shares the 'test-sets' segment
+  // with the list page. Matching on the segment alone marked the section
+  // read before the user ever saw the list, which (since /notifications/
+  // summary only returns entity_ids for still-unread rows) also erased the
+  // row's highlight on a later reload, before it had ever been shown.
   useEffect(() => {
     const segment = pathname?.split('/')[1];
     if (!segment || !isNotificationSection(segment)) return;
+    if (pathname !== `/${segment}`) return;
     if ((unreadBySection[segment] ?? 0) > 0) {
       markSectionRead(segment);
     }

--- a/apps/frontend/src/contexts/NotificationsContext.tsx
+++ b/apps/frontend/src/contexts/NotificationsContext.tsx
@@ -1,0 +1,216 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+import { usePathname } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { EventType } from '@/utils/websocket';
+import { useWebSocketContext } from './WebSocketContext';
+import { useActiveProject } from './ActiveProjectContext';
+import { ApiClientFactory } from '@/utils/api-client/client-factory';
+import { NotificationSection } from '@/constants/notifications';
+
+type SectionCounts = Partial<Record<NotificationSection, number>>;
+type SectionHighlights = Partial<Record<NotificationSection, string[]>>;
+
+interface NotificationEventPayload {
+  section?: string;
+  entity_id?: string | null;
+  project_id?: string | null;
+  payload?: { entity_ids?: string[] } | null;
+}
+
+interface NotificationsContextValue {
+  /** Unread count per section, for the sidebar badge. */
+  unreadBySection: SectionCounts;
+  /** Entity ids to gently highlight in a section's grid. */
+  highlightedIds: (section: NotificationSection) => string[];
+  /** Zero a section's badge and persist read_at on the backend. */
+  markSectionRead: (section: NotificationSection) => void;
+  /** Drop one id from a section's highlight list (e.g. on row click). */
+  clearHighlight: (section: NotificationSection, id: string) => void;
+}
+
+// Default (no provider in the tree) is "no notifications", not a thrown
+// error -- NavItem reads this deep in the nav tree, and unit tests that
+// render NavItem/NavSection/Sidebar in isolation should not need to wrap
+// every render in a NotificationsProvider, matching how PermissionsContext's
+// ambient default behaves.
+const defaultNotificationsContext: NotificationsContextValue = {
+  unreadBySection: {},
+  highlightedIds: () => [],
+  markSectionRead: () => {},
+  clearHighlight: () => {},
+};
+
+const NotificationsContext = createContext<NotificationsContextValue>(
+  defaultNotificationsContext
+);
+
+const SECTION_VALUES: string[] = Object.values(NotificationSection);
+
+function isNotificationSection(value: string): value is NotificationSection {
+  return SECTION_VALUES.includes(value);
+}
+
+/**
+ * Tracks per-section unread counts and highlightable entity ids for the
+ * sidebar badge and grid row highlight.
+ *
+ * Not to be confused with `components/common/NotificationContext`'s
+ * `NotificationProvider` (singular) -- that one is the generic toast/snackbar
+ * system. This is the persistent, backend-tracked "a background job
+ * finished" badge.
+ *
+ * Refetches `/notifications/summary` on mount and whenever the active
+ * project changes -- the summary is project-scoped (see
+ * `apps/backend/AGENTS.md`'s "Ambient Request Scope"), and the highlight
+ * list is fully replaced on that refetch, which is what resets a highlight
+ * left over from a different project's rows.
+ */
+export function NotificationsProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { subscribe, isConnected } = useWebSocketContext();
+  const { activeProject } = useActiveProject();
+  const pathname = usePathname();
+  const { data: session } = useSession();
+  // The endpoints resolve tenant context from the caller's org and 403 without
+  // one, so a user still in onboarding has nothing to fetch -- skip rather than
+  // fire a request on every onboarding page load that can only fail.
+  const hasOrganization = Boolean(
+    (session?.user as { organization_id?: string | null } | undefined)
+      ?.organization_id
+  );
+
+  const [unreadBySection, setUnreadBySection] = useState<SectionCounts>({});
+  const [highlighted, setHighlighted] = useState<SectionHighlights>({});
+
+  const fetchSummary = useCallback(async () => {
+    try {
+      const client = new ApiClientFactory().getNotificationsClient();
+      const { sections } = await client.getSummary();
+      const nextUnread: SectionCounts = {};
+      const nextHighlighted: SectionHighlights = {};
+      Object.entries(sections).forEach(([section, summary]) => {
+        if (!isNotificationSection(section) || !summary) return;
+        nextUnread[section] = summary.unread;
+        nextHighlighted[section] = summary.entity_ids;
+      });
+      setUnreadBySection(nextUnread);
+      setHighlighted(nextHighlighted);
+    } catch (error) {
+      console.warn('Failed to fetch notification summary:', error);
+    }
+    // Project scoping is server-side via the active-project cookie, not an
+    // explicit dependency here -- the effect below re-runs this on project change.
+  }, []);
+
+  useEffect(() => {
+    if (!hasOrganization) return;
+    fetchSummary();
+  }, [hasOrganization, activeProject?.id, fetchSummary]);
+
+  useEffect(() => {
+    const unsubscribe = subscribe(EventType.NOTIFICATION, message => {
+      const payload = message.payload as NotificationEventPayload | undefined;
+      if (!payload?.section || !isNotificationSection(payload.section)) return;
+
+      // A websocket event reaches every tab the user has open, regardless
+      // of which project that tab is viewing -- UserTarget delivery has no
+      // project concept. Ignore an event scoped to a different project
+      // than the one this tab is currently showing.
+      if (payload.project_id && payload.project_id !== activeProject?.id) {
+        return;
+      }
+
+      const section = payload.section;
+      setUnreadBySection(prev => ({
+        ...prev,
+        [section]: (prev[section] ?? 0) + 1,
+      }));
+
+      const newIds = [
+        ...(payload.entity_id ? [payload.entity_id] : []),
+        ...(payload.payload?.entity_ids ?? []),
+      ];
+      if (newIds.length > 0) {
+        setHighlighted(prev => ({
+          ...prev,
+          [section]: [...(prev[section] ?? []), ...newIds],
+        }));
+      }
+    });
+    return unsubscribe;
+    // `isConnected` is a required dependency, not decoration: React flushes
+    // child effects before parent effects, so on first commit
+    // WebSocketProvider has not yet populated the ref that `subscribe` reads,
+    // and `subscribe` silently returns a no-op unsubscribe. `subscribe` itself
+    // has a stable identity, so without re-running when the socket comes up
+    // the handler would never be registered at all.
+  }, [subscribe, isConnected, activeProject?.id]);
+
+  const markSectionRead = useCallback((section: NotificationSection) => {
+    setUnreadBySection(prev => {
+      if (!prev[section]) return prev;
+      return { ...prev, [section]: 0 };
+    });
+    new ApiClientFactory()
+      .getNotificationsClient()
+      .markRead({ section })
+      .catch(error => {
+        console.warn('Failed to mark notifications read:', error);
+      });
+  }, []);
+
+  // Visiting a section clears its badge. Fires again on a later render if a
+  // new notification for the current section arrives while already here --
+  // unreadBySection[section] going back above 0 re-triggers the effect.
+  useEffect(() => {
+    const segment = pathname?.split('/')[1];
+    if (!segment || !isNotificationSection(segment)) return;
+    if ((unreadBySection[segment] ?? 0) > 0) {
+      markSectionRead(segment);
+    }
+  }, [pathname, unreadBySection, markSectionRead]);
+
+  const clearHighlight = useCallback(
+    (section: NotificationSection, id: string) => {
+      setHighlighted(prev => {
+        const ids = prev[section];
+        if (!ids || !ids.includes(id)) return prev;
+        return { ...prev, [section]: ids.filter(existing => existing !== id) };
+      });
+    },
+    []
+  );
+
+  const highlightedIds = useCallback(
+    (section: NotificationSection) => highlighted[section] ?? [],
+    [highlighted]
+  );
+
+  const value: NotificationsContextValue = {
+    unreadBySection,
+    highlightedIds,
+    markSectionRead,
+    clearHighlight,
+  };
+
+  return (
+    <NotificationsContext.Provider value={value}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+}
+
+export function useNotifications(): NotificationsContextValue {
+  return useContext(NotificationsContext);
+}

--- a/apps/frontend/src/contexts/__tests__/NotificationsContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/NotificationsContext.test.tsx
@@ -1,0 +1,228 @@
+import React from 'react';
+import { render, screen, waitFor, act } from '@/test-utils';
+import '@testing-library/jest-dom';
+
+import {
+  NotificationsProvider,
+  useNotifications,
+} from '../NotificationsContext';
+import { NotificationSection } from '@/constants/notifications';
+import type { EventHandler } from '@/utils/websocket';
+
+const mockGetSummary = jest.fn();
+const mockMarkRead = jest.fn();
+
+let capturedHandler: EventHandler | null = null;
+const mockUnsubscribe = jest.fn();
+const mockSubscribe = jest.fn((_eventType: unknown, handler: EventHandler) => {
+  capturedHandler = handler;
+  return mockUnsubscribe;
+});
+
+jest.mock('../WebSocketContext', () => ({
+  // isConnected: true so the subscribe effect registers immediately -- the
+  // real parent/child effect-ordering seam is covered by
+  // NotificationsWebSocketWiring.test.tsx, which uses the real provider.
+  useWebSocketContext: () => ({ subscribe: mockSubscribe, isConnected: true }),
+}));
+
+// The provider skips fetching without an organization (onboarding users have
+// none and the endpoint 403s), so every test here needs one. Mutable so the
+// onboarding case can drop it.
+let mockSessionUser: { id: string; organization_id?: string | null } = {
+  id: 'user-1',
+  organization_id: 'org-1',
+};
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { user: mockSessionUser },
+    status: 'authenticated',
+  }),
+}));
+
+// Mutable so individual tests can simulate switching the active project,
+// matching the `mockSession` pattern in FeaturesContext.test.tsx.
+let mockActiveProject: { id: string } | null = { id: 'project-a' };
+
+jest.mock('../ActiveProjectContext', () => ({
+  useActiveProject: () => ({ activeProject: mockActiveProject }),
+}));
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getNotificationsClient: () => ({
+      getSummary: mockGetSummary,
+      markRead: mockMarkRead,
+    }),
+  })),
+}));
+
+function Probe() {
+  const { unreadBySection, highlightedIds, markSectionRead } =
+    useNotifications();
+  return (
+    <div>
+      <div data-testid="test-sets-unread">
+        {unreadBySection[NotificationSection.TEST_SETS] ?? 0}
+      </div>
+      <div data-testid="test-sets-highlights">
+        {highlightedIds(NotificationSection.TEST_SETS).join(',')}
+      </div>
+      <button onClick={() => markSectionRead(NotificationSection.TEST_SETS)}>
+        mark read
+      </button>
+    </div>
+  );
+}
+
+function emitNotification(payload: Record<string, unknown>) {
+  act(() => {
+    capturedHandler?.({ type: 'notification', payload });
+  });
+}
+
+beforeEach(() => {
+  mockGetSummary.mockReset().mockResolvedValue({ sections: {} });
+  mockMarkRead.mockReset().mockResolvedValue({ updated: 1 });
+  mockSubscribe.mockClear();
+  mockUnsubscribe.mockClear();
+  capturedHandler = null;
+  mockActiveProject = { id: 'project-a' };
+  mockSessionUser = { id: 'user-1', organization_id: 'org-1' };
+});
+
+describe('NotificationsProvider', () => {
+  it('fetches the summary on mount and exposes unread counts', async () => {
+    mockGetSummary.mockResolvedValue({
+      sections: { 'test-sets': { unread: 2, entity_ids: ['ts-1'] } },
+    });
+
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('2')
+    );
+    expect(screen.getByTestId('test-sets-highlights')).toHaveTextContent(
+      'ts-1'
+    );
+  });
+
+  it('increments unread count and highlights on a matching websocket event', async () => {
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+    emitNotification({
+      section: 'test-sets',
+      entity_id: 'ts-2',
+      project_id: 'project-a',
+    });
+
+    expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('1');
+    expect(screen.getByTestId('test-sets-highlights')).toHaveTextContent(
+      'ts-2'
+    );
+  });
+
+  it('ignores a websocket event scoped to a different project', async () => {
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+    emitNotification({
+      section: 'test-sets',
+      entity_id: 'ts-2',
+      project_id: 'project-b',
+    });
+
+    expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('0');
+  });
+
+  it('an org-wide event (no project_id) is not filtered out', async () => {
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+    emitNotification({ section: 'test-runs', entity_id: 'tr-1' });
+
+    // test-sets stays at 0; the event was for a different section, this just
+    // confirms an event with no project_id isn't dropped by the project guard.
+    expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('0');
+  });
+
+  it('markSectionRead zeroes the count and calls the mark-read endpoint', async () => {
+    mockGetSummary.mockResolvedValue({
+      sections: { 'test-sets': { unread: 3, entity_ids: [] } },
+    });
+
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('3')
+    );
+
+    act(() => {
+      screen.getByText('mark read').click();
+    });
+
+    expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('0');
+    await waitFor(() =>
+      expect(mockMarkRead).toHaveBeenCalledWith({
+        section: NotificationSection.TEST_SETS,
+      })
+    );
+  });
+
+  it('refetches the summary when the active project changes', async () => {
+    const { rerender } = render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalledTimes(1));
+
+    mockActiveProject = { id: 'project-b' };
+    rerender(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not fetch while the user has no organization (onboarding)', async () => {
+    mockSessionUser = { id: 'user-1', organization_id: null };
+
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+
+    // Give any effect a chance to fire before asserting the negative.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetSummary).not.toHaveBeenCalled();
+    expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('0');
+  });
+});

--- a/apps/frontend/src/contexts/__tests__/NotificationsContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/NotificationsContext.test.tsx
@@ -49,6 +49,21 @@ jest.mock('../ActiveProjectContext', () => ({
   useActiveProject: () => ({ activeProject: mockActiveProject }),
 }));
 
+// Mutable so tests can simulate being on the section's list page vs. a
+// nested detail sub-route (e.g. '/test-sets' vs '/test-sets/abc123').
+let mockPathname = '/';
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+const mockInvalidateQueries = jest.fn();
+
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQueryClient: () => ({ invalidateQueries: mockInvalidateQueries }),
+}));
+
 jest.mock('@/utils/api-client/client-factory', () => ({
   ApiClientFactory: jest.fn().mockImplementation(() => ({
     getNotificationsClient: () => ({
@@ -90,6 +105,8 @@ beforeEach(() => {
   capturedHandler = null;
   mockActiveProject = { id: 'project-a' };
   mockSessionUser = { id: 'user-1', organization_id: 'org-1' };
+  mockPathname = '/';
+  mockInvalidateQueries.mockClear();
 });
 
 describe('NotificationsProvider', () => {
@@ -130,6 +147,28 @@ describe('NotificationsProvider', () => {
     expect(screen.getByTestId('test-sets-highlights')).toHaveTextContent(
       'ts-2'
     );
+  });
+
+  it('invalidates the section query cache on a matching websocket event', async () => {
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+    emitNotification({
+      section: 'test-sets',
+      entity_id: 'ts-2',
+      project_id: 'project-a',
+    });
+
+    // Only the list queries -- not the whole ['test-sets'] prefix, which
+    // would also match (and needlessly refetch) some other test set's own
+    // detail-page query. See constants/query-keys.ts.
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['test-sets', 'list'],
+    });
   });
 
   it('ignores a websocket event scoped to a different project', async () => {
@@ -188,6 +227,49 @@ describe('NotificationsProvider', () => {
         section: NotificationSection.TEST_SETS,
       })
     );
+  });
+
+  it('marks a section read on landing on its own list page', async () => {
+    mockGetSummary.mockResolvedValue({
+      sections: { 'test-sets': { unread: 1, entity_ids: ['ts-1'] } },
+    });
+    mockPathname = '/test-sets';
+
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('0')
+    );
+    await waitFor(() =>
+      expect(mockMarkRead).toHaveBeenCalledWith({
+        section: NotificationSection.TEST_SETS,
+      })
+    );
+  });
+
+  it('does not mark a section read on a nested detail sub-route', async () => {
+    // Generating a test set redirects straight to that test set's own
+    // detail page (/test-sets/[id]) -- this must not consume the badge
+    // before the user ever sees the list.
+    mockGetSummary.mockResolvedValue({
+      sections: { 'test-sets': { unread: 1, entity_ids: ['ts-1'] } },
+    });
+    mockPathname = '/test-sets/ts-1';
+
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('1')
+    );
+    expect(mockMarkRead).not.toHaveBeenCalled();
   });
 
   it('refetches the summary when the active project changes', async () => {

--- a/apps/frontend/src/contexts/__tests__/NotificationsContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/NotificationsContext.test.tsx
@@ -302,7 +302,9 @@ describe('NotificationsProvider', () => {
     expect(screen.getByTestId('architect-unread')).toHaveTextContent('0');
     // Cleared server-side too, so it doesn't come back on the next load.
     await waitFor(() =>
-      expect(mockMarkRead).toHaveBeenCalledWith({ ids: ['notif-1'] })
+      expect(mockMarkRead).toHaveBeenCalledWith({
+        notification_ids: ['notif-1'],
+      })
     );
     expect(mockInvalidateQueries).not.toHaveBeenCalled();
   });

--- a/apps/frontend/src/contexts/__tests__/NotificationsContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/NotificationsContext.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom';
 import {
   NotificationsProvider,
   useNotifications,
+  useViewingEntity,
 } from '../NotificationsContext';
 import { NotificationSection } from '@/constants/notifications';
 import type { EventHandler } from '@/utils/websocket';
@@ -87,6 +88,17 @@ function Probe() {
       <button onClick={() => markSectionRead(NotificationSection.TEST_SETS)}>
         mark read
       </button>
+    </div>
+  );
+}
+
+/** Probe that declares an architect session as being on screen. */
+function ViewingProbe({ sessionId }: { sessionId: string | null }) {
+  const { unreadBySection } = useNotifications();
+  useViewingEntity(NotificationSection.ARCHITECT, sessionId);
+  return (
+    <div data-testid="architect-unread">
+      {unreadBySection[NotificationSection.ARCHITECT] ?? 0}
     </div>
   );
 }
@@ -270,6 +282,73 @@ describe('NotificationsProvider', () => {
       expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('1')
     );
     expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+
+  it('does not badge a notification for the entity currently on screen', async () => {
+    render(
+      <NotificationsProvider>
+        <ViewingProbe sessionId="session-1" />
+      </NotificationsProvider>
+    );
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+    emitNotification({
+      id: 'notif-1',
+      section: 'architect',
+      entity_id: 'session-1',
+      project_id: 'project-a',
+    });
+
+    expect(screen.getByTestId('architect-unread')).toHaveTextContent('0');
+    // Cleared server-side too, so it doesn't come back on the next load.
+    await waitFor(() =>
+      expect(mockMarkRead).toHaveBeenCalledWith({ ids: ['notif-1'] })
+    );
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it('still badges a notification for a different entity in that section', async () => {
+    render(
+      <NotificationsProvider>
+        <ViewingProbe sessionId="session-1" />
+      </NotificationsProvider>
+    );
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+    emitNotification({
+      id: 'notif-2',
+      section: 'architect',
+      entity_id: 'session-2',
+      project_id: 'project-a',
+    });
+
+    expect(screen.getByTestId('architect-unread')).toHaveTextContent('1');
+    expect(mockMarkRead).not.toHaveBeenCalled();
+  });
+
+  it('badges again once the entity is no longer on screen', async () => {
+    const { rerender } = render(
+      <NotificationsProvider>
+        <ViewingProbe sessionId="session-1" />
+      </NotificationsProvider>
+    );
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+    // Session closed -- the registration must have been torn down.
+    rerender(
+      <NotificationsProvider>
+        <ViewingProbe sessionId={null} />
+      </NotificationsProvider>
+    );
+
+    emitNotification({
+      id: 'notif-3',
+      section: 'architect',
+      entity_id: 'session-1',
+      project_id: 'project-a',
+    });
+
+    expect(screen.getByTestId('architect-unread')).toHaveTextContent('1');
   });
 
   it('refetches the summary when the active project changes', async () => {

--- a/apps/frontend/src/contexts/__tests__/NotificationsWebSocketWiring.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/NotificationsWebSocketWiring.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Integration test for the NotificationsProvider <-> WebSocketProvider seam.
+ *
+ * NotificationsContext.test.tsx mocks `useWebSocketContext` wholesale, so it
+ * cannot catch a wiring failure between the two providers. This test uses the
+ * REAL WebSocketProvider and mocks only the low-level WebSocketClient, so the
+ * effect-ordering contract between parent and child is actually exercised:
+ * React flushes child effects before parent effects, and the parent is what
+ * populates the client ref that `subscribe` needs.
+ */
+import React from 'react';
+import { render, screen, waitFor, act } from '@/test-utils';
+import '@testing-library/jest-dom';
+
+import { WebSocketProvider } from '../WebSocketContext';
+import {
+  NotificationsProvider,
+  useNotifications,
+} from '../NotificationsContext';
+import { NotificationSection } from '@/constants/notifications';
+import { EventType, type EventHandler } from '@/utils/websocket';
+
+const mockGetSummary = jest.fn();
+const mockMarkRead = jest.fn();
+
+// Handlers registered on the fake client, by event type.
+const registered = new Map<string, EventHandler>();
+let connectionChangeCb: ((connected: boolean) => void) | undefined;
+
+const mockClientSubscribe = jest.fn(
+  (eventType: string, handler: EventHandler) => {
+    registered.set(eventType, handler);
+    return () => registered.delete(eventType);
+  }
+);
+
+jest.mock('@/utils/websocket', () => {
+  const actual = jest.requireActual('@/utils/websocket');
+  return {
+    ...actual,
+    WebSocketClient: jest.fn().mockImplementation((options: unknown) => {
+      connectionChangeCb = (
+        options as { onConnectionChange?: (c: boolean) => void }
+      ).onConnectionChange;
+      return {
+        // Starts disconnected, like a real socket mid-handshake.
+        isConnected: false,
+        connectionId: undefined,
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+        subscribe: mockClientSubscribe,
+        subscribeToChannel: jest.fn(),
+        unsubscribeFromChannel: jest.fn(),
+        reconnect: jest.fn(),
+        send: jest.fn(),
+      };
+    }),
+  };
+});
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { user: { id: 'user-1', organization_id: 'org-1' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('../ActiveProjectContext', () => ({
+  useActiveProject: () => ({ activeProject: { id: 'project-a' } }),
+}));
+
+jest.mock('@/utils/api-client/websocket-token-client', () => ({
+  WebSocketTokenClient: jest.fn().mockImplementation(() => ({
+    getWebSocketToken: jest.fn().mockResolvedValue({ token: 'ws-token' }),
+  })),
+}));
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getNotificationsClient: () => ({
+      getSummary: mockGetSummary,
+      markRead: mockMarkRead,
+    }),
+  })),
+}));
+
+function Probe() {
+  const { unreadBySection } = useNotifications();
+  return (
+    <div data-testid="unread">
+      {unreadBySection[NotificationSection.TEST_SETS] ?? 0}
+    </div>
+  );
+}
+
+beforeEach(() => {
+  mockGetSummary.mockReset().mockResolvedValue({ sections: {} });
+  mockMarkRead.mockReset().mockResolvedValue({ updated: 1 });
+  mockClientSubscribe.mockClear();
+  registered.clear();
+  connectionChangeCb = undefined;
+});
+
+// One test rather than two: `WebSocketContext` keeps its client in
+// module-level state that survives unmount (deliberately, to dedupe tokens
+// across a Strict Mode remount), so a second render in this file reuses the
+// first client and never re-runs the constructor this mock hooks. Splitting
+// the assertions would be testing that singleton's lifecycle, not the wiring.
+describe('NotificationsProvider websocket wiring', () => {
+  it('registers a NOTIFICATION handler once connected and delivers events to the badge', async () => {
+    render(
+      <WebSocketProvider>
+        <NotificationsProvider>
+          <Probe />
+        </NotificationsProvider>
+      </WebSocketProvider>
+    );
+
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+    // The socket finishes its handshake after mount, as a real one does.
+    // Before this point `subscribe` is a no-op (the parent effect that
+    // populates the client ref has not run when the child effect fires).
+    act(() => {
+      connectionChangeCb?.(true);
+    });
+
+    await waitFor(() =>
+      expect(registered.has(EventType.NOTIFICATION)).toBe(true)
+    );
+
+    act(() => {
+      registered.get(EventType.NOTIFICATION)?.({
+        type: EventType.NOTIFICATION,
+        payload: {
+          section: NotificationSection.TEST_SETS,
+          entity_id: 'ts-1',
+          project_id: 'project-a',
+        },
+      });
+    });
+
+    expect(screen.getByTestId('unread')).toHaveTextContent('1');
+  });
+});

--- a/apps/frontend/src/utils/api-client/client-factory.ts
+++ b/apps/frontend/src/utils/api-client/client-factory.ts
@@ -37,6 +37,7 @@ import { ParametersClient } from './parameters-client';
 import { PreflightClient } from './preflight-client';
 import { ResolveClient } from './resolve-client';
 import { InsightsClient } from './insights-client';
+import { NotificationsClient } from './notifications-client';
 
 export class ApiClientFactory {
   private sessionToken?: string;
@@ -56,6 +57,7 @@ export class ApiClientFactory {
   private importClient: ImportClient | null = null;
   private filesClient: FilesClient | null = null;
   private featuresClient: FeaturesClient | null = null;
+  private notificationsClient: NotificationsClient | null = null;
   private usageClient: UsageClient | null = null;
   private permissionsClient: PermissionsClient | null = null;
   private architectClient: ArchitectClient | null = null;
@@ -323,6 +325,17 @@ export class ApiClientFactory {
       );
     }
     return this.featuresClient;
+  }
+
+  getNotificationsClient(): NotificationsClient {
+    if (!this.notificationsClient) {
+      this.notificationsClient = new NotificationsClient(
+        this.sessionToken,
+        undefined,
+        this.projectId
+      );
+    }
+    return this.notificationsClient;
   }
 
   getUsageClient(): UsageClient {

--- a/apps/frontend/src/utils/api-client/notifications-client.ts
+++ b/apps/frontend/src/utils/api-client/notifications-client.ts
@@ -1,0 +1,68 @@
+import { BaseApiClient } from './base-client';
+import { NotificationSection } from '@/constants/notifications';
+
+export interface NotificationSectionSummary {
+  unread: number;
+  entity_ids: string[];
+}
+
+export interface NotificationSummaryResponse {
+  sections: Partial<Record<NotificationSection, NotificationSectionSummary>>;
+}
+
+export interface Notification {
+  id: string;
+  event_type: string;
+  section: string;
+  title: string;
+  body: string | null;
+  is_failure: boolean;
+  entity_type: string | null;
+  entity_id: string | null;
+  payload: Record<string, unknown> | null;
+  read_at: string | null;
+  created_at: string;
+  project_id: string | null;
+}
+
+export interface MarkReadRequest {
+  section?: NotificationSection;
+  ids?: string[];
+}
+
+/**
+ * Client for `/notifications`. Notifications are created only by the
+ * backend (via a completed job) -- no create method here.
+ */
+export class NotificationsClient extends BaseApiClient {
+  async getSummary(): Promise<NotificationSummaryResponse> {
+    return this.fetch<NotificationSummaryResponse>('/notifications/summary', {
+      cache: 'no-store',
+    });
+  }
+
+  async getNotifications(params?: {
+    section?: NotificationSection;
+    unread_only?: boolean;
+    skip?: number;
+    limit?: number;
+  }): Promise<Notification[]> {
+    const query = new URLSearchParams();
+    if (params?.section) query.set('section', params.section);
+    if (params?.unread_only !== undefined)
+      query.set('unread_only', String(params.unread_only));
+    if (params?.skip !== undefined) query.set('skip', String(params.skip));
+    if (params?.limit !== undefined) query.set('limit', String(params.limit));
+    const suffix = query.toString() ? `?${query.toString()}` : '';
+    return this.fetch<Notification[]>(`/notifications/${suffix}`, {
+      cache: 'no-store',
+    });
+  }
+
+  async markRead(body: MarkReadRequest): Promise<{ updated: number }> {
+    return this.fetch<{ updated: number }>('/notifications/read', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+  }
+}

--- a/apps/frontend/src/utils/api-client/notifications-client.ts
+++ b/apps/frontend/src/utils/api-client/notifications-client.ts
@@ -27,7 +27,12 @@ export interface Notification {
 
 export interface MarkReadRequest {
   section?: NotificationSection;
-  ids?: string[];
+  /**
+   * `Notification.id` values -- NOT the `entity_id` of whatever the
+   * notification is about. Sending entity ids here matches nothing and comes
+   * back as `updated: 0`.
+   */
+  notification_ids?: string[];
 }
 
 /**

--- a/tests/backend/routes/test_notification.py
+++ b/tests/backend/routes/test_notification.py
@@ -128,7 +128,9 @@ class TestMarkRead:
             test_db, user_id=authenticated_user_id, organization_id=test_org_id, title="clear"
         )
 
-        response = authenticated_client.post("/notifications/read", json={"ids": [str(clear.id)]})
+        response = authenticated_client.post(
+            "/notifications/read", json={"notification_ids": [str(clear.id)]}
+        )
         assert response.status_code == 200
         assert response.json()["updated"] == 1
 
@@ -160,7 +162,7 @@ class TestMarkRead:
 
         response = authenticated_client.post(
             "/notifications/read",
-            json={"section": "test-runs", "ids": [str(in_test_sets.id)]},
+            json={"section": "test-runs", "notification_ids": [str(in_test_sets.id)]},
         )
         assert response.status_code == 200
         assert response.json()["updated"] == 0

--- a/tests/backend/routes/test_notification.py
+++ b/tests/backend/routes/test_notification.py
@@ -1,0 +1,174 @@
+"""Router tests for /notifications: summary, list, mark-read.
+
+The security-relevant case covered here: a user must never see another
+user's notifications in the same org (the ambient auto-filter scopes by
+org/project only, not by user -- see crud/notification.py).
+
+Project-scoping (a notification hidden once a different project is active)
+is covered at the CRUD level instead, in
+tests/backend/services/notification/test_service.py -- the `client`/`test_db`
+fixture overrides `get_tenant_db_session` with a no-op yielding the shared
+session, so an `X-Project-Id` request header here never reaches the real
+per-request scope-binding dependency it would in production.
+"""
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.crud.notification import create_notification
+from rhesis.backend.app.models.enums import NotificationEventType, NotificationSection
+from tests.backend.fixtures.test_setup import create_test_user
+
+
+@pytest.fixture
+def other_user(test_db: Session, test_org_id):
+    """A second real user in the same org, for cross-user isolation tests."""
+    return create_test_user(
+        test_db,
+        organization_id=uuid.UUID(test_org_id),
+        email=f"other-{uuid.uuid4().hex[:8]}@rhesis-test.com",
+        name="Other User",
+    )
+
+
+def _make_notification(db, *, user_id, organization_id, project_id=None, section=None, title="t"):
+    return create_notification(
+        db,
+        event_type=NotificationEventType.TestSet.GENERATION_COMPLETED,
+        section=section or NotificationSection.TEST_SETS.value,
+        title=title,
+        user_id=user_id,
+        organization_id=organization_id,
+        project_id=project_id,
+    )
+
+
+@pytest.mark.integration
+class TestNotificationSummary:
+    def test_empty_initially(self, authenticated_client: TestClient):
+        response = authenticated_client.get("/notifications/summary")
+        assert response.status_code == 200
+        assert response.json()["sections"] == {}
+
+    def test_counts_own_unread_notification(
+        self, authenticated_client: TestClient, test_db, test_org_id, authenticated_user_id
+    ):
+        _make_notification(test_db, user_id=authenticated_user_id, organization_id=test_org_id)
+
+        response = authenticated_client.get("/notifications/summary")
+        assert response.status_code == 200
+        sections = response.json()["sections"]
+        assert sections["test-sets"]["unread"] == 1
+
+    def test_excludes_other_users_notifications(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_org_id,
+        other_user,
+    ):
+        _make_notification(test_db, user_id=str(other_user.id), organization_id=test_org_id)
+
+        response = authenticated_client.get("/notifications/summary")
+        assert response.status_code == 200
+        assert response.json()["sections"] == {}
+
+    def test_counts_are_exact_beyond_the_highlight_scan_limit(
+        self, authenticated_client: TestClient, test_db, test_org_id, authenticated_user_id
+    ):
+        """Counts come from a SQL aggregate, so the bounded highlight scan
+        (``_SUMMARY_HIGHLIGHT_SCAN_LIMIT``) must not cap them."""
+        from rhesis.backend.app.crud import notification as notification_crud
+
+        over_limit = notification_crud._SUMMARY_HIGHLIGHT_SCAN_LIMIT + 5
+        for _ in range(over_limit):
+            _make_notification(test_db, user_id=authenticated_user_id, organization_id=test_org_id)
+
+        response = authenticated_client.get("/notifications/summary")
+        assert response.status_code == 200
+        assert response.json()["sections"]["test-sets"]["unread"] == over_limit
+
+
+@pytest.mark.integration
+class TestMarkRead:
+    def test_marks_only_the_requested_section(
+        self, authenticated_client: TestClient, test_db, test_org_id, authenticated_user_id
+    ):
+        _make_notification(
+            test_db,
+            user_id=authenticated_user_id,
+            organization_id=test_org_id,
+            section=NotificationSection.TEST_SETS.value,
+        )
+        _make_notification(
+            test_db,
+            user_id=authenticated_user_id,
+            organization_id=test_org_id,
+            section=NotificationSection.TEST_RUNS.value,
+        )
+
+        response = authenticated_client.post("/notifications/read", json={"section": "test-sets"})
+        assert response.status_code == 200
+        assert response.json()["updated"] == 1
+
+        summary = authenticated_client.get("/notifications/summary").json()["sections"]
+        assert "test-sets" not in summary
+        assert summary["test-runs"]["unread"] == 1
+
+    def test_marks_specific_ids(
+        self, authenticated_client: TestClient, test_db, test_org_id, authenticated_user_id
+    ):
+        keep = _make_notification(
+            test_db, user_id=authenticated_user_id, organization_id=test_org_id, title="keep"
+        )
+        clear = _make_notification(
+            test_db, user_id=authenticated_user_id, organization_id=test_org_id, title="clear"
+        )
+
+        response = authenticated_client.post("/notifications/read", json={"ids": [str(clear.id)]})
+        assert response.status_code == 200
+        assert response.json()["updated"] == 1
+
+        summary = authenticated_client.get("/notifications/summary").json()["sections"]
+        assert summary["test-sets"]["unread"] == 1
+        test_db.refresh(keep)
+        assert keep.read_at is None
+
+    def test_section_and_ids_narrow_together(
+        self, authenticated_client: TestClient, test_db, test_org_id, authenticated_user_id
+    ):
+        """Passing both must never mark more than either filter alone would.
+
+        The id below is in test-sets, so scoping to test-runs matches nothing --
+        an OR would have wrongly cleared the whole test-runs section too.
+        """
+        in_test_sets = _make_notification(
+            test_db,
+            user_id=authenticated_user_id,
+            organization_id=test_org_id,
+            section=NotificationSection.TEST_SETS.value,
+        )
+        _make_notification(
+            test_db,
+            user_id=authenticated_user_id,
+            organization_id=test_org_id,
+            section=NotificationSection.TEST_RUNS.value,
+        )
+
+        response = authenticated_client.post(
+            "/notifications/read",
+            json={"section": "test-runs", "ids": [str(in_test_sets.id)]},
+        )
+        assert response.status_code == 200
+        assert response.json()["updated"] == 0
+
+        summary = authenticated_client.get("/notifications/summary").json()["sections"]
+        assert summary["test-sets"]["unread"] == 1
+        assert summary["test-runs"]["unread"] == 1
+
+    def test_requires_section_or_ids(self, authenticated_client: TestClient):
+        response = authenticated_client.post("/notifications/read", json={})
+        assert response.status_code == 400

--- a/tests/backend/services/notification/test_catalog.py
+++ b/tests/backend/services/notification/test_catalog.py
@@ -1,0 +1,79 @@
+"""Tests for the notification catalog's render functions.
+
+Focused on the architect renderer, which is the only one that *declines*
+(returns None): architect_chat_task runs several times per user request and
+only the turn that concludes a background wait is a finished job.
+"""
+
+from unittest.mock import Mock
+
+from rhesis.backend.app.constants import ARCHITECT_RESUME_PREFIX, EntityType
+from rhesis.backend.app.models.enums import NotificationEventType, NotificationSection
+from rhesis.backend.app.services.notification.catalog import (
+    NOTIFICATION_CATALOG,
+    _render_architect_plan_completed,
+)
+
+RESUME_MESSAGE = f"{ARCHITECT_RESUME_PREFIX} The background tasks have finished."
+
+
+def _task(user_message: str, session_id: str = "session-1"):
+    """A stand-in for the bound Celery task, which renderers read kwargs off."""
+    task = Mock()
+    task.request.kwargs = {"session_id": session_id, "user_message": user_message}
+    task.request.headers = {}
+    return task
+
+
+class TestArchitectPlanCompletedRenderer:
+    def test_declines_an_ordinary_interactive_turn(self):
+        """The user is chatting live -- nothing to tell them about."""
+        rendered = _render_architect_plan_completed(
+            _task("Add tests for the login flow"),
+            {"session_id": "session-1", "awaiting_task": False},
+            None,
+        )
+        assert rendered is None
+
+    def test_declines_a_turn_that_starts_a_wait(self):
+        """awaiting_task means the long work is only just beginning."""
+        rendered = _render_architect_plan_completed(
+            _task(RESUME_MESSAGE),
+            {"session_id": "session-1", "awaiting_task": True},
+            None,
+        )
+        assert rendered is None
+
+    def test_notifies_when_a_resume_turn_leaves_nothing_pending(self):
+        rendered = _render_architect_plan_completed(
+            _task(RESUME_MESSAGE),
+            {"session_id": "session-1", "awaiting_task": False},
+            None,
+        )
+        assert rendered is not None
+        assert rendered.is_failure is False
+        assert rendered.entity_id == "session-1"
+        assert "Architect" in rendered.title
+
+    def test_notifies_on_a_failed_resume_turn(self):
+        """retval is normalized to {} on failure, so awaiting_task is absent."""
+        rendered = _render_architect_plan_completed(_task(RESUME_MESSAGE), {}, "boom")
+        assert rendered is not None
+        assert rendered.is_failure is True
+        assert rendered.entity_id == "session-1"
+
+    def test_falls_back_to_kwargs_for_the_session_id(self):
+        """The failure path has no retval to read session_id from."""
+        rendered = _render_architect_plan_completed(
+            _task(RESUME_MESSAGE, session_id="from-kwargs"), {}, "boom"
+        )
+        assert rendered is not None
+        assert rendered.entity_id == "from-kwargs"
+
+
+class TestArchitectCatalogEntry:
+    def test_registered_under_the_architect_section(self):
+        kind = NOTIFICATION_CATALOG[NotificationEventType.Architect.PLAN_COMPLETED]
+        assert kind.section == NotificationSection.ARCHITECT
+        assert kind.entity_type == EntityType.ARCHITECT_SESSION.value
+        assert kind.render is _render_architect_plan_completed

--- a/tests/backend/services/notification/test_service.py
+++ b/tests/backend/services/notification/test_service.py
@@ -1,0 +1,175 @@
+"""Tests for services.notification.notify().
+
+Covers: row creation, the websocket publish call (target + payload shape),
+and that a publish failure never propagates -- a Celery task's on_success
+must not fail because Redis is down.
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.crud.notification import get_notification_summary, get_notifications
+from rhesis.backend.app.models.enums import NotificationEventType
+from rhesis.backend.app.schemas.websocket import EventType, UserTarget
+from rhesis.backend.app.services.notification.catalog import RenderedNotification
+from rhesis.backend.app.services.notification.service import notify
+
+
+@pytest.mark.integration
+class TestNotify:
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db: Session, test_org_id, authenticated_user_id):
+        self.db = test_db
+        self.org_id = test_org_id
+        self.user_id = authenticated_user_id
+
+    def test_creates_notification_row(self):
+        rendered = RenderedNotification(title='"my set" is ready', body="10 tests generated")
+
+        with patch(
+            "rhesis.backend.app.services.notification.service.publish_event"
+        ) as mock_publish:
+            notify(
+                self.db,
+                event_type=NotificationEventType.TestSet.GENERATION_COMPLETED,
+                rendered=rendered,
+                user_id=self.user_id,
+                organization_id=self.org_id,
+                project_id=None,
+            )
+
+        rows = get_notifications(self.db, user_id=self.user_id)
+        assert any(r.title == '"my set" is ready' for r in rows)
+        mock_publish.assert_called_once()
+
+    def test_publishes_to_recipient_user_target(self):
+        rendered = RenderedNotification(title="Test run finished", entity_id=None)
+
+        with patch(
+            "rhesis.backend.app.services.notification.service.publish_event"
+        ) as mock_publish:
+            notify(
+                self.db,
+                event_type=NotificationEventType.TestRun.EXECUTION_COMPLETED,
+                rendered=rendered,
+                user_id=self.user_id,
+                organization_id=self.org_id,
+                project_id=None,
+            )
+
+        message, target = mock_publish.call_args[0]
+        assert isinstance(target, UserTarget)
+        assert target.user_id == str(self.user_id)
+        assert message.type == EventType.NOTIFICATION
+        assert message.payload["title"] == "Test run finished"
+        assert message.payload["section"] == "test-runs"
+
+    def test_publish_failure_does_not_raise(self):
+        rendered = RenderedNotification(title="Garak sync complete")
+
+        with patch(
+            "rhesis.backend.app.services.notification.service.publish_event",
+            side_effect=RuntimeError("redis is down"),
+        ):
+            # Must not raise -- a broker/Redis failure must not fail the caller.
+            notify(
+                self.db,
+                event_type=NotificationEventType.TestSet.GARAK_SYNC_COMPLETED,
+                rendered=rendered,
+                user_id=self.user_id,
+                organization_id=self.org_id,
+                project_id=None,
+            )
+
+        rows = get_notifications(self.db, user_id=self.user_id)
+        assert any(r.title == "Garak sync complete" for r in rows)
+
+    def test_failure_notification_is_flagged(self):
+        rendered = RenderedNotification(title="Test set generation failed", is_failure=True)
+
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            notify(
+                self.db,
+                event_type=NotificationEventType.TestSet.GENERATION_COMPLETED,
+                rendered=rendered,
+                user_id=self.user_id,
+                organization_id=self.org_id,
+                project_id=None,
+            )
+
+        rows = get_notifications(self.db, user_id=self.user_id)
+        row = next(r for r in rows if r.title == "Test set generation failed")
+        assert row.is_failure is True
+
+
+@pytest.mark.integration
+class TestNotificationProjectScoping:
+    """A notification created for project A must not count toward the badge
+    while a different project is active, per the ambient auto-filter (see
+    `apps/backend/AGENTS.md`'s "Ambient Request Scope").
+
+    `notify()`/`create_notification()` don't apply the auto-filter themselves
+    (writes always succeed); this exercises the *read* side
+    (`get_notification_summary`) under `bound_scope`, since the `client`
+    fixture's DI override means an `X-Project-Id` header can't reach the real
+    per-request scope-binding dependency in a router-level test.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db: Session, test_org_id, authenticated_user_id):
+        self.db = test_db
+        self.org_id = test_org_id
+        self.user_id = authenticated_user_id
+        self.project_a = models.Project(
+            name=f"Project A {uuid.uuid4().hex[:8]}", organization_id=uuid.UUID(test_org_id)
+        )
+        self.project_b = models.Project(
+            name=f"Project B {uuid.uuid4().hex[:8]}", organization_id=uuid.UUID(test_org_id)
+        )
+        self.db.add_all([self.project_a, self.project_b])
+        self.db.flush()
+
+    def _notify(self, project_id):
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            notify(
+                self.db,
+                event_type=NotificationEventType.TestSet.GENERATION_COMPLETED,
+                rendered=RenderedNotification(title="scoped"),
+                user_id=self.user_id,
+                organization_id=self.org_id,
+                project_id=project_id,
+            )
+
+    def test_hidden_while_a_different_project_is_active(self, bound_scope):
+        self._notify(str(self.project_a.id))
+
+        with bound_scope(
+            organization_id=self.org_id, user_id=self.user_id, project_id=str(self.project_b.id)
+        ):
+            summary = get_notification_summary(self.db, user_id=self.user_id)
+
+        assert summary == {}
+
+    def test_visible_in_its_own_project(self, bound_scope):
+        self._notify(str(self.project_a.id))
+
+        with bound_scope(
+            organization_id=self.org_id, user_id=self.user_id, project_id=str(self.project_a.id)
+        ):
+            summary = get_notification_summary(self.db, user_id=self.user_id)
+
+        assert summary["test-sets"]["unread"] == 1
+
+    def test_org_wide_notification_visible_regardless_of_active_project(self, bound_scope):
+        self._notify(None)
+
+        with bound_scope(
+            organization_id=self.org_id, user_id=self.user_id, project_id=str(self.project_b.id)
+        ):
+            summary = get_notification_summary(self.db, user_id=self.user_id)
+
+        assert summary["test-sets"]["unread"] == 1

--- a/tests/backend/services/test_task_notification.py
+++ b/tests/backend/services/test_task_notification.py
@@ -1,0 +1,101 @@
+"""Tests for services.task_notification.send_task_assignment_in_app_notification().
+
+The email counterpart (send_task_assignment_notification) has no existing test
+file; this covers only the new in-app path.
+"""
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.crud.notification import get_notifications
+from rhesis.backend.app.services.task_notification import (
+    send_task_assignment_in_app_notification,
+)
+from rhesis.backend.app.utils.crud_utils import get_or_create_status
+from tests.backend.fixtures.test_setup import create_test_user
+
+
+@pytest.mark.integration
+class TestSendTaskAssignmentInAppNotification:
+    @pytest.fixture(autouse=True)
+    def _setup(self, test_db: Session, test_org_id, authenticated_user_id):
+        self.db = test_db
+        self.org_id = test_org_id
+        self.creator_id = authenticated_user_id
+        self.assignee = create_test_user(
+            test_db,
+            organization_id=uuid.UUID(test_org_id),
+            email=f"assignee-{uuid.uuid4().hex[:8]}@rhesis-test.com",
+            name="Assignee User",
+        )
+        self.status = get_or_create_status(
+            db=test_db,
+            name="Open",
+            entity_type="Task",
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+        )
+
+    def _make_task(self, *, assignee_id=None, title="Do the thing"):
+        task = models.Task(
+            id=uuid.uuid4(),
+            organization_id=uuid.UUID(self.org_id),
+            user_id=uuid.UUID(self.creator_id),
+            assignee_id=assignee_id,
+            title=title,
+            status_id=self.status.id,
+        )
+        self.db.add(task)
+        self.db.commit()
+        return task
+
+    def test_creates_notification_for_the_assignee(self):
+        task = self._make_task(assignee_id=self.assignee.id)
+
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            send_task_assignment_in_app_notification(self.db, task)
+
+        rows = get_notifications(self.db, user_id=str(self.assignee.id))
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.section == "tasks"
+        assert row.event_type == "task.assigned"
+        assert row.entity_id == task.id
+        assert row.title == '"Do the thing" was assigned to you'
+
+    def test_does_not_notify_the_creator(self):
+        task = self._make_task(assignee_id=self.assignee.id)
+
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            send_task_assignment_in_app_notification(self.db, task)
+
+        creator_rows = get_notifications(self.db, user_id=self.creator_id)
+        assert creator_rows == []
+
+    def test_body_names_the_creator(self, test_db):
+        creator = (
+            test_db.query(models.User).filter(models.User.id == uuid.UUID(self.creator_id)).one()
+        )
+        task = self._make_task(assignee_id=self.assignee.id)
+
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            send_task_assignment_in_app_notification(self.db, task)
+
+        rows = get_notifications(self.db, user_id=str(self.assignee.id))
+        expected_name = creator.name or creator.given_name
+        assert rows[0].body == f"Assigned by {expected_name}"
+
+    def test_noop_without_an_assignee(self):
+        task = self._make_task(assignee_id=None)
+
+        with patch(
+            "rhesis.backend.app.services.notification.service.publish_event"
+        ) as mock_publish:
+            send_task_assignment_in_app_notification(self.db, task)
+
+        mock_publish.assert_not_called()
+        assert get_notifications(self.db, user_id=self.creator_id) == []

--- a/tests/backend/tasks/test_base_task.py
+++ b/tests/backend/tasks/test_base_task.py
@@ -16,7 +16,8 @@ from unittest.mock import Mock, patch
 import pytest
 from sqlalchemy.orm import Session
 
-from rhesis.backend.tasks.base import email_notification
+from rhesis.backend.app.models.enums import NotificationEventType
+from rhesis.backend.tasks.base import BaseTask, email_notification, in_app_notification
 
 
 class MockTask:
@@ -298,6 +299,122 @@ class TestEmailNotificationDecorator:
         assert getattr(generate_and_save_test_set, "send_email_notification_flag", False) is True
         assert getattr(collect_results, "send_email_notification_flag", False) is True
         assert getattr(email_notification_test, "send_email_notification_flag", False) is True
+
+
+class TestInAppNotificationDecorator:
+    """Test in_app_notification decorator"""
+
+    def test_decorator_sets_notification_kind(self):
+        @in_app_notification(NotificationEventType.TestSet.GENERATION_COMPLETED)
+        def mock_task_function(self):
+            return {"result": "success"}
+
+        assert (
+            mock_task_function._notification_kind
+            == NotificationEventType.TestSet.GENERATION_COMPLETED
+        )
+
+    def test_decorator_does_not_break_the_function(self):
+        @in_app_notification(NotificationEventType.TestRun.EXECUTION_COMPLETED)
+        def mock_task_function(self):
+            return {"result": "success"}
+
+        task = MockTask()
+        assert mock_task_function(task) == {"result": "success"}
+
+
+def _real_base_task(retries: int = 0) -> BaseTask:
+    """A BaseTask instance with a real (unbound) request context, to exercise
+    on_success/on_failure without a real Celery worker or DB.
+
+    ``Task.request`` is a read-only property backed by ``request_stack``
+    (``None`` until a task is bound to an app); ``push_request`` is Celery's
+    own supported way to populate it for a bare instance like this one.
+    """
+    from celery.utils.threads import LocalStack
+
+    task = BaseTask()
+    task.request_stack = LocalStack()
+    task.push_request(id="task-1", retries=retries, headers={}, kwargs={})
+    task.send_email_notification_flag = False
+    return task
+
+
+class TestOnSuccessInAppNotification:
+    """on_success calls _send_task_completion_notification iff _notification_kind is set."""
+
+    def test_calls_notification_when_kind_set(self):
+        task = _real_base_task()
+        task._notification_kind = NotificationEventType.TestSet.GENERATION_COMPLETED
+
+        with (
+            patch.object(task, "_send_task_completion_notification") as mock_notify,
+            patch.object(task, "_get_execution_time", return_value="1s"),
+            patch.object(task, "log_with_context"),
+        ):
+            task.on_success({"result": "ok"}, "task-1", [], {})
+
+        mock_notify.assert_called_once_with({"result": "ok"}, None)
+
+    def test_skips_notification_when_kind_not_set(self):
+        task = _real_base_task()
+
+        with (
+            patch.object(task, "_send_task_completion_notification") as mock_notify,
+            patch.object(task, "_get_execution_time", return_value="1s"),
+            patch.object(task, "log_with_context"),
+        ):
+            task.on_success({"result": "ok"}, "task-1", [], {})
+
+        mock_notify.assert_not_called()
+
+    def test_notification_failure_does_not_propagate(self):
+        task = _real_base_task()
+        task._notification_kind = NotificationEventType.TestSet.GENERATION_COMPLETED
+
+        with (
+            patch.object(
+                task,
+                "_send_task_completion_notification",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch.object(task, "_get_execution_time", return_value="1s"),
+            patch.object(task, "log_with_context"),
+        ):
+            # Must not raise -- a notification failure must not fail the task.
+            task.on_success({"result": "ok"}, "task-1", [], {})
+
+
+class TestOnFailureInAppNotification:
+    """on_failure only notifies once a task has permanently failed, not on a retry."""
+
+    def test_does_not_notify_while_retrying(self):
+        task = _real_base_task(retries=0)
+        task._notification_kind = NotificationEventType.TestRun.EXECUTION_COMPLETED
+        task.max_retries = 3
+
+        with (
+            patch.object(task, "_send_task_completion_notification") as mock_notify,
+            patch.object(task, "_get_execution_time", return_value="1s"),
+            patch.object(task, "log_with_context"),
+        ):
+            task.on_failure(ValueError("boom"), "task-1", [], {}, None)
+
+        mock_notify.assert_not_called()
+
+    def test_notifies_on_permanent_failure(self):
+        task = _real_base_task(retries=3)
+        task._notification_kind = NotificationEventType.TestRun.EXECUTION_COMPLETED
+        task.max_retries = 3
+
+        with (
+            patch.object(task, "_send_task_completion_notification") as mock_notify,
+            patch.object(task, "_get_execution_time", return_value="1s"),
+            patch.object(task, "log_with_context"),
+        ):
+            task.on_failure(ValueError("boom"), "task-1", [], {}, None)
+
+        mock_notify.assert_called_once_with(None, "boom")
 
 
 class TestTaskValidation:

--- a/tests/backend/tasks/test_base_task.py
+++ b/tests/backend/tasks/test_base_task.py
@@ -17,7 +17,12 @@ import pytest
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.models.enums import NotificationEventType
-from rhesis.backend.tasks.base import BaseTask, email_notification, in_app_notification
+from rhesis.backend.tasks.base import (
+    BaseTask,
+    SilentTask,
+    email_notification,
+    in_app_notification,
+)
 
 
 class MockTask:
@@ -322,6 +327,31 @@ class TestInAppNotificationDecorator:
         task = MockTask()
         assert mock_task_function(task) == {"result": "success"}
 
+    def test_registered_tasks_carry_their_notification_kind(self):
+        """Guards decorator *ordering* on the real tasks.
+
+        ``@in_app_notification`` must sit above ``@app.task`` so it stamps the
+        bound Task singleton. Below it, the attribute lands on the plain
+        function that app.task wraps, ``self._notification_kind`` is never
+        found at runtime, and the notification silently never fires.
+        """
+        from rhesis.backend.tasks.architect.chat import architect_chat_task
+        from rhesis.backend.tasks.execution.results import collect_results
+        from rhesis.backend.tasks.test_set import generate_and_save_test_set
+
+        assert (
+            getattr(generate_and_save_test_set, "_notification_kind", None)
+            == NotificationEventType.TestSet.GENERATION_COMPLETED
+        )
+        assert (
+            getattr(collect_results, "_notification_kind", None)
+            == NotificationEventType.TestRun.EXECUTION_COMPLETED
+        )
+        assert (
+            getattr(architect_chat_task, "_notification_kind", None)
+            == NotificationEventType.Architect.PLAN_COMPLETED
+        )
+
 
 def _real_base_task(retries: int = 0) -> BaseTask:
     """A BaseTask instance with a real (unbound) request context, to exercise
@@ -383,6 +413,84 @@ class TestOnSuccessInAppNotification:
         ):
             # Must not raise -- a notification failure must not fail the task.
             task.on_success({"result": "ok"}, "task-1", [], {})
+
+
+class TestSilentTaskInAppNotification:
+    """SilentTask must still send in-app notifications on success.
+
+    It overrides on_success with ``super(BaseTask, self)``, skipping
+    BaseTask.on_success entirely. Since it does *not* override on_failure,
+    dropping the notification here would leave a decorated SilentTask
+    notifying on failure only -- the architect task is one such task.
+    """
+
+    @staticmethod
+    def _silent_task() -> SilentTask:
+        from celery.utils.threads import LocalStack
+
+        task = SilentTask()
+        task.request_stack = LocalStack()
+        task.push_request(id="task-1", retries=0, headers={}, kwargs={})
+        return task
+
+    def test_notifies_on_success_when_kind_set(self):
+        task = self._silent_task()
+        task._notification_kind = NotificationEventType.Architect.PLAN_COMPLETED
+
+        with (
+            patch.object(task, "_send_task_completion_notification") as mock_notify,
+            patch.object(task, "log_with_context"),
+        ):
+            task.on_success({"result": "ok"}, "task-1", [], {})
+
+        mock_notify.assert_called_once_with({"result": "ok"}, None)
+
+    def test_skips_notification_when_kind_not_set(self):
+        task = self._silent_task()
+
+        with (
+            patch.object(task, "_send_task_completion_notification") as mock_notify,
+            patch.object(task, "log_with_context"),
+        ):
+            task.on_success({"result": "ok"}, "task-1", [], {})
+
+        mock_notify.assert_not_called()
+
+    def test_notification_failure_does_not_propagate(self):
+        task = self._silent_task()
+        task._notification_kind = NotificationEventType.Architect.PLAN_COMPLETED
+
+        with (
+            patch.object(
+                task,
+                "_send_task_completion_notification",
+                side_effect=RuntimeError("boom"),
+            ),
+            patch.object(task, "log_with_context"),
+        ):
+            # Must not raise -- a notification failure must not fail the task.
+            task.on_success({"result": "ok"}, "task-1", [], {})
+
+
+class TestDecliningRenderer:
+    """A renderer returning None means no notification row is written."""
+
+    def test_declined_render_writes_nothing(self):
+        task = _real_base_task()
+        task._notification_kind = NotificationEventType.Architect.PLAN_COMPLETED
+
+        with (
+            patch.object(task, "get_tenant_context", return_value=("org-1", "user-1", "proj-1")),
+            patch("rhesis.backend.app.services.notification.notify") as mock_notify,
+            patch.object(task, "get_db_session") as mock_session,
+            patch.object(task, "log_with_context"),
+        ):
+            # An ordinary interactive turn: no resume prefix, so the architect
+            # renderer declines.
+            task._send_task_completion_notification({"session_id": "s-1"}, None)
+
+        mock_notify.assert_not_called()
+        mock_session.assert_not_called()
 
 
 class TestOnFailureInAppNotification:


### PR DESCRIPTION
## Purpose

Long-running background jobs only told the user through email, which is the wrong channel when the user is still in the app. Generating a test set, running tests, or handing work to the Architect could take minutes, and the only way to find out it had finished was to leave and check your inbox, or keep reloading the page.

This adds in-app notifications: an unread count next to the relevant sidebar item, and a gentle highlight on the affected grid row once you go look. The websocket pub/sub this needs already existed and is unchanged — `EventType.NOTIFICATION` was defined on both sides and unused. Notifications are DB-backed so a job finishing while you are offline is not lost, and project-scoped so a badge only reflects the project you are currently in.

Completion emails are intentionally left in place. Removing them is a follow-up, once this path has been proven in practice.

## What Changed

**The mechanism.** A new `notification` table (`ProjectMixin` + `OrganizationAndUserMixin`, RLS enforced), a `notify()` primitive, and a declarative `NOTIFICATION_CATALOG` keyed by `NotificationEventType`. Adding a notification for a new job means one catalog entry — nothing in the task base class or the router changes. Three endpoints (`GET /notifications/summary`, `GET /notifications`, `POST /notifications/read`) behind a single `notification:read` capability.

**Coverage.** Every path that produces something the user is waiting on: test set generation, Garak import, Garak sync, test run execution, task assignment, and Architect plan completion.

**Two emission styles.** Celery jobs opt in with an `@in_app_notification(...)` decorator on the existing `on_success`/`on_failure` hooks. Task assignment calls `notify()` directly from the router, since it is synchronous request-time work with nothing to gain from a queue hop.

**Architect.** Architect runs several turns per user request — a turn hands off to long-running tasks, the monitor auto-resumes when they finish, and that turn may hand off again. Notifying on each one would spam. So a catalog renderer may now return `None` to decline, and Architect only notifies on the turn that both concludes a background wait and leaves nothing pending. Its awaited test sets and runs already notify for their own artifacts, so this means "your plan is ready for you again", not a re-announcement.

**Frontend.** `NotificationsProvider` tracks per-section unread counts and highlight ids, `NavItem` renders the badge (inline when expanded, MUI `Badge` when the rail is collapsed), and `BaseDataGrid` gained a `getRowClassName` passthrough for the row highlight. Sections are keyed by the sidebar segment string on both sides, so there is no mapping table — `NotificationSection` on the backend and `constants/notifications.ts` on the frontend just have to agree, the same relationship `FeatureName` and `Capability` already have.

`useViewingEntity` lets a page declare the entity it currently has on screen; a notification for that entity is marked read on arrival rather than badged. The Architect page uses it, since it already streams its own session live. It is keyed per entity, so a *different* Architect session finishing still badges.

## Additional Context

Three bugs found and fixed along the way, each worth calling out because they were all silent:

- **`SilentTask` dropped success notifications.** Its `on_success` calls `super(BaseTask, self)`, skipping `BaseTask.on_success` — where the notification block lives. Since it does not override `on_failure`, a decorated `SilentTask` (the Architect task) would have notified on failure only. The notification send is now a helper both classes call, matching what `SilentTask`'s own docstring says it is for ("skip generic completion *logging*").
- **Decorator ordering is load-bearing.** `@in_app_notification` must sit above `@app.task` so it stamps the bound Task singleton; below it, the attribute lands on the wrapped function and nothing ever fires. There is now a test asserting all three decorated tasks carry their kind.
- **Stale list grids.** A test set row exists from the moment generation is *submitted*, and the flow redirects straight to its detail page without touching the cache. Under the app-wide 5-minute `staleTime`, clicking back to the list served cache that predated the new row, so it only appeared after a hard reload. The three entity lists now pass `staleTime: 0`, matching the option's documented use in `useGridQuery` and the existing precedent in `AnnotationsGrid`.

Two smaller fixes: notification-driven cache invalidation is scoped to `[section, 'list']` rather than the whole `[section]` prefix, which was also matching a test set's own detail-page query and forcing an unrelated refetch; and the generation-completion handler no longer flips `isGenerating` locally ahead of the refreshed `testCount` prop, which used to bounce through the "No tests yet" empty state for one render before the grid mounted.

The `notification` table's RLS policies are written explicitly in the migration rather than relying on the `auto_apply_rls_policies` event trigger. The trigger does fire on a persistent database but did not for a fresh `CREATE TABLE` in the ephemeral test containers, so `tests/backend/security/test_rls_coverage.py` caught the table with no policies at all. Each `CREATE POLICY` is preceded by `DROP POLICY IF EXISTS` so it stays idempotent where the trigger did get there first.

Not in scope: removing the completion emails, and a notification drawer listing full history (`GET /notifications` is built and ready for it, but nothing consumes it yet).

## Testing

Automated — 479 backend tests and 176 frontend tests across 13 suites, `ruff`, `tsc --noEmit`, `eslint` and `prettier` all clean. New coverage worth noting:

- Cross-user isolation: user A's summary never returns user B's rows in the same org and project. The ambient auto-filter scopes by org and project but *not* by user, so every query adds an explicit `user_id` filter.
- Project scoping at the CRUD level via the `bound_scope` fixture — the router-level fixtures override `get_tenant_db_session`, so an `X-Project-Id` header cannot reach the real scope-binding dependency there.
- `mark_notifications_read` ANDs `section` and `ids` so passing both can never clear more than either alone.
- Summary counts come from a SQL aggregate and stay exact past the bounded highlight scan.
- A websocket-wiring test using the *real* `WebSocketProvider` (mocking only `WebSocketClient`), which is what caught the original effect-ordering bug where the `NOTIFICATION` subscription silently never attached.
- The Architect renderer declining an ordinary turn and a mid-plan turn, and firing on the concluding one.

Manual, against a local stack:

1. From a page that is not Test Sets, kick off a generation. The Test Sets badge appears without a reload; clicking through clears it and highlights the new row; clicking the row clears the highlight.
2. Repeat for a test run and a Garak import.
3. Assign a task to a second user — the badge lands on *their* Tasks item, not yours.
4. Start an Architect plan that generates a test set, then navigate away. You get the test set notification when it lands, and the Architect notification when the plan finishes. Sitting on the Architect page with that session open produces no badge for it; a second session finishing still badges.
5. Switch projects — a badge from another project disappears, and comes back on switching back.
6. Kick off a generation, close the tab before it finishes, reopen: the badge is there from `GET /notifications/summary`.
7. Force a generation failure: one notification, reading as a failure, not one per retry.
