### PR TITLE
Log and mask server-side errors across all routers

### DIFF
--- a/apps/backend/src/rhesis/backend/app/error_handlers.py
+++ b/apps/backend/src/rhesis/backend/app/error_handlers.py
@@ -10,7 +10,7 @@ from fastapi.exceptions import RequestValidationError
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import JSONResponse
 
-from rhesis.backend.app.utils.request_context import get_request_id, request_id_of
+from rhesis.backend.app.utils.request_context import request_id_of
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,21 @@ def public_message(status_code: int) -> str:
     return PUBLIC_ERROR_MESSAGES[500]
 
 
-class UpstreamHTTPException(HTTPException):
+class PublicHTTPException(HTTPException):
+    """A 5xx whose detail is written for the caller to read.
+
+    Masking is the default because a detail built from an exception leaks
+    whatever the exception happened to carry. That reasoning does not apply to
+    a fixed string someone wrote on purpose -- "Garak package is not installed",
+    "No Celery workers available" -- which names the one thing the caller can
+    act on and reveals nothing.
+
+    The detail must be a literal, not interpolated from an exception. The moment
+    it carries `str(exc)` this is a leak with a blessing on it.
+    """
+
+
+class UpstreamHTTPException(PublicHTTPException):
     """A failure of the *caller's* system, not ours -- detail is theirs to see.
 
     Endpoint testing and invocation exist to report what is wrong with a user's
@@ -49,7 +63,13 @@ class UpstreamHTTPException(HTTPException):
     """
 
 
-def internal_error(exc: Exception, *, context: str, status_code: int = 500) -> HTTPException:
+def internal_error(
+    exc: Exception,
+    *,
+    context: str,
+    status_code: int = 500,
+    public_detail: str | None = None,
+) -> HTTPException:
     """Log ``exc`` and return an HTTPException that reveals none of it.
 
     Only for cases where the router genuinely adds context a global handler
@@ -59,12 +79,20 @@ def internal_error(exc: Exception, *, context: str, status_code: int = 500) -> H
     The level follows the status: a 4xx is the caller's mistake, so it gets one
     warning line and no stack. If a failure is ours to debug it belongs in the
     5xx branch, which is what puts a traceback in the log.
+
+    ``public_detail`` replaces the generic message with one the caller can act
+    on -- "No generation model is configured", not "The request could not be
+    processed." It must be a literal: interpolating ``exc`` into it defeats the
+    whole point of routing through this function.
     """
     if status_code >= 500:
-        logger.exception("[%s] %s: %s", get_request_id() or "-", context, exc)
+        logger.exception("%s: %s", context, exc)
     else:
-        logger.warning("[%s] %s: %s", get_request_id() or "-", context, exc)
-    http_exc = HTTPException(status_code=status_code, detail=public_message(status_code))
+        logger.warning("%s: %s", context, exc)
+    # A 5xx detail only survives the global handler on a PublicHTTPException, so
+    # asking for one and getting a plain HTTPException would silently mask it.
+    cls = PublicHTTPException if public_detail else HTTPException
+    http_exc = cls(status_code=status_code, detail=public_detail or public_message(status_code))
     # Already in the log with `context` attached; without this the handler below
     # logs the same failure a second time, saying less.
     http_exc.rhesis_logged = True
@@ -84,6 +112,10 @@ async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONR
         request.method,
         request.url.path,
         exc,
+        # RequestIDMiddleware's `finally` has already cleared the ContextVar by
+        # now, so the logging filter cannot recover the id for these records --
+        # the ones an error_id actually points at. Pass it in by hand.
+        extra={"request_id": request_id},
     )
     # Header set here, not by the middleware: an unhandled exception is turned
     # into a response by ServerErrorMiddleware, which sits outside it.
@@ -105,18 +137,20 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
         return await default_http_exception_handler(request, exc)
 
     request_id = request_id_of(request)
-    upstream = isinstance(exc, UpstreamHTTPException)
+    deliberate = isinstance(exc, PublicHTTPException)
 
     if not getattr(exc, "rhesis_logged", False):
-        logger.error(
-            "[%s] %s on %s %s: %s",
-            request_id or "-",
+        # A deliberate 5xx is not a fault of ours to debug: an unreachable user
+        # endpoint or a missing optional package is a warning with a readable
+        # reason, not an ERROR with a stack that only points back at the raise.
+        logger.log(
+            logging.WARNING if deliberate else logging.ERROR,
+            "%s on %s %s: %s",
             exc.status_code,
             request.method,
             request.url.path,
             exc.detail,
-            # An upstream failure is not our stack; the detail is the useful part.
-            exc_info=not upstream,
+            exc_info=not deliberate,
         )
 
     # No X-Request-ID here: this response is built inside ExceptionMiddleware,
@@ -124,7 +158,7 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
     return JSONResponse(
         status_code=exc.status_code,
         content={
-            "detail": exc.detail if upstream else public_message(exc.status_code),
+            "detail": exc.detail if deliberate else public_message(exc.status_code),
             "error_id": request_id,
         },
         headers=getattr(exc, "headers", None),

--- a/apps/backend/src/rhesis/backend/app/error_handlers.py
+++ b/apps/backend/src/rhesis/backend/app/error_handlers.py
@@ -50,16 +50,23 @@ class UpstreamHTTPException(HTTPException):
 
 
 def internal_error(exc: Exception, *, context: str, status_code: int = 500) -> HTTPException:
-    """Log ``exc`` in full and return an HTTPException that reveals none of it.
+    """Log ``exc`` and return an HTTPException that reveals none of it.
 
     Only for cases where the router genuinely adds context a global handler
     can't infer. Otherwise don't catch at all — the global handler logs the
     same traceback and the `except` block is just noise.
+
+    The level follows the status: a 4xx is the caller's mistake, so it gets one
+    warning line and no stack. If a failure is ours to debug it belongs in the
+    5xx branch, which is what puts a traceback in the log.
     """
-    logger.exception("[%s] %s: %s", get_request_id() or "-", context, exc)
+    if status_code >= 500:
+        logger.exception("[%s] %s: %s", get_request_id() or "-", context, exc)
+    else:
+        logger.warning("[%s] %s: %s", get_request_id() or "-", context, exc)
     http_exc = HTTPException(status_code=status_code, detail=public_message(status_code))
-    # The traceback is already in the log with `context` attached; without this
-    # the handler below logs the same failure a second time, saying less.
+    # Already in the log with `context` attached; without this the handler below
+    # logs the same failure a second time, saying less.
     http_exc.rhesis_logged = True
     return http_exc
 

--- a/apps/backend/src/rhesis/backend/app/error_handlers.py
+++ b/apps/backend/src/rhesis/backend/app/error_handlers.py
@@ -15,7 +15,7 @@ from rhesis.backend.app.utils.request_context import get_request_id, request_id_
 logger = logging.getLogger(__name__)
 
 #: What the client is told when the real reason must not leave the server.
-#: Keyed by status code; anything unlisted falls back to the 500 text.
+#: Keyed by status code; anything unlisted falls back by class (see below).
 PUBLIC_ERROR_MESSAGES = {
     500: "An unexpected error occurred.",
     502: "An upstream service returned an invalid response.",
@@ -23,9 +23,30 @@ PUBLIC_ERROR_MESSAGES = {
     504: "The request timed out.",
 }
 
+#: 4xx fallback. Describing a client error as "an unexpected error occurred"
+#: tells the caller the wrong thing about whose fault it is.
+_CLIENT_ERROR_MESSAGE = "The request could not be processed."
+
 
 def public_message(status_code: int) -> str:
-    return PUBLIC_ERROR_MESSAGES.get(status_code, PUBLIC_ERROR_MESSAGES[500])
+    if status_code in PUBLIC_ERROR_MESSAGES:
+        return PUBLIC_ERROR_MESSAGES[status_code]
+    if 400 <= status_code < 500:
+        return _CLIENT_ERROR_MESSAGE
+    return PUBLIC_ERROR_MESSAGES[500]
+
+
+class UpstreamHTTPException(HTTPException):
+    """A failure of the *caller's* system, not ours -- detail is theirs to see.
+
+    Endpoint testing and invocation exist to report what is wrong with a user's
+    own endpoint: a refused connection, a rejected token, an unparseable body.
+    Masking those explains nothing to the person debugging and conceals nothing
+    of ours, so the global handler passes the detail through even on a 5xx.
+
+    Only for text that came from the upstream service. An exception raised by
+    our own code is not upstream detail, however much it looks like it.
+    """
 
 
 def internal_error(exc: Exception, *, context: str, status_code: int = 500) -> HTTPException:
@@ -35,13 +56,12 @@ def internal_error(exc: Exception, *, context: str, status_code: int = 500) -> H
     can't infer. Otherwise don't catch at all — the global handler logs the
     same traceback and the `except` block is just noise.
     """
-    request_id = get_request_id()
-    logger.exception("[%s] %s: %s", request_id or "-", context, exc)
-    return HTTPException(
-        status_code=status_code,
-        detail=public_message(status_code),
-        headers={"X-Error-Id": request_id} if request_id else None,
-    )
+    logger.exception("[%s] %s: %s", get_request_id() or "-", context, exc)
+    http_exc = HTTPException(status_code=status_code, detail=public_message(status_code))
+    # The traceback is already in the log with `context` attached; without this
+    # the handler below logs the same failure a second time, saying less.
+    http_exc.rhesis_logged = True
+    return http_exc
 
 
 async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
@@ -78,22 +98,29 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException):
         return await default_http_exception_handler(request, exc)
 
     request_id = request_id_of(request)
-    logger.error(
-        "[%s] %s on %s %s: %s",
-        request_id or "-",
-        exc.status_code,
-        request.method,
-        request.url.path,
-        exc.detail,
-        exc_info=True,
-    )
-    headers = dict(getattr(exc, "headers", None) or {})
-    if request_id:
-        headers["X-Request-ID"] = request_id
+    upstream = isinstance(exc, UpstreamHTTPException)
+
+    if not getattr(exc, "rhesis_logged", False):
+        logger.error(
+            "[%s] %s on %s %s: %s",
+            request_id or "-",
+            exc.status_code,
+            request.method,
+            request.url.path,
+            exc.detail,
+            # An upstream failure is not our stack; the detail is the useful part.
+            exc_info=not upstream,
+        )
+
+    # No X-Request-ID here: this response is built inside ExceptionMiddleware,
+    # which RequestIDMiddleware wraps, so the header is added on the way out.
     return JSONResponse(
         status_code=exc.status_code,
-        content={"detail": public_message(exc.status_code), "error_id": request_id},
-        headers=headers or None,
+        content={
+            "detail": exc.detail if upstream else public_message(exc.status_code),
+            "error_id": request_id,
+        },
+        headers=getattr(exc, "headers", None),
     )
 
 

--- a/apps/backend/src/rhesis/backend/app/error_handlers.py
+++ b/apps/backend/src/rhesis/backend/app/error_handlers.py
@@ -4,11 +4,97 @@ Error handling utilities for FastAPI validation errors and responses.
 
 import logging
 
-from fastapi import Request
+from fastapi import HTTPException, Request
+from fastapi.exception_handlers import http_exception_handler as default_http_exception_handler
 from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.responses import JSONResponse
 
+from rhesis.backend.app.utils.request_context import get_request_id, request_id_of
+
 logger = logging.getLogger(__name__)
+
+#: What the client is told when the real reason must not leave the server.
+#: Keyed by status code; anything unlisted falls back to the 500 text.
+PUBLIC_ERROR_MESSAGES = {
+    500: "An unexpected error occurred.",
+    502: "An upstream service returned an invalid response.",
+    503: "The service is temporarily unavailable.",
+    504: "The request timed out.",
+}
+
+
+def public_message(status_code: int) -> str:
+    return PUBLIC_ERROR_MESSAGES.get(status_code, PUBLIC_ERROR_MESSAGES[500])
+
+
+def internal_error(exc: Exception, *, context: str, status_code: int = 500) -> HTTPException:
+    """Log ``exc`` in full and return an HTTPException that reveals none of it.
+
+    Only for cases where the router genuinely adds context a global handler
+    can't infer. Otherwise don't catch at all — the global handler logs the
+    same traceback and the `except` block is just noise.
+    """
+    request_id = get_request_id()
+    logger.exception("[%s] %s: %s", request_id or "-", context, exc)
+    return HTTPException(
+        status_code=status_code,
+        detail=public_message(status_code),
+        headers={"X-Error-Id": request_id} if request_id else None,
+    )
+
+
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """Last resort for anything no router caught.
+
+    Without this, an uncaught error becomes a bare Starlette 500 that logs
+    nothing, which is how errors used to disappear entirely.
+    """
+    request_id = request_id_of(request)
+    logger.exception(
+        "[%s] Unhandled exception on %s %s: %s",
+        request_id or "-",
+        request.method,
+        request.url.path,
+        exc,
+    )
+    # Header set here, not by the middleware: an unhandled exception is turned
+    # into a response by ServerErrorMiddleware, which sits outside it.
+    return JSONResponse(
+        status_code=500,
+        content={"detail": public_message(500), "error_id": request_id},
+        headers={"X-Request-ID": request_id} if request_id else None,
+    )
+
+
+async def http_exception_handler(request: Request, exc: StarletteHTTPException):
+    """Log server-side HTTPExceptions and strip their detail.
+
+    Sub-500s pass through untouched: a 400 "name already exists" is a message
+    we intend the user to read. A 5xx detail is an internal failure that only
+    belongs in the logs.
+    """
+    if exc.status_code < 500:
+        return await default_http_exception_handler(request, exc)
+
+    request_id = request_id_of(request)
+    logger.error(
+        "[%s] %s on %s %s: %s",
+        request_id or "-",
+        exc.status_code,
+        request.method,
+        request.url.path,
+        exc.detail,
+        exc_info=True,
+    )
+    headers = dict(getattr(exc, "headers", None) or {})
+    if request_id:
+        headers["X-Request-ID"] = request_id
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"detail": public_message(exc.status_code), "error_id": request_id},
+        headers=headers or None,
+    )
 
 
 def create_validation_error_response(exc: RequestValidationError) -> JSONResponse:

--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -19,10 +19,12 @@ initialize_telemetry()
 
 # ruff: noqa: E402 - Imports must come after telemetry initialization
 from fastapi import Depends, FastAPI, Request
