### PR TITLE
fix(backend): allow sorting tests by prompt content

### DIFF
--- a/apps/backend/src/rhesis/backend/app/utils/relationship_sort.py
+++ b/apps/backend/src/rhesis/backend/app/utils/relationship_sort.py
@@ -6,6 +6,7 @@ from sqlalchemy import desc, select
 from sqlalchemy.orm import Query
 
 from rhesis.backend.app.models.category import Category
+from rhesis.backend.app.models.prompt import Prompt
 from rhesis.backend.app.models.requirement import Requirement
 from rhesis.backend.app.models.topic import Topic
 from rhesis.backend.app.models.type_lookup import TypeLookup
@@ -15,6 +16,7 @@ _RELATIONSHIP_SORT_FIELDS = {
     "topic.name": (Topic, "name", "topic_id"),
     "category.name": (Category, "name", "category_id"),
     "test_type.type_value": (TypeLookup, "type_value", "test_type_id"),
+    "prompt.content": (Prompt, "content", "prompt_id"),
 }
 VIRTUAL_RELATIONSHIP_SORT_FIELDS = frozenset(_RELATIONSHIP_SORT_FIELDS)
 

--- a/tests/backend/utils/test_relationship_sort.py
+++ b/tests/backend/utils/test_relationship_sort.py
@@ -19,6 +19,7 @@ from rhesis.backend.app.utils.relationship_sort import (
         "topic.name",
         "category.name",
         "test_type.type_value",
+        "prompt.content",
     ],
 )
 def test_virtual_relationship_sort_detection(sort_by):
@@ -33,6 +34,7 @@ def test_virtual_relationship_sort_detection(sort_by):
         "topic.name",
         "category.name",
         "test_type.type_value",
+        "prompt.content",
     ],
 )
 def test_model_supports_relationship_sort_for_test(sort_by):
@@ -47,6 +49,7 @@ def test_model_supports_relationship_sort_for_test(sort_by):
         "topic.name",
         "category.name",
         "test_type.type_value",
+        "prompt.content",
     ],
 )
 def test_validate_sort_field_accepts_relationship_sort_for_test(sort_by):
@@ -60,6 +63,7 @@ def test_validate_sort_field_accepts_relationship_sort_for_test(sort_by):
         "topic.name",
         "category.name",
         "test_type.type_value",
+        "prompt.content",
     ],
 )
 def test_validate_sort_field_rejects_relationship_sort_for_other_models(sort_by):
@@ -79,6 +83,7 @@ def test_validate_sort_field_rejects_relationship_sort_for_other_models(sort_by)
             "type_lookup.type_value",
             "test.test_type_id",
         ),
+        ("prompt.content", "prompt.content", "test.prompt_id"),
     ],
 )
 @pytest.mark.parametrize("sort_order", ["asc", "desc"])
@@ -108,6 +113,7 @@ def test_apply_relationship_sort_builds_correlated_subquery(
             "type_lookup.type_value",
             "test.test_type_id",
         ),
+        ("prompt.content", "prompt.content", "test.prompt_id"),
     ],
 )
 def test_query_builder_dispatches_relationship_sort(test_db, sort_by, related_column, foreign_key):


### PR DESCRIPTION
Fixes #2397

# What

Sorting the tests grid by the Content column returned a 400 and broke the grid.

# Why

The grid sends `sort_by=prompt.content`. The backend's relationship-sort table in `app/utils/relationship_sort.py` registered `requirement.name`, `topic.name`, `category.name` and `test_type.type_value`, but not `prompt.content`, so `validate_sort_field` rejected it.

# Change

Register `prompt.content` as a relationship sort on `Prompt.content` via `Test.prompt_id`. Sorting then uses the same correlated-subquery path as the other relationship fields, in both directions, and keeps working across pagination.

# Verification

Local verification script: `prompt.content` passes sort validation on `Test`, still returns 400 for models without a prompt relationship, and the generated SQL is `ORDER BY (SELECT prompt.content FROM prompt WHERE prompt.id = test.prompt_id)`. Before the change the same checks fail.

Extended `tests/backend/utils/test_relationship_sort.py`: `prompt.content` added to the detection, model-support, validation-accept, validation-reject parametrize lists, and to both correlated-subquery and QueryBuilder dispatch tests.

# Scope

Two files: `apps/backend/src/rhesis/backend/app/utils/relationship_sort.py` and `tests/backend/utils/test_relationship_sort.py`.
