### PR TITLE
Architect Urls Configmap 178e3b

### DIFF
--- a/charts/rhesis/templates/configmap.yaml
+++ b/charts/rhesis/templates/configmap.yaml
@@ -39,6 +39,7 @@ data:
   NEXT_PUBLIC_QUICK_START: {{ .Values.config.nextPublicQuickStart | quote }}
   NEXT_PUBLIC_SUPPORT_EMAIL: {{ .Values.config.nextPublicSupportEmail | quote }}
   ONBOARDING_VIDEO_URL: {{ .Values.config.onboardingVideoUrl | quote }}
+  ARCHITECT_HELP_ARTICLE_URLS: {{ .Values.config.architectHelpArticleUrls | quote }}
   # Branding overrides. Not NEXT_PUBLIC_* on purpose: that prefix bakes a value
   # into the client bundle at build time, which would mean one image per
   # deployment. The frontend reads these per request instead.

--- a/charts/rhesis/values-dev.yaml
+++ b/charts/rhesis/values-dev.yaml
@@ -31,6 +31,7 @@ config:
   nextPublicAppUrl: "https://dev-app.rhesis.ai"
   nextPublicSupportEmail: "hello@rhesis.ai"
   onboardingVideoUrl: "https://youtu.be/fNtxqGtBu2Y"
+  architectHelpArticleUrls: "https://docs.rhesis.ai/docs/getting-started/connecting-application,https://docs.rhesis.ai/docs/endpoints,https://docs.rhesis.ai/docs/endpoints/sdk-endpoints,https://docs.rhesis.ai/docs/concepts"
   # Backend
   rhesisBaseUrl: "https://dev-api.rhesis.ai"
   frontendUrl: "https://dev-app.rhesis.ai"

--- a/charts/rhesis/values-prd.yaml
+++ b/charts/rhesis/values-prd.yaml
@@ -40,6 +40,7 @@ config:
   nextPublicAppUrl: "https://app.rhesis.ai"
   nextPublicSupportEmail: "hello@rhesis.ai"
   onboardingVideoUrl: "https://youtu.be/fNtxqGtBu2Y"
+  architectHelpArticleUrls: "https://docs.rhesis.ai/docs/getting-started/connecting-application,https://docs.rhesis.ai/docs/endpoints,https://docs.rhesis.ai/docs/endpoints/sdk-endpoints,https://docs.rhesis.ai/docs/concepts"
   # Backend
   rhesisBaseUrl: "https://api.rhesis.ai"
   frontendUrl: "https://app.rhesis.ai"

--- a/charts/rhesis/values-stg.yaml
+++ b/charts/rhesis/values-stg.yaml
@@ -36,6 +36,7 @@ config:
   nextPublicAppUrl: "https://stg-app.rhesis.ai"
   nextPublicSupportEmail: "hello@rhesis.ai"
   onboardingVideoUrl: "https://youtu.be/fNtxqGtBu2Y"
+  architectHelpArticleUrls: "https://docs.rhesis.ai/docs/getting-started/connecting-application,https://docs.rhesis.ai/docs/endpoints,https://docs.rhesis.ai/docs/endpoints/sdk-endpoints,https://docs.rhesis.ai/docs/concepts"
   # Backend
   rhesisBaseUrl: "https://stg-api.rhesis.ai"
   frontendUrl: "https://stg-app.rhesis.ai"

--- a/charts/rhesis/values.yaml
+++ b/charts/rhesis/values.yaml
@@ -71,6 +71,7 @@ config:
   nextPublicQuickStart: "false"
   nextPublicSupportEmail: "hello@rhesis.ai"
   onboardingVideoUrl: ""
+  architectHelpArticleUrls: "https://docs.rhesis.ai/docs/getting-started/connecting-application,https://docs.rhesis.ai/docs/endpoints,https://docs.rhesis.ai/docs/endpoints/sdk-endpoints,https://docs.rhesis.ai/docs/concepts"
 
   # Branding — all empty means the built-in Rhesis look. Set them to rebrand a
   # deployment without rebuilding the image; the frontend reads them at request

