### PR TITLE
Stop tenant model rows running on our provider credentials

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/model.py
+++ b/apps/backend/src/rhesis/backend/app/crud/model.py
@@ -79,10 +79,37 @@ def get_models(
     )
 
 
+def _reject_rows_without_own_credentials(db: Session, model: schemas.ModelCreate) -> None:
+    """Refuse a row that has neither an API key nor an endpoint of its own.
+
+    Such a row falls back to reading its key from the process environment, so
+    it would run on this deployment's credentials rather than the tenant's.
+    Caught here so the tenant sees it while saving rather than when a test run
+    fails later; `_require_own_credentials` is the runtime backstop that also
+    covers rows edited into this shape or created before this check existed.
+    """
+    from rhesis.backend.app.utils.user_model_utils import has_own_credentials
+
+    if model.provider_type_id is None:
+        return
+    provider_type = (
+        db.query(models.TypeLookup).filter(models.TypeLookup.id == model.provider_type_id).first()
+    )
+    if provider_type is None:
+        return
+    if has_own_credentials(provider_type.type_value, model.key, model.endpoint):
+        return
+    raise ValueError(
+        f"Model '{model.name}' needs either an API key or an endpoint. Without one it would "
+        f"run on the server's own provider credentials."
+    )
+
+
 def create_model(
     db: Session, model: schemas.ModelCreate, organization_id: str = None, user_id: str = None
 ) -> models.Model:
     """Create a new model."""
+    _reject_rows_without_own_credentials(db, model)
     return create_item(db, models.Model, model, organization_id, user_id)
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/model.py
+++ b/apps/backend/src/rhesis/backend/app/routers/model.py
@@ -48,9 +48,12 @@ def create_model(
 ):
     """Create a new model."""
     organization_id, user_id = tenant_context
