### PR TITLE
Fix 422 responses echoing submitted passwords and tokens

### DIFF
--- a/apps/backend/src/rhesis/backend/app/error_handlers.py
+++ b/apps/backend/src/rhesis/backend/app/error_handlers.py
@@ -18,6 +18,14 @@ def create_validation_error_response(exc: RequestValidationError) -> JSONRespons
     Handles Pydantic validation errors that may contain non-JSON-serializable
     objects (like ValueError instances) in the error context.
 
+    Pydantic's ``input`` is deliberately dropped. For a *missing* field it holds
+    the whole request body rather than one value, so a signup that forgets its
+    email address answers with the password in cleartext -- and from there into
+    the browser console, which logs the error body for a 422. `loc`, `msg` and
+    `ctx` say which field, what is wrong and which rule broke it; the value adds
+    nothing the caller didn't just send us. Not masked by field name: the name
+    lists we have already miss `credentials` and `code`.
+
     Args:
         exc: The RequestValidationError from FastAPI/Pydantic
 
@@ -31,7 +39,6 @@ def create_validation_error_response(exc: RequestValidationError) -> JSONRespons
             "type": error.get("type"),
             "loc": error.get("loc"),
             "msg": error.get("msg"),
-            "input": error.get("input"),
         }
         # Only include ctx if it exists, and convert any non-serializable values to strings
         if "ctx" in error and error["ctx"]:
@@ -44,7 +51,14 @@ def create_validation_error_response(exc: RequestValidationError) -> JSONRespons
 
 def log_validation_error(exc: RequestValidationError, request: Request) -> None:
     """
-    Log validation errors with detailed information for debugging.
+    Log which fields a request failed validation on, and why.
+
+    Never the submitted value, for the same reason the response omits it. The
+    redaction patterns can't rescue this one: they match the word after
+    "password:", which in a validation message is the message itself, leaving
+    the real value sitting in "(input: ...)" further along the line.
+
+    Warning, not error: a 422 is the caller's mistake, not a server fault.
 
     Args:
         exc: The RequestValidationError from FastAPI/Pydantic
@@ -54,6 +68,10 @@ def log_validation_error(exc: RequestValidationError, request: Request) -> None:
         # Build a readable field path
         field_path = " -> ".join(str(loc) for loc in error["loc"])
 
-        logger.error(
-            f"Validation error: {field_path}: {error['msg']} (input: {error.get('input', 'N/A')})"
+        logger.warning(
+            "Validation error on %s %s: %s: %s",
+            request.method,
+            request.url.path,
+            field_path,
+            error["msg"],
         )

--- a/tests/backend/security/test_validation_errors.py
+++ b/tests/backend/security/test_validation_errors.py
@@ -1,0 +1,113 @@
+"""A 422 must not hand back, or write down, what the caller submitted.
+
+Pydantic attaches the offending value to every validation error. For a *missing*
+field there is no single value to attach, so it attaches the whole request body
+-- which is how a signup that forgets its email address ends up answering with
+the password of the person who typed it.
+"""
+
+import logging
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.testclient import TestClient
+from pydantic import BaseModel, Field, SecretStr
+
+from rhesis.backend.app.error_handlers import (
+    create_validation_error_response,
+    log_validation_error,
+)
+
+PASSWORD = "hunter2-but-far-too-short"
+CLIENT_SECRET = "sso-client-secret-value"
+
+
+@pytest.fixture
+def client() -> TestClient:
+    """Mirrors main.py's validation handler so both paths are the real ones."""
+    app = FastAPI()
+
+    class Signup(BaseModel):
+        email: str
+        password: str = Field(min_length=32)
+
+    class SSOConfig(BaseModel):
+        issuer: str
+        # SecretStr masks the value everywhere Pydantic prints it -- but `input`
+        # is the raw body, captured before any of that applies.
+        client_secret: SecretStr
+
+    @app.exception_handler(RequestValidationError)
+    async def handler(request: Request, exc: RequestValidationError):
+        log_validation_error(exc, request)
+        return create_validation_error_response(exc)
+
+    @app.post("/signup")
+    def signup(body: Signup):  # pragma: no cover - never reached
+        return {}
+
+    @app.put("/sso")
+    def sso(body: SSOConfig):  # pragma: no cover - never reached
+        return {}
+
+    return TestClient(app)
+
+
+def test_response_omits_the_offending_value(client):
+    response = client.post("/signup", json={"email": "a@b.com", "password": PASSWORD})
+
+    assert response.status_code == 422
+    assert "input" not in response.json()["detail"][0]
+    assert PASSWORD not in response.text
+
+
+def test_missing_field_does_not_echo_the_whole_body(client):
+    """The case that makes this more than cosmetic."""
+    response = client.post("/signup", json={"password": PASSWORD})
+
+    assert response.status_code == 422
+    assert PASSWORD not in response.text
+    assert response.json()["detail"][0]["loc"] == ["body", "email"]
+
+
+def test_secretstr_field_is_not_echoed_either(client):
+    """SecretStr is no defence here -- worth pinning so nobody assumes it is."""
+    response = client.put("/sso", json={"client_secret": CLIENT_SECRET})
+
+    assert response.status_code == 422
+    assert CLIENT_SECRET not in response.text
+
+
+def test_response_still_says_what_is_wrong(client):
+    """Dropping the value must not cost the caller the diagnosis."""
+    response = client.post("/signup", json={"email": "a@b.com", "password": "short"})
+
+    error = response.json()["detail"][0]
+    assert error["loc"] == ["body", "password"]
+    assert error["type"] == "string_too_short"
+    assert "at least 32" in error["msg"]
+    assert error["ctx"] == {"min_length": "32"}
+
+
+def test_logging_omits_the_offending_value(client, caplog):
+    with caplog.at_level(logging.DEBUG):
+        client.post("/signup", json={"email": "a@b.com", "password": PASSWORD})
+
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert PASSWORD not in logged
+    assert "password" in logged, "the field that failed is still worth logging"
+
+
+def test_logging_omits_the_whole_body_too(client, caplog):
+    with caplog.at_level(logging.DEBUG):
+        client.post("/signup", json={"password": PASSWORD})
+
+    assert PASSWORD not in "\n".join(r.getMessage() for r in caplog.records)
+
+
+def test_validation_error_is_not_logged_as_a_server_fault(client, caplog):
+    with caplog.at_level(logging.DEBUG):
+        client.post("/signup", json={"email": "a@b.com", "password": PASSWORD})
+
+    assert not [r for r in caplog.records if r.levelno >= logging.ERROR]


