### PR TITLE
Fix Security workflow failing on 40-character test names

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@main
         with:
-          extra_args: --results=verified,unknown
+          # Lob is excluded: through v3.96.0 its key pattern is `test_` + 35 word characters, so
+          # every 40-character pytest function name matches and Lob's API answers 403, which that
+          # version reads as "verified". Fixed upstream in 43b8e371a, unreleased. We don't use Lob.
+          extra_args: --results=verified,unknown --exclude-detectors=Lob
 
   changes:
     if: github.event_name != 'push'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,9 @@ repos:
         - id: trufflehog
           name: TruffleHog
           description: Detect secrets in your data.
-          entry: bash -c 'trufflehog git file://. --branch HEAD'
+          # Lob excluded for the same reason as in .github/workflows/security.yml: it flags any
+          # 40-character test_* function name as a verified key.
+          entry: bash -c 'trufflehog git file://. --branch HEAD --exclude-detectors=Lob'
           language: system
           stages: ["pre-commit", "pre-push"]
 


### PR DESCRIPTION
## Purpose

The `secrets` job in the Security workflow fails on any PR that adds a pytest function whose name is exactly 40 characters long. TruffleHog's Lob detector, through v3.96.0, matches `test_` followed by 35 word characters — the exact shape of a Python test name — and Lob's API answers 403 for those candidates, which that version reads as "key is active, account just lacks billing". The finding comes back `Verified: true`, the action's `--fail` fires, and the job exits 183.

Recent examples: PR #2477 hit four of them (`test_prose_without_a_value_is_left_alone`, `test_empty_test_list_returns_400_not_500`, `test_request_id_header_is_not_duplicated`, `test_upstream_exception_keeps_its_detail`), PR #2486 one (`test_summary_entity_ids_are_deduplicated`).

This is not branch-specific — `main` fails the same way. It did on 2026-08-12, commit b24c616c2, on `test_the_covered_roots_all_actually_emit`. `main` has been green since only because nothing merged after that happened to add a 40-character test name; `tests/` already contains 271 names of that length, but they sit in history rather than in any scanned diff.

## What Changed

- `.github/workflows/security.yml` — added `--exclude-detectors=Lob` to the TruffleHog `extra_args`.
- `.pre-commit-config.yaml` — same flag on the local `trufflehog` pre-commit/pre-push hook, so it doesn't start reporting the same false positives once contributors upgrade their local binary.

Both changes carry a comment explaining why the detector is off.

## Additional Context

- Fixed upstream in trufflesecurity/trufflehog@43b8e371a (#5188, "Update regex pattern and 403 handling in the Lob detector to fix false positives", 2026-08-11), which tightens the pattern to `[a-f0-9]{35}` and parses the 403 error code instead of trusting the status alone. That commit is on their `main`, but the newest release is v3.96.0 (2026-07-24) and the action pulls the released `:latest` image, so we can't get the fix yet.
- Lob is a third-party service for mailing physical letters and postcards. We don't use it, so excluding the detector costs no coverage. The exclusion can be dropped once a release containing the upstream fix ships.
- Two adjacent issues left out of this PR deliberately: the action is pinned to `@main` rather than a SHA, so upstream detector changes land in CI unannounced; and `--results=verified,unknown` means a detector that merely errors during verification fails the build, not just confirmed hits.

## Testing

Replayed the three previously failing scans with the exact CI arguments against the same image the workflow uses, all three now exit 0:

```bash
docker run --rm -v "$PWD":/repo -w /repo ghcr.io/trufflesecurity/trufflehog:latest \
  git file:///repo --since-commit <base> --branch <head> \
  --results=verified,unknown --exclude-detectors=Lob --fail --no-update
```

- PR #2477 `fix/harden-router-error-handling` — was 4 findings, now 0
- PR #2486 `fix/notification-accumulation` — was 1, now 0
- `b24c616c2` on `main` — was 1, now 0

The pre-commit entry also runs clean, and the flag is accepted by older local binaries (verified on 3.93.3). This PR's own Security run is the live check.