-    return model_crud.create_model(
-        db=db, model=model, organization_id=organization_id, user_id=user_id
-    )
+    try:
+        return model_crud.create_model(
+            db=db, model=model, organization_id=organization_id, user_id=user_id
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 @router.post("/test-connection", response_model=TestModelConnectionResponse)

--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -418,38 +418,88 @@ def _is_hosted_model(provider: str, api_key: Optional[str]) -> bool:
     """
     Check if an explicitly-selected Model row runs on Rhesis-operated infrastructure.
 
-    Only ever reached for a Model row an org explicitly picked via
-    `model_id` -- `_fetch_and_configure_model`'s two callers are
-    `get_generation_model_with_override` (explicit override) and
-    `_get_user_model` (the org configured a `model_id` for this purpose).
-    Whichever *other* provider the org names there -- their own
-    `vertex_ai`, `ollama`, `openai`, self-hosted `vllm`, whatever -- is
-    their own infrastructure choice: never Rhesis's, regardless of whether
-    they happened to leave the key blank (self-hosted servers commonly need
-    none). Broadening this to a bare `not api_key` (tried and reverted) both
-    overcounted those and was solving a case that doesn't occur.
+    A model is charged for if and only if *Rhesis supplied it*. There are
+    exactly three ways that happens, and this function covers the first:
+    the org picked one of Rhesis's own hosted providers. The other two are
+    the system default (:func:`resolve_default_hosted_model`, which stamps
+    unconditionally because whatever a deployment names as its
+    `DEFAULT_*_MODEL` is that deployment's own infra cost by definition) and
+    a Rhesis-issued platform key (:func:`_try_platform_key_model`, which
+    passes `metered` explicitly because a platform key looks like an org key).
 
-    `rhesis`/`polyphemus` are the two provider values that mean "use
-    Rhesis's own hosted infrastructure" as a selectable option in the
-    Models UI, so those alone accrue when the row carries no org key.
-    Note the *system default* -- what an org gets when it configures no
-    `model_id` at all -- is a different path entirely
-    (`resolve_default_hosted_model`), reached before this function and
-    unrestricted by provider: whatever a deployment names as its
-    `DEFAULT_*_MODEL` (`vertex_ai/gemini-2.5-flash`, in this dev
-    environment) *is* Rhesis's own infra cost for that deployment, by
-    definition of being the default.
+    So: `rhesis`/`polyphemus` are the two provider values meaning "use
+    Rhesis's own hosted infrastructure" in the Models UI, and they charge
+    when the row carries no org key of its own. Every *other* provider an
+    org names here -- their `vertex_ai`, `ollama`, `openai`, self-hosted
+    `vllm`, whatever -- is their infrastructure choice and never charges,
+    whatever the row's key or endpoint looks like.
+
+    Deliberately *not* inferred from credentials. A row for a non-Rhesis
+    provider with a blank key will fall through to whatever this deployment
+    has in `OPENAI_API_KEY` and friends, because every SDK provider treats a
+    falsy key as "read the environment". That is a real problem, but it is a
+    misconfiguration and a credential-leak problem, not a billing one:
+    the answer is to surface it (see `_warn_if_row_would_use_our_credentials`),
+    not to bill an org for a model we never agreed to supply. Trying to
+    encode it here is what made the two earlier attempts wrong -- a bare
+    `not api_key` swept in every keyless self-hosted row, and adding an
+    endpoint check still caught providers like `ollama` and `vllm` that fall
+    back to an implicit `localhost` base (`litellm/main.py`) and so reach the
+    org's own server with neither key nor endpoint set.
 
     Args:
         provider: The provider type value (e.g., "rhesis", "polyphemus", "openai")
-        api_key: The API key stored for the model, e.g. `model_record.key`,
-            which is nullable
+        api_key: The API key stored for the model, e.g. `model_record.key`.
+            Nullable, and blank or whitespace-only is treated as absent.
 
     Returns:
         True if this model's tokens should accrue against the org's
         MODEL_TOKENS quota.
     """
-    return provider in ("rhesis", "polyphemus") and not api_key
+    return provider in ("rhesis", "polyphemus") and not (api_key or "").strip()
+
+
+def has_own_credentials(provider: str, api_key: Optional[str], endpoint: Optional[str]) -> bool:
+    """Whether a Model row can be served without reaching for our credentials.
+
+    A tenant row needs either a key of its own or an endpoint of its own.
+    With neither, every provider falls back to reading its key from the
+    process environment (``litellm/main.py``: ``api_key or ... or
+    get_secret("OPENAI_API_KEY")``), so the row would quietly run on whatever
+    this deployment holds -- billed to us, attributed to nobody, and looking
+    to the tenant like a working configuration.
+
+    ``rhesis``/``polyphemus`` rows are exempt: running on our credentials with
+    no key is exactly what picking them means, and they are billed for it.
+    """
+    if provider in ("rhesis", "polyphemus"):
+        return True
+    return bool((api_key or "").strip() or (endpoint or "").strip())
+
+
+def _require_own_credentials(
+    provider: str, api_key: Optional[str], endpoint: Optional[str], model_name: str
+) -> None:
+    """Refuse to build a tenant model that would borrow our provider keys.
+
+    Raising beats warning here because the fallback is silent and succeeds:
+    without this the tenant gets working inference on our account and nobody
+    finds out. Refusing costs only rows that are already misconfigured, since
+    a row with no key of its own always has an endpoint in practice.
+    """
+    if has_own_credentials(provider, api_key, endpoint):
+        return
+    logger.error(
+        "Refusing to build model '%s' (provider '%s'): no API key and no endpoint, so it would "
+        "run on this deployment's environment credentials",
+        model_name,
+        provider,
+    )
+    raise ModelConfigurationError(
+        f"Your configured model '{model_name}' ({provider}) has neither an API key nor an "
+        f"endpoint. Add an API key, or an endpoint if it is a self-hosted model, in the "
+        f"Models settings."
+    )
 
 
 def ensure_language_model(model_or_provider: Union[str, BaseLLM]) -> BaseLLM:
@@ -657,7 +707,12 @@ def _fetch_and_configure_model(
     # Get provider configuration
     provider = model.provider_type.type_value
     model_name = model.model_name
-    api_key = model.key
+    # `Model.key` is NOT NULL but accepts "", and a whitespace-only key is the same
+    # misconfiguration. Normalize once so the provenance decision and the provider
+    # both see a single "no key" value rather than two that differ subtly: a "  "
+    # reaches LiteLLM as a real key and fails auth instead of falling back.
+    api_key = (model.key or "").strip() or None
+    _require_own_credentials(provider, api_key, model.endpoint, model.name)
 
     # Special handling for Rhesis system models
     if _is_rhesis_system_model(provider, api_key):

--- a/apps/backend/src/rhesis/backend/metrics/strategies/local.py
+++ b/apps/backend/src/rhesis/backend/metrics/strategies/local.py
@@ -668,10 +668,26 @@ def _resolve_metric_model(
 
         if model_record and model_record.provider_type:
             from rhesis.backend.app.utils.usage_tracking import stamp_usage_provenance
-            from rhesis.backend.app.utils.user_model_utils import _is_hosted_model
+            from rhesis.backend.app.utils.user_model_utils import (
+                _is_hosted_model,
+                has_own_credentials,
+            )
 
             provider = model_record.provider_type.type_value
-            api_key = model_record.key
+            # Same normalization as _fetch_and_configure_model: a whitespace-only
+            # key must not reach the provider as a real one.
+            api_key = (model_record.key or "").strip() or None
+
+            if not has_own_credentials(provider, api_key, model_record.endpoint):
+                # Would fall back to this deployment's environment credentials.
+                # Returning None drops to the default judge, which is a better
+                # outcome than silently evaluating on our own account.
+                logger.warning(
+                    f"[METRIC_MODEL] Model {model_id} for metric '{metric_name_for_log}' has "
+                    f"neither an API key nor an endpoint; using the default judge instead of "
+                    f"running it on this deployment's credentials"
+                )
+                return None
 
             extra_params = {}
             if model_record.endpoint and model_record.endpoint.strip():

--- a/tests/backend/app/test_usage_tracking.py
+++ b/tests/backend/app/test_usage_tracking.py
@@ -296,15 +296,145 @@ class TestIsHostedModel:
         "provider",
         ["openai", "gemini", "anthropic", "vertex_ai", "ollama", "vllm", "huggingface"],
     )
-    def test_any_org_selected_provider_never_accrues(self, provider):
-        """Regardless of whether a key is configured: an explicitly-selected
-        Model row for any provider other than rhesis/polyphemus is always
-        the org's own infrastructure choice."""
+    def test_a_provider_rhesis_does_not_supply_never_accrues(self, provider):
+        """Only a model Rhesis supplied is charged for. Any other provider an org
+        names is its own infrastructure choice, whatever its key looks like -- we
+        never agreed to supply it, so we never bill for it."""
         from rhesis.backend.app.utils.user_model_utils import _is_hosted_model
 
+        assert _is_hosted_model(provider, "sk-org-owned") is False
         assert _is_hosted_model(provider, None) is False
         assert _is_hosted_model(provider, "") is False
-        assert _is_hosted_model(provider, "sk-org-owned") is False
+        assert _is_hosted_model(provider, "   ") is False
+
+    def test_a_whitespace_only_key_reads_as_no_key(self):
+        """`Model.key` is NOT NULL but accepts "" and whitespace. A key of only
+        spaces authenticates nothing, so a Rhesis-hosted row carrying one is still
+        running on our credentials and still charges."""
+        from rhesis.backend.app.utils.user_model_utils import _is_hosted_model
+
+        assert _is_hosted_model("rhesis", "   ") is True
+        assert _is_hosted_model("polyphemus", "") is True
+
+
+class TestRowsThatWouldBorrowOurCredentials:
+    """A tenant row with neither a key nor an endpoint is refused.
+
+    Every provider falls back to reading its key from the process environment
+    when handed a falsy one, so such a row runs on this deployment's
+    credentials: we pay, the tenant is not billed because it is their row, and
+    it looks to them like a working configuration. Warning is not enough
+    because the fallback *succeeds*.
+    """
+
+    @pytest.mark.parametrize(
+        "api_key,endpoint",
+        [
+            ("sk-org-owned", None),
+            (None, "http://vllm.internal:8000"),
+            ("", "http://vllm.internal:8000"),
+            ("   ", "http://vllm.internal:8000"),
+        ],
+    )
+    def test_a_row_that_can_stand_on_its_own_is_allowed(self, api_key, endpoint):
+        """A key of its own, or an endpoint of its own. Self-hosted servers
+        commonly need no key at all, so an endpoint alone is enough."""
+        from rhesis.backend.app.utils.user_model_utils import has_own_credentials
+
+        assert has_own_credentials("openai", api_key, endpoint) is True
+
+    @pytest.mark.parametrize("api_key", [None, "", "   "])
+    def test_a_row_with_neither_is_not_allowed(self, api_key):
+        from rhesis.backend.app.utils.user_model_utils import has_own_credentials
+
+        assert has_own_credentials("openai", api_key, None) is False
+        assert has_own_credentials("openai", api_key, "  ") is False
+
+    @pytest.mark.parametrize("provider", ["rhesis", "polyphemus"])
+    def test_rhesis_hosted_rows_are_exempt(self, provider):
+        """Running on our credentials with no key is what picking these means,
+        and they are billed for it."""
+        from rhesis.backend.app.utils.user_model_utils import has_own_credentials
+
+        assert has_own_credentials(provider, None, None) is True
+
+    def test_resolution_refuses_rather_than_borrowing(self, caplog):
+        from rhesis.backend.app.utils.model_errors import ModelConfigurationError
+        from rhesis.backend.app.utils.user_model_utils import _require_own_credentials
+
+        with pytest.raises(ModelConfigurationError, match="neither an API key nor an endpoint"):
+            _require_own_credentials("openai", None, None, "my-model")
+
+    def test_resolution_allows_a_row_with_an_endpoint(self):
+        from rhesis.backend.app.utils.user_model_utils import _require_own_credentials
+
+        _require_own_credentials("vllm", None, "http://vllm.internal:8000", "my-model")
+
+
+class TestConfiguredModelProvenance:
+    """End-to-end through the resolver, because the predicate can be right while
+    a call site hands it the wrong arguments. These go through
+    ``_fetch_and_configure_model`` so the wiring itself is covered.
+    """
+
+    @pytest.fixture
+    def configured_model(self, monkeypatch):
+        """Build a Model row stub and return the resolver's stamped result."""
+
+        captured: dict = {}
+
+        def _resolve(*, provider="openai", key="", endpoint=None, capture=False):
+            model_row = SimpleNamespace(
+                name="configured",
+                model_name="gpt-4o",
+                key=key,
+                endpoint=endpoint,
+                provider_type=SimpleNamespace(type_value=provider),
+            )
+            monkeypatch.setattr(
+                "rhesis.backend.app.utils.user_model_utils.model_crud.get_model",
+                lambda **kwargs: model_row,
+            )
+
+            def _build(**kwargs):
+                captured.update(kwargs)
+                return _StubLLM(kwargs.get("model_name", "gpt-4o"))
+
+            monkeypatch.setattr("rhesis.backend.app.utils.user_model_utils.get_model", _build)
+            from rhesis.backend.app.utils.user_model_utils import _fetch_and_configure_model
+
+            model = _fetch_and_configure_model(None, "model-1", "org-1", "vertex_ai/default")
+            return captured if capture else model
+
+        return _resolve
+
+    @pytest.mark.parametrize("key", ["", "   "])
+    def test_a_row_with_no_key_and_no_endpoint_is_refused(self, configured_model, key):
+        """Rather than quietly resolving and running on our provider keys."""
+        from rhesis.backend.app.utils.model_errors import ModelConfigurationError
+
+        with pytest.raises(ModelConfigurationError, match="neither an API key nor an endpoint"):
+            configured_model(provider="openai", key=key, endpoint=None)
+
+    def test_a_keyless_self_hosted_row_is_not_metered(self, configured_model):
+        model = configured_model(provider="vllm", key="", endpoint="http://vllm.internal:8000")
+
+        assert model.usage_metered is False
+
+    def test_an_org_key_is_not_metered(self, configured_model):
+        model = configured_model(provider="openai", key="sk-org-owned", endpoint=None)
+
+        assert model.usage_metered is False
+
+    def test_a_whitespace_key_does_not_reach_the_provider(self, configured_model):
+        """Normalized to None so it cannot be sent as a real credential. With an
+        endpoint present the row is legitimate, so it resolves rather than being
+        refused."""
+        seen = configured_model(
+            provider="vllm", key="   ", endpoint="http://vllm.internal:8000", capture=True
+        )
+
+        assert seen["api_key"] is None
 
 
 class TestPlatformKeyModelProvenance:

--- a/tests/backend/crud/test_model_credential_guard.py
+++ b/tests/backend/crud/test_model_credential_guard.py
@@ -1,0 +1,78 @@
+"""A Model row must carry credentials of its own, checked when it is saved.
+
+Every SDK provider falls back to reading its key from the process environment
+when handed a falsy one (``litellm/main.py``: ``api_key or ... or
+get_secret("OPENAI_API_KEY")``). A tenant row with neither a key nor an
+endpoint therefore runs on this deployment's credentials: we pay the provider,
+the tenant is not billed because the row is theirs, and to them it looks like
+a working configuration.
+
+Rejecting it at write time gives the tenant the error while they are still
+looking at the form. ``_require_own_credentials`` in the resolution path is the
+backstop for rows edited into this shape, or created before this check existed.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from rhesis.backend.app.crud.model import _reject_rows_without_own_credentials
+
+PROVIDER_TYPE_ID = "33333333-3333-3333-3333-333333333333"
+
+
+def _db_returning(provider: str | None):
+    """A session whose provider_type lookup yields *provider* (None = missing row)."""
+    db = MagicMock()
+    row = SimpleNamespace(type_value=provider) if provider is not None else None
+    db.query.return_value.filter.return_value.first.return_value = row
+    return db
+
+
+def _row(*, key="", endpoint=None, provider_type_id=PROVIDER_TYPE_ID):
+    return SimpleNamespace(
+        name="my-model",
+        key=key,
+        endpoint=endpoint,
+        provider_type_id=provider_type_id,
+    )
+
+
+@pytest.mark.parametrize("key", ["", "   "])
+def test_rejects_a_row_with_no_key_and_no_endpoint(key):
+    with pytest.raises(ValueError, match="either an API key or an endpoint"):
+        _reject_rows_without_own_credentials(_db_returning("openai"), _row(key=key, endpoint=None))
+
+
+@pytest.mark.parametrize(
+    "key,endpoint",
+    [
+        ("sk-org-owned", None),
+        ("", "http://vllm.internal:8000"),
+        (None, "http://vllm.internal:8000"),
+    ],
+)
+def test_allows_a_row_that_can_stand_on_its_own(key, endpoint):
+    """A key, or an endpoint. Self-hosted servers commonly need no key at all,
+    which is why an endpoint alone is enough."""
+    _reject_rows_without_own_credentials(_db_returning("openai"), _row(key=key, endpoint=endpoint))
+
+
+@pytest.mark.parametrize("provider", ["rhesis", "polyphemus"])
+def test_allows_rhesis_hosted_rows_with_neither(provider):
+    """Running on our credentials with no key of its own is exactly what
+    picking a Rhesis-hosted provider means, and it is billed accordingly."""
+    _reject_rows_without_own_credentials(_db_returning(provider), _row(key="", endpoint=None))
+
+
+def test_skips_the_check_when_no_provider_is_set():
+    """Nothing to decide against, and the row cannot resolve to a model anyway."""
+    _reject_rows_without_own_credentials(_db_returning("openai"), _row(provider_type_id=None))
+
+
+def test_skips_the_check_when_the_provider_row_is_missing():
+    """A dangling provider_type_id is a different error; do not mask it here."""
+    _reject_rows_without_own_credentials(_db_returning(None), _row(key="", endpoint=None))


### PR DESCRIPTION
## Purpose

A Model row with no API key and no endpoint runs on this deployment's provider credentials.

`Model.key` is `NOT NULL` but `ModelCreate.key` is typed `key: str` with no `min_length`, so `""` passes validation. Every provider then falls back to the process environment when handed a falsy key. LiteLLM (`litellm/main.py:2128-2133`):

```python
api_key = (
    api_key
    or litellm.api_key
    or litellm.openai_key
    or get_secret("OPENAI_API_KEY")
)
```

Our own SDK providers do the same (`sdk/.../providers/openai.py:20`, `gemini.py:42`), and our deployments ship four provider keys via `infrastructure/k8s/manifests/secrets/rhesis-secrets.yaml.example`. So the row resolves, we pay the provider, and to the tenant it looks like a working configuration.

Raised by peqy as an improvement on #2386.

## What Changed

**Billing is not the fix.** This PR originally tried to charge these rows. That was wrong: a tenant's row belongs to them whether or not it carries a key, so it must never be billed to them. `_is_hosted_model` is unchanged in behaviour and still charges only for `rhesis`/`polyphemus` rows, which is what picking our hosted option means. The fix is to stop the row resolving at all.

- **Create rejects it** with a 400 naming what to add, so the tenant sees the problem while saving rather than when a test run fails later.
- **The resolution path refuses to build it**, which covers rows edited into this shape and rows created before this check existed.
- **The metric-judge path drops to the default judge** instead of raising, since failing an evaluation outright is worse than judging with the default model.
- **Blank and whitespace-only keys normalize to `None`** before any of that, so `"   "` produces the same clear configuration error instead of an opaque 401 from the provider. This also resolves peqy's second point, that `_resolve_metric_model` and `_fetch_and_configure_model` disagreed on what counts as a key.

`has_own_credentials(provider, key, endpoint)` is the single predicate behind all three: a row needs a key or an endpoint of its own. `rhesis`/`polyphemus` are exempt, because keyless-and-endpointless is exactly what those rows are.

## Additional Context

The write-time rejection is scoped to create on purpose. Update would need effective-value logic across optional fields where `None` is ambiguous between "unchanged" and "clear", and getting that wrong would break ordinary edits. The runtime refusal covers that case instead.

**Note for the Models UI:** this introduces a new 400 on model create. The message is user-facing and says what to add, so it is worth surfacing directly rather than as a generic failure.

Two earlier approaches were tried and rejected, recorded here so they are not retried:

- Charging a keyless row. Wrong per the above.
- Using the endpoint to infer "runs on our credentials". Still wrong: `ollama` and `vllm` fall back to an implicit `localhost` base (`litellm/main.py:4144`), so a self-hosted org with neither field set reaches its own server and would have been billed for its own hardware.

I also checked whether `litellm.validate_environment` could answer "would this find one of our keys" exactly. It does for `openai` and `anthropic`, but reports `keys_in_environment: True` for `vllm` simply because vllm needs no key, so it cannot distinguish the two cases.

**#2466 is the layer underneath this**: remove provider keys from deployments whose default model does not need them. That does not depend on having enumerated every code path, since the fallback can only borrow what is present in the environment.

## Testing

- `tests/backend/crud/test_model_credential_guard.py` (new) covers the write-time rejection, including the `rhesis`/`polyphemus` exemption and the cases where the check correctly skips.
- `tests/backend/app/test_usage_tracking.py` covers the predicate, the runtime refusal, and the billing rule. `TestConfiguredModelProvenance` goes through `_fetch_and_configure_model` rather than calling the predicate directly, because a predicate can be right while a call site hands it the wrong arguments.

```bash
cd apps/backend
uv run pytest ../../tests/backend/app/ ../../tests/backend/crud/ ../../tests/backend/routes/test_model.py \
              ../../tests/backend/metrics/ ../../tests/backend/utils/ ../../tests/backend/security/ -q
```

1824 passed, 3 skipped. `uvx ruff check` clean. Existing model route tests pass untouched, which also confirms the standard fixtures always supply a key or an endpoint.