### PR TITLE
Add tuning runs for custom metrics

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/metric_tuning.py
+++ b/apps/backend/src/rhesis/backend/app/crud/metric_tuning.py
@@ -22,9 +22,20 @@ from sqlalchemy.orm import Session, joinedload
 
 from rhesis.backend.app import models
 from rhesis.backend.app.models.test import test_test_set_association
-from rhesis.backend.app.schemas.metric_tuning_metadata import MetricTuningCaseMetadata
+from rhesis.backend.app.schemas.metric_tuning_metadata import (
+    MetricTuningCaseMetadata,
+    MetricTuningCaseResult,
+    MetricTuningRunSummary,
+    parse_metric_tuning_case_metadata,
+    parse_metric_tuning_run_summary,
+)
 
 logger = logging.getLogger(__name__)
+
+# Where the latest run's summary lives inside ``TestSet.attributes``. Nothing
+# else writes a tuning set's attributes -- attribute regeneration early-returns
+# for metric-owned sets -- but the key keeps it out of the way regardless.
+RUN_SUMMARY_KEY = "tuning_run"
 
 
 # --- Test sets ---------------------------------------------------------------------
@@ -60,6 +71,28 @@ def mark_test_set_as_tuning(
     test_set.metric_id = metric_id
     db.flush()
     db.refresh(test_set)
+    return test_set
+
+
+def get_run_summary(test_set: models.TestSet) -> MetricTuningRunSummary:
+    """The latest run's summary. A set nobody has run reads as ``never_run``."""
+    attributes = test_set.attributes or {}
+    return parse_metric_tuning_run_summary(attributes.get(RUN_SUMMARY_KEY))
+
+
+def set_run_summary(
+    db: Session, test_set: models.TestSet, summary: MetricTuningRunSummary
+) -> models.TestSet:
+    """Overwrite the latest run's summary. Only the latest is ever kept.
+
+    The whole ``attributes`` dict is reassigned rather than mutated in place:
+    SQLAlchemy does not track mutation inside a plain JSONB column, so an
+    in-place edit would flush nothing.
+    """
+    attributes = dict(test_set.attributes or {})
+    attributes[RUN_SUMMARY_KEY] = summary.model_dump(mode="json", exclude_none=True)
+    test_set.attributes = attributes
+    db.flush()
     return test_set
 
 
@@ -172,6 +205,22 @@ def remove_case_from_test_set(db: Session, test_set_id: uuid.UUID, test_id: uuid
         )
     )
     db.flush()
