### PR TITLE
Fix per-metric judge models being ignored in batch runs

### DIFF
--- a/apps/backend/src/rhesis/backend/metrics/evaluator.py
+++ b/apps/backend/src/rhesis/backend/metrics/evaluator.py
@@ -39,6 +39,7 @@ class MetricEvaluator:
         organization_id: Optional[str] = None,
         connector_metric_sender: Optional[ConnectorMetricSender] = None,
         extra_strategies: Optional[List[MetricStrategy]] = None,
+        metric_models: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Initialize evaluator with optional backend strategy overrides.
@@ -53,6 +54,9 @@ class MetricEvaluator:
             extra_strategies: Optional additional (or replacement) strategies.
                 Each strategy is registered by its ``backend_value()``.  Use
                 this for testing or to add custom backends without subclassing.
+            metric_models: Judge models already resolved by `model_id`, for callers
+                that have no live session to resolve them with. Required in the batch
+                path, which runs after its session is closed; see `prepare_metrics`.
         """
         score_evaluator = ScoreEvaluator()
 
@@ -61,6 +65,7 @@ class MetricEvaluator:
             db=db,
             organization_id=organization_id,
             score_evaluator=score_evaluator,
+            metric_models=metric_models,
         )
 
         self._connector_strategy: MetricStrategy = ConnectorStrategy(

--- a/apps/backend/src/rhesis/backend/metrics/strategies/local.py
+++ b/apps/backend/src/rhesis/backend/metrics/strategies/local.py
@@ -56,11 +56,13 @@ class LocalStrategy:
         db: Optional[Session] = None,
         organization_id: Optional[str] = None,
         score_evaluator: Optional[ScoreEvaluator] = None,
+        metric_models: Optional[Dict[str, Any]] = None,
     ) -> None:
         self._model = model
         self._db = db
         self._organization_id = organization_id
         self._score_evaluator = score_evaluator or ScoreEvaluator()
+        self._metric_models = metric_models
 
     def backend_value(self) -> str:
         return "__local__"
@@ -86,6 +88,7 @@ class LocalStrategy:
             model=self._model,
             db=self._db,
             organization_id=self._organization_id,
+            metric_models=self._metric_models,
         )
         return self._execute_metrics_in_parallel(
             metric_tasks,
@@ -124,6 +127,7 @@ class LocalStrategy:
             model=self._model,
             db=self._db,
             organization_id=self._organization_id,
+            metric_models=self._metric_models,
         )
         if not metric_tasks:
             logger.warning("No metrics to evaluate (async)")
@@ -703,6 +707,40 @@ def _resolve_metric_model(
     return None
 
 
+def _select_metric_model(
+    model_id: str,
+    db: Optional[Session],
+    organization_id: Optional[str],
+    metric_name_for_log: str,
+    metric_models: Optional[Dict[str, Any]],
+) -> Optional[Any]:
+    """Pick the judge model for a metric that configured its own `model_id`.
+
+    Prefers a pre-resolved model over the session, because the batch path runs
+    after its session is closed and can only resolve while it is still open.
+    Returning None here means the caller falls back to the default judge, so
+    every path that cannot honour the override says so at warning level -- a
+    silently ignored override is indistinguishable from having configured none.
+    """
+    if metric_models is not None and model_id in metric_models:
+        pre_resolved = metric_models[model_id]
+        if pre_resolved is None:
+            logger.warning(
+                f"[METRIC_MODEL] Model {model_id} configured for metric "
+                f"'{metric_name_for_log}' could not be resolved; using the default judge"
+            )
+        return pre_resolved
+
+    if db is not None:
+        return _resolve_metric_model(model_id, db, organization_id, metric_name_for_log)
+
+    logger.warning(
+        f"[METRIC_MODEL] Metric '{metric_name_for_log}' configures model {model_id} but it was "
+        f"neither pre-resolved nor resolvable here (no database session); using the default judge"
+    )
+    return None
+
+
 def prepare_metrics(
     metrics: List[MetricConfig],
     expected_output: Optional[str],
@@ -710,6 +748,7 @@ def prepare_metrics(
     model: Optional[Any] = None,
     db: Optional[Session] = None,
     organization_id: Optional[str] = None,
+    metric_models: Optional[Dict[str, Any]] = None,
 ) -> List[Tuple[str, BaseMetric, MetricConfig, str]]:
     """Instantiate metric objects via SDK factory, resolving models from DB.
 
