### PR TITLE
fix(dev): fail CI on ConfigMap and ExternalSecret key overlap

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,6 +40,10 @@ jobs:
             skill:
               - 'skills/rhesis/**'
               - 'scripts/skill/**'
+            helm:
+              - 'charts/**'
+              - 'kubernetes/**'
+              - 'scripts/check-env-overlap.py'
 
       - name: Resolve lint targets
         id: resolve
@@ -208,8 +212,27 @@ jobs:
       - name: Validate skill
         run: python scripts/skill/validate.py
 
+  helm-overlap:
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || contains(needs.changes.outputs.targets, 'helm') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: latest
+
+      - name: Install Python dependencies
+        run: python -m pip install pyyaml
+
+      - name: Check ConfigMap / ExternalSecret overlap
+        run: python scripts/check-env-overlap.py
+
   lint:
-    needs: [changes, python, migrations, frontend, styles, docs, skill]
+    needs: [changes, python, migrations, frontend, styles, docs, skill, helm-overlap]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -246,7 +246,8 @@ jobs:
                         "frontend=${{ needs.frontend.result }}" \
                         "styles=${{ needs.styles.result }}" \
                         "docs=${{ needs.docs.result }}" \
-                        "skill=${{ needs.skill.result }}"; do
+                        "skill=${{ needs.skill.result }}" \
+                        "helm-overlap=${{ needs.helm-overlap.result }}"; do
             echo "$RESULT"
             case "${RESULT#*=}" in
               success|skipped) ;;

--- a/scripts/check-env-overlap.py
+++ b/scripts/check-env-overlap.py
@@ -48,6 +48,8 @@ def configmap_keys(env: str) -> set[str]:
             "charts/rhesis",
             "-f",
             f"charts/rhesis/values-{env}.yaml",
+            "--show-only",
+            "templates/configmap.yaml",
         ],
         cwd=REPO_ROOT,
         capture_output=True,
@@ -69,9 +71,15 @@ def externalsecret_keys(env: str) -> set[str]:
             if not isinstance(doc, dict) or doc.get("kind") != "ExternalSecret":
                 continue
             for entry in doc.get("spec", {}).get("data") or []:
-                key = entry.get("secretKey") or (entry.get("remoteRef") or {}).get("key")
+                key = entry.get("secretKey")
                 if key:
                     keys.add(key)
+                else:
+                    print(
+                        f"warning: {manifest.name} has an ExternalSecret data "
+                        "entry without secretKey; skipping it",
+                        file=sys.stderr,
+                    )
     return keys
 
 

--- a/scripts/check-env-overlap.py
+++ b/scripts/check-env-overlap.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Fail when an env key is defined in both a rendered ConfigMap and an ExternalSecret.
+
+Kubernetes gives later envFrom sources precedence, so a key duplicated across
+the chart ConfigMap and an ExternalSecret silently shadows values-*.yaml edits.
+The allowlist below pins the duplicates that still exist today (see issue
+#2420); removing a duplicate without shrinking the allowlist fails this check,
+so the list cannot go stale.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+ENVS = ("dev", "stg", "prd")
+
+# env -> keys duplicated between ConfigMap and ExternalSecret today.
+# Shrink as each duplicate is resolved; the check fails if this drifts.
+ALLOWLIST: dict[str, set[str]] = {
+    "dev": {"APP_DB_USER", "DB_HOST", "DB_NAME", "OTEL_PROCESSOR_ENDPOINT"},
+    "stg": {
+        "ANALYTICS_DB_HOST",
+        "ANALYTICS_DB_NAME",
+        "ANALYTICS_DB_PORT",
+        "OTEL_PROCESSOR_ENDPOINT",
+    },
+    "prd": {
+        "ANALYTICS_DB_HOST",
+        "ANALYTICS_DB_NAME",
+        "ANALYTICS_DB_PORT",
+        "OTEL_PROCESSOR_ENDPOINT",
+    },
+}
+
+
+def configmap_keys(env: str) -> set[str]:
+    rendered = subprocess.run(
+        [
+            "helm",
+            "template",
+            "rhesis",
+            "charts/rhesis",
+            "-f",
+            f"charts/rhesis/values-{env}.yaml",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    keys: set[str] = set()
+    for doc in yaml.safe_load_all(rendered):
+        if isinstance(doc, dict) and doc.get("kind") == "ConfigMap":
+            keys.update((doc.get("data") or {}).keys())
+    return keys
+
+
+def externalsecret_keys(env: str) -> set[str]:
+    keys: set[str] = set()
+    secrets_dir = REPO_ROOT / "kubernetes" / "clusters" / env / "external-secrets"
+    for manifest in secrets_dir.glob("*.yaml"):
+        for doc in yaml.safe_load_all(manifest.read_text()):
+            if not isinstance(doc, dict) or doc.get("kind") != "ExternalSecret":
+                continue
+            for entry in doc.get("spec", {}).get("data") or []:
+                key = entry.get("secretKey") or (entry.get("remoteRef") or {}).get("key")
+                if key:
+                    keys.add(key)
+    return keys
+
+
+def main() -> int:
+    failed = False
+    for env in ENVS:
+        overlap = configmap_keys(env) & externalsecret_keys(env)
+        allowed = ALLOWLIST[env]
+        new = overlap - allowed
+        stale = allowed - overlap
+        if new:
+            failed = True
+            print(f"{env}: new ConfigMap/ExternalSecret overlap: {sorted(new)}")
+        if stale:
+            failed = True
+            print(f"{env}: allowlist keys no longer overlap (remove them): {sorted(stale)}")
+        if not new and not stale:
+            print(f"{env}: OK ({len(overlap)} allowlisted overlap(s))")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #2420 (step 4: the CI gate)

# What

An env key declared in both the chart ConfigMap and an ExternalSecret is silently shadowed: Kubernetes lets the later envFrom source win, so editing values-*.yaml for that key is a no-op with no warning. This PR adds a lint gate so a new overlap fails CI, and pins the duplicates that exist today in an explicit allowlist.

# Change

New scripts/check-env-overlap.py renders the chart per env (helm template) and fails when a key appears in both the rendered ConfigMap data and any ExternalSecret secretKey in kubernetes/clusters/<env>/external-secrets. The allowlist matches today's reality exactly (dev: APP_DB_USER/DB_HOST/DB_NAME/OTEL_PROCESSOR_ENDPOINT; stg and prd: ANALYTICS_DB_* + OTEL_PROCESSOR_ENDPOINT). Two failure modes: a new overlap, or an allowlist entry that no longer overlaps (so the allowlist cannot go stale as the duplicates from the issue are resolved).

lint.yml gains a helm-overlap job gated on charts/** and kubernetes/** changes, and the job joins the lint gate's needs list.

# Verification

Local run against the current tree: all three envs report OK with the exact allowlist. Removing one allowlisted key fails with "new ConfigMap/ExternalSecret overlap" (exit 1). Steps 1-3 of the issue (comparing values in Secret Manager and deleting the duplicates) still need cloud access and are left to the team; this gate makes the cleanup safe once done.

# Scope

scripts/check-env-overlap.py (new) and .github/workflows/lint.yml. No chart or kubernetes manifest values change.
