### PR TITLE
Add configurable brand colour, icon and product name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,9 +44,9 @@ SESSION_SECRET_KEY=
 # URL or a root-relative path, and also becomes the sidebar brand mark.
 # BRAND_PRODUCT_NAME replaces "Rhesis AI" in page titles (max 60 characters).
 
-# BRAND_PRIMARY_COLOR=#005B33
+# BRAND_PRIMARY_COLOR=#6A1B9A
 # BRAND_FAVICON_URL=https://www.example.com/favicon.png
-# BRAND_PRODUCT_NAME=Netgo
+# BRAND_PRODUCT_NAME=Acme
 
 # =============================================================================
 # DATABASE

--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,20 @@ SESSION_SECRET_KEY=
 # BACKEND_PORT=8080
 
 # =============================================================================
+# BRANDING
+# =============================================================================
+# Optional. Rebrands the frontend without rebuilding the image — both are read
+# at request time. Leave unset for the standard Rhesis look; a malformed value
+# is ignored with a warning.
+# BRAND_PRIMARY_COLOR must be 6-digit hex. BRAND_FAVICON_URL must be an https://
+# URL or a root-relative path, and also becomes the sidebar brand mark.
+# BRAND_PRODUCT_NAME replaces "Rhesis AI" in page titles (max 60 characters).
+
+# BRAND_PRIMARY_COLOR=#005B33
+# BRAND_FAVICON_URL=https://www.example.com/favicon.png
+# BRAND_PRODUCT_NAME=Netgo
+
+# =============================================================================
 # DATABASE
 # =============================================================================
 

--- a/apps/frontend/src/app/(protected)/onboarding/components/OnboardingSidebar.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/OnboardingSidebar.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import Image from 'next/image';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { Box, Typography } from '@mui/material';
+import BrandMark from '@/components/common/BrandMark';
+import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 import { DEFAULT_AUTHENTICATED_PATH } from '@/constants/paths';
 import { ONBOARDING_STEPS } from './onboarding-steps';
 import { onboardingSidebarSx } from './onboarding-styles';
