### PR TITLE
fix(dev): drop unused provider API keys from deployment secrets

### DIFF
--- a/charts/rhesis/values-dev.yaml
+++ b/charts/rhesis/values-dev.yaml
@@ -40,7 +40,7 @@ config:
   # GCP
   vertexAiProject: "playground-437609"
 
-  # AI model — Vertex defaults in dev (GEMINI_API_KEY + GOOGLE_APPLICATION_CREDENTIALS in ESO);
+  # AI model — Vertex defaults in dev (GOOGLE_APPLICATION_CREDENTIALS in ESO);
   # avoids requiring RHESIS_API_KEY for rhesis/rhesis
   defaultGenerationModel: "vertex_ai/gemini-3.1-flash-lite"
   defaultEvaluationModel: "vertex_ai/gemini-3.1-flash-lite"

--- a/infrastructure/k8s/manifests/secrets/rhesis-secrets.yaml.example
+++ b/infrastructure/k8s/manifests/secrets/rhesis-secrets.yaml.example
@@ -69,6 +69,18 @@ data:
   # nothing else: a provider constructor falls back to the process environment
   # when handed a falsy key, so an unused key here silently lets tenant models
   # run on your account.
+  #
+  # Uncomment the entry for each provider you actually use:
+  #
+  # Azure OpenAI (if using Azure)
+  # AZURE_OPENAI_API_KEY: <BASE64_ENCODED_AZURE_OPENAI_API_KEY>
+  #
+  # OpenAI (if using OpenAI directly)
+  # OPENAI_API_KEY: <BASE64_ENCODED_OPENAI_API_KEY>
+  #
+  # Google Gemini (if using Google AI)
+  # GEMINI_API_KEY: <BASE64_ENCODED_GEMINI_API_KEY>
+  # GOOGLE_API_KEY: <BASE64_ENCODED_GOOGLE_API_KEY>
 
   # =============================================================================
   # 📧 EMAIL CONFIGURATION

--- a/infrastructure/k8s/manifests/secrets/rhesis-secrets.yaml.example
+++ b/infrastructure/k8s/manifests/secrets/rhesis-secrets.yaml.example
@@ -65,17 +65,10 @@ data:
   # =============================================================================
   # 🤖 AI MODEL CONFIGURATION
   # =============================================================================
-  # Choose one or more AI providers based on your needs
-
-  # Azure OpenAI (if using Azure)
-  AZURE_OPENAI_API_KEY: <BASE64_ENCODED_AZURE_OPENAI_API_KEY>
-
-  # OpenAI (if using OpenAI directly)
-  OPENAI_API_KEY: <BASE64_ENCODED_OPENAI_API_KEY>
-
-  # Google Gemini (if using Google AI)
-  GEMINI_API_KEY: <BASE64_ENCODED_GEMINI_API_KEY>
-  GOOGLE_API_KEY: <BASE64_ENCODED_GOOGLE_API_KEY>
+  # Ship exactly the credential your deployment's default models require, and
+  # nothing else: a provider constructor falls back to the process environment
+  # when handed a falsy key, so an unused key here silently lets tenant models
+  # run on your account.
 
   # =============================================================================
   # 📧 EMAIL CONFIGURATION

--- a/kubernetes/clusters/dev/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/dev/external-secrets/rhesis-app-secrets.yaml
@@ -131,17 +131,6 @@ spec:
       remoteRef:
         key: dev-rhesis-auth-secret
 
-    # -----------------------------------------------------------------------
-    # AI model API keys
-    # -----------------------------------------------------------------------
-    - secretKey: GEMINI_API_KEY
-      remoteRef:
-        key: dev-rhesis-gemini-api-key
-
-    - secretKey: GOOGLE_API_KEY
-      remoteRef:
-        key: dev-rhesis-google-api-key
-
     - secretKey: PERSPECTIVE_API_KEY
       remoteRef:
         key: dev-rhesis-perspective-api-key

--- a/kubernetes/clusters/prd/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/prd/external-secrets/rhesis-app-secrets.yaml
@@ -90,17 +90,6 @@ spec:
       remoteRef:
         key: prd-rhesis-auth-secret
 
-    # -----------------------------------------------------------------------
-    # AI model API keys
-    # -----------------------------------------------------------------------
-    - secretKey: GEMINI_API_KEY
-      remoteRef:
-        key: prd-rhesis-gemini-api-key
-
-    - secretKey: GOOGLE_API_KEY
-      remoteRef:
-        key: prd-rhesis-google-api-key
-
     - secretKey: PERSPECTIVE_API_KEY
       remoteRef:
         key: prd-rhesis-perspective-api-key

--- a/kubernetes/clusters/stg/external-secrets/rhesis-app-secrets.yaml
+++ b/kubernetes/clusters/stg/external-secrets/rhesis-app-secrets.yaml
@@ -89,17 +89,6 @@ spec:
       remoteRef:
         key: stg-rhesis-auth-secret
 
-    # -----------------------------------------------------------------------
-    # AI model API keys
-    # -----------------------------------------------------------------------
-    - secretKey: GEMINI_API_KEY
-      remoteRef:
-        key: stg-rhesis-gemini-api-key
-
-    - secretKey: GOOGLE_API_KEY
-      remoteRef:
-        key: stg-rhesis-google-api-key
-
     - secretKey: PERSPECTIVE_API_KEY
       remoteRef:
         key: stg-rhesis-perspective-api-key


### PR DESCRIPTION
Fixes #2466

# What

Removes the unused provider API keys from deployment secrets. GEMINI_API_KEY and GOOGLE_API_KEY are dropped from the dev, stg and prd ExternalSecrets, and OPENAI_API_KEY / AZURE_OPENAI_API_KEY / GEMINI_API_KEY / GOOGLE_API_KEY are dropped from the example secret manifest.

# Why

Every deployment's DEFAULT_*_MODEL is vertex_ai/gemini-3.1-flash-lite (generation, evaluation, execution) and vertex_ai/text-embedding-005 (embedding). The vertex_ai provider authenticates with GOOGLE_APPLICATION_CREDENTIALS; the only consumers of the API keys were the google-genai / openai provider environment fallbacks, so a tenant model row with no key could silently resolve and run on our credentials. #2461 closes the known row-level path; removing the keys from the environment closes the whole class.

# Verification

The values files for all three environments confirm the vertex_ai defaults (charts/rhesis/values-{dev,stg,prd}.yaml). Source grep confirms the four key names appear only as provider-constructor fallbacks (sdk/src/rhesis/sdk/models/providers/gemini.py) and in the leak description comment (apps/backend/.../user_model_utils.py) — no other consumer. scripts/check-env-overlap.py still passes for all three envs.

# Scope

kubernetes/clusters/{dev,stg,prd}/external-secrets/rhesis-app-secrets.yaml, infrastructure/k8s/manifests/secrets/rhesis-secrets.yaml.example, charts/rhesis/values-dev.yaml (comment). Left untouched: the Secret Manager bootstrap tooling under infrastructure/config/ still lists GEMINI_API_KEY for secret creation; removing it is a separate onboarding-tooling decision.
