### PR TITLE
Fix travel-agent handoffs losing specialist results

### DIFF
--- a/agents/travel-agent/src/travel_agent/agents/destination_finder.py
+++ b/agents/travel-agent/src/travel_agent/agents/destination_finder.py
@@ -14,8 +14,18 @@ You choose a city for trips when the coordinator needs a destination.
 How to behave:
 
 1. Call get_random_destination. Do not choose a city without using the tool.
-2. Immediately call handoff_to_trip_coordinator to return the selected destination.
-   Do not send user-facing prose; the coordinator presents the destination to the user."""
+2. Write one line reporting the tool's result exactly as returned:
+   DESTINATION: <city returned by the tool>
+   You must write this line. Only your text crosses a handoff - the coordinator cannot
+   see your tool calls or their results - so a silent reply tells it nothing.
+3. Immediately call handoff_to_trip_coordinator.
+
+Never address the user. Everything you write is an internal note that the coordinator
+rewrites into the final plan.
+
+Always end your note with this exact line, so the coordinator knows the turn is
+back with it:
+Coordinator, take over."""
 
 DESCRIPTION = "Selects a random travel destination with get_random_destination."
 

--- a/agents/travel-agent/src/travel_agent/agents/logistics_planner.py
+++ b/agents/travel-agent/src/travel_agent/agents/logistics_planner.py
@@ -14,9 +14,25 @@ and the sightseeing stops in the plan.
 
 How to behave:
 
-1. Call estimate_travel with the destination and sightseeing stops you received.
-2. Immediately call handoff_to_trip_coordinator to return the travel-time guidance.
-   Do not send user-facing prose; the coordinator presents logistics to the user."""
+1. Find the destination ("DESTINATION: <city>") and the sightseeing stops
+   ("SIGHTSEEING STOPS: <list>") in the conversation. Either can also come from the
+   user's own message.
+2. With both: call estimate_travel with them, then write one line reporting the tool's
+   result:
+   LOGISTICS: <the travel-time guidance returned by the tool>
+   You must write this line. Only your text crosses a handoff - the coordinator cannot
+   see your tool calls or their results - so a silent reply tells it nothing.
+3. Missing the destination or the stops: do not ask the user and do not apologise.
+   Write exactly:
+   MISSING: <what is missing>, logistics skipped
+4. Either way, call handoff_to_trip_coordinator immediately afterwards.
+
+Never address the user. Everything you write is an internal note that the coordinator
+rewrites into the final plan.
+
+Always end your note with this exact line, so the coordinator knows the turn is
+back with it:
+Coordinator, take over."""
 
 DESCRIPTION = "Estimates mock sightseeing distances and travel times."
 

--- a/agents/travel-agent/src/travel_agent/agents/sightseeing_scout.py
+++ b/agents/travel-agent/src/travel_agent/agents/sightseeing_scout.py
@@ -13,9 +13,23 @@ You suggest sightseeing stops when the user did not already name specific sights
 
 How to behave:
 
-1. Call find_sightseeing with the destination and the user's stated interests or trip style.
-2. Immediately call handoff_to_trip_coordinator to return the sightseeing list.
-   Do not send user-facing prose; the coordinator presents the stops to the user."""
+1. Find the destination in the conversation. It appears either as a "DESTINATION: <city>"
+   note from the destination finder or in the user's own message.
+2. With a destination: call find_sightseeing with it plus the user's stated interests or
+   trip style, then write one line reporting the tool's result:
+   SIGHTSEEING STOPS: <the complete list returned by the tool>
+   You must write this line. Only your text crosses a handoff - the coordinator cannot
+   see your tool calls or their results - so a silent reply tells it nothing.
+3. Without a destination: do not ask the user and do not apologise. Write exactly:
+   MISSING: no destination available, sightseeing skipped
+4. Either way, call handoff_to_trip_coordinator immediately afterwards.
+
+Never address the user. Everything you write is an internal note that the coordinator
+rewrites into the final plan.
+
+Always end your note with this exact line, so the coordinator knows the turn is
+back with it:
+Coordinator, take over."""
 
 DESCRIPTION = "Finds mock sightseeing stops for a destination using an LLM-style tool."
 

