### PR TITLE
chore(sdk): migrate legacy rhesis.sdk.telemetry imports to rhesis.telemetry

### DIFF
--- a/agents/travel-agent/src/travel_agent/session.py
+++ b/agents/travel-agent/src/travel_agent/session.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from agent_framework import Message, Workflow
 
-from rhesis.sdk.telemetry.context import get_conversation_id, set_conversation_id
+from rhesis.telemetry.context import get_conversation_id, set_conversation_id
 from travel_agent.workflow import invoke_travel_workflow_async
 
 

--- a/agents/visit-prep/tests/test_span_tree.py
+++ b/agents/visit-prep/tests/test_span_tree.py
@@ -19,12 +19,12 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
+from rhesis.telemetry.attributes import AIAttributes
 from rhesis.telemetry.constants import ConversationContext
+from rhesis.telemetry.context import set_root_trace_id
 from rhesis.telemetry.exporter import RhesisOTLPExporter
 from rhesis.telemetry.schemas import AIOperationType
 
-from rhesis.sdk.telemetry.attributes import AIAttributes
-from rhesis.sdk.telemetry.context import set_root_trace_id
 from tests.mocks import gather_script, greeting_script, make_pipeline
 from visit_prep.pipeline import run_turn
 from visit_prep.state import VisitPrepState

