### PR TITLE
Add configurable brand colour, icon and product name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,20 @@ SESSION_SECRET_KEY=
 # BACKEND_PORT=8080
 
 # =============================================================================
+# BRANDING
+# =============================================================================
+# Optional. Rebrands the frontend without rebuilding the image — both are read
+# at request time. Leave unset for the standard Rhesis look; a malformed value
+# is ignored with a warning.
+# BRAND_PRIMARY_COLOR must be 6-digit hex. BRAND_FAVICON_URL must be an https://
+# URL or a root-relative path, and also becomes the sidebar brand mark.
+# BRAND_PRODUCT_NAME replaces "Rhesis AI" in page titles (max 60 characters).
+
+# BRAND_PRIMARY_COLOR=#6A1B9A
+# BRAND_FAVICON_URL=https://www.example.com/favicon.png
+# BRAND_PRODUCT_NAME=Acme
+
+# =============================================================================
 # DATABASE
 # =============================================================================
 

--- a/.env.example
+++ b/.env.example
@@ -40,11 +40,13 @@ SESSION_SECRET_KEY=
 # Optional. Rebrands the frontend without rebuilding the image — both are read
 # at request time. Leave unset for the standard Rhesis look; a malformed value
 # is ignored with a warning.
-# BRAND_PRIMARY_COLOR must be 6-digit hex. BRAND_FAVICON_URL must be an https://
+# BRAND_PRIMARY_COLOR and BRAND_SECONDARY_COLOR must be 6-digit hex; either can
+# be set on its own. BRAND_FAVICON_URL must be an https://
 # URL or a root-relative path, and also becomes the sidebar brand mark.
 # BRAND_PRODUCT_NAME replaces "Rhesis AI" in page titles (max 60 characters).
 
 # BRAND_PRIMARY_COLOR=#6A1B9A
+# BRAND_SECONDARY_COLOR=#C2185B
 # BRAND_FAVICON_URL=https://www.example.com/favicon.png
 # BRAND_PRODUCT_NAME=Acme
 

--- a/apps/frontend/src/app/(protected)/onboarding/components/OnboardingSidebar.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/OnboardingSidebar.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import Image from 'next/image';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { Box, Typography } from '@mui/material';
+import BrandMark from '@/components/common/BrandMark';
+import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 import { DEFAULT_AUTHENTICATED_PATH } from '@/constants/paths';
 import { ONBOARDING_STEPS } from './onboarding-steps';
 import { onboardingSidebarSx } from './onboarding-styles';
