### PR TITLE
Simplify Architect empty state and card the help articles

### DIFF
--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectHelpSection.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectHelpSection.tsx
@@ -3,7 +3,6 @@
 import React from 'react';
 import { Box } from '@mui/material';
 import { EntityEmptyStateEnrichmentSections } from '@/components/common/EntityEmptyStateEnrichmentParts';
-import { COMMUNITY_LINK_CARDS } from '@/constants/entity-empty-state-env';
 import type { EntityEmptyStateEnrichment } from '@/constants/entity-empty-state-types';
 import { useArchitectHelpArticles } from '@/hooks/useArchitectHelpArticles';
 import { useProjectNeedsEndpoint } from '@/hooks/useProjectNeedsEndpoint';
@@ -12,7 +11,7 @@ import { useProjectNeedsEndpoint } from '@/hooks/useProjectNeedsEndpoint';
 const MAX_WIDTH = 1126;
 
 /**
- * Getting-started help cards for a project that has no endpoint yet. Renders
+ * Getting-started help articles for a project that has no endpoint yet. Renders
  * nothing once an endpoint exists, so it fades out on its own as the user
  * completes setup.
  */
@@ -23,25 +22,17 @@ export default function ArchitectHelpSection() {
   // Stay hidden until we know the project has no endpoint — otherwise users who
   // do have one see the cards flash on every visit.
   if (!needsEndpoint) return null;
+  if (!articleUrls || articleUrls.length === 0) return null;
 
   const enrichment: EntityEmptyStateEnrichment = {
-    communityLinks: {
-      title: 'Community & Support',
-      items: COMMUNITY_LINK_CARDS,
+    helpArticles: {
+      title: 'Top Help Articles',
+      items: articleUrls.map(href => ({ href })),
     },
   };
 
-  if (articleUrls && articleUrls.length > 0) {
-    enrichment.helpArticles = {
-      title: 'Top Help Articles',
-      items: articleUrls.map(href => ({ href })),
-    };
-  }
-
   return (
-    // mt partly reclaims the space the hidden suggestion chips left behind —
-    // enough to settle the cards near the bottom without forcing a scrollbar.
-    <Box sx={{ width: '100%', maxWidth: MAX_WIDTH, mt: { xs: 2, md: 3 } }}>
+    <Box sx={{ width: '100%', maxWidth: MAX_WIDTH }}>
       <EntityEmptyStateEnrichmentSections enrichment={enrichment} />
     </Box>
   );

--- a/apps/frontend/src/app/(protected)/architect/components/ArchitectWelcome.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/ArchitectWelcome.tsx
@@ -81,21 +81,21 @@ export default function ArchitectWelcome({ onSubmit }: ArchitectWelcomeProps) {
         p: 4,
       }}
     >
-      {/* `my: 'auto'` centres the group while it fits, then resolves to 0 and
-          scrolls from the top once the help section makes it taller than the
-          viewport. `justifyContent: 'center'` would clip the leading edge.
-          The top padding only applies with the help section below: it counts
-          towards the centred box's height, so on its own it would push the
-          input off-centre by half its value. */}
+      {/* The input keeps its own vertical centre whether or not the help
+          articles sit below it: `flexGrow` claims the leftover space, and the
+          `minHeight` reserves most of the viewport for it once the articles
+          are there — so they start near the bottom edge and scroll into view. */}
       <Box
         sx={{
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
+          justifyContent: 'center',
           gap: 3,
           width: '100%',
-          my: 'auto',
-          pt: needsEndpoint ? { xs: 6, md: 18 } : 0,
+          flexGrow: 1,
+          flexShrink: 0,
+          minHeight: needsEndpoint ? '70vh' : 0,
         }}
       >
         <Box
@@ -197,9 +197,9 @@ export default function ArchitectWelcome({ onSubmit }: ArchitectWelcomeProps) {
             </Box>
           )}
         </Box>
-
-        <ArchitectHelpSection />
       </Box>
+
+      <ArchitectHelpSection />
     </Box>
   );
 }

--- a/apps/frontend/src/app/(protected)/architect/components/__tests__/ArchitectHelpSection.test.tsx
+++ b/apps/frontend/src/app/(protected)/architect/components/__tests__/ArchitectHelpSection.test.tsx
@@ -46,12 +46,17 @@ describe('ArchitectHelpSection', () => {
     setArticles(ARTICLE_URLS);
   });
 
