### PR TITLE
Add a rebase-over-merge rule for updating feature branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,19 @@ git checkout -b feature/short-description`.
   - `BREAKING CHANGE:` in the footer for breaking changes
   - Example: `fix(backend): resolve timeout issue in user endpoint`
 
+## Updating a Branch
+
+- **Rebase a feature branch onto `main`; don't merge `main` into it:**
+  `git fetch origin && git rebase origin/main`. Merging leaves a merge commit and interleaves
+  unrelated `main` changes into the branch's history, which makes the PR diff noisy and stops the
+  branch's own commits from reading as a clean sequence.
+- On conflicts: fix the files, `git add <file>`, then `git rebase --continue`. `git rebase --abort`
+  puts the branch back the way it was.
+- A rebase rewrites history, so pushing an already-pushed branch needs
+  `git push --force-with-lease` — it refuses to overwrite commits someone else pushed, which plain
+  `--force` will do. On a branch someone else is working on, tell them before you force-push.
+- **Never force-push `main`.**
+
 ## Task-specific workflows
 
 Opening a pull request, filing a GitHub issue, writing playground scripts, and linting Python each


### PR DESCRIPTION
## Purpose

Agents and contributors had no documented rule for how to bring a feature branch up to date with `main`, so `git merge main` into the branch was a live option. Merging that way leaves a merge commit and interleaves unrelated `main` changes into the branch's history, which makes the PR diff noisy and stops the branch's own commits from reading as a clean sequence. This writes the rebase-first rule down, along with the conflict and force-push handling that goes with it.

## What Changed

- Added a short `## Updating a Branch` section to the root `AGENTS.md`: rebase onto `origin/main` rather than merging `main` in, the conflict loop (`git add` then `git rebase --continue`, or `git rebase --abort` to back out), `git push --force-with-lease` for an already-pushed branch, a heads-up before force-pushing a shared branch, and never force-pushing `main`.

## Additional Context

- Root `AGENTS.md` is the home rather than the `pull-request` skill because the skill only loads when someone is opening a PR, whereas branches most often need updating mid-review, well after the PR exists. Root `AGENTS.md` is imported by `CLAUDE.md` and read natively by Cursor, so the rule is in context whenever git work happens.
- It is a new section rather than an addition to `## Git Commits` because that section is about authoring commits (approval, branch creation, staging, Conventional Commits), while rebasing, conflict handling and force-pushing are a separate operation with their own caveats. Keeping them under one heading also keeps the rule and its caveats together instead of buried in the commit-formatting bullets.
- The rule is stated in exactly one place — no copy in the `pull-request` skill or `CONTRIBUTING.md` — so it cannot drift.
- No pre-existing "never force-push `main`" prohibition was found anywhere in the repo docs, so that line is new here rather than carried over.

## Testing

Documentation only, so there is nothing to execute. Reviewing means reading the new `## Updating a Branch` section in `AGENTS.md` and checking the commands are correct and the wrapping matches the file's 100-character convention. No code, tests, or CI configuration were touched.