### PR DESCRIPTION
## Purpose

A 422 handed the caller back the value that failed validation, and wrote it to our logs. For a *missing* field, Pydantic has no single value to attach, so it attaches the entire request body — meaning a signup that omits its email address answered with the password of the person who typed it, in cleartext.

From the response body it spreads further: the browser's network tab, the browser console (`base-client.ts` logs the full error body for a 422), and anything that collects console output. `SecretStr` is no defence, since `input` is the raw body captured before Pydantic wraps anything.

This is not credential theft — you only get back what you sent. It's your own secret being copied into places nobody intended, and it needs a malformed request to fire (a frontend/backend field-name mismatch, a partial body, a direct API call). Moderate rather than urgent, but the exposed fields include user passwords and live auth tokens, and the fix is deleting one line.

Twenty endpoints accept a credential in the request body and were therefore affected: `/auth/register`, `/auth/login/email`, `/auth/reset-password`, `/auth/refresh`, `/auth/verify-email`, `/auth/magic-link/verify`, `/auth/exchange-code`, `POST`/`PUT` `/endpoints/` (`auth_token`, `client_secret`), `/endpoints/test`, `/endpoints/auto-configure`, the three `/tools/` routes (`credentials`), `POST`/`PUT` `/models/` and `/models/test-connection` (`key`, `api_key`), `PUT /tokens/{id}`, `PUT /platform/rhesis-key`, and `PUT /organizations/{id}/sso` (EE). `POST /auth/token-exchange` is not affected — it parses its form itself and never raises `RequestValidationError`.

## What Changed

- `create_validation_error_response` no longer copies Pydantic's `input` into the 422 response. `type`, `loc`, `msg` and `ctx` remain, so the caller still learns which field failed, why, and which rule broke it.
- `log_validation_error` no longer writes the submitted value either, and logs at warning rather than error — a 422 is the caller's mistake, not a server fault.
- New `tests/backend/security/test_validation_errors.py` covering both paths: the single-field case, the whole-body `missing` case, a `SecretStr` field, and an assertion that the diagnosis (`loc`/`type`/`msg`/`ctx`) survives.

Masking by field name was the alternative and doesn't hold up. Run the existing telemetry name filter (`_sanitize_metadata`, the closest thing we have) over the ten credential field names these endpoints accept, and `credentials` and `code` come through untouched — because the list has `credential` singular and no pattern for `code`. That's four of the twenty routes, with a list written by a careful person that's already out of date against today's schemas. Deleting the field has no list to keep current.

## Additional Context

- Pre-existing since #977, where these two functions were added. Not related to #2477 (`fix/harden-router-error-handling`), which changes 5xx responses and never touches the 422 path — I verified `create_validation_error_response` is byte-identical on `main` and on that branch. Deliberately based on `main` rather than stacked on #2477 so it can merge independently.
- `input` is documented as an *optional* property of FastAPI's `ValidationError` schema — only `loc`, `msg` and `type` are required — so dropping it stays schema-compliant.
- No consumer breaks: nothing in the frontend or the SDK reads `input`. `formatApiErrorDetail` and `getImportErrorMessage` both build their message from `loc` + `msg`.
- `ctx` is kept. Every validator that interpolates a submitted value into its message is on a non-credential field (`test_type`, provider type, auth method, parameter names). Worth remembering that a future validator writing `f"weak password: {v}"` would leak through `msg` regardless of this change.
- Follow-up worth considering, not included here: `base-client.ts` will keep `console.warn`-ing whatever a 422 body contains. Removing the secret at the source makes that harmless, but trimming `errorData` out of that log would be defence in depth.

## Testing

```bash
cd apps/backend
uv run pytest ../../tests/backend/security/test_validation_errors.py -v
```

Seven tests, all passing. Manual check of the worst case, a signup with the email field missing:

```
{"detail":[{"type":"missing","loc":["body","email"],"msg":"Field required"}]}
```

Previously that response carried `"input": {"password": "SuperSecret123!", ...}`.

Heads-up for the reviewer: Docker was unavailable on my machine, so `tests/backend/conftest.py` could not start its Testcontainers Postgres/Redis and I ran the new file from a copy outside that conftest. It builds its own `TestClient` and touches no database, so the result is valid — but the suite has not been run in place. Worth a full `tests/backend/security/` and `tests/backend/routes/` run in CI before merge, in case something asserts on a 422 shape I did not find by grep.
