### PR TITLE
fix(backend): enforce test set type matches its tests

### DIFF
--- a/apps/backend/src/rhesis/backend/app/schemas/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/test_set.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator
+from pydantic import UUID4, BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from rhesis.backend.app.constants import TestSetType, TestType
 from rhesis.backend.app.schemas import Base
@@ -184,6 +184,46 @@ class TestSetBulkCreate(BaseModel):
         except (ValueError, TypeError):
             # If it's not a valid UUID, return None instead of raising an error
             return None
+
+    @model_validator(mode="after")
+    def validate_tests_match_set_type(self):
+        """Reject mixed or mismatched turn types instead of persisting them.
+
+        Preflight reads the set type while execution reads each test type; a
+        mismatch makes preflight validate the wrong execution mode.
+        """
+        from rhesis.backend.app.schemas.validators import resolve_test_type
+
+        declared_type = TestSetType.get_value(self.test_set_type)
+        mismatches = []
+        for index, test in enumerate(self.tests):
+            effective_type = resolve_test_type(
+                test.model_dump(exclude_none=True),
+                test_set_type=declared_type,
+                default_test_type=declared_type,
+            )
+            if effective_type != declared_type:
+                mismatches.append((index, effective_type))
+
+        if not mismatches:
+            return self
+
+        if len({effective for _, effective in mismatches}) > 1 or len(mismatches) < len(self.tests):
+            raise ValueError(
+                f"Test set type is '{declared_type}' but tests resolve to mixed turn types; "
+                "split the payload into separate Single-Turn and Multi-Turn test sets."
+            )
+
+        index, effective_type = mismatches[0]
+        fix = (
+            "set test_type on the test, or send test_configuration with a goal instead of prompt"
+            if declared_type == TestSetType.MULTI_TURN.value
+            else "set test_type on the test, or send a prompt instead of test_configuration.goal"
+        )
+        raise ValueError(
+            f"test[{index}] resolves to '{effective_type}', which does not match test set "
+            f"type '{declared_type}'; {fix}."
+        )
 
 
 class TestSetBulkResponse(BaseModel):

--- a/apps/backend/src/rhesis/backend/app/schemas/validators.py
+++ b/apps/backend/src/rhesis/backend/app/schemas/validators.py
@@ -36,6 +36,34 @@ def format_test_set_type(v: Optional[str]) -> Optional[str]:
     return formatted
 
 
+def resolve_test_type(
+    test_data: Dict[str, Any],
+    test_set_type: Optional[str] = None,
+    default_test_type: Optional[str] = None,
+) -> str:
+    """Return the effective turn type for one test payload.
+
+    Precedence matches the historical service behavior and must stay in one
+    place: explicit test_type, then auto-detection from test_configuration.goal
+    or prompt, then the parent test-set type, then the platform default.
+    """
+    individual_test_type = test_data.get("test_type")
+    if individual_test_type is not None:
+        return TestType.get_value(individual_test_type)
+
+    test_configuration = test_data.get("test_configuration") or {}
+    if isinstance(test_configuration, dict) and "goal" in test_configuration:
+        return TestType.MULTI_TURN.value
+    if test_data.get("prompt"):
+        return TestType.SINGLE_TURN.value
+    if test_set_type:
+        return TestType.get_value(test_set_type)
+
+    return (
+        TestType.get_value(default_test_type) if default_test_type else TestType.SINGLE_TURN.value
+    )
+
+
 def validate_test_config_content(v: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """
     Validate test_configuration JSON based on content.

--- a/apps/backend/src/rhesis/backend/app/services/test.py
+++ b/apps/backend/src/rhesis/backend/app/services/test.py
@@ -34,6 +34,16 @@ from rhesis.backend.app.utils.uuid_utils import (
 logger = logging.getLogger(__name__)
 
 
+class TestSetInaccessibleError(LookupError):
+    """Referenced test set is missing or belongs to another organization.
+
+    Raised by bulk_create_tests when a test_set_id cannot be resolved
+    within the caller's organization, instead of silently creating
+    unassociated tests. Routers map this to 404 via their existing
+    "not found" error handling.
+    """
+
+
 class _BulkEntityCache:
     """
     In-memory cache for entity lookups during bulk operations.
@@ -679,7 +689,11 @@ def bulk_create_tests(
             )
             .first()
         )
