### PR TITLE
Migrate eager loading from reflection-based to explicit include()

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/crud/__init__.py
@@ -64,18 +64,15 @@ def get_endpoint(
     project_id: str = None,
 ) -> Optional[models.Endpoint]:
     """Get endpoint with relationships eagerly loaded."""
-    from rhesis.backend.app.utils.crud_utils import _check_and_raise_if_deleted
-
-    item = (
-        QueryBuilder(db, models.Endpoint)
-        .with_deleted()
-        .with_related(*_ENDPOINT_RELATED_FIELDS)
-        .with_organization_filter(organization_id)
-        .with_project_filter(project_id)
-        .with_visibility_filter(user_id)
-        .filter_by_id(endpoint_id)
+    return get_item_detail(
+        db,
+        models.Endpoint,
+        endpoint_id,
+        organization_id,
+        user_id,
+        project_id=project_id,
+        related_fields=_ENDPOINT_RELATED_FIELDS,
     )
-    return _check_and_raise_if_deleted(item, models.Endpoint, endpoint_id, False)
 
 
 def get_endpoints(
@@ -88,15 +85,17 @@ def get_endpoints(
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.Endpoint]:
-    return (
-        QueryBuilder(db, models.Endpoint)
-        .with_related(*_ENDPOINT_RELATED_FIELDS)
-        .with_organization_filter(organization_id)
-        .with_visibility_filter(user_id)
-        .with_odata_filter(filter)
-        .with_sorting(sort_by, sort_order)
-        .with_pagination(skip, limit)
-        .all()
+    return get_items_detail(
+        db,
+        models.Endpoint,
+        skip,
+        limit,
+        sort_by,
+        sort_order,
+        filter,
+        related_fields=_ENDPOINT_RELATED_FIELDS,
+        organization_id=organization_id,
+        user_id=user_id,
     )
 
 
@@ -167,7 +166,8 @@ def get_prompts(
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.Prompt]:
-    return get_items_detail(
+    # PromptDetail has no nested relationship fields -- plain get_items, no eager load.
+    return get_items(
         db,
         models.Prompt,
         skip,
@@ -876,11 +876,28 @@ def get_test(
     return get_item(db, models.Test, test_id, organization_id, user_id)
 
 
+# Every many-to-one relationship TestDetail serializes -- see schemas/test.py.
+# parent/source/organization/project are unused and intentionally excluded.
+_TEST_RELATED_FIELDS = (
+    include(models.Test.prompt),
+    include(models.Test.test_type),
+    include(models.Test.user),
+    include(models.Test.assignee),
+    include(models.Test.owner),
+    include(models.Test.topic),
+    include(models.Test.behavior),
+    include(models.Test.category),
+    include(models.Test.status),
+)
+
+
 def get_test_detail(
     db: Session, test_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.Test]:
     """Get test with all relationships loaded using optimized approach."""
-    return get_item_detail(db, models.Test, test_id, organization_id, user_id)
+    return get_item_detail(
+        db, models.Test, test_id, organization_id, user_id, related_fields=_TEST_RELATED_FIELDS
+    )
 
 
 def get_tests(
@@ -903,6 +920,7 @@ def get_tests(
         sort_by,
         sort_order,
         filter,
+        related_fields=_TEST_RELATED_FIELDS,
         organization_id=organization_id,
         user_id=user_id,
         exclude_explorer_rows=True,

--- a/apps/backend/src/rhesis/backend/app/crud/behavior.py
+++ b/apps/backend/src/rhesis/backend/app/crud/behavior.py
@@ -5,21 +5,14 @@ the bulk of the functions, and per-entity modules like this one take over as the
 around them is touched.
 
 ``_BEHAVIOR_RELATED_FIELDS`` covers exactly what ``BehaviorWithMetricsSchema`` in
-``routers/behavior.py`` serializes -- tags, user, and each metric with its metric_type,
+``routers/behavior.py`` serializes -- user, and each metric with its metric_type,
 backend_type and tags. Status, organization and project are left out because nothing reads
-them. The nested ``metrics.tags`` entry has to be listed on its own: ``selectinload``'s
-default cascade skips many-to-many relations, so without it every metric in the response
-lazy-loads its own tags.
+them. Behavior's own tags load via ``with_default_derived_field_loads`` (``TagsMixin``), same
+as every other entity -- only the nested ``metrics.tags`` needs to be listed explicitly here,
+since that cascade only covers many-to-one relations and ``metrics`` is many-to-many.
 
 ``get_behaviors`` is the plain list and loads none of that -- only ``get_behaviors_detail``
 eager-loads the relationships, which is why the list endpoint calls the detail variant.
-``get_behaviors_detail`` runs as two queries, mirroring ``get_metrics`` and
-``crud_utils.get_items_detail``: a joinless query picks the page's IDs (filter + sort +
-LIMIT/OFFSET), then a second query eager-loads the relationships for just those IDs.
-Without the split, Postgres would build every join for every matching row in the
-organization before it could sort and cut down to ``limit``. The second query's
-``WHERE id IN (...)`` does not preserve order, so the phase-1 sort is re-applied in Python
--- dropping that step silently returns the right page in the wrong order.
 """
 
 import uuid
@@ -31,14 +24,15 @@ from rhesis.backend.app import models, schemas
 from rhesis.backend.app.utils.crud_utils import (
     create_item,
     delete_item,
+    get_item_detail,
     get_items,
+    get_items_detail,
     update_item,
 )
-from rhesis.backend.app.utils.query_utils import QueryBuilder, include
+from rhesis.backend.app.utils.query_utils import include
 
 _BEHAVIOR_RELATED_FIELDS = (
     include(models.Behavior.user),
-    include(models.Behavior._tags_relationship, models.TaggedItem.tag),
     include(models.Behavior.metrics),
     include(models.Behavior.metrics, models.Metric.metric_type),
     include(models.Behavior.metrics, models.Metric.backend_type),
@@ -50,17 +44,14 @@ def get_behavior(
     db: Session, behavior_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.Behavior]:
     """Get behavior with relationships eagerly loaded."""
-    from rhesis.backend.app.utils.crud_utils import _check_and_raise_if_deleted
-
-    item = (
-        QueryBuilder(db, models.Behavior)
-        .with_deleted()
-        .with_related(*_BEHAVIOR_RELATED_FIELDS)
-        .with_organization_filter(organization_id)
-        .with_visibility_filter(user_id)
-        .filter_by_id(behavior_id)
+    return get_item_detail(
+        db,
+        models.Behavior,
+        behavior_id,
+        organization_id,
+        user_id,
+        related_fields=_BEHAVIOR_RELATED_FIELDS,
     )
-    return _check_and_raise_if_deleted(item, models.Behavior, behavior_id, False)
 
 
 def get_behaviors(
@@ -90,30 +81,18 @@ def get_behaviors_detail(
     user_id: str = None,
 ) -> List[models.Behavior]:
     """Get behaviors with related objects for BehaviorWithMetricsSchema, including metrics."""
-    ordered_ids = (
-        QueryBuilder(db, models.Behavior)
-        .with_organization_filter(organization_id)
-        .with_visibility_filter(user_id)
-        .with_odata_filter(filter)
-        .with_sorting(sort_by, sort_order)
-        .with_pagination(skip, limit)
-        .ids()
+    return get_items_detail(
+        db,
+        models.Behavior,
+        skip,
+        limit,
+        sort_by,
+        sort_order,
+        filter,
+        related_fields=_BEHAVIOR_RELATED_FIELDS,
+        organization_id=organization_id,
+        user_id=user_id,
     )
-    if not ordered_ids:
-        return []
-
-    items = (
-        QueryBuilder(db, models.Behavior)
-        .with_related(*_BEHAVIOR_RELATED_FIELDS)
-        .with_organization_filter(organization_id)
-        .with_visibility_filter(user_id)
-        .query.filter(models.Behavior.id.in_(ordered_ids))
-        .all()
-    )
-
-    # WHERE id IN (...) does not preserve order -- re-apply the phase-1 sort.
-    items_by_id = {item.id: item for item in items}
-    return [items_by_id[item_id] for item_id in ordered_ids if item_id in items_by_id]
 
 
 def create_behavior(

--- a/apps/backend/src/rhesis/backend/app/crud/comment.py
+++ b/apps/backend/src/rhesis/backend/app/crud/comment.py
@@ -35,12 +35,22 @@ from rhesis.backend.app.utils.query_utils import QueryBuilder, include
 
 logger = logging.getLogger(__name__)
 
+# Relationships serialized by schemas.CommentDetail -- user only.
+_COMMENT_RELATED_FIELDS = (include(models.Comment.user),)
+
 
 def get_comment(
     db: Session, comment_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.Comment]:
     """Get comment with relationships eagerly loaded."""
-    return get_item_detail(db, models.Comment, comment_id, organization_id, user_id)
+    return get_item_detail(
+        db,
+        models.Comment,
+        comment_id,
+        organization_id,
+        user_id,
+        related_fields=_COMMENT_RELATED_FIELDS,
+    )
 
 
 def get_comments(
@@ -62,6 +72,7 @@ def get_comments(
         sort_by,
         sort_order,
         filter,
+        related_fields=_COMMENT_RELATED_FIELDS,
         organization_id=organization_id,
         user_id=user_id,
     )

--- a/apps/backend/src/rhesis/backend/app/crud/metric.py
+++ b/apps/backend/src/rhesis/backend/app/crud/metric.py
@@ -16,6 +16,7 @@ from rhesis.backend.app import models, schemas
 from rhesis.backend.app.utils.crud_utils import (
     create_item,
     delete_item,
+    get_items_detail,
     update_item,
 )
 from rhesis.backend.app.utils.query_utils import QueryBuilder, include
@@ -45,7 +46,13 @@ _METRIC_RELATED_FIELDS = (
 def get_metric(
     db: Session, metric_id: uuid.UUID, organization_id: str, user_id: str = None
 ) -> Optional[models.Metric]:
-    """Get a specific metric by ID with its related objects, including many-to-many relationships"""
+    """Get a specific metric by ID with its related objects, including many-to-many relationships.
+
+    Deliberately not routed through ``get_item_detail``: a soft-deleted metric must come
+    back as ``None`` here (tested behavior), not raise ``ItemDeletedException`` -- unlike
+    every other entity's single-item fetch, callers of this one don't need to tell "not
+    found" apart from "deleted".
+    """
     return (
         QueryBuilder(db, models.Metric)
         .with_related(*_METRIC_RELATED_FIELDS)
@@ -57,19 +64,28 @@ def get_metric(
     )
 
 
-def _apply_metric_scope_filter(builder: QueryBuilder, metric_scope: str | None) -> None:
-    """Parse a comma-separated metric_scope string and apply a JSONB @> filter."""
+def _metric_scope_filter(metric_scope: str | None):
+    """Build a query transform filtering Metric.metric_scope by a comma-separated scope list.
+
+    Returns None when there's nothing to filter, so callers can pass the result straight
+    through as get_items_detail's extra_filter without an extra None-check.
+    """
     if not metric_scope:
-        return
+        return None
     from sqlalchemy import or_
     from sqlalchemy.dialects.postgresql import JSONB as PG_JSONB
     from sqlalchemy.sql.expression import cast
 
     scopes = [s.strip() for s in metric_scope.split(",") if s.strip()]
-    if scopes:
-        builder.query = builder.query.filter(
+    if not scopes:
+        return None
+
+    def _filter(q):
+        return q.filter(
             or_(*[models.Metric.metric_scope.op("@>")(cast([s], PG_JSONB)) for s in scopes])
         )
+
+    return _filter
 
 
 def get_metrics(
@@ -83,44 +99,20 @@ def get_metrics(
     organization_id: str = None,
     user_id: str = None,
 ) -> List[models.Metric]:
-    """Get all metrics with their related objects, including many-to-many relationships.
-
-    Runs as two queries, mirroring crud_utils.get_items_detail: a joinless
-    query picks the page's IDs (filter + sort + LIMIT/OFFSET), then a second
-    query eager-loads the metric relationships scoped to just those IDs.
-    Without this split, Postgres has to build all nine _METRIC_RELATED_FIELDS
-    joins for every matching row across the org before it can sort and cut
-    down to `limit`, so cost scales with total matching rows rather than
-    page size.
-    """
-    builder = (
-        QueryBuilder(db, models.Metric)
-        .with_organization_filter(organization_id)
-        .with_visibility_filter(user_id)
-        .with_odata_filter(filter)
-        .with_sorting(sort_by, sort_order)
-        .with_pagination(skip, limit)
+    """Get all metrics with their related objects, including many-to-many relationships."""
+    return get_items_detail(
+        db,
+        models.Metric,
+        skip,
+        limit,
+        sort_by,
+        sort_order,
+        filter,
+        related_fields=_METRIC_RELATED_FIELDS,
+        organization_id=organization_id,
+        user_id=user_id,
+        extra_filter=_metric_scope_filter(metric_scope),
     )
-
-    _apply_metric_scope_filter(builder, metric_scope)
-
-    ordered_ids = builder.ids()
-    if not ordered_ids:
-        return []
-
-    items = (
-        QueryBuilder(db, models.Metric)
-        .with_related(*_METRIC_RELATED_FIELDS)
-        .with_default_derived_field_loads()
-        .with_organization_filter(organization_id)
-        .with_visibility_filter(user_id)
-        .query.filter(models.Metric.id.in_(ordered_ids))
-        .all()
-    )
-
-    # WHERE id IN (...) does not preserve order -- re-apply the phase-1 sort.
-    items_by_id = {item.id: item for item in items}
-    return [items_by_id[item_id] for item_id in ordered_ids if item_id in items_by_id]
 
 
 def _preprocess_metric_data(

--- a/apps/backend/src/rhesis/backend/app/crud/model.py
+++ b/apps/backend/src/rhesis/backend/app/crud/model.py
@@ -35,6 +35,14 @@ from rhesis.backend.app.utils.crud_utils import (
 )
 from rhesis.backend.app.utils.query_utils import include
 
+# Relationships serialized by schemas.ModelDetail -- provider_type, status.
+# owner/assignee: unused, excluded. Public (no leading underscore) since
+# routers/model.py's own get_item_detail call for the single-item GET reuses it.
+MODEL_DETAIL_RELATED_FIELDS = (
+    include(models.Model.provider_type),
+    include(models.Model.status),
+)
+
 
 def get_model(
     db: Session, model_id: uuid.UUID, organization_id: str = None, user_id: str = None
@@ -74,6 +82,7 @@ def get_models(
         sort_by,
         sort_order,
         filter,
+        related_fields=MODEL_DETAIL_RELATED_FIELDS,
         organization_id=organization_id,
         user_id=user_id,
     )

--- a/apps/backend/src/rhesis/backend/app/crud/project.py
+++ b/apps/backend/src/rhesis/backend/app/crud/project.py
@@ -24,6 +24,9 @@ from rhesis.backend.app.utils.crud_utils import (
 )
 from rhesis.backend.app.utils.query_utils import include
 
+# Relationships serialized by schemas.ProjectDetail -- owner (tags load via the mixin cascade).
+_PROJECT_RELATED_FIELDS = (include(models.Project.owner),)
+
 
 def get_project(
     db: Session, project_id: uuid.UUID, organization_id: str = None, user_id: str = None
@@ -42,7 +45,14 @@ def get_project(
     from rhesis.backend.app.models.project_membership import ProjectMembership
     from rhesis.backend.app.scope import bypass_tenant_filter
 
-    project = get_item_detail(db, models.Project, project_id, organization_id, user_id)
+    project = get_item_detail(
+        db,
+        models.Project,
+        project_id,
+        organization_id,
+        user_id,
+        related_fields=_PROJECT_RELATED_FIELDS,
+    )
     if project is None or user_id is None:
         return project
 

--- a/apps/backend/src/rhesis/backend/app/crud/task.py
+++ b/apps/backend/src/rhesis/backend/app/crud/task.py
@@ -40,6 +40,15 @@ from rhesis.backend.app.utils.crud_utils import (
     get_items_detail,
     update_item,
 )
+from rhesis.backend.app.utils.query_utils import include
+
+# Relationships serialized by schemas.TaskDetail -- user, assignee, status, priority.
+_TASK_RELATED_FIELDS = (
+    include(models.Task.user),
+    include(models.Task.assignee),
+    include(models.Task.status),
+    include(models.Task.priority),
+)
 
 
 def get_task(
@@ -51,7 +60,13 @@ def get_task(
     # default -- TaskDetail.comment_count reads it directly, so it needs its
     # own explicit selectin_chains entry.
     return get_item_detail(
-        db, models.Task, task_id, organization_id, user_id, selectin_chains=[["comments"]]
+        db,
+        models.Task,
+        task_id,
+        organization_id,
+        user_id,
+        related_fields=_TASK_RELATED_FIELDS,
+        selectin_chains=[["comments"]],
     )
 
 
@@ -76,6 +91,7 @@ def get_tasks(
         sort_by,
         sort_order,
         filter,
+        related_fields=_TASK_RELATED_FIELDS,
         selectin_chains=[["comments"]],
         organization_id=organization_id,
         user_id=user_id,

--- a/apps/backend/src/rhesis/backend/app/crud/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/crud/test_run.py
@@ -27,7 +27,13 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
 from rhesis.backend.app import models, schemas
-from rhesis.backend.app.utils.crud_utils import create_item, delete_item, update_item
+from rhesis.backend.app.utils.crud_utils import (
+    create_item,
+    delete_item,
+    get_item_detail,
+    get_items_detail,
+    update_item,
+)
 from rhesis.backend.app.utils.name_generator import generate_memorable_name
 from rhesis.backend.app.utils.query_utils import QueryBuilder, include
 
@@ -69,37 +75,33 @@ def get_test_run(
     db: Session, test_run_id: uuid.UUID, organization_id: str = None, user_id: str = None
 ) -> Optional[models.TestRun]:
     """Get test_run with relationships eagerly loaded (including nested chains)."""
-    from rhesis.backend.app.utils.crud_utils import _check_and_raise_if_deleted
-
-    item = (
-        QueryBuilder(db, models.TestRun)
-        .with_deleted()
-        .with_related(*_TEST_RUN_RELATED_FIELDS)
-        .with_default_derived_field_loads()
-        .with_custom_filter(_defer_endpoint_last_token)
-        .with_organization_filter(organization_id)
-        .with_visibility_filter(user_id)
-        .filter_by_id(test_run_id)
+    return get_item_detail(
+        db,
+        models.TestRun,
+        test_run_id,
+        organization_id,
+        user_id,
+        related_fields=_TEST_RUN_RELATED_FIELDS,
+        extra_filter=_defer_endpoint_last_token,
     )
 
-    return _check_and_raise_if_deleted(item, models.TestRun, test_run_id)
 
-
-def get_test_runs(
+def _test_run_experiment_filter(
     db: Session,
-    skip: int = 0,
-    limit: int = 10,
-    sort_by: str = "created_at",
-    sort_order: str = "desc",
-    filter: str | None = None,
-    experiment_id: str | None = None,
-    parameter_version: str | None = None,
-    has_experiment: bool | None = None,
-    has_reviews: bool | None = None,
-    organization_id: str = None,
-    user_id: str = None,
-) -> List[models.TestRun]:
-    def experiment_filter(q):
+    experiment_id: str | None,
+    parameter_version: str | None,
+    has_experiment: bool | None,
+    has_reviews: bool | None,
+    organization_id: str | None,
+):
+    """Build the experiment/parameter/review row-selection filter for get_test_runs.
+
+    A row-selection filter (like ``with_odata_filter``), not a loader option --
+    must run on the phase-1 id query so the right page of ids is picked in the
+    first place; see get_items_detail's ``extra_filter`` vs ``hydrate_filter``.
+    """
+
+    def _filter(q):
         if experiment_id:
             q = q.filter(models.TestRun.experiment_id == experiment_id)
         if parameter_version:
@@ -132,18 +134,38 @@ def get_test_runs(
             q = q.filter(reviewed_result_exists if has_reviews else ~reviewed_result_exists)
         return q
 
-    return (
-        QueryBuilder(db, models.TestRun)
-        .with_related(*_TEST_RUN_RELATED_FIELDS)
-        .with_default_derived_field_loads()
-        .with_custom_filter(_defer_endpoint_last_token)
-        .with_custom_filter(experiment_filter)
-        .with_organization_filter(organization_id)
-        .with_visibility_filter(user_id)
-        .with_odata_filter(filter)
-        .with_pagination(skip, limit)
-        .with_sorting(sort_by, sort_order)
-        .all()
+    return _filter
+
+
+def get_test_runs(
+    db: Session,
+    skip: int = 0,
+    limit: int = 10,
+    sort_by: str = "created_at",
+    sort_order: str = "desc",
+    filter: str | None = None,
+    experiment_id: str | None = None,
+    parameter_version: str | None = None,
+    has_experiment: bool | None = None,
+    has_reviews: bool | None = None,
+    organization_id: str = None,
+    user_id: str = None,
+) -> List[models.TestRun]:
+    return get_items_detail(
+        db,
+        models.TestRun,
+        skip,
+        limit,
+        sort_by,
+        sort_order,
+        filter,
+        related_fields=_TEST_RUN_RELATED_FIELDS,
+        organization_id=organization_id,
+        user_id=user_id,
+        extra_filter=_test_run_experiment_filter(
+            db, experiment_id, parameter_version, has_experiment, has_reviews, organization_id
+        ),
+        hydrate_filter=_defer_endpoint_last_token,
     )
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/model.py
+++ b/apps/backend/src/rhesis/backend/app/routers/model.py
@@ -152,7 +152,14 @@ def read_model(
     # Use get_item_detail which properly handles soft-deleted items (raises ItemDeletedException)
     from rhesis.backend.app.utils.crud_utils import get_item_detail
 
-    db_model = get_item_detail(db, models.Model, model_id, organization_id, user_id)
+    db_model = get_item_detail(
+        db,
+        models.Model,
+        model_id,
+        organization_id,
+        user_id,
+        related_fields=model_crud.MODEL_DETAIL_RELATED_FIELDS,
+    )
     if db_model is None:
         raise HTTPException(status_code=404, detail="Model not found")
     annotate_model_availability(db, organization_id, [db_model])

--- a/apps/backend/src/rhesis/backend/app/services/experiment.py
+++ b/apps/backend/src/rhesis/backend/app/services/experiment.py
@@ -78,12 +78,13 @@ def get_visible_experiment(
     - Anything else surfaces as 404 (never 403). Returning 404 keeps
       experiment existence from leaking across users / orgs.
     """
-    db_experiment = crud.get_item(
+    db_experiment = crud.get_item_detail(
         db,
         Experiment,
         experiment_id,
         organization_id=organization_id,
         user_id=user_id,
+        related_fields=(crud.include(Experiment.project),),
     )
     if db_experiment is None:
         raise HTTPException(

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
 from pydantic import BaseModel
 from sqlalchemy import inspect
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Query, Session
 
 from rhesis.backend.app.constants import EntityType
 
@@ -344,13 +344,12 @@ def get_item_detail(
     user_id: str = None,
     include_deleted: bool = False,
     project_id: str = None,
-    nested_relationships: dict = None,
+    related_fields: tuple | list | None = None,
     selectin_chains: list | None = None,
+    extra_filter: Callable[[Query], Query] | None = None,
 ) -> Optional[T]:
     """
-    Get a single item with all first-level relationships eagerly loaded.
-
-    Uses selectinload for many-to-many and joinedload for other relationships.
+    Get a single item with explicitly declared relationships eagerly loaded.
 
     Args:
         db: Database session
@@ -363,16 +362,22 @@ def get_item_detail(
             the session auto-filter).  When provided the predicate is
             ``project_id = :pid OR project_id IS NULL`` so org-level rows
             remain visible.  ``None`` skips the filter.
-        nested_relationships: Dict specifying nested relationships to load.
-            Format: {"relationship_name": ["nested_rel1", "nested_rel2"]}. Mirrors
-            get_items_detail's parameter of the same name, for parity between the
-            single-item and list paths when a schema nests fields two levels deep.
+        related_fields: Pre-built ``include(...)`` load options -- e.g. a
+            module-level ``_ENTITY_RELATED_FIELDS`` tuple (see
+            ``crud/behavior.py`` for the pattern). Passed straight to
+            ``with_related``, so multi-hop chains and ``cols=`` scoping work
+            exactly as they would calling ``include()`` directly. Only what
+            the caller's response schema actually serializes should be
+            listed here.
         selectin_chains: Extra relationship-name chains to load with nested
-            selectinload, beyond with_optimized_loads' many-to-one/one-to-one
-            defaults -- e.g. a one-to-many relationship the response schema
-            reads directly (custom polymorphic relationships bypass the
-            comments/tasks/files/tags mixin defaults). Mirrors
-            get_items_detail's parameter of the same name.
+            selectinload, beyond ``related_fields`` -- e.g. a one-to-many
+            relationship the response schema reads directly (custom
+            polymorphic relationships bypass the comments/tasks/files/tags
+            mixin defaults). Mirrors get_items_detail's parameter of the same
+            name.
+        extra_filter: Optional query transform for entity-specific needs that
+            don't fit the generic filters above -- e.g. deferring a large
+            column (``TestRun``'s ``endpoint.last_token``).
 
     Returns:
         Item with relationships loaded or None if not found
@@ -381,70 +386,18 @@ def get_item_detail(
         ItemDeletedException: If item is soft-deleted and include_deleted is False
     """
     # Always check with deleted items first to differentiate not-found vs deleted
-    item = (
+    builder = (
         QueryBuilder(db, model)
         .with_deleted()  # Always include deleted to check status
-        .with_optimized_loads(skip_one_to_many=True, nested_relationships=nested_relationships)
+        .with_related(*(related_fields or ()))
         .with_default_derived_field_loads(selectin_chains)
         .with_organization_filter(organization_id)
         .with_project_filter(project_id)
         .with_visibility_filter(user_id)
-        .filter_by_id(item_id)
     )
-
-    # Use helper to check deletion status and raise exception if needed
-    return _check_and_raise_if_deleted(item, model, item_id, include_deleted)
-
-
-def get_item_with_deferred(
-    db: Session,
-    model: Type[T],
-    item_id: uuid.UUID,
-    deferred_fields: List[str],
-    organization_id: str = None,
-    user_id: str = None,
-    include_deleted: bool = False,
-) -> Optional[T]:
-    """
-    Get a single item with all relationships loaded AND specific deferred fields.
-
-    This is similar to get_item_detail but also explicitly loads deferred columns.
-
-    Args:
-        db: Database session
-        model: SQLAlchemy model class
-        item_id: ID of the item to retrieve
-        deferred_fields: List of deferred field names to explicitly load
-        organization_id: Organization ID for filtering
-        user_id: User ID for filtering
-        include_deleted: If True, include soft-deleted records (default: False)
-
-    Returns:
-        Item with relationships and deferred fields loaded or None if not found
-
-    Raises:
-        ItemDeletedException: If item is soft-deleted and include_deleted is False
-    """
-    from sqlalchemy.orm import undefer
-
-    # Build query with relationships loaded (same as get_item_detail)
-    item = (
-        QueryBuilder(db, model)
-        .with_deleted()  # Always include deleted to check status
-        .with_optimized_loads()
-        .with_organization_filter(organization_id)
-        .with_visibility_filter(user_id)
-    )
-
-    # Add undefer options for deferred fields BEFORE query execution
-    for field_name in deferred_fields:
-        if hasattr(model, field_name):
-            # Get the actual column attribute (not string)
-            column_attr = getattr(model, field_name)
-            item.query = item.query.options(undefer(column_attr))
-
-    # Execute the query with deferred fields included
-    item = item.filter_by_id(item_id)
+    if extra_filter:
+        builder = builder.with_custom_filter(extra_filter)
+    item = builder.filter_by_id(item_id)
 
     # Use helper to check deletion status and raise exception if needed
     return _check_and_raise_if_deleted(item, model, item_id, include_deleted)
@@ -481,28 +434,47 @@ def get_items_detail(
     sort_by: str = "created_at",
     sort_order: str = "desc",
     filter: str | None = None,
-    nested_relationships: dict = None,
+    related_fields: tuple | list | None = None,
     selectin_chains: list | None = None,
     organization_id: str = None,
     user_id: str = None,
     secondary_sort_by: str | None = None,
     secondary_sort_order: str = "asc",
     exclude_explorer_rows: bool = False,
+    extra_filter: Callable[[Query], Query] | None = None,
+    hydrate_filter: Callable[[Query], Query] | None = None,
 ) -> List[T]:
     """
-    Get multiple items with relationships eagerly loaded, pagination, sorting, and filtering.
+    Get multiple items with explicitly declared relationships eagerly loaded,
+    pagination, sorting, and filtering.
 
-    Uses selectinload for many-to-many and joinedload for other relationships.
     Also always selectin-loads comments/tasks/files/tags for any model that has
     them -- see QueryBuilder.with_default_derived_field_loads for why.
 
     Args:
-        nested_relationships: Dict specifying nested relationships to load.
-                            Format: {"relationship_name": ["nested_rel1", "nested_rel2"]}
+        related_fields: Pre-built ``include(...)`` load options -- e.g. a
+            module-level ``_ENTITY_RELATED_FIELDS`` tuple (see
+            ``crud/behavior.py`` for the pattern). Passed straight to
+            ``with_related``, so multi-hop chains and ``cols=`` scoping work
+            exactly as they would calling ``include()`` directly. Only what
+            the caller's response schema actually serializes should be listed
+            here.
         selectin_chains: Extra relationship-name chains to load with nested selectinload,
                         beyond the defaults above. Format: [["rel", "nested_rel"], ...]
         exclude_explorer_rows: Drop Explorer-owned rows. Only for models with an
                         ``explorer_row`` column (Test, TestSet).
+        extra_filter: Optional row-selection query transform for entity-specific
+            WHERE clauses the generic filters above don't cover -- e.g.
+            ``Metric``'s ``metric_scope`` or ``TestRun``'s experiment/review
+            filters. Applied only to the phase-1 id query, same scope as
+            ``with_odata_filter`` -- once phase 1 has picked the page's ids,
+            there is nothing left to filter in phase 2.
+        hydrate_filter: Optional query transform applied only to the phase-2
+            (eager-loaded) query, for loader-option tweaks that only make
+            sense once the full row is being fetched -- e.g. ``TestRun``
+            deferring ``Endpoint.last_token``. Applying a loader option like
+            this to the id-only phase-1 query would be meaningless (or emit
+            SQLAlchemy warnings), since that query never loads the relationship.
 
     Runs as two queries rather than one: a joinless query picks the page's IDs
     (filter + sort + LIMIT/OFFSET), then a second query eager-loads
@@ -520,6 +492,8 @@ def get_items_detail(
     )
     if exclude_explorer_rows:
         ids_builder = ids_builder.with_explorer_rows_excluded()
+    if extra_filter:
+        ids_builder = ids_builder.with_custom_filter(extra_filter)
     ordered_ids = (
         ids_builder.with_sorting(
             sort_by,
@@ -533,12 +507,10 @@ def get_items_detail(
     if not ordered_ids:
         return []
 
-    builder = QueryBuilder(db, model).with_optimized_loads(
-        skip_many_to_many=False,
-        skip_one_to_many=True,
-        nested_relationships=nested_relationships,
-    )
+    builder = QueryBuilder(db, model).with_related(*(related_fields or ()))
     builder = builder.with_default_derived_field_loads(selectin_chains)
+    if hydrate_filter:
+        builder = builder.with_custom_filter(hydrate_filter)
     items = (
         builder.with_organization_filter(organization_id)
         .with_visibility_filter(user_id)

--- a/apps/backend/src/rhesis/backend/app/utils/query_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/query_utils.py
@@ -186,7 +186,7 @@ class QueryBuilder:
             self.with_related(include(*resolve_chain(self.model, chain)))
 
         # Cascade one level into joined-in single-object relations (the ones
-        # with_optimized_loads/with_related eager-load via joinedload) whose
+        # with_related eager-loads via joinedload) whose
         # target model also carries these mixins. These relationships are
         # already strategy=joinedload (by convention, whether set by this
         # call or by the caller) -- selectinload-ing the same attribute
@@ -220,20 +220,6 @@ class QueryBuilder:
                 self.model.__name__,
                 self._eager_load_count,
             )
-
-    def with_optimized_loads(
-        self,
-        skip_many_to_many: bool = True,
-        skip_one_to_many: bool = True,
-        nested_relationships: dict = None,
-    ) -> "QueryBuilder":
-        """Apply optimized loading strategy.
-
-        Uses selectinload for many-to-many, joinedload for others."""
-        self.query = apply_optimized_loads(
-            self.query, self.model, skip_many_to_many, skip_one_to_many, nested_relationships
-        )
-        return self
 
     def with_deleted(self) -> "QueryBuilder":
         """
@@ -601,93 +587,3 @@ def get_model_relationships(
         relationships[rel.key] = rel
 
     return relationships
-
-
-def _build_nested_load_options(
-    parent_load,
-    parent_rel_prop: RelationshipProperty,
-    nested_spec,
-) -> List:
-    """
-    Recursively build chained load options for nested relationships.
-
-    Args:
-        parent_load: The parent load option (e.g. joinedload(Model.rel))
-        parent_rel_prop: The SQLAlchemy RelationshipProperty for the parent
-        nested_spec: Either a list of relationship names or a dict for deeper nesting.
-                     List format:  ["endpoint", "test_set"]
-                     Dict format:  {"endpoint": ["project"], "test_set": ["test_set_type"]}
-
-    Returns:
-        List of chained load options to apply to the query.
-    """
-    target_model = parent_rel_prop.mapper.class_
-    options = []
-
-    if isinstance(nested_spec, list):
-        for nested_rel_name in nested_spec:
-            if hasattr(target_model, nested_rel_name):
-                nested_attr = getattr(target_model, nested_rel_name)
-                options.append(parent_load.joinedload(nested_attr))
-    elif isinstance(nested_spec, dict):
-        for nested_rel_name, deeper_spec in nested_spec.items():
-            if hasattr(target_model, nested_rel_name):
-                nested_attr = getattr(target_model, nested_rel_name)
-                nested_load = parent_load.joinedload(nested_attr)
-                options.append(nested_load)
-                nested_rel_prop = inspect(target_model).relationships[nested_rel_name]
-                options.extend(
-                    _build_nested_load_options(nested_load, nested_rel_prop, deeper_spec)
-                )
-
-    return options
-
-
-def apply_optimized_loads(
-    query: Query,
-    model: Type,
-    skip_many_to_many: bool = True,
-    skip_one_to_many: bool = True,
-    nested_relationships: dict = None,
-) -> Query:
-    """
-    Apply optimized loading strategy using selectinload for many-to-many relationships
-    and joinedload for one-to-many/many-to-one relationships.
-
-    This avoids the cartesian product problem that occurs with joinedload on many-to-many.
-
-    Args:
-        nested_relationships: Dict specifying nested relationships to load.
-            Supports both flat and deep nesting formats:
-            - Flat:  {"tags": ["status"]}
-            - Deep:  {"test_configuration": {"endpoint": ["project"],
-                                             "test_set": ["test_set_type"]}}
-    """
-    relationships = get_model_relationships(
-        model, skip_many_to_many=False, skip_one_to_many=skip_one_to_many
-    )
-
-    for rel_name, rel_prop in relationships.items():
-        relationship_attr = getattr(model, rel_name)
-        has_nested = nested_relationships and rel_name in nested_relationships
-
-        if rel_prop.direction.name in ["MANYTOMANY"]:
-            if not skip_many_to_many:
-                if has_nested:
-                    base_load = selectinload(relationship_attr)
-                    query = query.options(base_load)
-                    for nested_rel in nested_relationships[rel_name]:
-                        nested_attr = getattr(rel_prop.mapper.class_, nested_rel)
-                        query = query.options(base_load.selectinload(nested_attr))
-                else:
-                    query = query.options(selectinload(relationship_attr))
-        else:
-            base_load = joinedload(relationship_attr)
-            query = query.options(base_load)
-            if has_nested:
-                for opt in _build_nested_load_options(
-                    base_load, rel_prop, nested_relationships[rel_name]
-                ):
-                    query = query.options(opt)
-
-    return query

--- a/tests/backend/test_secret_equality.py
+++ b/tests/backend/test_secret_equality.py
@@ -67,8 +67,8 @@ SENSITIVE_MARKERS = (
 ALLOWED_SITES: frozenset[tuple[str, int]] = frozenset(
     {
         # content_hash is a SHA-based fingerprint for version dedup, not a secret
-        ("apps/backend/src/rhesis/backend/app/services/experiment.py", 149),
-        ("apps/backend/src/rhesis/backend/app/services/experiment.py", 205),
+        ("apps/backend/src/rhesis/backend/app/services/experiment.py", 150),
+        ("apps/backend/src/rhesis/backend/app/services/experiment.py", 206),
         # auth_token_project_id is a UUID project reference, not a secret token;
         # comparing it to another project UUID is safe (no timing oracle risk)
         ("apps/backend/src/rhesis/backend/app/services/connector/manager.py", 1005),

--- a/tests/backend/utils/test_model_utils.py
+++ b/tests/backend/utils/test_model_utils.py
@@ -5,7 +5,7 @@ These tests verify the current behavior of functions before they are refactored
 to use the new direct parameter passing approach.
 """
 
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from sqlalchemy.orm import Session
@@ -113,63 +113,6 @@ class TestQueryBuilder:
 
         original_query.options.assert_not_called()
         assert query_builder._eager_load_count == 0
-
-    def test_query_builder_with_optimized_loads(
-        self, test_db: Session, authenticated_user_id, test_org_id
-    ):
-        """Test QueryBuilder with_optimized_loads method."""
-        # Create QueryBuilder instance
-        query_builder = QueryBuilder(test_db, models.Test)
-
-        # Mock the apply_optimized_loads function
-        with patch(
-            "rhesis.backend.app.utils.query_utils.apply_optimized_loads"
-        ) as mock_apply_optimized_loads:
-            mock_modified_query = MagicMock()
-            mock_apply_optimized_loads.return_value = mock_modified_query
-
-            nested_relationships = {"test_set": {"prompts": None}}
-
-            # Call with_optimized_loads
-            result = query_builder.with_optimized_loads(
-                skip_many_to_many=False,
-                skip_one_to_many=True,
-                nested_relationships=nested_relationships,
-            )
-
-            # Verify the method returns self and modifies the query
-            assert result == query_builder
-            assert query_builder.query == mock_modified_query
-
-            # Verify apply_optimized_loads was called with correct parameters
-            mock_apply_optimized_loads.assert_called_once_with(
-                ANY, models.Test, False, True, nested_relationships
-            )
-
-    def test_query_builder_chaining(self, test_db: Session, authenticated_user_id, test_org_id):
-        """Test QueryBuilder method chaining across with_related and with_optimized_loads."""
-        from rhesis.backend.app.utils.query_utils import include
-
-        query_builder = QueryBuilder(test_db, models.Test)
-        original_query = MagicMock()
-        query_builder.query = original_query
-        stage1 = MagicMock()
-        original_query.options.return_value = stage1
-
-        with patch(
-            "rhesis.backend.app.utils.query_utils.apply_optimized_loads"
-        ) as mock_apply_optimized_loads:
-            mock_final = MagicMock()
-            mock_apply_optimized_loads.return_value = mock_final
-
-            result = query_builder.with_related(include(models.Test.prompt)).with_optimized_loads(
-                skip_one_to_many=True
-            )
-
-            assert result is query_builder
-            assert original_query.options.call_count == 1
-            mock_apply_optimized_loads.assert_called_once()
-            assert query_builder.query is mock_final
 
     def test_query_builder_state_isolation(
         self, test_db: Session, authenticated_user_id, test_org_id


### PR DESCRIPTION
## Purpose

CRUD eager-loading used to rely on `with_optimized_loads`/`apply_optimized_loads`, which reflected a model's relationships and joined all of them automatically. That made it easy to accidentally load relationships a response schema never serializes, with no easy way to see from the code what a given endpoint actually returns.

## What Changed

- `get_item_detail`/`get_items_detail` in `crud_utils.py` now take an explicit `related_fields` tuple built with `include()`, instead of reflecting relationships automatically.
- Added `extra_filter` (phase-1 id query) and `hydrate_filter` (phase-2 eager-loaded query) hooks for entity-specific query transforms, replacing ad-hoc query building in individual CRUD functions.
- Endpoint, Test, Behavior, Comment, Metric, Model, Project, Task and TestRun CRUD each declare their own `_*_RELATED_FIELDS` scoped to only what their response schema serializes.
- `get_visible_experiment` now uses `get_item_detail` with an explicit `Experiment.project` include instead of lazy-loading it.
- Removed `with_optimized_loads`, `apply_optimized_loads`, and the unused `get_item_with_deferred`, along with their now-dead tests.

## Additional Context

Follow-up to earlier N+1 cleanup work; this closes out the eager-loading migration itself.

## Testing

Backend test suite covers the affected CRUD paths (`tests/backend/`). Manually verified endpoint/test/behavior/comment/metric/model/project/task/test-run detail and list responses still return the same fields.