### PR TITLE
refactor(backend): tighten QueryBuilder, fix org filter and metric_scope count

### DIFF
--- a/apps/backend/src/rhesis/backend/app/crud/__init__.py
+++ b/apps/backend/src/rhesis/backend/app/crud/__init__.py
@@ -396,7 +396,8 @@ def get_test_sets(
                     organization_id
                 )
                 subquery = (
-                    subquery_builder.query.join(models.TestConfiguration)
+                    subquery_builder.build()
+                    .join(models.TestConfiguration)
                     .join(models.TestRun)
                     .distinct()
                     .with_entities(models.TestSet.id)
@@ -409,7 +410,9 @@ def get_test_sets(
         query_builder = query_builder.with_custom_filter(has_runs_filter)
 
     # Exclude explorer test sets (they use the dedicated /explorer API)
-    return query_builder.with_explorer_rows_excluded().all()
+    return query_builder.with_custom_filter(
+        lambda q: q.filter(models.TestSet.explorer_row.is_(False))
+    ).all()
 
 
 def create_test_set(

--- a/apps/backend/src/rhesis/backend/app/crud/project.py
+++ b/apps/backend/src/rhesis/backend/app/crud/project.py
@@ -105,7 +105,7 @@ def get_projects(
                 )
                 .exists()
             )
-            builder.query = builder.query.filter(exists_subquery)
+            builder = builder.with_custom_filter(lambda q: q.filter(exists_subquery))
 
         return builder.with_pagination(skip, limit).with_sorting(sort_by, sort_order).all()
 
@@ -138,7 +138,7 @@ def count_projects(
                 )
                 .exists()
             )
-            builder.query = builder.query.filter(exists_subquery)
+            builder = builder.with_custom_filter(lambda q: q.filter(exists_subquery))
         return builder.count()
 
 

--- a/apps/backend/src/rhesis/backend/app/crud/source.py
+++ b/apps/backend/src/rhesis/backend/app/crud/source.py
@@ -82,9 +82,9 @@ def get_source_with_content(
         .with_default_derived_field_loads()
         .with_organization_filter(organization_id)
         .with_visibility_filter(user_id)
+        .with_custom_filter(lambda q: q.options(undefer(models.Source.content)))
+        .filter_by_id(source_id)
     )
-    item.query = item.query.options(undefer(models.Source.content))
-    item = item.filter_by_id(source_id)
     return _check_and_raise_if_deleted(item, models.Source, source_id, include_deleted)
 
 

--- a/apps/backend/src/rhesis/backend/app/routers/metric.py
+++ b/apps/backend/src/rhesis/backend/app/routers/metric.py
@@ -242,16 +242,18 @@ def read_metrics(
     # $filter.  When metric_scope is also active, override the header with an
     # accurate count that includes the JSONB filter.
     if metric_scope:
-        from rhesis.backend.app.utils.query_utils import QueryBuilder
+        from rhesis.backend.app.utils.crud_utils import count_items
 
-        cb = (
-            QueryBuilder(db, models.Metric)
-            .with_organization_filter(organization_id)
-            .with_visibility_filter(user_id)
-            .with_odata_filter(filter)
+        response.headers["X-Total-Count"] = str(
+            count_items(
+                db,
+                models.Metric,
+                filter,
+                organization_id,
+                user_id,
+                extra_filter=metric_crud._metric_scope_filter(metric_scope),
+            )
         )
-        metric_crud._apply_metric_scope_filter(cb, metric_scope)
-        response.headers["X-Total-Count"] = str(cb.count())
 
     if select:
         serialized = jsonable_encoder(results)

--- a/apps/backend/src/rhesis/backend/app/services/connector/handlers/metric_sync.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/handlers/metric_sync.py
@@ -123,11 +123,12 @@ def _get_existing_sdk_metrics(
     backend_type_id,
 ) -> Dict[str, models.Metric]:
     """Get existing SDK metrics for this org keyed by name."""
-    query_builder = QueryBuilder(db, models.Metric).with_organization_filter(organization_id)
-    query_builder.query = query_builder.query.filter(
-        models.Metric.backend_type_id == backend_type_id,
+    existing = (
+        QueryBuilder(db, models.Metric)
+        .with_organization_filter(organization_id)
+        .with_custom_filter(lambda q: q.filter(models.Metric.backend_type_id == backend_type_id))
+        .all()
     )
-    existing = query_builder.all()
 
     result = {}
     for m in existing:

--- a/apps/backend/src/rhesis/backend/app/services/connector/handlers/test_result.py
+++ b/apps/backend/src/rhesis/backend/app/services/connector/handlers/test_result.py
@@ -112,12 +112,16 @@ class TestResultHandler:
             # First, get a sample endpoint to determine the organization
             # We'll use this to filter statuses by organization for tenant isolation
             # Use QueryBuilder which properly handles soft delete filtering
-            query_builder = QueryBuilder(db, Endpoint)
-            query_builder.query = query_builder.query.filter(
-                Endpoint.project_id == project_id,
-                Endpoint.environment == environment,
+            sample_endpoint = (
+                QueryBuilder(db, Endpoint)
+                .with_custom_filter(
+                    lambda q: q.filter(
+                        Endpoint.project_id == project_id,
+                        Endpoint.environment == environment,
+                    )
+                )
+                .first()
             )
-            sample_endpoint = query_builder.first()
 
             if not sample_endpoint:
                 logger.debug(f"No endpoints found for {project_id}:{environment}")
@@ -139,16 +143,19 @@ class TestResultHandler:
 
             # Find recently created/updated endpoints in Error status for this project
             # Use QueryBuilder which properly handles soft delete filtering
-            query_builder = QueryBuilder(db, Endpoint).with_organization_filter(
-                str(organization_id)
+            recent_error_endpoints = (
+                QueryBuilder(db, Endpoint)
+                .with_organization_filter(str(organization_id))
+                .with_custom_filter(
+                    lambda q: q.filter(
+                        Endpoint.project_id == project_id,
+                        Endpoint.environment == environment,
+                        Endpoint.status_id == error_status.id,
+                        Endpoint.updated_at >= recent_cutoff,
+                    )
+                )
+                .all()
             )
-            query_builder.query = query_builder.query.filter(
-                Endpoint.project_id == project_id,
-                Endpoint.environment == environment,
-                Endpoint.status_id == error_status.id,
-                Endpoint.updated_at >= recent_cutoff,
-            )
-            recent_error_endpoints = query_builder.all()
 
             if not recent_error_endpoints:
                 logger.debug(f"No recent error endpoints found for {project_id}:{environment}")

--- a/apps/backend/src/rhesis/backend/app/services/endpoint/sdk_sync.py
+++ b/apps/backend/src/rhesis/backend/app/services/endpoint/sdk_sync.py
@@ -87,13 +87,18 @@ async def sync_sdk_endpoints(
 
     # Get all existing SDK endpoints for this project/environment
     # Use QueryBuilder which properly handles soft delete filtering
-    query_builder = QueryBuilder(db, models.Endpoint).with_organization_filter(organization_id)
-    query_builder.query = query_builder.query.filter(
-        models.Endpoint.project_id == project_id,
-        models.Endpoint.environment == environment,
-        models.Endpoint.connection_type == EndpointConnectionType.SDK.value,
+    existing_endpoints = (
+        QueryBuilder(db, models.Endpoint)
+        .with_organization_filter(organization_id)
+        .with_custom_filter(
+            lambda q: q.filter(
+                models.Endpoint.project_id == project_id,
+                models.Endpoint.environment == environment,
+                models.Endpoint.connection_type == EndpointConnectionType.SDK.value,
+            )
+        )
+        .all()
     )
-    existing_endpoints = query_builder.all()
 
     # Map existing endpoints by function name
     existing_by_function = {}

--- a/apps/backend/src/rhesis/backend/app/services/organization.py
+++ b/apps/backend/src/rhesis/backend/app/services/organization.py
@@ -1460,12 +1460,7 @@ def _assign_demo_entities_to_example_project(
 
 def _get_matching_records(db: Session, model, identifiers: set, organization_id: str):
     """Get records that match the initial data identifiers."""
-    query = (
-        QueryBuilder(db, model)
-        .with_organization_filter(organization_id)
-        .with_custom_filter(lambda q: q.filter(model.organization_id == organization_id))
-        .build()
-    )
+    query = QueryBuilder(db, model).with_organization_filter(organization_id).build()
 
     if model.__name__ == "Test":
         return query.join(models.Prompt).filter(models.Prompt.content.in_(identifiers)).all()
@@ -1603,14 +1598,7 @@ def rollback_initial_data(db: Session, organization_id: str, user_id: str | None
                 # — and joinedload across many one-to-many relationships
                 # produces cartesian-product result sets. Lazy-loading per
                 # relationship as we recurse is slower but bounded.
-                query = (
-                    QueryBuilder(db, model)
-                    .with_organization_filter(organization_id)
-                    .with_custom_filter(
-                        lambda q: q.filter(model.organization_id == organization_id)
-                    )
-                    .build()
-                )
+                query = QueryBuilder(db, model).with_organization_filter(organization_id).build()
 
                 if model.__name__ == "Test":
                     records = (

--- a/apps/backend/src/rhesis/backend/app/services/test_set.py
+++ b/apps/backend/src/rhesis/backend/app/services/test_set.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 
 def get_test_set(db: Session, test_set_id: uuid.UUID, organization_id: str = None):
     """Get test set by ID with organization filtering for security"""
-    builder = (
+    return (
         QueryBuilder(db, TestSet)
         .with_custom_filter(lambda q: q.filter(TestSet.id == test_set_id))
         .with_related(
@@ -53,17 +53,9 @@ def get_test_set(db: Session, test_set_id: uuid.UUID, organization_id: str = Non
             include(TestSet.prompts, Prompt.status),
             include(TestSet.prompts, Prompt.user),
         )
+        .with_organization_filter(organization_id)
+        .first()
     )
-
-    # Apply organization filtering if provided
-    if organization_id:
-        from uuid import UUID as UUIDType
-
-        builder = builder.with_custom_filter(
-            lambda q: q.filter(TestSet.organization_id == UUIDType(organization_id))
-        )
-
-    return builder.first()
 
 
 def create_pending_test_set(

--- a/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/crud_utils.py
@@ -491,7 +491,10 @@ def get_items_detail(
         .with_odata_filter(filter)
     )
     if exclude_explorer_rows:
-        ids_builder = ids_builder.with_explorer_rows_excluded()
+        # Explorer-owned rows are listed through the /explorer API only.
+        ids_builder = ids_builder.with_custom_filter(
+            lambda q: q.filter(model.explorer_row.is_(False))
+        )
     if extra_filter:
         ids_builder = ids_builder.with_custom_filter(extra_filter)
     ordered_ids = (
@@ -888,11 +891,16 @@ def count_items(
     organization_id: str = None,
     user_id: str = None,
     exclude_explorer_rows: bool = False,
+    extra_filter: Callable[[Query], Query] | None = None,
 ) -> int:
     """Get the total count of items matching filters (without pagination).
 
     ``exclude_explorer_rows`` must match the list endpoint's own filtering, otherwise
     the count and the returned page disagree.
+
+    ``extra_filter``: same row-selection query transform accepted by
+    ``get_items_detail`` -- pass the same one here so the count matches the
+    page it's counting.
     """
     builder = (
         QueryBuilder(db, model)
@@ -901,7 +909,10 @@ def count_items(
         .with_odata_filter(filter)
     )
     if exclude_explorer_rows:
-        builder = builder.with_explorer_rows_excluded()
+        # Explorer-owned rows are listed through the /explorer API only.
+        builder = builder.with_custom_filter(lambda q: q.filter(model.explorer_row.is_(False)))
+    if extra_filter:
+        builder = builder.with_custom_filter(extra_filter)
     return builder.count()
 
 

--- a/apps/backend/src/rhesis/backend/app/utils/derived_field_loads.py
+++ b/apps/backend/src/rhesis/backend/app/utils/derived_field_loads.py
@@ -1,0 +1,130 @@
+from typing import Dict, Type
+
+from sqlalchemy import inspect
+from sqlalchemy.orm import RelationshipProperty, joinedload
+
+from rhesis.backend.app.utils.query_utils import include, resolve_chain
+
+
+def get_model_relationships(
+    model: Type, skip_many_to_many: bool = True, skip_one_to_many: bool = True
+) -> Dict[str, RelationshipProperty]:
+    """
+    Get relationships from a SQLAlchemy model.
+
+    Args:
+        model: The SQLAlchemy model class
+        skip_many_to_many: If True, excludes many-to-many relationships
+                          (those with secondary tables)
+        skip_one_to_many: If True, excludes one-to-many relationships (those with uselist=True)
+
+    Returns:
+        Dictionary of relationship name to RelationshipProperty
+    """
+    mapper = inspect(model)
+    relationships = {}
+
+    for rel in mapper.relationships:
+        # Use hierarchical filtering to avoid overlap between many-to-many and one-to-many
+
+        # First, check if it's many-to-many (has secondary table)
+        if getattr(rel, "secondary", None) is not None:
+            # This is a many-to-many relationship
+            if skip_many_to_many:
+                continue
+        # Then, check if it's one-to-many (uselist=True but no secondary table)
+        elif rel.uselist:
+            # This is a pure one-to-many relationship
+            if skip_one_to_many:
+                continue
+        # Otherwise, it's many-to-one or one-to-one (uselist=False, no secondary)
+
+        # Include this relationship
+        relationships[rel.key] = rel
+
+    return relationships
+
+
+def derived_field_load_options(model: Type, extra_chains: list | None = None) -> list:
+    """Build eager-load options for comments/tasks/files/tags on ``model``, and
+    for any many-to-one/one-to-one relationship whose target model also has them.
+
+    Detail response schemas nest a related model's own derived fields
+    too (e.g. Test.prompt -> the nested PromptReference schema also gets
+    a "counts"/"tags" field, since Prompt has the same mixins), so those
+    need eager-loading as well -- not just this model's own. This is what
+    makes Test.prompt (near-1:1 with Test, so effectively N distinct
+    prompts per page) safe: without this, each row's prompt lazy-loads
+    its own comments/tasks/tags individually.
+
+    Checks the actual mixin class, not just attribute presence -- some
+    models (e.g. User.comments, "comments authored by this user") have an
+    unrelated attribute with the same name as a mixin's, which a plain
+    ``hasattr`` would wrongly match.
+
+    Safe to call unconditionally -- skips models/relationships that don't
+    have these mixins. Merges in any caller-supplied ``extra_chains`` too
+    (each a flat ``[name, ...]`` path, e.g. ``["_tags_relationship", "tag"]``),
+    deduped by full chain.
+    """
+    from rhesis.backend.app.models.mixins import (
+        CommentsMixin,
+        FilesMixin,
+        TagsMixin,
+        TasksMixin,
+    )
+
+    derived_field_chains = (
+        (CommentsMixin, ("comments",)),
+        (TasksMixin, ("tasks",)),
+        (FilesMixin, ("files",)),
+        (TagsMixin, ("_tags_relationship", "tag")),
+    )
+
+    chains = list(extra_chains or [])
+    seen = {tuple(chain) for chain in chains}
+
+    def _add(chain: list) -> None:
+        key = tuple(chain)
+        if key not in seen:
+            seen.add(key)
+            chains.append(list(chain))
+
+    for mixin, chain in derived_field_chains:
+        if issubclass(model, mixin):
+            _add(list(chain))
+
+    # resolve_chain turns the runtime [name, ...] chain into a tuple of real
+    # attributes; include() picks joinedload vs. selectinload per hop from
+    # each one's own cardinality, whether the chain is a single hop
+    # (comments/tasks/files/tags) or multi-hop (_tags_relationship -> tag) --
+    # no special-casing needed for either length.
+    options = [include(*resolve_chain(model, chain)) for chain in chains]
+
+    # Cascade one level into joined-in single-object relations (the ones
+    # with_related eager-loads via joinedload) whose target model also
+    # carries these mixins. These relationships are already
+    # strategy=joinedload (by convention, whether set by this call or by the
+    # caller) -- selectinload-ing the same attribute independently raises a
+    # loader-strategy conflict, so the nested load is chained off the
+    # existing joinedload instead of starting fresh.
+    seen_nested = set()
+    for rel_name, rel_prop in get_model_relationships(
+        model, skip_many_to_many=True, skip_one_to_many=True
+    ).items():
+        target_model = rel_prop.mapper.class_
+        for mixin, chain in derived_field_chains:
+            key = (rel_name, *chain)
+            if key in seen_nested or not issubclass(target_model, mixin):
+                continue
+            seen_nested.add(key)
+            load = joinedload(getattr(model, rel_name))
+            nested_model = target_model
+            for nested_name in chain:
+                load = load.selectinload(getattr(nested_model, nested_name))
+                nested_rel_prop = inspect(nested_model).relationships.get(nested_name)
+                if nested_rel_prop is not None:
+                    nested_model = nested_rel_prop.mapper.class_
+            options.append(load)
+
+    return options

--- a/apps/backend/src/rhesis/backend/app/utils/query_utils.py
+++ b/apps/backend/src/rhesis/backend/app/utils/query_utils.py
@@ -1,9 +1,9 @@
 import logging
-from typing import Callable, Dict, List, Optional, Type, TypeVar
+from typing import Callable, List, Optional, Type, TypeVar
 from uuid import UUID
 
 from sqlalchemy import desc, inspect, or_
-from sqlalchemy.orm import Query, RelationshipProperty, Session, joinedload, selectinload
+from sqlalchemy.orm import Query, Session, joinedload, selectinload
 
 # Removed unused imports - legacy tenant functions no longer needed
 from rhesis.backend.app.utils.odata import apply_odata_filter
@@ -130,87 +130,13 @@ class QueryBuilder:
         return self
 
     def with_default_derived_field_loads(self, extra_chains: list | None = None) -> "QueryBuilder":
-        """Selectin-load comments/tasks/files/tags for this model, and for any
-        many-to-one/one-to-one relationship whose target model also has them.
-
-        Detail response schemas nest a related model's own derived fields
-        too (e.g. Test.prompt -> the nested PromptReference schema also gets
-        a "counts"/"tags" field, since Prompt has the same mixins), so those
-        need eager-loading as well -- not just this model's own. This is what
-        makes Test.prompt (near-1:1 with Test, so effectively N distinct
-        prompts per page) safe: without this, each row's prompt lazy-loads
-        its own comments/tasks/tags individually.
-
-        Checks the actual mixin class, not just attribute presence -- some
-        models (e.g. User.comments, "comments authored by this user") have an
-        unrelated attribute with the same name as a mixin's, which a plain
-        ``hasattr`` would wrongly match.
-
-        Safe to call unconditionally -- skips models/relationships that don't
-        have these mixins. Merges in any caller-supplied ``extra_chains`` too
-        (each a flat ``[name, ...]`` path, e.g. ``["_tags_relationship", "tag"]``),
-        deduped by full chain.
+        """Eager-load comments/tasks/files/tags for this model (and one level of
+        cascade into related models that carry the same mixins) -- see
+        ``derived_field_loads.derived_field_load_options`` for the policy.
         """
-        from rhesis.backend.app.models.mixins import (
-            CommentsMixin,
-            FilesMixin,
-            TagsMixin,
-            TasksMixin,
-        )
+        from rhesis.backend.app.utils.derived_field_loads import derived_field_load_options
 
-        derived_field_chains = (
-            (CommentsMixin, ("comments",)),
-            (TasksMixin, ("tasks",)),
-            (FilesMixin, ("files",)),
-            (TagsMixin, ("_tags_relationship", "tag")),
-        )
-
-        chains = list(extra_chains or [])
-        seen = {tuple(chain) for chain in chains}
-
-        def _add(chain: list) -> None:
-            key = tuple(chain)
-            if key not in seen:
-                seen.add(key)
-                chains.append(list(chain))
-
-        for mixin, chain in derived_field_chains:
-            if issubclass(self.model, mixin):
-                _add(list(chain))
-        for chain in chains:
-            # resolve_chain turns the runtime [name, ...] chain into a tuple of
-            # real attributes; include() picks joinedload vs. selectinload per hop
-            # from each one's own cardinality, whether the chain is a single hop
-            # (comments/tasks/files/tags) or multi-hop (_tags_relationship -> tag)
-            # -- no special-casing needed for either length.
-            self.with_related(include(*resolve_chain(self.model, chain)))
-
-        # Cascade one level into joined-in single-object relations (the ones
-        # with_related eager-loads via joinedload) whose
-        # target model also carries these mixins. These relationships are
-        # already strategy=joinedload (by convention, whether set by this
-        # call or by the caller) -- selectinload-ing the same attribute
-        # independently raises a loader-strategy conflict, so the nested load
-        # is chained off the existing joinedload instead of starting fresh.
-        seen_nested = set()
-        for rel_name, rel_prop in get_model_relationships(
-            self.model, skip_many_to_many=True, skip_one_to_many=True
-        ).items():
-            target_model = rel_prop.mapper.class_
-            for mixin, chain in derived_field_chains:
-                key = (rel_name, *chain)
-                if key in seen_nested or not issubclass(target_model, mixin):
-                    continue
-                seen_nested.add(key)
-                load = joinedload(getattr(self.model, rel_name))
-                nested_model = target_model
-                for nested_name in chain:
-                    load = load.selectinload(getattr(nested_model, nested_name))
-                    nested_rel_prop = inspect(nested_model).relationships.get(nested_name)
-                    if nested_rel_prop is not None:
-                        nested_model = nested_rel_prop.mapper.class_
-                self.query = self.query.options(load)
-        return self
+        return self.with_related(*derived_field_load_options(self.model, extra_chains))
 
     def _maybe_warn_load_count(self) -> None:
         if self._eager_load_count >= _MAX_EAGER_LOADS_WARN:
@@ -268,33 +194,22 @@ class QueryBuilder:
         Raises:
             ValueError: If organization_id is required but not provided
         """
-        if has_organization_id(self.model):
-            # Check if model is exempt from organization filtering
-            exempt_models = ["User", "Organization", "Token"]
-            if self.model.__name__ in exempt_models:
-                # For exempt models, apply organization filter if provided, but don't require it
-                if organization_id and (
-                    isinstance(organization_id, str)
-                    and organization_id.strip()
-                    or not isinstance(organization_id, str)
-                ):
-                    self.query = self.query.filter(self.model.organization_id == organization_id)
-            else:
-                # For non-exempt models, organization_id is required
-                if organization_id and (
-                    isinstance(organization_id, str)
-                    and organization_id.strip()
-                    or not isinstance(organization_id, str)
-                ):
-                    # Use direct organization_id filtering (optimized)
-                    self.query = self.query.filter(self.model.organization_id == organization_id)
-                else:
-                    # SECURITY: organization_id must be provided for models that have it
-                    raise ValueError(
-                        f"organization_id is required for {self.model.__name__} "
-                        "but was not provided. This is a security requirement to "
-                        "prevent data leakage across organizations."
-                    )
+        if not has_organization_id(self.model):
+            return self
+
+        provided = organization_id and (
+            not isinstance(organization_id, str) or organization_id.strip()
+        )
+        if provided:
+            self.query = self.query.filter(self.model.organization_id == organization_id)
+        elif self.model.__name__ not in ("User", "Organization", "Token"):
+            # SECURITY: organization_id must be provided for non-exempt models
+            # that have it, to prevent data leakage across organizations.
+            raise ValueError(
+                f"organization_id is required for {self.model.__name__} "
+                "but was not provided. This is a security requirement to "
+                "prevent data leakage across organizations."
+            )
         return self
 
     def with_project_filter(self, project_id: Optional[str] = None) -> "QueryBuilder":
@@ -416,29 +331,6 @@ class QueryBuilder:
         self.query = filter_func(self.query)
         return self
 
-    def with_explorer_rows_excluded(self) -> "QueryBuilder":
-        """Drop Explorer-owned rows -- they are listed through the /explorer API only."""
-        self.query = self.query.filter(self.model.explorer_row.is_(False))
-        return self
-
-    def with_field_inclusion(self, include_fields: str) -> "QueryBuilder":
-        """Apply field inclusion using SQLAlchemy undefer for deferred fields"""
-        if not include_fields:
-            return self
-
-        # Parse comma-separated fields
-        fields = [field.strip() for field in include_fields.split(",") if field.strip()]
-
-        # Apply undefer for each field that exists on the model
-        for field in fields:
-            if hasattr(self.model, field):
-                # Use SQLAlchemy's undefer to force load deferred fields
-                from sqlalchemy.orm import undefer
-
-                self.query = self.query.options(undefer(field))
-
-        return self
-
     def _apply_sorting(self):
         """Apply sorting if configured"""
         from rhesis.backend.app.utils.count_sort import (
@@ -537,53 +429,3 @@ def has_organization_id(model: Type[T]) -> bool:
 def has_project_id(model: Type[T]) -> bool:
     """Check if model has project_id column."""
     return hasattr(model, "project_id") or "project_id" in inspect(model).columns.keys()
-
-
-def has_visibility(model: Type[T]) -> bool:
-    """Check if model supports visibility filtering.
-
-    Requires a ``visibility`` column and an owner column (``user_id`` or
-    ``owner_user_id``).
-    """
-    columns = inspect(model).columns.keys()
-    has_owner = "user_id" in columns or "owner_user_id" in columns
-    return "visibility" in columns and has_owner
-
-
-def get_model_relationships(
-    model: Type, skip_many_to_many: bool = True, skip_one_to_many: bool = True
-) -> Dict[str, RelationshipProperty]:
-    """
-    Get relationships from a SQLAlchemy model.
-
-    Args:
-        model: The SQLAlchemy model class
-        skip_many_to_many: If True, excludes many-to-many relationships
-                          (those with secondary tables)
-        skip_one_to_many: If True, excludes one-to-many relationships (those with uselist=True)
-
-    Returns:
-        Dictionary of relationship name to RelationshipProperty
-    """
-    mapper = inspect(model)
-    relationships = {}
-
-    for rel in mapper.relationships:
-        # Use hierarchical filtering to avoid overlap between many-to-many and one-to-many
-
-        # First, check if it's many-to-many (has secondary table)
-        if getattr(rel, "secondary", None) is not None:
-            # This is a many-to-many relationship
-            if skip_many_to_many:
-                continue
-        # Then, check if it's one-to-many (uselist=True but no secondary table)
-        elif rel.uselist:
-            # This is a pure one-to-many relationship
-            if skip_one_to_many:
-                continue
-        # Otherwise, it's many-to-one or one-to-one (uselist=False, no secondary)
-
-        # Include this relationship
-        relationships[rel.key] = rel
-
-    return relationships

--- a/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/batch/context.py
@@ -154,7 +154,7 @@ def prefetch_execution_context(
 
     bind_scope_to_session(session, organization_id, user_id or "", project_id)
 
-    test_set = get_test_set(session, str(test_config.test_set_id))
+    test_set = get_test_set(session, str(test_config.test_set_id), organization_id)
 
     endpoint = session.query(Endpoint).filter(Endpoint.id == test_config.endpoint_id).first()
     if not endpoint:

--- a/apps/backend/src/rhesis/backend/tasks/execution/orchestration.py
+++ b/apps/backend/src/rhesis/backend/tasks/execution/orchestration.py
@@ -39,7 +39,7 @@ def execute_test_cases(
         trace_id: Optional trace ID for trace-based evaluation
     """
 
-    test_set = get_test_set(session, str(test_config.test_set_id))
+    test_set = get_test_set(session, str(test_config.test_set_id), str(test_config.organization_id))
     if count_test_set_tests(session, test_set.id) == 0:
         raise TestExecutionError(
             "Cannot execute test set with 0 tests. Please add tests before executing."

--- a/tests/backend/routes/test_metric.py
+++ b/tests/backend/routes/test_metric.py
@@ -357,6 +357,15 @@ class TestMetricPerformance(MetricTestMixin, BaseEntityTests):
         page_2 = response.json()
         # page_2 might be empty if there aren't enough metrics, which is fine
 
+    def test_metric_list_with_metric_scope_filter(self, metric_factory):
+        """metric_scope must not break the X-Total-Count override in the router."""
+        metric_factory.create(self.get_sample_data())
+
+        response = metric_factory.client.get(f"{self.endpoints.list}?metric_scope=Single-Turn")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert int(response.headers["X-Total-Count"]) >= len(response.json())
+
 
 # === METRIC GENERATE ENDPOINT TESTS ===
 

--- a/tests/backend/security/test_visibility_filter.py
+++ b/tests/backend/security/test_visibility_filter.py
@@ -15,7 +15,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from rhesis.backend.app import models
-from rhesis.backend.app.utils.query_utils import QueryBuilder, has_visibility
+from rhesis.backend.app.utils.query_utils import QueryBuilder
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -106,23 +106,6 @@ def _insert_experiment(
     )
     db.flush()
     return exp_id
-
-
-# ---------------------------------------------------------------------------
-# has_visibility probe
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.unit
-class TestHasVisibility:
-    def test_test_set_has_visibility(self):
-        assert has_visibility(models.TestSet) is True
-
-    def test_experiment_has_visibility(self):
-        assert has_visibility(models.Experiment) is True
-
-    def test_project_no_visibility(self):
-        assert has_visibility(models.Project) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

Three related backend hardening fixes: a QueryBuilder cleanup, a tenant-isolation gap in `get_test_set`, and a pagination count that could drift from the list endpoint's own filtering.

## What Changed

- **QueryBuilder cleanup.** Routed every caller through `with_custom_filter()` instead of mutating `.query` directly, extracted derived-field-load option logic into its own module (`derived_field_loads.py`), and removed four now-unused escape hatches (`with_explorer_rows_excluded`, `with_field_inclusion`, `has_visibility`, `get_model_relationships`).
- **Organization filtering fix.** `get_test_set` wasn't routing its org check through `QueryBuilder.with_organization_filter`, and two callers (the batch execution context, orchestration) weren't passing `organization_id` at all — a real tenant-isolation gap.
- **Pagination count fix.** The `X-Total-Count` header for the `metric_scope`-filtered list endpoint built its own ad-hoc count query instead of reusing `count_items()`, risking drift from the list endpoint's own filtering.

## Testing

Existing regression tests updated where behavior changed; full backend suite passes.