### PR TITLE
Keep Explorer suggestions working without an embedding provider

### DIFF
--- a/apps/backend/src/rhesis/backend/app/services/explorer/embeddings.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/embeddings.py
@@ -28,7 +28,7 @@ from rhesis.backend.app.models.user import User
 from rhesis.backend.app.services.explorer.diversity_strategies import (
     DEFAULT_EMBEDDING_DIVERSITY_STRATEGY,
 )
-from rhesis.backend.app.utils.model_errors import ModelConfigurationError
+from rhesis.backend.app.utils.model_errors import EmbeddingProviderNotConfigured
 from rhesis.backend.app.utils.user_model_utils import get_user_embedding_model
 from rhesis.sdk.models.factory import get_model
 
@@ -147,10 +147,10 @@ def resolve_embedder(db: Session, user_id: str):
     from rhesis.sdk.models.providers.native import RhesisEmbedder
 
     if isinstance(embedder, RhesisEmbedder):
-        raise ModelConfigurationError(
+        raise EmbeddingProviderNotConfigured(
             "Embedding model resolved to the Rhesis native provider, which would call "
             "the embedding endpoint recursively. Set DEFAULT_EMBEDDING_MODEL to an "
-            "actual provider (e.g. vertex_ai/text-embedding-005)."
+            "actual provider (e.g. vertex_ai/text-embedding-005) to enable embeddings."
         )
 
     return embedder

--- a/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
@@ -29,6 +29,7 @@ from rhesis.backend.app.services.streaming_utils import (
     IncrementalJsonArrayParser,
 )
 from rhesis.backend.app.services.streaming_utils import ndjson as _ndjson
+from rhesis.backend.app.utils.model_errors import EmbeddingProviderNotConfigured
 
 logger = logging.getLogger(__name__)
 
@@ -328,19 +329,29 @@ async def generate_suggestions(
             sort_by_diversity,
         )
 
-        embedder = resolve_embedder(db, user_id)
-        texts = [(item.get("input") or "").strip() for item in suggestions]
+        # Embeddings only drive diversity ordering here, so a deployment with no
+        # embedding provider still gets its suggestions -- just unsorted and
+        # without vectors. Before, this resolve raised straight out of the
+        # function and took the whole suggestion request with it.
+        try:
+            embedder = resolve_embedder(db, user_id)
+        except EmbeddingProviderNotConfigured as e:
+            logger.warning("Suggestions generated without embeddings: %s", e)
+            embedder = None
 
-        vectors = await a_generate_embedding_vectors_batch(
-            texts,
-            db,
-            user_id,
-            embedder=embedder,
-        )
-        for item, vec in zip(suggestions, vectors):
-            item["embedding"] = vec
+        if embedder is not None:
+            texts = [(item.get("input") or "").strip() for item in suggestions]
 
-        suggestions = sort_by_diversity(suggestions)
+            vectors = await a_generate_embedding_vectors_batch(
+                texts,
+                db,
+                user_id,
+                embedder=embedder,
+            )
+            for item, vec in zip(suggestions, vectors):
+                item["embedding"] = vec
+
+            suggestions = sort_by_diversity(suggestions)
 
     logger.info(
         f"Generated {len(suggestions)} suggestions for "
@@ -426,7 +437,14 @@ async def suggestion_pipeline_stream(
             resolve_embedder,
         )
 
-        embedder = resolve_embedder(db, user_id)
+        # Degrade to a no-embedding stream rather than failing it: this resolve
+        # sits outside _embed_one's own try/except, so an unconfigured provider
+        # used to abort the entire suggestion stream, not just the vectors.
+        try:
+            embedder = resolve_embedder(db, user_id)
+        except EmbeddingProviderNotConfigured as e:
+            logger.warning("Suggestion stream running without embeddings: %s", e)
+            generate_embeddings = False
 
     # ── Shared state ──
     suggestions: List[Dict[str, Any]] = []

--- a/apps/backend/src/rhesis/backend/app/utils/model_errors.py
+++ b/apps/backend/src/rhesis/backend/app/utils/model_errors.py
@@ -12,6 +12,21 @@ class ModelConfigurationError(ValueError):
         super().__init__(self.message)
 
 
+class EmbeddingProviderNotConfigured(ModelConfigurationError):
+    """No real embedding provider is configured for this deployment.
+
+    Distinct from a provider that *is* configured but broken (bad key,
+    inaccessible model): that stays a plain ``ModelConfigurationError`` and
+    should still fail loudly. This one means ``DEFAULT_EMBEDDING_MODEL`` still
+    resolves to the Rhesis native provider, whose ``.generate()`` would call
+    this backend's own embedding endpoint over HTTP -- i.e. itself.
+
+    Subclasses ``ModelConfigurationError`` so existing handlers keep catching
+    it; callers that can degrade gracefully (embeddings are optional
+    enrichment) catch this narrower type and carry on without vectors.
+    """
+
+
 # Provider statuses that mean "this request is wrong", not "try again later":
 # bad request, missing/invalid credentials, no permission, unknown model.
 _PERMANENT_PROVIDER_STATUSES = frozenset({400, 401, 403, 404})

--- a/tests/backend/services/explorer/test_embeddings.py
+++ b/tests/backend/services/explorer/test_embeddings.py
@@ -6,7 +6,10 @@ import pytest
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app.services.explorer.embeddings import resolve_embedder
-from rhesis.backend.app.utils.model_errors import ModelConfigurationError
+from rhesis.backend.app.utils.model_errors import (
+    EmbeddingProviderNotConfigured,
+    ModelConfigurationError,
+)
 
 
 @pytest.mark.unit
@@ -39,9 +42,12 @@ class TestResolveEmbedder:
         fake_native_embedder = Mock(spec=RhesisEmbedder)
         mock_get_user_embedding_model.return_value = fake_native_embedder
 
-        with pytest.raises(ModelConfigurationError, match="recursively"):
+        with pytest.raises(EmbeddingProviderNotConfigured, match="recursively") as exc_info:
             resolve_embedder(test_db, authenticated_user_id)
 
+        # Callers that can degrade catch the narrow type; the subclassing keeps
+        # existing `except ModelConfigurationError` handlers working.
+        assert isinstance(exc_info.value, ModelConfigurationError)
         fake_native_embedder.generate.assert_not_called()
 
     @patch("rhesis.backend.app.services.explorer.embeddings.get_model")

--- a/tests/backend/services/explorer/test_suggestions.py
+++ b/tests/backend/services/explorer/test_suggestions.py
@@ -11,6 +11,7 @@ from rhesis.backend.app.services.explorer import (
     invoke_endpoint_for_suggestions_stream,
     suggestion_pipeline_stream,
 )
+from rhesis.backend.app.utils.model_errors import EmbeddingProviderNotConfigured
 
 # Resolved at call time inside EndpointInvoker, so the source modules are the patch targets.
 _DB_CTX_PATCH = "rhesis.backend.app.database.get_db_with_tenant_variables"
@@ -452,3 +453,53 @@ class TestSuggestionPipelineStream:
         assert sorted(done["diversity_order"]) == [0, 1]
         assert len(done["diversity_scores"]) == 2
         assert all(score is not None for score in done["diversity_scores"])
+
+    async def test_unconfigured_embedding_provider_still_streams_suggestions(
+        self, test_db: Session, test_org_id, authenticated_user_id
+    ):
+        """No embedding provider must not abort the stream.
+
+        resolve_embedder runs outside _embed_one's own try/except, so before
+        this it took the whole suggestion stream down with it -- even though
+        embeddings here only drive diversity ordering.
+        """
+        mock_invoker = MagicMock()
+        mock_invoker.invoke = AsyncMock(return_value=("an answer", None))
+        run_metrics = AsyncMock(return_value={"Correctness": {"score": 1.0, "is_successful": True}})
+        embed_one = AsyncMock()
+
+        with (
+            patch(
+                _GENERATE_SUGGESTIONS_PATCH,
+                new=AsyncMock(
+                    return_value=_fake_suggestion_stream([("", "first"), ("", "second")])
+                ),
+            ),
+            patch(_INVOKER_PATCH, return_value=mock_invoker),
+            patch(_RESOLVE_METRICS_PATCH, return_value=[]),
+            patch(_RUN_METRICS_PATCH, new=run_metrics),
+            patch(
+                _RESOLVE_EMBEDDER_PATCH,
+                side_effect=EmbeddingProviderNotConfigured("no provider configured"),
+            ),
+            patch(_EMBED_ONE_PATCH, new=embed_one),
+        ):
+            events = await _collect(
+                suggestion_pipeline_stream(
+                    db=test_db,
+                    test_set_identifier="some-test-set",
+                    organization_id=test_org_id,
+                    user_id=authenticated_user_id,
+                    endpoint_id=str(uuid.uuid4()),
+                    metric_names=["Correctness"],
+                    num_suggestions=2,
+                    generate_embeddings=True,
+                )
+            )
+
+        # The stream completes and still carries its suggestions...
+        done = next(e for e in events if e["type"] == "suggestions_done")
+        assert done["total"] == 2
+        # ...just with no embedding work attempted and no diversity ordering.
+        embed_one.assert_not_called()
+        assert not any(e["type"] == "embedding" for e in events)


### PR DESCRIPTION
## Purpose

A deployment with no embedding provider configured lost the **entire** Explorer suggestions feature, not just the embedding vectors.

`resolve_embedder()` raises when `DEFAULT_EMBEDDING_MODEL` still resolves to the Rhesis native provider (which would call this backend's own embedding endpoint over HTTP — infinite recursion). Both Explorer suggestion paths call it *outside* their per-item `try`/`except`: `generate_suggestions` at the top of its embedding block, and `suggestion_pipeline_stream` before the loop that spawns `_embed_one`. So the exception propagated straight out and took the whole request or stream with it.

That is disproportionate, because embeddings are optional enrichment here — they only drive diversity ordering. The response schema already models their absence (`SuggestedTest.embedding` is `Optional[List[float]] = None`), and `sort_by_diversity()` already handles items without vectors by placing them last with a `None` score.

## What Changed

- `utils/model_errors.py`: new `EmbeddingProviderNotConfigured`, a subclass of `ModelConfigurationError` so existing `except ModelConfigurationError` handlers keep catching it, while callers that can degrade catch the narrower type.
- `explorer/embeddings.py`: `resolve_embedder()` raises the new narrower type for the "no provider configured" case.
- `explorer/suggestions.py`: both call sites catch it, log a warning, and continue without embeddings — the non-streaming path skips the embed + diversity sort, and the streaming path disables embedding events so `_embed_one` is never spawned.

A provider that *is* configured but broken (bad key, inaccessible model) is unaffected: that stays a plain `ModelConfigurationError` and still fails loudly.

## Additional Context

- Related to, but independent of, the same recursion guard in `services/embedding/generator.py`, which is handled separately in #2465. Once both land, the two could be unified onto this shared exception type in a small follow-up.
- No API or schema change — a suggestions response simply comes back with `embedding: null` and no diversity ordering.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/services/explorer/ -v
```

203 tests pass, including one new case and one tightened assertion:

- `test_unconfigured_embedding_provider_still_streams_suggestions` — patches `resolve_embedder` to raise, asserts the stream still completes with all its suggestions, that no embedding work is attempted, and that no `embedding` events are emitted.
- `test_recursive_native_provider_fails_before_any_network_call` — now asserts the narrower `EmbeddingProviderNotConfigured` and that it is still a `ModelConfigurationError`.

The new test was verified to be load-bearing: stashing the `suggestions.py` change makes it fail, restoring it makes it pass.
