### PR TITLE
fix(frontend): make disabled rerun fields legible in dark mode

### DIFF
--- a/apps/frontend/src/components/common/drawerFormFieldSx.ts
+++ b/apps/frontend/src/components/common/drawerFormFieldSx.ts
@@ -87,8 +87,11 @@ export const drawerDisabledFieldSx: SxProps<Theme> = {
     padding: theme =>
       `${theme.spacing(2)} ${theme.spacing(1.5)} ${theme.spacing(2)} ${theme.spacing(2)} !important`,
     minHeight: '24px',
-    WebkitTextFillColor: theme => theme.palette.greyscale.border,
-    color: theme => theme.palette.greyscale.border,
+    // Use text.secondary, not greyscale.border: the border token is nearly
+    // invisible against the dark drawer surface and made disabled rerun
+    // fields unreadable in dark mode (#2400).
+    WebkitTextFillColor: theme => theme.palette.text.secondary,
+    color: theme => theme.palette.text.secondary,
     opacity: 1,
   },
 };

--- a/apps/frontend/src/components/common/drawerFormFieldSx.ts
+++ b/apps/frontend/src/components/common/drawerFormFieldSx.ts
@@ -89,7 +89,7 @@ export const drawerDisabledFieldSx: SxProps<Theme> = {
     minHeight: '24px',
     // Use text.secondary, not greyscale.border: the border token is nearly
     // invisible against the dark drawer surface and made disabled rerun
-    // fields unreadable in dark mode (#2400).
+    // fields unreadable in dark mode (issue 2400).
     WebkitTextFillColor: theme => theme.palette.text.secondary,
     color: theme => theme.palette.text.secondary,
     opacity: 1,


### PR DESCRIPTION
Fixes #2400

# What

Disabled fields in the re-run test modal were invisible in dark mode: drawerDisabledFieldSx coloured the text with greyscale.border, which has almost no contrast against the dark drawer surface.

# Change

Use text.secondary for the disabled field text (both color and WebkitTextFillColor), so disabled options stay visible but clearly marked as disabled in both themes.

# Verification

npm run type-check passes; eslint and prettier clean on the changed file. Change is styling-only in the shared drawer form field style.
