### PR TITLE
Fix doubled site name in docs page titles

### DIFF
--- a/docs/content/docs/concepts.mdx
+++ b/docs/content/docs/concepts.mdx
@@ -1,5 +1,5 @@
 ---
-title: Core Concepts – Rhesis
+title: Core Concepts
 description: The Rhesis evaluation workflow and platform structure — how to run evaluations and what each entity means.
 keywords: [AI testing concepts, LLM behaviors, AI metrics, endpoints, test workflow]
 ---

--- a/docs/content/docs/endpoints/index.mdx
+++ b/docs/content/docs/endpoints/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Endpoints – Rhesis
+title: Endpoints
 description: Configure and manage API endpoints that Rhesis tests execute against. Connect single-turn and multi-turn LLM applications for automated evaluation.
 keywords: [AI endpoint configuration, LLM API endpoint, test endpoint, LLM application testing]
 ---

--- a/docs/content/docs/getting-started/connecting-application.mdx
+++ b/docs/content/docs/getting-started/connecting-application.mdx
@@ -1,5 +1,5 @@
 ---
-title: Connect Your Application – Rhesis
+title: Connect Your Application
 description: Connect your LLM application to Rhesis via REST endpoints or the Python SDK. Rhesis orchestrates test inputs and records responses for evaluation.
 keywords: [connect LLM application, Rhesis integration, LLM API integration, Python SDK integration]
 ---

--- a/docs/content/docs/test-runs/execution.mdx
+++ b/docs/content/docs/test-runs/execution.mdx
@@ -1,5 +1,5 @@
 ---
-title: Test Execution – Rhesis
+title: Test Execution
 description: Execute test sets against your AI endpoints to evaluate model performance, safety, and reliability. Configure execution options and analyse results.
 keywords: [test execution, AI test runner, LLM evaluation, model safety testing, automated AI testing]
 ---

--- a/docs/content/docs/tour.mdx
+++ b/docs/content/docs/tour.mdx
@@ -1,5 +1,5 @@
 ---
-title: Tour – Rhesis
+title: Tour
 description: A walk through the Rhesis screens, from connecting an agent to reading the team's verdicts back from code.
 keywords: [Rhesis tour, AI agent review, domain expert feedback, agent evaluation workflow]
 ---

--- a/docs/content/docs/tracing/index.mdx
+++ b/docs/content/docs/tracing/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Tracing – Rhesis
+title: Tracing
 description: OpenTelemetry-based observability for LLM applications. Trace LLM calls, agent steps, and tool use to debug failures and understand model behaviour.
 keywords: [AI tracing, OpenTelemetry LLM, AI observability, LLM tracing, agent tracing]
 ---

--- a/docs/content/guides/index.mdx
+++ b/docs/content/guides/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Guides – Rhesis
+title: Guides
 description: Step-by-step guides for testing LLM applications with Rhesis — from a 10-minute quickstart to building custom metrics and CI/CD integration.
 keywords: [AI testing guides, LLM testing tutorial, custom metrics, CI/CD AI testing]
 ---

--- a/docs/content/sdk/client.mdx
+++ b/docs/content/sdk/client.mdx
@@ -1,5 +1,5 @@
 ---
-title: RhesisClient – Rhesis Python SDK
+title: RhesisClient
 description: The RhesisClient is the central entry point for the Rhesis SDK. Initialize telemetry, manage connectors for remote testing, and access the Rhesis API.
 keywords: [RhesisClient, Rhesis Python SDK, SDK API client, AI testing client]
 ---

--- a/docs/content/sdk/installation.mdx
+++ b/docs/content/sdk/installation.mdx
@@ -1,5 +1,5 @@
 ---
-title: SDK Installation & Setup – Rhesis
+title: SDK Installation & Setup
 description: Install the Rhesis Python SDK, configure authentication, and learn the core concepts — models, synthesizers, and metrics — to start testing your LLM applications.
 keywords: [Rhesis SDK, Python SDK install, AI testing SDK, SDK setup, pip install rhesis]
 ---