--- a/kubernetes/clusters/dev/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/dev/external-secrets/rhesis-app-secrets.yaml
@@ -344,10 +344,3 @@ spec:
     - secretKey: RHESIS_LICENSE_KID
       remoteRef:
         key: dev-rhesis-rhesis-license-kid
-
-##--------------------------------------------------------
-## Frontend content
-##--------------------------------------------------------
-    - secretKey: ARCHITECT_HELP_ARTICLE_URLS
-      remoteRef:
-        key: dev-rhesis-architect-help-article-urls

--- a/kubernetes/clusters/prd/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/prd/external-secrets/rhesis-app-secrets.yaml
@@ -317,10 +317,3 @@ spec:
     - secretKey: RHESIS_LICENSE_KID
       remoteRef:
         key: prd-rhesis-rhesis-license-kid
-
-##--------------------------------------------------------
-## Frontend content
-##--------------------------------------------------------
-    - secretKey: ARCHITECT_HELP_ARTICLE_URLS
-      remoteRef:
-        key: prd-rhesis-architect-help-article-urls

--- a/kubernetes/clusters/stg/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/stg/external-secrets/rhesis-app-secrets.yaml
@@ -320,10 +320,3 @@ spec:
     - secretKey: RHESIS_LICENSE_KID
       remoteRef:
         key: stg-rhesis-rhesis-license-kid
-
-##--------------------------------------------------------
-## Frontend content
-##--------------------------------------------------------
-    - secretKey: ARCHITECT_HELP_ARTICLE_URLS
-      remoteRef:
-        key: stg-rhesis-architect-help-article-urls

--- a/scripts/rh/dev.sh
+++ b/scripts/rh/dev.sh
@@ -164,7 +164,8 @@ NEXT_TELEMETRY_DISABLED=1
 
 # Docs cards shown on the Architect welcome screen while a project has no
 # endpoint. Read at request time by /api/architect-help; in the cloud it comes
-# from GCP Secret Manager instead. Hosts must be allowlisted in
+# from the Helm chart's ConfigMap (charts/rhesis/values.yaml config.architectHelpArticleUrls)
+# instead. Hosts must be allowlisted in
 # apps/frontend/src/app/api/og-metadata/og-metadata-utils.ts.
 ARCHITECT_HELP_ARTICLE_URLS=https://docs.rhesis.ai/docs/getting-started/connecting-application,https://docs.rhesis.ai/docs/endpoints,https://docs.rhesis.ai/docs/endpoints/sdk-endpoints,https://docs.rhesis.ai/docs/concepts
 EOF


### PR DESCRIPTION
This PR introduces changes from the `architect-urls-configmap-178e3b` branch.

## 📝 Summary

<!-- Add a brief summary of the changes here -->


## 📁 Files Changed (       9 files)

```
charts/rhesis/templates/configmap.yaml
charts/rhesis/values-dev.yaml
charts/rhesis/values-prd.yaml
charts/rhesis/values-stg.yaml
charts/rhesis/values.yaml
kubernetes/clusters/dev/external-secrets/rhesis-app-secrets.yaml
kubernetes/clusters/prd/external-secrets/rhesis-app-secrets.yaml
kubernetes/clusters/stg/external-secrets/rhesis-app-secrets.yaml
scripts/rh/dev.sh
```

## 📋 Commit Details

```
80b4ffec8 - chore(dev): move architect help urls from secrets to configmap (Md Asaduzzaman Miah, 2026-08-14 16:25)
```

## ✅ Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of code has been performed
- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Corresponding changes to documentation have been made
- [ ] Tests have been added/updated for new functionality
- [ ] All tests pass locally

## 🧪 Testing

<!-- Describe how to test the changes -->

## 📸 Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## 🔗 Related Issues

<!-- Link any related issues: Closes #123 -->