### PR TITLE
fix(frontend): refresh endpoints grid after save

### DIFF
--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/__tests__/useEndpointDetail.test.tsx
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/__tests__/useEndpointDetail.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useEndpointDetail } from '../useEndpointDetail';
+import { endpointKeys } from '@/constants/query-keys';
+import type { Endpoint } from '@/utils/api-client/interfaces/endpoint';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({
+    data: { session_token: 'tok', user: { id: 'u1', name: 'Alice' } },
+    status: 'authenticated',
+  }),
+}));
+
+jest.mock('@/components/common/NotificationContext', () => ({
+  useNotifications: () => ({ show: jest.fn(), close: jest.fn() }),
+}));
+
+jest.mock('@/components/common/Can', () => ({
+  useCan: () => true,
+  useCanWithStatus: () => ({ allowed: true, loading: false }),
+  Can: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  can: () => true,
+}));
+
+const mockUpdateEndpoint = jest.fn();
+const mockCreateEndpoint = jest.fn();
+
+jest.mock('@/actions/endpoints', () => ({
+  updateEndpoint: (...args: unknown[]) => mockUpdateEndpoint(...args),
+  createEndpoint: (...args: unknown[]) => mockCreateEndpoint(...args),
+}));
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getProjectsClient: () => ({ getProjects: jest.fn().mockResolvedValue([]) }),
+  })),
+}));
+
+const initialEndpoint: Endpoint = {
+  id: 'b6e8f1a2-3c4d-4e5f-8a9b-0c1d2e3f4a5b',
+  name: 'Test Endpoint',
+  connection_type: 'REST',
+  environment: 'development',
+  config_source: 'manual',
+  response_format: 'json',
+  status: {
+    id: 'b6e8f1a2-3c4d-4e5f-8a9b-0c1d2e3f4a5c',
+    name: 'Active',
+    entity_type: 'endpoint',
+  },
+};
+
+const wrapper = (queryClient: QueryClient) =>
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+
+describe('useEndpointDetail', () => {
+  it('invalidates endpoint queries after a successful save', async () => {
+    mockUpdateEndpoint.mockResolvedValue({
+      success: true,
+      data: initialEndpoint,
+    });
+    const queryClient = new QueryClient();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useEndpointDetail(initialEndpoint), {
+      wrapper: wrapper(queryClient),
+    });
+
+    await result.current.saveFields({ name: 'Renamed Endpoint' });
+
+    await waitFor(() =>
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: endpointKeys.all(),
+      })
+    );
+  });
+
+  it('keeps the just-saved change in the detail cache', async () => {
+    mockUpdateEndpoint.mockResolvedValue({
+      success: true,
+      data: initialEndpoint,
+    });
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(
+      endpointKeys.detail(initialEndpoint.id),
+      initialEndpoint
+    );
+
+    const { result } = renderHook(() => useEndpointDetail(initialEndpoint), {
+      wrapper: wrapper(queryClient),
+    });
+
+    await result.current.saveFields({ name: 'Renamed Endpoint' });
+
+    const cached = queryClient.getQueryData<Endpoint>(
+      endpointKeys.detail(initialEndpoint.id)
+    );
+    expect(cached?.name).toBe('Renamed Endpoint');
+  });
+});

--- a/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/useEndpointDetail.ts
+++ b/apps/frontend/src/app/(protected)/endpoints/[identifier]/components/useEndpointDetail.ts
@@ -102,6 +102,10 @@ export function useEndpointDetail(initialEndpoint: Endpoint) {
           endpointKeys.detail(endpoint.id),
           prev => (prev ? applyUpdate(prev) : prev)
         );
+        // Refetch the endpoints list (and any other endpoint consumers) so a
+        // change like Active -> Inactive shows up in the grid immediately,
+        // instead of waiting out the list query's staleTime.
+        void queryClient.invalidateQueries({ queryKey: endpointKeys.all() });
         notifications.show('Endpoint updated successfully', {
           severity: 'success',
         });


### PR DESCRIPTION
## Root Cause

Saving an endpoint (e.g. setting its status to Inactive) updated the endpoint's detail cache but never invalidated the endpoints **list** query. The grid query has a 5-minute `staleTime`, so returning to the grid kept showing the old Active badge until the cache went stale on its own.

## Fix

`saveFields` in `useEndpointDetail` now invalidates `endpointKeys.all()` after a successful save, so both the endpoints grid and the detail page refetch and reflect the persisted status immediately.

## Test

- New `useEndpointDetail.test.tsx` (2 cases):
  - a successful save calls `invalidateQueries({ queryKey: endpointKeys.all() })`
  - the just-saved change is still applied to the detail cache optimistically
- Pre-fix FAIL → post-fix PASS verified (invalidation case fails on `main`).
- Full `src/app/(protected)/endpoints` suite: 11 suites / 59 tests pass. `tsc --noEmit`, ESLint, Prettier clean.

## About the second symptom in #2396 (detail page unreachable)

I traced every code path a deactivated endpoint's detail page goes through on current `main` (backend `GET /endpoints/{id}` via `crud.get_endpoint`/`get_item_detail` — no status filter, no soft-delete on deactivation; frontend `useEndpoint`/`EndpointsClient.getEndpoint` and both detail pages — no status gate, row click link is `id`-based). There is no code that blocks an inactive endpoint's detail page today, so that half of the report appears to have been fixed since v0.12.0, or was a side effect of the stale grid data. The cache-invalidation fix here covers the remaining reproducible symptom.

## Diff Scope

- `apps/frontend/src/app/(protected)/endpoints/[identifier]/components/useEndpointDetail.ts` (4 lines)
- `.../components/__tests__/useEndpointDetail.test.tsx` (new)