### PR TITLE
fix(backend): linearize migration chain to resolve multiple heads

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/38ed899b9f41_add_owasp_behaviors_and_metrics_to_.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/38ed899b9f41_add_owasp_behaviors_and_metrics_to_.py
@@ -22,7 +22,7 @@ remove_metrics_from_organizations from:
     rhesis.backend.alembic.utils.metric_sync
 
 Revision ID: 38ed899b9f41
-Revises: 82881df987af
+Revises: 81fbf5ad9a1f
 Create Date: 2026-07-02
 """
 
@@ -43,7 +43,7 @@ from rhesis.backend.alembic.utils.metric_sync import (
 
 # revision identifiers, used by Alembic.
 revision: str = "38ed899b9f41"
-down_revision: Union[str, None] = "82881df987af"
+down_revision: Union[str, None] = "81fbf5ad9a1f"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary
- The OWASP migration (`38ed899b9f41`) and notification migration (`449d5364b4ff`) both branched from `82881df987af`, creating two Alembic heads that broke `alembic upgrade head` on fresh databases.
- Repoints the OWASP chain's `down_revision` from `82881df987af` to `81fbf5ad9a1f` (the notification head), making the chain linear instead of forked.

## Test plan
- [ ] `alembic heads` returns a single head (`b857edcac3c0`)
- [ ] `alembic upgrade head` succeeds on a fresh database
- [ ] Backend starts without migration errors