### PR TITLE
feat: enforce usage quotas across execute, generate, and hosted-model paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ celery_worker.log
 
 # Environments
 .env
+tier_config_dev.yaml
 .venv
 env/
 venv/

--- a/apps/backend/src/rhesis/backend/app/auth/quota_gates.py
+++ b/apps/backend/src/rhesis/backend/app/auth/quota_gates.py
@@ -1,0 +1,84 @@
+"""FastAPI dependency for quota enforcement.
+
+Thin adapter that routes request-scoped quota checks through
+:func:`~rhesis.backend.app.quota.enforcement.enforce_quota`.
+
+Where ``require_feature`` returns 404 to avoid enumerating unlicensed
+features, :func:`require_quota` lets
+:class:`~rhesis.backend.app.quota.enforcement.QuotaExceededError`
+propagate -- the global handler registered in ``main.py`` turns it into
+402. Enforcement is not a secret to hide; the client needs the resource,
+used and limit to render a sensible message, which 404 cannot carry.
+
+Deliberately does **not** mirror ``feature_gates.py``'s plain-session
+``_load_org`` + ``get_db_session`` pattern, even though that is the
+sibling gate's shape. ``usage`` (the table :func:`check_quota` reads for
+flow resources) carries a ``FORCE``'d RLS policy -- unlike ``organization``,
+which is merely RLS-*enabled*, so the app's own DB role is exempt from its
+policy and a GUC-less session still reads it fine. ``FORCE`` removes that
+owner exemption, so a session with no tenant GUCs bound would have failed
+the query outright, or read every org's usage as zero depending on how the
+driver surfaces the cast error -- either way, quota enforcement would
+never have actually blocked anyone.
+:func:`~rhesis.backend.app.dependencies.get_current_organization` already
+composes :func:`~rhesis.backend.app.dependencies.get_tenant_db_session`,
+which sets those GUCs, and is the primitive ``routers/usage.py`` /
+``routers/features.py`` already use to feed ``QuotaRegistry`` lookups --
+so this reuses it rather than re-deriving a narrower, RLS-unsafe version
+of the same thing.
+"""
+
+from __future__ import annotations
+
+from fastapi import Depends, Response
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.dependencies import get_current_organization, get_tenant_db_session
+from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.quota import QuotaResource, QuotaResourceLike
+from rhesis.backend.app.quota.enforcement import enforce_quota
+
+#: Set on the response when a SOFT-policy org is past its limit but still
+#: inside the grace band -- allowed, but worth surfacing before the request
+#: that finally crosses the ceiling gets blocked with no warning.
+QUOTA_WARNING_HEADER = "X-Quota-Warning"
+
+
+def require_quota(resource: QuotaResourceLike):
+    """Dependency factory: enforce *resource*'s quota for the current org.
+
+    Raises :class:`~rhesis.backend.app.quota.enforcement.QuotaExceededError`
+    when the org has reached its enforceable ceiling for *resource*; the
+    global handler in ``main.py`` turns that into HTTP 402. Returns the
+    :class:`Organization` on success so route handlers can use it directly,
+    the same contract as ``require_feature``.
+
+    ``db`` is requested via :func:`~rhesis.backend.app.dependencies.get_tenant_db_session`
+    alongside ``org`` via :func:`~rhesis.backend.app.dependencies.get_current_organization`
+    (which itself depends on the same callable). FastAPI caches a dependency
+    per callable per request, so both resolve to the *same* tenant-scoped
+    session -- required, not cosmetic, since :func:`check_quota` reads a
+    FORCE-RLS'd table (see the module docstring).
+
+    When the org is on a ``SOFT`` policy and past the advertised limit but
+    still inside the grace band, the request is allowed but the response
+    carries a :data:`QUOTA_WARNING_HEADER` header -- the caller is not
+    blocked yet, but the next request past the ceiling will be.
+    """
+    resource = resource if isinstance(resource, QuotaResource) else QuotaResource(resource)
+
+    def _dep(
+        response: Response,
+        org: Organization = Depends(get_current_organization),
+        db: Session = Depends(get_tenant_db_session),
+    ) -> Organization:
+        verdict = enforce_quota(db, str(org.id), org, resource)
+        if verdict.over_limit:
+            warning = f"{resource.value}={verdict.used}/{verdict.limit}"
+            response.headers[QUOTA_WARNING_HEADER] = warning
+        return org
+
+    return _dep
+
+
+__all__ = ["QUOTA_WARNING_HEADER", "require_quota"]

--- a/apps/backend/src/rhesis/backend/app/auth/rbac.py
+++ b/apps/backend/src/rhesis/backend/app/auth/rbac.py
@@ -167,12 +167,20 @@ def rbac_active_for(organization_id: Optional[UUID], db: Session) -> bool:
 # normally allow any project member — but membership management is sensitive
 # enough that we restrict it to org owners (and, in EE Phase 2, project admins
 # via role_id).  This matches the plan §1.5 "org Owner/project admin" ceiling.
+#
+# Usage.READ is deliberately NOT here, despite reading as "billing" at first
+# glance.  ``GET /usage`` carries consumption against plan limits — counters
+# and caps, no money: no price, invoice, payment method or spend figure.  It
+# is operational data that tells a member whether their next action will be
+# allowed, and quota enforcement blocks *members*, so hiding the reason from
+# them only turns a clear 402 into a support ticket.  The plan limits it
+# reports are already readable by any member via ungated ``GET /features``,
+# and most of the "used" figures are just counts of rows they can already
+# list.  When a real billing surface lands (spend, invoices, payment method,
+# upgrades) that gets its own permission, and *that* one is owner-only.
 _OWNER_ONLY_CAPABILITIES: frozenset[str] = frozenset(
     {
         str(Permission.Organization.UPDATE),
-        # Billing data: org totals against plan limits. Community has no
-        # Admin role, so the owner is the only "admin" to scope this to.
-        str(Permission.Usage.READ),
         str(Permission.Member.MANAGE),
         str(Permission.ProjectMember.MANAGE),
         str(Permission.Role.MANAGE),

--- a/apps/backend/src/rhesis/backend/app/main.py
+++ b/apps/backend/src/rhesis/backend/app/main.py
@@ -43,6 +43,7 @@ from rhesis.backend.app.error_handlers import (
     create_validation_error_response,
     log_validation_error,
 )
+from rhesis.backend.app.quota.enforcement import QuotaExceededError, quota_exceeded_response_body
 from rhesis.backend.app.routers import routers
 from rhesis.backend.app.utils.database_exceptions import ItemDeletedException, ItemNotFoundException
 from rhesis.backend.app.utils.git_utils import get_version_info
@@ -643,6 +644,32 @@ async def not_found_item_exception_handler(request: Request, exc: ItemNotFoundEx
     }
 
     return JSONResponse(status_code=404, content=response_content)
+
+
+# Global exception handler for quota-exceeded errors
+@app.exception_handler(QuotaExceededError)
+async def quota_exceeded_exception_handler(request: Request, exc: QuotaExceededError):
+    """Handle quota-exceeded errors with HTTP 402 Payment Required.
+
+    402, not 401/403/429: 401 and 403 clear the frontend session, which a
+    quota cap should not do, and 429 means rate limiting, not "you've used
+    up what your plan allows."
+
+    Raised from two places that share this one shape: the ``require_quota``
+    route dependency (``auth/quota_gates.py``), and the hosted-model token
+    gate (``utils/user_model_utils.py``), which can also fire deep inside a
+    request with no dependency involved -- Starlette's exception-handling
+    middleware catches both the same way, since it wraps the whole request,
+    not just route dependencies.
+
+    Does NOT catch every raise site, though: a route wrapped by a decorator
+    that swallows bare ``Exception`` before it reaches this middleware (e.g.
+    ``@handle_database_exceptions``) never gets here. ``routers/user.py``'s
+    ``create_user`` is one such case and builds this same response body
+    itself via :func:`~rhesis.backend.app.quota.enforcement.quota_exceeded_response_body`
+    rather than relying on this handler.
+    """
+    return JSONResponse(status_code=402, content=quota_exceeded_response_body(exc.verdict))
 
 
 # Global exception handler for request validation errors (422)

--- a/apps/backend/src/rhesis/backend/app/quota/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/quota/__init__.py
@@ -11,10 +11,18 @@ resource identifiers.  Add new members here when adding a new metered
 resource.  Because ``QuotaResource`` inherits from ``str``, members
 serialize transparently to JSON and compare equal to their raw string
 values (``QuotaResource.TEST_EXECUTIONS == "test_executions"``).
+
+Actual enforcement (blocking a request once a limit is reached) lives in
+:mod:`rhesis.backend.app.quota.enforcement`, not here -- this module only
+resolves *what the limits and overage policy are*, not what to do about
+them. Keeping that split means the token-usage gate in
+``user_model_utils.py`` and the HTTP gate in ``auth/quota_gates.py`` share
+one blocking rule instead of each re-deriving it.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Optional, Protocol, Union
 
@@ -48,6 +56,26 @@ class QuotaResource(str, Enum):
 QuotaResourceLike = Union[QuotaResource, str]
 
 
+class OveragePolicy(str, Enum):
+    """What happens when an organization reaches a limit.
+
+    ``HARD`` blocks at the limit. ``SOFT`` allows a configurable grace band
+    past it (see :attr:`QuotaPolicy.overage_tolerance_percent`) and only
+    blocks once that is exhausted, so a paying customer is warned before
+    being cut off mid-work rather than after.
+
+    Replaces the bare ``"hard"``/``"soft"`` strings previously carried on
+    ``TierSpec`` and in the tier YAML, keeping resource *and* policy
+    identifiers typed for the same reason (see :class:`QuotaResource`).
+    """
+
+    def __str__(self) -> str:
+        return self.value
+
+    HARD = "hard"
+    SOFT = "soft"
+
+
 # Free-tier defaults applied when no EE quota provider is installed, and the
 # safety-net catalog EE falls back to if its tier config YAML is missing or
 # malformed. Exported (not underscore-prefixed) so both consumers -- and a
@@ -64,6 +92,45 @@ FREE_TIER_LIMITS: dict[QuotaResource, int | None] = {
 }
 
 
+@dataclass(frozen=True)
+class QuotaPolicy:
+    """An organization's resolved limits plus what to do when they are hit.
+
+    :param limits: per-resource caps; ``None`` means unlimited.
+    :param overage: whether reaching a limit blocks immediately
+        (:attr:`OveragePolicy.HARD`) or allows a grace band
+        (:attr:`OveragePolicy.SOFT`).
+    :param overage_tolerance_percent: how far past a limit a ``SOFT`` tier
+        may run before it hard-blocks, as a whole percent. ``0`` means no
+        grace, which makes ``SOFT`` behave identically to ``HARD``.
+
+    A percent rather than a float multiplier so the tier YAML reads as
+    ``overage_tolerance_percent: 25`` instead of ``1.25``, and so
+    :meth:`ceiling_for` stays integer arithmetic -- ``used`` is an integer
+    count and comparing it against a float ceiling invites the usual
+    floating-point boundary surprises at exactly the value that decides
+    whether a customer is blocked.
+    """
+
+    limits: dict[QuotaResource, int | None] = field(default_factory=dict)
+    overage: OveragePolicy = OveragePolicy.HARD
+    overage_tolerance_percent: int = 0
+
+    def ceiling_for(self, limit: Optional[int]) -> Optional[int]:
+        """Return the value of ``used`` at which *limit* actually blocks.
+
+        ``None`` (unlimited) passes straight through. For ``HARD`` -- and
+        for ``SOFT`` with zero tolerance -- the ceiling is the limit itself,
+        so both policies fall out of one expression with no branch at the
+        call site.
+        """
+        if limit is None:
+            return None
+        if self.overage is not OveragePolicy.SOFT:
+            return limit
+        return limit * (100 + self.overage_tolerance_percent) // 100
+
+
 def limits_to_wire(limits: dict[QuotaResource, int | None]) -> dict[str, int | None]:
     """Convert a ``QuotaResource``-keyed limits dict to string keys for the wire.
 
@@ -75,36 +142,43 @@ def limits_to_wire(limits: dict[QuotaResource, int | None]) -> dict[str, int | N
 
 
 class QuotaProvider(Protocol):
-    """Pluggable limit resolver.
+    """Pluggable limit and overage-policy resolver.
 
-    Implementations decide what numeric limits apply to a given
-    organization for each metered resource.  Only one implementation is
-    active per process, installed via
-    :meth:`QuotaRegistry.set_quota_provider`.
+    Implementations decide what limits and overage policy apply to a given
+    organization. Only one implementation is active per process, installed
+    via :meth:`QuotaRegistry.set_quota_provider`.
+
+    Deliberately a single method. An earlier version of this protocol also
+    required ``get_limits()``, which meant every implementation carried two
+    overlapping methods that had to agree with each other. ``QuotaPolicy``
+    already carries ``limits``, so :meth:`QuotaRegistry.get_limits` derives
+    from :meth:`QuotaRegistry.get_policy` instead of asking providers for it
+    a second way.
     """
 
-    def get_limits(self, org: Optional[Organization] = None) -> dict[QuotaResource, int | None]: ...
+    def get_policy(self, org: Optional[Organization] = None) -> QuotaPolicy: ...
 
 
 class DefaultQuotaProvider:
-    """Returns hardcoded free-tier limits for every org.
+    """Returns hardcoded free-tier limits and hard enforcement for every org.
 
     Active when the EE package is not installed or no license is
     configured.  In production,
     :class:`~rhesis.backend.ee.licensing.quota_provider.ConfigQuotaProvider`
-    replaces this and resolves limits from the tier YAML config.
+    replaces this and resolves the policy from the tier YAML config.
     """
 
-    def get_limits(self, org: Optional[Organization] = None) -> dict[QuotaResource, int | None]:
-        return dict(FREE_TIER_LIMITS)
+    def get_policy(self, org: Optional[Organization] = None) -> QuotaPolicy:
+        return QuotaPolicy(limits=dict(FREE_TIER_LIMITS))
 
 
 class QuotaRegistry:
-    """Singleton registry for quota limits.
+    """Singleton registry for quota policy.
 
-    Holds the installed :class:`QuotaProvider`.  Callers query limits
-    via :meth:`get_limit` / :meth:`get_limits`; the provider decides
-    how to resolve them (hardcoded defaults vs. YAML config vs. DB).
+    Holds the installed :class:`QuotaProvider`.  Callers query the policy
+    via :meth:`get_policy`, or just the limits via :meth:`get_limit` /
+    :meth:`get_limits`; the provider decides how to resolve them (hardcoded
+    defaults vs. YAML config vs. DB).
     """
 
     _provider: QuotaProvider = DefaultQuotaProvider()
@@ -129,9 +203,19 @@ class QuotaRegistry:
         return QuotaResource(resource)
 
     @classmethod
+    def get_policy(cls, org: Optional[Organization] = None) -> QuotaPolicy:
+        """Return the resolved limits and overage policy for *org*."""
+        return cls._provider.get_policy(org)
+
+    @classmethod
     def get_limits(cls, org: Optional[Organization] = None) -> dict[QuotaResource, int | None]:
-        """Return all resource limits for *org*."""
-        return cls._provider.get_limits(org)
+        """Return all resource limits for *org*.
+
+        A thin wrapper over :meth:`get_policy` -- kept as its own method
+        because ``services/usage.py`` and ``routers/features.py`` only ever
+        need the limits, not the overage policy, and predate that field.
+        """
+        return cls.get_policy(org).limits
 
     @classmethod
     def get_limit(
@@ -155,6 +239,8 @@ class QuotaRegistry:
 __all__ = [
     "DefaultQuotaProvider",
     "FREE_TIER_LIMITS",
+    "OveragePolicy",
+    "QuotaPolicy",
     "QuotaProvider",
     "QuotaRegistry",
     "QuotaResource",

--- a/apps/backend/src/rhesis/backend/app/quota/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/quota/__init__.py
@@ -123,6 +123,14 @@ class QuotaPolicy:
         for ``SOFT`` with zero tolerance -- the ceiling is the limit itself,
         so both policies fall out of one expression with no branch at the
         call site.
+
+        The integer division floors, so a ``SOFT`` limit small enough that
+        the tolerance is worth less than one unit gets no grace band at all
+        (25% of 3 floors to 0, giving ``ceiling == limit``). That is correct
+        -- a fractional unit of quota is not a thing -- but it does mean a
+        tier's advertised tolerance quietly stops applying below
+        ``100 / tolerance_percent``. Real paid limits are far above that;
+        it mostly bites when writing deliberately tiny limits for testing.
         """
         if limit is None:
             return None

--- a/apps/backend/src/rhesis/backend/app/quota/enforcement.py
+++ b/apps/backend/src/rhesis/backend/app/quota/enforcement.py
@@ -87,12 +87,14 @@ def quota_exceeded_response_body(verdict: QuotaVerdict) -> dict:
     propagate there (see the note on :class:`QuotaExceededError`).
     """
     resource_display = verdict.resource.value.replace("_", " ")
+    is_stock = verdict.resource in _STOCK_COUNTERS
+    suffix = "" if is_stock else " for this period"
     return {
         "error": "quota_exceeded",
         "resource": verdict.resource.value,
         "used": verdict.used,
         "limit": verdict.limit,
-        "message": f"You've reached your {resource_display} limit for this billing period.",
+        "message": f"You've reached your {resource_display} limit{suffix}.",
     }
 
 
@@ -110,6 +112,7 @@ def _read_usage(db: Session, org_id: str, resource: QuotaResource) -> int:
         return counter(db, org_id)
 
     period_start, _period_end = _current_period()
+    # Explicit org_id filter; bypass the ORM auto-filter which may carry a different tenant.
     with bypass_tenant_filter():
         used = (
             db.query(Usage.used)

--- a/apps/backend/src/rhesis/backend/app/quota/enforcement.py
+++ b/apps/backend/src/rhesis/backend/app/quota/enforcement.py
@@ -1,0 +1,195 @@
+"""The single blocking rule quota enforcement uses, wherever it fires.
+
+:func:`check_quota` reads exactly one resource's usage against its policy
+and returns a verdict; it never raises. :func:`enforce_quota` wraps it and
+raises :class:`QuotaExceededError` when blocked -- the one call both
+``auth/quota_gates.py`` (the HTTP dependency) and
+``utils/user_model_utils.py`` (the pre-call token gate) use, so a request
+blocked at a route and a model resolution blocked inside a Celery task
+hit identical logic and produce an identical error shape (see
+``error_handlers.py``, which maps :class:`QuotaExceededError` to the 402
+response both paths share).
+
+Deliberately not :func:`~rhesis.backend.app.services.usage.get_usage_summary`:
+that computes every :class:`QuotaResource`, including three ``COUNT(*)``
+queries for stock resources a given check does not care about. A gate that
+runs on every execute/generate request, and on every hosted-model call,
+should not pay for six resources to answer a question about one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.models.usage import Usage
+from rhesis.backend.app.quota import QuotaPolicy, QuotaRegistry, QuotaResource
+from rhesis.backend.app.scope import bypass_tenant_filter
+from rhesis.backend.app.services.usage import _STOCK_COUNTERS, _current_period
+
+
+@dataclass(frozen=True)
+class QuotaVerdict:
+    """The outcome of checking one org's usage of one resource.
+
+    :param resource: the resource that was checked.
+    :param used: current usage (a live count for stock resources, the
+        current billing period's accrued total for flow resources).
+    :param limit: the tier's cap for this resource, or ``None`` if unlimited.
+    :param policy: the policy the verdict was computed under, so a caller
+        can render e.g. "warns at 100,000, blocks at 125,000" without a
+        second lookup.
+    :param allowed: whether the request may proceed.
+    :param over_limit: whether *used* has reached *limit*, independent of
+        *allowed*. ``over_limit and allowed`` is exactly the soft-overage
+        grace band: past the advertised limit but not yet at the hard
+        ceiling. ``over_limit`` is always ``False`` when *limit* is ``None``.
+    """
+
+    resource: QuotaResource
+    used: int
+    limit: Optional[int]
+    policy: QuotaPolicy
+    allowed: bool
+    over_limit: bool
+
+
+class QuotaExceededError(Exception):
+    """*resource* is at or past its enforceable ceiling; the request is blocked.
+
+    A domain exception, not an ``HTTPException``: the token gate in
+    ``user_model_utils.py`` can run inside a Celery task (metric evaluation
+    resolves models there), where there is no HTTP response to raise into.
+    Both that gate and the HTTP dependency in ``auth/quota_gates.py`` raise
+    this and let it propagate; the global handler registered in ``main.py``
+    is what turns it into a 402 when it reaches a request, and the Celery
+    task boundary is what turns it into a failed task when it doesn't.
+
+    A caller wrapped by a decorator that catches bare ``Exception`` before
+    it reaches that global handler (``@handle_database_exceptions``, at
+    least once so far -- see ``routers/user.py:create_user``) cannot rely
+    on this propagating cleanly, and must catch it and build the response
+    itself via :func:`quota_exceeded_response_body` instead.
+    """
+
+    def __init__(self, verdict: QuotaVerdict) -> None:
+        self.verdict = verdict
+        super().__init__(
+            f"Quota exceeded for {verdict.resource.value}: {verdict.used}/{verdict.limit} used"
+        )
+
+
+def quota_exceeded_response_body(verdict: QuotaVerdict) -> dict:
+    """Build the JSON body every 402 quota response shares.
+
+    Single source of truth so the shape can't drift between the global
+    ``QuotaExceededError`` handler in ``main.py`` and any call site that
+    must build the response itself instead of letting the exception
+    propagate there (see the note on :class:`QuotaExceededError`).
+    """
+    resource_display = verdict.resource.value.replace("_", " ")
+    return {
+        "error": "quota_exceeded",
+        "resource": verdict.resource.value,
+        "used": verdict.used,
+        "limit": verdict.limit,
+        "message": f"You've reached your {resource_display} limit for this billing period.",
+    }
+
+
+def _read_usage(db: Session, org_id: str, resource: QuotaResource) -> int:
+    """Read current usage for exactly one resource.
+
+    Stock resources (seats, projects, endpoints) are a live ``COUNT(*)`` via
+    the same ``_STOCK_COUNTERS`` map ``get_usage_summary`` uses. Flow
+    resources are a single targeted row lookup for the current billing
+    period, not the batch-all-resources query ``get_usage_summary`` runs --
+    a quota check only ever needs one number.
+    """
+    counter = _STOCK_COUNTERS.get(resource)
+    if counter is not None:
+        return counter(db, org_id)
+
+    period_start, _period_end = _current_period()
+    with bypass_tenant_filter():
+        used = (
+            db.query(Usage.used)
+            .filter(
+                Usage.organization_id == org_id,
+                Usage.resource == resource.value,
+                Usage.period_start == period_start,
+            )
+            .scalar()
+        )
+    return used or 0
+
+
+def check_quota(
+    db: Session,
+    org_id: str,
+    org: Optional[Organization],
+    resource: QuotaResource,
+) -> QuotaVerdict:
+    """Return whether *org_id* may still consume *resource*. Never raises.
+
+    Blocking rule, with ``ceiling = policy.ceiling_for(limit)``:
+
+    - ``limit is None`` -> always allowed (unlimited).
+    - ``used < limit`` -> allowed.
+    - ``used >= limit``, policy ``HARD`` -> blocked (``ceiling == limit``
+      for ``HARD``, so this is really just ``used >= ceiling``).
+    - ``limit <= used < ceiling``, policy ``SOFT`` -> allowed, over_limit
+      (the grace band).
+    - ``used >= ceiling``, policy ``SOFT`` -> blocked.
+    """
+    policy = QuotaRegistry.get_policy(org)
+    limit = policy.limits.get(resource)
+    used = _read_usage(db, org_id, resource)
+
+    if limit is None:
+        return QuotaVerdict(
+            resource=resource, used=used, limit=None, policy=policy, allowed=True, over_limit=False
+        )
+
+    ceiling = policy.ceiling_for(limit)
+    return QuotaVerdict(
+        resource=resource,
+        used=used,
+        limit=limit,
+        policy=policy,
+        allowed=used < ceiling,
+        over_limit=used >= limit,
+    )
+
+
+def enforce_quota(
+    db: Session,
+    org_id: str,
+    org: Optional[Organization],
+    resource: QuotaResource,
+) -> QuotaVerdict:
+    """Check *resource* for *org_id* and raise if blocked.
+
+    The shared entry point for both enforcement paths -- see the module
+    docstring. Returns the verdict when allowed, so a caller in the soft
+    grace band (``verdict.over_limit``) can still act on it (a warning
+    response header, say) without a second query.
+
+    :raises QuotaExceededError: if the verdict is not allowed.
+    """
+    verdict = check_quota(db, org_id, org, resource)
+    if not verdict.allowed:
+        raise QuotaExceededError(verdict)
+    return verdict
+
+
+__all__ = [
+    "QuotaExceededError",
+    "QuotaVerdict",
+    "check_quota",
+    "enforce_quota",
+    "quota_exceeded_response_body",
+]

--- a/apps/backend/src/rhesis/backend/app/quota/enforcement.py
+++ b/apps/backend/src/rhesis/backend/app/quota/enforcement.py
@@ -26,7 +26,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.usage import Usage
-from rhesis.backend.app.quota import QuotaPolicy, QuotaRegistry, QuotaResource
+from rhesis.backend.app.quota import QuotaRegistry, QuotaResource
 from rhesis.backend.app.scope import bypass_tenant_filter
 from rhesis.backend.app.services.usage import _STOCK_COUNTERS, _current_period
 
@@ -39,9 +39,6 @@ class QuotaVerdict:
     :param used: current usage (a live count for stock resources, the
         current billing period's accrued total for flow resources).
     :param limit: the tier's cap for this resource, or ``None`` if unlimited.
-    :param policy: the policy the verdict was computed under, so a caller
-        can render e.g. "warns at 100,000, blocks at 125,000" without a
-        second lookup.
     :param allowed: whether the request may proceed.
     :param over_limit: whether *used* has reached *limit*, independent of
         *allowed*. ``over_limit and allowed`` is exactly the soft-overage
@@ -52,7 +49,6 @@ class QuotaVerdict:
     resource: QuotaResource
     used: int
     limit: Optional[int]
-    policy: QuotaPolicy
     allowed: bool
     over_limit: bool
 
@@ -151,7 +147,7 @@ def check_quota(
 
     if limit is None:
         return QuotaVerdict(
-            resource=resource, used=used, limit=None, policy=policy, allowed=True, over_limit=False
+            resource=resource, used=used, limit=None, allowed=True, over_limit=False
         )
 
     ceiling = policy.ceiling_for(limit)
@@ -159,7 +155,6 @@ def check_quota(
         resource=resource,
         used=used,
         limit=limit,
-        policy=policy,
         allowed=used < ceiling,
         over_limit=used >= limit,
     )

--- a/apps/backend/src/rhesis/backend/app/routers/endpoint.py
+++ b/apps/backend/src/rhesis/backend/app/routers/endpoint.py
@@ -9,13 +9,16 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.auth.capabilities import Permission, capability
+from rhesis.backend.app.auth.quota_gates import require_quota
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import (
     get_endpoint_service,
     get_tenant_context,
     get_tenant_db_session,
 )
+from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.endpoint import (
     AutoConfigureRequest,
@@ -55,6 +58,7 @@ def create_endpoint(
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.ENDPOINTS)),
 ):
     """Create a new endpoint.
 

--- a/apps/backend/src/rhesis/backend/app/routers/garak.py
+++ b/apps/backend/src/rhesis/backend/app/routers/garak.py
@@ -11,9 +11,12 @@ import random
 from fastapi import Depends, HTTPException
 from sqlalchemy.orm import Session
 
+from rhesis.backend.app.auth.quota_gates import require_quota
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import get_tenant_context, get_tenant_db_session
+from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.garak import (
     GarakGenerateRequest,
@@ -261,6 +264,7 @@ def import_probes(
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.TEST_GENERATION)),
 ):
     """
     Import selected Garak probes as Rhesis test sets.
@@ -358,6 +362,7 @@ def sync_test_set(
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.TEST_GENERATION)),
 ):
     """
     Sync a Garak-imported test set with the latest probes.
@@ -412,6 +417,7 @@ def generate_dynamic_probe(
     current_user: User = Depends(require_current_user_or_token),
     probe_service: GarakProbeService = Depends(get_probe_service),
     db: Session = Depends(get_tenant_db_session),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.TEST_GENERATION)),
 ):
     """
     Generate a test set from a **dynamic** Garak probe using the user's LLM.

--- a/apps/backend/src/rhesis/backend/app/routers/project.py
+++ b/apps/backend/src/rhesis/backend/app/routers/project.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import schemas
 from rhesis.backend.app.auth.capabilities import Permission, capability
+from rhesis.backend.app.auth.quota_gates import require_quota
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 
 # Imported as a module, not by name: the route handlers below are called
@@ -17,7 +18,9 @@ from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
 )
+from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.utils.database_exceptions import handle_database_exceptions
 from rhesis.backend.app.utils.odata import apply_select
@@ -40,6 +43,7 @@ def create_project(
     db: Session = Depends(get_tenant_db_session),
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.PROJECTS)),
 ):
     """Create a new project. The creating user is automatically enrolled as a member."""
     from rhesis.backend.app.services.organization import enroll_user_in_project

--- a/apps/backend/src/rhesis/backend/app/routers/test.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test.py
@@ -10,13 +10,16 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.auth.capabilities import Permission, capability
+from rhesis.backend.app.auth.quota_gates import require_quota
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.crud import file as file_crud
 from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
 )
+from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.services.test import (
     bulk_create_tests,
@@ -329,6 +332,7 @@ async def execute_test_endpoint(
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
     _validate_model=Depends(validate_execution_model),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.TEST_EXECUTIONS)),
 ):
     """
     Execute a test in-place without worker infrastructure or database persistence.

--- a/apps/backend/src/rhesis/backend/app/routers/test_configuration.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_configuration.py
@@ -8,12 +8,15 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.auth.capabilities import Permission, capability
+from rhesis.backend.app.auth.quota_gates import require_quota
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
 )
+from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.utils.database_exceptions import handle_database_exceptions
 from rhesis.backend.app.utils.decorators import with_count_header
@@ -184,6 +187,7 @@ def execute_test_configuration_endpoint(
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
     _validate_model=Depends(validate_execution_model),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.TEST_EXECUTIONS)),
 ):
     """
     Execute a test configuration by running its test set.

--- a/apps/backend/src/rhesis/backend/app/routers/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/routers/test_set.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app import crud, models, schemas
 from rhesis.backend.app.auth.capabilities import Permission, capability
+from rhesis.backend.app.auth.quota_gates import require_quota
 from rhesis.backend.app.auth.user_utils import require_current_user_or_token
 from rhesis.backend.app.crud import metric as metric_crud
 from rhesis.backend.app.dependencies import (
@@ -17,8 +18,10 @@ from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
 )
+from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.test_set import TestSet
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas import services as services_schemas
 from rhesis.backend.app.schemas.embedding import (
@@ -101,6 +104,7 @@ def generate_test_set(
     current_user: User = Depends(require_current_user_or_token),
     scoped_project_id: Optional[str] = Depends(get_project_context),
     _validate_model=Depends(validate_generation_model),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.TEST_GENERATION)),
 ):
     """
     Generate test set using ConfigSynthesizer.