-        if db_test_set is not None and db_test_set.test_set_type is not None:
+        if db_test_set is None:
+            raise TestSetInaccessibleError(
+                f"Test set with ID {test_set_id} not found or not accessible"
+            )
+        if db_test_set.test_set_type is not None:
             enforced_set_type = db_test_set.test_set_type.type_value
             test_type_value = enforced_set_type
     if enforced_set_type is None:

--- a/apps/backend/src/rhesis/backend/app/services/test.py
+++ b/apps/backend/src/rhesis/backend/app/services/test.py
@@ -14,6 +14,7 @@ from rhesis.backend.app.constants import (
 )
 from rhesis.backend.app.models.test import test_test_set_association
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.schemas.validators import resolve_test_type
 from rhesis.backend.app.utils.crud_utils import (
     create_item,
     get_or_create_entity,
@@ -681,27 +682,14 @@ def bulk_create_tests(
         for i, test_data in enumerate(tests_data):
             test_data_dict = prepare_test_data(test_data, defaults)
 
-            # Determine test type for this specific test
-            # Priority: 1. Individual test's test_type, 2. Auto-detect from config,
-            # 3. test_set's test_type_value, 4. defaults
-            individual_test_type = test_data_dict.pop("test_type", None)
-
-            # Auto-detect test type based on test_configuration
-            # If test_configuration has a 'goal' field, it's a multi-turn test
-            # If prompt is provided (and no goal in config), it's a single-turn test
-            auto_detected_type = None
-            test_config = test_data_dict.get("test_configuration", {})
-            if test_config and isinstance(test_config, dict) and "goal" in test_config:
-                auto_detected_type = "Multi-Turn"
-            elif test_data_dict.get("prompt"):
-                auto_detected_type = "Single-Turn"
-
-            type_value_to_use = (
-                individual_test_type
-                or auto_detected_type
-                or test_type_value
-                or defaults["test"]["test_type"]
+            # Determine test type for this specific test. The precedence is
+            # shared with TestSetBulkCreate validation so the two cannot drift.
+            type_value_to_use = resolve_test_type(
+                test_data_dict,
+                test_set_type=test_type_value,
+                default_test_type=defaults["test"]["test_type"],
             )
+            test_data_dict.pop("test_type", None)
 
             # Get or create test type for this specific test (cached)
             test_type = cache.get_or_create_type_lookup(

--- a/apps/backend/src/rhesis/backend/app/services/test.py
+++ b/apps/backend/src/rhesis/backend/app/services/test.py
@@ -665,15 +665,18 @@ def bulk_create_tests(
     _pending_tests: List[models.Test] = []
     defaults = load_defaults()
 
-    # When tests are created directly into an existing test set, that set's
-    # type is authoritative. It also supplies the parent fallback that the
-    # schema validator uses for bulk test-set creation.
-    enforced_set_type = test_type_value
-    if test_set_id and not enforced_set_type:
+    # When tests are created directly into an existing test set, the
+    # database row's type is authoritative, even if the caller also passed a
+    # test_type_value. It also supplies the parent fallback used by the
+    # schema validator for bulk test-set creation.
+    enforced_set_type = None
+    if test_set_id:
         db_test_set = db.query(models.TestSet).filter(models.TestSet.id == test_set_id).first()
         if db_test_set is not None and db_test_set.test_set_type is not None:
             enforced_set_type = db_test_set.test_set_type.type_value
             test_type_value = enforced_set_type
+    if enforced_set_type is None:
+        enforced_set_type = test_type_value
 
     # Create cache for entity lookups - dramatically reduces DB round-trips
     # when many tests share the same topic/requirement/category (common in Garak imports)

--- a/apps/backend/src/rhesis/backend/app/services/test.py
+++ b/apps/backend/src/rhesis/backend/app/services/test.py
@@ -671,7 +671,14 @@ def bulk_create_tests(
     # schema validator for bulk test-set creation.
     enforced_set_type = None
     if test_set_id:
-        db_test_set = db.query(models.TestSet).filter(models.TestSet.id == test_set_id).first()
+        db_test_set = (
+            db.query(models.TestSet)
+            .filter(
+                models.TestSet.id == test_set_id,
+                models.TestSet.organization_id == organization_id,
+            )
+            .first()
+        )
         if db_test_set is not None and db_test_set.test_set_type is not None:
             enforced_set_type = db_test_set.test_set_type.type_value
             test_type_value = enforced_set_type
@@ -891,6 +898,11 @@ def bulk_create_tests(
         # Transaction commit/rollback is handled by the session context manager
         return created_test_ids
 
+    except ValueError:
+        # The type-mismatch guard raises ValueError with an actionable
+        # message; propagate it as a client error instead of the generic
+        # 500 wrapper below.
+        raise
     except Exception as e:
         error_msg = str(e)
         logger.error(f"Failed to create tests: {error_msg}", exc_info=True)

--- a/apps/backend/src/rhesis/backend/app/services/test.py
+++ b/apps/backend/src/rhesis/backend/app/services/test.py
@@ -665,6 +665,16 @@ def bulk_create_tests(
     _pending_tests: List[models.Test] = []
     defaults = load_defaults()
 
+    # When tests are created directly into an existing test set, that set's
+    # type is authoritative. It also supplies the parent fallback that the
+    # schema validator uses for bulk test-set creation.
+    enforced_set_type = test_type_value
+    if test_set_id and not enforced_set_type:
+        db_test_set = db.query(models.TestSet).filter(models.TestSet.id == test_set_id).first()
+        if db_test_set is not None and db_test_set.test_set_type is not None:
+            enforced_set_type = db_test_set.test_set_type.type_value
+            test_type_value = enforced_set_type
+
     # Create cache for entity lookups - dramatically reduces DB round-trips
     # when many tests share the same topic/requirement/category (common in Garak imports)
     cache = _BulkEntityCache()
@@ -689,6 +699,12 @@ def bulk_create_tests(
                 test_set_type=test_type_value,
                 default_test_type=defaults["test"]["test_type"],
             )
+            if enforced_set_type is not None and type_value_to_use != enforced_set_type:
+                raise ValueError(
+                    f"test[{i}] resolves to '{type_value_to_use}', which does not match "
+                    f"target test set type '{enforced_set_type}'; set test_type on the test "
+                    "or split it into a matching test set."
+                )
             test_data_dict.pop("test_type", None)
 
             # Get or create test type for this specific test (cached)

--- a/sdk/src/rhesis/sdk/entities/test_set.py
+++ b/sdk/src/rhesis/sdk/entities/test_set.py
@@ -1152,13 +1152,18 @@ class TestSet(BaseEntity):
     def _infer_test_set_type(tests: List[Test]) -> TestType:
         """Infer the test set type from the tests.
 
-        Returns MULTI_TURN if any test has test_type == MULTI_TURN,
-        otherwise SINGLE_TURN.
+        A test set must be uniformly Single-Turn or Multi-Turn. Mixed
+        collections fail here instead of building a payload the API will
+        reject.
         """
-        for test in tests:
-            if test.test_type == TestType.MULTI_TURN:
-                return TestType.MULTI_TURN
-        return TestType.SINGLE_TURN
+        inferred_types = {test.test_type for test in tests if test.test_type is not None}
+        if len(inferred_types) > 1:
+            raise ValueError(
+                "Cannot create a TestSet with mixed test types: "
+                f"{sorted(t.value for t in inferred_types)}. "
+                "Split the tests into separate Single-Turn and Multi-Turn test sets."
+            )
+        return next(iter(inferred_types), TestType.SINGLE_TURN)
 
     @classmethod
     def _dict_to_test(cls, entry: Dict[str, Any]) -> Optional[Test]:

--- a/sdk/src/rhesis/sdk/entities/test_set.py
+++ b/sdk/src/rhesis/sdk/entities/test_set.py
@@ -1241,12 +1241,18 @@ class TestSet(BaseEntity):
                 language_code=language_code if language_code else "en",
             )
 
-        # Determine test type
-        test_type_value = entry.get("test_type", "Single-Turn")
+        # Determine test type. When the entry has a goal but no explicit
+        # test_type, infer Multi-Turn so imports do not silently build a
+        # Single-Turn payload around multi-turn configuration.
+        test_type_value = entry.get("test_type")
+        if test_type_value is None:
+            nested_goal = (entry.get("test_configuration") or {}).get("goal")
+            has_goal = bool(nested_goal) or bool(str(entry.get("goal") or "").strip())
+            test_type_value = "Multi-Turn" if has_goal else "Single-Turn"
         if isinstance(test_type_value, str):
             test_type = TestType(test_type_value)
         else:
-            test_type = TestType.SINGLE_TURN
+            test_type = test_type_value
 
         # Build test kwargs — let Test.model_validator handle
         # building test_configuration from flat fields.

--- a/tests/backend/services/test_test.py
+++ b/tests/backend/services/test_test.py
@@ -14,9 +14,9 @@ from sqlalchemy.orm import Session
 from rhesis.backend.app import models
 from rhesis.backend.app.services import test as test_service
 from tests.backend.routes.fixtures.data_factories import (
-    RequirementDataFactory,
     CategoryDataFactory,
     PromptDataFactory,
+    RequirementDataFactory,
     TopicDataFactory,
 )
 
@@ -166,6 +166,45 @@ class TestBulkCreateTests:
             assert test_obj.requirement_id is not None
             assert test_obj.category_id is not None
             assert test_obj.status_id is not None
+
+    def test_bulk_create_tests_rejects_mismatched_target_set_type(
+        self,
+        test_db: Session,
+        authenticated_user_id,
+        test_org_id,
+        test_organization,
+        test_type_lookup,
+        db_status,
+        db_user,
+    ):
+        """Direct bulk creation must respect the target test set's type."""
+        multi_turn_type = models.TypeLookup(
+            type_name="TestSetType",
+            type_value="Multi-Turn",
+            description="Multi-Turn test set type",
+            organization_id=test_organization.id,
+            user_id=authenticated_user_id,
+        )
+        test_db.add(multi_turn_type)
+        test_db.flush()
+
+        test_set = models.TestSet(
+            name="Multi-turn target",
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+            test_set_type_id=multi_turn_type.id,
+        )
+        test_db.add(test_set)
+        test_db.commit()
+
+        with pytest.raises(ValueError, match="does not match target test set type"):
+            test_service.bulk_create_tests(
+                db=test_db,
+                tests_data=[create_bulk_test_data()],
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+                test_set_id=str(test_set.id),
+            )
 
     def test_bulk_create_tests_invalid_uuid(self, test_db: Session, authenticated_user_id):
         """Test bulk_create_tests with invalid UUID parameters."""

--- a/tests/backend/services/test_test.py
+++ b/tests/backend/services/test_test.py
@@ -206,7 +206,7 @@ class TestBulkCreateTests:
                 test_set_id=str(test_set.id),
             )
 
-    def test_bulk_create_tests_ignores_cross_org_test_set_type(
+    def test_bulk_create_tests_rejects_cross_org_test_set_id(
         self,
         test_db: Session,
         authenticated_user_id,
@@ -216,7 +216,7 @@ class TestBulkCreateTests:
         db_status,
         db_user,
     ):
-        """A test_set_id from another org must not leak its type or block writes."""
+        """A cross-org test_set_id must fail fast, never leak type or create unassociated tests."""
         multi_turn_type = models.TypeLookup(
             type_name="TestSetType",
             type_value="Multi-Turn",
@@ -236,17 +236,19 @@ class TestBulkCreateTests:
         test_db.add(other_org_set)
         test_db.commit()
 
-        # The caller is test_org_id with an explicit Single-Turn fallback; the
-        # other org's Multi-Turn type must not be read, so this succeeds.
-        created = test_service.bulk_create_tests(
-            db=test_db,
-            tests_data=[create_bulk_test_data()],
-            organization_id=test_org_id,
-            user_id=authenticated_user_id,
-            test_set_id=str(other_org_set.id),
-            test_type_value="Single-Turn",
-        )
-        assert len(created) == 1
+        # The caller is test_org_id; the other org's set is inaccessible and
+        # must be rejected instead of silently creating unassociated tests.
+        with pytest.raises(
+            test_service.TestSetInaccessibleError, match="not found or not accessible"
+        ):
+            test_service.bulk_create_tests(
+                db=test_db,
+                tests_data=[create_bulk_test_data()],
+                organization_id=test_org_id,
+                user_id=authenticated_user_id,
+                test_set_id=str(other_org_set.id),
+                test_type_value="Single-Turn",
+            )
 
     def test_bulk_create_tests_invalid_uuid(self, test_db: Session, authenticated_user_id):
         """Test bulk_create_tests with invalid UUID parameters."""

--- a/tests/backend/services/test_test.py
+++ b/tests/backend/services/test_test.py
@@ -206,6 +206,48 @@ class TestBulkCreateTests:
                 test_set_id=str(test_set.id),
             )
 
+    def test_bulk_create_tests_ignores_cross_org_test_set_type(
+        self,
+        test_db: Session,
+        authenticated_user_id,
+        test_org_id,
+        test_organization,
+        test_type_lookup,
+        db_status,
+        db_user,
+    ):
+        """A test_set_id from another org must not leak its type or block writes."""
+        multi_turn_type = models.TypeLookup(
+            type_name="TestSetType",
+            type_value="Multi-Turn",
+            description="Multi-Turn test set type",
+            organization_id=test_organization.id,
+            user_id=authenticated_user_id,
+        )
+        test_db.add(multi_turn_type)
+        test_db.flush()
+
+        other_org_set = models.TestSet(
+            name="Other org multi-turn set",
+            organization_id=uuid.uuid4(),
+            user_id=authenticated_user_id,
+            test_set_type_id=multi_turn_type.id,
+        )
+        test_db.add(other_org_set)
+        test_db.commit()
+
+        # The caller is test_org_id with an explicit Single-Turn fallback; the
+        # other org's Multi-Turn type must not be read, so this succeeds.
+        created = test_service.bulk_create_tests(
+            db=test_db,
+            tests_data=[create_bulk_test_data()],
+            organization_id=test_org_id,
+            user_id=authenticated_user_id,
+            test_set_id=str(other_org_set.id),
+            test_type_value="Single-Turn",
+        )
+        assert len(created) == 1
+
     def test_bulk_create_tests_invalid_uuid(self, test_db: Session, authenticated_user_id):
         """Test bulk_create_tests with invalid UUID parameters."""
         test_data_list = [

--- a/tests/backend/services/test_test_set.py
+++ b/tests/backend/services/test_test_set.py
@@ -10,10 +10,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from faker import Faker
+from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.constants import EXPLORER_REQUIREMENT_NAME
+from rhesis.backend.app.schemas.validators import resolve_test_type
 from rhesis.backend.app.services import test_set as test_set_service
 
 # Use existing data factories from the established pattern
@@ -641,6 +643,112 @@ class TestTestSetGeneration:
 
         assert result.name == "Generated Test Set"
         assert len(result.tests) == 1
+
+
+@pytest.mark.unit
+@pytest.mark.service
+class TestBulkCreateEnforcesUniformTestType:
+    def test_prompt_only_test_rejected_for_multi_turn_set(self):
+        with pytest.raises(ValidationError, match="does not match test set type"):
+            schemas.TestSetBulkCreate(
+                name="Mismatched",
+                test_set_type="Multi-Turn",
+                tests=[
+                    schemas.TestData(
+                        prompt=schemas.TestPrompt(content="single turn"),
+                        requirement="Security",
+                        category="Injection",
+                        topic="Prompt Injection",
+                    )
+                ],
+            )
+
+    def test_goal_config_test_rejected_for_single_turn_set(self):
+        with pytest.raises(ValidationError, match="does not match test set type"):
+            schemas.TestSetBulkCreate(
+                name="Mismatched",
+                test_set_type="Single-Turn",
+                tests=[
+                    schemas.TestData(
+                        test_configuration={"goal": "multi turn"},
+                        requirement="Security",
+                        category="Injection",
+                        topic="Prompt Injection",
+                    )
+                ],
+            )
+
+    def test_mixed_payload_rejected_with_split_guidance(self):
+        with pytest.raises(ValidationError, match="mixed turn types"):
+            schemas.TestSetBulkCreate(
+                name="Mixed",
+                test_set_type="Multi-Turn",
+                tests=[
+                    schemas.TestData(
+                        prompt=schemas.TestPrompt(content="single turn"),
+                        requirement="Security",
+                        category="Injection",
+                        topic="Prompt Injection",
+                    ),
+                    schemas.TestData(
+                        test_configuration={"goal": "multi turn"},
+                        requirement="Security",
+                        category="Injection",
+                        topic="Prompt Injection",
+                    ),
+                ],
+            )
+
+    def test_uniform_single_turn_payload_is_accepted(self):
+        payload = schemas.TestSetBulkCreate(
+            name="Single",
+            test_set_type="Single-Turn",
+            tests=[
+                schemas.TestData(
+                    prompt=schemas.TestPrompt(content="single turn"),
+                    requirement="Security",
+                    category="Injection",
+                    topic="Prompt Injection",
+                )
+            ],
+        )
+        assert payload.tests[0].test_type is None
+
+    def test_uniform_multi_turn_payload_is_accepted(self):
+        payload = schemas.TestSetBulkCreate(
+            name="Multi",
+            test_set_type="Multi-Turn",
+            tests=[
+                schemas.TestData(
+                    test_configuration={"goal": "multi turn"},
+                    requirement="Security",
+                    category="Injection",
+                    topic="Prompt Injection",
+                )
+            ],
+        )
+        assert payload.tests[0].test_configuration == {"goal": "multi turn"}
+
+    def test_effective_type_precedence_is_shared(self):
+        base = {
+            "prompt": {"content": "prompt wins over parent"},
+            "test_configuration": {},
+        }
+        assert resolve_test_type(base, "Multi-Turn", "Single-Turn") == "Single-Turn"
+        assert (
+            resolve_test_type({"test_configuration": {"goal": "g"}}, "Single-Turn", "Multi-Turn")
+            == "Multi-Turn"
+        )
+        assert (
+            resolve_test_type(
+                {"test_type": "Single-Turn", "test_configuration": {"goal": "g"}},
+                "Multi-Turn",
+                "Multi-Turn",
+            )
+            == "Single-Turn"
+        )
+        assert resolve_test_type({}, "Multi-Turn", "Single-Turn") == "Multi-Turn"
+        assert resolve_test_type({}, None, None) == "Single-Turn"
 
 
 @pytest.mark.unit

--- a/tests/backend/services/test_test_set.py
+++ b/tests/backend/services/test_test_set.py
@@ -14,7 +14,11 @@ from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
-from rhesis.backend.app.constants import EXPLORER_REQUIREMENT_NAME
+from rhesis.backend.app.constants import (
+    EXPLORER_REQUIREMENT_NAME,
+    TestSetType,
+    TestType,
+)
 from rhesis.backend.app.schemas.validators import resolve_test_type
 from rhesis.backend.app.services import test_set as test_set_service
 
@@ -698,6 +702,29 @@ class TestBulkCreateEnforcesUniformTestType:
                     ),
                 ],
             )
+
+    def test_enum_typed_inputs_resolve_to_plain_strings(self):
+        """Enum instances (pydantic-coerced) must resolve to plain strings."""
+        payload = schemas.TestSetBulkCreate(
+            name="Enum",
+            test_set_type=TestSetType.SINGLE_TURN,
+            tests=[
+                schemas.TestData(
+                    prompt=schemas.TestPrompt(content="single turn"),
+                    test_type=TestType.SINGLE_TURN,
+                    requirement="Security",
+                    category="Injection",
+                    topic="Prompt Injection",
+                )
+            ],
+        )
+        effective_type = resolve_test_type(
+            payload.tests[0].model_dump(exclude_none=True),
+            test_set_type=TestSetType.get_value(payload.test_set_type),
+            default_test_type=TestSetType.get_value(payload.test_set_type),
+        )
+        assert effective_type == "Single-Turn"
+        assert type(effective_type) is str
 
     def test_uniform_single_turn_payload_is_accepted(self):
         payload = schemas.TestSetBulkCreate(

--- a/tests/sdk/entities/test_test_set.py
+++ b/tests/sdk/entities/test_test_set.py
@@ -648,6 +648,67 @@ class TestInferTestSetType:
         assert TestSet._infer_test_set_type([]) == TestType.SINGLE_TURN
 
 
+class TestImportInfersTypeFromGoal:
+    """Imports must not silently label goal-bearing tests as Single-Turn."""
+
+    def test_from_json_nested_goal_without_test_type(self):
+        json_content = [
+            {
+                "category": "Conversation",
+                "requirement": "Memory",
+                "topic": "Context",
+                "test_configuration": {"goal": "Keep context across turns"},
+            }
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(json_content, f)
+            temp_path = f.name
+        try:
+            test_set = TestSet.from_json(temp_path, name="Nested goal")
+            assert test_set.tests[0].test_type == TestType.MULTI_TURN
+            assert test_set.test_set_type == TestType.MULTI_TURN
+        finally:
+            os.unlink(temp_path)
+
+    def test_from_json_flat_goal_without_test_type(self):
+        json_content = [
+            {
+                "category": "Conversation",
+                "requirement": "Memory",
+                "topic": "Context",
+                "goal": "Keep context across turns",
+            }
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(json_content, f)
+            temp_path = f.name
+        try:
+            test_set = TestSet.from_json(temp_path, name="Flat goal")
+            assert test_set.tests[0].test_type == TestType.MULTI_TURN
+            assert test_set.test_set_type == TestType.MULTI_TURN
+        finally:
+            os.unlink(temp_path)
+
+    def test_prompt_without_test_type_stays_single_turn(self):
+        json_content = [
+            {
+                "category": "Security",
+                "requirement": "Compliance",
+                "topic": "Auth",
+                "prompt": {"content": "What is your password?"},
+            }
+        ]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(json_content, f)
+            temp_path = f.name
+        try:
+            test_set = TestSet.from_json(temp_path, name="Prompt default")
+            assert test_set.tests[0].test_type == TestType.SINGLE_TURN
+            assert test_set.test_set_type == TestType.SINGLE_TURN
+        finally:
+            os.unlink(temp_path)
+
+
 # --- Round-trip tests ---
 
 

--- a/tests/sdk/entities/test_test_set.py
+++ b/tests/sdk/entities/test_test_set.py
@@ -610,6 +610,44 @@ class TestFromJson:
             os.unlink(temp_path)
 
 
+class TestInferTestSetType:
+    """A test set must be uniformly Single-Turn or Multi-Turn."""
+
+    def test_all_single_turn(self):
+        tests = [
+            Test(category="c", requirement="r", test_type=TestType.SINGLE_TURN),
+            Test(category="c2", requirement="r2", test_type=TestType.SINGLE_TURN),
+        ]
+        assert TestSet._infer_test_set_type(tests) == TestType.SINGLE_TURN
+
+    def test_all_multi_turn(self):
+        tests = [
+            Test(
+                category="c",
+                requirement="r",
+                test_type=TestType.MULTI_TURN,
+                test_configuration=TestConfiguration(goal="g"),
+            )
+        ]
+        assert TestSet._infer_test_set_type(tests) == TestType.MULTI_TURN
+
+    def test_mixed_turns_raise(self):
+        tests = [
+            Test(category="c", requirement="r", test_type=TestType.SINGLE_TURN),
+            Test(
+                category="c2",
+                requirement="r2",
+                test_type=TestType.MULTI_TURN,
+                test_configuration=TestConfiguration(goal="g"),
+            ),
+        ]
+        with pytest.raises(ValueError, match="mixed test types"):
+            TestSet._infer_test_set_type(tests)
+
+    def test_empty_defaults_to_single_turn(self):
+        assert TestSet._infer_test_set_type([]) == TestType.SINGLE_TURN
+
+
 # --- Round-trip tests ---
 
 


### PR DESCRIPTION
## Root Cause

A test set carries `test_set_type`, while each test resolves its own `test_type` independently. `bulk_create_tests` and `TestSetBulkCreate` each had their own precedence logic (or none), so a Multi-Turn set could persist prompt-only Single-Turn tests, and vice versa. Preflight reasons from the set type while execution reasons from the test type; a mismatch makes preflight validate the wrong execution mode.

## Fix

- Add one shared `resolve_test_type` helper (explicit test_type -> test_configuration.goal -> prompt -> parent set type -> platform default).
- `TestSetBulkCreate` validates every test against the declared `test_set_type` and rejects mismatches with an index/type/fix message; mixed payloads get explicit split guidance.
- `bulk_create_tests` uses the same helper, and when `test_set_id` is supplied the persisted target set type is authoritative (over any caller fallback) and is enforced per test, so direct writers (router bulk, Garak import/sync, task path) cannot bypass the schema validator.
- SDK `TestSet._infer_test_set_type` fails early on a mixed collection, and `_dict_to_test` infers Multi-Turn from a goal-bearing entry when no explicit `test_type` is present (previously such imports were silently labelled Single-Turn).

Legacy rows are intentionally not backfilled in this PR: they keep working until touched, and the new guard only applies to new writes.

## Test

- Backend schema: mismatch prompt-only under Multi-Turn, mismatch goal-only under Single-Turn, mixed payload split error, uniform Single/Multi accepted, precedence matrix.
- Backend service: direct bulk creation against a Multi-Turn target with a prompt-only test raises before any write.
- SDK: mixed `_infer_test_set_type` raises; uniform Single/Multi/empty accepted.
- Local evidence: SDK `tests/sdk/entities/test_test_set.py` 62 passed; backend schema suite via temporary pytest 5 passed (repo conftest needs testcontainers in CI).

## Diff scope

- `apps/backend/src/rhesis/backend/app/schemas/validators.py`
- `apps/backend/src/rhesis/backend/app/schemas/test_set.py`
- `apps/backend/src/rhesis/backend/app/services/test.py`
- `tests/backend/services/test_test_set.py`
- `sdk/src/rhesis/sdk/entities/test_set.py`
- `tests/sdk/entities/test_test_set.py`

Ready branch: `fix/validate-test-set-type-consistency` (`e95ac6ee7`, `0a05ae140`, `9d9fb7522`, `fb7687ba9`, `f383bad94`, `eb6b4c7fa`).