--- a/agents/travel-agent/src/travel_agent/utils.py
+++ b/agents/travel-agent/src/travel_agent/utils.py
@@ -3,11 +3,23 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from agent_framework import Content, Message
 
+logger = logging.getLogger(__name__)
+
 COORDINATOR_NAME = "trip_coordinator"
+
+# Served when the coordinator never produced user-facing text. Specialist prose is
+# never promoted in its place: specialists write internal notes addressed to the
+# coordinator, and one that stalls (for example because no destination reached it)
+# apologises to "the user" it thinks it is talking to.
+FALLBACK_RESPONSE = (
+    "I could not put a trip plan together this time. Tell me a destination - or ask for "
+    "a surprise one - and I will try again."
+)
 
 AGENT_LABELS: dict[str, str] = {
     "trip_coordinator": "Coordinator",
@@ -94,10 +106,15 @@ def record_function_calls(
         )
 
 
-def segment_texts(segments: list[dict[str, Any]]) -> list[str]:
-    """Concatenate each segment's streamed chunks into one non-empty string each."""
+def segment_texts(segments: list[dict[str, Any]], *, author: str | None = None) -> list[str]:
+    """Concatenate each segment's streamed chunks into one non-empty string each.
+
+    Pass ``author`` to keep only the segments that agent authored.
+    """
     texts: list[str] = []
     for segment in segments:
+        if author is not None and segment.get("author") != author:
+            continue
         joined = "".join(segment["parts"]).strip()
         if joined:
             texts.append(joined)
@@ -123,11 +140,25 @@ def user_visible_assistant_message(text: str) -> Message:
     )
 
 
+def authored_by_specialist(agent_response: Any) -> bool:
+    """Report whether a handoff response was written by a specialist, not the coordinator.
+
+    ``request_info`` fires from whichever agent ended its turn without handing off, so
+    the event can carry a specialist's internal note. Messages with no ``author_name``
+    are treated as the coordinator's: the check only rejects a known other agent.
+    """
+    for message in getattr(agent_response, "messages", None) or ():
+        author = getattr(message, "author_name", None)
+        if author and author != COORDINATOR_NAME:
+            return True
+    return False
+
+
 def capture_final_text(request_info_data: Any, *, fallback: list[str]) -> str | None:
-    """Pull the synthesised final answer out of a handoff request-info event."""
+    """Pull the coordinator's synthesised final answer out of a handoff request-info event."""
     agent_response = getattr(request_info_data, "agent_response", None)
     text = getattr(agent_response, "text", None)
-    if isinstance(text, str) and text.strip():
+    if isinstance(text, str) and text.strip() and not authored_by_specialist(agent_response):
         return text
     if fallback:
         joined = "\n".join(text for text in fallback if text).strip()
@@ -154,7 +185,12 @@ def resolve_response(
     *,
     final_text: str | None,
 ) -> tuple[str, str]:
-    """Pick the user-facing response text and the agent that authored it."""
+    """Pick the user-facing response text and the agent that authored it.
+
+    Only the coordinator's text is ever served. A specialist's segment is internal
+    research addressed to the coordinator, so when the coordinator produced nothing we
+    log the miss and serve :data:`FALLBACK_RESPONSE` rather than leaking that note.
+    """
     coordinator_text = last_segment_text(assistant_segments, author=COORDINATOR_NAME)
     if coordinator_text:
         return coordinator_text, COORDINATOR_NAME
