### PR TITLE
Fix OWASP migrations before changing behaviors->requirement

### DIFF
--- a/apps/backend/src/rhesis/backend/alembic/versions/38ed899b9f41_add_owasp_behaviors_and_metrics_to_.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/38ed899b9f41_add_owasp_behaviors_and_metrics_to_.py
@@ -29,6 +29,7 @@ Create Date: 2026-07-02
 from typing import Sequence, Union
 
 from alembic import op
+from sqlalchemy import inspect
 from sqlalchemy.orm import Session
 
 # Import reusable behavior/metric sync utilities
@@ -73,6 +74,13 @@ def upgrade() -> None:
     per-organization behavior lookup succeeds and associations are created.
     """
     bind = op.get_bind()
+
+    # Predates 491519fd3010 (rename_behavior_to_requirement), so on a fresh DB
+    # the table is still "behavior" here. Fresh installs seed OWASP data via
+    # onboarding anyway, so skip the backfill.
+    if not inspect(bind).has_table("requirement"):
+        return
+
     session = Session(bind=bind)
 
     try:

--- a/apps/backend/src/rhesis/backend/alembic/versions/b857edcac3c0_tag_owasp_metrics_and_behaviors.py
+++ b/apps/backend/src/rhesis/backend/alembic/versions/b857edcac3c0_tag_owasp_metrics_and_behaviors.py
@@ -17,6 +17,7 @@ Create Date: 2026-07-16
 from typing import Sequence, Union
 
 from alembic import op
+from sqlalchemy import inspect
 from sqlalchemy.orm import Session
 
 from rhesis.backend.alembic.utils.metric_sync import _list_organizations_with_owner
@@ -40,6 +41,12 @@ def _owasp_rows(session: Session, model, org_id):
 
 def upgrade() -> None:
     bind = op.get_bind()
+
+    # Predates 491519fd3010 (rename_behavior_to_requirement), so on a fresh DB
+    # the table is still "behavior" here. Nothing to tag yet; skip.
+    if not inspect(bind).has_table("requirement"):
+        return
+
     session = Session(bind=bind)
     try:
         orgs = _list_organizations_with_owner(session)


### PR DESCRIPTION
## Summary
- Fresh database migrations fail with `UndefinedTable: relation "requirement" does not exist`
- Two migrations (`38ed899b9f41`, `b857edcac3c0`) import the live `Requirement` ORM model instead of using raw SQL. #2487 renamed the `behavior` table to `requirement` and updated that model in place, but on a from-scratch DB these two migrations run *before* the rename  migration, when the table is still called `behavior` — so they crash querying a table that doesn't exist yet
- This never showed up on existing dev/prod databases since they already had the table from before the rename — it only breaks a full migration replay from an empty database
- Both migrations now skip their body when the `requirement` table isn't there yet, which is safe since fresh installs get OWASP behaviors/metrics seeded another way, through onboarding's `load_initial_data()`

## Test plan
- [ ] `alembic downgrade base && alembic upgrade head` on a fresh database completes without error
- [ ] Existing (already-migrated) dases upgrade to head with no behavior change