@@ -720,6 +759,10 @@ def prepare_metrics(
         model: Optional default LLM model for metrics evaluation.
         db: Optional database session for fetching metric-specific models.
         organization_id: Optional organization ID for secure model lookups.
+        metric_models: Models already resolved by `model_id` for callers with no live
+            session (the batch path). Key present with a value means resolved; key
+            present with `None` means resolution was attempted and failed; key absent
+            means not attempted, so fall back to resolving against `db`.
 
     Returns:
         List of tuples containing (class_name, metric_instance, metric_config, backend).
@@ -740,9 +783,9 @@ def prepare_metrics(
 
             metric_model = None
 
-            if model_id and db:
-                metric_model = _resolve_metric_model(
-                    model_id, db, organization_id, metric_name_for_log
+            if model_id:
+                metric_model = _select_metric_model(
+                    model_id, db, organization_id, metric_name_for_log, metric_models
                 )
 
             if metric_model is None and model is not None:

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
@@ -52,6 +52,11 @@ class ExecutionContext:
     # Per-test metric configs for behavior-mapped metrics (Priority 3) where each
     # test may have a different behavior with different metrics.
     per_test_metric_configs: Dict[str, List[MetricConfig]] = field(default_factory=dict)
+    # Judge models for metrics that configure their own `model_id`, resolved while the
+    # session is open because metric evaluation runs after it closes. A `None` value
+    # records a resolution that was attempted and failed, which is distinct from a
+    # `model_id` being absent here entirely; see `prepare_metrics`.
+    metric_models: Dict[str, Any] = field(default_factory=dict)
     test_data: Dict[str, Any] = field(default_factory=dict)
     input_files: Dict[str, List] = field(default_factory=dict)
     existing_result_ids: Set[str] = field(default_factory=set)
@@ -85,6 +90,42 @@ class ExecutionContext:
     def has_metrics(self) -> bool:
         """True if any test has metric configs to evaluate."""
         return bool(self.metric_configs) or bool(self.per_test_metric_configs)
+
+
+def _resolve_metric_judge_models(
+    session: Session,
+    organization_id: Optional[str],
+    metric_configs: List[MetricConfig],
+    per_test_metric_configs: Dict[str, List[MetricConfig]],
+) -> Dict[str, Any]:
+    """Resolve every distinct per-metric judge `model_id` in the batch, once each.
+
+    Deduped by `model_id` so a model shared by many metrics (or by many tests
+    sharing a behavior) costs one lookup rather than one per metric. Failures are
+    recorded as a `None` value rather than omitted, so the evaluator can tell
+    "tried and failed" from "never attempted" and warn accordingly.
+    """
+    from rhesis.backend.metrics.strategies.local import _resolve_metric_model
+
+    all_configs = list(metric_configs)
+    for configs in per_test_metric_configs.values():
+        all_configs.extend(configs)
+
+    resolved: Dict[str, Any] = {}
+    for config in all_configs:
+        model_id = (config.parameters or {}).get("model_id")
+        if not model_id or model_id in resolved:
+            continue
+        resolved[model_id] = _resolve_metric_model(
+            model_id, session, organization_id, config.name or config.class_name
+        )
+
+    if resolved:
+        failed = [mid for mid, model in resolved.items() if model is None]
+        logger.info(
+            f"Pre-resolved {len(resolved) - len(failed)}/{len(resolved)} per-metric judge models"
+        )
+    return resolved
 
 
 def prefetch_execution_context(
@@ -291,6 +332,14 @@ def prefetch_execution_context(
     except Exception as e:
         logger.warning(f"Failed to pre-fetch metrics: {e}")
 
+    # Resolve per-metric judge models now, while the session is still open. Metric
+    # evaluation happens after session.close(), so a `model_id` left unresolved here
+    # cannot be honoured later and the metric would quietly fall back to the default
+    # judge instead of the model the user picked.
+    metric_models = _resolve_metric_judge_models(
+        session, organization_id, metric_configs, per_test_metric_configs
+    )
+
     # Batch check existing results
     existing_result_ids: Set[str] = set()
     try:
@@ -362,6 +411,7 @@ def prefetch_execution_context(
         evaluation_model=evaluation_model,
         metric_configs=metric_configs,
         per_test_metric_configs=per_test_metric_configs,
+        metric_models=metric_models,
         test_data=test_data,
         existing_result_ids=existing_result_ids,
         batch_concurrency=batch_concurrency,

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/runner.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/runner.py
@@ -190,6 +190,9 @@ async def run_batch(
         evaluator = MetricEvaluator(
             model=ctx.evaluation_model,
             connector_metric_sender=ctx.connector_metric_sender,
+            # No `db` here on purpose: the session closed before this point. Judge
+            # models for per-metric `model_id` overrides were resolved in prefetch.
+            metric_models=ctx.metric_models,
         )
 
     # Snapshot test data before the main pass so recovery rounds can restore it

--- a/tests/backend/metrics/test_metric_judge_model_selection.py
+++ b/tests/backend/metrics/test_metric_judge_model_selection.py
@@ -1,0 +1,162 @@
+"""Tests for per-metric judge model (`model_id`) resolution.
+
+A metric can name its own judge model via `parameters["model_id"]`. The batch
+path evaluates metrics after its DB session has closed, so it cannot resolve
+that id at evaluation time the way the sequential path does -- it has to be
+pre-resolved during prefetch and handed over. These tests pin that the override
+is honoured in both paths, and that any path which *cannot* honour it says so
+instead of silently falling back to the default judge.
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+from rhesis.backend.metrics.strategies.local import (
+    _select_metric_model,
+    prepare_metrics,
+)
+from rhesis.sdk.metrics import MetricConfig
+
+MODEL_ID = "11111111-1111-1111-1111-111111111111"
+
+
+def _config_with_model_id(model_id=MODEL_ID, name="answer-relevancy"):
+    return MetricConfig(
+        class_name="RhesisPromptMetric",
+        backend="rhesis",
+        name=name,
+        parameters={"model_id": model_id} if model_id else {},
+    )
+
+
+class TestSelectMetricModel:
+    """The judge-model decision, including the paths that cannot honour an override."""
+
+    def test_prefers_a_pre_resolved_model_over_the_session(self):
+        pre_resolved = MagicMock(name="pre_resolved_model")
+        db = MagicMock(name="db")
+
+        with patch(
+            "rhesis.backend.metrics.strategies.local._resolve_metric_model"
+        ) as resolve_from_db:
+            selected = _select_metric_model(
+                MODEL_ID, db, "org-1", "answer-relevancy", {MODEL_ID: pre_resolved}
+            )
+
+        assert selected is pre_resolved
+        resolve_from_db.assert_not_called()
+
+    def test_resolves_from_the_session_when_nothing_was_pre_resolved(self):
+        db = MagicMock(name="db")
+        from_db = MagicMock(name="model_from_db")
+
+        with patch(
+            "rhesis.backend.metrics.strategies.local._resolve_metric_model",
+            return_value=from_db,
+        ) as resolve_from_db:
+            selected = _select_metric_model(MODEL_ID, db, "org-1", "answer-relevancy", None)
+
+        assert selected is from_db
+        resolve_from_db.assert_called_once_with(MODEL_ID, db, "org-1", "answer-relevancy")
+
+    def test_warns_when_the_override_cannot_be_resolved_at_all(self, caplog):
+        """No session and no pre-resolution: the batch bug this suite exists for.
+
+        Falling back to the default judge is acceptable; doing it silently is not,
+        because the user configured a specific model and would never learn it was
+        ignored.
+        """
+        with caplog.at_level(logging.WARNING):
+            selected = _select_metric_model(MODEL_ID, None, "org-1", "answer-relevancy", None)
+
+        assert selected is None
+        assert any(
+            MODEL_ID in record.message and record.levelno == logging.WARNING
+            for record in caplog.records
+        ), "expected a warning naming the model that could not be honoured"
+
+    def test_warns_when_pre_resolution_was_attempted_and_failed(self, caplog):
+        """A recorded None means "tried, failed" -- distinct from never attempted."""
+        with caplog.at_level(logging.WARNING):
+            selected = _select_metric_model(
+                MODEL_ID, None, "org-1", "answer-relevancy", {MODEL_ID: None}
+            )
+
+        assert selected is None
+        assert any(record.levelno == logging.WARNING for record in caplog.records)
+
+    def test_a_failed_pre_resolution_does_not_fall_back_to_the_session(self):
+        """Deliberate: the batch path's session is closed, so retrying it would raise."""
+        db = MagicMock(name="db")
+
+        with patch(
+            "rhesis.backend.metrics.strategies.local._resolve_metric_model"
+        ) as resolve_from_db:
+            _select_metric_model(MODEL_ID, db, "org-1", "answer-relevancy", {MODEL_ID: None})
+
+        resolve_from_db.assert_not_called()
+
+
+class TestPrepareMetricsHonoursTheOverride:
+    """End-to-end through prepare_metrics: the judge model reaches the metric."""
+
+    def _create_with_captured_model(self):
+        """Patch MetricFactory.create and report the `model` kwarg it received."""
+        captured = {}
+
+        def _create(backend, class_name, **kwargs):
+            captured["model"] = kwargs.get("model")
+            metric = MagicMock()
+            metric.requires_ground_truth = False
+            return metric
+
+        return captured, _create
+
+    def test_batch_path_uses_the_pre_resolved_judge(self):
+        """Regression: with db=None this used to silently use the default model."""
+        pre_resolved = MagicMock(name="pre_resolved_model")
+        default_model = MagicMock(name="default_model")
+        captured, create = self._create_with_captured_model()
+
+        with patch("rhesis.sdk.metrics.MetricFactory.create", side_effect=create):
+            tasks = prepare_metrics(
+                [_config_with_model_id()],
+                expected_output=None,
+                model=default_model,
+                db=None,
+                metric_models={MODEL_ID: pre_resolved},
+            )
+
+        assert len(tasks) == 1
+        assert captured["model"] is pre_resolved
+        assert captured["model"] is not default_model
+
+    def test_falls_back_to_the_default_judge_when_the_override_is_unresolvable(self):
+        default_model = MagicMock(name="default_model")
+        captured, create = self._create_with_captured_model()
+
+        with patch("rhesis.sdk.metrics.MetricFactory.create", side_effect=create):
+            prepare_metrics(
+                [_config_with_model_id()],
+                expected_output=None,
+                model=default_model,
+                db=None,
+                metric_models={MODEL_ID: None},
+            )
+
+        assert captured["model"] is default_model
+
+    def test_a_metric_without_an_override_uses_the_default_judge(self):
+        default_model = MagicMock(name="default_model")
+        captured, create = self._create_with_captured_model()
+
+        with patch("rhesis.sdk.metrics.MetricFactory.create", side_effect=create):
+            prepare_metrics(
+                [_config_with_model_id(model_id=None)],
+                expected_output=None,
+                model=default_model,
+                db=None,
+                metric_models={},
+            )
+
+        assert captured["model"] is default_model

--- a/tests/backend/tasks/test_batch_metric_judge_prefetch.py
+++ b/tests/backend/tasks/test_batch_metric_judge_prefetch.py
@@ -1,0 +1,131 @@
+"""Per-metric judge models are resolved during prefetch and reach the evaluator.
+
+Metric evaluation in the batch path runs after ``session.close()``, so a metric
+that names its own judge via ``parameters["model_id"]`` can only be resolved
+while prefetch still holds the session. Before this was wired, the batch
+evaluator was built with no ``db``, and every such override was dropped.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from rhesis.backend.tasks.execution.batch.context import (
+    ExecutionContext,
+    _resolve_metric_judge_models,
+)
+from rhesis.backend.tasks.execution.batch.runner import run_batch
+from rhesis.sdk.metrics import MetricConfig
+
+MODEL_A = "11111111-1111-1111-1111-111111111111"
+MODEL_B = "22222222-2222-2222-2222-222222222222"
+
+
+def _config(model_id, name="metric"):
+    return MetricConfig(
+        class_name="RhesisPromptMetric",
+        backend="rhesis",
+        name=name,
+        parameters={"model_id": model_id} if model_id else {},
+    )
+
+
+def _make_execution_context(**overrides) -> ExecutionContext:
+    defaults = dict(
+        test_config=MagicMock(),
+        test_run=MagicMock(),
+        test_set=MagicMock(),
+        endpoint=MagicMock(),
+        organization_id="org-1",
+        user_id="user-1",
+        recovery_rounds=0,
+    )
+    defaults.update(overrides)
+    return ExecutionContext(**defaults)
+
+
+class TestResolveMetricJudgeModels:
+    def test_resolves_each_distinct_model_once(self):
+        """Deduped by model_id: a judge shared by many metrics is one lookup, not N."""
+        session = MagicMock()
+        configs = [_config(MODEL_A, "m1"), _config(MODEL_B, "m2"), _config(MODEL_A, "m3")]
+
+        with patch(
+            "rhesis.backend.metrics.strategies.local._resolve_metric_model",
+            side_effect=lambda mid, *a: f"model-for-{mid}",
+        ) as resolve:
+            resolved = _resolve_metric_judge_models(session, "org-1", configs, {})
+
+        assert resolved == {MODEL_A: f"model-for-{MODEL_A}", MODEL_B: f"model-for-{MODEL_B}"}
+        assert resolve.call_count == 2
+
+    def test_covers_per_test_configs_too(self):
+        """Behavior-mapped metrics (P3) live in per_test_metric_configs, not the shared list."""
+        session = MagicMock()
+
+        with patch(
+            "rhesis.backend.metrics.strategies.local._resolve_metric_model",
+            side_effect=lambda mid, *a: f"model-for-{mid}",
+        ):
+            resolved = _resolve_metric_judge_models(
+                session,
+                "org-1",
+                [],
+                {"test-1": [_config(MODEL_A)], "test-2": [_config(MODEL_B)]},
+            )
+
+        assert set(resolved) == {MODEL_A, MODEL_B}
+
+    def test_records_a_failed_resolution_rather_than_omitting_it(self):
+        """The key must be present with None so the evaluator can tell this apart
+        from an override it was simply never told about."""
+        session = MagicMock()
+
+        with patch(
+            "rhesis.backend.metrics.strategies.local._resolve_metric_model",
+            return_value=None,
+        ):
+            resolved = _resolve_metric_judge_models(session, "org-1", [_config(MODEL_A)], {})
+
+        assert resolved == {MODEL_A: None}
+        assert MODEL_A in resolved
+
+    def test_metrics_without_an_override_add_nothing(self):
+        session = MagicMock()
+
+        with patch("rhesis.backend.metrics.strategies.local._resolve_metric_model") as resolve:
+            resolved = _resolve_metric_judge_models(session, "org-1", [_config(None)], {})
+
+        assert resolved == {}
+        resolve.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_the_batch_evaluator_receives_the_pre_resolved_judges():
+    """Regression: MetricEvaluator was built with neither db nor pre-resolved
+    models, so LocalStrategy's `if model_id and db` check dropped every override."""
+    pre_resolved = {MODEL_A: MagicMock(name="judge")}
+    ctx = _make_execution_context(
+        execution_model=None,
+        metric_configs=[_config(MODEL_A)],
+        metric_models=pre_resolved,
+        test_data={"t1": {"test": MagicMock()}},
+    )
+
+    with (
+        patch(
+            "rhesis.backend.tasks.execution.batch.runner.is_multi_turn_test",
+            return_value=False,
+        ),
+        patch("rhesis.backend.metrics.evaluator.MetricEvaluator") as mock_evaluator,
+        patch(
+            "rhesis.backend.tasks.execution.batch.runner._run_gather",
+            new=AsyncMock(return_value=[]),
+        ),
+    ):
+        await run_batch(ctx, ["t1"])
+
+    mock_evaluator.assert_called_once()
+    assert mock_evaluator.call_args.kwargs["metric_models"] is pre_resolved


### PR DESCRIPTION
## Purpose

A metric can name its own judge model via `parameters[\"model_id\"]`, chosen per metric in the UI. In batch test runs that choice was silently ignored and the org's default judge was used instead, so results came from a different model than the one configured.

`prepare_metrics` only honoured the override when a live DB session was available (`if model_id and db`). The batch path builds its `MetricEvaluator` after `session.close()`, so it passes no `db` and the branch never ran. Nothing surfaced it: the fallback logs at debug level as "using user's default model", which reads exactly like a metric that configured no override at all.

Found while auditing the follow-ups on #2382. The sequential path was unaffected.

## What Changed

- Resolve per-metric judge models in `prefetch_execution_context`, while the session is still open, and store them on `ExecutionContext`. Deduped by `model_id`, so a judge shared across many metrics or many tests of one behavior costs one lookup rather than one per metric.
- Pass them through `MetricEvaluator` and `LocalStrategy` into `prepare_metrics`, which now prefers a pre-resolved model and falls back to the session only when there is one.
- Keep three states distinguishable: key present with a value means resolved, key present with `None` means resolution was attempted and failed, key absent means never attempted. A failed pre-resolution deliberately does not retry against the session, because in the batch path that session is closed.
- Warn whenever an override cannot be honoured. Falling back to the default judge is acceptable; doing it silently is not, since the user picked a specific model and would never learn it was ignored.

## Additional Context

- Follow-up on #2382, which centralized token accrual (#2386). The accrual half of this problem was fixed there; this is the remaining correctness bug that the override was dropped at all.
- No migration, no config, no API change. `ExecutionContext.metric_models` has a default, so existing test helpers that construct it positionally are unaffected.

## Testing

`tests/backend/metrics/test_metric_judge_model_selection.py` and `tests/backend/tasks/test_batch_metric_judge_prefetch.py` are new, 13 tests covering the selection decision, the dedupe, and the runner wiring.

Both regression tests were confirmed to fail against the old code rather than merely passing against the new: restoring the `if model_id and db` guard makes `test_batch_path_uses_the_pre_resolved_judge` fail with the default model substituted for the configured one, and dropping the runner's `metric_models` kwarg makes `test_the_batch_evaluator_receives_the_pre_resolved_judges` fail.

```bash
cd apps/backend
uv run pytest ../../tests/backend/metrics/ ../../tests/backend/tasks/ -q
```

617 passed, 3 skipped. `uvx ruff check` clean.