@@ -269,7 +273,8 @@ def create_test_set_bulk(
     }
 
     Notes:
-    - demographic and dimension fields are accepted but ignored (dimension/demographic tables were removed)
+    - demographic and dimension fields are accepted but ignored (dimension/demographic
+      tables were removed)
     - expected_response is an optional field to specify the expected model response
     """
     try:
@@ -518,6 +523,7 @@ def execute_test_set(
     tenant_context=Depends(get_tenant_context),
     current_user: User = Depends(require_current_user_or_token),
     _validate_model=Depends(validate_execution_model),
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.TEST_EXECUTIONS)),
 ):
     """Submit a test set for execution against an endpoint.
 

--- a/apps/backend/src/rhesis/backend/app/routers/usage.py
+++ b/apps/backend/src/rhesis/backend/app/routers/usage.py
@@ -29,6 +29,11 @@ router = APIRouter(prefix="/usage", tags=["usage"])
 class UsageResourceItem(BaseModel):
     used: int
     limit: int | None
+    #: The value of ``used`` at which requests actually start failing --
+    #: ``limit`` plus the tier's overage tolerance on a SOFT policy, and
+    #: ``limit`` itself on a HARD one. Compare against this, not ``limit``,
+    #: to predict a 402; ``limit`` is what a progress bar fills toward.
+    ceiling: int | None
     period_start: str
     period_end: str
     kind: str

--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm.attributes import flag_modified
 from rhesis.backend.app import models, schemas
 from rhesis.backend.app.auth.capabilities import Permission, capability
 from rhesis.backend.app.auth.principal import resolve_principal_from_request