--- a/docs/scripts/check-page-titles.js
+++ b/docs/scripts/check-page-titles.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Stops page titles from repeating the site name.
+ *
+ * `src/app/layout.jsx` sets a title template of "%s – Rhesis", so Next appends
+ * the brand to every page title itself. A frontmatter `title: Endpoints – Rhesis`
+ * therefore renders as "Endpoints – Rhesis – Rhesis" in the browser tab and in
+ * search results. The suffix is easy to copy from a neighbouring page, which is
+ * how nine of them got it.
+ *
+ * The brand may still appear inside a title where it reads as prose
+ * ("Getting Started with Rhesis") or as part of a name ("RhesisClient") — only a
+ * trailing separator + brand is a violation.
+ */
+
+const CONTENT_DIR = path.resolve(__dirname, '..', 'content');
+
+// Matches " – Rhesis", " | Rhesis AI", " - Rhesis Python SDK" at the very end.
+const BRAND_SUFFIX = /\s*[–—|-]\s*Rhesis(\s+[\w.&]+){0,2}\s*$/i;
+
+function mdxFiles(dir) {
+  const found = [];
+  for (const item of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, item.name);
+    if (item.isDirectory()) {
+      if (!item.name.startsWith('.') && item.name !== 'node_modules') found.push(...mdxFiles(full));
+    } else if (item.isFile() && item.name.endsWith('.mdx') && !item.name.startsWith('_')) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+function frontmatterTitle(source) {
+  const block = source.match(/^---\n([\s\S]*?)\n---/);
+  if (!block) return null;
+  const line = block[1].match(/^title:\s*(.+)$/m);
+  return line ? line[1].trim().replace(/^['"]|['"]$/g, '') : null;
+}
+
+function main() {
+  const files = mdxFiles(CONTENT_DIR);
+  const violations = [];
+
+  for (const file of files) {
+    const title = frontmatterTitle(fs.readFileSync(file, 'utf8'));
+    if (!title) continue;
+
+    if (BRAND_SUFFIX.test(title)) {
+      violations.push({
+        rel: path.relative(path.dirname(CONTENT_DIR), file),
+        title,
+        fix: title.replace(BRAND_SUFFIX, '').trim(),
+      });
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log(`✅ Page title checks passed (${files.length} pages).`);
+    return;
+  }
+
+  const plural = violations.length === 1 ? 'title repeats' : 'titles repeat';
+  console.error(`❌ ${violations.length} page ${plural} the site name:\n`);
+  for (const v of violations) {
+    console.error(`  ${v.rel}`);
+    console.error(`    title: ${v.title}   → renders as "${v.title} – Rhesis"`);
+    console.error(`    Fix: title: ${v.fix}\n`);
+  }
+  console.error('The layout appends " – Rhesis" to every title; the page must not add it too.\n');
+
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/docs/src/Makefile
+++ b/docs/src/Makefile
@@ -1,7 +1,7 @@
 # Documentation Makefile
 # Provides convenient commands for linting and formatting documentation
 
-.PHONY: help lint lint-fast format format-check eslint images install
+.PHONY: help lint lint-fast format format-check eslint images titles install
 
 # Default target
 help:
@@ -12,25 +12,28 @@ help:
 	@echo "  format-check - Check code formatting (errors only)"
 	@echo "  eslint       - Run ESLint (errors only)"
 	@echo "  images       - Check image formats and sizes in public/"
+	@echo "  titles       - Check page titles do not repeat the site name"
 	@echo "  install      - Install dependencies"
 
 # Main lint target - runs all validation steps
-lint: format-check eslint images
+lint: format-check eslint images titles
 	@echo ""
 	@echo "✅ All lint checks passed!"
 	@echo "  ✓ Code formatting"
 	@echo "  ✓ ESLint"
 	@echo "  ✓ Image formats and sizes"
+	@echo "  ✓ Page titles"
 	@echo ""
 	@echo "💡 Note: Docs has no build step - use 'make lint-fast' for same checks"
 
 # Fast lint (same as regular lint for docs since no build/type-check step)
-lint-fast: format-check eslint images
+lint-fast: format-check eslint images titles
 	@echo ""
 	@echo "✅ Fast lint checks passed!"
 	@echo "  ✓ Code formatting"
 	@echo "  ✓ ESLint"
 	@echo "  ✓ Image formats and sizes"
+	@echo "  ✓ Page titles"
 	@echo ""
 	@echo "💡 Note: Docs linting is already fast (no type-check or build step needed)"
 
@@ -54,6 +57,11 @@ eslint:
 images:
 	@echo "🔍 Checking image formats and sizes..."
 	@npm run lint:images || (echo "❌ Image check failed" && exit 1)
+
+# Page titles - the layout already appends " – Rhesis" to every title
+titles:
+	@echo "🔍 Checking page titles..."
+	@npm run lint:titles || (echo "❌ Page title check failed" && exit 1)
 
 # Install dependencies
 install:

--- a/docs/src/package.json
+++ b/docs/src/package.json
@@ -14,6 +14,7 @@
     "lint:errors": "eslint . --ext .js,.jsx,.ts,.tsx --max-warnings 0",
     "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "lint:images": "node ../scripts/check-image-formats.js",
+    "lint:titles": "node ../scripts/check-page-titles.js",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "node --test --test-reporter=spec lib/__tests__"


### PR DESCRIPTION
## Purpose

`src/app/layout.jsx` sets a title template of `%s – Rhesis`, so Next appends the brand to every page title itself. Nine pages also carried the suffix in their own frontmatter, so they rendered doubled in the browser tab and in search results:

```
<title>Endpoints – Rhesis – Rhesis</title>
<title>Tour – Rhesis – Rhesis</title>
<title>RhesisClient – Rhesis Python SDK – Rhesis</title>
```

Found while building the per-page OG cards in #2464 — that PR strips the suffix for the card image, which left the real titles as the remaining problem. Independent of it; the two can merge in either order.

## What Changed

- Dropped the trailing brand suffix from the nine frontmatter titles. Each now matches the page's own H1, which already had it right (`# Endpoints`, `# Tour`, `# RhesisClient`, …).
- Added `docs/scripts/check-page-titles.js`, wired in as `npm run lint:titles` and a `titles` target in `make lint` / `make lint-fast`, so CI's docs job catches the next one. Same shape as the existing `check-image-formats.js`.

Only a *trailing* separator + brand is rejected, so prose like `Getting Started with Rhesis` and names like `RhesisClient` stay legal.

Left alone deliberately: `docs/index.mdx` (`Rhesis Documentation`) and `docs/getting-started/index.mdx` (`Getting Started with Rhesis`) read a little redundantly once the template appends the brand, but they are prose rather than the copy-pasted suffix, and rewording them is an editorial call rather than this bug.

## Additional Context

- Verified against the built output, not just the source: after `npm run build`, every affected page in `.next/server/app/*.html` now reads `Endpoints – Rhesis`, `RhesisClient – Rhesis`, and so on.
- Verified the guard actually fires by restoring one file's old title:

  ```
  ❌ 1 page title repeats the site name:
    content/docs/endpoints/index.mdx
      title: Endpoints – Rhesis   → renders as "Endpoints – Rhesis – Rhesis"
      Fix: title: Endpoints
  ```

## Testing

- `cd docs && make lint` — format, eslint, images, and the new title check all pass across 273 pages.
- `cd docs/src && node --test 'lib/__tests__/'*.test.js` — 41 pass.
- `cd docs/src && npm run build` — clean, and the rendered `<title>` tags are correct.