@@ -162,10 +198,9 @@ def resolve_response(
     if final_text:
         return final_text, COORDINATOR_NAME
 
-    for segment in reversed(assistant_segments):
-        joined = "".join(segment["parts"]).strip()
-        if joined:
-            author = segment.get("author") or "unknown"
-            return joined, author
-
-    return "", "unknown"
+    logger.warning(
+        "Coordinator produced no user-facing text; serving the fallback response. "
+        "Segments seen from: %s",
+        [segment.get("author") for segment in assistant_segments],
+    )
+    return FALLBACK_RESPONSE, COORDINATOR_NAME

--- a/agents/travel-agent/src/travel_agent/workflow.py
+++ b/agents/travel-agent/src/travel_agent/workflow.py
@@ -143,7 +143,10 @@ async def invoke_travel_workflow_async(
                 continue
 
             if event_type == "request_info":
-                captured = capture_final_text(data, fallback=segment_texts(assistant_segments))
+                captured = capture_final_text(
+                    data,
+                    fallback=segment_texts(assistant_segments, author=COORDINATOR_NAME),
+                )
                 if captured:
                     final_text = captured
                 continue


### PR DESCRIPTION
## Purpose

In a MAF handoff workflow only an agent's *text* crosses the handoff — the coordinator cannot see a specialist's tool calls or their results. The three specialist prompts told the agents to do exactly the wrong thing: call the tool, then hand back immediately without writing any prose. The coordinator was therefore handed nothing to build the plan from, and the stream-parsing helpers papered over the gap by falling back to whatever text any agent had produced, which could put a specialist's internal note in front of the user.

## What Changed

- **Specialists now report their tool results as text.** Each writes one labelled line before handing back: `DESTINATION: <city>`, `SIGHTSEEING STOPS: <complete list>`, or `LOGISTICS: <travel-time guidance>`. The same labels are what the downstream specialists read, so the scout and the planner can pick their inputs out of an earlier note or out of the user's own message — the labels act as a small protocol between agents.
- **Missing inputs no longer stall a turn.** A specialist without its inputs writes `MISSING: <what>, <step> skipped` and hands back, instead of asking the user or apologising to a "user" it isn't actually talking to. All three prompts now say never to address the user, and end with a fixed `Coordinator, take over.` line so the turn clearly returns.
- **Only the coordinator's text can reach the user.** `resolve_response` no longer falls back to the last non-empty segment from any agent; when the coordinator produced nothing it logs which agents *did* produce segments and serves a fixed `FALLBACK_RESPONSE`.
- **The same guard on the `request_info` path.** That event fires from whichever agent ended its turn without handing off, so it can carry a specialist's note. New `authored_by_specialist()` rejects those in `capture_final_text`. Messages with no `author_name` still count as the coordinator's — the check only rejects a *known* other agent, which is the safe direction.
- **`segment_texts()` takes an `author` filter**, and the workflow passes `COORDINATOR_NAME`, so the `request_info` fallback only ever draws on coordinator text.

## Additional Context

- No behaviour outside `agents/travel-agent` is touched, and no dependency or lockfile changes are included.
- **Known side effect:** `resolve_response` can no longer return an empty string, so the `RuntimeError("Travel workflow completed without producing a user-facing response.")` guard in `invoke_travel_workflow_async` is now unreachable. A hard failure became a soft one — a missing plan surfaces as the fallback message plus a `logger.warning` rather than an exception. That is the intended trade for a demo agent, but the now-dead `RuntimeError` is worth removing in a follow-up.
- This package has no test suite, so the changes are verified by running the agent.

## Testing

Both checks run from `agents/travel-agent/` and need `GOOGLE_API_KEY` in `.env`.

```bash
uv run python examples/run_traces.py
```

Confirm in the output that the coordinator's final plan restates all three specialist results — the destination, **every** sightseeing stop, and the travel-time guidance for city center / central station / airport — and that no `DESTINATION:` / `SIGHTSEEING STOPS:` / `LOGISTICS:` / `MISSING:` / `Coordinator, take over.` line leaks into the user-facing answer.

Then exercise the multi-turn path and a query that skips the scout:

```bash
uv run python -m travel_agent
```

- "Plan a family-friendly day trip at a random destination." — all three specialists run.
- "Plan a day trip to Barcelona visiting Sagrada Familia, Park Guell, and La Boqueria." — `sightseeing_scout` should not be invoked; logistics should still estimate travel around the named stops.
- A follow-up such as "slow the pace down" should keep the destination and stops without re-running the specialists.

Linting: `uvx ruff check` and `uvx ruff format --check` pass on `src/travel_agent`.
