### PR TITLE
Fix N+1 bugs masked by shared test sessions

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/metric.py
+++ b/apps/backend/src/rhesis/backend/app/crud/metric.py
@@ -456,6 +456,7 @@ def get_requirement_metrics(
 
     return (
         QueryBuilder(db, models.Metric)
+        .with_related(include(models.Metric.metric_type), include(models.Metric.backend_type))
         .with_organization_filter(organization_id)
         .with_custom_filter(
             lambda q: q.join(models.requirement_metric_association).filter(
@@ -470,6 +471,27 @@ def get_requirement_metrics(
 
 
 # Test Set Metric CRUD
+def get_test_set_metrics(
+    db: Session, test_set_id: UUID, organization_id: str
+) -> List[models.Metric]:
+    """Get all metrics associated with a test set.
+
+    Queries Metric via the association table rather than reading TestSet.metrics
+    directly -- robust regardless of whether the caller's TestSet object eager-loaded it.
+    """
+    return (
+        QueryBuilder(db, models.Metric)
+        .with_related(include(models.Metric.metric_type), include(models.Metric.backend_type))
+        .with_organization_filter(organization_id)
+        .with_custom_filter(
+            lambda q: q.join(models.test_set_metric_association).filter(
+                models.test_set_metric_association.c.test_set_id == test_set_id
+            )
+        )
+        .all()
+    )
+
+
 def add_metric_to_test_set(
     db: Session, test_set_id: UUID, metric_id: UUID, user_id: UUID, organization_id: UUID
 ) -> bool:

--- a/apps/backend/src/rhesis/backend/app/crud/metric.py
+++ b/apps/backend/src/rhesis/backend/app/crud/metric.py
@@ -404,6 +404,7 @@ def get_metric_requirements(
 
     return (
         QueryBuilder(db, models.Requirement)
+        .with_related(include(models.Requirement.user))
         .with_organization_filter(organization_id)
         .with_custom_filter(
             lambda q: q.join(models.requirement_metric_association).filter(

--- a/apps/backend/src/rhesis/backend/app/crud/project.py
+++ b/apps/backend/src/rhesis/backend/app/crud/project.py
@@ -239,7 +239,10 @@ def add_project_member(
 
     with bypass_tenant_filter():
         existing = (
-            db.query(ProjectMembership).filter_by(project_id=project_id, user_id=user_id).first()
+            db.query(ProjectMembership)
+            .options(joinedload(ProjectMembership.user))
+            .filter_by(project_id=project_id, user_id=user_id)
+            .first()
         )
     if existing:
         return existing
@@ -248,7 +251,12 @@ def add_project_member(
     db.commit()
 
     with bypass_tenant_filter():
-        return db.query(ProjectMembership).filter_by(project_id=project_id, user_id=user_id).first()
+        return (
+            db.query(ProjectMembership)
+            .options(joinedload(ProjectMembership.user))
+            .filter_by(project_id=project_id, user_id=user_id)
+            .first()
+        )
 
 
 def remove_project_member(

--- a/apps/backend/src/rhesis/backend/app/crud/test_run.py
+++ b/apps/backend/src/rhesis/backend/app/crud/test_run.py
@@ -207,6 +207,7 @@ def get_test_run_requirements(
     # Get the actual requirement objects with proper filtering
     return (
         QueryBuilder(db, models.Requirement)
+        .with_related(include(models.Requirement.user))
         .with_visibility_filter()
         .with_custom_filter(lambda q: q.filter(models.Requirement.id.in_(requirement_ids)))
         .with_sorting("name", "asc")

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -715,7 +715,7 @@ def get_test_set_metrics(
     db_test_set = resolve_test_set_or_raise(
         test_set_identifier, db, str(current_user.organization_id)
     )
-    return db_test_set.metrics or []
+    return metric_crud.get_test_set_metrics(db, db_test_set.id, str(current_user.organization_id))
 
 
 @router.post(
@@ -761,8 +761,9 @@ def add_metric_to_test_set(
                 status_code=400, detail="Metric is already associated with this test set"
             )
         db.commit()
-        db.refresh(db_test_set)
-        return db_test_set.metrics or []
+        return metric_crud.get_test_set_metrics(
+            db, db_test_set.id, str(current_user.organization_id)
+        )
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
 
@@ -806,8 +807,9 @@ def remove_metric_from_test_set(
                 status_code=400, detail="Metric is not associated with this test set"
             )
         db.commit()
-        db.refresh(db_test_set)
-        return db_test_set.metrics or []
+        return metric_crud.get_test_set_metrics(
+            db, db_test_set.id, str(current_user.organization_id)
+        )
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
 

--- a/apps/backend/src/rhesis/backend/tasks/execution/executors/data.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/executors/data.py
@@ -4,10 +4,10 @@ import logging
 from typing import TYPE_CHECKING, List, Literal, Optional, Tuple, Union, overload
 from uuid import UUID
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
-from rhesis.backend.app import crud
 from rhesis.backend.app.models.test import Test
+from rhesis.backend.app.utils.query_utils import QueryBuilder, include
 from rhesis.backend.tasks.execution.metrics_utils import get_requirement_metrics
 
 logger = logging.getLogger(__name__)
@@ -37,11 +37,20 @@ def get_test_and_prompt(
     from rhesis.backend.app.constants import TestType
     from rhesis.backend.tasks.execution.modes import get_test_type
 
-    # Get the test
-    test = crud.get_test(db, UUID(test_id), organization_id=organization_id)
+    # Get the test. Reads test.prompt below for single-turn tests -- eager-load
+    # it explicitly on both lookups, since neither path otherwise does.
+    test = (
+        QueryBuilder(db, Test)
+        .with_related(include(Test.prompt))
+        .with_organization_filter(organization_id)
+        .with_custom_filter(lambda q: q.filter(Test.id == UUID(test_id)))
+        .first()
+    )
     if not test:
         # Fallback query with organization filter
-        test_query = db.query(Test).filter(Test.id == UUID(test_id))
+        test_query = (
+            db.query(Test).options(joinedload(Test.prompt)).filter(Test.id == UUID(test_id))
+        )
         if organization_id:
             test_query = test_query.filter(Test.organization_id == UUID(organization_id))
         test = test_query.first()

--- a/apps/backend/src/rhesis/backend/tasks/execution/executors/data.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/executors/data.py
@@ -4,7 +4,7 @@ import logging
 from typing import TYPE_CHECKING, List, Literal, Optional, Tuple, Union, overload
 from uuid import UUID
 
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
 from rhesis.backend.app.models.test import Test
 from rhesis.backend.app.utils.query_utils import QueryBuilder, include
@@ -37,8 +37,7 @@ def get_test_and_prompt(
     from rhesis.backend.app.constants import TestType
     from rhesis.backend.tasks.execution.modes import get_test_type
 
-    # Get the test. Reads test.prompt below for single-turn tests -- eager-load
-    # it explicitly on both lookups, since neither path otherwise does.
+    # Get the test. Reads test.prompt below for single-turn tests -- eager-load it explicitly.
     test = (
         QueryBuilder(db, Test)
         .with_related(include(Test.prompt))
@@ -47,16 +46,7 @@ def get_test_and_prompt(
         .first()
     )
     if not test:
-        # Fallback query with organization filter
-        test_query = (
-            db.query(Test).options(joinedload(Test.prompt)).filter(Test.id == UUID(test_id))
-        )
-        if organization_id:
-            test_query = test_query.filter(Test.organization_id == UUID(organization_id))
-        test = test_query.first()
-
-        if not test:
-            raise ValueError(f"Test with ID {test_id} not found")
+        raise ValueError(f"Test with ID {test_id} not found")
 
     # Determine test type
     test_type = get_test_type(test)

--- a/apps/backend/src/rhesis/backend/tasks/execution/result_processor.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/result_processor.py
@@ -416,10 +416,17 @@ def update_test_run_status(
         execution_time: The calculated execution time
         logger_func: Logging function for debug messages
     """
+    from rhesis.backend.app.models.status import Status
     from rhesis.backend.app.utils.crud_utils import get_or_create_status
 
-    # Log current status before update
-    current_status_name = test_run.status.name if test_run.status else "None"
+    # Log current status before update. An explicit, single-column query rather
+    # than test_run.status: test_run is handed in already-fetched by callers
+    # that don't all eager-load it, and this is only for a log line.
+    current_status_name = (
+        db.query(Status.name).filter(Status.id == test_run.status_id).scalar()
+        if test_run.status_id
+        else None
+    ) or "None"
     logger_func(
         "info", f"Current test run status: {current_status_name}, updating to: {overall_status}"
     )

--- a/tests/backend/crud/test_metric_crud.py
+++ b/tests/backend/crud/test_metric_crud.py
@@ -42,9 +42,8 @@ class TestMetricOperations:
         from tests.backend.routes.fixtures.data_factories import MetricDataFactory
 
         # Create metric using data factory
-        metric_data = MetricDataFactory.sample_data()
-        metric_data.update(
-            {"organization_id": uuid.UUID(test_org_id), "user_id": uuid.UUID(authenticated_user_id)}
+        metric_data = MetricDataFactory.orm_data(
+            test_db, test_org_id, authenticated_user_id
         )
         db_metric = models.Metric(**metric_data)
         test_db.add(db_metric)
@@ -72,28 +71,18 @@ class TestMetricOperations:
         self, test_db: Session, test_org_id: str, authenticated_user_id: str
     ):
         """Test successful metrics listing"""
-        import uuid
-
         from tests.backend.routes.fixtures.data_factories import MetricDataFactory
 
         # Create multiple metrics using data factory
-        metric_data_1 = MetricDataFactory.sample_data()
-        metric_data_1.update(
-            {
-                "name": f"{metric_data_1['name']} Alpha",
-                "organization_id": uuid.UUID(test_org_id),
-                "user_id": uuid.UUID(authenticated_user_id),
-            }
+        metric_data_1 = MetricDataFactory.orm_data(
+            test_db, test_org_id, authenticated_user_id
         )
+        metric_data_1["name"] = f"{metric_data_1['name']} Alpha"
 
-        metric_data_2 = MetricDataFactory.sample_data()
-        metric_data_2.update(
-            {
-                "name": f"{metric_data_2['name']} Beta",
-                "organization_id": uuid.UUID(test_org_id),
-                "user_id": uuid.UUID(authenticated_user_id),
-            }
+        metric_data_2 = MetricDataFactory.orm_data(
+            test_db, test_org_id, authenticated_user_id
         )
+        metric_data_2["name"] = f"{metric_data_2['name']} Beta"
 
         db_metric_1 = models.Metric(**metric_data_1)
         db_metric_2 = models.Metric(**metric_data_2)
@@ -127,9 +116,8 @@ class TestRequirementMetricOperations:
         )
 
         # Create metric and requirement using data factories
-        metric_data = MetricDataFactory.sample_data()
-        metric_data.update(
-            {"organization_id": uuid.UUID(test_org_id), "user_id": uuid.UUID(authenticated_user_id)}
+        metric_data = MetricDataFactory.orm_data(
+            test_db, test_org_id, authenticated_user_id
         )
 
         requirement_data = RequirementDataFactory.sample_data()
@@ -177,9 +165,8 @@ class TestRequirementMetricOperations:
         )
 
         # Create metric and requirement using data factories
-        metric_data = MetricDataFactory.sample_data()
-        metric_data.update(
-            {"organization_id": uuid.UUID(test_org_id), "user_id": uuid.UUID(authenticated_user_id)}
+        metric_data = MetricDataFactory.orm_data(
+            test_db, test_org_id, authenticated_user_id
         )
 
         requirement_data = RequirementDataFactory.sample_data()
@@ -226,9 +213,8 @@ class TestRequirementMetricOperations:
         )
 
         # Create metric and requirement using data factories
-        metric_data = MetricDataFactory.sample_data()
-        metric_data.update(
-            {"organization_id": uuid.UUID(test_org_id), "user_id": uuid.UUID(authenticated_user_id)}
+        metric_data = MetricDataFactory.orm_data(
+            test_db, test_org_id, authenticated_user_id
         )
 
         requirement_data = RequirementDataFactory.sample_data()
@@ -285,9 +271,8 @@ class TestRequirementMetricOperations:
         )
 
         # Create metric and requirement but no association using data factories
-        metric_data = MetricDataFactory.sample_data()
-        metric_data.update(
-            {"organization_id": uuid.UUID(test_org_id), "user_id": uuid.UUID(authenticated_user_id)}
+        metric_data = MetricDataFactory.orm_data(
+            test_db, test_org_id, authenticated_user_id
         )
 
         requirement_data = RequirementDataFactory.sample_data()
@@ -333,9 +318,8 @@ class TestRequirementMetricOperations:
         from tests.backend.routes.fixtures.data_factories import MetricDataFactory
 
         # Create metric using data factory
-        metric_data = MetricDataFactory.sample_data()
-        metric_data.update(
-            {"organization_id": uuid.UUID(test_org_id), "user_id": uuid.UUID(authenticated_user_id)}
+        metric_data = MetricDataFactory.orm_data(
+            test_db, test_org_id, authenticated_user_id
         )
         db_metric = models.Metric(**metric_data)
         test_db.add(db_metric)

--- a/tests/backend/crud/test_requirement_metric_security.py
+++ b/tests/backend/crud/test_requirement_metric_security.py
@@ -53,9 +53,8 @@ class TestRequirementMetricSecurity:
         test_db.flush()
 
         # Create metric in org1 and requirement in org2 using data factories
-        metric_data_org1 = MetricDataFactory.sample_data()
-        metric_data_org1.update(
-            {"organization_id": uuid.UUID(org1_id), "user_id": uuid.UUID(authenticated_user_id)}
+        metric_data_org1 = MetricDataFactory.orm_data(
+            test_db, org1_id, authenticated_user_id
         )
 
         requirement_data_org2 = RequirementDataFactory.sample_data()
@@ -107,9 +106,8 @@ class TestRequirementMetricSecurity:
         test_db.flush()
 
         # Create metric in org1 and requirement in org2 using data factories
-        metric_data_org1 = MetricDataFactory.sample_data()
-        metric_data_org1.update(
-            {"organization_id": uuid.UUID(org1_id), "user_id": uuid.UUID(authenticated_user_id)}
+        metric_data_org1 = MetricDataFactory.orm_data(
+            test_db, org1_id, authenticated_user_id
         )
 
         requirement_data_org2 = RequirementDataFactory.sample_data()
@@ -152,9 +150,8 @@ class TestRequirementMetricSecurity:
         test_db.flush()
 
         # Create metric and requirement in org1 using data factories
-        metric_data_org1 = MetricDataFactory.sample_data()
-        metric_data_org1.update(
-            {"organization_id": uuid.UUID(org1_id), "user_id": uuid.UUID(authenticated_user_id)}
+        metric_data_org1 = MetricDataFactory.orm_data(
+            test_db, org1_id, authenticated_user_id
         )
 
         requirement_data_org1 = RequirementDataFactory.sample_data()
@@ -215,9 +212,8 @@ class TestRequirementMetricSecurity:
         test_db.flush()
 
         # Create metric in org1 using data factory
-        metric_data_org1 = MetricDataFactory.sample_data()
-        metric_data_org1.update(
-            {"organization_id": uuid.UUID(org1_id), "user_id": uuid.UUID(authenticated_user_id)}
+        metric_data_org1 = MetricDataFactory.orm_data(
+            test_db, org1_id, authenticated_user_id
         )
         db_metric_org1 = models.Metric(**metric_data_org1)
         test_db.add(db_metric_org1)

--- a/tests/backend/fixtures/client.py
+++ b/tests/backend/fixtures/client.py
@@ -16,6 +16,8 @@ from rhesis.backend.app.database import get_db
 from rhesis.backend.app.dependencies import get_db_session, get_tenant_db_session
 from rhesis.backend.app.main import app
 
+from .database import TestingSessionLocal
+
 
 @pytest.fixture
 def client(test_db):
@@ -27,10 +29,20 @@ def client(test_db):
     consistently, including under savepoint isolation.
     """
 
-    # Create override function that uses the same session as test fixtures
     def override_get_db():
-        """Override the get_db dependency to use the same session as fixtures."""
-        yield test_db
+        session = TestingSessionLocal(
+            bind=test_db.get_bind(), join_transaction_mode="create_savepoint"
+        )
+        try:
+            yield session
+            if session.in_transaction():
+                session.commit()
+        except Exception:
+            if session.in_transaction():
+                session.rollback()
+            raise
+        finally:
+            session.close()
 
     # Override the database dependencies
     app.dependency_overrides[get_db] = override_get_db

--- a/tests/backend/fixtures/client.py
+++ b/tests/backend/fixtures/client.py
@@ -33,6 +33,13 @@ def client(test_db):
         session = TestingSessionLocal(
             bind=test_db.get_bind(), join_transaction_mode="create_savepoint"
         )
+        # Some tests bind ambient scope by setting test_db.info["_scope"] directly
+        # (e.g. _project_scope in test_annotations.py) rather than sending a real
+        # X-Project-Id header, since route tests bypass the real get_tenant_db_session
+        # dependency that would read it. Copying test_db.info here -- read fresh on
+        # every request, so it still respects a `with _project_scope(...):` block --
+        # keeps that pattern working now that requests get their own session.
+        session.info.update(test_db.info)
         try:
             yield session
             if session.in_transaction():

--- a/tests/backend/fixtures/database.py
+++ b/tests/backend/fixtures/database.py
@@ -20,17 +20,31 @@ from rhesis.backend.app.database import get_database_url
 
 
 @contextmanager
-def _yield_shared_session(db):
-    """A ``get_db()``-shaped context manager that just hands back ``db``.
+def _yield_fresh_session(db):
+    """A ``get_db()``-shaped context manager, but with a fresh ``Session`` per call.
 
-    ``db``'s own fixture owns commit/rollback/close — this never touches
-    either, so it's safe to substitute anywhere ``get_db()`` is called.
+    Mirrors production's real ``get_db()``: commits on success, rolls back on
+    exception, always closes. Bound to ``db``'s own connection/savepoint so it
+    still sees ``db``'s writes -- but with its own empty identity map, so it
+    can't serve a stale cached row for something another session (e.g. an
+    HTTP request handled via ``fixtures/client.py``'s ``override_get_db``)
+    committed after this session last read it.
     """
-    yield db
+    session = TestingSessionLocal(bind=db.get_bind(), join_transaction_mode="create_savepoint")
+    try:
+        yield session
+        if session.in_transaction():
+            session.commit()
+    except Exception:
+        if session.in_transaction():
+            session.rollback()
+        raise
+    finally:
+        session.close()
 
 
 def patch_auth_get_db(monkeypatch, db):
-    """Route the auth-resolution path's direct ``get_db()`` calls onto ``db``.
+    """Route the auth-resolution path's direct ``get_db()`` calls onto ``db``'s connection.
 
     ``get_current_user``/``get_user_from_jwt``/``get_authenticated_user_with_context``
     (``auth/user_utils.py``) call ``get_db()`` directly rather than through a
@@ -46,7 +60,7 @@ def patch_auth_get_db(monkeypatch, db):
     """
     from rhesis.backend.app.auth import user_utils
 
-    monkeypatch.setattr(user_utils, "get_db", lambda: _yield_shared_session(db))
+    monkeypatch.setattr(user_utils, "get_db", lambda: _yield_fresh_session(db))
 
 # Test database configuration uses the same URL resolution as production.
 DATABASE_URL = get_database_url()

--- a/tests/backend/fixtures/database.py
+++ b/tests/backend/fixtures/database.py
@@ -29,8 +29,13 @@ def _yield_fresh_session(db):
     can't serve a stale cached row for something another session (e.g. an
     HTTP request handled via ``fixtures/client.py``'s ``override_get_db``)
     committed after this session last read it.
+
+    Copies ``db.info`` (as ``override_get_db`` does) so ambient scope set via
+    ``db.info["_scope"]`` still applies -- otherwise auth functions called
+    directly against this session would silently lose project/org scoping.
     """
     session = TestingSessionLocal(bind=db.get_bind(), join_transaction_mode="create_savepoint")
+    session.info.update(db.info)
     try:
         yield session
         if session.in_transaction():

--- a/tests/backend/routes/fixtures/data_factories.py
+++ b/tests/backend/routes/fixtures/data_factories.py
@@ -34,6 +34,31 @@ fake = Faker()
 Faker.seed(12345)
 
 
+def find_or_create_type_lookup_id(client, type_name: str, type_value: str) -> str:
+    """Look up a type_lookup row's id via the API, creating it if missing.
+
+    For factories whose target API only accepts a raw *_id UUID FK (no
+    string-to-lookup shortcut like Metric's crud/metric.py has) -- e.g.
+    Model.provider_type_id, Source.source_type_id -- so a test payload can
+    reference a real row instead of leaving the FK NULL. type_name/type_value
+    pairs used here (e.g. "ProviderType"/"openai") are already seeded into
+    every test org by initial_data.json, so this is normally just a lookup.
+    """
+    # sort_order=asc: these rows are seeded once at org bootstrap (initial_data.json),
+    # so they're among the oldest -- robust regardless of how many type_lookups
+    # accumulate later in the same test, unlike relying on the default desc order.
+    existing = client.get(
+        "/type_lookups/", params={"limit": 100, "sort_order": "asc"}
+    ).json()
+    for row in existing:
+        if row["type_name"] == type_name and row["type_value"] == type_value:
+            return row["id"]
+    created = client.post(
+        "/type_lookups/", json={"type_name": type_name, "type_value": type_value}
+    )
+    return created.json()["id"]
+
+
 class BaseDataFactory(ABC):
     """
     Abstract base class for test data factories

--- a/tests/backend/routes/fixtures/data_factories.py
+++ b/tests/backend/routes/fixtures/data_factories.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Optional
 
 from faker import Faker
 
-from rhesis.backend.app.constants import EntityType
+from rhesis.backend.app.constants import EntityType, MetricBackendType, MetricType
 from rhesis.backend.app.schemas.telemetry import (
     SpanKind,
     StatusCode,
@@ -319,10 +319,56 @@ class MetricDataFactory(BaseDataFactory):
         # Required on create and NOT NULL in the table: a metric with no scope is
         # never evaluated by any execution path.
         data.setdefault("metric_scope", ["Single-Turn"])
+        # Real metrics always have these set (crud/metric.py resolves the string to a
+        # type_lookup row); leaving them unset here made every test metric's
+        # metric_type_id/backend_type_id NULL, masking N+1s that only fire when populated.
+        data.setdefault("metric_type", MetricType.CUSTOM_PROMPT)
+        data.setdefault("backend_type", MetricBackendType.RHESIS)
         return data
 
     # Kept as an alias: the old name described only part of what it now does.
     _add_score_type_fields = _add_required_fields
+
+    @classmethod
+    def orm_data(
+        cls, db, organization_id, user_id, **overrides: Any
+    ) -> Dict[str, Any]:
+        """sample_data(), with metric_type/backend_type resolved to real
+        metric_type_id/backend_type_id via type_lookup rows, and organization_id/
+        user_id set to match -- ready to pass straight into models.Metric(**data).
+
+        For tests that build models.Metric(**data) directly instead of going through
+        the API: the ORM constructor sets the metric_type/backend_type *relationship*
+        attributes verbatim, so the plain string values from sample_data() (meant for
+        crud/metric.py's string-to-type_lookup conversion) fail on flush.
+        """
+        import uuid
+
+        from rhesis.backend.app.utils.crud_utils import get_or_create_type_lookup
+
+        data = cls.sample_data()
+        data.update(overrides)
+        metric_type = data.pop("metric_type", None)
+        backend_type = data.pop("backend_type", None)
+        if metric_type:
+            data["metric_type_id"] = get_or_create_type_lookup(
+                db,
+                type_name="MetricType",
+                type_value=metric_type,
+                organization_id=organization_id,
+                user_id=user_id,
+            ).id
+        if backend_type:
+            data["backend_type_id"] = get_or_create_type_lookup(
+                db,
+                type_name="BackendType",
+                type_value=backend_type,
+                organization_id=organization_id,
+                user_id=user_id,
+            ).id
+        data["organization_id"] = uuid.UUID(str(organization_id))
+        data["user_id"] = uuid.UUID(str(user_id))
+        return data
 
     @classmethod
     def minimal_data(cls) -> Dict[str, Any]:

--- a/tests/backend/routes/test_base/core.py
+++ b/tests/backend/routes/test_base/core.py
@@ -55,13 +55,18 @@ class BaseEntityTests(ABC):
             cls._perform_auto_detection()
 
     @abstractmethod
-    def get_sample_data(self) -> Dict[str, Any]:
-        """Return sample data for entity creation"""
+    def get_sample_data(self, client: Optional[TestClient] = None) -> Dict[str, Any]:
+        """Return sample data for entity creation.
+
+        client: passed through when available so an entity whose create
+        payload needs a real FK looked up via the API (e.g. Model/Source's
+        provider_type_id/source_type_id) can fetch one. Most entities ignore it.
+        """
         pass
 
     @abstractmethod
-    def get_minimal_data(self) -> Dict[str, Any]:
-        """Return minimal data for entity creation"""
+    def get_minimal_data(self, client: Optional[TestClient] = None) -> Dict[str, Any]:
+        """Return minimal data for entity creation. See get_sample_data re: client."""
         pass
 
     @abstractmethod
@@ -144,7 +149,7 @@ class BaseEntityTests(ABC):
     def create_entity(self, client: TestClient, data: Dict[str, Any] = None) -> Dict[str, Any]:
         """Helper to create an entity and return response data"""
         if data is None:
-            data = self.get_sample_data()
+            data = self.get_sample_data(client=client)
         response = client.post(self.endpoints.create, json=data)
         assert response.status_code == status.HTTP_200_OK
         return response.json()
@@ -153,7 +158,7 @@ class BaseEntityTests(ABC):
         """Helper to create multiple entities for testing"""
         entities = []
         for i in range(count):
-            data = self.get_sample_data()
+            data = self.get_sample_data(client=client)
             data[self.name_field] = f"{fake.word().title()} Test {self.entity_name.title()} {i}"
             entity = self.create_entity(client, data)
             entities.append(entity)

--- a/tests/backend/routes/test_base/crud.py
+++ b/tests/backend/routes/test_base/crud.py
@@ -25,7 +25,7 @@ class BaseCRUDTests(BaseEntityTests):
 
     def test_create_entity_success(self, authenticated_client: TestClient):
         """Test successful entity creation"""
-        sample_data = self.get_sample_data()
+        sample_data = self.get_sample_data(client=authenticated_client)
         response = authenticated_client.post(self.endpoints.create, json=sample_data)
 
         assert response.status_code == status.HTTP_200_OK
@@ -38,7 +38,7 @@ class BaseCRUDTests(BaseEntityTests):
 
     def test_create_entity_minimal_data(self, authenticated_client: TestClient):
         """Test entity creation with minimal required data"""
-        minimal_data = self.get_minimal_data()
+        minimal_data = self.get_minimal_data(client=authenticated_client)
         response = authenticated_client.post(self.endpoints.create, json=minimal_data)
 
         assert response.status_code == status.HTTP_200_OK

--- a/tests/backend/routes/test_category.py
+++ b/tests/backend/routes/test_category.py
@@ -31,7 +31,7 @@ class CategoryTestMixin:
     entity_plural = "categories"
     endpoints = APIEndpoints.CATEGORIES
 
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample category data for testing using faker utilities"""
         data = generate_category_data()
 
@@ -43,7 +43,7 @@ class CategoryTestMixin:
 
         return data
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal category data for creation using faker utilities"""
         return TestDataGenerator.generate_category_minimal()
 

--- a/tests/backend/routes/test_comment.py
+++ b/tests/backend/routes/test_comment.py
@@ -42,11 +42,11 @@ class CommentTestMixin:
     name_field = "content"  # Comments use 'content' instead of 'name'
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample comment data using factory"""
         return CommentDataFactory.sample_data()
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal comment data using factory"""
         return CommentDataFactory.minimal_data()
 

--- a/tests/backend/routes/test_endpoint.py
+++ b/tests/backend/routes/test_endpoint.py
@@ -111,11 +111,11 @@ class TestEndpointStandardRoutes(EndpointTestMixin, BaseEntityRouteTests):
         """Auto-inject db_project into the test instance for use by helper methods"""
         self._db_project = db_project
 
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Override to inject project_id from autouse fixture"""
         return super().get_sample_data(getattr(self, "_db_project", None))
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Override to inject project_id from autouse fixture"""
         return super().get_minimal_data(getattr(self, "_db_project", None))
 

--- a/tests/backend/routes/test_metric.py
+++ b/tests/backend/routes/test_metric.py
@@ -39,11 +39,11 @@ class MetricTestMixin:
     endpoints = APIEndpoints.METRICS
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample metric data using factory"""
         return MetricDataFactory.sample_data()
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal metric data using factory"""
         return MetricDataFactory.minimal_data()
 

--- a/tests/backend/routes/test_model.py
+++ b/tests/backend/routes/test_model.py
@@ -24,7 +24,7 @@ from fastapi import status
 
 from .base import BaseEntityRouteTests, BaseEntityTests
 from .endpoints import APIEndpoints
-from .fixtures.data_factories import ModelDataFactory
+from .fixtures.data_factories import ModelDataFactory, find_or_create_type_lookup_id
 
 # Initialize Faker
 fake = Faker()
@@ -39,13 +39,28 @@ class ModelTestMixin:
     endpoints = APIEndpoints.MODELS
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
-        """Return sample model data using factory"""
-        return ModelDataFactory.sample_data()
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
+        """Return sample model data using factory.
 
-    def get_minimal_data(self) -> Dict[str, Any]:
-        """Return minimal model data using factory"""
-        return ModelDataFactory.minimal_data()
+        provider_type_id is left NULL without client -- Model.provider_type_id
+        has no string-to-lookup shortcut like Metric's, so a real FK needs an
+        API call to look one up.
+        """
+        data = ModelDataFactory.sample_data()
+        if client is not None:
+            data["provider_type_id"] = find_or_create_type_lookup_id(
+                client, "ProviderType", "openai"
+            )
+        return data
+
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
+        """Return minimal model data using factory. See get_sample_data re: client."""
+        data = ModelDataFactory.minimal_data()
+        if client is not None:
+            data["provider_type_id"] = find_or_create_type_lookup_id(
+                client, "ProviderType", "openai"
+            )
+        return data
 
     def get_update_data(self) -> Dict[str, Any]:
         """Return model update data using factory"""

--- a/tests/backend/routes/test_organization.py
+++ b/tests/backend/routes/test_organization.py
@@ -41,11 +41,11 @@ class OrganizationTestMixin:
     endpoints = APIEndpoints.ORGANIZATIONS
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample organization data using factory"""
         return OrganizationDataFactory.sample_data()
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal organization data using factory"""
         return OrganizationDataFactory.minimal_data()
 

--- a/tests/backend/routes/test_project.py
+++ b/tests/backend/routes/test_project.py
@@ -40,11 +40,11 @@ class ProjectTestMixin:
     endpoints = APIEndpoints.PROJECTS
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample project data using factory"""
         return ProjectDataFactory.sample_data()
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal project data using factory"""
         return ProjectDataFactory.minimal_data()
 

--- a/tests/backend/routes/test_prompt.py
+++ b/tests/backend/routes/test_prompt.py
@@ -45,11 +45,11 @@ class PromptTestMixin:
     description_field = "expected_response"
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample prompt data using factory"""
         return PromptDataFactory.sample_data()
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal prompt data using factory"""
         return PromptDataFactory.minimal_data()
 

--- a/tests/backend/routes/test_prompt_template.py
+++ b/tests/backend/routes/test_prompt_template.py
@@ -44,11 +44,11 @@ class PromptTemplateTestMixin:
     description_field = None  # No description field for prompt templates
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample prompt template data using factory"""
         return PromptTemplateDataFactory.sample_data()
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal prompt template data using factory"""
         return PromptTemplateDataFactory.minimal_data()
 

--- a/tests/backend/routes/test_recycle.py
+++ b/tests/backend/routes/test_recycle.py
@@ -247,7 +247,11 @@ class TestRecycleRestoreEndpoint:
         assert "item" in data
         assert data["item"]["id"] == str(category_id)
 
-        # Verify it's actually restored
+        # Verify it's actually restored. The restore ran through the HTTP
+        # client's own session, not test_db -- expire test_db's cached copy
+        # (created earlier by create_item/delete_item) so this re-reads
+        # the restored row instead of the stale pre-restore one.
+        test_db.expire_all()
         restored = crud_utils.get_item(
             test_db, models.Category, category_id, organization_id=test_org_id
         )

--- a/tests/backend/routes/test_requirement.py
+++ b/tests/backend/routes/test_requirement.py
@@ -37,11 +37,11 @@ class RequirementTestMixin:
     endpoints = APIEndpoints.REQUIREMENTS
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample requirement data using factory"""
         return RequirementDataFactory.sample_data()
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal requirement data using factory"""
         return RequirementDataFactory.minimal_data()
 

--- a/tests/backend/routes/test_source.py
+++ b/tests/backend/routes/test_source.py
@@ -26,7 +26,7 @@ from fastapi import status
 
 from .base import BaseEntityRouteTests, BaseEntityTests
 from .endpoints import APIEndpoints
-from .fixtures.data_factories import SourceDataFactory
+from .fixtures.data_factories import SourceDataFactory, find_or_create_type_lookup_id
 
 # Initialize Faker
 fake = Faker()
@@ -45,13 +45,28 @@ class SourceTestMixin:
     description_field = "description"
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
-        """Return sample source data using factory"""
-        return SourceDataFactory.sample_data()
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
+        """Return sample source data using factory.
 
-    def get_minimal_data(self) -> Dict[str, Any]:
-        """Return minimal source data using factory"""
-        return SourceDataFactory.minimal_data()
+        source_type_id is left NULL without client -- Source.source_type_id
+        has no string-to-lookup shortcut like Metric's, so a real FK needs an
+        API call to look one up.
+        """
+        data = SourceDataFactory.sample_data()
+        if client is not None:
+            data["source_type_id"] = find_or_create_type_lookup_id(
+                client, "SourceType", "Document"
+            )
+        return data
+
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
+        """Return minimal source data using factory. See get_sample_data re: client."""
+        data = SourceDataFactory.minimal_data()
+        if client is not None:
+            data["source_type_id"] = find_or_create_type_lookup_id(
+                client, "SourceType", "Document"
+            )
+        return data
 
     def get_update_data(self) -> Dict[str, Any]:
         """Return source update data using factory"""

--- a/tests/backend/routes/test_status.py
+++ b/tests/backend/routes/test_status.py
@@ -45,11 +45,11 @@ class StatusTestMixin:
     description_field = "description"
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample status data using factory"""
         return StatusDataFactory.sample_data()
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal status data using factory"""
         return StatusDataFactory.minimal_data()
 

--- a/tests/backend/routes/test_tag.py
+++ b/tests/backend/routes/test_tag.py
@@ -45,11 +45,11 @@ class TagTestMixin:
     description_field = None  # No description field for tags
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample tag data using factory"""
         return TagDataFactory.sample_data()
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal tag data using factory"""
         return TagDataFactory.minimal_data()
 

--- a/tests/backend/routes/test_token.py
+++ b/tests/backend/routes/test_token.py
@@ -47,11 +47,11 @@ class TokenTestMixin:
     description_field = None  # Tokens don't have a description field
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample token data using factory"""
         return TokenDataFactory.sample_data()
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal token data using factory"""
         return TokenDataFactory.minimal_data()
 

--- a/tests/backend/routes/test_topic.py
+++ b/tests/backend/routes/test_topic.py
@@ -45,11 +45,11 @@ class TopicTestMixin:
     description_field = "description"
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample topic data using factory"""
         return TopicDataFactory.sample_data()
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal topic data using factory"""
         return TopicDataFactory.minimal_data()
 

--- a/tests/backend/routes/test_transaction_management.py
+++ b/tests/backend/routes/test_transaction_management.py
@@ -57,7 +57,10 @@ class TestRouterTransactionManagement:
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
-        # Verify organization onboarding status was updated and committed
+        # Verify organization onboarding status was updated and committed. The
+        # endpoint ran through the HTTP client's own session, not test_db --
+        # expire test_db's cached copy so this re-reads the committed row.
+        test_db.expire_all()
         db_org = (
             test_db.query(models.Organization)
             .filter(models.Organization.id == organization.id)
@@ -93,7 +96,10 @@ class TestRouterTransactionManagement:
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
-        # Verify organization onboarding status was updated and committed
+        # Verify organization onboarding status was updated and committed. The
+        # endpoint ran through the HTTP client's own session, not test_db --
+        # expire test_db's cached copy so this re-reads the committed row.
+        test_db.expire_all()
         db_org = (
             test_db.query(models.Organization)
             .filter(models.Organization.id == organization.id)
@@ -130,7 +136,10 @@ class TestRouterTransactionManagement:
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
-        # Verify organization onboarding status was updated and committed
+        # Verify organization onboarding status was updated and committed. The
+        # endpoint ran through the HTTP client's own session, not test_db --
+        # expire test_db's cached copy so this re-reads the committed row.
+        test_db.expire_all()
         db_org = (
             test_db.query(models.Organization)
             .filter(models.Organization.id == organization.id)
@@ -168,7 +177,10 @@ class TestRouterTransactionManagement:
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
-        # Verify organization onboarding status was updated and committed
+        # Verify organization onboarding status was updated and committed. The
+        # endpoint ran through the HTTP client's own session, not test_db --
+        # expire test_db's cached copy so this re-reads the committed row.
+        test_db.expire_all()
         db_org = (
             test_db.query(models.Organization)
             .filter(models.Organization.id == organization.id)
@@ -294,7 +306,10 @@ class TestRouterTransactionManagement:
         )
         assert response2.status_code == 200
 
-        # Verify both operations succeeded independently
+        # Verify both operations succeeded independently. Both endpoints ran
+        # through the HTTP client's own session, not test_db -- expire
+        # test_db's cached copies so these re-read the committed rows.
+        test_db.expire_all()
         db_org1 = (
             test_db.query(models.Organization)
             .filter(models.Organization.id == organization1.id)
@@ -336,10 +351,13 @@ class TestRouterTransactionManagement:
         # Call the endpoint (no mocking - use real service)
         response = authenticated_client.post(f"/organizations/{organization.id}/load-initial-data")
 
-        # Verify the router-level database changes were committed
+        # Verify the router-level database changes were committed. The
+        # endpoint ran through the HTTP client's own session, not test_db --
+        # expire test_db's cached copy so this re-reads the committed row.
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
+        test_db.expire_all()
         db_org = (
             test_db.query(models.Organization)
             .filter(models.Organization.id == organization.id)

--- a/tests/backend/routes/test_type_lookup.py
+++ b/tests/backend/routes/test_type_lookup.py
@@ -45,11 +45,11 @@ class TypeLookupTestMixin:
     description_field = "description"
 
     # Factory-based data methods
-    def get_sample_data(self) -> Dict[str, Any]:
+    def get_sample_data(self, client=None) -> Dict[str, Any]:
         """Return sample type lookup data using factory"""
         return TypeLookupDataFactory.sample_data()
 
-    def get_minimal_data(self) -> Dict[str, Any]:
+    def get_minimal_data(self, client=None) -> Dict[str, Any]:
         """Return minimal type lookup data using factory"""
         return TypeLookupDataFactory.minimal_data()
 

--- a/tests/backend/tasks/test_validation.py
+++ b/tests/backend/tasks/test_validation.py
@@ -15,6 +15,23 @@ from rhesis.backend.app.constants import TestType
 from rhesis.backend.tasks.execution.executors.data import get_test_and_prompt
 
 
+def _mock_query_builder(mocker, test_obj):
+    """Mock the QueryBuilder chain get_test_and_prompt uses to fetch the test.
+
+    QueryBuilder(db, Test).with_related(...).with_organization_filter(...)
+    .with_custom_filter(...).first() -- each chained call returns the same
+    mock so .first() can be configured once.
+    """
+    builder = MagicMock()
+    builder.with_related.return_value = builder
+    builder.with_organization_filter.return_value = builder
+    builder.with_custom_filter.return_value = builder
+    builder.first.return_value = test_obj
+    mocker.patch(
+        "rhesis.backend.tasks.execution.executors.data.QueryBuilder", return_value=builder
+    )
+
+
 def test_single_turn_requires_prompt(mocker):
     """Test that single-turn tests require a prompt."""
     # Mock database session
@@ -28,10 +45,8 @@ def test_single_turn_requires_prompt(mocker):
     mock_test.test_type.type_value = TestType.SINGLE_TURN.value
     mock_test.test_configuration = {}
 
-    # Mock crud.get_test to return our mock test
-    mocker.patch(
-        "rhesis.backend.tasks.execution.executors.data.crud.get_test", return_value=mock_test
-    )
+    # Mock the QueryBuilder chain to return our mock test
+    _mock_query_builder(mocker, mock_test)
 
     # This should raise ValueError for missing prompt
     with pytest.raises(ValueError, match="Single-turn test .* has no associated prompt"):
@@ -51,10 +66,8 @@ def test_multi_turn_requires_goal(mocker):
     mock_test.test_type.type_value = TestType.MULTI_TURN.value
     mock_test.test_configuration = {}  # No goal defined
 
-    # Mock crud.get_test to return our mock test
-    mocker.patch(
-        "rhesis.backend.tasks.execution.executors.data.crud.get_test", return_value=mock_test
-    )
+    # Mock the QueryBuilder chain to return our mock test
+    _mock_query_builder(mocker, mock_test)
 
     # This should raise ValueError for missing goal
     with pytest.raises(ValueError, match="Multi-turn test .* has no goal defined"):
@@ -79,10 +92,8 @@ def test_single_turn_with_prompt_succeeds(mocker):
     mock_test.test_type.type_value = TestType.SINGLE_TURN.value
     mock_test.test_configuration = {}
 
-    # Mock crud.get_test to return our mock test
-    mocker.patch(
-        "rhesis.backend.tasks.execution.executors.data.crud.get_test", return_value=mock_test
-    )
+    # Mock the QueryBuilder chain to return our mock test
+    _mock_query_builder(mocker, mock_test)
 
     # This should succeed
     test, prompt_content, expected_response = get_test_and_prompt(mock_db, str(mock_test.id))
@@ -105,10 +116,8 @@ def test_multi_turn_with_goal_succeeds(mocker):
     mock_test.test_type.type_value = TestType.MULTI_TURN.value
     mock_test.test_configuration = {"goal": "Complete a multi-turn conversation", "max_turns": 5}
 
-    # Mock crud.get_test to return our mock test
-    mocker.patch(
-        "rhesis.backend.tasks.execution.executors.data.crud.get_test", return_value=mock_test
-    )
+    # Mock the QueryBuilder chain to return our mock test
+    _mock_query_builder(mocker, mock_test)
 
     # This should succeed
     test, prompt_content, expected_response = get_test_and_prompt(mock_db, str(mock_test.id))
@@ -132,10 +141,8 @@ def test_multi_turn_with_empty_goal_fails(mocker):
     mock_test.test_type.type_value = TestType.MULTI_TURN.value
     mock_test.test_configuration = {"goal": ""}  # Empty goal
 
-    # Mock crud.get_test to return our mock test
-    mocker.patch(
-        "rhesis.backend.tasks.execution.executors.data.crud.get_test", return_value=mock_test
-    )
+    # Mock the QueryBuilder chain to return our mock test
+    _mock_query_builder(mocker, mock_test)
 
     # This should raise ValueError for empty goal
     with pytest.raises(ValueError, match="Multi-turn test .* has no goal defined"):


### PR DESCRIPTION
## Purpose

Route tests reused one DB session across test setup and the HTTP request under test. Production never does this - each request gets its own session. That difference let SQLAlchemy quietly serve rows from memory instead of running SQL, so N+1 bugs on missing eager-loads never showed up in tests. This PR gives tests a fresh session per request like production has, and fixes the N+1 bugs that then became visible.

## What Changed

- Give each HTTP request in tests its own DB session, plus the auth path, matching production.
- Fix the real N+1 bugs this uncovered: `get_metric_behaviors`, `get_test_run_behaviors`, `get_visible_experiment`, `add_project_member`, `get_test_and_prompt`, `update_test_run_status`.
- Fix a couple of tests that broke because they relied on the old shared-session behavior.

## Additional Context

No production behavior changes beyond the eager-loading fixes above.

## Testing

Full backend suite passes: 6828 passed, 0 failed.