### PR TITLE
Fix dev init writing an active RHESIS_API_KEY placeholder

### DIFF
--- a/scripts/rh/dev.sh
+++ b/scripts/rh/dev.sh
@@ -132,8 +132,11 @@ JWT_SECRET_KEY=${jwt_secret}
 # Session
 SESSION_SECRET_KEY=${session_secret}
 
-# Rhesis API Key (get one at https://app.rhesis.ai)
-RHESIS_API_KEY=your_api_key
+# Rhesis API Key (get one at https://app.rhesis.ai). Left commented on purpose:
+# get_platform_api_key() treats any non-empty value as a real key, so an active
+# placeholder makes Rhesis-hosted models 401 instead of falling through to the
+# DEFAULT_*_MODEL provider. Uncomment and set a real key to use hosted models.
+#RHESIS_API_KEY=your_api_key
 EOF
 }
 


### PR DESCRIPTION
## Purpose

`./rh dev init` wrote `RHESIS_API_KEY=your_api_key` as an **active** value rather than a commented-out example. `get_platform_api_key()` treats any non-empty value as a real key, so in local mode every Rhesis-hosted model authenticated against `api.rhesis.ai` with the literal string `your_api_key` and got a 401 — instead of falling through to the deployment's configured `DEFAULT_*_MODEL` provider.

This bites on a freshly initialised worktree whenever the workspace's generation model points at the seeded Rhesis-hosted default, which is the state a newly seeded org starts in. The visible symptom is unrelated to the actual cause: the Architect chat reports "The selected generation model could not produce a valid response... try a more capable model", while the backend log shows `[RhesisLLM] HTTP 401 ... {"detail":"Not authenticated"}`.

## What Changed

- `scripts/rh/dev.sh`: the generated backend `.env` now emits `#RHESIS_API_KEY=your_api_key`, commented out, with a note explaining why an active placeholder breaks model fallback.

## Additional Context

- No behaviour change for anyone who already set a real key — the line is only a template default for newly generated env files.
- Existing `.env` files are untouched; this only affects future `./rh dev init` runs.
- Found while debugging a local Architect failure that looked like a model-capability problem and was actually auth.

## Testing

Regenerate a backend env file and confirm the key is commented while the `dev init` marker still validates:

```bash
./rh dev init     # in a scratch worktree, or inspect the generated file
head -1 apps/backend/.env          # "# Generated by ./rh dev init on ..."
grep RHESIS_API_KEY apps/backend/.env   # "#RHESIS_API_KEY=your_api_key"
./rh dev status   # still reports the env files as initialised
```

Then start the backend and confirm a workspace using the Rhesis-hosted default model resolves to `DEFAULT_GENERATION_MODEL` instead of returning 401 from `api.rhesis.ai`.