@@ -15,6 +16,9 @@ interface OnboardingSidebarProps {
 export default function OnboardingSidebar({
   activeStep,
 }: OnboardingSidebarProps) {
+  const { branding } = useNavigationItems();
+  const productName = branding?.productName ?? 'Rhesis AI';
+
   return (
     <Box
       sx={{
@@ -35,11 +39,10 @@ export default function OnboardingSidebar({
           <Box
             sx={{ width: 40, height: 40, position: 'relative', flexShrink: 0 }}
           >
-            <Image
-              src="/logos/rhesis-logo-favicon.svg"
-              alt="Rhesis AI"
-              width={40}
-              height={40}
+            <BrandMark
+              src={branding?.iconUrl}
+              size={40}
+              alt={productName}
               priority
             />
           </Box>
@@ -51,7 +54,7 @@ export default function OnboardingSidebar({
               color: 'primary.main',
             }}
           >
-            Rhesis AI
+            {productName}
           </Typography>
         </Box>
 

--- a/apps/frontend/src/app/(protected)/onboarding/components/OnboardingStepHeader.tsx
+++ b/apps/frontend/src/app/(protected)/onboarding/components/OnboardingStepHeader.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import Image from 'next/image';
 import { Box, Typography } from '@mui/material';
+import BrandMark from '@/components/common/BrandMark';
+import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 
 interface OnboardingStepHeaderProps {
   title: string;
@@ -12,6 +13,8 @@ export default function OnboardingStepHeader({
   title,
   description,
 }: OnboardingStepHeaderProps) {
+  const { branding } = useNavigationItems();
+
   return (
     <Box
       sx={{
@@ -24,11 +27,10 @@ export default function OnboardingStepHeader({
       }}
     >
       <Box sx={{ width: 92, height: 92, position: 'relative', flexShrink: 0 }}>
-        <Image
-          src="/logos/rhesis-logo-favicon.svg"
-          alt="Rhesis AI"
-          width={92}
-          height={92}
+        <BrandMark
+          src={branding?.iconUrl}
+          size={92}
+          alt={branding?.productName ?? 'Rhesis AI'}
           priority
         />
       </Box>

--- a/apps/frontend/src/app/auth/signout/page.tsx
+++ b/apps/frontend/src/app/auth/signout/page.tsx
@@ -15,10 +15,16 @@ export default function SignOut() {
   // it still has to honour a deployment's brand colour, which the spinner below
   // picks up from `palette.primary`. Rebuild the light theme with the brand
   // colour read off the ambient one instead of the static `lightTheme` export.
-  const { brandColor } = useTheme().palette;
+  const { brandColor, brandSecondaryColor } = useTheme().palette;
   const theme = useMemo(
-    () => createTheme(getDesignTokens('light', brandColor)),
-    [brandColor]
+    () =>
+      createTheme(
+        getDesignTokens('light', {
+          primary: brandColor,
+          secondary: brandSecondaryColor,
+        })
+      ),
+    [brandColor, brandSecondaryColor]
   );
 
   useEffect(() => {

--- a/apps/frontend/src/app/auth/signout/page.tsx
+++ b/apps/frontend/src/app/auth/signout/page.tsx
@@ -1,16 +1,25 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Box, Typography, CircularProgress } from '@mui/material';
-import { ThemeProvider } from '@mui/material/styles';
+import { ThemeProvider, createTheme, useTheme } from '@mui/material/styles';
 import { handleClientSignOut } from '@/utils/client-auth';
 import BackgroundDecoration from '@/components/auth/BackgroundDecoration';
-import { lightTheme } from '@/styles/theme';
+import { getDesignTokens } from '@/styles/theme';
 import { scaledVh } from '@/styles/viewport-scaling';
 
 export default function SignOut() {
   const _searchParams = useSearchParams();
+  // This page pins light mode, so it can't use the ambient theme directly — but
+  // it still has to honour a deployment's brand colour, which the spinner below
+  // picks up from `palette.primary`. Rebuild the light theme with the brand
+  // colour read off the ambient one instead of the static `lightTheme` export.
+  const { brandColor } = useTheme().palette;
+  const theme = useMemo(
+    () => createTheme(getDesignTokens('light', brandColor)),
+    [brandColor]
+  );
 
   useEffect(() => {
     // The backend logout call goes through the /api/backend proxy, which
@@ -20,7 +29,7 @@ export default function SignOut() {
   }, []);
 
   return (
-    <ThemeProvider theme={lightTheme}>
+    <ThemeProvider theme={theme}>
       <Box
         sx={{
           display: 'flex',

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -52,6 +52,7 @@ import { type Organization } from '../utils/api-client/interfaces/organization';
 import { type UserSettings } from '../utils/api-client/interfaces/user';
 import { type Session } from 'next-auth';
 import ThemeContextProvider from '../components/providers/ThemeProvider';
+import { getServerBranding } from '../config/branding';
 import { BACKGROUND_DEFAULT } from '../styles/theme-background';
 import { Capability } from '../constants/capabilities';
 
@@ -95,14 +96,21 @@ html[data-theme-mode='${mode}'],html[data-theme-mode='${mode}'] body{background-
   .join('\n');
 
 // This function will be used to get navigation items with dynamic data
-async function getNavigationItems(session: Session | null): Promise<{
+async function getNavigationItems(
+  session: Session | null,
+  // Only a fallback: the real organisation name replaces it below whenever the
+  // lookup succeeds. It matters on the paths where it can't — no session yet, or
+  // the request failed — since that is where a branded deployment would
+  // otherwise flash "Rhesis AI" in its sidebar.
+  fallbackName: string
+): Promise<{
   items: NavigationItem[];
   organizationName: string;
   organization: Organization | null;
 }> {
   'use server';
 
-  let organizationName = 'Rhesis AI';
+  let organizationName = fallbackName;
   let organization: Organization | null = null;
 
   if (session?.user?.organization_id && !session.error) {
@@ -296,16 +304,30 @@ async function getNavigationItems(session: Session | null): Promise<{
   };
 }
 
-export const metadata: Metadata = {
-  title: {
-    template: '%s | Rhesis AI',
-    default: 'Rhesis AI',
-  },
-  description: 'Rhesis AI | OSS Gen AI Testing Platform',
-  icons: {
-    icon: '/logos/rhesis-logo-favicon.svg',
-  },
-};
+/**
+ * A function rather than a static `metadata` object so the favicon and product
+ * name are resolved per request from the environment, letting one image serve
+ * deployments with different branding.
+ */
+export async function generateMetadata(): Promise<Metadata> {
+  const { faviconUrl, productName, isDefaultProductName } = getServerBranding();
+
+  return {
+    title: {
+      // Pages set a bare `title` ('Architect'); this supplies the suffix.
+      template: `%s | ${productName}`,
+      default: productName,
+    },
+    // The Rhesis tagline would be wrong copy on a rebranded deployment, so a
+    // configured product name replaces it rather than being appended to it.
+    description: isDefaultProductName
+      ? 'Rhesis AI | OSS Gen AI Testing Platform'
+      : productName,
+    icons: {
+      icon: faviconUrl,
+    },
+  };
+}
 
 const AUTHENTICATION: AuthenticationProps = {
   signIn: handleSignIn,
@@ -323,20 +345,31 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
   const storedThemeMode =
     themeCookie === 'dark' || themeCookie === 'light' ? themeCookie : undefined;
 
+  // Branding is read here rather than in a client component because its env
+  // vars carry no `NEXT_PUBLIC_` prefix — see `config/branding.ts`. Reading it
+  // on the server and passing it down as props also keeps the server-rendered
+  // markup and the hydrated tree in agreement.
+  const deploymentBranding = getServerBranding();
+
   // Get navigation with dynamic organization name
   const {
     items: navigation,
     organizationName,
     organization,
-  } = await getNavigationItems(session);
+  } = await getNavigationItems(session, deploymentBranding.productName);
 
   const branding: BrandingProps = {
     title: organizationName,
-    logo: <ThemeAwareLogo />,
+    logo: <ThemeAwareLogo productName={deploymentBranding.productName} />,
+    iconUrl: deploymentBranding.faviconUrl,
+    productName: deploymentBranding.productName,
     homeUrl: '/architect',
   };
   const runtimeEnvScript = `window.__ENV__=${JSON.stringify({
     apiBaseUrl: process.env.API_BASE_URL ?? 'http://localhost:8080',
+    brandPrimaryColor: deploymentBranding.primaryColor,
+    brandFaviconUrl: deploymentBranding.faviconUrl,
+    brandProductName: deploymentBranding.productName,
   }).replace(/</g, '\\u003c')};`;
 
   // Fetch the active project, and the full member-project list for the
@@ -405,6 +438,7 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
         <ThemeContextProvider
           disableTransitionOnChange
           initialMode={storedThemeMode ?? 'light'}
+          brandColor={deploymentBranding.primaryColor}
         >
           <LayoutContent
             session={session}

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -438,7 +438,10 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
         <ThemeContextProvider
           disableTransitionOnChange
           initialMode={storedThemeMode ?? 'light'}
-          brandColor={deploymentBranding.primaryColor}
+          brandColors={{
+            primary: deploymentBranding.primaryColor,
+            secondary: deploymentBranding.secondaryColor,
+          }}
         >
           <LayoutContent
             session={session}

--- a/apps/frontend/src/components/auth/AuthPageShell.tsx
+++ b/apps/frontend/src/components/auth/AuthPageShell.tsx
@@ -3,7 +3,8 @@
 import * as React from 'react';
 import { Box, Typography } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
-import Image from 'next/image';
+import BrandMark from '@/components/common/BrandMark';
+import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 import BackgroundDecoration from './BackgroundDecoration';
 import {
   AUTH_FONT_DISPLAY,
@@ -84,8 +85,17 @@ interface AuthPageShellProps {
 }
 
 export default function AuthPageShell({ children }: AuthPageShellProps) {
-  const mode = useTheme().palette.mode;
-  const t = getAuthTokens(mode);
+  const { mode, brandColor } = useTheme().palette;
+  const t = getAuthTokens(mode, brandColor);
+  // `NavigationProvider` wraps every route, auth pages included, so the
+  // server-resolved branding is available here without a second env read.
+  const { branding } = useNavigationItems();
+  const productName = branding?.productName ?? 'Rhesis AI';
+  const isRebranded = productName !== 'Rhesis AI';
+  // A rebranded sign-in page must not send its users to rhesis.ai, and there is
+  // no configured homepage to send them to instead — so the wordmark stops
+  // being a link and just labels the page.
+  const wordmarkHref = isRebranded ? undefined : 'https://www.rhesis.ai';
 
   return (
     <Box
@@ -116,10 +126,14 @@ export default function AuthPageShell({ children }: AuthPageShellProps) {
         }}
       >
         <Box
-          component="a"
-          href="https://www.rhesis.ai"
-          target="_blank"
-          rel="noopener noreferrer"
+          {...(wordmarkHref
+            ? {
+                component: 'a' as const,
+                href: wordmarkHref,
+                target: '_blank',
+                rel: 'noopener noreferrer',
+              }
+            : {})}
           sx={{
             display: 'flex',
             alignItems: 'center',
@@ -127,11 +141,10 @@ export default function AuthPageShell({ children }: AuthPageShellProps) {
             textDecoration: 'none',
           }}
         >
-          <Image
-            src="/logos/rhesis-logo-favicon.svg"
-            alt="Rhesis AI"
-            width={44}
-            height={44}
+          <BrandMark
+            src={branding?.iconUrl}
+            size={44}
+            alt={productName}
             priority
           />
           <Typography
@@ -143,7 +156,7 @@ export default function AuthPageShell({ children }: AuthPageShellProps) {
               color: mode === 'dark' ? '#fff' : '#111827',
             }}
           >
-            Rhesis AI
+            {productName}
           </Typography>
         </Box>
 
@@ -387,7 +400,7 @@ export default function AuthPageShell({ children }: AuthPageShellProps) {
           color: t.muted,
         }}
       >
-        © 2026 Rhesis AI
+        © 2026 {productName}
       </Box>
     </Box>
   );

--- a/apps/frontend/src/components/auth/__tests__/authTokens.test.ts
+++ b/apps/frontend/src/components/auth/__tests__/authTokens.test.ts
@@ -1,0 +1,41 @@
+import { getContrastRatio } from '@mui/system/colorManipulator';
+import { getAuthTokens } from '../authTokens';
+
+/** A dark brand colour, far enough from Rhesis blue to make swaps obvious. */
+const BRAND = '#6A1B9A';
+
+describe('getAuthTokens', () => {
+  it('keeps the rhesis.ai accents when no brand colour is configured', () => {
+    expect(getAuthTokens('light').accent).toBe('#0080af');
+    expect(getAuthTokens('dark').accent).toBe('#22a5d1');
+    expect(getAuthTokens('light').accentShadow).toBe(
+      '0 6px 14px -4px rgba(0,128,175,0.55)'
+    );
+  });
+
+  it('applies a configured brand colour to the accents', () => {
+    const light = getAuthTokens('light', BRAND);
+    expect(light.accent).toBe('#6a1b9a');
+    expect(light.accentHover).not.toBe(light.accent);
+    expect(light.accentShadow).toContain('rgba(106, 27, 154, 0.55)');
+  });
+
+  it('leaves the non-accent tokens alone', () => {
+    // Only the three accent tokens are brand-driven; ground, ink and the
+    // hairlines mirror the website and stay put.
+    const plain = getAuthTokens('dark');
+    const branded = getAuthTokens('dark', BRAND);
+    expect(branded.ground).toBe(plain.ground);
+    expect(branded.ink).toBe(plain.ink);
+    expect(branded.hairline).toBe(plain.hairline);
+  });
+
+  it('lifts the accent on dark so white button text stays readable', () => {
+    // The reason the hand-picked pair moves #0080af to #22a5d1 on dark: these
+    // accents are button fills carrying white labels.
+    const darkAccent = getAuthTokens('dark', BRAND).accent;
+    expect(getContrastRatio(darkAccent, '#030712')).toBeGreaterThan(
+      getContrastRatio(BRAND, '#030712')
+    );
+  });
+});

--- a/apps/frontend/src/components/auth/authTokens.ts
+++ b/apps/frontend/src/components/auth/authTokens.ts
@@ -10,6 +10,8 @@
  * this — the rest of the app stays on the MUI theme and Be Vietnam Pro.
  */
 
+import { alpha, darken, lighten } from '@mui/system/colorManipulator';
+
 /** Geist, registered in `src/styles/fonts.css`. Auth pages only. */
 export const AUTH_FONT_SANS =
   '"Geist", "Be Vietnam Pro", system-ui, sans-serif';
@@ -90,8 +92,34 @@ const DARK: AuthTokens = {
   accentShadow: '0 6px 14px -4px rgba(34,165,209,0.4)',
 };
 
-export function getAuthTokens(mode: 'light' | 'dark'): AuthTokens {
-  return mode === 'dark' ? DARK : LIGHT;
+/**
+ * Applies a deployment's `BRAND_PRIMARY_COLOR` to the three accent tokens.
+ *
+ * The sign-in screen is the first thing a white-label user sees, so leaving it
+ * on Rhesis blue while the app itself is rebranded is the most visible way to
+ * get this wrong. The dark-mode lift mirrors what the hand-picked pair already
+ * does (`#0080af` → `#22a5d1`, i.e. roughly `lighten(0.13)`) — a saturated
+ * brand colour carrying white button text needs the extra contrast against
+ * `#030712`.
+ */
+function withBrandAccent(tokens: AuthTokens, brandColor: string): AuthTokens {
+  const accent =
+    tokens === DARK ? lighten(brandColor, 0.13) : brandColor.toLowerCase();
+
+  return {
+    ...tokens,
+    accent,
+    accentHover: tokens === DARK ? lighten(accent, 0.15) : darken(accent, 0.15),
+    accentShadow: `0 6px 14px -4px ${alpha(accent, tokens === DARK ? 0.4 : 0.55)}`,
+  };
+}
+
+export function getAuthTokens(
+  mode: 'light' | 'dark',
+  brandColor?: string
+): AuthTokens {
+  const tokens = mode === 'dark' ? DARK : LIGHT;
+  return brandColor ? withBrandAccent(tokens, brandColor) : tokens;
 }
 
 /** Shapes, lifted from the website's radius scale and hero CTAs. */

--- a/apps/frontend/src/components/auth/useAuthStyles.ts
+++ b/apps/frontend/src/components/auth/useAuthStyles.ts
@@ -37,10 +37,10 @@ export interface AuthStyles {
  * hover pair ended up duplicated across five files.
  */
 export function useAuthStyles(): AuthStyles {
-  const mode = useTheme().palette.mode;
+  const { mode, brandColor } = useTheme().palette;
 
   return useMemo(() => {
-    const t = getAuthTokens(mode);
+    const t = getAuthTokens(mode, brandColor);
 
     return {
       tokens: t,
@@ -117,5 +117,5 @@ export function useAuthStyles(): AuthStyles {
         textDecoration: 'none',
       },
     };
-  }, [mode]);
+  }, [mode, brandColor]);
 }

--- a/apps/frontend/src/components/common/BrandMark.tsx
+++ b/apps/frontend/src/components/common/BrandMark.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import { DEFAULT_FAVICON_URL } from '@/config/branding';
+
+interface BrandMarkProps {
+  /** `BRAND_FAVICON_URL` when configured; falls back to the Rhesis icon. */
+  src?: string;
+  /** Rendered size in px — the mark is always square. */
+  size: number;
+  alt: string;
+  priority?: boolean;
+}
+
+/**
+ * The square brand mark in the app chrome, honouring `BRAND_FAVICON_URL` so a
+ * rebranded deployment shows its own icon next to the organisation name instead
+ * of the Rhesis platypus.
+ *
+ * A remote URL renders as a plain `<img>`, not `next/image`: the optimizer
+ * refuses any host absent from `images.remotePatterns`, and the host here is
+ * whatever a deployment put in its values file — unknowable at build time.
+ * Widening `remotePatterns` to `**` to work around that would turn the
+ * optimizer into an open image proxy. Favicons are a few KB, so there is
+ * nothing to optimise anyway. Local paths keep `next/image`.
+ */
+export default function BrandMark({
+  src,
+  size,
+  alt,
+  priority = false,
+}: BrandMarkProps) {
+  const resolved = src || DEFAULT_FAVICON_URL;
+  const isRemote = /^https?:\/\//i.test(resolved);
+
+  if (isRemote) {
+    return (
+      <img
+        src={resolved}
+        alt={alt}
+        width={size}
+        height={size}
+        // Keeps a non-square source from stretching, and stops a broken or
+        // slow remote icon from shifting the sidebar layout.
+        style={{ width: size, height: size, objectFit: 'contain' }}
+        {...(priority ? { fetchPriority: 'high' as const } : {})}
+      />
+    );
+  }
+
+  return (
+    <Image
+      src={resolved}
+      alt={alt}
+      width={size}
+      height={size}
+      priority={priority}
+    />
+  );
+}

--- a/apps/frontend/src/components/common/ThemeAwareLogo.tsx
+++ b/apps/frontend/src/components/common/ThemeAwareLogo.tsx
@@ -5,7 +5,15 @@ import Image from 'next/image';
 import { Box } from '@mui/material';
 import { ColorModeContext } from '../providers/ThemeProvider';
 
-export default function ThemeAwareLogo() {
+interface ThemeAwareLogoProps {
+  /** `BRAND_PRODUCT_NAME`, for the alt text. The wordmark image itself is still
+   * the Rhesis one — only `BRAND_FAVICON_URL` replaces artwork (see BrandMark). */
+  productName?: string;
+}
+
+export default function ThemeAwareLogo({
+  productName = 'Rhesis AI',
+}: ThemeAwareLogoProps) {
   const { mode } = React.useContext(ColorModeContext);
 
   const logoSrc =
@@ -17,7 +25,7 @@ export default function ThemeAwareLogo() {
     <Box sx={{ display: 'flex', alignItems: 'center', height: '100%' }}>
       <Image
         src={logoSrc}
-        alt="Rhesis AI Logo"
+        alt={`${productName} logo`}
         width={130}
         height={35}
         style={{ width: 'auto', height: '35px' }}

--- a/apps/frontend/src/components/navigation/Sidebar.tsx
+++ b/apps/frontend/src/components/navigation/Sidebar.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState, useContext } from 'react';
-import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import Box from '@mui/material/Box';
@@ -21,6 +20,7 @@ import SwapHorizOutlinedIcon from '@mui/icons-material/SwapHorizOutlined';
 import Divider from '@mui/material/Divider';
 import { useNavigationItems } from '@/contexts/NavigationItemsContext';
 import { useSidebarCollapse } from '@/components/layout/AppShell';
+import BrandMark from '@/components/common/BrandMark';
 import { UserAvatar } from '@/components/common/UserAvatar';
 import { Can } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
@@ -114,7 +114,7 @@ export function Sidebar() {
   // Support drawer
   const [supportOpen, setSupportOpen] = useState(false);
 
-  const orgName = branding?.title ?? 'Rhesis AI';
+  const orgName = branding?.title ?? branding?.productName ?? 'Rhesis AI';
   const groups = groupNavItems(navigation);
 
   const mainGroups = groups.filter(g => g.type !== 'footer-links') as (
@@ -216,11 +216,10 @@ export function Sidebar() {
                   },
                 }}
               >
-                <Image
-                  src="/logos/rhesis-logo-favicon.svg"
-                  alt="Rhesis logo"
-                  width={40}
-                  height={40}
+                <BrandMark
+                  src={branding?.iconUrl}
+                  size={40}
+                  alt={`${orgName} logo`}
                   priority
                 />
               </ButtonBase>
@@ -268,11 +267,10 @@ export function Sidebar() {
                   justifyContent: 'center',
                 }}
               >
-                <Image
-                  src="/logos/rhesis-logo-favicon.svg"
-                  alt="Rhesis logo"
-                  width={40}
-                  height={40}
+                <BrandMark
+                  src={branding?.iconUrl}
+                  size={40}
+                  alt={`${orgName} logo`}
                   priority
                 />
               </Box>

--- a/apps/frontend/src/components/providers/ThemeProvider.tsx
+++ b/apps/frontend/src/components/providers/ThemeProvider.tsx
@@ -16,6 +16,14 @@ interface ThemeContextProviderProps {
   children: React.ReactNode;
   disableTransitionOnChange?: boolean;
   initialMode?: 'light' | 'dark';
+  /**
+   * Validated `BRAND_PRIMARY_COLOR` for white-label deployments, passed down
+   * from the root layout (a Server Component) because the env var has no
+   * `NEXT_PUBLIC_` prefix and so is unreadable from the client bundle. Server
+   * render and hydration both receive it as a prop, so the two agree and the
+   * theme does not flash Rhesis blue first.
+   */
+  brandColor?: string;
 }
 
 const THEME_MODE_KEY = 'theme-mode';
@@ -31,6 +39,7 @@ export default function ThemeContextProvider({
   children,
   disableTransitionOnChange = false,
   initialMode = 'light',
+  brandColor,
 }: ThemeContextProviderProps) {
   const [mode, setMode] = React.useState<'light' | 'dark'>(initialMode);
 
@@ -95,7 +104,10 @@ export default function ThemeContextProvider({
     [mode, disableTransitionOnChange]
   );
 
-  const theme = React.useMemo(() => createTheme(getDesignTokens(mode)), [mode]);
+  const theme = React.useMemo(
+    () => createTheme(getDesignTokens(mode, brandColor)),
+    [mode, brandColor]
+  );
 
   return (
     <ColorModeContext.Provider value={colorMode}>

--- a/apps/frontend/src/components/providers/ThemeProvider.tsx
+++ b/apps/frontend/src/components/providers/ThemeProvider.tsx
@@ -5,7 +5,7 @@ import {
   ThemeProvider as MuiThemeProvider,
   createTheme,
 } from '@mui/material/styles';
-import { getDesignTokens } from '../../styles/theme';
+import { getDesignTokens, type BrandColors } from '../../styles/theme';
 
 export const ColorModeContext = React.createContext({
   toggleColorMode: () => {},
@@ -17,13 +17,13 @@ interface ThemeContextProviderProps {
   disableTransitionOnChange?: boolean;
   initialMode?: 'light' | 'dark';
   /**
-   * Validated `BRAND_PRIMARY_COLOR` for white-label deployments, passed down
-   * from the root layout (a Server Component) because the env var has no
-   * `NEXT_PUBLIC_` prefix and so is unreadable from the client bundle. Server
-   * render and hydration both receive it as a prop, so the two agree and the
-   * theme does not flash Rhesis blue first.
+   * Validated `BRAND_PRIMARY_COLOR` / `BRAND_SECONDARY_COLOR` for white-label
+   * deployments, passed down from the root layout (a Server Component) because
+   * the env vars have no `NEXT_PUBLIC_` prefix and so are unreadable from the
+   * client bundle. Server render and hydration both receive them as a prop, so
+   * the two agree and the theme does not flash Rhesis blue first.
    */
-  brandColor?: string;
+  brandColors?: BrandColors;
 }
 
 const THEME_MODE_KEY = 'theme-mode';
@@ -39,7 +39,7 @@ export default function ThemeContextProvider({
   children,
   disableTransitionOnChange = false,
   initialMode = 'light',
-  brandColor,
+  brandColors,
 }: ThemeContextProviderProps) {
   const [mode, setMode] = React.useState<'light' | 'dark'>(initialMode);
 
@@ -104,9 +104,20 @@ export default function ThemeContextProvider({
     [mode, disableTransitionOnChange]
   );
 
+  // Destructured so the memo keys on the colour values rather than the object's
+  // identity — a fresh `{primary, secondary}` literal from the caller would
+  // otherwise rebuild the whole theme on every render.
+  const brandPrimary = brandColors?.primary;
+  const brandSecondary = brandColors?.secondary;
   const theme = React.useMemo(
-    () => createTheme(getDesignTokens(mode, brandColor)),
-    [mode, brandColor]
+    () =>
+      createTheme(
+        getDesignTokens(mode, {
+          primary: brandPrimary,
+          secondary: brandSecondary,
+        })
+      ),
+    [mode, brandPrimary, brandSecondary]
   );
 
   return (

--- a/apps/frontend/src/config/__tests__/branding.test.ts
+++ b/apps/frontend/src/config/__tests__/branding.test.ts
@@ -128,36 +128,70 @@ describe('normalizeProductName', () => {
 describe('getServerBranding', () => {
   const original = {
     color: process.env.BRAND_PRIMARY_COLOR,
+    secondary: process.env.BRAND_SECONDARY_COLOR,
     favicon: process.env.BRAND_FAVICON_URL,
     product: process.env.BRAND_PRODUCT_NAME,
   };
 
+  // Assigning `undefined` to a process.env key stores the *string* "undefined"
+  // rather than clearing it, which leaked a bogus BRAND_FAVICON_URL into the
+  // next test and made it warn about the wrong variable. Delete instead.
+  const restore = (key: string, value: string | undefined) => {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  };
+
   afterEach(() => {
-    process.env.BRAND_PRIMARY_COLOR = original.color;
-    process.env.BRAND_FAVICON_URL = original.favicon;
-    process.env.BRAND_PRODUCT_NAME = original.product;
+    restore('BRAND_PRIMARY_COLOR', original.color);
+    restore('BRAND_SECONDARY_COLOR', original.secondary);
+    restore('BRAND_FAVICON_URL', original.favicon);
+    restore('BRAND_PRODUCT_NAME', original.product);
   });
 
   it('reads every variable from the environment', () => {
     process.env.BRAND_PRIMARY_COLOR = '#6A1B9A';
+    process.env.BRAND_SECONDARY_COLOR = '#C2185B';
     process.env.BRAND_FAVICON_URL = 'https://example.com/fav.png';
     process.env.BRAND_PRODUCT_NAME = 'Acme';
 
     expect(getServerBranding()).toEqual({
       primaryColor: '#6A1B9A',
+      secondaryColor: '#C2185B',
       faviconUrl: 'https://example.com/fav.png',
       productName: 'Acme',
       isDefaultProductName: false,
     });
   });
 
+  it('accepts a secondary colour on its own', () => {
+    delete process.env.BRAND_PRIMARY_COLOR;
+    process.env.BRAND_SECONDARY_COLOR = '#C2185B';
+
+    const b = getServerBranding();
+    expect(b.primaryColor).toBeUndefined();
+    expect(b.secondaryColor).toBe('#C2185B');
+  });
+
+  it('names the offending variable when the secondary colour is malformed', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    process.env.BRAND_SECONDARY_COLOR = 'not-a-colour';
+
+    expect(getServerBranding().secondaryColor).toBeUndefined();
+    expect(
+      warn.mock.calls.some(c => String(c[0]).includes('BRAND_SECONDARY_COLOR'))
+    ).toBe(true);
+    warn.mockRestore();
+  });
+
   it('reports Rhesis defaults when nothing is configured', () => {
     delete process.env.BRAND_PRIMARY_COLOR;
+    delete process.env.BRAND_SECONDARY_COLOR;
     delete process.env.BRAND_FAVICON_URL;
     delete process.env.BRAND_PRODUCT_NAME;
 
     expect(getServerBranding()).toEqual({
       primaryColor: undefined,
+      secondaryColor: undefined,
       faviconUrl: DEFAULT_FAVICON_URL,
       productName: DEFAULT_PRODUCT_NAME,
       isDefaultProductName: true,

--- a/apps/frontend/src/config/__tests__/branding.test.ts
+++ b/apps/frontend/src/config/__tests__/branding.test.ts
@@ -1,0 +1,161 @@
+import {
+  DEFAULT_FAVICON_URL,
+  DEFAULT_PRODUCT_NAME,
+  getServerBranding,
+  normalizeBrandColor,
+  normalizeFaviconUrl,
+  normalizeProductName,
+} from '../branding';
+
+describe('normalizeBrandColor', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('accepts 6-digit hex and normalizes case', () => {
+    expect(normalizeBrandColor('#6a1b9a')).toBe('#6A1B9A');
+    expect(normalizeBrandColor('  #6A1B9A  ')).toBe('#6A1B9A');
+  });
+
+  it('treats absent and empty values as unset without warning', () => {
+    expect(normalizeBrandColor(undefined)).toBeUndefined();
+    expect(normalizeBrandColor('')).toBeUndefined();
+    expect(normalizeBrandColor('   ')).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['#fff', 'the 3-digit form'],
+    ['6A1B9A', 'a missing hash'],
+    ['green', 'a colour name'],
+    ['#00zz33', 'non-hex digits'],
+  ])('rejects %s (%s) and warns', color => {
+    expect(normalizeBrandColor(color)).toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('normalizeFaviconUrl', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('accepts https URLs', () => {
+    expect(
+      normalizeFaviconUrl('https://cdn.example.com/assets/favicon.png')
+    ).toBe('https://cdn.example.com/assets/favicon.png');
+  });
+
+  it('accepts root-relative paths', () => {
+    expect(normalizeFaviconUrl('/logos/custom.png')).toBe('/logos/custom.png');
+  });
+
+  it('falls back to the default when unset', () => {
+    expect(normalizeFaviconUrl(undefined)).toBe(DEFAULT_FAVICON_URL);
+    expect(normalizeFaviconUrl('')).toBe(DEFAULT_FAVICON_URL);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['http://example.com/favicon.png', 'plain http would be mixed content'],
+    ['javascript:alert(1)', 'a script URL must never reach <head>'],
+    ['data:image/png;base64,AAAA', 'other schemes are not allowed'],
+    ['not a url', 'unparseable'],
+    ['example.com/favicon.png', 'scheme-less is unparseable'],
+  ])('rejects %s (%s)', url => {
+    expect(normalizeFaviconUrl(url)).toBe(DEFAULT_FAVICON_URL);
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe('normalizeProductName', () => {
+  let warn: jest.SpyInstance;
+
+  beforeEach(() => {
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('accepts a name and trims surrounding whitespace', () => {
+    expect(normalizeProductName('Acme')).toBe('Acme');
+    expect(normalizeProductName('  Acme  ')).toBe('Acme');
+  });
+
+  it('preserves spacing and case inside the name', () => {
+    expect(normalizeProductName('Acme AI Studio')).toBe('Acme AI Studio');
+  });
+
+  it('falls back to the default when unset', () => {
+    expect(normalizeProductName(undefined)).toBe(DEFAULT_PRODUCT_NAME);
+    expect(normalizeProductName('   ')).toBe(DEFAULT_PRODUCT_NAME);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('rejects an over-long name rather than truncating it', () => {
+    expect(normalizeProductName('N'.repeat(61))).toBe(DEFAULT_PRODUCT_NAME);
+    expect(warn).toHaveBeenCalled();
+    expect(normalizeProductName('N'.repeat(60))).toHaveLength(60);
+  });
+});
+
+describe('getServerBranding', () => {
+  const original = {
+    color: process.env.BRAND_PRIMARY_COLOR,
+    favicon: process.env.BRAND_FAVICON_URL,
+    product: process.env.BRAND_PRODUCT_NAME,
+  };
+
+  afterEach(() => {
+    process.env.BRAND_PRIMARY_COLOR = original.color;
+    process.env.BRAND_FAVICON_URL = original.favicon;
+    process.env.BRAND_PRODUCT_NAME = original.product;
+  });
+
+  it('reads every variable from the environment', () => {
+    process.env.BRAND_PRIMARY_COLOR = '#6A1B9A';
+    process.env.BRAND_FAVICON_URL = 'https://example.com/fav.png';
+    process.env.BRAND_PRODUCT_NAME = 'Acme';
+
+    expect(getServerBranding()).toEqual({
+      primaryColor: '#6A1B9A',
+      faviconUrl: 'https://example.com/fav.png',
+      productName: 'Acme',
+      isDefaultProductName: false,
+    });
+  });
+
+  it('reports Rhesis defaults when nothing is configured', () => {
+    delete process.env.BRAND_PRIMARY_COLOR;
+    delete process.env.BRAND_FAVICON_URL;
+    delete process.env.BRAND_PRODUCT_NAME;
+
+    expect(getServerBranding()).toEqual({
+      primaryColor: undefined,
+      faviconUrl: DEFAULT_FAVICON_URL,
+      productName: DEFAULT_PRODUCT_NAME,
+      isDefaultProductName: true,
+    });
+  });
+
+  it('flags an explicit "Rhesis AI" as the default, not an override', () => {
+    // Keeps the Rhesis marketing description on a deployment that sets the name
+    // to what it already was.
+    process.env.BRAND_PRODUCT_NAME = 'Rhesis AI';
+    expect(getServerBranding().isDefaultProductName).toBe(true);
+  });
+});

--- a/apps/frontend/src/config/__tests__/branding.test.ts
+++ b/apps/frontend/src/config/__tests__/branding.test.ts
@@ -74,9 +74,21 @@ describe('normalizeFaviconUrl', () => {
     ['data:image/png;base64,AAAA', 'other schemes are not allowed'],
     ['not a url', 'unparseable'],
     ['example.com/favicon.png', 'scheme-less is unparseable'],
+    [
+      '//example.com/favicon.png',
+      'protocol-relative resolves to an external host',
+    ],
+    ['/\\example.com/favicon.png', 'browsers normalise /\\ to //'],
   ])('rejects %s (%s)', url => {
     expect(normalizeFaviconUrl(url)).toBe(DEFAULT_FAVICON_URL);
     expect(warn).toHaveBeenCalled();
+  });
+
+  it('still accepts an ordinary root-relative path with nested segments', () => {
+    // The // guard must not catch a single leading slash followed by a path.
+    expect(normalizeFaviconUrl('/assets/brand/icon.png')).toBe(
+      '/assets/brand/icon.png'
+    );
   });
 });
 

--- a/apps/frontend/src/config/branding.ts
+++ b/apps/frontend/src/config/branding.ts
@@ -50,7 +50,7 @@ export function normalizeBrandColor(
 
   if (!HEX_COLOR_PATTERN.test(trimmed)) {
     console.warn(
-      `[branding] Ignoring BRAND_PRIMARY_COLOR "${trimmed}": expected a 6-digit hex colour such as #6A1B9A.`
+      `[branding] Ignoring BRAND_PRIMARY_COLOR "${trimmed}": expected a 6-digit hex colour in #RRGGBB form.`
     );
     return undefined;
   }

--- a/apps/frontend/src/config/branding.ts
+++ b/apps/frontend/src/config/branding.ts
@@ -70,7 +70,19 @@ export function normalizeFaviconUrl(value: string | undefined | null): string {
   const trimmed = value?.trim();
   if (!trimmed) return DEFAULT_FAVICON_URL;
 
-  if (trimmed.startsWith('/')) return trimmed;
+  if (trimmed.startsWith('/')) {
+    // `//host/icon.png` is protocol-relative: it looks root-relative but the
+    // browser resolves it against an external host, inheriting the page's
+    // scheme — so it would slip past the https check below. The backslash form
+    // is here too because browsers normalise `/\` to `//`.
+    if (/^\/[/\\]/.test(trimmed)) {
+      console.warn(
+        `[branding] Ignoring BRAND_FAVICON_URL "${trimmed}": protocol-relative URLs point at an external host. Use an explicit https:// URL.`
+      );
+      return DEFAULT_FAVICON_URL;
+    }
+    return trimmed;
+  }
 
   let parsed: URL;
   try {

--- a/apps/frontend/src/config/branding.ts
+++ b/apps/frontend/src/config/branding.ts
@@ -1,0 +1,131 @@
+/**
+ * Runtime branding overrides, for deployments that need their own colour, icon
+ * and product name (white-label / on-prem installs).
+ *
+ * All three are plain env vars, deliberately *without* the `NEXT_PUBLIC_`
+ * prefix: that prefix inlines a value into the client bundle at build time,
+ * which would mean one Docker image per deployment. These are read on the
+ * server at request time and handed to the client via props and
+ * `window.__ENV__` — the same route `API_BASE_URL` already takes (see
+ * `url-resolver.ts`).
+ *
+ * In Kubernetes they arrive from the chart's ConfigMap, which every app
+ * deployment already loads with `envFrom`. None of them is a secret — all three
+ * end up visible in the served HTML — so they do not belong in Secret Manager.
+ */
+
+/** Shipped Rhesis favicon, used whenever no override is configured. */
+export const DEFAULT_FAVICON_URL = '/logos/rhesis-logo-favicon.svg';
+
+/** Product name in page titles, the sidebar and image alt text. */
+export const DEFAULT_PRODUCT_NAME = 'Rhesis AI';
+
+/** Long enough for a real product name, short enough to keep `<title>` sane. */
+const MAX_PRODUCT_NAME_LENGTH = 60;
+
+/** 6-digit hex only: MUI's colour manipulators need a parseable value, and the
+ * 3-digit form would silently widen what deployments can put in a values file. */
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+export interface Branding {
+  /** Undefined means "use the built-in Rhesis palette", not "no colour". */
+  primaryColor?: string;
+  faviconUrl: string;
+  productName: string;
+  /** True when `productName` is the Rhesis default, so callers can keep
+   * Rhesis-specific copy (the marketing description) out of a branded build. */
+  isDefaultProductName: boolean;
+}
+
+/**
+ * Validates a configured brand colour, returning undefined when it is absent
+ * or malformed. A typo in a values file must fall back to the Rhesis palette
+ * rather than take the app down or paint half the UI `undefined`.
+ */
+export function normalizeBrandColor(
+  value: string | undefined | null
+): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+
+  if (!HEX_COLOR_PATTERN.test(trimmed)) {
+    console.warn(
+      `[branding] Ignoring BRAND_PRIMARY_COLOR "${trimmed}": expected a 6-digit hex colour such as #6A1B9A.`
+    );
+    return undefined;
+  }
+
+  return trimmed.toUpperCase();
+}
+
+/**
+ * Validates a configured favicon URL, falling back to the Rhesis default.
+ *
+ * Only absolute `https://` URLs and root-relative paths are accepted. `http://`
+ * is rejected because it would make an https page issue a mixed-content
+ * request, and rejecting every other scheme keeps `javascript:` out of an
+ * attribute we render into `<head>`.
+ */
+export function normalizeFaviconUrl(value: string | undefined | null): string {
+  const trimmed = value?.trim();
+  if (!trimmed) return DEFAULT_FAVICON_URL;
+
+  if (trimmed.startsWith('/')) return trimmed;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    console.warn(
+      `[branding] Ignoring BRAND_FAVICON_URL "${trimmed}": not a valid URL.`
+    );
+    return DEFAULT_FAVICON_URL;
+  }
+
+  if (parsed.protocol !== 'https:') {
+    console.warn(
+      `[branding] Ignoring BRAND_FAVICON_URL "${trimmed}": only https:// URLs and root-relative paths are allowed.`
+    );
+    return DEFAULT_FAVICON_URL;
+  }
+
+  return parsed.toString();
+}
+
+/**
+ * Validates a configured product name — the `%s | <name>` suffix on every page
+ * title, and the fallback shown in the sidebar before the organisation loads.
+ *
+ * Over-long values are rejected rather than truncated: a cut-off name in the
+ * browser tab is harder to diagnose than the default reappearing next to a
+ * warning.
+ */
+export function normalizeProductName(value: string | undefined | null): string {
+  const trimmed = value?.trim();
+  if (!trimmed) return DEFAULT_PRODUCT_NAME;
+
+  if (trimmed.length > MAX_PRODUCT_NAME_LENGTH) {
+    console.warn(
+      `[branding] Ignoring BRAND_PRODUCT_NAME: ${trimmed.length} characters exceeds the ${MAX_PRODUCT_NAME_LENGTH}-character limit.`
+    );
+    return DEFAULT_PRODUCT_NAME;
+  }
+
+  return trimmed;
+}
+
+/**
+ * Reads branding from the environment. Server-side only — the env vars carry no
+ * `NEXT_PUBLIC_` prefix, so in a client bundle every read compiles to
+ * `undefined` and this would quietly report the defaults.
+ */
+export function getServerBranding(): Branding {
+  const productName = normalizeProductName(process.env.BRAND_PRODUCT_NAME);
+
+  return {
+    primaryColor: normalizeBrandColor(process.env.BRAND_PRIMARY_COLOR),
+    faviconUrl: normalizeFaviconUrl(process.env.BRAND_FAVICON_URL),
+    productName,
+    isDefaultProductName: productName === DEFAULT_PRODUCT_NAME,
+  };
+}

--- a/apps/frontend/src/config/branding.ts
+++ b/apps/frontend/src/config/branding.ts
@@ -30,6 +30,9 @@ const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 export interface Branding {
   /** Undefined means "use the built-in Rhesis palette", not "no colour". */
   primaryColor?: string;
+  /** Secondary/CTA colour. Independent of `primaryColor` — a deployment can set
+   * either on its own. */
+  secondaryColor?: string;
   faviconUrl: string;
   productName: string;
   /** True when `productName` is the Rhesis default, so callers can keep
@@ -43,14 +46,16 @@ export interface Branding {
  * rather than take the app down or paint half the UI `undefined`.
  */
 export function normalizeBrandColor(
-  value: string | undefined | null
+  value: string | undefined | null,
+  // Named so the warning tells the operator which variable to go and fix.
+  varName = 'BRAND_PRIMARY_COLOR'
 ): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
 
   if (!HEX_COLOR_PATTERN.test(trimmed)) {
     console.warn(
-      `[branding] Ignoring BRAND_PRIMARY_COLOR "${trimmed}": expected a 6-digit hex colour in #RRGGBB form.`
+      `[branding] Ignoring ${varName} "${trimmed}": expected a 6-digit hex colour in #RRGGBB form.`
     );
     return undefined;
   }
@@ -136,6 +141,10 @@ export function getServerBranding(): Branding {
 
   return {
     primaryColor: normalizeBrandColor(process.env.BRAND_PRIMARY_COLOR),
+    secondaryColor: normalizeBrandColor(
+      process.env.BRAND_SECONDARY_COLOR,
+      'BRAND_SECONDARY_COLOR'
+    ),
     faviconUrl: normalizeFaviconUrl(process.env.BRAND_FAVICON_URL),
     productName,
     isDefaultProductName: productName === DEFAULT_PRODUCT_NAME,

--- a/apps/frontend/src/styles/__tests__/brand-palette.test.ts
+++ b/apps/frontend/src/styles/__tests__/brand-palette.test.ts
@@ -3,7 +3,9 @@ import {
   contrastTextFor,
   deriveBrandAccents,
   deriveBrandPrimary,
+  deriveBrandSecondary,
   deriveBrandSurfaces,
+  deriveSecondaryAccents,
 } from '../brand-palette';
 import { getDesignTokens } from '../theme';
 
@@ -104,6 +106,49 @@ describe('deriveBrandAccents', () => {
   });
 });
 
+describe('deriveBrandSecondary', () => {
+  it('builds a lighten/darken ramp around the configured colour', () => {
+    const s = deriveBrandSecondary(BRAND);
+    expect(s.main).toBe(BRAND);
+    expect(s.light).not.toBe(s.main);
+    expect(s.dark).not.toBe(s.main);
+    expect(getContrastRatio(s.light, '#FFFFFF')).toBeLessThan(
+      getContrastRatio(s.dark, '#FFFFFF')
+    );
+  });
+
+  it('picks readable label text for a pale secondary', () => {
+    expect(deriveBrandSecondary(PALE_BRAND).contrastText).toBe('#1A1A1A');
+    expect(deriveBrandSecondary(BRAND).contrastText).toBe('#FFFFFF');
+  });
+});
+
+describe('deriveSecondaryAccents', () => {
+  it('returns the Figma literals verbatim when nothing is configured', () => {
+    // Including the orange→yellow hover and its dark label, so the default
+    // secondary button is untouched.
+    expect(deriveSecondaryAccents()).toEqual({
+      main: '#FD6E12',
+      mainHover: '#FDD803',
+      contrastText: '#FFFFFF',
+      hoverContrastText: '#1A1A1A',
+    });
+  });
+
+  it('brightens on hover, matching the Rhesis behaviour', () => {
+    const a = deriveSecondaryAccents(BRAND);
+    expect(getContrastRatio(a.mainHover, '#FFFFFF')).toBeLessThan(
+      getContrastRatio(a.main, '#FFFFFF')
+    );
+  });
+
+  it('recomputes the label colour for the lighter hover fill', () => {
+    // A hover fill light enough to need dark text must not keep white text.
+    const a = deriveSecondaryAccents(PALE_BRAND);
+    expect(a.hoverContrastText).toBe('#1A1A1A');
+  });
+});
+
 describe('getDesignTokens brand integration', () => {
   it('is byte-identical to the Rhesis palette when no brand colour is passed', () => {
     // The regression guard: adding the parameter must not shift the default look.
@@ -124,7 +169,23 @@ describe('getDesignTokens brand integration', () => {
               contrastText: '#FFFFFF',
             }
       );
+      expect(palette.secondary).toEqual(
+        mode === 'light'
+          ? {
+              main: '#FD6E12',
+              light: '#FDD803',
+              dark: '#1A1A1A',
+              contrastText: '#FFFFFF',
+            }
+          : {
+              main: '#FD6E12',
+              light: '#F78166',
+              dark: '#58A6FF',
+              contrastText: '#FFFFFF',
+            }
+      );
       expect(palette.brandColor).toBeUndefined();
+      expect(palette.brandSecondaryColor).toBeUndefined();
     }
 
     expect(getDesignTokens('light').palette.background).toMatchObject({
@@ -136,15 +197,32 @@ describe('getDesignTokens brand integration', () => {
   });
 
   it('applies a brand colour to the palette and exposes the raw value', () => {
-    const palette = getDesignTokens('light', BRAND).palette;
+    const palette = getDesignTokens('light', { primary: BRAND }).palette;
     expect(palette.primary.main).toBe(BRAND);
     expect(palette.brandColor).toBe(BRAND);
     expect(palette.background.light4).not.toBe('#33A6CB');
   });
 
+  it('lets either colour be set on its own', () => {
+    // A deployment that only wants a new primary must not lose the Rhesis
+    // secondary, and vice versa.
+    const primaryOnly = getDesignTokens('light', { primary: BRAND }).palette;
+    expect(primaryOnly.primary.main).toBe(BRAND);
+    expect(primaryOnly.secondary.main).toBe('#FD6E12');
+
+    const secondaryOnly = getDesignTokens('light', {
+      secondary: PALE_BRAND,
+    }).palette;
+    expect(secondaryOnly.secondary.main).toBe(PALE_BRAND);
+    expect(secondaryOnly.primary.main).toBe('#0080AF');
+    expect(secondaryOnly.background.light1).toBe('#F2F9FD');
+  });
+
   it('leaves dark-mode background tints as greys', () => {
     // Only light mode's light1-4 are brand-tinted; dark's are true greys.
-    expect(getDesignTokens('dark', BRAND).palette.background).toMatchObject({
+    expect(
+      getDesignTokens('dark', { primary: BRAND }).palette.background
+    ).toMatchObject({
       light1: '#0D1117',
       light2: '#161B22',
     });

--- a/apps/frontend/src/styles/__tests__/brand-palette.test.ts
+++ b/apps/frontend/src/styles/__tests__/brand-palette.test.ts
@@ -1,0 +1,152 @@
+import { getContrastRatio } from '@mui/system/colorManipulator';
+import {
+  contrastTextFor,
+  deriveBrandAccents,
+  deriveBrandPrimary,
+  deriveBrandSurfaces,
+} from '../brand-palette';
+import { getDesignTokens } from '../theme';
+
+/** A dark brand colour, far enough from Rhesis blue to make swaps obvious. */
+const BRAND = '#6A1B9A';
+/** A pale brand colour, to prove contrast is computed and not assumed white. */
+const PALE_BRAND = '#FDD803';
+
+describe('contrastTextFor', () => {
+  it('uses white on a dark brand colour', () => {
+    expect(contrastTextFor(BRAND)).toBe('#FFFFFF');
+  });
+
+  it('uses near-black on a pale brand colour', () => {
+    expect(contrastTextFor(PALE_BRAND)).toBe('#1A1A1A');
+  });
+
+  it('always clears the WCAG UI-component ratio', () => {
+    for (const color of [BRAND, PALE_BRAND, '#808080', '#FFFFFF', '#000000']) {
+      expect(
+        getContrastRatio(color, contrastTextFor(color))
+      ).toBeGreaterThanOrEqual(3);
+    }
+  });
+});
+
+describe('deriveBrandPrimary', () => {
+  it('keeps the brand colour as light-mode main', () => {
+    expect(deriveBrandPrimary(BRAND, 'light').main).toBe(BRAND);
+  });
+
+  it('lifts main and demotes the raw brand colour in dark mode', () => {
+    const dark = deriveBrandPrimary(BRAND, 'dark');
+    expect(dark.dark).toBe(BRAND);
+    expect(dark.main).not.toBe(BRAND);
+    // Lighter against a dark surface, matching how the Rhesis dark palette
+    // promotes #33A6CB over #0080AF.
+    expect(getContrastRatio(dark.main, '#0D1117')).toBeGreaterThan(
+      getContrastRatio(BRAND, '#0D1117')
+    );
+  });
+
+  it('reproduces the hand-picked Rhesis shades from #0080AF', () => {
+    // The factors in brand-palette.ts were fitted to the Figma palette; if
+    // someone retunes them, this is the check that says how far they drifted.
+    const light = deriveBrandPrimary('#0080AF', 'light');
+    // Designed #005F82 is rgb(0, 95, 130) — one unit per channel away.
+    expect(light.dark).toBe('rgb(0, 94, 129)');
+  });
+
+  it('picks readable button text for a pale brand colour', () => {
+    expect(deriveBrandPrimary(PALE_BRAND, 'light').contrastText).toBe(
+      '#1A1A1A'
+    );
+  });
+});
+
+describe('deriveBrandSurfaces', () => {
+  it('lands near the designed Rhesis tints for #0080AF', () => {
+    const surfaces = deriveBrandSurfaces('#0080AF');
+    // Designed #F2F9FD is rgb(242, 249, 253) and #E4F2FA is rgb(228, 242, 250);
+    // the derived tints sit within a few units of both.
+    expect(surfaces.light1).toBe('rgb(242, 248, 251)');
+    expect(surfaces.light2).toBe('rgb(229, 242, 247)');
+  });
+
+  it('orders the tints from lightest to strongest', () => {
+    const s = deriveBrandSurfaces(BRAND);
+    const contrastOnWhite = (c: string) => getContrastRatio(c, '#FFFFFF');
+    expect(contrastOnWhite(s.light1)).toBeLessThan(contrastOnWhite(s.light2));
+    expect(contrastOnWhite(s.light2)).toBeLessThan(contrastOnWhite(s.light3));
+    expect(contrastOnWhite(s.light3)).toBeLessThan(contrastOnWhite(s.light4));
+  });
+});
+
+describe('deriveBrandAccents', () => {
+  it('returns the Figma literals verbatim when no brand colour is set', () => {
+    // These are the exact strings the component overrides used before the
+    // brand hook existed, so the default theme is untouched.
+    expect(deriveBrandAccents('light')).toEqual({
+      main: '#0080AF',
+      mainHover: '#005F82',
+      contrastText: '#FFFFFF',
+      onSurface: '#0080AF',
+      softHover: 'rgba(0, 128, 175, 0.04)',
+    });
+    expect(deriveBrandAccents('dark').onSurface).toBe('#33A6CB');
+  });
+
+  it('uses the brand colour for solid fills in both modes', () => {
+    expect(deriveBrandAccents('light', BRAND).main).toBe(BRAND);
+    expect(deriveBrandAccents('dark', BRAND).main).toBe(BRAND);
+  });
+
+  it('lightens only the on-surface colour for dark mode', () => {
+    expect(deriveBrandAccents('dark', BRAND).onSurface).not.toBe(BRAND);
+    expect(deriveBrandAccents('light', BRAND).onSurface).toBe(BRAND);
+  });
+});
+
+describe('getDesignTokens brand integration', () => {
+  it('is byte-identical to the Rhesis palette when no brand colour is passed', () => {
+    // The regression guard: adding the parameter must not shift the default look.
+    for (const mode of ['light', 'dark'] as const) {
+      const palette = getDesignTokens(mode).palette;
+      expect(palette.primary).toEqual(
+        mode === 'light'
+          ? {
+              main: '#0080AF',
+              light: '#33A6CB',
+              dark: '#005F82',
+              contrastText: '#FFFFFF',
+            }
+          : {
+              main: '#33A6CB',
+              light: '#66C2DC',
+              dark: '#0080AF',
+              contrastText: '#FFFFFF',
+            }
+      );
+      expect(palette.brandColor).toBeUndefined();
+    }
+
+    expect(getDesignTokens('light').palette.background).toMatchObject({
+      light1: '#F2F9FD',
+      light2: '#E4F2FA',
+      light3: '#C2E5F5',
+      light4: '#33A6CB',
+    });
+  });
+
+  it('applies a brand colour to the palette and exposes the raw value', () => {
+    const palette = getDesignTokens('light', BRAND).palette;
+    expect(palette.primary.main).toBe(BRAND);
+    expect(palette.brandColor).toBe(BRAND);
+    expect(palette.background.light4).not.toBe('#33A6CB');
+  });
+
+  it('leaves dark-mode background tints as greys', () => {
+    // Only light mode's light1-4 are brand-tinted; dark's are true greys.
+    expect(getDesignTokens('dark', BRAND).palette.background).toMatchObject({
+      light1: '#0D1117',
+      light2: '#161B22',
+    });
+  });
+});

--- a/apps/frontend/src/styles/brand-palette.ts
+++ b/apps/frontend/src/styles/brand-palette.ts
@@ -93,6 +93,64 @@ export function deriveBrandSurfaces(brandColor: string): BrandSurfaces {
   };
 }
 
+/**
+ * Builds `palette.secondary` for one mode from a configured secondary colour.
+ *
+ * Unlike primary, the Rhesis secondary slots are not a tint ramp — `light` is
+ * the accent yellow, and `dark` is near-black in light mode and a stray blue in
+ * dark mode. There is no relationship to generalise, so a configured colour gets
+ * a plain lighten/darken ramp instead. The defaults are kept verbatim when
+ * nothing is configured, so this only applies to deployments that opt in.
+ *
+ * `main` is the same in both modes, matching the current theme, where the
+ * secondary orange does not shift for dark surfaces the way primary does.
+ */
+export function deriveBrandSecondary(secondaryColor: string): BrandPrimary {
+  return {
+    main: secondaryColor,
+    light: lighten(secondaryColor, 0.25),
+    dark: darken(secondaryColor, 0.26),
+    contrastText: contrastTextFor(secondaryColor),
+  };
+}
+
+export interface SecondaryAccents {
+  main: string;
+  /** Hover fill. Brightens rather than darkens, keeping the spirit of the
+   * Rhesis orange→yellow hover. */
+  mainHover: string;
+  contrastText: string;
+  /** Text colour on top of `mainHover`, recomputed because a lighter fill can
+   * flip the readable choice. */
+  hoverContrastText: string;
+}
+
+/**
+ * Resolves the secondary colours used directly by the contained/outlined
+ * secondary button overrides. With no configured colour it returns the Figma
+ * literals, including the orange→yellow hover and its dark label.
+ */
+export function deriveSecondaryAccents(
+  secondaryColor?: string
+): SecondaryAccents {
+  if (!secondaryColor) {
+    return {
+      main: '#FD6E12',
+      mainHover: '#FDD803',
+      contrastText: '#FFFFFF',
+      hoverContrastText: '#1A1A1A',
+    };
+  }
+
+  const mainHover = lighten(secondaryColor, 0.25);
+  return {
+    main: secondaryColor,
+    mainHover,
+    contrastText: contrastTextFor(secondaryColor),
+    hoverContrastText: contrastTextFor(mainHover),
+  };
+}
+
 export interface BrandAccents {
   /** Solid brand fill: app bar, contained primary button, active pill. */
   main: string;

--- a/apps/frontend/src/styles/brand-palette.ts
+++ b/apps/frontend/src/styles/brand-palette.ts
@@ -1,0 +1,142 @@
+/**
+ * Derives a primary palette from a single configured brand colour, for
+ * deployments that set `BRAND_PRIMARY_COLOR` (see `config/branding.ts`).
+ *
+ * The lighten/darken factors here are not arbitrary — they are the ones that
+ * reproduce the hand-picked Rhesis palette from `#0080AF` almost exactly
+ * (`darken(0.26)` lands on `#005F82`, `lighten(0.95)` on `#F2F8FB` against a
+ * designed `#F2F9FD`). So a custom colour gets the same relationships the
+ * Figma palette was built with, rather than a fresh guess.
+ *
+ * Imports the colour helpers from `@mui/system/colorManipulator` rather than
+ * `@mui/material/styles`: they are pure functions, and the deep path keeps this
+ * module importable from server components too.
+ */
+import {
+  alpha,
+  darken,
+  getContrastRatio,
+  lighten,
+} from '@mui/system/colorManipulator';
+
+/** The Rhesis primary. Also the reference point the factors below were fitted to. */
+const RHESIS_PRIMARY = '#0080AF';
+
+/** Dark text for light brand colours — matches `text.secondary` in the theme. */
+const DARK_CONTRAST_TEXT = '#1A1A1A';
+const LIGHT_CONTRAST_TEXT = '#FFFFFF';
+
+/** MUI's own default `contrastThreshold`, i.e. the WCAG ratio for UI components
+ * and large text. Buttons and chips are the main consumers. */
+const CONTRAST_THRESHOLD = 3;
+
+export interface BrandPrimary {
+  main: string;
+  light: string;
+  dark: string;
+  contrastText: string;
+}
+
+export interface BrandSurfaces {
+  light1: string;
+  light2: string;
+  light3: string;
+  light4: string;
+}
+
+/**
+ * Picks white or near-black text for a background, so a pale brand colour
+ * (yellow, mint) still gets readable button labels instead of white-on-white.
+ */
+export function contrastTextFor(background: string): string {
+  return getContrastRatio(background, LIGHT_CONTRAST_TEXT) >= CONTRAST_THRESHOLD
+    ? LIGHT_CONTRAST_TEXT
+    : DARK_CONTRAST_TEXT;
+}
+
+/**
+ * Builds `palette.primary` for one mode.
+ *
+ * Dark mode shifts `main` lighter and keeps the raw brand colour as `dark`,
+ * mirroring how the Rhesis dark palette promotes `#33A6CB` to `main` and
+ * demotes `#0080AF` — a saturated brand colour is hard to read on a dark
+ * surface at full strength.
+ */
+export function deriveBrandPrimary(
+  brandColor: string,
+  mode: 'light' | 'dark'
+): BrandPrimary {
+  const main = mode === 'light' ? brandColor : lighten(brandColor, 0.25);
+
+  return {
+    main,
+    light: lighten(brandColor, mode === 'light' ? 0.25 : 0.45),
+    dark: mode === 'light' ? darken(brandColor, 0.26) : brandColor,
+    contrastText: contrastTextFor(main),
+  };
+}
+
+/**
+ * Builds the light-mode `background.light1`–`light4` tints.
+ *
+ * These four are brand-tinted surfaces, not greys — 12 components read them for
+ * hovers, selected rows and callouts. Leaving them at the Rhesis blues would
+ * put a custom-coloured button on a blue panel, which reads as a half-finished
+ * rebrand. Dark mode's equivalents are true greys and stay untouched.
+ */
+export function deriveBrandSurfaces(brandColor: string): BrandSurfaces {
+  return {
+    light1: lighten(brandColor, 0.95),
+    light2: lighten(brandColor, 0.9),
+    light3: lighten(brandColor, 0.75),
+    light4: lighten(brandColor, 0.25),
+  };
+}
+
+export interface BrandAccents {
+  /** Solid brand fill: app bar, contained primary button, active pill. */
+  main: string;
+  /** Hover state for a solid brand fill. */
+  mainHover: string;
+  /** Text/icon colour placed on top of `main`. */
+  contrastText: string;
+  /** Brand colour readable *against* the current mode's surface — used for
+   * outlined/text buttons, checkboxes and focus borders. */
+  onSurface: string;
+  /** Barely-there wash for text-button hover. */
+  softHover: string;
+}
+
+/**
+ * Resolves the brand-dependent colours that the `components` style overrides
+ * use directly instead of going through `palette.primary`.
+ *
+ * Without this, a deployment's custom colour would reach buttons via the
+ * palette but leave the app bar, checkboxes, pill toggles and input focus
+ * borders on Rhesis blue. Passing no `brandColor` returns the exact Figma
+ * literals those overrides were written with — including `softHover`, where
+ * `alpha(#0080AF, 0.04)` reproduces the original `rgba(0, 128, 175, 0.04)`
+ * string character for character.
+ *
+ * Chart palettes are deliberately not derived: a readable series palette needs
+ * distinguishable hues, not tints of one colour.
+ */
+export function deriveBrandAccents(
+  mode: 'light' | 'dark',
+  brandColor?: string
+): BrandAccents {
+  const main = brandColor ?? RHESIS_PRIMARY;
+
+  return {
+    main,
+    mainHover: brandColor ? darken(brandColor, 0.26) : '#005F82',
+    contrastText: contrastTextFor(main),
+    onSurface:
+      mode === 'light'
+        ? main
+        : brandColor
+          ? lighten(brandColor, 0.25)
+          : '#33A6CB',
+    softHover: alpha(main, 0.04),
+  };
+}

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -17,29 +17,42 @@ import {
   contrastTextFor,
   deriveBrandAccents,
   deriveBrandPrimary,
+  deriveBrandSecondary,
   deriveBrandSurfaces,
+  deriveSecondaryAccents,
 } from './brand-palette';
 export { GREYSCALE, BORDER_RADIUS, BACKDROP_COLORS, ELEVATION, FAB_GROUP_GAP };
+
+/** Deployment brand colours (`BRAND_PRIMARY_COLOR`, `BRAND_SECONDARY_COLOR`). */
+export interface BrandColors {
+  primary?: string;
+  secondary?: string;
+}
 
 /**
  * Define theme settings for both light and dark modes.
  *
- * `brandColor` overrides the Rhesis primary for white-label deployments
- * (`BRAND_PRIMARY_COLOR`, threaded down from the root layout). When it is
- * omitted every token below is the literal Figma value, so the default Rhesis
- * theme is unaffected by this parameter existing.
+ * `brand` overrides the Rhesis primary and secondary for white-label
+ * deployments, threaded down from the root layout. Either colour can be set on
+ * its own. When a colour is omitted every token below is the literal Figma
+ * value, so the default Rhesis theme is unaffected by this parameter existing.
  */
-const getDesignTokens = (mode: PaletteMode, brandColor?: string) => {
+const getDesignTokens = (mode: PaletteMode, brand: BrandColors = {}) => {
   const gs = mode === 'light' ? GREYSCALE.light : GREYSCALE.dark;
+  const brandColor = brand.primary;
   const brandPrimary = brandColor
     ? deriveBrandPrimary(brandColor, mode)
     : undefined;
   const brandSurfaces = brandColor
     ? deriveBrandSurfaces(brandColor)
     : undefined;
+  const brandSecondary = brand.secondary
+    ? deriveBrandSecondary(brand.secondary)
+    : undefined;
   // Brand colours for the `components` overrides further down, which set
-  // colours directly rather than reading `palette.primary`.
+  // colours directly rather than reading `palette.primary`/`palette.secondary`.
   const accent = deriveBrandAccents(mode, brandColor);
+  const secondaryAccent = deriveSecondaryAccents(brand.secondary);
 
   return {
     palette: {
@@ -53,7 +66,7 @@ const getDesignTokens = (mode: PaletteMode, brandColor?: string) => {
               dark: '#005F82', // darker shade
               contrastText: '#FFFFFF',
             },
-            secondary: {
+            secondary: brandSecondary ?? {
               main: '#FD6E12', // Secondary CTA Orange
               light: '#FDD803', // Accent Yellow
               dark: '#1A1A1A', // Dark Black
@@ -94,7 +107,7 @@ const getDesignTokens = (mode: PaletteMode, brandColor?: string) => {
               dark: '#0080AF',
               contrastText: '#FFFFFF',
             },
-            secondary: {
+            secondary: brandSecondary ?? {
               main: '#FD6E12',
               light: '#F78166',
               dark: '#58A6FF',
@@ -128,6 +141,7 @@ const getDesignTokens = (mode: PaletteMode, brandColor?: string) => {
       // Greyscale ramp available on palette for both modes
       greyscale: gs,
       brandColor,
+      brandSecondaryColor: brand.secondary,
     },
     shape: {
       borderRadius: 8,
@@ -370,9 +384,12 @@ const getDesignTokens = (mode: PaletteMode, brandColor?: string) => {
               '&.Mui-disabled': { backgroundColor: 'unset', color: 'unset' },
             },
             '&.MuiButton-containedSecondary': {
-              backgroundColor: '#FD6E12',
-              color: '#FFFFFF',
-              '&:hover': { backgroundColor: '#FDD803', color: '#1A1A1A' },
+              backgroundColor: secondaryAccent.main,
+              color: secondaryAccent.contrastText,
+              '&:hover': {
+                backgroundColor: secondaryAccent.mainHover,
+                color: secondaryAccent.hoverContrastText,
+              },
             },
             '&.MuiButton-outlinedPrimary': {
               color: accent.onSurface,
@@ -385,13 +402,13 @@ const getDesignTokens = (mode: PaletteMode, brandColor?: string) => {
               },
             },
             '&.MuiButton-outlinedSecondary': {
-              color: '#FD6E12',
-              borderColor: '#FD6E12',
+              color: secondaryAccent.main,
+              borderColor: secondaryAccent.main,
               backgroundColor: 'transparent',
               '&:hover': {
-                backgroundColor: '#FD6E12',
-                color: '#FFFFFF',
-                borderColor: '#FD6E12',
+                backgroundColor: secondaryAccent.main,
+                color: secondaryAccent.contrastText,
+                borderColor: secondaryAccent.main,
               },
             },
             '&.MuiButton-textPrimary': {
@@ -764,6 +781,8 @@ declare module '@mui/material/styles' {
      * blue on the server and swap after hydration.
      */
     brandColor?: string;
+    /** The raw configured `BRAND_SECONDARY_COLOR`. Undefined on the default theme. */
+    brandSecondaryColor?: string;
   }
   interface PaletteOptions {
     greyscale?: {
@@ -777,6 +796,7 @@ declare module '@mui/material/styles' {
       fieldSurface?: string;
     };
     brandColor?: string;
+    brandSecondaryColor?: string;
   }
 }
 

--- a/apps/frontend/src/styles/theme.ts
+++ b/apps/frontend/src/styles/theme.ts
@@ -13,11 +13,33 @@ import {
   ELEVATION,
   FAB_GROUP_GAP,
 } from './theme-constants';
+import {
+  contrastTextFor,
+  deriveBrandAccents,
+  deriveBrandPrimary,
+  deriveBrandSurfaces,
+} from './brand-palette';
 export { GREYSCALE, BORDER_RADIUS, BACKDROP_COLORS, ELEVATION, FAB_GROUP_GAP };
 
-// Define theme settings for both light and dark modes
-const getDesignTokens = (mode: PaletteMode) => {
+/**
+ * Define theme settings for both light and dark modes.
+ *
+ * `brandColor` overrides the Rhesis primary for white-label deployments
+ * (`BRAND_PRIMARY_COLOR`, threaded down from the root layout). When it is
+ * omitted every token below is the literal Figma value, so the default Rhesis
+ * theme is unaffected by this parameter existing.
+ */
+const getDesignTokens = (mode: PaletteMode, brandColor?: string) => {
   const gs = mode === 'light' ? GREYSCALE.light : GREYSCALE.dark;
+  const brandPrimary = brandColor
+    ? deriveBrandPrimary(brandColor, mode)
+    : undefined;
+  const brandSurfaces = brandColor
+    ? deriveBrandSurfaces(brandColor)
+    : undefined;
+  // Brand colours for the `components` overrides further down, which set
+  // colours directly rather than reading `palette.primary`.
+  const accent = deriveBrandAccents(mode, brandColor);
 
   return {
     palette: {
@@ -25,7 +47,7 @@ const getDesignTokens = (mode: PaletteMode) => {
       ...(mode === 'light'
         ? {
             // Light mode - Rhesis AI colors
-            primary: {
+            primary: brandPrimary ?? {
               main: '#0080AF', // Figma primary blue
               light: '#33A6CB', // lighter tint
               dark: '#005F82', // darker shade
@@ -40,10 +62,12 @@ const getDesignTokens = (mode: PaletteMode) => {
             background: {
               default: BACKGROUND_DEFAULT.light,
               paper: '#FFFFFF',
-              light1: '#F2F9FD',
-              light2: '#E4F2FA',
-              light3: '#C2E5F5',
-              light4: '#33A6CB',
+              ...(brandSurfaces ?? {
+                light1: '#F2F9FD',
+                light2: '#E4F2FA',
+                light3: '#C2E5F5',
+                light4: '#33A6CB',
+              }),
             },
             text: {
               primary: '#3D3D3D',
@@ -64,7 +88,7 @@ const getDesignTokens = (mode: PaletteMode) => {
           }
         : {
             // Dark mode
-            primary: {
+            primary: brandPrimary ?? {
               main: '#33A6CB', // slightly lighter for dark bg readability
               light: '#66C2DC',
               dark: '#0080AF',
@@ -103,6 +127,7 @@ const getDesignTokens = (mode: PaletteMode) => {
           }),
       // Greyscale ramp available on palette for both modes
       greyscale: gs,
+      brandColor,
     },
     shape: {
       borderRadius: 8,
@@ -280,9 +305,10 @@ const getDesignTokens = (mode: PaletteMode) => {
       MuiAppBar: {
         styleOverrides: {
           root: {
-            backgroundColor: mode === 'light' ? '#0080AF' : '#161B22',
+            backgroundColor: mode === 'light' ? accent.main : '#161B22',
             '& .MuiSvgIcon-root': {
-              color: '#FFFFFF',
+              // Dark mode's bar is grey, so its icons stay white regardless.
+              color: mode === 'light' ? accent.contrastText : '#FFFFFF',
             },
           },
         },
@@ -305,9 +331,9 @@ const getDesignTokens = (mode: PaletteMode) => {
       MuiDataGrid: {
         styleOverrides: {
           checkboxInput: {
-            color: mode === 'light' ? '#0080AF' : '#33A6CB',
+            color: accent.onSurface,
             '&.Mui-checked, &.MuiCheckbox-indeterminate': {
-              color: mode === 'light' ? '#0080AF' : '#33A6CB',
+              color: accent.onSurface,
             },
           },
         },
@@ -338,9 +364,9 @@ const getDesignTokens = (mode: PaletteMode) => {
             fontWeight: 600,
             borderRadius: 8,
             '&.MuiButton-containedPrimary': {
-              backgroundColor: '#0080AF',
-              color: '#FFFFFF',
-              '&:hover': { backgroundColor: '#005F82' },
+              backgroundColor: accent.main,
+              color: accent.contrastText,
+              '&:hover': { backgroundColor: accent.mainHover },
               '&.Mui-disabled': { backgroundColor: 'unset', color: 'unset' },
             },
             '&.MuiButton-containedSecondary': {
@@ -349,13 +375,13 @@ const getDesignTokens = (mode: PaletteMode) => {
               '&:hover': { backgroundColor: '#FDD803', color: '#1A1A1A' },
             },
             '&.MuiButton-outlinedPrimary': {
-              color: mode === 'dark' ? '#33A6CB' : '#0080AF',
-              borderColor: mode === 'dark' ? '#33A6CB' : '#0080AF',
+              color: accent.onSurface,
+              borderColor: accent.onSurface,
               backgroundColor: 'transparent',
               '&:hover': {
-                backgroundColor: mode === 'dark' ? '#33A6CB' : '#0080AF',
-                color: '#FFFFFF',
-                borderColor: mode === 'dark' ? '#33A6CB' : '#0080AF',
+                backgroundColor: accent.onSurface,
+                color: contrastTextFor(accent.onSurface),
+                borderColor: accent.onSurface,
               },
             },
             '&.MuiButton-outlinedSecondary': {
@@ -369,10 +395,10 @@ const getDesignTokens = (mode: PaletteMode) => {
               },
             },
             '&.MuiButton-textPrimary': {
-              color: mode === 'light' ? '#0080AF' : '#33A6CB',
+              color: accent.onSurface,
               '&:hover': {
                 backgroundColor:
-                  mode === 'light' ? 'rgba(0, 128, 175, 0.04)' : '#1F242B',
+                  mode === 'light' ? accent.softHover : '#1F242B',
               },
             },
           },
@@ -394,9 +420,9 @@ const getDesignTokens = (mode: PaletteMode) => {
                 mode === 'light' ? GREYSCALE.light.body : GREYSCALE.dark.body,
               backgroundColor: 'transparent',
               '&.active, &[aria-pressed="true"]': {
-                backgroundColor: '#0080AF',
-                color: '#FFFFFF',
-                borderColor: '#0080AF',
+                backgroundColor: accent.main,
+                color: accent.contrastText,
+                borderColor: accent.main,
               },
               '&:hover': {
                 backgroundColor:
@@ -541,7 +567,7 @@ const getDesignTokens = (mode: PaletteMode) => {
                     : GREYSCALE.dark.border,
               },
               '&:hover fieldset': {
-                borderColor: '#0080AF',
+                borderColor: accent.onSurface,
               },
             },
             ...(mode === 'dark' && {
@@ -727,6 +753,17 @@ declare module '@mui/material/styles' {
       surface2: string;
       fieldSurface: string;
     };
+    /**
+     * The raw configured `BRAND_PRIMARY_COLOR`, before any per-mode lightening.
+     * Undefined on the default Rhesis theme.
+     *
+     * Carried on the palette so consumers that need the *unshifted* brand
+     * colour — the auth pages, which run their own palette — can read it from
+     * the ambient theme. That keeps server render and hydration in agreement;
+     * reading `window.__ENV__` in those components instead would render Rhesis
+     * blue on the server and swap after hydration.
+     */
+    brandColor?: string;
   }
   interface PaletteOptions {
     greyscale?: {
@@ -739,6 +776,7 @@ declare module '@mui/material/styles' {
       surface2?: string;
       fieldSurface?: string;
     };
+    brandColor?: string;
   }
 }
 

--- a/apps/frontend/src/types/env.d.ts
+++ b/apps/frontend/src/types/env.d.ts
@@ -4,6 +4,10 @@ declare global {
   interface Window {
     __ENV__?: {
       apiBaseUrl: string;
+      /** Absent unless the deployment sets `BRAND_PRIMARY_COLOR`. */
+      brandPrimaryColor?: string;
+      brandFaviconUrl?: string;
+      brandProductName?: string;
     };
   }
 }

--- a/apps/frontend/src/types/navigation.ts
+++ b/apps/frontend/src/types/navigation.ts
@@ -55,8 +55,18 @@ export type NavigationItem =
   | NavigationActionItem;
 
 export interface BrandingProps {
+  /** Organisation name, falling back to `productName` before it resolves. */
   title: string;
   logo: ReactNode;
+  /**
+   * Brand mark shown in the sidebar — `BRAND_FAVICON_URL` when a deployment
+   * sets one, otherwise the shipped Rhesis icon. Threaded through here rather
+   * than read from `window.__ENV__` so the server and client render the same
+   * `src` and hydration stays quiet.
+   */
+  iconUrl?: string;
+  /** `BRAND_PRODUCT_NAME`, for alt text and labels. */
+  productName?: string;
   homeUrl?: string;
 }
 

--- a/charts/rhesis/templates/configmap.yaml
+++ b/charts/rhesis/templates/configmap.yaml
@@ -43,6 +43,7 @@ data:
   # into the client bundle at build time, which would mean one image per
   # deployment. The frontend reads these per request instead.
   BRAND_PRIMARY_COLOR: {{ .Values.config.brandPrimaryColor | quote }}
+  BRAND_SECONDARY_COLOR: {{ .Values.config.brandSecondaryColor | quote }}
   BRAND_FAVICON_URL: {{ .Values.config.brandFaviconUrl | quote }}
   BRAND_PRODUCT_NAME: {{ .Values.config.brandProductName | quote }}
 

--- a/charts/rhesis/templates/configmap.yaml
+++ b/charts/rhesis/templates/configmap.yaml
@@ -39,6 +39,12 @@ data:
   NEXT_PUBLIC_QUICK_START: {{ .Values.config.nextPublicQuickStart | quote }}
   NEXT_PUBLIC_SUPPORT_EMAIL: {{ .Values.config.nextPublicSupportEmail | quote }}
   ONBOARDING_VIDEO_URL: {{ .Values.config.onboardingVideoUrl | quote }}
+  # Branding overrides. Not NEXT_PUBLIC_* on purpose: that prefix bakes a value
+  # into the client bundle at build time, which would mean one image per
+  # deployment. The frontend reads these per request instead.
+  BRAND_PRIMARY_COLOR: {{ .Values.config.brandPrimaryColor | quote }}
+  BRAND_FAVICON_URL: {{ .Values.config.brandFaviconUrl | quote }}
+  BRAND_PRODUCT_NAME: {{ .Values.config.brandProductName | quote }}
 
   # -------------------------------------------------------------------------
   # Backend

--- a/charts/rhesis/values.yaml
+++ b/charts/rhesis/values.yaml
@@ -71,6 +71,18 @@ config:
   nextPublicQuickStart: "false"
   nextPublicSupportEmail: "hello@rhesis.ai"
   onboardingVideoUrl: ""
+
+  # Branding — both empty means the built-in Rhesis look. Set them to rebrand a
+  # deployment without rebuilding the image; the frontend reads them at request
+  # time and falls back to the defaults if a value is malformed.
+  # brandPrimaryColor: 6-digit hex, e.g. "#6A1B9A". Drives the primary palette,
+  #   app bar, buttons, brand-tinted surfaces and the sign-in screen accent.
+  # brandFaviconUrl: https:// URL or a root-relative path, e.g.
+  #   "https://www.example.com/favicon.png". Also used as the sidebar brand mark.
+  # brandProductName: replaces "Rhesis AI" in page titles, e.g. "Acme".
+  brandPrimaryColor: ""
+  brandFaviconUrl: ""
+  brandProductName: ""
   # Backend
   rhesisBaseUrl: ""
   frontendUrl: ""

--- a/charts/rhesis/values.yaml
+++ b/charts/rhesis/values.yaml
@@ -72,15 +72,18 @@ config:
   nextPublicSupportEmail: "hello@rhesis.ai"
   onboardingVideoUrl: ""
 
-  # Branding — both empty means the built-in Rhesis look. Set them to rebrand a
+  # Branding — all empty means the built-in Rhesis look. Set them to rebrand a
   # deployment without rebuilding the image; the frontend reads them at request
   # time and falls back to the defaults if a value is malformed.
   # brandPrimaryColor: 6-digit hex, e.g. "#6A1B9A". Drives the primary palette,
   #   app bar, buttons, brand-tinted surfaces and the sign-in screen accent.
   # brandFaviconUrl: https:// URL or a root-relative path, e.g.
   #   "https://www.example.com/favicon.png". Also used as the sidebar brand mark.
+  # brandSecondaryColor: 6-digit hex for the secondary/CTA colour. Independent of
+  #   brandPrimaryColor — set either on its own.
   # brandProductName: replaces "Rhesis AI" in page titles, e.g. "Acme".
   brandPrimaryColor: ""
+  brandSecondaryColor: ""
   brandFaviconUrl: ""
   brandProductName: ""
   # Backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,10 @@ x-telemetry-config: &telemetry-config
 x-nextjs-frontend: &nextjs-frontend
   NEXTAUTH_SECRET: ${NEXTAUTH_SECRET:?NEXTAUTH_SECRET is required, no safe default}
   NEXT_TELEMETRY_DISABLED: 1
+  # Optional branding overrides, read at request time — see .env.example
+  BRAND_PRIMARY_COLOR: ${BRAND_PRIMARY_COLOR:-}
+  BRAND_FAVICON_URL: ${BRAND_FAVICON_URL:-}
+  BRAND_PRODUCT_NAME: ${BRAND_PRODUCT_NAME:-}
 
 
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ x-nextjs-frontend: &nextjs-frontend
   NEXT_TELEMETRY_DISABLED: 1
   # Optional branding overrides, read at request time — see .env.example
   BRAND_PRIMARY_COLOR: ${BRAND_PRIMARY_COLOR:-}
+  BRAND_SECONDARY_COLOR: ${BRAND_SECONDARY_COLOR:-}
   BRAND_FAVICON_URL: ${BRAND_FAVICON_URL:-}
   BRAND_PRODUCT_NAME: ${BRAND_PRODUCT_NAME:-}
 

--- a/docs/content/docs/deployment/environment-variables.mdx
+++ b/docs/content/docs/deployment/environment-variables.mdx
@@ -37,19 +37,26 @@ and the public URL usually differ.
 
 ## Branding
 
-Replace the Rhesis colour, icon and product name with your own. All three are read at request time, so
-the same image serves every deployment — no rebuild, and no `NEXT_PUBLIC_` counterpart.
+Replace the Rhesis colours, icon and product name with your own. All four are read at request time, so
+the same image serves every deployment — no rebuild, and no `NEXT_PUBLIC_` counterpart. Each is
+independent; set only the ones you need.
 
 | Variable | Description | Default |
 |---|---|---|
 | `BRAND_PRIMARY_COLOR` | 6-digit hex colour, e.g. `#6A1B9A`. Drives the primary palette, app bar, buttons, brand-tinted surfaces and the sign-in accent | *(unset — Rhesis blue)* |
+| `BRAND_SECONDARY_COLOR` | 6-digit hex colour for the secondary/CTA accent — secondary buttons and anything using `palette.secondary` | *(unset — Rhesis orange)* |
 | `BRAND_FAVICON_URL` | `https://` URL or root-relative path, e.g. `https://www.example.com/favicon.png`. Used as the browser-tab icon and as the brand mark in the sidebar, onboarding and sign-in header | `/logos/rhesis-logo-favicon.svg` |
 | `BRAND_PRODUCT_NAME` | Name in page titles (`Architect` becomes `Architect \| Acme`), the sign-in header and footer, and the sidebar before the organisation loads. Max 60 characters | `Rhesis AI` |
 
-Light and dark shades are derived from the one colour, and button label text switches between white and
+Light and dark shades are derived from each colour, and button label text switches between white and
 near-black to stay readable — a pale brand colour does not need extra configuration. A malformed value is
 ignored with a warning in the frontend logs and the Rhesis default applies, so a typo cannot break a
 deployment.
+
+One difference between the two colours: the built-in secondary uses a different hue for its hover
+(orange to yellow) and near-black for `secondary.dark`. A configured `BRAND_SECONDARY_COLOR` gets a plain
+lighten/darken ramp instead, so secondary buttons brighten on hover within your own hue rather than
+shifting to another colour.
 
 Setting `BRAND_PRODUCT_NAME` also drops the Rhesis tagline from the page description and stops the
 sign-in wordmark linking to rhesis.ai.

--- a/docs/content/docs/deployment/environment-variables.mdx
+++ b/docs/content/docs/deployment/environment-variables.mdx
@@ -35,6 +35,32 @@ These four secrets have no default; the stack refuses to start if any is unset.
 Ports are the host bind ports and are independent of the URLs — behind a reverse proxy the published port
 and the public URL usually differ.
 
+## Branding
+
+Replace the Rhesis colour, icon and product name with your own. All three are read at request time, so
+the same image serves every deployment — no rebuild, and no `NEXT_PUBLIC_` counterpart.
+
+| Variable | Description | Default |
+|---|---|---|
+| `BRAND_PRIMARY_COLOR` | 6-digit hex colour, e.g. `#6A1B9A`. Drives the primary palette, app bar, buttons, brand-tinted surfaces and the sign-in accent | *(unset — Rhesis blue)* |
+| `BRAND_FAVICON_URL` | `https://` URL or root-relative path, e.g. `https://www.example.com/favicon.png`. Used as the browser-tab icon and as the brand mark in the sidebar, onboarding and sign-in header | `/logos/rhesis-logo-favicon.svg` |
+| `BRAND_PRODUCT_NAME` | Name in page titles (`Architect` becomes `Architect \| Acme`), the sign-in header and footer, and the sidebar before the organisation loads. Max 60 characters | `Rhesis AI` |
+
+Light and dark shades are derived from the one colour, and button label text switches between white and
+near-black to stay readable — a pale brand colour does not need extra configuration. A malformed value is
+ignored with a warning in the frontend logs and the Rhesis default applies, so a typo cannot break a
+deployment.
+
+Setting `BRAND_PRODUCT_NAME` also drops the Rhesis tagline from the page description and stops the
+sign-in wordmark linking to rhesis.ai.
+
+Three things keep their Rhesis identity on purpose: chart palettes, which need distinguishable hues
+rather than tints of one colour; the sign-in page's background artwork; and the Documentation, Blog and
+GitHub links in the sign-in header.
+
+On Kubernetes, set these through the chart instead — see
+[Kubernetes (Helm)](/docs/deployment/kubernetes-helm).
+
 ## Database
 
 Defaults point at the built-in `postgres` container. Set these to use your own database (see

--- a/docs/content/docs/deployment/kubernetes-helm.mdx
+++ b/docs/content/docs/deployment/kubernetes-helm.mdx
@@ -333,18 +333,19 @@ frontend:
 
 ## Rebrand the frontend
 
-Set your colour, icon and product name under `config`. They go into the chart's ConfigMap, which
+Set your colours, icon and product name under `config`. They go into the chart's ConfigMap, which
 every deployment already loads — nothing to add to Secret Manager, since none of them is a secret
-(all three end up in the served HTML).
+(all four end up in the served HTML).
 
 <CodeBlock filename="charts/rhesis/values-customer.yaml" language="yaml">
 {`config:
   brandPrimaryColor: "#6A1B9A"
+  brandSecondaryColor: "#C2185B"
   brandFaviconUrl: "https://www.example.com/favicon.png"
   brandProductName: "Acme"`}
 </CodeBlock>
 
-Quote the colour — an unquoted `#` starts a YAML comment. See
+Quote the colours — an unquoted `#` starts a YAML comment. See
 [Environment Variables](/docs/deployment/environment-variables) for what each one covers and how
 malformed values are handled.
 

--- a/docs/content/docs/deployment/kubernetes-helm.mdx
+++ b/docs/content/docs/deployment/kubernetes-helm.mdx
@@ -331,6 +331,29 @@ frontend:
     host: your-app-domain.com`}
 </CodeBlock>
 
+## Rebrand the frontend
+
+Set your colour, icon and product name under `config`. They go into the chart's ConfigMap, which
+every deployment already loads — nothing to add to Secret Manager, since none of them is a secret
+(all three end up in the served HTML).
+
+<CodeBlock filename="charts/rhesis/values-customer.yaml" language="yaml">
+{`config:
+  brandPrimaryColor: "#6A1B9A"
+  brandFaviconUrl: "https://www.example.com/favicon.png"
+  brandProductName: "Acme"`}
+</CodeBlock>
+
+Quote the colour — an unquoted `#` starts a YAML comment. See
+[Environment Variables](/docs/deployment/environment-variables) for what each one covers and how
+malformed values are handled.
+
+ConfigMap changes don't restart pods on their own:
+
+```bash
+kubectl rollout restart deployment frontend -n rhesis
+```
+
 ## Minimal vs. full deployment
 
 Only 4 of the 6 chart components have public images. Rhesis publishes

--- a/scripts/check-hardcoded-styles.js
+++ b/scripts/check-hardcoded-styles.js
@@ -106,6 +106,7 @@ const EXCLUDE_PATTERNS = [
   /\.next/,
   /theme\.ts$/, // Exclude the theme file itself
   /authTokens\.ts$/, // Same reason as theme.ts: the auth pages' palette is defined here
+  /brand-palette\.ts$/, // Same reason: holds the Rhesis literals a custom brand colour falls back to
   /globals\.css$/, // Exclude globals.css (contains theme definitions)
   /check-hardcoded-styles\.js$/, // Exclude this script itself
   /apps\/documentation\/components\//, // Temporarily exclude docs components (need refactoring)


### PR DESCRIPTION
## Purpose

White-label deployments need their own colours, icon and product name without a per-customer image build. This adds four environment variables that the frontend reads at request time, so the same image serves every deployment.

They are deliberately **not** `NEXT_PUBLIC_*`: that prefix inlines a value into the client bundle at build time, which would mean one Docker image per deployment. This follows the rule already stated in `next.config.ts` — "one Docker image works across all environments without build args" — and rides the existing `window.__ENV__` runtime-config mechanism.

They also do **not** go in GCP Secret Manager. None of them is a secret; all four end up in the served HTML. They live in the chart's ConfigMap, which every app deployment already loads via `envFrom`, so a self-hosted deployment sets them in its own `values.yaml`.

| Variable | Example | Default |
|---|---|---|
| `BRAND_PRIMARY_COLOR` | `#6A1B9A` | *(unset — Rhesis blue)* |
| `BRAND_SECONDARY_COLOR` | `#C2185B` | *(unset — Rhesis orange)* |
| `BRAND_FAVICON_URL` | `https://cdn.example.com/favicon.png` | `/logos/rhesis-logo-favicon.svg` |
| `BRAND_PRODUCT_NAME` | `Acme` | `Rhesis AI` |

Each is independent — a deployment can set only the ones it needs.

## What Changed

- **`config/branding.ts`** — validates and resolves all four, falling back to the Rhesis default with a warning that names the offending variable. A malformed value cannot break a deployment; `javascript:`, plain `http://` and protocol-relative (`//host/…`) favicon URLs are rejected outright.
- **`styles/brand-palette.ts`** — derives the palettes from the configured hexes. The primary factors are fitted to the existing Figma palette (`darken(0.26)` on `#0080AF` lands one unit off the designed `#005F82`), so a custom colour inherits the relationships the palette was built with. Button label text is chosen by contrast ratio, so a pale brand colour gets dark labels instead of unreadable white ones.
- **`styles/theme.ts`** — `getDesignTokens(mode, brand?: BrandColors)`. Also routes the ~12 component overrides that set brand colours directly (app bar, contained/outlined/text primary buttons, contained/outlined secondary buttons, checkboxes, pill toggles, input focus border) through the derived values; without that they would have stayed Rhesis blue and orange while the palette changed.
- **Favicon** — root layout's static `metadata` became `generateMetadata()` so the icon resolves per request.
- **Titles** — `%s | Rhesis AI` becomes `%s | <product name>`. A configured name also replaces the Rhesis tagline in the page description.
- **Brand mark** — new `BrandMark` component used by the sidebar (collapsed and expanded), onboarding sidebar/step header, and the sign-in header.
- **Auth pages** — accent tokens, header wordmark, brand mark and footer follow the branding. A rebranded wordmark stops linking to rhesis.ai.
- **Chart / compose / docs** — the four `config.brand*` values into the ConfigMap; `.env.example` and both deployment docs pages.

## Additional Context

**The default Rhesis theme is unchanged.** With nothing configured, both palettes return the Figma literals verbatim — there is a test asserting primary *and* secondary are identical, including that `alpha('#0080AF', 0.04)` reproduces the original `rgba(0, 128, 175, 0.04)` string character for character.

**Primary and secondary are derived differently, on purpose.** Primary has a coherent tint ramp to generalise from. Secondary does not: `light` is the accent yellow, and `dark` is near-black in light mode and a stray blue (`#58A6FF`) in dark mode — three unrelated slots rather than a ramp. A configured `BRAND_SECONDARY_COLOR` therefore gets a plain lighten/darken ramp, and its contained-button hover brightens within the same hue instead of jumping to another colour the way orange→yellow does. Documented for operators.

**Deliberately left on Rhesis identity**, all noted in the docs:

- Chart palettes — a readable series palette needs distinguishable hues, not tints of one colour.
- The sign-in background artwork — light mode's is a raster PNG that can't be recoloured in code.
- The Documentation, Blog and GitHub links in the sign-in header — removing navigation is a product decision, not a theming one.

**`BrandMark` uses a plain `<img>` for remote URLs**, not `next/image`. The optimizer refuses any host absent from `images.remotePatterns`, and the host here comes from a values file — unknowable at build time. Widening `remotePatterns` to `**` would turn the optimizer into an open image proxy. Favicons are a few KB, so there is nothing to optimise.

**Three things worth a reviewer's eye:**

1. The white-vs-dark label decision uses MUI's default `contrastThreshold` of 3. A brand colour whose contrast against white lands near 3:1 — mid-bright oranges, ambers and mid greens — therefore gets white labels by a narrow margin, where dark labels would score much better. The threshold stays at 3 because raising it to 4.5 would flip Rhesis's own `#0080AF` (4.47:1) to dark text, a regression on the default theme. Forcing one or the other per deployment would need a follow-up variable.
2. **The existing Rhesis secondary orange `#FD6E12` is 2.83:1 against white**, below the WCAG UI-component threshold, yet the theme hardcodes `contrastText: '#FFFFFF'`. This PR does not change that — it would be a visual regression outside its scope — but it means a *configured* secondary gets contrast-checked labels while the default keeps its sub-threshold white. Worth deciding separately whether to fix the default.
3. `scripts/check-hardcoded-styles.js` gains an exemption for `brand-palette.ts`, alongside the existing `theme.ts` and `authTokens.ts` entries, since the file exists to hold palette literals. The tradeoff is that future hex added to that file won't be caught.

Branding is per-deployment, not per-organisation — on multi-tenant rhesis.ai every org would see the same colours. That matches the Kubernetes-deployment framing of the request; org-scoped branding would be a different change built on `organization.logo_url`.

Unrelated but found while checking what actually renders: the organisation settings form has a **Logo URL** field that is saved but never displayed anywhere in the UI. Not touched here, but it will mislead operators who set it expecting a logo to appear.

## Testing

`npx tsc --noEmit` clean, no new lint warnings, **208 suites / 1916 tests pass** (43 new).

Verified against a running dev server with the variables set — served HTML carried the configured `rel="icon"` href, the brand colour in the CSS with zero Rhesis blue remaining, the configured `<title>`, and the branded `window.__ENV__` payload. With the variables unset the same page served the Rhesis favicon and blue, and no `brandPrimaryColor` key.

To try it locally, add to `apps/frontend/.env.local` and restart the frontend:

```
BRAND_PRIMARY_COLOR=#6A1B9A
BRAND_SECONDARY_COLOR=#C2185B
BRAND_FAVICON_URL=https://cdn.example.com/favicon.png
BRAND_PRODUCT_NAME=Acme
```

Check the sign-in page (accents, header wordmark, footer, tab icon), then log in for the sidebar brand mark, app bar and buttons. Remove the lines and confirm nothing about the Rhesis look changed.

**Not verified end-to-end:** the `<page> | <product name>` title suffix on an inner page, and the sidebar brand mark in the running app — both need an authenticated session. The template string and the sidebar `src` are covered by unit tests and read from the same resolved values as the verified pieces.

`helm template` was never run against the ConfigMap change — `helm` was not available locally. The four lines follow the exact form of their neighbours and the values keys exist, but it is unverified.