@@ -15,6 +16,9 @@ interface OnboardingSidebarProps {
 export default function OnboardingSidebar({
   activeStep,
 }: OnboardingSidebarProps) {
+  const { branding } = useNavigationItems();
+  const productName = branding?.productName ?? 'Rhesis AI';
+
   return (
     <Box
       sx={{
@@ -35,11 +39,10 @@ export default function OnboardingSidebar({
           <Box
             sx={{ width: 40, height: 40, position: 'relative', flexShrink: 0 }}
           >
-            <Image
-              src="/logos/rhesis-logo-favicon.svg"
-              alt="Rhesis AI"
-              width={40}
-              height={40}
+            <BrandMark
+              src={branding?.iconUrl}
+              size={40}
+              alt={productName}
               priority
             />
           </Box>
@@ -51,7 +54,7 @@ export default function OnboardingSidebar({
               color: 'primary.main',
             }}
           >
-            Rhesis AI
+            {productName}
           </Typography>
         </Box>
 

--- a/apps/frontend/src/app/(protected)/onboarding/components/OnboardingStepHeader.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/OnboardingStepHeader.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import Image from 'next/image';
 import { Box, Typography } from '@mui/material';
+import BrandMark from '@/components/common/BrandMark';
+import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 
 interface OnboardingStepHeaderProps {
   title: string;
@@ -12,6 +13,8 @@ export default function OnboardingStepHeader({
   title,
   description,
 }: OnboardingStepHeaderProps) {
+  const { branding } = useNavigationItems();
+
   return (
     <Box
       sx={{
@@ -24,11 +27,10 @@ export default function OnboardingStepHeader({
       }}
     >
       <Box sx={{ width: 92, height: 92, position: 'relative', flexShrink: 0 }}>
-        <Image
-          src="/logos/rhesis-logo-favicon.svg"
-          alt="Rhesis AI"
-          width={92}
-          height={92}
+        <BrandMark
+          src={branding?.iconUrl}
+          size={92}
+          alt={branding?.productName ?? 'Rhesis AI'}
           priority
         />
       </Box>

--- a/apps/frontend/src/app/auth/signout/page.tsx
+++ b/apps/frontend/src/app/auth/signout/page.tsx
@@ -1,16 +1,25 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Box, Typography, CircularProgress } from '@mui/material';
-import { ThemeProvider } from '@mui/material/styles';
+import { ThemeProvider, createTheme, useTheme } from '@mui/material/styles';
 import { handleClientSignOut } from '@/utils/client-auth';
 import BackgroundDecoration from '@/components/auth/BackgroundDecoration';
-import { lightTheme } from '@/styles/theme';
+import { getDesignTokens } from '@/styles/theme';
 import { scaledVh } from '@/styles/viewport-scaling';
 
 export default function SignOut() {
   const _searchParams = useSearchParams();
+  // This page pins light mode, so it can't use the ambient theme directly — but
+  // it still has to honour a deployment's brand colour, which the spinner below
+  // picks up from `palette.primary`. Rebuild the light theme with the brand
+  // colour read off the ambient one instead of the static `lightTheme` export.
+  const { brandColor } = useTheme().palette;
+  const theme = useMemo(
+    () => createTheme(getDesignTokens('light', brandColor)),
+    [brandColor]
+  );
 
   useEffect(() => {
     // The backend logout call goes through the /api/backend proxy, which
@@ -20,7 +29,7 @@ export default function SignOut() {
   }, []);
 
   return (
-    <ThemeProvider theme={lightTheme}>
+    <ThemeProvider theme={theme}>
       <Box
         sx={{
           display: 'flex',

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -52,6 +52,7 @@ import { type Organization } from '../utils/api-client/interfaces/organization';
 import { type UserSettings } from '../utils/api-client/interfaces/user';
 import { type Session } from 'next-auth';
 import ThemeContextProvider from '../components/providers/ThemeProvider';
+import { getServerBranding } from '../config/branding';
 import { BACKGROUND_DEFAULT } from '../styles/theme-background';
 import { Capability } from '../constants/capabilities';
 
@@ -95,14 +96,21 @@ html[data-theme-mode='${mode}'],html[data-theme-mode='${mode}'] body{background-
   .join('\n');
 
 // This function will be used to get navigation items with dynamic data
-async function getNavigationItems(session: Session | null): Promise<{
+async function getNavigationItems(
+  session: Session | null,
+  // Only a fallback: the real organisation name replaces it below whenever the
+  // lookup succeeds. It matters on the paths where it can't — no session yet, or
+  // the request failed — since that is where a branded deployment would
+  // otherwise flash "Rhesis AI" in its sidebar.
+  fallbackName: string
+): Promise<{
   items: NavigationItem[];
   organizationName: string;
   organization: Organization | null;
 }> {
   'use server';
 
-  let organizationName = 'Rhesis AI';
+  let organizationName = fallbackName;
   let organization: Organization | null = null;
 
   if (session?.user?.organization_id && !session.error) {
@@ -296,16 +304,30 @@ async function getNavigationItems(session: Session | null): Promise<{
   };
 }
 
-export const metadata: Metadata = {
-  title: {
-    template: '%s | Rhesis AI',
-    default: 'Rhesis AI',
-  },
-  description: 'Rhesis AI | OSS Gen AI Testing Platform',
-  icons: {
-    icon: '/logos/rhesis-logo-favicon.svg',
-  },
-};
+/**
+ * A function rather than a static `metadata` object so the favicon and product
+ * name are resolved per request from the environment, letting one image serve
+ * deployments with different branding.
+ */
+export async function generateMetadata(): Promise<Metadata> {
+  const { faviconUrl, productName, isDefaultProductName } = getServerBranding();
+
+  return {
+    title: {
+      // Pages set a bare `title` ('Architect'); this supplies the suffix.
+      template: `%s | ${productName}`,
+      default: productName,
+    },
+    // The Rhesis tagline would be wrong copy on a rebranded deployment, so a
+    // configured product name replaces it rather than being appended to it.
+    description: isDefaultProductName
+      ? 'Rhesis AI | OSS Gen AI Testing Platform'
+      : productName,
+    icons: {
+      icon: faviconUrl,
+    },
+  };
+}
 
 const AUTHENTICATION: AuthenticationProps = {
   signIn: handleSignIn,
@@ -323,20 +345,31 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
   const storedThemeMode =
     themeCookie === 'dark' || themeCookie === 'light' ? themeCookie : undefined;
 
+  // Branding is read here rather than in a client component because its env
+  // vars carry no `NEXT_PUBLIC_` prefix — see `config/branding.ts`. Reading it
+  // on the server and passing it down as props also keeps the server-rendered
+  // markup and the hydrated tree in agreement.
+  const deploymentBranding = getServerBranding();
+
   // Get navigation with dynamic organization name
   const {
     items: navigation,
     organizationName,
     organization,
-  } = await getNavigationItems(session);
+  } = await getNavigationItems(session, deploymentBranding.productName);
 
   const branding: BrandingProps = {
     title: organizationName,
-    logo: <ThemeAwareLogo />,
+    logo: <ThemeAwareLogo productName={deploymentBranding.productName} />,
+    iconUrl: deploymentBranding.faviconUrl,
+    productName: deploymentBranding.productName,
     homeUrl: '/architect',
   };
   const runtimeEnvScript = `window.__ENV__=${JSON.stringify({
     apiBaseUrl: process.env.API_BASE_URL ?? 'http://localhost:8080',
+    brandPrimaryColor: deploymentBranding.primaryColor,
+    brandFaviconUrl: deploymentBranding.faviconUrl,
+    brandProductName: deploymentBranding.productName,
   }).replace(/</g, '\\u003c')};`;
 
   // Fetch the active project, and the full member-project list for the
@@ -405,6 +438,7 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
         <ThemeContextProvider
           disableTransitionOnChange
           initialMode={storedThemeMode ?? 'light'}
+          brandColor={deploymentBranding.primaryColor}
         >
           <LayoutContent
             session={session}

--- a/apps/frontend/src/components/auth/AuthPageShell.tsx
+++ b/apps/frontend/src/components/auth/AuthPageShell.tsx
@@ -3,7 +3,8 @@
 import * as React from 'react';
 import { Box, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import Image from 'next/image';
+import BrandMark from '@/components/common/BrandMark';
+import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 import BackgroundDecoration from './BackgroundDecoration';
 import {
   AUTH_FONT_DISPLAY,
@@ -84,8 +85,17 @@ interface AuthPageShellProps {
 }
 
 export default function AuthPageShell({ children }: AuthPageShellProps) {
-  const mode = useTheme().palette.mode;
-  const t = getAuthTokens(mode);
+  const { mode, brandColor } = useTheme().palette;
+  const t = getAuthTokens(mode, brandColor);
+  // `NavigationProvider` wraps every route, auth pages included, so the
+  // server-resolved branding is available here without a second env read.
+  const { branding } = useNavigationItems();
+  const productName = branding?.productName ?? 'Rhesis AI';
+  const isRebranded = productName !== 'Rhesis AI';
+  // A rebranded sign-in page must not send its users to rhesis.ai, and there is
+  // no configured homepage to send them to instead — so the wordmark stops
+  // being a link and just labels the page.
+  const wordmarkHref = isRebranded ? undefined : 'https://www.rhesis.ai';
 
   return (
     <Box
@@ -116,10 +126,14 @@ export default function AuthPageShell({ children }: AuthPageShellProps) {
         }}
       >
         <Box
-          component="a"
-          href="https://www.rhesis.ai"
-          target="_blank"
-          rel="noopener noreferrer"
+          {...(wordmarkHref
+            ? {
+                component: 'a' as const,
+                href: wordmarkHref,
+                target: '_blank',
+                rel: 'noopener noreferrer',
+              }
+            : {})}
           sx={{
             display: 'flex',
             alignItems: 'center',
@@ -127,11 +141,10 @@ export default function AuthPageShell({ children }: AuthPageShellProps) {
             textDecoration: 'none',
           }}
         >
-          <Image
-            src="/logos/rhesis-logo-favicon.svg"
-            alt="Rhesis AI"
-            width={44}
-            height={44}
+          <BrandMark
+            src={branding?.iconUrl}
+            size={44}
+            alt={productName}
             priority
           />
           <Typography
@@ -143,7 +156,7 @@ export default function AuthPageShell({ children }: AuthPageShellProps) {
               color: mode === 'dark' ? '#fff' : '#111827',
             }}
           >
-            Rhesis AI
+            {productName}
           </Typography>
         </Box>
 
@@ -387,7 +400,7 @@ export default function AuthPageShell({ children }: AuthPageShellProps) {
           color: t.muted,
         }}
       >
-        © 2026 Rhesis AI
+        © 2026 {productName}
       </Box>
     </Box>
   );

--- a/apps/frontend/src/components/auth/__tests__/authTokens.test.ts
+++ b/apps/frontend/src/components/auth/__tests__/authTokens.test.ts
@@ -1,8 +1,8 @@
 import { getContrastRatio } from '@mui/system/colorManipulator';
 import { getAuthTokens } from '../authTokens';
 
-/** netgo green — the colour that motivated the branding feature. */
-const BRAND = '#005B33';
+/** A dark brand colour, far enough from Rhesis blue to make swaps obvious. */
+const BRAND = '#6A1B9A';
 
 describe('getAuthTokens', () => {
   it('keeps the rhesis.ai accents when no brand colour is configured', () => {
@@ -15,9 +15,9 @@ describe('getAuthTokens', () => {
 
   it('applies a configured brand colour to the accents', () => {
     const light = getAuthTokens('light', BRAND);
-    expect(light.accent).toBe('#005b33');
+    expect(light.accent).toBe('#6a1b9a');
     expect(light.accentHover).not.toBe(light.accent);
-    expect(light.accentShadow).toContain('rgba(0, 91, 51, 0.55)');
+    expect(light.accentShadow).toContain('rgba(106, 27, 154, 0.55)');
   });
 
   it('leaves the non-accent tokens alone', () => {

--- a/apps/frontend/src/components/auth/__tests__/authTokens.test.ts
+++ b/apps/frontend/src/components/auth/__tests__/authTokens.test.ts
@@ -1,0 +1,41 @@
+import { getContrastRatio } from '@mui/system/colorManipulator';
+import { getAuthTokens } from '../authTokens';
+
+/** netgo green — the colour that motivated the branding feature. */
+const BRAND = '#005B33';
+
+describe('getAuthTokens', () => {
+  it('keeps the rhesis.ai accents when no brand colour is configured', () => {
+    expect(getAuthTokens('light').accent).toBe('#0080af');
+    expect(getAuthTokens('dark').accent).toBe('#22a5d1');
+    expect(getAuthTokens('light').accentShadow).toBe(
+      '0 6px 14px -4px rgba(0,128,175,0.55)'
+    );
+  });
+
+  it('applies a configured brand colour to the accents', () => {
+    const light = getAuthTokens('light', BRAND);
+    expect(light.accent).toBe('#005b33');
+    expect(light.accentHover).not.toBe(light.accent);
+    expect(light.accentShadow).toContain('rgba(0, 91, 51, 0.55)');
+  });
+
+  it('leaves the non-accent tokens alone', () => {
+    // Only the three accent tokens are brand-driven; ground, ink and the
+    // hairlines mirror the website and stay put.
+    const plain = getAuthTokens('dark');
+    const branded = getAuthTokens('dark', BRAND);
+    expect(branded.ground).toBe(plain.ground);
+    expect(branded.ink).toBe(plain.ink);
+    expect(branded.hairline).toBe(plain.hairline);
+  });
+
+  it('lifts the accent on dark so white button text stays readable', () => {
+    // The reason the hand-picked pair moves #0080af to #22a5d1 on dark: these
+    // accents are button fills carrying white labels.
+    const darkAccent = getAuthTokens('dark', BRAND).accent;
+    expect(getContrastRatio(darkAccent, '#030712')).toBeGreaterThan(
+      getContrastRatio(BRAND, '#030712')
+    );
+  });
+});

--- a/apps/frontend/src/components/auth/authTokens.ts
+++ b/apps/frontend/src/components/auth/authTokens.ts
@@ -10,6 +10,8 @@
  * this — the rest of the app stays on the MUI theme and Be Vietnam Pro.
  */
 
+import { alpha, darken, lighten } from '@mui/system/colorManipulator';
+
 /** Geist, registered in `src/styles/fonts.css`. Auth pages only. */
 export const AUTH_FONT_SANS =
   '"Geist", "Be Vietnam Pro", system-ui, sans-serif';
@@ -90,8 +92,34 @@ const DARK: AuthTokens = {
   accentShadow: '0 6px 14px -4px rgba(34,165,209,0.4)',
 };
 
-export function getAuthTokens(mode: 'light' | 'dark'): AuthTokens {
-  return mode === 'dark' ? DARK : LIGHT;
+/**
+ * Applies a deployment's `BRAND_PRIMARY_COLOR` to the three accent tokens.
+ *
+ * The sign-in screen is the first thing a white-label user sees, so leaving it
+ * on Rhesis blue while the app itself is rebranded is the most visible way to
+ * get this wrong. The dark-mode lift mirrors what the hand-picked pair already
+ * does (`#0080af` → `#22a5d1`, i.e. roughly `lighten(0.13)`) — a saturated
+ * brand colour carrying white button text needs the extra contrast against
+ * `#030712`.
+ */
+function withBrandAccent(tokens: AuthTokens, brandColor: string): AuthTokens {
+  const accent =
+    tokens === DARK ? lighten(brandColor, 0.13) : brandColor.toLowerCase();
+
+  return {
+    ...tokens,
+    accent,
+    accentHover: tokens === DARK ? lighten(accent, 0.15) : darken(accent, 0.15),
+    accentShadow: `0 6px 14px -4px ${alpha(accent, tokens === DARK ? 0.4 : 0.55)}`,
+  };
+}
+
+export function getAuthTokens(
+  mode: 'light' | 'dark',
+  brandColor?: string
+): AuthTokens {
+  const tokens = mode === 'dark' ? DARK : LIGHT;
+  return brandColor ? withBrandAccent(tokens, brandColor) : tokens;
 }
 
 /** Shapes, lifted from the website's radius scale and hero CTAs. */

--- a/apps/frontend/src/components/auth/useAuthStyles.ts
+++ b/apps/frontend/src/components/auth/useAuthStyles.ts
@@ -37,10 +37,10 @@ export interface AuthStyles {
  * hover pair ended up duplicated across five files.
  */
 export function useAuthStyles(): AuthStyles {
-  const mode = useTheme().palette.mode;
+  const { mode, brandColor } = useTheme().palette;
 
   return useMemo(() => {
-    const t = getAuthTokens(mode);
+    const t = getAuthTokens(mode, brandColor);
 
     return {
       tokens: t,
@@ -117,5 +117,5 @@ export function useAuthStyles(): AuthStyles {
         textDecoration: 'none',
       },
     };
-  }, [mode]);
+  }, [mode, brandColor]);
 }

--- a/apps/frontend/src/components/common/BrandMark.tsx
+++ b/apps/frontend/src/components/common/BrandMark.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import { DEFAULT_FAVICON_URL } from '@/config/branding';
+
+interface BrandMarkProps {
+  /** `BRAND_FAVICON_URL` when configured; falls back to the Rhesis icon. */
+  src?: string;
+  /** Rendered size in px — the mark is always square. */
+  size: number;
+  alt: string;
+  priority?: boolean;
+}
+
+/**
+ * The square brand mark in the app chrome, honouring `BRAND_FAVICON_URL` so a
+ * rebranded deployment shows its own icon next to the organisation name instead
+ * of the Rhesis platypus.
+ *
+ * A remote URL renders as a plain `<img>`, not `next/image`: the optimizer
+ * refuses any host absent from `images.remotePatterns`, and the host here is
+ * whatever a customer put in their values file — unknowable at build time.
+ * Widening `remotePatterns` to `**` to work around that would turn the
+ * optimizer into an open image proxy. Favicons are a few KB, so there is
+ * nothing to optimise anyway. Local paths keep `next/image`.
+ */
+export default function BrandMark({
+  src,
+  size,
+  alt,
+  priority = false,
+}: BrandMarkProps) {
+  const resolved = src || DEFAULT_FAVICON_URL;
+  const isRemote = /^https?:\/\//i.test(resolved);
+
+  if (isRemote) {
+    return (
+      <img
+        src={resolved}
+        alt={alt}
+        width={size}
+        height={size}
+        // Keeps a non-square source from stretching, and stops a broken or
+        // slow remote icon from shifting the sidebar layout.
+        style={{ width: size, height: size, objectFit: 'contain' }}
+        {...(priority ? { fetchPriority: 'high' as const } : {})}
+      />
+    );
+  }
+
+  return (
+    <Image
+      src={resolved}
+      alt={alt}
+      width={size}
+      height={size}
+      priority={priority}
+    />
+  );
+}

--- a/apps/frontend/src/components/common/BrandMark.tsx
+++ b/apps/frontend/src/components/common/BrandMark.tsx
@@ -20,7 +20,7 @@ interface BrandMarkProps {
  *
  * A remote URL renders as a plain `<img>`, not `next/image`: the optimizer
  * refuses any host absent from `images.remotePatterns`, and the host here is
- * whatever a customer put in their values file — unknowable at build time.
+ * whatever a deployment put in its values file — unknowable at build time.
  * Widening `remotePatterns` to `**` to work around that would turn the
  * optimizer into an open image proxy. Favicons are a few KB, so there is
  * nothing to optimise anyway. Local paths keep `next/image`.

--- a/apps/frontend/src/components/common/ThemeAwareLogo.tsx
+++ b/apps/frontend/src/components/common/ThemeAwareLogo.tsx
@@ -5,7 +5,15 @@ import Image from 'next/image';
 import { Box } from '@mui/material';
 import { ColorModeContext } from '../providers/ThemeProvider';
 
-export default function ThemeAwareLogo() {
+interface ThemeAwareLogoProps {
+  /** `BRAND_PRODUCT_NAME`, for the alt text. The wordmark image itself is still
+   * the Rhesis one — only `BRAND_FAVICON_URL` replaces artwork (see BrandMark). */
+  productName?: string;
+}
+
+export default function ThemeAwareLogo({
+  productName = 'Rhesis AI',
+}: ThemeAwareLogoProps) {
   const { mode } = React.useContext(ColorModeContext);
 
   const logoSrc =
@@ -17,7 +25,7 @@ export default function ThemeAwareLogo() {
     <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
       <Image
         src={logoSrc}
-        alt="Rhesis AI Logo"
+        alt={`${productName} logo`}
         width={130}
         height={35}
         style={{ width: 'auto', height: '35px' }}

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useContext } from 'react';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import Box from '@mui/material/Box';
@@ -21,6 +20,7 @@ import SwapHorizOutlinedIcon from '@mui/icons-material/SwapHorizOutlined';
 import Divider from '@mui/material/Divider';
 import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 import { useSidebarCollapse } from '@/components/layout/AppShell';
+import BrandMark from '@/components/common/BrandMark';
 import { UserAvatar } from '@/components/common/UserAvatar';
 import { Can } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
@@ -114,7 +114,7 @@ export function Sidebar() {
   // Support drawer
   const [supportOpen, setSupportOpen] = useState(false);
 
-  const orgName = branding?.title ?? 'Rhesis AI';
+  const orgName = branding?.title ?? branding?.productName ?? 'Rhesis AI';
   const groups = groupNavItems(navigation);
 
   const mainGroups = groups.filter(g => g.type !== 'footer-links') as (
@@ -216,11 +216,10 @@ export function Sidebar() {
                   },
                 }}
               >
-                <Image
-                  src="/logos/rhesis-logo-favicon.svg"
-                  alt="Rhesis logo"
-                  width={40}
-                  height={40}
+                <BrandMark
+                  src={branding?.iconUrl}
+                  size={40}
+                  alt={`${orgName} logo`}
                   priority
                 />
               </ButtonBase>
@@ -268,11 +267,10 @@ export function Sidebar() {
                   justifyContent: 'center',
                 }}
               >
-                <Image
-                  src="/logos/rhesis-logo-favicon.svg"
-                  alt="Rhesis logo"
-                  width={40}
-                  height={40}
+                <BrandMark
+                  src={branding?.iconUrl}
+                  size={40}
+                  alt={`${orgName} logo`}
                   priority
                 />
               </Box>

--- a/apps/frontend/src/components/providers/ThemeProvider.tsx
+++ b/apps/frontend/src/components/providers/ThemeProvider.tsx
@@ -16,6 +16,14 @@ interface ThemeContextProviderProps {
   children: React.ReactNode;
   disableTransitionOnChange?: boolean;
   initialMode?: 'light' | 'dark';
+  /**
+   * Validated `BRAND_PRIMARY_COLOR` for white-label deployments, passed down
+   * from the root layout (a Server Component) because the env var has no
+   * `NEXT_PUBLIC_` prefix and so is unreadable from the client bundle. Server
+   * render and hydration both receive it as a prop, so the two agree and the
+   * theme does not flash Rhesis blue first.
+   */
+  brandColor?: string;
 }
 
 const THEME_MODE_KEY = 'theme-mode';
@@ -31,6 +39,7 @@ export default function ThemeContextProvider({
   children,
   disableTransitionOnChange = false,
   initialMode = 'light',
+  brandColor,
 }: ThemeContextProviderProps) {
   const [mode, setMode] = React.useState<'light' | 'dark'>(initialMode);
 
@@ -95,7 +104,10 @@ export default function ThemeContextProvider({
     [mode, disableTransitionOnChange]
   );
 
-  const theme = React.useMemo(() => createTheme(getDesignTokens(mode)), [mode]);
+  const theme = React.useMemo(
+    () => createTheme(getDesignTokens(mode, brandColor)),
+    [mode, brandColor]
+  );
 
   return (
     <ColorModeContext.Provider value={colorMode}>

--- a/apps/frontend/src/config/__tests__/branding.test.ts
+++ b/apps/frontend/src/config/__tests__/branding.test.ts
@@ -19,8 +19,8 @@ describe('normalizeBrandColor', () => {
   });
 
   it('accepts 6-digit hex and normalizes case', () => {
-    expect(normalizeBrandColor('#005b33')).toBe('#005B33');
-    expect(normalizeBrandColor('  #005B33  ')).toBe('#005B33');
+    expect(normalizeBrandColor('#6a1b9a')).toBe('#6A1B9A');
+    expect(normalizeBrandColor('  #6A1B9A  ')).toBe('#6A1B9A');
   });
 
   it('treats absent and empty values as unset without warning', () => {
@@ -32,7 +32,7 @@ describe('normalizeBrandColor', () => {
 
   it.each([
     ['#fff', 'the 3-digit form'],
-    ['005B33', 'a missing hash'],
+    ['6A1B9A', 'a missing hash'],
     ['green', 'a colour name'],
     ['#00zz33', 'non-hex digits'],
   ])('rejects %s (%s) and warns', color => {
@@ -54,8 +54,8 @@ describe('normalizeFaviconUrl', () => {
 
   it('accepts https URLs', () => {
     expect(
-      normalizeFaviconUrl('https://www.netgo.de/hubfs/netgo_favicon.png')
-    ).toBe('https://www.netgo.de/hubfs/netgo_favicon.png');
+      normalizeFaviconUrl('https://cdn.example.com/assets/favicon.png')
+    ).toBe('https://cdn.example.com/assets/favicon.png');
   });
 
   it('accepts root-relative paths', () => {
@@ -92,12 +92,12 @@ describe('normalizeProductName', () => {
   });
 
   it('accepts a name and trims surrounding whitespace', () => {
-    expect(normalizeProductName('Netgo')).toBe('Netgo');
-    expect(normalizeProductName('  Netgo  ')).toBe('Netgo');
+    expect(normalizeProductName('Acme')).toBe('Acme');
+    expect(normalizeProductName('  Acme  ')).toBe('Acme');
   });
 
   it('preserves spacing and case inside the name', () => {
-    expect(normalizeProductName('netgo AI Studio')).toBe('netgo AI Studio');
+    expect(normalizeProductName('Acme AI Studio')).toBe('Acme AI Studio');
   });
 
   it('falls back to the default when unset', () => {
@@ -127,14 +127,14 @@ describe('getServerBranding', () => {
   });
 
   it('reads every variable from the environment', () => {
-    process.env.BRAND_PRIMARY_COLOR = '#005B33';
+    process.env.BRAND_PRIMARY_COLOR = '#6A1B9A';
     process.env.BRAND_FAVICON_URL = 'https://example.com/fav.png';
-    process.env.BRAND_PRODUCT_NAME = 'Netgo';
+    process.env.BRAND_PRODUCT_NAME = 'Acme';
 
     expect(getServerBranding()).toEqual({
-      primaryColor: '#005B33',
+      primaryColor: '#6A1B9A',
       faviconUrl: 'https://example.com/fav.png',
-      productName: 'Netgo',
+      productName: 'Acme',
       isDefaultProductName: false,
     });
   });

--- a/apps/frontend/src/config/__tests__/branding.test.ts
+++ b/apps/frontend/src/config/__tests__/branding.test.ts
@@ -1,0 +1,161 @@
+import {
+  DEFAULT_FAVICON_URL,
+  DEFAULT_PRODUCT_NAME,
+  getServerBranding,
+  normalizeBrandColor,
+  normalizeFaviconUrl,
+  normalizeProductName,
+} from '../branding';
+
+describe('normalizeBrandColor', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('accepts 6-digit hex and normalizes case', () => {
+    expect(normalizeBrandColor('#005b33')).toBe('#005B33');
+    expect(normalizeBrandColor('  #005B33  ')).toBe('#005B33');
+  });
+
+  it('treats absent and empty values as unset without warning', () => {
+    expect(normalizeBrandColor(undefined)).toBeUndefined();
+    expect(normalizeBrandColor('')).toBeUndefined();
+    expect(normalizeBrandColor('   ')).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['#fff', 'the 3-digit form'],
+    ['005B33', 'a missing hash'],
+    ['green', 'a colour name'],
+    ['#00zz33', 'non-hex digits'],
+  ])('rejects %s (%s) and warns', color => {
+    expect(normalizeBrandColor(color)).toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('normalizeFaviconUrl', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('accepts https URLs', () => {
+    expect(
+      normalizeFaviconUrl('https://www.netgo.de/hubfs/netgo_favicon.png')
+    ).toBe('https://www.netgo.de/hubfs/netgo_favicon.png');
+  });
+
+  it('accepts root-relative paths', () => {
+    expect(normalizeFaviconUrl('/logos/custom.png')).toBe('/logos/custom.png');
+  });
+
+  it('falls back to the default when unset', () => {
+    expect(normalizeFaviconUrl(undefined)).toBe(DEFAULT_FAVICON_URL);
+    expect(normalizeFaviconUrl('')).toBe(DEFAULT_FAVICON_URL);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['http://example.com/favicon.png', 'plain http would be mixed content'],
+    ['javascript:alert(1)', 'a script URL must never reach <head>'],
+    ['data:image/png;base64,AAAA', 'other schemes are not allowed'],
+    ['not a url', 'unparseable'],
+    ['example.com/favicon.png', 'scheme-less is unparseable'],
+  ])('rejects %s (%s)', url => {
+    expect(normalizeFaviconUrl(url)).toBe(DEFAULT_FAVICON_URL);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('normalizeProductName', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('accepts a name and trims surrounding whitespace', () => {
+    expect(normalizeProductName('Netgo')).toBe('Netgo');
+    expect(normalizeProductName('  Netgo  ')).toBe('Netgo');
+  });
+
+  it('preserves spacing and case inside the name', () => {
+    expect(normalizeProductName('netgo AI Studio')).toBe('netgo AI Studio');
+  });
+
+  it('falls back to the default when unset', () => {
+    expect(normalizeProductName(undefined)).toBe(DEFAULT_PRODUCT_NAME);
+    expect(normalizeProductName('   ')).toBe(DEFAULT_PRODUCT_NAME);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('rejects an over-long name rather than truncating it', () => {
+    expect(normalizeProductName('N'.repeat(61))).toBe(DEFAULT_PRODUCT_NAME);
+    expect(warn).toHaveBeenCalled();
+    expect(normalizeProductName('N'.repeat(60))).toHaveLength(60);
+  });
+});
+
+describe('getServerBranding', () => {
+  const original = {
+    color: process.env.BRAND_PRIMARY_COLOR,
+    favicon: process.env.BRAND_FAVICON_URL,
+    product: process.env.BRAND_PRODUCT_NAME,
+  };
+
+  afterEach(() => {
+    process.env.BRAND_PRIMARY_COLOR = original.color;
+    process.env.BRAND_FAVICON_URL = original.favicon;
+    process.env.BRAND_PRODUCT_NAME = original.product;
+  });
+
+  it('reads every variable from the environment', () => {
+    process.env.BRAND_PRIMARY_COLOR = '#005B33';
+    process.env.BRAND_FAVICON_URL = 'https://example.com/fav.png';
+    process.env.BRAND_PRODUCT_NAME = 'Netgo';
+
+    expect(getServerBranding()).toEqual({
+      primaryColor: '#005B33',
+      faviconUrl: 'https://example.com/fav.png',
+      productName: 'Netgo',
+      isDefaultProductName: false,
+    });
+  });
+
+  it('reports Rhesis defaults when nothing is configured', () => {
+    delete process.env.BRAND_PRIMARY_COLOR;
+    delete process.env.BRAND_FAVICON_URL;
+    delete process.env.BRAND_PRODUCT_NAME;
+
+    expect(getServerBranding()).toEqual({
+      primaryColor: undefined,
+      faviconUrl: DEFAULT_FAVICON_URL,
+      productName: DEFAULT_PRODUCT_NAME,
+      isDefaultProductName: true,
+    });
+  });
+
+  it('flags an explicit "Rhesis AI" as the default, not an override', () => {
+    // Keeps the Rhesis marketing description on a deployment that sets the name
+    // to what it already was.
+    process.env.BRAND_PRODUCT_NAME = 'Rhesis AI';
+    expect(getServerBranding().isDefaultProductName).toBe(true);
+  });
+});

--- a/apps/frontend/src/config/branding.ts
+++ b/apps/frontend/src/config/branding.ts
@@ -1,0 +1,130 @@
+/**
+ * Runtime branding overrides, for deployments that need their own colour and
+ * favicon (white-label / on-prem installs).
+ *
+ * Both values are plain env vars, deliberately *without* the `NEXT_PUBLIC_`
+ * prefix: that prefix inlines a value into the client bundle at build time,
+ * which would mean one Docker image per customer. These are read on the server
+ * at request time and handed to the client via props and `window.__ENV__` —
+ * the same route `API_BASE_URL` already takes (see `url-resolver.ts`).
+ *
+ * In Kubernetes they arrive from the chart's ConfigMap, which every app
+ * deployment already loads with `envFrom`. Neither value is a secret — both
+ * end up visible in the served HTML — so they do not belong in Secret Manager.
+ */
+
+/** Shipped Rhesis favicon, used whenever no override is configured. */
+export const DEFAULT_FAVICON_URL = '/logos/rhesis-logo-favicon.svg';
+
+/** Product name in page titles, the sidebar and image alt text. */
+export const DEFAULT_PRODUCT_NAME = 'Rhesis AI';
+
+/** Long enough for a real product name, short enough to keep `<title>` sane. */
+const MAX_PRODUCT_NAME_LENGTH = 60;
+
+/** 6-digit hex only: MUI's colour manipulators need a parseable value, and the
+ * 3-digit form would silently widen what deployments can put in a values file. */
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+export interface Branding {
+  /** Undefined means "use the built-in Rhesis palette", not "no colour". */
+  primaryColor?: string;
+  faviconUrl: string;
+  productName: string;
+  /** True when `productName` is the Rhesis default, so callers can keep
+   * Rhesis-specific copy (the marketing description) out of a branded build. */
+  isDefaultProductName: boolean;
+}
+
+/**
+ * Validates a configured brand colour, returning undefined when it is absent
+ * or malformed. A typo in a values file must fall back to the Rhesis palette
+ * rather than take the app down or paint half the UI `undefined`.
+ */
+export function normalizeBrandColor(
+  value: string | undefined | null
+): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+
+  if (!HEX_COLOR_PATTERN.test(trimmed)) {
+    console.warn(
+      `[branding] Ignoring BRAND_PRIMARY_COLOR "${trimmed}": expected a 6-digit hex colour such as #005B33.`
+    );
+    return undefined;
+  }
+
+  return trimmed.toUpperCase();
+}
+
+/**
+ * Validates a configured favicon URL, falling back to the Rhesis default.
+ *
+ * Only absolute `https://` URLs and root-relative paths are accepted. `http://`
+ * is rejected because it would make an https page issue a mixed-content
+ * request, and rejecting every other scheme keeps `javascript:` out of an
+ * attribute we render into `<head>`.
+ */
+export function normalizeFaviconUrl(value: string | undefined | null): string {
+  const trimmed = value?.trim();
+  if (!trimmed) return DEFAULT_FAVICON_URL;
+
+  if (trimmed.startsWith('/')) return trimmed;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    console.warn(
+      `[branding] Ignoring BRAND_FAVICON_URL "${trimmed}": not a valid URL.`
+    );
+    return DEFAULT_FAVICON_URL;
+  }
+
+  if (parsed.protocol !== 'https:') {
+    console.warn(
+      `[branding] Ignoring BRAND_FAVICON_URL "${trimmed}": only https:// URLs and root-relative paths are allowed.`
+    );
+    return DEFAULT_FAVICON_URL;
+  }
+
+  return parsed.toString();
+}
+
+/**
+ * Validates a configured product name — the `%s | <name>` suffix on every page
+ * title, and the fallback shown in the sidebar before the organisation loads.
+ *
+ * Over-long values are rejected rather than truncated: a cut-off name in the
+ * browser tab is harder to diagnose than the default reappearing next to a
+ * warning.
+ */
+export function normalizeProductName(value: string | undefined | null): string {
+  const trimmed = value?.trim();
+  if (!trimmed) return DEFAULT_PRODUCT_NAME;
+
+  if (trimmed.length > MAX_PRODUCT_NAME_LENGTH) {
+    console.warn(
+      `[branding] Ignoring BRAND_PRODUCT_NAME: ${trimmed.length} characters exceeds the ${MAX_PRODUCT_NAME_LENGTH}-character limit.`
+    );
+    return DEFAULT_PRODUCT_NAME;
+  }
+
+  return trimmed;
+}
+
+/**
+ * Reads branding from the environment. Server-side only — the env vars carry no
+ * `NEXT_PUBLIC_` prefix, so in a client bundle every read compiles to
+ * `undefined` and this would quietly report the defaults.
+ */
+export function getServerBranding(): Branding {
+  const productName = normalizeProductName(process.env.BRAND_PRODUCT_NAME);
+
+  return {
+    primaryColor: normalizeBrandColor(process.env.BRAND_PRIMARY_COLOR),
+    faviconUrl: normalizeFaviconUrl(process.env.BRAND_FAVICON_URL),
+    productName,
+    isDefaultProductName: productName === DEFAULT_PRODUCT_NAME,
+  };
+}

--- a/apps/frontend/src/config/branding.ts
+++ b/apps/frontend/src/config/branding.ts
@@ -1,15 +1,16 @@
 /**
- * Runtime branding overrides, for deployments that need their own colour and
- * favicon (white-label / on-prem installs).
+ * Runtime branding overrides, for deployments that need their own colour, icon
+ * and product name (white-label / on-prem installs).
  *
- * Both values are plain env vars, deliberately *without* the `NEXT_PUBLIC_`
+ * All three are plain env vars, deliberately *without* the `NEXT_PUBLIC_`
  * prefix: that prefix inlines a value into the client bundle at build time,
- * which would mean one Docker image per customer. These are read on the server
- * at request time and handed to the client via props and `window.__ENV__` —
- * the same route `API_BASE_URL` already takes (see `url-resolver.ts`).
+ * which would mean one Docker image per deployment. These are read on the
+ * server at request time and handed to the client via props and
+ * `window.__ENV__` — the same route `API_BASE_URL` already takes (see
+ * `url-resolver.ts`).
  *
  * In Kubernetes they arrive from the chart's ConfigMap, which every app
- * deployment already loads with `envFrom`. Neither value is a secret — both
+ * deployment already loads with `envFrom`. None of them is a secret — all three
  * end up visible in the served HTML — so they do not belong in Secret Manager.
  */
 
@@ -49,7 +50,7 @@ export function normalizeBrandColor(
 
   if (!HEX_COLOR_PATTERN.test(trimmed)) {
     console.warn(
-      `[branding] Ignoring BRAND_PRIMARY_COLOR "${trimmed}": expected a 6-digit hex colour such as #005B33.`
+      `[branding] Ignoring BRAND_PRIMARY_COLOR "${trimmed}": expected a 6-digit hex colour such as #6A1B9A.`
     );
     return undefined;
   }

--- a/apps/frontend/src/styles/__tests__/brand-palette.test.ts
+++ b/apps/frontend/src/styles/__tests__/brand-palette.test.ts
@@ -7,8 +7,8 @@ import {
 } from '../brand-palette';
 import { getDesignTokens } from '../theme';
 
-/** netgo green — the colour that motivated this feature. */
-const BRAND = '#005B33';
+/** A dark brand colour, far enough from Rhesis blue to make swaps obvious. */
+const BRAND = '#6A1B9A';
 /** A pale brand colour, to prove contrast is computed and not assumed white. */
 const PALE_BRAND = '#FDD803';
 

--- a/apps/frontend/src/styles/__tests__/brand-palette.test.ts
+++ b/apps/frontend/src/styles/__tests__/brand-palette.test.ts
@@ -1,0 +1,152 @@
+import { getContrastRatio } from '@mui/system/colorManipulator';
+import {
+  contrastTextFor,
+  deriveBrandAccents,
+  deriveBrandPrimary,
+  deriveBrandSurfaces,
+} from '../brand-palette';
+import { getDesignTokens } from '../theme';
+
+/** netgo green — the colour that motivated this feature. */
+const BRAND = '#005B33';
+/** A pale brand colour, to prove contrast is computed and not assumed white. */
+const PALE_BRAND = '#FDD803';
+
+describe('contrastTextFor', () => {
+  it('uses white on a dark brand colour', () => {
+    expect(contrastTextFor(BRAND)).toBe('#FFFFFF');
+  });
+
+  it('uses near-black on a pale brand colour', () => {
+    expect(contrastTextFor(PALE_BRAND)).toBe('#1A1A1A');
+  });
+
+  it('always clears the WCAG UI-component ratio', () => {
+    for (const color of [BRAND, PALE_BRAND, '#808080', '#FFFFFF', '#000000']) {
+      expect(
+        getContrastRatio(color, contrastTextFor(color))
+      ).toBeGreaterThanOrEqual(3);
+    }
+  });
+});
+
+describe('deriveBrandPrimary', () => {
+  it('keeps the brand colour as light-mode main', () => {
+    expect(deriveBrandPrimary(BRAND, 'light').main).toBe(BRAND);
+  });
+
+  it('lifts main and demotes the raw brand colour in dark mode', () => {
+    const dark = deriveBrandPrimary(BRAND, 'dark');
+    expect(dark.dark).toBe(BRAND);
+    expect(dark.main).not.toBe(BRAND);
+    // Lighter against a dark surface, matching how the Rhesis dark palette
+    // promotes #33A6CB over #0080AF.
+    expect(getContrastRatio(dark.main, '#0D1117')).toBeGreaterThan(
+      getContrastRatio(BRAND, '#0D1117')
+    );
+  });
+
+  it('reproduces the hand-picked Rhesis shades from #0080AF', () => {
+    // The factors in brand-palette.ts were fitted to the Figma palette; if
+    // someone retunes them, this is the check that says how far they drifted.
+    const light = deriveBrandPrimary('#0080AF', 'light');
+    // Designed #005F82 is rgb(0, 95, 130) — one unit per channel away.
+    expect(light.dark).toBe('rgb(0, 94, 129)');
+  });
+
+  it('picks readable button text for a pale brand colour', () => {
+    expect(deriveBrandPrimary(PALE_BRAND, 'light').contrastText).toBe(
+      '#1A1A1A'
+    );
+  });
+});
+
+describe('deriveBrandSurfaces', () => {
+  it('lands near the designed Rhesis tints for #0080AF', () => {
+    const surfaces = deriveBrandSurfaces('#0080AF');
+    // Designed #F2F9FD is rgb(242, 249, 253) and #E4F2FA is rgb(228, 242, 250);
+    // the derived tints sit within a few units of both.
+    expect(surfaces.light1).toBe('rgb(242, 248, 251)');
+    expect(surfaces.light2).toBe('rgb(229, 242, 247)');
+  });
+
+  it('orders the tints from lightest to strongest', () => {
+    const s = deriveBrandSurfaces(BRAND);
+    const contrastOnWhite = (c: string) => getContrastRatio(c, '#FFFFFF');
+    expect(contrastOnWhite(s.light1)).toBeLessThan(contrastOnWhite(s.light2));
+    expect(contrastOnWhite(s.light2)).toBeLessThan(contrastOnWhite(s.light3));
+    expect(contrastOnWhite(s.light3)).toBeLessThan(contrastOnWhite(s.light4));
+  });
+});
+
+describe('deriveBrandAccents', () => {
+  it('returns the Figma literals verbatim when no brand colour is set', () => {
+    // These are the exact strings the component overrides used before the
+    // brand hook existed, so the default theme is untouched.
+    expect(deriveBrandAccents('light')).toEqual({
+      main: '#0080AF',
+      mainHover: '#005F82',
+      contrastText: '#FFFFFF',
+      onSurface: '#0080AF',
+      softHover: 'rgba(0, 128, 175, 0.04)',
+    });
+    expect(deriveBrandAccents('dark').onSurface).toBe('#33A6CB');
+  });
+
+  it('uses the brand colour for solid fills in both modes', () => {
+    expect(deriveBrandAccents('light', BRAND).main).toBe(BRAND);
+    expect(deriveBrandAccents('dark', BRAND).main).toBe(BRAND);
+  });
+
+  it('lightens only the on-surface colour for dark mode', () => {
+    expect(deriveBrandAccents('dark', BRAND).onSurface).not.toBe(BRAND);
+    expect(deriveBrandAccents('light', BRAND).onSurface).toBe(BRAND);
+  });
+});
+
+describe('getDesignTokens brand integration', () => {
+  it('is byte-identical to the Rhesis palette when no brand colour is passed', () => {
+    // The regression guard: adding the parameter must not shift the default look.
+    for (const mode of ['light', 'dark'] as const) {
+      const palette = getDesignTokens(mode).palette;
+      expect(palette.primary).toEqual(
+        mode === 'light'
+          ? {
+              main: '#0080AF',
+              light: '#33A6CB',
+              dark: '#005F82',
+              contrastText: '#FFFFFF',
+            }
+          : {
+              main: '#33A6CB',
+              light: '#66C2DC',
+              dark: '#0080AF',
+              contrastText: '#FFFFFF',
+            }
+      );
+      expect(palette.brandColor).toBeUndefined();
+    }
+
+    expect(getDesignTokens('light').palette.background).toMatchObject({
+      light1: '#F2F9FD',
+      light2: '#E4F2FA',
+      light3: '#C2E5F5',
+      light4: '#33A6CB',
+    });
+  });
+
+  it('applies a brand colour to the palette and exposes the raw value', () => {
+    const palette = getDesignTokens('light', BRAND).palette;
+    expect(palette.primary.main).toBe(BRAND);
+    expect(palette.brandColor).toBe(BRAND);
+    expect(palette.background.light4).not.toBe('#33A6CB');
+  });
+
+  it('leaves dark-mode background tints as greys', () => {
+    // Only light mode's light1-4 are brand-tinted; dark's are true greys.
+    expect(getDesignTokens('dark', BRAND).palette.background).toMatchObject({
+      light1: '#0D1117',
+      light2: '#161B22',
+    });
+  });
+});

--- a/apps/frontend/src/styles/brand-palette.ts
+++ b/apps/frontend/src/styles/brand-palette.ts
@@ -1,0 +1,142 @@
+/**
+ * Derives a primary palette from a single configured brand colour, for
+ * deployments that set `BRAND_PRIMARY_COLOR` (see `config/branding.ts`).
+ *
+ * The lighten/darken factors here are not arbitrary — they are the ones that
+ * reproduce the hand-picked Rhesis palette from `#0080AF` almost exactly
+ * (`darken(0.26)` lands on `#005F82`, `lighten(0.95)` on `#F2F8FB` against a
+ * designed `#F2F9FD`). So a custom colour gets the same relationships the
+ * Figma palette was built with, rather than a fresh guess.
+ *
+ * Imports the colour helpers from `@mui/system/colorManipulator` rather than
+ * `@mui/material/styles`: they are pure functions, and the deep path keeps this
+ * module importable from server components too.
+ */
+import {
+  alpha,
+  darken,
+  getContrastRatio,
+  lighten,
+} from '@mui/system/colorManipulator';
+
+/** The Rhesis primary. Also the reference point the factors below were fitted to. */
+const RHESIS_PRIMARY = '#0080AF';
+
+/** Dark text for light brand colours — matches `text.secondary` in the theme. */
+const DARK_CONTRAST_TEXT = '#1A1A1A';
+const LIGHT_CONTRAST_TEXT = '#FFFFFF';
+
+/** MUI's own default `contrastThreshold`, i.e. the WCAG ratio for UI components
+ * and large text. Buttons and chips are the main consumers. */
+const CONTRAST_THRESHOLD = 3;
+
+export interface BrandPrimary {
+  main: string;
+  light: string;
+  dark: string;
+  contrastText: string;
+}
+
+export interface BrandSurfaces {
+  light1: string;
+  light2: string;
+  light3: string;
+  light4: string;
+}
+
+/**
+ * Picks white or near-black text for a background, so a pale brand colour
+ * (yellow, mint) still gets readable button labels instead of white-on-white.
+ */
+export function contrastTextFor(background: string): string {
+  return getContrastRatio(background, LIGHT_CONTRAST_TEXT) >= CONTRAST_THRESHOLD
+    ? LIGHT_CONTRAST_TEXT
+    : DARK_CONTRAST_TEXT;
+}
+
+/**
+ * Builds `palette.primary` for one mode.
+ *
+ * Dark mode shifts `main` lighter and keeps the raw brand colour as `dark`,
+ * mirroring how the Rhesis dark palette promotes `#33A6CB` to `main` and
+ * demotes `#0080AF` — a saturated brand colour is hard to read on a dark
+ * surface at full strength.
+ */
+export function deriveBrandPrimary(
+  brandColor: string,
+  mode: 'light' | 'dark'
+): BrandPrimary {
+  const main = mode === 'light' ? brandColor : lighten(brandColor, 0.25);
+
+  return {
+    main,
+    light: lighten(brandColor, mode === 'light' ? 0.25 : 0.45),
+    dark: mode === 'light' ? darken(brandColor, 0.26) : brandColor,
+    contrastText: contrastTextFor(main),
+  };
+}
+
+/**
+ * Builds the light-mode `background.light1`–`light4` tints.
+ *
+ * These four are brand-tinted surfaces, not greys — 12 components read them for
+ * hovers, selected rows and callouts. Leaving them at the Rhesis blues would
+ * put a custom-coloured button on a blue panel, which reads as a half-finished
+ * rebrand. Dark mode's equivalents are true greys and stay untouched.
+ */
+export function deriveBrandSurfaces(brandColor: string): BrandSurfaces {
+  return {
+    light1: lighten(brandColor, 0.95),
+    light2: lighten(brandColor, 0.9),
+    light3: lighten(brandColor, 0.75),
+    light4: lighten(brandColor, 0.25),
+  };
+}
+
+export interface BrandAccents {
+  /** Solid brand fill: app bar, contained primary button, active pill. */
+  main: string;
+  /** Hover state for a solid brand fill. */
+  mainHover: string;
+  /** Text/icon colour placed on top of `main`. */
+  contrastText: string;
+  /** Brand colour readable *against* the current mode's surface — used for
+   * outlined/text buttons, checkboxes and focus borders. */
+  onSurface: string;
+  /** Barely-there wash for text-button hover. */
+  softHover: string;
+}
+
+/**
+ * Resolves the brand-dependent colours that the `components` style overrides
+ * use directly instead of going through `palette.primary`.
+ *
+ * Without this, a deployment's custom colour would reach buttons via the
+ * palette but leave the app bar, checkboxes, pill toggles and input focus
+ * borders on Rhesis blue. Passing no `brandColor` returns the exact Figma
+ * literals those overrides were written with — including `softHover`, where
+ * `alpha(#0080AF, 0.04)` reproduces the original `rgba(0, 128, 175, 0.04)`
+ * string character for character.
+ *
+ * Chart palettes are deliberately not derived: a readable series palette needs
+ * distinguishable hues, not tints of one colour.
+ */
+export function deriveBrandAccents(
+  mode: 'light' | 'dark',
+  brandColor?: string
+): BrandAccents {
+  const main = brandColor ?? RHESIS_PRIMARY;
+
+  return {
+    main,
+    mainHover: brandColor ? darken(brandColor, 0.26) : '#005F82',
+    contrastText: contrastTextFor(main),
+    onSurface:
+      mode === 'light'
+        ? main
+        : brandColor
+          ? lighten(brandColor, 0.25)
+          : '#33A6CB',
+    softHover: alpha(main, 0.04),
+  };
+}

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -13,11 +13,33 @@ import {
   ELEVATION,
   FAB_GROUP_GAP,
 } from './theme-constants';
+import {
+  contrastTextFor,
+  deriveBrandAccents,
+  deriveBrandPrimary,
+  deriveBrandSurfaces,
+} from './brand-palette';
 export { GREYSCALE, BORDER_RADIUS, BACKDROP_COLORS, ELEVATION, FAB_GROUP_GAP };
 
-// Define theme settings for both light and dark modes
-const getDesignTokens = (mode: PaletteMode) => {
+/**
+ * Define theme settings for both light and dark modes.
+ *
+ * `brandColor` overrides the Rhesis primary for white-label deployments
+ * (`BRAND_PRIMARY_COLOR`, threaded down from the root layout). When it is
+ * omitted every token below is the literal Figma value, so the default Rhesis
+ * theme is unaffected by this parameter existing.
+ */
+const getDesignTokens = (mode: PaletteMode, brandColor?: string) => {
   const gs = mode === 'light' ? GREYSCALE.light : GREYSCALE.dark;
+  const brandPrimary = brandColor
+    ? deriveBrandPrimary(brandColor, mode)
+    : undefined;
+  const brandSurfaces = brandColor
+    ? deriveBrandSurfaces(brandColor)
+    : undefined;
+  // Brand colours for the `components` overrides further down, which set
+  // colours directly rather than reading `palette.primary`.
+  const accent = deriveBrandAccents(mode, brandColor);
 
   return {
     palette: {
@@ -25,7 +47,7 @@ const getDesignTokens = (mode: PaletteMode) => {
       ...(mode === 'light'
         ? {
             // Light mode - Rhesis AI colors
-            primary: {
+            primary: brandPrimary ?? {
               main: '#0080AF', // Figma primary blue
               light: '#33A6CB', // lighter tint
               dark: '#005F82', // darker shade
@@ -40,10 +62,12 @@ const getDesignTokens = (mode: PaletteMode) => {
             background: {
               default: BACKGROUND_DEFAULT.light,
               paper: '#FFFFFF',
-              light1: '#F2F9FD',
-              light2: '#E4F2FA',
-              light3: '#C2E5F5',
-              light4: '#33A6CB',
+              ...(brandSurfaces ?? {
+                light1: '#F2F9FD',
+                light2: '#E4F2FA',
+                light3: '#C2E5F5',
+                light4: '#33A6CB',
+              }),
             },
             text: {
               primary: '#3D3D3D',
@@ -64,7 +88,7 @@ const getDesignTokens = (mode: PaletteMode) => {
           }
         : {
             // Dark mode
-            primary: {
+            primary: brandPrimary ?? {
               main: '#33A6CB', // slightly lighter for dark bg readability
               light: '#66C2DC',
               dark: '#0080AF',
@@ -103,6 +127,7 @@ const getDesignTokens = (mode: PaletteMode) => {
           }),
       // Greyscale ramp available on palette for both modes
       greyscale: gs,
+      brandColor,
     },
     shape: {
       borderRadius: 8,
@@ -280,9 +305,10 @@ const getDesignTokens = (mode: PaletteMode) => {
       MuiAppBar: {
         styleOverrides: {
           root: {
-            backgroundColor: mode === 'light' ? '#0080AF' : '#161B22',
+            backgroundColor: mode === 'light' ? accent.main : '#161B22',
             '& .MuiSvgIcon-root': {
-              color: '#FFFFFF',
+              // Dark mode's bar is grey, so its icons stay white regardless.
+              color: mode === 'light' ? accent.contrastText : '#FFFFFF',
             },
           },
         },
@@ -305,9 +331,9 @@ const getDesignTokens = (mode: PaletteMode) => {
       MuiDataGrid: {
         styleOverrides: {
           checkboxInput: {
-            color: mode === 'light' ? '#0080AF' : '#33A6CB',
+            color: accent.onSurface,
             '&.Mui-checked, &.MuiCheckbox-indeterminate': {
-              color: mode === 'light' ? '#0080AF' : '#33A6CB',
+              color: accent.onSurface,
             },
           },
         },
@@ -338,9 +364,9 @@ const getDesignTokens = (mode: PaletteMode) => {
             fontWeight: 600,
             borderRadius: 8,
             '&.MuiButton-containedPrimary': {
-              backgroundColor: '#0080AF',
-              color: '#FFFFFF',
-              '&:hover': { backgroundColor: '#005F82' },
+              backgroundColor: accent.main,
+              color: accent.contrastText,
+              '&:hover': { backgroundColor: accent.mainHover },
               '&.Mui-disabled': { backgroundColor: 'unset', color: 'unset' },
             },
             '&.MuiButton-containedSecondary': {
@@ -349,13 +375,13 @@ const getDesignTokens = (mode: PaletteMode) => {
               '&:hover': { backgroundColor: '#FDD803', color: '#1A1A1A' },
             },
             '&.MuiButton-outlinedPrimary': {
-              color: mode === 'dark' ? '#33A6CB' : '#0080AF',
-              borderColor: mode === 'dark' ? '#33A6CB' : '#0080AF',
+              color: accent.onSurface,
+              borderColor: accent.onSurface,
               backgroundColor: 'transparent',
               '&:hover': {
-                backgroundColor: mode === 'dark' ? '#33A6CB' : '#0080AF',
-                color: '#FFFFFF',
-                borderColor: mode === 'dark' ? '#33A6CB' : '#0080AF',
+                backgroundColor: accent.onSurface,
+                color: contrastTextFor(accent.onSurface),
+                borderColor: accent.onSurface,
               },
             },
             '&.MuiButton-outlinedSecondary': {
@@ -369,10 +395,10 @@ const getDesignTokens = (mode: PaletteMode) => {
               },
             },
             '&.MuiButton-textPrimary': {
-              color: mode === 'light' ? '#0080AF' : '#33A6CB',
+              color: accent.onSurface,
               '&:hover': {
                 backgroundColor:
-                  mode === 'light' ? 'rgba(0, 128, 175, 0.04)' : '#1F242B',
+                  mode === 'light' ? accent.softHover : '#1F242B',
               },
             },
           },
@@ -394,9 +420,9 @@ const getDesignTokens = (mode: PaletteMode) => {
                 mode === 'light' ? GREYSCALE.light.body : GREYSCALE.dark.body,
               backgroundColor: 'transparent',
               '&.active, &[aria-pressed="true"]': {
-                backgroundColor: '#0080AF',
-                color: '#FFFFFF',
-                borderColor: '#0080AF',
+                backgroundColor: accent.main,
+                color: accent.contrastText,
+                borderColor: accent.main,
               },
               '&:hover': {
                 backgroundColor:
@@ -541,7 +567,7 @@ const getDesignTokens = (mode: PaletteMode) => {
                     : GREYSCALE.dark.border,
               },
               '&:hover fieldset': {
-                borderColor: '#0080AF',
+                borderColor: accent.onSurface,
               },
             },
             ...(mode === 'dark' && {
@@ -727,6 +753,17 @@ declare module '@mui/material/styles' {
       surface2: string;
       fieldSurface: string;
     };
+    /**
+     * The raw configured `BRAND_PRIMARY_COLOR`, before any per-mode lightening.
+     * Undefined on the default Rhesis theme.
+     *
+     * Carried on the palette so consumers that need the *unshifted* brand
+     * colour — the auth pages, which run their own palette — can read it from
+     * the ambient theme. That keeps server render and hydration in agreement;
+     * reading `window.__ENV__` in those components instead would render Rhesis
+     * blue on the server and swap after hydration.
+     */
+    brandColor?: string;
   }
   interface PaletteOptions {
     greyscale?: {
@@ -739,6 +776,7 @@ declare module '@mui/material/styles' {
       surface2?: string;
       fieldSurface?: string;
     };
+    brandColor?: string;
   }
 }
 

--- a/apps/frontend/src/types/env.d.ts
+++ b/apps/frontend/src/types/env.d.ts
@@ -4,6 +4,10 @@ declare global {
   interface Window {
     __ENV__?: {
       apiBaseUrl: string;
+      /** Absent unless the deployment sets `BRAND_PRIMARY_COLOR`. */
+      brandPrimaryColor?: string;
+      brandFaviconUrl?: string;
+      brandProductName?: string;
     };
   }
 }

--- a/apps/frontend/src/types/navigation.ts
+++ b/apps/frontend/src/types/navigation.ts
@@ -55,8 +55,18 @@ export type NavigationItem =
   | NavigationActionItem;
 
 export interface BrandingProps {
+  /** Organisation name, falling back to `productName` before it resolves. */
   title: string;
   logo: ReactNode;
+  /**
+   * Brand mark shown in the sidebar — `BRAND_FAVICON_URL` when a deployment
+   * sets one, otherwise the shipped Rhesis icon. Threaded through here rather
+   * than read from `window.__ENV__` so the server and client render the same
+   * `src` and hydration stays quiet.
+   */
+  iconUrl?: string;
+  /** `BRAND_PRODUCT_NAME`, for alt text and labels. */
+  productName?: string;
   homeUrl?: string;
 }
 

--- a/charts/rhesis/templates/configmap.yaml
+++ b/charts/rhesis/templates/configmap.yaml
@@ -39,6 +39,12 @@ data:
   NEXT_PUBLIC_QUICK_START: {{ .Values.config.nextPublicQuickStart | quote }}
   NEXT_PUBLIC_SUPPORT_EMAIL: {{ .Values.config.nextPublicSupportEmail | quote }}
   ONBOARDING_VIDEO_URL: {{ .Values.config.onboardingVideoUrl | quote }}
+  # Branding overrides. Not NEXT_PUBLIC_* on purpose: that prefix bakes a value
+  # into the client bundle at build time, which would mean one image per
+  # deployment. The frontend reads these per request instead.
+  BRAND_PRIMARY_COLOR: {{ .Values.config.brandPrimaryColor | quote }}
+  BRAND_FAVICON_URL: {{ .Values.config.brandFaviconUrl | quote }}
+  BRAND_PRODUCT_NAME: {{ .Values.config.brandProductName | quote }}
 
   # -------------------------------------------------------------------------
   # Backend

--- a/charts/rhesis/values.yaml
+++ b/charts/rhesis/values.yaml
@@ -75,11 +75,11 @@ config:
   # Branding — both empty means the built-in Rhesis look. Set them to rebrand a
   # deployment without rebuilding the image; the frontend reads them at request
   # time and falls back to the defaults if a value is malformed.
-  # brandPrimaryColor: 6-digit hex, e.g. "#005B33". Drives the primary palette,
+  # brandPrimaryColor: 6-digit hex, e.g. "#6A1B9A". Drives the primary palette,
   #   app bar, buttons, brand-tinted surfaces and the sign-in screen accent.
   # brandFaviconUrl: https:// URL or a root-relative path, e.g.
   #   "https://www.example.com/favicon.png". Also used as the sidebar brand mark.
-  # brandProductName: replaces "Rhesis AI" in page titles, e.g. "Netgo".
+  # brandProductName: replaces "Rhesis AI" in page titles, e.g. "Acme".
   brandPrimaryColor: ""
   brandFaviconUrl: ""
   brandProductName: ""

--- a/charts/rhesis/values.yaml
+++ b/charts/rhesis/values.yaml
@@ -71,6 +71,18 @@ config:
   nextPublicQuickStart: "false"
   nextPublicSupportEmail: "hello@rhesis.ai"
   onboardingVideoUrl: ""
+
+  # Branding — both empty means the built-in Rhesis look. Set them to rebrand a
+  # deployment without rebuilding the image; the frontend reads them at request
+  # time and falls back to the defaults if a value is malformed.
+  # brandPrimaryColor: 6-digit hex, e.g. "#005B33". Drives the primary palette,
+  #   app bar, buttons, brand-tinted surfaces and the sign-in screen accent.
+  # brandFaviconUrl: https:// URL or a root-relative path, e.g.
+  #   "https://www.example.com/favicon.png". Also used as the sidebar brand mark.
+  # brandProductName: replaces "Rhesis AI" in page titles, e.g. "Netgo".
+  brandPrimaryColor: ""
+  brandFaviconUrl: ""
+  brandProductName: ""
   # Backend
   rhesisBaseUrl: ""
   frontendUrl: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,10 @@ x-telemetry-config: &telemetry-config
 x-nextjs-frontend: &nextjs-frontend
   NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required, no safe default}
   NEXT_TELEMETRY_DISABLED: 1
+  # Optional branding overrides, read at request time — see .env.example
+  BRAND_PRIMARY_COLOR: ${BRAND_PRIMARY_COLOR:-}
+  BRAND_FAVICON_URL: ${BRAND_FAVICON_URL:-}
+  BRAND_PRODUCT_NAME: ${BRAND_PRODUCT_NAME:-}
 
 
 services:

--- a/docs/content/docs/deployment/environment-variables.mdx
+++ b/docs/content/docs/deployment/environment-variables.mdx
@@ -35,6 +35,32 @@ These four secrets have no default; the stack refuses to start if any is unset.
 Ports are the host bind ports and are independent of the URLs — behind a reverse proxy the published port
 and the public URL usually differ.
 
+## Branding
+
+Replace the Rhesis colour, icon and product name with your own. All three are read at request time, so
+the same image serves every deployment — no rebuild, and no `NEXT_PUBLIC_` counterpart.
+
+| Variable | Description | Default |
+|---|---|---|
+| `BRAND_PRIMARY_COLOR` | 6-digit hex colour, e.g. `#EE7103`. Drives the primary palette, app bar, buttons, brand-tinted surfaces and the sign-in accent | *(unset — Rhesis blue)* |
+| `BRAND_FAVICON_URL` | `https://` URL or root-relative path, e.g. `https://www.example.com/favicon.png`. Used as the browser-tab icon and as the brand mark in the sidebar, onboarding and sign-in header | `/logos/rhesis-logo-favicon.svg` |
+| `BRAND_PRODUCT_NAME` | Name in page titles (`Architect` becomes `Architect \| Netgo`), the sign-in header and footer, and the sidebar before the organisation loads. Max 60 characters | `Rhesis AI` |
+
+Light and dark shades are derived from the one colour, and button label text switches between white and
+near-black to stay readable — a pale brand colour does not need extra configuration. A malformed value is
+ignored with a warning in the frontend logs and the Rhesis default applies, so a typo cannot break a
+deployment.
+
+Setting `BRAND_PRODUCT_NAME` also drops the Rhesis tagline from the page description and stops the
+sign-in wordmark linking to rhesis.ai.
+
+Three things keep their Rhesis identity on purpose: chart palettes, which need distinguishable hues
+rather than tints of one colour; the sign-in page's background artwork; and the Documentation, Blog and
+GitHub links in the sign-in header.
+
+On Kubernetes, set these through the chart instead — see
+[Kubernetes (Helm)](/docs/deployment/kubernetes-helm).
+
 ## Database
 
 Defaults point at the built-in `postgres` container. Set these to use your own database (see

--- a/docs/content/docs/deployment/environment-variables.mdx
+++ b/docs/content/docs/deployment/environment-variables.mdx
@@ -42,9 +42,9 @@ the same image serves every deployment — no rebuild, and no `NEXT_PUBLIC_` cou
 
 | Variable | Description | Default |
 |---|---|---|
-| `BRAND_PRIMARY_COLOR` | 6-digit hex colour, e.g. `#EE7103`. Drives the primary palette, app bar, buttons, brand-tinted surfaces and the sign-in accent | *(unset — Rhesis blue)* |
+| `BRAND_PRIMARY_COLOR` | 6-digit hex colour, e.g. `#6A1B9A`. Drives the primary palette, app bar, buttons, brand-tinted surfaces and the sign-in accent | *(unset — Rhesis blue)* |
 | `BRAND_FAVICON_URL` | `https://` URL or root-relative path, e.g. `https://www.example.com/favicon.png`. Used as the browser-tab icon and as the brand mark in the sidebar, onboarding and sign-in header | `/logos/rhesis-logo-favicon.svg` |
-| `BRAND_PRODUCT_NAME` | Name in page titles (`Architect` becomes `Architect \| Netgo`), the sign-in header and footer, and the sidebar before the organisation loads. Max 60 characters | `Rhesis AI` |
+| `BRAND_PRODUCT_NAME` | Name in page titles (`Architect` becomes `Architect \| Acme`), the sign-in header and footer, and the sidebar before the organisation loads. Max 60 characters | `Rhesis AI` |
 
 Light and dark shades are derived from the one colour, and button label text switches between white and
 near-black to stay readable — a pale brand colour does not need extra configuration. A malformed value is

--- a/docs/content/docs/deployment/kubernetes-helm.mdx
+++ b/docs/content/docs/deployment/kubernetes-helm.mdx
@@ -339,9 +339,9 @@ every deployment already loads — nothing to add to Secret Manager, since none 
 
 <CodeBlock filename="charts/rhesis/values-customer.yaml" language="yaml">
 {`config:
-  brandPrimaryColor: "#EE7103"
+  brandPrimaryColor: "#6A1B9A"
   brandFaviconUrl: "https://www.example.com/favicon.png"
-  brandProductName: "Netgo"`}
+  brandProductName: "Acme"`}
 </CodeBlock>
 
 Quote the colour — an unquoted `#` starts a YAML comment. See

--- a/docs/content/docs/deployment/kubernetes-helm.mdx
+++ b/docs/content/docs/deployment/kubernetes-helm.mdx
@@ -331,6 +331,29 @@ frontend:
     host: your-app-domain.com`}
 </CodeBlock>
 
+## Rebrand the frontend
+
+Set your colour, icon and product name under `config`. They go into the chart's ConfigMap, which
+every deployment already loads — nothing to add to Secret Manager, since none of them is a secret
+(all three end up in the served HTML).
+
+<CodeBlock filename="charts/rhesis/values-customer.yaml" language="yaml">
+{`config:
+  brandPrimaryColor: "#EE7103"
+  brandFaviconUrl: "https://www.example.com/favicon.png"
+  brandProductName: "Netgo"`}
+</CodeBlock>
+
+Quote the colour — an unquoted `#` starts a YAML comment. See
+[Environment Variables](/docs/deployment/environment-variables) for what each one covers and how
+malformed values are handled.
+
+ConfigMap changes don't restart pods on their own:
+
+```bash
+kubectl rollout restart deployment frontend -n rhesis
+```
+
 ## Minimal vs. full deployment
 
 Only 4 of the 6 chart components have public images. Rhesis publishes


### PR DESCRIPTION
## Purpose

White-label deployments need their own colour, icon and product name without a per-customer image build. This adds three environment variables that the frontend reads at request time, so the same image serves every deployment.

They are deliberately **not** `NEXT_PUBLIC_*`: that prefix inlines a value into the client bundle at build time, which would mean one Docker image per deployment. This follows the rule already stated in `next.config.ts` — "one Docker image works across all environments without build args" — and rides the existing `window.__ENV__` runtime-config mechanism.

They also do **not** go in GCP Secret Manager. None of the three is a secret; all three end up in the served HTML. They live in the chart's ConfigMap, which every app deployment already loads via `envFrom`, so a self-hosted deployment sets them in its own `values.yaml`.

| Variable | Example | Default |
|---|---|---|
| `BRAND_PRIMARY_COLOR` | `#6A1B9A` | *(unset — Rhesis blue)* |
| `BRAND_FAVICON_URL` | `https://cdn.example.com/favicon.png` | `/logos/rhesis-logo-favicon.svg` |
| `BRAND_PRODUCT_NAME` | `Acme` | `Rhesis AI` |

## What Changed

- **`config/branding.ts`** — validates and resolves all three, falling back to the Rhesis default with a warning. A malformed value cannot break a deployment; `javascript:` and plain `http://` favicon URLs are rejected outright.
- **`styles/brand-palette.ts`** — derives the full palette from the one hex. The lighten/darken factors are fitted to the existing Figma palette (`darken(0.26)` on `#0080AF` lands one unit off the designed `#005F82`), so a custom colour inherits the relationships the palette was built with. Button label text is chosen by contrast ratio, so a pale brand colour gets dark labels instead of unreadable white ones.
- **`styles/theme.ts`** — `getDesignTokens(mode, brandColor?)`. Also routes the ~10 component overrides that set brand colours directly (app bar, contained/outlined/text primary buttons, checkboxes, pill toggles, input focus border) through the derived values; without that they would have stayed blue while the palette changed.
- **Favicon** — root layout's static `metadata` became `generateMetadata()` so the icon resolves per request.
- **Titles** — `%s | Rhesis AI` becomes `%s | <product name>`. A configured name also replaces the Rhesis tagline in the page description.
- **Brand mark** — new `BrandMark` component used by the sidebar (collapsed and expanded), onboarding sidebar/step header, and the sign-in header.
- **Auth pages** — accent tokens, header wordmark, brand mark and footer follow the branding. A rebranded wordmark stops linking to rhesis.ai.
- **Chart / compose / docs** — `config.brandPrimaryColor`, `config.brandFaviconUrl`, `config.brandProductName` into the ConfigMap; `.env.example` and both deployment docs pages.

## Additional Context

**The default Rhesis theme is unchanged.** Passing no brand colour returns the Figma literals verbatim — there is a test asserting the palette is identical, including that `alpha('#0080AF', 0.04)` reproduces the original `rgba(0, 128, 175, 0.04)` string character for character.

**Deliberately left on Rhesis identity**, all noted in the docs:

- Chart palettes — a readable series palette needs distinguishable hues, not tints of one colour.
- The sign-in background artwork — light mode's is a raster PNG that can't be recoloured in code.
- The Documentation, Blog and GitHub links in the sign-in header — removing navigation is a product decision, not a theming one.

**`BrandMark` uses a plain `<img>` for remote URLs**, not `next/image`. The optimizer refuses any host absent from `images.remotePatterns`, and the host here comes from a values file — unknowable at build time. Widening `remotePatterns` to `**` would turn the optimizer into an open image proxy. Favicons are a few KB, so there is nothing to optimise.

**Two things worth a reviewer's eye:**

1. The white-vs-dark label decision uses MUI's default `contrastThreshold` of 3. A brand colour whose contrast against white lands near 3:1 — mid-bright oranges, ambers and mid greens — therefore gets white labels by a narrow margin, where dark labels would score much better. The threshold stays at 3 because raising it to 4.5 would flip Rhesis's own `#0080AF` (4.47:1) to dark text, a regression on the default theme. Forcing one or the other per deployment would need a follow-up variable.
2. `helm` was not available locally, so `helm template` was never run against the ConfigMap change. The two lines follow the exact form of their neighbours and the values keys exist, but it is unverified.

Branding is per-deployment, not per-organisation — on multi-tenant rhesis.ai every org would see the same colour. That matches the Kubernetes-deployment framing of the request; org-scoped branding would be a different change built on `organization.logo_url`.

## Testing

`npx tsc --noEmit` clean, no new lint warnings, **220 suites / 2018 tests pass** (35 new).

Verified against a running dev server with all three variables set — served HTML carried the configured `rel="icon"` href, the brand colour in the CSS with zero Rhesis blue remaining, the configured `<title>`, and the branded `window.__ENV__` payload. With the variables unset the same page served the Rhesis favicon and blue, and no `brandPrimaryColor` key.

To try it locally, add to `apps/frontend/.env.local` and restart the frontend:

```
BRAND_PRIMARY_COLOR=#6A1B9A
BRAND_FAVICON_URL=https://cdn.example.com/favicon.png
BRAND_PRODUCT_NAME=Acme
```

Check the sign-in page (accents, header wordmark, footer, tab icon), then log in for the sidebar brand mark, app bar and buttons. Remove the lines and confirm nothing about the Rhesis look changed.

**Not verified end-to-end:** the `<page> | <product name>` title suffix on an inner page, and the sidebar brand mark in the running app — both need an authenticated session, which the local backend wasn't up for. The template string and the sidebar `src` are both covered by unit tests and read straight from the same resolved values as the verified pieces.