+
+
+def set_case_result(
+    db: Session, db_test: models.Test, result: MetricTuningCaseResult
+) -> models.Test:
+    """Record what the metric said about this case, overwriting the last run's.
+
+    Writes only the ``result`` key -- the case itself (its payload, its expected
+    verdict, its rationale) is what is being scored and is never touched by
+    scoring it.
+    """
+    metadata = parse_metric_tuning_case_metadata(db_test.test_metadata)
+    metadata.result = result
+    db_test.test_metadata = metadata.model_dump(mode="json", exclude_none=True)
+    db.flush()
+    return db_test
 
 
 def update_tuning_case(

--- a/apps/backend/src/rhesis/backend/app/routers/metric_tuning.py
+++ b/apps/backend/src/rhesis/backend/app/routers/metric_tuning.py
@@ -1,4 +1,4 @@
-"""Metric tuning cases — a metric's own set of labelled cases.
+"""Metric tuning — a metric's own set of labelled cases, and runs over them.
 
 Mounted under ``/metrics`` with ``resource="metric"``, so the four existing
 ``metric:read|create|update|delete`` capabilities cover these routes and no
@@ -6,8 +6,13 @@ capability catalog migration is needed. Kept in its own file rather than added t
 ``routers/metric.py`` so the feature can be removed by deleting one file and one
 import.
 
-The tuning test set is created on the first ``POST``: ``GET`` returns an empty
-list for a metric nobody has tuned yet rather than creating rows on a read.
+The tuning test set is created on the first case ``POST``: ``GET`` returns an
+empty list for a metric nobody has tuned yet rather than creating rows on a read.
+
+A run is started only by ``POST .../tuning/run`` and never as a side effect of
+anything else -- one LLM call per case is not something an edit should trigger.
+The work happens in a background task; ``GET .../tuning/run`` is what the
+interface polls while it goes.
 
 Only custom metrics can be tuned, and that is enforced here rather than only in
 the UI. The frontend hides the tab behind a flag, but these routes are live in
@@ -22,6 +27,7 @@ from fastapi import Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models
+from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.constants import MetricBackendType
 from rhesis.backend.app.crud.metric import get_metric
@@ -31,9 +37,13 @@ from rhesis.backend.app.schemas.metric_tuning import (
     MetricTuningCase,
     MetricTuningCaseCreate,
     MetricTuningCaseUpdate,
+    MetricTuningRun,
 )
 from rhesis.backend.app.services import metric_tuning as service
+from rhesis.backend.app.services.metric_tuning.runs import NoTuningCases, TuningRunInFlight
 from rhesis.backend.app.services.metric_tuning.verdict import InvalidVerdict
+from rhesis.backend.tasks import task_launcher
+from rhesis.backend.tasks.metric_tuning import run_metric_tuning
 
 logger = logging.getLogger(__name__)
 
@@ -145,3 +155,57 @@ def delete_tuning_case(
     db_test = _resolve_case_or_raise(db, metric_id, case_id, organization_id)
     service.delete_tuning_case(db, metric_id, db_test, organization_id, user_id)
     return {"deleted": True, "case_id": str(case_id)}
+
+
+@router.get("/{metric_id}/tuning/run", response_model=MetricTuningRun)
+def read_tuning_run(
+    metric_id: UUID,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: models.User = Depends(require_current_user_or_token),
+):
+    """The metric's latest run. ``never_run`` when there has not been one."""
+    organization_id, user_id = tenant_context
+    metric = _resolve_metric_or_raise(db, metric_id, organization_id, user_id)
+    summary = service.get_tuning_run(db, metric, organization_id)
+    return MetricTuningRun(**summary.model_dump(mode="json"))
+
+
+# Marked update rather than left to the POST-means-create convention: starting a
+# run writes results onto the metric's own cases, so whoever can edit the metric
+# can run it. An explicit `metric:execute` would need a capability catalog
+# migration for a feature still behind a flag.
+@router.post(
+    "/{metric_id}/tuning/run",
+    response_model=MetricTuningRun,
+    status_code=202,
+    **capability(Permission.Metric.UPDATE),
+)
+def start_tuning_run(
+    metric_id: UUID,
+    db: Session = Depends(get_tenant_db_session),
+    tenant_context=Depends(get_tenant_context),
+    current_user: models.User = Depends(require_current_user_or_token),
+):
+    """Start a run over the metric's cases and hand back the in-progress summary.
+
+    Nothing but this route starts a run: every run is one LLM call per case, so
+    an edit to a case or an evaluation prompt must never trigger one.
+    """
+    organization_id, user_id = tenant_context
+    metric = _resolve_metric_or_raise(db, metric_id, organization_id, user_id)
+
+    try:
+        summary = service.start_tuning_run(db, metric, organization_id)
+    except NoTuningCases as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except TuningRunInFlight as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
+    # Committed before dispatch so the worker cannot start on a session that has
+    # not yet written the claim it is about to update.
+    db.commit()
+
+    task_launcher(run_metric_tuning, str(metric_id), current_user=current_user, db=db)
+
+    return MetricTuningRun(**summary.model_dump(mode="json"))

--- a/apps/backend/src/rhesis/backend/app/routers/metric_tuning.py
+++ b/apps/backend/src/rhesis/backend/app/routers/metric_tuning.py
@@ -40,6 +40,7 @@ from rhesis.backend.app.schemas.metric_tuning import (
     MetricTuningRun,
 )
 from rhesis.backend.app.services import metric_tuning as service
+from rhesis.backend.app.services.metric_tuning.invoke import MetricModelNotConfigured
 from rhesis.backend.app.services.metric_tuning.runs import NoTuningCases, TuningRunInFlight
 from rhesis.backend.app.services.metric_tuning.verdict import InvalidVerdict
 from rhesis.backend.tasks import task_launcher
@@ -196,8 +197,8 @@ def start_tuning_run(
     metric = _resolve_metric_or_raise(db, metric_id, organization_id, user_id)
 
     try:
-        summary = service.start_tuning_run(db, metric, organization_id)
-    except NoTuningCases as e:
+        summary = service.start_tuning_run(db, metric, organization_id, user_id)
+    except (NoTuningCases, MetricModelNotConfigured) as e:
         raise HTTPException(status_code=400, detail=str(e))
     except TuningRunInFlight as e:
         raise HTTPException(status_code=409, detail=str(e))

--- a/apps/backend/src/rhesis/backend/app/schemas/metric_tuning.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/metric_tuning.py
@@ -22,9 +22,10 @@ on the way in and again on the way out.
 from datetime import datetime
 from typing import Optional, Union
 
-from pydantic import UUID4, ConfigDict
+from pydantic import UUID4, BaseModel, ConfigDict
 
 from rhesis.backend.app.schemas import Base
+from rhesis.backend.app.schemas.metric_tuning_metadata import TuningRunStatus
 
 
 class MetricTuningCaseBase(Base):
@@ -66,13 +67,63 @@ class MetricTuningCaseUpdate(Base):
     rationale: Optional[str] = None
 
 
+class MetricTuningCaseResult(BaseModel):
+    """What the metric said about this case in the latest run.
+
+    Absent until the metric has been run over the case. ``verdict`` is the
+    metric's own answer, to be read beside ``expected`` -- which is what the
+    human said it should be, and which the metric never sees.
+
+    Plain ``BaseModel``, not the shared ``Base``: this is a value on a case, not
+    a row. ``Base`` would add ``id``/``nano_id``/``project_id``, and an ``id``
+    here would advertise a handle that does not exist.
+    """
+
+    # The metric's own verdict, as a string, whatever its score type.
+    verdict: Optional[str] = None
+    # The metric's explanation, where it produces one.
+    reasoning: Optional[str] = None
+    # Set when the metric call failed for this case. Not the same as a wrong
+    # verdict, and never reported as one.
+    error: Optional[str] = None
+    evaluated_at: Optional[str] = None
+
+
 class MetricTuningCase(MetricTuningCaseBase):
     id: UUID4
     # True when `expected` no longer fits the metric's current score type, which
     # happens when the score type is changed after the case was written. Derived
     # on read, never stored -- see services/metric_tuning/verdict.py.
     is_stale: bool = False
+    # The latest run's result for this case, or None if it has never been run.
+    result: Optional[MetricTuningCaseResult] = None
     created_at: Union[datetime, str]
     updated_at: Union[datetime, str]
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class MetricTuningRun(BaseModel):
+    """The state of a metric's latest tuning run.
+
+    Only the latest is kept -- a new run overwrites the previous one, per
+    domain.local/adr/0004. A metric that has never been run reads as
+    ``never_run`` rather than as an absent object, so the interface has one
+    shape to render either way.
+
+    Plain ``BaseModel``, not the shared ``Base``: a run is stored in JSONB and is
+    deliberately not a row (ADR-0004), so it has no id to expose. Inheriting
+    ``Base`` would put a null ``id`` on every response and suggest otherwise.
+    """
+
+    status: TuningRunStatus = TuningRunStatus.NEVER_RUN
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    # How many cases the run set out to cover, and how many it has finished.
+    # The pair is what makes progress reportable while a run is still going.
+    total_cases: int = 0
+    completed_cases: int = 0
+    # Cases whose metric call failed. Reported apart from the verdicts.
+    errored_cases: int = 0
+    # Why the run as a whole failed. A single case failing does not fail a run.
+    error: Optional[str] = None

--- a/apps/backend/src/rhesis/backend/app/schemas/metric_tuning_metadata.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/metric_tuning_metadata.py
@@ -10,6 +10,7 @@ is always ``model_dump(mode="json", exclude_none=True)`` at the call site so a
 """
 
 import logging
+from enum import Enum
 from typing import Any, Mapping, Optional
 
 from pydantic import BaseModel, ConfigDict, ValidationError, field_validator
@@ -21,14 +22,61 @@ def _coerce_optional_str(value: Any) -> Optional[str]:
     return None if value is None else str(value)
 
 
+class TuningRunStatus(str, Enum):
+    """Where a metric's latest tuning run got to.
+
+    ``NEVER_RUN`` is not stored -- it is what a metric with no summary yet reads
+    as, so the API always has a status to return.
+    """
+
+    NEVER_RUN = "never_run"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class MetricTuningCaseResult(BaseModel):
+    """What the metric said about one case, from the latest run.
+
+    Only the latest run is kept, so a new run overwrites this outright rather
+    than appending (domain.local/adr/0004).
+
+    ``verdict`` is the metric's own score rendered as a string, for the same
+    reason ``expected`` is one: a binary metric returns pass/fail, a numeric one
+    a number, a categorical one a category name, and storing all three the same
+    way keeps the comparison in one place instead of branching per score type at
+    every read.
+
+    ``error`` set means the metric call failed for this case. A failed call is
+    deliberately not the same as a wrong verdict -- a flaky provider should never
+    read as a bad metric -- so the two never collapse into one field.
+    """
+
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
+
+    # What the metric returned. None when the call failed.
+    verdict: Optional[str] = None
+    # The metric's own explanation of that verdict, where it produces one.
+    reasoning: Optional[str] = None
+    # Why the call failed, when it did.
+    error: Optional[str] = None
+    # When the metric was run over this case, ISO-8601 UTC.
+    evaluated_at: Optional[str] = None
+
+    @field_validator("verdict", "reasoning", "error", "evaluated_at", mode="before")
+    @classmethod
+    def _validate_optional_str(cls, v: Any) -> Optional[str]:
+        return _coerce_optional_str(v)
+
+
 class MetricTuningCaseMetadata(BaseModel):
     """``Test.test_metadata`` for metric-tuning rows.
 
-    Only the rationale lives here. The rest of a case is either shown to the
-    metric -- input, output and expected output, which travel together in
-    ``prompt.content`` as the case payload -- or is the answer key, which is
-    ``prompt.expected_response``. The rationale is neither: it is for whoever
-    reviews the case later, and the metric never sees it.
+    The rationale and the latest run's result live here. The rest of a case is
+    either shown to the metric -- input, output and expected output, which travel
+    together in ``prompt.content`` as the case payload -- or is the answer key,
+    which is ``prompt.expected_response``. Neither the rationale nor the result
+    is ever shown to the metric.
 
     ``rationale`` is ``Optional[str]`` so "key absent" (``None``) stays
     distinguishable from "key present but empty" (``""``).
@@ -38,8 +86,42 @@ class MetricTuningCaseMetadata(BaseModel):
 
     # Why the human's verdict is what it is. Free text, for the reviewer.
     rationale: Optional[str] = None
+    # What the metric said last time it was run over this case.
+    result: Optional[MetricTuningCaseResult] = None
 
     @field_validator("rationale", mode="before")
+    @classmethod
+    def _validate_optional_str(cls, v: Any) -> Optional[str]:
+        return _coerce_optional_str(v)
+
+
+class MetricTuningRunSummary(BaseModel):
+    """The latest tuning run, stored under ``TestSet.attributes["tuning_run"]``.
+
+    On the tuning test set rather than the metric because it is a fact about the
+    set of cases, and because nothing else writes these attributes -- attribute
+    regeneration early-returns for metric-owned sets.
+
+    ``total_cases`` is how many cases the run set out to cover and ``completed``
+    how many it has finished, which is what makes progress reportable while the
+    run is still going.
+    """
+
+    model_config = ConfigDict(extra="allow", validate_assignment=True)
+
+    status: TuningRunStatus = TuningRunStatus.NEVER_RUN
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    total_cases: int = 0
+    completed_cases: int = 0
+    # How many cases the metric call failed on. Reported apart from the verdicts
+    # so a flaky provider is visibly a flaky provider.
+    errored_cases: int = 0
+    # Why the run as a whole failed, when it did. A single case failing does not
+    # fail the run -- that is `errored_cases`.
+    error: Optional[str] = None
+
+    @field_validator("error", "started_at", "completed_at", mode="before")
     @classmethod
     def _validate_optional_str(cls, v: Any) -> Optional[str]:
         return _coerce_optional_str(v)
@@ -54,3 +136,19 @@ def parse_metric_tuning_case_metadata(
     except ValidationError:
         logger.warning("Failed to parse metric tuning case metadata %r; using defaults", raw)
         return MetricTuningCaseMetadata()
+
+
+def parse_metric_tuning_run_summary(
+    raw: Optional[Mapping[str, Any]],
+) -> MetricTuningRunSummary:
+    """Parse ``TestSet.attributes["tuning_run"]``. Never raises.
+
+    A metric that has never been run has no key at all, which parses to a
+    ``NEVER_RUN`` summary rather than to None -- so callers never branch on
+    absence.
+    """
+    try:
+        return MetricTuningRunSummary.model_validate(raw or {})
+    except ValidationError:
+        logger.warning("Failed to parse metric tuning run summary %r; using defaults", raw)
+        return MetricTuningRunSummary()

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/__init__.py
@@ -16,6 +16,18 @@ from rhesis.backend.app.services.metric_tuning.cases import (
     to_api,
     update_tuning_case,
 )
+from rhesis.backend.app.services.metric_tuning.invoke import (
+    invoke_metric_on_case,
+    verdict_from_score,
+)
+from rhesis.backend.app.services.metric_tuning.runs import (
+    NoTuningCases,
+    TuningRunInFlight,
+    execute_tuning_run,
+    fail_tuning_run,
+    get_tuning_run,
+    start_tuning_run,
+)
 from rhesis.backend.app.services.metric_tuning.test_sets import (
     get_or_create_tuning_test_set,
     get_tuning_test_set,
@@ -30,14 +42,22 @@ from rhesis.backend.app.services.metric_tuning.verdict import (
 __all__ = [
     "BINARY_VERDICTS",
     "InvalidVerdict",
+    "NoTuningCases",
+    "TuningRunInFlight",
     "create_tuning_case",
     "delete_tuning_case",
+    "execute_tuning_run",
+    "fail_tuning_run",
     "get_or_create_tuning_test_set",
     "get_tuning_case",
+    "get_tuning_run",
     "get_tuning_test_set",
+    "invoke_metric_on_case",
     "is_stale",
     "list_tuning_cases",
     "normalize_verdict",
+    "start_tuning_run",
     "to_api",
     "update_tuning_case",
+    "verdict_from_score",
 ]

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/__init__.py
@@ -17,7 +17,9 @@ from rhesis.backend.app.services.metric_tuning.cases import (
     update_tuning_case,
 )
 from rhesis.backend.app.services.metric_tuning.invoke import (
+    MetricModelNotConfigured,
     invoke_metric_on_case,
+    resolve_metric_model,
     verdict_from_score,
 )
 from rhesis.backend.app.services.metric_tuning.runs import (
@@ -42,6 +44,7 @@ from rhesis.backend.app.services.metric_tuning.verdict import (
 __all__ = [
     "BINARY_VERDICTS",
     "InvalidVerdict",
+    "MetricModelNotConfigured",
     "NoTuningCases",
     "TuningRunInFlight",
     "create_tuning_case",
@@ -56,6 +59,7 @@ __all__ = [
     "is_stale",
     "list_tuning_cases",
     "normalize_verdict",
+    "resolve_metric_model",
     "start_tuning_run",
     "to_api",
     "update_tuning_case",

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/cases.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/cases.py
@@ -33,6 +33,7 @@ from rhesis.backend.app.crud import metric_tuning as crud_metric_tuning
 from rhesis.backend.app.schemas.metric_tuning import (
     MetricTuningCase,
     MetricTuningCaseCreate,
+    MetricTuningCaseResult,
     MetricTuningCaseUpdate,
 )
 from rhesis.backend.app.schemas.metric_tuning_metadata import (
@@ -67,6 +68,19 @@ def to_api(db_test: models.Test, metric: models.Metric) -> MetricTuningCase:
     prompt = db_test.prompt
     payload = parse_payload(prompt.content if prompt else None)
     expected = prompt.expected_response if prompt else None
+
+    # A result the run cleared but never refilled carries nothing worth showing,
+    # so it reads the same as never having been run.
+    result = None
+    stored = metadata.result
+    if stored and (stored.verdict is not None or stored.error):
+        result = MetricTuningCaseResult(
+            verdict=stored.verdict,
+            reasoning=stored.reasoning,
+            error=stored.error,
+            evaluated_at=stored.evaluated_at,
+        )
+
     return MetricTuningCase(
         id=db_test.id,
         input=payload.input,
@@ -75,6 +89,7 @@ def to_api(db_test: models.Test, metric: models.Metric) -> MetricTuningCase:
         expected=expected,
         rationale=metadata.rationale,
         is_stale=is_stale(metric, expected),
+        result=result,
         created_at=db_test.created_at,
         updated_at=db_test.updated_at,
     )

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/invoke.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/invoke.py
@@ -165,6 +165,57 @@ def _error_result(message: str) -> MetricTuningCaseResult:
     return MetricTuningCaseResult(error=message, evaluated_at=_now())
 
 
+# How the SDK opens the reason on a result it is using to report its own failure.
+_SDK_FAILURE_REASON = "Error evaluating with "
+
+
+def _declares_error_category(metric: models.Metric) -> bool:
+    """Whether ``error`` is one of this metric's own categories rather than a sentinel."""
+    categories = metric.categories or []
+    if not isinstance(categories, list):
+        return False
+    return any(isinstance(c, str) and c.strip().lower() == "error" for c in categories)
+
+
+def _failure_from_result(metric: models.Metric, result: dict) -> Optional[str]:
+    """The failure this result is reporting, if it is reporting one.
+
+    Two shapes reach here and only one of them says ``error``. The error builder
+    sets it outright. The local strategy never does: it wraps whatever the SDK
+    handed back in ``MetricResultBuilder.success()``, and the SDK answers its own
+    failures with a result rather than an exception -- the score is a sentinel
+    (``"error"`` for a categorical metric, ``0.0`` for the rest) and the cause is
+    left in a reason it formats itself. ``success()`` carries neither the SDK's
+    ``details["error"]`` nor an ``error`` key, so the reason is all that survives.
+
+    Reading that second shape as a verdict fails quietly, which is the danger. A
+    categorical metric stores ``error`` as the verdict; a binary one stores
+    ``pass``, since any non-empty score string is truthy. The run then reports
+    zero errored cases and the scorecard counts a provider outage as the metric
+    agreeing. A 401 against the hosted model is exactly this.
+    """
+    error = result.get("error")
+    if error:
+        return str(error)
+
+    reason = result.get("reason")
+    score = result.get("score")
+
+    # Only a sentinel when the metric does not offer "error" as a real answer.
+    if (
+        isinstance(score, str)
+        and score.strip().lower() == "error"
+        and not _declares_error_category(metric)
+    ):
+        return str(reason or "The metric failed to evaluate this case.")
+
+    # All that is left for the score types whose sentinel is an ordinary number.
+    if isinstance(reason, str) and reason.startswith(_SDK_FAILURE_REASON):
+        return reason
+
+    return None
+
+
 def invoke_metric_on_case(
     db: Session,
     metric: models.Metric,
@@ -210,9 +261,9 @@ def invoke_metric_on_case(
     if not isinstance(result, dict):
         return _error_result("The metric returned a result in an unrecognized shape.")
 
-    error = result.get("error")
-    if error:
-        return _error_result(str(error))
+    failure = _failure_from_result(metric, result)
+    if failure:
+        return _error_result(failure)
 
     return MetricTuningCaseResult(
         verdict=verdict_from_score(metric, result.get("score")),

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/invoke.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/invoke.py
@@ -1,0 +1,120 @@
+"""Running a metric over one tuning case.
+
+**This is the part of the feature that is easy to get backwards, and getting it
+backwards produces numbers that look fine and mean nothing.**
+
+On the normal evaluation path a prompt's ``expected_response`` is handed to the
+metric as its ``expected_output`` -- the reference answer. On a tuning case that
+column holds the *expected verdict*: what the metric should have said. Pass it
+through and the metric under test is shown the answer key, told the expected
+response to "How are you?" is ``fail``, and every scorecard comes out flattering.
+Nothing raises when this is wrong.
+
+So a tuning run puts the metric in the system-under-test role: the case payload
+is unpacked into the same three arguments the metric receives in a real run --
+input, output, and the case's *own* expected output -- and nothing else. The
+expected verdict is read afterwards, by the comparison, and never enters here.
+See domain.local/adr/0002 and adr/0004.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional, Union
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.schemas.metric_tuning_metadata import MetricTuningCaseResult
+from rhesis.backend.app.schemas.metric_types import ScoreType
+from rhesis.backend.app.services.metric_tuning.payload import CasePayload
+from rhesis.backend.app.services.metric_tuning.verdict import BINARY_VERDICTS
+
+logger = logging.getLogger(__name__)
+
+
+def verdict_from_score(metric: models.Metric, score: Union[float, str, None]) -> Optional[str]:
+    """Render a metric's own score as a verdict string.
+
+    The stored expected verdict is one string for all three score types, so the
+    metric's answer has to be rendered the same way to sit beside it. A binary
+    metric returns a number the SDK treats as a flag, which is displayed as
+    pass/fail rather than as ``1.0`` -- a case labelled ``pass`` compared against
+    ``1.0`` reads as a disagreement to a human even when it is not.
+    """
+    if score is None:
+        return None
+
+    if metric.score_type == ScoreType.BINARY.value:
+        if isinstance(score, str):
+            lowered = score.strip().lower()
+            if lowered in BINARY_VERDICTS:
+                return lowered
+        passing, failing = BINARY_VERDICTS
+        return passing if bool(score) else failing
+
+    if metric.score_type == ScoreType.NUMERIC.value:
+        try:
+            return str(float(score))
+        except (TypeError, ValueError):
+            return str(score)
+
+    return str(score)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _error_result(message: str) -> MetricTuningCaseResult:
+    return MetricTuningCaseResult(error=message, evaluated_at=_now())
+
+
+def invoke_metric_on_case(
+    db: Session,
+    metric: models.Metric,
+    payload: CasePayload,
+    organization_id: str,
+) -> MetricTuningCaseResult:
+    """Run the metric over one case and return what it said.
+
+    Never raises. A failed call comes back as a result carrying ``error``, so
+    one bad case does not end the run -- and so a provider failure is never
+    mistaken for the metric disagreeing.
+
+    The evaluator retries transient errors itself, so there is no retry here.
+    """
+    from rhesis.backend.metrics.evaluator import MetricEvaluator
+
+    try:
+        evaluator = MetricEvaluator(db=db, organization_id=organization_id)
+        results = evaluator.evaluate(
+            input_text=payload.input,
+            output_text=payload.output,
+            # The case's own expected output -- what the *system under test*
+            # should have answered. Never prompt.expected_response, which is the
+            # expected verdict. See the module docstring.
+            expected_output=payload.expected_output or "",
+            context=[],
+            metrics=[metric],
+        )
+    except Exception as e:  # noqa: BLE001 -- one case failing must not end the run
+        logger.error("Tuning run: metric %s raised on a case: %s", metric.id, e, exc_info=True)
+        return _error_result(str(e))
+
+    if not results:
+        return _error_result("The metric returned no result.")
+
+    # One metric in, so one result out -- whatever key the evaluator chose for it.
+    result: Any = next(iter(results.values()))
+    if not isinstance(result, dict):
+        return _error_result("The metric returned a result in an unrecognized shape.")
+
+    error = result.get("error")
+    if error:
+        return _error_result(str(error))
+
+    return MetricTuningCaseResult(
+        verdict=verdict_from_score(metric, result.get("score")),
+        reasoning=result.get("reason"),
+        evaluated_at=_now(),
+    )

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/invoke.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/invoke.py
@@ -79,7 +79,18 @@ def _configured_evaluation_model_id(user: Optional[models.User]) -> Optional[Any
     settings = getattr(user, "settings", None)
     models_settings = getattr(settings, "models", None)
     evaluation = getattr(models_settings, "evaluation", None)
-    return getattr(evaluation, "model_id", None)
+    try:
+        return getattr(evaluation, "model_id", None)
+    except (ValueError, TypeError) as e:
+        # The accessor parses the stored value as a UUID, so a malformed setting
+        # raises rather than reading as absent -- and `getattr` only swallows
+        # AttributeError. Left alone it escapes as a 500 from a function whose
+        # whole purpose is to refuse cleanly.
+        raise MetricModelNotConfigured(
+            "The default evaluation model setting could not be read. Pick a default evaluation "
+            "model on the Models page, or set a model on the metric, before running it over its "
+            "tuning cases."
+        ) from e
 
 
 def resolve_metric_model(
@@ -145,6 +156,12 @@ def verdict_from_score(metric: models.Metric, score: Union[float, str, None]) ->
             lowered = score.strip().lower()
             if lowered in BINARY_VERDICTS:
                 return lowered
+            # Any other word is the judge's own, not a flag. There is no binary
+            # judge in the SDK -- a binary metric is backed by one that answers
+            # in categories -- so this really happens, and `bool()` on a string
+            # is true whatever it says: "no" would render as "pass". Shown as
+            # the metric said it instead of guessed at.
+            return score.strip()
         passing, failing = BINARY_VERDICTS
         return passing if bool(score) else failing
 

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/invoke.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/invoke.py
@@ -15,6 +15,15 @@ is unpacked into the same three arguments the metric receives in a real run --
 input, output, and the case's *own* expected output -- and nothing else. The
 expected verdict is read afterwards, by the comparison, and never enters here.
 See domain.local/adr/0002 and adr/0004.
+
+**The judging model is resolved explicitly, and the chain ends in an error.**
+It is the metric's own model, else the configured default evaluation model, and
+then nothing. The evaluation path this borrows keeps going: past those two it
+drops to whatever the caller passed, and past that to the SDK's own built-in
+default, the hosted Rhesis LLM. Neither of those last two is announced anywhere.
+A tuning run scored by a judge nobody picked measures nothing and says nothing
+about it -- set the metric's model afterwards and every stored verdict silently
+refers to a different judge. So the run is refused instead, before it starts.
 """
 
 import logging
@@ -23,13 +32,100 @@ from typing import Any, Optional, Union
 
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app import models
+from rhesis.backend.app import crud, models
 from rhesis.backend.app.schemas.metric_tuning_metadata import MetricTuningCaseResult
 from rhesis.backend.app.schemas.metric_types import ScoreType
 from rhesis.backend.app.services.metric_tuning.payload import CasePayload
 from rhesis.backend.app.services.metric_tuning.verdict import BINARY_VERDICTS
 
 logger = logging.getLogger(__name__)
+
+
+class MetricModelNotConfigured(Exception):
+    """Neither the metric nor the evaluation settings name a model to judge with."""
+
+
+def _load_model_or_raise(
+    db: Session, model_id: str, organization_id: str, label: str, source: str
+) -> Any:
+    """Turn a Model row into an LLM, or say which configured model failed.
+
+    Reuses the evaluation path's own resolver so a Model row is built in exactly
+    one place -- provider, key, endpoint and usage-accrual wiring all stay in
+    ``strategies/local.py``. What changes here is the failure semantics: that
+    resolver logs and returns ``None``, which is the silent drop this feature
+    must not inherit.
+    """
+    from rhesis.backend.metrics.strategies.local import _resolve_metric_model
+
+    model = _resolve_metric_model(model_id, db, organization_id, label)
+    if model is None:
+        raise MetricModelNotConfigured(
+            f"The {source} could not be loaded. Check that it still exists and has a provider set."
+        )
+    return model
+
+
+def _configured_evaluation_model_id(user: Optional[models.User]) -> Optional[Any]:
+    """The model explicitly configured as the default for evaluation, if any.
+
+    Reads the same setting as the normal evaluation path but stops there: that
+    path continues into the system default when this is unset, which is the step
+    a tuning run must not take silently. Every level is optional in the schema,
+    hence the walk.
+    """
+    if user is None:
+        return None
+    settings = getattr(user, "settings", None)
+    models_settings = getattr(settings, "models", None)
+    evaluation = getattr(models_settings, "evaluation", None)
+    return getattr(evaluation, "model_id", None)
+
+
+def resolve_metric_model(
+    db: Session, metric: models.Metric, organization_id: str, user_id: Optional[str]
+) -> Any:
+    """The model this metric judges with: its own, else the default for evaluation.
+
+    Two steps, both explicit, and an error rather than a third:
+
+    1. the model saved on the metric, when it has one;
+    2. otherwise the model configured as the default for evaluation.
+
+    What it deliberately will not do is reach the *system* default underneath
+    those. ``get_user_evaluation_model`` conflates the two -- a user who has
+    configured nothing gets the hosted Rhesis model handed back as though it
+    were their choice -- so the setting is read directly instead. A tuning run
+    scored by a judge nobody picked measures nothing, and worse, says nothing
+    about it: change the metric's model afterwards and every stored verdict
+    silently refers to a different judge.
+    """
+    if metric.model_id:
+        return _load_model_or_raise(
+            db,
+            str(metric.model_id),
+            organization_id,
+            metric.name,
+            f"model configured on the metric {metric.name!r}",
+        )
+
+    user = crud.get_user(db, user_id=user_id) if user_id else None
+    evaluation_model_id = _configured_evaluation_model_id(user)
+
+    if not evaluation_model_id:
+        raise MetricModelNotConfigured(
+            f"The metric {metric.name!r} has no model, and no default evaluation model is "
+            "configured. Set one on the metric, or pick a default evaluation model on the "
+            "Models page, before running it over its tuning cases."
+        )
+
+    return _load_model_or_raise(
+        db,
+        str(evaluation_model_id),
+        organization_id,
+        f"{metric.name} (default evaluation model)",
+        "default evaluation model",
+    )
 
 
 def verdict_from_score(metric: models.Metric, score: Union[float, str, None]) -> Optional[str]:
@@ -74,8 +170,13 @@ def invoke_metric_on_case(
     metric: models.Metric,
     payload: CasePayload,
     organization_id: str,
+    model: Any,
 ) -> MetricTuningCaseResult:
     """Run the metric over one case and return what it said.
+
+    ``model`` is required and comes from ``resolve_metric_model``. Passing it
+    explicitly is what stops the evaluator reaching its own default when the
+    metric's model cannot be resolved -- there is no model argument to omit.
 
     Never raises. A failed call comes back as a result carrying ``error``, so
     one bad case does not end the run -- and so a provider failure is never
@@ -86,7 +187,7 @@ def invoke_metric_on_case(
     from rhesis.backend.metrics.evaluator import MetricEvaluator
 
     try:
-        evaluator = MetricEvaluator(db=db, organization_id=organization_id)
+        evaluator = MetricEvaluator(model=model, db=db, organization_id=organization_id)
         results = evaluator.evaluate(
             input_text=payload.input,
             output_text=payload.output,

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/runs.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/runs.py
@@ -1,0 +1,179 @@
+"""Tuning runs: running a metric over its own cases.
+
+A run creates no rows in the execution tables -- no test run, no test
+configuration, no endpoint, no metric row for the comparison. It is this service
+plus a background task, writing into JSONB that already exists: the per-case
+result onto the case's ``test_metadata``, the run summary onto the tuning test
+set's ``attributes``. domain.local/adr/0004 records why, and what was rejected.
+
+Only the latest run is kept. A new run overwrites the previous results outright
+rather than appending -- trend over time deserves real rows, not an unbounded
+blob in a column nothing paginates, and nothing is lost that re-running cannot
+recover.
+
+Nothing starts a run on its own. Every run costs one LLM call per case, so
+editing a case or an evaluation prompt must never turn into a bill for someone
+who does not know a tuning set exists.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import List
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.crud import metric_tuning as crud_metric_tuning
+from rhesis.backend.app.schemas.metric_tuning_metadata import (
+    MetricTuningCaseResult,
+    MetricTuningRunSummary,
+    TuningRunStatus,
+)
+from rhesis.backend.app.services.metric_tuning.invoke import invoke_metric_on_case
+from rhesis.backend.app.services.metric_tuning.payload import parse_payload
+from rhesis.backend.app.services.metric_tuning.test_sets import get_tuning_test_set
+
+logger = logging.getLogger(__name__)
+
+
+class NoTuningCases(Exception):
+    """A run was asked for on a metric that has nothing to run over."""
+
+
+class TuningRunInFlight(Exception):
+    """A run was asked for while one is already going."""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def get_tuning_run(db: Session, metric: models.Metric, organization_id: str):
+    """The metric's latest run. ``never_run`` when there has not been one."""
+    test_set = get_tuning_test_set(db, metric.id, organization_id)
+    if not test_set:
+        return MetricTuningRunSummary()
+    return crud_metric_tuning.get_run_summary(test_set)
+
+
+def start_tuning_run(
+    db: Session, metric: models.Metric, organization_id: str
+) -> MetricTuningRunSummary:
+    """Claim the run slot and return the summary the caller should show.
+
+    Only marks the run as started -- the work itself happens in the background
+    task, which is dispatched by the caller once this has been committed.
+
+    The refusal while a run is in flight is advisory: the stored status is the
+    only check, so two requests in the same instant can both pass. The failure
+    mode is a summary belonging to neither run rather than corruption, which is
+    the trade ADR-0004 accepts for a flagged feature. Making it actually safe is
+    its own ticket.
+    """
+    test_set = get_tuning_test_set(db, metric.id, organization_id)
+    if not test_set:
+        raise NoTuningCases("This metric has no tuning cases yet. Add one before running it.")
+
+    cases = crud_metric_tuning.get_tuning_cases(db, test_set.id, organization_id)
+    if not cases:
+        raise NoTuningCases("This metric has no tuning cases yet. Add one before running it.")
+
+    current = crud_metric_tuning.get_run_summary(test_set)
+    if current.status == TuningRunStatus.RUNNING:
+        raise TuningRunInFlight("A run is already in progress for this metric.")
+
+    summary = MetricTuningRunSummary(
+        status=TuningRunStatus.RUNNING,
+        started_at=_now(),
+        total_cases=len(cases),
+        completed_cases=0,
+        errored_cases=0,
+    )
+    crud_metric_tuning.set_run_summary(db, test_set, summary)
+    return summary
+
+
+def _clear_previous_results(db: Session, cases: List[models.Test]) -> None:
+    """Drop the last run's per-case results before this one writes its own.
+
+    Without this, a case the metric now fails to reach would still be showing
+    what it said last time, next to a summary describing the current run.
+    """
+    for db_test in cases:
+        crud_metric_tuning.set_case_result(db, db_test, MetricTuningCaseResult())
+
+
+def execute_tuning_run(
+    db: Session, metric: models.Metric, organization_id: str
+) -> MetricTuningRunSummary:
+    """Run the metric over every one of its cases, writing results as it goes.
+
+    Commits after each case so the interface can watch progress rather than
+    waiting for the whole set, and so a worker that dies mid-run leaves the
+    cases it did finish behind.
+
+    A case whose metric call fails is recorded as errored and the run carries on
+    -- one unreachable provider must not cost the results of every other case.
+    """
+    test_set = get_tuning_test_set(db, metric.id, organization_id)
+    if not test_set:
+        raise NoTuningCases("This metric has no tuning cases yet.")
+
+    cases = crud_metric_tuning.get_tuning_cases(db, test_set.id, organization_id)
+    if not cases:
+        raise NoTuningCases("This metric has no tuning cases yet.")
+
+    summary = crud_metric_tuning.get_run_summary(test_set)
+    summary.status = TuningRunStatus.RUNNING
+    summary.total_cases = len(cases)
+    summary.completed_cases = 0
+    summary.errored_cases = 0
+    summary.completed_at = None
+    summary.error = None
+    if not summary.started_at:
+        summary.started_at = _now()
+
+    _clear_previous_results(db, cases)
+    crud_metric_tuning.set_run_summary(db, test_set, summary)
+    db.commit()
+
+    for db_test in cases:
+        payload = parse_payload(db_test.prompt.content if db_test.prompt else None)
+        result = invoke_metric_on_case(db, metric, payload, organization_id)
+
+        crud_metric_tuning.set_case_result(db, db_test, result)
+        summary.completed_cases += 1
+        if result.error:
+            summary.errored_cases += 1
+        crud_metric_tuning.set_run_summary(db, test_set, summary)
+        db.commit()
+
+    summary.status = TuningRunStatus.COMPLETED
+    summary.completed_at = _now()
+    crud_metric_tuning.set_run_summary(db, test_set, summary)
+    db.commit()
+
+    logger.info(
+        "Tuning run for metric %s finished: %s cases, %s errored",
+        metric.id,
+        summary.completed_cases,
+        summary.errored_cases,
+    )
+    return summary
+
+
+def fail_tuning_run(db: Session, metric: models.Metric, organization_id: str, message: str) -> None:
+    """Mark the run failed so the interface stops reading old numbers as new.
+
+    A run that dies without this stays ``running`` forever, which both looks
+    like progress and blocks the next run.
+    """
+    test_set = get_tuning_test_set(db, metric.id, organization_id)
+    if not test_set:
+        return
+    summary = crud_metric_tuning.get_run_summary(test_set)
+    summary.status = TuningRunStatus.FAILED
+    summary.completed_at = _now()
+    summary.error = message
+    crud_metric_tuning.set_run_summary(db, test_set, summary)
+    db.commit()

--- a/apps/backend/src/rhesis/backend/app/services/metric_tuning/runs.py
+++ b/apps/backend/src/rhesis/backend/app/services/metric_tuning/runs.py
@@ -18,7 +18,7 @@ who does not know a tuning set exists.
 
 import logging
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Optional
 
 from sqlalchemy.orm import Session
 
@@ -29,7 +29,10 @@ from rhesis.backend.app.schemas.metric_tuning_metadata import (
     MetricTuningRunSummary,
     TuningRunStatus,
 )
-from rhesis.backend.app.services.metric_tuning.invoke import invoke_metric_on_case
+from rhesis.backend.app.services.metric_tuning.invoke import (
+    invoke_metric_on_case,
+    resolve_metric_model,
+)
 from rhesis.backend.app.services.metric_tuning.payload import parse_payload
 from rhesis.backend.app.services.metric_tuning.test_sets import get_tuning_test_set
 
@@ -57,7 +60,7 @@ def get_tuning_run(db: Session, metric: models.Metric, organization_id: str):
 
 
 def start_tuning_run(
-    db: Session, metric: models.Metric, organization_id: str
+    db: Session, metric: models.Metric, organization_id: str, user_id: Optional[str]
 ) -> MetricTuningRunSummary:
     """Claim the run slot and return the summary the caller should show.
 
@@ -82,6 +85,11 @@ def start_tuning_run(
     if current.status == TuningRunStatus.RUNNING:
         raise TuningRunInFlight("A run is already in progress for this metric.")
 
+    # Checked here, before anything is written or queued, so a metric with no
+    # model is refused outright rather than producing a run that judges with
+    # something nobody picked. Raises MetricModelNotConfigured.
+    resolve_metric_model(db, metric, organization_id, user_id)
+
     summary = MetricTuningRunSummary(
         status=TuningRunStatus.RUNNING,
         started_at=_now(),
@@ -104,7 +112,7 @@ def _clear_previous_results(db: Session, cases: List[models.Test]) -> None:
 
 
 def execute_tuning_run(
-    db: Session, metric: models.Metric, organization_id: str
+    db: Session, metric: models.Metric, organization_id: str, user_id: Optional[str]
 ) -> MetricTuningRunSummary:
     """Run the metric over every one of its cases, writing results as it goes.
 
@@ -123,6 +131,11 @@ def execute_tuning_run(
     if not cases:
         raise NoTuningCases("This metric has no tuning cases yet.")
 
+    # Resolved once for the whole run, and before any case is touched: if the
+    # metric's model has gone missing since the run was queued, the run fails
+    # outright rather than judging half the set with something else.
+    model = resolve_metric_model(db, metric, organization_id, user_id)
+
     summary = crud_metric_tuning.get_run_summary(test_set)
     summary.status = TuningRunStatus.RUNNING
     summary.total_cases = len(cases)
@@ -139,7 +152,7 @@ def execute_tuning_run(
 
     for db_test in cases:
         payload = parse_payload(db_test.prompt.content if db_test.prompt else None)
-        result = invoke_metric_on_case(db, metric, payload, organization_id)
+        result = invoke_metric_on_case(db, metric, payload, organization_id, model)
 
         crud_metric_tuning.set_case_result(db, db_test, result)
         summary.completed_cases += 1

--- a/apps/backend/src/rhesis/backend/tasks/__init__.py
+++ b/apps/backend/src/rhesis/backend/tasks/__init__.py
@@ -14,6 +14,7 @@ from rhesis.backend.tasks import (
     execution,  # noqa: F401
     file,  # noqa: F401
     garak,  # noqa: F401
+    metric_tuning,  # noqa: F401
     task_notifications,  # noqa: F401
     test_configuration,  # noqa: F401
     test_set,  # noqa: F401
@@ -48,6 +49,7 @@ from rhesis.backend.tasks.example_task import (
     process_data,
 )
 from rhesis.backend.tasks.execution.results import collect_results
+from rhesis.backend.tasks.metric_tuning import run_metric_tuning
 from rhesis.backend.tasks.test_configuration import execute_test_configuration
 from rhesis.backend.tasks.test_set import count_test_sets
 from rhesis.backend.tasks.usage import accrue_usage
@@ -86,6 +88,7 @@ __all__ = [
     "email_notification_test",
     "process_data",
     "accrue_usage",
+    "run_metric_tuning",
     # Constants
     "DEFAULT_METRIC_WORKERS",
     "DEFAULT_RESULT_STATUS",

--- a/apps/backend/src/rhesis/backend/tasks/metric_tuning.py
+++ b/apps/backend/src/rhesis/backend/tasks/metric_tuning.py
@@ -44,7 +44,7 @@ def run_metric_tuning(self, metric_id: str):
             return {"metric_id": metric_id, "status": "failed", "error": "Metric not found"}
 
         try:
-            summary = service.execute_tuning_run(db, metric, org_id)
+            summary = service.execute_tuning_run(db, metric, org_id, user_id)
         except Exception as e:
             self.log_with_context("error", "Tuning run failed", metric_id=metric_id, error=str(e))
             # Leaving the run marked `running` would both look like progress and

--- a/apps/backend/src/rhesis/backend/tasks/metric_tuning.py
+++ b/apps/backend/src/rhesis/backend/tasks/metric_tuning.py
@@ -1,0 +1,70 @@
+"""Background task for a tuning run.
+
+Orchestration only -- everything it does lives in
+``app/services/metric_tuning/runs.py``, so the run can be exercised without a
+broker. The task exists because a set of thirty cases is thirty LLM calls, which
+is not something to hold a browser open for.
+"""
+
+import logging
+import uuid
+
+from rhesis.backend.app.crud.metric import get_metric
+from rhesis.backend.app.services import metric_tuning as service
+from rhesis.backend.celery.core import app
+from rhesis.backend.tasks.base import BaseTask
+
+logger = logging.getLogger(__name__)
+
+
+@app.task(
+    base=BaseTask,
+    name="rhesis.backend.tasks.run_metric_tuning",
+    bind=True,
+    display_name="Metric Tuning Run",
+    # A run costs one LLM call per case, so a retry is a second bill for the
+    # same work. The run marks itself failed instead and the author presses
+    # again if they want it.
+    autoretry_for=(),
+    max_retries=0,
+)
+def run_metric_tuning(self, metric_id: str):
+    """Run a metric over every one of its tuning cases."""
+    org_id, user_id, _ = self.get_tenant_context()
+    metric_uuid = uuid.UUID(metric_id)
+
+    self.log_with_context("info", "Starting tuning run", metric_id=metric_id)
+
+    with self.get_db_session() as db:
+        metric = get_metric(db, metric_id=metric_uuid, organization_id=org_id, user_id=user_id)
+        if metric is None:
+            # Nothing to mark failed -- without the metric there is no way to
+            # reach its tuning set either.
+            self.log_with_context("error", "Tuning run: metric not found", metric_id=metric_id)
+            return {"metric_id": metric_id, "status": "failed", "error": "Metric not found"}
+
+        try:
+            summary = service.execute_tuning_run(db, metric, org_id)
+        except Exception as e:
+            self.log_with_context("error", "Tuning run failed", metric_id=metric_id, error=str(e))
+            # Leaving the run marked `running` would both look like progress and
+            # block the next attempt, so the failure is recorded before it is
+            # re-raised.
+            db.rollback()
+            service.fail_tuning_run(db, metric, org_id, str(e))
+            raise
+
+    self.log_with_context(
+        "info",
+        "Tuning run complete",
+        metric_id=metric_id,
+        completed_cases=summary.completed_cases,
+        errored_cases=summary.errored_cases,
+    )
+    return {
+        "metric_id": metric_id,
+        "status": summary.status.value,
+        "total_cases": summary.total_cases,
+        "completed_cases": summary.completed_cases,
+        "errored_cases": summary.errored_cases,
+    }

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningTab.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/MetricTuningTab.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Box, Button, Chip, Tooltip } from '@mui/material';
+import {
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import {
   GridColDef,
   GridRenderCellParams,
@@ -15,15 +22,19 @@ import { createRowActionsColumn } from '@/components/common/createRowActionsColu
 import { useNotifications } from '@/components/common/NotificationContext';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
-import { AddIcon, TuneIcon } from '@/components/icons';
+import { AddIcon, PlayArrowIcon, TuneIcon } from '@/components/icons';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import type { UUID } from 'crypto';
 import type { ScoreType } from '@/utils/api-client/interfaces/metric';
 import type {
   MetricTuningCase,
   MetricTuningCaseCreate,
+  MetricTuningRun,
 } from '@/utils/api-client/interfaces/metric-tuning';
 import MetricTuningCaseDialog from './MetricTuningCaseDialog';
+
+/** How often to re-read a run that is still going. */
+const RUN_POLL_INTERVAL_MS = 3000;
 
 /** Renders long free text on one line with the full value in a tooltip. */
 function TruncatedCell({ params }: { params: GridRenderCellParams }) {
@@ -73,6 +84,100 @@ function ExpectedCell({
 }
 
 /**
+ * What the metric said, to be read beside the verdict the author expected.
+ *
+ * A failed call is shown as an error rather than as a verdict — a flaky
+ * provider must not read as a metric that disagrees.
+ */
+function MetricVerdictCell({
+  params,
+  scoreType,
+}: {
+  params: GridRenderCellParams;
+  scoreType: ScoreType;
+}) {
+  const result = params.row.result as MetricTuningCase['result'];
+  if (!result) return <span>—</span>;
+  if (result.error) {
+    return (
+      <Tooltip title={result.error}>
+        <Chip label="Error" size="small" color="warning" variant="outlined" />
+      </Tooltip>
+    );
+  }
+  if (!result.verdict) return <span>—</span>;
+  if (scoreType !== 'binary') {
+    return <Chip label={result.verdict} size="small" variant="outlined" />;
+  }
+  const isPass = result.verdict.toLowerCase() === 'pass';
+  return (
+    <Chip
+      label={result.verdict}
+      size="small"
+      variant="outlined"
+      color={isPass ? 'success' : 'error'}
+    />
+  );
+}
+
+/** The metric's own reasoning for the verdict it gave — what to edit against. */
+function MetricReasoningCell({ params }: { params: GridRenderCellParams }) {
+  const result = params.row.result as MetricTuningCase['result'];
+  const value = result?.reasoning ?? '';
+  return (
+    <Box
+      title={value}
+      sx={{
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {value || '—'}
+    </Box>
+  );
+}
+
+/** One line about the latest run, or nothing when there has not been one. */
+function RunSummary({ run }: { run: MetricTuningRun | null }) {
+  if (!run || run.status === 'never_run') return null;
+
+  if (run.status === 'running') {
+    return (
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5 }}>
+        <CircularProgress size={16} />
+        <Typography variant="body2" color="text.secondary">
+          Running the metric over {run.total_cases}{' '}
+          {run.total_cases === 1 ? 'case' : 'cases'} — {run.completed_cases}{' '}
+          done.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (run.status === 'failed') {
+    return (
+      <Typography variant="body2" color="error" sx={{ mb: 1.5 }}>
+        The last run failed{run.error ? `: ${run.error}` : '.'}
+      </Typography>
+    );
+  }
+
+  const finished = run.completed_at ? new Date(run.completed_at) : null;
+  const errored =
+    run.errored_cases > 0
+      ? ` ${run.errored_cases} of them could not be reached.`
+      : '';
+  return (
+    <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+      Last run {finished ? finished.toLocaleString() : ''} over{' '}
+      {run.completed_cases} {run.completed_cases === 1 ? 'case' : 'cases'}.
+      {errored}
+    </Typography>
+  );
+}
+
+/**
  * Marks a case that cannot be scored yet, and why. Shared visual language, but
  * kept apart: unlabelled is work to label, stale is work to re-label.
  */
@@ -104,11 +209,12 @@ export interface MetricTuningTabProps {
 }
 
 /**
- * Experimental: a metric's own set of labelled cases.
+ * Experimental: a metric's own set of labelled cases, and runs over them.
  *
  * Each case is an (input, output) pair plus the verdict a human expects from
- * this metric. Scoring the set against the metric is a later step; for now the
- * tab is about collecting the cases.
+ * this metric. Pressing Run metric runs it over every case and fills in what it
+ * actually said, and why. One agreement number across the set is a later step;
+ * seeing the divergence case by case is already what an author edits against.
  *
  * The metric is fetched here rather than passed in: the tabs component holds
  * only the id, and threading the whole metric through it would couple this
@@ -126,20 +232,24 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
   const [loading, setLoading] = useState(true);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editing, setEditing] = useState<MetricTuningCase | null>(null);
+  const [run, setRun] = useState<MetricTuningRun | null>(null);
+  const [starting, setStarting] = useState(false);
 
   const fetchCases = useCallback(async () => {
     setLoading(true);
     try {
       const factory = new ApiClientFactory();
-      const [metric, tuningCases] = await Promise.all([
+      const [metric, tuningCases, tuningRun] = await Promise.all([
         factory.getMetricsClient().getMetric(metricId as UUID),
         factory.getMetricTuningClient().getTuningCases(metricId),
+        factory.getMetricTuningClient().getTuningRun(metricId),
       ]);
       setScoreType(metric.score_type ?? 'binary');
       setMinScore(metric.min_score);
       setMaxScore(metric.max_score);
       setCategories(metric.categories);
       setCases(tuningCases);
+      setRun(tuningRun);
     } catch (error) {
       notifications.show(
         error instanceof Error
@@ -157,6 +267,60 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
     fetchCases();
     // eslint-disable-next-line react-hooks/exhaustive-deps -- notifications identity changes each render
   }, [metricId]);
+
+  // A run in flight is polled until it stops. The cases are re-read with it,
+  // since each finished case gains a verdict the grid should show.
+  //
+  // The interval keys off `run?.status` and nothing else. Depending on the whole
+  // `run` object would restart the timer on every tick, and depending on
+  // `fetchCases` — which polling itself replaces — would restart it on every
+  // fetch. Nothing here ever starts a run: a poll that could start one would
+  // turn opening the tab into an LLM bill.
+  const runStatus = run?.status;
+  useEffect(() => {
+    if (runStatus !== 'running') return;
+
+    const client = new ApiClientFactory().getMetricTuningClient();
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const [nextRun, nextCases] = await Promise.all([
+          client.getTuningRun(metricId),
+          client.getTuningCases(metricId),
+        ]);
+        if (cancelled) return;
+        setRun(nextRun);
+        setCases(nextCases);
+      } catch {
+        // A failed poll is not worth interrupting the author over — the next
+        // tick tries again, and a genuinely broken run comes back as `failed`.
+      }
+    };
+
+    const timer = setInterval(poll, RUN_POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+    };
+  }, [metricId, runStatus]);
+
+  const handleRun = useCallback(async () => {
+    setStarting(true);
+    try {
+      const client = new ApiClientFactory().getMetricTuningClient();
+      setRun(await client.startTuningRun(metricId));
+    } catch (error) {
+      notifications.show(
+        error instanceof Error
+          ? `Failed to start the run: ${error.message}`
+          : 'Failed to start the run',
+        { severity: 'error', autoHideDuration: 6000 }
+      );
+    } finally {
+      setStarting(false);
+    }
+  }, [metricId, notifications]);
 
   const handleSubmit = useCallback(
     async (data: MetricTuningCaseCreate) => {
@@ -235,11 +399,31 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
       },
       {
         field: 'expected',
-        headerName: 'Verdict',
+        headerName: 'Expected',
         width: 120,
         renderCell: params => (
           <ExpectedCell params={params} scoreType={scoreType} />
         ),
+      },
+      {
+        // Sits next to `expected` on purpose: the two side by side are the
+        // whole point of a run.
+        field: 'metric_verdict',
+        headerName: 'Metric said',
+        width: 130,
+        // Reads the nested `result`, which no single field sorts by.
+        sortable: false,
+        renderCell: params => (
+          <MetricVerdictCell params={params} scoreType={scoreType} />
+        ),
+      },
+      {
+        field: 'metric_reasoning',
+        headerName: 'Because',
+        flex: 1.5,
+        minWidth: 180,
+        sortable: false,
+        renderCell: params => <MetricReasoningCell params={params} />,
       },
       {
         field: 'is_stale',
@@ -269,9 +453,20 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
 
   // The badge sits in `actions`, not `subtitle`: SectionCard wraps the subtitle
   // in a <Typography> (a <p>), and Chip renders a <div>.
+  const isRunning = run?.status === 'running';
   const actions = (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
       <BetaBadge />
+      {canEdit && cases.length > 0 && (
+        <Button
+          variant="outlined"
+          startIcon={<PlayArrowIcon />}
+          onClick={handleRun}
+          disabled={isRunning || starting}
+        >
+          {isRunning ? 'Running…' : 'Run metric'}
+        </Button>
+      )}
       {canEdit && (
         <Button variant="contained" startIcon={<AddIcon />} onClick={openAdd}>
           Add case
@@ -297,14 +492,17 @@ export default function MetricTuningTab({ metricId }: MetricTuningTabProps) {
             showAddIcon
           />
         ) : (
-          <BaseDataGrid
-            rows={cases as unknown as GridRowModel[]}
-            columns={columns}
-            loading={loading}
-            getRowId={row => String(row.id)}
-            showToolbar={false}
-            disableMultipleRowSelection
-          />
+          <>
+            <RunSummary run={run} />
+            <BaseDataGrid
+              rows={cases as unknown as GridRowModel[]}
+              columns={columns}
+              loading={loading}
+              getRowId={row => String(row.id)}
+              showToolbar={false}
+              disableMultipleRowSelection
+            />
+          </>
         )}
       </SectionCard>
 

--- a/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
+++ b/apps/frontend/src/app/(protected)/metrics/[identifier]/tuning/__tests__/MetricTuningTab.test.tsx
@@ -2,12 +2,17 @@ import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import MetricTuningTab from '../MetricTuningTab';
-import type { MetricTuningCase } from '@/utils/api-client/interfaces/metric-tuning';
+import type {
+  MetricTuningCase,
+  MetricTuningRun,
+} from '@/utils/api-client/interfaces/metric-tuning';
 
 const mockGetTuningCases = jest.fn();
 const mockCreateTuningCase = jest.fn();
 const mockUpdateTuningCase = jest.fn();
 const mockDeleteTuningCase = jest.fn();
+const mockGetTuningRun = jest.fn();
+const mockStartTuningRun = jest.fn();
 const mockGetMetric = jest.fn();
 
 jest.mock('@/utils/api-client/client-factory', () => ({
@@ -17,6 +22,8 @@ jest.mock('@/utils/api-client/client-factory', () => ({
       createTuningCase: mockCreateTuningCase,
       updateTuningCase: mockUpdateTuningCase,
       deleteTuningCase: mockDeleteTuningCase,
+      getTuningRun: mockGetTuningRun,
+      startTuningRun: mockStartTuningRun,
     }),
     getMetricsClient: () => ({
       getMetric: mockGetMetric,
@@ -46,17 +53,29 @@ const CASE: MetricTuningCase = {
   expected: 'pass',
   rationale: 'polite answer',
   is_stale: false,
+  result: null,
   created_at: '2026-08-06T00:00:00Z',
   updated_at: '2026-08-06T00:00:00Z',
 };
 
 const BINARY_METRIC = { score_type: 'binary' as const };
 
+const NEVER_RUN: MetricTuningRun = {
+  status: 'never_run',
+  started_at: null,
+  completed_at: null,
+  total_cases: 0,
+  completed_cases: 0,
+  errored_cases: 0,
+  error: null,
+};
+
 describe('MetricTuningTab', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetTuningCases.mockResolvedValue([]);
     mockGetMetric.mockResolvedValue(BINARY_METRIC);
+    mockGetTuningRun.mockResolvedValue(NEVER_RUN);
   });
 
   it('shows the empty state when the metric has no cases', async () => {
@@ -288,5 +307,161 @@ describe('MetricTuningTab', () => {
     render(<MetricTuningTab metricId={METRIC_ID} />);
 
     expect(await screen.findByText('No tuning cases yet')).toBeInTheDocument();
+  });
+});
+
+describe('MetricTuningTab — runs', () => {
+  const RUNNING: MetricTuningRun = {
+    status: 'running',
+    started_at: '2026-08-13T10:00:00Z',
+    completed_at: null,
+    total_cases: 3,
+    completed_cases: 1,
+    errored_cases: 0,
+    error: null,
+  };
+
+  const COMPLETED: MetricTuningRun = {
+    status: 'completed',
+    started_at: '2026-08-13T10:00:00Z',
+    completed_at: '2026-08-13T10:01:00Z',
+    total_cases: 1,
+    completed_cases: 1,
+    errored_cases: 0,
+    error: null,
+  };
+
+  const SCORED_CASE: MetricTuningCase = {
+    ...CASE,
+    result: {
+      verdict: 'fail',
+      reasoning: 'The answer contains an insult.',
+      error: null,
+      evaluated_at: '2026-08-13T10:00:30Z',
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetMetric.mockResolvedValue(BINARY_METRIC);
+    mockGetTuningCases.mockResolvedValue([CASE]);
+    mockGetTuningRun.mockResolvedValue(NEVER_RUN);
+    mockStartTuningRun.mockResolvedValue(RUNNING);
+  });
+
+  it('offers a run control once there are cases to run', async () => {
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    expect(
+      await screen.findByRole('button', { name: /run metric/i })
+    ).toBeEnabled();
+  });
+
+  it('does not offer a run for a metric with no cases', async () => {
+    mockGetTuningCases.mockResolvedValue([]);
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    await screen.findByText('No tuning cases yet');
+    expect(
+      screen.queryByRole('button', { name: /run metric/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('starts a run only when the author asks for one', async () => {
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    // Loading the tab must not cost an LLM call per case.
+    await screen.findByRole('button', { name: /run metric/i });
+    expect(mockStartTuningRun).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /run metric/i }));
+
+    await waitFor(() =>
+      expect(mockStartTuningRun).toHaveBeenCalledWith(METRIC_ID)
+    );
+  });
+
+  it('shows that a run is in progress, and how far along', async () => {
+    mockGetTuningRun.mockResolvedValue(RUNNING);
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    expect(await screen.findByText(/1 done/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /running/i })).toBeDisabled();
+  });
+
+  it('shows when the last run finished', async () => {
+    mockGetTuningRun.mockResolvedValue(COMPLETED);
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    expect(await screen.findByText(/last run/i)).toBeInTheDocument();
+  });
+
+  it('says nothing about runs before there has been one', async () => {
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    await screen.findByText('How are you?');
+    expect(screen.queryByText(/last run/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the metric's verdict and its reasoning for each case", async () => {
+    mockGetTuningCases.mockResolvedValue([SCORED_CASE]);
+    mockGetTuningRun.mockResolvedValue(COMPLETED);
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    // 'pass' is what the author expected, 'fail' is what the metric said —
+    // both on the row, which is the whole point of a run.
+    expect(await screen.findByText('pass')).toBeInTheDocument();
+    expect(screen.getByText('fail')).toBeInTheDocument();
+    expect(
+      screen.getByText('The answer contains an insult.')
+    ).toBeInTheDocument();
+  });
+
+  it('marks a case whose metric call failed rather than calling it a verdict', async () => {
+    mockGetTuningCases.mockResolvedValue([
+      {
+        ...CASE,
+        result: {
+          verdict: null,
+          reasoning: null,
+          error: 'provider unreachable',
+          evaluated_at: '2026-08-13T10:00:30Z',
+        },
+      },
+    ]);
+    mockGetTuningRun.mockResolvedValue(COMPLETED);
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    expect(await screen.findByText('Error')).toBeInTheDocument();
+  });
+
+  it('reports a failed run instead of leaving old numbers on screen', async () => {
+    mockGetTuningRun.mockResolvedValue({
+      ...COMPLETED,
+      status: 'failed',
+      error: 'the worker died',
+    });
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    expect(await screen.findByText(/the worker died/i)).toBeInTheDocument();
+  });
+
+  it('survives a failed start', async () => {
+    mockStartTuningRun.mockRejectedValue(new Error('already running'));
+
+    render(<MetricTuningTab metricId={METRIC_ID} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /run metric/i }));
+
+    await waitFor(() => expect(mockStartTuningRun).toHaveBeenCalled());
+    expect(
+      await screen.findByRole('button', { name: /run metric/i })
+    ).toBeEnabled();
   });
 });

--- a/apps/frontend/src/utils/api-client/interfaces/metric-tuning.ts
+++ b/apps/frontend/src/utils/api-client/interfaces/metric-tuning.ts
@@ -12,6 +12,23 @@ import { UUID } from 'crypto';
  * for categorical. The backend validates it against the metric on write, and
  * re-checks it on read to set `is_stale`.
  */
+/**
+ * What the metric said about a case in the latest run.
+ *
+ * Read `verdict` beside the case's `expected` — the human's answer, which the
+ * metric never sees. `error` set means the call failed, which is deliberately
+ * not the same thing as the metric being wrong.
+ */
+export interface MetricTuningCaseResult {
+  /** The metric's own verdict, as a string, whatever its score type. */
+  verdict: string | null;
+  /** The metric's explanation, where it produces one. */
+  reasoning: string | null;
+  /** Why the metric call failed for this case, when it did. */
+  error: string | null;
+  evaluated_at: string | null;
+}
+
 export interface MetricTuningCase {
   id: UUID;
   /** The input given to the system under test. */
@@ -29,8 +46,35 @@ export interface MetricTuningCase {
    * which happens when the score type is changed after the case was written.
    */
   is_stale: boolean;
+  /** The latest run's result, or null if the metric has not been run over it. */
+  result: MetricTuningCaseResult | null;
   created_at: string;
   updated_at: string;
+}
+
+/**
+ * Where a metric's latest tuning run got to.
+ *
+ * `never_run` rather than an absent object, so the tab renders one shape either
+ * way.
+ */
+export type TuningRunStatus = 'never_run' | 'running' | 'completed' | 'failed';
+
+/**
+ * A metric's latest tuning run. Only the latest is kept — a new run overwrites
+ * the previous one.
+ */
+export interface MetricTuningRun {
+  status: TuningRunStatus;
+  started_at: string | null;
+  completed_at: string | null;
+  /** How many cases the run covers, and how many it has finished so far. */
+  total_cases: number;
+  completed_cases: number;
+  /** Cases whose metric call failed. Counted apart from the verdicts. */
+  errored_cases: number;
+  /** Why the run as a whole failed. One case failing does not fail a run. */
+  error: string | null;
 }
 
 export interface MetricTuningCaseCreate {

--- a/apps/frontend/src/utils/api-client/metric-tuning-client.ts
+++ b/apps/frontend/src/utils/api-client/metric-tuning-client.ts
@@ -5,6 +5,7 @@ import {
   MetricTuningCaseCreate,
   MetricTuningCaseDeleteResponse,
   MetricTuningCaseUpdate,
+  MetricTuningRun,
 } from './interfaces/metric-tuning';
 import { UUID } from 'crypto';
 
@@ -17,6 +18,10 @@ import { UUID } from 'crypto';
 export class MetricTuningClient extends BaseApiClient {
   private basePath(metricId: UUID | string): string {
     return `${API_ENDPOINTS.metrics}/${metricId}/tuning/cases`;
+  }
+
+  private runPath(metricId: UUID | string): string {
+    return `${API_ENDPOINTS.metrics}/${metricId}/tuning/run`;
   }
 
   /** Cases for a metric. Empty when it has no tuning test set yet. */
@@ -59,5 +64,25 @@ export class MetricTuningClient extends BaseApiClient {
       `${this.basePath(metricId)}/${caseId}`,
       { method: 'DELETE' }
     );
+  }
+
+  /** The metric's latest run. `never_run` when there has not been one. */
+  async getTuningRun(metricId: UUID | string): Promise<MetricTuningRun> {
+    return this.fetch<MetricTuningRun>(this.runPath(metricId), {
+      cache: 'no-store',
+    });
+  }
+
+  /**
+   * Starts a run over the metric's cases and returns the in-progress summary.
+   *
+   * The work happens in the background — poll `getTuningRun` for progress.
+   * Every run is one LLM call per case, so this is only ever called from an
+   * explicit action, never from an effect that watches the cases.
+   */
+  async startTuningRun(metricId: UUID | string): Promise<MetricTuningRun> {
+    return this.fetch<MetricTuningRun>(this.runPath(metricId), {
+      method: 'POST',
+    });
   }
 }

--- a/tests/backend/routes/test_metric_tuning_runs.py
+++ b/tests/backend/routes/test_metric_tuning_runs.py
@@ -40,6 +40,34 @@ CASE_EXPECTED = "fail"
 CASE_RATIONALE = "the metric scored 0, but this is toxic so it should be 1"
 
 
+def _make_model(db: Session, organization_id, user_id) -> models.Model:
+    """A judging model for a metric — or for the evaluation setting — to point at.
+
+    A run resolves the metric's own model, else the configured default
+    evaluation model, and refuses if there is neither. So every runnable metric
+    here needs one of the two.
+    """
+    provider_lookup = get_or_create_type_lookup(
+        db=db,
+        type_name="ProviderType",
+        type_value="openai",
+        organization_id=organization_id,
+        user_id=user_id,
+        commit=False,
+    )
+    model = models.Model(
+        name=f"Judge {uuid.uuid4().hex[:6]}",
+        model_name="gpt-4o-mini",
+        key="sk-not-a-real-key",
+        provider_type_id=provider_lookup.id,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    db.add(model)
+    db.flush()
+    return model
+
+
 def _make_metric(
     db: Session,
     name: str,
@@ -48,6 +76,7 @@ def _make_metric(
     *,
     score_type: str = "binary",
     backend_type: str = "custom",
+    with_model: bool = True,
     **columns,
 ) -> models.Metric:
     backend_type_lookup = get_or_create_type_lookup(
@@ -58,6 +87,7 @@ def _make_metric(
         user_id=user_id,
         commit=False,
     )
+    model = _make_model(db, organization_id, user_id) if with_model else None
     metric = models.Metric(
         name=name,
         description="Metric under tuning",
@@ -65,6 +95,7 @@ def _make_metric(
         score_type=score_type,
         metric_scope=[MetricScope.SINGLE_TURN.value],
         backend_type_id=backend_type_lookup.id,
+        model_id=model.id if model else None,
         organization_id=organization_id,
         user_id=user_id,
         **columns,
@@ -108,6 +139,33 @@ def framework_metric(test_db: Session, test_org_id, authenticated_user_id) -> mo
         authenticated_user_id,
         backend_type="deepeval",
     )
+
+
+@pytest.fixture
+def metric_without_model(test_db: Session, test_org_id, authenticated_user_id) -> models.Metric:
+    """A metric with no judging model — nothing to run it with."""
+    return _make_metric(
+        test_db,
+        f"Modelless {uuid.uuid4().hex[:6]}",
+        test_org_id,
+        authenticated_user_id,
+        with_model=False,
+    )
+
+
+def _set_evaluation_model(db: Session, user_id, model_id) -> None:
+    """Point the default evaluation model at ``model_id`` (or clear it).
+
+    Goes through ``user.settings.update`` rather than writing the column: the
+    settings manager is cached per User instance, so a raw column write can be
+    read back stale.
+    """
+    user = db.query(models.User).filter(models.User.id == user_id).first()
+    user.settings.update(
+        {"models": {"evaluation": {"model_id": str(model_id) if model_id else None}}}
+    )
+    db.flush()
+    db.commit()
 
 
 @pytest.fixture
@@ -155,11 +213,14 @@ def _evaluator_returning(*results):
     return factory, evaluator
 
 
-def _run(test_db: Session, metric: models.Metric, org_id, *results):
+def _run(test_db: Session, metric: models.Metric, org_id, *results, user_id=None):
     """Execute a run with the metric invocation stubbed. Returns the evaluator mock."""
     factory, evaluator = _evaluator_returning(*results)
     with patch("rhesis.backend.metrics.evaluator.MetricEvaluator", factory):
-        service.execute_tuning_run(test_db, metric, org_id)
+        service.execute_tuning_run(test_db, metric, org_id, user_id)
+    # Kept on the mock so a test can assert how the evaluator was constructed,
+    # not just what it was asked to evaluate.
+    evaluator.constructed_with = factory.call_args
     return evaluator
 
 
@@ -245,6 +306,62 @@ class TestStartTuningRun:
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_a_metric_with_no_model_falls_back_to_the_evaluation_default(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        authenticated_user_id,
+        metric_without_model: models.Metric,
+        no_dispatch,
+    ):
+        """Step two of the chain: the model configured as the evaluation default."""
+        _create_case(authenticated_client, metric_without_model.id)
+        default_model = _make_model(test_db, test_org_id, authenticated_user_id)
+        _set_evaluation_model(test_db, authenticated_user_id, default_model.id)
+
+        response = authenticated_client.post(f"/metrics/{metric_without_model.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_202_ACCEPTED, response.text
+        assert no_dispatch.call_count == 1
+
+    def test_neither_a_metric_model_nor_an_evaluation_default_is_refused(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        authenticated_user_id,
+        metric_without_model: models.Metric,
+        no_dispatch,
+    ):
+        """Where the chain ends: an error, not a third silent step.
+
+        The evaluation path keeps going past here — to whatever the caller
+        passed, then to the SDK's own hosted default. A scorecard produced by a
+        judge nobody chose measures nothing, so the run is refused instead.
+        """
+        _create_case(authenticated_client, metric_without_model.id)
+        _set_evaluation_model(test_db, authenticated_user_id, None)
+
+        response = authenticated_client.post(f"/metrics/{metric_without_model.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "model" in response.json()["detail"].lower()
+        no_dispatch.assert_not_called()
+
+    def test_the_refusal_leaves_no_run_behind(
+        self,
+        authenticated_client: TestClient,
+        metric_without_model: models.Metric,
+        no_dispatch,
+    ):
+        """Refused before anything is claimed, so the status is untouched."""
+        _create_case(authenticated_client, metric_without_model.id)
+        authenticated_client.post(f"/metrics/{metric_without_model.id}/tuning/run")
+
+        body = authenticated_client.get(f"/metrics/{metric_without_model.id}/tuning/run").json()
+
+        assert body["status"] == "never_run"
+
 
 @pytest.mark.integration
 @pytest.mark.routes
@@ -312,6 +429,25 @@ class TestRunResults:
         assert cases[0]["result"]["reasoning"] == "No insult detected."
         assert cases[0]["result"]["error"] is None
         assert cases[0]["result"]["evaluated_at"]
+
+    def test_the_metric_is_judged_with_its_own_model(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """An explicit model reaches the evaluator, so it never picks one itself.
+
+        `MetricEvaluator` falls back to the SDK's built-in default when no model
+        is passed. Passing one is what removes that possibility — there is no
+        argument left to omit.
+        """
+        _create_case(authenticated_client, tuning_metric.id)
+        evaluator = _run(test_db, tuning_metric, test_org_id, {"score": 1.0, "reason": "ok"})
+
+        model = evaluator.constructed_with.kwargs.get("model")
+        assert model is not None, "no model passed — the evaluator would pick its own default"
 
     def test_a_numeric_metrics_verdict_is_its_number(
         self,

--- a/tests/backend/routes/test_metric_tuning_runs.py
+++ b/tests/backend/routes/test_metric_tuning_runs.py
@@ -397,6 +397,33 @@ class TestStartTuningRun:
         assert "model" in response.json()["detail"].lower()
         no_dispatch.assert_not_called()
 
+    def test_an_unreadable_evaluation_model_setting_is_still_a_refusal(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        authenticated_user_id,
+        metric_without_model: models.Metric,
+        no_dispatch,
+    ):
+        """A broken setting must refuse like a missing one, not crash.
+
+        The settings accessor parses the stored value as a UUID, so a malformed
+        one raises rather than reading as absent — and the walk that reads it
+        only guards against a missing attribute. Unhandled it escapes as a 500
+        from the very function whose job is to refuse cleanly.
+        """
+        _create_case(authenticated_client, metric_without_model.id)
+        user = test_db.query(models.User).filter(models.User.id == authenticated_user_id).first()
+        user.settings.update({"models": {"evaluation": {"model_id": "not-a-uuid"}}})
+        test_db.flush()
+        test_db.commit()
+
+        response = authenticated_client.post(f"/metrics/{metric_without_model.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "model" in response.json()["detail"].lower()
+        no_dispatch.assert_not_called()
+
     def test_the_refusal_leaves_no_run_behind(
         self,
         authenticated_client: TestClient,

--- a/tests/backend/routes/test_metric_tuning_runs.py
+++ b/tests/backend/routes/test_metric_tuning_runs.py
@@ -1,0 +1,480 @@
+"""Integration tests for tuning runs — running a metric over its own cases.
+
+Tests the two run endpoints:
+- POST /metrics/{metric_id}/tuning/run
+- GET  /metrics/{metric_id}/tuning/run
+
+plus what a run leaves behind on the case list.
+
+The metric invocation is stubbed throughout, which is what makes these
+deterministic and free of LLM calls. Celery is stubbed too: this codebase tests
+background work by mocking the dispatch and calling the service the task would
+have called, rather than by running a broker.
+
+The test that matters most is ``test_the_metric_never_sees_the_expected_verdict``.
+Route the metric under test through the normal evaluation path and it is handed
+the answer key; nothing raises, the numbers just come out flattering. That test
+is the only thing that fails loudly when someone reconnects the wire.
+
+Run with: python -m pytest tests/backend/routes/test_metric_tuning_runs.py -v
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app import models
+from rhesis.backend.app.schemas.metric import MetricScope
+from rhesis.backend.app.services import metric_tuning as service
+from rhesis.backend.app.utils.crud_utils import get_or_create_type_lookup
+
+CASE_INPUT = "How are you?"
+CASE_OUTPUT = "I am fine you fucking basterd"
+CASE_EXPECTED_OUTPUT = "I am fine, thanks for asking."
+# The expected verdict — the answer key. The metric must never be shown this.
+CASE_EXPECTED = "fail"
+CASE_RATIONALE = "the metric scored 0, but this is toxic so it should be 1"
+
+
+def _make_metric(
+    db: Session,
+    name: str,
+    organization_id,
+    user_id,
+    *,
+    score_type: str = "binary",
+    backend_type: str = "custom",
+    **columns,
+) -> models.Metric:
+    backend_type_lookup = get_or_create_type_lookup(
+        db=db,
+        type_name="BackendType",
+        type_value=backend_type,
+        organization_id=organization_id,
+        user_id=user_id,
+        commit=False,
+    )
+    metric = models.Metric(
+        name=name,
+        description="Metric under tuning",
+        evaluation_prompt="Score how toxic the answer is.",
+        score_type=score_type,
+        metric_scope=[MetricScope.SINGLE_TURN.value],
+        backend_type_id=backend_type_lookup.id,
+        organization_id=organization_id,
+        user_id=user_id,
+        **columns,
+    )
+    db.add(metric)
+    db.flush()
+    db.commit()
+    db.refresh(metric)
+    return metric
+
+
+@pytest.fixture
+def tuning_metric(test_db: Session, test_org_id, authenticated_user_id) -> models.Metric:
+    """A binary custom metric with no tuning test set yet."""
+    return _make_metric(
+        test_db, f"Toxicity Run {uuid.uuid4().hex[:6]}", test_org_id, authenticated_user_id
+    )
+
+
+@pytest.fixture
+def numeric_metric(test_db: Session, test_org_id, authenticated_user_id) -> models.Metric:
+    return _make_metric(
+        test_db,
+        f"Numeric Run {uuid.uuid4().hex[:6]}",
+        test_org_id,
+        authenticated_user_id,
+        score_type="numeric",
+        min_score=0.0,
+        max_score=1.0,
+        threshold=0.5,
+    )
+
+
+@pytest.fixture
+def framework_metric(test_db: Session, test_org_id, authenticated_user_id) -> models.Metric:
+    """A framework-provided metric — its prompt is not the org's to tune."""
+    return _make_metric(
+        test_db,
+        f"Framework Run {uuid.uuid4().hex[:6]}",
+        test_org_id,
+        authenticated_user_id,
+        backend_type="deepeval",
+    )
+
+
+@pytest.fixture
+def no_dispatch():
+    """Stop the route from actually queueing the background task.
+
+    Yields the mock so a test can assert the run was dispatched exactly once
+    with the metric it was asked for.
+    """
+    with patch("rhesis.backend.app.routers.metric_tuning.task_launcher") as launcher:
+        yield launcher
+
+
+def _create_case(client: TestClient, metric_id, **overrides) -> dict:
+    body = {
+        "input": CASE_INPUT,
+        "output": CASE_OUTPUT,
+        "expected_output": CASE_EXPECTED_OUTPUT,
+        "expected": CASE_EXPECTED,
+        "rationale": CASE_RATIONALE,
+    }
+    body.update(overrides)
+    response = client.post(f"/metrics/{metric_id}/tuning/cases", json=body)
+    assert response.status_code == status.HTTP_201_CREATED, response.text
+    return response.json()
+
+
+def _evaluator_returning(*results):
+    """A stubbed MetricEvaluator whose evaluate() yields the given results in order.
+
+    Each entry is either a result dict or an exception to raise. The mock is
+    returned so tests can inspect the arguments the metric was invoked with.
+    """
+    calls = list(results)
+    evaluator = MagicMock()
+
+    def _evaluate(**kwargs):
+        outcome = calls.pop(0) if calls else {"score": 0.0, "reason": "no more stubs"}
+        if isinstance(outcome, Exception):
+            raise outcome
+        return {"Metric": outcome}
+
+    evaluator.evaluate.side_effect = _evaluate
+    factory = MagicMock(return_value=evaluator)
+    return factory, evaluator
+
+
+def _run(test_db: Session, metric: models.Metric, org_id, *results):
+    """Execute a run with the metric invocation stubbed. Returns the evaluator mock."""
+    factory, evaluator = _evaluator_returning(*results)
+    with patch("rhesis.backend.metrics.evaluator.MetricEvaluator", factory):
+        service.execute_tuning_run(test_db, metric, org_id)
+    return evaluator
+
+
+@pytest.mark.integration
+@pytest.mark.routes
+class TestStartTuningRun:
+    """POST /metrics/{metric_id}/tuning/run"""
+
+    def test_a_metric_with_no_cases_is_told_to_add_some(
+        self,
+        authenticated_client: TestClient,
+        tuning_metric: models.Metric,
+        no_dispatch,
+    ):
+        """An empty scorecard would say nothing; the refusal says what to do."""
+        response = authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "tuning case" in response.json()["detail"].lower()
+        no_dispatch.assert_not_called()
+
+    def test_starting_a_run_reports_it_in_progress(
+        self,
+        authenticated_client: TestClient,
+        tuning_metric: models.Metric,
+        no_dispatch,
+    ):
+        _create_case(authenticated_client, tuning_metric.id)
+        _create_case(authenticated_client, tuning_metric.id, input="Another one")
+
+        response = authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        body = response.json()
+        assert body["status"] == "running"
+        assert body["total_cases"] == 2
+        assert body["completed_cases"] == 0
+        assert body["started_at"]
+
+    def test_starting_a_run_queues_the_background_work(
+        self,
+        authenticated_client: TestClient,
+        tuning_metric: models.Metric,
+        no_dispatch,
+    ):
+        """Thirty cases is thirty LLM calls — the browser does not wait for them."""
+        _create_case(authenticated_client, tuning_metric.id)
+
+        authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        assert no_dispatch.call_count == 1
+        assert str(tuning_metric.id) in no_dispatch.call_args.args
+
+    def test_a_second_run_is_refused_while_one_is_going(
+        self,
+        authenticated_client: TestClient,
+        tuning_metric: models.Metric,
+        no_dispatch,
+    ):
+        _create_case(authenticated_client, tuning_metric.id)
+        authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        response = authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert no_dispatch.call_count == 1
+
+    def test_a_framework_metric_cannot_be_run(
+        self,
+        authenticated_client: TestClient,
+        framework_metric: models.Metric,
+        no_dispatch,
+    ):
+        """Refused in the API, not only by hiding the button."""
+        response = authenticated_client.post(f"/metrics/{framework_metric.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "custom" in response.json()["detail"].lower()
+        no_dispatch.assert_not_called()
+
+    def test_unknown_metric_404s(self, authenticated_client: TestClient, no_dispatch):
+        response = authenticated_client.post(f"/metrics/{uuid.uuid4()}/tuning/run")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.integration
+@pytest.mark.routes
+class TestReadTuningRun:
+    """GET /metrics/{metric_id}/tuning/run"""
+
+    def test_a_metric_never_run_reads_as_never_run(
+        self, authenticated_client: TestClient, tuning_metric: models.Metric
+    ):
+        """One shape either way, so the tab has nothing to branch on."""
+        response = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["status"] == "never_run"
+
+    def test_reports_when_the_last_run_finished(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+        no_dispatch,
+    ):
+        _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id, {"score": 0.0, "reason": "toxic"})
+
+        body = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+
+        assert body["status"] == "completed"
+        assert body["completed_at"]
+        assert body["total_cases"] == 1
+        assert body["completed_cases"] == 1
+
+    def test_a_framework_metric_cannot_be_read(
+        self, authenticated_client: TestClient, framework_metric: models.Metric
+    ):
+        response = authenticated_client.get(f"/metrics/{framework_metric.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.integration
+@pytest.mark.routes
+class TestRunResults:
+    """What a finished run leaves on the cases."""
+
+    def test_each_case_shows_the_metrics_verdict_and_reasoning(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        _create_case(authenticated_client, tuning_metric.id)
+        _run(
+            test_db,
+            tuning_metric,
+            test_org_id,
+            {"score": 1.0, "reason": "No insult detected."},
+        )
+
+        cases = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/cases").json()
+
+        assert cases[0]["result"]["verdict"] == "pass"
+        assert cases[0]["result"]["reasoning"] == "No insult detected."
+        assert cases[0]["result"]["error"] is None
+        assert cases[0]["result"]["evaluated_at"]
+
+    def test_a_numeric_metrics_verdict_is_its_number(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        numeric_metric: models.Metric,
+    ):
+        _create_case(authenticated_client, numeric_metric.id, expected="0.8")
+        _run(test_db, numeric_metric, test_org_id, {"score": 0.79, "reason": "close"})
+
+        cases = authenticated_client.get(f"/metrics/{numeric_metric.id}/tuning/cases").json()
+
+        assert cases[0]["result"]["verdict"] == "0.79"
+
+    def test_the_metric_never_sees_the_expected_verdict(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """The one that stops a flattering, meaningless scorecard.
+
+        The metric is invoked as the system under test: it gets the case payload
+        and nothing else. `expected_output` is the case's own expected output —
+        never `prompt.expected_response`, which holds the expected verdict.
+        """
+        _create_case(authenticated_client, tuning_metric.id)
+        evaluator = _run(test_db, tuning_metric, test_org_id, {"score": 0.0, "reason": "toxic"})
+
+        kwargs = evaluator.evaluate.call_args.kwargs
+        assert kwargs["input_text"] == CASE_INPUT
+        assert kwargs["output_text"] == CASE_OUTPUT
+        assert kwargs["expected_output"] == CASE_EXPECTED_OUTPUT
+        # The verdict and the reviewer's rationale reach the metric nowhere at all.
+        passed = " ".join(str(v) for v in kwargs.values())
+        assert CASE_EXPECTED not in passed
+        assert CASE_RATIONALE not in passed
+
+    def test_a_failed_call_is_errored_and_the_run_continues(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """A flaky provider must never read as a bad metric."""
+        _create_case(authenticated_client, tuning_metric.id)
+        _create_case(authenticated_client, tuning_metric.id, input="The second one")
+
+        _run(
+            test_db,
+            tuning_metric,
+            test_org_id,
+            RuntimeError("provider unreachable"),
+            {"score": 1.0, "reason": "fine"},
+        )
+
+        cases = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/cases").json()
+        assert cases[0]["result"]["error"] == "provider unreachable"
+        assert cases[0]["result"]["verdict"] is None
+        # The run carried on rather than stopping at the first failure.
+        assert cases[1]["result"]["verdict"] == "pass"
+
+        summary = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+        assert summary["status"] == "completed"
+        assert summary["completed_cases"] == 2
+        assert summary["errored_cases"] == 1
+
+    def test_an_error_result_from_the_evaluator_is_errored_too(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """The evaluator reports some failures as a result rather than by raising."""
+        _create_case(authenticated_client, tuning_metric.id)
+        _run(
+            test_db,
+            tuning_metric,
+            test_org_id,
+            {"score": 0.0, "reason": "Evaluation failed", "error": "rate limited"},
+        )
+
+        cases = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/cases").json()
+        assert cases[0]["result"]["error"] == "rate limited"
+        assert cases[0]["result"]["verdict"] is None
+
+    def test_running_does_not_modify_the_cases(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """Scoring must never edit the thing being scored."""
+        before = _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id, {"score": 1.0, "reason": "fine"})
+
+        after = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/cases").json()[0]
+
+        for field in ("input", "output", "expected_output", "expected", "rationale"):
+            assert after[field] == before[field], field
+
+    def test_only_the_latest_run_is_kept(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id, {"score": 0.0, "reason": "first run"})
+        _run(test_db, tuning_metric, test_org_id, {"score": 1.0, "reason": "second run"})
+
+        cases = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/cases").json()
+
+        assert cases[0]["result"]["verdict"] == "pass"
+        assert cases[0]["result"]["reasoning"] == "second run"
+
+    def test_a_case_added_after_a_run_has_no_result(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        _create_case(authenticated_client, tuning_metric.id)
+        _run(test_db, tuning_metric, test_org_id, {"score": 1.0, "reason": "fine"})
+
+        fresh = _create_case(authenticated_client, tuning_metric.id, input="Added later")
+
+        assert fresh["result"] is None
+
+    def test_a_failed_run_says_so(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """Otherwise old numbers sit there being read as new ones."""
+        _create_case(authenticated_client, tuning_metric.id)
+        service.fail_tuning_run(test_db, tuning_metric, test_org_id, "worker died")
+
+        body = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/run").json()
+
+        assert body["status"] == "failed"
+        assert body["error"] == "worker died"
+
+    def test_a_failed_run_does_not_block_the_next_one(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+        no_dispatch,
+    ):
+        _create_case(authenticated_client, tuning_metric.id)
+        service.fail_tuning_run(test_db, tuning_metric, test_org_id, "worker died")
+
+        response = authenticated_client.post(f"/metrics/{tuning_metric.id}/tuning/run")
+
+        assert response.status_code == status.HTTP_202_ACCEPTED

--- a/tests/backend/routes/test_metric_tuning_runs.py
+++ b/tests/backend/routes/test_metric_tuning_runs.py
@@ -31,6 +31,7 @@ from rhesis.backend.app import models
 from rhesis.backend.app.schemas.metric import MetricScope
 from rhesis.backend.app.services import metric_tuning as service
 from rhesis.backend.app.utils.crud_utils import get_or_create_type_lookup
+from rhesis.backend.metrics.result_builder import MetricResultBuilder
 
 CASE_INPUT = "How are you?"
 CASE_OUTPUT = "I am fine you fucking basterd"
@@ -130,6 +131,33 @@ def numeric_metric(test_db: Session, test_org_id, authenticated_user_id) -> mode
 
 
 @pytest.fixture
+def categorical_metric(test_db: Session, test_org_id, authenticated_user_id) -> models.Metric:
+    return _make_metric(
+        test_db,
+        f"Categorical Run {uuid.uuid4().hex[:6]}",
+        test_org_id,
+        authenticated_user_id,
+        score_type="categorical",
+        categories=["helpful", "harmful"],
+        passing_categories=["helpful"],
+    )
+
+
+@pytest.fixture
+def error_category_metric(test_db: Session, test_org_id, authenticated_user_id) -> models.Metric:
+    """A metric that answers ``error`` as a real category, not as a failure."""
+    return _make_metric(
+        test_db,
+        f"Error Category Run {uuid.uuid4().hex[:6]}",
+        test_org_id,
+        authenticated_user_id,
+        score_type="categorical",
+        categories=["ok", "error"],
+        passing_categories=["ok"],
+    )
+
+
+@pytest.fixture
 def framework_metric(test_db: Session, test_org_id, authenticated_user_id) -> models.Metric:
     """A framework-provided metric — its prompt is not the org's to tune."""
     return _make_metric(
@@ -191,6 +219,27 @@ def _create_case(client: TestClient, metric_id, **overrides) -> dict:
     response = client.post(f"/metrics/{metric_id}/tuning/cases", json=body)
     assert response.status_code == status.HTTP_201_CREATED, response.text
     return response.json()
+
+
+def _local_strategy_result(score, reason: str) -> dict:
+    """What the local strategy actually hands back for a completed evaluation.
+
+    Built with the real builder rather than a hand-written dict, because the
+    thing under test is a property of the real shape: the SDK reports its own
+    failures as a *result*, the local strategy wraps that in ``success()``, and
+    ``success()`` has no ``error`` key to find. Stubbing the connector's shape
+    instead is what let this go unnoticed.
+    """
+    result = MetricResultBuilder.success(
+        score=score,
+        reason=reason,
+        is_successful=False,
+        backend="rhesis",
+        name="Metric",
+        class_name="CategoricalJudge",
+    )
+    assert "error" not in result, "the premise of these tests"
+    return result
 
 
 def _evaluator_returning(*results):
@@ -537,6 +586,113 @@ class TestRunResults:
         cases = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/cases").json()
         assert cases[0]["result"]["error"] == "rate limited"
         assert cases[0]["result"]["verdict"] is None
+
+    def test_a_provider_failure_the_sdk_reports_as_a_result_is_errored(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        categorical_metric: models.Metric,
+    ):
+        """The failure that actually happens, in the shape it actually arrives in.
+
+        A 401 against the judging model does not raise and does not set
+        ``error``. It comes back as a scored result whose score is the SDK's
+        sentinel, and reading that as a verdict is what produced a run of
+        "1 cases, 0 errored" with ``error`` stored as the metric's answer.
+        """
+        _create_case(authenticated_client, categorical_metric.id, expected="helpful")
+
+        _run(
+            test_db,
+            categorical_metric,
+            test_org_id,
+            _local_strategy_result(
+                "error",
+                "Error evaluating with Toxicity: AuthenticationError: 401 Unauthorized",
+            ),
+        )
+
+        cases = authenticated_client.get(f"/metrics/{categorical_metric.id}/tuning/cases").json()
+        assert cases[0]["result"]["verdict"] is None
+        assert "401" in cases[0]["result"]["error"]
+
+        summary = authenticated_client.get(f"/metrics/{categorical_metric.id}/tuning/run").json()
+        assert summary["errored_cases"] == 1
+
+    def test_a_provider_failure_on_a_binary_metric_is_not_recorded_as_a_pass(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        tuning_metric: models.Metric,
+    ):
+        """The same failure on a binary metric, where reading it as a verdict flatters.
+
+        ``error`` is a non-empty string and therefore truthy, so the sentinel
+        renders as ``pass`` -- an unreachable provider recorded as the metric
+        agreeing with the case.
+        """
+        _create_case(authenticated_client, tuning_metric.id)
+
+        _run(
+            test_db,
+            tuning_metric,
+            test_org_id,
+            _local_strategy_result(
+                "error", "Error evaluating with Toxicity: AuthenticationError: 401"
+            ),
+        )
+
+        cases = authenticated_client.get(f"/metrics/{tuning_metric.id}/tuning/cases").json()
+        assert cases[0]["result"]["verdict"] is None, "a failed call is not a passing case"
+        assert cases[0]["result"]["error"]
+
+    def test_a_numeric_failure_is_errored_rather_than_a_zero(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        numeric_metric: models.Metric,
+    ):
+        """A numeric metric's failure sentinel is an ordinary number.
+
+        Nothing in the score distinguishes it from a real 0.0, so the reason the
+        SDK writes is the only thing left to go on.
+        """
+        _create_case(authenticated_client, numeric_metric.id, expected="0.5")
+
+        _run(
+            test_db,
+            numeric_metric,
+            test_org_id,
+            _local_strategy_result(0.0, "Error evaluating with Relevance: timed out"),
+        )
+
+        cases = authenticated_client.get(f"/metrics/{numeric_metric.id}/tuning/cases").json()
+        assert cases[0]["result"]["verdict"] is None
+        assert cases[0]["result"]["error"] == "Error evaluating with Relevance: timed out"
+
+    def test_a_metric_that_answers_error_as_a_category_keeps_its_verdict(
+        self,
+        authenticated_client: TestClient,
+        test_db: Session,
+        test_org_id,
+        error_category_metric: models.Metric,
+    ):
+        """``error`` is only a sentinel for metrics that do not offer it as an answer."""
+        _create_case(authenticated_client, error_category_metric.id, expected="error")
+
+        _run(
+            test_db,
+            error_category_metric,
+            test_org_id,
+            _local_strategy_result("error", "The response reports a system error."),
+        )
+
+        cases = authenticated_client.get(f"/metrics/{error_category_metric.id}/tuning/cases").json()
+        assert cases[0]["result"]["verdict"] == "error"
+        assert cases[0]["result"]["error"] is None
 
     def test_running_does_not_modify_the_cases(
         self,

--- a/tests/backend/services/metric_tuning/test_invoke.py
+++ b/tests/backend/services/metric_tuning/test_invoke.py
@@ -1,0 +1,65 @@
+"""Unit tests for rendering a metric's own score as a verdict string.
+
+A narrow seam, tested on its own for the same reason the verdict validation is:
+the rules differ per score type, and driving each one through a whole run would
+be slow and would bury what is actually being asserted.
+
+Run with: python -m pytest tests/backend/services/metric_tuning/test_invoke.py -v
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from rhesis.backend.app.services.metric_tuning.invoke import verdict_from_score
+
+
+def _metric(score_type: str) -> SimpleNamespace:
+    """A stand-in for the Metric row — only score_type is read."""
+    return SimpleNamespace(score_type=score_type)
+
+
+class TestBinaryVerdicts:
+    """A binary metric returns a number the SDK treats as a flag."""
+
+    @pytest.mark.parametrize("score", [1.0, 1, True, 0.7])
+    def test_a_truthy_score_is_pass(self, score):
+        assert verdict_from_score(_metric("binary"), score) == "pass"
+
+    @pytest.mark.parametrize("score", [0.0, 0, False])
+    def test_a_falsy_score_is_fail(self, score):
+        assert verdict_from_score(_metric("binary"), score) == "fail"
+
+    @pytest.mark.parametrize("score", ["pass", "PASS", " Fail "])
+    def test_a_metric_that_already_answers_in_words_is_taken_at_its_word(self, score):
+        assert verdict_from_score(_metric("binary"), score) == score.strip().lower()
+
+    def test_rendered_as_pass_not_as_one_point_zero(self):
+        """`1.0` beside an expected `pass` reads as a disagreement to a human."""
+        assert verdict_from_score(_metric("binary"), 1.0) == "pass"
+
+
+class TestNumericVerdicts:
+    def test_a_number_is_its_own_verdict(self):
+        assert verdict_from_score(_metric("numeric"), 0.79) == "0.79"
+
+    def test_an_integer_score_normalizes_to_a_float(self):
+        assert verdict_from_score(_metric("numeric"), 1) == "1.0"
+
+    def test_a_number_that_arrived_as_a_string_still_normalizes(self):
+        assert verdict_from_score(_metric("numeric"), "0.5") == "0.5"
+
+    def test_an_unparseable_score_is_kept_verbatim(self):
+        """Better a verdict a human can see is wrong than one silently dropped."""
+        assert verdict_from_score(_metric("numeric"), "not a number") == "not a number"
+
+
+class TestCategoricalVerdicts:
+    def test_the_category_is_the_verdict(self):
+        assert verdict_from_score(_metric("categorical"), "toxic") == "toxic"
+
+
+class TestNoScore:
+    def test_no_score_is_no_verdict(self):
+        """A failed call has no verdict — and must not be given a default one."""
+        assert verdict_from_score(_metric("binary"), None) is None

--- a/tests/backend/services/metric_tuning/test_invoke.py
+++ b/tests/backend/services/metric_tuning/test_invoke.py
@@ -38,6 +38,21 @@ class TestBinaryVerdicts:
         """`1.0` beside an expected `pass` reads as a disagreement to a human."""
         assert verdict_from_score(_metric("binary"), 1.0) == "pass"
 
+    @pytest.mark.parametrize("score", ["no", "false", "0", "harmful"])
+    def test_a_word_the_metric_chose_itself_is_not_read_as_a_flag(self, score):
+        """The failure here is silent and flattering, which is why it is tested.
+
+        There is no binary judge in the SDK factory, so a binary metric is backed
+        by one that answers in categories. Falling through to ``bool()`` would
+        make every non-empty string truthy -- ``no`` and ``false`` would both
+        render as ``pass``, and every case would agree.
+        """
+        assert verdict_from_score(_metric("binary"), score) == score
+
+    def test_a_word_it_does_recognize_still_wins(self):
+        """The as-is path must not swallow the pass/fail the metric did answer."""
+        assert verdict_from_score(_metric("binary"), " FAIL ") == "fail"
+
 
 class TestNumericVerdicts:
     def test_a_number_is_its_own_verdict(self):


### PR DESCRIPTION
> ### 🎯 This merges into `feat/metric-tuning-test-sets`, not `main`
>
> Base branch is **#2446**, the integration branch for the whole metric tuning effort. This is ticket 02 of the tuning-runs work, cut from that branch and merging back into it. Migrations for the effort are held there so an early schema guess can be corrected in place rather than needing a corrective migration stacked on top; `main` sees exactly one merge at the end.

## Purpose

A metric author can now write down what their metric *should* say — a tuning case per situation, each with an expected verdict — but has no way to find out whether it actually says it. So the labelled cases sit there being correct and inert, and checking a metric still means running something, reading the output and forming an impression. Editing an evaluation prompt stays guesswork with no feedback.

This adds the run: press a button and the metric is run over every case it has. Each case then shows what the metric said and why, beside the verdict the author expected. That side-by-side is what you edit an evaluation prompt against.

No agreement number yet — that is ticket 03. Seeing the divergence case by case is already the substance of a run, and the ratio needs the agreed/disagreed/skipped split that ticket brings.

## What Changed

- **The metric is invoked as the system under test.** `services/metric_tuning/invoke.py` unpacks the case payload into the same three arguments the metric receives in a real run — input, output, and the case's *own* expected output — and nothing else. This is the part of the feature that is easy to get backwards and the reason the whole thing is shaped this way; see the caveat below.
- **A run creates no rows in the execution tables.** No test run, no test configuration, no endpoint, no metric row for the comparison. It is a service plus a Celery task writing into JSONB that already exists: the per-case result onto `test.test_metadata["result"]`, the run summary onto the tuning test set's `attributes["tuning_run"]`. ADR-0004 records why, and the two schema constraints that rule out reusing the execution path.
- **Only the latest run is kept.** A new run clears the previous per-case results before writing its own — otherwise a case the metric can no longer reach would keep showing what it said last time, beside a summary describing the current run. Trend over time deserves real rows rather than an unbounded blob in a column nothing paginates, and nothing is lost that re-running cannot recover.
- **Two routes**, `POST` and `GET /metrics/{id}/tuning/run`. 400 when the metric has no cases (an empty scorecard says nothing; the refusal says what to do), 409 while a run is in flight, 400 on a non-custom metric. The `POST` is marked `metric:update` explicitly rather than left to the POST-means-create convention — running writes results onto the metric's own cases, and an explicit `metric:execute` would need a capability catalog migration for something still behind a flag.
- **A failed metric call is an errored case, not a wrong verdict.** The run continues over the rest and the count is reported apart from the verdicts, so one unreachable provider never reads as a bad metric. This needed a fix after the first review pass: the SDK reports its own failures as a *result* rather than by raising, and `LocalStrategy` wraps that in `MetricResultBuilder.success()`, which carries no `error` key at all. Only the key was being checked, so a 401 against the judging model produced a run of "1 cases, 0 errored" with the failure stored as the metric's answer — `error` on a categorical metric, `pass` on a binary one, `0.0` on a numeric one. The score sentinel and the reason the SDK writes are now both read.
- **The judging model is resolved explicitly, and the chain ends in an error.** It is the model saved on the metric, else the model configured as the default for evaluation, else the run is refused with a 400 before anything is written or queued. The evaluation path this borrows keeps going past those two — to whatever the caller passed, and then to the SDK's own built-in default, the hosted Rhesis LLM — and announces neither. That is how a tuning run reached a model nobody picked and died on a 401. `get_user_evaluation_model` is deliberately not used: it conflates "the user configured a model" with "the system has a default", which is the silent step being removed. A run scored by a judge nobody chose measures nothing and says nothing about it — set the metric's model afterwards and every stored verdict silently refers to a different judge.
- **The task does not retry.** A run is one LLM call per case, so an autoretry is a second bill for the same work; it marks the run failed instead and the author presses again. A run that dies is recorded as `failed` rather than left `running`, which would both look like progress and block the next attempt.
- **The run commits after each case**, so the tab shows real progress rather than jumping from nothing to everything, and a worker that dies mid-run leaves the cases it did finish behind.
- **A binary metric's verdict renders as pass/fail, not `1.0`.** The SDK returns a float that it treats as a flag; `1.0` displayed beside an expected `pass` reads as a disagreement to a human even when it is not.
- **Tab changes**: a Run metric control, polling while a run is in flight, a line saying when the last run finished, and "Metric said" / "Because" columns sitting next to "Expected".

## Additional Context

- **The caveat worth reviewing closely, and the one a reader is most likely to skip.** On the normal evaluation path `prompt.expected_response` is passed to a metric as its `expected_output`. On a tuning case that column holds the **expected verdict**. Route the metric under test through that path and it is handed the answer key — told the expected response to "How are you?" is `fail` — and the resulting agreement number is meaningless. Nothing fails loudly; the numbers just come out flattering. `test_the_metric_never_sees_the_expected_verdict` is the only thing that fails if someone reconnects that wire, which is why it asserts the arguments the evaluator received *and* that neither the verdict nor the reviewer's rationale appears anywhere among them.
- **Concurrency is advisory, deliberately.** The stored status is the only guard, so two requests in the same instant can both pass. The failure mode is a summary belonging to neither run rather than corruption — the trade ADR-0004 accepts for a flagged feature with one author per metric. Making it actually safe is ticket 04.
- **`MetricTuningRun` and `MetricTuningCaseResult` extend plain `BaseModel`, not the shared `Base`.** `Base` carries `id`/`nano_id`/`project_id`, and a null `id` on a run response would advertise a handle to something ADR-0004 says is deliberately not a row.
- **Still invisible in every deployment.** The tab stays behind `NEXT_PUBLIC_METRIC_TUNING`, which defaults to off and nothing sets it. The routes are live, which is why the custom-metric refusal is enforced server-side rather than only by hiding the button.
- **On size**: ~1700 added lines, which is well past the repo's 400-line guideline. It is one ticket and one logical change — backend, interface and tests for a single capability — and roughly half of it is tests and docstrings. Reviewing per commit splits it into backend, backend tests, and frontend.

## Testing

`cd apps/backend && uv run pytest ../../tests/backend/routes/test_metric_tuning_runs.py ../../tests/backend/services/metric_tuning/test_invoke.py` — 50 tests. The 28 route tests cover starting a run, the in-progress and finished summaries, the no-cases and non-custom refusals, the concurrent-run refusal, per-case verdict and reasoning, every flavour of errored case (the evaluator raising, the evaluator setting an `error` key, and the shape that actually occurs — a failure the SDK reports as a scored result with no error key, on both a categorical and a numeric metric, plus a metric that offers `error` as a real category keeping its verdict), a failed run surfacing as failed and not blocking the next one, only-the-latest-run-kept, a case added after a run having no result, and that a run leaves the cases themselves byte-for-byte unmodified. The 22 unit tests cover verdict rendering per score type, including the words a binary metric's judge can answer with that are not `pass`/`fail` — `bool()` on any of them is true, so they would otherwise all render as `pass`.

The metric invocation and the Celery dispatch are both stubbed, so the suite is deterministic and makes no LLM calls.

Neighbouring suites still pass: `test_metric_tuning.py`, `test_metric_tuning_metadata.py`, `services/metric_tuning/` — 122 together with the new ones; `test_test_set_update.py`, `test_test_test_sets.py`, `test_test_bulk_delete.py`, `test_explorer.py` — 101; `tasks/test_base_task.py`, `tasks/test_pipeline_wiring.py` — 25.

Frontend: `npx jest --testPathPatterns "MetricTuning|metric-tuning"` — 31 tests, 10 of them new: the run control appearing only once there are cases, that loading the tab starts nothing, the in-flight state and its progress, the last-run line, the metric's verdict and reasoning on the row, the error marker, and a failed run being reported. `npx tsc --noEmit` and `npm run lint` are clean.

To exercise it by hand, add `NEXT_PUBLIC_METRIC_TUNING=true` to `apps/frontend/.env.local`, restart the frontend, open a custom metric's Tuning tab, add a case or two and press Run metric. A Celery worker must be running for the run to progress past `running`.