-  it('renders both sections when the project has no endpoint', () => {
+  it('renders the help articles when the project has no endpoint', () => {
     render(<ArchitectHelpSection />);
 
     expect(screen.getByText('Top Help Articles')).toBeInTheDocument();
-    expect(screen.getByText('Community & Support')).toBeInTheDocument();
-    expect(screen.getByText('Documentation')).toBeInTheDocument();
+  });
+
+  it('never renders community links', () => {
+    render(<ArchitectHelpSection />);
+
+    expect(screen.queryByText('Community & Support')).not.toBeInTheDocument();
+    expect(screen.queryByText('Documentation')).not.toBeInTheDocument();
   });
 
   it('renders nothing once the project has an endpoint', () => {
@@ -60,7 +65,6 @@ describe('ArchitectHelpSection', () => {
     render(<ArchitectHelpSection />);
 
     expect(screen.queryByText('Top Help Articles')).not.toBeInTheDocument();
-    expect(screen.queryByText('Community & Support')).not.toBeInTheDocument();
   });
 
   it('renders nothing while the endpoint check is still loading', () => {
@@ -68,15 +72,14 @@ describe('ArchitectHelpSection', () => {
 
     render(<ArchitectHelpSection />);
 
-    expect(screen.queryByText('Community & Support')).not.toBeInTheDocument();
+    expect(screen.queryByText('Top Help Articles')).not.toBeInTheDocument();
   });
 
-  it('still shows community links when no article URLs are configured', () => {
+  it('renders nothing when no article URLs are configured', () => {
     setArticles([]);
 
     render(<ArchitectHelpSection />);
 
     expect(screen.queryByText('Top Help Articles')).not.toBeInTheDocument();
-    expect(screen.getByText('Community & Support')).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/components/common/EntityEmptyStateEnrichmentParts.tsx
+++ b/apps/frontend/src/components/common/EntityEmptyStateEnrichmentParts.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Box, Button, Paper, Skeleton, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import { ArrowOutwardIcon } from '@/components/icons';
-import { BORDER_RADIUS } from '@/styles/theme-constants';
+import { BORDER_RADIUS, ELEVATION } from '@/styles/theme-constants';
 import {
   emptyStateCardShellSx,
   emptyStateEnrichedActionSx,
@@ -174,17 +174,24 @@ function EmptyStateArticleCard({ article }: { article: EmptyStateArticle }) {
   const imageUrl = article.imageUrl ?? metadata?.imageUrl ?? null;
 
   const content = (
-    <Box
+    // `overflow: hidden` lets the preview run edge to edge and still pick up
+    // the card's rounded top corners.
+    <Paper
+      elevation={0}
       sx={{
         display: 'flex',
         flexDirection: 'column',
-        gap: '14px',
-        alignItems: 'flex-start',
-        width: '100%',
+        height: '100%',
+        overflow: 'hidden',
+        border: theme => `1px solid ${theme.palette.greyscale.border}`,
+        borderRadius: BORDER_RADIUS.md,
+        boxShadow: ELEVATION.xs,
+        transition: theme =>
+          theme.transitions.create(['box-shadow', 'border-color']),
       }}
     >
       {loading ? (
-        <Skeleton variant="rounded" width="100%" height={148} />
+        <Skeleton variant="rectangular" width="100%" height={148} />
       ) : (
         imageUrl && (
           <Box
@@ -192,15 +199,22 @@ function EmptyStateArticleCard({ article }: { article: EmptyStateArticle }) {
             src={imageUrl}
             alt=""
             sx={{
+              display: 'block',
               width: '100%',
               height: 148,
               objectFit: 'cover',
-              borderRadius: BORDER_RADIUS.sm,
             }}
           />
         )
       )}
-      <Box sx={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+      <Box
+        sx={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '5px',
+          p: '16px',
+        }}
+      >
         <Typography
           sx={{
             fontWeight: 700,
@@ -223,7 +237,7 @@ function EmptyStateArticleCard({ article }: { article: EmptyStateArticle }) {
           </Typography>
         )}
       </Box>
-    </Box>
+    </Paper>
   );
 
   if (article.href) {
@@ -236,7 +250,13 @@ function EmptyStateArticleCard({ article }: { article: EmptyStateArticle }) {
         sx={{
           textDecoration: 'none',
           color: 'inherit',
+          display: 'block',
           width: '100%',
+          height: '100%',
+          '&:hover .MuiPaper-root': {
+            boxShadow: ELEVATION.s,
+            borderColor: 'primary.main',
+          },
         }}
       >
         {content}


### PR DESCRIPTION
## Purpose

The Architect getting-started state showed seven cards to a user who has no endpoint yet: four help articles and three Community & Support links. That pushed the input field high up the page and buried the one thing the screen is actually for. This trims it to the four articles and gives the input back its vertical centre, closer to how comparable products (lemlist's lemAgent home) handle the same moment.

## What Changed

- `ArchitectHelpSection` no longer renders the Community & Support cards, and returns `null` when no article URLs are configured (it previously still rendered the community cards in that case). `COMMUNITY_LINK_CARDS` stays in place for the other entity empty states.
- `ArchitectWelcome` replaces the `my: 'auto'` + top-padding trick with a hero block that holds its own vertical centre: `flexGrow: 1` claims the leftover space and `minHeight: '70vh'` reserves most of the viewport for it, so the articles start near the bottom edge and scroll into view. With an endpoint present (no help section) the block centres in the full area exactly as before.
- Help article previews are now real cards — a bordered `Paper` with `ELEVATION.xs`, a full-bleed preview image, 16px text padding and equal heights across the row. Hover lifts the shadow to `ELEVATION.s` and tints the border `primary.main` so they read as the links they are.

## Additional Context

- `EmptyStateArticleCard` is shared, so the card styling also applies to the help-article previews on the other entity empty states (tests, test sets, endpoints, …). That was intentional — they are the same element and should look the same everywhere.
- `70vh` was chosen to put the articles at roughly the same fraction of the viewport as the reference design. It is a single value in `ArchitectWelcome.tsx` if it needs tuning.

## Testing

- `npx tsc --noEmit` — clean.
- `npm run lint` — 0 errors.
- `npx jest EntityEmptyState architect` — 142 tests pass. `ArchitectHelpSection.test.tsx` was updated: community links are now asserted absent, and "no article URLs" means nothing renders.
- Manually: open Architect in a project with no endpoint. The heading and input sit centred in the upper part of the pane, there are no Community & Support cards, and the four article cards start near the bottom edge. In a project that has an endpoint, the input centres as before and no cards appear.