+from rhesis.backend.app.auth.quota_gates import require_quota
 from rhesis.backend.app.auth.rbac import authorize
 from rhesis.backend.app.auth.user_utils import (
     require_current_user_or_token,
@@ -23,11 +24,6 @@ from rhesis.backend.app.dependencies import (
 from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
 from rhesis.backend.app.quota import QuotaResource
-from rhesis.backend.app.quota.enforcement import (
-    QuotaExceededError,
-    enforce_quota,
-    quota_exceeded_response_body,
-)
 from rhesis.backend.app.routers.auth import create_session_token
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.polyphemus import (
@@ -132,34 +128,16 @@ def create_user(
     user: schemas.UserCreate,
     db: Session = Depends(get_tenant_db_session),
     current_user: User = Depends(require_current_user_or_token_without_context),
+    # Gates both inviting and re-inviting -- each consumes a seat, since
+    # count_org_seats counts every row carrying this organization_id and a
+    # re-invite reassigns one. Safe despite @handle_database_exceptions'
+    # bare `except Exception`: dependencies resolve before the route body
+    # runs, so QuotaExceededError never passes through the decorator and
+    # reaches the global 402 handler in main.py intact.
+    _quota_gate: Organization = Depends(require_quota(QuotaResource.SEATS)),
 ):
     # Set the organization_id from the current user
     user.organization_id = current_user.organization_id
-
-    # Enforce the seat limit before inviting OR re-inviting -- both consume a
-    # seat (count_org_seats counts any row with this organization_id, and a
-    # re-invite reassigns one). Skipped for an orgless caller: this endpoint
-    # uses require_current_user_or_token_without_context specifically so
-    # such a caller can still reach it, and there is no org to enforce a
-    # seat limit against. Called directly rather than via the require_quota
-    # dependency because that composes the stricter with-context auth chain
-    # (get_tenant_context raises 403 on a missing org) this endpoint
-    # deliberately opts out of.
-    #
-    # Caught and turned into a JSONResponse here, not left to propagate to
-    # the global QuotaExceededError handler in main.py: this endpoint is
-    # wrapped by @handle_database_exceptions, whose bare `except Exception`
-    # would catch it first and rewrite it into an unrelated 500. Returning a
-    # Response directly from inside the decorated function bypasses that
-    # try/except entirely, since nothing is raised through it.
-    if current_user.organization_id:
-        organization = (
-            db.query(Organization).filter(Organization.id == current_user.organization_id).first()
-        )
-        try:
-            enforce_quota(db, str(current_user.organization_id), organization, QuotaResource.SEATS)
-        except QuotaExceededError as exc:
-            return JSONResponse(status_code=402, content=quota_exceeded_response_body(exc.verdict))
 
     # Validate, normalize, and verify the email domain can receive mail
     try:

--- a/apps/backend/src/rhesis/backend/app/routers/user.py
+++ b/apps/backend/src/rhesis/backend/app/routers/user.py
@@ -20,7 +20,14 @@ from rhesis.backend.app.dependencies import (
     get_tenant_context,
     get_tenant_db_session,
 )
+from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.app.quota.enforcement import (
+    QuotaExceededError,
+    enforce_quota,
+    quota_exceeded_response_body,
+)
 from rhesis.backend.app.routers.auth import create_session_token
 from rhesis.backend.app.routers.base import RhesisRouter
 from rhesis.backend.app.schemas.polyphemus import (
@@ -128,6 +135,31 @@ def create_user(
 ):
     # Set the organization_id from the current user
     user.organization_id = current_user.organization_id
+
+    # Enforce the seat limit before inviting OR re-inviting -- both consume a
+    # seat (count_org_seats counts any row with this organization_id, and a
+    # re-invite reassigns one). Skipped for an orgless caller: this endpoint
+    # uses require_current_user_or_token_without_context specifically so
+    # such a caller can still reach it, and there is no org to enforce a
+    # seat limit against. Called directly rather than via the require_quota
+    # dependency because that composes the stricter with-context auth chain
+    # (get_tenant_context raises 403 on a missing org) this endpoint
+    # deliberately opts out of.
+    #
+    # Caught and turned into a JSONResponse here, not left to propagate to
+    # the global QuotaExceededError handler in main.py: this endpoint is
+    # wrapped by @handle_database_exceptions, whose bare `except Exception`
+    # would catch it first and rewrite it into an unrelated 500. Returning a
+    # Response directly from inside the decorated function bypasses that
+    # try/except entirely, since nothing is raised through it.
+    if current_user.organization_id:
+        organization = (
+            db.query(Organization).filter(Organization.id == current_user.organization_id).first()
+        )
+        try:
+            enforce_quota(db, str(current_user.organization_id), organization, QuotaResource.SEATS)
+        except QuotaExceededError as exc:
+            return JSONResponse(status_code=402, content=quota_exceeded_response_body(exc.verdict))
 
     # Validate, normalize, and verify the email domain can receive mail
     try:

--- a/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
+++ b/apps/backend/src/rhesis/backend/app/services/explorer/suggestions.py
@@ -57,9 +57,10 @@ def _suggestions_response_model(num_suggestions: int) -> type[BaseModel]:
     )
 
 
-def _get_generation_model(db: Session, user_id: str):
+def _get_generation_model(db: Session, user_id: str, organization_id: str):
     """Get the user's configured generation model for suggestion generation."""
     from rhesis.backend.app.config.settings import get_model_settings
+    from rhesis.backend.app.quota.enforcement import QuotaExceededError
     from rhesis.backend.app.utils.user_model_utils import (
         get_user_generation_model,
         resolve_default_hosted_model,
@@ -69,13 +70,18 @@ def _get_generation_model(db: Session, user_id: str):
         user = user_crud.get_user_by_id(db, user_id)
         if user:
             return get_user_generation_model(db, user)
+    except QuotaExceededError:
+        # Not a lookup failure -- let it propagate. The broad except below
+        # would otherwise log it as "error fetching" and fall through to a
+        # second, identical quota check a few lines down.
+        raise
     except Exception as e:
         logger.warning(f"Error fetching user generation model: {e}")
 
     # resolve_default_hosted_model, not a bare get_model(): this is the
     # system default, which runs on our credentials. May return a string on
     # construction failure; the caller unwraps that via ensure_language_model.
-    return resolve_default_hosted_model(get_model_settings().generation_model)
+    return resolve_default_hosted_model(get_model_settings().generation_model, db, organization_id)
 
 
 def _build_suggestion_prompt(
@@ -177,7 +183,7 @@ def _prepare_suggestion_context(
 
     from rhesis.backend.app.utils.user_model_utils import ensure_language_model
 
-    model = ensure_language_model(_get_generation_model(db, user_id))
+    model = ensure_language_model(_get_generation_model(db, user_id, organization_id))
     response_model = _suggestions_response_model(num_suggestions)
 
     return {

--- a/apps/backend/src/rhesis/backend/app/services/usage.py
+++ b/apps/backend/src/rhesis/backend/app/services/usage.py
@@ -225,12 +225,22 @@ def get_usage_summary(
     org: Optional[Organization],
     period_start: Optional[date] = None,
 ) -> dict:
-    """Return ``{resources: {<resource>: {used, limit, period_start, period_end, kind}}, edition}``.
+    """Return ``{resources: {<resource>: {used, limit, ceiling, period_start, period_end,
+    kind}}, edition}``.
 
     Flow resources report cumulative usage from the ``usage`` table for the
     requested billing period (the current one by default). ``kind``
     (``"flow"`` or ``"stock"``) lets the frontend group resources without
     duplicating the flow/stock split as a second, hand-maintained list.
+
+    ``limit`` is the advertised cap; ``ceiling`` is the value of ``used`` at
+    which requests actually start failing, which on a ``SOFT`` tier is
+    ``limit`` plus its overage tolerance. Both are reported because they
+    answer different questions: ``limit`` is what a progress bar fills
+    toward, ``ceiling`` is what a client must compare against to predict a
+    402. Sending only ``limit`` is what made the frontend's pre-emptive
+    execute-gating disagree with the backend, disabling the Run button for
+    a paying org that still had its whole grace band left.
 
     Pass *period_start* (first day of a month) to report a past month
     instead of the current one -- this only affects flow resources. Stock
@@ -256,7 +266,8 @@ def get_usage_summary(
         last_day = monthrange(period_start.year, period_start.month)[1]
         period_end = period_start.replace(day=last_day)
 
-    limits = QuotaRegistry.get_limits(org)
+    policy = QuotaRegistry.get_policy(org)
+    limits = policy.limits
 
     with bypass_tenant_filter():
         flow_used = {
@@ -276,9 +287,11 @@ def get_usage_summary(
         else:
             used = flow_used.get(resource.value, 0)
             item_start, item_end = period_start, period_end
+        limit = limits.get(resource)
         resources[resource.value] = {
             "used": used,
-            "limit": limits.get(resource),
+            "limit": limit,
+            "ceiling": policy.ceiling_for(limit),
             "period_start": item_start.isoformat(),
             "period_end": item_end.isoformat(),
             "kind": STOCK_KIND if counter is not None else FLOW_KIND,

--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -547,24 +547,21 @@ def _enforce_model_token_quota(db: Session, organization_id: Optional[str]) -> N
     """Enforce the MODEL_TOKENS quota for *organization_id* before a hosted
     model is constructed.
 
-    Every real call site of :func:`resolve_default_hosted_model` and
-    :func:`_fetch_and_configure_model` already has an organization id in
-    scope -- either from a resolved ``User`` or from the org-scoped
-    ``TestConfiguration``/context object driving the call -- so this is
-    required, not optional, forcing new call sites to pass one rather than
-    silently omitting it. ``organization_id`` itself stays ``Optional``
-    only as a last-resort escape hatch: if a future caller genuinely has
-    none, this skips the check and logs, rather than raising on a org-less
-    construction path we haven't seen yet.
+    Fails closed: a missing ``organization_id`` raises ``ValueError``
+    rather than silently skipping enforcement. Every real call site
+    already has an org id in scope, so a ``None`` here means a new caller
+    forgot to thread it -- failing loud surfaces the gap immediately
+    instead of granting unmetered access.
 
+    :raises ValueError: if *organization_id* is falsy.
     :raises ~rhesis.backend.app.quota.enforcement.QuotaExceededError: if
         the org has reached its enforceable ceiling for ``MODEL_TOKENS``.
     """
     if not organization_id:
-        logger.warning(
-            "No organization_id available for a hosted-model quota check; skipping enforcement."
+        raise ValueError(
+            "No organization_id available for a hosted-model quota check. "
+            "Every production call site must pass one; see the docstring."
         )
-        return
     organization = db.query(Organization).filter(Organization.id == organization_id).first()
     enforce_quota(db, str(organization_id), organization, QuotaResource.MODEL_TOKENS)
 

--- a/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/user_model_utils.py
@@ -18,7 +18,10 @@ from rhesis.backend.app.config.settings import (
 )
 from rhesis.backend.app.crud import model as model_crud
 from rhesis.backend.app.crud import user as user_crud
+from rhesis.backend.app.models.organization import Organization
 from rhesis.backend.app.models.user import User
+from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.app.quota.enforcement import enforce_quota
 from rhesis.backend.app.services.platform_key import get_platform_api_key
 from rhesis.backend.app.utils.model_errors import ModelConfigurationError
 from rhesis.backend.app.utils.usage_tracking import stamp_usage_provenance
@@ -540,7 +543,35 @@ def ensure_language_model(model_or_provider: Union[str, BaseLLM]) -> BaseLLM:
     return model_or_provider
 
 
-def resolve_default_hosted_model(default_model: str) -> Union[str, BaseLLM]:
+def _enforce_model_token_quota(db: Session, organization_id: Optional[str]) -> None:
+    """Enforce the MODEL_TOKENS quota for *organization_id* before a hosted
+    model is constructed.
+
+    Every real call site of :func:`resolve_default_hosted_model` and
+    :func:`_fetch_and_configure_model` already has an organization id in
+    scope -- either from a resolved ``User`` or from the org-scoped
+    ``TestConfiguration``/context object driving the call -- so this is
+    required, not optional, forcing new call sites to pass one rather than
+    silently omitting it. ``organization_id`` itself stays ``Optional``
+    only as a last-resort escape hatch: if a future caller genuinely has
+    none, this skips the check and logs, rather than raising on a org-less
+    construction path we haven't seen yet.
+
+    :raises ~rhesis.backend.app.quota.enforcement.QuotaExceededError: if
+        the org has reached its enforceable ceiling for ``MODEL_TOKENS``.
+    """
+    if not organization_id:
+        logger.warning(
+            "No organization_id available for a hosted-model quota check; skipping enforcement."
+        )
+        return
+    organization = db.query(Organization).filter(Organization.id == organization_id).first()
+    enforce_quota(db, str(organization_id), organization, QuotaResource.MODEL_TOKENS)
+
+
+def resolve_default_hosted_model(
+    default_model: str, db: Session, organization_id: Optional[str]
+) -> Union[str, BaseLLM]:
     """
     Instantiate the system default model, falling back to the bare string.
 
@@ -559,17 +590,33 @@ def resolve_default_hosted_model(default_model: str) -> Union[str, BaseLLM]:
     Construction is cheap (no network call -- provider `__init__`s only set
     up client config) so doing it eagerly costs nothing.
 
-    Takes no organization id: which org to bill is read from the ambient
-    context when usage is actually emitted (see
-    `rhesis.backend.app.usage_attribution`), not captured here.
+    Takes ``db``/``organization_id`` -- unlike an earlier version of this
+    function, which took neither and left MODEL_TOKENS display-only. Every
+    real caller (checked directly rather than assumed) already has an
+    organization id in scope even when it has no resolvable *user*: the
+    batch/sequential execution paths that hit this when a test config
+    carries no user still have `test_config.organization_id`. Which org to
+    *bill* still comes from the ambient context at emission time (see
+    `rhesis.backend.app.usage_attribution`) -- this is only the pre-call
+    check that a hosted call is allowed to happen at all.
 
     Args:
         default_model: A "provider/model_name" string, e.g. "rhesis/rhesis"
+        db: Database session, tenant-scoped for *organization_id* (RLS on
+            the `usage` table this indirectly reads requires it -- see
+            `auth/quota_gates.py` for the same requirement on the HTTP gate).
+        organization_id: The org to enforce the quota against.
 
     Returns:
         A model stamped `usage_metered=True` when construction succeeds; the
         original string otherwise.
+
+    Raises:
+        ~rhesis.backend.app.quota.enforcement.QuotaExceededError: if the org
+            has reached its enforceable ceiling for `MODEL_TOKENS`.
     """
+    _enforce_model_token_quota(db, organization_id)
+
     # No provider restriction: the *system default* is by definition the
     # model this deployment runs on its own credentials, whatever provider
     # it names. A deployment configured with
@@ -702,7 +749,7 @@ def _fetch_and_configure_model(
 
     if not model or not model.provider_type:
         logger.warning("Model with id=%s not found or has no provider_type", model_id)
-        return resolve_default_hosted_model(default_model)
+        return resolve_default_hosted_model(default_model, db, organization_id)
 
     # Get provider configuration
     provider = model.provider_type.type_value
@@ -713,6 +760,19 @@ def _fetch_and_configure_model(
     # reaches LiteLLM as a real key and fails auth instead of falling back.
     api_key = (model.key or "").strip() or None
     _require_own_credentials(provider, api_key, model.endpoint, model.name)
+
+    # Enforce MODEL_TOKENS once, up front, iff this call will end up billed to
+    # us. _is_hosted_model(provider, api_key) is exactly that predicate for
+    # every branch below: the two special-cased branches (rhesis / polyphemus
+    # without a stored key) only special-case providers _is_hosted_model
+    # already considers hosted, and the general path's own `metered=` kwarg
+    # a few lines down is this identical expression. Gating here rather than
+    # unconditionally at function entry is what keeps an org's own key (a
+    # non-hosted provider, or a hosted provider with its own key) from ever
+    # being blocked by *our* token quota -- their call was never going to
+    # cost us anything.
+    if _is_hosted_model(provider, api_key):
+        _enforce_model_token_quota(db, organization_id)
 
     # Special handling for Rhesis system models
     if _is_rhesis_system_model(provider, api_key):
@@ -730,7 +790,7 @@ def _fetch_and_configure_model(
         )
         if hosted is not None:
             return hosted
-        return resolve_default_hosted_model(default_model)
+        return resolve_default_hosted_model(default_model, db, organization_id)
 
     # Special handling for Polyphemus models without a stored API key.
     #
@@ -840,7 +900,12 @@ def _get_user_model(
     model_id = model_settings.model_id
 
     if not model_id:
-        return resolve_default_hosted_model(default_model)
+        # Guard, not str(user.organization_id) unconditionally: for an orgless
+        # user that produces the literal string "None", not an actual null --
+        # exactly the bug peqy flagged on #2355 for this same branch, just
+        # reintroduced by adding the org argument back for the quota check.
+        org_id = str(user.organization_id) if user.organization_id else None
+        return resolve_default_hosted_model(default_model, db, org_id)
 
     return _fetch_and_configure_model(
         db=db,

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
@@ -18,6 +18,7 @@ from rhesis.backend.app.models.test import Test
 from rhesis.backend.app.models.test_configuration import TestConfiguration
 from rhesis.backend.app.models.test_run import TestRun
 from rhesis.backend.app.models.test_set import TestSet
+from rhesis.backend.app.quota.enforcement import QuotaExceededError
 from rhesis.backend.metrics.metric_config import metric_model_to_config
 from rhesis.sdk.metrics import MetricConfig
 
@@ -201,11 +202,25 @@ def prefetch_execution_context(
                 # Penelope / the metric judge, and a model built there carries
                 # no provenance stamp. See resolve_default_hosted_model.
                 logger.warning(f"User {user_id} not found, using default models")
-                execution_model = resolve_default_hosted_model(model_settings.execution_model)
-                evaluation_model = resolve_default_hosted_model(model_settings.evaluation_model)
+                execution_model = resolve_default_hosted_model(
+                    model_settings.execution_model, session, organization_id
+                )
+                evaluation_model = resolve_default_hosted_model(
+                    model_settings.evaluation_model, session, organization_id
+                )
         else:
-            execution_model = resolve_default_hosted_model(model_settings.execution_model)
-            evaluation_model = resolve_default_hosted_model(model_settings.evaluation_model)
+            execution_model = resolve_default_hosted_model(
+                model_settings.execution_model, session, organization_id
+            )
+            evaluation_model = resolve_default_hosted_model(
+                model_settings.evaluation_model, session, organization_id
+            )
+    except QuotaExceededError:
+        # Not a resolution failure -- let it propagate as-is. The broad
+        # except below would otherwise retry the identical call against the
+        # same org and quota state, misreport it as "failed to resolve" in
+        # the log, and only raise the same error a second time anyway.
+        raise
     except Exception as e:
         from rhesis.backend.app.config.settings import get_model_settings
         from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
@@ -213,9 +228,13 @@ def prefetch_execution_context(
         logger.warning(f"Failed to resolve execution/evaluation models: {e}")
         model_settings = get_model_settings()
         if execution_model is None:
-            execution_model = resolve_default_hosted_model(model_settings.execution_model)
+            execution_model = resolve_default_hosted_model(
+                model_settings.execution_model, session, organization_id
+            )
         if evaluation_model is None:
-            evaluation_model = resolve_default_hosted_model(model_settings.evaluation_model)
+            evaluation_model = resolve_default_hosted_model(
+                model_settings.evaluation_model, session, organization_id
+            )
 
     # Warm the session identity map with prompt/requirement/requirement.metrics eager-loaded
     # for every test in the batch, in one query. get_test_and_prompt/get_test_metrics

--- a/apps/backend/src/rhesis/backend/tasks/execution/sequential.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/sequential.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from rhesis.backend.app.models.test_configuration import TestConfiguration
 from rhesis.backend.app.models.test_run import TestRun
+from rhesis.backend.app.quota.enforcement import QuotaExceededError
 from rhesis.backend.tasks.enums import ExecutionMode
 from rhesis.backend.tasks.execution.shared import (
     create_execution_result,
@@ -66,6 +67,7 @@ def execute_tests_sequentially(
         override_execution_model_id = attrs.get("execution_model_id")
         override_evaluation_model_id = attrs.get("evaluation_model_id")
         seq_user_id = str(test_config.user_id) if test_config.user_id else None
+        seq_org_id = str(test_config.organization_id) if test_config.organization_id else None
 
         if seq_user_id:
             user = user_crud.get_user_by_id(session, seq_user_id)
@@ -82,21 +84,40 @@ def execute_tests_sequentially(
                 # Penelope / the metric judge, and a model built there carries
                 # no provenance stamp. See resolve_default_hosted_model.
                 logger.warning(f"User {seq_user_id} not found, using default models")
-                execution_model = resolve_default_hosted_model(model_settings.execution_model)
-                evaluation_model = resolve_default_hosted_model(model_settings.evaluation_model)
+                execution_model = resolve_default_hosted_model(
+                    model_settings.execution_model, session, seq_org_id
+                )
+                evaluation_model = resolve_default_hosted_model(
+                    model_settings.evaluation_model, session, seq_org_id
+                )
         else:
-            execution_model = resolve_default_hosted_model(model_settings.execution_model)
-            evaluation_model = resolve_default_hosted_model(model_settings.evaluation_model)
+            execution_model = resolve_default_hosted_model(
+                model_settings.execution_model, session, seq_org_id
+            )
+            evaluation_model = resolve_default_hosted_model(
+                model_settings.evaluation_model, session, seq_org_id
+            )
+    except QuotaExceededError:
+        # Not a resolution failure -- let it propagate as-is. The broad
+        # except below would otherwise retry the identical call against the
+        # same org and quota state, misreport it as "failed to resolve" in
+        # the log, and only raise the same error a second time anyway.
+        raise
     except Exception as e:
         from rhesis.backend.app.config.settings import get_model_settings
         from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
 
         logger.warning(f"Failed to resolve execution/evaluation models: {e}")
         model_settings = get_model_settings()
+        fallback_org_id = str(test_config.organization_id) if test_config.organization_id else None
         if execution_model is None:
-            execution_model = resolve_default_hosted_model(model_settings.execution_model)
+            execution_model = resolve_default_hosted_model(
+                model_settings.execution_model, session, fallback_org_id
+            )
         if evaluation_model is None:
-            evaluation_model = resolve_default_hosted_model(model_settings.evaluation_model)
+            evaluation_model = resolve_default_hosted_model(
+                model_settings.evaluation_model, session, fallback_org_id
+            )
 
     # Execute tests one by one
     for i, test in enumerate(tests, 1):

--- a/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
+++ b/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
@@ -5,9 +5,11 @@ import { useSession } from 'next-auth/react';
 import { usePathname } from 'next/navigation';
 import AuthErrorBoundary from './error-boundary';
 import VerificationBanner from '@/components/auth/VerificationBanner';
+import QuotaBanner from '@/components/auth/QuotaBanner';
 import { FeaturesProvider } from '@/contexts/FeaturesContext';
 import type { FeaturesResponse } from '@/utils/api-client/features-client';
 import { PermissionsProvider } from '@/contexts/PermissionsContext';
+import { UsageProvider } from '@/contexts/UsageContext';
 import { useActiveProject } from '@/contexts/ActiveProjectContext';
 import { AppShell } from '@/components/layout/AppShell';
 import { Sidebar } from '@/components/navigation/Sidebar';
@@ -104,15 +106,18 @@ export function ProtectedLayoutClient({
     <AuthErrorBoundary>
       <FeaturesProvider initialFeatures={initialFeatures}>
         <PermissionsProvider initialPermissions={initialPermissions}>
-          <WebSocketProvider>
-            <NotificationsProvider>
-              {!isOnboarding && (
-                <TermsAcceptanceGate initialTermsStatus={initialTermsStatus} />
-              )}
-              {!isOnboarding && !chromeless && <VerificationBanner />}
-              {content}
-            </NotificationsProvider>
-          </WebSocketProvider>
+          <UsageProvider>
+            <WebSocketProvider>
+              <NotificationsProvider>
+                {!isOnboarding && (
+                  <TermsAcceptanceGate initialTermsStatus={initialTermsStatus} />
+                )}
+                {!isOnboarding && !chromeless && <VerificationBanner />}
+                {!isOnboarding && !chromeless && <QuotaBanner />}
+                {content}
+              </NotificationsProvider>
+            </WebSocketProvider>
+          </UsageProvider>
         </PermissionsProvider>
       </FeaturesProvider>
     </AuthErrorBoundary>

--- a/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
+++ b/apps/frontend/src/app/(protected)/ProtectedLayoutClient.tsx
@@ -110,7 +110,9 @@ export function ProtectedLayoutClient({
             <WebSocketProvider>
               <NotificationsProvider>
                 {!isOnboarding && (
-                  <TermsAcceptanceGate initialTermsStatus={initialTermsStatus} />
+                  <TermsAcceptanceGate
+                    initialTermsStatus={initialTermsStatus}
+                  />
                 )}
                 {!isOnboarding && !chromeless && <VerificationBanner />}
                 {!isOnboarding && !chromeless && <QuotaBanner />}

--- a/apps/frontend/src/app/(protected)/layout.tsx
+++ b/apps/frontend/src/app/(protected)/layout.tsx
@@ -19,9 +19,12 @@ import { ProtectedLayoutClient } from './ProtectedLayoutClient';
  * nested server components (page.tsx via prefetchList/hasServerCapability)
  * share the same responses without issuing duplicate requests.
  *
- * `GET /usage` is deliberately absent: only the Usage page reads it, so it
- * mounts its own `UsageProvider` rather than making every protected
- * navigation pay for a license lookup plus four counting queries.
+ * `GET /usage` has no server seed here (unlike features/permissions):
+ * `UsageProvider` is mounted client-side in `ProtectedLayoutClient` so
+ * `QuotaBanner` and execute-gating (`RunDrawer`) can read it anywhere in
+ * the app, not just the Usage settings page. The cost this used to avoid
+ * (a license lookup plus four counting queries) is real, but is paid once
+ * per `UsageContext`'s 5-minute `staleTime` window, not per navigation.
  */
 export default async function ProtectedLayout({
   children,

--- a/apps/frontend/src/components/auth/QuotaBanner.tsx
+++ b/apps/frontend/src/components/auth/QuotaBanner.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Box, IconButton, Link as MuiLink, Typography, useTheme } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+import CloseIcon from '@mui/icons-material/Close';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
+import NextLink from 'next/link';
+import { useUsage } from '@/contexts/UsageContext';
+import { QUOTA_RESOURCE_LABELS, type QuotaResource } from '@/constants/quota';
+
+/** Utilization at or above this fraction surfaces the banner. */
+const WARNING_THRESHOLD = 0.8;
+
+interface WorstResource {
+  resource: QuotaResource;
+  used: number;
+  limit: number;
+  ratio: number;
+}
+
+/**
+ * Finds the single resource closest to (or past) its limit, or `null` if
+ * every resource is comfortably under `WARNING_THRESHOLD`.
+ *
+ * Only one resource is surfaced at a time -- stacking a banner per
+ * over-threshold resource would compete with `VerificationBanner` and the
+ * app chrome for the same header space. A resource with `limit: null`
+ * (unlimited) never contributes: there is no ratio to compute.
+ */
+function findWorstResource(
+  resources: Readonly<Record<string, { used: number; limit: number | null }>>
+): WorstResource | null {
+  let worst: WorstResource | null = null;
+  for (const [resource, item] of Object.entries(resources)) {
+    if (item.limit === null || item.limit <= 0) continue;
+    const ratio = item.used / item.limit;
+    if (ratio >= WARNING_THRESHOLD && (!worst || ratio > worst.ratio)) {
+      worst = { resource: resource as QuotaResource, used: item.used, limit: item.limit, ratio };
+    }
+  }
+  return worst;
+}
+
+export default function QuotaBanner() {
+  const theme = useTheme();
+  const { resources, loading } = useUsage();
+  const [dismissedFor, setDismissedFor] = useState<QuotaResource | null>(null);
+
+  const worst = useMemo(() => {
+    if (loading) return null;
+    return findWorstResource(resources);
+  }, [resources, loading]);
+
+  // Re-surfaces if a *different* resource crosses the threshold after the
+  // current one was dismissed, rather than staying silenced for the rest
+  // of the session -- dismissing a spans warning shouldn't also hide a
+  // later, unrelated seats warning.
+  if (!worst || dismissedFor === worst.resource) {
+    return null;
+  }
+
+  const label = QUOTA_RESOURCE_LABELS[worst.resource];
+  const percent = Math.round(worst.ratio * 100);
+  const isDark = theme.palette.mode === 'dark';
+  const bgGradient = isDark
+    ? `linear-gradient(135deg, ${alpha(theme.palette.warning.dark, 0.85)} 0%, ${alpha(theme.palette.warning.main, 0.7)} 100%)`
+    : `linear-gradient(135deg, ${theme.palette.warning.main} 0%, ${theme.palette.warning.light} 100%)`;
+  const textColor = theme.palette.warning.contrastText;
+
+  return (
+    <Box
+      sx={{
+        background: bgGradient,
+        py: 0.5,
+        px: 2,
+        minHeight: theme => theme.spacing(4),
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        position: 'relative',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+        }}
+      >
+        <WarningAmberIcon
+          sx={{
+            fontSize: theme => theme.typography.body2.fontSize,
+            color: textColor,
+          }}
+        />
+        <Typography
+          variant="caption"
+          sx={{
+            color: textColor,
+            fontWeight: theme => theme.typography.fontWeightMedium,
+          }}
+        >
+          {`You've used ${percent}% of your ${label.toLowerCase()} limit for this billing period.`}
+        </Typography>
+        <MuiLink
+          component={NextLink}
+          href="/organizations/usage"
+          variant="caption"
+          sx={{
+            color: textColor,
+            fontWeight: theme => theme.typography.fontWeightBold,
+            textDecorationColor: alpha(textColor, 0.5),
+          }}
+        >
+          View usage
+        </MuiLink>
+      </Box>
+      <IconButton
+        size="small"
+        onClick={() => setDismissedFor(worst.resource)}
+        aria-label="Dismiss banner"
+        sx={{
+          position: 'absolute',
+          right: theme => theme.spacing(1),
+          color: textColor,
+          opacity: 0.8,
+          p: 0.25,
+          '&:hover': {
+            opacity: 1,
+            backgroundColor: alpha(textColor, 0.1),
+          },
+        }}
+      >
+        <CloseIcon
+          sx={{
+            fontSize: theme => theme.typography.body2.fontSize,
+          }}
+        />
+      </IconButton>
+    </Box>
+  );
+}

--- a/apps/frontend/src/components/auth/QuotaBanner.tsx
+++ b/apps/frontend/src/components/auth/QuotaBanner.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { Box, IconButton, Link as MuiLink, Typography, useTheme } from '@mui/material';
+import {
+  Box,
+  IconButton,
+  Link as MuiLink,
+  Typography,
+  useTheme,
+} from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import CloseIcon from '@mui/icons-material/Close';
 import WarningAmberIcon from '@mui/icons-material/WarningAmber';
@@ -47,7 +53,12 @@ function findWorstResource(
     if (!(resource in QUOTA_RESOURCE_LABELS)) continue;
     const ratio = item.limit === 0 ? 1 : item.used / item.limit;
     if (ratio >= WARNING_THRESHOLD && (!worst || ratio > worst.ratio)) {
-      worst = { resource: resource as QuotaResource, used: item.used, limit: item.limit, ratio };
+      worst = {
+        resource: resource as QuotaResource,
+        used: item.used,
+        limit: item.limit,
+        ratio,
+      };
     }
   }
   return worst;

--- a/apps/frontend/src/components/auth/QuotaBanner.tsx
+++ b/apps/frontend/src/components/auth/QuotaBanner.tsx
@@ -23,6 +23,7 @@ interface WorstResource {
   used: number;
   limit: number;
   ratio: number;
+  kind: 'flow' | 'stock';
 }
 
 /**
@@ -45,7 +46,9 @@ interface WorstResource {
  * than just this banner.
  */
 function findWorstResource(
-  resources: Readonly<Record<string, { used: number; limit: number | null }>>
+  resources: Readonly<
+    Record<string, { used: number; limit: number | null; kind: 'flow' | 'stock' }>
+  >
 ): WorstResource | null {
   let worst: WorstResource | null = null;
   for (const [resource, item] of Object.entries(resources)) {
@@ -58,6 +61,7 @@ function findWorstResource(
         used: item.used,
         limit: item.limit,
         ratio,
+        kind: item.kind,
       };
     }
   }
@@ -123,7 +127,9 @@ export default function QuotaBanner() {
             fontWeight: theme => theme.typography.fontWeightMedium,
           }}
         >
-          {`You've used ${percent}% of your ${label.toLowerCase()} limit for this billing period.`}
+          {worst.kind === 'stock'
+            ? `You've used ${percent}% of your ${label.toLowerCase()} limit.`
+            : `You've used ${percent}% of your ${label.toLowerCase()} limit for this period.`}
         </Typography>
         <MuiLink
           component={NextLink}

--- a/apps/frontend/src/components/auth/QuotaBanner.tsx
+++ b/apps/frontend/src/components/auth/QuotaBanner.tsx
@@ -47,7 +47,10 @@ interface WorstResource {
  */
 function findWorstResource(
   resources: Readonly<
-    Record<string, { used: number; limit: number | null; kind: 'flow' | 'stock' }>
+    Record<
+      string,
+      { used: number; limit: number | null; kind: 'flow' | 'stock' }
+    >
   >
 ): WorstResource | null {
   let worst: WorstResource | null = null;

--- a/apps/frontend/src/components/auth/QuotaBanner.tsx
+++ b/apps/frontend/src/components/auth/QuotaBanner.tsx
@@ -27,14 +27,25 @@ interface WorstResource {
  * over-threshold resource would compete with `VerificationBanner` and the
  * app chrome for the same header space. A resource with `limit: null`
  * (unlimited) never contributes: there is no ratio to compute.
+ *
+ * `limit: 0` is a real configured value meaning "none allowed", not a
+ * missing limit, so it reports as fully consumed rather than being skipped
+ * -- skipping it hid the banner from precisely the orgs that were already
+ * blocked. Matches `UsageOverviewTab`'s handling of the same case.
+ *
+ * Resources with no label are skipped: the backend can add a `QuotaResource`
+ * before `constants/quota.ts` catches up, and this component renders inside
+ * the protected layout, so a missing label would throw on every page rather
+ * than just this banner.
  */
 function findWorstResource(
   resources: Readonly<Record<string, { used: number; limit: number | null }>>
 ): WorstResource | null {
   let worst: WorstResource | null = null;
   for (const [resource, item] of Object.entries(resources)) {
-    if (item.limit === null || item.limit <= 0) continue;
-    const ratio = item.used / item.limit;
+    if (item.limit === null || item.limit < 0) continue;
+    if (!(resource in QUOTA_RESOURCE_LABELS)) continue;
+    const ratio = item.limit === 0 ? 1 : item.used / item.limit;
     if (ratio >= WARNING_THRESHOLD && (!worst || ratio > worst.ratio)) {
       worst = { resource: resource as QuotaResource, used: item.used, limit: item.limit, ratio };
     }

--- a/apps/frontend/src/components/auth/__tests__/QuotaBanner.test.tsx
+++ b/apps/frontend/src/components/auth/__tests__/QuotaBanner.test.tsx
@@ -66,7 +66,9 @@ describe('QuotaBanner', () => {
   it('warns once a resource crosses 80% utilization', () => {
     mockUsage({ [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) });
     render(<QuotaBanner />);
-    expect(screen.getByText(/80% of your test runs limit/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/80% of your test runs limit/i)
+    ).toBeInTheDocument();
   });
 
   it('treats a limit of zero as fully consumed rather than skipping it', () => {
@@ -74,7 +76,9 @@ describe('QuotaBanner', () => {
     // it hid the banner from exactly the orgs that were already blocked.
     mockUsage({ [QuotaResource.PROJECTS]: item(0, 0) });
     render(<QuotaBanner />);
-    expect(screen.getByText(/100% of your projects limit/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/100% of your projects limit/i)
+    ).toBeInTheDocument();
   });
 
   it('surfaces only the worst resource when several are over the threshold', () => {

--- a/apps/frontend/src/components/auth/__tests__/QuotaBanner.test.tsx
+++ b/apps/frontend/src/components/auth/__tests__/QuotaBanner.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import QuotaBanner from '../QuotaBanner';
+import { QuotaResource } from '@/constants/quota';
+import type { UsageResourceItem } from '@/utils/api-client/usage-client';
+
+jest.mock('@/contexts/UsageContext', () => ({
+  useUsage: jest.fn(),
+}));
+
+import { useUsage } from '@/contexts/UsageContext';
+
+/** Build a `UsageResourceItem`; `ceiling` defaults to `limit` (a hard tier). */
+function item(
+  used: number,
+  limit: number | null,
+  ceiling?: number | null
+): UsageResourceItem {
+  return {
+    used,
+    limit,
+    ceiling: ceiling === undefined ? limit : ceiling,
+    period_start: '2026-08-01',
+    period_end: '2026-08-31',
+    kind: 'flow',
+  };
+}
+
+function mockUsage(
+  resources: Record<string, UsageResourceItem>,
+  loading = false
+) {
+  (useUsage as jest.Mock).mockReturnValue({
+    resources,
+    edition: 'community',
+    loading,
+    error: null,
+  });
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('QuotaBanner', () => {
+  it('renders nothing while usage is still loading', () => {
+    mockUsage({ [QuotaResource.TEST_EXECUTIONS]: item(999, 1000) }, true);
+    const { container } = render(<QuotaBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when every resource is comfortably under the threshold', () => {
+    mockUsage({ [QuotaResource.TEST_EXECUTIONS]: item(10, 1000) });
+    const { container } = render(<QuotaBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for an unlimited resource no matter how high usage is', () => {
+    mockUsage({ [QuotaResource.MODEL_TOKENS]: item(10_000_000, null) });
+    const { container } = render(<QuotaBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('warns once a resource crosses 80% utilization', () => {
+    mockUsage({ [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) });
+    render(<QuotaBanner />);
+    expect(screen.getByText(/80% of your test runs limit/i)).toBeInTheDocument();
+  });
+
+  it('treats a limit of zero as fully consumed rather than skipping it', () => {
+    // `limit: 0` is a real configured value meaning "none allowed". Skipping
+    // it hid the banner from exactly the orgs that were already blocked.
+    mockUsage({ [QuotaResource.PROJECTS]: item(0, 0) });
+    render(<QuotaBanner />);
+    expect(screen.getByText(/100% of your projects limit/i)).toBeInTheDocument();
+  });
+
+  it('surfaces only the worst resource when several are over the threshold', () => {
+    mockUsage({
+      [QuotaResource.TEST_EXECUTIONS]: item(850, 1000),
+      [QuotaResource.PROJECTS]: item(99, 100),
+    });
+    render(<QuotaBanner />);
+    expect(screen.getByText(/99% of your projects limit/i)).toBeInTheDocument();
+    expect(screen.queryByText(/test runs/i)).not.toBeInTheDocument();
+  });
+
+  it('ignores a resource the label map does not know about', () => {
+    // The backend can add a QuotaResource before constants/quota.ts catches
+    // up. This component renders inside the protected layout, so throwing on
+    // a missing label would take down every page, not just the banner.
+    mockUsage({ some_future_resource: item(99, 100) });
+    const { container } = render(<QuotaBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('stays dismissed for the resource that was dismissed', async () => {
+    mockUsage({ [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) });
+    render(<QuotaBanner />);
+
+    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+
+    expect(screen.queryByText(/test runs limit/i)).not.toBeInTheDocument();
+  });
+
+  it('re-surfaces when a different resource crosses the threshold', async () => {
+    const { rerender } = render(<QuotaBanner />);
+    mockUsage({ [QuotaResource.TEST_EXECUTIONS]: item(800, 1000) });
+    rerender(<QuotaBanner />);
+
+    await userEvent.click(screen.getByRole('button', { name: /dismiss/i }));
+
+    // A dismissed test-runs warning must not silence a later seats warning.
+    mockUsage({
+      [QuotaResource.TEST_EXECUTIONS]: item(800, 1000),
+      [QuotaResource.SEATS]: item(10, 10),
+    });
+    rerender(<QuotaBanner />);
+
+    expect(screen.getByText(/100% of your seats limit/i)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -79,6 +79,8 @@ import type { UUID } from 'crypto';
 import { readActiveProjectId } from '@/utils/active-project';
 import { formatDate } from '@/utils/date';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
+import { useResourceUsage } from '@/contexts/UsageContext';
+import { QuotaResource, QUOTA_RESOURCE_LABELS } from '@/constants/quota';
 
 // ---------------------------------------------------------------------------
 // Shared local types
@@ -1006,15 +1008,38 @@ export default function RunDrawer(props: RunDrawerProps) {
   // Form validity
   // -----------------------------------------------------------------------
 
+  // Proactive quota gate: mirrors the backend's require_quota(TEST_EXECUTIONS)
+  // check on the execute endpoints, so the button is disabled before a
+  // request goes out at all rather than only after it comes back 402. Not a
+  // replacement for that check -- usage can change between render and
+  // submit, so the server-side gate is still authoritative; this is purely
+  // about giving the user the answer earlier.
+  const executionUsage = useResourceUsage(QuotaResource.TEST_EXECUTIONS);
+  const executionQuotaExhausted =
+    executionUsage !== null &&
+    executionUsage.limit !== null &&
+    executionUsage.used >= executionUsage.limit;
+
   const canExecute = useMemo(() => {
     const endpointId = resolveEndpointId();
     const testSetIds = resolveTestSetIds();
     if (!endpointId || testSetIds.length === 0) return false;
     if (mode === 'runExperiment' && internalVersionHashes.size === 0)
       return false;
+    if (executionQuotaExhausted) return false;
     return true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, selectedEndpoint, selectedTestSet, internalVersionHashes]);
+  }, [
+    mode,
+    selectedEndpoint,
+    selectedTestSet,
+    internalVersionHashes,
+    executionQuotaExhausted,
+  ]);
+
+  const quotaExhaustedMessage = executionQuotaExhausted
+    ? `You've reached your ${QUOTA_RESOURCE_LABELS[QuotaResource.TEST_EXECUTIONS].toLowerCase()} limit for this billing period.`
+    : undefined;
 
   // Effective test set type for multi-turn detection
   const effectiveTestSetType = useMemo(() => {
@@ -1898,7 +1923,7 @@ export default function RunDrawer(props: RunDrawerProps) {
       onClose={onClose}
       title={title}
       loading={loading || endpointsLoading || executing}
-      error={error}
+      error={error ?? quotaExhaustedMessage}
       onSave={handleExecute}
       saveDisabled={!canExecute}
       saveButtonText={saveButtonText}

--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -1014,11 +1014,16 @@ export default function RunDrawer(props: RunDrawerProps) {
   // replacement for that check -- usage can change between render and
   // submit, so the server-side gate is still authoritative; this is purely
   // about giving the user the answer earlier.
+  //
+  // Compares against `ceiling`, not `limit`: on a soft tier those differ by
+  // the overage tolerance, and gating on `limit` would disable the button
+  // for an org the backend would still happily accept -- erasing exactly the
+  // grace band the tier grants.
   const executionUsage = useResourceUsage(QuotaResource.TEST_EXECUTIONS);
   const executionQuotaExhausted =
     executionUsage !== null &&
-    executionUsage.limit !== null &&
-    executionUsage.used >= executionUsage.limit;
+    executionUsage.ceiling !== null &&
+    executionUsage.used >= executionUsage.ceiling;
 
   const canExecute = useMemo(() => {
     const endpointId = resolveEndpointId();

--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -1043,7 +1043,7 @@ export default function RunDrawer(props: RunDrawerProps) {
   ]);
 
   const quotaExhaustedMessage = executionQuotaExhausted
-    ? `You've reached your ${QUOTA_RESOURCE_LABELS[QuotaResource.TEST_EXECUTIONS].toLowerCase()} limit for this billing period.`
+    ? `You've reached your ${QUOTA_RESOURCE_LABELS[QuotaResource.TEST_EXECUTIONS].toLowerCase()} limit for this period.`
     : undefined;
 
   // Effective test set type for multi-turn detection

--- a/apps/frontend/src/components/common/__tests__/RunDrawer.test.tsx
+++ b/apps/frontend/src/components/common/__tests__/RunDrawer.test.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import RunDrawer from '../RunDrawer';
+import type { BaseDrawerProps } from '../BaseDrawer';
+import { QuotaResource } from '@/constants/quota';
+import type { UsageResourceItem } from '@/utils/api-client/usage-client';
+
+/**
+ * Covers only the quota-gate logic RunDrawer added on top of its existing
+ * (untested) execute-configuration form: `canExecute` blocking on the
+ * resource's `ceiling`, not its `limit`. `rerunTestRun` mode is used because
+ * it takes `endpointId`/`testSetId` directly as props (`RerunConfig`) rather
+ * than through dropdown selection, and its config renders read-only fields
+ * instead of the editable project/endpoint pickers -- the minimal surface
+ * that reaches `canExecute` without exercising the rest of this 2000+ line
+ * form, which has no existing test coverage of its own.
+ */
+
+jest.mock('../BaseDrawer', () => ({
+  __esModule: true,
+  default: ({
+    open,
+    children,
+    onSave,
+    saveButtonText,
+    saveDisabled,
+    error,
+    title,
+  }: BaseDrawerProps) =>
+    open ? (
+      <div data-testid="base-drawer">
+        <h2>{title}</h2>
+        {error && <div role="alert">{error}</div>}
+        {children}
+        <button onClick={onSave} disabled={saveDisabled}>
+          {saveButtonText}
+        </button>
+      </div>
+    ) : null,
+}));
+
+jest.mock('../ModelSelector', () => ({
+  __esModule: true,
+  default: () => <div data-testid="model-selector-stub" />,
+}));
+
+jest.mock('@/hooks/useEndpoints', () => ({
+  useEndpoints: jest.fn(() => ({ data: [], isLoading: false })),
+}));
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(() => ({ status: 'authenticated' })),
+}));
+
+jest.mock('../NotificationContext', () => ({
+  useNotifications: jest.fn(() => ({ show: jest.fn(), close: jest.fn() })),
+}));
+
+jest.mock('@/contexts/UsageContext', () => ({
+  useResourceUsage: jest.fn(),
+}));
+
+jest.mock('@/utils/api-client/client-factory', () => ({
+  ApiClientFactory: jest.fn().mockImplementation(() => ({
+    getTestSetsClient: () => ({
+      getTestSet: jest
+        .fn()
+        .mockResolvedValue({ test_set_type: { type_value: 'single_turn' } }),
+      getTestSetMetrics: jest.fn().mockResolvedValue([]),
+    }),
+    getParametersClient: () => ({
+      getExperiment: jest.fn().mockResolvedValue(null),
+    }),
+    getProjectsClient: () => ({
+      getProjects: jest.fn().mockResolvedValue({ data: [] }),
+    }),
+    getTestRunsClient: () => ({}),
+  })),
+}));
+
+import { useResourceUsage } from '@/contexts/UsageContext';
+
+/** `ceiling` defaults to `limit` (a hard-tier verdict, no grace band). */
+function usageItem(
+  used: number,
+  limit: number | null,
+  ceiling?: number | null
+): UsageResourceItem {
+  return {
+    used,
+    limit,
+    ceiling: ceiling === undefined ? limit : ceiling,
+    period_start: '2026-08-01',
+    period_end: '2026-08-31',
+    kind: 'flow',
+  };
+}
+
+function mockExecutionUsage(item: UsageResourceItem | null) {
+  (useResourceUsage as jest.Mock).mockImplementation((resource: string) =>
+    resource === QuotaResource.TEST_EXECUTIONS ? item : null
+  );
+}
+
+const rerunConfig = {
+  testSetId: 'ts-1',
+  testSetName: 'My Test Set',
+  endpointId: 'ep-1',
+  endpointName: 'My Endpoint',
+  projectName: 'My Project',
+  testRunId: 'run-1',
+};
+
+function renderRunDrawer() {
+  return render(
+    <RunDrawer
+      open
+      onClose={jest.fn()}
+      onSuccess={jest.fn()}
+      mode="rerunTestRun"
+      data={rerunConfig}
+    />
+  );
+}
+
+describe('RunDrawer quota gate', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('enables Run when usage has not reached the limit', () => {
+    mockExecutionUsage(usageItem(50, 100));
+    renderRunDrawer();
+
+    expect(screen.getByRole('button', { name: /re-run tests/i })).toBeEnabled();
+  });
+
+  it('disables Run at the ceiling, not the bare limit', () => {
+    // Soft tier: limit 100, 25% tolerance -> ceiling 125. Past the
+    // advertised limit but still inside the grace band the backend allows.
+    mockExecutionUsage(usageItem(110, 100, 125));
+    renderRunDrawer();
+
+    expect(screen.getByRole('button', { name: /re-run tests/i })).toBeEnabled();
+  });
+
+  it('disables Run once usage reaches the ceiling', () => {
+    mockExecutionUsage(usageItem(125, 100, 125));
+    renderRunDrawer();
+
+    expect(
+      screen.getByRole('button', { name: /re-run tests/i })
+    ).toBeDisabled();
+  });
+
+  it('never blocks an unlimited resource', () => {
+    mockExecutionUsage(usageItem(1_000_000, null, null));
+    renderRunDrawer();
+
+    expect(screen.getByRole('button', { name: /re-run tests/i })).toBeEnabled();
+  });
+
+  it('does not block while usage is still loading (useResourceUsage returns null)', () => {
+    mockExecutionUsage(null);
+    renderRunDrawer();
+
+    expect(screen.getByRole('button', { name: /re-run tests/i })).toBeEnabled();
+  });
+
+  it('shows the quota-exhausted message in the drawer error slot once blocked', () => {
+    mockExecutionUsage(usageItem(100, 100, 100));
+    renderRunDrawer();
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/test runs limit/i);
+  });
+});

--- a/apps/frontend/src/contexts/UsageContext.tsx
+++ b/apps/frontend/src/contexts/UsageContext.tsx
@@ -2,16 +2,22 @@
 
 /**
  * Read-only usage accounting: per-resource counters, limits, and the
- * current billing period, for the org usage dashboard tab.
+ * current billing period. Backs the Usage dashboard tab, `QuotaBanner`,
+ * and execute-gating (`RunDrawer`'s `canExecute`).
  *
  * Mirrors `FeaturesContext`'s caching pattern: `useQuery` scoped by
  * `userScope`, with `staleTime` matching the other ambient providers.
  *
- * Unlike `FeaturesProvider`, this is mounted by the Usage page itself rather
- * than the protected layout -- nothing else reads usage, and `GET /usage`
- * is too costly to issue on every protected navigation. That also means
- * there is no SSR-seeded `initialData`: the page shows its loading
- * skeleton for one round trip instead.
+ * Mounted in `ProtectedLayoutClient` alongside `FeaturesProvider`/
+ * `PermissionsProvider`, not just the Usage page: `QuotaBanner` and
+ * execute-gating both need this outside that one page. That was a
+ * deliberate tradeoff, not an oversight -- `GET /usage` costs a license
+ * lookup plus four counting queries, paid once per `staleTime` window
+ * (5 minutes) rather than never, so every session now carries a fixed
+ * background cost proactive quota UI didn't have before. Unlike
+ * `FeaturesProvider`, there is still no SSR-seeded `initialData`: the
+ * first consumer on a given page shows a loading state for one round
+ * trip instead.
  *
  * Fail-closed, same as `FeaturesContext`/`PermissionsContext`: `resources`
  * is empty during the initial fetch and on error, never a stale/default

--- a/apps/frontend/src/utils/api-client/__tests__/base-client.test.ts
+++ b/apps/frontend/src/utils/api-client/__tests__/base-client.test.ts
@@ -1,4 +1,4 @@
-import { BaseApiClient } from '../base-client';
+import { BaseApiClient, type ApiErrorData } from '../base-client';
 
 // Concrete subclass to expose protected methods under test
 class TestableClient extends BaseApiClient {
@@ -249,6 +249,92 @@ describe('BaseApiClient', () => {
           message: expect.stringContaining('already associated'),
         })
       );
+    });
+
+    describe('402 quota exceeded', () => {
+      function makeQuotaError() {
+        return {
+          error: 'quota_exceeded',
+          resource: 'test_executions',
+          used: 100,
+          limit: 100,
+          message:
+            "You've reached your test executions limit for this billing period.",
+        };
+      }
+
+      it('surfaces resource/used/limit as typed fields on the error', async () => {
+        fetchMock.mockResolvedValue(
+          makeFetchResponse(makeQuotaError(), 402, {
+            'content-type': 'application/json',
+          })
+        );
+
+        let caughtError:
+          | (Error & { status?: number; data?: ApiErrorData })
+          | null = null;
+        try {
+          await client.fetchPublic('/test_configurations/1/execute', {
+            method: 'POST',
+          });
+        } catch (e) {
+          caughtError = e as Error & { status?: number; data?: ApiErrorData };
+        }
+
+        expect(caughtError).not.toBeNull();
+        expect(caughtError?.status).toBe(402);
+        expect(caughtError?.data?.resource).toBe('test_executions');
+        expect(caughtError?.data?.used).toBe(100);
+        expect(caughtError?.data?.limit).toBe(100);
+      });
+
+      it('does not encode resource/used/limit into the message string the way 404/410 do', async () => {
+        // getApiErrorMessage only strips the "API error: N - " prefix, not a
+        // further table:/id:/name:-style encoding -- and callers such as
+        // RunDrawer's execute catch block pass the message straight into
+        // setError(). A structured encoding here would display raw to users.
+        fetchMock.mockResolvedValue(
+          makeFetchResponse(makeQuotaError(), 402, {
+            'content-type': 'application/json',
+          })
+        );
+
+        await expect(
+          client.fetchPublic('/test_configurations/1/execute', {
+            method: 'POST',
+          })
+        ).rejects.toThrow(
+          "API error: 402 - You've reached your test executions limit for this billing period."
+        );
+      });
+
+      it('logs a 402 as a warning, not an error', async () => {
+        // Asserts the specific call rather than "console.error was never
+        // called": a 5xx test elsewhere in this suite schedules a real-timer
+        // retry backoff that can fire during a later test's execution window
+        // and log unrelated to this one -- a global absence assertion would
+        // be flaky against that, independent of whether 402 logging is right.
+        const warnSpy = jest
+          .spyOn(console, 'warn')
+          .mockImplementation(() => {});
+        fetchMock.mockResolvedValue(
+          makeFetchResponse(makeQuotaError(), 402, {
+            'content-type': 'application/json',
+          })
+        );
+
+        await expect(
+          client.fetchPublic('/test_configurations/1/execute', {
+            method: 'POST',
+          })
+        ).rejects.toThrow();
+
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[VALIDATION] API Response Error:',
+          expect.objectContaining({ status: 402 })
+        );
+        warnSpy.mockRestore();
+      });
     });
   });
 

--- a/apps/frontend/src/utils/api-client/__tests__/base-client.test.ts
+++ b/apps/frontend/src/utils/api-client/__tests__/base-client.test.ts
@@ -259,7 +259,7 @@ describe('BaseApiClient', () => {
           used: 100,
           limit: 100,
           message:
-            "You've reached your test executions limit for this billing period.",
+            "You've reached your test executions limit for this period.",
         };
       }
 
@@ -304,7 +304,7 @@ describe('BaseApiClient', () => {
             method: 'POST',
           })
         ).rejects.toThrow(
-          "API error: 402 - You've reached your test executions limit for this billing period."
+          "API error: 402 - You've reached your test executions limit for this period."
         );
       });
 

--- a/apps/frontend/src/utils/api-client/__tests__/base-client.test.ts
+++ b/apps/frontend/src/utils/api-client/__tests__/base-client.test.ts
@@ -258,8 +258,7 @@ describe('BaseApiClient', () => {
           resource: 'test_executions',
           used: 100,
           limit: 100,
-          message:
-            "You've reached your test executions limit for this period.",
+          message: "You've reached your test executions limit for this period.",
         };
       }
 

--- a/apps/frontend/src/utils/api-client/base-client.ts
+++ b/apps/frontend/src/utils/api-client/base-client.ts
@@ -23,6 +23,17 @@ export interface ApiErrorData {
   table_name?: string;
   item_id?: string;
   item_name?: string;
+  /** Present on a 402 quota-exceeded body (see
+   * `rhesis.backend.app.quota.enforcement.quota_exceeded_response_body`):
+   * the `QuotaResource` value the org exhausted. */
+  resource?: string;
+  /** Current usage for `resource`, on a 402 quota-exceeded body. */
+  used?: number;
+  /** The resource's limit, on a 402 quota-exceeded body. `null` would mean
+   * unlimited, but a 402 for an unlimited resource cannot happen -- present
+   * for type-shape parity with the backend response, not because it's ever
+   * actually null here. */
+  limit?: number | null;
   [key: string]: unknown;
 }
 
@@ -408,6 +419,19 @@ export class BaseApiClient {
             const rateLimitInfo = errorMessage; // e.g., "10 per 1 hour"
             errorMessage = `Too many requests. You've exceeded the rate limit (${rateLimitInfo}). Please try again later.`;
           }
+
+          // 402 Payment Required means a quota was exhausted (see
+          // require_quota / QuotaExceededError on the backend). Deliberately
+          // NOT string-encoded into the message the way 410/404 encode
+          // table_name/item_id below: getApiErrorMessage only strips the
+          // "API error: {status} - " prefix, not a further table:/id:/name:-
+          // style encoding, and callers (RunDrawer's own execute catch
+          // block, among others) pass its return value straight into
+          // setError() for display. The body's `message` is already a full,
+          // friendly sentence -- parseApiErrorResponse above has already
+          // used it as errorMessage -- and `error.data.resource/.used/.limit`
+          // (typed on ApiErrorData) is there for any caller that wants
+          // structured access without parsing the message string at all.
 
           // For 410 Gone and 404 Not Found responses, encode critical data in the message
           // so it survives serialization across Next.js server-client boundary

--- a/apps/frontend/src/utils/api-client/base-client.ts
+++ b/apps/frontend/src/utils/api-client/base-client.ts
@@ -362,7 +362,8 @@ export class BaseApiClient {
         if (!response.ok) {
           // Determine if this is an expected validation/client error or an unexpected server error
           // 404 Not Found and 410 Gone are expected states for missing/deleted items
-          const isClientError = [400, 404, 409, 410, 422, 429].includes(
+          // 402 is a quota block: an expected, server-enforced state, not a fault.
+          const isClientError = [400, 402, 404, 409, 410, 422, 429].includes(
             response.status
           );
           const logLevel = isClientError ? 'warn' : 'error';
@@ -535,7 +536,7 @@ export class BaseApiClient {
           // 410 Gone is included as it's an expected state for soft-deleted items
           const isClientError =
             errWithStatus.status &&
-            [400, 409, 410, 422, 429].includes(errWithStatus.status);
+            [400, 402, 409, 410, 422, 429].includes(errWithStatus.status);
           if (isClientError) {
           } else {
           }

--- a/apps/frontend/src/utils/api-client/usage-client.ts
+++ b/apps/frontend/src/utils/api-client/usage-client.ts
@@ -3,6 +3,14 @@ import { BaseApiClient } from './base-client';
 export interface UsageResourceItem {
   used: number;
   limit: number | null;
+  /**
+   * The value of `used` at which requests actually start failing: `limit`
+   * plus the tier's overage tolerance on a soft policy, `limit` itself on a
+   * hard one. Compare against this, not `limit`, to predict a 402 -- gating
+   * on `limit` disables actions for a paying org that still has its whole
+   * grace band left. `limit` is what a progress bar fills toward.
+   */
+  ceiling: number | null;
   period_start: string;
   period_end: string;
   /**

--- a/ee/backend/src/rhesis/backend/ee/licensing/quota_provider.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/quota_provider.py
@@ -1,9 +1,10 @@
-"""Config-backed quota provider that resolves limits from tier_config.yaml.
+"""Config-backed quota provider that resolves policy from tier_config.yaml.
 
 Installed by :func:`~rhesis.backend.ee.bootstrap` when the EE package
 is present.  Resolves the organization's edition from the license
-provider, then looks up per-resource limits in the YAML-loaded tier
-catalog.  Unlicensed orgs get the community (free-tier) entry.
+provider, then looks up the limits and overage policy defined in the
+YAML-loaded tier catalog.  Unlicensed orgs get the community (free-tier)
+entry.
 """
 
 from __future__ import annotations
@@ -12,19 +13,19 @@ import logging
 from typing import Optional
 
 from rhesis.backend.app.models.organization import Organization
-from rhesis.backend.app.quota import QuotaResource
+from rhesis.backend.app.quota import QuotaPolicy
 from rhesis.backend.ee.licensing.entitlements import LicenseEdition
-from rhesis.backend.ee.licensing.tiers import resolve_limits
+from rhesis.backend.ee.licensing.tiers import resolve_policy
 
 logger = logging.getLogger(__name__)
 
 
 class ConfigQuotaProvider:
-    """Resolves quota limits from the tier YAML config.
+    """Resolves quota policy from the tier YAML config.
 
     For each organization, it determines the edition from the license
-    provider's entitlements, then returns the limits defined in the
-    config for that edition.
+    provider's entitlements, then returns the limits and overage policy
+    defined in the config for that edition.
     """
 
     def _resolve_edition(self, org: Optional[Organization]) -> Optional[LicenseEdition]:
@@ -52,9 +53,9 @@ class ConfigQuotaProvider:
             return None
         return edition
 
-    def get_limits(self, org: Optional[Organization] = None) -> dict[QuotaResource, int | None]:
+    def get_policy(self, org: Optional[Organization] = None) -> QuotaPolicy:
         edition = self._resolve_edition(org)
-        return resolve_limits(edition)
+        return resolve_policy(edition)
 
 
 __all__ = ["ConfigQuotaProvider"]

--- a/ee/backend/src/rhesis/backend/ee/licensing/tier_config.dev.yaml
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tier_config.dev.yaml
@@ -22,6 +22,11 @@
 #
 #   model_tokens is small enough that a single Architect message or explorer
 #   suggestion crosses it, which is the runaway-spend path this exists for.
+#
+# Every finite team limit here is >= 4 on purpose. `QuotaPolicy.ceiling_for`
+# floors, so 25% of anything below 4 is worth less than one unit and the
+# grace band collapses to nothing -- a team limit of 2 would block exactly
+# like a hard one and make the soft path look broken while testing it.
 
 community:
   all_features: false
@@ -47,9 +52,9 @@ team:
     tracing_spans: 40
     test_generation: 10
     model_tokens: 2000
-    seats: 2
-    projects: 2
-    endpoints: 2
+    seats: 4
+    projects: 4
+    endpoints: 4
   retention_days: 90
   overage: soft
   overage_tolerance_percent: 25

--- a/ee/backend/src/rhesis/backend/ee/licensing/tier_config.dev.yaml
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tier_config.dev.yaml
@@ -1,0 +1,73 @@
+# Dev-only tier config with deliberately tiny limits, for exercising quota
+# enforcement without generating thousands of test runs first.
+#
+# NOT loaded by default. Opt in explicitly:
+#
+#   RHESIS_TIER_CONFIG=<abs path to this file>
+#
+# Same schema and the same startup validation as tier_config.yaml: every
+# declared LicenseEdition needs an entry (including community), limit keys
+# must match QuotaResource, and limits must be null or a non-negative int.
+#
+# The numbers are chosen so each branch of the blocking rule is reachable by
+# hand:
+#
+#   community (hard, 0% tolerance)
+#     3 test executions -> the 4th is blocked outright.
+#
+#   team (soft, 25% tolerance)
+#     4 test executions -> ceiling is 4 * 125 // 100 = 5.
+#     runs 1-3 clean, run 4 allowed with a warning header (in grace),
+#     run 5 blocked. That is the boundary worth eyeballing in a browser.
+#
+#   model_tokens is small enough that a single Architect message or explorer
+#   suggestion crosses it, which is the runaway-spend path this exists for.
+
+community:
+  all_features: false
+  features: []
+  limits:
+    test_executions: 3
+    tracing_spans: 20
+    test_generation: 5
+    model_tokens: 1000
+    seats: 1
+    projects: 1
+    endpoints: 1
+  retention_days: 14
+  overage: hard
+  overage_tolerance_percent: 0
+
+team:
+  all_features: false
+  features:
+    - rbac
+  limits:
+    test_executions: 4
+    tracing_spans: 40
+    test_generation: 10
+    model_tokens: 2000
+    seats: 2
+    projects: 2
+    endpoints: 2
+  retention_days: 90
+  overage: soft
+  overage_tolerance_percent: 25
+
+enterprise: &unlimited_tier
+  all_features: true
+  features: []
+  limits:
+    test_executions: null
+    tracing_spans: null
+    test_generation: null
+    model_tokens: null
+    seats: null
+    projects: null
+    endpoints: null
+  retention_days: 365
+  overage: soft
+  overage_tolerance_percent: 25
+
+master:
+  <<: *unlimited_tier

--- a/ee/backend/src/rhesis/backend/ee/licensing/tier_config.yaml
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tier_config.yaml
@@ -34,6 +34,7 @@ team:
     endpoints: null
   retention_days: 90
   overage: soft
+  overage_tolerance_percent: 25
 
 enterprise: &unlimited_tier
   all_features: true
@@ -48,6 +49,7 @@ enterprise: &unlimited_tier
     endpoints: null
   retention_days: 365
   overage: soft
+  overage_tolerance_percent: 25
 
 # Internal tier (see LicenseEdition docstring). Currently identical to
 # enterprise; the merge key keeps that fact explicit instead of two

--- a/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
@@ -334,7 +334,12 @@ def _fallback_catalog() -> _FallbackCatalog:
 def _load_tier_config() -> dict[LicenseEdition, TierSpec]:
     """Load tier specs from YAML, falling back to the bundled file."""
     config_path_str = os.environ.get(ENV_TIER_CONFIG)
-    config_path = Path(config_path_str) if config_path_str else _BUNDLED_CONFIG
+    if config_path_str:
+        config_path = Path(config_path_str)
+        if not config_path.is_absolute():
+            config_path = _BUNDLED_CONFIG.parent / config_path
+    else:
+        config_path = _BUNDLED_CONFIG
 
     try:
         raw = yaml.safe_load(config_path.read_text())

--- a/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
@@ -176,9 +176,10 @@ def _parse_limits(raw: dict[str, int | None]) -> dict[QuotaResource, int | None]
     ``/features`` response, so they are rejected here rather than surfacing
     far from their cause.
 
-    :raises ValueError: on an unrecognized key, or a value that is neither
-        ``None`` (unlimited) nor a non-negative ``int``. Deliberately not
-        caught by :func:`_load_tier_config`'s fallback -- a config that
+    :raises ValueError: on an unrecognized key, a value that is neither
+        ``None`` (unlimited) nor a non-negative ``int``, or a ``limits``
+        mapping that doesn't cover every :class:`QuotaResource`. Deliberately
+        not caught by :func:`_load_tier_config`'s fallback -- a config that
         parses as YAML but is semantically wrong is a real bug that must
         surface at startup, not degrade into a silently-unmetered or
         permanently-blocked resource.
@@ -206,7 +207,45 @@ def _parse_limits(raw: dict[str, int | None]) -> dict[QuotaResource, int | None]
             )
 
         result[resource] = value
+
+    # A resource this dict never mentions and a resource explicitly set to
+    # `null` both end up absent from `result` -- and `QuotaPolicy.limits.get()`
+    # reads either as unlimited. The unknown-key check above catches a typo
+    # that adds a key; nothing caught the opposite typo, a key that's simply
+    # missing -- most likely a new QuotaResource member added without every
+    # tier config being updated for it, which would then silently unmeter it
+    # everywhere rather than block, the same failure mode _parse_limits exists
+    # to prevent for typo'd keys.
+    missing = sorted(r.value for r in QuotaResource if r not in result)
+    if missing:
+        raise ValueError(
+            f"Tier config `limits` is missing resource(s): {missing}. Every "
+            f"QuotaResource member must have an explicit entry (use null for "
+            f"unlimited) -- an absent resource is not 'inherits a default', "
+            f"it reads as unlimited to every caller."
+        )
     return result
+
+
+def _parse_all_features(raw: object) -> bool:
+    """Validate a raw YAML ``all_features`` value.
+
+    :func:`~rhesis.backend.ee.licensing.verify.verify_token` reads the minted
+    claim back with ``bool(lic.get(LIC_ALL_FEATURES, False))``, and Python's
+    ``bool()`` treats any non-empty string as ``True`` -- including the
+    string ``"false"``. An unvalidated ``all_features: "false"`` in the YAML
+    would therefore mint a token that unlocks every registered EE feature,
+    the opposite of what the config says. Reject anything that isn't a real
+    bool here, at load time, rather than at verify time on every request.
+
+    :raises ValueError: if *raw* is not a ``bool``.
+    """
+    if not isinstance(raw, bool):
+        raise ValueError(
+            f"Invalid all_features in tier config: {raw!r} ({type(raw).__name__}). "
+            f"Expected true or false."
+        )
+    return raw
 
 
 def _parse_overage(raw: object) -> OveragePolicy:
@@ -251,7 +290,26 @@ def _parse_overage_tolerance(raw: object) -> int:
     return raw
 
 
-def _fallback_catalog() -> dict[LicenseEdition, TierSpec]:
+class _FallbackCatalog(dict):
+    """Marks a catalog as the intentional safety-net from :func:`_fallback_catalog`.
+
+    A genuinely broken multi-tier config can also collapse to a bare
+    ``{COMMUNITY: TierSpec(...)}`` -- e.g. every paid entry gets dropped by
+    the per-entry shape checks in :func:`_load_tier_config` while community
+    itself stays valid. That result is indistinguishable from the on-purpose
+    fallback *by shape alone*, and :func:`_assert_catalog_complete` used to
+    tell them apart by comparing key sets, which made the two cases look
+    identical: a paying org silently gets free-tier limits and no error is
+    raised, when the real bug is a malformed config for two other tiers.
+
+    Subclassing ``dict`` rather than returning a separate boolean means the
+    marker survives being passed through anything that treats the catalog as
+    a plain mapping (which is everywhere else in this module), with no
+    signature changes required.
+    """
+
+
+def _fallback_catalog() -> _FallbackCatalog:
     """Safety-net catalog used when the tier config can't be read at all.
 
     Only the community entry is populated, using the same numbers as
@@ -263,12 +321,14 @@ def _fallback_catalog() -> dict[LicenseEdition, TierSpec]:
     and :func:`is_sellable` correctly reports paid tiers as unsellable until
     the config is fixed, rather than minting tokens against stale defaults.
     """
-    return {
-        LicenseEdition.COMMUNITY: TierSpec(
-            edition=LicenseEdition.COMMUNITY,
-            limits=dict(FREE_TIER_LIMITS),
-        )
-    }
+    return _FallbackCatalog(
+        {
+            LicenseEdition.COMMUNITY: TierSpec(
+                edition=LicenseEdition.COMMUNITY,
+                limits=dict(FREE_TIER_LIMITS),
+            )
+        }
+    )
 
 
 def _load_tier_config() -> dict[LicenseEdition, TierSpec]:
@@ -338,8 +398,10 @@ def _load_tier_config() -> dict[LicenseEdition, TierSpec]:
         # here would duplicate TierSpec's default and silently drift from
         # it if that default ever changes.
         overrides: dict[str, object] = {
-            key: spec_raw[key] for key in ("all_features", "retention_days") if key in spec_raw
+            key: spec_raw[key] for key in ("retention_days",) if key in spec_raw
         }
+        if "all_features" in spec_raw:
+            overrides["all_features"] = _parse_all_features(spec_raw["all_features"])
         if "overage" in spec_raw:
             overrides["overage"] = _parse_overage(spec_raw["overage"])
         if "overage_tolerance_percent" in spec_raw:
@@ -373,12 +435,15 @@ def _assert_catalog_complete(catalog: dict[LicenseEdition, TierSpec]) -> None:
     unlicensed org -- which reads downstream as *unlimited*. Requiring it
     here turns that fail-open into a startup failure.
 
-    Skipped when the catalog is the free-tier fallback, which is by design
-    community-only -- see :func:`_fallback_catalog`.
+    Skipped only for the genuine safety-net fallback -- see
+    :class:`_FallbackCatalog`. Checking ``isinstance`` rather than comparing
+    key sets matters: a real multi-tier config that lost every paid entry to
+    :func:`_load_tier_config`'s per-entry shape checks also collapses to a
+    bare ``{COMMUNITY: ...}``, and that case must still raise.
 
     :raises RuntimeError: naming exactly which editions are missing.
     """
-    if set(catalog) == {LicenseEdition.COMMUNITY}:
+    if isinstance(catalog, _FallbackCatalog):
         return
 
     missing = sorted(e.value for e in CATALOG_EDITIONS - set(catalog))

--- a/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
+++ b/ee/backend/src/rhesis/backend/ee/licensing/tiers.py
@@ -32,7 +32,13 @@ from typing import Optional
 import yaml
 
 from rhesis.backend.app.features import FeatureName
-from rhesis.backend.app.quota import FREE_TIER_LIMITS, QuotaResource, limits_to_wire
+from rhesis.backend.app.quota import (
+    FREE_TIER_LIMITS,
+    OveragePolicy,
+    QuotaPolicy,
+    QuotaResource,
+    limits_to_wire,
+)
 from rhesis.backend.ee.licensing.entitlements import (
     ENV_TIER_CONFIG,
     LIC_ALL_FEATURES,
@@ -111,7 +117,11 @@ class TierSpec:
     :param limits: metered resource limits keyed by
         :class:`QuotaResource`.  ``None`` values mean unlimited.
     :param retention_days: data retention in days for this tier.
-    :param overage: ``"hard"`` (block) or ``"soft"`` (warn + allow).
+    :param overage: whether reaching a limit blocks immediately or allows
+        the grace band in :attr:`overage_tolerance_percent`.
+    :param overage_tolerance_percent: for :attr:`OveragePolicy.SOFT`, how
+        far past a limit this tier may run before it hard-blocks. Ignored
+        (equivalent to ``0``) for :attr:`OveragePolicy.HARD`.
     """
 
     edition: LicenseEdition
@@ -119,7 +129,16 @@ class TierSpec:
     features: frozenset[FeatureName] = frozenset()
     limits: dict[QuotaResource, int | None] = field(default_factory=dict)
     retention_days: int = 14
-    overage: str = "hard"
+    overage: OveragePolicy = OveragePolicy.HARD
+    overage_tolerance_percent: int = 0
+
+    def to_policy(self) -> QuotaPolicy:
+        """Return the :class:`QuotaPolicy` this tier grants."""
+        return QuotaPolicy(
+            limits=dict(self.limits),
+            overage=self.overage,
+            overage_tolerance_percent=self.overage_tolerance_percent,
+        )
 
     def feature_values(self) -> list[str]:
         """Return granted feature identifiers as sorted wire strings."""
@@ -188,6 +207,48 @@ def _parse_limits(raw: dict[str, int | None]) -> dict[QuotaResource, int | None]
 
         result[resource] = value
     return result
+
+
+def _parse_overage(raw: object) -> OveragePolicy:
+    """Coerce a raw YAML ``overage`` value to an :class:`OveragePolicy`.
+
+    :raises ValueError: on anything other than ``"hard"`` or ``"soft"``.
+    Deliberately not caught by :func:`_load_tier_config`'s fallback, for the
+    same reason as :func:`_parse_limits`: an overage policy this backend
+    doesn't recognize is a config bug, not a "no data yet" situation, and
+    guessing a default here could turn a paid tier's intended grace period
+    into an unannounced hard block, or vice versa.
+    """
+    try:
+        return OveragePolicy(raw)
+    except ValueError:
+        raise ValueError(
+            f"Invalid overage policy {raw!r} in tier config. "
+            f"Valid values: {[p.value for p in OveragePolicy]}"
+        )
+
+
+def _parse_overage_tolerance(raw: object) -> int:
+    """Validate a raw YAML ``overage_tolerance_percent`` value.
+
+    Same shape as the limit-value checks in :func:`_parse_limits`: ``bool``
+    is rejected explicitly because it passes ``isinstance(v, int)``, and a
+    negative percent would make :meth:`QuotaPolicy.ceiling_for` return a
+    ceiling *below* the limit, blocking a soft tier before it even reaches
+    the number it was promised.
+
+    :raises ValueError: if *raw* is not a non-negative ``int``.
+    """
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise ValueError(
+            f"Invalid overage_tolerance_percent in tier config: {raw!r} "
+            f"({type(raw).__name__}). Expected a non-negative integer."
+        )
+    if raw < 0:
+        raise ValueError(
+            f"Invalid overage_tolerance_percent in tier config: {raw!r}. Must be non-negative."
+        )
+    return raw
 
 
 def _fallback_catalog() -> dict[LicenseEdition, TierSpec]:
@@ -276,11 +337,16 @@ def _load_tier_config() -> dict[LicenseEdition, TierSpec]:
         # defaults apply for the rest. Hardcoding e.g. `retention_days=14`
         # here would duplicate TierSpec's default and silently drift from
         # it if that default ever changes.
-        overrides = {
-            key: spec_raw[key]
-            for key in ("all_features", "retention_days", "overage")
-            if key in spec_raw
+        overrides: dict[str, object] = {
+            key: spec_raw[key] for key in ("all_features", "retention_days") if key in spec_raw
         }
+        if "overage" in spec_raw:
+            overrides["overage"] = _parse_overage(spec_raw["overage"])
+        if "overage_tolerance_percent" in spec_raw:
+            overrides["overage_tolerance_percent"] = _parse_overage_tolerance(
+                spec_raw["overage_tolerance_percent"]
+            )
+
         catalog[edition] = TierSpec(
             edition=edition,
             features=features,
@@ -353,20 +419,26 @@ def resolve_tier(edition: LicenseEdition) -> TierSpec:
     return EDITION_ENTITLEMENTS[edition]
 
 
-def resolve_limits(edition: Optional[LicenseEdition]) -> dict[QuotaResource, int | None]:
-    """Return limits for *edition*, falling back to community defaults.
+def resolve_policy(edition: Optional[LicenseEdition]) -> QuotaPolicy:
+    """Return the full :class:`QuotaPolicy` for *edition*, falling back to
+    community defaults.
 
     Used for quota lookups, not minting -- unlike :func:`resolve_tier`,
     this intentionally accepts ``None``/``community`` and any edition
     absent from the catalog, since every org (licensed or not) needs a
-    resolvable limits dict.
+    resolvable policy.
     """
     spec = EDITION_ENTITLEMENTS.get(edition) if edition is not None else None
     if spec is None:
         spec = EDITION_ENTITLEMENTS.get(LicenseEdition.COMMUNITY)
     if spec is None:
-        return {}
-    return dict(spec.limits)
+        return QuotaPolicy()
+    return spec.to_policy()
+
+
+def resolve_limits(edition: Optional[LicenseEdition]) -> dict[QuotaResource, int | None]:
+    """Return just the limits for *edition*. See :func:`resolve_policy`."""
+    return resolve_policy(edition).limits
 
 
 def tier_to_lic_claim(
@@ -398,6 +470,7 @@ __all__ = [
     "all_sellable",
     "is_sellable",
     "resolve_limits",
+    "resolve_policy",
     "resolve_tier",
     "tier_to_lic_claim",
 ]

--- a/ee/backend/src/rhesis/backend/ee/rbac/models.py
+++ b/ee/backend/src/rhesis/backend/ee/rbac/models.py
@@ -123,15 +123,21 @@ def _primary_action(cap: str) -> str:
 # Org-level reads excluded from the read-only **Viewer** baseline.
 # ``role:read`` exposes the org's custom role catalog; only Owner and Admin
 # need it (Admin needs it to assign roles via member:manage).  ``token:read``
-# exposes API token metadata.  ``usage:read`` exposes metered consumption
-# against plan limits — billing data, not org context.  Everything else
-# ending in ``:read`` — including ``organization:read`` and ``member:read``
-# for basic org context — is fine for a Viewer.
+# exposes API token metadata.  Everything else ending in ``:read`` —
+# including ``organization:read`` and ``member:read`` for basic org context —
+# is fine for a Viewer.
+#
+# ``usage:read`` was excluded here as "billing data" and is deliberately no
+# longer.  It reports consumption against plan limits — counters and caps,
+# with no money in it — which is operational rather than financial: quota
+# enforcement blocks Members, so they need to see why.  See the longer note
+# on ``_OWNER_ONLY_CAPABILITIES`` in ``app/auth/rbac.py``, which this mirrors;
+# the two must agree, or community and EE disagree about who may read usage.
 #
 # Excluding a read here also keeps it away from **Member**: that set is
-# ``project_actions | viewer_permissions``, and all three of these are
+# ``project_actions | viewer_permissions``, and both of these are
 # org-scoped, so they never enter ``project_actions``.
-_VIEWER_EXCLUDED_READS: frozenset[str] = frozenset({"role:read", "token:read", "usage:read"})
+_VIEWER_EXCLUDED_READS: frozenset[str] = frozenset({"role:read", "token:read"})
 
 
 def _viewer_permissions(cap_set: set[str]) -> set[str]:

--- a/sdk/src/rhesis/sdk/entities/base_entity.py
+++ b/sdk/src/rhesis/sdk/entities/base_entity.py
@@ -131,6 +131,7 @@ class BaseEntity(BaseModel):
         if missing:
             raise ValueError(f"Required fields for push: {', '.join(missing)}")
 
+    @handle_http_errors
     def push(self) -> Optional[Dict[str, Any]]:
         """Save the entity to the database."""
         self._validate_push_requirements()

--- a/tests/backend/app/test_quota_enforcement.py
+++ b/tests/backend/app/test_quota_enforcement.py
@@ -1,0 +1,226 @@
+"""Tests for :mod:`rhesis.backend.app.quota.enforcement`.
+
+The single blocking rule every enforcement point shares -- see the module's
+own docstring. Flow-resource tests use the real `usage` table via `test_db`
+(Postgres-backed, SAVEPOINT-isolated); stock-resource tests create Project
+rows directly, mirroring `tests/backend/services/test_usage.py`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rhesis.backend.app.models.project import Project
+from rhesis.backend.app.quota import OveragePolicy, QuotaPolicy, QuotaRegistry, QuotaResource
+from rhesis.backend.app.quota.enforcement import (
+    QuotaExceededError,
+    check_quota,
+    enforce_quota,
+    quota_exceeded_response_body,
+)
+from rhesis.backend.app.services.usage import increment_usage
+
+
+class _FixedPolicyProvider:
+    """Installs one fixed `QuotaPolicy` regardless of org, for deterministic
+    boundary testing -- the real EE provider resolves this from YAML, which
+    is exercised separately in `tests/backend/ee/licensing/test_tiers.py`."""
+
+    def __init__(self, policy: QuotaPolicy):
+        self._policy = policy
+
+    def get_policy(self, org=None) -> QuotaPolicy:
+        return self._policy
+
+
+@pytest.fixture
+def clean_registry():
+    """Reset the registry before and after, mirroring test_quota_registry.py."""
+    saved_provider = QuotaRegistry._provider
+    QuotaRegistry.reset()
+    yield
+    QuotaRegistry._provider = saved_provider
+
+
+def _install(policy: QuotaPolicy) -> None:
+    QuotaRegistry.set_quota_provider(_FixedPolicyProvider(policy))
+
+
+class TestCheckQuotaUnlimited:
+    def test_none_limit_is_always_allowed(self, test_db, test_org_id, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: None}))
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 1_000_000)
+
+        verdict = check_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+        assert verdict.allowed is True
+        assert verdict.over_limit is False
+        assert verdict.limit is None
+
+    def test_resource_absent_from_policy_is_unlimited(self, test_db, test_org_id, clean_registry):
+        """A resource the policy simply doesn't mention is unlimited, same
+        as an explicit `None` -- `QuotaPolicy.limits.get()` returns `None`
+        either way."""
+        _install(QuotaPolicy(limits={}))
+
+        verdict = check_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+        assert verdict.allowed is True
+        assert verdict.limit is None
+
+
+class TestCheckQuotaHard:
+    def test_below_limit_is_allowed(self, test_db, test_org_id, clean_registry):
+        _install(
+            QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 10}, overage=OveragePolicy.HARD)
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 9)
+
+        verdict = check_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+        assert verdict.allowed is True
+        assert verdict.over_limit is False
+
+    def test_at_limit_is_blocked(self, test_db, test_org_id, clean_registry):
+        """HARD's ceiling is the limit itself -- see `QuotaPolicy.ceiling_for`."""
+        _install(
+            QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 10}, overage=OveragePolicy.HARD)
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 10)
+
+        verdict = check_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+        assert verdict.allowed is False
+        assert verdict.over_limit is True
+
+    def test_zero_tolerance_soft_behaves_like_hard(self, test_db, test_org_id, clean_registry):
+        """SOFT with `overage_tolerance_percent=0` collapses to the same
+        ceiling as HARD -- one expression, no branch at the call site."""
+        _install(
+            QuotaPolicy(
+                limits={QuotaResource.TEST_EXECUTIONS: 10},
+                overage=OveragePolicy.SOFT,
+                overage_tolerance_percent=0,
+            )
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 10)
+
+        verdict = check_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+        assert verdict.allowed is False
+
+
+class TestCheckQuotaSoftBoundary:
+    """The 25% grace band. Ceiling = limit * 125 // 100 = 125 for limit=100.
+
+    Off-by-one here is the difference between a 25% grace and a 25%-plus-one
+    grace, so the ceiling-1 / ceiling boundary gets its own explicit test.
+    """
+
+    def _install_soft_100(self):
+        _install(
+            QuotaPolicy(
+                limits={QuotaResource.TEST_EXECUTIONS: 100},
+                overage=OveragePolicy.SOFT,
+                overage_tolerance_percent=25,
+            )
+        )
+
+    def test_below_limit_is_allowed_not_over_limit(self, test_db, test_org_id, clean_registry):
+        self._install_soft_100()
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 99)
+
+        verdict = check_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+        assert verdict.allowed is True
+        assert verdict.over_limit is False
+
+    def test_at_limit_is_allowed_and_over_limit(self, test_db, test_org_id, clean_registry):
+        """Past the advertised limit but still inside the grace band: allowed,
+        but `over_limit` so a caller can surface a warning."""
+        self._install_soft_100()
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 100)
+
+        verdict = check_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+        assert verdict.allowed is True
+        assert verdict.over_limit is True
+
+    def test_one_below_ceiling_is_allowed(self, test_db, test_org_id, clean_registry):
+        self._install_soft_100()
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 124)
+
+        verdict = check_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+        assert verdict.allowed is True
+        assert verdict.over_limit is True
+
+    def test_at_ceiling_is_blocked(self, test_db, test_org_id, clean_registry):
+        self._install_soft_100()
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 125)
+
+        verdict = check_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+        assert verdict.allowed is False
+        assert verdict.over_limit is True
+
+
+class TestCheckQuotaStockResources:
+    """Stock resources are a live `COUNT(*)`, not an accrued counter --
+    no accrual lag, so there is no separate warning-band concern to test
+    beyond the same boundary rule already covered for flow resources."""
+
+    def test_reads_a_live_project_count(self, test_db, test_org_id, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.PROJECTS: 1}, overage=OveragePolicy.HARD))
+        test_db.add(Project(name="quota-enforcement-test-project", organization_id=test_org_id))
+        test_db.commit()
+
+        verdict = check_quota(test_db, test_org_id, None, QuotaResource.PROJECTS)
+
+        assert verdict.used >= 1
+        assert verdict.allowed is False
+
+    def test_under_the_stock_limit_is_allowed(self, test_db, test_org_id, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.PROJECTS: 100}, overage=OveragePolicy.HARD))
+
+        verdict = check_quota(test_db, test_org_id, None, QuotaResource.PROJECTS)
+
+        assert verdict.allowed is True
+
+
+class TestEnforceQuota:
+    def test_returns_the_verdict_when_allowed(self, test_db, test_org_id, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 10}))
+
+        verdict = enforce_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+        assert verdict.allowed is True
+
+    def test_raises_when_blocked(self, test_db, test_org_id, clean_registry):
+        _install(
+            QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 10}, overage=OveragePolicy.HARD)
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 10)
+
+        with pytest.raises(QuotaExceededError) as exc_info:
+            enforce_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+        assert exc_info.value.verdict.resource is QuotaResource.TEST_EXECUTIONS
+        assert exc_info.value.verdict.allowed is False
+
+
+class TestQuotaExceededResponseBody:
+    def test_shape_matches_the_shared_402_contract(self, test_db, test_org_id, clean_registry):
+        _install(
+            QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 10}, overage=OveragePolicy.HARD)
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 10)
+        verdict = check_quota(test_db, test_org_id, None, QuotaResource.TEST_EXECUTIONS)
+
+        body = quota_exceeded_response_body(verdict)
+
+        assert body["error"] == "quota_exceeded"
+        assert body["resource"] == QuotaResource.TEST_EXECUTIONS.value
+        assert body["used"] == 10
+        assert body["limit"] == 10
+        assert "test executions" in body["message"]

--- a/tests/backend/app/test_quota_registry.py
+++ b/tests/backend/app/test_quota_registry.py
@@ -7,6 +7,7 @@ import pytest
 from rhesis.backend.app.quota import (
     FREE_TIER_LIMITS,
     DefaultQuotaProvider,
+    QuotaPolicy,
     QuotaProvider,
     QuotaRegistry,
     QuotaResource,
@@ -29,13 +30,18 @@ def clean_registry():
 
 
 class _FixedProvider:
-    """Provider returning a fixed limits dict, regardless of org."""
+    """Provider returning a fixed limits dict, regardless of org.
+
+    Wraps the limits in a ``QuotaPolicy`` since ``QuotaProvider`` now exposes
+    only ``get_policy()`` -- see the protocol's docstring on why the earlier
+    two-method shape was collapsed into one.
+    """
 
     def __init__(self, limits: dict[QuotaResource, int | None]):
         self._limits = limits
 
-    def get_limits(self, org=None) -> dict[QuotaResource, int | None]:
-        return dict(self._limits)
+    def get_policy(self, org=None) -> QuotaPolicy:
+        return QuotaPolicy(limits=dict(self._limits))
 
 
 class TestDefaultQuotaProvider:
@@ -99,4 +105,4 @@ class TestReset:
 class TestQuotaProviderProtocol:
     def test_default_provider_satisfies_protocol(self):
         provider: QuotaProvider = DefaultQuotaProvider()
-        assert provider.get_limits() == FREE_TIER_LIMITS
+        assert provider.get_policy().limits == FREE_TIER_LIMITS

--- a/tests/backend/app/test_quota_token_gate.py
+++ b/tests/backend/app/test_quota_token_gate.py
@@ -138,17 +138,13 @@ class TestResolveDefaultHostedModelTokenGate:
         with pytest.raises(QuotaExceededError):
             resolve_default_hosted_model("rhesis/default", db=None, organization_id="org-1")
 
-    def test_no_organization_id_skips_the_check_instead_of_raising(self, monkeypatch, caplog):
-        """A last-resort escape hatch, not a silent bypass: an org-less
-        construction path logs rather than raising or blocking."""
+    def test_no_organization_id_raises_instead_of_silently_skipping(self, monkeypatch):
+        """Fail closed: a missing org id is a caller bug, not a grace path."""
         monkeypatch.setattr(
             "rhesis.backend.app.utils.user_model_utils.get_model",
             lambda name, **kwargs: SimpleNamespace(model_name=name),
         )
         from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
 
-        with caplog.at_level("WARNING"):
-            model = resolve_default_hosted_model("rhesis/default", db=None, organization_id=None)
-
-        assert model.model_name == "rhesis/default"
-        assert "No organization_id" in caplog.text
+        with pytest.raises(ValueError, match="No organization_id"):
+            resolve_default_hosted_model("rhesis/default", db=None, organization_id=None)

--- a/tests/backend/app/test_quota_token_gate.py
+++ b/tests/backend/app/test_quota_token_gate.py
@@ -1,0 +1,155 @@
+"""The MODEL_TOKENS gate in :mod:`rhesis.backend.app.utils.user_model_utils`.
+
+Pure unit tests -- no database, no Docker. ``_enforce_model_token_quota`` is
+monkeypatched to always raise, so these check *whether the gate is reached
+at all*, not its blocking arithmetic (covered by ``test_quota_enforcement.py``).
+
+The regression this guards is the one that matters most: an org running on
+its own provider key must never be blocked by *our* token quota, because
+their call was never going to cost us anything. ``_is_hosted_model`` is the
+single predicate deciding that for every branch of
+``_fetch_and_configure_model`` -- see its docstring.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from rhesis.backend.app.quota import OveragePolicy, QuotaPolicy, QuotaResource
+from rhesis.backend.app.quota.enforcement import QuotaExceededError, QuotaVerdict
+
+
+def _always_blocks(db, organization_id):
+    """A stand-in for ``_enforce_model_token_quota`` that always raises, so a
+    passing construction call proves the gate was never reached -- not that
+    it happened to evaluate as allowed. Patched at this level (rather than
+    the ``enforce_quota`` it wraps) so these tests need no real ``db``: the
+    real helper's own DB lookup is skipped entirely, and only whether it
+    gets *called at all* is under test here."""
+    raise QuotaExceededError(
+        QuotaVerdict(
+            resource=QuotaResource.MODEL_TOKENS,
+            used=999,
+            limit=1,
+            policy=QuotaPolicy(overage=OveragePolicy.HARD),
+            allowed=False,
+            over_limit=True,
+        )
+    )
+
+
+@pytest.fixture
+def blocking_gate(monkeypatch):
+    """Install `_always_blocks` as `_enforce_model_token_quota` for the test."""
+    monkeypatch.setattr(
+        "rhesis.backend.app.utils.user_model_utils._enforce_model_token_quota", _always_blocks
+    )
+
+
+@pytest.fixture
+def configured_model(monkeypatch):
+    """Build a Model row stub and run it through `_fetch_and_configure_model`.
+
+    Mirrors the fixture of the same name in `test_usage_tracking.py`'s
+    `TestConfiguredModelProvenance`, duplicated rather than imported: that
+    fixture is class-scoped there, and this file's concern (does the gate
+    fire) is deliberately separate from provenance stamping.
+    """
+
+    def _resolve(*, provider="openai", key=""):
+        model_row = SimpleNamespace(
+            name="configured",
+            model_name="gpt-4o",
+            key=key,
+            endpoint="http://self-hosted.internal:8000" if not key else None,
+            provider_type=SimpleNamespace(type_value=provider),
+        )
+        monkeypatch.setattr(
+            "rhesis.backend.app.utils.user_model_utils.model_crud.get_model",
+            lambda **kwargs: model_row,
+        )
+        monkeypatch.setattr(
+            "rhesis.backend.app.utils.user_model_utils.get_model",
+            lambda **kwargs: SimpleNamespace(model_name=kwargs.get("model_name", "gpt-4o")),
+        )
+        from rhesis.backend.app.utils.user_model_utils import _fetch_and_configure_model
+
+        return _fetch_and_configure_model(None, "model-1", "org-1", "vertex_ai/default")
+
+    return _resolve
+
+
+class TestTokenGateFiresOnlyForHostedModels:
+    @pytest.mark.parametrize("provider", ["rhesis", "polyphemus"])
+    def test_hosted_provider_with_no_org_key_is_blocked(
+        self, configured_model, blocking_gate, provider
+    ):
+        """`rhesis`/`polyphemus` with no stored key run on our credentials --
+        this is exactly what `_is_hosted_model` returns True for."""
+        with pytest.raises(QuotaExceededError):
+            configured_model(provider=provider, key="")
+
+    @pytest.mark.parametrize("provider", ["rhesis", "polyphemus"])
+    def test_hosted_provider_with_an_org_key_is_not_blocked(
+        self, configured_model, blocking_gate, provider
+    ):
+        """An org-supplied key on a hosted-provider row means self-hosted or
+        custom-endpoint use of the same protocol, not our infrastructure --
+        `_is_hosted_model` is False, so the gate must not even run."""
+        model = configured_model(provider=provider, key="sk-org-owned")
+
+        assert model.model_name == "gpt-4o"
+
+    @pytest.mark.parametrize(
+        "provider", ["openai", "gemini", "anthropic", "vertex_ai", "ollama", "vllm"]
+    )
+    def test_a_provider_rhesis_does_not_supply_is_never_blocked(
+        self, configured_model, blocking_gate, provider
+    ):
+        """The regression that matters most: an org's own provider key must
+        never be blocked by our token quota, whatever it is -- their call
+        was never going to cost us anything."""
+        model = configured_model(provider=provider, key="sk-org-owned")
+
+        assert model.model_name == "gpt-4o"
+
+    def test_a_keyless_self_hosted_row_is_never_blocked(self, configured_model, blocking_gate):
+        """A keyless self-hosted row (own endpoint, no key) is not a hosted
+        model either -- still the org's own infrastructure."""
+        model = configured_model(provider="vllm", key="")
+
+        assert model.model_name == "gpt-4o"
+
+
+class TestResolveDefaultHostedModelTokenGate:
+    """The system default is unconditionally ours to pay for (see
+    `resolve_default_hosted_model`'s docstring), so the gate always fires
+    here regardless of provider -- the inverse of the row-level gate above.
+    """
+
+    def test_blocked_when_the_gate_fires(self, blocking_gate, monkeypatch):
+        monkeypatch.setattr(
+            "rhesis.backend.app.utils.user_model_utils.get_model",
+            lambda name, **kwargs: SimpleNamespace(model_name=name),
+        )
+        from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
+
+        with pytest.raises(QuotaExceededError):
+            resolve_default_hosted_model("rhesis/default", db=None, organization_id="org-1")
+
+    def test_no_organization_id_skips_the_check_instead_of_raising(self, monkeypatch, caplog):
+        """A last-resort escape hatch, not a silent bypass: an org-less
+        construction path logs rather than raising or blocking."""
+        monkeypatch.setattr(
+            "rhesis.backend.app.utils.user_model_utils.get_model",
+            lambda name, **kwargs: SimpleNamespace(model_name=name),
+        )
+        from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
+
+        with caplog.at_level("WARNING"):
+            model = resolve_default_hosted_model("rhesis/default", db=None, organization_id=None)
+
+        assert model.model_name == "rhesis/default"
+        assert "No organization_id" in caplog.text

--- a/tests/backend/app/test_quota_token_gate.py
+++ b/tests/backend/app/test_quota_token_gate.py
@@ -17,7 +17,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from rhesis.backend.app.quota import OveragePolicy, QuotaPolicy, QuotaResource
+from rhesis.backend.app.quota import QuotaResource
 from rhesis.backend.app.quota.enforcement import QuotaExceededError, QuotaVerdict
 
 
@@ -33,7 +33,6 @@ def _always_blocks(db, organization_id):
             resource=QuotaResource.MODEL_TOKENS,
             used=999,
             limit=1,
-            policy=QuotaPolicy(overage=OveragePolicy.HARD),
             allowed=False,
             over_limit=True,
         )

--- a/tests/backend/app/test_usage_tracking.py
+++ b/tests/backend/app/test_usage_tracking.py
@@ -488,6 +488,13 @@ class TestPlatformKeyModelProvenance:
 class TestResolveDefaultHostedModel:
     """The system default always runs on the server's own credentials."""
 
+    @pytest.fixture(autouse=True)
+    def _bypass_quota_gate(self, monkeypatch):
+        monkeypatch.setattr(
+            "rhesis.backend.app.utils.user_model_utils._enforce_model_token_quota",
+            lambda db, org_id: None,
+        )
+
     def test_stamps_a_non_rhesis_default_as_metered(self, monkeypatch):
         """Regression: a ``vertex_ai/...`` default used to be handed back as
         a bare string with no accrual, so its tokens were never counted."""

--- a/tests/backend/app/test_usage_tracking.py
+++ b/tests/backend/app/test_usage_tracking.py
@@ -498,7 +498,9 @@ class TestResolveDefaultHostedModel:
 
         from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
 
-        model = resolve_default_hosted_model("vertex_ai/gemini-2.5-flash")
+        model = resolve_default_hosted_model(
+            "vertex_ai/gemini-2.5-flash", db=None, organization_id=None
+        )
 
         assert model.model_name == "vertex_ai/gemini-2.5-flash"
         assert model.usage_metered is True
@@ -519,9 +521,9 @@ class TestResolveDefaultHostedModel:
 
         from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
 
-        assert resolve_default_hosted_model("vertex_ai/gemini-2.5-flash") == (
-            "vertex_ai/gemini-2.5-flash"
-        )
+        assert resolve_default_hosted_model(
+            "vertex_ai/gemini-2.5-flash", db=None, organization_id=None
+        ) == ("vertex_ai/gemini-2.5-flash")
 
     def test_a_user_with_no_configured_model_gets_the_stamped_default(self, monkeypatch):
         """Covers `_get_user_model`'s no-model_id branch, which nothing
@@ -559,7 +561,9 @@ class TestResolveDefaultHostedModel:
 
         from rhesis.backend.app.utils.user_model_utils import resolve_default_hosted_model
 
-        model = resolve_default_hosted_model("vertex_ai/gemini-2.5-flash")
+        model = resolve_default_hosted_model(
+            "vertex_ai/gemini-2.5-flash", db=None, organization_id=None
+        )
         with usage_attribution("org-42"):
             model.emit(30)
 

--- a/tests/backend/ee/licensing/test_tiers.py
+++ b/tests/backend/ee/licensing/test_tiers.py
@@ -8,6 +8,7 @@ verifies to entitlements that grant exactly those features.
 from __future__ import annotations
 
 import pytest
+import yaml
 
 from rhesis.backend.app.features import FeatureName
 from rhesis.backend.app.quota import (
@@ -33,6 +34,7 @@ from rhesis.backend.ee.licensing.tiers import (
     SELLABLE_EDITIONS,
     TierSpec,
     _assert_catalog_complete,
+    _fallback_catalog,
     _load_tier_config,
     all_sellable,
     is_sellable,
@@ -118,8 +120,26 @@ class TestLoadTierConfig:
     or silently misparse into a wrong-but-valid-looking TierSpec."""
 
     def _load_from(self, tmp_path, monkeypatch, content: str) -> dict:
+        """Parse *content* as a tier config, filling any `limits` mapping
+        out to full QuotaResource coverage (defaulting to null/unlimited)
+        before writing it.
+
+        `_parse_limits` now requires every QuotaResource to have an explicit
+        entry (see its docstring). Most tests in this class are about some
+        other behavior -- a malformed shape, an unknown edition, an overage
+        value -- and write a minimal `limits: {seats: 3}` block that would
+        otherwise fail that unrelated coverage check for a reason the test
+        isn't exercising. Backfilling here keeps those fixtures minimal
+        without any test asserting on QuotaResource coverage by accident.
+        """
+        parsed = yaml.safe_load(content) or {}
+        for spec in parsed.values():
+            if isinstance(spec, dict) and isinstance(spec.get("limits"), dict):
+                for resource in QuotaResource:
+                    spec["limits"].setdefault(resource.value, None)
+
         config_file = tmp_path / "tier_config.yaml"
-        config_file.write_text(content)
+        config_file.write_text(yaml.safe_dump(parsed))
         monkeypatch.setenv(ENV_TIER_CONFIG, str(config_file))
         return _load_tier_config()
 
@@ -224,6 +244,38 @@ class TestLoadTierConfig:
         limits = catalog[LicenseEdition.COMMUNITY].limits
         assert limits[QuotaResource.SEATS] == 0
         assert limits[QuotaResource.PROJECTS] is None
+
+    def test_limits_missing_a_resource_raises(self, tmp_path, monkeypatch):
+        """A `limits` block that omits a resource must fail loud, not read as
+        unlimited for that resource -- the same failure mode an unknown key
+        already fails loud for, just the opposite typo. Bypasses `_load_from`
+        (which backfills missing resources for every other test in this
+        class) to exercise the real, unfilled-in loader path."""
+        config_file = tmp_path / "tier_config.yaml"
+        config_file.write_text(f"community:\n  limits:\n    {QuotaResource.SEATS.value}: 3\n")
+        monkeypatch.setenv(ENV_TIER_CONFIG, str(config_file))
+
+        with pytest.raises(ValueError, match="missing resource"):
+            _load_tier_config()
+
+    def test_invalid_all_features_value_is_rejected(self, tmp_path, monkeypatch):
+        """`bool("false")` is `True` -- an unvalidated quoted string here
+        would mint a token unlocking every EE feature for a tier the config
+        says shouldn't have them."""
+        with pytest.raises(ValueError, match="all_features"):
+            self._load_from(
+                tmp_path,
+                monkeypatch,
+                'community:\n  all_features: "false"\n  limits:\n    seats: 3\n',
+            )
+
+    def test_real_all_features_bool_is_accepted(self, tmp_path, monkeypatch):
+        catalog = self._load_from(
+            tmp_path,
+            monkeypatch,
+            "community:\n  all_features: true\n  limits:\n    seats: 3\n",
+        )
+        assert catalog[LicenseEdition.COMMUNITY].all_features is True
 
     def test_unrecognized_overage_value_raises(self, tmp_path, monkeypatch):
         with pytest.raises(ValueError, match="[Ii]nvalid overage policy"):
@@ -358,8 +410,18 @@ class TestCatalogCompleteness:
     def test_community_only_fallback_is_exempt(self):
         """_fallback_catalog() is community-only by design; the gate must
         not turn a degraded-but-working config into a boot failure."""
-        fallback = {LicenseEdition.COMMUNITY: TierSpec(edition=LicenseEdition.COMMUNITY)}
-        _assert_catalog_complete(fallback)
+        _assert_catalog_complete(_fallback_catalog())
+
+    def test_a_plain_community_only_dict_is_not_exempt(self):
+        """The gate distinguishes the *marked* fallback from a real config
+        that merely collapsed to the same shape -- e.g. every paid tier got
+        dropped by _load_tier_config's per-entry checks while community
+        stayed valid. A bare dict with the identical keys must still raise;
+        only the actual _fallback_catalog() marker is exempt (see
+        _FallbackCatalog's docstring for why this used to silently pass)."""
+        degraded = {LicenseEdition.COMMUNITY: TierSpec(edition=LicenseEdition.COMMUNITY)}
+        with pytest.raises(RuntimeError, match="missing an entry"):
+            _assert_catalog_complete(degraded)
 
     def test_missing_community_entry_raises(self):
         """A catalog with every paid tier but no community entry must fail.

--- a/tests/backend/ee/licensing/test_tiers.py
+++ b/tests/backend/ee/licensing/test_tiers.py
@@ -10,7 +10,13 @@ from __future__ import annotations
 import pytest
 
 from rhesis.backend.app.features import FeatureName
-from rhesis.backend.app.quota import FREE_TIER_LIMITS, OveragePolicy, QuotaPolicy, QuotaResource
+from rhesis.backend.app.quota import (
+    FREE_TIER_LIMITS,
+    OveragePolicy,
+    QuotaPolicy,
+    QuotaResource,
+    limits_to_wire,
+)
 from rhesis.backend.ee.licensing.entitlements import (
     ENV_TIER_CONFIG,
     LIC_ALL_FEATURES,
@@ -28,16 +34,30 @@ from rhesis.backend.ee.licensing.tiers import (
     TierSpec,
     _assert_catalog_complete,
     _load_tier_config,
-    _parse_overage,
-    _parse_overage_tolerance,
     all_sellable,
     is_sellable,
-    resolve_limits,
     resolve_policy,
     resolve_tier,
     tier_to_lic_claim,
 )
 from rhesis.backend.ee.licensing.verify import verify_token
+
+
+@pytest.fixture
+def bundled_catalog(monkeypatch):
+    """Reload the catalog from the bundled YAML, ignoring any ambient override.
+
+    Tests that assert the *shipped* tier numbers must not read whatever
+    ``RHESIS_TIER_CONFIG`` happens to point at. That variable is a documented
+    local workflow (``tier_config.dev.yaml`` sets deliberately tiny limits for
+    exercising enforcement by hand) and the app calls ``load_dotenv``, so
+    putting it in ``apps/backend/.env`` -- the natural way to switch it on --
+    otherwise fails these tests with numbers that are correct for the config
+    actually loaded.
+    """
+    monkeypatch.setenv(ENV_TIER_CONFIG, str(_BUNDLED_CONFIG))
+    return _load_tier_config()
+
 
 pytestmark = pytest.mark.skipif(
     not pytest.importorskip(
@@ -77,11 +97,11 @@ class TestCatalogShape:
         """COMMUNITY is in the catalog (for resolve_limits) despite being non-sellable."""
         assert LicenseEdition.COMMUNITY in EDITION_ENTITLEMENTS
 
-    def test_community_limits_match_core_free_tier_defaults(self):
+    def test_community_limits_match_core_free_tier_defaults(self, bundled_catalog):
         """The YAML's community entry must stay in sync with core's
         FREE_TIER_LIMITS -- the two are duplicated by necessity (core can't
         import EE), so drift between them would only show up here."""
-        assert resolve_limits(LicenseEdition.COMMUNITY) == FREE_TIER_LIMITS
+        assert bundled_catalog[LicenseEdition.COMMUNITY].limits == FREE_TIER_LIMITS
 
     def test_limit_keys_are_quota_resources(self):
         """All limit keys in every tier spec are QuotaResource members."""
@@ -251,34 +271,6 @@ class TestLoadTierConfig:
             )
 
 
-class TestParseOverage:
-    def test_valid_values_round_trip(self):
-        assert _parse_overage("hard") is OveragePolicy.HARD
-        assert _parse_overage("soft") is OveragePolicy.SOFT
-
-    def test_unrecognized_value_raises(self):
-        with pytest.raises(ValueError, match="[Ii]nvalid overage policy"):
-            _parse_overage("lenient")
-
-
-class TestParseOverageTolerance:
-    def test_non_negative_int_is_valid(self):
-        assert _parse_overage_tolerance(0) == 0
-        assert _parse_overage_tolerance(25) == 25
-
-    def test_bool_is_rejected_even_though_it_is_an_int_subclass(self):
-        with pytest.raises(ValueError, match="overage_tolerance_percent"):
-            _parse_overage_tolerance(True)
-
-    def test_negative_is_rejected(self):
-        with pytest.raises(ValueError, match="overage_tolerance_percent"):
-            _parse_overage_tolerance(-1)
-
-    def test_non_int_is_rejected(self):
-        with pytest.raises(ValueError, match="overage_tolerance_percent"):
-            _parse_overage_tolerance("25")
-
-
 class TestTierSpecToPolicy:
     def test_carries_limits_overage_and_tolerance(self):
         spec = TierSpec(
@@ -321,14 +313,22 @@ class TestResolvePolicy:
         assert policy.overage_tolerance_percent == 0
         assert policy.ceiling_for(1_000) == 1_000
 
-    def test_none_edition_falls_back_to_community(self):
-        assert resolve_policy(None).limits == resolve_policy(LicenseEdition.COMMUNITY).limits
+    @pytest.mark.parametrize("edition", [None, LicenseEdition.UNKNOWN])
+    def test_unresolvable_edition_falls_back_to_a_populated_community_tier(self, edition):
+        """Comparing only against ``resolve_policy(COMMUNITY)`` would not be
+        enough: both sides come from the same function, so the assertion also
+        holds when the community entry has vanished and both are an empty
+        dict. An empty limits dict reads as *unlimited* downstream, so that
+        fail-open case is exactly what needs catching -- hence the second
+        assertion that every resource is actually covered.
 
-    def test_unknown_edition_falls_back_to_community(self):
-        assert (
-            resolve_policy(LicenseEdition.UNKNOWN).limits
-            == resolve_policy(LicenseEdition.COMMUNITY).limits
-        )
+        Deliberately no assertion on the numbers themselves: ``resolve_policy``
+        reads the catalog loaded at import time, which honours an ambient
+        ``RHESIS_TIER_CONFIG`` (see the ``bundled_catalog`` fixture)."""
+        policy = resolve_policy(edition)
+
+        assert policy.limits == resolve_policy(LicenseEdition.COMMUNITY).limits
+        assert set(policy.limits) == set(QuotaResource)
 
 
 class TestCatalogCompleteness:
@@ -408,9 +408,8 @@ class TestTierToLicClaim:
         assert claim[LIC_ALL_FEATURES] is False
         assert claim[LIC_FEATURES] == [FeatureName.RBAC.value]
 
-    def test_team_claim_has_quota_limits(self):
-        claim = tier_to_lic_claim(LicenseEdition.TEAM)
-        limits = claim[LIC_LIMITS]
+    def test_team_claim_has_quota_limits(self, bundled_catalog):
+        limits = limits_to_wire(bundled_catalog[LicenseEdition.TEAM].limits)
         assert limits[str(QuotaResource.TEST_EXECUTIONS)] == 100_000
         assert limits[str(QuotaResource.SEATS)] is None
 

--- a/tests/backend/ee/licensing/test_tiers.py
+++ b/tests/backend/ee/licensing/test_tiers.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import pytest
 
 from rhesis.backend.app.features import FeatureName
-from rhesis.backend.app.quota import FREE_TIER_LIMITS, QuotaResource
+from rhesis.backend.app.quota import FREE_TIER_LIMITS, OveragePolicy, QuotaPolicy, QuotaResource
 from rhesis.backend.ee.licensing.entitlements import (
     ENV_TIER_CONFIG,
     LIC_ALL_FEATURES,
@@ -28,9 +28,12 @@ from rhesis.backend.ee.licensing.tiers import (
     TierSpec,
     _assert_catalog_complete,
     _load_tier_config,
+    _parse_overage,
+    _parse_overage_tolerance,
     all_sellable,
     is_sellable,
     resolve_limits,
+    resolve_policy,
     resolve_tier,
     tier_to_lic_claim,
 )
@@ -201,6 +204,131 @@ class TestLoadTierConfig:
         limits = catalog[LicenseEdition.COMMUNITY].limits
         assert limits[QuotaResource.SEATS] == 0
         assert limits[QuotaResource.PROJECTS] is None
+
+    def test_unrecognized_overage_value_raises(self, tmp_path, monkeypatch):
+        with pytest.raises(ValueError, match="[Ii]nvalid overage policy"):
+            self._load_from(
+                tmp_path,
+                monkeypatch,
+                "community:\n  limits:\n    seats: 3\n  overage: lenient\n",
+            )
+
+    def test_overage_and_tolerance_are_parsed_from_the_entry(self, tmp_path, monkeypatch):
+        catalog = self._load_from(
+            tmp_path,
+            monkeypatch,
+            "community:\n  limits:\n    seats: 3\n"
+            "  overage: soft\n  overage_tolerance_percent: 10\n",
+        )
+        spec = catalog[LicenseEdition.COMMUNITY]
+        assert spec.overage is OveragePolicy.SOFT
+        assert spec.overage_tolerance_percent == 10
+
+    def test_omitted_overage_fields_use_tierspec_defaults(self, tmp_path, monkeypatch):
+        """HARD / 0% -- unchanged behavior for a tier that doesn't opt in."""
+        catalog = self._load_from(
+            tmp_path,
+            monkeypatch,
+            "community:\n  limits:\n    seats: 3\n",
+        )
+        spec = catalog[LicenseEdition.COMMUNITY]
+        assert spec.overage is OveragePolicy.HARD
+        assert spec.overage_tolerance_percent == 0
+
+    @pytest.mark.parametrize(
+        "value,description",
+        [("-1", "negative"), ("true", "bool"), ('"25"', "string"), ("1.5", "float")],
+    )
+    def test_invalid_overage_tolerance_values_are_rejected(
+        self, tmp_path, monkeypatch, value, description
+    ):
+        with pytest.raises(ValueError, match="overage_tolerance_percent"):
+            self._load_from(
+                tmp_path,
+                monkeypatch,
+                f"community:\n  limits:\n    seats: 3\n"
+                f"  overage: soft\n  overage_tolerance_percent: {value}\n",
+            )
+
+
+class TestParseOverage:
+    def test_valid_values_round_trip(self):
+        assert _parse_overage("hard") is OveragePolicy.HARD
+        assert _parse_overage("soft") is OveragePolicy.SOFT
+
+    def test_unrecognized_value_raises(self):
+        with pytest.raises(ValueError, match="[Ii]nvalid overage policy"):
+            _parse_overage("lenient")
+
+
+class TestParseOverageTolerance:
+    def test_non_negative_int_is_valid(self):
+        assert _parse_overage_tolerance(0) == 0
+        assert _parse_overage_tolerance(25) == 25
+
+    def test_bool_is_rejected_even_though_it_is_an_int_subclass(self):
+        with pytest.raises(ValueError, match="overage_tolerance_percent"):
+            _parse_overage_tolerance(True)
+
+    def test_negative_is_rejected(self):
+        with pytest.raises(ValueError, match="overage_tolerance_percent"):
+            _parse_overage_tolerance(-1)
+
+    def test_non_int_is_rejected(self):
+        with pytest.raises(ValueError, match="overage_tolerance_percent"):
+            _parse_overage_tolerance("25")
+
+
+class TestTierSpecToPolicy:
+    def test_carries_limits_overage_and_tolerance(self):
+        spec = TierSpec(
+            edition=LicenseEdition.TEAM,
+            limits={QuotaResource.SEATS: 10},
+            overage=OveragePolicy.SOFT,
+            overage_tolerance_percent=25,
+        )
+
+        policy = spec.to_policy()
+
+        assert isinstance(policy, QuotaPolicy)
+        assert policy.limits == {QuotaResource.SEATS: 10}
+        assert policy.overage is OveragePolicy.SOFT
+        assert policy.overage_tolerance_percent == 25
+        assert policy.ceiling_for(10) == 12
+
+
+class TestResolvePolicy:
+    def test_real_team_tier_is_soft_with_25_percent_tolerance(self):
+        """Locks in the shipped tier_config.yaml values the plan calls for:
+        team warns at the limit and hard-blocks at limit + 25%."""
+        policy = resolve_policy(LicenseEdition.TEAM)
+
+        assert policy.overage is OveragePolicy.SOFT
+        assert policy.overage_tolerance_percent == 25
+        assert policy.ceiling_for(100_000) == 125_000
+
+    def test_real_enterprise_tier_is_soft_with_25_percent_tolerance(self):
+        policy = resolve_policy(LicenseEdition.ENTERPRISE)
+
+        assert policy.overage is OveragePolicy.SOFT
+        assert policy.overage_tolerance_percent == 25
+
+    def test_real_community_tier_is_hard_with_no_tolerance(self):
+        """Free tier gets no grace band -- blocks exactly at the limit."""
+        policy = resolve_policy(LicenseEdition.COMMUNITY)
+
+        assert policy.overage is OveragePolicy.HARD
+        assert policy.overage_tolerance_percent == 0
+        assert policy.ceiling_for(1_000) == 1_000
+
+    def test_none_edition_falls_back_to_community(self):
+        assert resolve_policy(None).limits == resolve_policy(LicenseEdition.COMMUNITY).limits
+
+    def test_unknown_edition_falls_back_to_community(self):
+        assert (
+            resolve_policy(LicenseEdition.UNKNOWN).limits
+            == resolve_policy(LicenseEdition.COMMUNITY).limits
+        )
 
 
 class TestCatalogCompleteness:

--- a/tests/backend/routes/test_quota_gates.py
+++ b/tests/backend/routes/test_quota_gates.py
@@ -1,0 +1,151 @@
+"""Integration tests for :func:`~rhesis.backend.app.auth.quota_gates.require_quota`.
+
+Goes through the real app and a real gated route (`POST /projects/`) rather
+than a mocked-dependency mini-app, unlike `ee/licensing/test_feature_gates.py`
+-- `require_quota` reads the FORCE-RLS'd `usage` table (for flow resources)
+and a live `COUNT(*)` (for stock resources), and its own module docstring
+explains why a GUC-less session would silently never block anyone. Only a
+real tenant-scoped session (what `authenticated_client` gives us) exercises
+that path honestly.
+
+The org's real license/tier is irrelevant here: every test installs a fixed
+`QuotaPolicy` directly via `QuotaRegistry`, the same technique
+`test_quota_enforcement.py` uses, so these don't depend on which tier config
+file happens to be active in the environment (`RHESIS_TIER_CONFIG` can point
+anywhere -- see `tier_config.dev.yaml` for local low-limit testing).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import Response, status
+from fastapi.testclient import TestClient
+
+from rhesis.backend.app.auth.quota_gates import QUOTA_WARNING_HEADER, require_quota
+from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.quota import OveragePolicy, QuotaPolicy, QuotaRegistry, QuotaResource
+from rhesis.backend.app.services.usage import increment_usage
+
+
+class _FixedPolicyProvider:
+    def __init__(self, policy: QuotaPolicy):
+        self._policy = policy
+
+    def get_policy(self, org=None) -> QuotaPolicy:
+        return self._policy
+
+
+@pytest.fixture
+def clean_registry():
+    saved_provider = QuotaRegistry._provider
+    QuotaRegistry.reset()
+    yield
+    QuotaRegistry._provider = saved_provider
+
+
+def _install(policy: QuotaPolicy) -> None:
+    QuotaRegistry.set_quota_provider(_FixedPolicyProvider(policy))
+
+
+def _project_payload() -> dict:
+    import time
+
+    return {"name": f"quota-gate-test-project-{int(time.time() * 1_000_000) % 1_000_000}"}
+
+
+@pytest.fixture
+def authenticated_org(test_db, test_org_id) -> Organization:
+    return test_db.query(Organization).filter(Organization.id == test_org_id).one()
+
+
+class TestRequireQuotaStockResource:
+    """`POST /projects/` is gated on `QuotaResource.PROJECTS`, a stock (live
+    COUNT) resource -- no accrual lag, so "already at the limit" is exactly
+    "the next create is blocked", tested directly."""
+
+    def test_under_the_limit_succeeds(self, authenticated_client: TestClient, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.PROJECTS: 1_000}))
+
+        response = authenticated_client.post("/projects/", json=_project_payload())
+
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_at_the_limit_returns_402(self, authenticated_client: TestClient, clean_registry):
+        _install(QuotaPolicy(limits={QuotaResource.PROJECTS: 0}, overage=OveragePolicy.HARD))
+
+        response = authenticated_client.post("/projects/", json=_project_payload())
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED
+        body = response.json()
+        assert body["error"] == "quota_exceeded"
+        assert body["resource"] == QuotaResource.PROJECTS.value
+        assert body["limit"] == 0
+
+
+class TestRequireQuotaFlowResourceWarningHeader:
+    """The SOFT-policy grace band sets `QUOTA_WARNING_HEADER` on an allowed
+    response, so a caller past the advertised limit is warned before the
+    next request finally crosses the ceiling.
+
+    Exercised by calling `require_quota`'s returned dependency directly
+    (real `db`/`org`, no route needed) -- driving this through a real
+    execute endpoint would mean standing up a full test-execution pipeline
+    just to observe a response header. The HTTP wiring itself (the same
+    dependency, reached via `Depends()`) is already covered end-to-end by
+    `TestRequireQuotaStockResource` above.
+    """
+
+    def test_below_limit_sets_no_warning(
+        self, test_db, test_org_id, authenticated_org, clean_registry
+    ):
+        _install(
+            QuotaPolicy(
+                limits={QuotaResource.TEST_EXECUTIONS: 100},
+                overage=OveragePolicy.SOFT,
+                overage_tolerance_percent=25,
+            )
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 50)
+        response = Response()
+
+        dep = require_quota(QuotaResource.TEST_EXECUTIONS)
+        dep(response=response, org=authenticated_org, db=test_db)
+
+        assert QUOTA_WARNING_HEADER not in response.headers
+
+    def test_in_the_grace_band_sets_the_warning_header(
+        self, test_db, test_org_id, authenticated_org, clean_registry
+    ):
+        _install(
+            QuotaPolicy(
+                limits={QuotaResource.TEST_EXECUTIONS: 100},
+                overage=OveragePolicy.SOFT,
+                overage_tolerance_percent=25,
+            )
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 110)
+        response = Response()
+
+        dep = require_quota(QuotaResource.TEST_EXECUTIONS)
+        dep(response=response, org=authenticated_org, db=test_db)
+
+        assert response.headers[QUOTA_WARNING_HEADER] == "test_executions=110/100"
+
+    def test_at_the_ceiling_raises_instead_of_returning(
+        self, test_db, test_org_id, authenticated_org, clean_registry
+    ):
+        from rhesis.backend.app.quota.enforcement import QuotaExceededError
+
+        _install(
+            QuotaPolicy(
+                limits={QuotaResource.TEST_EXECUTIONS: 100},
+                overage=OveragePolicy.SOFT,
+                overage_tolerance_percent=25,
+            )
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, 125)
+        response = Response()
+
+        dep = require_quota(QuotaResource.TEST_EXECUTIONS)
+        with pytest.raises(QuotaExceededError):
+            dep(response=response, org=authenticated_org, db=test_db)

--- a/tests/backend/routes/test_quota_gates.py
+++ b/tests/backend/routes/test_quota_gates.py
@@ -23,8 +23,9 @@ from fastapi.testclient import TestClient
 
 from rhesis.backend.app.auth.quota_gates import QUOTA_WARNING_HEADER, require_quota
 from rhesis.backend.app.models.organization import Organization
+from rhesis.backend.app.models.project import Project
 from rhesis.backend.app.quota import OveragePolicy, QuotaPolicy, QuotaRegistry, QuotaResource
-from rhesis.backend.app.services.usage import increment_usage
+from rhesis.backend.app.services.usage import count_org_projects, count_org_seats, increment_usage
 
 
 class _FixedPolicyProvider:
@@ -61,17 +62,35 @@ def authenticated_org(test_db, test_org_id) -> Organization:
 class TestRequireQuotaStockResource:
     """`POST /projects/` is gated on `QuotaResource.PROJECTS`, a stock (live
     COUNT) resource -- no accrual lag, so "already at the limit" is exactly
-    "the next create is blocked", tested directly."""
+    "the next create is blocked".
 
-    def test_under_the_limit_succeeds(self, authenticated_client: TestClient, clean_registry):
-        _install(QuotaPolicy(limits={QuotaResource.PROJECTS: 1_000}))
+    Both limits are derived from the org's *actual* project count rather than
+    hardcoded. An earlier version used a fixed limit of 0 to block and 1,000
+    to allow, which passed with the stock counters stubbed to return 0 --
+    i.e. it proved nothing about whether the live count was ever read. Here a
+    wrong count moves the boundary and both tests fail.
+    """
+
+    def test_one_below_the_limit_succeeds(
+        self, authenticated_client: TestClient, test_db, test_org_id, clean_registry
+    ):
+        existing = count_org_projects(test_db, test_org_id)
+        _install(
+            QuotaPolicy(limits={QuotaResource.PROJECTS: existing + 1}, overage=OveragePolicy.HARD)
+        )
 
         response = authenticated_client.post("/projects/", json=_project_payload())
 
         assert response.status_code == status.HTTP_200_OK
 
-    def test_at_the_limit_returns_402(self, authenticated_client: TestClient, clean_registry):
-        _install(QuotaPolicy(limits={QuotaResource.PROJECTS: 0}, overage=OveragePolicy.HARD))
+    def test_at_the_limit_returns_402(
+        self, authenticated_client: TestClient, test_db, test_org_id, clean_registry
+    ):
+        test_db.add(Project(name="quota-gate-existing-project", organization_id=test_org_id))
+        test_db.commit()
+        existing = count_org_projects(test_db, test_org_id)
+        assert existing >= 1, "fixture should leave at least the project just created"
+        _install(QuotaPolicy(limits={QuotaResource.PROJECTS: existing}, overage=OveragePolicy.HARD))
 
         response = authenticated_client.post("/projects/", json=_project_payload())
 
@@ -79,7 +98,55 @@ class TestRequireQuotaStockResource:
         body = response.json()
         assert body["error"] == "quota_exceeded"
         assert body["resource"] == QuotaResource.PROJECTS.value
-        assert body["limit"] == 0
+        assert body["limit"] == existing
+        # The live count really was read, not defaulted to 0.
+        assert body["used"] == existing
+
+
+class TestSeatGateOnUserInvite:
+    """`POST /users/` is the one gated route wrapped by
+    `@handle_database_exceptions`, whose bare `except Exception` rewrites
+    anything raised out of the route body into a 500.
+
+    The gate survives that only because it runs as a `Depends()` -- FastAPI
+    resolves dependencies before calling the decorated function, so
+    `QuotaExceededError` never passes through the decorator and reaches the
+    global 402 handler intact. Nothing else in the suite covers that, and
+    reordering the decorator or inlining the check into the body would break
+    it silently, so it is pinned here.
+    """
+
+    def test_at_the_seat_limit_returns_402(
+        self, authenticated_client: TestClient, test_db, test_org_id, clean_registry
+    ):
+        existing = count_org_seats(test_db, test_org_id)
+        _install(QuotaPolicy(limits={QuotaResource.SEATS: existing}, overage=OveragePolicy.HARD))
+
+        response = authenticated_client.post(
+            "/users/", json={"email": "quota-gate-invitee@example.com"}
+        )
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED, response.text
+        body = response.json()
+        assert body["error"] == "quota_exceeded"
+        assert body["resource"] == QuotaResource.SEATS.value
+        assert body["used"] == existing
+
+    def test_under_the_seat_limit_is_not_blocked_by_quota(
+        self, authenticated_client: TestClient, test_db, test_org_id, clean_registry
+    ):
+        """Only asserts the quota gate did not fire -- the invite itself can
+        still fail on email deliverability, which is not this gate's business."""
+        existing = count_org_seats(test_db, test_org_id)
+        _install(
+            QuotaPolicy(limits={QuotaResource.SEATS: existing + 1}, overage=OveragePolicy.HARD)
+        )
+
+        response = authenticated_client.post(
+            "/users/", json={"email": "quota-gate-invitee@example.com"}
+        )
+
+        assert response.status_code != status.HTTP_402_PAYMENT_REQUIRED, response.text
 
 
 class TestRequireQuotaFlowResourceWarningHeader:

--- a/tests/backend/routes/test_quota_gates.py
+++ b/tests/backend/routes/test_quota_gates.py
@@ -149,6 +149,128 @@ class TestSeatGateOnUserInvite:
         assert response.status_code != status.HTTP_402_PAYMENT_REQUIRED, response.text
 
 
+@pytest.fixture
+def _bypass_model_validation():
+    """Replace ``validate_execution_model`` and ``validate_generation_model``
+    with no-ops so the quota gate is the first dependency that can block.
+
+    Without this, FastAPI resolves model validation before the quota gate
+    (signature order), and a missing/invalid model config would return 400
+    before the gate ever fires -- hiding the thing under test.
+    """
+    from rhesis.backend.app.main import app
+    from rhesis.backend.app.utils.execution_validation import (
+        validate_execution_model,
+        validate_generation_model,
+    )
+
+    app.dependency_overrides[validate_execution_model] = lambda: None
+    app.dependency_overrides[validate_generation_model] = lambda: None
+    yield
+    app.dependency_overrides.pop(validate_execution_model, None)
+    app.dependency_overrides.pop(validate_generation_model, None)
+
+
+class TestFlowResourceQuotaGate:
+    """Flow resources (TEST_EXECUTIONS, TEST_GENERATION) are period-scoped
+    counters read from the ``usage`` table, not live ``COUNT(*)`` queries.
+    The blocking arithmetic is identical to stock resources (same
+    ``enforce_quota`` call), but the read path is different -- a missing or
+    un-incremented ``usage`` row means the gate reads zero and never blocks.
+
+    These tests seed the ``usage`` table via ``increment_usage``, then hit
+    a real gated route through ``authenticated_client`` and assert 402.
+    Model-validation dependencies are overridden to no-ops so the quota
+    gate is the one that decides the response.
+    """
+
+    def test_execute_at_the_limit_returns_402(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_org_id,
+        clean_registry,
+        _bypass_model_validation,
+    ):
+        limit = 10
+        _install(QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: limit}, overage=OveragePolicy.HARD))
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_EXECUTIONS, limit)
+
+        response = authenticated_client.post(
+            "/test_configurations/00000000-0000-0000-0000-000000000001/execute"
+        )
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED, response.text
+        body = response.json()
+        assert body["error"] == "quota_exceeded"
+        assert body["resource"] == QuotaResource.TEST_EXECUTIONS.value
+        assert body["used"] == limit
+        assert body["limit"] == limit
+
+    def test_execute_under_the_limit_is_not_blocked(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_org_id,
+        clean_registry,
+        _bypass_model_validation,
+    ):
+        """The gate passes; the route itself returns 404 (no such test config)
+        -- that's fine, we only care that the quota gate did not fire."""
+        _install(
+            QuotaPolicy(limits={QuotaResource.TEST_EXECUTIONS: 100}, overage=OveragePolicy.HARD)
+        )
+
+        response = authenticated_client.post(
+            "/test_configurations/00000000-0000-0000-0000-000000000001/execute"
+        )
+
+        assert response.status_code != status.HTTP_402_PAYMENT_REQUIRED, response.text
+
+    def test_generate_at_the_limit_returns_402(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_org_id,
+        clean_registry,
+        _bypass_model_validation,
+    ):
+        limit = 5
+        _install(
+            QuotaPolicy(limits={QuotaResource.TEST_GENERATION: limit}, overage=OveragePolicy.HARD)
+        )
+        increment_usage(test_db, test_org_id, QuotaResource.TEST_GENERATION, limit)
+
+        response = authenticated_client.post(
+            "/test_sets/generate", json={"num_tests": 1}
+        )
+
+        assert response.status_code == status.HTTP_402_PAYMENT_REQUIRED, response.text
+        body = response.json()
+        assert body["error"] == "quota_exceeded"
+        assert body["resource"] == QuotaResource.TEST_GENERATION.value
+        assert body["used"] == limit
+        assert body["limit"] == limit
+
+    def test_generate_under_the_limit_is_not_blocked(
+        self,
+        authenticated_client: TestClient,
+        test_db,
+        test_org_id,
+        clean_registry,
+        _bypass_model_validation,
+    ):
+        _install(
+            QuotaPolicy(limits={QuotaResource.TEST_GENERATION: 100}, overage=OveragePolicy.HARD)
+        )
+
+        response = authenticated_client.post(
+            "/test_sets/generate", json={"num_tests": 1}
+        )
+
+        assert response.status_code != status.HTTP_402_PAYMENT_REQUIRED, response.text
+
+
 class TestRequireQuotaFlowResourceWarningHeader:
     """The SOFT-policy grace band sets `QUOTA_WARNING_HEADER` on an allowed
     response, so a caller past the advertised limit is warned before the

--- a/tests/backend/routes/test_usage.py
+++ b/tests/backend/routes/test_usage.py
@@ -43,7 +43,14 @@ class TestUsageEndpoint:
         body = response.json()
 
         for item in body["resources"].values():
-            assert set(item.keys()) == {"used", "limit", "period_start", "period_end", "kind"}
+            assert set(item.keys()) == {
+                "used",
+                "limit",
+                "ceiling",
+                "period_start",
+                "period_end",
+                "kind",
+            }
             assert isinstance(item["used"], int)
             assert item["kind"] in ("flow", "stock")
 

--- a/tests/backend/security/test_authz_http_enforcement.py
+++ b/tests/backend/security/test_authz_http_enforcement.py
@@ -24,7 +24,8 @@ The EE per-role matrix is exhaustively covered at the provider level in
 Routes used (resolved from the live capability map):
 - ``PUT /organizations/{id}`` → ``organization:update`` (owner-only, core/non-EE).
 - ``GET /requirements/`` → ``requirement:read`` (ordinary, not owner-only).
-- ``GET /usage`` → ``usage:read`` (owner-only in community, Owner/Admin in EE).
+- ``GET /usage`` → ``usage:read`` (authorized, but held by every org member
+  in both community and EE -- see the note on ``_OWNER_ONLY_CAPABILITIES``).
 
 Run with:
     cd apps/backend
@@ -150,33 +151,56 @@ class TestHttpAuthzEnforcement:
         assert resp.status_code == 200, resp.text
 
     def test_owner_allowed_on_usage_route(self, client, test_db):
-        """Usage is billing data, but the org owner may read it."""
         _org, _user, token = _make_context(test_db, owner=True)
         resp = client.get(USAGE_ROUTE, headers=_auth(token))
         assert resp.status_code == 200, (
             f"Org owner wrongly denied usage:read: {resp.status_code} {resp.text}"
         )
 
-    def test_non_owner_denied_on_usage_route(self, client, test_db):
-        """A plain member may not read the org's usage totals or plan limits.
+    def test_non_owner_allowed_on_usage_route(self, client, test_db):
+        """A plain member may read the org's usage against plan limits.
 
-        Regression guard: ``GET /usage`` used to sit in
-        ``AUTHZ_EXEMPT_ROUTES``, so any authenticated member could read it.
+        ``usage:read`` is not owner-only: it reports consumption against
+        plan limits -- counters and caps, no money -- and quota enforcement
+        blocks members, so they need to see why. See the note on
+        ``_OWNER_ONLY_CAPABILITIES`` in ``app/auth/rbac.py``.
         """
         _org, _user, token = _make_context(test_db, owner=False)
         resp = client.get(USAGE_ROUTE, headers=_auth(token))
-        assert resp.status_code == 403, (
-            f"Expected 403 for non-owner usage:read, got {resp.status_code}: {resp.text}"
+        assert resp.status_code == 200, (
+            f"Non-owner member wrongly denied usage:read: {resp.status_code} {resp.text}"
         )
-        assert resp.headers.get("X-Accepted-Permissions") == USAGE_ROUTE_CAP
 
-    def test_usage_history_is_gated_too(self, client, test_db):
-        """The history endpoint behind the charts carries the same data."""
+    def test_non_owner_allowed_on_usage_history(self, client, test_db):
+        """The history endpoint behind the charts carries the same data class,
+        so it moves with the summary rather than being split from it."""
         _org, _user, token = _make_context(test_db, owner=False)
         resp = client.get(f"{USAGE_ROUTE}/history", headers=_auth(token))
-        assert resp.status_code == 403, (
-            f"Expected 403 for non-owner usage history, got {resp.status_code}: {resp.text}"
+        assert resp.status_code == 200, (
+            f"Non-owner member wrongly denied usage history: {resp.status_code} {resp.text}"
         )
+
+    def test_usage_still_goes_through_authorization(self):
+        """Members may read usage, but the route is still *authorized*, not
+        exempt.
+
+        This is what the original regression guard was really protecting:
+        ``GET /usage`` once sat in ``AUTHZ_EXEMPT_ROUTES``, bypassing authz
+        entirely. Widening who holds ``usage:read`` is a deliberate policy
+        change; putting the route back on the bypass list is not, and would
+        expose it to callers with no org context at all.
+        """
+        from rhesis.backend.app.auth.public_routes import AUTHZ_EXEMPT_ROUTES, PUBLIC_ROUTES
+
+        for method in ("GET",):
+            assert (method, USAGE_ROUTE) not in AUTHZ_EXEMPT_ROUTES
+            assert (method, f"{USAGE_ROUTE}/history") not in AUTHZ_EXEMPT_ROUTES
+            assert (method, USAGE_ROUTE) not in PUBLIC_ROUTES
+
+    def test_usage_requires_authentication(self, client):
+        """Unauthenticated callers are still rejected outright."""
+        resp = client.get(USAGE_ROUTE)
+        assert resp.status_code == 401, resp.text
 
 
 def _assign_role(test_db, organization_id, user_id, role_name: str) -> None:
@@ -272,21 +296,20 @@ class TestHttpAuthzEnforcementByRole:
             resp = client.get(f"/organizations/{org.id}", headers=_auth(token))
         assert resp.status_code == 200, resp.text
 
-    def test_admin_allowed_on_usage_read(self, client, test_db):
-        """EE Admin is an org admin, so billing data is in scope."""
-        _org, _user, token = self._context(test_db, "Admin")
-        with _ee_active():
-            resp = client.get(USAGE_ROUTE, headers=_auth(token))
-        assert resp.status_code == 200, resp.text
+    @pytest.mark.parametrize("role_name", ["Admin", "Member", "Viewer"])
+    def test_every_role_allowed_on_usage_read(self, role_name, client, test_db):
+        """``usage:read`` is part of the Viewer baseline, and Member's set is
+        built from it, so every role holds it.
 
-    @pytest.mark.parametrize("role_name", ["Member", "Viewer"])
-    def test_non_admin_roles_denied_on_usage_read(self, role_name, client, test_db):
-        """usage:read is excluded from the Viewer baseline, and Member's set is
-        built from it, so neither role holds it."""
+        Kept in step with community, where ``usage:read`` is likewise not in
+        ``_OWNER_ONLY_CAPABILITIES``: if these two drift, whether a member can
+        see their own quota starts depending on whether EE happens to be
+        active, which is not a licensing distinction anyone intends.
+        """
         _org, _user, token = self._context(test_db, role_name)
         with _ee_active():
             resp = client.get(USAGE_ROUTE, headers=_auth(token))
-        assert resp.status_code == 403, resp.text
+        assert resp.status_code == 200, resp.text
 
     def test_viewer_denied_on_organization_update(self, client, test_db):
         org, _user, token = self._context(test_db, "Viewer")


### PR DESCRIPTION
## Purpose

Usage limits have been display-only since Sub-plan 2 landed: `routers/usage.py` says so in its own docstring, and nothing read `TierSpec.overage`. This is Sub-plan 3 of the usage-limits master plan, which closes that gap end to end. The driving goal is preventing runaway hosted-model token spend, since Rhesis pays the Vertex COGS for `MODEL_TOKENS` — that's why the token gate covers every real path a model gets constructed on (system default, per-request override, local-mode platform key, Polyphemus delegation), not just the HTTP execute/generate endpoints.

## What Changed

- Added `OveragePolicy` (HARD/SOFT) and `QuotaPolicy` (limits + policy + overage tolerance) to core, replacing a bare-limits-only model. Soft tiers get a configurable grace band past their advertised limit (team/enterprise ship with 25%) before they actually block; hard tiers (community) block at the limit with no grace.
- `check_quota`/`enforce_quota` in `quota/enforcement.py` is the single blocking rule every enforcement point shares, so a route gated via `require_quota` and a hosted-model call gated inside `user_model_utils.py` hit identical logic and produce an identical 402 shape.
- Wired `require_quota` onto every test execute/generate endpoint, and onto project/endpoint/seat creation (stock resources, gated on a live count rather than an accrued counter).
- Gated `MODEL_TOKENS` at the model-resolution layer (`resolve_default_hosted_model` / `_fetch_and_configure_model`), which is the one place already covered by `test_language_model_construction_boundary.py`'s no-bypass guarantee — so this covers every real token-burning path, not just the HTTP endpoints in front of it.
- Frontend: `GET /usage` now reports each resource's effective `ceiling` (not just `limit`), so `RunDrawer`'s pre-emptive execute-gating disables the button at the same point the backend would actually 402 it, including the soft-tier grace band. Added a persistent `QuotaBanner` (shown at 80% utilization) and 402 handling in `base-client.ts`.
- Made `usage:read` readable by every org member instead of owner-only. It reports consumption against plan limits — no price, invoice, or payment method — and quota enforcement blocks members, so they need to see why. Plan limits are already exposed to every member via the ungated `GET /features`; this only extends that to the `used` side. The route stays fully authorized (not re-added to the exempt-routes list, which is the regression the original owner-only guard was actually protecting against).
- Fixed three pre-existing gaps in the tier-config loader found while reviewing this: an unvalidated `all_features` YAML value that `bool()` could coerce into unlocking every EE feature from a quoted `"false"`; a `limits` mapping that could silently omit a resource (reading as unlimited) with no coverage check; and a catalog-completeness gate that couldn't tell a genuine free-tier fallback from a real multi-tier config that lost every paid entry to shape checks, silently downgrading paying orgs.
- Added a dev-only `tier_config.dev.yaml` (opt-in via `RHESIS_TIER_CONFIG`) with deliberately tiny limits, for exercising every branch of the blocking rule by hand.

## Additional Context

Sub-plan 3 of the usage-limits master plan (Sub-plans 1 and 2 — tier config, `QuotaResource`, usage accounting, `GET /usage` dashboard — are already on `main`). No data backfill needed for the `usage:read` permission change: built-in roles compute their permission sets from code at request time, not from stored `role_permission` rows.

Existing free orgs may already exceed the stock limits (seats/projects/endpoints), since those were display-only until now — nothing gets deleted, but the next create after this ships can 402 for an org already over. Community's numbers (1 project / 1 endpoint / 3 seats) were logged in the design doc as a starting proposal pending unit-economics validation, and retuning them is now a config change (YAML), not a code change.

## Testing

Backend: `cd apps/backend && uv run pytest ../../tests/backend/app/ ../../tests/backend/services/ ../../tests/backend/ee/ ../../tests/backend/routes/test_quota_gates.py ../../tests/backend/routes/test_usage.py ../../tests/backend/security/ -v` — 3822 passed. Covers the exact 25% soft-overage boundary (allowed at `ceiling - 1`, blocked at `ceiling`), tier-config validation, the 402 HTTP path, and a regression proving the `MODEL_TOKENS` gate never fires for a model running on an org's own credentials.

Frontend: `cd apps/frontend && npx tsc --noEmit && npx eslint <touched files>` — clean. New `QuotaBanner.test.tsx` covers the zero-limit and unknown-resource edge cases.

Manually verified locally against `tier_config.dev.yaml`: execute button disables and the API 402s at the community tier's hard limit, and the soft grace band on team allows one run into the 25% band with a warning header before blocking.