### PR TITLE
Fix test run error pill UX and enable pre-flight checks by default

### DIFF
--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsTableView.tsx
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/TestsTableView.tsx
@@ -41,6 +41,7 @@ import ReviewJudgementDrawer from './ReviewJudgementDrawer';
 import { findStatusByCategory } from '@/utils/test-result-status';
 import {
   getEvaluationContent,
+  getExecutionErrorTooltip,
   getFailedMetricNames,
   getGoalContent,
   getTestResultDisplayStatus,
@@ -341,7 +342,7 @@ export default function TestsTableView({
           getTestResultDisplayStatus(row, isMultiTurn).label,
         renderCell: params => {
           const status = getTestResultDisplayStatus(params.row, isMultiTurn);
-          return (
+          const badge = (
             <GridBadge
               label={status.label}
               sx={{
@@ -358,6 +359,21 @@ export default function TestsTableView({
               }}
             />
           );
+          if (status.hasExecutionError) {
+            const tooltip = getExecutionErrorTooltip(
+              params.row,
+              status,
+              requirements
+            );
+            return (
+              <Tooltip title={tooltip} enterDelay={500}>
+                <Box component="span" sx={{ display: 'inline-flex' }}>
+                  {badge}
+                </Box>
+              </Tooltip>
+            );
+          }
+          return badge;
         },
       },
       {
@@ -660,7 +676,14 @@ export default function TestsTableView({
         },
       },
     ];
-  }, [isMultiTurn, prompts, theme, isConfirmingReview, openTestDrawer]);
+  }, [
+    isMultiTurn,
+    prompts,
+    theme,
+    isConfirmingReview,
+    openTestDrawer,
+    requirements,
+  ]);
 
   return (
     <Box sx={{ width: '100%', minWidth: 0 }}>

--- a/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/test-run-results-grid-utils.ts
+++ b/apps/frontend/src/app/(protected)/test-runs/[identifier]/components/test-run-results-grid-utils.ts
@@ -16,6 +16,7 @@ export type TestResultDisplayStatus = {
   hasConflict: boolean;
   automatedPassed?: boolean;
   hasExecutionError: boolean;
+  errorReason?: string;
   reviewData?: {
     reviewer: string;
     comments: string;
@@ -111,6 +112,9 @@ export function getTestResultDisplayStatus(
         isOverruled: false,
         hasConflict: false,
         hasExecutionError: true,
+        errorReason:
+          test.test_output.goal_evaluation?.reason ||
+          'Test execution encountered an error',
       };
     }
 
@@ -172,6 +176,8 @@ export function getTestResultDisplayStatus(
       isOverruled: false,
       hasConflict: false,
       hasExecutionError: true,
+      errorReason:
+        'No metrics to evaluate. Ensure the requirement has metrics configured.',
     };
   }
 
@@ -233,6 +239,47 @@ export function getTestResultDisplayStatus(
     automatedPassed: originalPassed,
     hasExecutionError: false,
   };
+}
+
+function getHttpErrorReason(test: TestResultDetail): string | undefined {
+  const output = test.test_output as Record<string, unknown> | undefined;
+  if (!output) return undefined;
+
+  const isHttpError =
+    output.error_type === 'http_error' ||
+    (output.error &&
+      typeof output.status_code === 'number' &&
+      output.status_code >= 400);
+  if (!isHttpError) return undefined;
+
+  const statusCode =
+    typeof output.status_code === 'number' ? output.status_code : undefined;
+  const errorMsg = typeof output.error === 'string' ? output.error : '';
+  if (statusCode) {
+    return `Endpoint returned HTTP ${statusCode}${errorMsg ? `: ${errorMsg}` : ''}`;
+  }
+  return `Endpoint returned an error${errorMsg ? `: ${errorMsg}` : ''}`;
+}
+
+export function getExecutionErrorTooltip(
+  test: TestResultDetail,
+  status: TestResultDisplayStatus,
+  requirements?: Array<{ id: string; metrics: Array<unknown> }>
+): string {
+  if (!status.hasExecutionError) return '';
+
+  const httpReason = getHttpErrorReason(test);
+  if (httpReason) return httpReason;
+
+  const requirement = test.test?.requirement;
+  if (requirement && requirements) {
+    const reqData = requirements.find(r => r.id === requirement.id);
+    if (reqData && reqData.metrics.length === 0) {
+      return `No metrics to evaluate because the requirement "${requirement.name}" has no metrics configured`;
+    }
+  }
+
+  return status.errorReason || '';
 }
 
 export { truncateText };

--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -360,7 +360,7 @@ export default function RunDrawer(props: RunDrawerProps) {
   const [tags, setTags] = useState<string[]>([]);
 
   // ---- Preflight ----
-  const [preflightEnabled, setPreflightEnabled] = useState(false);
+  const [preflightEnabled, setPreflightEnabled] = useState(true);
   const [preflightDialogOpen, setPreflightDialogOpen] = useState(false);
   const [preflightCorrelationId, setPreflightCorrelationId] = useState('');
   const [preflightChecks, setPreflightChecks] = useState<

--- a/apps/frontend/src/components/common/RunDrawer.tsx
+++ b/apps/frontend/src/components/common/RunDrawer.tsx
@@ -414,6 +414,7 @@ export default function RunDrawer(props: RunDrawerProps) {
     setSelectedTestSet(null);
     setSelectedSearchTestSets([]);
     setTestSetInput('');
+    setPreflightEnabled(true);
     setPreflightDialogOpen(false);
     setPreflightCorrelationId('');
     setPreflightChecks([]);


### PR DESCRIPTION
## Purpose

When a test run shows "Error" pills in the Result column (e.g. because a requirement has no metrics configured), users have no way to understand why. This PR adds informative tooltips and also enables pre-flight checks by default so these misconfigurations are caught before execution.

## What Changed

- Added hover tooltips on the Error pill in the test run's Test Cases table. The tooltip shows a specific reason based on what went wrong:
  - Requirement has no metrics: `No metrics to evaluate because the requirement "X" has no metrics configured`
  - HTTP error from endpoint: `Endpoint returned HTTP 500: ...`
  - Multi-turn execution error: uses the goal evaluation reason from the Penelope trace when available
  - Generic fallback: `No metrics to evaluate. Ensure the requirement has metrics configured.`
- Pre-flight checks now default to enabled in the RunDrawer (both run and rerun flows). Users can still toggle them off.

## Additional Context

- The error tooltip logic is in `getExecutionErrorTooltip()`, which cross-references the `requirements` array to provide requirement-specific messages when possible.
- No backend changes needed. The tooltip uses existing data on the test result (test_output, test_metrics, requirement reference).

## Testing

- Create a test set with a requirement that has no metrics configured. Run it and verify the Error pills show a tooltip explaining the missing metrics.
- Run a test against an endpoint that returns an HTTP error. Verify the tooltip shows the status code.
- Open the RunDrawer and verify pre-flight checks are enabled by default. Toggle them off and back on to confirm the control still works.


<img width="601" height="549" alt="image" src="https://github.com/user-attachments/assets/dcdc1875-0e3a-4a19-bd23-d21e0a8c03a9" />


<img width="385" height="271" alt="image" src="https://github.com/user-attachments/assets/b9fc4a96-1e24-4b60-ae9a-b867c438d916" />
