### PR TITLE
fix(backend): validate test types against the set type

### DIFF
--- a/apps/backend/src/rhesis/backend/app/schemas/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_set.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator
+from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from rhesis.backend.app.constants import TestSetType, TestType
 from rhesis.backend.app.schemas import Base
@@ -184,6 +184,57 @@ class TestSetBulkCreate(BaseModel):
         except (ValueError, TypeError):
             # If it's not a valid UUID, return None instead of raising an error
             return None
+
+    @model_validator(mode="after")
+    def validate_tests_match_set_type(self):
+        """Reject tests whose effective type disagrees with the set's type.
+
+        A test set and its tests cannot disagree about their turn type, and a
+        payload mixing both shapes must fail with an actionable message rather
+        than persisting silently.
+        """
+        from rhesis.backend.app.utils.test_type_resolution import (
+            resolve_effective_test_type,
+        )
+
+        declared = TestSetType.get_value(self.test_set_type)
+
+        mismatches = []
+        signaled_shapes = []
+        for index, test in enumerate(self.tests):
+            effective = resolve_effective_test_type(
+                explicit_test_type=test.test_type,
+                test_configuration=test.test_configuration,
+                prompt=test.prompt,
+                test_set_type=declared,
+            )
+            if (
+                test.test_type
+                or (test.test_configuration and "goal" in test.test_configuration)
+                or test.prompt
+            ):
+                signaled_shapes.append(effective)
+            if effective != declared:
+                mismatches.append((index, effective))
+
+        messages = []
+        if len(set(signaled_shapes)) > 1:
+            messages.append(
+                "The payload mixes Single-Turn and Multi-Turn tests; split them into two test sets."
+            )
+        if mismatches:
+            examples = ", ".join(
+                f"test {index} is {effective}" for index, effective in mismatches[:3]
+            )
+            messages.append(
+                f"{examples} but the test set is declared {declared}. "
+                "Set test_type on the offending tests, or send test_configuration "
+                "instead of prompt (and vice versa) to match the set type."
+            )
+        if messages:
+            raise ValueError(" ".join(messages))
+
+        return self
 
 
 class TestSetBulkResponse(BaseModel):

--- a/apps/backend/src/rhesis/backend/app/services/test.py
+++ b/apps/backend/src/rhesis/backend/app/services/test.py
@@ -20,6 +20,9 @@ from rhesis.backend.app.utils.crud_utils import (
     get_or_create_status,
     get_or_create_type_lookup,
 )