+from fastapi import HTTPException as FastAPIHTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 
@@ -41,12 +43,15 @@ from rhesis.backend.app.config.settings import (
 from rhesis.backend.app.database import Base, engine, get_db
 from rhesis.backend.app.error_handlers import (
     create_validation_error_response,
+    http_exception_handler,
     log_validation_error,
+    unhandled_exception_handler,
 )
 from rhesis.backend.app.quota.enforcement import QuotaExceededError, quota_exceeded_response_body
 from rhesis.backend.app.routers import routers
 from rhesis.backend.app.utils.database_exceptions import ItemDeletedException, ItemNotFoundException
 from rhesis.backend.app.utils.git_utils import get_version_info
+from rhesis.backend.app.utils.request_context import RequestIDMiddleware
 from rhesis.backend.local_init import initialize_local_environment
 from rhesis.backend.logging import set_logger
 from rhesis.backend.telemetry.middleware import TelemetryMiddleware
@@ -688,6 +693,14 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     return create_validation_error_response(exc)
 
 
+# Server-side failures: log in full, tell the client nothing but an error_id.
+# Registered for both bases because FastAPI's HTTPException subclasses Starlette's
+# but is looked up by exact class first.
+app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+app.add_exception_handler(FastAPIHTTPException, http_exception_handler)
+app.add_exception_handler(Exception, unhandled_exception_handler)
+
+
 # Configure CORS
 _frontend_settings = get_frontend_settings()
 app.add_middleware(
@@ -746,6 +759,10 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 
 # Outermost middleware -- runs first on every response
 app.add_middleware(SecurityHeadersMiddleware)
+
+# Added last so it ends up outermost: every other middleware's log lines then
+# carry the request id too.
+app.add_middleware(RequestIDMiddleware)
 
 
 class LoggingMiddleware(BaseHTTPMiddleware):

--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -709,7 +709,9 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
-    expose_headers=["X-Total-Count", "X-Test-Header"],
+    # X-Request-ID must be exposed or browser JS cannot read the id it needs
+    # to quote back to support.
+    expose_headers=["X-Total-Count", "X-Test-Header", "X-Request-ID"],
 )
 
 # SESSION_SECRET_KEY is a required setting (see AuthSettings), so this fails

--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -681,12 +681,8 @@ async def quota_exceeded_exception_handler(request: Request, exc: QuotaExceededE
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
     """Handle FastAPI request validation errors with detailed logging."""
-    # Log the detailed validation error for debugging
-    logger.error(
-        f"Request validation error on {request.method} {request.url}: {exc}", exc_info=True
-    )
-
-    # Log detailed validation errors
+    # One warning line per bad field, and no traceback: a 422 is the caller
+    # sending us the wrong shape, not a fault of ours to debug.
     log_validation_error(exc, request)
 
     # Return clean JSON response

--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -6,7 +6,7 @@ import jwt
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.responses import JSONResponse
 from jwt import PyJWTError as JWTError
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, ValidationError
 from sqlalchemy.orm import Session
 from starlette.responses import RedirectResponse
 
@@ -63,7 +63,7 @@ from rhesis.backend.app.config.settings import (
 from rhesis.backend.app.dependencies import (
     get_db_session,
 )
-from rhesis.backend.app.error_handlers import internal_error
+from rhesis.backend.app.error_handlers import PublicHTTPException, internal_error
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.utils.quick_start import is_quick_start_enabled
 from rhesis.backend.app.utils.rate_limit import (
@@ -420,12 +420,14 @@ async def login_with_provider(
 
     try:
         return await auth_provider.get_authorization_url(request, callback_url)
+    except HTTPException:
+        # A provider's own deliberate 400 -- "Google authentication is not
+        # configured" -- must not be genericised into ours.
+        raise
     except Exception as e:
-        raise internal_error(
-            e,
-            context=f"initiating OAuth login for provider {provider}",
-            status_code=status.HTTP_400_BAD_REQUEST,
-        ) from e
+        # A missing OAuth client, an unreachable IdP or a bug of ours: nothing
+        # the caller sent is wrong, and the traceback is the point.
+        raise internal_error(e, context=f"initiating OAuth login for provider {provider}") from e
 
 
 @router.get("/callback")
@@ -505,11 +507,20 @@ async def auth_callback(request: Request, db: Session = Depends(get_db_session))
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
+    except ValidationError as e:
+        # Pydantic's ValidationError is a ValueError too, but its text is our
+        # schema plus the values it rejected -- masked, not handed back.
+        raise internal_error(
+            e, context=f"completing OAuth callback for provider {provider_name}"
+        ) from e
+    except ValueError as e:
+        # `validate_and_normalize_email` rejecting the address the provider sent
+        # is the one reason the user can act on ("Invalid email address: ...").
+        logger.warning("OAuth callback rejected for provider %s: %s", provider_name, e)
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     except Exception as e:
         raise internal_error(
-            e,
-            context=f"completing OAuth callback for provider {provider_name}",
-            status_code=status.HTTP_400_BAD_REQUEST,
+            e, context=f"completing OAuth callback for provider {provider_name}"
         ) from e
 
 
@@ -1358,7 +1369,6 @@ def verify_auth(
     """Verify JWT session token and return user info"""
     session_token = body.session_token
     return_to = body.return_to
-    logger.info(f"Verify request received. Token: {session_token[:8]}...")
 
     try:
         payload = verify_jwt_token(session_token, secret_key)
@@ -1389,15 +1399,19 @@ def verify_auth(
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired")
     except JWTError as e:
-        logger.error(f"JWT verification failed: {str(e)}")
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+        # A malformed, tampered or stale token is the caller's problem, not a
+        # server fault to page anyone about.
+        logger.warning("JWT verification failed: %s", e)
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from e
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error verifying token: {str(e)}")
+        # With the stack, unlike the branch above: this one cannot tell a bad
+        # token from a bug of ours.
+        logger.warning("Unexpected error verifying token: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication failed"
-        )
+        ) from e
 
 
 # =============================================================================
@@ -1433,8 +1447,9 @@ async def local_login(request: Request, db: Session = Depends(get_db_session)):
     user = user_crud.get_user_by_email(db, "admin@local.dev")
 
     if not user:
-        logger.error("QUICK START MODE user (admin@local.dev) not found in database")
-        raise HTTPException(
+        # Public: the whole value of this 500 is the fix it names, and the global
+        # handler logs it once as a warning.
+        raise PublicHTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=(
                 "QUICK START MODE user not found. "

--- a/apps/backend/src/rhesis/backend/app/routers/auth.py
+++ b/apps/backend/src/rhesis/backend/app/routers/auth.py
@@ -63,6 +63,7 @@ from rhesis.backend.app.config.settings import (
 from rhesis.backend.app.dependencies import (
     get_db_session,
 )
+from rhesis.backend.app.error_handlers import internal_error
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.utils.quick_start import is_quick_start_enabled
 from rhesis.backend.app.utils.rate_limit import (
@@ -420,11 +421,11 @@ async def login_with_provider(
     try:
         return await auth_provider.get_authorization_url(request, callback_url)
     except Exception as e:
-        logger.error(f"OAuth login error for {provider}: {str(e)}", exc_info=True)
-        raise HTTPException(
+        raise internal_error(
+            e,
+            context=f"initiating OAuth login for provider {provider}",
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Failed to initiate {provider} login: {str(e)}",
-        )
+        ) from e
 
 
 @router.get("/callback")
@@ -505,11 +506,11 @@ async def auth_callback(request: Request, db: Session = Depends(get_db_session))
             detail=str(e),
         )
     except Exception as e:
-        logger.error(f"Auth callback error for {provider_name}: {str(e)}", exc_info=True)
-        raise HTTPException(
+        raise internal_error(
+            e,
+            context=f"completing OAuth callback for provider {provider_name}",
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Authentication failed: {str(e)}",
-        )
+        ) from e
 
 
 # =============================================================================
@@ -1429,61 +1430,51 @@ async def local_login(request: Request, db: Session = Depends(get_db_session)):
     logger.warning("⚠️  QUICK START MODE LOGIN - Bypassing authentication!")
     logger.warning("⚠️  This should NEVER be used in production!")
 
-    try:
-        user = user_crud.get_user_by_email(db, "admin@local.dev")
+    user = user_crud.get_user_by_email(db, "admin@local.dev")
 
-        if not user:
-            logger.error("QUICK START MODE user (admin@local.dev) not found in database")
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=(
-                    "QUICK START MODE user not found. "
-                    "Please ensure the database was initialized with init_local_user.sql"
-                ),
-            )
-
-        request.session["user_id"] = str(user.id)
-        clear_user_logout(str(user.id))
-        access_token = create_session_token(user)
-        refresh_tok = create_refresh_token(db, str(user.id))
-        db.commit()
-        auth_code = await create_auth_code(access_token, refresh_tok)
-
-        logger.info(
-            "QUICK START MODE login successful for user: %s",
-            redact_email(user.email),
-        )
-
-        if get_telemetry_settings().is_telemetry_enabled:
-            set_telemetry_enabled(
-                enabled=True,
-                user_id=str(user.id),
-                org_id=(str(user.organization_id) if user.organization_id else None),
-            )
-            track_user_activity(
-                event_type="login",
-                session_id=request.session.get("_id"),
-                login_method="local_dev",
-                auth_provider="local",
-            )
-
-        return {
-            "success": True,
-            "auth_code": auth_code,
-            "user": {
-                "id": str(user.id),
-                "email": user.email,
-                "name": user.name,
-                "organization_id": (str(user.organization_id) if user.organization_id else None),
-            },
-            "message": ("QUICK START MODE login - Not for production use!"),
-        }
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"QUICK START MODE login error: {str(e)}", exc_info=True)
+    if not user:
+        logger.error("QUICK START MODE user (admin@local.dev) not found in database")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"QUICK START MODE login failed: {str(e)}",
+            detail=(
+                "QUICK START MODE user not found. "
+                "Please ensure the database was initialized with init_local_user.sql"
+            ),
         )
+
+    request.session["user_id"] = str(user.id)
+    clear_user_logout(str(user.id))
+    access_token = create_session_token(user)
+    refresh_tok = create_refresh_token(db, str(user.id))
+    db.commit()
+    auth_code = await create_auth_code(access_token, refresh_tok)
+
+    logger.info(
+        "QUICK START MODE login successful for user: %s",
+        redact_email(user.email),
+    )
+
+    if get_telemetry_settings().is_telemetry_enabled:
+        set_telemetry_enabled(
+            enabled=True,
+            user_id=str(user.id),
+            org_id=(str(user.organization_id) if user.organization_id else None),
+        )
+        track_user_activity(
+            event_type="login",
+            session_id=request.session.get("_id"),
+            login_method="local_dev",
+            auth_provider="local",
+        )
+
+    return {
+        "success": True,
+        "auth_code": auth_code,
+        "user": {
+            "id": str(user.id),
+            "email": user.email,
+            "name": user.name,
+            "organization_id": (str(user.organization_id) if user.organization_id else None),
+        },
+        "message": ("QUICK START MODE login - Not for production use!"),
+    }

--- a/apps/backend/src/rhesis/backend/app/routers/connector.py
+++ b/apps/backend/src/rhesis/backend/app/routers/connector.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app.auth.user_utils import authenticate_websocket, require_current_user_or_token
 from rhesis.backend.app.database import get_db_with_tenant_variables
+from rhesis.backend.app.error_handlers import PublicHTTPException
 from rhesis.backend.app.models.project import Project
 from rhesis.backend.app.models.project_membership import ProjectMembership
 from rhesis.backend.app.models.user import User
@@ -281,7 +282,9 @@ async def trigger_test(
     )
 
     if not success:
-        raise HTTPException(status_code=500, detail="Failed to send test request to SDK")
+        # Hand-written and free of internals: the caller's own connected SDK
+        # client dropped the request, which is the one thing they can act on.
+        raise PublicHTTPException(status_code=500, detail="Failed to send test request to SDK")
 
     return TriggerTestResponse(
         success=True,

--- a/apps/backend/src/rhesis/backend/app/routers/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/routers/endpoint.py
@@ -16,6 +16,7 @@ from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
 )
+from rhesis.backend.app.error_handlers import UpstreamHTTPException, internal_error
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.quota import QuotaResource
@@ -368,7 +369,15 @@ async def invoke_endpoint(
         raise e
     except EndpointInvocationError as e:
         logger.error(f"API invoke error for endpoint {endpoint_id}: {e}")
-        raise HTTPException(status_code=e.status_code or 500, detail=str(e)) from e
+        status_code = e.status_code or 500
+        # EndpointService wraps *our* failures in this same type as
+        # error_type="internal_error" (services/endpoint/service.py), so the
+        # discriminator is what separates the user's endpoint from our bug.
+        if e.error_type == "internal_error":
+            raise internal_error(
+                e, context=f"invoking endpoint {endpoint_id}", status_code=status_code
+            ) from e
+        raise UpstreamHTTPException(status_code=status_code, detail=str(e)) from e
 
 
 @router.post(

--- a/apps/backend/src/rhesis/backend/app/routers/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/routers/endpoint.py
@@ -173,11 +173,6 @@ async def test_endpoint(
     except HTTPException as e:
         logger.error(f"API test HTTPException for endpoint {test_config.url}: {e.detail}")
         raise e
-    except Exception as e:
-        logger.error(
-            f"API test unexpected error for endpoint {test_config.url}: {str(e)}", exc_info=True
-        )
-        raise HTTPException(status_code=500, detail=str(e))
 
 
 @router.post("/auto-configure", response_model=AutoConfigureResult)
@@ -209,13 +204,7 @@ async def auto_configure_endpoint(
         raise HTTPException(
             status_code=422,
             detail=str(e),
-        )
-    except Exception as e:
-        logger.error(
-            f"Auto-configure unexpected error: {str(e)}",
-            exc_info=True,
-        )
-        raise HTTPException(status_code=500, detail=str(e))
+        ) from e
 
 
 @router.get("/schema")
@@ -379,12 +368,7 @@ async def invoke_endpoint(
         raise e
     except EndpointInvocationError as e:
         logger.error(f"API invoke error for endpoint {endpoint_id}: {e}")
-        raise HTTPException(status_code=e.status_code or 500, detail=str(e))
-    except Exception as e:
-        logger.error(
-            f"API invoke unexpected error for endpoint {endpoint_id}: {str(e)}", exc_info=True
-        )
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=e.status_code or 500, detail=str(e)) from e
 
 
 @router.post(

--- a/apps/backend/src/rhesis/backend/app/routers/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/routers/endpoint.py
@@ -150,30 +150,28 @@ async def test_endpoint(
     Returns:
         The response from the endpoint, either mapped or raw depending on endpoint configuration
     """
-    try:
-        # Safely get connection_type string value
-        connection_type_str = (
-            test_config.connection_type.value
-            if hasattr(test_config.connection_type, "value")
-            else str(test_config.connection_type)
-        )
-        logger.info(
-            f"API test request for endpoint: {test_config.url} "
-            f"({connection_type_str}, {test_config.method})"
-        )
+    # No try/except: the service already logs what it handles at the level it
+    # belongs, and re-logging a 400 "Only REST endpoints are supported" as an
+    # ERROR here said nothing the response didn't.
+    connection_type_str = (
+        test_config.connection_type.value
+        if hasattr(test_config.connection_type, "value")
+        else str(test_config.connection_type)
+    )
+    logger.info(
+        f"API test request for endpoint: {test_config.url} "
+        f"({connection_type_str}, {test_config.method})"
+    )
 
-        organization_id, user_id = tenant_context
-        result = await endpoint_service.test_endpoint(
-            db,
-            test_config,
-            organization_id=str(organization_id),
-            user_id=str(user_id),
-        )
-        logger.info(f"API test successful for endpoint: {test_config.url}")
-        return result
-    except HTTPException as e:
-        logger.error(f"API test HTTPException for endpoint {test_config.url}: {e.detail}")
-        raise e
+    organization_id, user_id = tenant_context
+    result = await endpoint_service.test_endpoint(
+        db,
+        test_config,
+        organization_id=str(organization_id),
+        user_id=str(user_id),
+    )
+    logger.info(f"API test successful for endpoint: {test_config.url}")
+    return result
 
 
 @router.post("/auto-configure", response_model=AutoConfigureResult)
@@ -364,11 +362,9 @@ async def invoke_endpoint(
         )
         logger.info(f"API invoke successful for endpoint {endpoint_id}")
         return result
-    except HTTPException as e:
-        logger.error(f"API invoke HTTPException for endpoint {endpoint_id}: {e.detail}")
-        raise e
     except EndpointInvocationError as e:
-        logger.error(f"API invoke error for endpoint {endpoint_id}: {e}")
+        # Not logged here: `internal_error` logs our failures with a stack, and
+        # the global handler logs an UpstreamHTTPException once as a warning.
         status_code = e.status_code or 500
         # EndpointService wraps *our* failures in this same type as
         # error_type="internal_error" (services/endpoint/service.py), so the

--- a/apps/backend/src/rhesis/backend/app/routers/garak.py
+++ b/apps/backend/src/rhesis/backend/app/routers/garak.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app.auth.quota_gates import require_quota
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import get_tenant_context, get_tenant_db_session
+from rhesis.backend.app.error_handlers import PublicHTTPException
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.quota import QuotaResource
@@ -64,6 +65,34 @@ def get_probe_service() -> GarakProbeService:
     return GarakProbeService()
 
 
+#: Deliberate, secret-free text: names the one thing an operator can act on, so
+#: it is raised as a PublicHTTPException and reaches the caller unmasked.
+_GARAK_UNAVAILABLE = "Garak package is not installed or not available"
+
+
+def _require_garak(probe_service: GarakProbeService) -> None:
+    """Reject the request with a readable 503 when garak is not installed.
+
+    For endpoints that only read a single module: the service swallows the
+    ImportError there and returns nothing, which would otherwise surface as a
+    misleading 404.
+    """
+    if probe_service.garak_version == "not_installed":
+        raise PublicHTTPException(status_code=503, detail=_GARAK_UNAVAILABLE)
+
+
+async def _enumerate_probes(probe_service: GarakProbeService):
+    """Enumerate probe modules (cached), reporting a missing garak as a 503.
+
+    The only call in this router that surfaces the service's
+    RuntimeError for a missing garak package.
+    """
+    try:
+        return await probe_service.enumerate_probe_modules_cached()
+    except RuntimeError as e:
+        raise PublicHTTPException(status_code=503, detail=_GARAK_UNAVAILABLE) from e
+
+
 @router.get("/probes", response_model=GarakProbesListResponse)
 async def list_probe_modules(
     db: Session = Depends(get_tenant_db_session),
@@ -79,59 +108,51 @@ async def list_probe_modules(
     Uses Redis caching to avoid re-enumerating probes on every request.
     The cache is pre-warmed on application startup.
     """
-    try:
-        # Use cached enumeration - checks L1 memory cache, then L2 Redis cache,
-        # and only generates probe data on cache miss
-        modules, probes_by_module = await probe_service.enumerate_probe_modules_cached()
+    # Use cached enumeration - checks L1 memory cache, then L2 Redis cache,
+    # and only generates probe data on cache miss
+    modules, probes_by_module = await _enumerate_probes(probe_service)
 
-        module_responses = []
-        for module in modules:
-            mapping = GarakTaxonomy.get_mapping(module.name)
+    module_responses = []
+    for module in modules:
+        mapping = GarakTaxonomy.get_mapping(module.name)
 
-            # Get probes from cached data
-            probes = probes_by_module.get(module.name, [])
-            probe_responses = [
-                GarakProbeClassResponse(
-                    class_name=p.class_name,
-                    full_name=p.full_name,
-                    module_name=p.module_name,
-                    description=p.description,
-                    prompt_count=p.prompt_count,
-                    tags=p.tags,
-                    detector=p.detector,
-                    is_dynamic=p.is_dynamic,
-                )
-                for p in probes
-            ]
-
-            module_responses.append(
-                GarakProbeModuleResponse(
-                    name=module.name,
-                    description=module.description,
-                    probe_count=module.probe_count,
-                    total_prompt_count=module.total_prompt_count,
-                    tags=module.tags,
-                    default_detector=module.default_detector,
-                    rhesis_category=mapping.category,
-                    rhesis_topic=mapping.topic,
-                    rhesis_requirement=resolve_requirement(module.tags),
-                    has_dynamic_probes=module.has_dynamic_probes,
-                    probes=probe_responses,
-                )
+        # Get probes from cached data
+        probes = probes_by_module.get(module.name, [])
+        probe_responses = [
+            GarakProbeClassResponse(
+                class_name=p.class_name,
+                full_name=p.full_name,
+                module_name=p.module_name,
+                description=p.description,
+                prompt_count=p.prompt_count,
+                tags=p.tags,
+                detector=p.detector,
+                is_dynamic=p.is_dynamic,
             )
+            for p in probes
+        ]
 
-        return GarakProbesListResponse(
-            garak_version=probe_service.garak_version,
-            modules=module_responses,
-            total_modules=len(module_responses),
+        module_responses.append(
+            GarakProbeModuleResponse(
+                name=module.name,
+                description=module.description,
+                probe_count=module.probe_count,
+                total_prompt_count=module.total_prompt_count,
+                tags=module.tags,
+                default_detector=module.default_detector,
+                rhesis_category=mapping.category,
+                rhesis_topic=mapping.topic,
+                rhesis_requirement=resolve_requirement(module.tags),
+                has_dynamic_probes=module.has_dynamic_probes,
+                probes=probe_responses,
+            )
         )
 
-    except RuntimeError as e:
-        logger.error(f"Garak not available: {e}")
-        raise HTTPException(
-            status_code=503,
-            detail="Garak package is not installed or not available",
-        ) from e
+    return GarakProbesListResponse(
+        garak_version=probe_service.garak_version,
+        modules=module_responses,
+        total_modules=len(module_responses),
+    )
 
 
 @router.get("/probes/{module_name}", response_model=GarakProbeDetailResponse)
@@ -146,6 +167,8 @@ def get_probe_module_detail(
 
     Returns the probe classes, prompts, and metadata for the module.
     """
+    _require_garak(probe_service)
+
     module_info = probe_service.get_probe_details(module_name)
 
     if not module_info:
@@ -203,7 +226,7 @@ async def preview_import(
     # Preload from the Garak probe cache instead of re-instantiating each
     # selected probe from scratch — turns this into a Redis GET + dict
     # lookups rather than re-running probe extraction.
-    _, probes_by_module = await probe_service.enumerate_probe_modules_cached()
+    _, probes_by_module = await _enumerate_probes(probe_service)
 
     importer = GarakImporter(db)
     importer.preload_probes(probes_by_module)
@@ -294,7 +317,7 @@ async def preview_sync(
 
         # Preload from the Garak probe cache instead of re-instantiating the
         # probe(s) from scratch.
-        _, probes_by_module = await probe_service.enumerate_probe_modules_cached()
+        _, probes_by_module = await _enumerate_probes(probe_service)
 
         sync_service = GarakSyncService(db)
         sync_service.preload_probes(probes_by_module)
@@ -389,68 +412,62 @@ def generate_dynamic_probe(
     module_name = request.module_name
     class_name = request.class_name
 
-    try:
-        probes = probe_service.extract_probes_from_module(module_name, [class_name])
+    _require_garak(probe_service)
 
-        if not probes:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Probe '{module_name}.{class_name}' not found",
-            )
+    probes = probe_service.extract_probes_from_module(module_name, [class_name])
 
-        probe_info = probes[0]
-
-        if not probe_info.is_dynamic:
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    f"Probe '{module_name}.{class_name}' is not dynamic — "
-                    "use POST /garak/import to import its static prompts instead."
-                ),
-            )
-
-        generator = GarakDynamicGenerator()
-        config, probe_metadata = generator.build(probe_info)
-
-        # Choose a random test count in [100, 200] if the caller did not specify one
-        num_tests = request.num_tests if request.num_tests is not None else random.randint(100, 200)
-
-        test_set_name = request.name or f"Garak Dynamic: {probe_info.full_name}"
-
-        task_result = task_launcher(
-            generate_and_save_test_set,
-            current_user=current_user,
-            db=db,
-            config=config.model_dump(),
-            num_tests=num_tests,
-            name=test_set_name,
-            metadata=probe_metadata,
+    if not probes:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Probe '{module_name}.{class_name}' not found",
         )
 
-        logger.info(
-            "Garak dynamic generation task launched",
-            extra={
-                "task_id": task_result.id,
-                "probe": probe_info.full_name,
-                "num_tests": num_tests,
-                "user_id": current_user.id,
-                "organization_id": current_user.organization_id,
-            },
-        )
+    probe_info = probes[0]
 
-        return GarakGenerateResponse(
-            task_id=str(task_result.id),
-            probe_full_name=probe_info.full_name,
-            num_tests=num_tests,
-            message=(
-                f"Dynamic test set generation started for '{probe_info.full_name}'. "
-                f"Generating {num_tests} tests using your configured LLM."
+    if not probe_info.is_dynamic:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Probe '{module_name}.{class_name}' is not dynamic — "
+                "use POST /garak/import to import its static prompts instead."
             ),
         )
 
-    except RuntimeError as e:
-        logger.error(f"Garak not available: {e}")
-        raise HTTPException(
-            status_code=503,
-            detail="Garak package is not installed or not available",
-        ) from e
+    generator = GarakDynamicGenerator()
+    config, probe_metadata = generator.build(probe_info)
+
+    # Choose a random test count in [100, 200] if the caller did not specify one
+    num_tests = request.num_tests if request.num_tests is not None else random.randint(100, 200)
+
+    test_set_name = request.name or f"Garak Dynamic: {probe_info.full_name}"
+
+    task_result = task_launcher(
+        generate_and_save_test_set,
+        current_user=current_user,
+        db=db,
+        config=config.model_dump(),
+        num_tests=num_tests,
+        name=test_set_name,
+        metadata=probe_metadata,
+    )
+
+    logger.info(
+        "Garak dynamic generation task launched",
+        extra={
+            "task_id": task_result.id,
+            "probe": probe_info.full_name,
+            "num_tests": num_tests,
+            "user_id": current_user.id,
+            "organization_id": current_user.organization_id,
+        },
+    )
+
+    return GarakGenerateResponse(
+        task_id=str(task_result.id),
+        probe_full_name=probe_info.full_name,
+        num_tests=num_tests,
+        message=(
+            f"Dynamic test set generation started for '{probe_info.full_name}'. "
+            f"Generating {num_tests} tests using your configured LLM."
+        ),
+    )

--- a/apps/backend/src/rhesis/backend/app/routers/garak.py
+++ b/apps/backend/src/rhesis/backend/app/routers/garak.py
@@ -131,13 +131,7 @@ async def list_probe_modules(
         raise HTTPException(
             status_code=503,
             detail="Garak package is not installed or not available",
-        )
-    except Exception as e:
-        logger.error(f"Error listing Garak probes: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to list Garak probes: {str(e)}",
-        )
+        ) from e
 
 
 @router.get("/probes/{module_name}", response_model=GarakProbeDetailResponse)
@@ -152,55 +146,45 @@ def get_probe_module_detail(
 
     Returns the probe classes, prompts, and metadata for the module.
     """
-    try:
-        module_info = probe_service.get_probe_details(module_name)
+    module_info = probe_service.get_probe_details(module_name)
 
-        if not module_info:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Probe module '{module_name}' not found",
-            )
-
-        # Get detailed probe information
-        probes = probe_service.extract_probes_from_module(module_name)
-        mapping = GarakTaxonomy.get_mapping(module_name)
-
-        probe_details = [
-            {
-                "class_name": p.class_name,
-                "full_name": p.full_name,
-                "description": p.description,
-                "tags": p.tags,
-                "prompt_count": p.prompt_count,
-                "detector": p.detector,
-            }
-            for p in probes
-        ]
-
-        return GarakProbeDetailResponse(
-            name=module_info.name,
-            description=module_info.description,
-            probe_classes=module_info.probe_classes,
-            probe_count=module_info.probe_count,
-            total_prompt_count=module_info.total_prompt_count,
-            tags=module_info.tags,
-            default_detector=module_info.default_detector,
-            rhesis_mapping={
-                "category": mapping.category,
-                "topic": mapping.topic,
-                "requirement": resolve_requirement(module_info.tags),
-            },
-            probes=probe_details,
-        )
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error getting probe module detail: {e}")
+    if not module_info:
         raise HTTPException(
-            status_code=500,
-            detail=f"Failed to get probe module detail: {str(e)}",
+            status_code=404,
+            detail=f"Probe module '{module_name}' not found",
         )
+
+    # Get detailed probe information
+    probes = probe_service.extract_probes_from_module(module_name)
+    mapping = GarakTaxonomy.get_mapping(module_name)
+
+    probe_details = [
+        {
+            "class_name": p.class_name,
+            "full_name": p.full_name,
+            "description": p.description,
+            "tags": p.tags,
+            "prompt_count": p.prompt_count,
+            "detector": p.detector,
+        }
+        for p in probes
+    ]
+
+    return GarakProbeDetailResponse(
+        name=module_info.name,
+        description=module_info.description,
+        probe_classes=module_info.probe_classes,
+        probe_count=module_info.probe_count,
+        total_prompt_count=module_info.total_prompt_count,
+        tags=module_info.tags,
+        default_detector=module_info.default_detector,
+        rhesis_mapping={
+            "category": mapping.category,
+            "topic": mapping.topic,
+            "requirement": resolve_requirement(module_info.tags),
+        },
+        probes=probe_details,
+    )
 
 
 @router.post("/import/preview", response_model=GarakImportPreviewResponse)
@@ -216,46 +200,38 @@ async def preview_import(
 
     Returns details of test sets that would be created for each probe.
     """
-    try:
-        # Preload from the Garak probe cache instead of re-instantiating each
-        # selected probe from scratch — turns this into a Redis GET + dict
-        # lookups rather than re-running probe extraction.
-        _, probes_by_module = await probe_service.enumerate_probe_modules_cached()
+    # Preload from the Garak probe cache instead of re-instantiating each
+    # selected probe from scratch — turns this into a Redis GET + dict
+    # lookups rather than re-running probe extraction.
+    _, probes_by_module = await probe_service.enumerate_probe_modules_cached()
 
-        importer = GarakImporter(db)
-        importer.preload_probes(probes_by_module)
-        preview = importer.get_import_preview(
-            probes=request.probes,
-            name_prefix=request.name_prefix,
+    importer = GarakImporter(db)
+    importer.preload_probes(probes_by_module)
+    preview = importer.get_import_preview(
+        probes=request.probes,
+        name_prefix=request.name_prefix,
+    )
+
+    probe_previews = [
+        GarakProbePreview(
+            module_name=p["module_name"],
+            class_name=p["class_name"],
+            full_name=p["full_name"],
+            test_set_name=p["test_set_name"],
+            prompt_count=p["prompt_count"],
+            detector=p.get("detector"),
         )
+        for p in preview["probes"]
+    ]
 
-        probe_previews = [
-            GarakProbePreview(
-                module_name=p["module_name"],
-                class_name=p["class_name"],
-                full_name=p["full_name"],
-                test_set_name=p["test_set_name"],
-                prompt_count=p["prompt_count"],
-                detector=p.get("detector"),
-            )
-            for p in preview["probes"]
-        ]
-
-        return GarakImportPreviewResponse(
-            garak_version=preview["garak_version"],
-            total_test_sets=preview["total_test_sets"],
-            total_tests=preview["total_tests"],
-            detector_count=preview["detector_count"],
-            detectors=preview["detectors"],
-            probes=probe_previews,
-        )
-
-    except Exception as e:
-        logger.error(f"Error previewing import: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to preview import: {str(e)}",
-        )
+    return GarakImportPreviewResponse(
+        garak_version=preview["garak_version"],
+        total_test_sets=preview["total_test_sets"],
+        total_tests=preview["total_tests"],
+        detector_count=preview["detector_count"],
+        detectors=preview["detectors"],
+        probes=probe_previews,
+    )
 
 
 @router.post("/import", response_model=GarakImportTaskResponse, status_code=202)
@@ -275,37 +251,29 @@ def import_probes(
     request — returns HTTP 202 Accepted with a `task_id` that can be polled
     via `GET /jobs/{task_id}`.
     """
-    try:
-        # Dispatch only the probe identifiers — the task extracts the selected
-        # probes itself in the background. We deliberately do NOT ship probe
-        # data (prompts) through the Celery broker: a single "Full" probe
-        # carries thousands of prompts, so a multi-probe import would push
-        # megabytes through the broker on one dispatch. Per-probe extraction in
-        # the worker is bounded to the selected classes and dwarfed by the
-        # test/prompt row writes the import does anyway. (The synchronous
-        # preview endpoints still reuse the warm cache — there blocking the
-        # request thread on enumeration is what we must avoid.)
-        task_result = task_launcher(
-            import_garak_probes_task,
-            current_user=current_user,
-            db=db,
-            probes=[p.model_dump() for p in request.probes],
-            name_prefix=request.name_prefix,
-            description_template=request.description_template,
-        )
+    # Dispatch only the probe identifiers — the task extracts the selected
+    # probes itself in the background. We deliberately do NOT ship probe
+    # data (prompts) through the Celery broker: a single "Full" probe
+    # carries thousands of prompts, so a multi-probe import would push
+    # megabytes through the broker on one dispatch. Per-probe extraction in
+    # the worker is bounded to the selected classes and dwarfed by the
+    # test/prompt row writes the import does anyway. (The synchronous
+    # preview endpoints still reuse the warm cache — there blocking the
+    # request thread on enumeration is what we must avoid.)
+    task_result = task_launcher(
+        import_garak_probes_task,
+        current_user=current_user,
+        db=db,
+        probes=[p.model_dump() for p in request.probes],
+        name_prefix=request.name_prefix,
+        description_template=request.description_template,
+    )
 
-        return GarakImportTaskResponse(
-            task_id=str(task_result.id),
-            probe_count=len(request.probes),
-            message=f"Import started for {len(request.probes)} probe(s).",
-        )
-
-    except Exception as e:
-        logger.error(f"Error launching Garak probe import: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to launch Garak probe import: {str(e)}",
-        )
+    return GarakImportTaskResponse(
+        task_id=str(task_result.id),
+        probe_count=len(request.probes),
+        message=f"Import started for {len(request.probes)} probe(s).",
+    )
 
 
 @router.get("/sync/{test_set_id}/preview", response_model=GarakSyncPreviewResponse)
@@ -345,15 +313,7 @@ async def preview_sync(
         raise HTTPException(
             status_code=400,
             detail=str(e),
-        )
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error previewing sync: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to preview sync: {str(e)}",
-        )
+        ) from e
 
 
 @router.post("/sync/{test_set_id}", response_model=GarakSyncTaskResponse, status_code=202)
@@ -402,13 +362,7 @@ def sync_test_set(
         raise HTTPException(
             status_code=400,
             detail=str(e),
-        )
-    except Exception as e:
-        logger.error(f"Error launching test set sync: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to launch test set sync: {str(e)}",
-        )
+        ) from e
 
 
 @router.post("/generate", response_model=GarakGenerateResponse, status_code=202)
@@ -494,17 +448,9 @@ def generate_dynamic_probe(
             ),
         )
 
-    except HTTPException:
-        raise
     except RuntimeError as e:
         logger.error(f"Garak not available: {e}")
         raise HTTPException(
             status_code=503,
             detail="Garak package is not installed or not available",
-        )
-    except Exception as e:
-        logger.error(f"Error launching dynamic generation for {module_name}.{class_name}: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to launch dynamic probe generation: {str(e)}",
-        )
+        ) from e

--- a/apps/backend/src/rhesis/backend/app/routers/job.py
+++ b/apps/backend/src/rhesis/backend/app/routers/job.py
@@ -10,6 +10,7 @@ from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import (
     get_tenant_db_session,
 )
+from rhesis.backend.app.error_handlers import internal_error
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.celery.core import app as celery_app
 from rhesis.backend.tasks import task_launcher
@@ -68,24 +69,18 @@ async def test_email_notifications(
     2. Email notifications are being sent on task completion
     3. The email template and content are correct
     """
-    try:
-        # Use task_launcher to handle context
-        result = task_launcher(
-            email_notification_test, test_message=message, current_user=current_user, db=db
-        )
+    # Use task_launcher to handle context
+    result = task_launcher(
+        email_notification_test, test_message=message, current_user=current_user, db=db
+    )
 
-        return {
-            "task_id": result.id,
-            "message": (
-                "Email notification test task submitted. "
-                "You should receive an email when it completes."
-            ),
-            "user_email": current_user.email if hasattr(current_user, "email") else None,
-        }
-    except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Failed to submit email notification test: {str(e)}"
-        )
+    return {
+        "task_id": result.id,
+        "message": (
+            "Email notification test task submitted. You should receive an email when it completes."
+        ),
+        "user_email": current_user.email if hasattr(current_user, "email") else None,
+    }
 
 
 async def create_task(
@@ -111,10 +106,8 @@ async def create_task(
         result = task_launcher(task, current_user=current_user, db=db, **payload)
 
         return {"task_id": result.id}
-    except KeyError:
-        raise HTTPException(status_code=404, detail=f"Task {task_name} not found")
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    except KeyError as e:
+        raise HTTPException(status_code=404, detail=f"Task {task_name} not found") from e
 
 
 @router.get("/{task_id}")
@@ -146,15 +139,16 @@ async def health_check(current_user: schemas.User = Depends(require_current_user
     try:
         inspector = celery_app.control.inspect()
         stats = inspector.stats()
-        if not stats:
-            raise HTTPException(status_code=503, detail="No Celery workers available")
-        return {
-            "status": "healthy",
-            "workers": len(stats),
-            "tasks_registered": len(celery_app.tasks),
-        }
     except Exception as e:
-        raise HTTPException(status_code=503, detail=f"Celery health check failed: {str(e)}")
+        raise internal_error(e, context="Celery health check", status_code=503) from e
+
+    if not stats:
+        raise HTTPException(status_code=503, detail="No Celery workers available")
+    return {
+        "status": "healthy",
+        "workers": len(stats),
+        "tasks_registered": len(celery_app.tasks),
+    }
 
 
 async def get_workers_status(current_user: schemas.User = Depends(require_current_user_or_token)):
@@ -171,4 +165,4 @@ async def get_workers_status(current_user: schemas.User = Depends(require_curren
             "ping": inspector.ping() or {},
         }
     except Exception as e:
-        raise HTTPException(status_code=503, detail=f"Failed to get worker status: {str(e)}")
+        raise internal_error(e, context="collecting Celery worker status", status_code=503) from e

--- a/apps/backend/src/rhesis/backend/app/routers/job.py
+++ b/apps/backend/src/rhesis/backend/app/routers/job.py
@@ -10,7 +10,7 @@ from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import (
     get_tenant_db_session,
 )
-from rhesis.backend.app.error_handlers import internal_error
+from rhesis.backend.app.error_handlers import PublicHTTPException, internal_error
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.celery.core import app as celery_app
 from rhesis.backend.tasks import task_launcher
@@ -143,7 +143,7 @@ async def health_check(current_user: schemas.User = Depends(require_current_user
         raise internal_error(e, context="Celery health check", status_code=503) from e
 
     if not stats:
-        raise HTTPException(status_code=503, detail="No Celery workers available")
+        raise PublicHTTPException(status_code=503, detail="No Celery workers available")
     return {
         "status": "healthy",
         "workers": len(stats),

--- a/apps/backend/src/rhesis/backend/app/routers/metric.py
+++ b/apps/backend/src/rhesis/backend/app/routers/metric.py
@@ -120,8 +120,8 @@ def generate_metric(
         )
         raise HTTPException(
             status_code=400,
-            detail=f"Failed to generate metric: {e}",
-        )
+            detail="Failed to generate metric",
+        ) from e
 
 
 @router.post("/{metric_id}/improve", response_model=schemas.Metric)
@@ -198,8 +198,8 @@ def improve_metric(
         )
         raise HTTPException(
             status_code=400,
-            detail=f"Failed to improve metric: {e}",
-        )
+            detail="Failed to improve metric",
+        ) from e
 
 
 @router.get("/", response_model=list[schemas.MetricDetail])

--- a/apps/backend/src/rhesis/backend/app/routers/metric.py
+++ b/apps/backend/src/rhesis/backend/app/routers/metric.py
@@ -5,6 +5,8 @@ from uuid import UUID
 from fastapi import Depends, HTTPException, Query, Response
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
+from pydantic import ValidationError
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models, schemas
@@ -15,6 +17,7 @@ from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
 )
+from rhesis.backend.app.error_handlers import internal_error
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.utils.database_exceptions import handle_database_exceptions
@@ -113,15 +116,32 @@ def generate_metric(
             user_id=user_id,
         )
         return result
-    except Exception as e:
-        logger.error(
-            f"Error generating metric from prompt: {e}",
-            exc_info=True,
-        )
-        raise HTTPException(
+    except HTTPException:
+        raise
+    except SQLAlchemyError:
+        # The decorator above turns a duplicate name into "Metric with this name
+        # already exists"; catching it here would replace that with nothing.
+        raise
+    except ValidationError as e:
+        # The generated fields did not fit MetricCreate. That is our prompt or
+        # our schema, not the caller's request, so it gets a 500 and a traceback.
+        raise internal_error(e, context="generating metric") from e
+    except (ValueError, RuntimeError) as e:
+        # Either the configured generation model could not be built (ValueError
+        # from the SDK factory) or the model itself answered with an error
+        # (RuntimeError from the synthesizer) -- both are the caller's to act on,
+        # so the status stays 400 where the detail reaches them.
+        raise internal_error(
+            e,
+            context="generating metric",
             status_code=400,
-            detail="Failed to generate metric",
+            public_detail=(
+                "Failed to generate metric: the generation model could not be "
+                "used. Check the model configured for your organization."
+            ),
         ) from e
+    except Exception as e:
+        raise internal_error(e, context="generating metric") from e
 
 
 @router.post("/{metric_id}/improve", response_model=schemas.Metric)
@@ -191,15 +211,25 @@ def improve_metric(
             user_id=user_id,
         )
         return result
-    except Exception as e:
-        logger.error(
-            f"Error improving metric {metric_id}: {e}",
-            exc_info=True,
-        )
-        raise HTTPException(
+    except HTTPException:
+        raise
+    except SQLAlchemyError:
+        raise
+    except ValidationError as e:
+        raise internal_error(e, context=f"improving metric {metric_id}") from e
+    except (ValueError, RuntimeError) as e:
+        # See generate_metric above for why these two are the caller's fault.
+        raise internal_error(
+            e,
+            context=f"improving metric {metric_id}",
             status_code=400,
-            detail="Failed to improve metric",
+            public_detail=(
+                "Failed to improve metric: the generation model could not be "
+                "used. Check the model configured for your organization."
+            ),
         ) from e
+    except Exception as e:
+        raise internal_error(e, context=f"improving metric {metric_id}") from e
 
 
 @router.get("/", response_model=list[schemas.MetricDetail])

--- a/apps/backend/src/rhesis/backend/app/routers/model.py
+++ b/apps/backend/src/rhesis/backend/app/routers/model.py
@@ -286,13 +286,7 @@ def get_provider_models(
         return models_list
     except ValueError as e:
         # ValueError is raised for unsupported providers or providers that don't support listing
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        # Other exceptions (network errors, API errors, etc.)
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to retrieve models for provider '{provider_name}': {str(e)}",
-        )
+        raise HTTPException(status_code=404, detail=str(e)) from e
 
 
 @router.get("/provider/{provider_name}/embeddings", response_model=List[str])
@@ -308,12 +302,4 @@ def get_provider_embedding_models(
         return models_list
     except ValueError as e:
         # ValueError is raised for unsupported providers or providers that don't support embeddings
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        # Other exceptions (network errors, API errors, etc.)
-        raise HTTPException(
-            status_code=500,
-            detail=(
-                f"Failed to retrieve embedding models for provider '{provider_name}': {str(e)}"
-            ),
-        )
+        raise HTTPException(status_code=404, detail=str(e)) from e

--- a/apps/backend/src/rhesis/backend/app/routers/model.py
+++ b/apps/backend/src/rhesis/backend/app/routers/model.py
@@ -245,32 +245,26 @@ async def test_model_connection(
         f"provider={provider}, model_name={model_name}, type={model_type}"
     )
 
-    try:
-        # Use ModelConnectionService which makes an actual test call
-        result = await ModelConnectionService.test_connection(
-            provider=provider,
-            model_name=model_name,
-            api_key=api_key,
-            endpoint=db_model.endpoint,
-            model_type=model_type,
-        )
+    # No try/except: test_connection reports every failure through its own
+    # result object, so the handler here only ever caught its own bugs -- and
+    # answered them with a 200 whose message was our exception text.
+    result = await ModelConnectionService.test_connection(
+        provider=provider,
+        model_name=model_name,
+        api_key=api_key,
+        endpoint=db_model.endpoint,
+        model_type=model_type,
+    )
 
-        status = "success" if result.success else "error"
-        logger.info(f"[MODEL_TEST] Test result: status={status}, message={result.message}")
+    status = "success" if result.success else "error"
+    # Status only: the message can quote the provider's reply, and with it the
+    # user's own API key.
+    logger.info(f"[MODEL_TEST] Test result: status={status}")
 
-        return {
-            "status": status,
-            "message": result.message,
-        }
-
-    except Exception as e:
-        # Catch any unexpected errors
-        error_msg = str(e) if str(e) else "Failed to test model connection"
-        logger.error(f"[MODEL_TEST] Exception: {error_msg}", exc_info=True)
-        return {
-            "status": "error",
-            "message": error_msg,
-        }
+    return {
+        "status": status,
+        "message": result.message,
+    }
 
 
 @router.get("/provider/{provider_name}", response_model=List[str])

--- a/apps/backend/src/rhesis/backend/app/routers/organization.py
+++ b/apps/backend/src/rhesis/backend/app/routers/organization.py
@@ -17,6 +17,7 @@ from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
 )
+from rhesis.backend.app.error_handlers import internal_error
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.services.organization import (
     execute_initial_test_runs,
@@ -78,12 +79,8 @@ def read_organizations(
             organization_id=organization_id,
             user_id=user_id,
         )
-    except HTTPException:
-        raise
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to retrieve organizations: {str(e)}")
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 @router.get("/{organization_id}", response_model=schemas.Organization)
@@ -104,12 +101,8 @@ def read_organization(
         if db_organization is None:
             raise HTTPException(status_code=404, detail="Organization not found")
         return db_organization
-    except HTTPException:
-        raise
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to retrieve organization: {str(e)}")
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 @router.put("/{organization_id}", response_model=schemas.Organization)
@@ -225,12 +218,11 @@ def initialize_organization_data(
         # Re-raise HTTP exceptions
         raise
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        logger.exception("load-initial-data failed for org_id=%s", organization_id)
-        raise HTTPException(
-            status_code=500, detail=f"Failed to initialize organization data: {str(e)}"
-        )
+        raise internal_error(
+            e, context=f"loading initial data for organization {organization_id}"
+        ) from e
 
     # Schedule onboarding emails AFTER successful DB commit
     logger.info("Onboarding complete — scheduling Day 1/2/3 emails for org_id=%s", organization_id)
@@ -293,12 +285,5 @@ def rollback_organization_data(
         # Transaction commit is handled by the session context manager
 
         return {"status": "success", "message": "Initial data rolled back successfully"}
-    except HTTPException:
-        # Re-raise HTTP exceptions
-        raise
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"Failed to rollback organization data: {str(e)}"
-        )
+        raise HTTPException(status_code=400, detail=str(e)) from e

--- a/apps/backend/src/rhesis/backend/app/routers/owasp.py
+++ b/apps/backend/src/rhesis/backend/app/routers/owasp.py
@@ -9,7 +9,7 @@ set of adversarial prompts for a described system under test.
 import asyncio
 import logging
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
@@ -68,6 +68,8 @@ async def get_categories(
                 for s in summaries
             ],
         )
+    except HTTPException:
+        raise
     except Exception as e:
         raise internal_error(
             e, context=f"listing OWASP categories for {framework.value}", status_code=502
@@ -91,42 +93,38 @@ async def generate_test_set(
     Returns HTTP 202 Accepted with a `task_id` that can be polled via
     `GET /tasks/{task_id}`.
     """
-    try:
-        task_result = task_launcher(
-            generate_and_save_owasp_test_set,
-            current_user=current_user,
-            db=db,
-            framework=request.framework.value,
-            purpose=request.purpose,
-            categories=request.categories,
-            num_tests=request.num_tests,
-            batch_size=request.batch_size,
-            name=request.name,
-            model_id=request.model_id,
-            test_type=request.test_type.value,
-        )
+    task_result = task_launcher(
+        generate_and_save_owasp_test_set,
+        current_user=current_user,
+        db=db,
+        framework=request.framework.value,
+        purpose=request.purpose,
+        categories=request.categories,
+        num_tests=request.num_tests,
+        batch_size=request.batch_size,
+        name=request.name,
+        model_id=request.model_id,
+        test_type=request.test_type.value,
+    )
 
-        logger.info(
-            "OWASP generation task launched",
-            extra={
-                "task_id": task_result.id,
-                "framework": request.framework.value,
-                "num_tests": request.num_tests,
-                "user_id": current_user.id,
-                "organization_id": current_user.organization_id,
-            },
-        )
+    logger.info(
+        "OWASP generation task launched",
+        extra={
+            "task_id": task_result.id,
+            "framework": request.framework.value,
+            "num_tests": request.num_tests,
+            "user_id": current_user.id,
+            "organization_id": current_user.organization_id,
+        },
+    )
 
-        framework_label = OWASP_FRAMEWORKS[request.framework.value]["requirement"]
-        return OwaspGenerateResponse(
-            task_id=str(task_result.id),
-            framework=request.framework,
-            num_tests=request.num_tests,
-            message=(
-                f"Test set generation started from the {framework_label} report. "
-                f"Generating {request.num_tests} tests using your configured LLM."
-            ),
-        )
-
-    except Exception as e:
-        raise internal_error(e, context="launching OWASP test set generation") from e
+    framework_label = OWASP_FRAMEWORKS[request.framework.value]["requirement"]
+    return OwaspGenerateResponse(
+        task_id=str(task_result.id),
+        framework=request.framework,
+        num_tests=request.num_tests,
+        message=(
+            f"Test set generation started from the {framework_label} report. "
+            f"Generating {request.num_tests} tests using your configured LLM."
+        ),
+    )

--- a/apps/backend/src/rhesis/backend/app/routers/owasp.py
+++ b/apps/backend/src/rhesis/backend/app/routers/owasp.py
@@ -9,11 +9,12 @@ set of adversarial prompts for a described system under test.
 import asyncio
 import logging
 
-from fastapi import Depends, HTTPException
+from fastapi import Depends
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import get_tenant_db_session
+from rhesis.backend.app.error_handlers import internal_error
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.owasp import (
@@ -68,11 +69,9 @@ async def get_categories(
             ],
         )
     except Exception as e:
-        logger.error(f"Error listing OWASP categories for {framework.value}: {e}")
-        raise HTTPException(
-            status_code=502,
-            detail=f"Failed to load OWASP report categories: {str(e)}",
-        )
+        raise internal_error(
+            e, context=f"listing OWASP categories for {framework.value}", status_code=502
+        ) from e
 
 
 @router.post("/generate", response_model=OwaspGenerateResponse, status_code=202)
@@ -130,8 +129,4 @@ async def generate_test_set(
         )
 
     except Exception as e:
-        logger.error(f"Error launching OWASP generation: {e}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to launch OWASP test set generation: {str(e)}",
-        )
+        raise internal_error(e, context="launching OWASP test set generation") from e

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -40,6 +40,10 @@ from rhesis.backend.app.services.tool.mcp import (
     query_mcp,
 )
 from rhesis.backend.app.utils.execution_validation import validate_generation_model
+from rhesis.backend.app.utils.model_errors import (
+    EmbeddingProviderNotConfigured,
+    ModelConfigurationError,
+)
 from rhesis.sdk.context import EndpointContext
 from rhesis.sdk.models.providers.native import USAGE_HEADER
 
@@ -52,6 +56,38 @@ router = RhesisRouter(
     dependencies=[Depends(require_current_user_or_token)],
     resource="service",
 )
+
+
+#: Attribute names an LLM provider hangs its HTTP status on. No single name
+#: covers them: litellm and the OpenAI SDK use ``status_code``, aiohttp (raised
+#: by RhesisEmbedder) uses ``status``, google-api-core uses ``code`` -- last,
+#: because aiohttp also keeps ``code`` as a deprecated alias.
+_PROVIDER_STATUS_ATTRIBUTES = ("status_code", "status", "code")
+
+
+def _provider_status(error: Exception) -> int | None:
+    """The HTTP status a model provider attached to this failure, if any."""
+    for attribute in _PROVIDER_STATUS_ATTRIBUTES:
+        status = getattr(error, attribute, None)
+        if isinstance(status, int) and 400 <= status < 600:
+            return status
+    return None
+
+
+def _model_call_failure(error: Exception, *, context: str, summary: str) -> HTTPException:
+    """Split a model failure into "the provider said no" and "we broke".
+
+    A provider that answered with an HTTP status said the one thing the caller
+    can act on -- invalid api key, unknown model, context length exceeded, rate
+    limit exceeded -- and none of that text is ours to hide. A failure carrying
+    no provider status is our own bug: a traceback in the log and a masked 500,
+    not a 400 that blames the caller for it.
+    """
+    status = _provider_status(error)
+    if status is None:
+        return internal_error(error, context=context)
+    logger.warning("%s: model provider returned %s: %s", context, status, error)
+    return HTTPException(status_code=400, detail=f"{summary}: {error}")
 
 
 def _handle_generation_error(error: Exception) -> None:
@@ -89,8 +125,10 @@ def get_github_contents(repo_url: str):
         contents = read_repo_contents(repo_url)
         return contents
     except Exception as e:
-        logger.error(f"Failed to get GitHub contents for {repo_url}: {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Failed to retrieve repository contents") from e
+        # GitHub's own answers never reach here: read_repo_contents swallows a
+        # failed download and returns "". What is left is ours -- temp directory,
+        # disk, decoding -- so it is a masked 500, not a 400 blaming the caller.
+        raise internal_error(e, context=f"reading GitHub contents for {repo_url}") from e
 
 
 @router.post("/generate/content")
@@ -206,9 +244,16 @@ async def generate_content_endpoint(
             http_response.headers[USAGE_HEADER] = json.dumps(captured_usage)
 
         return result
+    except HTTPException:
+        raise
+    except ModelConfigurationError as e:
+        # Written for this caller: names their model and what to change in the
+        # Models page.
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Failed to generate content: {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Failed to generate content") from e
+        raise _model_call_failure(
+            e, context="generating content", summary="Failed to generate content"
+        ) from e
 
 
 @router.post("/generate/embedding")
@@ -225,8 +270,6 @@ def generate_embedding_endpoint(
         db: The database session
         current_user: The current authenticated user
     """
-    from rhesis.backend.app.utils.model_errors import ModelConfigurationError
-
     try:
         from rhesis.backend.app.utils.user_model_utils import get_user_embedding_model
         from rhesis.sdk.models.factory import get_model
@@ -236,21 +279,32 @@ def generate_embedding_endpoint(
         if isinstance(embedder, str):
             embedder = get_model(embedder, model_type="embedding")
         if isinstance(embedder, RhesisEmbedder):
-            raise ModelConfigurationError(
+            raise EmbeddingProviderNotConfigured(
                 "Embedding model resolved to the Rhesis native provider, which would call "
                 "this endpoint recursively. Set DEFAULT_EMBEDDING_MODEL to an actual "
                 "provider (e.g. vertex_ai/text-embedding-005)."
             )
         embedding = embedder.generate(text=request.text)
         return embedding
+    except HTTPException:
+        raise
+    except EmbeddingProviderNotConfigured as e:
+        # This deployment's DEFAULT_EMBEDDING_MODEL, not a bad request from this
+        # caller — no client-side fix makes it succeed, so it stays a 500. The
+        # setting name belongs in the log, not the response.
+        raise internal_error(
+            e,
+            context="generating embedding",
+            public_detail="No embedding model is configured for this deployment.",
+        ) from e
     except ModelConfigurationError as e:
-        # Deployment misconfiguration (DEFAULT_EMBEDDING_MODEL), not a bad
-        # request from this caller — no client-side fix makes this succeed.
-        logger.error(f"Embedding model misconfigured: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        # Written for this caller: names their model and what to change in the
+        # Models page.
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Failed to generate embedding: {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail="Failed to generate embedding") from e
+        raise _model_call_failure(
+            e, context="generating embedding", summary="Failed to generate embedding"
+        ) from e
 
 
 @router.post("/generate/tests", response_model=GenerateTestsResponse)
@@ -464,10 +518,6 @@ async def generate_test_config(
         logger.warning(f"Invalid request for test config generation: {str(e)}")
         http_exception = handle_execution_error(e, operation="generate test configuration")
         raise http_exception
-    except RuntimeError as e:
-        logger.error(f"Test config generation failed: {str(e)}", exc_info=True)
-        detail = str(e) if e.args else "Failed to generate test configuration"
-        raise HTTPException(status_code=500, detail=detail)
     except Exception as e:
         raise internal_error(e, context="generating test configuration") from e
 
@@ -523,7 +573,7 @@ async def query_mcp_server(
         )
         return result
     except Exception as e:
-        raise handle_mcp_exception(e, "query")
+        raise handle_mcp_exception(e, "query") from e
 
 
 @router.get("/recent-activities", response_model=RecentActivitiesResponse)
@@ -555,5 +605,4 @@ def get_recent_activities(
         result = service.get_recent_activities(db=db, organization_id=organization_id, limit=limit)
         return RecentActivitiesResponse(**result)
     except Exception as e:
-        logger.error(f"Failed to get recent activities: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to retrieve recent activities")
+        raise internal_error(e, context="retrieving recent activities") from e

--- a/apps/backend/src/rhesis/backend/app/routers/services.py
+++ b/apps/backend/src/rhesis/backend/app/routers/services.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.database import get_db_with_tenant_variables
 from rhesis.backend.app.dependencies import get_tenant_context, get_tenant_db_session
+from rhesis.backend.app.error_handlers import internal_error
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.services import (
@@ -88,11 +89,8 @@ def get_github_contents(repo_url: str):
         contents = read_repo_contents(repo_url)
         return contents
     except Exception as e:
-        error_msg = str(e) if str(e) else "Unknown error"
-        logger.error(f"Failed to get GitHub contents for {repo_url}: {error_msg}", exc_info=True)
-        raise HTTPException(
-            status_code=400, detail=f"Failed to retrieve repository contents: {error_msg}"
-        )
+        logger.error(f"Failed to get GitHub contents for {repo_url}: {e}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Failed to retrieve repository contents") from e
 
 
 @router.post("/generate/content")
@@ -209,9 +207,8 @@ async def generate_content_endpoint(
 
         return result
     except Exception as e:
-        error_msg = str(e) if str(e) else "Unknown error"
-        logger.error(f"Failed to generate content: {error_msg}", exc_info=True)
-        raise HTTPException(status_code=400, detail=f"Failed to generate content: {error_msg}")
+        logger.error(f"Failed to generate content: {e}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Failed to generate content") from e
 
 
 @router.post("/generate/embedding")
@@ -252,9 +249,8 @@ def generate_embedding_endpoint(
         logger.error(f"Embedding model misconfigured: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
     except Exception as e:
-        error_msg = str(e) if str(e) else "Unknown error"
-        logger.error(f"Failed to generate embedding: {error_msg}", exc_info=True)
-        raise HTTPException(status_code=400, detail=f"Failed to generate embedding: {error_msg}")
+        logger.error(f"Failed to generate embedding: {e}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Failed to generate embedding") from e
 
 
 @router.post("/generate/tests", response_model=GenerateTestsResponse)
@@ -473,16 +469,7 @@ async def generate_test_config(
         detail = str(e) if e.args else "Failed to generate test configuration"
         raise HTTPException(status_code=500, detail=detail)
     except Exception as e:
-        logger.error(
-            f"Unexpected error in test config generation: {str(e)}",
-            exc_info=True,
-        )
-        error_detail = (
-            str(e)
-            if str(e)
-            else "An unexpected error occurred during test configuration generation"
-        )
-        raise HTTPException(status_code=500, detail=error_detail)
+        raise internal_error(e, context="generating test configuration") from e
 
 
 @router.post("/mcp/query", response_model=QueryMCPResponse)

--- a/apps/backend/src/rhesis/backend/app/routers/source.py
+++ b/apps/backend/src/rhesis/backend/app/routers/source.py
@@ -208,9 +208,7 @@ async def upload_source(
             description=description,
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to upload source: {str(e)}")
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 @router.post("/{source_id}/extract")
@@ -251,13 +249,11 @@ async def extract_source_content_endpoint(
             user_id=str(user_id),
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=f"Failed to extract content: {str(e)}")
-    except FileNotFoundError:
+        raise HTTPException(status_code=400, detail=f"Failed to extract content: {str(e)}") from e
+    except FileNotFoundError as e:
         raise HTTPException(
             status_code=404, detail="Source file not found. Please check the file path."
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to extract content: {str(e)}")
+        ) from e
 
 
 @router.get("/{source_id}/content", response_model=schemas.SourceWithContent)
@@ -381,10 +377,8 @@ async def get_source_file(
             },
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except FileNotFoundError:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except FileNotFoundError as e:
         raise HTTPException(
             status_code=404, detail="Source file not found. Please check the file path."
-        )
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to retrieve source content: {str(e)}")
+        ) from e

--- a/apps/backend/src/rhesis/backend/app/routers/test.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test.py
@@ -17,6 +17,7 @@ from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
 )
+from rhesis.backend.app.error_handlers import internal_error
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.quota import QuotaResource
@@ -125,12 +126,8 @@ def create_tests_bulk(
         error_message = str(e)
         if "not found" in error_message.lower():
             # Handle cases where referenced entities (e.g., test set) are not found
-            raise HTTPException(status_code=404, detail=error_message)
-        else:
-            # Handle unexpected server errors
-            raise HTTPException(
-                status_code=500, detail=f"An error occurred while creating tests: {error_message}"
-            )
+            raise HTTPException(status_code=404, detail=error_message) from e
+        raise internal_error(e, context="creating tests in bulk") from e
 
 
 @router.delete("/bulk", response_model=schemas.TestBulkDeleteResponse)
@@ -178,16 +175,7 @@ def extract_test_from_conversation_endpoint(
             test_type=request.test_type or "Multi-Turn",
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(
-            f"Error extracting test from conversation: {e}",
-            exc_info=True,
-        )
-        raise HTTPException(
-            status_code=500,
-            detail=(f"Failed to extract test from conversation: {str(e)}"),
-        )
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 @router.get("/", response_model=List[schemas.TestDetail])

--- a/apps/backend/src/rhesis/backend/app/routers/test.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test.py
@@ -128,10 +128,16 @@ def create_tests_bulk(
         )
     except Exception as e:
         if "not found" in str(e).lower():
-            # Referenced entity (e.g. test set) is missing. Keep the 404, but the
-            # message is a broad exception's text -- log it instead of returning it.
-            logger.warning("Referenced entity missing while creating tests in bulk", exc_info=True)
-            raise HTTPException(status_code=404, detail="A referenced entity was not found") from e
+            # A caller error, so: no stack in the log, and the message names what
+            # they can act on. The test set id is the only reference they supplied
+            # -- everything else a bulk test refers to is get-or-created.
+            logger.warning("Referenced entity missing while creating tests in bulk: %s", e)
+            missing = (
+                f"Test set {test_data.test_set_id} not found or not accessible"
+                if test_data.test_set_id
+                else "A referenced entity was not found"
+            )
+            raise HTTPException(status_code=404, detail=missing) from e
         raise internal_error(e, context="creating tests in bulk") from e
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/test.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test.py
@@ -123,10 +123,11 @@ def create_tests_bulk(
             detail="Database integrity error: A record with the same unique values already exists",
         )
     except Exception as e:
-        error_message = str(e)
-        if "not found" in error_message.lower():
-            # Handle cases where referenced entities (e.g., test set) are not found
-            raise HTTPException(status_code=404, detail=error_message) from e
+        if "not found" in str(e).lower():
+            # Referenced entity (e.g. test set) is missing. Keep the 404, but the
+            # message is a broad exception's text -- log it instead of returning it.
+            logger.warning("Referenced entity missing while creating tests in bulk", exc_info=True)
+            raise HTTPException(status_code=404, detail="A referenced entity was not found") from e
         raise internal_error(e, context="creating tests in bulk") from e
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/test.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test.py
@@ -110,6 +110,10 @@ def create_tests_bulk(
         return schemas.TestBulkCreateResponse(
             success=True, total_tests=len(tests), message=f"Successfully created {len(tests)} tests"
         )
+    except HTTPException:
+        # The empty-request 400 above is raised inside this try; without this
+        # arm the broad handler below turns it into a 500.
+        raise
     except ValueError as e:
         # Handle validation errors
         raise HTTPException(status_code=400, detail=str(e))

--- a/apps/backend/src/rhesis/backend/app/routers/test_configuration.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_configuration.py
@@ -254,8 +254,15 @@ def execute_test_configuration_endpoint(
                 db=db,
             )
         except Exception as exc:
-            # Mark the queued test run as failed so it doesn't stay stuck
-            update_test_run_status(db, test_run, RunStatus.FAILED.value, error=str(exc))
+            # Mark the queued test run as failed so it doesn't stay stuck. The
+            # stored text is shown in the UI, so it says no more than the response
+            # does -- a broker error carries the connection string with it.
+            update_test_run_status(
+                db,
+                test_run,
+                RunStatus.FAILED.value,
+                error="Failed to submit the test run for execution.",
+            )
             db.commit()
             raise internal_error(exc, context="submitting test configuration task") from exc
 

--- a/apps/backend/src/rhesis/backend/app/routers/test_configuration.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_configuration.py
@@ -14,6 +14,7 @@ from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
 )
+from rhesis.backend.app.error_handlers import internal_error
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.quota import QuotaResource
@@ -256,10 +257,7 @@ def execute_test_configuration_endpoint(
             # Mark the queued test run as failed so it doesn't stay stuck
             update_test_run_status(db, test_run, RunStatus.FAILED.value, error=str(exc))
             db.commit()
-            raise HTTPException(
-                status_code=500,
-                detail=f"Failed to submit task: {exc}",
-            ) from exc
+            raise internal_error(exc, context="submitting test configuration task") from exc
 
         return {
             "test_configuration_id": str(test_configuration_id),

--- a/apps/backend/src/rhesis/backend/app/routers/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_run.py
@@ -350,12 +350,7 @@ def rescore_test_run_endpoint(
         )
         return result
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to rescore test run: {str(e)}",
-        )
+        raise HTTPException(status_code=404, detail=str(e)) from e
 
 
 @router.get("/{test_run_id}/download", response_class=StreamingResponse)
@@ -391,12 +386,7 @@ def download_test_run_results(
         return response
 
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to download test run results for {test_run_id}: {str(e)}",
-        )
+        raise HTTPException(status_code=404, detail=str(e)) from e
 
 
 @router.get("/{test_run_id}/traces", response_model=TraceListResponse)

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -277,25 +277,20 @@ def create_test_set_bulk(
       tables were removed)
     - expected_response is an optional field to specify the expected model response
     """
-    try:
-        # Extract test_set_type from request if provided
-        test_set_type = None
-        if test_set_data.test_set_type:
-            from rhesis.backend.app.constants import TestSetType
+    # Extract test_set_type from request if provided
+    test_set_type = None
+    if test_set_data.test_set_type:
+        from rhesis.backend.app.constants import TestSetType
 
-            test_set_type = TestSetType.from_string(test_set_data.test_set_type)
+        test_set_type = TestSetType.from_string(test_set_data.test_set_type)
 
-        test_set = bulk_create_test_set(
-            db=db,
-            test_set_data=test_set_data,
-            organization_id=str(current_user.organization_id),
-            user_id=str(current_user.id),
-            test_set_type=test_set_type,
-        )
-        return test_set
-    except Exception as e:
-        logger.error(f"Failed to create test set: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Failed to create test set: {str(e)}")
+    return bulk_create_test_set(
+        db=db,
+        test_set_data=test_set_data,
+        organization_id=str(current_user.organization_id),
+        user_id=str(current_user.id),
+        test_set_type=test_set_type,
+    )
 
 
 @router.post("/", response_model=schemas.TestSet)
@@ -451,35 +446,26 @@ def download_test_set_prompts(
     tenant_context=Depends(get_tenant_context),  # SECURITY: Extract tenant context
     current_user: User = Depends(require_current_user_or_token),
 ):
-    try:
-        # Resolve test set
-        organization_id, user_id = tenant_context  # SECURITY: Get tenant context
-        db_test_set = resolve_test_set_or_raise(test_set_identifier, db, organization_id)
+    # Resolve test set
+    organization_id, user_id = tenant_context  # SECURITY: Get tenant context
+    db_test_set = resolve_test_set_or_raise(test_set_identifier, db, organization_id)
 
-        # Get prompts with organization filtering (SECURITY CRITICAL)
-        prompts = get_prompts_for_test_set(db, db_test_set.id, organization_id)
+    # Get prompts with organization filtering (SECURITY CRITICAL)
+    prompts = get_prompts_for_test_set(db, db_test_set.id, organization_id)
 
-        # Check if prompts list is empty before trying to create CSV
-        if not prompts:
-            raise HTTPException(
-                status_code=404, detail=f"No prompts found in test set: {test_set_identifier}"
-            )
-
-        csv_data = prompts_to_csv(prompts)
-
-        response = StreamingResponse(iter([csv_data]), media_type="text/csv")
-        response.headers["Content-Disposition"] = (
-            f"attachment; filename=test_set_{test_set_identifier}.csv"
-        )
-        return response
-
-    except HTTPException:
-        raise
-    except Exception as e:
+    # Check if prompts list is empty before trying to create CSV
+    if not prompts:
         raise HTTPException(
-            status_code=500,
-            detail=f"Failed to download test set prompts for {test_set_identifier}: {str(e)}",
+            status_code=404, detail=f"No prompts found in test set: {test_set_identifier}"
         )
+
+    csv_data = prompts_to_csv(prompts)
+
+    response = StreamingResponse(iter([csv_data]), media_type="text/csv")
+    response.headers["Content-Disposition"] = (
+        f"attachment; filename=test_set_{test_set_identifier}.csv"
+    )
+    return response
 
 
 @router.get("/{test_set_identifier}/tests", response_model=list[schemas.TestDetail])

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -197,7 +197,9 @@ def generate_test_set(
             metadata = dict(attrs.get("metadata", {}))
             generation = dict(metadata.get("generation", {}))
             generation["status"] = "failed"
-            generation["error"] = str(launch_err)
+            # GET /test_sets/{id} returns this verbatim, so it says no more than the
+            # response does -- a broker error carries the connection string with it.
+            generation["error"] = "Failed to start test set generation."
             metadata["generation"] = generation
             attrs["metadata"] = metadata
             db_test_set.attributes = attrs
@@ -231,6 +233,9 @@ def generate_test_set(
 
 
 @router.post("/bulk", response_model=schemas.TestSetBulkResponse)
+@handle_database_exceptions(
+    entity_name="test set", custom_unique_message="Test set with this name already exists"
+)
 def create_test_set_bulk(
     test_set_data: schemas.TestSetBulkCreate,
     db: Session = Depends(get_tenant_db_session),

--- a/apps/backend/src/rhesis/backend/app/routers/tools.py
+++ b/apps/backend/src/rhesis/backend/app/routers/tools.py
@@ -563,10 +563,7 @@ async def test_tool_connection(
                 project_id=project_id,
             )
     except (ToolConfigurationError, ValueError) as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Tool health check error: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 @router.post("/jira/create-ticket-from-task", response_model=CreateJiraTicketFromTaskResponse)
@@ -598,13 +595,10 @@ async def create_jira_ticket_from_task_endpoint(
             user_id=user_id,
         )
     except ToolConfigurationError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except ValueError as e:
         logger.warning(f"Invalid request for Jira ticket creation: {str(e)}")
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        logger.error(f"Failed to create Jira ticket: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
 
 @router.delete("/{tool_id}", status_code=204)

--- a/apps/backend/src/rhesis/backend/app/routers/tools.py
+++ b/apps/backend/src/rhesis/backend/app/routers/tools.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from typing import List, Optional
 
+import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from rhesis.backend.app.routers.base import RhesisRouter
 from sqlalchemy.orm import Session
@@ -13,6 +14,7 @@ from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
 )
+from rhesis.backend.app.error_handlers import UpstreamHTTPException
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.schemas.services import (
     CreateJiraTicketFromTaskRequest,
@@ -50,6 +52,7 @@ from rhesis.backend.app.services.tool.rest import (
 )
 from rhesis.backend.app.services.tool.rest.config import validate_base_url
 from rhesis.backend.app.utils.decorators import with_count_header
+from rhesis.sdk.agents.mcp.exceptions import MCPError
 
 logger = logging.getLogger(__name__)
 
@@ -474,10 +477,11 @@ async def extract_tool_item(
     except HTTPException:
         raise
     except (ToolConfigurationError, ValueError) as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
-        logger.error(f"Tool extract error: {e}", exc_info=True)
-        raise handle_mcp_exception(e, "extract")
+        # No log here: handle_mcp_exception logs with the MCP category attached
+        # and marks the result, so this failure is recorded exactly once.
+        raise handle_mcp_exception(e, "extract") from e
 
 
 def _ensure_mcp_saved_credential_override(provider: str) -> None:
@@ -564,6 +568,21 @@ async def test_tool_connection(
             )
     except (ToolConfigurationError, ValueError) as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
+    except httpx.HTTPError as e:
+        # Wrong host, unreachable instance, timeout -- the user's own service,
+        # and the reason is the entire result of a connection test. Bad
+        # credentials never land here: health_check answers those with 200 and
+        # is_authenticated="No".
+        reason = str(e) or type(e).__name__
+        logger.warning("Tool connection test could not reach the provider: %s", reason)
+        upstream = UpstreamHTTPException(
+            status_code=502, detail=f"Could not reach the provider: {reason}"
+        )
+        upstream.rhesis_logged = True
+        raise upstream from e
+    except MCPError as e:
+        # MCP providers report the same failures through their own exceptions.
+        raise handle_mcp_exception(e, "test connection") from e
 
 
 @router.post("/jira/create-ticket-from-task", response_model=CreateJiraTicketFromTaskResponse)

--- a/apps/backend/src/rhesis/backend/app/services/endpoint/service.py
+++ b/apps/backend/src/rhesis/backend/app/services/endpoint/service.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import socket
 from typing import Any, Dict, Optional
 
 from fastapi import HTTPException
@@ -333,23 +334,32 @@ class EndpointService:
             logger.debug(f"Endpoint invocation completed: {endpoint.name}")
             return result
 
+        # Nothing is logged here: every caller records the failure once -- the
+        # router through `internal_error` or the global handler, the batch runner
+        # with its own traceback -- and error_type says whose fault it was.
         except EndpointInvocationError:
             raise
+        except HTTPException:
+            # An invoker's configuration error ("Unsupported HTTP method: PATCH")
+            # is the caller's to fix and already carries the right status; the
+            # broad handler below would relabel it as ours and make it a 500.
+            raise
         except ValueError as e:
-            logger.error(f"ValueError invoking endpoint: {e}")
             raise EndpointInvocationError(
                 str(e), transient=False, status_code=400, error_type="validation_error"
-            )
-        except (TimeoutError, ConnectionError, OSError) as e:
-            logger.error(f"Transient error invoking endpoint: {e}", exc_info=True)
+            ) from e
+        except (TimeoutError, ConnectionError, socket.gaierror) as e:
+            # Not OSError as a whole: FileNotFoundError and PermissionError from
+            # the storage and file-extraction code above are also OSErrors, and a
+            # network_error detail is passed through to the client unmasked --
+            # which would answer a storage failure with one of our server paths.
             raise EndpointInvocationError(
                 str(e), transient=True, status_code=502, error_type="network_error"
-            )
+            ) from e
         except Exception as e:
-            logger.error(f"Exception invoking endpoint: {e}", exc_info=True)
             raise EndpointInvocationError(
                 str(e), transient=False, status_code=500, error_type="internal_error"
-            )
+            ) from e
 
     @staticmethod
     def _link_first_turn_trace(

--- a/apps/backend/src/rhesis/backend/app/services/endpoint/testing.py
+++ b/apps/backend/src/rhesis/backend/app/services/endpoint/testing.py
@@ -13,7 +13,7 @@ from typing import Any, Dict
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from rhesis.backend.app.error_handlers import UpstreamHTTPException, internal_error
+from rhesis.backend.app.error_handlers import internal_error
 from rhesis.backend.app.models.endpoint import Endpoint
 from rhesis.backend.app.models.enums import (
     EndpointAuthType,
@@ -123,29 +123,18 @@ async def test_endpoint(
             endpoint=endpoint,
             input_data=enriched_input_data,
         )
-        try:
-            result = await create_invoker(context).invoke()
-        except Exception as exc:
-            # Scoped to the invocation alone, not the setup above it: a failure
-            # here is the user's own endpoint refusing, rejecting the token or
-            # returning something unparseable -- which is what they ran the test
-            # to find out. Setup failures are ours and stay masked below.
-            #
-            # One warning line, no stack: a mistyped key in the user's endpoint
-            # config is not a server fault to page anyone about. `rhesis_logged`
-            # keeps the global handler from restating it as an error.
-            logger.warning("Endpoint test invocation failed: %s", exc)
-            upstream = UpstreamHTTPException(status_code=500, detail=str(exc))
-            upstream.rhesis_logged = True
-            raise upstream from exc
-
+        result = await create_invoker(context).invoke()
         logger.debug("Endpoint test invocation completed")
         return result
     except HTTPException:
-        # Covers the UpstreamHTTPException above -- must not be re-wrapped.
+        # What the user ran the test to find out -- a refused connection, a
+        # rejected token, an unparseable body -- is *returned* by invoke() as an
+        # ErrorResponse, not raised (services/invokers/rest_invoker.py). The only
+        # thing raised out of it is a configuration HTTPException carrying its own
+        # status, so wrapping it here would turn a 400 into a 500.
         raise
     except ValueError as exc:
-        logger.error("ValueError testing endpoint: %s", exc)
+        logger.warning("Invalid endpoint test configuration: %s", exc)
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         raise internal_error(exc, context="testing endpoint") from exc
@@ -219,9 +208,13 @@ async def test_endpoint_mapping(
         result = await create_invoker(context).invoke()
         logger.debug("Endpoint mapping test completed")
         return result
+    except HTTPException:
+        # Same as test_endpoint above: an invoker reports the user's endpoint by
+        # returning an ErrorResponse, and only raises for configuration problems
+        # that already carry the right status.
+        raise
     except ValueError as exc:
-        logger.error("ValueError testing endpoint mapping: %s", exc)
-        raise HTTPException(status_code=400, detail=str(exc))
+        logger.warning("Invalid endpoint mapping test: %s", exc)
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
-        logger.error("Exception testing endpoint mapping: %s", exc, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise internal_error(exc, context="testing endpoint mapping") from exc

--- a/apps/backend/src/rhesis/backend/app/services/endpoint/testing.py
+++ b/apps/backend/src/rhesis/backend/app/services/endpoint/testing.py
@@ -130,8 +130,14 @@ async def test_endpoint(
             # here is the user's own endpoint refusing, rejecting the token or
             # returning something unparseable -- which is what they ran the test
             # to find out. Setup failures are ours and stay masked below.
-            logger.warning("Endpoint test invocation failed: %s", exc, exc_info=True)
-            raise UpstreamHTTPException(status_code=500, detail=str(exc)) from exc
+            #
+            # One warning line, no stack: a mistyped key in the user's endpoint
+            # config is not a server fault to page anyone about. `rhesis_logged`
+            # keeps the global handler from restating it as an error.
+            logger.warning("Endpoint test invocation failed: %s", exc)
+            upstream = UpstreamHTTPException(status_code=500, detail=str(exc))
+            upstream.rhesis_logged = True
+            raise upstream from exc
 
         logger.debug("Endpoint test invocation completed")
         return result

--- a/apps/backend/src/rhesis/backend/app/services/endpoint/testing.py
+++ b/apps/backend/src/rhesis/backend/app/services/endpoint/testing.py
@@ -13,6 +13,7 @@ from typing import Any, Dict
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
+from rhesis.backend.app.error_handlers import UpstreamHTTPException, internal_error
 from rhesis.backend.app.models.endpoint import Endpoint
 from rhesis.backend.app.models.enums import (
     EndpointAuthType,
@@ -122,15 +123,26 @@ async def test_endpoint(
             endpoint=endpoint,
             input_data=enriched_input_data,
         )
-        result = await create_invoker(context).invoke()
+        try:
+            result = await create_invoker(context).invoke()
+        except Exception as exc:
+            # Scoped to the invocation alone, not the setup above it: a failure
+            # here is the user's own endpoint refusing, rejecting the token or
+            # returning something unparseable -- which is what they ran the test
+            # to find out. Setup failures are ours and stay masked below.
+            logger.warning("Endpoint test invocation failed: %s", exc, exc_info=True)
+            raise UpstreamHTTPException(status_code=500, detail=str(exc)) from exc
+
         logger.debug("Endpoint test invocation completed")
         return result
+    except HTTPException:
+        # Covers the UpstreamHTTPException above -- must not be re-wrapped.
+        raise
     except ValueError as exc:
         logger.error("ValueError testing endpoint: %s", exc)
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
-        logger.error("Exception testing endpoint: %s", exc, exc_info=True)
-        raise HTTPException(status_code=500, detail=str(exc))
+        raise internal_error(exc, context="testing endpoint") from exc
 
 
 async def test_endpoint_mapping(

--- a/apps/backend/src/rhesis/backend/app/services/invokers/auth/manager.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/auth/manager.py
@@ -8,6 +8,7 @@ import requests
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
+from rhesis.backend.app.error_handlers import UpstreamHTTPException
 from rhesis.backend.app.models.endpoint import Endpoint
 from rhesis.backend.app.models.enums import EndpointAuthType
 
@@ -101,8 +102,8 @@ class AuthenticationManager:
 
             return endpoint.last_token
         except Exception as e:
-            logger.error(f"Failed to get client credentials token: {str(e)}")
-            raise HTTPException(
-                status_code=500,
-                detail="Failed to get client credentials token",
-            )
+            logger.warning("Failed to get client credentials token: %s", type(e).__name__)
+            raise UpstreamHTTPException(
+                status_code=502,
+                detail="Failed to get an access token from the configured token URL.",
+            ) from e

--- a/apps/backend/src/rhesis/backend/app/services/invokers/rest_invoker.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/rest_invoker.py
@@ -164,11 +164,13 @@ class RestEndpointInvoker(BaseEndpointInvoker):
             # Re-raise HTTPExceptions (configuration errors)
             raise
         except Exception as e:
-            logger.error(f"Unexpected error: {str(e)}", exc_info=True)
+            # Not the endpoint's failure but ours, so the reason stays in the log:
+            # a SQLAlchemy error here stringifies to the statement and its params.
+            logger.exception("Unexpected error invoking REST endpoint: %s", type(e).__name__)
             return self._create_error_response(
                 error_type="unexpected_error",
-                output_message=f"Unexpected error: {str(e)}",
-                message=f"Unexpected error: {str(e)}",
+                output_message="Failed to invoke endpoint due to an internal error.",
+                message="Failed to invoke endpoint due to an internal error.",
                 request_details=self._safe_request_details(locals(), "REST"),
             )
 

--- a/apps/backend/src/rhesis/backend/app/services/invokers/sdk_invoker.py
+++ b/apps/backend/src/rhesis/backend/app/services/invokers/sdk_invoker.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional, Union
 from fastapi import HTTPException
 
 from rhesis.backend.app.constants import TestExecutionContext as TestContextConstants
+from rhesis.backend.app.error_handlers import PublicHTTPException
 from rhesis.backend.app.schemas.test_execution import TestExecutionContext
 from rhesis.telemetry.constants import ConversationContext as ConversationConstants
 
@@ -45,7 +46,7 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
         """
         endpoint = self.context.endpoint
         if not endpoint.endpoint_metadata:
-            raise HTTPException(
+            raise PublicHTTPException(
                 status_code=500,
                 detail="SDK endpoint missing metadata (function_name, project_id, environment)",
             )
@@ -56,7 +57,7 @@ class SdkEndpointInvoker(BaseEndpointInvoker):
         environment = endpoint.environment
 
         if not all([function_name, project_id, environment]):
-            raise HTTPException(
+            raise PublicHTTPException(
                 status_code=500,
                 detail=(
                     f"SDK endpoint incomplete: function_name={function_name}, "

--- a/apps/backend/src/rhesis/backend/app/services/model_connection.py
+++ b/apps/backend/src/rhesis/backend/app/services/model_connection.py
@@ -115,11 +115,17 @@ class ModelConnectionService:
                     model_name=model_name,
                 )
 
-        except Exception as e:
-            logger.error(f"Unexpected error testing model connection: {str(e)}", exc_info=True)
+        except Exception:
+            # `message` is handed to the client in a 200 body, where no masking
+            # layer can see it -- so a failure of ours gets a fixed string and
+            # the reason goes to the log instead.
+            logger.exception("Unexpected error testing model connection")
             return ModelConnectionTestResult(
                 success=False,
-                message=f"Unexpected error: {str(e)}",
+                message=(
+                    "The connection test could not be completed due to an "
+                    "internal error. Please try again."
+                ),
                 provider=provider,
                 model_name=model_name,
             )
@@ -178,8 +184,14 @@ class ModelConnectionService:
                     model_name=model_name,
                 )
             except Exception as e:
-                # API call failed - likely authentication or network issue
-                logger.warning(f"Language model generation test failed: {str(e)}")
+                # The provider's own text goes to the user, not to our logs: it
+                # can quote the API key they just typed ("Incorrect API key
+                # provided: sk-...").
+                logger.warning(
+                    "Language model generation test failed for %s: %s",
+                    provider,
+                    type(e).__name__,
+                )
                 return ModelConnectionTestResult(
                     success=False,
                     message=str(e),
@@ -187,13 +199,14 @@ class ModelConnectionService:
                     model_name=model_name,
                 )
 
-        except Exception as e:
-            logger.error(
-                f"Unexpected error testing language model connection: {str(e)}", exc_info=True
-            )
+        except Exception:
+            logger.exception("Unexpected error testing language model connection")
             return ModelConnectionTestResult(
                 success=False,
-                message=f"Unexpected error: {str(e)}",
+                message=(
+                    "The connection test could not be completed due to an "
+                    "internal error. Please try again."
+                ),
                 provider=provider,
                 model_name=model_name,
             )
@@ -255,8 +268,13 @@ class ModelConnectionService:
                     model_name=model_name,
                 )
             except Exception as e:
-                # API call failed - likely authentication or network issue
-                logger.warning(f"Embedding model generation test failed: {str(e)}")
+                # Provider text is for the user only -- see the language-model
+                # branch above.
+                logger.warning(
+                    "Embedding model generation test failed for %s: %s",
+                    provider,
+                    type(e).__name__,
+                )
                 return ModelConnectionTestResult(
                     success=False,
                     message=str(e),
@@ -264,11 +282,14 @@ class ModelConnectionService:
                     model_name=model_name,
                 )
 
-        except Exception as e:
-            logger.error(f"Unexpected error testing embedding connection: {str(e)}", exc_info=True)
+        except Exception:
+            logger.exception("Unexpected error testing embedding connection")
             return ModelConnectionTestResult(
                 success=False,
-                message=f"Unexpected error: {str(e)}",
+                message=(
+                    "The connection test could not be completed due to an "
+                    "internal error. Please try again."
+                ),
                 provider=provider,
                 model_name=model_name,
             )

--- a/apps/backend/src/rhesis/backend/app/services/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_set.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from typing import Any, Dict, List
 from uuid import UUID
 
+from pydantic import ValidationError
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, contains_eager
 
 from rhesis.backend.app import models, schemas
@@ -363,8 +365,20 @@ def bulk_create_test_set(
         # Transaction commit/rollback is handled by the session context manager
         return test_set
 
+    except ValidationError as e:
+        # The uploaded test set is malformed -- the caller's fault, so it must not
+        # be laundered into a bare Exception. Reported as which fields failed and
+        # why: pydantic's own str() echoes the submitted values back.
+        problems = "; ".join(
+            f"{'.'.join(str(part) for part in err['loc'])}: {err['msg']}" for err in e.errors()
+        )
+        raise ValueError(f"Invalid test set data: {problems}") from e
+    except IntegrityError:
+        # A constraint the caller tripped (duplicate name, bad reference). Left
+        # intact so the router's handle_database_exceptions can map it to a 4xx.
+        raise
     except Exception as e:
-        raise Exception(f"Failed to create test set: {str(e)}")
+        raise Exception(f"Failed to create test set: {str(e)}") from e
 
 
 def create_test_set_associations(
@@ -1060,12 +1074,20 @@ def _submit_test_configuration_for_execution(
             current_user=current_user,
             db=db,
         )
-    except Exception as exc:
+    except Exception:
         # Mark the queued test run as failed so it doesn't stay stuck
         from rhesis.backend.tasks.enums import RunStatus
         from rhesis.backend.tasks.execution.run import update_test_run_status
 
-        update_test_run_status(db, test_run, RunStatus.FAILED.value, error=str(exc))
+        # Same rule as the response: the stored text is shown in the UI, and a
+        # broker error carries the connection string with it. Full text in the log.
+        logger.exception("Failed to submit test configuration %s for execution", test_config_id)
+        update_test_run_status(
+            db,
+            test_run,
+            RunStatus.FAILED.value,
+            error="Failed to submit the test run for execution.",
+        )
         db.commit()
         raise
 

--- a/apps/backend/src/rhesis/backend/app/services/tool/mcp/exceptions.py
+++ b/apps/backend/src/rhesis/backend/app/services/tool/mcp/exceptions.py
@@ -4,9 +4,16 @@ import logging
 
 from fastapi import HTTPException
 
+from rhesis.backend.app.error_handlers import UpstreamHTTPException
 from rhesis.sdk.agents.mcp.exceptions import MCPApplicationError, MCPError
 
 logger = logging.getLogger(__name__)
+
+
+def _already_logged(exc: HTTPException) -> HTTPException:
+    """Mark an exception this function has logged, so the global handler won't repeat it."""
+    exc.rhesis_logged = True
+    return exc
 
 
 def handle_mcp_exception(e: Exception, operation: str) -> HTTPException:
@@ -18,29 +25,39 @@ def handle_mcp_exception(e: Exception, operation: str) -> HTTPException:
         operation: Description of operation (e.g., "search", "extract", "query")
 
     Returns:
-        HTTPException with appropriate status code and message
+        HTTPException with appropriate status code and message. Rejected
+        credentials and connection failures come back as an
+        ``UpstreamHTTPException``, so the reason survives 5xx masking: those
+        describe the user's own MCP server, which is the one thing they can act
+        on. Everything else is masked by the global handler.
     """
     if isinstance(e, MCPError):
         # All MCP errors have status_code set by their __init__
         status_code = e.status_code if e.status_code else 500
 
-        # For MCPApplicationError, use the detail attribute directly to avoid redundant prefixes
-        # For other errors, use the string representation
-        if isinstance(e, MCPApplicationError):
-            message = e.detail
-        else:
-            message = str(e)
+        # MCPApplicationError.detail is the MCP server's own response text, so it
+        # is the user's to read. Every other message was written by our own code.
+        upstream_detail = e.detail if isinstance(e, MCPApplicationError) else None
+        message = upstream_detail if upstream_detail is not None else str(e)
 
-        # Map MCP authentication errors (401, 403) to 502 Bad Gateway
-        # These are external service auth issues, not user session issues
-        # This prevents the frontend from logging users out when MCP tools have auth problems
-        if status_code in {401, 403} and e.category == "application":
+        # A tool's 401/403 is its own token being rejected, not the caller's
+        # Rhesis session: answering 401 here makes the frontend log them out.
+        tool_auth_failed = status_code in {401, 403} and e.category == "application"
+        if tool_auth_failed:
             status_code = 502
-            message = f"MCP tool authentication failed: {message}"
+            message = (
+                f"MCP tool authentication failed: {upstream_detail}"
+                if upstream_detail
+                else "MCP tool authentication failed."
+            )
+
+        # Rejected credentials or an unreachable server describe the user's own
+        # MCP setup; nothing of ours is in either message.
+        from_users_mcp_server = tool_auth_failed or e.category == "connection"
 
         # Log based on severity (client errors vs server errors)
         original_error_name = type(e.original_error).__name__ if e.original_error else None
-        if status_code >= 500:
+        if status_code >= 500 and not from_users_mcp_server:
             logger.error(
                 f"MCP {operation} error [{e.category}] ({status_code}): {message}",
                 exc_info=True,
@@ -52,11 +69,14 @@ def handle_mcp_exception(e: Exception, operation: str) -> HTTPException:
                 extra={"category": e.category, "original_error": original_error_name},
             )
 
-        return HTTPException(status_code=status_code, detail=message)
+        exception_class = UpstreamHTTPException if from_users_mcp_server else HTTPException
+        return _already_logged(exception_class(status_code=status_code, detail=message))
 
     # Non-MCP errors
     logger.error(f"Unexpected error in MCP {operation}: {str(e)}", exc_info=True)
-    return HTTPException(
-        status_code=500,
-        detail=f"An unexpected error occurred during {operation}. Please try again.",
+    return _already_logged(
+        HTTPException(
+            status_code=500,
+            detail=f"An unexpected error occurred during {operation}. Please try again.",
+        )
     )

--- a/apps/backend/src/rhesis/backend/app/utils/execution_validation.py
+++ b/apps/backend/src/rhesis/backend/app/utils/execution_validation.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import get_tenant_db_session
+from rhesis.backend.app.error_handlers import internal_error
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 from rhesis.backend.app.utils.user_model_utils import (
@@ -133,10 +134,5 @@ def handle_execution_error(error: Exception, operation: str = "execute tests") -
         logger.warning(f"Permission denied for {operation}: {str(error)}")
         return HTTPException(status_code=403, detail=str(error))
 
-    # Unexpected error - include error details for better debugging
-    error_msg = str(error) if str(error) else "An unexpected error occurred"
-    logger.error(f"Failed to {operation}: {error_msg}", exc_info=True)
-    return HTTPException(
-        status_code=500,
-        detail=f"Failed to {operation}: {error_msg}",
-    )
+    # Unexpected: the reason goes to the log with a stack, not to the caller.
+    return internal_error(error, context=f"failed to {operation}")

--- a/apps/backend/src/rhesis/backend/app/utils/request_context.py
+++ b/apps/backend/src/rhesis/backend/app/utils/request_context.py
@@ -1,0 +1,89 @@
+"""Per-request correlation ID.
+
+The ID ties a generic error response back to the log line that holds the real
+traceback: the client is told ``error_id``, the logs carry the same value.
+"""
+
+import re
+import uuid
+from contextvars import ContextVar, Token
+from typing import Optional
+
+REQUEST_ID_HEADER = b"x-request-id"
+
+_request_id: ContextVar[str] = ContextVar("request_id", default="")
+
+# An inbound ID is attacker-controlled and lands in log lines, so anything that
+# could forge a newline or bloat the log is dropped rather than escaped.
+_SAFE_INBOUND_ID = re.compile(r"^[A-Za-z0-9_\-]{1,64}$")
+
+
+def new_request_id() -> str:
+    return uuid.uuid4().hex[:12]
+
+
+def get_request_id() -> str:
+    """Current request's ID, or "" outside a request (scripts, Celery)."""
+    return _request_id.get()
+
+
+def set_request_id(value: str) -> Token:
+    return _request_id.set(value)
+
+
+def reset_request_id(token: Token) -> None:
+    _request_id.reset(token)
+
+
+class RequestIDMiddleware:
+    """Assign every request an ID, and echo it as ``X-Request-ID``.
+
+    Deliberately not a ``BaseHTTPMiddleware``: that one runs the downstream app
+    in a new anyio task, and this ContextVar has to stay readable both
+    downstream (log records) and back up in the exception handlers above it.
+    Pure ASGI keeps everything in one task, so both directions see the value.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        request_id = _inbound_id(scope) or new_request_id()
+        token = set_request_id(request_id)
+        # Also on the scope so handlers can read request.state.request_id.
+        scope.setdefault("state", {})["request_id"] = request_id
+
+        async def send_with_header(message):
+            if message["type"] == "http.response.start":
+                headers = message.setdefault("headers", [])
+                headers.append((REQUEST_ID_HEADER, request_id.encode("latin-1")))
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_with_header)
+        finally:
+            reset_request_id(token)
+
+
+def request_id_of(request) -> str:
+    """The id for ``request``, preferring the scope over the ContextVar.
+
+    Exception handlers run in Starlette's ServerErrorMiddleware, which sits
+    *outside* this middleware -- by the time an exception surfaces there the
+    ContextVar has already been reset on the way out. The scope is the same
+    dict object throughout, so it still carries the id.
+    """
+    return getattr(request.state, "request_id", "") or get_request_id()
+
+
+def _inbound_id(scope) -> Optional[str]:
+    """Reuse the proxy's ID when it supplies a safe-looking one."""
+    for name, value in scope.get("headers", []):
+        if name.lower() == REQUEST_ID_HEADER:
+            candidate = value.decode("latin-1", errors="replace")
+            return candidate if _SAFE_INBOUND_ID.match(candidate) else None
+    return None

--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -22,17 +22,126 @@ LOG_FORMAT = "%(asctime)s - %(role_prefix)s%(request_prefix)s%(name)s - %(leveln
 LOG_DATE_FORMAT = "%m/%d/%Y %I:%M:%S%p"
 
 
+#: Value characters. Stops where a value ends in prose, JSON or a dict repr;
+#: excluding brackets and backslashes also stops an inserted ``[REDACTED]`` from
+#: being matched again by a later pattern.
+_VALUE = r"[^\s\"',;)}\[\]\\]+"
+
+#: Optional quote around the separator, so a logged header dict repr still
+#: matches: ``{'Authorization': 'Bearer ...'}``.
+_SEP = r"[\"']?\s*[:=]\s*[\"']?\s*"
+
+#: A few words may sit between the keyword and the separator. OpenAI's and
+#: Anthropic's auth-error bodies read "Incorrect API key provided: sk-...", and
+#: those bodies reach our logs verbatim through the endpoint invoker.
+_FILLER = r"(?:\s+\w+){0,3}?"
+
+#: Words that follow a secret keyword in ordinary diagnostics. Redacting these
+#: hides the very thing the line was written to say.
+_NON_SECRET_VALUES = frozenset(
+    {
+        "blank",
+        "configured",
+        "empty",
+        "expired",
+        "false",
+        "found",
+        "invalid",
+        "missing",
+        "nil",
+        "no",
+        "none",
+        "not",
+        "null",
+        "present",
+        "provided",
+        "redacted",
+        "required",
+        "set",
+        "true",
+        "unknown",
+        "unset",
+    }
+)
+
+
+def _looks_like_secret(value: str) -> bool:
+    """Whether a keyword's captured value is credential-shaped rather than prose."""
+    parts = [part for part in re.split(r"[-_]", value) if part]
+    if parts and all(part.lower() in _NON_SECRET_VALUES for part in parts):
+        return False
+    # A plain lowercase word is prose; credentials carry digits, case or separators.
+    if value.isalpha() and value.islower():
+        return False
+    return len(value) >= 12 or any(char.isdigit() for char in value)
+
+
+def _redact_if_secret(match: re.Match) -> str:
+    """Replacement for keyword patterns: group 1 is the prefix, group 2 the value."""
+    if _looks_like_secret(match.group(2)):
+        return f"{match.group(1)}[REDACTED]"
+    return match.group(0)
+
+
 _SENSITIVE_PATTERNS = [
+    # Shape-based first: these need no keyword beside them, which is the only way
+    # to catch a key quoted inside an upstream error body or a traceback frame.
     (
-        re.compile(r"(authorization:\s*Bearer\s+)[\w\-\.]+", re.IGNORECASE),
+        re.compile(r"\beyJ[\w\-\.]+\.eyJ[\w\-\.]+\.[\w\-\.]+", re.IGNORECASE),
+        r"[REDACTED_JWT]",
+    ),
+    (
+        re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}", re.IGNORECASE),
+        r"[REDACTED]",
+    ),
+    (
+        re.compile(r"\b(?:gh[pousr]_|github_pat_)[A-Za-z0-9_]{16,}", re.IGNORECASE),
+        r"[REDACTED]",
+    ),
+    (
+        re.compile(r"\bxox[abprs]-[A-Za-z0-9\-]{10,}", re.IGNORECASE),
+        r"[REDACTED]",
+    ),
+    (
+        re.compile(r"\bAIza[0-9A-Za-z_\-]{30,}", re.IGNORECASE),
+        r"[REDACTED]",
+    ),
+    (
+        re.compile(r"(rh-[\w]{40,})", re.IGNORECASE),
+        r"rh-[REDACTED]",
+    ),
+    (
+        re.compile(r"(AKIA[\w]{16})", re.IGNORECASE),
+        r"AKIA[REDACTED]",
+    ),
+    # Any scheme's userinfo password. Enumerating schemes missed both of ours:
+    # SQLAlchemy writes "postgresql+psycopg2://" and the Celery broker "redis://".
+    (
+        re.compile(r"\b([a-z][a-z0-9+.\-]*://[^:/\s@]*:)([^@\s/]+)(@)", re.IGNORECASE),
+        r"\1[REDACTED]\3",
+    ),
+    # Header name touching its value: unambiguously a credential, no shape check.
+    (
+        re.compile(rf"(authorization{_SEP}Bearer\s+)[\w\-\.]+", re.IGNORECASE),
         r"\1[REDACTED]",
     ),
     (
-        re.compile(r"(authorization:\s*Basic\s+)[\w\+/=]+", re.IGNORECASE),
+        re.compile(rf"(authorization{_SEP}Basic\s+)[\w\+/=]+", re.IGNORECASE),
         r"\1[REDACTED]",
     ),
+    # The lookahead stops this from re-redacting the "Bearer"/"Basic" left behind
+    # by the two patterns above.
     (
-        re.compile(r"(authorization:\s*)[\w\-\.]+", re.IGNORECASE),
+        re.compile(
+            rf"(authorization{_SEP})(?!Bearer\b|Basic\b)[\w\-\.]+",
+            re.IGNORECASE,
+        ),
+        r"\1[REDACTED]",
+    ),
+    # A Bearer token with no header name in reach -- rest_invoker logs whole
+    # header dicts, and nesting puts the token well away from any name.
+    (
+        re.compile(r"\b(Bearer\s+)(?!token\b|auth)[\w\-\.=+/]{8,}", re.IGNORECASE),
         r"\1[REDACTED]",
     ),
     (
@@ -45,101 +154,56 @@ _SENSITIVE_PATTERNS = [
     ),
     (
         re.compile(
-            r"(x-[a-z\-]*(?:api|auth|token)[a-z\-]*:\s*)[\w\-\.]+",
+            rf"(x-[a-z\-]*(?:api|auth|token)[a-z\-]*{_SEP})[\w\-\.]+",
             re.IGNORECASE,
         ),
         r"\1[REDACTED]",
     ),
-    # A space is a separator too, not just - and _: an upstream service's own
-    # error body says "invalid api key: sk-live-..." in prose, and that body
-    # reaches us verbatim. Only a space -- \s would let a match jump log lines.
+    # Keyword patterns. A space is a separator too, not just - and _: an upstream
+    # service's own error body says "invalid api key: sk-live-..." in prose. The
+    # value is only redacted when it looks like a credential, so a diagnostic
+    # ("api key: not configured") still reads.
+    (
+        re.compile(rf"(api[-_ ]?key{_FILLER}{_SEP})({_VALUE})", re.IGNORECASE),
+        _redact_if_secret,
+    ),
+    (
+        re.compile(rf"(password{_FILLER}{_SEP})({_VALUE})", re.IGNORECASE),
+        _redact_if_secret,
+    ),
+    (
+        re.compile(rf"(client[-_ ]?secret{_FILLER}{_SEP})({_VALUE})", re.IGNORECASE),
+        _redact_if_secret,
+    ),
     (
         re.compile(
-            r"(api[-_ ]?key[\"']?\s*[:=]\s*[\"']?)[\w\-]+",
+            rf"(aws[-_ ]?secret[-_ ]?(?:access[-_ ]?)?key{_FILLER}{_SEP})({_VALUE})",
             re.IGNORECASE,
         ),
-        r"\1[REDACTED]",
+        _redact_if_secret,
     ),
     (
-        re.compile(r"(rh-[\w]{40,})", re.IGNORECASE),
-        r"rh-[REDACTED]",
+        re.compile(rf"(secret{_FILLER}{_SEP})({_VALUE})", re.IGNORECASE),
+        _redact_if_secret,
     ),
     (
         re.compile(
-            r"(password[\"']?\s*[:=]\s*[\"']?)[^\s\"']+",
+            rf"((?:session|access|refresh)[-_ ]?token{_FILLER}{_SEP})({_VALUE})",
             re.IGNORECASE,
         ),
-        r"\1[REDACTED]",
+        _redact_if_secret,
     ),
     (
         re.compile(
-            r"(secret[\"']?\s*[:=]\s*[\"']?)[\w\-\.]+",
-            re.IGNORECASE,
-        ),
-        r"\1[REDACTED]",
-    ),
-    (
-        re.compile(
-            r"(session[-_ ]?token[\"']?\s*[:=]\s*[\"']?)[\w\-\.]+",
-            re.IGNORECASE,
-        ),
-        r"\1[REDACTED]",
-    ),
-    (
-        re.compile(
-            r"\beyJ[\w\-\.]+\.eyJ[\w\-\.]+\.[\w\-\.]+",
-            re.IGNORECASE,
-        ),
-        r"[REDACTED_JWT]",
-    ),
-    (
-        re.compile(
-            r"((?:access|refresh)[-_ ]?token[\"']?\s*[:=]\s*[\"']?)"
-            r"[\w\-\.]+",
-            re.IGNORECASE,
-        ),
-        r"\1[REDACTED]",
-    ),
-    (
-        re.compile(
-            r"(client[-_ ]?secret[\"']?\s*[:=]\s*[\"']?)[\w\-]+",
-            re.IGNORECASE,
-        ),
-        r"\1[REDACTED]",
-    ),
-    (
-        re.compile(
-            r"((?:postgres|mysql|mongodb)://[^:]+:)([^@]+)(@)",
-            re.IGNORECASE,
-        ),
-        r"\1[REDACTED]\3",
-    ),
-    (
-        re.compile(r"(AKIA[\w]{16})", re.IGNORECASE),
-        r"AKIA[REDACTED]",
-    ),
-    (
-        re.compile(
-            r"(aws[-_ ]?secret[-_ ]?(?:access[-_ ]?)?key[\"']?"
-            r"\s*[:=]\s*[\"']?)[\w\+/=]+",
-            re.IGNORECASE,
-        ),
-        r"\1[REDACTED]",
-    ),
-    (
-        re.compile(
-            r"(private_key[\"']?\s*[:=]\s*[\"']?)"
+            rf"(private_key{_SEP})"
             r"-----BEGIN[^-]+-----[^-]+-----END[^-]+-----",
             re.IGNORECASE,
         ),
         r"\1[REDACTED_PRIVATE_KEY]",
     ),
     (
-        re.compile(
-            r"(token[\"']?\s*[:=]\s*[\"']?)[\w\-\.]{20,}",
-            re.IGNORECASE,
-        ),
-        r"\1[REDACTED]",
+        re.compile(rf"(token{_FILLER}{_SEP})([\w\-\.]{{20,}})", re.IGNORECASE),
+        _redact_if_secret,
     ),
 ]
 
@@ -202,6 +266,14 @@ class JsonLogFormatter(logging.Formatter):
             "module": record.name,
             "message": f"{record.name}: {record.getMessage()}",
         }
+        # Without this a logger.exception() reaches GCP with no frames at all;
+        # stack_trace is the key Error Reporting parses. Redaction still applies:
+        # set_logger wraps this formatter in RedactingFormatter, which redacts the
+        # serialised payload, traceback text included.
+        if record.exc_info:
+            payload["stack_trace"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack_info"] = self.formatStack(record.stack_info)
         for field in _STRUCTURED_EXTRA_FIELDS:
             value = getattr(record, field, None)
             if value is not None:
@@ -222,7 +294,9 @@ class _WorkerContextFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         record.worker_role = self.worker_role
         record.role_prefix = f"[{self.worker_role}] - " if self.worker_role else ""
-        request_id = get_request_id()
+        # unhandled_exception_handler runs outside RequestIDMiddleware, so it
+        # passes request_id through extra= after the ContextVar was reset.
+        request_id = getattr(record, "request_id", None) or get_request_id()
         record.request_id = request_id or None
         record.request_prefix = f"[{request_id}] " if request_id else ""
         return True

--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from pathlib import Path
 
 from rhesis.backend.app.config.settings import get_application_settings, get_logging_settings
+from rhesis.backend.app.utils.request_context import get_request_id
 
 application_settings = get_application_settings()
 logging_settings = get_logging_settings()
@@ -17,7 +18,7 @@ ENVIRONMENT = application_settings.backend_env
 JSON_LOGGER_ENABLED = application_settings.json_logger_enabled
 DEV_MODE = application_settings.dev_mode
 # role_prefix is "" for API; Celery workers get "[MAIN] - " via the filter.
-LOG_FORMAT = "%(asctime)s - %(role_prefix)s%(name)s - %(levelname)s - %(message)s"
+LOG_FORMAT = "%(asctime)s - %(role_prefix)s%(request_prefix)s%(name)s - %(levelname)s - %(message)s"
 LOG_DATE_FORMAT = "%m/%d/%Y %I:%M:%S%p"
 
 
@@ -177,6 +178,8 @@ class RedactingFormatter(logging.Formatter):
 #: one nobody can rely on. Add a key here when you want to query by it.
 _STRUCTURED_EXTRA_FIELDS = (
     "worker_role",
+    # Ties a client's error_id to the log line holding the traceback.
+    "request_id",
     # rhesis.backend.app.utils.usage_tracking -- token usage that could not be
     # billed to an org, or came from a model with no provenance stamp. Alerting
     # on these needs them as fields, not as prose inside `message`.
@@ -204,7 +207,10 @@ class JsonLogFormatter(logging.Formatter):
 
 
 class _WorkerContextFilter(logging.Filter):
-    """Stamp ``worker_role`` / ``role_prefix`` on every record (empty for API)."""
+    """Stamp ``worker_role`` / ``role_prefix`` / ``request_id`` on every record.
+
+    All empty outside a request (API startup, Celery, scripts).
+    """
 
     def __init__(self, worker_role: str | None = None):
         super().__init__()
@@ -213,6 +219,9 @@ class _WorkerContextFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         record.worker_role = self.worker_role
         record.role_prefix = f"[{self.worker_role}] - " if self.worker_role else ""
+        request_id = get_request_id()
+        record.request_id = request_id or None
+        record.request_prefix = f"[{request_id}] " if request_id else ""
         return True
 
 

--- a/apps/backend/src/rhesis/backend/logging/logging_config.py
+++ b/apps/backend/src/rhesis/backend/logging/logging_config.py
@@ -50,9 +50,12 @@ _SENSITIVE_PATTERNS = [
         ),
         r"\1[REDACTED]",
     ),
+    # A space is a separator too, not just - and _: an upstream service's own
+    # error body says "invalid api key: sk-live-..." in prose, and that body
+    # reaches us verbatim. Only a space -- \s would let a match jump log lines.
     (
         re.compile(
-            r"(api[-_]?key[\"']?\s*[:=]\s*[\"']?)[\w\-]+",
+            r"(api[-_ ]?key[\"']?\s*[:=]\s*[\"']?)[\w\-]+",
             re.IGNORECASE,
         ),
         r"\1[REDACTED]",
@@ -77,7 +80,7 @@ _SENSITIVE_PATTERNS = [
     ),
     (
         re.compile(
-            r"(session[-_]?token[\"']?\s*[:=]\s*[\"']?)[\w\-\.]+",
+            r"(session[-_ ]?token[\"']?\s*[:=]\s*[\"']?)[\w\-\.]+",
             re.IGNORECASE,
         ),
         r"\1[REDACTED]",
@@ -91,7 +94,7 @@ _SENSITIVE_PATTERNS = [
     ),
     (
         re.compile(
-            r"((?:access|refresh)[-_]?token[\"']?\s*[:=]\s*[\"']?)"
+            r"((?:access|refresh)[-_ ]?token[\"']?\s*[:=]\s*[\"']?)"
             r"[\w\-\.]+",
             re.IGNORECASE,
         ),
@@ -99,7 +102,7 @@ _SENSITIVE_PATTERNS = [
     ),
     (
         re.compile(
-            r"(client[-_]?secret[\"']?\s*[:=]\s*[\"']?)[\w\-]+",
+            r"(client[-_ ]?secret[\"']?\s*[:=]\s*[\"']?)[\w\-]+",
             re.IGNORECASE,
         ),
         r"\1[REDACTED]",
@@ -117,7 +120,7 @@ _SENSITIVE_PATTERNS = [
     ),
     (
         re.compile(
-            r"(aws[-_]?secret[-_]?(?:access[-_]?)?key[\"']?"
+            r"(aws[-_ ]?secret[-_ ]?(?:access[-_ ]?)?key[\"']?"
             r"\s*[:=]\s*[\"']?)[\w\+/=]+",
             re.IGNORECASE,
         ),

--- a/tests/backend/app/test_logging_security.py
+++ b/tests/backend/app/test_logging_security.py
@@ -1,6 +1,9 @@
 """Tests to verify that sensitive information is not logged."""
 
+import pytest
+
 from rhesis.backend.app.services.invokers.common.headers import HeaderManager
+from rhesis.backend.logging.logging_config import _redact
 
 
 class TestHeaderSanitization:
@@ -171,3 +174,43 @@ class TestHeaderSanitization:
             assert sanitized[keyword.upper()] == "***REDACTED***", (
                 f"Keyword '{keyword}' was not properly redacted"
             )
+
+
+class TestLogLineRedaction:
+    """Credentials that reach a log *message* rather than a header.
+
+    Upstream services describe their own auth failures in prose, and that text
+    comes back to us verbatim -- through an endpoint test, an invoker error, a
+    traceback. The formatter is the last place to catch it.
+    """
+
+    @pytest.mark.parametrize(
+        "line,secret",
+        [
+            # Space-separated, as an upstream error body actually phrases it.
+            ('{"error":"invalid api key: sk-live-9f8e7d6c"}', "sk-live-9f8e7d6c"),
+            ("upstream said: client secret = abc123def", "abc123def"),
+            ("aws secret access key: AbC123xyz", "AbC123xyz"),
+            ("session token: tok-abc-123", "tok-abc-123"),
+            ("refresh token = 0123456789abcdef", "0123456789abcdef"),
+            # The pre-existing separators must keep working.
+            ("api_key: sk-underscore-style", "sk-underscore-style"),
+            ("api-key=sk-dash-style", "sk-dash-style"),
+        ],
+    )
+    def test_secret_in_message_is_redacted(self, line, secret):
+        redacted = _redact(line)
+        assert secret not in redacted
+        assert "[REDACTED]" in redacted
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "the api key was missing from the request",
+            "No api keys configured for this project",
+            "client secret rotation is due",
+        ],
+    )
+    def test_prose_without_a_value_is_left_alone(self, line):
+        """Over-redaction hides the diagnosis, so a bare mention must survive."""
+        assert _redact(line) == line

--- a/tests/backend/app/test_logging_security.py
+++ b/tests/backend/app/test_logging_security.py
@@ -1,9 +1,24 @@
 """Tests to verify that sensitive information is not logged."""
 
+import io
+import json
+import logging
+
 import pytest
 
 from rhesis.backend.app.services.invokers.common.headers import HeaderManager
-from rhesis.backend.logging.logging_config import _redact
+from rhesis.backend.logging.logging_config import (
+    JsonLogFormatter,
+    RedactingFormatter,
+    _redact,
+    _WorkerContextFilter,
+)
+
+
+# Assembled at runtime so secret scanners -- GitHub push protection and the
+# trufflehog CI job -- do not read these fixtures as live credentials.
+_FAKE_SLACK_TOKEN = "xoxb-" + "1234567890-" + "abcdefghijklmno"
+_FAKE_PW = "p4ss" + "w0rd"
 
 
 class TestHeaderSanitization:
@@ -209,8 +224,170 @@ class TestLogLineRedaction:
             "the api key was missing from the request",
             "No api keys configured for this project",
             "client secret rotation is due",
+            # A separator is present, but the value is prose rather than a key.
+            "api key: not configured",
+            "api key = missing for organization 42",
+            "API key: none",
+            "client secret: unset",
+            "session token: expired at 2026-01-01",
+            "access token: null",
+            "refresh token = invalid",
+            "password: empty",
+            "password: rotated",
+            "api key: not_configured",
+            "Bearer token is missing",
         ],
     )
     def test_prose_without_a_value_is_left_alone(self, line):
         """Over-redaction hides the diagnosis, so a bare mention must survive."""
         assert _redact(line) == line
+
+    @pytest.mark.parametrize(
+        "line,secret",
+        [
+            # No keyword touches the value here -- only the key's own shape does.
+            (
+                "Incorrect API key provided: sk-proj-aBcD1234EfGh5678",
+                "sk-proj-aBcD1234EfGh5678",
+            ),
+            (
+                "anthropic api-key sk-ant-api03-XYZabc123DEFghi456jkl",
+                "sk-ant-api03-XYZabc123DEFghi456jkl",
+            ),
+            (
+                "fatal: token ghp_abcdefghij1234567890ABCDEFGHIJ rejected",
+                "ghp_abcdefghij1234567890ABCDEFGHIJ",
+            ),
+            (
+                "github_pat_11ABCDEFG0abcdefghij_klmnop",
+                "github_pat_11ABCDEFG0abcdefghij_klmnop",
+            ),
+            (f"slack said {_FAKE_SLACK_TOKEN}", _FAKE_SLACK_TOKEN),
+            (
+                "AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZ0123456 is not valid",
+                "AIzaSyABCDEFGHIJKLMNOPQRSTUVWXYZ0123456",
+            ),
+        ],
+    )
+    def test_key_shape_is_redacted_without_a_keyword(self, line, secret):
+        redacted = _redact(line)
+        assert secret not in redacted
+        assert "[REDACTED]" in redacted
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # rest_invoker logs the whole header dict; its repr puts quotes
+            # between the header name and the token.
+            "headers={'Authorization': 'Bearer sk-live-abc123def456'}",
+            '{"Authorization": "Bearer sk-live-abc123def456"}',
+            # No header name in reach at all.
+            "Bearer sk-live-abc123def456",
+        ],
+    )
+    def test_bearer_token_is_redacted_away_from_its_header_name(self, line):
+        redacted = _redact(line)
+        assert "sk-live-abc123def456" not in redacted
+        assert "[REDACTED]" in redacted
+
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # SQLAlchemy and the Celery broker write these exact schemes.
+            f"postgresql://user:{_FAKE_PW}@host/db",
+            f"postgresql+psycopg2://user:{_FAKE_PW}@host:5432/db",
+            f"redis://default:{_FAKE_PW}@broker:6379/0",
+            f"rediss://default:{_FAKE_PW}@broker:6379/0",
+            f"amqps://guest:{_FAKE_PW}@rabbit:5671//",
+            f"https://user:{_FAKE_PW}@example.com/callback",
+        ],
+    )
+    def test_connection_url_password_is_redacted(self, line):
+        redacted = _redact(line)
+        assert _FAKE_PW not in redacted
+        assert "[REDACTED]" in redacted
+
+    def test_url_without_credentials_is_left_alone(self):
+        line = "GET https://api.example.com/v1/things failed with 503"
+        assert _redact(line) == line
+
+    def test_bearer_token_is_redacted_once(self):
+        """The generic authorization pattern must not re-fire on "Bearer"."""
+        redacted = _redact("Authorization: Bearer sk-live-abc123def456")
+        assert redacted == "Authorization: Bearer [REDACTED]"
+
+    def test_redaction_stops_at_the_value_boundary(self):
+        """A greedy value class swallowed the comma and the next field with it."""
+        redacted = _redact("password: hunter2, user: bob")
+        assert redacted == "password: [REDACTED], user: bob"
+
+
+class TestJsonLogFormatterTraceback:
+    """The JSON formatter is the one every deployed environment uses.
+
+    The routers no longer log their own context -- they rely on the global
+    exception handler's traceback -- so a JSON line without frames loses the
+    error entirely.
+    """
+
+    @staticmethod
+    def _emit(logger_call) -> dict:
+        """Run *logger_call* through the real handler chain and parse the line."""
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(RedactingFormatter(JsonLogFormatter()))
+        handler.addFilter(_WorkerContextFilter(None))
+        logger = logging.getLogger("test_logging_security.json")
+        logger.handlers = [handler]
+        logger.propagate = False
+        logger.setLevel(logging.DEBUG)
+        try:
+            logger_call(logger)
+        finally:
+            logger.handlers = []
+        return json.loads(stream.getvalue())
+
+    def test_exception_carries_the_traceback(self):
+        def emit(logger):
+            try:
+                raise RuntimeError("upstream refused the call")
+            except RuntimeError:
+                logger.exception("Unhandled error in endpoint")
+
+        payload = self._emit(emit)
+        stack = payload["stack_trace"]
+        assert "Traceback (most recent call last)" in stack
+        assert "RuntimeError: upstream refused the call" in stack
+        assert "test_logging_security.py" in stack
+
+    def test_traceback_text_is_redacted(self):
+        def emit(logger):
+            try:
+                raise RuntimeError("Incorrect API key provided: sk-proj-aBcD1234EfGh5678")
+            except RuntimeError:
+                logger.exception("Unhandled error in endpoint")
+
+        payload = self._emit(emit)
+        assert "sk-proj-aBcD1234EfGh5678" not in json.dumps(payload)
+        assert "[REDACTED]" in payload["stack_trace"]
+
+    def test_stack_info_is_included(self):
+        payload = self._emit(lambda logger: logger.error("no exception", stack_info=True))
+        assert "Stack (most recent call last)" in payload["stack_info"]
+
+    def test_plain_record_has_no_traceback_fields(self):
+        payload = self._emit(lambda logger: logger.info("nothing wrong"))
+        assert "stack_trace" not in payload
+        assert "stack_info" not in payload
+
+    def test_explicit_request_id_survives_the_filter(self):
+        """The global handler runs outside RequestIDMiddleware, so it passes the
+        id via extra=; the filter used to overwrite it with the reset ContextVar."""
+        payload = self._emit(
+            lambda logger: logger.error("boom", extra={"request_id": "abc123def456"})
+        )
+        assert payload["request_id"] == "abc123def456"
+
+    def test_request_id_is_absent_outside_a_request(self):
+        payload = self._emit(lambda logger: logger.info("startup"))
+        assert "request_id" not in payload

--- a/tests/backend/routes/test_connector.py
+++ b/tests/backend/routes/test_connector.py
@@ -150,7 +150,10 @@ class TestConnectorHTTPEndpoints:
 
             assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
             data = response.json()
-            assert "failed" in data["detail"].lower()
+            # 5xx detail is generic by design; the real reason goes to the logs
+            # under this error_id. See app/error_handlers.py.
+            assert data["detail"] == "An unexpected error occurred."
+            assert data["error_id"]
 
     def test_trigger_test_project_not_a_member(self, authenticated_client: TestClient):
         """Test trigger when the user is not a member of the requested project.

--- a/tests/backend/routes/test_connector.py
+++ b/tests/backend/routes/test_connector.py
@@ -150,9 +150,9 @@ class TestConnectorHTTPEndpoints:
 
             assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
             data = response.json()
-            # 5xx detail is generic by design; the real reason goes to the logs
-            # under this error_id. See app/error_handlers.py.
-            assert data["detail"] == "An unexpected error occurred."
+            # A deliberate, secret-free message (PublicHTTPException) reaches the
+            # caller unmasked -- their SDK client dropped the request.
+            assert "failed" in data["detail"].lower()
             assert data["error_id"]
 
     def test_trigger_test_project_not_a_member(self, authenticated_client: TestClient):

--- a/tests/backend/routes/test_execution_validation.py
+++ b/tests/backend/routes/test_execution_validation.py
@@ -273,14 +273,16 @@ class TestHandleExecutionError:
         assert "user does not have access" in str(result.detail).lower()
 
     def test_handle_generic_exception(self):
-        """Test generic exceptions are converted to 500."""
+        """Test generic exceptions are converted to a masked 500."""
         error = RuntimeError("Something unexpected happened")
 
         result = handle_execution_error(error, "execute test configuration")
 
         assert result.status_code == 500
-        assert "execute test configuration" in str(result.detail).lower()
-        assert "something unexpected happened" in str(result.detail).lower()
+        # The reason belongs in the log, not the response. See app/error_handlers.py.
+        assert result.detail == "An unexpected error occurred."
+        assert "something unexpected happened" not in str(result.detail).lower()
+        assert getattr(result, "rhesis_logged", False) is True
 
 
 class TestErrorMessageContent:

--- a/tests/backend/routes/test_services.py
+++ b/tests/backend/routes/test_services.py
@@ -70,8 +70,9 @@ class TestGenerateContentEndpoint:
                 )
 
             assert exc_info.value.status_code == 400
-            assert "Failed to generate content:" in str(exc_info.value.detail)
-            assert "Model initialization failed" in str(exc_info.value.detail)
+            # The provider's own error text stays in the logs, not the response.
+            assert str(exc_info.value.detail) == "Failed to generate content"
+            assert "Model initialization failed" not in str(exc_info.value.detail)
 
 
 class TestGenerateEmbeddingEndpoint:
@@ -99,7 +100,9 @@ class TestGenerateEmbeddingEndpoint:
                 generate_embedding_endpoint(mock_request, db=mock_db, current_user=mock_user)
 
             assert exc_info.value.status_code == 400
-            assert "Failed to generate embedding:" in str(exc_info.value.detail)
+            # The provider's own error text stays in the logs, not the response.
+            assert str(exc_info.value.detail) == "Failed to generate embedding"
+            assert "Provider rejected the request" not in str(exc_info.value.detail)
 
     def test_recursive_native_provider_returns_500_not_400(self):
         """DEFAULT_EMBEDDING_MODEL resolving back to RhesisEmbedder is a server

--- a/tests/backend/routes/test_services.py
+++ b/tests/backend/routes/test_services.py
@@ -4,11 +4,25 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastapi import HTTPException, Response
 
+from rhesis.backend.app.error_handlers import public_message
 from rhesis.backend.app.routers.services import (
     generate_content_endpoint,
     generate_embedding_endpoint,
 )
 from rhesis.backend.app.schemas.services import GenerateContentRequest, GenerateEmbeddingRequest
+from rhesis.backend.app.utils.model_errors import ModelConfigurationError
+
+
+class ProviderError(Exception):
+    """Stand-in for a litellm/openai provider error.
+
+    Those carry the status the provider answered with on ``status_code``, which
+    is what separates "the provider said no" from a bug of ours.
+    """
+
+    def __init__(self, message: str, status_code: int = 401):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class TestGenerateContentEndpoint:
@@ -47,9 +61,35 @@ class TestGenerateContentEndpoint:
             mock_get_gen.assert_called_once_with(mock_db, mock_user)
 
     @pytest.mark.asyncio
-    async def test_generate_content_endpoint_exception_handling(self):
-        """Test that exceptions are properly handled and converted to HTTPException."""
-        # Arrange
+    async def test_provider_error_keeps_the_providers_reason(self):
+        """A provider that answered with a status told the caller the one thing
+        they can act on -- "invalid api key" -- so it stays a 400 that says so."""
+        mock_request = GenerateContentRequest(
+            prompt="Generate a test function",
+            schema={"type": "object"},
+        )
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+        http_response = Response()
+
+        with patch(
+            "rhesis.backend.app.utils.user_model_utils.get_generation_model_with_override"
+        ) as mock_get_gen:
+            mock_get_gen.side_effect = ProviderError("invalid api key", status_code=401)
+
+            with pytest.raises(HTTPException) as exc_info:
+                await generate_content_endpoint(
+                    mock_request, http_response, db=mock_db, current_user=mock_user
+                )
+
+            assert exc_info.value.status_code == 400
+            assert str(exc_info.value.detail) == "Failed to generate content: invalid api key"
+
+    @pytest.mark.asyncio
+    async def test_internal_failure_is_masked(self):
+        """A failure with no provider status is ours: masked 500, logged with a
+        traceback. This is the exemption's edge -- it must not widen to cover
+        our own bugs."""
         mock_request = GenerateContentRequest(
             prompt="Generate a test function",
             schema={"type": "object"},
@@ -63,16 +103,16 @@ class TestGenerateContentEndpoint:
         ) as mock_get_gen:
             mock_get_gen.side_effect = Exception("Model initialization failed")
 
-            # Act & Assert
             with pytest.raises(HTTPException) as exc_info:
                 await generate_content_endpoint(
                     mock_request, http_response, db=mock_db, current_user=mock_user
                 )
 
-            assert exc_info.value.status_code == 400
-            # The provider's own error text stays in the logs, not the response.
-            assert str(exc_info.value.detail) == "Failed to generate content"
+            assert exc_info.value.status_code == 500
+            assert str(exc_info.value.detail) == public_message(500)
             assert "Model initialization failed" not in str(exc_info.value.detail)
+            # Logged by internal_error, so the global handler won't repeat it.
+            assert getattr(exc_info.value, "rhesis_logged", False) is True
 
 
 class TestGenerateEmbeddingEndpoint:
@@ -85,8 +125,9 @@ class TestGenerateEmbeddingEndpoint:
     input change fixes the second one.
     """
 
-    def test_plain_provider_error_returns_400(self):
-        """A provider-side failure is still a 400 — the request itself is bad."""
+    def test_plain_provider_error_returns_400_with_the_reason(self):
+        """A provider-side failure is still a 400 — the request itself is bad —
+        and the provider's reason is what makes it actionable."""
         mock_request = GenerateEmbeddingRequest(text="some text")
         mock_db = MagicMock()
         mock_user = MagicMock()
@@ -94,15 +135,57 @@ class TestGenerateEmbeddingEndpoint:
         with patch(
             "rhesis.backend.app.utils.user_model_utils.get_user_embedding_model"
         ) as mock_get_embedding_model:
-            mock_get_embedding_model.side_effect = Exception("Provider rejected the request")
+            mock_get_embedding_model.side_effect = ProviderError(
+                "context length exceeded", status_code=400
+            )
 
             with pytest.raises(HTTPException) as exc_info:
                 generate_embedding_endpoint(mock_request, db=mock_db, current_user=mock_user)
 
             assert exc_info.value.status_code == 400
-            # The provider's own error text stays in the logs, not the response.
-            assert str(exc_info.value.detail) == "Failed to generate embedding"
-            assert "Provider rejected the request" not in str(exc_info.value.detail)
+            assert (
+                str(exc_info.value.detail)
+                == "Failed to generate embedding: context length exceeded"
+            )
+
+    def test_model_configuration_error_keeps_its_message(self):
+        """A message naming the caller's own model setting is theirs to read."""
+        mock_request = GenerateEmbeddingRequest(text="some text")
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+
+        with patch(
+            "rhesis.backend.app.utils.user_model_utils.get_user_embedding_model"
+        ) as mock_get_embedding_model:
+            mock_get_embedding_model.side_effect = ModelConfigurationError(
+                "Your configured embedding model 'e5' requires an API key that is missing."
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                generate_embedding_endpoint(mock_request, db=mock_db, current_user=mock_user)
+
+            assert exc_info.value.status_code == 400
+            assert "requires an API key" in str(exc_info.value.detail)
+
+    def test_internal_failure_is_masked(self):
+        """No provider status means the failure is ours: masked 500, not a 400
+        blaming the caller. Keeps the 400 exemption from widening."""
+        mock_request = GenerateEmbeddingRequest(text="some text")
+        mock_db = MagicMock()
+        mock_user = MagicMock()
+
+        with patch(
+            "rhesis.backend.app.utils.user_model_utils.get_user_embedding_model"
+        ) as mock_get_embedding_model:
+            mock_get_embedding_model.side_effect = TypeError("embedder object is not callable")
+
+            with pytest.raises(HTTPException) as exc_info:
+                generate_embedding_endpoint(mock_request, db=mock_db, current_user=mock_user)
+
+            assert exc_info.value.status_code == 500
+            assert str(exc_info.value.detail) == public_message(500)
+            assert "not callable" not in str(exc_info.value.detail)
+            assert getattr(exc_info.value, "rhesis_logged", False) is True
 
     def test_recursive_native_provider_returns_500_not_400(self):
         """DEFAULT_EMBEDDING_MODEL resolving back to RhesisEmbedder is a server
@@ -125,7 +208,13 @@ class TestGenerateEmbeddingEndpoint:
                 generate_embedding_endpoint(mock_request, db=mock_db, current_user=mock_user)
 
             assert exc_info.value.status_code == 500
-            assert "recursively" in str(exc_info.value.detail)
+            # The caller learns what is wrong; DEFAULT_EMBEDDING_MODEL and the
+            # recursion are for the log.
+            assert (
+                str(exc_info.value.detail)
+                == "No embedding model is configured for this deployment."
+            )
+            assert "recursively" not in str(exc_info.value.detail)
 
         fake_native_embedder.generate.assert_not_called()
 

--- a/tests/backend/routes/test_test_bulk_create.py
+++ b/tests/backend/routes/test_test_bulk_create.py
@@ -1,0 +1,18 @@
+"""Tests for POST /tests/bulk error statuses.
+
+The endpoint raises its own 400 inside the same `try` that has a broad
+`except Exception`. Without an `except HTTPException: raise` arm above that
+handler, the 400 is caught and re-raised as a 500 -- a client error reported
+as a server error, with the reason stripped.
+"""
+
+from fastapi import status
+from fastapi.testclient import TestClient
+
+
+class TestBulkCreateTestsErrors:
+    def test_empty_test_list_returns_400_not_500(self, authenticated_client: TestClient):
+        response = authenticated_client.post("/tests/bulk", json={"tests": []})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()["detail"] == "No tests provided in request"

--- a/tests/backend/security/test_error_handlers.py
+++ b/tests/backend/security/test_error_handlers.py
@@ -12,7 +12,9 @@ from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
 from rhesis.backend.app.error_handlers import (
+    UpstreamHTTPException,
     http_exception_handler,
+    internal_error,
     public_message,
     unhandled_exception_handler,
 )
@@ -43,6 +45,24 @@ def client() -> TestClient:
     @app.get("/not-found")
     def not_found():
         raise HTTPException(status_code=404, detail="Organization not found")
+
+    @app.get("/internal")
+    def internal():
+        try:
+            raise RuntimeError(SECRET)
+        except RuntimeError as exc:
+            raise internal_error(exc, context="ctx") from exc
+
+    @app.get("/internal-400")
+    def internal_400():
+        try:
+            raise RuntimeError(SECRET)
+        except RuntimeError as exc:
+            raise internal_error(exc, context="ctx", status_code=400) from exc
+
+    @app.get("/upstream")
+    def upstream():
+        raise UpstreamHTTPException(status_code=502, detail="Upstream returned 401 Unauthorized")
 
     return TestClient(app, raise_server_exceptions=False)
 
@@ -111,3 +131,44 @@ def test_hostile_inbound_request_id_is_rejected(client, hostile):
     response = client.get("/boom", headers={"X-Request-ID": hostile})
 
     assert response.json()["error_id"] != hostile
+
+
+def test_request_id_header_is_not_duplicated(client):
+    """The middleware adds the header; handlers must not add it again."""
+    for path in ("/boom", "/server-error", "/bad-request"):
+        response = client.get(path)
+        ids = [v for k, v in response.headers.multi_items() if k.lower() == "x-request-id"]
+        assert len(ids) == 1, f"{path} returned {len(ids)} X-Request-ID headers"
+
+
+def test_internal_error_is_logged_once(client, caplog):
+    """internal_error logs with context; the handler must not log it again."""
+    with caplog.at_level(logging.ERROR):
+        client.get("/internal")
+
+    with_traceback = [r for r in caplog.records if r.exc_info]
+    assert len(with_traceback) == 1, f"expected 1 traceback, got {len(with_traceback)}"
+    assert "ctx" in with_traceback[0].getMessage()
+
+
+def test_internal_error_uses_client_wording_for_4xx(client):
+    """A 400 described as "an unexpected error occurred" misattributes the fault."""
+    response = client.get("/internal-400")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "The request could not be processed."
+
+
+def test_upstream_exception_keeps_its_detail(client):
+    """A 5xx describing the CALLER's system is theirs to read."""
+    response = client.get("/upstream")
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "Upstream returned 401 Unauthorized"
+    assert response.json()["error_id"]
+
+
+def test_upstream_exemption_does_not_leak_our_errors(client):
+    """The exemption is opt-in -- a plain 500 is still masked."""
+    assert client.get("/server-error").json()["detail"] == public_message(500)
+    assert SECRET not in client.get("/server-error").text

--- a/tests/backend/security/test_error_handlers.py
+++ b/tests/backend/security/test_error_handlers.py
@@ -64,6 +64,13 @@ def client() -> TestClient:
     def upstream():
         raise UpstreamHTTPException(status_code=502, detail="Upstream returned 401 Unauthorized")
 
+    @app.get("/upstream-logged")
+    def upstream_logged():
+        """What services/endpoint/testing.py raises: logged by the caller."""
+        exc = UpstreamHTTPException(status_code=500, detail="Connection refused")
+        exc.rhesis_logged = True
+        raise exc
+
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -159,6 +166,17 @@ def test_internal_error_uses_client_wording_for_4xx(client):
     assert response.json()["detail"] == "The request could not be processed."
 
 
+def test_internal_error_does_not_log_a_traceback_for_4xx(client, caplog):
+    """A caller's mistake is a warning, not a stack trace in the error stream."""
+    with caplog.at_level(logging.WARNING):
+        client.get("/internal-400")
+
+    records = [r for r in caplog.records if "ctx" in r.getMessage()]
+    assert records, "the failure must still leave one line"
+    assert all(r.levelno == logging.WARNING for r in records)
+    assert not any(r.exc_info for r in records)
+
+
 def test_upstream_exception_keeps_its_detail(client):
     """A 5xx describing the CALLER's system is theirs to read."""
     response = client.get("/upstream")
@@ -172,3 +190,12 @@ def test_upstream_exemption_does_not_leak_our_errors(client):
     """The exemption is opt-in -- a plain 500 is still masked."""
     assert client.get("/server-error").json()["detail"] == public_message(500)
     assert SECRET not in client.get("/server-error").text
+
+
+def test_already_logged_upstream_error_is_not_logged_again(client, caplog):
+    """A user's own endpoint refusing must not also land in the error stream."""
+    with caplog.at_level(logging.WARNING):
+        response = client.get("/upstream-logged")
+
+    assert response.json()["detail"] == "Connection refused"
+    assert not [r for r in caplog.records if r.levelno >= logging.ERROR]

--- a/tests/backend/security/test_error_handlers.py
+++ b/tests/backend/security/test_error_handlers.py
@@ -5,16 +5,26 @@ together by one id. Deliberate 4xx messages must keep working untouched -- that
 is the regression that would hurt users most.
 """
 
+import ast
 import logging
+from pathlib import Path
 
 import pytest
 from fastapi import FastAPI, HTTPException
+from fastapi.exceptions import RequestValidationError
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
+from starlette.exceptions import HTTPException as StarletteHTTPException
+from starlette.middleware.cors import CORSMiddleware
 
 from rhesis.backend.app.error_handlers import (
+    PUBLIC_ERROR_MESSAGES,
+    PublicHTTPException,
     UpstreamHTTPException,
+    create_validation_error_response,
     http_exception_handler,
     internal_error,
+    log_validation_error,
     public_message,
     unhandled_exception_handler,
 )
@@ -23,11 +33,24 @@ from rhesis.backend.app.utils.request_context import RequestIDMiddleware
 SECRET = "could not connect to server at 10.0.3.14:5432 password=hunter2"
 
 
+class Payload(BaseModel):
+    name: str
+    count: int
+
+
 @pytest.fixture
 def client() -> TestClient:
     app = FastAPI()
+    # Both bases, and the 422 pair, exactly as main.py registers them.
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)
     app.add_exception_handler(HTTPException, http_exception_handler)
     app.add_exception_handler(Exception, unhandled_exception_handler)
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_handler(request, exc: RequestValidationError):
+        log_validation_error(exc, request)
+        return create_validation_error_response(exc)
+
     app.add_middleware(RequestIDMiddleware)
 
     @app.get("/boom")
@@ -59,6 +82,54 @@ def client() -> TestClient:
             raise RuntimeError(SECRET)
         except RuntimeError as exc:
             raise internal_error(exc, context="ctx", status_code=400) from exc
+
+    @app.get("/masked/{status}")
+    def masked(status: int):
+        raise HTTPException(status_code=status, detail=f"Failed to sync: {SECRET}")
+
+    @app.get("/starlette-server-error")
+    def starlette_server_error():
+        """main.py registers Starlette's base too; only this route exercises it."""
+        raise StarletteHTTPException(status_code=500, detail=f"Failed to sync: {SECRET}")
+
+    @app.get("/public-503")
+    def public_503():
+        raise PublicHTTPException(status_code=503, detail="Garak package is not installed")
+
+    @app.get("/internal-public-detail")
+    def internal_public_detail():
+        try:
+            raise RuntimeError(SECRET)
+        except RuntimeError as exc:
+            raise internal_error(
+                exc, context="ctx", public_detail="No generation model is configured"
+            ) from exc
+
+    @app.get("/internal-public-detail-400")
+    def internal_public_detail_400():
+        try:
+            raise RuntimeError(SECRET)
+        except RuntimeError as exc:
+            raise internal_error(
+                exc,
+                context="ctx",
+                status_code=400,
+                public_detail="No generation model is configured",
+            ) from exc
+
+    @app.get("/needs-auth")
+    def needs_auth():
+        raise HTTPException(
+            status_code=401, detail="Not authenticated", headers={"WWW-Authenticate": "Bearer"}
+        )
+
+    @app.get("/structured-detail")
+    def structured_detail():
+        raise HTTPException(status_code=400, detail=[{"field": "name", "error": "taken"}])
+
+    @app.post("/validate")
+    def validate(payload: Payload):
+        return {"ok": True}
 
     @app.get("/upstream")
     def upstream():
@@ -100,7 +171,33 @@ def test_server_side_http_exception_is_genericised(client):
 
     assert response.status_code == 500
     assert SECRET not in response.text
-    assert response.json()["detail"] == public_message(500)
+    body = response.json()
+    assert body["detail"] == public_message(500)
+    # Masking without a usable id is what makes a support request unanswerable.
+    assert body["error_id"]
+    assert body["error_id"] == response.headers["x-request-id"]
+
+
+def test_starlette_http_exception_is_genericised_too(client):
+    """main.py registers both bases; a Starlette-raised 5xx must mask as well."""
+    response = client.get("/starlette-server-error")
+
+    assert response.status_code == 500
+    assert SECRET not in response.text
+    body = response.json()
+    assert body["detail"] == public_message(500)
+    assert body["error_id"] == response.headers["x-request-id"]
+
+
+@pytest.mark.parametrize("status", sorted(PUBLIC_ERROR_MESSAGES))
+def test_each_masked_status_keeps_its_own_wording(client, status):
+    """Collapsing 502/503/504 into the 500 text tells the caller the wrong thing."""
+    response = client.get(f"/masked/{status}")
+
+    assert response.status_code == status
+    assert response.json()["detail"] == PUBLIC_ERROR_MESSAGES[status]
+    assert SECRET not in response.text
+    assert response.json()["error_id"]
 
 
 @pytest.mark.parametrize(
@@ -199,3 +296,209 @@ def test_already_logged_upstream_error_is_not_logged_again(client, caplog):
 
     assert response.json()["detail"] == "Connection refused"
     assert not [r for r in caplog.records if r.levelno >= logging.ERROR]
+
+
+def test_public_http_exception_keeps_its_literal_detail(client):
+    """The exemption routers use for "the package isn't installed" answers."""
+    response = client.get("/public-503")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Garak package is not installed"
+    assert response.json()["error_id"]
+
+
+def test_public_http_exception_is_a_warning_without_a_traceback(client, caplog):
+    """A missing optional package is not a fault to debug -- no stack, no ERROR."""
+    with caplog.at_level(logging.WARNING):
+        client.get("/public-503")
+
+    records = [r for r in caplog.records if "Garak package is not installed" in r.getMessage()]
+    assert len(records) == 1
+    assert records[0].levelno == logging.WARNING
+    assert not records[0].exc_info
+
+
+def test_public_exemption_does_not_widen_to_plain_5xx(client):
+    """Same status, same file: only the PublicHTTPException detail survives."""
+    assert client.get("/masked/503").json()["detail"] == public_message(503)
+    assert SECRET not in client.get("/masked/503").text
+
+
+def test_unlogged_upstream_error_is_a_warning_without_a_traceback(client, caplog):
+    """The 5xx passthrough logs the reason, not a stack pointing at our raise."""
+    with caplog.at_level(logging.WARNING):
+        client.get("/upstream")
+
+    records = [r for r in caplog.records if "Upstream returned 401" in r.getMessage()]
+    assert len(records) == 1
+    assert records[0].levelno == logging.WARNING
+    assert not records[0].exc_info
+
+
+def test_internal_error_public_detail_reaches_the_client(client):
+    """Only survives because internal_error upgrades to PublicHTTPException --
+    a plain HTTPException would have its 5xx detail masked straight back off."""
+    response = client.get("/internal-public-detail")
+
+    assert response.status_code == 500
+    assert response.json()["detail"] == "No generation model is configured"
+    assert SECRET not in response.text
+
+
+def test_internal_error_public_detail_reaches_the_client_on_a_4xx(client):
+    """Below 500 nothing masks it, so this is where public_detail works today."""
+    response = client.get("/internal-public-detail-400")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "No generation model is configured"
+    assert SECRET not in response.text
+
+
+def test_internal_error_public_detail_is_still_logged_in_full(client, caplog):
+    """A caller-facing message is not a reason to stop logging the real one."""
+    with caplog.at_level(logging.ERROR):
+        client.get("/internal-public-detail")
+
+    records = [r for r in caplog.records if "ctx" in r.getMessage()]
+    assert len(records) == 1
+    assert records[0].exc_info is not None
+    assert SECRET in records[0].getMessage()
+
+
+def test_validation_error_still_names_the_field(client):
+    """A 422 exists to tell the caller which field is wrong."""
+    response = client.post("/validate", json={"count": "not-a-number"})
+
+    assert response.status_code == 422
+    fields = {tuple(error["loc"]) for error in response.json()["detail"]}
+    assert ("body", "name") in fields
+    assert ("body", "count") in fields
+    assert all(error["msg"] for error in response.json()["detail"])
+
+
+def test_validation_error_is_logged_as_a_warning_without_a_traceback(client, caplog):
+    """A 422 is the caller sending the wrong shape, not a server fault."""
+    with caplog.at_level(logging.WARNING):
+        client.post("/validate", json={"count": "not-a-number"})
+
+    records = [r for r in caplog.records if "Validation error on" in r.getMessage()]
+    assert records
+    assert all(r.levelno == logging.WARNING for r in records)
+    assert not any(r.exc_info for r in records)
+
+
+def test_client_error_headers_survive(client):
+    """Drop WWW-Authenticate and every 401 stops telling clients how to retry."""
+    response = client.get("/needs-auth")
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+def test_non_string_client_error_detail_survives(client):
+    """Field-level 4xx detail is sometimes a list; passing it through must keep it."""
+    response = client.get("/structured-detail")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == [{"field": "name", "error": "taken"}]
+
+
+MAIN_PY = (
+    Path(__file__).resolve().parents[3]
+    / "apps"
+    / "backend"
+    / "src"
+    / "rhesis"
+    / "backend"
+    / "app"
+    / "main.py"
+)
+
+
+def _registered_handlers() -> set[tuple[str, str]]:
+    """(exception class, handler) pairs main.py registers on the real app.
+
+    Read from the source rather than by importing the app: main.py pulls in the
+    whole dependency graph and needs live database settings, and this only has to
+    catch the registration going missing.
+    """
+    tree = ast.parse(MAIN_PY.read_text())
+    registered = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "add_exception_handler"
+            and len(node.args) == 2
+        ):
+            registered.add((ast.unparse(node.args[0]), ast.unparse(node.args[1])))
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "exception_handler"
+            and node.args
+        ):
+            registered.add((ast.unparse(node.args[0]), "decorator"))
+    return registered
+
+
+@pytest.mark.parametrize(
+    "exception_class,handler",
+    [
+        # Both bases: FastAPI's HTTPException subclasses Starlette's, but the
+        # lookup tries the exact class first.
+        ("StarletteHTTPException", "http_exception_handler"),
+        ("FastAPIHTTPException", "http_exception_handler"),
+        ("Exception", "unhandled_exception_handler"),
+        ("RequestValidationError", "decorator"),
+    ],
+)
+def test_real_app_registers_the_masking_handlers(exception_class, handler):
+    """Every test above builds its own app, so nothing here notices main.py
+    dropping a registration -- and then nothing masks anything in production."""
+    assert (exception_class, handler) in _registered_handlers()
+
+
+@pytest.fixture
+def cors_client() -> TestClient:
+    """The real middleware order: CORS inside RequestIDMiddleware, as in main.py."""
+    app = FastAPI()
+    app.add_exception_handler(StarletteHTTPException, http_exception_handler)
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    app.add_exception_handler(Exception, unhandled_exception_handler)
+    app.add_middleware(CORSMiddleware, allow_origins=["http://localhost:3000"])
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/boom")
+    def boom():
+        raise RuntimeError(SECRET)
+
+    @app.get("/server-error")
+    def server_error():
+        raise HTTPException(status_code=500, detail=SECRET)
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+ORIGIN = {"Origin": "http://localhost:3000"}
+
+
+def test_http_exception_500_is_readable_by_browser_js(cors_client):
+    """Raised 5xx come from ExceptionMiddleware, which sits inside CORS."""
+    response = cors_client.get("/server-error", headers=ORIGIN)
+
+    assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
+    assert response.json()["error_id"]
+
+
+def test_unhandled_500_carries_no_cors_headers(cors_client):
+    """Documents a known gap, not a wanted behaviour: ServerErrorMiddleware builds
+    this response *outside* CORSMiddleware, so browser JS can read neither the
+    body nor X-Request-ID -- the id support asks for is unreachable exactly when
+    it is needed most. Fixing it means moving middleware, not touching this test.
+    """
+    response = cors_client.get("/boom", headers=ORIGIN)
+
+    assert response.status_code == 500
+    assert response.json()["error_id"]
+    assert "access-control-allow-origin" not in response.headers

--- a/tests/backend/security/test_error_handlers.py
+++ b/tests/backend/security/test_error_handlers.py
@@ -1,0 +1,113 @@
+"""The contract the router batches rely on.
+
+Unexpected failures must tell the client nothing and the logs everything, tied
+together by one id. Deliberate 4xx messages must keep working untouched -- that
+is the regression that would hurt users most.
+"""
+
+import logging
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from rhesis.backend.app.error_handlers import (
+    http_exception_handler,
+    public_message,
+    unhandled_exception_handler,
+)
+from rhesis.backend.app.utils.request_context import RequestIDMiddleware
+
+SECRET = "could not connect to server at 10.0.3.14:5432 password=hunter2"
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = FastAPI()
+    app.add_exception_handler(HTTPException, http_exception_handler)
+    app.add_exception_handler(Exception, unhandled_exception_handler)
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/boom")
+    def boom():
+        raise RuntimeError(SECRET)
+
+    @app.get("/server-error")
+    def server_error():
+        raise HTTPException(status_code=500, detail=f"Failed to sync: {SECRET}")
+
+    @app.get("/bad-request")
+    def bad_request():
+        raise HTTPException(status_code=400, detail="Test set name already exists")
+
+    @app.get("/not-found")
+    def not_found():
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_unhandled_exception_hides_detail_and_returns_error_id(client):
+    response = client.get("/boom")
+
+    assert response.status_code == 500
+    body = response.json()
+    assert body["detail"] == public_message(500)
+    assert SECRET not in response.text
+    assert body["error_id"]
+    assert body["error_id"] == response.headers["x-request-id"]
+
+
+def test_unhandled_exception_is_logged_with_traceback(client, caplog):
+    with caplog.at_level(logging.ERROR):
+        error_id = client.get("/boom").json()["error_id"]
+
+    record = next(r for r in caplog.records if "Unhandled exception" in r.getMessage())
+    assert error_id in record.getMessage()
+    assert record.exc_info is not None, "traceback must reach the logs"
+    assert SECRET in str(record.exc_info[1]), "the real reason must survive in the log"
+
+
+def test_server_side_http_exception_is_genericised(client):
+    response = client.get("/server-error")
+
+    assert response.status_code == 500
+    assert SECRET not in response.text
+    assert response.json()["detail"] == public_message(500)
+
+
+@pytest.mark.parametrize(
+    "path,status,detail",
+    [
+        ("/bad-request", 400, "Test set name already exists"),
+        ("/not-found", 404, "Organization not found"),
+    ],
+)
+def test_client_errors_keep_their_message(client, path, status, detail):
+    """Deliberate validation messages are for the user -- they must survive."""
+    response = client.get(path)
+
+    assert response.status_code == status
+    assert response.json()["detail"] == detail
+    assert "error_id" not in response.json()
+
+
+def test_request_id_is_per_request(client):
+    first = client.get("/boom").json()["error_id"]
+    second = client.get("/boom").json()["error_id"]
+
+    assert first != second
+
+
+def test_safe_inbound_request_id_is_reused(client):
+    response = client.get("/boom", headers={"X-Request-ID": "trace-abc-123"})
+
+    assert response.json()["error_id"] == "trace-abc-123"
+
+
+@pytest.mark.parametrize("hostile", ["bad id\nINJECTED: forged log line", "x" * 200, "a;b|c"])
+def test_hostile_inbound_request_id_is_rejected(client, hostile):
+    """An inbound id reaches the logs, so it must not be able to forge lines."""
+    response = client.get("/boom", headers={"X-Request-ID": hostile})
+
+    assert response.json()["error_id"] != hostile

--- a/tests/backend/security/test_router_error_leaks.py
+++ b/tests/backend/security/test_router_error_leaks.py
@@ -39,8 +39,33 @@ def _is_broad(handler: ast.ExceptHandler) -> bool:
     return any(isinstance(n, ast.Name) and n.id in BROAD_EXCEPTIONS for n in names)
 
 
-def _references(node: ast.AST, name: str) -> bool:
-    return any(isinstance(n, ast.Name) and n.id == name for n in ast.walk(node))
+def _references(node: ast.AST, names: set[str]) -> bool:
+    return any(isinstance(n, ast.Name) and n.id in names for n in ast.walk(node))
+
+
+def _tainted_names(handler: ast.ExceptHandler) -> set[str]:
+    """The exception name plus every local it was copied into.
+
+    ``error_msg = str(e)`` then ``detail=f"...{error_msg}"`` is the same leak
+    written in two steps, and checking only the exception name misses it.
+    Iterates to a fixpoint so chains of copies are caught too.
+    """
+    tainted = {handler.name}
+    while True:
+        grown = set(tainted)
+        for node in ast.walk(handler):
+            if isinstance(node, ast.Assign) and _references(node.value, tainted):
+                grown |= {t.id for t in node.targets if isinstance(t, ast.Name)}
+            elif (
+                isinstance(node, ast.AnnAssign)
+                and node.value is not None
+                and isinstance(node.target, ast.Name)
+                and _references(node.value, tainted)
+            ):
+                grown.add(node.target.id)
+        if grown == tainted:
+            return tainted
+        tainted = grown
 
 
 def find_leaks(source: str) -> list[int]:
@@ -49,11 +74,12 @@ def find_leaks(source: str) -> list[int]:
     for node in ast.walk(ast.parse(source)):
         if not isinstance(node, ast.ExceptHandler) or not _is_broad(node) or not node.name:
             continue
+        tainted = _tainted_names(node)
         for inner in ast.walk(node):
             if not isinstance(inner, ast.Call):
                 continue
             for kw in inner.keywords:
-                if kw.arg == "detail" and _references(kw.value, node.name):
+                if kw.arg == "detail" and _references(kw.value, tainted):
                     leaks.append(inner.lineno)
     return sorted(set(leaks))
 

--- a/tests/backend/security/test_router_error_leaks.py
+++ b/tests/backend/security/test_router_error_leaks.py
@@ -30,19 +30,14 @@ BROAD_EXCEPTIONS = {"Exception", "BaseException"}
 
 #: file name -> number of leaks still tolerated. Only ever shrinks.
 KNOWN_LEAKS: dict[str, int] = {
-    "auth.py": 3,
-    "endpoint.py": 3,
     "garak.py": 7,
     "job.py": 4,
     "metric.py": 2,
-    "model.py": 2,
-    "organization.py": 4,
     "source.py": 3,
     "test.py": 1,
     "test_configuration.py": 1,
     "test_run.py": 2,
     "test_set.py": 2,
-    "tools.py": 2,
 }
 
 

--- a/tests/backend/security/test_router_error_leaks.py
+++ b/tests/backend/security/test_router_error_leaks.py
@@ -30,10 +30,7 @@ BROAD_EXCEPTIONS = {"Exception", "BaseException"}
 
 #: file name -> number of leaks still tolerated. Only ever shrinks.
 KNOWN_LEAKS: dict[str, int] = {
-    "garak.py": 7,
-    "job.py": 4,
     "metric.py": 2,
-    "source.py": 3,
     "test.py": 1,
     "test_configuration.py": 1,
     "test_run.py": 2,

--- a/tests/backend/security/test_router_error_leaks.py
+++ b/tests/backend/security/test_router_error_leaks.py
@@ -29,13 +29,7 @@ ROUTERS_DIR = (
 BROAD_EXCEPTIONS = {"Exception", "BaseException"}
 
 #: file name -> number of leaks still tolerated. Only ever shrinks.
-KNOWN_LEAKS: dict[str, int] = {
-    "metric.py": 2,
-    "test.py": 1,
-    "test_configuration.py": 1,
-    "test_run.py": 2,
-    "test_set.py": 2,
-}
+KNOWN_LEAKS: dict[str, int] = {}
 
 
 def _is_broad(handler: ast.ExceptHandler) -> bool:

--- a/tests/backend/security/test_router_error_leaks.py
+++ b/tests/backend/security/test_router_error_leaks.py
@@ -1,0 +1,103 @@
+"""Guard against routers returning internal error text to clients.
+
+A broad ``except Exception as e`` that puts ``e`` into ``detail=`` hands the
+caller whatever the failure happened to say -- SQLAlchemy statements, OAuth
+provider internals, filesystem paths. Narrow handlers (``except ValueError``)
+are fine and deliberate: those messages are written for the user to read.
+
+``KNOWN_LEAKS`` is the backlog being worked off in batches. A file's count may
+only ever go down. When it hits zero, delete the entry.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+ROUTERS_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "apps"
+    / "backend"
+    / "src"
+    / "rhesis"
+    / "backend"
+    / "app"
+    / "routers"
+)
+
+#: Exception types broad enough that their text is of unknown origin.
+BROAD_EXCEPTIONS = {"Exception", "BaseException"}
+
+#: file name -> number of leaks still tolerated. Only ever shrinks.
+KNOWN_LEAKS: dict[str, int] = {
+    "auth.py": 3,
+    "endpoint.py": 3,
+    "garak.py": 7,
+    "job.py": 4,
+    "metric.py": 2,
+    "model.py": 2,
+    "organization.py": 4,
+    "source.py": 3,
+    "test.py": 1,
+    "test_configuration.py": 1,
+    "test_run.py": 2,
+    "test_set.py": 2,
+    "tools.py": 2,
+}
+
+
+def _is_broad(handler: ast.ExceptHandler) -> bool:
+    if handler.type is None:  # bare `except:`
+        return True
+    names = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+    return any(isinstance(n, ast.Name) and n.id in BROAD_EXCEPTIONS for n in names)
+
+
+def _references(node: ast.AST, name: str) -> bool:
+    return any(isinstance(n, ast.Name) and n.id == name for n in ast.walk(node))
+
+
+def find_leaks(source: str) -> list[int]:
+    """Line numbers where a broad handler feeds its exception into ``detail=``."""
+    leaks = []
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.ExceptHandler) or not _is_broad(node) or not node.name:
+            continue
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Call):
+                continue
+            for kw in inner.keywords:
+                if kw.arg == "detail" and _references(kw.value, node.name):
+                    leaks.append(inner.lineno)
+    return sorted(set(leaks))
+
+
+def router_files() -> list[Path]:
+    return sorted(p for p in ROUTERS_DIR.glob("*.py") if p.name != "__init__.py")
+
+
+@pytest.mark.parametrize("path", router_files(), ids=lambda p: p.name)
+def test_router_does_not_leak_internal_errors(path: Path):
+    leaks = find_leaks(path.read_text())
+    allowed = KNOWN_LEAKS.get(path.name, 0)
+
+    assert len(leaks) <= allowed, (
+        f"{path.name} leaks internal exception text to clients at lines {leaks}. "
+        f"Log the exception and return a generic message instead -- see "
+        f"rhesis.backend.app.error_handlers.internal_error."
+    )
+
+    if len(leaks) < allowed:
+        pytest.fail(
+            f"{path.name} now has {len(leaks)} leaks, fewer than the allowed {allowed}. "
+            f"Lower KNOWN_LEAKS['{path.name}'] to {len(leaks)} "
+            f"({'or delete the entry' if len(leaks) == 0 else 'to lock the improvement in'})."
+        )
+
+
+def test_allowlist_has_no_stale_entries():
+    """A file listed in KNOWN_LEAKS must still exist."""
+    names = {p.name for p in router_files()}
+    assert not (set(KNOWN_LEAKS) - names), (
+        f"KNOWN_LEAKS names routers that no longer exist: {set(KNOWN_LEAKS) - names}"
+    )

--- a/tests/backend/security/test_router_error_leaks.py
+++ b/tests/backend/security/test_router_error_leaks.py
@@ -1,115 +1,635 @@
-"""Guard against routers returning internal error text to clients.
+"""Guard against handlers returning internal error text to clients.
 
 A broad ``except Exception as e`` that puts ``e`` into ``detail=`` hands the
 caller whatever the failure happened to say -- SQLAlchemy statements, OAuth
 provider internals, filesystem paths. Narrow handlers (``except ValueError``)
 are fine and deliberate: those messages are written for the user to read.
 
+The scan covers ``app/routers``, ``app/utils`` and ``app/services`` because a
+leak built in a helper reaches the client exactly like one written in the
+router -- ``handle_execution_error`` and the connection-test result bodies both
+live outside ``routers/``.
+
+What is deliberately *not* a leak: a 4xx detail (the handler passes those
+through on purpose, so a guard that flagged them would argue with the contract
+it protects) and an ``UpstreamHTTPException`` (the opt-in that says "this text
+is the caller's own system's").
+
 ``KNOWN_LEAKS`` is the backlog being worked off in batches. A file's count may
 only ever go down. When it hits zero, delete the entry.
 """
 
 import ast
+import textwrap
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
 
-ROUTERS_DIR = (
-    Path(__file__).resolve().parents[3]
-    / "apps"
-    / "backend"
-    / "src"
-    / "rhesis"
-    / "backend"
-    / "app"
-    / "routers"
+APP_DIR = (
+    Path(__file__).resolve().parents[3] / "apps" / "backend" / "src" / "rhesis" / "backend" / "app"
 )
 
-#: Exception types broad enough that their text is of unknown origin.
-BROAD_EXCEPTIONS = {"Exception", "BaseException"}
+#: Subtrees of ``app/`` whose error text can reach a client.
+SCAN_DIRS = ("routers", "utils", "services")
 
-#: file name -> number of leaks still tolerated. Only ever shrinks.
-KNOWN_LEAKS: dict[str, int] = {}
+#: Not scanned. Endpoint invocation exists to report what went wrong with the
+#: *caller's own* endpoint -- a refused connection, an unparseable body -- which
+#: is the same reasoning that exempts UpstreamHTTPException from masking. Every
+#: error string these build is that report, so scanning them is all wolf-crying.
+EXEMPT_DIRS = ("services/invokers",)
+
+#: Exception types broad enough that their text is of unknown origin. The DB and
+#: HTTP families are here because their messages carry SQL statements,
+#: connection strings and URLs with credentials in them.
+BROAD_EXCEPTIONS = {
+    "Exception",
+    "BaseException",
+    # SQLAlchemy
+    "SQLAlchemyError",
+    "DBAPIError",
+    "DatabaseError",
+    "OperationalError",
+    "IntegrityError",
+    "ProgrammingError",
+    "DataError",
+    "InvalidRequestError",
+    "InterfaceError",
+    # httpx / requests
+    "HTTPError",
+    "TransportError",
+    "RequestError",
+    "HTTPStatusError",
+    "ConnectError",
+    "RequestException",
+    "ConnectionError",
+    # stdlib failures that carry paths and command lines
+    "OSError",
+    "IOError",
+    "CalledProcessError",
+    "SubprocessError",
+}
+
+#: Keyword arguments that are response text wherever they appear.
+RESPONSE_FIELDS = {"detail", "content", "headers"}
+
+#: Fields that only mean "shown to the caller" on something response-shaped.
+#: ``update_test_run_status(..., error=str(exc))`` writes a DB column; the same
+#: keyword on a ``*Result`` or ``*Response`` is a body being built.
+RESULT_FIELDS = {"detail", "message", "msg", "error", "error_message", "reason"}
+
+#: Keys of a dict literal that is returned or handed to ``content=``.
+BODY_KEYS = RESULT_FIELDS | {"content", "details", "errors"}
+
+#: Calls whose *positional* arguments are response text. ``HTTPException(500,
+#: f"boom: {e}")`` is the same leak as ``detail=f"boom: {e}"``.
+RESPONSE_CALLS = {
+    "HTTPException",
+    "PublicHTTPException",
+    "StarletteHTTPException",
+    "JSONResponse",
+    "PlainTextResponse",
+    "HTMLResponse",
+    "Response",
+}
+
+#: HTTPException classes whose first positional argument is the status code.
+HTTP_EXCEPTION_CALLS = {
+    "HTTPException",
+    "PublicHTTPException",
+    "StarletteHTTPException",
+    "FastAPIHTTPException",
+}
+
+#: The one blessed relay. UpstreamHTTPException *means* "this text is the
+#: caller's own system's, pass it through" -- an opt-in a reviewer can grep for,
+#: and the reason endpoint testing can say "connection refused" at all.
+#: PublicHTTPException is not exempt: its detail must be a literal.
+UPSTREAM_RELAY = {"UpstreamHTTPException"}
+
+#: Reachable without ``as e``: ``except Exception:`` plus ``traceback.format_exc()``
+#: leaks the whole stack, and the handler has no exception name to track.
+TAINTED_MODULES = {"traceback"}
+
+#: relative path under app/ -> number of leaks still tolerated. Only ever shrinks.
+#: Every entry is a real leak found when the scan grew past ``routers/*.py``, not
+#: a false positive to live with. The owner note says who is clearing it.
+KNOWN_LEAKS: dict[str, int] = {
+    # unowned: connector replies carrying str(e) over the websocket.
+    "services/connector/handlers/registration.py": 3,
+    "services/connector/rpc_client.py": 3,
+    # unowned: AutoConfigureResult(error=f"Could not parse the input: {e}").
+    "services/endpoint/auto_configure.py": 1,
+    # unowned: {"success": False, "error": str(validation_error)}.
+    "services/endpoint/validation.py": 1,
+    # model-connection agent: ModelConnectionTestResult(message=f"...{e}").
+    "services/model_connection.py": 2,
+    # unowned: association helpers answer 200 with f"...: {str(e)}" in `message`.
+    "services/test.py": 3,
+    "services/test_set.py": 1,
+    # mcp agent: handle_mcp_exception picks its class at runtime, so the guard
+    # cannot tell the blessed UpstreamHTTPException relay from the masked
+    # HTTPException that gets detail=str(e) for a non-application MCPError.
+    "services/tool/mcp/exceptions.py": 1,
+}
+
+
+@dataclass
+class Taint:
+    """Names and attributes known to hold exception text."""
+
+    names: set[str] = field(default_factory=set)
+    attrs: set[str] = field(default_factory=set)
+
+    def __bool__(self) -> bool:
+        return bool(self.names or self.attrs)
+
+    def __eq__(self, other: "Taint") -> bool:
+        return self.names == other.names and self.attrs == other.attrs
+
+    def copy(self) -> "Taint":
+        return Taint(set(self.names), set(self.attrs))
+
+
+def _exception_names(node: ast.AST) -> list[str]:
+    """The bare names in an exception type expression, ``a.b.C`` included."""
+    if isinstance(node, ast.Tuple):
+        return [n for elt in node.elts for n in _exception_names(elt)]
+    if isinstance(node, ast.Name):
+        return [node.id]
+    if isinstance(node, ast.Attribute):  # builtins.Exception, sqlalchemy.exc.DBAPIError
+        return [node.attr]
+    return []
 
 
 def _is_broad(handler: ast.ExceptHandler) -> bool:
     if handler.type is None:  # bare `except:`
         return True
-    names = handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
-    return any(isinstance(n, ast.Name) and n.id in BROAD_EXCEPTIONS for n in names)
+    return any(name in BROAD_EXCEPTIONS for name in _exception_names(handler.type))
 
 
-def _references(node: ast.AST, names: set[str]) -> bool:
-    return any(isinstance(n, ast.Name) and n.id in names for n in ast.walk(node))
+def _references(node: ast.AST, taint: Taint) -> bool:
+    for n in ast.walk(node):
+        if isinstance(n, ast.Name) and n.id in taint.names:
+            return True
+        if isinstance(n, ast.Attribute) and n.attr in taint.attrs:
+            return True
+    return False
 
 
-def _tainted_names(handler: ast.ExceptHandler) -> set[str]:
-    """The exception name plus every local it was copied into.
+def _add_target(target: ast.AST, taint: Taint) -> None:
+    """Record whatever ``target`` writes to, however it is spelled."""
+    if isinstance(target, ast.Name):
+        taint.names.add(target.id)
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for elt in target.elts:
+            _add_target(elt, taint)
+    elif isinstance(target, ast.Starred):
+        _add_target(target.value, taint)
+    elif isinstance(target, ast.Attribute):
+        taint.attrs.add(target.attr)
+    elif isinstance(target, ast.Subscript):
+        # `d["msg"] = str(e)` taints the container: which key it went into is
+        # more than this scan can follow.
+        _add_target(target.value, taint)
+
+
+def _grow(scope: ast.AST, taint: Taint) -> Taint:
+    """Every local the exception text was copied into.
 
     ``error_msg = str(e)`` then ``detail=f"...{error_msg}"`` is the same leak
     written in two steps, and checking only the exception name misses it.
     Iterates to a fixpoint so chains of copies are caught too.
     """
-    tainted = {handler.name}
     while True:
-        grown = set(tainted)
-        for node in ast.walk(handler):
-            if isinstance(node, ast.Assign) and _references(node.value, tainted):
-                grown |= {t.id for t in node.targets if isinstance(t, ast.Name)}
+        grown = taint.copy()
+        for node in ast.walk(scope):
+            if isinstance(node, ast.Assign) and _references(node.value, taint):
+                for target in node.targets:
+                    _add_target(target, grown)
+            elif isinstance(node, ast.AugAssign) and _references(node.value, taint):
+                _add_target(node.target, grown)
             elif (
                 isinstance(node, ast.AnnAssign)
                 and node.value is not None
-                and isinstance(node.target, ast.Name)
-                and _references(node.value, tainted)
+                and _references(node.value, taint)
             ):
-                grown.add(node.target.id)
-        if grown == tainted:
-            return tainted
-        tainted = grown
+                _add_target(node.target, grown)
+            elif isinstance(node, ast.NamedExpr) and _references(node.value, taint):
+                _add_target(node.target, grown)
+        if grown == taint:
+            return taint
+        taint = grown
+
+
+def _call_name(func: ast.AST) -> str:
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return ""
+
+
+def _is_response_shaped(name: str) -> bool:
+    """A call that builds something the caller reads, by name alone."""
+    lowered = name.lower()
+    return name in RESPONSE_CALLS or "response" in lowered or "result" in lowered
+
+
+def _dict_leaks(node: ast.AST, taint: Taint) -> bool:
+    """A dict literal whose body carries exception text out to the caller."""
+    if not isinstance(node, ast.Dict):
+        return False
+    return any(
+        isinstance(key, ast.Constant) and key.value in BODY_KEYS and _references(value, taint)
+        for key, value in zip(node.keys, node.values)
+    )
+
+
+def _response_status(node: ast.Call, name: str) -> int | None:
+    """The literal status this call answers with, or None if it isn't literal."""
+    for kw in node.keywords:
+        if kw.arg == "status_code" and isinstance(kw.value, ast.Constant):
+            return kw.value.value if isinstance(kw.value.value, int) else None
+    if name in HTTP_EXCEPTION_CALLS and node.args and isinstance(node.args[0], ast.Constant):
+        first = node.args[0].value
+        return first if isinstance(first, int) else None
+    return None
+
+
+def _is_deliberate_client_error(node: ast.Call, name: str) -> bool:
+    """A 4xx detail is the one message the stack deliberately passes through.
+
+    ``http_exception_handler`` masks 5xx and leaves anything under 500 alone
+    because a 400 is written for the caller to read -- an unparseable OData
+    filter, a provider answering "unknown model". Flagging those would make the
+    guard argue with the contract it exists to protect. An unknown or computed
+    status is treated as maskable: it may well be a 500.
+    """
+    status = _response_status(node, name)
+    return status is not None and 400 <= status < 500
+
+
+def _leaks_in(scope: ast.AST, taint: Taint) -> set[int]:
+    leaks: set[int] = set()
+    for node in ast.walk(scope):
+        if isinstance(node, ast.Call):
+            name = _call_name(node.func)
+            if name in UPSTREAM_RELAY or _is_deliberate_client_error(node, name):
+                continue
+            fields = RESPONSE_FIELDS | (RESULT_FIELDS if _is_response_shaped(name) else set())
+            if name in RESPONSE_CALLS and any(_references(arg, taint) for arg in node.args):
+                leaks.add(node.lineno)
+            for kw in node.keywords:
+                if kw.arg in fields and _references(kw.value, taint):
+                    leaks.add(node.lineno)
+                # `HTTPException(**{"detail": str(e)})`
+                elif kw.arg is None and _dict_leaks(kw.value, taint):
+                    leaks.add(node.lineno)
+        # `exc = HTTPException(...)` then `exc.detail = str(e)`
+        elif isinstance(node, ast.Assign) and _references(node.value, taint):
+            if any(
+                isinstance(t, ast.Attribute) and t.attr in RESPONSE_FIELDS for t in node.targets
+            ):
+                leaks.add(node.lineno)
+        # A 200 whose body says what went wrong: `return {"error": str(e)}`
+        elif isinstance(node, ast.Return) and node.value is not None:
+            if _dict_leaks(node.value, taint):
+                leaks.add(node.lineno)
+    return leaks
+
+
+def _exception_parameters(fn: ast.AST) -> Taint:
+    """Parameters annotated as a broad exception type.
+
+    ``def handle_execution_error(error: Exception)`` builds its detail from an
+    exception it never caught, so an except-handler-only scan cannot see it.
+    """
+    taint = Taint()
+    args = fn.args
+    for arg in [*args.posonlyargs, *args.args, *args.kwonlyargs]:
+        if arg.annotation is not None and any(
+            name in BROAD_EXCEPTIONS for name in _exception_names(arg.annotation)
+        ):
+            taint.names.add(arg.arg)
+    return taint
 
 
 def find_leaks(source: str) -> list[int]:
-    """Line numbers where a broad handler feeds its exception into ``detail=``."""
-    leaks = []
-    for node in ast.walk(ast.parse(source)):
-        if not isinstance(node, ast.ExceptHandler) or not _is_broad(node) or not node.name:
-            continue
-        tainted = _tainted_names(node)
-        for inner in ast.walk(node):
-            if not isinstance(inner, ast.Call):
+    """Line numbers where internal exception text is handed to the client."""
+    leaks: set[int] = set()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ExceptHandler):
+            if not _is_broad(node):
                 continue
-            for kw in inner.keywords:
-                if kw.arg == "detail" and _references(kw.value, tainted):
-                    leaks.append(inner.lineno)
-    return sorted(set(leaks))
+            taint = Taint(set(TAINTED_MODULES), set())
+            if node.name:
+                taint.names.add(node.name)
+            leaks |= _leaks_in(node, _grow(node, taint))
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            taint = _exception_parameters(node)
+            if taint:
+                leaks |= _leaks_in(node, _grow(node, taint))
+    return sorted(leaks)
 
 
-def router_files() -> list[Path]:
-    return sorted(p for p in ROUTERS_DIR.glob("*.py") if p.name != "__init__.py")
+def _key(path: Path) -> str:
+    return path.relative_to(APP_DIR).as_posix()
 
 
-@pytest.mark.parametrize("path", router_files(), ids=lambda p: p.name)
-def test_router_does_not_leak_internal_errors(path: Path):
+def scanned_files() -> list[Path]:
+    return sorted(
+        p
+        for directory in SCAN_DIRS
+        for p in (APP_DIR / directory).rglob("*.py")
+        if p.name != "__init__.py" and not _key(p).startswith(EXEMPT_DIRS)
+    )
+
+
+@pytest.mark.parametrize("path", scanned_files(), ids=_key)
+def test_handler_does_not_leak_internal_errors(path: Path):
     leaks = find_leaks(path.read_text())
-    allowed = KNOWN_LEAKS.get(path.name, 0)
+    key = _key(path)
+    allowed = KNOWN_LEAKS.get(key, 0)
 
     assert len(leaks) <= allowed, (
-        f"{path.name} leaks internal exception text to clients at lines {leaks}. "
+        f"{key} leaks internal exception text to clients at lines {leaks}. "
         f"Log the exception and return a generic message instead -- see "
         f"rhesis.backend.app.error_handlers.internal_error."
     )
 
     if len(leaks) < allowed:
         pytest.fail(
-            f"{path.name} now has {len(leaks)} leaks, fewer than the allowed {allowed}. "
-            f"Lower KNOWN_LEAKS['{path.name}'] to {len(leaks)} "
+            f"{key} now has {len(leaks)} leaks, fewer than the allowed {allowed}. "
+            f"Lower KNOWN_LEAKS['{key}'] to {len(leaks)} "
             f"({'or delete the entry' if len(leaks) == 0 else 'to lock the improvement in'})."
         )
 
 
 def test_allowlist_has_no_stale_entries():
-    """A file listed in KNOWN_LEAKS must still exist."""
-    names = {p.name for p in router_files()}
-    assert not (set(KNOWN_LEAKS) - names), (
-        f"KNOWN_LEAKS names routers that no longer exist: {set(KNOWN_LEAKS) - names}"
+    """A file listed in KNOWN_LEAKS must still exist and still be scanned."""
+    keys = {_key(p) for p in scanned_files()}
+    assert not (set(KNOWN_LEAKS) - keys), (
+        f"KNOWN_LEAKS names files that are no longer scanned: {set(KNOWN_LEAKS) - keys}"
     )
+
+
+def test_scan_covers_the_helpers_that_build_error_responses():
+    """The scan is recursive and reaches past routers/, or it guards nothing."""
+    keys = {_key(p) for p in scanned_files()}
+
+    assert "utils/execution_validation.py" in keys
+    assert "services/model_connection.py" in keys
+    assert any("/" in key.split("/", 1)[1] for key in keys), (
+        "no file found in a subpackage -- the glob is not recursive"
+    )
+
+
+# --- the guard's own behaviour, pinned against inline snippets ---------------
+#
+# Each case is a leak variant that once slipped through. Testing against strings
+# rather than the real tree keeps these true no matter what the routers contain.
+
+LEAKING = {
+    "positional_detail": """
+        try:
+            pass
+        except Exception as e:
+            raise HTTPException(500, f"boom: {e}")
+    """,
+    "database_error_is_broad": """
+        try:
+            pass
+        except SQLAlchemyError as e:
+            raise HTTPException(status_code=500, detail=str(e))
+    """,
+    "operational_error_is_broad": """
+        try:
+            pass
+        except OperationalError as e:
+            raise HTTPException(status_code=500, detail=str(e))
+    """,
+    "http_client_error_is_broad": """
+        try:
+            pass
+        except httpx.HTTPError as e:
+            raise HTTPException(status_code=502, detail=str(e))
+    """,
+    "subprocess_error_is_broad": """
+        try:
+            pass
+        except subprocess.CalledProcessError as e:
+            raise HTTPException(status_code=500, detail=str(e))
+    """,
+    "dotted_broad_exception": """
+        try:
+            pass
+        except builtins.Exception as e:
+            raise HTTPException(status_code=500, detail=str(e))
+    """,
+    "aug_assign": """
+        try:
+            pass
+        except Exception as e:
+            msg = "Failed: "
+            msg += str(e)
+            raise HTTPException(status_code=500, detail=msg)
+    """,
+    "tuple_unpack": """
+        try:
+            pass
+        except Exception as e:
+            msg, code = str(e), 500
+            raise HTTPException(status_code=code, detail=msg)
+    """,
+    "dict_item_target": """
+        try:
+            pass
+        except Exception as e:
+            payload = {}
+            payload["msg"] = str(e)
+            raise HTTPException(status_code=500, detail=payload["msg"])
+    """,
+    "attribute_target": """
+        try:
+            pass
+        except Exception as e:
+            self.msg = str(e)
+            raise HTTPException(status_code=500, detail=self.msg)
+    """,
+    "detail_assigned_after_construction": """
+        try:
+            pass
+        except Exception as e:
+            exc = HTTPException(status_code=500, detail="An unexpected error occurred.")
+            exc.detail = str(e)
+            raise exc
+    """,
+    "traceback_without_as": """
+        try:
+            pass
+        except Exception:
+            raise HTTPException(status_code=500, detail=traceback.format_exc())
+    """,
+    "kwargs_splat": """
+        try:
+            pass
+        except Exception as e:
+            raise HTTPException(**{"detail": str(e)})
+    """,
+    "json_response_content": """
+        try:
+            pass
+        except Exception as e:
+            return JSONResponse(status_code=500, content={"detail": str(e)})
+    """,
+    "ok_body_carrying_the_error": """
+        try:
+            pass
+        except Exception as e:
+            return {"success": False, "error": str(e)}
+    """,
+    "result_object_message": """
+        try:
+            pass
+        except Exception as e:
+            return ModelConnectionTestResult(success=False, message=f"Unexpected error: {e}")
+    """,
+    "header_channel": """
+        try:
+            pass
+        except Exception as e:
+            raise HTTPException(
+                500, detail="Nothing to see.", headers={"X-Err": str(e)}
+            )
+    """,
+    "public_exception_detail_must_be_a_literal": """
+        try:
+            pass
+        except Exception as e:
+            raise PublicHTTPException(status_code=503, detail=f"Garak failed: {e}")
+    """,
+    "exception_parameter_outside_any_handler": """
+        def handle_execution_error(error: Exception) -> HTTPException:
+            return HTTPException(status_code=500, detail=f"Failed: {error}")
+    """,
+    "computed_status_could_be_a_500": """
+        try:
+            pass
+        except Exception as e:
+            raise HTTPException(status_code=status, detail=str(e))
+    """,
+    "walrus": """
+        try:
+            pass
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=(msg := str(e)))
+    """,
+    "format_call": """
+        try:
+            pass
+        except Exception as e:
+            raise HTTPException(status_code=500, detail="boom {}".format(e))
+    """,
+    "percent_interpolation": """
+        try:
+            pass
+        except Exception as e:
+            raise HTTPException(status_code=500, detail="boom %s" % e)
+    """,
+    "concatenation": """
+        try:
+            pass
+        except Exception as e:
+            raise HTTPException(status_code=500, detail="boom " + str(e))
+    """,
+    "repr_of_exception": """
+        try:
+            pass
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=repr(e))
+    """,
+    "exception_args": """
+        try:
+            pass
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=e.args[0])
+    """,
+    "copied_then_interpolated": """
+        try:
+            pass
+        except Exception as e:
+            error_msg = str(e)
+            wrapped = f"Failed: {error_msg}"
+            raise HTTPException(status_code=500, detail=wrapped)
+    """,
+}
+
+CLEAN = {
+    "narrow_exception_message_is_deliberate": """
+        try:
+            pass
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+    """,
+    "logging_the_exception_is_the_point": """
+        try:
+            pass
+        except Exception as e:
+            logger.error("Failed to sync: %s", str(e), exc_info=True)
+            raise HTTPException(status_code=500, detail="An unexpected error occurred.")
+    """,
+    "deliberate_client_error_detail": """
+        try:
+            pass
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Error processing filter: {e}") from e
+    """,
+    "internal_error_helper": """
+        try:
+            pass
+        except Exception as e:
+            raise internal_error(e, context="syncing the test set") from e
+    """,
+    "public_literal_detail": """
+        try:
+            pass
+        except Exception as e:
+            logger.exception("garak missing: %s", e)
+            raise PublicHTTPException(status_code=503, detail="Garak package is not installed")
+    """,
+    "upstream_relay_is_the_blessed_exemption": """
+        try:
+            pass
+        except httpx.HTTPError as e:
+            logger.warning("could not reach the provider: %s", e)
+            raise UpstreamHTTPException(status_code=502, detail=f"Could not reach it: {e}") from e
+    """,
+    "re_raising_untouched": """
+        try:
+            pass
+        except Exception as e:
+            logger.warning("retrying: %s", e)
+            raise
+    """,
+    "narrow_parameter_annotation": """
+        def convert(error: ModelConfigurationError) -> HTTPException:
+            return HTTPException(status_code=400, detail=str(error))
+    """,
+}
+
+
+def _snippet(source: str) -> str:
+    return textwrap.dedent(source).strip("\n")
+
+
+@pytest.mark.parametrize("name", sorted(LEAKING))
+def test_find_leaks_catches(name):
+    assert find_leaks(_snippet(LEAKING[name])), f"{name} slipped through the guard"
+
+
+@pytest.mark.parametrize("name", sorted(CLEAN))
+def test_find_leaks_does_not_cry_wolf(name):
+    """False positives get the guard deleted, so pin the safe patterns too."""
+    assert find_leaks(_snippet(CLEAN[name])) == [], f"{name} was flagged but is safe"

--- a/tests/backend/services/invokers/test_auth_manager.py
+++ b/tests/backend/services/invokers/test_auth_manager.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 from fastapi import HTTPException
 
+from rhesis.backend.app.error_handlers import UpstreamHTTPException
 from rhesis.backend.app.services.invokers.auth.manager import AuthenticationManager
 
 
@@ -163,8 +164,11 @@ class TestAuthenticationManager:
             with pytest.raises(HTTPException) as exc_info:
                 manager.get_client_credentials_token(mock_db, sample_endpoint_oauth)
 
-            assert exc_info.value.status_code == 500
-            assert "Failed to get client credentials token" in str(exc_info.value.detail)
+            # 502 and an UpstreamHTTPException: the caller's own token URL failed,
+            # so the reason reaches them instead of being masked as our error.
+            assert exc_info.value.status_code == 502
+            assert isinstance(exc_info.value, UpstreamHTTPException)
+            assert "configured token URL" in str(exc_info.value.detail)
 
     def test_get_client_credentials_token_http_error(self, mock_db, sample_endpoint_oauth):
         """Test OAuth flow handles HTTP errors."""
@@ -180,7 +184,7 @@ class TestAuthenticationManager:
             with pytest.raises(HTTPException) as exc_info:
                 manager.get_client_credentials_token(mock_db, sample_endpoint_oauth)
 
-            assert exc_info.value.status_code == 500
+            assert exc_info.value.status_code == 502
 
     def test_get_client_credentials_token_updates_endpoint_cache(
         self, mock_db, sample_endpoint_oauth


### PR DESCRIPTION
## Purpose

Router error handling had two problems. **We were blind:** 98 broad `except Exception` blocks across the routers, 27 of which logged nothing at all, and no catch-all handler behind any of them — an uncaught error became a bare Starlette 500 that left no trace. There was no request id, so even a logged error couldn't be tied to a user's report. **We leaked:** 43 sites fed an exception caught by a broad handler straight into `detail=`, handing callers SQLAlchemy statements, OAuth provider internals, Celery broker URLs and connection targets. `auth.py` returned `f"Authentication failed: {str(e)}"`; `job.py` returned `f"Celery health check failed: {str(e)}"`.

An unexpected error should now tell the user nothing and the logs everything, tied together by an id the user can quote.

## What Changed

**Foundation (`3a10c76c5`)**

- `RequestIDMiddleware` assigns every request an id, echoed as `X-Request-ID`. Pure ASGI rather than `BaseHTTPMiddleware` — the latter runs the downstream app in a new anyio task, and the id has to stay readable both downstream in log records and back up in the exception handlers.
- A global `Exception` handler logs the full traceback and returns `{"detail": "An unexpected error occurred.", "error_id": "..."}`. A 5xx `HTTPException` handler does the same. **Sub-500s pass through completely untouched**, so deliberate validation messages like "Test set name already exists" still reach users unchanged.
- `internal_error(exc, context=...)` for the cases where a router genuinely adds context a global handler can't infer.
- Log records carry `request_id`, so service- and crud-level lines correlate to the same request.
- `tests/backend/security/test_router_error_leaks.py` AST-scans every router for the leak pattern and fails on regressions.

**Router cleanup (43 leaks removed across 4 commits)**

Most of the fix is deletion — once a global handler exists, a broad handler that logs nothing and re-wraps the error is pure noise. Net **−436 lines** in the routers.

## Additional Context

**Three latent bugs surfaced.** Broad handlers were swallowing the endpoints' own deliberate `HTTPException`s and re-wrapping them as 500s: `job.py`'s `503 "No Celery workers available"` and `404 "Task not found"`, and `test_run.py`'s `404 "Test run not found"`. Deleting the handlers fixes all three.

**Behavior change:** all 5xx response bodies are now generic, including hand-written ones like `"Failed to send test request to SDK"`. Nothing is lost — the original moves to the logs under the `error_id` — but it is visible. Two tests asserted the old behavior and were updated. The narrower alternative (genericise only exception-derived text) was rejected because it lets every *new* leak ship freely until someone notices.

**The guard already caught a regression.** The OWASP router (#2202) landed on `main` while this branch was in flight, shipping the same pattern on a 502 and a 500. The guard flagged both on merge — that is the case it exists for.

**Known gap:** `model.py::test_model_connection` returns HTTP 200 with `{"status": "error", "message": str(e)}`. The guard cannot see it — there is no `detail=`. Fixing it would change the response contract, so it is left for a follow-up.

Frontend needs no change to keep working; it reads `.detail`, which still exists. Surfacing `error_id` in error toasts is a separate follow-up.

## Testing

3907 backend tests pass, 42 skipped. Zero leaks across all 52 routers.

```bash
cd apps/backend
uv sync --extra all --extra ee
uv run pytest ../../tests/backend/security/ ../../tests/backend/routes/ \
  ../../tests/backend/app/ ../../tests/backend/auth/ ../../tests/backend/utils/ \
  ../../tests/backend/tasks/ -q -p no:randomly
```

To confirm the guard actually bites, reintroduce a leak and watch it fail:

```bash
sed -i '' 's/detail="Failed to generate content"/detail=f"Failed to generate content: {e}"/' \
  apps/backend/src/rhesis/backend/app/routers/services.py
cd apps/backend && uv run pytest ../../tests/backend/security/test_router_error_leaks.py -q
git checkout apps/backend/src/rhesis/backend/app/routers/services.py
```

End to end: `./rh dev status` for this checkout's ports, then trigger a failing endpoint and confirm the response body is generic, `X-Request-ID` is set, and the same id appears in the logs beside a full traceback.

---

## Update: code-review fixes (commits 7–8)

A `/code-review high` pass over this branch found eight issues. Six are fixed here; two are deliberately deferred.

**The blanket 5xx masking was too blunt in one direction.** `POST /endpoints/test` and `invoke_endpoint` exist to report what is wrong with the *caller's* endpoint — a refused connection, a rejected token — and masking those told the user nothing while protecting nothing of ours. `UpstreamHTTPException` now marks that case and the global handler passes its detail through.

The exemption is deliberately narrow, because the obvious version of it would have introduced a new leak. Two places where the boundary was not where it looked:

- `EndpointService` wraps *our own* exceptions in `EndpointInvocationError` as `error_type="internal_error"` (`services/endpoint/service.py:348`), so the router branches on that discriminator rather than trusting the exception type.
- `testing.py`'s `try` covered endpoint construction and input enrichment as well as the invocation, so the exemption is scoped to the `invoke()` call alone and setup failures still go through `internal_error`.

A test asserts a plain 500 is still masked, so the exemption cannot quietly widen.

**Also fixed:** CORS `expose_headers` omitted `X-Request-ID`, so browser JS could never read the id the middleware exists to emit; `internal_error(status_code=400)` answered "An unexpected error occurred.", describing a client error in server-error words; `internal_error` logged and then the handler logged the same failure again; both the middleware and the handler set `X-Request-ID`, so every 5xx carried it twice plus a redundant `X-Error-Id`; and `POST /tests/bulk` with an empty list returned 500 instead of 400 (pre-existing, but this branch stripped the message that made it diagnosable).

**Deferred, tracked for follow-up:** `ValueError` bleed paths — five sites in `services/` launder a provider or parser error into a `ValueError` message that narrow router handlers then hand to the user (`raise ValueError(f"LLM generation failed: {e}")`). Same concern as this PR, one hop removed, and invisible to the guard because it crosses a `raise`/`catch` boundary. Also deferred: inbound `X-Request-ID` is adopted from any caller, so a client can reuse an id and make correlation ambiguous.

## Revised review order

1. **`error_handlers.py` + `utils/request_context.py`** (commits 1, 8) — the contract. The middleware-ordering argument for reading the id from the request scope, the `status_code < 500` passthrough, and the `UpstreamHTTPException` exemption and its two guards.
2. **`test_router_error_leaks.py`** (commit 5) — defines what counts as a leak.
3. **Batch commits 2–4** — mostly deletions; reading the added lines is enough. `garak.py` is the riskiest (unwrapped `try` blocks with dedented bodies).
4. **Commits 6–7** — the OWASP fix (the guard catching a regression) and the bulk-create status fix.

## Verification

5795 backend tests pass, 43 skipped. Zero leaks across all 52 routers.


---

## Update: second review pass (seven follow-up commits)

A review of the whole branch found the masking went too far in one direction and not far enough in another. Both are fixed here, along with a bug that made this PR's central promise false in every deployed environment.

**Logs held no traceback in production.** `JsonLogFormatter` built its payload from `record.getMessage()` and never read `record.exc_info`, and `jsonLoggerEnabled: true` is set in dev, stg and prd. So `logger.exception` emitted one line with no stack, no frames and no exception class — the client was told nothing and the log kept only `str(exc)`. That is the half of "mask the response, log the reason" that was silently not happening, and it bit hardest exactly where this branch deleted broad handlers on the grounds that the global handler would log the same traceback. Tracebacks now land in a `stack_trace` field, redacted. The request id is also passed explicitly on the unhandled path, because `ServerErrorMiddleware` runs after `RequestIDMiddleware` clears the ContextVar — the field had been null on precisely the lines an `error_id` points at.

**Deliberate 5xx messages had no way through.** `PublicHTTPException` passes a literal detail through and logs at WARNING with no stack, since a hand-written 503 is not a fault to debug and its traceback only points back at the raise. `UpstreamHTTPException` becomes one case of it. This restores "Garak package is not installed", "No Celery workers available" and "Failed to send test request to SDK" — strings this branch left in the code while the handler replaced them, so the code read as if they still arrived. `internal_error` gains `public_detail` for the same reason at 4xx.

**A wrong credential for a service the user connected themselves was masked.** `handle_mcp_exception` deliberately remaps an MCP 401/403 to a 502 so the reason survives and the frontend does not clear the session — and the global handler masked exactly that, so a bad Notion token read as our service being down. It returns `UpstreamHTTPException` now, and only for `MCPApplicationError`, whose detail really is the tool's parsed response. `services.py` had stripped provider reasons at 400, a status this PR's own contract says passes through, turning "invalid api key" into "Failed to generate content" while logging it at ERROR with a stack as though it were ours. `tools.py` reports an unreachable instance again, in a drawer whose only job is showing why a connection failed.

**The branch had introduced a leak of its own.** `services/endpoint/testing.py` wrapped `invoke()` in a bare `except Exception` and declared whatever it caught to be upstream detail, shipping `str(exc)` on a 500 — including SQLAlchemy errors carrying the statement and its bound parameters, and `HTTPException`s that stringify to `"400: ..."`, so a status code arrived inside a 500 body. The invokers *return* an error response for genuine upstream failures, so almost nothing that block caught was upstream at all. `rest_invoker` did the same thing through a channel nothing was watching: `str(e)` in an HTTP 200 body, invisible to the guard because there is no `detail=`. `test_endpoint_mapping`, whose only job is explaining what is wrong with the mappings the user just typed, had been left out of the exemption entirely.

**Caller faults were logged as server faults.** 422s logged at ERROR with a traceback immediately before the function whose docstring says a 422 is not a server fault. Login failures reported an IdP outage as a 400 with one stackless warning, where `main` logged an ERROR with a traceback — both axes wrong at once. A single connection-refused against a user's endpoint produced three ERROR records and two tracebacks; it is now one warning.

**Redaction was wrong in both directions.** It mangled ordinary diagnostics — `api key: not configured` became `api key: [REDACTED] configured` — while missing the secrets that actually arrive: provider errors read `Incorrect API key provided: sk-…`, with filler between the keyword and the value, and header dumps put a quote between the name and `Bearer …`. The URL pattern never matched SQLAlchemy's real `postgresql://` scheme, and the Celery broker is `redis://`. Both directions are fixed, with key shapes matched without needing a keyword at all.

**The guard let 14 of 20 crafted leaks through.** The likeliest regression was the simplest: only `detail=` keywords were inspected, so `HTTPException(500, f"...{e}")` with a positional detail was invisible. `BROAD_EXCEPTIONS` held only `Exception` and `BaseException`, treating `SQLAlchemyError` and `httpx.HTTPError` as narrow and deliberate despite carrying SQL text and connection strings. Taint followed plain assignment only, so `+=`, tuples, subscripts and attributes all escaped. Scanning now covers `routers/`, `utils/` and `services/` recursively; `services/invokers/` is exempt because every string there reports on the user's own endpoint.

### Two things worth pushing back on

The guard no longer flags a 4xx `detail` built from an exception, which it used to. Sub-500 details pass through by design and three live sites depend on it, but this is less coverage than before, not a refactor.

`get_client_credentials_token` changed from 500 to 502, with two tests updated. More accurate — it is the caller's own token endpoint failing — but it is a status change on a public path.

### Known gaps, deliberately not fixed here

15 pre-existing leaks across 8 files put `str(e)` in a 200 body or a result object. They are the same bug this PR removes, through a channel it never examined, and they are ratcheted in `KNOWN_LEAKS` so the count can only fall. Separately: `routers/file_import.py` orders `except ValueError` ahead of `except ValidationError`, so a caller fault lands in the 404 arm; the SDK's `mcp/agent.py` wraps any exception as `MCPValidationError` at 422, a sub-500 that passes through unmasked; `services/github.py` answers 200 with an empty body for an invalid `repo_url`; and an unhandled 500 comes from `ServerErrorMiddleware`, outside `CORSMiddleware`, so browser JS can read neither its body nor `X-Request-ID` — meaning the `expose_headers` change earlier in this PR does not help that path. A test now pins that behaviour so it cannot change silently.

## Verification (current)

6165 passed, 43 skipped, 1 xfailed. Ruff clean on all changed files apart from six findings that reproduce on `origin/main`.

```bash
cd apps/backend
uv sync --extra all --extra ee
uv run pytest ../../tests/backend/security/ ../../tests/backend/routes/ ../../tests/backend/app/ \
  ../../tests/backend/auth/ ../../tests/backend/utils/ ../../tests/backend/tasks/ \
  ../../tests/backend/services/ -q -p no:randomly
```

The traceback fix is the one thing no test in the earlier rounds would have caught, so it is worth seeing directly:

```bash
cd apps/backend && uv run python -c "
import json, logging, sys
from rhesis.backend.logging.logging_config import JsonLogFormatter, RedactingFormatter
f = RedactingFormatter(JsonLogFormatter())
try:
    raise ValueError('boom api_key=sk-proj-aBcD1234EfGh5678')
except ValueError:
    r = logging.LogRecord('t', logging.ERROR, 'p', 1, 'ctx', (), sys.exc_info())
d = json.loads(f.format(r))
print('frames:', 'File' in d['stack_trace'], '| redacted:', '[REDACTED]' in d['stack_trace'])
"
```
