### PR TITLE
Fix CORS in worktrees by shifting the backend's FRONTEND_URL

### DIFF
--- a/scripts/rh/worktree.sh
+++ b/scripts/rh/worktree.sh
@@ -82,6 +82,8 @@ rewrite_backend_env_ports() {
     set_env_var "$file" DB_PORT "$(dev_port_for postgres "$offset")"
     set_env_url_port "$file" BROKER_URL "$(dev_port_for redis "$offset")"
     set_env_url_port "$file" CELERY_RESULT_BACKEND "$(dev_port_for redis "$offset")"
+    # The backend's CORS allowlist is derived from this, so it must track the worktree's frontend
+    set_env_var "$file" FRONTEND_URL "http://localhost:$(dev_port_for frontend "$offset")"
 }
 
 rewrite_frontend_env_ports() {


### PR DESCRIPTION
## Purpose

`./rh worktree <name>` copies `apps/backend/.env` from the main checkout and then shifts its ports, but it never touched `FRONTEND_URL`. That variable is the backend's entire CORS allowlist — `apps/backend/src/rhesis/backend/app/config/settings.py` reads it as `FrontendSettings.url` and `cors_origins` returns just that one scheme+host+port. So every worktree ran a backend that only allowed origin `http://localhost:3000` while its own frontend served on `3000 + offset`. Browser requests failed their CORS preflight: the backend logged `"OPTIONS /auth/local-login HTTP/1.1" 400` and the browser showed `TypeError: Failed to fetch`. Server-side Next.js calls kept working, which made it look like only some requests were broken.

Two ways to land in it, both real: an older main `.env` generated before `FRONTEND_URL` existed has no such line, so Pydantic's `http://localhost:3000` default applies; a freshly generated one has `FRONTEND_URL=http://localhost:3000` and the copy carried it over unshifted.

## What Changed

- `rewrite_backend_env_ports()` in `scripts/rh/worktree.sh` now writes `FRONTEND_URL=http://localhost:<worktree frontend port>`.
- It uses `set_env_var`, not `set_env_url_port`. `set_env_url_port` returns early when the key is absent from the file, which would leave the older-`.env` case broken; `set_env_var` appends when missing and substitutes when present, so both cases are covered.

## Additional Context

- Existing worktrees are not repaired by this change. Fix one by hand: append `FRONTEND_URL=http://localhost:<its frontend port>` to `apps/backend/.env` (`./rh dev status` prints the port), then restart the backend. `apps/backend/start.sh` sources `.env` and exports it at launch, so a `--reload` cycle will not pick the change up.
- `rewrite_frontend_env_ports()` already shifted `FRONTEND_URL` in `apps/frontend/.env.local`; only the backend side was missing.
- `scripts/rh/dev.sh` already sets a shifted `FRONTEND_URL` when generating a backend `.env` from scratch, so `./rh dev init` inside a worktree was never affected — only the copy-and-shift path was.
- Follow-up to #2443, which fixed the same CORS failure for the `./rh dev init` path in `create_backend_env`. This is the other half: `./rh worktree` never runs that generator, it copies main's `.env` and shifts the ports, so it kept missing the variable.

## Testing

Verified without creating a real worktree, by calling the function directly against two throwaway env files — one with no `FRONTEND_URL` line, one with `FRONTEND_URL=http://localhost:3000` — at offset 40:

```bash
source scripts/rh/common.sh; source scripts/rh/ports.sh; source scripts/rh/portalloc.sh
eval "$(awk '/^rewrite_backend_env_ports\(\) \{/,/^\}/' scripts/rh/worktree.sh)"
rewrite_backend_env_ports "$f" 40
```

Both files ended up with `FRONTEND_URL=http://localhost:3040` (appended in the first case, substituted in the second), alongside the already-correct `PORT=8120`, `DB_PORT=11040` and `BROKER_URL=redis://localhost:11041/0`. `bash -n scripts/rh/worktree.sh` passes and `./rh dev status` still runs from a worktree root.

