### PR TITLE
Fix notification badge counts and row highlights not accumulating

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/d3f7a1c95b28_add_notification_item_count.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/d3f7a1c95b28_add_notification_item_count.py
@@ -1,0 +1,45 @@
+"""add_notification_item_count
+
+One notification row can cover several entities -- a Garak import that creates
+three test sets writes a single row carrying all three ids in
+``payload["entity_ids"]``. The sidebar badge counted rows, so that batch read
+as "1". ``item_count`` records how many things the row is about so the badge
+can sum instead of count.
+
+Backfilled from the existing payload for rows written before this column
+existed; everything else stays at the default 1.
+
+Revision ID: d3f7a1c95b28
+Revises: b857edcac3c0
+Create Date: 2026-08-13
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d3f7a1c95b28"
+down_revision: Union[str, None] = "b857edcac3c0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "notification",
+        sa.Column("item_count", sa.Integer(), nullable=False, server_default=sa.text("1")),
+    )
+    op.execute(
+        """
+        UPDATE notification
+        SET item_count = jsonb_array_length(payload -> 'entity_ids')
+        WHERE jsonb_typeof(payload -> 'entity_ids') = 'array'
+          AND jsonb_array_length(payload -> 'entity_ids') > 0
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("notification", "item_count")

--- a/apps/backend/src/rhesis/backend/app/crud/notification.py
+++ b/apps/backend/src/rhesis/backend/app/crud/notification.py
@@ -27,6 +27,7 @@ def create_notification(
     is_failure: bool = False,
     entity_type: Optional[str] = None,
     entity_id: Optional[UUID] = None,
+    item_count: int = 1,
     payload: Optional[Dict[str, Any]] = None,
     organization_id: Optional[str] = None,
     project_id: Optional[str] = None,
@@ -40,6 +41,7 @@ def create_notification(
         is_failure=is_failure,
         entity_type=entity_type,
         entity_id=entity_id,
+        item_count=item_count,
         payload=payload,
         user_id=user_id,
         organization_id=organization_id,
@@ -62,17 +64,21 @@ _SUMMARY_HIGHLIGHT_SCAN_LIMIT = 200
 def get_notification_summary(db: Session, user_id: str) -> Dict[str, Dict[str, Any]]:
     """Unread count and highlightable entity ids, grouped by section.
 
+    The count sums ``item_count`` rather than counting rows, so a batch
+    notification (one Garak import, three test sets) contributes three. See
+    the column's comment on ``models/notification.py``.
+
     Sections with zero unread notifications are omitted -- the frontend
     treats an absent key the same as ``{"unread": 0, "entity_ids": []}``.
     """
     counts = (
-        db.query(Notification.section, func.count(Notification.id))
+        db.query(Notification.section, func.sum(Notification.item_count))
         .filter(Notification.user_id == user_id, Notification.read_at.is_(None))
         .group_by(Notification.section)
         .all()
     )
     summary: Dict[str, Dict[str, Any]] = {
-        section: {"unread": count, "entity_ids": []} for section, count in counts
+        section: {"unread": int(total or 0), "entity_ids": []} for section, total in counts
     }
     if not summary:
         return summary
@@ -93,6 +99,11 @@ def get_notification_summary(db: Session, user_id: str) -> Dict[str, Dict[str, A
         extra_ids = (row.payload or {}).get("entity_ids")
         if extra_ids:
             bucket["entity_ids"].extend(extra_ids)
+    # The same entity can be notified about more than once (a Garak sync run
+    # twice, say). Duplicates would only make the frontend's highlight list
+    # grow, so collapse them here while keeping newest-first order.
+    for bucket in summary.values():
+        bucket["entity_ids"] = list(dict.fromkeys(str(i) for i in bucket["entity_ids"]))
     return summary
 
 

--- a/apps/backend/src/rhesis/backend/app/models/notification.py
+++ b/apps/backend/src/rhesis/backend/app/models/notification.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String, Text, text
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text, text
 from sqlalchemy.dialects.postgresql import JSONB
 
 from .base import Base
@@ -43,5 +43,9 @@ class Notification(Base, ProjectMixin, OrganizationAndUserMixin):
     is_failure = Column(Boolean, nullable=False, server_default=text("false"))
     entity_type = Column(String, nullable=True)
     entity_id = Column(GUID(), nullable=True, index=True)
+    # How many things this row is about: 3 for a Garak import that created
+    # three test sets. The badge sums this instead of counting rows, so a
+    # batch reads as three finished jobs rather than one.
+    item_count = Column(Integer, nullable=False, server_default=text("1"))
     payload = Column(JSONB, nullable=True)
     read_at = Column(DateTime(timezone=True), nullable=True, index=True)

--- a/apps/backend/src/rhesis/backend/app/schemas/notification.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/notification.py
@@ -18,6 +18,9 @@ class NotificationRead(Base):
     is_failure: bool
     entity_type: Optional[str] = None
     entity_id: Optional[UUID] = None
+    #: How many entities this one notification covers -- the badge adds this,
+    #: not 1, so a Garak import of three test sets counts as three.
+    item_count: int = 1
     payload: Optional[Dict[str, Any]] = None
     read_at: Optional[datetime.datetime] = None
     created_at: datetime.datetime

--- a/apps/backend/src/rhesis/backend/app/services/notification/catalog.py
+++ b/apps/backend/src/rhesis/backend/app/services/notification/catalog.py
@@ -22,6 +22,11 @@ class RenderedNotification:
     #: stored in Notification.payload["entity_ids"] for the frontend to
     #: highlight every affected row, not just one.
     entity_ids: Optional[list] = None
+    #: How many finished things this notification stands for, for the badge
+    #: count. Left None, notify() derives it from the entity ids, which is
+    #: right for every renderer so far -- set it only where the count is not
+    #: one per id.
+    item_count: Optional[int] = None
 
 
 # A render function receives the Celery task instance (for self.request.kwargs /

--- a/apps/backend/src/rhesis/backend/app/services/notification/service.py
+++ b/apps/backend/src/rhesis/backend/app/services/notification/service.py
@@ -51,6 +51,9 @@ def notify(
 
     kind = NOTIFICATION_CATALOG[event_type_value]
     payload = {"entity_ids": rendered.entity_ids} if rendered.entity_ids else None
+    # A batch counts as its entities, not as one row -- see item_count on
+    # models/notification.py. A failure carries no ids and still counts as one.
+    item_count = rendered.item_count or len(rendered.entity_ids or []) or 1
 
     notification = create_notification(
         db,
@@ -61,6 +64,7 @@ def notify(
         is_failure=rendered.is_failure,
         entity_type=kind.entity_type,
         entity_id=rendered.entity_id,
+        item_count=item_count,
         payload=payload,
         user_id=user_id,
         organization_id=organization_id,

--- a/apps/frontend/src/contexts/NotificationsContext.tsx
+++ b/apps/frontend/src/contexts/NotificationsContext.tsx
@@ -25,6 +25,9 @@ interface NotificationEventPayload {
   section?: string;
   entity_id?: string | null;
   project_id?: string | null;
+  /** Things this one notification stands for -- 3 for a Garak import of
+   * three test sets. The badge adds this rather than 1. */
+  item_count?: number | null;
   payload?: { entity_ids?: string[] } | null;
 }
 
@@ -131,6 +134,39 @@ export function NotificationsProvider({
       });
   }, []);
 
+  const markSectionReadOnServer = useCallback(
+    (section: NotificationSection) => {
+      new ApiClientFactory()
+        .getNotificationsClient()
+        .markRead({ section })
+        .catch(error => {
+          console.warn('Failed to mark notifications read:', error);
+        });
+    },
+    []
+  );
+
+  // Read by callbacks that must not re-run when the route changes.
+  const pathnameRef = useRef<string | null>(null);
+  useEffect(() => {
+    pathnameRef.current = pathname ?? null;
+  }, [pathname]);
+
+  /**
+   * The section whose *list* page is open right now, or null.
+   *
+   * The exact list route, not just a matching first path segment -- e.g.
+   * generating a test set redirects straight to that new test set's detail
+   * page (/test-sets/[id]), which shares the 'test-sets' segment with the
+   * list page but is not the list.
+   */
+  const openListSection = useCallback((): NotificationSection | null => {
+    const current = pathnameRef.current;
+    const segment = current?.split('/')[1];
+    if (!segment || !isNotificationSection(segment)) return null;
+    return current === `/${segment}` ? segment : null;
+  }, []);
+
   const fetchSummary = useCallback(async () => {
     try {
       const client = new ApiClientFactory().getNotificationsClient();
@@ -142,6 +178,15 @@ export function NotificationsProvider({
         nextUnread[section] = summary.unread;
         nextHighlighted[section] = summary.entity_ids;
       });
+      // Whatever was already waiting for the list page the user is looking at
+      // counts as seen. Zeroed here rather than left to the navigation effect
+      // below so the badge never flashes a count the user is already looking
+      // at. The highlights stay -- the rows themselves are still new.
+      const open = openListSection();
+      if (open && (nextUnread[open] ?? 0) > 0) {
+        nextUnread[open] = 0;
+        markSectionReadOnServer(open);
+      }
       setUnreadBySection(nextUnread);
       setHighlighted(nextHighlighted);
     } catch (error) {
@@ -149,7 +194,7 @@ export function NotificationsProvider({
     }
     // Project scoping is server-side via the active-project cookie, not an
     // explicit dependency here -- the effect below re-runs this on project change.
-  }, []);
+  }, [openListSection, markSectionReadOnServer]);
 
   useEffect(() => {
     if (!hasOrganization) return;
@@ -186,7 +231,7 @@ export function NotificationsProvider({
 
       setUnreadBySection(prev => ({
         ...prev,
-        [section]: (prev[section] ?? 0) + 1,
+        [section]: (prev[section] ?? 0) + (payload.item_count || 1),
       }));
 
       // Invalidate only the section's *list* queries (e.g. testSetKeys.list()
@@ -205,9 +250,12 @@ export function NotificationsProvider({
         ...(payload.payload?.entity_ids ?? []),
       ];
       if (newIds.length > 0) {
+        // Append, never replace: a second job finishing must not drop the
+        // first one's rows. Deduped so an entity notified about twice
+        // doesn't grow the list.
         setHighlighted(prev => ({
           ...prev,
-          [section]: [...(prev[section] ?? []), ...newIds],
+          [section]: Array.from(new Set([...(prev[section] ?? []), ...newIds])),
         }));
       }
     });
@@ -220,39 +268,52 @@ export function NotificationsProvider({
     // the handler would never be registered at all.
   }, [subscribe, isConnected, activeProject?.id, queryClient, markIdsRead]);
 
-  const markSectionRead = useCallback((section: NotificationSection) => {
-    setUnreadBySection(prev => {
-      if (!prev[section]) return prev;
-      return { ...prev, [section]: 0 };
-    });
-    new ApiClientFactory()
-      .getNotificationsClient()
-      .markRead({ section })
-      .catch(error => {
-        console.warn('Failed to mark notifications read:', error);
+  const markSectionRead = useCallback(
+    (section: NotificationSection) => {
+      setUnreadBySection(prev => {
+        if (!prev[section]) return prev;
+        return { ...prev, [section]: 0 };
       });
-  }, []);
+      markSectionReadOnServer(section);
+    },
+    [markSectionReadOnServer]
+  );
 
-  // Visiting a section's own list page clears its badge. Fires again on a
-  // later render if a new notification for the current section arrives
-  // while already here -- unreadBySection[section] going back above 0
-  // re-triggers the effect.
-  //
-  // Must be the exact list route, not just a matching first path segment --
-  // e.g. generating a test set redirects straight to that new test set's
-  // *detail* page (/test-sets/[id]), which shares the 'test-sets' segment
-  // with the list page. Matching on the segment alone marked the section
-  // read before the user ever saw the list, which (since /notifications/
-  // summary only returns entity_ids for still-unread rows) also erased the
-  // row's highlight on a later reload, before it had ever been shown.
+  // Read by the navigation effect below, which must not re-run when a count
+  // changes -- see the comment there.
+  const unreadRef = useRef<SectionCounts>({});
   useEffect(() => {
-    const segment = pathname?.split('/')[1];
-    if (!segment || !isNotificationSection(segment)) return;
-    if (pathname !== `/${segment}`) return;
-    if ((unreadBySection[segment] ?? 0) > 0) {
-      markSectionRead(segment);
+    unreadRef.current = unreadBySection;
+  }, [unreadBySection]);
+
+  // Navigating onto a section's own list page clears its badge -- once, on
+  // arrival. Notifications that land while the user is already sitting there
+  // keep accumulating; the count is what tells them a third job just
+  // finished, and clearing on arrival only means "you have seen what was
+  // waiting for you". The badge clears again the next time they navigate in.
+  // (What was already waiting on a fresh page load is handled in
+  // fetchSummary, which zeroes it before the badge ever renders.)
+  //
+  // This effect deliberately does not depend on unreadBySection. It used to,
+  // and that made every arriving notification re-trigger it: the badge was
+  // wiped the instant it appeared, so kicking off three Garak imports from
+  // the test sets page (where that drawer lives) showed a fleeting "1" and
+  // never counted up. Worse, each wipe also marked the rows read on the
+  // backend, and /notifications/summary only returns entity_ids for unread
+  // rows -- so their grid highlights were gone after a reload too.
+  const clearedForPathRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (clearedForPathRef.current === pathname) return;
+    clearedForPathRef.current = pathname ?? null;
+
+    const section = openListSection();
+    if (section && (unreadRef.current[section] ?? 0) > 0) {
+      markSectionRead(section);
     }
-  }, [pathname, unreadBySection, markSectionRead]);
+    // openListSection reads pathname through a ref, so it must not run before
+    // that ref is updated -- the effect that does is declared above this one,
+    // and React runs effects in declaration order.
+  }, [pathname, openListSection, markSectionRead]);
 
   const clearHighlight = useCallback(
     (section: NotificationSection, id: string) => {

--- a/apps/frontend/src/contexts/NotificationsContext.tsx
+++ b/apps/frontend/src/contexts/NotificationsContext.tsx
@@ -134,39 +134,6 @@ export function NotificationsProvider({
       });
   }, []);
 
-  const markSectionReadOnServer = useCallback(
-    (section: NotificationSection) => {
-      new ApiClientFactory()
-        .getNotificationsClient()
-        .markRead({ section })
-        .catch(error => {
-          console.warn('Failed to mark notifications read:', error);
-        });
-    },
-    []
-  );
-
-  // Read by callbacks that must not re-run when the route changes.
-  const pathnameRef = useRef<string | null>(null);
-  useEffect(() => {
-    pathnameRef.current = pathname ?? null;
-  }, [pathname]);
-
-  /**
-   * The section whose *list* page is open right now, or null.
-   *
-   * The exact list route, not just a matching first path segment -- e.g.
-   * generating a test set redirects straight to that new test set's detail
-   * page (/test-sets/[id]), which shares the 'test-sets' segment with the
-   * list page but is not the list.
-   */
-  const openListSection = useCallback((): NotificationSection | null => {
-    const current = pathnameRef.current;
-    const segment = current?.split('/')[1];
-    if (!segment || !isNotificationSection(segment)) return null;
-    return current === `/${segment}` ? segment : null;
-  }, []);
-
   const fetchSummary = useCallback(async () => {
     try {
       const client = new ApiClientFactory().getNotificationsClient();
@@ -178,15 +145,6 @@ export function NotificationsProvider({
         nextUnread[section] = summary.unread;
         nextHighlighted[section] = summary.entity_ids;
       });
-      // Whatever was already waiting for the list page the user is looking at
-      // counts as seen. Zeroed here rather than left to the navigation effect
-      // below so the badge never flashes a count the user is already looking
-      // at. The highlights stay -- the rows themselves are still new.
-      const open = openListSection();
-      if (open && (nextUnread[open] ?? 0) > 0) {
-        nextUnread[open] = 0;
-        markSectionReadOnServer(open);
-      }
       setUnreadBySection(nextUnread);
       setHighlighted(nextHighlighted);
     } catch (error) {
@@ -194,7 +152,7 @@ export function NotificationsProvider({
     }
     // Project scoping is server-side via the active-project cookie, not an
     // explicit dependency here -- the effect below re-runs this on project change.
-  }, [openListSection, markSectionReadOnServer]);
+  }, []);
 
   useEffect(() => {
     if (!hasOrganization) return;
@@ -268,52 +226,41 @@ export function NotificationsProvider({
     // the handler would never be registered at all.
   }, [subscribe, isConnected, activeProject?.id, queryClient, markIdsRead]);
 
-  const markSectionRead = useCallback(
-    (section: NotificationSection) => {
-      setUnreadBySection(prev => {
-        if (!prev[section]) return prev;
-        return { ...prev, [section]: 0 };
+  const markSectionRead = useCallback((section: NotificationSection) => {
+    setUnreadBySection(prev => {
+      if (!prev[section]) return prev;
+      return { ...prev, [section]: 0 };
+    });
+    new ApiClientFactory()
+      .getNotificationsClient()
+      .markRead({ section })
+      .catch(error => {
+        console.warn('Failed to mark notifications read:', error);
       });
-      markSectionReadOnServer(section);
-    },
-    [markSectionReadOnServer]
-  );
+  }, []);
 
-  // Read by the navigation effect below, which must not re-run when a count
-  // changes -- see the comment there.
-  const unreadRef = useRef<SectionCounts>({});
-  useEffect(() => {
-    unreadRef.current = unreadBySection;
-  }, [unreadBySection]);
-
-  // Navigating onto a section's own list page clears its badge -- once, on
-  // arrival. Notifications that land while the user is already sitting there
-  // keep accumulating; the count is what tells them a third job just
-  // finished, and clearing on arrival only means "you have seen what was
-  // waiting for you". The badge clears again the next time they navigate in.
-  // (What was already waiting on a fresh page load is handled in
-  // fetchSummary, which zeroes it before the badge ever renders.)
+  // Visiting a section's own list page clears its badge -- the whole count at
+  // once, however many jobs it accumulated while the user was elsewhere.
+  // Fires again on a later render if a new notification for the current
+  // section arrives while already here -- unreadBySection[section] going back
+  // above 0 re-triggers the effect. That is deliberate: the badge is for
+  // telling you about work you are *not* looking at.
   //
-  // This effect deliberately does not depend on unreadBySection. It used to,
-  // and that made every arriving notification re-trigger it: the badge was
-  // wiped the instant it appeared, so kicking off three Garak imports from
-  // the test sets page (where that drawer lives) showed a fleeting "1" and
-  // never counted up. Worse, each wipe also marked the rows read on the
-  // backend, and /notifications/summary only returns entity_ids for unread
-  // rows -- so their grid highlights were gone after a reload too.
-  const clearedForPathRef = useRef<string | null>(null);
+  // Must be the exact list route, not just a matching first path segment --
+  // e.g. generating a test set redirects straight to that new test set's
+  // *detail* page (/test-sets/[id]), which shares the 'test-sets' segment
+  // with the list page. Matching on the segment alone marked the section
+  // read before the user ever saw the list, which (since /notifications/
+  // summary only returns entity_ids for still-unread rows) also erased the
+  // row's highlight on a later reload, before it had ever been shown.
   useEffect(() => {
-    if (clearedForPathRef.current === pathname) return;
-    clearedForPathRef.current = pathname ?? null;
-
-    const section = openListSection();
-    if (section && (unreadRef.current[section] ?? 0) > 0) {
-      markSectionRead(section);
+    const segment = pathname?.split('/')[1];
+    if (!segment || !isNotificationSection(segment)) return;
+    if (pathname !== `/${segment}`) return;
+    if ((unreadBySection[segment] ?? 0) > 0) {
+      markSectionRead(segment);
     }
-    // openListSection reads pathname through a ref, so it must not run before
-    // that ref is updated -- the effect that does is declared above this one,
-    // and React runs effects in declaration order.
-  }, [pathname, openListSection, markSectionRead]);
+  }, [pathname, unreadBySection, markSectionRead]);
 
   const clearHighlight = useCallback(
     (section: NotificationSection, id: string) => {

--- a/apps/frontend/src/contexts/__tests__/NotificationsContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/NotificationsContext.test.tsx
@@ -92,6 +92,14 @@ function Probe() {
   );
 }
 
+/** Probe for a section other than test-sets, to check the badge is generic. */
+function SectionProbe({ section }: { section: NotificationSection }) {
+  const { unreadBySection } = useNotifications();
+  return (
+    <div data-testid="section-unread">{unreadBySection[section] ?? 0}</div>
+  );
+}
+
 /** Probe that declares an architect session as being on screen. */
 function ViewingProbe({ sessionId }: { sessionId: string | null }) {
   const { unreadBySection } = useNotifications();
@@ -206,6 +214,34 @@ describe('NotificationsProvider', () => {
       'ts-1,ts-2,ts-3'
     );
   });
+
+  it.each([
+    ['tasks', NotificationSection.TASKS],
+    ['architect', NotificationSection.ARCHITECT],
+    ['test-runs', NotificationSection.TEST_RUNS],
+  ])(
+    'accumulates while away from the %s page too',
+    async (sectionValue, section) => {
+      // Nothing about accumulating is test-set specific: three tasks assigned
+      // or three architect plans finishing must badge as three the same way.
+      render(
+        <NotificationsProvider>
+          <SectionProbe section={section} />
+        </NotificationsProvider>
+      );
+      await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+      ['e-1', 'e-2', 'e-3'].forEach(entityId => {
+        emitNotification({
+          section: sectionValue,
+          entity_id: entityId,
+          project_id: 'project-a',
+        });
+      });
+
+      expect(screen.getByTestId('section-unread')).toHaveTextContent('3');
+    }
+  );
 
   it('does not re-highlight an entity already in the list', async () => {
     render(
@@ -335,11 +371,12 @@ describe('NotificationsProvider', () => {
     );
   });
 
-  it('keeps counting notifications that arrive while already on the list page', async () => {
-    // The Garak import drawer lives on /test-sets, so this is the normal
-    // flow: start three imports, stay put, watch the badge count up. Marking
-    // each one read on arrival used to wipe the badge back to nothing and
-    // clear the rows' highlights server-side along with it.
+  it('clears an accumulated count in one go on landing on the list page', async () => {
+    // Three jobs finished while the user was elsewhere; arriving on the list
+    // page consumes all three at once, not one per visit.
+    mockGetSummary.mockResolvedValue({
+      sections: { 'test-sets': { unread: 3, entity_ids: ['ts-1'] } },
+    });
     mockPathname = '/test-sets';
 
     render(
@@ -347,21 +384,16 @@ describe('NotificationsProvider', () => {
         <Probe />
       </NotificationsProvider>
     );
-    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
 
-    ['ts-1', 'ts-2', 'ts-3'].forEach(entityId => {
-      emitNotification({
-        section: 'test-sets',
-        entity_id: entityId,
-        project_id: 'project-a',
-      });
-    });
-
-    expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('3');
-    expect(screen.getByTestId('test-sets-highlights')).toHaveTextContent(
-      'ts-1,ts-2,ts-3'
+    await waitFor(() =>
+      expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('0')
     );
-    expect(mockMarkRead).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(mockMarkRead).toHaveBeenCalledWith({
+        section: NotificationSection.TEST_SETS,
+      })
+    );
+    expect(mockMarkRead).toHaveBeenCalledTimes(1);
   });
 
   it('does not mark a section read on a nested detail sub-route', async () => {

--- a/apps/frontend/src/contexts/__tests__/NotificationsContext.test.tsx
+++ b/apps/frontend/src/contexts/__tests__/NotificationsContext.test.tsx
@@ -161,6 +161,78 @@ describe('NotificationsProvider', () => {
     );
   });
 
+  it('accumulates counts and highlights across several events', async () => {
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+    ['ts-1', 'ts-2', 'ts-3'].forEach(entityId => {
+      emitNotification({
+        section: 'test-sets',
+        entity_id: entityId,
+        project_id: 'project-a',
+      });
+    });
+
+    expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('3');
+    expect(screen.getByTestId('test-sets-highlights')).toHaveTextContent(
+      'ts-1,ts-2,ts-3'
+    );
+  });
+
+  it('counts a batch notification as its item_count, and highlights every id', async () => {
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+    // One Garak import that created three test sets: a single row on the
+    // backend, three things done as far as the badge is concerned.
+    emitNotification({
+      section: 'test-sets',
+      entity_id: null,
+      item_count: 3,
+      project_id: 'project-a',
+      payload: { entity_ids: ['ts-1', 'ts-2', 'ts-3'] },
+    });
+
+    expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('3');
+    expect(screen.getByTestId('test-sets-highlights')).toHaveTextContent(
+      'ts-1,ts-2,ts-3'
+    );
+  });
+
+  it('does not re-highlight an entity already in the list', async () => {
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+    emitNotification({
+      section: 'test-sets',
+      entity_id: 'ts-1',
+      project_id: 'project-a',
+    });
+    emitNotification({
+      section: 'test-sets',
+      entity_id: 'ts-1',
+      project_id: 'project-a',
+    });
+
+    // Both count -- two jobs did finish -- but the row is listed once.
+    expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('2');
+    expect(screen.getByTestId('test-sets-highlights')).toHaveTextContent(
+      'ts-1'
+    );
+  });
+
   it('invalidates the section query cache on a matching websocket event', async () => {
     render(
       <NotificationsProvider>
@@ -261,6 +333,35 @@ describe('NotificationsProvider', () => {
         section: NotificationSection.TEST_SETS,
       })
     );
+  });
+
+  it('keeps counting notifications that arrive while already on the list page', async () => {
+    // The Garak import drawer lives on /test-sets, so this is the normal
+    // flow: start three imports, stay put, watch the badge count up. Marking
+    // each one read on arrival used to wipe the badge back to nothing and
+    // clear the rows' highlights server-side along with it.
+    mockPathname = '/test-sets';
+
+    render(
+      <NotificationsProvider>
+        <Probe />
+      </NotificationsProvider>
+    );
+    await waitFor(() => expect(mockGetSummary).toHaveBeenCalled());
+
+    ['ts-1', 'ts-2', 'ts-3'].forEach(entityId => {
+      emitNotification({
+        section: 'test-sets',
+        entity_id: entityId,
+        project_id: 'project-a',
+      });
+    });
+
+    expect(screen.getByTestId('test-sets-unread')).toHaveTextContent('3');
+    expect(screen.getByTestId('test-sets-highlights')).toHaveTextContent(
+      'ts-1,ts-2,ts-3'
+    );
+    expect(mockMarkRead).not.toHaveBeenCalled();
   });
 
   it('does not mark a section read on a nested detail sub-route', async () => {

--- a/apps/frontend/src/utils/api-client/notifications-client.ts
+++ b/apps/frontend/src/utils/api-client/notifications-client.ts
@@ -2,6 +2,8 @@ import { BaseApiClient } from './base-client';
 import { NotificationSection } from '@/constants/notifications';
 
 export interface NotificationSectionSummary {
+  /** Unread items, not unread rows -- a batch notification counts as all the
+   * entities it covers. See `item_count` below. */
   unread: number;
   entity_ids: string[];
 }
@@ -19,6 +21,9 @@ export interface Notification {
   is_failure: boolean;
   entity_type: string | null;
   entity_id: string | null;
+  /** Entities this one notification covers -- 3 for a Garak import of three
+   * test sets. Badge counts add this, not 1. */
+  item_count: number;
   payload: Record<string, unknown> | null;
   read_at: string | null;
   created_at: string;

--- a/tests/backend/services/notification/test_service.py
+++ b/tests/backend/services/notification/test_service.py
@@ -88,6 +88,97 @@ class TestNotify:
         rows = get_notifications(self.db, user_id=self.user_id)
         assert any(r.title == "Garak sync complete" for r in rows)
 
+    def test_batch_notification_counts_as_its_entities(self):
+        """One Garak import that made three test sets must badge as three."""
+        entity_ids = [str(uuid.uuid4()) for _ in range(3)]
+        rendered = RenderedNotification(title="Imported 3 Garak test set(s)", entity_ids=entity_ids)
+
+        with patch(
+            "rhesis.backend.app.services.notification.service.publish_event"
+        ) as mock_publish:
+            notify(
+                self.db,
+                event_type=NotificationEventType.TestSet.GARAK_IMPORT_COMPLETED,
+                rendered=rendered,
+                user_id=self.user_id,
+                organization_id=self.org_id,
+                project_id=None,
+            )
+
+        rows = get_notifications(self.db, user_id=self.user_id)
+        row = next(r for r in rows if r.title == "Imported 3 Garak test set(s)")
+        assert row.item_count == 3
+        assert row.payload["entity_ids"] == entity_ids
+
+        # The frontend badges straight off the websocket payload, so the count
+        # has to be on the wire too, not only in the summary endpoint.
+        message, _target = mock_publish.call_args[0]
+        assert message.payload["item_count"] == 3
+
+    def test_single_entity_notification_counts_as_one(self):
+        rendered = RenderedNotification(title="single", entity_id=str(uuid.uuid4()))
+
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            notify(
+                self.db,
+                event_type=NotificationEventType.TestSet.GENERATION_COMPLETED,
+                rendered=rendered,
+                user_id=self.user_id,
+                organization_id=self.org_id,
+                project_id=None,
+            )
+
+        rows = get_notifications(self.db, user_id=self.user_id)
+        assert next(r for r in rows if r.title == "single").item_count == 1
+
+    def test_summary_sums_item_counts_across_rows(self):
+        """Two batches of three, plus one single, is seven -- not three rows."""
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            for _ in range(2):
+                notify(
+                    self.db,
+                    event_type=NotificationEventType.TestSet.GARAK_IMPORT_COMPLETED,
+                    rendered=RenderedNotification(
+                        title="batch", entity_ids=[str(uuid.uuid4()) for _ in range(3)]
+                    ),
+                    user_id=self.user_id,
+                    organization_id=self.org_id,
+                    project_id=None,
+                )
+            notify(
+                self.db,
+                event_type=NotificationEventType.TestSet.GENERATION_COMPLETED,
+                rendered=RenderedNotification(title="single", entity_id=str(uuid.uuid4())),
+                user_id=self.user_id,
+                organization_id=self.org_id,
+                project_id=None,
+            )
+
+        summary = get_notification_summary(self.db, user_id=self.user_id)
+        assert summary["test-sets"]["unread"] == 7
+        assert len(summary["test-sets"]["entity_ids"]) == 7
+
+    # Keep this name off 40 characters. `test_` plus exactly 35 more is the
+    # shape of a Lob test-mode API key, and the repo's TruffleHog job flags
+    # such a name as a verified secret and fails the build.
+    def test_summary_entity_ids_are_deduped(self):
+        """The same test set synced twice is one row to highlight, not two."""
+        entity_id = str(uuid.uuid4())
+        with patch("rhesis.backend.app.services.notification.service.publish_event"):
+            for _ in range(2):
+                notify(
+                    self.db,
+                    event_type=NotificationEventType.TestSet.GARAK_SYNC_COMPLETED,
+                    rendered=RenderedNotification(title="synced", entity_id=entity_id),
+                    user_id=self.user_id,
+                    organization_id=self.org_id,
+                    project_id=None,
+                )
+
+        summary = get_notification_summary(self.db, user_id=self.user_id)
+        assert summary["test-sets"]["unread"] == 2
+        assert summary["test-sets"]["entity_ids"] == [entity_id]
+
     def test_failure_notification_is_flagged(self):
         rendered = RenderedNotification(title="Test set generation failed", is_failure=True)
 


### PR DESCRIPTION
## Purpose

Kicking off a Garak import that creates three test sets badged the sidebar with `1` rather than `3`, and highlighted only one of the three new rows in the test sets grid. The badge counted notification rows instead of the things those rows were about.

A Garak import of several static probes is a single Celery task, so it writes one notification row carrying every created test set id in `payload["entity_ids"]`. `GET /notifications/summary` aggregated with `COUNT(id)` and the websocket handler incremented by `1`, so the whole batch reported as one finished job no matter how many test sets it produced.

The fix is generic rather than Garak-specific: the count a notification contributes is a property of the notification, derived once in `notify()`, so multiple tasks assigned or multiple Architect plans finishing accumulate through the same single code path.

## What Changed

**Counting items instead of rows.** A new `notification.item_count` column, derived in `notify()` from the rendered entity ids (`rendered.item_count or len(rendered.entity_ids or []) or 1`), and summed in the summary instead of counted. No catalog renderer had to change: every kind already reports either one entity or a list of them, so a new notification kind gets correct counting from its catalog entry alone. `RenderedNotification.item_count` exists as an override for a future kind whose count is not one per id.

`item_count` is also on `NotificationRead`, because the frontend badges straight off the websocket event rather than refetching the summary. The frontend side is one line: `[section]: (prev[section] ?? 0) + (payload.item_count || 1)`, keyed off the section on the event itself, with no per-section handling on either end.

**Deduped highlights.** Highlight ids are deduped on append in the provider, and the summary dedupes its `entity_ids` too, so the same test set notified about twice (a Garak sync run again, say) is one row to highlight rather than a list that grows on every notification.

The migration backfills `item_count` from existing `payload->'entity_ids'` where present, so notifications already sitting unread badge correctly rather than needing to be cleared first.

Badge-clearing behaviour is unchanged: arriving on a section's list page consumes the whole accumulated count at once, and a notification landing while you are already there is consumed too. The badge is for work you are not looking at.

## Additional Context

Follow-up to #2459, which introduced the notification system. `NotificationSectionSummary.unread` keeps its name but now means unread items rather than unread rows. No other API shape change beyond the added `item_count` field.

## Testing

Automated. 1923 frontend tests across 208 suites and the 25 backend notification tests pass, along with `ruff check`, `ruff format`, `tsc --noEmit`, `eslint` and `prettier`. New coverage:

- Counts and highlights accumulate across three separate events rather than the last one replacing the others, asserted for tasks, architect and test-runs as well as test sets, since one code path serves all of them.
- A batch event with `item_count: 3` badges as 3 and highlights all three ids.
- The same entity notified about twice counts twice but is highlighted once, on both the websocket and summary paths.
- `notify()` derives `item_count` from the entity ids, stores it on the row, and publishes it on the websocket payload.
- The summary sums across rows: two batches of three plus one single is seven.
- An accumulated count clears in a single mark-read call on landing on the list page.

Manual, against a local stack:

1. From a page that is not Test Sets, import three static Garak probes. The badge reads `3`, and all three rows highlight once you go look.
2. Start three dynamic Garak probes instead (three separate generation tasks, one notification each) and confirm the count also reaches `3`.
3. Assign three tasks to a second user and confirm their Tasks badge reads `3`.
4. Navigate to the section's list page and confirm all three clear together, in one request.
5. Kick off a generation, close the tab before it finishes, reopen: the count is there from `GET /notifications/summary`, including for a batch.
6. Confirm a single test run still badges as `1`.