--- a/apps/backend/src/rhesis/backend/app/services/architect/runner.py
+++ b/apps/backend/src/rhesis/backend/app/services/architect/runner.py
@@ -246,7 +246,7 @@ async def persist_state(
     subsequent turns can reuse it for coherent multi-turn tracing.
     """
     from rhesis.backend.app import crud, schemas
-    from rhesis.sdk.telemetry.context import get_root_trace_id
+    from rhesis.telemetry.context import get_root_trace_id
 
     snapshot = agent.dump_state()
     root_trace_id = get_root_trace_id()

--- a/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/core.py
+++ b/apps/backend/src/rhesis/backend/app/services/telemetry/enrichment/core.py
@@ -8,6 +8,7 @@ import logging
 from typing import Dict, List, Optional
 
 import litellm
+from rhesis.telemetry.attributes import AIAttributes
 from rhesis.telemetry.schemas import StatusCode
 
 from rhesis.backend.app.models.trace import Trace
@@ -17,7 +18,6 @@ from rhesis.backend.app.schemas.enrichment import (
     TokenCosts,
 )
 from rhesis.backend.app.services.exchange_rate import get_usd_to_eur_rate
-from rhesis.sdk.telemetry.attributes import AIAttributes
 
 litellm.suppress_debug_info = True
 for _logger_name in ("LiteLLM", "LiteLLM Router", "LiteLLM Proxy"):

--- a/apps/backend/src/rhesis/backend/tasks/architect/telemetry.py
+++ b/apps/backend/src/rhesis/backend/tasks/architect/telemetry.py
@@ -27,7 +27,7 @@ async def _conversation_telemetry_context(
     cleared on exit so they do not leak into surrounding scopes that
     share the same asyncio task.
     """
-    from rhesis.sdk.telemetry.context import (
+    from rhesis.telemetry.context import (
         set_conversation_id,
         set_conversation_mapped_input,
         set_conversation_trace_id,

--- a/docs/content/docs/tracing/multi-agent.mdx
+++ b/docs/content/docs/tracing/multi-agent.mdx
@@ -73,7 +73,7 @@ Use `@observe` with the `ai.agent.invoke` span name to instrument any agent func
 <CodeBlock filename="app.py" language="python">
 {`from rhesis.sdk import RhesisClient, observe
 from rhesis.telemetry.schemas import AIOperationType
-from rhesis.sdk.telemetry.attributes import AIAttributes
+from rhesis.telemetry.attributes import AIAttributes
 
 client = RhesisClient(api_key="your-api-key", project_id="your-project-id")
 
@@ -99,7 +99,7 @@ To explicitly record when one agent hands off to another, create a handoff span 
 
 <CodeBlock filename="app.py" language="python">
 {`from rhesis.telemetry.schemas import AIOperationType
-from rhesis.sdk.telemetry.attributes import AIAttributes
+from rhesis.telemetry.attributes import AIAttributes
 
 @observe(
     span_name=AIOperationType.AGENT_HANDOFF,
@@ -117,7 +117,7 @@ def handoff_to_analyst(findings: str) -> str:
 <CodeBlock filename="multi_agent.py" language="python">
 {`from rhesis.sdk import RhesisClient, endpoint, observe
 from rhesis.telemetry.schemas import AIOperationType
-from rhesis.sdk.telemetry.attributes import AIAttributes
+from rhesis.telemetry.attributes import AIAttributes
 
 client = RhesisClient(api_key="your-api-key", project_id="your-project-id")
 

--- a/docs/content/docs/tracing/semantic-conventions.mdx
+++ b/docs/content/docs/tracing/semantic-conventions.mdx
@@ -88,7 +88,7 @@ Note: `ai.agent.*` spans are valid — see [Agent Operations](#agent-operations)
 Use `AIAttributes` for span attributes:
 
 <CodeBlock filename="app.py" language="python">
-{`from rhesis.sdk.telemetry.attributes import AIAttributes
+{`from rhesis.telemetry.attributes import AIAttributes
 
 span.set_attribute(AIAttributes.MODEL_PROVIDER, "openai")
 span.set_attribute(AIAttributes.MODEL_NAME, "gpt-4")
@@ -164,7 +164,7 @@ span.set_attribute(AIAttributes.LLM_TOKENS_OUTPUT, 200)`}
 Use `AIEvents` for span events:
 
 <CodeBlock filename="app.py" language="python">
-{`from rhesis.sdk.telemetry.attributes import AIEvents, AIAttributes
+{`from rhesis.telemetry.attributes import AIEvents, AIAttributes
 
 with tracer.start_as_current_span("ai.llm.invoke") as span:
     # Prompt event

--- a/docs/content/guides/telemetry-configuration/decorators.mdx
+++ b/docs/content/guides/telemetry-configuration/decorators.mdx
@@ -134,7 +134,7 @@ If you're instrumenting a custom chat server (not using `@endpoint`'s automatic 
 
 <CodeBlock filename="chat_server.py" language="python">
 {`from rhesis.sdk import observe
-from rhesis.sdk.telemetry.context import (
+from rhesis.telemetry.context import (
     set_conversation_id,
     set_conversation_trace_id,
     set_conversation_mapped_input,

--- a/examples/telemetry/crewai_example.py
+++ b/examples/telemetry/crewai_example.py
@@ -27,13 +27,13 @@ Traces appear in the Rhesis UI under Traces (http://localhost:3000/traces).
 import os
 from pathlib import Path
 
-from crewai import Agent, LLM, Task
+from crewai import LLM, Agent, Task
 from dotenv import load_dotenv
+from rhesis.telemetry.attributes import AIAttributes
+from rhesis.telemetry.schemas import AIOperationType
 
 from rhesis.sdk import RhesisClient, observe
 from rhesis.sdk.telemetry import auto_instrument
-from rhesis.sdk.telemetry.attributes import AIAttributes
-from rhesis.telemetry.schemas import AIOperationType
 
 os.environ.setdefault("CREWAI_TELEMETRY_OPT_OUT", "true")
 

--- a/examples/telemetry/llamaindex_example.py
+++ b/examples/telemetry/llamaindex_example.py
@@ -33,11 +33,11 @@ from dotenv import load_dotenv
 from llama_index.core import Document, Settings, VectorStoreIndex, get_response_synthesizer
 from llama_index.core.schema import NodeWithScore
 from opentelemetry import trace
+from rhesis.telemetry.attributes import AIAttributes, AIEvents
 from rhesis.telemetry.schemas import AIOperationType
 
 from rhesis.sdk import RhesisClient, observe
 from rhesis.sdk.telemetry import auto_instrument
-from rhesis.sdk.telemetry.attributes import AIAttributes, AIEvents
 
 env_path = Path(__file__).parent / ".env"
 if env_path.exists():

--- a/examples/telemetry/openai_sdk_example.py
+++ b/examples/telemetry/openai_sdk_example.py
@@ -32,15 +32,15 @@ from typing import Any, Literal
 
 from dotenv import load_dotenv
 from opentelemetry import trace
-from rhesis.telemetry.schemas import AIOperationType
-
-from rhesis.sdk import RhesisClient, observe
-from rhesis.sdk.telemetry import auto_instrument
-from rhesis.sdk.telemetry.attributes import (
+from rhesis.telemetry.attributes import (
     AIAttributes,
     create_llm_attributes,
     create_tool_attributes,
 )
+from rhesis.telemetry.schemas import AIOperationType
+
+from rhesis.sdk import RhesisClient, observe
+from rhesis.sdk.telemetry import auto_instrument
 
 env_path = Path(__file__).parent / ".env"
 if env_path.exists():

--- a/packages/rhesis/pyproject.toml
+++ b/packages/rhesis/pyproject.toml
@@ -63,6 +63,7 @@ pattern = '''version\s*=\s*["'](?P<version>[^"']+)["']'''
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/rhesis"]
+include = ["src/rhesis/py.typed"]
 
 [tool.uv]
 exclude-newer = "1 week"
@@ -88,4 +89,3 @@ constraint-dependencies = [
     "uv>=0.11.15",
     "pillow>=12.3.0",
 ]
-

--- a/packages/rhesis/src/rhesis/telemetry/attributes.py
+++ b/packages/rhesis/src/rhesis/telemetry/attributes.py
@@ -5,6 +5,19 @@ from typing import Any, Dict
 # Import semantic layer constants from schemas (single source of truth)
 from rhesis.telemetry.schemas import FORBIDDEN_SPAN_DOMAINS
 
+# Declared, not inferred: the backwards-compatible shim at rhesis.sdk.telemetry.attributes has to
+# forward this exact set, and a test asserts it does. Inferring the surface from the module
+# namespace cannot tell MAX_CONTENT_LENGTH from the FORBIDDEN_SPAN_DOMAINS import above, so a new
+# constant here could skip the shim unnoticed.
+__all__ = [
+    "MAX_CONTENT_LENGTH",
+    "AIAttributes",
+    "AIEvents",
+    "create_llm_attributes",
+    "create_tool_attributes",
+    "validate_span_name",
+]
+
 # Max characters of prompt/completion content recorded on a span event.
 # Framework-agnostic: shared by all integrations.
 MAX_CONTENT_LENGTH = 8000

--- a/packages/rhesis/src/rhesis/telemetry/context.py
+++ b/packages/rhesis/src/rhesis/telemetry/context.py
@@ -5,6 +5,25 @@ from typing import Optional
 
 from rhesis.telemetry.schemas import TestExecutionContext
 
+# Declared, not inferred: the backwards-compatible shim at rhesis.sdk.telemetry.context has to
+# forward this exact set, and a test asserts it does.
+__all__ = [
+    "get_conversation_id",
+    "get_conversation_mapped_input",
+    "get_conversation_trace_id",
+    "get_root_trace_id",
+    "get_test_execution_context",
+    "is_llm_observation_active",
+    "is_tracing_disabled",
+    "set_conversation_id",
+    "set_conversation_mapped_input",
+    "set_conversation_trace_id",
+    "set_llm_observation_active",
+    "set_root_trace_id",
+    "set_test_execution_context",
+    "set_tracing_disabled",
+]
+
 # Context variable to thread test execution context through call stack
 # This avoids polluting function signatures with internal parameters
 _test_execution_context: ContextVar[Optional[TestExecutionContext]] = ContextVar(

--- a/packages/rhesis/src/rhesis/telemetry/token_extraction.py
+++ b/packages/rhesis/src/rhesis/telemetry/token_extraction.py
@@ -17,6 +17,11 @@ regardless of the provider or framework being used.
 import logging
 from typing import Any, Dict, Tuple, Union
 
+# Declared, not inferred: the backwards-compatible shim at
+# rhesis.sdk.telemetry.utils.token_extraction has to forward this exact set, and a test asserts it
+# does.
+__all__ = ["extract_token_usage", "get_first_value"]
+
 logger = logging.getLogger(__name__)
 
 

--- a/sdk/src/rhesis/sdk/agents/_tool_tracing.py
+++ b/sdk/src/rhesis/sdk/agents/_tool_tracing.py
@@ -19,7 +19,7 @@ from opentelemetry import trace
 from opentelemetry.trace import Span, Status, StatusCode
 
 from rhesis.sdk.agents.schemas import ToolResult
-from rhesis.sdk.telemetry.attributes import AIAttributes, AIEvents
+from rhesis.telemetry.attributes import AIAttributes, AIEvents
 from rhesis.telemetry.schemas import AIOperationType
 
 # Cap tool input/output content stamped on spans to avoid blowing up the

--- a/sdk/src/rhesis/sdk/agents/base.py
+++ b/sdk/src/rhesis/sdk/agents/base.py
@@ -28,8 +28,8 @@ from rhesis.sdk.agents.schemas import (
 )
 from rhesis.sdk.models.base import BaseLLM
 from rhesis.sdk.models.factory import get_model
-from rhesis.sdk.telemetry.attributes import AIAttributes, AIEvents
-from rhesis.sdk.telemetry.context import is_tracing_disabled
+from rhesis.telemetry.attributes import AIAttributes, AIEvents
+from rhesis.telemetry.context import is_tracing_disabled
 from rhesis.telemetry.schemas import AIOperationType
 
 logger = logging.getLogger(__name__)

--- a/sdk/src/rhesis/sdk/agents/tracing.py
+++ b/sdk/src/rhesis/sdk/agents/tracing.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 from opentelemetry import context, trace
 
 from rhesis.sdk.agents.events import AgentEventHandler
-from rhesis.sdk.telemetry.attributes import AIAttributes, AIEvents
+from rhesis.telemetry.attributes import AIAttributes, AIEvents
 from rhesis.telemetry.schemas import AIOperationType
 
 logger = logging.getLogger(__name__)

--- a/sdk/src/rhesis/sdk/connector/executor.py
+++ b/sdk/src/rhesis/sdk/connector/executor.py
@@ -11,7 +11,10 @@ from typing import Any
 
 from rhesis.sdk.connector.schemas import TestStatus
 from rhesis.sdk.connector.serializer import TypeSerializer
-from rhesis.sdk.telemetry.context import (
+from rhesis.sdk.telemetry.tracer import pop_result_trace_id
+from rhesis.telemetry.constants import ConversationContext as ConvContextConstants
+from rhesis.telemetry.constants import TestExecutionContext as TestContextConstants
+from rhesis.telemetry.context import (
     get_root_trace_id,
     set_conversation_id,
     set_conversation_mapped_input,
@@ -20,9 +23,6 @@ from rhesis.sdk.telemetry.context import (
     set_test_execution_context,
     set_tracing_disabled,
 )
-from rhesis.sdk.telemetry.tracer import pop_result_trace_id
-from rhesis.telemetry.constants import ConversationContext as ConvContextConstants
-from rhesis.telemetry.constants import TestExecutionContext as TestContextConstants
 
 logger = logging.getLogger(__name__)
 

--- a/sdk/src/rhesis/sdk/decorators/builders.py
+++ b/sdk/src/rhesis/sdk/decorators/builders.py
@@ -96,7 +96,7 @@ def create_observer(
             if hasattr(self, method_name):
                 raise ValueError(f"Method '{method_name}' already exists on this observer")
 
-            from rhesis.sdk.telemetry.attributes import validate_span_name
+            from rhesis.telemetry.attributes import validate_span_name
 
             if not validate_span_name(span_name):
                 raise ValueError(
@@ -111,7 +111,7 @@ def create_observer(
                 attributes = {**self._base_attributes, **default_attributes, **extra_attributes}
 
                 if operation_type:
-                    from rhesis.sdk.telemetry.attributes import AIAttributes
+                    from rhesis.telemetry.attributes import AIAttributes
 
                     attributes[AIAttributes.OPERATION_TYPE] = operation_type
 
@@ -120,12 +120,12 @@ def create_observer(
             # Add helpful docstring
             custom_method.__doc__ = f"""
             Convenience decorator for {method_name} operations.
-            
+
             Automatically sets:
             - span_name: "{span_name}"
             {f'- ai.operation.type: "{operation_type}"' if operation_type else ""}
             {f"- Default attributes: {default_attributes}" if default_attributes else ""}
-            
+
             Example:
                 @{self._name}_observer.{method_name}()
                 def my_function():

--- a/sdk/src/rhesis/sdk/decorators/observe.py
+++ b/sdk/src/rhesis/sdk/decorators/observe.py
@@ -168,8 +168,8 @@ class ObserveDecorator:
                 return openai.chat.completions.create(...)
         """
         # Import here to avoid circular imports
-        from rhesis.sdk.telemetry.attributes import AIAttributes
-        from rhesis.sdk.telemetry.context import set_llm_observation_active
+        from rhesis.telemetry.attributes import AIAttributes
+        from rhesis.telemetry.context import set_llm_observation_active
         from rhesis.telemetry.schemas import AIOperationType
 
         attributes = {
@@ -243,7 +243,7 @@ class ObserveDecorator:
             async def run(query: str) -> str:
                 ...
         """
-        from rhesis.sdk.telemetry.attributes import AIAttributes
+        from rhesis.telemetry.attributes import AIAttributes
         from rhesis.telemetry.schemas import AIOperationType
 
         attributes = {
@@ -278,7 +278,7 @@ class ObserveDecorator:
             def get_weather(city: str) -> dict:
                 return requests.get(f"api/{city}").json()
         """
-        from rhesis.sdk.telemetry.attributes import AIAttributes
+        from rhesis.telemetry.attributes import AIAttributes
         from rhesis.telemetry.schemas import AIOperationType
 
         attributes = {
@@ -314,7 +314,7 @@ class ObserveDecorator:
             def search_docs(query: str) -> list:
                 return vector_db.search(query, k=5)
         """
-        from rhesis.sdk.telemetry.attributes import AIAttributes
+        from rhesis.telemetry.attributes import AIAttributes
         from rhesis.telemetry.schemas import AIOperationType
 
         attributes = {
@@ -352,7 +352,7 @@ class ObserveDecorator:
             def embed_texts(texts: List[str]) -> List[List[float]]:
                 return embedding_model.encode(texts)
         """
-        from rhesis.sdk.telemetry.attributes import AIAttributes
+        from rhesis.telemetry.attributes import AIAttributes
         from rhesis.telemetry.schemas import AIOperationType
 
         attributes = {
@@ -390,7 +390,7 @@ class ObserveDecorator:
             def rerank_documents(query: str, docs: List[str]) -> List[str]:
                 return reranker.rerank(query, docs, top_n=10)
         """
-        from rhesis.sdk.telemetry.attributes import AIAttributes
+        from rhesis.telemetry.attributes import AIAttributes
         from rhesis.telemetry.schemas import AIOperationType
 
         attributes = {
@@ -428,7 +428,7 @@ class ObserveDecorator:
             def evaluate_relevance(query: str, response: str) -> float:
                 return evaluator.score_relevance(query, response)
         """
-        from rhesis.sdk.telemetry.attributes import AIAttributes
+        from rhesis.telemetry.attributes import AIAttributes
         from rhesis.telemetry.schemas import AIOperationType
 
         attributes = {
@@ -465,7 +465,7 @@ class ObserveDecorator:
             def check_content_safety(text: str) -> bool:
                 return safety_checker.is_safe(text)
         """
-        from rhesis.sdk.telemetry.attributes import AIAttributes
+        from rhesis.telemetry.attributes import AIAttributes
         from rhesis.telemetry.schemas import AIOperationType
 
         attributes = {
@@ -502,7 +502,7 @@ class ObserveDecorator:
             def preprocess_text(text: str) -> str:
                 return clean_and_normalize(text)
         """
-        from rhesis.sdk.telemetry.attributes import AIAttributes
+        from rhesis.telemetry.attributes import AIAttributes
         from rhesis.telemetry.schemas import AIOperationType
 
         attributes = {

--- a/sdk/src/rhesis/sdk/models/base.py
+++ b/sdk/src/rhesis/sdk/models/base.py
@@ -95,19 +95,20 @@ def _normalize_usage(usage: Any) -> Optional[TokenUsage]:
     result as a simple "emit or skip" decision.
 
     Delegates the actual key-name matching to
-    :func:`~rhesis.sdk.telemetry.utils.token_extraction.extract_token_usage`,
+    :func:`~rhesis.telemetry.token_extraction.extract_token_usage`,
     which already handles every provider dialect and is used by the
     LangChain tracing integration -- there is no reason for the accrual
-    path to grow a second, thinner copy of that logic. Imported lazily
-    because ``rhesis.sdk.telemetry`` builds the OTel tracer and exporter
-    on package init, and this module is on the import path of every SDK
-    user; the ``on_usage is None`` guard in the callers means the import
-    only ever happens for callers that actually wired up accrual.
+    path to grow a second, thinner copy of that logic. The function is
+    pure stdlib, but importing it runs ``rhesis.telemetry.__init__``,
+    which pulls in the OpenTelemetry SDK and the exporter -- so it stays
+    lazy, because this module is on the import path of every SDK user;
+    the ``on_usage is None`` guard in the callers means the import only
+    ever happens for callers that actually wired up accrual.
     """
     if not usage:
         return None
 
-    from rhesis.sdk.telemetry.utils.token_extraction import extract_token_usage
+    from rhesis.telemetry.token_extraction import extract_token_usage
 
     input_tokens, output_tokens, total_tokens = extract_token_usage(usage)
     if not total_tokens:

--- a/sdk/src/rhesis/sdk/telemetry/__init__.py
+++ b/sdk/src/rhesis/sdk/telemetry/__init__.py
@@ -2,17 +2,16 @@
 
 # Core tracing API
 # Helpers
-from rhesis.sdk.telemetry.attributes import (
+# Auto-instrumentation
+from rhesis.sdk.telemetry.observer import auto_instrument, disable_auto_instrument
+from rhesis.sdk.telemetry.tracer import Tracer
+from rhesis.telemetry.attributes import (
     AIAttributes,
     AIEvents,
     create_llm_attributes,
     create_tool_attributes,
     validate_span_name,
 )
-
-# Auto-instrumentation
-from rhesis.sdk.telemetry.observer import auto_instrument, disable_auto_instrument
-from rhesis.sdk.telemetry.tracer import Tracer
 
 # Re-export from rhesis.telemetry (lightweight foundation)
 from rhesis.telemetry.exporter import RhesisOTLPExporter

--- a/sdk/src/rhesis/sdk/telemetry/attributes.py
+++ b/sdk/src/rhesis/sdk/telemetry/attributes.py
@@ -5,8 +5,9 @@ These moved to ``rhesis.telemetry.attributes`` so that framework integrations ca
 lightweight ``rhesis[telemetry]`` package instead of the full SDK. Nothing here imports anything
 heavier than stdlib, so there was no reason for it to sit behind torch and deepeval.
 
-New code should import from ``rhesis.telemetry.attributes``. This module stays for the ~64 existing
-import sites.
+Import from ``rhesis.telemetry.attributes``. Every site in this repository does; this module stays
+only for consumers outside it — released ``rhesis-haystack`` versions and user code written against
+the old path — and is not the path to add new imports to.
 """
 
 from rhesis.telemetry.attributes import (

--- a/sdk/src/rhesis/sdk/telemetry/context.py
+++ b/sdk/src/rhesis/sdk/telemetry/context.py
@@ -7,8 +7,9 @@ lightweight ``rhesis[telemetry]`` package instead of the full SDK.
 The ContextVars themselves live in the new module, so importing from either path reads and writes
 the same state — there is no second set.
 
-New code should import from ``rhesis.telemetry.context``. This module stays for the ~25 existing
-import sites, including ``apps/backend``.
+Import from ``rhesis.telemetry.context``. Every site in this repository does; this module stays only
+for consumers outside it — released ``rhesis-haystack`` versions and user code written against the
+old path — and is not the path to add new imports to.
 """
 
 from rhesis.telemetry.context import (

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/mapping.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/mapping.py
@@ -6,7 +6,7 @@ semantic conventions, with span names like ``"chat gpt-4"`` /
 the ``gen_ai.*`` namespace.
 
 The Rhesis backend, by contrast, expects span names from the ``ai.*`` /
-``function.*`` namespaces (see :mod:`rhesis.sdk.telemetry.attributes`). The
+``function.*`` namespaces (see :mod:`rhesis.telemetry.attributes`). The
 framework-neutral parts of that bridge (GenAI constants, attribute/event
 translation, message-event synthesis) live in
 :mod:`rhesis.sdk.telemetry.integrations.genai` and are re-exported here so
@@ -20,8 +20,6 @@ That makes them trivial to unit test.
 from __future__ import annotations
 
 from typing import Any, Mapping
-
-from rhesis.sdk.telemetry.attributes import AIAttributes
 
 # Framework-neutral GenAI pieces, re-exported under their historical names so
 # the translator and tests keep working unchanged. New MAF-specific helpers
@@ -70,6 +68,7 @@ from rhesis.sdk.telemetry.integrations.genai import (  # noqa: F401
 from rhesis.sdk.telemetry.integrations.genai import (
     coerce_message_list as _coerce_message_list,
 )
+from rhesis.telemetry.attributes import AIAttributes
 from rhesis.telemetry.schemas import AIOperationType
 
 INSTRUMENTATION_SCOPE_PREFIX = "agent_framework"
@@ -89,7 +88,7 @@ WORKFLOW_RUN_SPAN_NAME = "workflow.run"
 HANDOFF_TOOL_PREFIX = "handoff_to_"
 
 # Operation -> Rhesis span name. The validator in
-# :mod:`rhesis.sdk.telemetry.attributes` accepts ``ai.<domain>(.<action>)?`` and
+# :mod:`rhesis.telemetry.attributes` accepts ``ai.<domain>(.<action>)?`` and
 # anything starting with ``function.``, so we are careful to land here.
 _OPERATION_TO_SPAN_NAME: Mapping[str, str] = {
     OP_CHAT: AIOperationType.LLM_INVOKE,
@@ -128,7 +127,7 @@ def translate_span_name(original_name: str, attributes: Mapping[str, Any]) -> st
 
     If neither path matches, we sanitize ``original_name`` into the
     ``function.maf.*`` namespace so it always satisfies
-    :func:`rhesis.sdk.telemetry.attributes.validate_span_name`. This protects
+    :func:`rhesis.telemetry.attributes.validate_span_name`. This protects
     the integration against MAF adding new operations under us.
 
     Args:

--- a/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/agent_framework/translator.py
@@ -28,12 +28,6 @@ from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
 from opentelemetry.trace import SpanContext, SpanKind, TraceFlags
 from opentelemetry.trace.status import Status, StatusCode
 
-from rhesis.sdk.telemetry.attributes import AIAttributes
-from rhesis.sdk.telemetry.context import (
-    get_conversation_id,
-    is_llm_observation_active,
-    set_llm_observation_active,
-)
 from rhesis.sdk.telemetry.integrations.agent_framework import mapping
 
 # Shared with other native-GenAI integrations (see genai.py); imported under
@@ -45,7 +39,13 @@ from rhesis.sdk.telemetry.integrations.genai import (
 from rhesis.sdk.telemetry.integrations.genai import (
     translate_events as _translate_events,
 )
+from rhesis.telemetry.attributes import AIAttributes
 from rhesis.telemetry.constants import ConversationContext
+from rhesis.telemetry.context import (
+    get_conversation_id,
+    is_llm_observation_active,
+    set_llm_observation_active,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -203,7 +203,7 @@ def _safe_fallback_span(span: ReadableSpan) -> ReadableSpan:
     """Build the safest possible wrapper when :func:`translate_span` raises.
 
     The raw MAF span name (e.g. ``"chat gpt-4"``) fails the Rhesis
-    backend's :func:`~rhesis.sdk.telemetry.attributes.validate_span_name`
+    backend's :func:`~rhesis.telemetry.attributes.validate_span_name`
     regex, so simply forwarding the original span on a translation error
     causes silent HTTP 422 drops. Funnel the span into ``function.maf.*``
     instead so the backend accepts it. The original name is stashed as
@@ -469,7 +469,7 @@ def conversation_root_attributes(span: ReadableSpan) -> dict[str, Any] | None:
     (from the nested chat spans via :data:`_conversation_content`) so the
     recorded run shows its conversation content in the UI. Whether it is *also*
     a multi-turn turn root depends on the agent having set a real
-    conversation/session id (via ``rhesis.sdk.telemetry.context``,
+    conversation/session id (via ``rhesis.telemetry.context``,
     ``set_conversation_id``), captured at chat-span *start* while the
     contextvar is still active:
 
@@ -647,7 +647,7 @@ class MAFLLMDedupSpanProcessor(SpanProcessor):
     What this dedups (and what it does NOT):
 
     * Toggles
-      :func:`~rhesis.sdk.telemetry.context.is_llm_observation_active` for the
+      :func:`~rhesis.telemetry.context.is_llm_observation_active` for the
       duration of MAF ``chat`` spans so that any **flag-checking
       auto-instrumentation running inside an MAF agent** skips emitting a
       duplicate ``ai.llm.invoke`` span. The LangChain callback is the canonical

--- a/sdk/src/rhesis/sdk/telemetry/integrations/genai.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/genai.py
@@ -30,7 +30,7 @@ from typing import Any, Iterable, Mapping, Optional, Sequence
 from opentelemetry.sdk.trace import Event, ReadableSpan, SpanProcessor
 from opentelemetry.sdk.trace.export import SpanExporter
 
-from rhesis.sdk.telemetry.attributes import AIAttributes
+from rhesis.telemetry.attributes import AIAttributes
 
 logger = logging.getLogger(__name__)
 

--- a/sdk/src/rhesis/sdk/telemetry/integrations/langchain/callback.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/langchain/callback.py
@@ -7,8 +7,8 @@ from opentelemetry import context as otel_context
 from opentelemetry import trace
 from opentelemetry.trace import SpanKind, Status, StatusCode
 
-from rhesis.sdk.telemetry.attributes import AIAttributes, AIEvents
-from rhesis.sdk.telemetry.context import is_llm_observation_active, is_tracing_disabled
+from rhesis.telemetry.attributes import AIAttributes, AIEvents
+from rhesis.telemetry.context import is_llm_observation_active, is_tracing_disabled
 from rhesis.telemetry.schemas import AIOperationType
 
 from .extractors import (

--- a/sdk/src/rhesis/sdk/telemetry/integrations/langchain/extractors.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/langchain/extractors.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any, Dict, List, Optional
 
 # Re-exported for backwards compatibility; canonical home is attributes.py
-from rhesis.sdk.telemetry.attributes import MAX_CONTENT_LENGTH  # noqa: F401
+from rhesis.telemetry.attributes import MAX_CONTENT_LENGTH  # noqa: F401
 
 logger = logging.getLogger(__name__)
 

--- a/sdk/src/rhesis/sdk/telemetry/integrations/langchain/llm_processing.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/langchain/llm_processing.py
@@ -11,8 +11,8 @@ from typing import Any, Dict, List
 
 from opentelemetry import trace
 
-from rhesis.sdk.telemetry.attributes import AIAttributes, AIEvents
-from rhesis.sdk.telemetry.utils import extract_token_usage
+from rhesis.telemetry.attributes import AIAttributes, AIEvents
+from rhesis.telemetry.token_extraction import extract_token_usage
 
 from .extractors import MAX_CONTENT_LENGTH, extract_model_name, extract_provider
 

--- a/sdk/src/rhesis/sdk/telemetry/integrations/pydantic_ai/mapping.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/pydantic_ai/mapping.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
-from rhesis.sdk.telemetry.attributes import AIAttributes
 from rhesis.sdk.telemetry.integrations.genai import (  # noqa: F401
     GEN_AI_AGENT_NAME,
     GEN_AI_OPERATION_NAME,
@@ -38,6 +37,7 @@ from rhesis.sdk.telemetry.integrations.genai import (  # noqa: F401
 from rhesis.sdk.telemetry.integrations.genai import (
     translate_attributes as _translate_genai_attributes,
 )
+from rhesis.telemetry.attributes import AIAttributes
 from rhesis.telemetry.schemas import AIOperationType
 
 # Pydantic AI's instrumentation scope (InstrumentationSettings tracer name).
@@ -81,7 +81,7 @@ def translate_span_name(original_name: str, attributes: Mapping[str, Any]) -> st
     falls back to scanning the original span name (fuzzy). If neither path
     matches, the name is sanitized into the ``function.pydantic_ai.*``
     namespace so it always satisfies
-    :func:`rhesis.sdk.telemetry.attributes.validate_span_name`. This protects
+    :func:`rhesis.telemetry.attributes.validate_span_name`. This protects
     the integration against Pydantic AI adding new operations under us.
     """
     operation = attributes.get(GEN_AI_OPERATION_NAME)

--- a/sdk/src/rhesis/sdk/telemetry/integrations/pydantic_ai/translator.py
+++ b/sdk/src/rhesis/sdk/telemetry/integrations/pydantic_ai/translator.py
@@ -36,17 +36,17 @@ from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
 from opentelemetry.trace import SpanContext, SpanKind, TraceFlags
 from opentelemetry.trace.status import Status, StatusCode
 
-from rhesis.sdk.telemetry.attributes import AIAttributes
-from rhesis.sdk.telemetry.context import (
-    is_llm_observation_active,
-    set_llm_observation_active,
-)
 from rhesis.sdk.telemetry.integrations.genai import (
     AncestryRegistry,
     TranslatedSpan,
     translate_events,
 )
 from rhesis.sdk.telemetry.integrations.pydantic_ai import mapping
+from rhesis.telemetry.attributes import AIAttributes
+from rhesis.telemetry.context import (
+    is_llm_observation_active,
+    set_llm_observation_active,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -157,7 +157,7 @@ def _safe_fallback_span(span: ReadableSpan) -> ReadableSpan:
     """Build the safest possible wrapper when :func:`translate_span` raises.
 
     The raw Pydantic AI span name (e.g. ``"chat gpt-4o"``) fails the Rhesis
-    backend's :func:`~rhesis.sdk.telemetry.attributes.validate_span_name`
+    backend's :func:`~rhesis.telemetry.attributes.validate_span_name`
     regex, so simply forwarding the original span on a translation error
     causes silent HTTP 422 drops. Funnel the span into
     ``function.pydantic_ai.*`` instead so the backend accepts it. The original
@@ -321,7 +321,7 @@ class PydanticAILLMDedupSpanProcessor(SpanProcessor):
        shared :class:`~rhesis.sdk.telemetry.integrations.genai.AncestryRegistry`,
        so the exporter can resolve handoff
        ``from`` agents across export batches.
-    2. Toggles :func:`~rhesis.sdk.telemetry.context.is_llm_observation_active`
+    2. Toggles :func:`~rhesis.telemetry.context.is_llm_observation_active`
        for the duration of Pydantic AI ``chat`` spans so that any flag-checking
        auto-instrumentation running inside an agent run (e.g. the LangChain
        callback) skips emitting a duplicate ``ai.llm.invoke`` span.

--- a/sdk/src/rhesis/sdk/telemetry/tracer.py
+++ b/sdk/src/rhesis/sdk/telemetry/tracer.py
@@ -11,8 +11,10 @@ from typing import Any, Optional
 from opentelemetry import trace
 from opentelemetry.trace import NonRecordingSpan, SpanContext, TraceFlags
 
-from rhesis.sdk.telemetry.attributes import AIAttributes
-from rhesis.sdk.telemetry.context import (
+from rhesis.telemetry.attributes import AIAttributes
+from rhesis.telemetry.constants import ConversationContext as ConvContextConstants
+from rhesis.telemetry.constants import TestExecutionContext as TestContextConstants
+from rhesis.telemetry.context import (
     get_conversation_id,
     get_conversation_mapped_input,
     get_conversation_trace_id,
@@ -21,8 +23,6 @@ from rhesis.sdk.telemetry.context import (
     is_tracing_disabled,
     set_root_trace_id,
 )
-from rhesis.telemetry.constants import ConversationContext as ConvContextConstants
-from rhesis.telemetry.constants import TestExecutionContext as TestContextConstants
 from rhesis.telemetry.provider import get_tracer_provider
 from rhesis.telemetry.schemas import TestExecutionContext
 

--- a/sdk/src/rhesis/sdk/telemetry/utils/__init__.py
+++ b/sdk/src/rhesis/sdk/telemetry/utils/__init__.py
@@ -5,6 +5,10 @@ from rhesis.sdk.telemetry.utils.provider_detection import (
     identify_provider_from_class_name,
     identify_provider_from_model_name,
 )
+
+# Deliberately routed through the legacy submodule rather than ``rhesis.telemetry``: this package is
+# itself the old public surface, and importing the shim keeps the whole compatibility layer in one
+# place. New code should use ``rhesis.telemetry.token_extraction``.
 from rhesis.sdk.telemetry.utils.token_extraction import extract_token_usage
 
 __all__ = [

--- a/tests/backend/services/telemetry/test_enrichment.py
+++ b/tests/backend/services/telemetry/test_enrichment.py
@@ -5,18 +5,18 @@ from unittest.mock import Mock
 import litellm
 import pytest
 
+# Import semantic layer constants
+from rhesis.telemetry.attributes import AIAttributes
+
 from rhesis.backend.app.models.trace import Trace
 from rhesis.backend.app.schemas.enrichment import TokenCosts
 from rhesis.backend.app.services.exchange_rate import get_usd_to_eur_rate
-from rhesis.backend.app.services.telemetry.enrichment.processor import TraceEnricher
 from rhesis.backend.app.services.telemetry.enrichment import (
     calculate_token_costs,
     detect_anomalies,
     extract_metadata,
 )
-
-# Import semantic layer constants
-from rhesis.sdk.telemetry.attributes import AIAttributes
+from rhesis.backend.app.services.telemetry.enrichment.processor import TraceEnricher
 
 
 class TestCalculateTokenCosts:

--- a/tests/backend/tasks/architect/test_chat.py
+++ b/tests/backend/tasks/architect/test_chat.py
@@ -133,7 +133,7 @@ async def test_persist_state_stamps_root_trace_id_on_agent_state():
 
     with (
         patch(
-            "rhesis.sdk.telemetry.context.get_root_trace_id",
+            "rhesis.telemetry.context.get_root_trace_id",
             return_value="deadbeef" * 4,
         ),
         patch(
@@ -176,7 +176,7 @@ async def test_persist_state_omits_trace_id_when_tracing_disabled():
     )
 
     with (
-        patch("rhesis.sdk.telemetry.context.get_root_trace_id", return_value=None),
+        patch("rhesis.telemetry.context.get_root_trace_id", return_value=None),
         patch(
             "rhesis.backend.app.services.architect.runner.get_db_with_tenant_variables"
         ) as mock_db_ctx,
@@ -207,7 +207,7 @@ async def test_conversation_context_sets_and_clears_contextvars():
     """The async context manager must bind all three SDK ContextVars
     on entry and clear them on exit so they cannot leak into the next
     Celery task that reuses the same asyncio worker."""
-    from rhesis.sdk.telemetry.context import (
+    from rhesis.telemetry.context import (
         get_conversation_id,
         get_conversation_mapped_input,
         get_conversation_trace_id,
@@ -237,7 +237,7 @@ async def test_conversation_context_sets_and_clears_contextvars():
 async def test_conversation_context_clears_on_exception():
     """Exceptions inside the block must not leak ContextVars to later
     tasks running on the same worker."""
-    from rhesis.sdk.telemetry.context import (
+    from rhesis.telemetry.context import (
         get_conversation_id,
         get_conversation_trace_id,
     )
@@ -259,7 +259,7 @@ async def test_conversation_context_skips_unset_values():
     """First-turn callers pass ``conversation_trace_id=None`` so the
     SDK tracer generates a fresh trace; only non-empty values are
     bound so we don't accidentally clobber an outer scope's state."""
-    from rhesis.sdk.telemetry.context import (
+    from rhesis.telemetry.context import (
         get_conversation_id,
         get_conversation_trace_id,
     )

--- a/tests/sdk/connector/test_executor.py
+++ b/tests/sdk/connector/test_executor.py
@@ -166,7 +166,7 @@ class TestTraceIdPropagation:
     @pytest.mark.asyncio
     async def test_trace_id_from_context_var_async(self, executor):
         """Test trace_id retrieval from context var for async functions."""
-        from rhesis.sdk.telemetry.context import get_root_trace_id, set_root_trace_id
+        from rhesis.telemetry.context import get_root_trace_id, set_root_trace_id
 
         test_trace_id = "abc123def456789012345678901234ab"
 

--- a/tests/sdk/connector/test_executor_context.py
+++ b/tests/sdk/connector/test_executor_context.py
@@ -2,10 +2,10 @@
 
 import pytest
 from rhesis.telemetry.constants import TestExecutionContext as TestContextConstants
+from rhesis.telemetry.context import get_test_execution_context
 
 from rhesis.sdk.connector.executor import TestExecutor
 from rhesis.sdk.context import EndpointContext
-from rhesis.sdk.telemetry.context import get_test_execution_context
 
 
 @pytest.fixture

--- a/tests/sdk/telemetry/integrations/test_agent_framework.py
+++ b/tests/sdk/telemetry/integrations/test_agent_framework.py
@@ -47,13 +47,13 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcess
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (  # noqa: E402
     InMemorySpanExporter,
 )
+from rhesis.telemetry.attributes import AIAttributes, validate_span_name  # noqa: E402
 from rhesis.telemetry.constants import ConversationContext  # noqa: E402
-
-from rhesis.sdk.telemetry.attributes import AIAttributes, validate_span_name  # noqa: E402
-from rhesis.sdk.telemetry.context import (  # noqa: E402
+from rhesis.telemetry.context import (  # noqa: E402
     is_llm_observation_active,
     set_llm_observation_active,
 )
+
 from rhesis.sdk.telemetry.integrations.agent_framework import (  # noqa: E402
     MAFIntegration,
     MAFLLMDedupSpanProcessor,

--- a/tests/sdk/telemetry/integrations/test_pydantic_ai_integration.py
+++ b/tests/sdk/telemetry/integrations/test_pydantic_ai_integration.py
@@ -21,12 +21,12 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 from opentelemetry.trace import StatusCode
 from pydantic_ai import Agent, BinaryContent
 from pydantic_ai.models.test import TestModel
-
-from rhesis.sdk.telemetry.attributes import AIAttributes, validate_span_name
-from rhesis.sdk.telemetry.context import (
+from rhesis.telemetry.attributes import AIAttributes, validate_span_name
+from rhesis.telemetry.context import (
     is_llm_observation_active,
     set_llm_observation_active,
 )
+
 from rhesis.sdk.telemetry.integrations.pydantic_ai import (
     PINNED_INSTRUMENTATION_VERSION,
     PydanticAIIntegration,

--- a/tests/sdk/telemetry/test_attributes.py
+++ b/tests/sdk/telemetry/test_attributes.py
@@ -1,6 +1,6 @@
 """Tests for telemetry semantic convention helpers."""
 
-from rhesis.sdk.telemetry.attributes import (
+from rhesis.telemetry.attributes import (
     AIAttributes,
     AIEvents,
     create_llm_attributes,

--- a/tests/sdk/telemetry/test_context.py
+++ b/tests/sdk/telemetry/test_context.py
@@ -1,8 +1,7 @@
 """Tests for test execution context variables."""
 
 import pytest
-
-from rhesis.sdk.telemetry.context import (
+from rhesis.telemetry.context import (
     get_test_execution_context,
     set_test_execution_context,
 )

--- a/tests/sdk/telemetry/test_convenience_decorators.py
+++ b/tests/sdk/telemetry/test_convenience_decorators.py
@@ -3,11 +3,10 @@
 from unittest.mock import MagicMock
 
 import pytest
+from rhesis.telemetry.attributes import AIAttributes
 
-from rhesis.sdk import decorators
-from rhesis.sdk.decorators import observe
 from rhesis.sdk.decorators import _state as decorators_state
-from rhesis.sdk.telemetry.attributes import AIAttributes
+from rhesis.sdk.decorators import observe
 
 
 @pytest.fixture

--- a/tests/sdk/telemetry/test_conversation_tracing.py
+++ b/tests/sdk/telemetry/test_conversation_tracing.py
@@ -14,15 +14,15 @@ from unittest.mock import MagicMock, patch
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExportResult
 from opentelemetry.trace import SpanContext, SpanKind, Status, StatusCode, TraceFlags
-
 from rhesis.telemetry.constants import ConversationContext as ConvCtx
-from rhesis.sdk.telemetry.context import (
+from rhesis.telemetry.context import (
     get_conversation_id,
     get_conversation_trace_id,
     set_conversation_id,
     set_conversation_trace_id,
 )
 from rhesis.telemetry.exporter import RhesisOTLPExporter
+
 from rhesis.sdk.telemetry.tracer import Tracer
 
 # ---------------------------------------------------------------------------

--- a/tests/sdk/telemetry/test_custom_observers.py
+++ b/tests/sdk/telemetry/test_custom_observers.py
@@ -3,11 +3,10 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from rhesis.telemetry.attributes import AIAttributes
 
-from rhesis.sdk import decorators
 from rhesis.sdk.decorators import ObserverBuilder, create_observer
 from rhesis.sdk.decorators import _state as decorators_state
-from rhesis.sdk.telemetry.attributes import AIAttributes
 
 
 class TestCreateObserver:

--- a/tests/sdk/telemetry/test_legacy_import_paths.py
+++ b/tests/sdk/telemetry/test_legacy_import_paths.py
@@ -1,0 +1,86 @@
+"""The ``rhesis.sdk.telemetry`` re-export shims stay usable and stay in sync.
+
+``attributes``, ``context`` and ``token_extraction`` moved into the lightweight ``rhesis`` package
+(#2462) so framework integrations can depend on ``rhesis[telemetry]`` instead of the whole SDK. Every
+import site in this repository now uses the canonical ``rhesis.telemetry.*`` paths (#2473), which
+means nothing in the repository exercises the old paths any more — and a compatibility surface no
+test touches is one that breaks silently.
+
+What breaks if these fail: released ``rhesis-haystack`` versions import
+``rhesis.sdk.telemetry.attributes`` and ``rhesis.sdk.telemetry.context``, and so does any user code
+written before the move.
+"""
+
+import importlib
+
+import pytest
+from rhesis.telemetry import attributes as canonical_attributes
+from rhesis.telemetry import context as canonical_context
+from rhesis.telemetry import token_extraction as canonical_token_extraction
+
+SHIMS = [
+    ("rhesis.sdk.telemetry.attributes", canonical_attributes),
+    ("rhesis.sdk.telemetry.context", canonical_context),
+    ("rhesis.sdk.telemetry.utils.token_extraction", canonical_token_extraction),
+]
+
+
+@pytest.mark.parametrize("legacy_path, canonical", SHIMS, ids=lambda v: getattr(v, "__name__", v))
+def test_shim_re_exports_the_same_objects(legacy_path, canonical):
+    """Each name the shim advertises resolves to the canonical object, not a copy of it."""
+    legacy = importlib.import_module(legacy_path)
+
+    assert legacy.__all__, f"{legacy_path} advertises nothing"
+    for name in legacy.__all__:
+        assert getattr(legacy, name) is getattr(canonical, name), (
+            f"{legacy_path}.{name} is not {canonical.__name__}.{name}"
+        )
+
+
+@pytest.mark.parametrize("legacy_path, canonical", SHIMS, ids=lambda v: getattr(v, "__name__", v))
+def test_shim_forwards_everything_public(legacy_path, canonical):
+    """A symbol added to the canonical module must be added to the shim as well.
+
+    Only names *defined* in the canonical module count, so imports it makes for its own use (a
+    constant pulled from ``schemas``, say) are not treated as part of its surface.
+    """
+    legacy = importlib.import_module(legacy_path)
+
+    own_public_names = {
+        name
+        for name, value in vars(canonical).items()
+        if not name.startswith("_") and getattr(value, "__module__", None) == canonical.__name__
+    }
+    missing = own_public_names - set(legacy.__all__)
+    assert not missing, f"{legacy_path} does not forward {sorted(missing)}"
+
+
+def test_context_vars_are_shared_across_both_paths():
+    """The ContextVars live in one module, so a write through either path is visible from the other.
+
+    This is what lets the SDK and a framework integration read the same turn state while importing
+    from different paths. A shim that rebound its own ContextVars would pass the identity tests above
+    and still split the state in two.
+    """
+    legacy = importlib.import_module("rhesis.sdk.telemetry.context")
+
+    legacy.set_root_trace_id("cafe" * 8)
+    try:
+        assert canonical_context.get_root_trace_id() == "cafe" * 8
+
+        canonical_context.set_conversation_id("conv-1")
+        assert legacy.get_conversation_id() == "conv-1"
+    finally:
+        legacy.set_root_trace_id(None)
+        canonical_context.set_conversation_id(None)
+
+
+def test_legacy_utils_package_still_exports_token_extraction():
+    """``rhesis.sdk.telemetry.utils`` published ``extract_token_usage``; it still does.
+
+    This is the one place in the repository that still imports a legacy telemetry path, and it does
+    so deliberately: the module *is* the old public surface.
+    """
+    utils = importlib.import_module("rhesis.sdk.telemetry.utils")
+
+    assert utils.extract_token_usage is canonical_token_extraction.extract_token_usage

--- a/tests/sdk/telemetry/test_legacy_import_paths.py
+++ b/tests/sdk/telemetry/test_legacy_import_paths.py
@@ -1,10 +1,10 @@
 """The ``rhesis.sdk.telemetry`` re-export shims stay usable and stay in sync.
 
 ``attributes``, ``context`` and ``token_extraction`` moved into the lightweight ``rhesis`` package
-(#2462) so framework integrations can depend on ``rhesis[telemetry]`` instead of the whole SDK. Every
-import site in this repository now uses the canonical ``rhesis.telemetry.*`` paths (#2473), which
-means nothing in the repository exercises the old paths any more — and a compatibility surface no
-test touches is one that breaks silently.
+(#2462) so framework integrations can depend on ``rhesis[telemetry]`` instead of the whole SDK.
+Every import site in this repository now uses the canonical ``rhesis.telemetry.*`` paths (#2473),
+which means nothing here exercises the old paths any more — and a compatibility surface no test
+touches is one that breaks silently.
 
 What breaks if these fail: released ``rhesis-haystack`` versions import
 ``rhesis.sdk.telemetry.attributes`` and ``rhesis.sdk.telemetry.context``, and so does any user code
@@ -38,29 +38,36 @@ def test_shim_re_exports_the_same_objects(legacy_path, canonical):
 
 
 @pytest.mark.parametrize("legacy_path, canonical", SHIMS, ids=lambda v: getattr(v, "__name__", v))
-def test_shim_forwards_everything_public(legacy_path, canonical):
-    """A symbol added to the canonical module must be added to the shim as well.
+def test_shim_forwards_the_whole_canonical_surface(legacy_path, canonical):
+    """The shim forwards exactly what the canonical module declares public, no more and no less.
 
-    Only names *defined* in the canonical module count, so imports it makes for its own use (a
-    constant pulled from ``schemas``, say) are not treated as part of its surface.
+    Compared against the canonical ``__all__`` rather than inferred from the module namespace,
+    because inference cannot answer the question. Filtering ``vars()`` by ``__module__`` catches
+    functions and classes but silently drops constants — ``MAX_CONTENT_LENGTH`` is an ``int`` and
+    carries no ``__module__`` — while dropping the underscore-prefixed names would keep imports the
+    module makes for its own use, like ``FORBIDDEN_SPAN_DOMAINS`` from ``schemas``. Either way a new
+    public constant could be added to a canonical module and skip the shim unnoticed.
+
+    A failure here is a decision to make, not a line to delete: a name added to the canonical
+    module either belongs on the old path too, or the shim deliberately stops short and this test
+    should say so.
     """
     legacy = importlib.import_module(legacy_path)
 
-    own_public_names = {
-        name
-        for name, value in vars(canonical).items()
-        if not name.startswith("_") and getattr(value, "__module__", None) == canonical.__name__
-    }
-    missing = own_public_names - set(legacy.__all__)
+    missing = set(canonical.__all__) - set(legacy.__all__)
+    extra = set(legacy.__all__) - set(canonical.__all__)
     assert not missing, f"{legacy_path} does not forward {sorted(missing)}"
+    assert not extra, (
+        f"{legacy_path} advertises {sorted(extra)}, which {canonical.__name__} does not"
+    )
 
 
 def test_context_vars_are_shared_across_both_paths():
     """The ContextVars live in one module, so a write through either path is visible from the other.
 
     This is what lets the SDK and a framework integration read the same turn state while importing
-    from different paths. A shim that rebound its own ContextVars would pass the identity tests above
-    and still split the state in two.
+    from different paths. A shim that rebound its own ContextVars would pass the identity tests
+    above and still split the state in two.
     """
     legacy = importlib.import_module("rhesis.sdk.telemetry.context")
 

--- a/tests/sdk/telemetry/test_semantic_layer_constants.py
+++ b/tests/sdk/telemetry/test_semantic_layer_constants.py
@@ -1,6 +1,6 @@
 """Tests for semantic layer constants."""
 
-from rhesis.sdk.telemetry.attributes import AIAttributes, AIEvents
+from rhesis.telemetry.attributes import AIAttributes, AIEvents
 from rhesis.telemetry.schemas import FORBIDDEN_SPAN_DOMAINS, AIOperationType
 
 

--- a/tests/sdk/telemetry/test_tracer.py
+++ b/tests/sdk/telemetry/test_tracer.py
@@ -3,8 +3,8 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from rhesis.telemetry.attributes import AIAttributes
 
-from rhesis.sdk.telemetry.attributes import AIAttributes
 from rhesis.sdk.telemetry.tracer import Tracer
 
 


### PR DESCRIPTION
Closes #2473

## What

Point every telemetry import site in this repository at the canonical
`rhesis.telemetry.*` modules, keep the `rhesis.sdk.telemetry.*` shims for outside consumers, and give
the light package the `py.typed` marker it turns out to need.

## Why

#2462 moved `attributes`, `context` and `token_extraction` into the light `rhesis` package so
framework integrations can depend on `rhesis[telemetry]` instead of the whole SDK, and left
re-export shims behind. Every call site here still went through the shims, which made the canonical
path the exception and kept the old ones looking load-bearing.

## Changes

**`chore(sdk): import telemetry primitives from rhesis.telemetry`** — 43 files across `sdk/`,
`apps/backend/`, `tests/`, `agents/`, `examples/` and `docs/`. The path flattens on the way:
`utils.token_extraction` → `token_extraction`. Two mock targets in
`tests/backend/tasks/architect/test_chat.py` move with the lazy import they patch — a mock on the
shim would no longer be seen by code importing from the canonical module.

The grep from the issue now returns exactly one line, in `sdk/src/rhesis/sdk/telemetry/utils/__init__.py`,
which keeps re-exporting `extract_token_usage` through the shim deliberately: that package is itself
the old public surface, and there is now a comment saying so. The shim docstrings say they exist for
consumers outside this repository rather than counting internal call sites.

**`test(sdk): pin the legacy telemetry import shims`** — nothing here exercises the old paths any
more, and a compatibility surface no test touches is one that breaks silently. Released
`rhesis-haystack` versions import two of them. The test asserts that each advertised name is the
canonical object rather than a copy, that a public symbol added to a canonical module must be
forwarded, and that the ContextVars are shared across both paths — that identity is what lets the SDK
and a framework integration read the same turn state while importing from different places.

**`fix(telemetry): ship a py.typed marker in the light package`** — not in the issue, found while
doing the matching swap in the Haystack integration. `rhesis-sdk` ships `rhesis/py.typed` at the
namespace root, and that marker is what makes type checkers accept `rhesis.telemetry.*`. Depend on
`rhesis[telemetry]` without the SDK and there is no marker, so a type checker skips those imports:
the integration's mypy run reports 11 `import-untyped` errors on fully annotated modules the moment
it drops `rhesis-sdk`. Confirmed present in the built wheel.

## Testing

- `make -C sdk test` — 2429 passed, 16 skipped
- `tests/backend/{services/architect,tasks,services/telemetry}` — 574 passed, 3 skipped
- `agents/visit-prep` and `agents/travel-agent` span-tree tests — 5 and 3 passed
- ruff check and format clean on every touched file

## Note for the reviewer

The `py.typed` commit is what unblocks
[deepset-ai/haystack-core-integrations#3669](https://github.com/deepset-ai/haystack-core-integrations/pull/3669),
which now depends on `rhesis[telemetry]>=0.13.0` instead of `rhesis-sdk`. That integration needs a
release of the light package carrying both this marker and the modules #2462 moved — published
`rhesis` 0.12.0 predates the move.
