### PR TITLE
fix(dev): make rhesis meta-package editable in local dev

### DIFF
--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -198,7 +198,7 @@ torch = [
     # GPU extra: use CUDA on Linux/Windows, fall back to PyPI (CPU) on macOS
     { index = "pytorch-cu128", extra = "gpu", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-rhesis = { path = "../../packages/rhesis" }
+rhesis = { path = "../../packages/rhesis", editable = true }
 rhesis-sdk = { path = "../../sdk", editable = true }
 rhesis-penelope = { path = "../../penelope", editable = true }
 rhesis-backend-ee = { path = "../../ee/backend", editable = true }

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -39,7 +39,7 @@ conflicts = [[
 ]]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-08-06T12:56:06.74257Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -6791,7 +6791,7 @@ wheels = [
 
 [[package]]
 name = "rhesis"
-source = { directory = "../../packages/rhesis" }
+source = { editable = "../../packages/rhesis" }
 dependencies = [
     { name = "pydantic" },
     { name = "requests" },
@@ -6981,7 +6981,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.31" },
     { name = "pyyaml" },
     { name = "redis", specifier = ">=5.0.0,<6.0.0" },
-    { name = "rhesis", directory = "../../packages/rhesis" },
+    { name = "rhesis", editable = "../../packages/rhesis" },
     { name = "rhesis-backend-ee", marker = "extra == 'ee'", editable = "../../ee/backend" },
     { name = "rhesis-penelope", marker = "extra == 'all'", editable = "../../penelope" },
     { name = "rhesis-sdk", marker = "extra == 'all'", editable = "../../sdk" },
@@ -7190,7 +7190,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ragas", specifier = ">=0.3.7,<0.4" },
     { name = "requests", specifier = ">=2.31.0" },
-    { name = "rhesis", extras = ["telemetry"], directory = "../../packages/rhesis" },
+    { name = "rhesis", extras = ["telemetry"], editable = "../../packages/rhesis" },
     { name = "tenacity", specifier = ">=8.2.3" },
     { name = "tiktoken", specifier = ">=0.9.0" },
     { name = "torch" },

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -245,7 +245,7 @@ override-dependencies = [
 ]
 
 [tool.uv.sources]
-rhesis = { path = "../packages/rhesis" }
+rhesis = { path = "../packages/rhesis", editable = true }
 rhesis-penelope = { path = "../penelope", editable = true }
 
 [tool.pyright]


### PR DESCRIPTION
## Summary
- Marks the `rhesis` meta-package (`packages/rhesis`) as `editable = true` in both `sdk/pyproject.toml` and `apps/backend/pyproject.toml`, matching the other local packages (sdk, penelope, backend-ee).
- Without this, new files added to `packages/rhesis/src/` (e.g. `telemetry/attributes.py`) are missing at runtime until a manual wheel rebuild. The non-editable install used a stale built copy.

## Test plan
- [ ] `uv sync` in `apps/backend/` completes without errors
- [ ] `uv run python -c "from rhesis.telemetry.attributes import AIAttributes"` succeeds
- [ ] Backend starts without `ModuleNotFoundError: No module named 'rhesis.telemetry.attributes'`