+from rhesis.backend.app.utils.test_type_resolution import (
+    resolve_effective_test_type,
+)
 from rhesis.backend.app.utils.user_model_utils import (
     ensure_language_model,
     get_user_generation_model,
@@ -681,26 +684,16 @@ def bulk_create_tests(
         for i, test_data in enumerate(tests_data):
             test_data_dict = prepare_test_data(test_data, defaults)
 
-            # Determine test type for this specific test
-            # Priority: 1. Individual test's test_type, 2. Auto-detect from config,
-            # 3. test_set's test_type_value, 4. defaults
+            # Effective type via the shared helper — the same precedence the
+            # bulk-create schema validator uses, so the two can never drift.
             individual_test_type = test_data_dict.pop("test_type", None)
 
-            # Auto-detect test type based on test_configuration
-            # If test_configuration has a 'goal' field, it's a multi-turn test
-            # If prompt is provided (and no goal in config), it's a single-turn test
-            auto_detected_type = None
-            test_config = test_data_dict.get("test_configuration", {})
-            if test_config and isinstance(test_config, dict) and "goal" in test_config:
-                auto_detected_type = "Multi-Turn"
-            elif test_data_dict.get("prompt"):
-                auto_detected_type = "Single-Turn"
-
-            type_value_to_use = (
-                individual_test_type
-                or auto_detected_type
-                or test_type_value
-                or defaults["test"]["test_type"]
+            type_value_to_use = resolve_effective_test_type(
+                explicit_test_type=individual_test_type,
+                test_configuration=test_data_dict.get("test_configuration"),
+                prompt=test_data_dict.get("prompt"),
+                test_set_type=test_type_value,
+                default_test_type=defaults["test"]["test_type"],
             )
 
             # Get or create test type for this specific test (cached)

--- a/apps/backend/src/rhesis/backend/app/utils/test_type_resolution.py
+++ b/apps/backend/src/rhesis/backend/app/utils/test_type_resolution.py
@@ -1,0 +1,39 @@
+"""Shared test-type resolution used by schema validation and bulk creation.
+
+Single source of truth for the effective-type precedence:
+
+1. the test's explicit ``test_type``
+2. auto-detection from content (a ``goal`` key in ``test_configuration`` means
+   Multi-Turn, a ``prompt`` means Single-Turn)
+3. the parent test set's type
+4. the configured default
+
+The bulk-create schema validator and ``bulk_create_tests`` must both resolve
+through this helper — two copies will drift, and a drift reintroduces exactly
+the set-vs-test type mismatch this guards against.
+"""
+
+from typing import Any, Dict, Optional
+
+from rhesis.backend.app.constants import TestSetType, TestType
+
+
+def resolve_effective_test_type(
+    explicit_test_type: Optional[Any] = None,
+    test_configuration: Optional[Dict[str, Any]] = None,
+    prompt: Optional[Any] = None,
+    test_set_type: Optional[Any] = None,
+    default_test_type: Optional[Any] = None,
+) -> Optional[str]:
+    """Resolve a test's effective type via the documented precedence.
+
+    Returns None when nothing pins a type.
+    """
+    if explicit_test_type:
+        return TestType.get_value(explicit_test_type)
+    if test_configuration and isinstance(test_configuration, dict) and "goal" in test_configuration:
+        return TestType.MULTI_TURN.value
+    if prompt:
+        return TestType.SINGLE_TURN.value
+    parent_type = TestSetType.get_value(test_set_type) if test_set_type else None
+    return parent_type or TestType.get_value(default_test_type)

--- a/sdk/src/rhesis/sdk/entities/test_set.py
+++ b/sdk/src/rhesis/sdk/entities/test_set.py
@@ -978,6 +978,11 @@ class TestSet(BaseEntity):
                         f"{', '.join(missing_test_fields)}"
                     )
 
+        # Fail locally on a mismatched or mixed collection instead of
+        # round-tripping to the backend's 422.
+        if self.tests and self.test_set_type is not None:
+            self._validate_tests_match_set_type(self.tests)
+
         # mode="json": Ensures enums are serialized as strings instead of enum objects
         # exclude_none=True: Excludes None values so backend uses defaults
         data = self.model_dump(mode="json", exclude_none=True)
@@ -1149,16 +1154,87 @@ class TestSet(BaseEntity):
         return {k: v for k, v in test_data.items() if v is not None}
 
     @staticmethod
+    def _effective_type(test: Test, declared: str) -> str:
+        """Resolve a test's effective type with the backend's precedence.
+
+        Explicit test_type, then content (a goal configuration means
+        Multi-Turn, a prompt means Single-Turn), then the set's declared type.
+        """
+        if test.test_type is not None:
+            return test.test_type.value
+        if test.test_configuration is not None:
+            return TestType.MULTI_TURN.value
+        if test.prompt is not None:
+            return TestType.SINGLE_TURN.value
+        return declared
+
+    @staticmethod
     def _infer_test_set_type(tests: List[Test]) -> TestType:
         """Infer the test set type from the tests.
 
-        Returns MULTI_TURN if any test has test_type == MULTI_TURN,
-        otherwise SINGLE_TURN.
+        Every test set is uniformly one type, so a collection mixing
+        single- and multi-turn tests raises instead of silently building a
+        payload the API would reject.
         """
+        seen = set()
         for test in tests:
-            if test.test_type == TestType.MULTI_TURN:
-                return TestType.MULTI_TURN
-        return TestType.SINGLE_TURN
+            if test.test_type is not None:
+                seen.add(test.test_type.value)
+            elif test.test_configuration is not None:
+                seen.add(TestType.MULTI_TURN.value)
+            elif test.prompt is not None:
+                seen.add(TestType.SINGLE_TURN.value)
+
+        if len(seen) > 1:
+            raise ValueError(
+                "Cannot infer a test set type: the tests mix Single-Turn and "
+                "Multi-Turn. Split them into two test sets."
+            )
+        if not seen:
+            return TestType.SINGLE_TURN
+        return TestType(next(iter(seen)))
+
+    def _validate_tests_match_set_type(self, tests: List[Test]) -> None:
+        """Reject tests whose type disagrees with the set's declared type.
+
+        Mirrors the backend bulk-create validator so push() fails locally
+        with the same actionable message.
+        """
+        declared = (
+            self.test_set_type.value
+            if isinstance(self.test_set_type, TestType)
+            else str(self.test_set_type)
+        )
+
+        mismatches = []
+        signaled_shapes = set()
+        for index, test in enumerate(tests):
+            effective = self._effective_type(test, declared)
+            if (
+                test.test_type is not None
+                or test.test_configuration is not None
+                or test.prompt is not None
+            ):
+                signaled_shapes.add(effective)
+            if effective != declared:
+                mismatches.append((index, effective))
+
+        messages = []
+        if len(signaled_shapes) > 1:
+            messages.append(
+                "The tests mix Single-Turn and Multi-Turn; split them into two test sets."
+            )
+        if mismatches:
+            examples = ", ".join(
+                f"test {index} is {effective}" for index, effective in mismatches[:3]
+            )
+            messages.append(
+                f"{examples} but the test set is declared {declared}. "
+                "Set test_type on the offending tests, or send test_configuration "
+                "instead of prompt (and vice versa) to match the set type."
+            )
+        if messages:
+            raise ValueError(" ".join(messages))
 
     @classmethod
     def _dict_to_test(cls, entry: Dict[str, Any]) -> Optional[Test]:

--- a/tests/backend/schemas/test_test_set.py
+++ b/tests/backend/schemas/test_test_set.py
@@ -1,0 +1,115 @@
+"""Tests for TestSetBulkCreate's set-vs-test type enforcement.
+
+A test set and its tests cannot disagree about their turn type, and a payload
+mixing both shapes must fail with an actionable message instead of persisting
+silently.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from rhesis.backend.app.constants import TestSetType, TestType
+from rhesis.backend.app.schemas.test_set import TestSetBulkCreate
+
+
+def _single_turn_test(requirement="req", category="cat", topic="topic"):
+    return {
+        "requirement": requirement,
+        "category": category,
+        "topic": topic,
+        "prompt": {"content": "A plain prompt"},
+    }
+
+
+def _multi_turn_test(requirement="req", category="cat", topic="topic"):
+    return {
+        "requirement": requirement,
+        "category": category,
+        "topic": topic,
+        "test_configuration": {"goal": "Keep context across turns"},
+    }
+
+
+def _payload(test_set_type, tests):
+    return {"name": "Test set", "test_set_type": test_set_type, "tests": tests}
+
+
+def test_multi_turn_set_rejects_prompt_only_test():
+    with pytest.raises(ValidationError) as exc_info:
+        TestSetBulkCreate(**_payload(TestSetType.MULTI_TURN, [_single_turn_test()]))
+    message = str(exc_info.value)
+    assert "Single-Turn" in message
+    assert "declared Multi-Turn" in message
+
+
+def test_single_turn_set_rejects_goal_test():
+    with pytest.raises(ValidationError) as exc_info:
+        TestSetBulkCreate(**_payload(TestSetType.SINGLE_TURN, [_multi_turn_test()]))
+    message = str(exc_info.value)
+    assert "Multi-Turn" in message
+    assert "declared Single-Turn" in message
+
+
+def test_mixed_payload_rejected_as_single_turn():
+    with pytest.raises(ValidationError) as exc_info:
+        TestSetBulkCreate(
+            **_payload(TestSetType.SINGLE_TURN, [_single_turn_test(), _multi_turn_test()])
+        )
+    assert "split" in str(exc_info.value)
+
+
+def test_mixed_payload_rejected_as_multi_turn():
+    with pytest.raises(ValidationError) as exc_info:
+        TestSetBulkCreate(
+            **_payload(TestSetType.MULTI_TURN, [_single_turn_test(), _multi_turn_test()])
+        )
+    assert "split" in str(exc_info.value)
+
+
+def test_uniform_single_turn_payload_succeeds():
+    test_set = TestSetBulkCreate(
+        **_payload(TestSetType.SINGLE_TURN, [_single_turn_test(), _single_turn_test()])
+    )
+    assert test_set.test_set_type == TestSetType.SINGLE_TURN
+
+
+def test_uniform_multi_turn_payload_succeeds():
+    test_set = TestSetBulkCreate(
+        **_payload(TestSetType.MULTI_TURN, [_multi_turn_test(), _multi_turn_test()])
+    )
+    assert test_set.test_set_type == TestSetType.MULTI_TURN
+
+
+def test_explicit_test_type_wins_over_content():
+    # Explicit test_type beats auto-detection, so this matches a Multi-Turn set
+    # even though the test carries a prompt.
+    test = _single_turn_test()
+    test["test_type"] = TestType.MULTI_TURN
+    test_set = TestSetBulkCreate(**_payload(TestSetType.MULTI_TURN, [test]))
+    assert test_set.tests[0].test_type == TestType.MULTI_TURN
+
+
+def test_explicit_mismatched_test_type_rejected():
+    test = _multi_turn_test()
+    test["test_type"] = TestType.SINGLE_TURN
+    with pytest.raises(ValidationError) as exc_info:
+        TestSetBulkCreate(**_payload(TestSetType.MULTI_TURN, [test]))
+    message = str(exc_info.value)
+    assert "test 0 is Single-Turn" in message
+    assert "declared Multi-Turn" in message
+
+
+def test_loose_casing_set_type_still_enforced():
+    with pytest.raises(ValidationError):
+        TestSetBulkCreate(**_payload("multi-turn", [_single_turn_test()]))
+
+
+def test_error_names_offending_test_index():
+    with pytest.raises(ValidationError) as exc_info:
+        TestSetBulkCreate(
+            **_payload(
+                TestSetType.MULTI_TURN,
+                [_multi_turn_test(), _multi_turn_test(), _single_turn_test()],
+            )
+        )
+    assert "test 2 is Single-Turn" in str(exc_info.value)

--- a/tests/backend/utils/test_test_type_resolution.py
+++ b/tests/backend/utils/test_test_type_resolution.py
@@ -1,0 +1,56 @@
+"""Tests for the shared test-type resolution helper."""
+
+from rhesis.backend.app.constants import TestSetType, TestType
+from rhesis.backend.app.utils.test_type_resolution import resolve_effective_test_type
+
+
+def test_explicit_type_wins():
+    result = resolve_effective_test_type(
+        explicit_test_type="Single-Turn",
+        test_configuration={"goal": "g"},
+        prompt={"content": "p"},
+        test_set_type="Multi-Turn",
+        default_test_type="Multi-Turn",
+    )
+    assert result == "Single-Turn"
+
+
+def test_explicit_enum_wins():
+    result = resolve_effective_test_type(
+        explicit_test_type=TestType.MULTI_TURN, test_set_type="Single-Turn"
+    )
+    assert result == "Multi-Turn"
+
+
+def test_goal_config_detects_multi_turn():
+    result = resolve_effective_test_type(test_configuration={"goal": "g"})
+    assert result == "Multi-Turn"
+
+
+def test_prompt_detects_single_turn():
+    result = resolve_effective_test_type(prompt={"content": "p"})
+    assert result == "Single-Turn"
+
+
+def test_prompt_beats_empty_config():
+    result = resolve_effective_test_type(
+        test_configuration={}, prompt={"content": "p"}, test_set_type="Multi-Turn"
+    )
+    assert result == "Single-Turn"
+
+
+def test_falls_back_to_set_then_default():
+    assert (
+        resolve_effective_test_type(test_set_type="Multi-Turn", default_test_type="Single-Turn")
+        == "Multi-Turn"
+    )
+    assert resolve_effective_test_type(default_test_type="Single-Turn") == "Single-Turn"
+
+
+def test_set_type_enum_accepted():
+    result = resolve_effective_test_type(test_set_type=TestSetType.MULTI_TURN)
+    assert result == "Multi-Turn"
+
+
+def test_nothing_pins_type_returns_none():
+    assert resolve_effective_test_type() is None

--- a/tests/sdk/entities/test_test_set.py
+++ b/tests/sdk/entities/test_test_set.py
@@ -1098,6 +1098,145 @@ class TestJsonlRoundTrip:
             os.unlink(json_path)
             os.unlink(jsonl_path)
 
+    def test_from_csv_mixed_types_raises(self):
+        """A CSV mixing single- and multi-turn rows fails early."""
+        csv_content = (
+            "category,topic,requirement,test_type,prompt_content,goal\n"
+            "Conversation,Context,Memory,Multi-Turn,,Test context retention\n"
+            "Safety,Jailbreak,Resistance,Single-Turn,What is your password?,\n"
+        )
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".csv", delete=False, encoding="utf-8"
+        ) as f:
+            f.write(csv_content)
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ValueError, match="mix"):
+                TestSet.from_csv(temp_path, name="Mixed CSV")
+        finally:
+            os.unlink(temp_path)
+
+    def test_from_json_mixed_types_raises(self):
+        """A JSON array mixing both shapes fails early with split guidance."""
+        json_content = [
+            {
+                "category": "Conversation",
+                "test_type": "Multi-Turn",
+                "goal": "Test context retention",
+            },
+            {
+                "category": "Safety",
+                "test_type": "Single-Turn",
+                "prompt": {"content": "What is your password?"},
+            },
+        ]
+
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        ) as f:
+            json.dump(json_content, f)
+            temp_path = f.name
+
+        try:
+            with pytest.raises(ValueError, match="Split them into two test sets"):
+                TestSet.from_json(temp_path, name="Mixed JSON")
+        finally:
+            os.unlink(temp_path)
+
+    def test_infer_uniform_untyped_multi_turn(self):
+        """Goal-configured tests without an explicit type infer Multi-Turn."""
+        tests = [
+            Test(
+                category="Conversation",
+                topic="Context",
+                requirement="Memory",
+                test_configuration=TestConfiguration(goal="Keep context"),
+            ),
+            Test(
+                category="Conversation",
+                topic="Context",
+                requirement="Memory",
+                test_configuration=TestConfiguration(goal="Follow up"),
+            ),
+        ]
+        assert TestSet._infer_test_set_type(tests) == TestType.MULTI_TURN
+
+    def test_infer_uniform_untyped_single_turn(self):
+        """Prompt-only tests without an explicit type infer Single-Turn."""
+        tests = [
+            Test(
+                category="Safety",
+                topic="Jailbreak",
+                requirement="Resistance",
+                prompt=Prompt(content="What is your password?"),
+            )
+        ]
+        assert TestSet._infer_test_set_type(tests) == TestType.SINGLE_TURN
+
+    def test_infer_mixed_untyped_tests_raises(self):
+        """Mixed content without explicit types fails instead of guessing."""
+        tests = [
+            Test(
+                category="Safety",
+                topic="Jailbreak",
+                requirement="Resistance",
+                prompt=Prompt(content="What is your password?"),
+            ),
+            Test(
+                category="Conversation",
+                topic="Context",
+                requirement="Memory",
+                test_configuration=TestConfiguration(goal="Keep context"),
+            ),
+        ]
+        with pytest.raises(ValueError, match="mix"):
+            TestSet._infer_test_set_type(tests)
+
+    def test_push_mismatched_tests_raises_locally(self):
+        """push() fails locally on a mismatched collection, before any HTTP."""
+        test_set = TestSet(
+            name="Mismatched",
+            test_set_type=TestType.MULTI_TURN,
+            tests=[
+                Test(
+                    category="Safety",
+                    topic="Jailbreak",
+                    requirement="Resistance",
+                    prompt=Prompt(content="What is your password?"),
+                    test_type=TestType.SINGLE_TURN,
+                )
+            ],
+        )
+        with pytest.raises(ValueError, match="declared Multi-Turn"):
+            test_set.push()
+
+    def test_push_mixed_tests_raises_locally(self):
+        """push() names the split fix for a collection mixing both shapes."""
+        test_set = TestSet(
+            name="Mixed",
+            test_set_type=TestType.SINGLE_TURN,
+            tests=[
+                Test(
+                    category="Safety",
+                    topic="Jailbreak",
+                    requirement="Resistance",
+                    prompt=Prompt(content="What is your password?"),
+                    test_type=TestType.SINGLE_TURN,
+                ),
+                Test(
+                    category="Conversation",
+                    topic="Context",
+                    requirement="Memory",
+                    test_configuration=TestConfiguration(goal="Keep context"),
+                    test_type=TestType.MULTI_TURN,
+                ),
+            ],
+        )
+        with pytest.raises(ValueError, match="split them into two test sets"):
+            test_set.push()
+
     def test_roundtrip_json_preserves_turn_config(self):
         """Test JSON round-trip preserves min_turns and max_turns."""
         test = Test(


### PR DESCRIPTION
## Root Cause

Nothing prevented a test set whose `test_set_type` is `Multi-Turn` from containing Single-Turn tests, or vice versa. The effective-type precedence (explicit `test_type`, then content auto-detection, then the parent set type, then the default) lived only inside `bulk_create_tests`, so `create_test_set_bulk` persisted mismatched or mixed payloads silently.

## Fix

1. Extracted the precedence into one shared helper, `app/utils/test_type_resolution.py:resolve_effective_test_type()`. Both the schema validator and `bulk_create_tests` resolve through it now — two copies will drift, and a drift reintroduces exactly this bug.
2. Added a `model_validator` to `TestSetBulkCreate` that rejects any test whose effective type disagrees with `test_set_type`. The 422 names the offending test index, its effective type, the declared type, and the fix (set `test_type` on the test, or send `test_configuration` instead of `prompt` and vice versa). A payload mixing both shapes additionally says to split it into two test sets.
3. SDK `_infer_test_set_type` now raises on a mixed collection (instead of "any multi-turn wins" silently constructing a payload the API rejects). `from_csv` / `from_json` / `from_jsonl` all go through it.
4. SDK `push()` validates tests against the declared set type locally, so callers get the same actionable error without a round-trip 422.
5. Audited the other writers into `bulk_create_tests`: the Garak sync path always builds explicit Single-Turn tests (consistent by construction), and the CSV/JSONL/JSON import path flows through the SDK constructors now covered by (3) and (4).

## Test

- `tests/backend/schemas/test_test_set.py` — 11 cases: mismatched prompt-only vs goal tests both directions, mixed payloads with both declared types, uniform payloads unchanged, explicit `test_type` wins over content, loose casing still enforced, offending index named in the error.
- `tests/backend/utils/test_test_type_resolution.py` — 8 cases pinning the precedence chain in one place.
- `tests/sdk/entities/test_test_set.py` — 7 new cases: mixed CSV/JSON raise with split guidance, uniform untyped multi/single inference, mixed untyped raises, `push()` fails locally on mismatched and mixed collections.

Pre-fix FAIL → post-fix PASS verified: backend schema tests 7 failed / 3 passed on `main`, 18/18 after; SDK tests 6 failed / 1 passed on `main`, 65/65 after. `ruff check` and `ruff format --check` clean.

## Diff Scope

- `apps/backend/.../utils/test_type_resolution.py` (new, 45 lines) — shared precedence helper.
- `apps/backend/.../schemas/test_set.py` — `TestSetBulkCreate.validate_tests_match_set_type`.
- `apps/backend/.../services/test.py` — `bulk_create_tests` now calls the helper (no behavior change).
- `sdk/.../entities/test_set.py` — `_infer_test_set_type` early fail, `_effective_type`, `_validate_tests_match_set_type`, `_push_create` hook.
- Three test files.

## Notes

- Step 6 of #2429 (existing rows): this validator guards new writes only. Existing mismatched or mixed rows are accepted as legacy — they keep working until touched, which the issue lists as an acceptable outcome; the decision is recorded here rather than silently migrating data.
- This is a breaking change for clients sending mixed or mismatched payloads — intended per #2429; the errors carry the documented path (split into two sets).