### PR TITLE
Fix role UI showing in community edition

### DIFF
--- a/apps/frontend/src/app/(protected)/organizations/team/components/MemberAccessDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/MemberAccessDrawer.tsx
@@ -18,6 +18,8 @@ import { useSession } from 'next-auth/react';
 import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { User } from '@/utils/api-client/interfaces/user';
 import { Project, ProjectMember } from '@/utils/api-client/interfaces/project';
+import { useFeature } from '@/contexts/FeaturesContext';
+import { FeatureName } from '@/constants/features';
 import {
   getMemberRoleExtensions,
   type UserProjectMembership,
@@ -77,8 +79,17 @@ export default function MemberAccessDrawer({
   const { status } = useSession();
   const [projectAccess, setProjectAccess] = useState<ProjectAccess[]>([]);
   const [loading, setLoading] = useState(false);
-  const { OrgRoleCell, ProjectRoleCell, fetchUserProjectMemberships } =
-    getMemberRoleExtensions();
+  const rbacEnabled = useFeature(FeatureName.RBAC);
+  const {
+    OrgRoleCell: RawOrgRoleCell,
+    ProjectRoleCell: RawProjectRoleCell,
+    fetchUserProjectMemberships: rawFetchMemberships,
+  } = getMemberRoleExtensions();
+  const OrgRoleCell = rbacEnabled ? RawOrgRoleCell : undefined;
+  const ProjectRoleCell = rbacEnabled ? RawProjectRoleCell : undefined;
+  const fetchUserProjectMemberships = rbacEnabled
+    ? rawFetchMemberships
+    : undefined;
 
   useEffect(() => {
     if (!open || !user || !isAuthenticated(status)) return;

--- a/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
+++ b/apps/frontend/src/app/(protected)/organizations/team/components/TeamMembersGrid.tsx
@@ -49,6 +49,8 @@ import TeamFilterDrawer from './TeamFilterDrawer';
 import MemberAccessDrawer from './MemberAccessDrawer';
 import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
+import { useFeature } from '@/contexts/FeaturesContext';
+import { FeatureName } from '@/constants/features';
 import { getMemberRoleExtensions } from '@/lib/extension-registries';
 import { getMemberJoinStatus } from '@/utils/member-join-status';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
@@ -183,13 +185,16 @@ export default function TeamMembersGrid({
     setAccessDrawerOpen(true);
   }, []);
 
-  const { OrgRoleCell, prewarmCaches } = getMemberRoleExtensions();
+  const rbacEnabled = useFeature(FeatureName.RBAC);
+  const { OrgRoleCell: RawOrgRoleCell, prewarmCaches } =
+    getMemberRoleExtensions();
+  const OrgRoleCell = rbacEnabled ? RawOrgRoleCell : undefined;
 
   useEffect(() => {
-    if (isAuthenticated(status)) {
+    if (rbacEnabled && isAuthenticated(status)) {
       prewarmCaches?.({ canManageRoles: canManageMembers });
     }
-  }, [prewarmCaches, canManageMembers, status]);
+  }, [rbacEnabled, prewarmCaches, canManageMembers, status]);
 
   const showRoleColumn = Boolean(OrgRoleCell);
   const currentUserId = session?.user?.id;

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectAddMemberDrawer.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectAddMemberDrawer.tsx
@@ -22,6 +22,8 @@ import { ApiClientFactory } from '@/utils/api-client/client-factory';
 import { UsersClient } from '@/utils/api-client/users-client';
 import { User } from '@/utils/api-client/interfaces/user';
 import { useNotifications } from '@/components/common/NotificationContext';
+import { useFeature } from '@/contexts/FeaturesContext';
+import { FeatureName } from '@/constants/features';
 import { getMemberRoleExtensions } from '@/lib/extension-registries';
 
 function getUserDisplayName(user: User): string {
@@ -53,7 +55,10 @@ export default function ProjectAddMemberDrawer({
   const [selectedRoleId, setSelectedRoleId] = useState<string | null>(null);
   const [adding, setAdding] = useState(false);
 
-  const { AddMemberRoleField } = getMemberRoleExtensions();
+  const rbacEnabled = useFeature(FeatureName.RBAC);
+  const { AddMemberRoleField: RawAddMemberRoleField } =
+    getMemberRoleExtensions();
+  const AddMemberRoleField = rbacEnabled ? RawAddMemberRoleField : undefined;
 
   const resetForm = useCallback(() => {
     setSelectedUser(null);

--- a/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMembers.tsx
+++ b/apps/frontend/src/app/(protected)/projects/[identifier]/components/ProjectMembers.tsx
@@ -20,6 +20,8 @@ import { useCan } from '@/components/common/Can';
 import { Capability } from '@/constants/capabilities';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { projectKeys } from '@/constants/query-keys';
+import { useFeature } from '@/contexts/FeaturesContext';
+import { FeatureName } from '@/constants/features';
 import { getMemberRoleExtensions } from '@/lib/extension-registries';
 import { isAuthenticated } from '@/hooks/useIsAuthenticated';
 
@@ -113,15 +115,18 @@ export default function ProjectMembers({
     }
   };
 
-  const { ProjectRoleCell, prewarmProjectCaches } = getMemberRoleExtensions();
+  const rbacEnabled = useFeature(FeatureName.RBAC);
+  const { ProjectRoleCell: RawProjectRoleCell, prewarmProjectCaches } =
+    getMemberRoleExtensions();
+  const ProjectRoleCell = rbacEnabled ? RawProjectRoleCell : undefined;
 
   useEffect(() => {
-    if (isAuthenticated(status) && projectId) {
+    if (rbacEnabled && isAuthenticated(status) && projectId) {
       prewarmProjectCaches?.(projectId, {
         canManageRoles: canManageMembers,
       });
     }
-  }, [projectId, prewarmProjectCaches, canManageMembers, status]);
+  }, [rbacEnabled, projectId, prewarmProjectCaches, canManageMembers, status]);
 
   const columns: GridColDef[] = React.useMemo(() => {
     const RoleCell = ProjectRoleCell;


### PR DESCRIPTION
## Purpose

When EE code is loaded but the organization does not have an RBAC license (community edition), role-related UI elements still appear in member grids and drawers. The EE bundle registers role extension components unconditionally at load time, and four components checked only whether the extension was registered, not whether RBAC was actually licensed. This left empty role columns, broken role chips, and non-functional role pickers visible to community users.

`TeamInviteForm` already had the correct pattern: gate on `useFeature(FeatureName.RBAC)` before using the extension. The other four consumers were missing this check.

## What Changed

- **TeamMembersGrid**: gate `OrgRoleCell` and cache pre-warming on `rbacEnabled`, hiding the Role column in community edition
- **MemberAccessDrawer**: gate `OrgRoleCell`, `ProjectRoleCell`, and `fetchUserProjectMemberships` on `rbacEnabled`, falling back to community behavior (static role label, per-project fetch)
- **ProjectMembers**: gate `ProjectRoleCell` and cache pre-warming on `rbacEnabled`, falling back to the static "member" label
- **ProjectAddMemberDrawer**: gate `AddMemberRoleField` on `rbacEnabled`, hiding the role picker

## Additional Context

- Follows the same pattern already established in `TeamInviteForm` (lines 94-97)
- Also skips RBAC cache pre-warming when the feature is off, avoiding wasted 403 requests

## Testing

- Run the app without an RBAC/enterprise license (community edition)
- Open the Team page: the Role column should not appear in the members grid
- Open the invite drawer: no org-role picker should appear next to email fields, no project-role picker next to selected projects
- Click a member row to open the access drawer: no org-role chip should appear, project cards should show a static "Member" badge
- Open a project's members tab: the Role column should show a static "member" label, not the EE role chip
- Open the add-member drawer on a project: no role picker field should appear
- With an RBAC license: all role UI should still render and function normally